### PR TITLE
fix(backdrop): let the familiar backdrop reach the top bar

### DIFF
--- a/src/components/backdrop-scrim.test.ts
+++ b/src/components/backdrop-scrim.test.ts
@@ -116,3 +116,33 @@ assert.match(
   /writeFamiliarBackdropImage\(familiarId, blob\)/,
   "uploads persist through the per-familiar backdrop store",
 );
+
+// ── Top bar joins the backdrop (cave-vyp3e) ──────────────────────────────────
+// .shell-top and .top-bar paint an opaque var(--bg-base) so they read as a
+// seamless extension of the canvas. With a backdrop on, everything below them
+// is translucent, so an opaque bar cut the image off in a hard line. Pin the
+// glass AND both fallbacks: a translucent band with no scrim would leave the
+// bar's controls and search text sitting on raw photo.
+assert.match(
+  css,
+  /html\[data-backdrop-on\] \.shell-top,\s*\n\s*html\[data-backdrop-on\] \.top-bar \{[^}]*background: color-mix\(in oklch, var\(--bg-base\) 46%, transparent\);[^}]*\}/,
+  "both top bars take the same 46% glass the native titlebar already uses",
+);
+assert.match(
+  css,
+  /html\[data-backdrop-on\] \.shell-top,\s*\n\s*html\[data-backdrop-on\] \.top-bar \{[^}]*backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);[^}]*\}/,
+  "the band blurs the backdrop behind it rather than only tinting it",
+);
+// Both fallbacks restore the OPAQUE band. The native rule falls back to
+// transparent because the window supplies its own material; in the browser the
+// baseline is var(--bg-base), so transparent would strand the controls.
+assert.match(
+  css,
+  /@supports not \(\(backdrop-filter: blur\(1px\)\) or \(-webkit-backdrop-filter: blur\(1px\)\)\) \{\s*\n\s*html\[data-backdrop-on\] \.shell-top,\s*\n\s*html\[data-backdrop-on\] \.top-bar \{\s*\n\s*background: var\(--bg-base\);/,
+  "without backdrop-filter the bar falls back to the opaque band, not a bare wash",
+);
+assert.match(
+  css,
+  /@media \(prefers-reduced-transparency: reduce\) \{\s*\n\s*html\[data-backdrop-on\] \.shell-top,\s*\n\s*html\[data-backdrop-on\] \.top-bar \{[^}]*backdrop-filter: none;[^}]*\}/,
+  "reduced-transparency drops the glass instead of merely thinning it",
+);

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -115,6 +115,46 @@ html[data-backdrop-on] .cave-chat-linear {
   background: color-mix(in oklch, var(--bg-base) 16%, transparent);
 }
 
+/* ── The top bar joins the backdrop (cave-vyp3e) ─────────────────────────────
+   .shell-top (desktop) and .top-bar (mobile) both paint an opaque
+   var(--bg-base) to read as a seamless extension of the canvas. That is right
+   with no backdrop and wrong with one: everything below them goes translucent
+   above, so the familiar's image stopped in a hard line at the top bar.
+
+   This is the SAME glass the native shell already gives itself — see
+   `:root[data-tauri-titlebar] .shell-top` in globals/desktop-chrome.css, which
+   is why the packaged app already looked right and the browser tab did not.
+   Reusing its exact values keeps the two shells identical rather than
+   introducing a second, slightly different titlebar treatment.
+
+   Deliberately NOT `background: transparent` like .shell-root above: the bar
+   carries controls and search text directly over the image, so it needs the
+   scrim-plus-blur that the content panes get from their own glass. Both
+   fallbacks below come from the native rule and matter here for the same
+   reasons — without them the band would drop to unscrimmed text on a photo. */
+html[data-backdrop-on] .shell-top,
+html[data-backdrop-on] .top-bar {
+  background: color-mix(in oklch, var(--bg-base) 46%, transparent);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+}
+
+/* No blur available: fall back to the seamless opaque band rather than a bare
+   translucent one, which would leave the controls sitting on raw image. */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  html[data-backdrop-on] .shell-top,
+  html[data-backdrop-on] .top-bar {
+    background: var(--bg-base);
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  html[data-backdrop-on] .shell-top,
+  html[data-backdrop-on] .top-bar {
+    background: var(--bg-base);
+    backdrop-filter: none;
+  }
+}
+
 /* ── Readable transcript over the image (cave-5oeu) ──────────────────────────
    The session transcript deliberately flattens bubbles to bare text on the
    pane (.cave-chat-linear strips bubble fills/borders), so with a backdrop

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -121,17 +121,23 @@ html[data-backdrop-on] .cave-chat-linear {
    with no backdrop and wrong with one: everything below them goes translucent
    above, so the familiar's image stopped in a hard line at the top bar.
 
-   This is the SAME glass the native shell already gives itself — see
-   `:root[data-tauri-titlebar] .shell-top` in globals/desktop-chrome.css, which
-   is why the packaged app already looked right and the browser tab did not.
-   Reusing its exact values keeps the two shells identical rather than
-   introducing a second, slightly different titlebar treatment.
+   The lit state below copies the SAME glass the native shell already gives
+   itself — see `:root[data-tauri-titlebar] .shell-top` in
+   globals/desktop-chrome.css, which is why the packaged app already looked
+   right and the browser tab did not. Matching its values keeps the two shells
+   showing one titlebar treatment rather than two slightly different ones.
 
    Deliberately NOT `background: transparent` like .shell-root above: the bar
    carries controls and search text directly over the image, so it needs the
-   scrim-plus-blur that the content panes get from their own glass. Both
-   fallbacks below come from the native rule and matter here for the same
-   reasons — without them the band would drop to unscrimmed text on a photo. */
+   scrim-plus-blur that the content panes get from their own glass.
+
+   ⚠️ The two fallbacks below intentionally DIVERGE from the native rule, which
+   drops to `background: transparent`. Do not "resync" them. The native window
+   supplies its own material behind a transparent band; here the baseline is an
+   opaque var(--bg-base), so transparent would leave the bar's controls sitting
+   on unscrimmed photo the moment blur is unavailable or the reader asks for
+   reduced transparency. Restoring the opaque band is the safe direction in
+   both cases — and for prefers-reduced-transparency it is the correct one. */
 html[data-backdrop-on] .shell-top,
 html[data-backdrop-on] .top-bar {
   background: color-mix(in oklch, var(--bg-base) 46%, transparent);


### PR DESCRIPTION
## What you asked for vs what was already there

Per-familiar backdrops **already exist** (cave-kf8p) and I did not rebuild them:
`readFamiliarBackdropImage` / `writeFamiliarBackdropImage` persist an image per
familiar, `setFamiliarBackdropEnabled` toggles it, and Familiar Studio → **Look**
surfaces the controls. Switching the active familiar already swaps the image.

The actual gap was the one you named: the backdrop stopped at the top bar.

## Why

`backdrop.css` turns the big opaque paints translucent while a backdrop is
frontmost:

```css
html[data-backdrop-on] .shell-root,
html[data-backdrop-on] .shell-detail-panel,
html[data-backdrop-on] .shell-detail { background: transparent; }
```

`.shell-top` (desktop) and `.top-bar` (mobile) are not in that list. Both paint
an opaque `var(--bg-base)` to read as a seamless extension of the canvas —
correct with no backdrop, wrong with one — so the image ended in a hard line
across the top of the window.

The native shell had already fixed this for itself in
`globals/desktop-chrome.css`:

```css
:root[data-tauri-titlebar] .shell-top {
  background: color-mix(in oklch, var(--bg-base) 46%, transparent);
  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
}
```

That is why the packaged desktop app already looked right and the browser tab
and mobile bar did not.

## The change

Extend that same treatment to `html[data-backdrop-on]`, reusing the native
rule's exact values so the two shells render one titlebar treatment rather than
two subtly different ones.

Two deliberate choices:

- **Not `background: transparent`** like `.shell-root`. The bar carries controls
  and search text directly over the image, so it needs the scrim-and-blur that
  content panes get from their own glass.
- **Both fallbacks restore the opaque band**, where the native rule falls back
  to `transparent`. The native window supplies its own material; in the browser
  the baseline *is* `var(--bg-base)`, so transparent would strand the controls
  on raw photo. For `prefers-reduced-transparency` that is also the correct
  direction — less transparency, not more.

## Verification

- `tsc --noEmit` and `pnpm lint` both exit 0
- 4 pins added to `backdrop-scrim.test.ts`, covering the glass, the blur, and
  both fallbacks
- Every pin mutation-tested: reverting the rule, dropping the blur, weakening
  the `@supports` fallback to `transparent`, and deleting the
  reduced-transparency block each fail a **different** assertion, and all pass
  once restored