### PR TITLE
fix(codex): let the probe timeout be overridden instead of raising it again

### DIFF
--- a/src/app/api/chat/send/harness-routing-codex-direct.test.ts
+++ b/src/app/api/chat/send/harness-routing-codex-direct.test.ts
@@ -26,6 +26,15 @@ const fixturePath = fileURLToPath(
   new URL("../../../../lib/fixtures/codex/0.145.0-tool-lifecycle.jsonl", import.meta.url),
 );
 
+// This test asserts ROUTING, not probe latency. The probe launches three cold
+// Node fixture processes, and if they miss the production 5s budget the route
+// does not fail loudly — it silently serves the turn through the generic coven
+// fallback, so the miss surfaces as a bogus routing assertion failure. It did
+// exactly that on CI run 31129333186, against a PR that touched only two
+// scripts. Opt out of the budget rather than chase it (cave-qwebr).
+const previousProbeTimeout = process.env.COVEN_CODEX_PROBE_TIMEOUT_MS;
+process.env.COVEN_CODEX_PROBE_TIMEOUT_MS = "120000";
+
 const previousHome = process.env.COVEN_HOME;
 const previousCaveHome = process.env.COVEN_CAVE_HOME;
 const previousCovenBin = process.env.COVEN_BIN;
@@ -439,6 +448,8 @@ try {
   else process.env.COVEN_BIN = previousCovenBin;
   if (previousCodexBin === undefined) delete process.env.CODEX_BIN;
   else process.env.CODEX_BIN = previousCodexBin;
+  if (previousProbeTimeout === undefined) delete process.env.COVEN_CODEX_PROBE_TIMEOUT_MS;
+  else process.env.COVEN_CODEX_PROBE_TIMEOUT_MS = previousProbeTimeout;
   if (previousCovenSocket === undefined) delete process.env.COVEN_SOCKET;
   else process.env.COVEN_SOCKET = previousCovenSocket;
   await new Promise((resolve, reject) => daemon.close((error) => error ? reject(error) : resolve()));

--- a/src/lib/codex-compatibility.test.ts
+++ b/src/lib/codex-compatibility.test.ts
@@ -9,6 +9,7 @@ import {
   CodexJsonlDecoder,
   CodexSchemaCache,
   codexProbeEnv,
+  codexProbeTimeoutMs,
   discoverCodexRuntime,
   codexSchemaSignatureVerifierFromEnv,
   parseCodexVersionOutput,
@@ -472,6 +473,47 @@ try {
   assert.equal((await readCodexSchemaCache(cachePath, verify, new Date("2026-07-24T12:00:00.000Z")))?.contentHash, newerDocument.contentHash, "failed refresh preserves the newest last-known-good cache");
 } finally {
   await rm(cacheDir, { recursive: true, force: true });
+}
+
+// cave-qwebr: the probe timeout is overridable so fixture-driven tests can opt
+// out of a production latency budget. A missed budget does NOT fail loudly --
+// the route silently serves the turn through the generic coven fallback -- so
+// the override exists to keep routing assertions from reporting a timing miss
+// as a routing bug. Production keeps the bounded 5s default.
+{
+  // ProcessEnv is augmented with required members here, so build probe envs the
+  // way codexProbeEnv does rather than passing bare literals.
+  const probeEnv = (value?: string) => {
+    const env = {} as NodeJS.ProcessEnv;
+    if (value !== undefined) env.COVEN_CODEX_PROBE_TIMEOUT_MS = value;
+    return env;
+  };
+
+  assert.equal(codexProbeTimeoutMs(probeEnv()), 5_000, "absent override keeps the production default");
+  assert.equal(codexProbeTimeoutMs(probeEnv("")), 5_000, "empty is absent");
+  assert.equal(codexProbeTimeoutMs(probeEnv("   ")), 5_000, "blank is absent");
+  assert.equal(codexProbeTimeoutMs(probeEnv("120000")), 120_000, "a valid override is honored");
+  assert.equal(codexProbeTimeoutMs(probeEnv("1500")), 1_500, "an override may also shorten it");
+
+  // Malformed values degrade to the default rather than disabling the timeout:
+  // execFile treats 0 as "no timeout", so a typo must never hang a chat turn on
+  // a wedged binary.
+  for (const bad of ["0", "-1", "abc", "NaN", "Infinity", "-Infinity", "1e", "12,000"]) {
+    assert.equal(
+      codexProbeTimeoutMs(probeEnv(bad)),
+      5_000,
+      `${JSON.stringify(bad)} falls back to the bounded default`,
+    );
+  }
+
+  // Defaults are evaluated per call, so an override set after module load still
+  // takes effect — which is what lets a test set it before importing the route.
+  const previous = process.env.COVEN_CODEX_PROBE_TIMEOUT_MS;
+  process.env.COVEN_CODEX_PROBE_TIMEOUT_MS = "90000";
+  assert.equal(codexProbeTimeoutMs(), 90_000, "reads process.env by default");
+  if (previous === undefined) delete process.env.COVEN_CODEX_PROBE_TIMEOUT_MS;
+  else process.env.COVEN_CODEX_PROBE_TIMEOUT_MS = previous;
+  assert.equal(codexProbeTimeoutMs(), 5_000, "restores once the override is cleared");
 }
 
 console.log("codex-compatibility: ok");

--- a/src/lib/codex-compatibility.ts
+++ b/src/lib/codex-compatibility.ts
@@ -928,10 +928,36 @@ function codexProbeCacheKey(target: Required<CodexProbeTarget>, env: NodeJS.Proc
  */
 const CODEX_PROBE_TIMEOUT_MS = 5_000;
 
+/**
+ * The probe timeout, overridable via `COVEN_CODEX_PROBE_TIMEOUT_MS`.
+ *
+ * Production keeps the bounded 5s default: a hung binary must not stall a chat
+ * turn indefinitely. The override exists for FIXTURE-DRIVEN TESTS, which assert
+ * routing correctness and have no business riding a latency budget — when the
+ * budget is missed they do not fail loudly, they silently take the generic
+ * fallback and the assertion reports as a routing bug.
+ *
+ * That is why this is an override rather than another raise of the constant.
+ * 1.5s was raised to 5s for exactly this symptom and 5s went on to miss too, so
+ * raising it again buys a quieter suite at the cost of a slower production
+ * failure — and buys it only until the next loaded runner. (cave-qwebr)
+ *
+ * Anything not a finite number greater than zero falls back to the default, so
+ * a malformed value degrades to today's behavior instead of disabling the
+ * timeout.
+ */
+export function codexProbeTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.COVEN_CODEX_PROBE_TIMEOUT_MS;
+  if (raw === undefined || raw.trim() === "") return CODEX_PROBE_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return CODEX_PROBE_TIMEOUT_MS;
+  return parsed;
+}
+
 /** Safe local discovery; failures become an explicit unavailable report. */
 export async function discoverCodexRuntime(
   command: string | CodexProbeTarget = "codex",
-  timeout = CODEX_PROBE_TIMEOUT_MS,
+  timeout = codexProbeTimeoutMs(),
   env?: NodeJS.ProcessEnv,
 ): Promise<CodexRuntimeReport> {
   try {
@@ -977,7 +1003,7 @@ export async function discoverCodexRuntime(
 /** Single-flight, bounded-cadence discovery for chat turns. */
 export async function discoverCachedCodexRuntime(
   command: string | CodexProbeTarget = "codex",
-  timeout = CODEX_PROBE_TIMEOUT_MS,
+  timeout = codexProbeTimeoutMs(),
   env = codexProbeEnv(),
   now = Date.now(),
 ): Promise<CodexRuntimeReport> {
@@ -1023,7 +1049,7 @@ function startCodexRuntimeDiscovery(
  */
 export function peekCachedCodexRuntime(
   command: string | CodexProbeTarget = "codex",
-  timeout = CODEX_PROBE_TIMEOUT_MS,
+  timeout = codexProbeTimeoutMs(),
   env = codexProbeEnv(),
   now = Date.now(),
 ): CodexRuntimeReport {


### PR DESCRIPTION
Closes `cave-qwebr`.

### The failure

`harness-routing-codex-direct.test.ts` intermittently fails the required `Frontend build` on CI ubuntu:

> the verified CLI must serve this turn directly, not fall back

The probe spawns **three cold Node fixture processes**. When a loaded runner misses the 5s budget, the route does not fail loudly — it silently serves the turn through the generic `coven run codex` fallback. So a **timing** miss is reported as a **routing** bug, on a PR that never touched routing (CI run `31129333186`, PR #4401 — a two-file scripts-only change).

### Why not just raise the constant again

That is the move that already failed. The constant's own comment records it: `1.5s reproducibly fell back on CI ubuntu runners`, so it was raised to 5s — and 5s has now missed too. Raising it again buys a quieter suite at the cost of a slower production failure, and only until the next loaded runner.

So production keeps the bounded 5s default (a hung binary must not stall a chat turn), and `COVEN_CODEX_PROBE_TIMEOUT_MS` lets the fixture-driven test opt out of a latency budget it has no business riding. The three call sites pick it up through their default parameters, which are evaluated **per call** — which is what lets a test set the override before importing the route.

### Malformed values degrade, never disable

`execFile` treats `0` as *no timeout*, so a typo must never hang a turn on a wedged binary. Anything that is not a finite number greater than zero falls back to 5s — covered for `0`, negatives, `NaN`, `Infinity`, and unparseable strings.

### Verified end to end, not just at the parser

Parser tests alone would not prove the knob reaches the probe. Setting the override to **1 ms** makes the integration test fail with the bead's exact assertion, and the recorded argv shows the generic fallback path:

```
coven argv: [["run","--help"],["run","--help"],["run","--help"],
             ["adapter","list","--json"],
             ["run","codex","--stream-json","--familiar","opal", ...]]
```

That is the CI failure mode reproduced deterministically, which also means this test now has a way to prove the fallback path on purpose rather than by accident.

### Verification

- `codex-compatibility.test.ts`, `harness-routing-codex-direct.test.ts`, `route-codex-runtime-availability.integration.test.ts` — all pass
- red-checked both directions: stubbing the env read fails the parser tests; a 1 ms override fails the routing test
- `tsc --noEmit` clean