### PR TITLE
fix: align research and review character limits

### DIFF
--- a/src/app/api/github/review/route.test.ts
+++ b/src/app/api/github/review/route.test.ts
@@ -25,3 +25,5 @@ assert.doesNotMatch(source, /:\s*token\b/, "review route must not return token m
 console.log("github-review-route.test.ts OK");
 assert.match(source, /new Set\(\["APPROVE", "REQUEST_CHANGES", "COMMENT"\]\)/, "review events are allow-listed");
 assert.match(source, /event !== "APPROVE" && !text/, "non-approve reviews require a body");
+assert.match(source, /GITHUB_REVIEW_BODY_MAX_LENGTH/, "review body cap is shared between the UI and route");
+assert.match(source, /review body must be at most/, "oversized review bodies fail before GitHub dispatch");

--- a/src/app/api/github/review/route.ts
+++ b/src/app/api/github/review/route.ts
@@ -12,6 +12,7 @@
 
 import { NextResponse } from "next/server";
 import { resolveGitHubToken } from "@/lib/github-token";
+import { GITHUB_REVIEW_BODY_MAX_LENGTH } from "@/lib/github-review";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -44,6 +45,12 @@ export async function POST(req: Request) {
   }
   if (event !== "APPROVE" && !text) {
     return NextResponse.json({ ok: false, error: "review body required" }, { status: 400 });
+  }
+  if (text.length > GITHUB_REVIEW_BODY_MAX_LENGTH) {
+    return NextResponse.json(
+      { ok: false, error: `review body must be at most ${GITHUB_REVIEW_BODY_MAX_LENGTH} characters` },
+      { status: 400 },
+    );
   }
 
   const token = resolveGitHubToken();

--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/research-mission-routing";
 import {
   RESEARCH_BOUND_LIMITS,
+  RESEARCH_INTENT_MAX_LENGTH,
   RESEARCH_INTENT_MIN_LENGTH,
   RESEARCH_MISSION_MODES,
   type CreateResearchMissionInput,
@@ -274,6 +275,18 @@ export function ResearchMissionComposer({
   const plan = useMemo(() => defaultResearchPlan(effectiveMode), [effectiveMode]);
   const trimmedIntent = intent.trim();
   const intentTooShort = trimmedIntent.length > 0 && trimmedIntent.length < RESEARCH_INTENT_MIN_LENGTH;
+  // Grow the box with the brief instead of scrolling three fixed rows. The CSS
+  // caps it at ~12 lines, so `auto` then scrollHeight settles at the smaller of
+  // content height and that ceiling; past it the element scrolls as before.
+  // Measured on every intent change, including programmatic ones (slash
+  // completions, /improve rewrites, restored drafts), not just typing.
+  const intentBoxRef = useRef<HTMLTextAreaElement | null>(null);
+  useEffect(() => {
+    const el = intentBoxRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [intent]);
 
   // Strength + assembled brief are pure reads of the textarea, so they track
   // hand edits made after the builder closed.
@@ -477,6 +490,8 @@ export function ResearchMissionComposer({
           <label htmlFor="research-intent" className="sr-only">What should we investigate?</label>
           <textarea
             id="research-intent"
+            ref={intentBoxRef}
+            maxLength={RESEARCH_INTENT_MAX_LENGTH}
             value={intent}
             onChange={(event) => {
               setIntent(event.target.value);
@@ -525,6 +540,16 @@ export function ResearchMissionComposer({
               Add at least {RESEARCH_INTENT_MIN_LENGTH} characters so the familiar has a real question to investigate.
             </p>
           ) : null}
+          {/* Static text, deliberately not a live region — announcing every
+              keystroke would drown the composer. The ceiling is visible while
+              writing rather than discovered as a server rejection afterwards. */}
+          <span
+            className={`research-intent-count${
+              intent.length >= RESEARCH_INTENT_MAX_LENGTH * 0.9 ? " research-intent-count--near" : ""
+            }`}
+          >
+            {intent.length.toLocaleString()} / {RESEARCH_INTENT_MAX_LENGTH.toLocaleString()}
+          </span>
         </div>
 
         {attachedLinks.length > 0 ? (

--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -863,8 +863,12 @@ export function ResearchMissionDetail({
                 }}
                 placeholder="What should the next iteration prioritize?"
                 aria-label="Refined research direction"
+                aria-describedby="research-refine-direction-count"
                 maxLength={RESEARCH_DIRECTION_MAX_LENGTH}
               />
+              <span id="research-refine-direction-count" className="research-desk-refine__count">
+                {direction.length.toLocaleString()} / {RESEARCH_DIRECTION_MAX_LENGTH.toLocaleString()}
+              </span>
               <div className="research-desk-refine__actions">
                 <Button
                   size="xs"

--- a/src/components/role-surfaces/research-studio-modals.tsx
+++ b/src/components/role-surfaces/research-studio-modals.tsx
@@ -604,7 +604,7 @@ export function GenerationConfigModal({
 }) {
   const meta = studioMetaForKind(kind);
   const isMedia = !isResearchGenerationKind(kind);
-  const nearCap = directions.length >= RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH - 200;
+  const nearCap = directions.length >= RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH * 0.9;
   const mediaConfigurationError = (() => {
     if (!isMedia) return null;
     if (!readiness) return "Media readiness is still loading.";
@@ -705,13 +705,15 @@ export function GenerationConfigModal({
             value={directions}
             maxLength={RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH}
             onChange={(event) => onDirectionsChange(event.target.value)}
+            aria-describedby="research-studio-directions-count"
             placeholder="Audience, tone, emphasis — kept with the generation for future pipelines"
           />
-          {nearCap ? (
-            <span className="research-studio-config__count" aria-live="polite">
-              {directions.length} / {RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH}
-            </span>
-          ) : null}
+          <span
+            id="research-studio-directions-count"
+            className={`research-studio-config__count${nearCap ? " research-studio-config__count--near" : ""}`}
+          >
+            {directions.length.toLocaleString()} / {RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH.toLocaleString()}
+          </span>
         </div>
         {isMedia ? (
           <div className="research-studio-config__media">

--- a/src/components/role-surfaces/research-tab-desk.test.ts
+++ b/src/components/role-surfaces/research-tab-desk.test.ts
@@ -71,6 +71,8 @@ test("checkpoint direction can be drafted agentically without auto-continuing", 
   assert.match(detail, /Apply direction/);
   assert.match(detail, /Keep mine/);
   assert.match(detail, /maxLength=\{RESEARCH_DIRECTION_MAX_LENGTH\}/);
+  assert.match(detail, /research-refine-direction-count/);
+  assert.match(detail, /direction\.length\.toLocaleString\(\)\} \/ \{RESEARCH_DIRECTION_MAX_LENGTH\.toLocaleString\(\)/);
   assert.match(
     detail,
     /onClick=\{\(\) => void runAction\(\{ action: "refine", direction \}\)\}/,
@@ -80,6 +82,7 @@ test("checkpoint direction can be drafted agentically without auto-continuing", 
     /generateResearchRefineDirection\([\s\S]{0,800}?runAction\(\{ action: "refine"/,
   );
   assert.match(css, /\.research-desk-refine__actions \{/);
+  assert.match(css, /\.research-desk-refine__count \{/);
   assert.match(css, /\.research-desk-refine__suggestion \{/);
 });
 

--- a/src/components/role-surfaces/research-tab-studio.test.ts
+++ b/src/components/role-surfaces/research-tab-studio.test.ts
@@ -86,6 +86,15 @@ test("create failures surface the server's message inline (409 no-artifact inclu
   assert.match(modals, /artifact\.state === "published" \|\| artifact\.state === "working"/);
 });
 
+test("generation directions show a bounded, quiet character count", () => {
+  assert.match(modals, /maxLength=\{RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH\}/);
+  assert.match(modals, /directions\.length\.toLocaleString\(\)\} \/ \{RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH\.toLocaleString\(\)/);
+  assert.match(modals, /aria-describedby="research-studio-directions-count"/);
+  assert.match(modals, /id="research-studio-directions-count"/);
+  assert.doesNotMatch(modals, /research-studio-config__count" aria-live/);
+  assert.match(css, /\.research-studio-config__count--near/);
+});
+
 test("markdown editor never fakes persistence", () => {
   // The backend exposes list/create/remove only — no update fetcher — so the
   // primary action is clipboard, plainly labeled, with the gap stated.

--- a/src/components/role-surfaces/reviewer-surface.test.ts
+++ b/src/components/role-surfaces/reviewer-surface.test.ts
@@ -194,6 +194,16 @@ test("the queue derives from the familiar's real sessions", () => {
   assert.match(surface, /useRoleSurfaceState<ReviewerState>/);
 });
 
+test("review bodies stay bounded before GitHub dispatch", () => {
+  assert.match(surface, /GITHUB_REVIEW_BODY_MAX_LENGTH/);
+  assert.match(surface, /maxLength=\{GITHUB_REVIEW_BODY_MAX_LENGTH\}/);
+  assert.match(surface, /next\.slice\(0, GITHUB_REVIEW_BODY_MAX_LENGTH\)/);
+  assert.match(surface, /rd-character-count/);
+  assert.match(surface, /aria-describedby="rd-note-help rd-note-count"/);
+  assert.match(surface, /aria-describedby="rd-rc-help rd-rc-count"/);
+  assert.match(reviewDeckCss, /\.rd-character-count \{/);
+});
+
 test("bucket filter announcements run outside React state updaters", () => {
   assert.match(
     surface,

--- a/src/components/role-surfaces/reviewer-surface.tsx
+++ b/src/components/role-surfaces/reviewer-surface.tsx
@@ -68,6 +68,7 @@ import { usePrReadiness } from "./use-pr-readiness";
 import { useReviewSource } from "./use-review-source";
 import { SurfaceEmpty, SurfaceError, SurfaceLoading } from "./surface-room";
 import { REVIEWER_SURFACE_ID } from "./ids";
+import { GITHUB_REVIEW_BODY_MAX_LENGTH } from "@/lib/github-review";
 
 /** Queue size plus the scope and pressure the room header shows as status chips. */
 export type ReviewDeckCounts = {
@@ -268,8 +269,9 @@ export function ReviewerSurface({ context }: { context: RoleSurfaceContext }) {
   const setNote = useCallback(
     (next: string) => {
       if (!selected) return;
-      setNotes((prev) => ({ ...prev, [selected.session.id]: next }));
-      if (next.trim()) setNoteError(null);
+      const bounded = next.slice(0, GITHUB_REVIEW_BODY_MAX_LENGTH);
+      setNotes((prev) => ({ ...prev, [selected.session.id]: bounded }));
+      if (bounded.trim()) setNoteError(null);
     },
     [selected],
   );
@@ -1403,11 +1405,15 @@ export function ReviewerSurface({ context }: { context: RoleSurfaceContext }) {
                 className="rd-note"
                 placeholder="Add a note…"
                 value={note}
+                maxLength={GITHUB_REVIEW_BODY_MAX_LENGTH}
                 disabled={!selected}
                 onChange={(e) => setNote(e.target.value)}
-                aria-describedby="rd-note-help"
+                aria-describedby="rd-note-help rd-note-count"
                 aria-invalid={noteError ? true : undefined}
               />
+              <span id="rd-note-count" className="rd-character-count">
+                {note.length.toLocaleString()} / {GITHUB_REVIEW_BODY_MAX_LENGTH.toLocaleString()}
+              </span>
               {noteError ? (
                 <span className="rd-error" role="alert">
                   {noteError}
@@ -1581,10 +1587,14 @@ export function ReviewerSurface({ context }: { context: RoleSurfaceContext }) {
               className="rd-composer-textarea"
               placeholder="Describe what has to change…"
               value={note}
+              maxLength={GITHUB_REVIEW_BODY_MAX_LENGTH}
               onChange={(e) => setNote(e.target.value)}
-              aria-describedby="rd-rc-help"
+              aria-describedby="rd-rc-help rd-rc-count"
               aria-invalid={noteError ? true : undefined}
             />
+            <span id="rd-rc-count" className="rd-character-count">
+              {note.length.toLocaleString()} / {GITHUB_REVIEW_BODY_MAX_LENGTH.toLocaleString()}
+            </span>
             {noteError ? (
               <span className="rd-error" role="alert">
                 {noteError}

--- a/src/lib/github-review.ts
+++ b/src/lib/github-review.ts
@@ -1,0 +1,2 @@
+/** Cave-owned ceiling for a pull-request review body before GitHub dispatch. */
+export const GITHUB_REVIEW_BODY_MAX_LENGTH = 10_000;

--- a/src/lib/research-generations.test.ts
+++ b/src/lib/research-generations.test.ts
@@ -30,6 +30,17 @@ test("extractive and media kind unions stay explicit and composable", () => {
   assert.equal(isResearchGenerationMediaKind("slides"), false);
 });
 
+test("generation directions use the shared 10,000-character ceiling", () => {
+  assert.equal(RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH, 10_000);
+  assert.equal(
+    validateCreateResearchGenerationInput({
+      familiarId: "nova", kind: "blog", sourceMissionId: "m-1",
+      directions: "x".repeat(RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH),
+    }).ok,
+    true,
+  );
+});
+
 test("media kinds carry capability copy rather than stale readiness claims", () => {
   assert.deepEqual(
     RESEARCH_GENERATION_MEDIA_KINDS,

--- a/src/lib/research-generations.ts
+++ b/src/lib/research-generations.ts
@@ -528,7 +528,7 @@ export function isResearchGenerationContent(
 const FAMILIAR_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
 const MISSION_ID_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
-export const RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH = 2_000;
+export const RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH = 10_000;
 
 export function isValidResearchGenerationFamiliarId(value: unknown): value is string {
   return (

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -15,6 +15,8 @@ import {
   RESEARCH_CONSTRAINT_MAX_COUNT,
   RESEARCH_CONSTRAINT_MAX_LENGTH,
   RESEARCH_DELIVERABLE_MAX_LENGTH,
+  RESEARCH_DIRECTION_MAX_LENGTH,
+  RESEARCH_INTENT_MAX_LENGTH,
   RESEARCH_INTENT_MIN_LENGTH,
   RESEARCH_PROJECT_ROOT_MAX_LENGTH,
   RESEARCH_HARNESS_IDS,
@@ -77,6 +79,19 @@ test("mission parser validates shared-state fields and reconstructs safe data", 
     ...validMission(),
     constraints: ["x".repeat(RESEARCH_CONSTRAINT_MAX_LENGTH + 1)],
   }), null);
+});
+
+test("research prompt limits retain the requested intent and direction capacity", () => {
+  assert.equal(RESEARCH_INTENT_MAX_LENGTH, 25_000);
+  assert.equal(RESEARCH_DIRECTION_MAX_LENGTH, 10_000);
+  assert.equal(
+    validateCreateResearchMissionInput({ ...validMission(), intent: "i".repeat(RESEARCH_INTENT_MAX_LENGTH) }).ok,
+    true,
+  );
+  assert.equal(
+    validateCreateResearchMissionInput({ ...validMission(), intent: "i".repeat(RESEARCH_INTENT_MAX_LENGTH + 1) }).ok,
+    false,
+  );
 });
 
 test("mission parser strips private process-owner provenance from public state", () => {

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -728,12 +728,17 @@ export function parseResearchMission(value: unknown): ResearchMission | null {
  *  that would still spend a real familiar session. Enforced by the create
  *  validator (server) and the desk composer (client). */
 export const RESEARCH_INTENT_MIN_LENGTH = 8;
-export const RESEARCH_INTENT_MAX_LENGTH = 10_000;
+/** Upper bound on a mission brief. Raised 10k → 25k (cave-e8z): real briefs
+ *  carry pasted context — prior findings, source lists, constraints — and hit
+ *  the old cap, which surfaced only as a server rejection after the writing was
+ *  done. The composer now shows the count as you type, so the ceiling is
+ *  visible rather than discovered. */
+export const RESEARCH_INTENT_MAX_LENGTH = 25_000;
 export const RESEARCH_TITLE_MAX_LENGTH = 160;
 export const RESEARCH_DELIVERABLE_MAX_LENGTH = 160;
 export const RESEARCH_AUDIENCE_MAX_LENGTH = 500;
 export const RESEARCH_PROJECT_ROOT_MAX_LENGTH = 2_000;
-export const RESEARCH_DIRECTION_MAX_LENGTH = 2_000;
+export const RESEARCH_DIRECTION_MAX_LENGTH = 10_000;
 export const RESEARCH_CONSTRAINT_MAX_COUNT = 20;
 export const RESEARCH_CONSTRAINT_MAX_LENGTH = 500;
 

--- a/src/lib/server/flow-copilot-session.test.ts
+++ b/src/lib/server/flow-copilot-session.test.ts
@@ -441,7 +441,40 @@ test("the current maximum Research input is measured and pathological quoting fa
   assert.equal(plainPrompt.split(plainDeliverable).length - 1, 1);
   assert.equal(plainPrompt.split(plainAudience).length - 1, 1);
   const plainArgs = flowLaunchArgs(plainPrompt);
-  assert.doesNotThrow(() => assertCopilotCommandLineFitsWindows("copilot.exe", plainArgs, "win32"));
+  // cave-r3vmj raised RESEARCH_INTENT_MAX_LENGTH to 25k so real briefs can carry
+  // pasted context. Copilot is argv-only today, so a maximum-length intent no
+  // longer fits the bounded Windows command line even with plain quoting — the
+  // guard fails closed with the actionable message rather than truncating a
+  // prompt. Every other platform, and any runtime with stdin prompt support, is
+  // unaffected. Moving Copilot to stdin is what would lift this ceiling.
+  assert.ok(
+    windowsCommandLineUtf16Length("copilot.exe", plainArgs) > WINDOWS_COPILOT_COMMAND_LINE_SAFE_UNITS,
+    "a maximum-length intent exceeds the bounded argv transport",
+  );
+  assert.throws(
+    () => assertCopilotCommandLineFitsWindows("copilot.exe", plainArgs, "win32"),
+    /Shorten the Research mission intent or use a runtime with stdin prompt support/,
+  );
+  assert.doesNotThrow(
+    () => assertCopilotCommandLineFitsWindows("copilot.exe", plainArgs, "darwin"),
+    "the ceiling is a Windows argv limit, not a product-wide one",
+  );
+
+  // A brief that does fit still launches — the ceiling is a real size, not a
+  // blanket refusal.
+  const fittingValidated = validateCreateResearchMissionInput({
+    ...researchMission("i".repeat(8_000)),
+    deliverable: plainDeliverable,
+    audience: plainAudience,
+  });
+  assert.equal(fittingValidated.ok, true);
+  const fittingPrompt = compileFlowPrompt(
+    buildResearchMissionFlow(researchMission(fittingValidated.value.intent, fittingValidated.value), 1),
+  );
+  assert.doesNotThrow(
+    () => assertCopilotCommandLineFitsWindows("copilot.exe", flowLaunchArgs(fittingPrompt), "win32"),
+    "an 8k intent still launches through the Windows argv transport",
+  );
 
   const validatedQuoted = validateCreateResearchMissionInput({
     ...researchMission('"'.repeat(RESEARCH_INTENT_MAX_LENGTH)),

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { ConversationFile } from "../cave-conversations.ts";
 import type { FlowRunRecord } from "../flows.ts";
-import { allowedResearchActions, type ResearchMission, type ResearchSourcePatch } from "../research-missions.ts";
+import {
+  allowedResearchActions,
+  RESEARCH_DIRECTION_MAX_LENGTH,
+  type ResearchMission,
+  type ResearchSourcePatch,
+} from "../research-missions.ts";
 import {
   CopilotArgvTransportError,
   CopilotPromptTransportError,
@@ -600,8 +605,8 @@ test("create and refine reject invalid prompt data before any launch or lossy pe
     },
   }));
   await assert.rejects(
-    refineRunner.act(stored.id, { action: "refine", direction: `x${"y".repeat(2_000)}` }),
-    /at most 2000 characters/,
+    refineRunner.act(stored.id, { action: "refine", direction: "x".repeat(RESEARCH_DIRECTION_MAX_LENGTH + 1) }),
+    new RegExp(`at most ${RESEARCH_DIRECTION_MAX_LENGTH} characters`),
   );
   await assert.rejects(
     refineRunner.act(stored.id, { action: "refine", direction: "valid prefix\0hidden" }),

--- a/src/styles/globals/surface-research-desk.css
+++ b/src/styles/globals/surface-research-desk.css
@@ -812,6 +812,13 @@
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: 1px;
 }
+.research-desk-refine__count {
+  align-self: flex-end;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-2xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+}
 .research-desk-refine__actions {
   display: flex;
   flex-wrap: wrap;

--- a/src/styles/globals/surface-research-prompt.css
+++ b/src/styles/globals/surface-research-prompt.css
@@ -77,10 +77,33 @@
 }
 .research-intake__card textarea {
   min-height: 96px;
-  max-height: 60vh;
+  /* ~12 lines (cave-r3vmj). The composer sizes the element to its content on
+     every change; this is the ceiling it settles against, after which the box
+     scrolls. `lh` is the honest unit here — it tracks the line-height above,
+     so the cap stays 12 lines if the type scale moves. The px value is the
+     fallback for engines without `lh`. */
+  max-height: 306px;
+  max-height: calc(12lh + (var(--space-3) * 2));
   font-size: var(--text-md);
   line-height: 1.5;
   padding: var(--space-3) 14px;
+  /* Room for the counter so a long brief never runs under it. */
+  padding-bottom: calc(var(--space-3) + 14px);
+}
+
+/* Character count, anchored inside the prompt box (its container is already
+   position: relative for the slash-command palette). */
+.research-intent-count {
+  position: absolute;
+  right: 12px;
+  bottom: 8px;
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+.research-intent-count--near {
+  color: var(--text-warning, var(--text-strong));
 }
 
 /* ── Slash-command palette (design 548–559): anchored under the textarea. ── */

--- a/src/styles/globals/surface-research-studio.css
+++ b/src/styles/globals/surface-research-studio.css
@@ -668,6 +668,7 @@
   font-size: var(--text-2xs);
   color: var(--text-muted);
 }
+.research-studio-config__count--near { color: var(--color-warning); }
 .research-studio-config__note {
   margin: 0;
   font-size: var(--text-xs);

--- a/src/styles/review-deck.css
+++ b/src/styles/review-deck.css
@@ -542,6 +542,13 @@
   outline: none;
 }
 .rd-note:focus-visible { border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-strong)); }
+.rd-character-count {
+  align-self: flex-end;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+}
 
 /* ── Checkpoints footer ── */
 .rd-checkpoints {


### PR DESCRIPTION
Re-targets the work from #4624 directly at `main`.

#4624 is stacked on #4621, and #4621 was closed (superseded), which orphaned
the stack: the async merge endpoint refuses with *"Pull request must be open
and not in draft mode"* — referring to the closed parent, not to #4624 — and
`PATCH base` is rejected with *"Cannot change the base branch because the pull
request is part of a stack."* This PR is the same head against `main` so the
work can land.

## Contents

Aligns the Research Desk / Studio direction ceilings and the Review Deck
review-body limit so UI bounds, client validation, and server validation agree,
and raises the Research intent cap to 25,000 with a live character count and a
prompt box that grows to ~12 lines.

## Why this is safe to land as-is

- Head `ede17a463` is a single commit on top of `3501db3c2`, which is already
  on `main`, so the diff against `main` is exactly the intended 20 files.
- That head already has a green `Frontend build` — all seven parallel
  validation jobs plus the aggregator's Playwright pass.
- Payload verified present after the rebase: `RESEARCH_INTENT_MAX_LENGTH =
  25_000`, the `research-intent-count` markup, and the `12lh` height cap.

Original PR #4624 stays open against its stack parent; it should be closed once
this lands.