### PR TITLE
fix(grimoire): scope the graph scan before truncating it

### DIFF
--- a/src/app/api/grimoire/graph/route.ts
+++ b/src/app/api/grimoire/graph/route.ts
@@ -4,18 +4,54 @@ import { scanGrimoireGraph } from "@/lib/server/grimoire-graph-scan";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+/** Same shape rule the research routes apply to a familiar id. */
+const FAMILIAR_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
 /**
- * Grimoire graph — the full-corpus doc graph (cave-hand).
+ * A scope is a familiar multiselect, so a handful of ids. The bound keeps a
+ * hostile query string from making the server build a large Set and re-scan
+ * against it; it is not a correctness limit.
+ */
+const MAX_SCOPE_IDS = 64;
+
+/**
+ * Grimoire graph — the doc graph (cave-hand), optionally scoped to familiars.
  *
- *   GET /api/grimoire/graph → { ok, nodes, edges, meta }
+ *   GET /api/grimoire/graph                         → coven-wide
+ *   GET /api/grimoire/graph?familiarId=a&familiarId=b → scoped to {a, b}
  *
  * Nodes cover every knowledge entry, scanned memory file, and journal day
  * (orphans included); edges carry their generator (`link` / `mention` / `tag`).
- * `meta` reports the scan bounds so the client can say what was left out
- * rather than truncating silently. Takes no input, so there is no
- * user-controlled path to guard.
+ * `meta` reports the scan bounds so the client can say what was left out rather
+ * than truncating silently.
+ *
+ * The scope is applied BEFORE the scan cap (cave-z6xvd), so a scoped request
+ * returns that familiar's most-recent N rather than their slice of the coven's
+ * most-recent N.
+ *
+ * On the input guard: this route previously took none, so its comment said
+ * there was "no user-controlled path to guard". That is still true of the
+ * filesystem — a scope id is only ever compared for equality against the
+ * `familiarId` already recorded on inventory entries, and never joined into a
+ * path, so an unknown id matches nothing by construction rather than by
+ * validation. The shape and count checks below therefore exist to bound the
+ * input and reject obvious garbage early, not to prevent traversal.
  */
-export async function GET() {
-  const { graph, meta } = await scanGrimoireGraph();
+export async function GET(req: Request) {
+  const requested = new URL(req.url).searchParams
+    .getAll("familiarId")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  if (requested.length > MAX_SCOPE_IDS) {
+    return NextResponse.json(
+      { ok: false, error: `at most ${MAX_SCOPE_IDS} familiarId values` },
+      { status: 400 },
+    );
+  }
+  if (requested.some((value) => !FAMILIAR_ID_RE.test(value))) {
+    return NextResponse.json({ ok: false, error: "invalid familiarId" }, { status: 400 });
+  }
+
+  const { graph, meta } = await scanGrimoireGraph(new Set(requested));
   return NextResponse.json({ ok: true, nodes: graph.nodes, edges: graph.edges, meta });
 }

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -356,7 +356,20 @@ assert.match(view, /b\.type === "mention" \? "Mentions this doc \(unlinked\)" : 
 assert.match(view, /from "@\/lib\/grimoire-graph"/, "grimoire-view builds the fallback graph via the graph lib");
 assert.match(view, /import\("@\/components\/grimoire-graph-view"\)/, "the canvas graph is lazy-loaded (dynamic import)");
 assert.match(view, /ssr: false/, "the graph view is client-only (no SSR)");
-assert.match(view, /fetch\("\/api\/grimoire\/graph"/, "the full-corpus graph comes from the server scan");
+assert.match(view, /fetch\(`\/api\/grimoire\/graph\$\{params\}`/, "the graph comes from the server scan");
+// cave-z6xvd: the familiar scope rides the request so the scan's cap applies to
+// the scoped set. Scoping only on the client meant a familiar saw their (F/T)
+// slice of the coven's most-recent N, never all of their own files.
+assert.match(
+  view,
+  /familiarId=\$\{encodeURIComponent\(id\)\}/,
+  "the scan request carries the familiar scope",
+);
+assert.match(
+  view,
+  /\}, \[scanTick, scopeKey\]\)/,
+  "the scan refetches when the scope changes, keyed by value so a new Set identity alone does not",
+);
 assert.match(view, /const localGraph = useMemo\([\s\S]{0,200}buildDocGraph\(/, "the fallback graph is memoized from buildDocGraph");
 assert.match(view, /markdown: k\.body/, "the fallback graph reads each knowledge body (already loaded)");
 assert.match(view, /const graph = scan\?\.graph \?\? localGraph/, "the server scan wins, the local graph stands in — never blank");

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -143,7 +143,7 @@ type GrimoireGraphScan = {
   refreshGraph: () => void;
 };
 
-function useGrimoireGraphScan(): GrimoireGraphScan {
+function useGrimoireGraphScan(familiarScope: ReadonlySet<string>): GrimoireGraphScan {
   const [state, setState] = useState<Omit<GrimoireGraphScan, "refreshGraph">>({
     scan: null,
     scanning: true,
@@ -151,12 +151,24 @@ function useGrimoireGraphScan(): GrimoireGraphScan {
   });
   const [scanTick, setScanTick] = useState(0);
 
+  // Key the scan on the scope's VALUE, not the Set's identity. `scopeFamiliarIds`
+  // is a new Set on most parent renders, so depending on it directly would
+  // refetch the whole corpus on every render rather than when the selection
+  // actually changes (cave-z6xvd).
+  const scopeKey = useMemo(() => [...familiarScope].sort().join(","), [familiarScope]);
+
   useEffect(() => {
     const controller = new AbortController();
     setState((s) => ({ ...s, scanning: true }));
     void (async () => {
       try {
-        const res = await fetch("/api/grimoire/graph", { cache: "no-store", signal: controller.signal });
+        // Scoping server-side means the cap applies to THIS familiar's files
+        // rather than the coven's, so a scoped view is complete up to the cap
+        // instead of showing its (F/T) slice.
+        const params = scopeKey
+          ? `?${scopeKey.split(",").map((id) => `familiarId=${encodeURIComponent(id)}`).join("&")}`
+          : "";
+        const res = await fetch(`/api/grimoire/graph${params}`, { cache: "no-store", signal: controller.signal });
         const json = await res.json();
         if (controller.signal.aborted) return;
         if (json.ok && Array.isArray(json.nodes) && Array.isArray(json.edges)) {
@@ -179,7 +191,7 @@ function useGrimoireGraphScan(): GrimoireGraphScan {
       }
     })();
     return () => controller.abort();
-  }, [scanTick]);
+  }, [scanTick, scopeKey]);
 
   const refreshGraph = useCallback(() => setScanTick((t) => t + 1), []);
   return { ...state, refreshGraph };
@@ -752,7 +764,9 @@ export function GrimoireView({
     },
     [controlledView, onViewChange],
   );
-  const { scan, scanning, scanError, refreshGraph } = useGrimoireGraphScan();
+  const { scan, scanning, scanError, refreshGraph } = useGrimoireGraphScan(
+    scopeFamiliarIds ?? EMPTY_FAMILIAR_SCOPE,
+  );
   const [collapsedSections, setCollapsedSections] = useState<Record<RailSectionId, boolean>>(
     readCollapsedSections,
   );

--- a/src/lib/server/grimoire-graph-scan.test.ts
+++ b/src/lib/server/grimoire-graph-scan.test.ts
@@ -48,10 +48,19 @@ assert.match(
   /O\(n²\)/,
   "the cap documents the O(n²) renderer constraint that actually bounds it",
 );
+// cave-z6xvd inverted this: the cap is applied AFTER the scope now, so the doc
+// must say so. The previous pin asserted the OPPOSITE ordering, which is how
+// this test earns its keep — a change to the ordering cannot land while the
+// comment still promises the old one.
 assert.match(
   scan,
-  /applied coven-wide BEFORE the\s*\n?\s*\*? ?client's familiar scoping/,
-  "the cap documents that it precedes familiar scoping — the limitation raising it cannot fix",
+  /applied AFTER the familiar scope/,
+  "the cap documents that the scope precedes it, which is what makes a scoped view complete",
+);
+assert.match(
+  scan,
+  /familiarInScope\(familiarScope, m\.familiarId\)/,
+  "the memory set is scoped BEFORE it is truncated, not after",
 );
 
 // ── Bounds are reported, never silently applied ──────────────────────────────
@@ -60,8 +69,15 @@ assert.match(
 // the notice unable to say what was left out.
 assert.match(
   scan,
-  /memory: \{ scanned: memoryScanSet\.length, total: memoryMarkdown\.length \}/,
+  /scanned: memoryScanSet\.length,[\s\S]{0,80}total: memoryMarkdown\.length/,
   "meta reports both the scanned count and the true total for memory",
+);
+// Both counts are scope-relative once a scope is supplied, so the notice must be
+// able to tell which reading it holds rather than inferring it from the numbers.
+assert.match(
+  scan,
+  /scoped: familiarScope\.size > 0/,
+  "meta says whether its memory counts are scope-relative",
 );
 assert.match(
   scan,

--- a/src/lib/server/grimoire-graph-scan.ts
+++ b/src/lib/server/grimoire-graph-scan.ts
@@ -19,13 +19,21 @@ import { open } from "node:fs/promises";
 import { listKnowledgeEntries } from "./knowledge-vault";
 import { listMemoryFileEntries } from "./memory-file-inventory";
 import { listJournalEntries, readJournalEntry } from "./journal-store";
+import { familiarInScope } from "../familiar-multiselect";
 import { parseMdDocument } from "../md-frontmatter";
 import { buildDocGraph, type DocGraph, type GraphSourceDoc } from "../grimoire-graph";
 import type { WikiDocIndex } from "../wiki-link-resolve";
 
 export type GrimoireGraphMeta = {
   knowledge: { scanned: number };
-  memory: { scanned: number; total: number };
+  /**
+   * Scope-relative once a familiar scope is supplied: `total` counts the
+   * markdown memory files owned by the scope, not the whole coven, so
+   * `scanned < total` keeps meaning "this scope has more than the cap shows"
+   * rather than "the coven does" (cave-z6xvd). `scoped` says which reading
+   * applies, so the shortfall notice never has to infer it.
+   */
+  memory: { scanned: number; total: number; scoped: boolean };
   journal: { scanned: number; total: number };
 };
 
@@ -54,13 +62,19 @@ export type GrimoireGraphMeta = {
  * further is a RENDERER change first: make repulsion Barnes-Hut, or bound the
  * node count independently of the scan. Do not raise it on I/O evidence alone.
  *
- * Note what this cap can and cannot fix. It is applied coven-wide BEFORE the
- * client's familiar scoping, so a scoped view shows that familiar's slice of
- * the coven's most-recent N — never all of their files. Going 400 → 1200 took a
- * familiar owning 260 of ~2065 files from ~35 nodes to ~150, but closing the
- * gap entirely needs scoping to happen before truncation (cave-ed4s3). Until
- * then the graph view states the shortfall outright rather than implying the
- * scoped count is the familiar's whole corpus.
+ * The cap is now applied AFTER the familiar scope rather than coven-wide, so a
+ * scoped view gets that familiar's most-recent N instead of their slice of the
+ * coven's most-recent N (cave-z6xvd). It used to be the other way round, which
+ * meant a familiar owning F of T files saw roughly (F/T) × CAP of their own —
+ * 260 of ~2065 files is 12.6%, so 400 → 1200 moved them from ~35 nodes to ~150
+ * and reaching all 260 would have needed a cap near 2065, i.e. the whole corpus
+ * at 1.89s of settle time.
+ *
+ * Scoping first is why the cap no longer has to grow to fix that: coverage goes
+ * UP while the node count stays SMALL, so the O(n²) sim stays cheap. The
+ * unscoped ("All") view is unchanged and still bounded coven-wide by this cap,
+ * and the graph view still states any remaining shortfall outright — `meta`
+ * reports it scope-relative (cave-ed4s3).
  */
 export const MEMORY_SCAN_CAP = 1200;
 /** …and the most recent N journal days. */
@@ -129,7 +143,28 @@ function memoryBasename(fullPath: string): string {
   return seg.replace(MARKDOWN_RE, "");
 }
 
-export async function scanGrimoireGraph(): Promise<{ graph: DocGraph; meta: GrimoireGraphMeta }> {
+/**
+ * Scan the corpus, optionally narrowed to a familiar scope.
+ *
+ * The scope is applied BEFORE the cap, which is the whole point (cave-z6xvd).
+ * Truncating coven-wide and scoping afterwards handed a familiar owning F of T
+ * files roughly (F/T) × CAP of their own — never all F, whatever the cap. At
+ * 260 of ~2065 files that is 12.6%, so cap 1200 showed ~150 of 260 and closing
+ * the gap by raising the cap would have needed ~2065, where the O(n²) force sim
+ * costs 1.9s to settle.
+ *
+ * Scoping first is better on BOTH axes rather than a trade: the familiar gets
+ * all of their files up to the cap, AND the node count stays small so the sim
+ * stays cheap. Only MEMORY entries carry an owner, so only they are scoped —
+ * knowledge and journal stay coven-wide, matching `scopeDocGraph`, because they
+ * are the graph's connective tissue.
+ *
+ * An empty scope means "All" and reproduces the previous coven-wide behavior
+ * exactly, so the unscoped caller is unchanged.
+ */
+export async function scanGrimoireGraph(
+  familiarScope: ReadonlySet<string> = new Set(),
+): Promise<{ graph: DocGraph; meta: GrimoireGraphMeta }> {
   const [knowledge, memoryEntries, journalDays] = await Promise.all([
     listKnowledgeEntries(),
     listMemoryFileEntries(),
@@ -152,7 +187,7 @@ export async function scanGrimoireGraph(): Promise<{ graph: DocGraph; meta: Grim
 
   // Memory — most recently modified markdown files, bounded reads.
   const memoryMarkdown = memoryEntries
-    .filter((m) => MARKDOWN_RE.test(m.fullPath))
+    .filter((m) => MARKDOWN_RE.test(m.fullPath) && familiarInScope(familiarScope, m.familiarId))
     .sort((a, b) => (a.modified < b.modified ? 1 : a.modified > b.modified ? -1 : 0));
   const memoryScanSet = memoryMarkdown.slice(0, MEMORY_SCAN_CAP);
   const memoryDocs = await mapConcurrent(memoryScanSet, async (m) => {
@@ -191,7 +226,11 @@ export async function scanGrimoireGraph(): Promise<{ graph: DocGraph; meta: Grim
   const graph = buildDocGraph(docs, index);
   const meta: GrimoireGraphMeta = {
     knowledge: { scanned: knowledge.length },
-    memory: { scanned: memoryScanSet.length, total: memoryMarkdown.length },
+    memory: {
+      scanned: memoryScanSet.length,
+      total: memoryMarkdown.length,
+      scoped: familiarScope.size > 0,
+    },
     journal: { scanned: journalScanSet.length, total: journalDays.length },
   };
   return { graph, meta };


### PR DESCRIPTION
Closes `cave-z6xvd`. Follow-up to `cave-ed4s3`, which raised the cap and made the truncation notice honest but could not close the underlying limitation.

### The limitation the cap could never fix

`scanGrimoireGraph` took the `MEMORY_SCAN_CAP` most-recently-modified memory files **across the whole coven**, and familiar scoping happened afterwards, on the client. Because truncation preceded scoping, a familiar owning F of T files received roughly **(F/T) × CAP of their own files** — never all F, whatever the cap.

At 260 of ~2065 files that is 12.6%:

| cap | that familiar sees |
|---|---|
| 400 | ~35 nodes |
| 1200 (shipped) | ~150 nodes |
| ~2065 | all 260 — i.e. scan everything |

And "just scan everything" isn't available, because the ceiling is the **renderer**, not I/O. `tickForceSim` is symmetric O(n²) over ~148 ticks to settle:

| cap | nodes | ms/tick | settle |
|---|---|---|---|
| 1200 | 1392 | 4.4 | 0.65s |
| 2000 | 2320 | 12.8 | **1.89s** |
| 3393 | 3812 | 36.6 | 5.42s |

At 2000 the sim alone is 77% of a 60fps frame before any canvas drawing, re-paid on every reheat.

### The fix

Apply the scope **before** the cap. This is strictly better on both axes rather than a trade-off:

- **fidelity** — the familiar gets all their files, up to the cap
- **render** — scoped node counts stay small, so the O(n²) sim stays cheap *even though coverage went up*

Only memory entries carry an owner, so only they are scoped; knowledge and journal stay coven-wide, matching `scopeDocGraph`, because they're the graph's connective tissue. **An empty scope is "All" and reproduces the previous behavior exactly**, so the unscoped view is unchanged.

`meta.memory` becomes scope-relative and gains `scoped`, so the shortfall notice can say which reading it holds rather than inferring it from the numbers.

### On the new route input

The route's old comment said it took no input, so there was *"no user-controlled path to guard"*. That is still true of the **filesystem**: a scope id is only ever compared for equality against the `familiarId` already recorded on inventory entries, and is never joined into a path — so an unknown id matches nothing *by construction*, not by validation. The shape and count checks exist to bound the input and reject garbage early, and the comment now says exactly that instead of leaving a reader to assume traversal was the concern.

### One subtlety worth naming

The client keys its refetch on the scope's **value**, not the `Set`'s identity. `scopeFamiliarIds` is a new `Set` on most parent renders, so depending on it directly would rescan the whole corpus on every render rather than when the selection actually changes.

### Verification

- **13** grimoire / inventory / multiselect test files pass
- `tsc --noEmit` clean, `eslint` clean
- red-checked both directions: dropping the scope filter fails *"scoped BEFORE it is truncated"*; dropping the query param fails *"the scan request carries the familiar scope"*
- two stale pins updated — including one that asserted the **old** ordering in the cap's own doc comment, which is exactly the kind of drift that pin exists to catch

⚠️ `api-contracts.test.ts` still fails on this branch for the unrelated red-main reason (`/research/generations/media-ticket` has no entry), fixed by #4658. `/grimoire/graph` passes its own contract.