### PR TITLE
fix(worktree): make the head-mismatch diagnosis reachable

### DIFF
--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -3194,6 +3194,28 @@ function collectInventory(
                 Date.parse(right.mergedAt!) - Date.parse(left.mergedAt!),
             )[0] ?? null
         : null;
+    // The near miss (cave-5ulwl): same repo and base filters as exactMerged, but
+    // the OPPOSITE head test. This never feeds landedness — that still demands
+    // exact equality above — it only lets the classifier say "one fast-forward
+    // behind" instead of the generic "not proven landed". Widening exactMerged
+    // itself would silently mark behind-HEAD units as landed, which is the
+    // failure this is designed to avoid.
+    const branchMerged =
+      defaultBranch.branch !== null && prs.canonicalRepo !== null
+        ? unitPullRequests
+            .filter(
+              (pullRequest) =>
+                pullRequest.state === "MERGED" &&
+                pullRequest.headRefOid !== unit.head &&
+                pullRequest.baseRepository.toLowerCase() ===
+                  prs.canonicalRepo!.toLowerCase() &&
+                pullRequest.baseRefName === defaultBranch.branch,
+            )
+            .sort(
+              (left, right) =>
+                Date.parse(right.mergedAt!) - Date.parse(left.mergedAt!),
+            )[0] ?? null
+        : null;
     const landing =
       unit.branch !== null && ancestry.value && defaultBranch.oid !== null
         ? exactDefaultLandingAt(
@@ -3285,6 +3307,13 @@ function collectInventory(
             number: exactMerged.number,
             url: exactMerged.url,
             headOid: exactMerged.headRefOid,
+          }
+        : null,
+      branchMergedPr: branchMerged
+        ? {
+            number: branchMerged.number,
+            url: branchMerged.url,
+            headOid: branchMerged.headRefOid,
           }
         : null,
       activeWorkflowUrls,

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -1222,4 +1222,69 @@ function legacyObservation(overrides = {}) {
   );
 }
 
+// ── cave-5ulwl: the head-mismatch reason must be REACHABLE ──────────────────
+// It was dead code. `mergedPr` is built by the inventory from an exact
+// `headRefOid === head` filter, so `mergedPr.headOid !== head` could never be
+// true for any observation the inventory produces, and a unit sitting one
+// commit behind its own merged PR fell through to the generic
+// "not proven landed" — which reads as "may hold unlanded work".
+{
+  const item = classifyLifecycleUnit(
+    observation({
+      head: "a".repeat(40),
+      headOnDefaultBranch: false,
+      mergedPr: null,
+      branchMergedPr: { number: 4658, url: "https://example.test/4658", headOid: "b".repeat(40) },
+    }),
+    NOW,
+  );
+  assert.equal(item.lane, "recovery", "a behind-HEAD unit is still preserved");
+  const reasons = item.reasons.join("\n");
+  assert.match(reasons, /does not match merged PR #4658/, "names the PR that actually merged");
+  assert.match(reasons, /bbbbbbbbb/, "names the commit to fast-forward to");
+  assert.match(reasons, /--ff-only/, "names the remedy, since the fix is mechanical");
+  assert.doesNotMatch(
+    reasons,
+    /not proven landed/,
+    "the specific diagnosis replaces the generic one rather than joining it",
+  );
+}
+
+// The near miss must NEVER be mistaken for landing evidence: exact equality is
+// what proves a unit landed, and widening that is the failure this design
+// avoids. A behind-HEAD unit stays in recovery, never cleanup-ready.
+{
+  const item = classifyLifecycleUnit(
+    observation({
+      head: "a".repeat(40),
+      headOnDefaultBranch: false,
+      mergedPr: null,
+      branchMergedPr: { number: 1, url: "https://example.test/1", headOid: "c".repeat(40) },
+      updatedAtMs: NOW - 30 * DAY,
+    }),
+    NOW,
+  );
+  assert.notEqual(item.lane, "cleanup-ready", "a near miss is not landing evidence");
+}
+
+// A near miss whose head EQUALS this unit's head is not a mismatch at all, and
+// an absent field must read as "no near miss known" for legacy callers.
+{
+  const head = "a".repeat(40);
+  for (const near of [
+    { number: 9, url: "https://example.test/9", headOid: head },
+    null,
+  ]) {
+    const item = classifyLifecycleUnit(
+      observation({ head, headOnDefaultBranch: false, mergedPr: null, branchMergedPr: near }),
+      NOW,
+    );
+    assert.match(
+      item.reasons.join("\n"),
+      /not proven landed/,
+      "without a genuine mismatch the generic reason still applies",
+    );
+  }
+}
+
 console.log("worktree-lifecycle.test.ts: ok");

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -81,7 +81,20 @@ export type WorktreeLifecycleObservation = {
    */
   mentionTaskIds: string[];
   openPrs: WorktreePrRef[];
+  /**
+   * A merged PR whose head is EXACTLY this unit's HEAD. Exact equality is the
+   * point: it is what proves the unit landed, so it must not be widened.
+   */
   mergedPr: WorktreeMergedPrRef | null;
+  /**
+   * The near miss: a merged PR for this unit's BRANCH whose head is a DIFFERENT
+   * commit. It never proves landing — it exists so the classifier can say "one
+   * fast-forward behind" instead of the generic "not proven landed".
+   *
+   * Optional so legacy callers that never populate it keep their old behaviour;
+   * absent reads as "no near miss known" (cave-5ulwl).
+   */
+  branchMergedPr?: WorktreeMergedPrRef | null;
   activeWorkflowUrls: string[];
   headOnDefaultBranch: boolean;
   remoteRefsContainingHead: string[];
@@ -268,6 +281,37 @@ export type WorktreeLifecycleBudgets = {
     expired: number;
   };
 };
+
+/**
+ * The merged PR this unit's HEAD *should* be at, when it demonstrably is not.
+ *
+ * Two sources, deliberately kept apart from the landedness test:
+ *  - `mergedPr` with a differing head. Unreachable from the inventory, which
+ *    builds that field from an exact `headRefOid === head` filter, but kept for
+ *    library callers that construct observations themselves.
+ *  - `branchMergedPr`, the near miss: the branch HAS a merged PR, this worktree
+ *    just sits at a different commit — usually a fixup pushed after the local
+ *    HEAD was last synced.
+ *
+ * Before cave-5ulwl only the first existed, so the second case fell through to
+ * the generic "not proven landed", which reads as "may hold unlanded work" when
+ * the truth is "one fast-forward behind".
+ */
+function mergedPrHeadMismatch(
+  observation: Pick<WorktreeLifecycleObservation, "head" | "mergedPr" | "branchMergedPr">,
+): WorktreeMergedPrRef | null {
+  if (observation.mergedPr) {
+    return observation.mergedPr.headOid === observation.head ? null : observation.mergedPr;
+  }
+  const nearMiss = observation.branchMergedPr ?? null;
+  if (!nearMiss || nearMiss.headOid === observation.head) return null;
+  return nearMiss;
+}
+
+/** Names the remedy, because the fix is mechanical once the commit is known. */
+function headMismatchReason(pr: WorktreeMergedPrRef): string {
+  return `local HEAD does not match merged PR #${pr.number} head ${pr.headOid.slice(0, 9)} — fast-forward with \`git merge --ff-only ${pr.headOid}\` if this unit holds nothing else`;
+}
 
 export const RETIREMENT_COOLDOWN_MS = 8 * 60 * 60 * 1000;
 /** Branch namespaces whose content is a snapshot to preserve, never retire.
@@ -559,9 +603,10 @@ function classifyLifecycleUnitInternal(
     );
   }
 
-  if (observation.mergedPr && observation.mergedPr.headOid !== observation.head) {
+  const headMismatchPr = mergedPrHeadMismatch(observation);
+  if (headMismatchPr) {
     return withReasons(observation, "recovery", [
-      `local HEAD does not match merged PR #${observation.mergedPr.number} head`,
+      headMismatchReason(headMismatchPr),
       ...reviewAfterReasons(observation.metadata, nowMs),
     ]);
   }
@@ -630,10 +675,9 @@ function classifyLifecycleUnitWithoutMetadata(
     ]);
   }
 
-  if (observation.mergedPr && observation.mergedPr.headOid !== observation.head) {
-    return withReasons(observation, "recovery", [
-      `local HEAD does not match merged PR #${observation.mergedPr.number} head`,
-    ]);
+  const legacyHeadMismatchPr = mergedPrHeadMismatch(observation);
+  if (legacyHeadMismatchPr) {
+    return withReasons(observation, "recovery", [headMismatchReason(legacyHeadMismatchPr)]);
   }
 
   const landed = observation.headOnDefaultBranch || observation.mergedPr !== null;


### PR DESCRIPTION
Closes `cave-5ulwl`.

### The dead guard

`worktree-lifecycle.ts` guards at two sites to report *"local HEAD does not match merged PR #N head"*:

```ts
if (observation.mergedPr && observation.mergedPr.headOid !== observation.head) { … }
```

That branch **can never be taken**. The inventory builds `mergedPr` from an exact-equality filter and then assigns `headOid` from that same PR:

```ts
.filter(pr => pr.state === "MERGED" && pr.headRefOid === unit.head && …)
mergedPr: exactMerged ? { …, headOid: exactMerged.headRefOid } : null
```

So `mergedPr.headOid === head` by construction. Dead at both sites, and no test constructed a mismatching `mergedPr` either — nothing would have noticed.

### Why it matters — the case it names is real and common

When a worktree sits **behind** its own PR head (usually a fixup pushed after the local HEAD was last synced), no exact match exists, `mergedPr` is null, and the unit falls through to the generic:

> HEAD is not proven landed on the default branch or an exact merged PR

which reads as *"this might hold unlanded work"* when the truth is *"this is one fast-forward behind"*.

Measured on 2026-08-15: **7 of 45** units sat in that lane. Of three sampled, **all three** were ancestors of their merged PR head with **zero local-only commits** and clean trees.

| unit | local | merged PR head |
|---|---|---|
| `cave-1bw8w` | `a36db242b` | `d6dd3fd84` (#4613) |
| `cave-66s6g` | `b515c928a` | `db09b0db5` (#4637) |
| `cave-4xv9v` | `6c82306f2` | `466623835` (#4658) |

### The fix

The inventory now also computes a **near miss** — the newest `MERGED` PR for the unit's branch whose head *differs* — on a separate field, and the classifier reports it with the remedy: `git merge --ff-only <mergedHead>`.

**Deliberately not widening `exactMerged`.** Landedness must keep requiring exact equality; relaxing it there would silently mark behind-HEAD units as *landed*, which is the opposite of the intended repair. `branchMergedPr` never feeds `landed`, and a behind-HEAD unit stays in `recovery` exactly as before — only the sentence changes.

`branchMergedPr` is optional, so library callers that never populate it keep today's behaviour, and the original `mergedPr`-mismatch path is retained for callers that construct observations themselves.

### Coverage

- the reason is **reachable**, and names the PR, the commit, and the remedy
- a near miss is never mistaken for landing evidence — the unit is not `cleanup-ready`
- a near miss whose head *equals* HEAD, and an absent field, both still yield the generic reason
- **red-checked**: reverting the near-miss lookup fails on *"names the PR that actually merged"*
- `tsc --noEmit` clean

Related: `cave-jcdgb` carries the measurements and the broader ancestor-based relaxation. This PR is only about making the existing diagnosis reachable.