### PR TITLE
feat(code): collapsible sessions rail that keeps project context when collapsed

### DIFF
--- a/src/components/code-session-rail.tsx
+++ b/src/components/code-session-rail.tsx
@@ -122,7 +122,7 @@ export function CodeSessionRail({
                       onSelect(row.id);
                     }}
                     aria-current={selected ? "true" : undefined}
-                    aria-label={open ? undefined : `Open ${title}, ${activity}`}
+                    aria-label={open ? undefined : `Open ${title} in ${group.label}, ${activity}`}
                     title={open ? undefined : title}
                     className={
                       open

--- a/src/components/code-session-rail.tsx
+++ b/src/components/code-session-rail.tsx
@@ -51,11 +51,20 @@ export type CodeSessionRailProps = {
   selectedId: string | null;
   onSelect: (sessionId: string) => void;
   onNewSession?: () => void;
+  open?: boolean;
+  onExpand?: () => void;
 };
 
-export function CodeSessionRail({ sessions, selectedId, onSelect, onNewSession }: CodeSessionRailProps) {
+export function CodeSessionRail({
+  sessions,
+  selectedId,
+  onSelect,
+  onNewSession,
+  open = true,
+  onExpand,
+}: CodeSessionRailProps) {
   const groups = groupCodeRailSessions(sessions);
-  const newButton = onNewSession ? (
+  const newButton = open && onNewSession ? (
     <div className="px-2 pb-1">
       <button
         type="button"
@@ -68,6 +77,9 @@ export function CodeSessionRail({ sessions, selectedId, onSelect, onNewSession }
     </div>
   ) : null;
   if (groups.length === 0) {
+    if (!open) {
+      return <nav aria-label="Coding sessions" className="flex h-full min-h-0 flex-col" />;
+    }
     return (
       <div className="flex h-full flex-col py-2">
         {newButton}
@@ -79,52 +91,82 @@ export function CodeSessionRail({ sessions, selectedId, onSelect, onNewSession }
     );
   }
   return (
-    <nav aria-label="Coding sessions" className="flex h-full min-h-0 flex-col overflow-y-auto py-2">
-      {newButton}      {groups.map((group) => (
+    <nav
+      aria-label="Coding sessions"
+      className={`flex h-full min-h-0 flex-col ${open ? "overflow-y-auto py-2" : "items-center gap-1"}`}
+    >
+      {newButton}
+      {groups.map((group) => (
         <section key={group.root || "(unknown)"} className="mb-2">
-          <div
-            className="truncate px-3 py-1 text-[length:var(--text-2xs)] font-semibold uppercase tracking-wider text-[var(--text-secondary)]"
-            title={group.root || undefined}
-          >
-            {group.label}
-          </div>
-          <ul className="flex flex-col">
+          {open ? (
+            <div
+              className="truncate px-3 py-1 text-[length:var(--text-2xs)] font-semibold uppercase tracking-wider text-[var(--text-secondary)]"
+              title={group.root || undefined}
+            >
+              {group.label}
+            </div>
+          ) : null}
+          <ul className={`flex flex-col ${open ? "" : "items-center gap-1"}`}>
             {group.sessions.map((row) => {
               const branch = codeSessionBranch(row);
               const diffstat = codeSessionDiffstat(row);
               const selected = row.id === selectedId;
+              const title = row.title || row.id;
+              const activity = codeSessionActivity(row);
               return (
                 <li key={row.id}>
                   <button
                     type="button"
-                    onClick={() => onSelect(row.id)}
+                    onClick={() => {
+                      onExpand?.();
+                      onSelect(row.id);
+                    }}
                     aria-current={selected ? "true" : undefined}
-                    className={`focus-ring-inset flex w-full flex-col gap-0.5 px-3 py-1.5 text-left ${
-                      selected ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]"
-                    }`}
+                    aria-label={open ? undefined : `Open ${title}, ${activity}`}
+                    title={open ? undefined : title}
+                    className={
+                      open
+                        ? `focus-ring-inset flex w-full flex-col gap-0.5 px-3 py-1.5 text-left ${
+                            selected ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]"
+                          }`
+                        : `focus-ring relative flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] ${
+                            selected ? "bg-[var(--bg-hover)] text-[var(--text-primary)]" : ""
+                          }`
+                    }
                   >
-                    <span className="flex min-w-0 items-center gap-1.5">
-                      <ActivityDot row={row} />
-                      <span className="min-w-0 truncate text-[length:var(--text-xs)] text-[var(--text-primary)]">
-                        {row.title || row.id}
-                      </span>
-                    </span>
-                    {(branch || diffstat || row.pullRequest || row.git?.isWorktree) ? (
-                      <span className="flex min-w-0 items-center gap-1.5 pl-3">
-                        {row.git?.isWorktree ? (
-                          <Icon name="ph:git-fork" width={10} height={10} className="shrink-0 text-[var(--text-muted)]" />
-                        ) : null}
-                        {branch ? (
-                          <span className="min-w-0 truncate font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]" title={branch}>
-                            {branch}
+                    {open ? (
+                      <>
+                        <span className="flex min-w-0 items-center gap-1.5">
+                          <ActivityDot row={row} />
+                          <span className="min-w-0 truncate text-[length:var(--text-xs)] text-[var(--text-primary)]">
+                            {title}
+                          </span>
+                        </span>
+                        {(branch || diffstat || row.pullRequest || row.git?.isWorktree) ? (
+                          <span className="flex min-w-0 items-center gap-1.5 pl-3">
+                            {row.git?.isWorktree ? (
+                              <Icon name="ph:git-fork" width={10} height={10} className="shrink-0 text-[var(--text-muted)]" />
+                            ) : null}
+                            {branch ? (
+                              <span className="min-w-0 truncate font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]" title={branch}>
+                                {branch}
+                              </span>
+                            ) : null}
+                            {diffstat ? (
+                              <span className="shrink-0 font-mono text-[length:var(--text-2xs)] text-[var(--text-secondary)]">{diffstat}</span>
+                            ) : null}
+                            {row.pullRequest ? <PrChip pr={row.pullRequest} /> : null}
                           </span>
                         ) : null}
-                        {diffstat ? (
-                          <span className="shrink-0 font-mono text-[length:var(--text-2xs)] text-[var(--text-secondary)]">{diffstat}</span>
-                        ) : null}
-                        {row.pullRequest ? <PrChip pr={row.pullRequest} /> : null}
-                      </span>
-                    ) : null}
+                      </>
+                    ) : (
+                      <>
+                        <Icon name="ph:terminal-window" width={16} height={16} aria-hidden />
+                        <span className="absolute right-1 top-1">
+                          <ActivityDot row={row} />
+                        </span>
+                      </>
+                    )}
                   </button>
                 </li>
               );

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -501,8 +501,8 @@ assert.match(
 );
 assert.match(
   rail,
-  /aria-label=\{open \? undefined : `Open \$\{title\}, \$\{activity\}`\}/,
-  "collapsed session buttons identify the session and expose activity without relying on color",
+  /aria-label=\{open \? undefined : `Open \$\{title\} in \$\{group\.label\}, \$\{activity\}`\}/,
+  "collapsed session buttons identify the session, project, and activity without relying on color",
 );
 assert.match(
   rail,

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -490,6 +490,27 @@ const newSession = await readFile(new URL("./code-new-session.tsx", import.meta.
 const rail = await readFile(new URL("./code-session-rail.tsx", import.meta.url), "utf8");
 
 assert.match(
+  codeView,
+  /<SurfaceRail[\s\S]*storageKey="cave:code:sessions-rail"[\s\S]*title="Sessions"[\s\S]*ariaLabel="Coding sessions"/,
+  "Code Workshop sessions use the shared persisted left rail",
+);
+assert.match(
+  codeView,
+  /\{fitsRail \? \(\s*<SurfaceRail[\s\S]*\) : \(\s*<div[\s\S]*<CodeSessionRail/,
+  "the measured layout uses the collapsible rail only when it fits and preserves narrow list-first drill-in",
+);
+assert.match(
+  rail,
+  /aria-label=\{open \? undefined : `Open \$\{title\}, \$\{activity\}`\}/,
+  "collapsed session buttons identify the session and expose activity without relying on color",
+);
+assert.match(
+  rail,
+  /onClick=\{\(\) => \{\s*onExpand\?\.\(\);\s*onSelect\(row\.id\);/,
+  "collapsed session buttons expand before selection",
+);
+
+assert.match(
   composer,
   /streamFamiliarText\(\{\s*familiarId: row\.familiarId,\s*sessionId: row\.id,/,
   "the composer RESUMES the selected session (sessionId rides) — never forks a new thread",
@@ -657,7 +678,17 @@ assert.match(
 );
 assert.match(
   codeView,
-  /fitsRail \? "block w-64 border-r" : selected \? "hidden" : "block w-full"/,
+  /\{fitsRail \? \(\s*<SurfaceRail/,
+  "a Room wide enough for both zones uses the collapsible shared sessions rail",
+);
+assert.match(
+  codeView,
+  /defaultWidth=\{CODE_ROOM_RAIL_WIDTH_PX\}/,
+  "the persisted rail starts at the width used by the measured layout model",
+);
+assert.match(
+  codeView,
+  /\$\{selected \? "hidden" : "block w-full"\}/,
   "picking a session hides the rail only while the Room is too narrow for both",
 );
 assert.match(

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -22,6 +22,7 @@ import dynamic from "next/dynamic";
 import { Icon } from "@/lib/icon";
 import {
   CODE_GITHUB_TABS,
+  CODE_ROOM_RAIL_WIDTH_PX,
   codeRoomFitsRail,
   codeSessionWorkRoot,
   groupCodeRailSessions,
@@ -36,6 +37,7 @@ import { CodeWorkbench } from "@/components/code-workbench";
 import { CodeNewSession } from "@/components/code-new-session";
 import { CodeSourceContext } from "@/components/code-source-context";
 import { GithubOrganizationSettings } from "@/components/settings-github";
+import { SurfaceRail } from "@/components/ui/surface-rail";
 import type { GitHubItemTarget } from "@/lib/github-item-url";
 import type { PendingCodeOpen } from "@/lib/pending-code-open";
 import { codeTopTabForGitHubTarget, type PendingCodeNavigation } from "@/lib/pending-code-navigation";
@@ -229,6 +231,12 @@ export function CodeView({
       ? workbenchTarget.open.origin
       : null;
   const originSessionId = workbenchTarget?.open.sessionId ?? null;
+  const selectSession = (sessionId: string) => {
+    // A manual switch is a context change — drop any pending file focus so it
+    // cannot replay into the newly picked workbench.
+    setWorkbenchTarget(null);
+    setSelectedId(sessionId);
+  };
 
   const selected = useMemo(() => {
     if (!selectedId) return null;
@@ -316,28 +324,53 @@ export function CodeView({
               rail beside the workbench, the rail is the landing screen and the
               workbench replaces it once a session is picked (Back returns).
               Driven by the Room's measured width, not the viewport — this
-              surface can sit in a split beside another page (cave-k3a9u).
-              w-64 is CODE_ROOM_RAIL_WIDTH_PX. */}
-          <div
-            className={`${
-              fitsRail ? "block w-64 border-r" : selected ? "hidden" : "block w-full"
-            } shrink-0 border-[var(--border-hairline)]`}
-          >
-            <CodeSessionRail
-              sessions={sessions}
-              selectedId={selectedId ?? null}
-              onSelect={(id) => {
-                // A manual switch is a context change — drop any pending file
-                // focus so it can't replay into the newly picked workbench.
-                setWorkbenchTarget(null);
-                setSelectedId(id);
-              }}
-              onNewSession={() => {
-                setNewSessionSeed("");
-                setNewSessionOpen(true);
-              }}
-            />
-          </div>
+              surface can sit in a split beside another page (cave-k3a9u). */}
+          {fitsRail ? (
+            <SurfaceRail
+              storageKey="cave:code:sessions-rail"
+              title="Sessions"
+              ariaLabel="Coding sessions"
+              defaultWidth={CODE_ROOM_RAIL_WIDTH_PX}
+              actions={
+                <button
+                  type="button"
+                  onClick={() => {
+                    setNewSessionSeed("");
+                    setNewSessionOpen(true);
+                  }}
+                  title="New session"
+                  aria-label="New session"
+                  className="focus-ring text-[var(--accent-presence)]"
+                >
+                  <Icon name="ph:plus-bold" width={14} aria-hidden />
+                </button>
+              }
+            >
+              {(open, setOpen) => (
+                <CodeSessionRail
+                  sessions={sessions}
+                  selectedId={selectedId ?? null}
+                  onSelect={selectSession}
+                  open={open}
+                  onExpand={() => setOpen(true)}
+                />
+              )}
+            </SurfaceRail>
+          ) : (
+            <div
+              className={`${selected ? "hidden" : "block w-full"} shrink-0 border-[var(--border-hairline)]`}
+            >
+              <CodeSessionRail
+                sessions={sessions}
+                selectedId={selectedId ?? null}
+                onSelect={selectSession}
+                onNewSession={() => {
+                  setNewSessionSeed("");
+                  setNewSessionOpen(true);
+                }}
+              />
+            </div>
+          )}
           <div
             className={`${selected || fitsRail ? "flex" : "hidden"} min-w-0 flex-1 flex-col`}
           >


### PR DESCRIPTION
## Summary

Wraps the Code Workshop session list in the shared `SurfaceRail`, so the sessions rail collapses and resizes like every other left rail and remembers its state per surface. Collapsed rows stay icon-only without losing what they identify.

## Why

The Code Workshop was the last surface whose left rail could not collapse — the list was a fixed 256px column, so a Room split beside another page gave the workbench whatever was left. Reusing `SurfaceRail` makes the behaviour and the persistence identical to the other surfaces instead of Code-specific.

Bead: `cave-24d2r.1`.

## Changes

- `code-view.tsx` renders `SurfaceRail` (`storageKey="cave:code:sessions-rail"`, `defaultWidth={CODE_ROOM_RAIL_WIDTH_PX}`) **only when the measured Room fits it**. `codeRoomFitsRail` is preserved, so a narrow Room keeps the list-first drill-in and Back navigation rather than collapsing into an unusable sliver.
- `code-session-rail.tsx` gains `open` / `onExpand` and renders a collapsed variant: a 32px icon button per session with the activity dot pinned to its corner.
- Collapsed rows keep their meaning without color: `aria-label` carries session title, project group, and activity, with the title also in `title=`. That was a second-review finding — the first collapsed implementation dropped project context from the accessible name, which made two sessions from different projects indistinguishable to a screen reader.
- Clicking a collapsed row **expands before selecting** (`onExpand?.()` then `onSelect`), so picking a session never leaves you in a collapsed rail looking at a workbench you cannot navigate back from.
- `selectSession` is extracted in `code-view.tsx` and clears `workbenchTarget`, so a manual switch drops any pending file focus instead of replaying it into the newly picked session.

## Verification

Verified in full on 2026-08-08 at base `7c7e5aaac` (per `cave-24d2r.1`): focused `code-surface-mode`, `surface-rail` 10/10, `code-surface` 17/17; `pnpm test:app` 1137 files; `pnpm test:api` 357 files; `pnpm typecheck`; `pnpm lint` with zero design drift and zero ESLint warnings; `check:tests-wired` 1570 files; `git diff --check`.

`code-surface-mode.test.ts` adds source-text assertions for each behaviour above — the rail wiring and storage key, the fits-vs-narrow branch, the collapsed accessible name, and expand-before-select.

## Current status

⚠️ Not mergeable yet, for reasons outside this change:

- **Conflicts with `main`** in `code-session-rail.tsx` and `code-surface-mode.test.ts` (the branch's merge-base is `7c7e5aaac`; `main` has since taken the Coding Room rebuild and more).
- **`main` is red** — `a633d22db` merged the `cave-x6rw` split feature directly to `main` with no PR and no CI, breaking 20 test files. PR #4618 is repairing them, and it touches `code-surface-mode.test.ts` too, so the conflict here is best resolved *after* #4618 lands rather than twice.