### PR TITLE
Restore Tauri Research media playback

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -380,6 +380,7 @@ export const SUITES = {
     "src/lib/server/process-intent-lock.test.ts",
     "src/lib/server/research-generations.test.ts",
     "src/lib/server/research-media-store.test.ts",
+    "src/lib/research-media-ticket.test.ts",
     "src/lib/server/chat-attachment-store.test.ts",
     "src/lib/server/research-podcast-pipeline.test.ts",
     "src/lib/server/research-video-renderer.test.ts",

--- a/src/app/api/research/generations/media-ticket/route.ts
+++ b/src/app/api/research/generations/media-ticket/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+
+import { isValidResearchGenerationFamiliarId } from "@/lib/research-generations";
+import {
+  RESEARCH_MEDIA_PATH,
+  RESEARCH_MEDIA_TICKET_PARAM,
+  signResearchMediaTicket,
+} from "@/lib/research-media-ticket";
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
+import { listResearchGenerations } from "@/lib/server/research-generations";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function hasReadyMedia(generation: Awaited<ReturnType<typeof listResearchGenerations>>[number] | undefined) {
+  return Boolean(
+    generation?.status === "ready" &&
+      ((generation.content?.kind === "podcast" && generation.content.audio) ||
+        ((generation.content?.kind === "short-video" || generation.content?.kind === "long-video") &&
+          generation.content.video)),
+  );
+}
+
+/**
+ * Mint the restricted URL that native audio/video elements need. This request
+ * goes through patched fetch, so packaged Tauri proves the regular sidecar
+ * credential before the capability is ever issued.
+ */
+export async function GET(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+  const url = new URL(req.url);
+  const familiarId = url.searchParams.get("familiarId")?.trim() ?? "";
+  const id = url.searchParams.get("id")?.trim() ?? "";
+  if (!isValidResearchGenerationFamiliarId(familiarId) || !/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(id)) {
+    return NextResponse.json({ ok: false, error: "familiarId and id required" }, { status: 400 });
+  }
+  try {
+    const generation = (await listResearchGenerations(familiarId)).find((entry) => entry.id === id);
+    if (!hasReadyMedia(generation)) {
+      return NextResponse.json({ ok: false, error: "media not found" }, { status: 404 });
+    }
+    const secret = process.env.COVEN_CAVE_AUTH_TOKEN?.trim();
+    const params = new URLSearchParams({ familiarId, id });
+    if (secret) {
+      params.set(RESEARCH_MEDIA_TICKET_PARAM, await signResearchMediaTicket({
+        secret,
+        familiarId,
+        generationId: id,
+      }));
+    }
+    return NextResponse.json({ ok: true, mediaUrl: `${RESEARCH_MEDIA_PATH}?${params}` });
+  } catch {
+    return NextResponse.json({ ok: false, error: "failed to prepare media" }, { status: 500 });
+  }
+}

--- a/src/app/api/research/generations/media/route.test.ts
+++ b/src/app/api/research/generations/media/route.test.ts
@@ -5,7 +5,8 @@ import test from "node:test";
 const route = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
 
 test("media serving is local-only, streaming, and range-capable", () => {
-  assert.match(route, /rejectNonLocalRequest/);
+  assert.match(route, /rejectResearchMediaRequest/);
+  assert.match(route, /await rejectResearchMediaRequest\(req\)/);
   assert.match(route, /openResearchGenerationMedia/);
   assert.match(route, /handle\.createReadStream/);
   assert.match(route, /autoClose: true/);
@@ -14,6 +15,16 @@ test("media serving is local-only, streaming, and range-capable", () => {
   assert.match(route, /content-range/);
   assert.match(route, /range \? 206/);
   assert.match(route, /status: 416/);
+});
+
+test("native players can use the restricted media-ticket path without weakening the route", () => {
+  const ticketRoute = readFileSync(new URL("../media-ticket/route.ts", import.meta.url), "utf8");
+  assert.match(ticketRoute, /rejectNonLocalRequest/);
+  assert.match(ticketRoute, /signResearchMediaTicket/);
+  assert.match(ticketRoute, /RESEARCH_MEDIA_TICKET_PARAM/);
+  assert.match(ticketRoute, /hasReadyMedia/);
+  assert.match(ticketRoute, /media not found/);
+  assert.match(ticketRoute, /RESEARCH_MEDIA_PATH/);
 });
 
 test("media route resolves only ready generation file references", () => {

--- a/src/app/api/research/generations/media/route.ts
+++ b/src/app/api/research/generations/media/route.ts
@@ -6,7 +6,7 @@ import {
   isValidResearchGenerationFamiliarId,
   type ResearchGenerationMediaFileRef,
 } from "@/lib/research-generations";
-import { rejectNonLocalRequest } from "@/lib/server/api-security";
+import { rejectResearchMediaRequest } from "@/lib/server/api-security";
 import { listResearchGenerations } from "@/lib/server/research-generations";
 import {
   openResearchGenerationMedia,
@@ -27,7 +27,7 @@ function mediaRefForGeneration(generation: Awaited<ReturnType<typeof listResearc
 }
 
 export async function GET(req: Request) {
-  const forbidden = rejectNonLocalRequest(req);
+  const forbidden = await rejectResearchMediaRequest(req);
   if (forbidden) return forbidden;
   const url = new URL(req.url);
   const familiarId = url.searchParams.get("familiarId")?.trim() ?? "";

--- a/src/components/role-surfaces/research-studio-modals.tsx
+++ b/src/components/role-surfaces/research-studio-modals.tsx
@@ -1156,7 +1156,12 @@ export function GenerationViewerModal({
     (content?.kind === "podcast" && content.audio) ||
       ((content?.kind === "short-video" || content?.kind === "long-video") && content.video),
   );
-  const { url: mediaUrl, status: mediaStatus, retry: retryMedia } = useResearchMediaUrl(
+  const {
+    url: mediaUrl,
+    status: mediaStatus,
+    retry: retryMedia,
+    reportPlaybackFailure,
+  } = useResearchMediaUrl(
     generation.familiarId,
     generation.id,
     hasMedia,
@@ -1255,6 +1260,7 @@ export function GenerationViewerModal({
                 controls
                 preload="metadata"
                 src={mediaUrl}
+                onError={reportPlaybackFailure}
               >
                 Your browser cannot play this audio file.
               </audio>
@@ -1292,6 +1298,7 @@ export function GenerationViewerModal({
                 controls
                 preload="metadata"
                 src={mediaUrl}
+                onError={reportPlaybackFailure}
               >
                 Your browser cannot play this video file.
               </video>

--- a/src/components/role-surfaces/research-studio-modals.tsx
+++ b/src/components/role-surfaces/research-studio-modals.tsx
@@ -34,6 +34,7 @@ import { PodcastTranscript } from "@/components/role-surfaces/podcast-transcript
 import { AuthedImage } from "@/components/ui/authed-image";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { copyText } from "@/lib/clipboard";
+import { useResearchMediaUrl } from "@/lib/research-media-client";
 import {
   RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH,
   RESEARCH_GENERATION_MEDIA_KINDS,
@@ -1151,7 +1152,15 @@ export function GenerationViewerModal({
     content?.kind === "diagram" ? content.mermaid : generationContentToMarkdown(generation);
   const footerCopyLabel =
     content?.kind === "diagram" ? "Copy Mermaid" : content?.kind === "thread" ? "Copy thread" : "Copy";
-  const mediaUrl = `/api/research/generations/media?familiarId=${encodeURIComponent(generation.familiarId)}&id=${encodeURIComponent(generation.id)}`;
+  const hasMedia = Boolean(
+    (content?.kind === "podcast" && content.audio) ||
+      ((content?.kind === "short-video" || content?.kind === "long-video") && content.video),
+  );
+  const { url: mediaUrl, status: mediaStatus, retry: retryMedia } = useResearchMediaUrl(
+    generation.familiarId,
+    generation.id,
+    hasMedia,
+  );
   const infographicUrl =
     content?.kind === "infographic" && content.stats.length > 0
       ? `/api/research/generations/infographic?familiarId=${encodeURIComponent(generation.familiarId)}&id=${encodeURIComponent(generation.id)}`
@@ -1233,14 +1242,23 @@ export function GenerationViewerModal({
         {content?.kind === "podcast" && content.audio ? (
           <div className="research-studio-viewer__media">
             <span className="research-studio-viewer__label">Podcast audio</span>
-            <audio
-              className="research-studio-viewer__audio"
-              controls
-              preload="metadata"
-              src={mediaUrl}
-            >
-              Your browser cannot play this audio file.
-            </audio>
+            {mediaStatus === "loading" ? <p className="research-studio__note" role="status">Loading podcast audio…</p> : null}
+            {mediaStatus === "error" ? (
+              <div role="alert">
+                <p className="research-studio__error">Couldn’t load podcast audio.</p>
+                <button type="button" className="research-studio-act" onClick={retryMedia}>Retry</button>
+              </div>
+            ) : null}
+            {mediaUrl ? (
+              <audio
+                className="research-studio-viewer__audio"
+                controls
+                preload="metadata"
+                src={mediaUrl}
+              >
+                Your browser cannot play this audio file.
+              </audio>
+            ) : null}
           </div>
         ) : null}
 
@@ -1261,14 +1279,23 @@ export function GenerationViewerModal({
         {(content?.kind === "short-video" || content?.kind === "long-video") && content.video ? (
           <div className="research-studio-viewer__media">
             <span className="research-studio-viewer__label">Video preview</span>
-            <video
-              className="research-studio-viewer__video"
-              controls
-              preload="metadata"
-              src={mediaUrl}
-            >
-              Your browser cannot play this video file.
-            </video>
+            {mediaStatus === "loading" ? <p className="research-studio__note" role="status">Loading video preview…</p> : null}
+            {mediaStatus === "error" ? (
+              <div role="alert">
+                <p className="research-studio__error">Couldn’t load video preview.</p>
+                <button type="button" className="research-studio-act" onClick={retryMedia}>Retry</button>
+              </div>
+            ) : null}
+            {mediaUrl ? (
+              <video
+                className="research-studio-viewer__video"
+                controls
+                preload="metadata"
+                src={mediaUrl}
+              >
+                Your browser cannot play this video file.
+              </video>
+            ) : null}
           </div>
         ) : null}
 
@@ -1339,8 +1366,7 @@ export function GenerationViewerModal({
             ⤓ Download .md
           </button>
         ) : null}
-        {(content?.kind === "podcast" && content.audio) ||
-        ((content?.kind === "short-video" || content?.kind === "long-video") && content.video) ? (
+        {hasMedia && mediaUrl ? (
           <a
             className="research-studio-act"
             href={`${mediaUrl}&download=1`}

--- a/src/components/role-surfaces/research-tab-studio.test.ts
+++ b/src/components/role-surfaces/research-tab-studio.test.ts
@@ -65,6 +65,13 @@ test("media lifecycle text, cancellation, players, and download use persisted st
   assert.doesNotMatch(tab, /\{ \.\.\.entry, status: "cancelled"/);
   assert.match(modals, /<audio[\s\S]*controls[\s\S]*preload="metadata"/);
   assert.match(modals, /<video[\s\S]*controls[\s\S]*preload="metadata"/);
+  assert.match(modals, /useResearchMediaUrl/);
+  assert.doesNotMatch(modals, /const mediaUrl = `\/api\/research\/generations\/media/);
+  assert.match(modals, /Loading podcast audio…/);
+  assert.match(modals, /Loading video preview…/);
+  assert.match(modals, /Couldn’t load podcast audio/);
+  assert.match(modals, /Couldn’t load video preview/);
+  assert.match(modals, /onClick=\{retryMedia\}/);
   assert.match(modals, /download=1/);
 });
 

--- a/src/components/role-surfaces/research-tab-studio.test.ts
+++ b/src/components/role-surfaces/research-tab-studio.test.ts
@@ -72,6 +72,7 @@ test("media lifecycle text, cancellation, players, and download use persisted st
   assert.match(modals, /Couldn’t load podcast audio/);
   assert.match(modals, /Couldn’t load video preview/);
   assert.match(modals, /onClick=\{retryMedia\}/);
+  assert.match(modals, /onError=\{reportPlaybackFailure\}/);
   assert.match(modals, /download=1/);
 });
 

--- a/src/lib/research-media-client.ts
+++ b/src/lib/research-media-client.ts
@@ -69,7 +69,7 @@ export function useResearchMediaUrl(familiarId: string, generationId: string, en
     };
   }, [attempt, enabled, familiarId, generationId, scope]);
 
-  const current = state.scope === scope
+  const current: Pick<ResearchMediaUrlState, "url" | "status"> = state.scope === scope
     ? state
     : { url: null, status: enabled ? "loading" : "idle" };
   return { ...current, retry, reportPlaybackFailure };

--- a/src/lib/research-media-client.ts
+++ b/src/lib/research-media-client.ts
@@ -8,6 +8,11 @@ export type ResearchMediaUrlState = {
   url: string | null;
   status: "idle" | "loading" | "ready" | "error";
   retry: () => void;
+  reportPlaybackFailure: () => void;
+};
+
+type ResearchMediaUrlStateInternal = Omit<ResearchMediaUrlState, "retry" | "reportPlaybackFailure"> & {
+  scope: string;
 };
 
 function mediaTicketUrl(familiarId: string, generationId: string) {
@@ -22,20 +27,27 @@ function mediaTicketUrl(familiarId: string, generationId: string) {
  * generation-scoped capability instead of the sidecar credential.
  */
 export function useResearchMediaUrl(familiarId: string, generationId: string, enabled: boolean): ResearchMediaUrlState {
+  const scope = `${familiarId}\u0000${generationId}`;
   const [attempt, setAttempt] = useState(0);
-  const [state, setState] = useState<Omit<ResearchMediaUrlState, "retry">>({
+  const [state, setState] = useState<ResearchMediaUrlStateInternal>({
+    scope,
     url: null,
     status: enabled ? "loading" : "idle",
   });
   const retry = useCallback(() => setAttempt((value) => value + 1), []);
+  const reportPlaybackFailure = useCallback(() => {
+    setState((current) => (
+      current.scope === scope ? { ...current, url: null, status: "error" } : current
+    ));
+  }, [scope]);
 
   useEffect(() => {
     if (!enabled) {
-      setState({ url: null, status: "idle" });
+      setState({ scope, url: null, status: "idle" });
       return;
     }
     let active = true;
-    setState({ url: null, status: "loading" });
+    setState({ scope, url: null, status: "loading" });
     void (async () => {
       try {
         const response = await fetch(mediaTicketUrl(familiarId, generationId));
@@ -47,15 +59,18 @@ export function useResearchMediaUrl(familiarId: string, generationId: string, en
         if (url.origin !== window.location.origin || url.pathname !== RESEARCH_MEDIA_PATH) {
           throw new Error("media ticket returned an invalid URL");
         }
-        if (active) setState({ url: `${url.pathname}${url.search}`, status: "ready" });
+        if (active) setState({ scope, url: `${url.pathname}${url.search}`, status: "ready" });
       } catch {
-        if (active) setState({ url: null, status: "error" });
+        if (active) setState({ scope, url: null, status: "error" });
       }
     })();
     return () => {
       active = false;
     };
-  }, [attempt, enabled, familiarId, generationId]);
+  }, [attempt, enabled, familiarId, generationId, scope]);
 
-  return { ...state, retry };
+  const current = state.scope === scope
+    ? state
+    : { url: null, status: enabled ? "loading" : "idle" };
+  return { ...current, retry, reportPlaybackFailure };
 }

--- a/src/lib/research-media-client.ts
+++ b/src/lib/research-media-client.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { RESEARCH_MEDIA_PATH } from "@/lib/research-media-ticket";
+
+export type ResearchMediaUrlState = {
+  url: string | null;
+  status: "idle" | "loading" | "ready" | "error";
+  retry: () => void;
+};
+
+function mediaTicketUrl(familiarId: string, generationId: string) {
+  const params = new URLSearchParams({ familiarId, id: generationId });
+  return `/api/research/generations/media-ticket?${params}`;
+}
+
+/**
+ * Resolve the native-player URL through authenticated fetch. Packaged Tauri
+ * injects the sidecar credential into fetch but native media subrequests
+ * cannot set that header, so the returned URL carries a short-lived,
+ * generation-scoped capability instead of the sidecar credential.
+ */
+export function useResearchMediaUrl(familiarId: string, generationId: string, enabled: boolean): ResearchMediaUrlState {
+  const [attempt, setAttempt] = useState(0);
+  const [state, setState] = useState<Omit<ResearchMediaUrlState, "retry">>({
+    url: null,
+    status: enabled ? "loading" : "idle",
+  });
+  const retry = useCallback(() => setAttempt((value) => value + 1), []);
+
+  useEffect(() => {
+    if (!enabled) {
+      setState({ url: null, status: "idle" });
+      return;
+    }
+    let active = true;
+    setState({ url: null, status: "loading" });
+    void (async () => {
+      try {
+        const response = await fetch(mediaTicketUrl(familiarId, generationId));
+        const body = await response.json() as { ok?: unknown; mediaUrl?: unknown };
+        if (!response.ok || body.ok !== true || typeof body.mediaUrl !== "string") {
+          throw new Error("media ticket request failed");
+        }
+        const url = new URL(body.mediaUrl, window.location.origin);
+        if (url.origin !== window.location.origin || url.pathname !== RESEARCH_MEDIA_PATH) {
+          throw new Error("media ticket returned an invalid URL");
+        }
+        if (active) setState({ url: `${url.pathname}${url.search}`, status: "ready" });
+      } catch {
+        if (active) setState({ url: null, status: "error" });
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [attempt, enabled, familiarId, generationId]);
+
+  return { ...state, retry };
+}

--- a/src/lib/research-media-ticket.test.ts
+++ b/src/lib/research-media-ticket.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+
+import {
+  RESEARCH_MEDIA_TICKET_PARAM,
+  isValidResearchMediaTicketRequest,
+  signResearchMediaTicket,
+  verifyResearchMediaTicket,
+} from "./research-media-ticket.ts";
+
+const secret = "research-media-ticket-test-secret";
+const familiarId = "rida";
+const generationId = "gen_123";
+const now = 1_800_000_000_000;
+
+const ticket = await signResearchMediaTicket({
+  secret,
+  familiarId,
+  generationId,
+  expiresAt: now + 60_000,
+  nonce: "nonceA",
+});
+
+{
+  const result = await verifyResearchMediaTicket(ticket, secret, { familiarId, generationId }, now);
+  assert.equal(result.ok, true);
+  assert.equal(result.expiresAt, now + 60_000);
+}
+
+{
+  const result = await verifyResearchMediaTicket(ticket, secret, { familiarId, generationId: "other" }, now);
+  assert.deepEqual(result, { ok: false, reason: "scope" });
+}
+
+{
+  const result = await verifyResearchMediaTicket(ticket, "other-secret", { familiarId, generationId }, now);
+  assert.deepEqual(result, { ok: false, reason: "signature" });
+}
+
+{
+  const expired = await signResearchMediaTicket({
+    secret,
+    familiarId,
+    generationId,
+    expiresAt: now - 1,
+    nonce: "nonceExpired",
+  });
+  const result = await verifyResearchMediaTicket(expired, secret, { familiarId, generationId }, now);
+  assert.deepEqual(result, { ok: false, reason: "expired" });
+}
+
+{
+  const url = new URL("http://127.0.0.1:43123/api/research/generations/media");
+  url.searchParams.set("familiarId", familiarId);
+  url.searchParams.set("id", generationId);
+  url.searchParams.set(RESEARCH_MEDIA_TICKET_PARAM, ticket);
+  assert.equal(await isValidResearchMediaTicketRequest(new Request(url), secret), true);
+  assert.equal(await isValidResearchMediaTicketRequest(new Request(url, { method: "HEAD" }), secret), true);
+  assert.equal(await isValidResearchMediaTicketRequest(new Request(url, { method: "POST" }), secret), false);
+  url.pathname = "/api/research/generations";
+  assert.equal(await isValidResearchMediaTicketRequest(new Request(url), secret), false);
+}
+
+console.log("research-media-ticket.test.ts: ok");

--- a/src/lib/research-media-ticket.ts
+++ b/src/lib/research-media-ticket.ts
@@ -1,0 +1,107 @@
+import { timingSafeEqualString } from "../proxy-helpers.ts";
+
+export const RESEARCH_MEDIA_PATH = "/api/research/generations/media";
+export const RESEARCH_MEDIA_TICKET_PARAM = "mediaTicket";
+export const RESEARCH_MEDIA_TICKET_TTL_MS = 60 * 60 * 1_000;
+
+const VERSION = "v1";
+const FIELD = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+const SIGNATURE = /^[A-Za-z0-9_-]{43}$/;
+
+export type ResearchMediaTicketVerification =
+  | { ok: true; expiresAt: number; familiarId: string; generationId: string }
+  | { ok: false; reason: "expired" | "malformed" | "signature" | "scope" };
+
+function base64Url(bytes: Uint8Array) {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+async function hmac(secret: string, message: string) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return base64Url(new Uint8Array(await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(message))));
+}
+
+function payload(expiresAt: number, familiarId: string, generationId: string, nonce: string) {
+  return `${VERSION}.${expiresAt}.${familiarId}.${generationId}.${nonce}`;
+}
+
+export async function signResearchMediaTicket({
+  secret,
+  familiarId,
+  generationId,
+  expiresAt = Date.now() + RESEARCH_MEDIA_TICKET_TTL_MS,
+  nonce = crypto.randomUUID().replace(/-/g, ""),
+}: {
+  secret: string;
+  familiarId: string;
+  generationId: string;
+  expiresAt?: number;
+  nonce?: string;
+}) {
+  if (
+    !Number.isSafeInteger(expiresAt) ||
+    expiresAt <= 0 ||
+    !FIELD.test(familiarId) ||
+    !FIELD.test(generationId) ||
+    !FIELD.test(nonce)
+  ) {
+    throw new Error("research media ticket: invalid scope");
+  }
+  const body = payload(expiresAt, familiarId, generationId, nonce);
+  return `${body}.${await hmac(secret, body)}`;
+}
+
+export async function verifyResearchMediaTicket(
+  ticket: string,
+  secret: string,
+  expected: { familiarId: string; generationId: string },
+  now = Date.now(),
+): Promise<ResearchMediaTicketVerification> {
+  const parts = ticket.split(".");
+  if (parts.length !== 6 || parts[0] !== VERSION) return { ok: false, reason: "malformed" };
+  const [, rawExpiry, familiarId, generationId, nonce, suppliedSignature] = parts;
+  const expiresAt = Number(rawExpiry);
+  if (
+    !Number.isFinite(expiresAt) ||
+    expiresAt <= 0 ||
+    !FIELD.test(familiarId) ||
+    !FIELD.test(generationId) ||
+    !FIELD.test(nonce) ||
+    !SIGNATURE.test(suppliedSignature)
+  ) {
+    return { ok: false, reason: "malformed" };
+  }
+  const expectedSignature = await hmac(secret, payload(expiresAt, familiarId, generationId, nonce));
+  if (!timingSafeEqualString(suppliedSignature, expectedSignature)) {
+    return { ok: false, reason: "signature" };
+  }
+  if (expiresAt <= now) return { ok: false, reason: "expired" };
+  if (familiarId !== expected.familiarId || generationId !== expected.generationId) {
+    return { ok: false, reason: "scope" };
+  }
+  return { ok: true, expiresAt, familiarId, generationId };
+}
+
+/**
+ * True only for a ticket-bearing native media subresource request. Both the
+ * proxy and the route call this, so an opaque ticket cannot authorize any
+ * other API path or a different generation.
+ */
+export async function isValidResearchMediaTicketRequest(req: Request, secret: string | null | undefined) {
+  if (!secret || (req.method !== "GET" && req.method !== "HEAD")) return false;
+  const url = new URL(req.url);
+  if (url.pathname !== RESEARCH_MEDIA_PATH) return false;
+  const familiarId = url.searchParams.get("familiarId")?.trim() ?? "";
+  const generationId = url.searchParams.get("id")?.trim() ?? "";
+  const ticket = url.searchParams.get(RESEARCH_MEDIA_TICKET_PARAM) ?? "";
+  if (!FIELD.test(familiarId) || !FIELD.test(generationId) || !ticket) return false;
+  return (await verifyResearchMediaTicket(ticket, secret, { familiarId, generationId })).ok;
+}

--- a/src/lib/server/api-security.test.ts
+++ b/src/lib/server/api-security.test.ts
@@ -4,7 +4,8 @@ import { afterEach, test } from "node:test";
 
 import { MOBILE_ACCESS_HEADER, TOKEN_HEADER } from "../../proxy-helpers.ts";
 import { LOCAL_REQUEST_REQUIRED_CODE } from "../project-errors.ts";
-import { readJsonBody, rejectNonLocalRequest } from "./api-security.ts";
+import { signResearchMediaTicket } from "../research-media-ticket.ts";
+import { readJsonBody, rejectNonLocalRequest, rejectResearchMediaRequest } from "./api-security.ts";
 
 const ORIGINAL_SIDECAR_TOKEN = process.env.COVEN_CAVE_AUTH_TOKEN;
 
@@ -77,6 +78,35 @@ test("accepts valid loopback plus sidecar token requests", () => {
   );
 
   assert.equal(res, null);
+});
+
+test("accepts only a scoped media ticket when native playback cannot set the sidecar header", async () => {
+  process.env.COVEN_CAVE_AUTH_TOKEN = "sidecar-secret";
+  const ticket = await signResearchMediaTicket({
+    secret: "sidecar-secret",
+    familiarId: "rida",
+    generationId: "gen_1",
+  });
+  const url = new URL("http://127.0.0.1:3000/api/research/generations/media");
+  url.searchParams.set("familiarId", "rida");
+  url.searchParams.set("id", "gen_1");
+  url.searchParams.set("mediaTicket", ticket);
+
+  assert.equal(
+    await rejectResearchMediaRequest(new Request(url, { headers: { host: "127.0.0.1:3000" } })),
+    null,
+  );
+  assert.ok(
+    await rejectResearchMediaRequest(new Request(url, {
+      headers: { host: "127.0.0.1:3000", [MOBILE_ACCESS_HEADER]: "1" },
+    })),
+    "mobile-marked requests remain denied",
+  );
+  url.pathname = "/api/research/generations";
+  assert.ok(
+    await rejectResearchMediaRequest(new Request(url, { headers: { host: "127.0.0.1:3000" } })),
+    "the ticket cannot grant a different route",
+  );
 });
 
 test("accepts loopback origins without widening the host allowlist", () => {

--- a/src/lib/server/api-security.ts
+++ b/src/lib/server/api-security.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server.js";
 
 import { LOCAL_REQUEST_REQUIRED_CODE } from "../project-errors.ts";
 import { isLocalOrigin } from "./local-origin.ts";
+import { MOBILE_ACCESS_HEADER } from "../../proxy-helpers.ts";
+import { isValidResearchMediaTicketRequest } from "../research-media-ticket.ts";
 
 const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
 
@@ -51,6 +53,32 @@ export function rejectNonLocalRequest(req: Request): NextResponse | null {
   }
 
   return null;
+}
+
+/**
+ * Research media is the one local route that must accept a native media
+ * subrequest. A Tauri HTMLMediaElement cannot attach the sidecar header, so a
+ * valid generation-scoped media ticket is an alternative credential. Keep the
+ * exception here rather than weakening the shared local-origin rule used by
+ * desktop-only APIs.
+ */
+export async function rejectResearchMediaRequest(req: Request): Promise<NextResponse | null> {
+  const ordinary = rejectNonLocalRequest(req);
+  if (!ordinary) return null;
+
+  if (req.headers.get(MOBILE_ACCESS_HEADER) === "1") return ordinary;
+  const host = req.headers.get("host");
+  if (!isLocalHost(host)) return ordinary;
+  const origin = req.headers.get("origin");
+  if (origin) {
+    try {
+      if (!isLocalHost(new URL(origin).host)) return ordinary;
+    } catch {
+      return ordinary;
+    }
+  }
+  const secret = process.env.COVEN_CAVE_AUTH_TOKEN?.trim();
+  return await isValidResearchMediaTicketRequest(req, secret) ? null : ordinary;
 }
 
 export async function readJsonBody<T>(req: Request, maxBytes: number): Promise<JsonBodyResult<T>> {

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -21,6 +21,7 @@ const proxyHelpersSource = await readFile(new URL("./proxy-helpers.ts", import.m
 assert.match(source, /export async function proxy\(req: NextRequest\)/, "Next 16 proxy entrypoint should guard requests");
 assert.match(source, /matcher:\s*\["\/\(\(\?!_next\/static\|_next\/image\|favicon\.ico\)\.\*\)"\]/, "proxy should guard API and mobile browser routes");
 assert.match(source, /process\.env\.COVEN_CAVE_AUTH_TOKEN/, "proxy should require the per-launch sidecar token");
+assert.match(source, /isValidResearchMediaTicketRequest/, "proxy should accept only the restricted native media ticket when a media element cannot send the sidecar header");
 assert.match(source, /process\.env\.COVEN_CAVE_BUNDLE === "1"[\s\S]*missing sidecar auth token/, "bundled sidecar mode should fail closed when its auth token is missing");
 assert.match(
   source,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -28,6 +28,7 @@ import {
 } from "./proxy-helpers";
 import { isValidMobileAccessCredential } from "./lib/mobile-access-token.ts";
 import { PRESENCE_COOKIE, verifyPresenceToken } from "./lib/passkey-presence.ts";
+import { isValidResearchMediaTicketRequest } from "./lib/research-media-ticket.ts";
 
 // Re-exported here so existing call sites (and tests) that imported these
 // from "./proxy" keep working.
@@ -217,9 +218,10 @@ export async function proxy(req: NextRequest) {
     if (!sidecarToken || !supplied) return false;
     return timingSafeEqualString(supplied, sidecarToken);
   };
+  const mediaTicketAuthenticated = await isValidResearchMediaTicketRequest(req, sidecarToken);
   const sidecarAuthenticatedAtGate = sidecarTokenMatches(
     req.headers.get(TOKEN_HEADER) ?? req.nextUrl.searchParams.get(TOKEN_PARAM),
-  );
+  ) || mediaTicketAuthenticated;
   // The local-peer stamp distinguishes direct from forwarded traffic, but TCP
   // loopback is not OS-user identity. When mobile access is armed, the Tauri
   // app must also present its per-launch sidecar credential and a plain local
@@ -398,6 +400,9 @@ export async function proxy(req: NextRequest) {
   }
 
   if (!sidecarAuthenticated && !mobileAccessVerified) {
+    if (mediaTicketAuthenticated) {
+      return nextWithMobileAccessMarker(req, remoteIngress);
+    }
     // A verified signed mobile invite is the paired phone's credential: the
     // token is minted by this desktop from its access secret and already
     // passed mobileAccessGate above. Requiring the webview's per-launch


### PR DESCRIPTION
## Summary

Restore Research Studio podcast and video playback in packaged Tauri without placing the sidecar credential in a native media URL.

## Why

In packaged Tauri, the auth bridge stamps `x-coven-cave-token` onto `window.fetch`, but native `<audio>` and `<video>` requests cannot carry that header. Research Studio pointed those elements straight at `/api/research/generations/media`, so the sidecar correctly returned 401 before platform media decoding began. This is common to Windows WebView2, macOS WKWebView, and Linux WebKitGTK.

Tracks Bead `cave-f95`.

## Changes

- Mint a one-hour, HMAC-signed media capability only after an authenticated fetch proves the sidecar credential.
- Scope the capability to one familiar, generation, exact media route, and GET/HEAD; reject expiry, tampering, mobile ingress, other paths, and other generations.
- Preserve the existing HTTP Range/206 stream instead of loading research video (up to 500 MiB) into a Blob.
- Resolve player and download URLs through a dedicated hook with honest loading and retry states.
- Cover capability signing/validation, route scope, local-origin behavior, media route wiring, UI wiring, and CI test registration.

## Verification

Passed locally:

- Focused ticket, API-security, media-route, Studio-contract, and middleware tests.
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `pnpm build`

`pnpm test:api` was stopped after its unrelated `scripts/worktree-lifecycle-create.test.mjs` fixture hung on this host's unsupported Coven maintenance helper. The media-specific API tests passed before that suite reached the unrelated fixture. Native Tauri behavior still needs exact-head platform CI because this WSL environment cannot validate Windows WebView2, macOS WKWebView, or Linux WebKitGTK.

## Risk + rollout notes

The capability is a replayable, loopback-only read grant for one generation for one hour so media seeking and long-video playback remain functional. It never exposes the per-launch sidecar token, is useless for other API routes, and expires on its own. No migration or release note is required.