### PR TITLE
fix(e2e): stop the desktop project collecting tests/mobile specs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -156,6 +156,16 @@ export default defineConfig({
       name: "desktop",
       dependencies: ["preferences-iphone-13"],
       testMatch: /.*\.spec\.ts/,
+      // tests/mobile/** belongs to the pixel-5 and iphone-13 projects below.
+      // Without this, `/.*\.spec\.ts/` also matches them and every mobile spec
+      // runs a THIRD time under Desktop Chrome. That was survivable only while
+      // mobile specs happened to be viewport-agnostic; the first one that
+      // genuinely is not (tests/mobile/workspace-half-split.spec.ts, asserting
+      // the container-width tab fallback) fails all 22 of its cases there and
+      // burns ~4.5 minutes locally. Doubled by `retries: 1` and multiplied on
+      // CI's slower runners, that is what pushed the job past its 60-minute cap
+      // so every PR reported a bare "cancelled" with no failing test (cave-3wmla).
+      testIgnore: /mobile\/.*\.spec\.ts/,
       grepInvert: PERSISTED_SCREEN_SCALE_TEST,
       use: { ...devices["Desktop Chrome"] },
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -165,7 +165,14 @@ export default defineConfig({
       // burns ~4.5 minutes locally. Doubled by `retries: 1` and multiplied on
       // CI's slower runners, that is what pushed the job past its 60-minute cap
       // so every PR reported a bare "cancelled" with no failing test (cave-3wmla).
-      testIgnore: /mobile\/.*\.spec\.ts/,
+      //
+      // Anchor on the `tests/mobile/` SEGMENT, not a bare `mobile/`: Playwright
+      // matches testIgnore against the ABSOLUTE path, so a loose pattern also
+      // matches any checkout whose own directory contains "mobile" — a worktree
+      // named `…-ignores-mobile` silently ignored EVERY desktop spec and the
+      // project collected 0 tests. That would still have looked green on CI,
+      // whose runner path has no such segment.
+      testIgnore: /[\\/]tests[\\/]mobile[\\/]/,
       grepInvert: PERSISTED_SCREEN_SCALE_TEST,
       use: { ...devices["Desktop Chrome"] },
     },


### PR DESCRIPTION
## Summary

The `desktop` Playwright project declares `testMatch: /.*\.spec\.ts/` with no `testIgnore`, so it also collects `tests/mobile/**`. Every mobile spec therefore runs a **third** time under Desktop Chrome, on top of its legitimate `pixel-5` and `iphone-13` runs.

That was survivable only while mobile specs happened to be viewport-agnostic. `tests/mobile/workspace-half-split.spec.ts` is the first that genuinely is not — it asserts the container-width tab fallback, which does not exist at desktop viewport — so all 22 of its cases fail there.

## Why this blocks every PR

Measured locally:

```
desktop spec, --project=desktop --workers=2  →  28 passed,  1m24s
mobile  spec, --project=desktop              →  22 FAILED,  4m24s
```

Doubled by `retries: 1` and multiplied on CI's slower runners, that is what pushes `Frontend build` past its 60-minute cap (`ci.yml`, `timeout-minutes: 60`). Four runs on #4618 head `11aceeb89` were killed at **exactly** 60 minutes:

```
14:47:44 → 15:48:00
15:53:00 → 16:53:15
17:34:39 → 18:34:56
19:06:36 → 20:06:53
```

Each reported a bare `cancelled` with no failing test, which is why this read as a hang rather than a misconfiguration.

## Why it hid for five days

It reached `main` via the `cave-x6rw` direct push, which bypassed CI. Playwright then never actually ran on `main` in that window — docs-only pushes skipped it by path filter, and **every** frontend push died at `Validate frontend` on the stale source-text pins before reaching the e2e step. #4618 fixes those pins, so its job advanced to Playwright for the first time and immediately exposed this.

Verified across the last 12 `ci.yml` runs on `main`: `e2e` reports `skipped` in all of them. The path filter is not at fault — `classifyCiPaths()` on a representative frontend commit returns `{ frontend: true, e2e: true }`; the step is unreached because the job aborts on the earlier failure.

## The anchoring, and a bug I shipped and caught

The first commit used `/mobile\/.*\.spec\.ts/`. Playwright matches `testIgnore` against the **absolute** path, so that also matches any checkout whose own directory contains "mobile" — and this branch's worktree is named `cave-3wmla-desktop-ignores-mobile`. It ignored *every* desktop spec; the project collected **0 tests**.

It would have looked green here, since the CI runner path (`/home/runner/work/coven-cave/coven-cave`) has no such segment. The second commit anchors on the path segment and I verified all four combinations (loose vs anchored × worktree path vs CI path).

Worth stating plainly: my first check only asked *"are mobile specs gone?"* and got the answer I wanted. Asking the complementary question — *"did desktop specs survive?"* — is what caught it.

## Verification

```
desktop  195 tests in 44 files   (was 0 under the loose pattern)
desktop-owned half-split specs   24 kept
mobile specs under desktop        0   ← the fix
mobile specs under pixel-5       35   ← coverage intact
```

**No coverage is lost.** `tests/mobile/**` still runs under `pixel-5` and `iphone-13`, which is where those assertions belong.

## Risk

Config-only, one project's collection. It cannot change what any other project runs.

Independent of #4618 (stale source-text pins) and #4626 (a missing `ALIAS_LOADER` registration). `main` needs all three; they touch different concerns.

Closes `cave-3wmla`.