### PR TITLE
Restore source contract baselines

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -229,6 +229,7 @@ const contracts: RouteContract[] = [
   { route: "/research/generations/cancel", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/research/generations/infographic", methods: ["GET"], kind: "stream", localOriginGuard: true, pathGuard: true },
   { route: "/research/generations/media", methods: ["GET"], kind: "stream", localOriginGuard: true, pathGuard: true },
+  { route: "/research/generations/media-ticket", methods: ["GET"], kind: "json", localOriginGuard: true },
   { route: "/research/generations/readiness", methods: ["GET"], kind: "json", localOriginGuard: true },
   { route: "/research/generations/render", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/research/links", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
@@ -413,9 +414,15 @@ for (const contract of contracts) {
     // (/x/oauth/start passes rejectNonLocalRequest into
     // createXOAuthStartRouteHandlers, which calls it), and reading only the
     // route file would report that as a missing guard when it is present.
-    assert.match(effectiveSource, /isLocalOrigin|rejectNonLocalRequest/, `${contract.route} must preserve local-origin guard`);
+    assert.match(
+      effectiveSource,
+      /isLocalOrigin|rejectNonLocalRequest|rejectResearchMediaRequest/,
+      `${contract.route} must preserve local-origin guard`,
+    );
     if (effectiveSource.includes("rejectNonLocalRequest")) {
       assert.match(effectiveSource, /rejectNonLocalRequest\(req\)/, `${contract.route} must call the shared local-origin guard`);
+    } else if (effectiveSource.includes("rejectResearchMediaRequest")) {
+      assert.match(effectiveSource, /rejectResearchMediaRequest\(req\)/, `${contract.route} must call the shared research media guard`);
     } else {
       assert.match(effectiveSource, /status:\s*403/, `${contract.route} local-origin guard must preserve 403 response`);
     }

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -278,19 +278,20 @@ assert.match(
   "Stat labels keep the uppercase/tracking hierarchy at the lifted 10px size",
 );
 
-const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const foundations = readFileSync(new URL("../styles/globals/foundations.css", import.meta.url), "utf8");
+const primitivesCss = readFileSync(new URL("../styles/globals/primitives.css", import.meta.url), "utf8");
 assert.match(
-  globals,
+  foundations,
   /--text-muted: color-mix\(in oklch, var\(--foreground\) 72%, transparent\);/,
   "Dark-mode --text-muted mixes at 72% — 55% passed AA only on Coven; 72% clears 4.5:1 on every premade palette (theme-contrast-audit.test.ts)",
 );
 assert.match(
-  globals,
+  foundations,
   /--text-muted: color-mix\(in oklch, var\(--foreground\) 76%, transparent\);/,
   "Light-mode --text-muted overrides to 76% (dark ink needs a higher mix for the same contrast)",
 );
 assert.doesNotMatch(
-  globals,
+  foundations,
   /--text-muted: color-mix\(in oklch, var\(--foreground\) 40%, transparent\);/,
   "The old 40% muted-ink mix (~3:1 on dark, ~2.5:1 on light) must not return",
 );
@@ -301,12 +302,12 @@ assert.match(
   "Chat rows should render the session initiator attribution pill",
 );
 assert.doesNotMatch(
-  globals,
+  primitivesCss,
   /\.ui-initiator-chip\[data-initiator="familiar"\]\s*\{[\s\S]*?color:\s*var\(--accent\);/,
   "Familiar initiator attribution text must not use the low-contrast accent token",
 );
 assert.match(
-  globals,
+  primitivesCss,
   /\.ui-initiator-chip\[data-initiator="familiar"\]\s*\{[\s\S]*?color:\s*var\(--text-secondary\);/,
   "Familiar initiator attribution text should use a readable text token",
 );
@@ -314,7 +315,7 @@ assert.match(
 // ── Row chrome consistency (origin + initiator pills, action buttons) ─────────
 // Both pills must share one base rule so adjacent pills read as siblings.
 assert.match(
-  globals,
+  primitivesCss,
   /\.ui-origin-chip,\s*\.ui-initiator-chip\s*\{[\s\S]*?border-radius:\s*var\(--radius-pill\);[\s\S]*?\}/,
   "Origin and initiator pills must share a single base chrome rule",
 );
@@ -356,7 +357,11 @@ assert.match(
 assert.match(source, /const \[selectMode, setSelectMode\] = useState\(false\)/, "a select mode toggles bulk-select");
 assert.match(source, /const \[selectedIds, setSelectedIds\] = useState<Set<string>>/, "selected chat ids live in a Set");
 assert.match(source, /setSelectMode\(\(v\) => !v\); setSelectedIds\(new Set\(\)\)/, "the header Select toggle clears any selection");
-assert.match(source, /useEffect\(\(\) => \{ setSelectMode\(false\); setSelectedIds\(new Set\(\)\); \}, \[familiar\?\.id\]\)/, "selection resets when the active familiar changes");
+assert.match(
+  source,
+  /useEffect\(\(\) => \{\s*clearSessionFilters\(\);\s*setSelectMode\(false\);\s*setSelectedIds\(new Set\(\)\);\s*\}, \[clearSessionFilters, familiar\?\.id\]\)/,
+  "selection resets with the familiar-scoped filters when the active familiar changes",
+);
 assert.match(source, /role=\{selectMode \? "checkbox" : "button"\}/, "rows are checkboxes in select mode");
 // Row click = open (Sessions): clicking a row opens the session directly on
 // every device; select mode still toggles selection. The old inline detail

--- a/tests/research-studio-media.spec.ts
+++ b/tests/research-studio-media.spec.ts
@@ -5,6 +5,28 @@ const FAMILIAR_ID = "rida";
 const MISSION_ID = "m-media";
 const ELEVENLABS_VOICE_ID = DEFAULT_ELEVENLABS_VOICE_ID;
 const now = new Date().toISOString();
+const SILENT_WAV = (() => {
+  const sampleRate = 8_000;
+  const dataSize = 1_600;
+  const bytes = Buffer.alloc(44 + dataSize);
+  bytes.write("RIFF", 0);
+  bytes.writeUInt32LE(36 + dataSize, 4);
+  bytes.write("WAVEfmt ", 8);
+  bytes.writeUInt32LE(16, 16);
+  bytes.writeUInt16LE(1, 20);
+  bytes.writeUInt16LE(1, 22);
+  bytes.writeUInt32LE(sampleRate, 24);
+  bytes.writeUInt32LE(sampleRate * 2, 28);
+  bytes.writeUInt16LE(2, 32);
+  bytes.writeUInt16LE(16, 34);
+  bytes.write("data", 36);
+  bytes.writeUInt32LE(dataSize, 40);
+  return bytes;
+})();
+const BLACK_MP4 = Buffer.from(
+  "AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAMxbW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAMgAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAlt0cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAMgAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAADIAAAAAAABAAAAAAHTbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAAAoAAAACABVxAAAAAAALWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABWaWRlb0hhbmRsZXIAAAABfm1pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAAAT5zdGJsAAAAvnN0c2QAAAAAAAAAAQAAAK5hdmMxAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAABAAEABIAAAASAAAAAAAAAABFUxhdmM2Mi4yOC4xMDEgbGlieDI2NAAAAAAAAAAAAAAAGP//AAAANGF2Y0MBZAAK/+EAF2dkAAqs2V7ARAAAAwAEAAADAFA8SJZYAQAGaOvjyyLA/fj4AAAAABBwYXNwAAAAAQAAAAEAAAAUYnJ0cgAAAAAAAABwqAAAAAAAAAAYc3R0cwAAAAAAAAABAAAAAgAABAAAAAAUc3RzcwAAAAAAAAABAAAAAQAAABxzdHNjAAAAAAAAAAEAAAABAAAAAgAAAAEAAAAUc3RzegAAAAAAAAAAAAAAAgAAAsUAAAAMAAAAFHN0Y28AAAAAAAAAAQAAA2EAAABidWR0YQAAAFptZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAAC1pbHN0AAAAJal0b28AAAAdZGF0YQAAAAEAAAAATGF2ZjYyLjEyLjEwMQAAAAgZnJlZQAAAtltdGF0AAACrgYF//+q3EXpvebZSLdWLEgg2SPu73gyNjQgLSBjb3JlIDE2NSByMzIyMiBiMzU2MDVhIC0gSC4yNjQvTVBFRy00IEFWQyBjb2RlYyAtIENvcHlsZWZ0IDIwMDMtMjAyNSAtIGh0dHA6Ly93d3cudmlkZW9sYW4ub3JnL3gyNjQuaHRtbCAtIG9wdGlvbnM6IGNhYmFjPTEgcmVmPTMgZGVibG9jaz0xOjA6MCBhbmFseXNlPTB4MzoweDExMyBtZT1oZXggc3VibWU9NyBwc3k9MSBwc3lfcmQ9MS4wMDowLjAyIG1peGVkX3JlZj0xIG1lX3JhbmdlPTE2IGNocm9tYV9tZT0xIHRyZWxsaXM9MSA4eDhkY3Q9MSBjcW09MCBkZWFkem9uZT0yMSwxMSBmYXN0X3Bza2lwPTEgY2hyb21hX3FwX29mZnNldD0tMiB0aHJlYWRzPTEgbG9va2FoZWFkX3RocmVhZHM9MSBzbGljZWRfdGhyZWFkcz0wIG5yPTAgZGVjaW1hdGU9MSBpbnRlcmxhY2VkPTAgYmx1cmF5X2NvbXBhdD0wIGNvbnN0cmFpbmVkX2ludHJhPTAgYmZyYW1lcz0zIGJfcHlyYW1pZD0yIGJfYWRhcHQ9MSBiX2JpYXM9MCBkaXJlY3Q9MSB3ZWlnaHRiPTEgb3Blbl9nb3A9MCB3ZWlnaHRwPTIga2V5aW50PTI1MCBrZXlpbnRfbWluPTEwIHNjZW5lY3V0PTQwIGludHJhX3JlZnJlc2g9MCByY19sb29rYWhlYWQ9NDAgcmM9Y3JmIG1idHJlZT0xIGNyZj0yMy4wIHFjb21wPTAuNjAgcXBtaW49MCBxcG1heD02OSBxcHN0ZXA9NCBpcF9yYXRpbz0xLjQwIGFxPTE6MS4wMACEAAAAAA9liIQAO//+906/AptUwmEAAAAIQZohbEN//uA=",
+  "base64",
+);
 
 const MISSION = {
   version: 1,
@@ -281,17 +303,32 @@ async function boot(
         });
         return;
       }
+      if (url.pathname.endsWith("/media-ticket")) {
+        const params = new URLSearchParams({
+          familiarId: url.searchParams.get("familiarId") ?? "",
+          id: url.searchParams.get("id") ?? "",
+          ticket: "test-ticket",
+        });
+        await route.fulfill({
+          json: {
+            ok: true,
+            mediaUrl: `/api/research/generations/media?${params}`,
+          },
+        });
+        return;
+      }
       if (url.pathname.endsWith("/media")) {
         const target = records.get(url.searchParams.get("id") ?? "");
+        const body = target?.kind === "podcast" ? SILENT_WAV : BLACK_MP4;
         await route.fulfill({
-          status: 206,
+          status: 200,
           headers: {
             "content-type":
               target?.kind === "podcast" ? "audio/wav" : "video/mp4",
-            "content-range": "bytes 0-0/1",
             "accept-ranges": "bytes",
+            "content-length": String(body.byteLength),
           },
-          body: "0",
+          body,
         });
         return;
       }


### PR DESCRIPTION
## Summary
- update Chat list source assertions for familiar-scoped filter resets and modular CSS ownership
- register the Research media-ticket route and signed media guard in the exhaustive API contract inventory
- mock ticket minting and valid media bytes in Research playback E2E coverage

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` (1,211 files)
- `pnpm test:api` (379 files)
- `pnpm check:tests-wired`
- `COVEN_CAVE_E2E=1 pnpm exec playwright test tests/research-studio-media.spec.ts --project=desktop --grep 'configures, reviews|resumes drafts'`\n\nBead: `cave-0hdw7`