### PR TITLE
fix(ci): stop a recovery dispatch cancelling the run it exists to rescue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,25 @@ on:
   pull_request:
     branches: [main]
 
+# A recovery dispatch resolves to the SAME group as the pull_request run it is
+# rescuing — `github.event.pull_request` is null for a dispatch, so the group
+# falls through to `inputs.expected_sha`, which is that exact head. With
+# cancel-in-progress on, the dispatch therefore CANCELS the run it came to
+# replace (cave-f22tp).
+#
+# Observed 2026-08-14 on #4618: head 11aceeb89 collected three cancelled runs
+# and no verdict — a pull_request run killed ~60 minutes in, then two dispatches
+# killed in turn. The cancellations are also self-perpetuating, because
+# ci-recovery's `cancelled_latest_run` wedge test (cave-geaji) reads a
+# cancellation as proof that recovery is needed, so each cooldown fires another
+# dispatch. The required check can never report while that runs.
+#
+# So a dispatch never cancels: with cancel-in-progress false it QUEUES behind
+# the in-flight run for that head and starts only once the group frees. A push
+# still supersedes its predecessor, which is the behaviour this setting is for.
 concurrency:
   group: ci-${{ github.event.pull_request.head.sha || inputs.expected_sha || github.sha }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' && github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/scripts/ci-recovery-workflow.test.mjs
+++ b/scripts/ci-recovery-workflow.test.mjs
@@ -63,6 +63,18 @@ assert.equal(
   "ci-${{ github.event.pull_request.head.sha || inputs.expected_sha || github.sha }}",
   "late pull_request delivery and its recovery dispatch must share one concurrency key",
 );
+// Sharing the key is deliberate; CANCELLING across it is not. A dispatch
+// resolves to the same group as the run it is rescuing, so with a blanket
+// cancel-in-progress it kills that run and the required check never reports —
+// observed on #4618, where one head collected three cancelled runs and no
+// verdict, each cancellation feeding ci-recovery's `cancelled_latest_run`
+// wedge test and provoking the next dispatch (cave-f22tp). Excluded from
+// cancellation, a dispatch queues behind the in-flight run instead.
+assert.equal(
+  ciWorkflow.concurrency["cancel-in-progress"],
+  "${{ github.event_name != 'workflow_dispatch' && github.ref != 'refs/heads/main' }}",
+  "a recovery dispatch must never cancel the run it exists to rescue",
+);
 const expectedJobGuards = {
   paths: "github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha",
   ios:

--- a/scripts/ci-recovery.mjs
+++ b/scripts/ci-recovery.mjs
@@ -227,6 +227,22 @@ async function decideRecovery(context, runs, now) {
   // Observed on #4514: head 02f74118ff carried exactly one run, cancelled, and
   // `pnpm ci:recovery` reported it as covered and declined to help (cave-geaji).
   if (latest.status === "completed" && latest.conclusion === CANCELLED) {
+    // …unless recovery has already been tried on this exact head and the head
+    // is STILL sitting on a cancellation. Dispatching again would repeat
+    // whatever did not work the first time, and the cooldown does not stop it:
+    // it only bounds the rate, so a head that keeps ending up cancelled draws
+    // one dispatch per cooldown forever.
+    //
+    // That is not hypothetical. On #4618 head 11aceeb89 collected three
+    // cancelled runs and no verdict — the dispatches shared ci.yml's
+    // concurrency group and cancelled the very runs they were rescuing, and
+    // each cancellation then read as this wedge and justified the next
+    // dispatch (cave-f22tp). ci.yml no longer lets a dispatch cancel, which
+    // removes the cause; this removes the loop even if something else cancels.
+    const alreadyRecovered = runs.some((run) => run.event === "workflow_dispatch");
+    if (alreadyRecovered) {
+      return { recover: false, reason: "recovery_already_attempted" };
+    }
     return { recover: true, reason: "cancelled_latest_run" };
   }
 

--- a/scripts/ci-recovery.test.mjs
+++ b/scripts/ci-recovery.test.mjs
@@ -644,6 +644,42 @@ test("a cancelled run that is the NEWEST for a static head is recovered", async 
   assert.equal(result.recoveries[0].reason, "cancelled_latest_run");
 });
 
+test("a head still cancelled after a recovery dispatch is not recovered again", async () => {
+  // The loop cave-f22tp fixes. Recovery already ran on this head and the head
+  // is STILL sitting on a cancellation, so dispatching repeats whatever did not
+  // work. The cooldown does not save us: it bounds the rate, not the repetition,
+  // so a head that keeps ending up cancelled draws one dispatch per cooldown
+  // forever.
+  //
+  // Live case: #4618 head 11aceeb89 collected three cancelled runs and no
+  // verdict — each dispatch cancelled the run it was rescuing (shared
+  // concurrency group), and each cancellation then read as the wedge above.
+  const pr = pull();
+  const dispatched = workflowRun({
+    id: 9401,
+    status: "completed",
+    conclusion: "cancelled",
+    headSha: pr.head.sha,
+    event: "workflow_dispatch",
+    createdAt: new Date(NOW - 3 * 60 * 60 * 1000).toISOString(),
+  });
+  const cancelled = workflowRun({
+    id: 9402,
+    status: "completed",
+    conclusion: "cancelled",
+    headSha: pr.head.sha,
+  });
+  const fixture = githubFixture({
+    pulls: [pr],
+    runsBySha: { [pr.head.sha]: [cancelled, dispatched] },
+  });
+
+  const result = await runCiRecovery(options(fixture.fetchImpl, false));
+
+  assert.equal(result.recoveries.length, 0, "a second recovery on the same head must not fire");
+  assert.equal(result.skipped[0].reason, "recovery_already_attempted");
+});
+
 test("a cancelled run underneath a NEWER run is left alone", async () => {
   // The case the original reasoning describes and gets right: something newer
   // is already running for this head, so the cancellation was a supersession


### PR DESCRIPTION
## What happened

PR #4618 — the repair for a red `main` — could not report a required check. Its head `11aceeb89` collected **three cancelled runs and no verdict, with no commit between any of them**:

```
17:31  workflow_dispatch  cancelled
15:49  workflow_dispatch  cancelled
14:47  pull_request       cancelled   ← ~60 minutes in, healthy
```

Because #4618 is the repair everything else waits on, #4613, #4620 and #4627 were blocked by a CI mechanism rather than by any code.

## Why

`ci.yml`'s concurrency group is keyed on the head SHA, and a recovery dispatch resolves to the **same key**: `github.event.pull_request` is null for a `workflow_dispatch`, so the expression falls through to `inputs.expected_sha` — that exact head.

Sharing the key is deliberate, and the workflow contract test says so: *"late pull_request delivery and its recovery dispatch must share one concurrency key."* **Cancelling** across it is not. With a blanket `cancel-in-progress`, the dispatch kills the run it came to replace.

It then feeds itself. `ci-recovery` treats a cancelled **latest** run as a wedge needing recovery (`cancelled_latest_run`, added for `cave-geaji`), so a cancellation *caused by a dispatch* is indistinguishable from the condition that justifies the next dispatch. The cooldown only bounds the rate — one per hour, forever — and the full suite takes 25–40 minutes, comfortably inside that window.

## The fix — two changes, because they fail differently

- **`ci.yml`** excludes `workflow_dispatch` from `cancel-in-progress`. A dispatch now **queues** behind the in-flight run for that head instead of killing it. A push still supersedes its predecessor, which is what the setting is for.
- **`ci-recovery.mjs`** refuses to dispatch when the head is still cancelled **and** a `workflow_dispatch` already ran on it (`recovery_already_attempted`). That closes the loop even if something other than a dispatch does the cancelling.

## Verification

- New unit test: a head still cancelled after a recovery dispatch is not recovered again. **Reverting the guard fails it** (`✖ a head still cancelled after a recovery dispatch is not recovered again`) — confirmed, not assumed.
- New workflow-contract assertion pins the `cancel-in-progress` expression beside the group it already pinned, so the two cannot drift apart again.
- `ci-recovery.test.mjs` 24/24, `ci-recovery-workflow.test.mjs` green.

## Note

The existing `cancelled_latest_run` behaviour is preserved for the case it was written for — a *first* cancellation on a static head, `cave-geaji`'s #4514. Only the repeat is refused.

Bead: `cave-f22tp`.