### PR TITLE
feat(research): 25k intent cap, a live character count, and a growing prompt box

### DIFF
--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/research-mission-routing";
 import {
   RESEARCH_BOUND_LIMITS,
+  RESEARCH_INTENT_MAX_LENGTH,
   RESEARCH_INTENT_MIN_LENGTH,
   RESEARCH_MISSION_MODES,
   type CreateResearchMissionInput,
@@ -274,6 +275,18 @@ export function ResearchMissionComposer({
   const plan = useMemo(() => defaultResearchPlan(effectiveMode), [effectiveMode]);
   const trimmedIntent = intent.trim();
   const intentTooShort = trimmedIntent.length > 0 && trimmedIntent.length < RESEARCH_INTENT_MIN_LENGTH;
+  // Grow the box with the brief instead of scrolling three fixed rows. The CSS
+  // caps it at ~12 lines, so `auto` then scrollHeight settles at the smaller of
+  // content height and that ceiling; past it the element scrolls as before.
+  // Measured on every intent change, including programmatic ones (slash
+  // completions, /improve rewrites, restored drafts), not just typing.
+  const intentBoxRef = useRef<HTMLTextAreaElement | null>(null);
+  useEffect(() => {
+    const el = intentBoxRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [intent]);
 
   // Strength + assembled brief are pure reads of the textarea, so they track
   // hand edits made after the builder closed.
@@ -477,6 +490,8 @@ export function ResearchMissionComposer({
           <label htmlFor="research-intent" className="sr-only">What should we investigate?</label>
           <textarea
             id="research-intent"
+            ref={intentBoxRef}
+            maxLength={RESEARCH_INTENT_MAX_LENGTH}
             value={intent}
             onChange={(event) => {
               setIntent(event.target.value);
@@ -525,6 +540,16 @@ export function ResearchMissionComposer({
               Add at least {RESEARCH_INTENT_MIN_LENGTH} characters so the familiar has a real question to investigate.
             </p>
           ) : null}
+          {/* Static text, deliberately not a live region — announcing every
+              keystroke would drown the composer. The ceiling is visible while
+              writing rather than discovered as a server rejection afterwards. */}
+          <span
+            className={`research-intent-count${
+              intent.length >= RESEARCH_INTENT_MAX_LENGTH * 0.9 ? " research-intent-count--near" : ""
+            }`}
+          >
+            {intent.length.toLocaleString()} / {RESEARCH_INTENT_MAX_LENGTH.toLocaleString()}
+          </span>
         </div>
 
         {attachedLinks.length > 0 ? (

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -728,7 +728,12 @@ export function parseResearchMission(value: unknown): ResearchMission | null {
  *  that would still spend a real familiar session. Enforced by the create
  *  validator (server) and the desk composer (client). */
 export const RESEARCH_INTENT_MIN_LENGTH = 8;
-export const RESEARCH_INTENT_MAX_LENGTH = 10_000;
+/** Upper bound on a mission brief. Raised 10k → 25k (cave-r3vmj): real briefs
+ *  carry pasted context — prior findings, source lists, constraints — and hit
+ *  the old cap, which surfaced only as a server rejection after the writing was
+ *  done. The composer now shows the count as you type, so the ceiling is
+ *  visible rather than discovered. */
+export const RESEARCH_INTENT_MAX_LENGTH = 25_000;
 export const RESEARCH_TITLE_MAX_LENGTH = 160;
 export const RESEARCH_DELIVERABLE_MAX_LENGTH = 160;
 export const RESEARCH_AUDIENCE_MAX_LENGTH = 500;

--- a/src/lib/server/flow-copilot-session.test.ts
+++ b/src/lib/server/flow-copilot-session.test.ts
@@ -441,7 +441,40 @@ test("the current maximum Research input is measured and pathological quoting fa
   assert.equal(plainPrompt.split(plainDeliverable).length - 1, 1);
   assert.equal(plainPrompt.split(plainAudience).length - 1, 1);
   const plainArgs = flowLaunchArgs(plainPrompt);
-  assert.doesNotThrow(() => assertCopilotCommandLineFitsWindows("copilot.exe", plainArgs, "win32"));
+  // cave-r3vmj raised RESEARCH_INTENT_MAX_LENGTH to 25k so real briefs can carry
+  // pasted context. Copilot is argv-only today, so a maximum-length intent no
+  // longer fits the bounded Windows command line even with plain quoting — the
+  // guard fails closed with the actionable message rather than truncating a
+  // prompt. Every other platform, and any runtime with stdin prompt support, is
+  // unaffected. Moving Copilot to stdin is what would lift this ceiling.
+  assert.ok(
+    windowsCommandLineUtf16Length("copilot.exe", plainArgs) > WINDOWS_COPILOT_COMMAND_LINE_SAFE_UNITS,
+    "a maximum-length intent exceeds the bounded argv transport",
+  );
+  assert.throws(
+    () => assertCopilotCommandLineFitsWindows("copilot.exe", plainArgs, "win32"),
+    /Shorten the Research mission intent or use a runtime with stdin prompt support/,
+  );
+  assert.doesNotThrow(
+    () => assertCopilotCommandLineFitsWindows("copilot.exe", plainArgs, "darwin"),
+    "the ceiling is a Windows argv limit, not a product-wide one",
+  );
+
+  // A brief that does fit still launches — the ceiling is a real size, not a
+  // blanket refusal.
+  const fittingValidated = validateCreateResearchMissionInput({
+    ...researchMission("i".repeat(8_000)),
+    deliverable: plainDeliverable,
+    audience: plainAudience,
+  });
+  assert.equal(fittingValidated.ok, true);
+  const fittingPrompt = compileFlowPrompt(
+    buildResearchMissionFlow(researchMission(fittingValidated.value.intent, fittingValidated.value), 1),
+  );
+  assert.doesNotThrow(
+    () => assertCopilotCommandLineFitsWindows("copilot.exe", flowLaunchArgs(fittingPrompt), "win32"),
+    "an 8k intent still launches through the Windows argv transport",
+  );
 
   const validatedQuoted = validateCreateResearchMissionInput({
     ...researchMission('"'.repeat(RESEARCH_INTENT_MAX_LENGTH)),

--- a/src/styles/globals/surface-research-prompt.css
+++ b/src/styles/globals/surface-research-prompt.css
@@ -77,10 +77,33 @@
 }
 .research-intake__card textarea {
   min-height: 96px;
-  max-height: 60vh;
+  /* ~12 lines (cave-r3vmj). The composer sizes the element to its content on
+     every change; this is the ceiling it settles against, after which the box
+     scrolls. `lh` is the honest unit here — it tracks the line-height above,
+     so the cap stays 12 lines if the type scale moves. The px value is the
+     fallback for engines without `lh`. */
+  max-height: 306px;
+  max-height: calc(12lh + (var(--space-3) * 2));
   font-size: var(--text-md);
   line-height: 1.5;
   padding: var(--space-3) 14px;
+  /* Room for the counter so a long brief never runs under it. */
+  padding-bottom: calc(var(--space-3) + 14px);
+}
+
+/* Character count, anchored inside the prompt box (its container is already
+   position: relative for the slash-command palette). */
+.research-intent-count {
+  position: absolute;
+  right: 12px;
+  bottom: 8px;
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+.research-intent-count--near {
+  color: var(--text-warning, var(--text-strong));
 }
 
 /* ── Slash-command palette (design 548–559): anchored under the textarea. ── */


### PR DESCRIPTION
Three changes to the Research Desk mission composer. Bead `cave-r3vmj`.

## What changed

| | |
|---|---|
| **Cap** | `RESEARCH_INTENT_MAX_LENGTH` 10,000 → **25,000** |
| **Count** | live `1,234 / 25,000` inside the box, amber past 90% |
| **Size** | grows with the brief, capped at ~12 lines, was a fixed 3 rows |

A note on the request's wording: it asked to raise the *minimum*. `RESEARCH_INTENT_MIN_LENGTH` is 8 and exists to block one-word launches that still spend a familiar session — a 25,000 minimum would make the desk unusable — so the cap is what was being hit. Flagging the interpretation rather than burying it.

The counter is deliberately **not** a live region; announcing every keystroke would drown the composer. The textarea also gained `maxLength`, so the browser now enforces what the server validator already did. The height cap is expressed in `lh` so it tracks the line-height if the type scale moves, with a px fallback. Resizing runs on every intent change, not just typing, so slash completions and `/improve` rewrites resize it too.

## A real ceiling, deliberately accepted

Raising the cap surfaced a genuine constraint rather than a stale test:

```
CopilotPromptTransportError: Copilot flow prompt is too large for a safe Windows
launch (42434 UTF-16 command-line units; safe limit 30000).
```

Copilot takes its flow prompt through **argv only**, and `flow-copilot-session.ts:299` bounds that at 30,000 UTF-16 units **on `win32`**. The scaffolding around the intent costs ~17,400 units, so the practical ceiling for that one path is ~12,500 characters.

So a maximum-length brief cannot launch through **Copilot on Windows**. The existing guard fails closed with a message naming the cause and the remedy — it does not truncate a prompt. **Every other platform, and any runtime with stdin prompt support, is unaffected.**

`flow-copilot-session.test.ts` previously asserted that a maximum-length intent always fits. That is no longer true, so it now pins the honest contract:

- the plain maximum exceeds the argv budget and **throws on `win32`**
- the **same input is fine on `darwin`** — the ceiling is a Windows argv limit, not a product-wide one
- an **8k brief still launches**, so the ceiling is a real size rather than a blanket refusal

Moving Copilot to stdin is what would lift this properly; that is separate work and worth its own bead.

## Verification

`tsc --noEmit` clean · lint clean including the design tokenizer (0 drift) · `ui-consistency` ok · `check-tests-wired` 1,662 · six research suites at exit 0 · `flow-copilot-session` 32 passing.

One implementation note: the composer already had an `intentRef` holding the intent *string* for the enhance race rule, so the new element ref is `intentBoxRef` — the existing race guard is untouched.