### PR TITLE
fix(ci): skip an un-dispatchable PR head instead of aborting the whole recovery

### DIFF
--- a/scripts/ci-recovery.mjs
+++ b/scripts/ci-recovery.mjs
@@ -79,10 +79,12 @@ export async function runCiRecovery({
         skipped.push({ number: recovery.number, reason: drift });
         continue;
       }
-      dispatchable.push({
-        recovery,
-        supportsExpectedSha: await workflowSupportsExpectedSha(context, recovery.sha),
-      });
+      const contract = await inspectRecoveryDispatch(context, recovery.sha);
+      if (!contract.dispatchable) {
+        skipped.push({ number: recovery.number, reason: "workflow_not_dispatchable" });
+        continue;
+      }
+      dispatchable.push({ recovery, supportsExpectedSha: contract.supportsExpectedSha });
     }
   }
 
@@ -104,9 +106,16 @@ export async function runCiRecovery({
         `${recovery.dispatched ? "dispatched" : "eligible"} ${recovery.ref} ${recovery.sha.slice(0, 12)}`,
     );
   }
+  // Say what was dropped. `skipped` was collected and never printed, so a run
+  // that recovered only some of its candidates read exactly like one that
+  // recovered all of them.
+  for (const entry of skipped) {
+    log(`#${entry.number} skipped ${entry.reason}`);
+  }
   log(
     `CI recovery: ${result.scanned} open PR${result.scanned === 1 ? "" : "s"} scanned; ` +
-      `${recoveries.length} ${apply ? "dispatched" : "eligible"}.`,
+      `${recoveries.length} ${apply ? "dispatched" : "eligible"}` +
+      `${skipped.length > 0 ? `; ${skipped.length} skipped` : ""}.`,
   );
   return result;
 }
@@ -280,7 +289,19 @@ async function workflowJobCount(context, runId) {
   return payload.total_count;
 }
 
-async function workflowSupportsExpectedSha(context, sha) {
+/** Inspect the CI workflow at an exact head and decide how it may be dispatched.
+ *
+ *  Three outcomes, and keeping them distinct is the whole point:
+ *  - `{dispatchable: false}` — that head's ci.yml has no `workflow_dispatch`
+ *    trigger, so it cannot be dispatched by anyone. A permanent fact about the
+ *    branch, not an ambiguity, so the caller skips this candidate and continues.
+ *  - `{dispatchable: true, supportsExpectedSha}` — dispatch it, with the SHA
+ *    guard when the head carries the complete guarded contract.
+ *  - throws — the guard contract is only PARTIALLY configured. That one stays
+ *    fatal: we cannot tell whether the exact-SHA guard will be honoured, so a
+ *    dispatch might silently test a different commit than the one we checked.
+ */
+async function inspectRecoveryDispatch(context, sha) {
   const url =
     `${context.apiUrl}/repos/${context.repositoryPath}/contents/.github/workflows/${WORKFLOW_FILE}` +
     `?ref=${encodeURIComponent(sha)}`;
@@ -308,7 +329,11 @@ async function workflowSupportsExpectedSha(context, sha) {
     typeof triggers !== "object" ||
     !Object.hasOwn(triggers, "workflow_dispatch")
   ) {
-    throw new Error("CI workflow does not support recovery dispatches");
+    // Un-dispatchable, not ambiguous. This used to throw, which aborted the
+    // WHOLE apply — so a single stale branch whose ci.yml predates dispatch
+    // support disabled recovery for every other PR in the repository
+    // (cave-qibp6: #4646 blocked #4643 and #4641, and nothing was dispatched).
+    return { dispatchable: false, supportsExpectedSha: false };
   }
   const inputs = workflow?.on?.workflow_dispatch?.inputs;
   const expectedInput =
@@ -337,14 +362,16 @@ async function workflowSupportsExpectedSha(context, sha) {
     workflow?.jobs?.build?.if === EXPECTED_JOB_GUARD &&
     !Object.hasOwn(workflow?.jobs ?? {}, "paths") &&
     !Object.hasOwn(workflow?.jobs ?? {}, "ios");
-  if (hasCompleteGuardedContract || hasPreviousGuardedContract) return true;
+  if (hasCompleteGuardedContract || hasPreviousGuardedContract) {
+    return { dispatchable: true, supportsExpectedSha: true };
+  }
 
   const hasGuardedProtocolMarker =
     hasExpectedInput || JSON.stringify(workflow).includes("inputs.expected_sha");
   if (hasGuardedProtocolMarker) {
     throw new Error("CI workflow recovery contract was partially configured");
   }
-  return false;
+  return { dispatchable: true, supportsExpectedSha: false };
 }
 
 async function dispatchWorkflow(context, ref, expectedSha, supportsExpectedSha) {

--- a/scripts/ci-recovery.test.mjs
+++ b/scripts/ci-recovery.test.mjs
@@ -301,6 +301,90 @@ test("apply fails closed when the required job lacks the expected SHA guard", as
   assert.equal(fixture.requests.some((request) => request.method === "POST"), false);
 });
 
+test("an un-dispatchable head is skipped without blocking the other candidates", async () => {
+  // The head listed FIRST is the un-dispatchable one, because that is the case
+  // that used to abort everything: its ci.yml predates workflow_dispatch, so it
+  // can never be dispatched by anyone, and throwing for it stranded every other
+  // eligible PR in the repository (cave-qibp6).
+  const stale = pull({ number: 4646, sha: "c".repeat(40), branch: "codex/stale-workflow" });
+  const healthy = pull({ number: 4643, sha: "d".repeat(40), branch: "codex/current-workflow" });
+  const fixture = githubFixture({
+    pulls: [stale, healthy],
+    workflowsBySha: {
+      [stale.head.sha]: "name: CI\non:\n  pull_request:\n",
+      [healthy.head.sha]: GUARDED_CI_WORKFLOW,
+    },
+  });
+  const messages = [];
+
+  const result = await runCiRecovery(
+    options(fixture.fetchImpl, true, { log: (message) => messages.push(message) }),
+  );
+
+  assert.deepEqual(
+    result.recoveries.map((recovery) => recovery.number),
+    [healthy.number],
+  );
+  assert.deepEqual(result.skipped, [
+    { number: stale.number, reason: "workflow_not_dispatchable" },
+  ]);
+  assert.deepEqual(
+    fixture.requests.filter((request) => request.method === "POST"),
+    [
+      {
+        method: "POST",
+        path: `/repos/${REPOSITORY}/actions/workflows/ci.yml/dispatches`,
+        body: { ref: healthy.head.ref, inputs: { expected_sha: healthy.head.sha } },
+      },
+    ],
+  );
+  // A dropped candidate has to be visible; a silent skip reads as full coverage.
+  assert.equal(
+    messages.some((message) => message.includes("#4646 skipped workflow_not_dispatchable")),
+    true,
+  );
+  assert.equal(messages.some((message) => message.includes("1 skipped")), true);
+});
+
+test("a partial guard contract still aborts every dispatch, even beside a healthy candidate", async () => {
+  // The safety property the skip above must not have weakened. A partial
+  // contract is ambiguous rather than un-dispatchable: the exact-SHA guard may
+  // not be honoured, so the dispatch could test a different commit. That stays
+  // fatal for the whole run, before any mutation.
+  const partial = pull({ number: 1, sha: "e".repeat(40), branch: "fix/partial" });
+  const healthy = pull({ number: 2, sha: "f".repeat(40), branch: "fix/healthy" });
+  const fixture = githubFixture({
+    pulls: [partial, healthy],
+    workflowsBySha: {
+      [partial.head.sha]: GUARDED_CI_WORKFLOW.replace(`run-name: ${GUARDED_RUN_NAME}\n`, ""),
+      [healthy.head.sha]: GUARDED_CI_WORKFLOW,
+    },
+  });
+
+  await assert.rejects(
+    runCiRecovery(options(fixture.fetchImpl, true)),
+    /CI workflow recovery contract was partially configured/,
+  );
+  assert.equal(fixture.requests.some((request) => request.method === "POST"), false);
+});
+
+test("a legacy dispatchable head is still dispatched without inputs", async () => {
+  const legacy = pull({ number: 7, sha: "b".repeat(40) });
+  const fixture = githubFixture({
+    pulls: [legacy],
+    workflowsBySha: { [legacy.head.sha]: "name: CI\non:\n  workflow_dispatch:\n" },
+  });
+
+  const result = await runCiRecovery(options(fixture.fetchImpl, true));
+
+  assert.equal(result.recoveries[0].dispatched, true);
+  assert.deepEqual(result.skipped, []);
+  assert.deepEqual(
+    fixture.requests.filter((request) => request.method === "POST")[0].body,
+    { ref: legacy.head.ref },
+  );
+});
+
 test("existing CI, young PRs, drafts, and fork heads are never dispatched", async () => {
   const healthy = pull({ number: 1, sha: "1".repeat(40) });
   const young = pull({


### PR DESCRIPTION
## The outage

`pnpm ci:recovery:apply` currently exits 1 with `ci-recovery: CI workflow does not support recovery dispatches` and dispatches **nothing at all** — while three PRs sit `BLOCKED` with no `Frontend build` run on their head and nothing visibly failing.

## Cause

`workflowSupportsExpectedSha()` (`scripts/ci-recovery.mjs`) inspects `.github/workflows/ci.yml` at each candidate head and **throws** when that head has no `workflow_dispatch` trigger. The call sits inside the deliberate *"complete every candidate read before the first mutation"* loop, so the throw escapes `runCiRecovery` entirely and no candidate is dispatched — including candidates whose own workflow is perfectly dispatchable.

Observed 2026-08-14. Eligible candidates and their `workflow_dispatch` occurrence counts in `ci.yml` at that exact head:

| PR | head | occurrences |
|----|------|-------------|
| #4646 | `a23a8a5813fa` | **0** |
| #4643 | `b1f565dfe6bc` | 8 |
| #4641 | `df58dd1459b6` | 5 |
| (`main`) | — | 8 |

#4646 is an old branch predating dispatch support, and it alone blocked recovery for the two that would have worked. **Any** stale long-lived branch does this, permanently and repository-wide.

## The fix

Split the two cases the single `throw` was conflating:

- **No `workflow_dispatch` trigger** → that head cannot be dispatched by anyone, ever. A permanent fact about the branch, not an ambiguity. Skip the candidate with a stated reason and carry on.
- **A *partially* configured guard contract** → **still aborts the whole apply, before any mutation.** This one is a genuine safety property: we cannot tell whether the exact-SHA guard will be honoured, so a dispatch could silently test a different commit than the one we checked. `CLAUDE.md` documents this abort and it is unchanged.

A test pins the partial-guard abort *alongside a healthy candidate*, so the safety property cannot be quietly weakened by a later change.

Also: **print skipped candidates.** `skipped` was collected into the result and never passed to `log()`, so a run that recovered only some of its candidates read exactly like one that recovered all of them.

Renamed to `inspectRecoveryDispatch` because it now returns three outcomes rather than a boolean — overloading a falsy return here would be easy to misread.

## Verification

- `node --test scripts/ci-recovery.test.mjs` → **27 pass, 0 fail** (24 existing + 3 new)
- `node --test scripts/ci-recovery-workflow.test.mjs` → 1 pass, 0 fail
- Against the **pre-fix** `ci-recovery.mjs` the new suite is **26 pass / 1 fail** — the un-dispatchable test. The other two new tests pass on both old and new code by design: they are regression guards for the partial-guard abort and the legacy no-input dispatch.
- `eslint` clean on both changed files.

Does not touch branch protection, and does not change what counts as CI coverage — the required `Frontend build` context still has to report and pass on the exact head.

Closes cave-qibp6.