### PR TITLE
docs(code): record the two-GitHub-surfaces decision where a reader will find it

### DIFF
--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -15,6 +15,18 @@
  * Activity/PRs/Issues/Reviews tabs; the dock's GitHub tab mounts a second,
  * session-scoped copy so triage never has to displace a running shell.
  * Workspace routing lives outside this component.
+ *
+ * TWO GITHUB SURFACES ARE INTENTIONAL (cave-xxp9f, owner decision 2026-08-15).
+ * The 2026-07-26 Coding Room design said "there is no top-level GitHub page",
+ * and cave-uod42 (#4319) built the dock tab without removing these top tabs.
+ * That split is now the decision rather than drift:
+ *   - top tabs  — full-width triage, for scanning a long list
+ *   - dock tab  — a session-scoped glance that never displaces a running shell
+ * Pending-GitHub navigation (pending-code-navigation.ts) therefore keeps
+ * routing to the TOP tabs, and tests/code-surface.spec.ts pins that landing.
+ * Do not "reconcile" either to the spec line above without a new owner call —
+ * note the design doc itself is not in this repository, so this comment is the
+ * record.
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";


### PR DESCRIPTION
Closes `cave-xxp9f`. **Comment-only — no behaviour change.**

`cave-xxp9f` asked whether to retire the top-level Activity/PRs/Issues/Reviews tabs now that the Coding Room dock has a GitHub tab. It was explicitly blocked on an owner decision, and the owner chose: **keep both**.

The split is now deliberate rather than drift:

| surface | role |
|---|---|
| top tabs | full-width triage, for scanning a long list |
| dock tab | a session-scoped glance that never displaces a running shell |

So pending-GitHub navigation (`pending-code-navigation.ts`) keeps routing to the **top** tabs, and the landing pin in `tests/code-surface.spec.ts` stays as-is. Nothing is rewired.

### Why the record goes in the code comment

The bead's plan was "amend the spec". I went looking for it first: **the 2026-07-26 Coding Room design doc is not in this repository.** `docs/superpowers` has 139 files on `main` and none of them is that spec — not tracked, not sitting untracked on disk. `git grep "top-level GitHub page"` across `docs/` returns nothing.

So there was no spec to amend, and the header comment in `code-view.tsx` was already the only written description of the split. This makes it the decision of record, next to the code it governs, and tells the next reader not to "reconcile" either surface to a spec line they can't find.

That absent-spec pattern is worth noting on its own: several beads this week (`cave-3pnnq`, `cave-jcdgb`) also cite `docs/superpowers/specs/...` documents whose notes say they were left uncommitted. A decision recorded only in an uncommitted doc is a decision the repository does not have.