### PR TITLE
Exercise every React hook lint source glob

### DIFF
--- a/scripts/eslint/react-hooks-gate.test.mjs
+++ b/scripts/eslint/react-hooks-gate.test.mjs
@@ -34,42 +34,31 @@ async function hookErrorsFor(relativePath, source) {
 
 // A hook after an early return — the exact shape that crashed the Relations
 // graph (cave-qxq4l) with "Rendered more hooks than during the previous
-// render". One case per linted scope; the src/lib fixture is a custom hook in a
-// .ts file rather than a component, because .ts cannot carry JSX.
-const OFFENDERS = [
-  [
-    "src/components/__react-hooks-gate-fixture.tsx",
-    `import { useState } from "react";
-
-export function ConditionalHook({ enabled }: { enabled: boolean }) {
-  if (!enabled) return null;
-  const [value] = useState(0);
-  return <div>{value}</div>;
-}
-`,
-  ],
-  [
-    "src/lib/__react-hooks-gate-fixture.ts",
-    `import { useState } from "react";
+// render". One case per configured source glob proves both extensions are
+// enforced in every linted scope.
+const TS_OFFENDER = `import { useState } from "react";
 
 export function useConditional(enabled: boolean) {
   if (!enabled) return null;
   const [value] = useState(0);
   return value;
 }
-`,
-  ],
-  [
-    "src/app/__react-hooks-gate-fixture.tsx",
-    `import { useState } from "react";
+`;
+const TSX_OFFENDER = `import { useState } from "react";
 
-export default function Page({ enabled }: { enabled: boolean }) {
+export function ConditionalHook({ enabled }: { enabled: boolean }) {
   if (!enabled) return null;
   const [value] = useState(0);
   return <div>{value}</div>;
 }
-`,
-  ],
+`;
+const OFFENDERS = [
+  ["src/components/__react-hooks-gate-fixture.ts", TS_OFFENDER],
+  ["src/components/__react-hooks-gate-fixture.tsx", TSX_OFFENDER],
+  ["src/app/__react-hooks-gate-fixture.ts", TS_OFFENDER],
+  ["src/app/__react-hooks-gate-fixture.tsx", TSX_OFFENDER],
+  ["src/lib/__react-hooks-gate-fixture.ts", TS_OFFENDER],
+  ["src/lib/__react-hooks-gate-fixture.tsx", TSX_OFFENDER],
 ];
 
 for (const [relativePath, source] of OFFENDERS) {


### PR DESCRIPTION
## Summary

Extend the executable Rules of Hooks gate to prove ESLint rejects conditional hooks in every configured source glob: `ts` and `tsx` across `src/components`, `src/app`, and `src/lib`.

## Context

PR #4668 landed the underlying Rules of Hooks enforcement. PR #4672 then landed and expanded the original behavioral test from this PR while #4671 was waiting on CI. This follow-up preserves that stronger `main` version and closes the remaining runtime-coverage gap by exercising all six source glob variants.

## Changes

- share representative invalid TypeScript and TSX fixtures
- run each fixture through the real ESLint config in all three source areas
- retain the clean control and severity assertions from `main`

## Verification

- `node scripts/rules-of-hooks-gate.test.mjs`
- `node scripts/eslint/react-hooks-gate.test.mjs`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:app` (1,213 files)
- `pnpm test:api` (379 files)
- `pnpm check:tests-wired` (1,673 files)

Bead: `cave-hmltt`