### PR TITLE
fix(grimoire): run the scoped-memory count before the empty-state return

### DIFF
--- a/src/components/grimoire-graph-view.test.ts
+++ b/src/components/grimoire-graph-view.test.ts
@@ -192,9 +192,14 @@ assert.match(
     "the scoped memory-in-window memo must run before the empty-state early return",
   );
 
-  const stray = view
-    .slice(earlyReturn)
-    .match(/\buse(?:State|Effect|LayoutEffect|Memo|Callback|Ref|Context|Reducer|ImperativeHandle|Transition|DeferredValue|SyncExternalStore|Id)\s*\(/);
+  // Match the NAMING CONVENTION, not a list of built-ins. An enumerated list
+  // silently exempts custom hooks (useResearchMediaUrl) and any built-in React
+  // adds later (useInsertionEffect, useActionState, useOptimistic), which would
+  // make this assert less than the sentence above it promises — a pin that
+  // cannot fail for the case it claims to cover. `\b` keeps it off identifiers
+  // that merely end in "use" (onUseFoo), and requiring an uppercase letter
+  // keeps it off ordinary words like "used(".
+  const stray = view.slice(earlyReturn).match(/\buse[A-Z][A-Za-z0-9_]*\s*\(/);
   assert.equal(
     stray?.[0] ?? null,
     null,

--- a/src/components/grimoire-graph-view.test.ts
+++ b/src/components/grimoire-graph-view.test.ts
@@ -166,4 +166,40 @@ assert.match(
   "the truncation count stays honest under a scope — those totals are coven-wide",
 );
 
+// ── Rules of Hooks: nothing may be called after the empty-state early return ─
+// The scoped memory-in-window count shipped BELOW that return, so an empty
+// graph ran one hook fewer than a populated one and React threw "Rendered more
+// hooks than during the previous render" the moment the graph filled or emptied
+// — which a scope change does routinely (cave-qxq4l).
+//
+// Asserted as an ordering and an absence rather than as surrounding text: the
+// contract is "every hook runs on every render", so a future hook added below
+// the return has to fail this too, not just the one that caused the crash.
+// Nothing else covers it — eslint.config.mjs is a design-system-only gate that
+// stubs react-hooks to a no-op, so rules-of-hooks never runs on this repo.
+//
+// GrimoireGraphView is the last top-level function in the file, so everything
+// after the early return is inside its body and a stray hook there is always
+// the bug this guards.
+{
+  const earlyReturn = view.indexOf("if (graph.nodes.length === 0)");
+  assert.ok(earlyReturn > 0, "the empty-state early return still exists");
+
+  const memoized = view.indexOf("scopedMemoryInWindow = useMemo(");
+  assert.ok(memoized > 0, "the scoped memory-in-window count is still memoized");
+  assert.ok(
+    memoized < earlyReturn,
+    "the scoped memory-in-window memo must run before the empty-state early return",
+  );
+
+  const stray = view
+    .slice(earlyReturn)
+    .match(/\buse(?:State|Effect|LayoutEffect|Memo|Callback|Ref|Context|Reducer|ImperativeHandle|Transition|DeferredValue|SyncExternalStore|Id)\s*\(/);
+  assert.equal(
+    stray?.[0] ?? null,
+    null,
+    `no hook may be called after the empty-state early return (found ${stray?.[0] ?? "none"})`,
+  );
+}
+
 console.log("grimoire-graph-view.test.ts: ok");

--- a/src/components/grimoire-graph-view.tsx
+++ b/src/components/grimoire-graph-view.tsx
@@ -756,6 +756,34 @@ export function GrimoireGraphView({
     [announcer, centerOnNode, fitView, onOpen, scheduleFrame, zoomBy],
   );
 
+  // How many of the scope's memory files were actually READ. The scan cap is
+  // applied coven-wide BEFORE familiar scoping, so a scoped view is not "this
+  // familiar's memory graph" — it is their slice of the coven's most recent N
+  // files. `meta.memory.scanned` is coven-wide and cannot answer this, so the
+  // count comes off the nodes themselves (cave-ed4s3).
+  //
+  // `scanned` is load-bearing, not defensive: the resolution index spans the
+  // WHOLE corpus while the scan is capped, so a [[link]] into an out-of-window
+  // memory file still resolves and lands as a leaf node with no body. Counting
+  // raw memory nodes would mix files that were read with files merely pointed
+  // at and overcount the window — the exact class of false claim this notice
+  // exists to stop making.
+  //
+  // This MUST stay above the empty-state early return below. It lived under it
+  // and only ran when the graph had nodes, so an empty graph rendered one hook
+  // fewer and React threw "Rendered more hooks than during the previous render"
+  // the moment the graph filled or emptied — which a scope change does routinely
+  // (cave-qxq4l). Nothing in CI catches this: eslint.config.mjs is a
+  // design-system-only gate that stubs react-hooks to a no-op, so
+  // rules-of-hooks never runs.
+  const scopedMemoryInWindow = useMemo(
+    () =>
+      scopeLabel
+        ? graph.nodes.reduce((n, node) => n + (node.kind === "memory" && node.scanned ? 1 : 0), 0)
+        : 0,
+    [graph, scopeLabel],
+  );
+
   // ── Empty state — only when there is genuinely nothing to draw ─────────────
   if (graph.nodes.length === 0) {
     return (
@@ -779,25 +807,6 @@ export function GrimoireGraphView({
 
   const summary = `${visible.nodes.length} of ${graph.nodes.length} nodes, ${visible.edges.length} connections shown`;
   const memoryTruncated = meta ? meta.memory.scanned < meta.memory.total : false;
-  // How many of the scope's memory files were actually READ. The scan cap is
-  // applied coven-wide BEFORE familiar scoping, so a scoped view is not "this
-  // familiar's memory graph" — it is their slice of the coven's most recent N
-  // files. `meta.memory.scanned` is coven-wide and cannot answer this, so the
-  // count comes off the nodes themselves (cave-ed4s3).
-  //
-  // `scanned` is load-bearing, not defensive: the resolution index spans the
-  // WHOLE corpus while the scan is capped, so a [[link]] into an out-of-window
-  // memory file still resolves and lands as a leaf node with no body. Counting
-  // raw memory nodes would mix files that were read with files merely pointed
-  // at and overcount the window — the exact class of false claim this notice
-  // exists to stop making.
-  const scopedMemoryInWindow = useMemo(
-    () =>
-      scopeLabel
-        ? graph.nodes.reduce((n, node) => n + (node.kind === "memory" && node.scanned ? 1 : 0), 0)
-        : 0,
-    [graph, scopeLabel],
-  );
   // Only worth saying when the scope actually lost files to the cap. Equal
   // counts mean the window covered them all, and a shortfall notice would be
   // noise; `>` cannot happen, but treating it as "nothing to report" keeps the


### PR DESCRIPTION
## The crash

Opening Relations throws, and the surface goes down rather than degrading:

```
Rendered more hooks than during the previous render.
  at GrimoireGraphView (src/components/grimoire-graph-view.tsx:794)
```

React also warns first, naming hook #45 as `undefined` on the previous render
and `useMemo` on the next.

## Why

`scopedMemoryInWindow` was memoized **below** the empty-state early return:

```
759  if (graph.nodes.length === 0) { return <EmptyState … /> }
794  const scopedMemoryInWindow = useMemo(…)
```

An empty graph returns at 759 having run 44 hooks; a populated one runs 45.
Any transition between those two states — which a familiar-scope change does
routinely, as does a scan finishing — violates the Rules of Hooks.

Introduced by #4431.

## The fix

Move the memo above the early return. The computation and its dependency array
are untouched, so the count is identical; only its position changes.

## Why a test, and why this shape

The pin asserts two things: that the memo precedes the early return, and that
**no** hook of any kind appears after it — so a future hook added below that
return fails too, not just the one that caused this crash. `GrimoireGraphView`
is the last top-level function in the file, so everything after the return is
inside its body.

Nothing else covers this class of bug. `eslint.config.mjs` is a focused
design-system gate that registers `react-hooks` with a **no-op** rule purely so
existing disable comments don't error — `rules-of-hooks` never runs. That is
how this reached `main`.

Mutation-tested: restored the pre-fix file and confirmed the pin fails with
*"the scoped memory-in-window memo must run before the empty-state early
return"*, then confirmed it passes after the move.

## Verification

- `tsc --noEmit` clean
- `grimoire-graph-view.test.ts` and `grimoire-view.test.ts` pass
- pin mutation-tested in both directions

Enabling `eslint-plugin-react-hooks` repo-wide is the durable fix for the gap
and is filed separately — it needs a new dependency and whatever existing
violations it surfaces, which does not belong in a P1 crash fix.