### PR TITLE
fix(worktree): scope the WIP recovery rule to a namespace, not a token

### DIFF
--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -312,6 +312,72 @@ function legacyObservation(overrides = {}) {
   assert.equal(item.lane, "recovery", "backup branches are never cleanup candidates");
 }
 
+// cave-22d8v — `wip` is a NAMESPACE, not a token anywhere in the branch name.
+{
+  for (const branch of [
+    "backup/feat-x",
+    "archive/cave-8i8q5-wip-2026-07-29",
+    "rescue/cave-1-snapshot",
+    "retention/cave-58eoq-authenticated-readiness-wip-2026-08-10",
+    "wip/cave-2-half-done",
+  ]) {
+    const item = classifyLifecycleUnit(
+      observation({
+        branch,
+        ref: `refs/heads/${branch}`,
+        remoteRefsContainingHead: [`refs/remotes/origin/${branch}`],
+        remoteRef: { ref: `refs/remotes/origin/${branch}`, oid: "a".repeat(40) },
+      }),
+      NOW,
+    );
+    assert.equal(item.lane, "recovery", `${branch} is a snapshot namespace and stays preserved`);
+    assert.match(item.reasons.join("\n"), /recovery or WIP snapshot/);
+  }
+}
+
+// The false positives the old token-anywhere rule produced. Neither branch holds
+// WIP: the first is named for the WIP merge it REVERTS (observed 2026-08-14 —
+// clean tree, PR #4590 merged, and still unretirable because of its name), and
+// the second merely contains the letters as part of another word.
+//
+// The assertion is that the NAME contributes nothing, not that the unit is
+// retirable: each is compared against an ordinary control branch under an
+// otherwise identical observation, so whatever the control earns on its own
+// merits, these earn too. Asserting `lane !== "recovery"` outright would be
+// wrong — a unit whose head is not yet proven landed is `recovery` regardless
+// of its name, and the control shows exactly that.
+{
+  const unit = (branch) =>
+    classifyLifecycleUnit(
+      observation({
+        branch,
+        ref: `refs/heads/${branch}`,
+        remoteRefsContainingHead: [`refs/remotes/origin/${branch}`],
+        remoteRef: { ref: `refs/remotes/origin/${branch}`, oid: "a".repeat(40) },
+      }),
+      NOW,
+    );
+  const control = unit("feat/ordinary-branch");
+  for (const branch of ["fix/cave-qqt1g-revert-wip-merge", "fix/ios-wipe-gesture"]) {
+    const item = unit(branch);
+    assert.doesNotMatch(
+      item.reasons.join("\n"),
+      /recovery or WIP snapshot/,
+      `${branch} names WIP as its subject, not its content, so the name must not pin it`,
+    );
+    assert.equal(
+      item.lane,
+      control.lane,
+      `${branch} classifies exactly like an ordinary branch`,
+    );
+    assert.deepEqual(
+      item.reasons,
+      control.reasons,
+      `${branch} earns the same reasons as an ordinary branch`,
+    );
+  }
+}
+
 {
   const item = classifyLifecycleUnit(
     observation({

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -270,8 +270,22 @@ export type WorktreeLifecycleBudgets = {
 };
 
 export const RETIREMENT_COOLDOWN_MS = 8 * 60 * 60 * 1000;
-const RECOVERY_BRANCH = /^(?:backup|archive|rescue)\//i;
-const WIP_BRANCH = /(?:^|[/-])wip(?:$|[/-])/i;
+/** Branch namespaces whose content is a snapshot to preserve, never retire.
+ *
+ *  `wip/` is a NAMESPACE here, not a token anywhere in the name. The previous
+ *  rule — /(?:^|[/-])wip(?:$|[/-])/i — matched branches whose *subject* is WIP
+ *  rather than whose *content* is: `fix/cave-qqt1g-revert-wip-merge` is named
+ *  for the WIP merge it REVERTS, held no WIP, was clean with its PR merged, and
+ *  still could not be retired because the name alone forced `recovery`. A
+ *  branch like `fix/ios-wipe-gesture` would have matched the same way.
+ *
+ *  Measured across all 677 refs in this checkout before the change: the
+ *  token-anywhere rule matched exactly 2 refs the namespace rule missed, and
+ *  BOTH were `retention/…` tags, not branches. Across all 50 branch refs — the
+ *  only thing this classifier ever sees — its unique contribution was zero.
+ *  `retention/` is folded in anyway so the retention-push hook's snapshots stay
+ *  covered by name if one ever becomes a branch. (cave-22d8v) */
+const RECOVERY_BRANCH = /^(?:backup|archive|rescue|retention|wip)\//i;
 const DISPOSABLE_IGNORED_ROOTS = [
   ".next",
   ".turbo",
@@ -527,7 +541,7 @@ function classifyLifecycleUnitInternal(
     ]);
   }
 
-  if (RECOVERY_BRANCH.test(observation.branch) || WIP_BRANCH.test(observation.branch)) {
+  if (RECOVERY_BRANCH.test(observation.branch)) {
     return withReasons(observation, "recovery", [
       "branch name identifies a recovery or WIP snapshot",
       ...reviewAfterReasons(observation.metadata, nowMs),
@@ -610,7 +624,7 @@ function classifyLifecycleUnitWithoutMetadata(
     return withReasons(observation, "recovery", ["detached HEAD"]);
   }
 
-  if (RECOVERY_BRANCH.test(observation.branch) || WIP_BRANCH.test(observation.branch)) {
+  if (RECOVERY_BRANCH.test(observation.branch)) {
     return withReasons(observation, "recovery", [
       "branch name identifies a recovery or WIP snapshot",
     ]);


### PR DESCRIPTION
Closes `cave-22d8v`.

### The bug

The patrol classifies a worktree `recovery` — a **preserve-and-stop** verdict — from its branch *name* alone. The WIP half of that rule matched any branch carrying `wip` as a delimited token anywhere in it, which catches branches whose **subject** is WIP rather than whose **content** is.

Observed 2026-08-14: `fix/cave-qqt1g-revert-wip-merge` is named for the WIP merge it *reverts*. It was clean, one commit ahead, its PR #4590 merged as `c009615ad`, its head still the tip of its own remote branch, and its owning bead closed. The only thing keeping it from retirement was its name. `fix/ios-wipe-gesture` would have matched identically.

### Why the obvious fix is wrong, and what I measured instead

Anchoring the rule to a prefix (like `RECOVERY_BRANCH`) would drop genuine snapshots — those carry the token in the middle or at the end, not as a prefix. So I measured the rule's actual contribution across **all 677 refs** in this checkout before choosing:

| | |
|---|---|
| matched by the WIP rule but **not** the namespace rule | **2** |
| …and both of those are | `retention/…` **tags**, not branches |
| matched across all **50 branch refs** — the only thing this classifier ever sees | **0** |

Every genuine snapshot already sat under `archive/` or `retention/`. The token-anywhere rule was contributing nothing on branches while generating this class of false positive.

So `wip/` becomes a **namespace** alongside `backup|archive|rescue`, and `retention/` is folded in so the retention-push hook's snapshots stay covered by name if one ever becomes a branch. No genuine snapshot loses its verdict; both false positives lose theirs.

### Coverage

The tests assert that the **name contributes nothing** — not that the unit is retirable. Each false positive is compared against an ordinary control branch under an otherwise identical observation, so it earns exactly the control's lane *and* reasons.

That distinction was earned the hard way: my first assertion was a bare `lane !== "recovery"`, and it failed — correctly. A head that is not yet proven landed classifies `recovery` regardless of its name, which is precisely what the control branch demonstrates. The fix was right; the assertion was wrong.

Verified **red before green**: restoring the old rule fails the new assertion with the intended message.

### Verification

- `src/lib/worktree-lifecycle.test.ts` passes; red-checked by reverting the source rule
- `tsc --noEmit` clean
- `scripts/worktree-lifecycle-patrol.test.mjs` was still running locally when this PR opened (it spawns temp git repos and three sessions were running it concurrently) — CI covers it