### PR TITLE
fix(security): preserve Copilot path verification for full-mode chat launches

### DIFF
--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -60,9 +60,9 @@ assert.deepEqual(
     model: null,
     permissionMode: "full",
     addDirs: [],
-  }).slice(0, 6),
-  ["--no-auto-update", "--allow-all", "--output-format", "json", "--stream", "on"],
-  "the direct full-mode routing decision keeps its approval flag before the reviewed JSONL launch contract",
+  }).slice(0, 7),
+  ["--no-auto-update", "--allow-all-tools", "--allow-all-urls", "--output-format", "json", "--stream", "on"],
+  "direct full-mode routing approves tools and URLs without disabling path verification",
 );
 
 for (const capabilityVersion of ["1.0.70.1", "1.0.64", "0.9.9", "2.0.0", "2.0.0-rc.1"]) {

--- a/src/lib/copilot-stream.test.ts
+++ b/src/lib/copilot-stream.test.ts
@@ -350,7 +350,8 @@ assert.deepEqual(
     "/Users/example/.coven/workspaces/familiars/sage",
     "--plugin-dir",
     "/Applications/CovenCave.app/marketplace/plugins/coven-memory",
-    "--allow-all",
+    "--allow-all-tools",
+    "--allow-all-urls",
     "--output-format",
     "json",
     "--stream",
@@ -358,8 +359,9 @@ assert.deepEqual(
     "-p",
     "do the thing",
   ],
-  "fresh full-permission turns preserve the manifest approval argv with their session, model, trust grants, and trailing prompt",
+  "fresh full-permission turns pre-approve tools and URLs while preserving path verification for their trust grants",
 );
+assert.ok(!freshArgs.includes("--allow-all"), "full chat turns never disable cwd and --add-dir path verification");
 
 const opus5Args = buildCopilotStreamArgs({
   spec,

--- a/src/lib/copilot-stream.ts
+++ b/src/lib/copilot-stream.ts
@@ -276,14 +276,12 @@ const COPILOT_ADD_DIR_FLAG = "--add-dir";
 // schema selection and before its first JSONL frame.
 export const COPILOT_NO_AUTO_UPDATE_ARG = "--no-auto-update";
 
-// Approval argv for unattended one-shot runs (flow sessions). A `-p` spawn
-// cannot answer approval prompts, so without these the CLI auto-denies every
-// tool — the "mission workspace was read-only all session" failure that left
-// research missions without artifacts/primary.md. Deliberately narrower than
-// the manifest's full_args (`--allow-all`): tools and URLs are approved, but
-// file-path verification stays ON, confining writes to the spawn cwd plus the
-// explicit `--add-dir` grants (native flags verified against CLI 1.0.73).
-const COPILOT_UNATTENDED_ARGS = ["--allow-all-tools", "--allow-all-urls"];
+// Approval argv for non-interactive launches. A `-p` spawn cannot answer
+// approval prompts, so without these the CLI auto-denies every tool. These are
+// deliberately narrower than the manifest's full_args (`--allow-all`): tools
+// and URLs are approved, but file-path verification stays ON, confining writes
+// to the spawn cwd plus explicit `--add-dir` grants.
+const COPILOT_NONINTERACTIVE_APPROVAL_ARGS = ["--allow-all-tools", "--allow-all-urls"];
 
 function stringArray(value: unknown): string[] | null {
   if (!Array.isArray(value)) return null;
@@ -480,8 +478,9 @@ export type CopilotStreamLaunch = {
    * Granted directories to trust at the harness level (repeatable
    * `--add-dir`). Without these the runtime-scope preamble's grants are
    * prompt-text-only: read-only sessions deny every granted-root access, and
-   * full sessions ride `--allow-all` instead of an explicit trust list
-   * (cave-n1yc). The spawn cwd is already trusted and must not be included.
+   * full sessions pre-approve tools and URLs while retaining the explicit
+   * trust list (cave-n1yc). The spawn cwd is already trusted and must not be
+   * included.
    */
   addDirs: string[];
   /** Trusted, app-bundled skill-only plugins loaded for this process. */
@@ -525,17 +524,14 @@ export function buildCopilotStreamArgs(launch: CopilotStreamLaunch): string[] {
   for (const dir of launch.pluginDirs ?? []) {
     if (dir) args.push("--plugin-dir", dir);
   }
-  // Sandbox mapping from the manifest. A direct `-p` process has no stdin to
-  // answer approval prompts, so full chats retain their existing manifest
-  // approval contract instead of auto-denying every requested tool.
-  // Unattended one-shots pre-approve tools/URLs (auto-deny otherwise) while
-  // path verification keeps the cwd + --add-dir write boundary.
-  if (launch.permissionMode === "full") {
-    args.push(...spec.sandboxFullArgs);
-  } else if (launch.permissionMode === "read") {
+  // A direct `-p` process has no stdin to answer approval prompts. Full chats
+  // and unattended one-shots therefore pre-approve tools/URLs (auto-deny
+  // otherwise) while path verification keeps the cwd + --add-dir boundary.
+  // Do not use the manifest's blanket `--allow-all`: it disables that boundary.
+  if (launch.permissionMode === "read") {
     args.push(...spec.sandboxReadOnlyArgs);
-  } else if (launch.permissionMode === "unattended") {
-    args.push(...COPILOT_UNATTENDED_ARGS);
+  } else if (launch.permissionMode === "full" || launch.permissionMode === "unattended") {
+    args.push(...COPILOT_NONINTERACTIVE_APPROVAL_ARGS);
   }
   args.push(...spec.prefixArgs, launch.prompt);
   return args;


### PR DESCRIPTION
## Summary
- replace blanket `--allow-all` for direct full-mode Copilot launches with `--allow-all-tools` and `--allow-all-urls`
- preserve path verification so writes remain confined to the spawn `cwd` plus explicit `--add-dir` grants
- share clearly named non-interactive approval arguments across full and unattended modes
- preserve current `--no-auto-update`, model, plugin directory, and JSONL launch behavior

## Verification
- targeted Copilot stream and routing tests
- pnpm typecheck
- pnpm lint
- pnpm test:app
- pnpm test:api (379 files)
- pnpm check:tests-wired (1,671 files)

Review: #pullrequestreview-4941208944
Bead: cave-wxqgv