### PR TITLE
fix(worktree-lifecycle): stop closed beads voting in the orphan ownership tally

### DIFF
--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -2654,7 +2654,28 @@ function collectOrphanedMetadata(
       return normalized === null ? [] : [normalized];
     }),
   );
-  const structuredRecords = tasks.flatMap((task) => task.structured);
+  // Count ownership over the same population the repair loop below serves:
+  // non-closed beads. A closed bead's record is skipped there
+  // (`if (task.status === "closed") continue;`), so it can never be repaired —
+  // and letting it vote here charged an open bead for an ambiguity that could
+  // never be resolved. Two records naming one branch made the count 2, which
+  // appends "appears in 2 structured metadata records" and sets `repairable`
+  // false; the open record then stayed broken forever because clearing the
+  // other contributor was impossible by construction.
+  //
+  // Measured 2026-08-14: 161 closed beads in this checkout hold a worktree
+  // record whose path is gone, against 3 non-closed. Every correctly-completed
+  // unit adds one — closing the bead is the last step of a clean retirement —
+  // so the pool of unreachable voters only grows (cave-yyjfs).
+  //
+  // Duplicates between two non-closed beads are still counted, which is the
+  // genuine ambiguity the reason exists for. Note the sibling tally at the
+  // `validMetadata` filter further down deliberately stays repository-wide:
+  // it gates budget exceptions and is fail-closed on purpose, where narrowing
+  // the population would *loosen* a budget rather than unblock a repair.
+  const structuredRecords = tasks
+    .filter((task) => task.status !== "closed")
+    .flatMap((task) => task.structured);
   const branchOwnershipCounts = new Map<string, number>();
   const pathOwnershipCounts = new Map<string, number>();
   for (const record of structuredRecords) {

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -61,6 +61,7 @@ const duplicateWorktreeInventory = path.join(fixtureRoot, "duplicate-worktree-in
 const metadataAlias = path.join(fixtureRoot, "old-alias");
 const orphanedMissingPath = path.join(fixtureRoot, "missing-orphan");
 const orphanedClosedPath = path.join(fixtureRoot, "missing-closed");
+const orphanedContestedPath = path.join(fixtureRoot, "missing-contested");
 const orphanedPresentPath = path.join(repo, ".worktrees", "orphaned-present");
 const orphanedDanglingPath = path.join(repo, ".worktrees", "orphaned-dangling");
 
@@ -2458,7 +2459,7 @@ printf '%s\n' '[{"id":"cave-old","status":"closed","title":"Old work","metadata"
 elif [ "\${LIFECYCLE_ORPHANED_METADATA_AMBIGUOUS:-0}" = "1" ]; then
 printf '%s\n' '[{"id":"cave-old","status":"closed","title":"Old work","metadata":{"coven":{"worktree":{"branch":"feat/old","path":"${old}","owner":"Kitty","purpose":"Landed fixture","disposition":"pr","createdAt":"2026-07-20T12:00:00Z"}}}},{"id":"cave-orphan-malformed-sibling","status":"open","title":"Malformed sibling orphan fixture","metadata":{"coven":{"worktree":{"branch":"feat/orphaned-malformed","path":"${path.join(fixtureRoot, "missing-orphan-malformed")}","owner":"Kitty","purpose":"Malformed sibling fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"},"worktrees":[{"branch":"feat/orphaned-malformed-sibling","path":"relative/orphaned","owner":"Kitty","purpose":"Malformed sibling fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"}]}}},{"id":"cave-orphan-duplicate-branch","status":"open","title":"Duplicate branch orphan fixture","metadata":{"coven":{"worktree":{"branch":"feat/orphaned-duplicate-branch","path":"${orphanedMissingPath}","owner":"Kitty","purpose":"Duplicate branch fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"},"worktrees":[{"branch":"feat/orphaned-duplicate-branch","path":"${orphanedClosedPath}","owner":"Kitty","purpose":"Duplicate branch fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"}]}}},{"id":"cave-orphan-duplicate-path","status":"open","title":"Duplicate path orphan fixture","metadata":{"coven":{"worktree":{"branch":"feat/orphaned-duplicate-path","path":"${orphanedMissingPath}","owner":"Kitty","purpose":"Duplicate path fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"},"worktrees":[{"branch":"feat/orphaned-duplicate-path-sibling","path":"${orphanedMissingPath}/","owner":"Kitty","purpose":"Duplicate path fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"}]}}}]'
 elif [ "\${LIFECYCLE_ORPHANED_METADATA:-0}" = "1" ]; then
-printf '%s\n' '[{"id":"cave-orphan","status":"open","title":"Orphaned metadata fixture","metadata":{"unrelated":"preserved","coven":{"sibling":"preserved","worktree":{"branch":"feat/orphaned","path":"${orphanedMissingPath}/","owner":"Kitty","purpose":"Orphaned metadata fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z","futureField":{"preserve":true}}}}},{"id":"cave-present-path","status":"open","title":"Present path fixture","metadata":{"coven":{"worktree":{"branch":"feat/present-path","path":"${orphanedPresentPath}","owner":"Kitty","purpose":"Present path fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"}}}},{"id":"cave-dangling-path","status":"open","title":"Dangling path fixture","metadata":{"coven":{"worktree":{"branch":"feat/dangling-path","path":"${orphanedDanglingPath}","owner":"Kitty","purpose":"Dangling path fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"}}}},{"id":"cave-closed-orphan","status":"closed","title":"Closed orphaned metadata fixture","metadata":{"coven":{"worktree":{"branch":"feat/closed-orphan","path":"${orphanedClosedPath}","owner":"Kitty","purpose":"Closed orphaned metadata fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"}}}}]'
+printf '%s\n' '[{"id":"cave-orphan","status":"open","title":"Orphaned metadata fixture","metadata":{"unrelated":"preserved","coven":{"sibling":"preserved","worktree":{"branch":"feat/orphaned","path":"${orphanedMissingPath}/","owner":"Kitty","purpose":"Orphaned metadata fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z","futureField":{"preserve":true}}}}},{"id":"cave-present-path","status":"open","title":"Present path fixture","metadata":{"coven":{"worktree":{"branch":"feat/present-path","path":"${orphanedPresentPath}","owner":"Kitty","purpose":"Present path fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"}}}},{"id":"cave-dangling-path","status":"open","title":"Dangling path fixture","metadata":{"coven":{"worktree":{"branch":"feat/dangling-path","path":"${orphanedDanglingPath}","owner":"Kitty","purpose":"Dangling path fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"}}}},{"id":"cave-closed-orphan","status":"closed","title":"Closed orphaned metadata fixture","metadata":{"coven":{"worktree":{"branch":"feat/closed-orphan","path":"${orphanedClosedPath}","owner":"Kitty","purpose":"Closed orphaned metadata fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"}}}},{"id":"cave-orphan-contested","status":"open","title":"Contested-by-closed orphan fixture","metadata":{"coven":{"worktree":{"branch":"feat/orphaned-contested","path":"${orphanedContestedPath}","owner":"Kitty","purpose":"Contested-by-closed fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"}}}},{"id":"cave-closed-contender","status":"closed","title":"Closed contender fixture","metadata":{"coven":{"worktree":{"branch":"feat/orphaned-contested","path":"${orphanedContestedPath}","owner":"Kitty","purpose":"Closed contender fixture","disposition":"active","createdAt":"2026-07-20T12:00:00Z"}}}}]'
 elif [ "\${LIFECYCLE_MALFORMED_WORKTREES:-0}" = "1" ]; then
 printf '%s\n' '[{"id":"cave-multi","status":"closed","title":"Malformed array","metadata":{"coven":{"worktree":{"branch":"feat/old","path":"${old}","owner":"Kitty","purpose":"Primary fixture","disposition":"pr","createdAt":"2026-07-20T12:00:00Z"},"worktrees":{}}}}]'
 elif [ "\${LIFECYCLE_DUPLICATE_WORKTREE_BRANCH:-0}" = "1" ]; then
@@ -2775,8 +2776,8 @@ exit 0
   const orphanedMetadataReport = JSON.parse(
     patrol(["--json"], { LIFECYCLE_ORPHANED_METADATA: "1" }),
   );
-  assert.equal(orphanedMetadataReport.orphanedMetadata.length, 3);
-  assert.equal(orphanedMetadataReport.orphanedMetadataCount, 3);
+  assert.equal(orphanedMetadataReport.orphanedMetadata.length, 4);
+  assert.equal(orphanedMetadataReport.orphanedMetadataCount, 4);
   assert.deepEqual(orphanedMetadataReport.orphanedMetadataErrors, []);
   assert.equal(orphanedMetadataReport.orphanedMetadataErrorCount, 0);
   const orphanedByBead = new Map(
@@ -2805,6 +2806,15 @@ exit 0
     /exists on disk/i,
   );
   assert.equal(orphanedByBead.has("cave-closed-orphan"), false);
+  // A closed bead must not vote in the ownership tally. cave-closed-contender
+  // claims the same branch AND the same path as the open cave-orphan-contested;
+  // while closed records were counted, that pushed both tallies to 2, stamped
+  // "appears in 2 structured metadata records" on the open record, and set
+  // repairable false. Nothing could ever clear it, because the contender is
+  // closed and the repair loop skips closed beads (cave-yyjfs).
+  assert.equal(orphanedByBead.has("cave-closed-contender"), false);
+  assert.equal(orphanedByBead.get("cave-orphan-contested").repairable, true);
+  assert.deepEqual(orphanedByBead.get("cave-orphan-contested").reasons, []);
   const ambiguousOrphanedMetadataReport = JSON.parse(
     patrol(["--json"], { LIFECYCLE_ORPHANED_METADATA_AMBIGUOUS: "1" }),
   );


### PR DESCRIPTION
Closes cave-yyjfs (in part — see *What this does not do* below).

## The defect

`collectOrphanedMetadata` builds `branchOwnershipCounts` and `pathOwnershipCounts` from **every** task:

```ts
const structuredRecords = tasks.flatMap((task) => task.structured);
```

then, fifteen lines later, skips closed tasks when choosing repair candidates:

```ts
for (const task of tasks) {
  if (task.status === "closed") continue;
```

So a closed bead's stale worktree record still votes in the tally it is then excluded from acting on. If an open bead's record names the same branch or path, the count reaches 2, `reconcileOrphanedMetadata` appends `"branch X appears in 2 structured metadata records"`, and `repairable` goes `false`.

That open record can then **never** be repaired. Resolving the ambiguity would mean clearing the other claimant, and the other claimant is closed — which the repair loop skips by construction. A closed bead permanently poisons an open one.

## The fix

Count over the same population the repair loop serves. Duplicates between two non-closed beads are still counted, which is the genuine ambiguity the reason exists for.

## Why the sibling tally is deliberately left alone

There is a second `structuredRecords` further down feeding the `validMetadata` filter, with the same `length === 1` uniqueness checks. It is **intentionally** repository-wide and is not touched here:

- It gates **budget exceptions** and its own comment states the stance — a malformed record anywhere means the exception inventory is not known to be complete, and *an exception wrongly believed present loosens a budget*. Narrowing its population would loosen a gate, the opposite of the fail-closed intent.
- It also requires a live `unit` match, so a stale record at an absent path cannot become an exception on its own.

## Measurement

On the primary checkout, 2026-08-14:

| | count |
|---|---|
| closed beads holding a worktree record whose path is gone | **161** |
| non-closed beads in the same state | **3** |

Closing the bead is the last step of a *clean* retirement, so every correctly-completed unit that is retired by hand deposits one more unreachable voter. The pool only grows.

**No branch or path is contested by an open+closed pair today** (verified: 0 of each). This prevents a latent failure; it does not unstick any record that is currently blocked.

## Test

`cave-orphan-contested` (open) and `cave-closed-contender` (closed) claim the same branch **and** the same path. Asserts the closed bead stays excluded from candidates, and the open one comes back `repairable: true` with no reasons.

Mutation-verified: reverting only the source change and keeping the test makes `scripts/worktree-lifecycle-patrol.test.mjs` exit 1 with an `AssertionError`. Baseline with the fix exits 0.

## What this does not do

The other half of cave-yyjfs is untouched: the 161 stranded records stay unreachable, because the closed-status skip in the repair loop is deliberate and pinned by the pre-existing `cave-closed-orphan` fixture. Whether to let the collector see closed beads at all is a separate, larger decision and is left open on the bead.