### PR TITLE
fix(split): collapse the inactive mobile pane, and repair two stale e2e assertions

### DIFF
--- a/src/styles/globals/surface-chat-overlays.css
+++ b/src/styles/globals/surface-chat-overlays.css
@@ -994,6 +994,12 @@
   width: 100% !important;
 }
 
+/* `> [data-panel][data-active="false"]` covers the two-pane path, whose Panel
+   elements carry NO class at all — only the tile path gets .split-host__tile*.
+   Without it the inactive pane stayed fully laid out under the tab fallback, so
+   mobile rendered BOTH panes stacked past the viewport and the tabs changed
+   nothing visually (cave-ktvy0). */
+.split-host__group[data-presentation="tabs"] > [data-panel][data-active="false"],
 .split-host__group[data-presentation="tabs"] .split-host__tile-panel[data-active="false"],
 .split-host__group[data-presentation="tabs"] .split-host__tile[data-active="false"] {
   position: absolute !important;

--- a/tests/chat-boot-landing.spec.ts
+++ b/tests/chat-boot-landing.spec.ts
@@ -239,10 +239,14 @@ test.describe("chat boot landing", () => {
     await expect(page.getByText("Requesting microphone…")).toBeVisible();
     await voiceDialog.getByRole("button", { name: "End call" }).click();
     await expect(voiceDialog).toHaveCount(0);
-    await page.getByRole("button", { name: "Chat options" }).click();
-    // The unified + menu folds the old Improve section into enhance rows.
-    await expect(page.getByRole("menuitem", { name: "Enhance prompt" })).toBeVisible();
-    await page.keyboard.press("Escape");
+    // The enhance affordance is no longer behind an overflow menu on the landing
+    // surface: the composer surfaces it directly (composer-enhance.tsx), so there
+    // is no "Chat options"/"Session options" trigger to click here — the page
+    // snapshot at turn zero shows `button "Enhance prompt"` and
+    // `button "Enhance options"` inline, both disabled until there is a prompt.
+    // Assert the affordance where it now lives (cave-ktvy0).
+    await expect(page.getByRole("button", { name: "Enhance prompt" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Enhance options" })).toBeVisible();
   });
 });
 

--- a/tests/mobile/workspace-half-split.spec.ts
+++ b/tests/mobile/workspace-half-split.spec.ts
@@ -4,6 +4,12 @@ import { BUILT_IN_WORKSPACE_PAGE_IDS } from "../../src/lib/workspace-page-regist
 for (const pageId of BUILT_IN_WORKSPACE_PAGE_IDS) {
   test(`${pageId} uses the container-width tab fallback`, async ({ page }) => {
     test.setTimeout(120_000);
+    // Pin a narrow viewport. The tab fallback is a CONTAINER-WIDTH behaviour,
+    // and the desktop project deliberately runs tests/mobile specs too (see the
+    // header comment in playwright.config.ts), so without this the assertion ran
+    // at 1280x720 where the switcher correctly never engages — 49 guaranteed
+    // failures per run. Its desktop sibling pins 1440x900 the same way.
+    await page.setViewportSize({ width: 393, height: 851 });
     await page.addInitScript(() => {
       window.localStorage.setItem("cave:onboarding:dismissed", "1");
     });


### PR DESCRIPTION
Rebuilt on top of `main` after #4637 restored the green frontend baseline. Everything #4637 already covers has been dropped from this branch — what remains is the three fixes `main` still lacks, all of them found by running the e2e suite to completion rather than by reading it.

### 1. Split: the inactive pane never collapsed on mobile (product bug)

The collapsing rule existed but could not match. It targets `.split-host__tile-panel` / `.split-host__tile`, while the two-pane path renders its Panel elements with **no class at all**. Measured on Pixel 5 before the fix:

```
active   393x376
inactive 393x507   <- fully laid out, taller than the active pane
```

So a phone rendered both panes stacked past the viewport and the tab switcher changed nothing visible. Adding `> [data-panel][data-active="false"]` — which is exactly what the spec measures — gives:

```
active   393x491   <- reclaims the space
inactive 0x0
```

`tests/mobile/workspace-half-split.spec.ts --project=pixel-5`: **23 failed / 4 passed → 27 passed**. The rule stays scoped to `[data-presentation="tabs"]`, which only exists when `splitPresentation(hostWidth)` resolves to tabs at narrow widths, so desktop splits are untouched by construction.

### 2. `workspace-half-split.spec.ts` asserted a mobile container width at desktop width

The spec was registered on a project that runs at desktop viewport, so its container assertion measured the wrong layout. It now sets `393x851` explicitly.

### 3. `chat-boot-landing.spec.ts` clicked a control that does not exist

Line 242 clicked `getByRole("button", { name: "Chat options" })` and timed out. Playwright's own `error-context.md` snapshot shows no session-header overflow trigger exists on the landing surface after a voice call ends — `composer-enhance.tsx` renders `Enhance prompt` and `Enhance options` inline instead. The assertion now targets those. Verified locally: `--project=desktop -g "landing surfaces board work and voice call from turn zero"` → **5 passed**.

### Not included, deliberately

- The ~20 source-text pin repairs and the alias-loader registration — #4637 and #4626 landed equivalents.
- The `workspace.tsx` deep-link fix — #4637 fixed the same race with a synchronous ref, which also covers `commitMode`; that supersedes the mount-skip approach.
- A change to `workspace-page-registry.ts` alias titles that was on the previous branch. It was **wrong**: `calendar` and `familiar-work-queue` are aliases whose own titles are deliberately distinct from their canonical entries (`inbox` → "Rituals", `board` → "Tasks"), with the relationship carried by `landmark` ("Rituals / Calendar", "Tasks / Work queue"). Retitling the aliases would have duplicated the canonical titles and erased that distinction. `main` is correct here.

Supersedes #4618.