### PR TITLE
feat(backdrop): fall back to an accent wash when a familiar has no image

### DIFF
--- a/src/components/backdrop-scrim.test.ts
+++ b/src/components/backdrop-scrim.test.ts
@@ -146,3 +146,30 @@ assert.match(
   /@media \(prefers-reduced-transparency: reduce\) \{\s*\n\s*html\[data-backdrop-on\] \.shell-top,\s*\n\s*html\[data-backdrop-on\] \.top-bar \{[^}]*backdrop-filter: none;[^}]*\}/,
   "reduced-transparency drops the glass instead of merely thinning it",
 );
+
+// ── Accent wash fallback (cave-vyp3e follow-up) ──────────────────────────────
+// A familiar switched on with no uploaded image enabled a layer with nothing
+// in it, so the toggle read as broken. The wash is the tail of the chain:
+// familiar image → app image → accent. (Reuses `layer`, read above.)
+assert.match(
+  css,
+  /html\[data-backdrop\] \.cave-backdrop-layer\[data-backdrop-style="accent"\] \{[^}]*radial-gradient\(/s,
+  "the accent style paints a gradient wash rather than a flat tint",
+);
+assert.match(
+  css,
+  /color-mix\(in oklch, var\(--cave-backdrop-accent, var\(--accent-presence\)\) 22%, transparent\)/,
+  "the wash is seeded from the familiar accent and falls back to the theme accent",
+);
+// Ordering is the contract, not the boolean: the wash must be REACHED ONLY
+// when both images are absent, and must never pre-empt Blaze.
+assert.match(
+  layer,
+  /accentShowing =\s*\n?\s*effectiveEnabled && !blazeShowing && effectiveUrl === null && accentWash !== null/,
+  "the wash requires no image of either kind and yields to Blaze",
+);
+assert.match(
+  layer,
+  /data-backdrop-style=\{blazeShowing \? "blaze" : accentShowing \? "accent" : "image"\}/,
+  "Blaze outranks the wash, which outranks the image style",
+);

--- a/src/components/cave-backdrop-layer.tsx
+++ b/src/components/cave-backdrop-layer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import "@/styles/backdrop.css";
 import {
   applyBackdropToDocument,
@@ -32,9 +32,15 @@ import { CaveBackdropBlaze } from "@/components/cave-backdrop-blaze";
 export function CaveBackdropLayer({
   active,
   familiarId = null,
+  accent = null,
 }: {
   active: boolean;
   familiarId?: string | null;
+  /** The active familiar's resolved accent color. Paints a wash derived from
+   *  it when the familiar is switched on but no image — theirs or the app's —
+   *  is available to show. Without this that state renders an enabled layer
+   *  with nothing in it, so the switch looked broken (cave-vyp3e follow-up). */
+  accent?: string | null;
 }) {
   const prefs = useBackdropPrefs();
   const imageRevision = useBackdropImageRevision();
@@ -67,6 +73,15 @@ export function CaveBackdropLayer({
   // per-familiar opt-in) still takes the layer over while it is showing.
   const blazeShowing =
     effectiveEnabled && prefs.style === "blaze" && !familiarImageShowing;
+  // Last resort in the fallback chain: familiar image → app image → accent
+  // wash. Reached only when the layer is enabled and BOTH images are absent,
+  // which is exactly the state a familiar lands in when it is switched on
+  // without an upload — previously an enabled-but-empty layer, so the toggle
+  // appeared to do nothing. Blaze owns the layer when selected, so it is
+  // checked first and the wash never competes with it.
+  const accentWash = accent?.trim() || null;
+  const accentShowing =
+    effectiveEnabled && !blazeShowing && effectiveUrl === null && accentWash !== null;
 
   // Load (or clear) the stored image whenever the backdrop is toggled or its
   // bytes change. writeBackdropImage publishes the latter independently from
@@ -154,7 +169,13 @@ export function CaveBackdropLayer({
     <div
       className="cave-backdrop-layer"
       data-on={active ? "true" : "false"}
-      data-backdrop-style={blazeShowing ? "blaze" : "image"}
+      data-backdrop-style={blazeShowing ? "blaze" : accentShowing ? "accent" : "image"}
+      // Custom property, not a background shorthand: the gradient's shape and
+      // stops live in backdrop.css next to the rest of the layer's painting,
+      // so only the seed color crosses from JS. React writes custom properties
+      // through style.setProperty, which takes the value as a single
+      // declaration — a stray ";" makes it invalid rather than injecting.
+      style={accentShowing ? ({ "--cave-backdrop-accent": accentWash } as CSSProperties) : undefined}
       aria-hidden
     >
       {blazeShowing && active ? <CaveBackdropBlaze /> : null}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -3750,6 +3750,15 @@ export function Workspace() {
       <CaveBackdropLayer
         active={mode === "home" || mode === "chat"}
         familiarId={mode === "chat" ? activeId : null}
+        // Same resolved color the rail ring uses, so a familiar with no
+        // uploaded image still tints the room recognisably. Scoped to the
+        // chat familiar exactly like familiarId — on Home there is no single
+        // familiar whose accent would be the honest one to show.
+        accent={
+          mode === "chat"
+            ? resolvedFamiliars.find((f) => f.id === activeId)?.color ?? null
+            : null
+        }
       />
       <Shell
         ref={shellRef}

--- a/src/lib/cave-backdrop-blaze.test.ts
+++ b/src/lib/cave-backdrop-blaze.test.ts
@@ -113,10 +113,14 @@ assert.match(
   /\{blazeShowing && active \? <CaveBackdropBlaze \/> : null\}/,
   "the GPU loop unmounts whenever no backdrop surface is frontmost",
 );
+// Blaze is the FIRST branch, so it still owns the layer whenever it is
+// selected. Deliberately open-ended after that: the accent wash added a third
+// value (backdrop-scrim.test.ts owns the full ordering), and pinning the whole
+// ternary here made this fail for a change that never touched Blaze.
 assert.match(
   layer,
-  /data-backdrop-style=\{blazeShowing \? "blaze" : "image"\}/,
-  "CSS can target the active backdrop style",
+  /data-backdrop-style=\{blazeShowing \? "blaze" : /,
+  "CSS can target the active backdrop style, and Blaze outranks the others",
 );
 assert.match(
   layer,

--- a/src/lib/cave-backdrop.test.ts
+++ b/src/lib/cave-backdrop.test.ts
@@ -372,10 +372,22 @@ assert.match(
   "the layer revokes its previous object URL before replacing or clearing it",
 );
 assert.match(layer, /root\.dataset\.backdropOn = "1"/, "the frontmost-surface flag rides <html>");
+// Asserts the two scoping props, not the element's full shape. The trailing
+// `/>` used to be part of this pattern, which made any ADDED prop fail a pin
+// about scoping — the accent wash prop tripped it without changing either
+// contract below.
 assert.match(
   workspace,
-  /<CaveBackdropLayer\s+active=\{mode === "home" \|\| mode === "chat"\}\s+familiarId=\{mode === "chat" \? activeId : null\}\s*\/>/,
+  /<CaveBackdropLayer\s+active=\{mode === "home" \|\| mode === "chat"\}\s+familiarId=\{mode === "chat" \? activeId : null\}/,
   "the workspace scopes the backdrop to Home + Chat, with the active chat familiar as the override scope",
+);
+// The accent seed follows the SAME scope as familiarId. Unscoped, Home (which
+// has no single active familiar) would wash the room in whichever familiar was
+// last selected in chat.
+assert.match(
+  workspace,
+  /accent=\{\s*mode === "chat"\s*\?\s*resolvedFamiliars\.find\(\(f\) => f\.id === activeId\)\?\.color \?\? null\s*:\s*null\s*\}/,
+  "the accent wash is seeded only from the active chat familiar, never on Home",
 );
 assert.match(css, /html\[data-backdrop-on\] \.shell-root,/, "shell panes go translucent only while a backdrop surface is frontmost");
 assert.match(

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -25,6 +25,26 @@ html[data-backdrop] .cave-backdrop-layer[data-on="true"] {
   opacity: var(--cave-backdrop-opacity, 0.35);
 }
 
+/* Accent wash — the tail of the fallback chain (familiar image → app image →
+   this). A familiar switched on with no upload used to enable an empty layer,
+   so the toggle read as broken; this gives it something that is still visibly
+   THEIRS, seeded from the same accent that drives their rail ring.
+
+   A top-anchored radial rather than a flat fill: the scrim below already
+   darkens toward the bottom where composers and transcripts sit, so a uniform
+   tint would fight it. Kept well under the image path's strength — this is a
+   hint of color on the canvas, not a picture, and it must not cost contrast on
+   surfaces the user cannot re-tune. --cave-backdrop-accent is set inline by
+   cave-backdrop-layer.tsx; the fallback keeps the rule valid if it is ever
+   missing. */
+html[data-backdrop] .cave-backdrop-layer[data-backdrop-style="accent"] {
+  background-image: radial-gradient(
+    120% 80% at 50% 0%,
+    color-mix(in oklch, var(--cave-backdrop-accent, var(--accent-presence)) 22%, transparent),
+    transparent 62%
+  );
+}
+
 /* Readability floor: bg-base gradient scrim, heavier toward the bottom where
    composers and transcripts live. Sits inside the layer so the intensity
    slider scales image and scrim together. */


### PR DESCRIPTION
## The gap

Switching a familiar's backdrop on **without uploading an image** enabled the
layer and painted nothing. The fallback ran familiar image → app image, and
with neither present the layer rendered empty — so the toggle looked broken.

That is not a hypothetical state: `isFamiliarBackdropOn` treats an explicit
`true` as on regardless of whether an image exists, which is exactly what the
Look tab's switch writes.

## The change

A third rung on the chain: **familiar image → app image → accent wash**. When
the layer is enabled and both images are absent, paint a wash seeded from the
familiar's resolved accent — the same color that drives their rail ring, so the
room still reads as theirs.

```
familiar image  ─┐
app image       ─┼─→ first one present wins
accent wash     ─┘   (new: only when neither exists)
```

Ordering is the contract, and the pins assert it rather than the boolean:

- **Blaze still owns the layer** when that style is selected.
- The wash is reached **only when no image of either kind exists**, so it can
  never pre-empt a picture the user actually uploaded.

## Design notes

- The gradient's shape and stops live in `backdrop.css` beside the rest of the
  layer's painting; only the seed color crosses from JS, as a custom property.
  React writes custom properties through `style.setProperty`, so a stray `;` in
  a user-supplied color makes the value invalid rather than injecting anything.
- Top-anchored radial rather than a flat fill: the scrim already darkens toward
  the bottom where composers and transcripts sit, and a uniform tint would fight
  it.
- Kept well under the image path's strength. This is a hint of color on the
  canvas, not a picture, and it must not cost contrast on surfaces the user
  cannot re-tune.
- Scoped to the chat familiar exactly like `familiarId`. On Home there is no
  single familiar whose accent would be the honest one to show.

## Verification

- `tsc --noEmit` and `pnpm lint` both exit 0
- 4 pins added, each **mutation-tested**: removing the CSS rule, letting the
  wash pre-empt Blaze, letting it override an existing image, and inverting the
  attribute precedence each fail a **different** assertion, and all pass once
  restored