### PR TITLE
Harden research media contract tests

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -429,7 +429,11 @@ for (const contract of contracts) {
       `${contract.route} must preserve local-origin guard`,
     );
     if (effectiveSource.includes("rejectResearchMediaRequest")) {
-      assert.match(effectiveSource, /rejectResearchMediaRequest\(req\)/, `${contract.route} must call the shared media guard`);
+      assert.match(
+        effectiveSource,
+        /await\s+rejectResearchMediaRequest\(\s*[A-Za-z_$][\w$]*\s*\)/,
+        `${contract.route} must call the shared media guard`,
+      );
       const guardSource = readFileSync(
         path.join(apiRoot, "..", "..", "lib", "server", "api-security.ts"),
         "utf8",

--- a/tests/research-studio-media.spec.ts
+++ b/tests/research-studio-media.spec.ts
@@ -6,6 +6,33 @@ const MISSION_ID = "m-media";
 const ELEVENLABS_VOICE_ID = DEFAULT_ELEVENLABS_VOICE_ID;
 const now = new Date().toISOString();
 
+function createSilentWav() {
+  const sampleRate = 8_000;
+  const dataBytes = 160;
+  const wav = Buffer.alloc(44 + dataBytes);
+  wav.write("RIFF", 0);
+  wav.writeUInt32LE(36 + dataBytes, 4);
+  wav.write("WAVEfmt ", 8);
+  wav.writeUInt32LE(16, 16);
+  wav.writeUInt16LE(1, 20);
+  wav.writeUInt16LE(1, 22);
+  wav.writeUInt32LE(sampleRate, 24);
+  wav.writeUInt32LE(sampleRate * 2, 28);
+  wav.writeUInt16LE(2, 32);
+  wav.writeUInt16LE(16, 34);
+  wav.write("data", 36);
+  wav.writeUInt32LE(dataBytes, 40);
+  return wav;
+}
+
+// One black 16x16 H.264 frame. Real media bytes keep the browser from firing
+// the viewer's playback-error path before the assertions can inspect it.
+const BLACK_MP4 = Buffer.from(
+  "AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAMtbW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAHgAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAld0cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAB4AAAAAAABAAAAAAHPbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAAAyAAAABgBVxAAAAAAALWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABWaWRlb0hhbmRsZXIAAAABem1pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAAATpzdGJsAAAAtnN0c2QAAAAAAAAAAQAAAKZhdmMxAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAABAAEABIAAAASAAAAAAAAAABFUxhdmM2Mi4yOC4xMDEgbGlieDI2NAAAAAAAAAAAAAAAGP//AAAALGF2Y0MBQsAK/+EAFWdCwAraewEQAAADABAAAAMDIPEiagEABGjOD8gAAAAQcGFzcAAAAAEAAAABAAAAFGJ0cnQAAAAAAAClGgAAAAAAAAAYc3R0cwAAAAAAAAABAAAAAwAAAgAAAAAUc3RzcwAAAAAAAAABAAAAAQAAABxzdHNjAAAAAAAAAAEAAAABAAAAAwAAAAEAAAAgc3RzegAAAAAAAAAAAAAAAwAAAmgAAAAJAAAACQAAABRzdGNvAAAAAAAAAAEAAANdAAAAYnVkdGEAAABabWV0YQAAAAAAAAAhaGRscgAAAAAAAAAAbWRpcmFwcGwAAAAAAAAAAAAAAAAtaWxzdAAAACWpdG9vAAAAHWRhdGEAAAABAAAAAExhdmY2Mi4xMi4xMDEAAAAIZnJlZQAAAoJtZGF0AAACVgYF//9S3EXpvebZSLeWLNgg2SPu73gyNjQgLSBjb3JlIDE2NSByMzIyMiBiMzU2MDVhIC0gSC4yNjQvTVBFRy00IEFWQyBjb2RlYyAtIENvcHlsZWZ0IDIwMDMtMjAyNSAtIGh0dHA6Ly93d3cudmlkZW9sYW4ub3JnL3gyNjQuaHRtbCAtIG9wdGlvbnM6IGNhYmFjPTAgcmVmPTEgZGVibG9jaz0wOi0zOi0zIGFuYWx5c2U9MDowIG1lPWRpYSBzdWJtZT0wIHBzeT0xIHBzeV9yZD0yLjAwOjAuNzAgbWl4ZWRfcmVmPTAgbWVfcmFuZ2U9MTYgY2hyb21hX21lPTEgdHJlbGxpcz0wIDh4OGRjdD0wIGNxbT0wIGRlYWR6b25lPTIxLDExIGZhc3RfcHNraXA9MSBjaHJvbWFfcXBfb2Zmc2V0PTAgdGhyZWFkcz0xIGxvb2thaGVhZF90aHJlYWRzPTEgc2xpY2VkX3RocmVhZHM9MCBucj0wIGRlY2ltYXRlPTEgaW50ZXJsYWNlZD0wIGJsdXJheV9jb21wYXQ9MCBjb25zdHJhaW5lZF9pbnRyYT0wIGJmcmFtZXM9MCB3ZWlnaHRwPTAga2V5aW50PTI1MCBrZXlpbnRfbWluPTI1IHNjZW5lY3V0PTAgaW50cmFfcmVmcmVzaD0wIHJjPWNyZiBtYnRyZWU9MCBjcmY9MjMuMCBxY29tcD0wLjYwIHFwbWluPTAgcXBtYXg9NjkgcXBzdGVwPTQgaXBfcmF0aW89MS40MCBhcT0wAIAAAAAKZYiEOiYoAAkC4AAAAAVBmiAmlAAAAAVBmkAqlA==",
+  "base64",
+);
+const SILENT_WAV = createSilentWav();
+
 const MISSION = {
   version: 1,
   id: MISSION_ID,
@@ -204,32 +231,6 @@ async function boot(
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
     window.localStorage.setItem("cave:active-familiar", "rida");
   });
-  // #4634 wired onError={reportPlaybackFailure} onto the <audio>/<video>
-  // elements, which tears the player AND its Download link out of the DOM the
-  // moment the browser cannot decode the source. This harness has always served
-  // a 1-byte placeholder for /media — harmless before that change, fatal after —
-  // so the media assertions began failing on every PR without the product being
-  // broken. This suite has no real codecs and no media fixtures; it fakes the
-  // whole backend already, so it fakes decode support too rather than shipping
-  // a binary just to satisfy a decoder. React binds media events directly to
-  // the element (they do not bubble), so dropping the listener at registration
-  // is what actually suppresses it. (cave-4xv9v)
-  await page.addInitScript(() => {
-    const add = HTMLMediaElement.prototype.addEventListener;
-    // Annotate every parameter and `this` explicitly. `as typeof add` asserts
-    // the assembled function's TYPE but does not contextually type the function
-    // expression's parameters, so under noImplicitAny they were four errors
-    // (TS7006 ×3 plus TS2683 on `this`) and typecheck failed.
-    HTMLMediaElement.prototype.addEventListener = function patched(
-      this: HTMLMediaElement,
-      type: string,
-      listener: EventListenerOrEventListenerObject,
-      options?: boolean | AddEventListenerOptions,
-    ) {
-      if (type === "error") return;
-      return add.call(this, type, listener, options);
-    } as typeof add;
-  });
   await page.route("**/api/familiars**", (route) =>
     route.fulfill({
       json: {
@@ -307,21 +308,26 @@ async function boot(
         });
         return;
       }
-      // #4634 put a ticket hop in front of playback: the client asks for a
-      // signed media URL and only renders <audio>/<video> once it resolves, so
-      // an unmocked ticket meant no media element at all and the viewer showed
-      // "Couldn't load podcast audio." The spec's route regex already matched
-      // this path, so the request was intercepted and fell through to the
-      // generations LIST response — shaped nothing like a ticket — rather than
-      // reaching a real handler. Answer it before /media, whose bytes the
-      // resolved URL then requests. (cave-4xv9v)
+      // Playback resolves a scoped URL before the native media request.
       if (url.pathname.endsWith("/media-ticket")) {
-        const familiarId = url.searchParams.get("familiarId") ?? "";
         const id = url.searchParams.get("id") ?? "";
+        const target = records.get(id);
+        if (!target || target.status !== "ready") {
+          await route.fulfill({
+            status: 404,
+            json: { ok: false, error: "media not found" },
+          });
+          return;
+        }
+        const params = new URLSearchParams({
+          familiarId: FAMILIAR_ID,
+          id,
+          mediaTicket: "e2e-ticket",
+        });
         await route.fulfill({
           json: {
             ok: true,
-            mediaUrl: `/api/research/generations/media?familiarId=${encodeURIComponent(familiarId)}&id=${encodeURIComponent(id)}`,
+            mediaUrl: `/api/research/generations/media?${params}`,
           },
         });
         return;
@@ -329,14 +335,13 @@ async function boot(
       if (url.pathname.endsWith("/media")) {
         const target = records.get(url.searchParams.get("id") ?? "");
         await route.fulfill({
-          status: 206,
+          status: 200,
           headers: {
             "content-type":
               target?.kind === "podcast" ? "audio/wav" : "video/mp4",
-            "content-range": "bytes 0-0/1",
             "accept-ranges": "bytes",
           },
-          body: "0",
+          body: target?.kind === "podcast" ? SILENT_WAV : BLACK_MP4,
         });
         return;
       }


### PR DESCRIPTION
## Summary
- require the shared research-media guard to be awaited without coupling the contract to a specific request parameter name
- exercise the signed media-ticket exchange with valid silent WAV and black MP4 bytes
- remove the E2E monkey patch that suppressed playback-error handling

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test:app
- pnpm test:api (379 files)
- pnpm check:tests-wired (1,671 files)
- COVEN_CAVE_PORT=3101 pnpm exec playwright test tests/research-studio-media.spec.ts --project=desktop (7 tests)

Bead: cave-l2co4