### PR TITLE
ci: fully parallelize frontend validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,31 +90,8 @@ jobs:
         working-directory: apps/ios/CovenCave
         run: xcodebuild -scheme CovenCave -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build
 
-  frontend-static:
-    name: Frontend lint, types & test wiring
-    needs: paths
-    if: needs.paths.outputs.frontend == 'true' && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          persist-credentials: false
-
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm lint
-      - run: pnpm typecheck
-      - run: pnpm check:tests-wired
-
-  frontend-tests:
-    name: Frontend tests (${{ matrix.suite }})
+  frontend-validation:
+    name: Frontend validation (${{ matrix.validation.name }})
     needs: paths
     if: needs.paths.outputs.frontend == 'true' && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)
     runs-on: ubuntu-latest
@@ -122,7 +99,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [app, api, mobile]
+        validation:
+          - name: lint
+            command: lint
+          - name: typecheck
+            command: typecheck
+          - name: test wiring
+            command: check:tests-wired
+          - name: app tests
+            command: test:app
+          - name: API tests
+            command: test:api
+          - name: mobile tests
+            command: test:mobile
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -136,7 +125,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test:${{ matrix.suite }}
+      - run: pnpm ${{ matrix.validation.command }}
 
   frontend-bundle:
     name: Frontend bundle
@@ -178,7 +167,7 @@ jobs:
 
   build:
     name: Frontend build
-    needs: [paths, ios, frontend-static, frontend-tests, frontend-bundle]
+    needs: [paths, ios, frontend-validation, frontend-bundle]
     if: always() && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -189,8 +178,7 @@ jobs:
         env:
           PATHS_RESULT: ${{ needs.paths.result }}
           FRONTEND_ENABLED: ${{ needs.paths.outputs.frontend }}
-          FRONTEND_STATIC_RESULT: ${{ needs.frontend-static.result }}
-          FRONTEND_TESTS_RESULT: ${{ needs.frontend-tests.result }}
+          FRONTEND_VALIDATION_RESULT: ${{ needs.frontend-validation.result }}
           FRONTEND_BUNDLE_RESULT: ${{ needs.frontend-bundle.result }}
           IOS_ENABLED: ${{ needs.paths.outputs.ios }}
           IOS_RESULT: ${{ needs.ios.result }}
@@ -198,8 +186,7 @@ jobs:
           set -euo pipefail
           test "$PATHS_RESULT" = "success"
           if [ "$FRONTEND_ENABLED" = "true" ]; then
-            test "$FRONTEND_STATIC_RESULT" = "success"
-            test "$FRONTEND_TESTS_RESULT" = "success"
+            test "$FRONTEND_VALIDATION_RESULT" = "success"
             test "$FRONTEND_BUNDLE_RESULT" = "success"
           fi
           if [ "$IOS_ENABLED" = "true" ]; then

--- a/scripts/ci-recovery-workflow.test.mjs
+++ b/scripts/ci-recovery-workflow.test.mjs
@@ -37,21 +37,41 @@ assert.match(detector.run, /node scripts\/ci-recovery\.mjs --apply/);
 const ciSource = await readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
 const ciWorkflow = parse(ciSource);
 assert.deepEqual(
-  Object.keys(ciWorkflow.jobs),
-  ["paths", "ios", "frontend-static", "frontend-tests", "frontend-bundle", "build"],
+  Object.keys(ciWorkflow.jobs).sort(),
+  ["build", "frontend-bundle", "frontend-validation", "ios", "paths"],
   "routine CI classifies once, fans frontend validation out, then reports through the required job",
 );
 assert.equal(ciWorkflow.jobs.build.name, "Frontend build");
 assert.deepEqual(ciWorkflow.jobs.build.needs, [
   "paths",
   "ios",
-  "frontend-static",
-  "frontend-tests",
+  "frontend-validation",
   "frontend-bundle",
 ]);
 assert.equal(ciWorkflow.jobs.ios.name, "iOS build");
-assert.deepEqual(ciWorkflow.jobs["frontend-tests"].strategy.matrix.suite, ["app", "api", "mobile"]);
-assert.equal(ciWorkflow.jobs["frontend-tests"].strategy["fail-fast"], false);
+assert.deepEqual(ciWorkflow.jobs["frontend-validation"].strategy.matrix.validation, [
+  { name: "lint", command: "lint" },
+  { name: "typecheck", command: "typecheck" },
+  { name: "test wiring", command: "check:tests-wired" },
+  { name: "app tests", command: "test:app" },
+  { name: "API tests", command: "test:api" },
+  { name: "mobile tests", command: "test:mobile" },
+]);
+assert.equal(ciWorkflow.jobs["frontend-validation"].strategy["fail-fast"], false);
+assert.equal(
+  ciWorkflow.jobs["frontend-validation"].steps.at(-1)?.run,
+  "pnpm ${{ matrix.validation.command }}",
+  "each frontend validation matrix lane runs its declared command",
+);
+const bundleRun = ciWorkflow.jobs["frontend-bundle"].steps.at(-1)?.run;
+assert.ok(bundleRun, "the frontend bundle job ends with a build script");
+assert.match(bundleRun, /if \[ "\$attempt" -lt 3 \]; then/);
+assert.match(bundleRun, /::error::pnpm build failed after 3 attempts/);
+assert.doesNotMatch(
+  bundleRun,
+  /echo "::warning::pnpm build attempt \$attempt failed; retrying with clean \.next"\n\s*rm -rf \.next\n\s*done/,
+  "the terminal build failure must not claim that another retry will run",
+);
 assert.equal(
   ciWorkflow["run-name"],
   "CI ${{ github.event_name }} ${{ inputs.expected_sha || github.sha }}",
@@ -87,9 +107,7 @@ const expectedJobGuards = {
   paths: "github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha",
   ios:
     "needs.paths.outputs.ios == 'true' && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)",
-  "frontend-static":
-    "needs.paths.outputs.frontend == 'true' && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)",
-  "frontend-tests":
+  "frontend-validation":
     "needs.paths.outputs.frontend == 'true' && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)",
   "frontend-bundle":
     "needs.paths.outputs.frontend == 'true' && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)",
@@ -118,8 +136,7 @@ const prerequisite = ciWorkflow.jobs.build.steps.find(
 );
 assert.ok(prerequisite, "the required Frontend build aggregates prerequisite job results");
 assert.match(prerequisite.run, /test "\$IOS_RESULT" = "success"/);
-assert.match(prerequisite.run, /test "\$FRONTEND_STATIC_RESULT" = "success"/);
-assert.match(prerequisite.run, /test "\$FRONTEND_TESTS_RESULT" = "success"/);
+assert.match(prerequisite.run, /test "\$FRONTEND_VALIDATION_RESULT" = "success"/);
 assert.match(prerequisite.run, /test "\$FRONTEND_BUNDLE_RESULT" = "success"/);
 
 const releaseSource = await readFile(


### PR DESCRIPTION
## Summary

Runs lint, typecheck, test wiring, app tests, API tests, and mobile tests as six independent matrix lanes. Keeps Frontend bundle separate and Frontend build as the sole required aggregate.

## Why

PR #4650 split the expensive test and bundle work, but its static job still serialized three independent validations. This follow-up completes cave-bsmir by making every independent frontend validation concurrent without changing path-aware selection or branch protection.

## Changes

- replace the serial static job and three-suite test matrix with one six-lane validation matrix
- keep fail-fast disabled so every lane reports its own verdict
- aggregate the matrix and bundle results through Frontend build
- pin the full job graph, lane commands, and terminal retry logging in the workflow contract test

## Verification

- node scripts/ci-recovery-workflow.test.mjs
- pnpm lint
- pnpm typecheck
- pnpm check:tests-wired — 1,669 files
- pnpm test:app — 1,209 files
- pnpm test:api — 379 files
- pnpm test:mobile — 88 files
- git diff --check

## Risk + rollout notes

CI-only change. It increases concurrent frontend jobs from five to seven while preserving Frontend build as the sole required status. No application runtime behavior changes.

Bead: cave-bsmir