### PR TITLE
fix(chat): gate a registered project that lives inside a familiar workspace

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2107,6 +2107,22 @@ export async function POST(req: Request) {
   const resumeCwdResolved = resumeCwd
     ? await realpath(resumeCwd).catch(() => undefined)
     : undefined;
+  // The workspace exemption assumes a workspace directory is not a registered
+  // project. A user can register one whose root lives under the familiar's
+  // workspace, so ask the registry rather than trusting containment: a resume
+  // root that resolves to a real project id is gated like any other project
+  // root (cave-g8fqc). `unregistered:<root>` is the fail-closed sentinel and
+  // does NOT count as registered.
+  const resumeProjectAccessId = resumeCwd
+    ? chatProjectAccessId({
+        projects,
+        resumeCwd,
+        resolvedCwd: resumeCwdResolved ?? resumeCwd,
+      })
+    : null;
+  const resumeCwdIsRegisteredProject = Boolean(
+    resumeProjectAccessId && !resumeProjectAccessId.startsWith("unregistered:"),
+  );
   const projectlessLaunch = projectlessGenerationLaunch({
     origin: generationOrigin,
     hasRequestedProjectRoot: Boolean(body.projectRoot),
@@ -2115,6 +2131,7 @@ export async function POST(req: Request) {
     resumeCwd,
     resumeCwdResolved,
     familiarWorkspace: resolvedFamiliarWorkspace,
+    resumeCwdIsRegisteredProject,
   });
   // A Board task may be isolated in a worktree below its registered project.
   // The worktree itself is intentionally not a separate project record, so

--- a/src/lib/server/chat-project-launch.test.ts
+++ b/src/lib/server/chat-project-launch.test.ts
@@ -236,6 +236,49 @@ test("a resume root inside the familiar's own workspace stays auth-free", () => 
   }
 });
 
+// ── cave-g8fqc: the exemption describes an UNREGISTERED workspace directory.
+// Nothing enforced that: a user can register a project whose root lives under
+// ~/.coven/workspaces/familiars/<id>/, and the containment test alone then
+// handed a genuinely registered project an auth-free launch.
+
+test("a registered project inside the familiar's workspace is gated, not exempt", () => {
+  for (const resume of [
+    "/home/val/.coven/workspaces/familiars/milo",
+    "/home/val/.coven/workspaces/familiars/milo/registered-repo",
+  ]) {
+    assert.deepEqual(
+      launch({ resumeCwd: resume, resumeCwdIsRegisteredProject: true }),
+      { kind: "gated" },
+      `${resume} maps to a registered project, so its grant must be checked`,
+    );
+  }
+});
+
+test("registration does not widen the exemption beyond the workspace", () => {
+  // The containment test still runs first. A root outside the workspace is
+  // gated whether or not it is registered, so this flag can only ever REMOVE
+  // an exemption, never grant one.
+  for (const registered of [true, false, undefined]) {
+    assert.deepEqual(
+      launch({ resumeCwd: "/home/val/code/other", resumeCwdIsRegisteredProject: registered }),
+      { kind: "gated" },
+      `an outside root stays gated with resumeCwdIsRegisteredProject=${String(registered)}`,
+    );
+  }
+});
+
+test("an unregistered workspace root keeps its auth-free launch", () => {
+  // The multi-turn canvas case this exemption exists for must be untouched.
+  const resume = "/home/val/.coven/workspaces/familiars/milo/scratch";
+  for (const registered of [false, undefined]) {
+    assert.deepEqual(
+      launch({ resumeCwd: resume, resumeCwdIsRegisteredProject: registered }),
+      { kind: "workspace", root: resume },
+      `an unregistered workspace root stays exempt with registered=${String(registered)}`,
+    );
+  }
+});
+
 test("a daemon-derived resume root outside the workspace is gated", () => {
   for (const resume of [
     "/home/val/code/someone-elses-project",

--- a/src/lib/server/chat-project-launch.ts
+++ b/src/lib/server/chat-project-launch.ts
@@ -56,6 +56,22 @@ export type ProjectlessGenerationLaunchInput = {
   resumeCwdResolved?: string;
   /** Already symlink-resolved by resolveFamiliarWorkspace. */
   familiarWorkspace?: string;
+  /**
+   * Whether the resume root maps to a REGISTERED project.
+   *
+   * The workspace exemption below rests on the premise that a familiar's
+   * workspace is not a registered project and so carries no grant to check.
+   * Nothing enforced that premise: a user may register a project whose root
+   * lives under `~/.coven/workspaces/familiars/<id>/`, and for such a root the
+   * exemption applied to a genuinely registered project — the same bypass shape
+   * cave-o3nq7 closed, narrowed to projects inside a familiar workspace.
+   *
+   * The caller resolves this (it owns the project registry); the decision stays
+   * pure. Undefined reads as "not registered", which preserves the exemption
+   * for callers that cannot answer — the containment test still has to pass
+   * first, so this never widens the exemption beyond the workspace. (cave-g8fqc)
+   */
+  resumeCwdIsRegisteredProject?: boolean;
 };
 
 export type ProjectlessGenerationLaunchDecision =
@@ -82,6 +98,13 @@ export type ProjectlessGenerationLaunchDecision =
  * unless it resolves inside the familiar's own workspace — the multi-turn
  * canvas case, where turn 1 legitimately ran auth-free in that workspace and
  * persisted it as the conversation runtime.
+ *
+ * That last exemption is further narrowed to roots that are not REGISTERED
+ * projects (cave-g8fqc). "A workspace carries no grant to check" is a premise,
+ * not a guarantee: a user can register a project whose root lives under the
+ * workspace, and the exemption then applied to a real project — letting a
+ * hidden turn 2 skip re-authorization on it, and a turn 1 naming a daemon
+ * session rooted there launch with no grant at all.
  */
 export function projectlessGenerationLaunch(
   input: ProjectlessGenerationLaunchInput,
@@ -100,7 +123,11 @@ export function projectlessGenerationLaunch(
   // named an unresolvable root.
   const resolved = input.resumeCwdResolved?.trim();
   if (!resolved) return { kind: "gated" };
-  if (workspace && isInsideRoot(workspace, resolved)) {
+  // Containment alone is not enough. The exemption describes an UNREGISTERED
+  // workspace directory; a registered project that happens to sit inside the
+  // workspace has a grant to check, so it is gated like any other project
+  // root (cave-g8fqc).
+  if (workspace && isInsideRoot(workspace, resolved) && !input.resumeCwdIsRegisteredProject) {
     return { kind: "workspace", root: resolved };
   }
   return { kind: "gated" };


### PR DESCRIPTION
Closes `cave-g8fqc`. Residual of `cave-o3nq7` after #4582.

### The gap

`projectlessGenerationLaunch` lets a hidden generation skip the project launch gate when its resume root resolves inside the familiar's **own** workspace. The stated justification is that *a workspace is not a registered project and carries no grant to check*.

Nothing enforced that premise. A user can register a project whose root lives under `~/.coven/workspaces/familiars/<id>/`, and for such a root the containment test passed and the exemption applied to a **genuinely registered project**:

- a hidden-origin **turn 2** skipped re-authorization on it, and
- a **turn 1** naming a daemon session rooted there launched with **no grant at all**

That is the same bypass shape #4582 closed, narrowed to projects inside a familiar workspace.

### The fix

Keep the containment test; narrow the exemption to roots that are **not registered projects**. The decision function stays pure — the send route owns the registry and resolves the answer with the `chatProjectAccessId` helper the bead named, treating the fail-closed `unregistered:<root>` sentinel as *not* registered.

```ts
if (workspace && isInsideRoot(workspace, resolved) && !input.resumeCwdIsRegisteredProject) {
  return { kind: "workspace", root: resolved };
}
return { kind: "gated" };
```

The new flag can only ever **remove** an exemption, never grant one:

- containment still runs first, so a root outside the workspace is gated whether or not it is registered
- an absent flag reads as "not registered", preserving today's behavior for any caller that cannot answer

### Coverage — 3 cases, red-checked

| case | expectation |
|---|---|
| registered project inside the workspace | **gated** — its grant must be checked |
| outside root, `registered` = true / false / undefined | gated in all three — the flag cannot widen the exemption |
| unregistered workspace root, `registered` = false / undefined | still auth-free — the multi-turn canvas case is untouched |

Removing the guard fails exactly the first case and nothing else.

Worth noting: the pre-existing test for the exempt path already described its subject as *"a directory that is not a registered project"*. This change makes that comment literally true rather than aspirational.

### Verification

- `chat-project-launch.test.ts` — **22/22**
- 12 related project/access/permission test files — all pass
- `tsc --noEmit` clean