### PR TITLE
fix(tests): restore green main after two merges landed without their tests

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -229,6 +229,10 @@ const contracts: RouteContract[] = [
   { route: "/research/generations/cancel", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/research/generations/infographic", methods: ["GET"], kind: "stream", localOriginGuard: true, pathGuard: true },
   { route: "/research/generations/media", methods: ["GET"], kind: "stream", localOriginGuard: true, pathGuard: true },
+  // Mints the signed ticket the media route above consumes. No pathGuard: it
+  // never resolves a filesystem path — it validates familiarId/id as opaque
+  // ids and returns a URL, so there is no "path not allowed" 403 to preserve.
+  { route: "/research/generations/media-ticket", methods: ["GET"], kind: "json", localOriginGuard: true },
   { route: "/research/generations/readiness", methods: ["GET"], kind: "json", localOriginGuard: true },
   { route: "/research/generations/render", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/research/links", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
@@ -413,8 +417,29 @@ for (const contract of contracts) {
     // (/x/oauth/start passes rejectNonLocalRequest into
     // createXOAuthStartRouteHandlers, which calls it), and reading only the
     // route file would report that as a missing guard when it is present.
-    assert.match(effectiveSource, /isLocalOrigin|rejectNonLocalRequest/, `${contract.route} must preserve local-origin guard`);
-    if (effectiveSource.includes("rejectNonLocalRequest")) {
+    // rejectResearchMediaRequest counts: it CALLS rejectNonLocalRequest first
+    // and returns null whenever that passes, so it is a narrowing rather than a
+    // weakening. It relaxes only when the host and the origin are both local
+    // AND a signed media ticket validates — the carve-out exists because a
+    // native <audio>/<video> element cannot go through patched fetch, so the
+    // ticket proves the sidecar credential instead (#4634).
+    assert.match(
+      effectiveSource,
+      /isLocalOrigin|rejectNonLocalRequest|rejectResearchMediaRequest/,
+      `${contract.route} must preserve local-origin guard`,
+    );
+    if (effectiveSource.includes("rejectResearchMediaRequest")) {
+      assert.match(effectiveSource, /rejectResearchMediaRequest\(req\)/, `${contract.route} must call the shared media guard`);
+      const guardSource = readFileSync(
+        path.join(apiRoot, "..", "..", "lib", "server", "api-security.ts"),
+        "utf8",
+      );
+      assert.match(
+        guardSource,
+        /export async function rejectResearchMediaRequest[\s\S]{0,200}rejectNonLocalRequest\(req\)/,
+        "rejectResearchMediaRequest must still delegate to the local-origin guard",
+      );
+    } else if (effectiveSource.includes("rejectNonLocalRequest")) {
       assert.match(effectiveSource, /rejectNonLocalRequest\(req\)/, `${contract.route} must call the shared local-origin guard`);
     } else {
       assert.match(effectiveSource, /status:\s*403/, `${contract.route} local-origin guard must preserve 403 response`);

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -356,7 +356,16 @@ assert.match(
 assert.match(source, /const \[selectMode, setSelectMode\] = useState\(false\)/, "a select mode toggles bulk-select");
 assert.match(source, /const \[selectedIds, setSelectedIds\] = useState<Set<string>>/, "selected chat ids live in a Set");
 assert.match(source, /setSelectMode\(\(v\) => !v\); setSelectedIds\(new Set\(\)\)/, "the header Select toggle clears any selection");
-assert.match(source, /useEffect\(\(\) => \{ setSelectMode\(false\); setSelectedIds\(new Set\(\)\); \}, \[familiar\?\.id\]\)/, "selection resets when the active familiar changes");
+// Behavior, not formatting: the effect must be keyed on the active familiar and
+// must clear BOTH the mode and the ids. It was pinned to a single-line literal
+// with an exact `[familiar?.id]` dep list, so #4647 broke it by reformatting the
+// body and adding clearSessionFilters() to the same effect — a change that
+// strictly does MORE of what this guards, yet failed the suite on every PR.
+assert.match(
+  source,
+  /useEffect\(\(\) => \{[\s\S]{0,200}?setSelectMode\(false\);[\s\S]{0,120}?setSelectedIds\(new Set\(\)\);[\s\S]{0,120}?\}, \[[^\]]*familiar\?\.id[^\]]*\]\)/,
+  "selection resets when the active familiar changes",
+);
 assert.match(source, /role=\{selectMode \? "checkbox" : "button"\}/, "rows are checkboxes in select mode");
 // Row click = open (Sessions): clicking a row opens the session directly on
 // every device; select mode still toggles selection. The old inline detail

--- a/tests/research-studio-media.spec.ts
+++ b/tests/research-studio-media.spec.ts
@@ -216,7 +216,16 @@ async function boot(
   // is what actually suppresses it. (cave-4xv9v)
   await page.addInitScript(() => {
     const add = HTMLMediaElement.prototype.addEventListener;
-    HTMLMediaElement.prototype.addEventListener = function patched(type, listener, options) {
+    // Annotate every parameter and `this` explicitly. `as typeof add` asserts
+    // the assembled function's TYPE but does not contextually type the function
+    // expression's parameters, so under noImplicitAny they were four errors
+    // (TS7006 ×3 plus TS2683 on `this`) and typecheck failed.
+    HTMLMediaElement.prototype.addEventListener = function patched(
+      this: HTMLMediaElement,
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions,
+    ) {
       if (type === "error") return;
       return add.call(this, type, listener, options);
     } as typeof add;

--- a/tests/research-studio-media.spec.ts
+++ b/tests/research-studio-media.spec.ts
@@ -204,6 +204,23 @@ async function boot(
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
     window.localStorage.setItem("cave:active-familiar", "rida");
   });
+  // #4634 wired onError={reportPlaybackFailure} onto the <audio>/<video>
+  // elements, which tears the player AND its Download link out of the DOM the
+  // moment the browser cannot decode the source. This harness has always served
+  // a 1-byte placeholder for /media — harmless before that change, fatal after —
+  // so the media assertions began failing on every PR without the product being
+  // broken. This suite has no real codecs and no media fixtures; it fakes the
+  // whole backend already, so it fakes decode support too rather than shipping
+  // a binary just to satisfy a decoder. React binds media events directly to
+  // the element (they do not bubble), so dropping the listener at registration
+  // is what actually suppresses it. (cave-4xv9v)
+  await page.addInitScript(() => {
+    const add = HTMLMediaElement.prototype.addEventListener;
+    HTMLMediaElement.prototype.addEventListener = function patched(type, listener, options) {
+      if (type === "error") return;
+      return add.call(this, type, listener, options);
+    } as typeof add;
+  });
   await page.route("**/api/familiars**", (route) =>
     route.fulfill({
       json: {
@@ -277,6 +294,25 @@ async function boot(
                 ? undefined
                 : "Install ffmpeg and download a local voice.",
             },
+          },
+        });
+        return;
+      }
+      // #4634 put a ticket hop in front of playback: the client asks for a
+      // signed media URL and only renders <audio>/<video> once it resolves, so
+      // an unmocked ticket meant no media element at all and the viewer showed
+      // "Couldn't load podcast audio." The spec's route regex already matched
+      // this path, so the request was intercepted and fell through to the
+      // generations LIST response — shaped nothing like a ticket — rather than
+      // reaching a real handler. Answer it before /media, whose bytes the
+      // resolved URL then requests. (cave-4xv9v)
+      if (url.pathname.endsWith("/media-ticket")) {
+        const familiarId = url.searchParams.get("familiarId") ?? "";
+        const id = url.searchParams.get("id") ?? "";
+        await route.fulfill({
+          json: {
+            ok: true,
+            mediaUrl: `/api/research/generations/media?familiarId=${encodeURIComponent(familiarId)}&id=${encodeURIComponent(id)}`,
           },
         });
         return;


### PR DESCRIPTION
Closes `cave-4xv9v`. **`main` is red and every open PR inherits it** — this unblocks all of them.

Reproduced on clean `main` (`57e944d59`), and the identical two failures appear on unrelated PRs (#4652 and #4647's own head) at near-identical job durations, so neither belongs to any one PR.

### 1. A new route with no API contract entry

#4634 added `src/app/api/research/generations/media-ticket/route.ts` and no contract entry, so `api-contracts.test.ts` failed on *"every src/app/api route must have an API contract entry"* (59 passed before it).

Added it as `GET` / `json` / `localOriginGuard`. Deliberately **not** `pathGuard`: that flag asserts a `"path not allowed"` 403, and this route resolves no filesystem path — it validates `familiarId`/`id` as opaque ids and returns a URL.

### 2. …which unmasked a second failure underneath it

With the route list matching, the per-contract loop finally ran and failed on **`/research/generations/media` must preserve local-origin guard**. #4634 had also swapped that route from `rejectNonLocalRequest` to `rejectResearchMediaRequest`, a name the guard regex didn't recognize.

I checked whether that was a weakening before touching the contract. It isn't:

```ts
export async function rejectResearchMediaRequest(req) {
  const ordinary = rejectNonLocalRequest(req);
  if (!ordinary) return null;                     // identical when the ordinary guard passes
  …                                                // else: host local, origin local,
  return await isValidResearchMediaTicketRequest(req, secret) ? null : ordinary;
}
```

It calls the ordinary guard first and only relaxes when host **and** origin are local **and** a signed ticket validates — the carve-out exists because a native `<audio>`/`<video>` element cannot go through patched fetch. So the contract now **recognizes** the guard rather than being loosened, and additionally asserts that the delegation to `rejectNonLocalRequest` still exists in `api-security.ts` — so the guard can't be hollowed out later while the route keeps its name.

### 3. A stale source-text pin

`chat-list-delete.test.ts` failed on *"selection resets when the active familiar changes"* (493 passed before it). #4647 reformatted the one-line effect into a multi-line body and added `clearSessionFilters()` to it:

```diff
-  useEffect(() => { setSelectMode(false); setSelectedIds(new Set()); }, [familiar?.id]);
+  useEffect(() => {
+    clearSessionFilters();
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }, [clearSessionFilters, familiar?.id]);
```

The guarded behavior is intact and now does strictly *more*. The pin encoded the old formatting and an exact `[familiar?.id]` dep list, so a change that improved the code failed the suite on every PR. Rewritten to assert behavior — an effect keyed on `familiar?.id` that clears **both** the mode and the ids — tolerant of formatting and dep order.

### Verification

- both failures reproduced on clean `main` first, then fixed
- `api-contracts.test.ts` — **282 route contracts** pass
- red-checked: removing `setSelectedIds(new Set())` still fails the rewritten pin
- `tsc --noEmit` clean

Note the `app` suite stops at its first failure, so there may be further failures after `chat-list-delete` that were never reached. CI on this branch is the check for that.