### PR TITLE
test(research): clarify prompt limit coverage

### DIFF
--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -81,7 +81,7 @@ test("mission parser validates shared-state fields and reconstructs safe data", 
   }), null);
 });
 
-test("research prompt limits retain the requested intent and direction capacity", () => {
+test("research prompt limits validate intent capacity and pin the shared direction ceiling", () => {
   assert.equal(RESEARCH_INTENT_MAX_LENGTH, 25_000);
   assert.equal(RESEARCH_DIRECTION_MAX_LENGTH, 10_000);
   assert.equal(


### PR DESCRIPTION
## Summary

Rename the Research prompt-limit contract test so its title matches its actual coverage: intent boundary validation plus a pinned shared direction ceiling.

Follow-up to the Copilot review on #4663.

## Verification

- `node --experimental-strip-types --test src/lib/research-missions.test.ts` (53 passing)
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

Bead: `cave-r0bkx`