### PR TITLE
Make approved specs durable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Treat `main` as the canonical project state. Before starting work, fetch and branch from current `origin/main`.
 - Use branches and worktrees only as short-lived PR transport for active implementation. Do not use branches as durable storage, coordination logs, or half-finished agent memory.
 - Keep durable coordination in tracked workflow artifacts: plans, specs, issues, PR descriptions/checklists, release notes, and handoff docs.
+- Land an approved spec or plan on `main` through its own docs PR even when the implementation is deferred or abandoned. Bead citations must resolve on `main`; archive tags are recovery sources, not the canonical location of an approved design.
 - Before opening a PR, make the branch PR-shaped: scoped diff, relevant local verification, and a summary of what changed.
 - Create managed worktrees through `pnpm beads:worktrees:create --bead cave-123
   --branch fix/cave-123-example --owner kitty --purpose "Repair example"` so the

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,7 +113,7 @@ Point-in-time records. Read for intent, not for current behavior.
 
 ## Other trees under `docs/`
 
-- [`superpowers/`](superpowers) — the approved spec and plan store beads cite (133 files)
+- [`superpowers/`](superpowers) — the approved spec and plan store beads cite (142 files)
 - [`specs/`](specs) — **frozen** (55 files). The earlier flat convention, which overlapped `superpowers/` from 2026-06-30 to 2026-08-06. Closed to new files, and deliberately not migrated: beads cite these by path, including one open unit. See [`specs/README.md`](specs/README.md) for the reasoning and for the three undated standing contracts it holds
 - [`plans/`](plans), [`audits/`](audits) — small point-in-time sets predating the `superpowers/` store
 - [`design-handoff/`](design-handoff), [`diagrams/`](diagrams), [`screenshots/`](screenshots), [`familiar-chatout-codex/`](familiar-chatout-codex) — supporting material

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -49,3 +49,12 @@ Committing a design here makes it survive the authoring machine, which is what
 this directory is for. It does not make it survive a checkout that is never
 pushed. If a design matters, get it onto `origin`, and consider also pasting it
 into the bead's `DESIGN` field, which syncs through Dolt independently of git.
+
+Approval is the durability boundary. Once a spec or plan is approved, land it
+on `main` through a docs-only PR even if its implementation is deferred,
+reworked, or abandoned. A Bead may cite an approved design only by a path that
+resolves on `main`.
+
+Archive tags remain valuable recovery evidence, but they are not the canonical
+home of an approved design: a reader should not need to discover a retired
+branch name before they can open the document that governs active work.

--- a/docs/superpowers/plans/2026-08-04-administrative-cleanup-review.md
+++ b/docs/superpowers/plans/2026-08-04-administrative-cleanup-review.md
@@ -1,0 +1,1028 @@
+# Administrative Cleanup Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a local-only, exact-candidate review path for clean landed branches and worktrees blocked only by missing lifecycle metadata or non-closed Beads.
+
+**Architecture:** Introduce a `review-needed` lifecycle lane that is evaluated only after every hard safety check passes. Extend inventory output with structured Bead evidence, then reuse the existing exact-OID retirement operations through a separate one-candidate review function and CLI that validates a short-lived authorization recorded on a curation Bead. Automatic apply remains limited to `retire-after-gate`.
+
+**Tech Stack:** TypeScript on Node.js, Git CLI, `bd` CLI, GitHub CLI, repository maintenance gate, strict `worktree-guard`, Node `assert` tests.
+
+---
+
+## File Map
+
+- Modify `src/lib/worktree-lifecycle.ts`: add the lane, structured task references, and administrative-only classification.
+- Modify `src/lib/worktree-lifecycle.test.ts`: pin classification precedence, rendering, and automatic-retirement separation.
+- Modify `scripts/worktree-lifecycle-inventory.ts`: preserve matching Bead title/status/update evidence and merged-PR base information.
+- Modify `scripts/worktree-lifecycle-patrol.test.mjs`: test real inventory and human/JSON patrol output.
+- Modify `scripts/worktree-lifecycle-retirement.ts`: extract a one-unit retirement primitive, add strict guard execution, and expose reviewed retirement.
+- Modify `scripts/worktree-lifecycle-retirement.test.mjs`: test exact selection, drift, strict guard, and partial failures.
+- Create `scripts/worktree-lifecycle-review.ts`: parse exact CLI inputs, validate current Bead authorization, acquire the local maintenance lease, reprobe, retire, and verify.
+- Create `scripts/worktree-lifecycle-review.test.mjs`: exercise authorization parsing and end-to-end orchestration with injected dependencies.
+- Modify `package.json`: expose `pnpm beads:worktrees:review`.
+- Modify `scripts/run-tests.mjs`: wire the new test into focused and full suites.
+- Modify `.agents/skills/branch-curator/SKILL.md`: document when the review lane is allowed.
+- Modify `.agents/skills/branch-curator/references/deletion-proof.md`: make the reviewed administrative override normative and bounded.
+- Modify `AGENTS.md` and `CLAUDE.md`: replace the claim that metadata-free worktrees are permanently unretirable with the reviewed local-only path.
+
+### Task 1: Classify Administrative-Only Blockers
+
+**Files:**
+- Modify: `src/lib/worktree-lifecycle.ts`
+- Test: `src/lib/worktree-lifecycle.test.ts`
+
+- [ ] **Step 1: Write failing lane and precedence tests**
+
+Add `taskRefs` to the test observation helper:
+
+```ts
+function taskRef(overrides = {}) {
+  return {
+    id: "cave-open",
+    title: "Open administrative task",
+    status: "open",
+    updatedAt: "2026-07-29T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function observation(overrides = {}) {
+  const head = overrides.head ?? "a".repeat(40);
+  return {
+    kind: "worktree",
+    path: "/repo/.worktrees/feat-x",
+    ref: "refs/heads/feat/x",
+    branch: "feat/x",
+    head,
+    isPrimary: false,
+    protectedBranch: false,
+    changes: [],
+    ignoredPaths: [],
+    nonDisposableIgnoredPaths: [],
+    indexFlags: [],
+    processOwners: [],
+    claimOwners: [],
+    taskIds: [],
+    taskRefs: [],
+    openPrs: [],
+    mergedPr: null,
+    activeWorkflowUrls: [],
+    headOnDefaultBranch: false,
+    remoteRefsContainingHead: ["refs/remotes/origin/feat/x"],
+    updatedAtMs: NOW - 2 * DAY,
+    probeErrors: [],
+    metadata: metadata(),
+    metadataErrors: [],
+    remoteRef: { ref: "refs/remotes/origin/feat/x", oid: head },
+    sessionIds: [],
+    ...overrides,
+  };
+}
+```
+
+Add focused cases:
+
+```ts
+{
+  const item = classifyLifecycleUnit(
+    observation({
+      metadata: null,
+      headOnDefaultBranch: true,
+    }),
+    NOW,
+  );
+  assert.equal(item.lane, "review-needed");
+  assert.match(item.reasons.join("\n"), /missing structured lifecycle metadata/i);
+}
+
+{
+  const item = classifyLifecycleUnit(
+    observation({
+      taskIds: ["cave-open"],
+      taskRefs: [taskRef()],
+      headOnDefaultBranch: true,
+    }),
+    NOW,
+  );
+  assert.equal(item.lane, "review-needed");
+  assert.match(item.reasons.join("\n"), /cave-open/);
+}
+
+{
+  const item = classifyLifecycleUnit(
+    observation({
+      changes: ["? uncommitted.txt"],
+      metadata: null,
+      taskIds: ["cave-open"],
+      taskRefs: [taskRef()],
+      headOnDefaultBranch: true,
+    }),
+    NOW,
+  );
+  assert.equal(item.lane, "active", "dirty state outranks administrative review");
+}
+
+{
+  const item = classifyLifecycleUnit(
+    observation({
+      metadataErrors: ["duplicate structured metadata"],
+      headOnDefaultBranch: true,
+    }),
+    NOW,
+  );
+  assert.equal(item.lane, "uncertain", "malformed metadata is never reviewable");
+}
+
+{
+  const item = classifyLifecycleUnit(
+    observation({
+      metadata: null,
+      branch: "backup/example",
+      ref: "refs/heads/backup/example",
+      headOnDefaultBranch: true,
+    }),
+    NOW,
+  );
+  assert.equal(item.lane, "recovery", "recovery naming outranks missing paperwork");
+}
+```
+
+- [ ] **Step 2: Run the lifecycle unit test and confirm failure**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/worktree-lifecycle.test.ts
+```
+
+Expected: FAIL because `review-needed` and `taskRefs` are not defined and missing metadata still classifies as `uncertain`.
+
+- [ ] **Step 3: Add the lane and structured Bead reference**
+
+Add these types:
+
+```ts
+export type WorktreeLifecycleLane =
+  | "active"
+  | "recovery"
+  | "cooldown"
+  | "review-needed"
+  | "retire-after-gate"
+  | "uncertain"
+  | "protected";
+
+export type WorktreeTaskRef = {
+  id: string;
+  title: string;
+  status: "open" | "in_progress" | "blocked" | "deferred";
+  updatedAt: string;
+};
+```
+
+Add `taskRefs: WorktreeTaskRef[]` to `WorktreeLifecycleObservation`, its compatibility fields, and all normalization paths. Add the human label:
+
+```ts
+const HUMAN_LANE_LABELS: Record<WorktreeLifecycleLane, string> = {
+  active: "active",
+  recovery: "recovery",
+  cooldown: "cooldown",
+  "review-needed": "review-needed",
+  "retire-after-gate": "cleanup-ready",
+  uncertain: "uncertain",
+  protected: "protected",
+};
+```
+
+- [ ] **Step 4: Separate hard activity from administrative blockers**
+
+Rename `activeReasons` to `hardActiveReasons` and remove the `taskIds` clause. Add:
+
+```ts
+function administrativeReasons(observation: WorktreeLifecycleObservation): string[] {
+  const reasons: string[] = [];
+  if (observation.metadata === null) {
+    reasons.push("missing structured lifecycle metadata");
+  }
+  if (observation.taskRefs.length > 0) {
+    reasons.push(
+      `non-closed Beads require maintainer review: ${observation.taskRefs
+        .map((task) => `${task.id} (${task.status})`)
+        .join(", ")}`,
+    );
+  }
+  return reasons;
+}
+```
+
+Refactor both metadata and metadata-free paths to share a final landed-unit function:
+
+```ts
+function classifyLandedUnit(
+  observation: WorktreeLifecycleObservation,
+  nowMs: number,
+  reviewAfter: string[],
+): WorktreeLifecycleItem {
+  if (observation.updatedAtMs === null || !Number.isFinite(observation.updatedAtMs)) {
+    return withReasons(observation, "uncertain", [
+      "branch/worktree recency is unavailable",
+      ...reviewAfter,
+    ]);
+  }
+
+  if (nowMs - observation.updatedAtMs < RETIREMENT_COOLDOWN_MS) {
+    return withReasons(observation, "cooldown", [
+      "landed work remains inside the mandatory 8-hour cooldown",
+      ...reviewAfter,
+    ]);
+  }
+
+  const administrative = administrativeReasons(observation);
+  if (administrative.length > 0) {
+    return withReasons(observation, "review-needed", [
+      ...administrative,
+      "local retirement requires exact current maintainer authorization",
+      ...reviewAfter,
+    ]);
+  }
+
+  return withReasons(observation, "retire-after-gate", [
+    "clean landed work is older than 8 hours",
+    "removal still requires the repository-wide maintenance gate and final deletion proof",
+    ...reviewAfter,
+  ]);
+}
+```
+
+Preserve this precedence in `classifyLifecycleUnitInternal`:
+
+1. protected;
+2. hard activity;
+3. probe errors;
+4. metadata errors;
+5. detached/recovery/WIP state;
+6. exact landing and remote divergence;
+7. recency/cooldown;
+8. administrative review;
+9. automatic cleanup-ready.
+
+- [ ] **Step 5: Update lane ordering, counts, and report summary**
+
+Insert `"review-needed"` between cooldown and cleanup-ready:
+
+```ts
+const LANE_ORDER: WorktreeLifecycleLane[] = [
+  "active",
+  "recovery",
+  "cooldown",
+  "review-needed",
+  "retire-after-gate",
+  "uncertain",
+  "protected",
+];
+```
+
+Update the summary sentence to include:
+
+```ts
+`${counts["review-needed"]} review-needed`
+```
+
+Add a rendering assertion that the report includes the task ID, status, and exact review-needed count.
+
+- [ ] **Step 6: Run the lifecycle unit test**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/worktree-lifecycle.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the classifier change**
+
+```bash
+git add src/lib/worktree-lifecycle.ts src/lib/worktree-lifecycle.test.ts
+git commit -m "feat(worktrees): classify administrative cleanup review"
+```
+
+### Task 2: Preserve and Render Exact Bead and PR Evidence
+
+**Files:**
+- Modify: `scripts/worktree-lifecycle-inventory.ts`
+- Modify: `src/lib/worktree-lifecycle.ts`
+- Test: `scripts/worktree-lifecycle-patrol.test.mjs`
+
+- [ ] **Step 1: Write failing inventory tests for Bead details**
+
+Extend the Beads fixture rows in `scripts/worktree-lifecycle-patrol.test.mjs` with `updated_at`. Add a clean landed fixture whose only blocker is a non-closed Bead, then assert:
+
+```js
+const reviewItem = report.items.find((item) => item.branch === "feat/review-needed");
+assert.equal(reviewItem.lane, "review-needed");
+assert.deepEqual(reviewItem.taskRefs, [
+  {
+    id: "cave-review",
+    title: "Review landed legacy work",
+    status: "blocked",
+    updatedAt: "2026-07-28T12:00:00Z",
+  },
+]);
+```
+
+Add a human-output assertion:
+
+```js
+assert.match(stdout, /cave-review \(blocked\): Review landed legacy work/);
+assert.match(stdout, /updated 2026-07-28T12:00:00Z/);
+```
+
+- [ ] **Step 2: Write failing merged-PR base evidence test**
+
+For a squash-merged fixture whose head is retained only by `refs/pull/912/head`, assert:
+
+```js
+assert.deepEqual(reviewItem.mergedPr, {
+  number: 912,
+  url: "https://github.com/OpenCoven/coven-cave/pull/912",
+  headOid: reviewItem.head,
+  base: "main",
+});
+```
+
+- [ ] **Step 3: Run the patrol test and confirm failure**
+
+Run:
+
+```bash
+node --experimental-strip-types scripts/worktree-lifecycle-patrol.test.mjs
+```
+
+Expected: FAIL because inventory emits only `taskIds` and merged PRs omit `base`.
+
+- [ ] **Step 4: Parse structured Bead details**
+
+Extend `BeadTask`:
+
+```ts
+type BeadTask = {
+  id: string;
+  title: string;
+  status: "open" | "in_progress" | "blocked" | "deferred" | "closed";
+  updatedAt: string;
+  text: string;
+  structured: StructuredMetadataRecord[];
+  structuredErrors: string[];
+};
+```
+
+Require a canonical `updated_at` string from `bd list --json`, validate it with the existing RFC3339 parser, and map it to `updatedAt`. Replace `matchingTasks(...): string[]` with:
+
+```ts
+function matchingTasks(
+  branch: string | null,
+  worktreePath: string | null,
+  head: string,
+  tasks: BeadTask[],
+): WorktreeTaskRef[] {
+  const matchedBranch =
+    branch !== null && !PROTECTED_BRANCHES.has(branch) ? branch : null;
+  const branchBeadIds = new Set(matchedBranch ? beadIdsInText(matchedBranch) : []);
+  const normalizedWorktreePath =
+    worktreePath === null ? null : normalizeAbsoluteWorktreePath(worktreePath);
+  const exactOid = new RegExp(`(?:^|[^0-9a-f])${head}(?:$|[^0-9a-f])`, "i");
+
+  return tasks
+    .filter((task) => task.status !== "closed")
+    .filter(
+      (task) =>
+        task.structured.some(
+          (record) =>
+            (matchedBranch !== null && record.branch === matchedBranch) ||
+            (normalizedWorktreePath !== null &&
+              normalizeAbsoluteWorktreePath(record.path) === normalizedWorktreePath),
+        ) ||
+        branchBeadIds.has(task.id.toLowerCase()) ||
+        exactOid.test(task.text) ||
+        (matchedBranch !== null && task.text.includes(matchedBranch)) ||
+        (matchedBranch !== null &&
+          worktreePath !== null &&
+          task.text.includes(worktreePath)),
+    )
+    .map(({ id, title, status, updatedAt }) => ({
+      id,
+      title,
+      status,
+      updatedAt,
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+```
+
+At observation construction:
+
+```ts
+const taskRefs = matchingTasks(unit.branch, unit.path, unit.head, tasks.tasks);
+
+return {
+  taskIds: taskRefs.map((task) => task.id),
+  taskRefs,
+};
+```
+
+- [ ] **Step 5: Include merged PR base**
+
+Extend `WorktreeMergedPrRef`:
+
+```ts
+export type WorktreeMergedPrRef = WorktreePrRef & {
+  headOid: string;
+  base: string;
+};
+```
+
+Populate it from the already-validated `exactMerged.baseRefName`:
+
+```ts
+mergedPr: exactMerged
+  ? {
+      number: exactMerged.number,
+      url: exactMerged.url,
+      headOid: exactMerged.headRefOid,
+      base: exactMerged.baseRefName,
+    }
+  : null,
+```
+
+- [ ] **Step 6: Render review evidence**
+
+In the report loop, when `item.lane === "review-needed"`, render each structured task:
+
+```ts
+for (const task of item.taskRefs) {
+  lines.push(
+    `  Bead ${task.id} (${task.status}): ${task.title}; updated ${task.updatedAt}`,
+  );
+}
+```
+
+Do not infer that an old timestamp makes the task stale.
+
+- [ ] **Step 7: Run lifecycle and patrol tests**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/worktree-lifecycle.test.ts
+node --experimental-strip-types scripts/worktree-lifecycle-patrol.test.mjs
+```
+
+Expected: both PASS.
+
+- [ ] **Step 8: Commit inventory evidence**
+
+```bash
+git add scripts/worktree-lifecycle-inventory.ts scripts/worktree-lifecycle-patrol.test.mjs src/lib/worktree-lifecycle.ts
+git commit -m "feat(worktrees): report administrative review evidence"
+```
+
+### Task 3: Add Strict One-Candidate Reviewed Retirement
+
+**Files:**
+- Modify: `scripts/worktree-lifecycle-retirement.ts`
+- Test: `scripts/worktree-lifecycle-retirement.test.mjs`
+
+- [ ] **Step 1: Write failing selection tests**
+
+Import `reviewLifecycleUnit` and add:
+
+```js
+test("review retirement selects one exact review-needed ref and OID", () => {
+  const selected = makeItem({
+    ref: "refs/heads/fix/legacy",
+    branch: "fix/legacy",
+    head: hex("a"),
+    lane: "review-needed",
+  });
+  const unrelated = makeItem({
+    ref: "refs/heads/fix/other",
+    branch: "fix/other",
+    head: hex("b"),
+    lane: "review-needed",
+  });
+  const { calls, operations } = makeOperations();
+
+  const report = reviewLifecycleUnit({
+    items: [unrelated, selected],
+    expectedRef: selected.ref,
+    expectedHead: selected.head,
+    gateHandle: { generation: 1, token: "gate-token" },
+    operations,
+  });
+
+  assert.equal(report.retired.length, 1);
+  assert.equal(report.retired[0].ref, selected.ref);
+  assert.equal(calls.some(([name, ref]) => name === "deleteLocalRef" && ref === unrelated.ref), false);
+});
+```
+
+Add refusal tests for:
+
+- no matching ref;
+- duplicate matching items;
+- wrong expected OID;
+- lane `retire-after-gate`;
+- reprobe changing to `active`;
+- reprobe changing task IDs or metadata state while remaining review-needed.
+
+- [ ] **Step 2: Write failing strict guard tests**
+
+Extend `RetirementOperations` fixtures with:
+
+```js
+guardWorktree(item) {
+  calls.push(["guardWorktree", item.ref]);
+  return overrides.guardWorktree?.(item) ?? { ok: true };
+},
+```
+
+Assert `guardWorktree` runs immediately before `removeWorktree` and a refusal prevents every destructive operation.
+
+- [ ] **Step 3: Run retirement tests and confirm failure**
+
+Run:
+
+```bash
+node --experimental-strip-types scripts/worktree-lifecycle-retirement.test.mjs
+```
+
+Expected: FAIL because no review function or guard operation exists.
+
+- [ ] **Step 4: Extract a shared exact-unit transaction**
+
+Refactor the current per-item body into:
+
+```ts
+function retireExactLifecycleUnit({
+  item,
+  expectedLane,
+  gateHandle,
+  operations,
+}: {
+  item: WorktreeLifecycleItem;
+  expectedLane: "retire-after-gate" | "review-needed";
+  gateHandle: RetirementGateHandle;
+  operations: RetirementOperations;
+}): RetirementReport {
+  // Use the existing heartbeat, reprobe, remote precheck, cleanup,
+  // compare-delete, restoration, and postcondition sequence.
+}
+```
+
+Change identity validation to accept an expected lane:
+
+```ts
+function retirementIdentityError(
+  expected: WorktreeLifecycleItem,
+  actual: WorktreeLifecycleItem,
+  expectedLane: "retire-after-gate" | "review-needed",
+): string | null {
+  if (actual.path !== expected.path) return "retirement candidate path changed during final retirement probe";
+  if (actual.ref !== expected.ref) return "retirement candidate ref changed during final retirement probe";
+  if (actual.head !== expected.head) return "retirement candidate OID changed during final retirement probe";
+  if (actual.lane !== expectedLane) return "retirement candidate lane changed during final retirement probe";
+  return null;
+}
+```
+
+Keep `retireLifecycleUnits` filtering only `retire-after-gate`.
+
+- [ ] **Step 5: Implement exact review selection**
+
+Add:
+
+```ts
+export function reviewLifecycleUnit({
+  items,
+  expectedRef,
+  expectedHead,
+  gateHandle,
+  operations,
+}: {
+  items: WorktreeLifecycleItem[];
+  expectedRef: string;
+  expectedHead: string;
+  gateHandle: RetirementGateHandle;
+  operations: RetirementOperations;
+}): RetirementReport {
+  const matches = items.filter((item) => item.ref === expectedRef);
+  if (matches.length !== 1) {
+    return blockedReview(expectedRef, expectedHead, "review candidate must resolve to one lifecycle unit");
+  }
+  const item = matches[0]!;
+  if (item.head !== expectedHead) {
+    return blockedReview(expectedRef, expectedHead, "review candidate OID does not match authorization");
+  }
+  if (item.lane !== "review-needed") {
+    return blockedReview(expectedRef, expectedHead, "candidate is not in the review-needed lane");
+  }
+  return retireExactLifecycleUnit({
+    item,
+    expectedLane: "review-needed",
+    gateHandle,
+    operations,
+  });
+}
+```
+
+- [ ] **Step 6: Run strict worktree guard before removal**
+
+Add `guardWorktree(item)` to `RetirementOperations`. Call it after the final gate heartbeat and before `removeWorktree`.
+
+In `createGitRetirementOperations`, invoke:
+
+```ts
+const args = [
+  "scripts/worktree-guard.mjs",
+  "--strict-worktree-remove",
+  worktreePath,
+  "--expected-head",
+  item.head,
+];
+
+if (!item.headOnDefaultBranch && item.mergedPr) {
+  args.push(
+    "--retained-by-github-pr",
+    "origin",
+    repo,
+    String(item.mergedPr.number),
+    "--expected-base",
+    item.mergedPr.base,
+  );
+}
+
+const guarded = node(normalizedRoot, args, 120_000, {
+  WT_GUARD_BYPASS: undefined,
+  WT_GUARD_TEST_MODE: undefined,
+});
+```
+
+Return failure on any nonzero status or malformed success JSON. Never set `WT_GUARD_BYPASS`.
+
+- [ ] **Step 7: Run retirement tests**
+
+Run:
+
+```bash
+node --experimental-strip-types scripts/worktree-lifecycle-retirement.test.mjs
+```
+
+Expected: PASS, including the assertion that automatic apply ignores review-needed items.
+
+- [ ] **Step 8: Commit the reviewed retirement primitive**
+
+```bash
+git add scripts/worktree-lifecycle-retirement.ts scripts/worktree-lifecycle-retirement.test.mjs
+git commit -m "feat(worktrees): add exact reviewed local retirement"
+```
+
+### Task 4: Build the Authorization-Aware Review CLI
+
+**Files:**
+- Create: `scripts/worktree-lifecycle-review.ts`
+- Create: `scripts/worktree-lifecycle-review.test.mjs`
+- Modify: `package.json`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write failing argument and authorization tests**
+
+Define the command:
+
+```text
+pnpm beads:worktrees:review \
+  --ref refs/heads/fix/legacy \
+  --expected-head aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  --curation-bead cave-123 \
+  --confirm-local-administrative-review
+```
+
+Test `parseArgs` rejects:
+
+- short branch names instead of `refs/heads/...`;
+- `main` and `__dolt_remote_info__`;
+- abbreviated or malformed OIDs;
+- missing curation Bead;
+- missing confirmation;
+- any remote-delete argument;
+- more than one candidate.
+
+Use this authorization note format:
+
+```text
+COVEN_ADMIN_CLEANUP_V1 {"ref":"refs/heads/fix/legacy","oid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","scope":"local-only","authorizedBy":"BunsDev","authorizedAt":"2026-08-04T21:30:00.000Z","expiresAt":"2026-08-05T21:30:00.000Z","instruction":"lax administrative cleanup for this exact candidate"}
+```
+
+Test rejection for malformed JSON, duplicate matching records, mismatched ref/OID, non-local scope, blank author/instruction, future `authorizedAt`, expired authorization, authorization older than 24 hours, closed curation Bead, and candidate-owning Bead used as the curation Bead.
+
+- [ ] **Step 2: Write failing orchestration tests**
+
+Inject dependencies and assert this order:
+
+```js
+assert.deepEqual(calls, [
+  "read-curation-bead",
+  "collect-inventory-before-gate",
+  "acquire-maintenance-gate",
+  "collect-inventory-under-gate",
+  "create-retirement-operations",
+  "review-exact-unit",
+  "heartbeat-before-post-inventory",
+  "verify-before-post-inventory",
+  "collect-post-inventory",
+  "verify-after-post-inventory",
+  "release-maintenance-gate",
+]);
+```
+
+Add failure tests for lease acquisition, changed inventory fingerprint, candidate no longer review-needed, newly matched task ownership, retirement block, post-inventory failure, and release failure.
+
+- [ ] **Step 3: Run the new test and confirm failure**
+
+Run:
+
+```bash
+node --experimental-strip-types scripts/worktree-lifecycle-review.test.mjs
+```
+
+Expected: FAIL because the CLI does not exist.
+
+- [ ] **Step 4: Implement strict argument parsing**
+
+Create `scripts/worktree-lifecycle-review.ts` with:
+
+```ts
+type ReviewOptions = {
+  repo: string;
+  root: string;
+  ref: string;
+  expectedHead: string;
+  curationBead: string;
+  confirmed: true;
+  nowMs: number;
+  json: boolean;
+};
+```
+
+Use `git check-ref-format` plus explicit protected-ref rejection. Require a full 40- or 64-character lowercase hexadecimal OID.
+
+- [ ] **Step 5: Parse and validate current authorization**
+
+Run:
+
+```ts
+const result = command("bd", ["show", beadId, "--json"], root);
+```
+
+Require one non-closed Bead. Scan `notes` line-by-line for the exact `COVEN_ADMIN_CLEANUP_V1 ` prefix, parse JSON, and validate:
+
+```ts
+type AdministrativeCleanupAuthorization = {
+  ref: string;
+  oid: string;
+  scope: "local-only";
+  authorizedBy: string;
+  authorizedAt: string;
+  expiresAt: string;
+  instruction: string;
+};
+```
+
+Require one matching unexpired record, `authorizedAt <= now`, `now - authorizedAt <= 24 hours`, and `expiresAt > now`. Reject if the curation Bead ID appears in the candidate's `taskIds`.
+
+- [ ] **Step 6: Implement the lease-held review transaction**
+
+Follow this sequence:
+
+```ts
+const before = collectWorktreeLifecycleInventory({ repo, root, nowMs });
+const candidate = exactReviewCandidate(before.items, options.ref, options.expectedHead);
+validateAuthorization(curationBead, candidate, nowMs);
+
+const acquired = acquireMaintenanceGate({
+  ownerId: `worktree-review-${curationBead.id}`,
+  purpose: `administrative local cleanup ${options.ref}@${options.expectedHead}`,
+  repoDir: root,
+});
+if (!acquired.ok) throw new Error(acquired.reason ?? "maintenance lease unavailable");
+
+try {
+  const underGate = collectWorktreeLifecycleInventory({ repo, root, nowMs: Date.now() });
+  requireUnchangedReviewCandidate(candidate, underGate.items);
+  const operations = createGitRetirementOperations({
+    root,
+    repo,
+    gateHandle: acquired.handle,
+    nowMs: Date.now,
+  });
+  const retirement = reviewLifecycleUnit({
+    items: underGate.items,
+    expectedRef: options.ref,
+    expectedHead: options.expectedHead,
+    gateHandle: acquired.handle,
+    operations,
+  });
+  // Heartbeat, verify, collect post-inventory, verify again.
+  return buildReviewReport(retirement, postInventory);
+} finally {
+  releaseMaintenanceGate(acquired.handle);
+}
+```
+
+Return nonzero if retirement is blocked, partial, post-inventory is unavailable, or release fails. Report partial local state explicitly.
+
+- [ ] **Step 7: Wire the command and tests**
+
+Add to `package.json`:
+
+```json
+"beads:worktrees:review": "node --experimental-strip-types scripts/worktree-lifecycle-review.ts --repo OpenCoven/coven-cave"
+```
+
+Add `scripts/worktree-lifecycle-review.test.mjs` beside the existing patrol and retirement tests in every relevant `scripts/run-tests.mjs` suite.
+
+- [ ] **Step 8: Run focused review tests**
+
+Run:
+
+```bash
+node --experimental-strip-types scripts/worktree-lifecycle-review.test.mjs
+node --experimental-strip-types scripts/worktree-lifecycle-retirement.test.mjs
+node --experimental-strip-types scripts/worktree-lifecycle-patrol.test.mjs
+```
+
+Expected: all PASS.
+
+- [ ] **Step 9: Commit the CLI**
+
+```bash
+git add package.json scripts/run-tests.mjs scripts/worktree-lifecycle-review.ts scripts/worktree-lifecycle-review.test.mjs
+git commit -m "feat(worktrees): add administrative review command"
+```
+
+### Task 5: Update Normative Cleanup Documentation
+
+**Files:**
+- Modify: `.agents/skills/branch-curator/SKILL.md`
+- Modify: `.agents/skills/branch-curator/references/deletion-proof.md`
+- Modify: `AGENTS.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Document the new lane in Branch Curator**
+
+Add `review-needed` to the classification table:
+
+```md
+| `REVIEW` | Every hard safety proof passed; only missing metadata and/or non-closed Beads remain | Obtain current exact maintainer authorization and run the local-only review command |
+```
+
+State explicitly that `REVIEW` is not `DELETE`, never authorizes remote deletion, and cannot override dirty state, active ownership, recovery evidence, recency, or unique work.
+
+- [ ] **Step 2: Add the normative authorization record**
+
+In `deletion-proof.md`, document the exact note:
+
+```text
+COVEN_ADMIN_CLEANUP_V1 {"ref":"refs/heads/fix/legacy","oid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","scope":"local-only","authorizedBy":"BunsDev","authorizedAt":"2026-08-04T21:30:00.000Z","expiresAt":"2026-08-05T21:30:00.000Z","instruction":"Approve local administrative cleanup for this exact candidate"}
+```
+
+Require:
+
+- a separate non-closed curation Bead;
+- one exact ref and OID;
+- current authorization no older than 24 hours;
+- local-only scope;
+- a held maintenance lease;
+- complete fresh proof;
+- strict `worktree-guard`;
+- no candidate Bead mutation.
+
+- [ ] **Step 3: Replace obsolete permanent-uncertainty wording**
+
+In `AGENTS.md` and `CLAUDE.md`, replace:
+
+```text
+pnpm beads:worktrees:apply can never retire it
+```
+
+with:
+
+```text
+automatic apply cannot retire it. After it is clean, landed, older than the
+cooldown, and free of every live-work signal, a maintainer may use the exact
+local-only administrative review path. Missing metadata never becomes automatic
+deletion authority.
+```
+
+Keep the prohibition on hand-writing missing metadata.
+
+- [ ] **Step 4: Commit documentation**
+
+```bash
+git add .agents/skills/branch-curator/SKILL.md .agents/skills/branch-curator/references/deletion-proof.md AGENTS.md CLAUDE.md
+git commit -m "docs(worktrees): define reviewed administrative cleanup"
+```
+
+### Task 6: Run Integrated Verification
+
+**Files:**
+- Verify all files changed in Tasks 1-5.
+
+- [ ] **Step 1: Run the focused lifecycle suite**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/worktree-lifecycle.test.ts
+node --experimental-strip-types scripts/worktree-lifecycle-patrol.test.mjs
+node --experimental-strip-types scripts/worktree-lifecycle-retirement.test.mjs
+node --experimental-strip-types scripts/worktree-lifecycle-review.test.mjs
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Run test-wiring validation**
+
+Run:
+
+```bash
+pnpm check:tests-wired
+```
+
+Expected: PASS and the new review test is reported as wired.
+
+- [ ] **Step 3: Run the repository test runner for lifecycle files**
+
+Run:
+
+```bash
+pnpm test -- src/lib/worktree-lifecycle.test.ts scripts/worktree-lifecycle-patrol.test.mjs scripts/worktree-lifecycle-retirement.test.mjs scripts/worktree-lifecycle-review.test.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run lint and type checks**
+
+Run:
+
+```bash
+pnpm lint
+pnpm typecheck
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Exercise read-only patrol output**
+
+Run:
+
+```bash
+pnpm beads:worktrees
+pnpm beads:worktrees:json > /tmp/cave-worktree-review-report.json
+jq '.counts[\"review-needed\"]' /tmp/cave-worktree-review-report.json
+```
+
+Expected: patrol succeeds, no mutation occurs, and JSON contains a nonnegative `review-needed` count.
+
+- [ ] **Step 6: Verify automatic apply cannot select review-needed**
+
+Run the retirement unit test assertion directly:
+
+```bash
+node --experimental-strip-types scripts/worktree-lifecycle-retirement.test.mjs
+```
+
+Expected: PASS with the test proving `retireLifecycleUnits` filters only `retire-after-gate`.
+
+- [ ] **Step 7: Record evidence in the implementation Bead**
+
+```bash
+bd update cave-jcdgb --append-notes "Verification: lifecycle, patrol, retirement, and review tests pass; test wiring, lint, and typecheck pass. Administrative review remains exact-candidate, local-only, strict-guarded, and excluded from automatic apply."
+```
+
+- [ ] **Step 8: Commit any verification-only fixes**
+
+If verification required source changes, stage only those exact files and commit:
+
+```bash
+git add src/lib/worktree-lifecycle.ts src/lib/worktree-lifecycle.test.ts \
+  scripts/worktree-lifecycle-inventory.ts scripts/worktree-lifecycle-patrol.ts \
+  scripts/worktree-lifecycle-patrol.test.mjs scripts/worktree-lifecycle-retirement.ts \
+  scripts/worktree-lifecycle-retirement.test.mjs scripts/worktree-lifecycle-review.ts \
+  scripts/worktree-lifecycle-review.test.mjs package.json scripts/run-tests.mjs \
+  .agents/skills/branch-curator/SKILL.md \
+  .agents/skills/branch-curator/references/deletion-proof.md AGENTS.md CLAUDE.md
+git commit -m "fix(worktrees): complete administrative review verification"
+```
+
+If no files changed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-08-04-administrative-cleanup-review-design.md
+++ b/docs/superpowers/specs/2026-08-04-administrative-cleanup-review-design.md
@@ -1,0 +1,105 @@
+# Administrative Cleanup Review Design
+
+## Goal
+
+Let maintainers retire clean, landed local branches and worktrees when the only
+remaining blockers are lifecycle paperwork: missing structured worktree
+metadata and/or a non-closed Bead. Preserve every existing protection against
+dirty, active, unique, recent, recovery, or remotely divergent work.
+
+## Classification
+
+Add a `review-needed` lifecycle lane. A unit may enter this lane only when:
+
+- it is not the primary checkout, protected, detached, recovery-named, or WIP-named;
+- the worktree has no tracked, untracked, ignored, submodule, or index-flag state;
+- no process, Coven claim, Coven session, open pull request, or active workflow owns it;
+- all required probes completed successfully;
+- its exact HEAD is on the fetched default branch or matches the exact head of a merged
+  pull request;
+- any same-named remote ref is absent or points to the same commit;
+- branch and recovery activity is older than the existing eight-hour cooldown; and
+- the only remaining blockers are missing lifecycle metadata and/or one or more
+  non-closed Beads.
+
+Malformed, duplicate, or conflicting metadata remains `uncertain`; it is not
+equivalent to absent metadata. Unique commits, mismatched merged-PR heads,
+divergent remotes, and recovery dispositions remain `recovery`. Dirty or
+runtime-owned units remain `active`.
+
+Automatic retirement must never consume `review-needed` units.
+
+## Patrol Output
+
+`pnpm beads:worktrees` reports each `review-needed` unit with:
+
+- the exact local ref and HEAD OID;
+- whether a registered worktree exists;
+- each administrative blocker;
+- the owning Bead IDs, titles, statuses, and update timestamps; and
+- the evidence proving the commit landed and remains retained.
+
+The report explains that a current maintainer may authorize one exact local
+cleanup candidate. It must not describe the unit as stale, abandoned, or safe
+to delete without that approval.
+
+## Review Command
+
+Provide a bounded command for one candidate at a time. Its interface requires:
+
+- one fully qualified local branch ref;
+- the expected HEAD OID shown by the patrol;
+- a non-closed curation Bead recording current maintainer authorization; and
+- an explicit administrative-review confirmation flag.
+
+The command acquires the repository maintenance lease and rebuilds the complete
+inventory. It proceeds only if the ref and OID are unchanged and the candidate
+still classifies as `review-needed`.
+
+Immediately before mutation it reruns the Beads, process, claim, session,
+worktree, GitHub PR, workflow, recency, retention, and recovery checks. It then
+runs strict `worktree-guard`, removes a clean worktree without force when one
+exists, and compare-deletes the exact local ref. It verifies both postconditions
+before reporting success.
+
+The command is local-only. It never deletes a remote ref, closes or edits a
+candidate-owning Bead, synthesizes lifecycle metadata, shortens the cooldown,
+accepts a wildcard, or approves a batch.
+
+## Failure Handling
+
+Every lookup, parse, lease, guard, and postcondition failure stops the
+transaction and preserves the candidate. OID drift, new worktree changes, new
+runtime ownership, a new PR or workflow, changed task ownership, or a lost
+maintenance lease invalidates the authorization.
+
+If worktree removal succeeds but exact ref deletion refuses because the ref
+advanced, the advanced ref remains intact and the command reports the partial
+local state explicitly. No force-removal or bypass path is provided.
+
+## Testing
+
+Unit classification tests cover:
+
+- missing metadata alone;
+- open, blocked, and deferred Beads;
+- missing metadata plus non-closed Beads;
+- malformed or duplicate metadata;
+- dirty, ignored, submodule, and index-flag state;
+- active processes, claims, sessions, PRs, and workflows;
+- unique commits, merged-PR head mismatch, and divergent remotes;
+- recovery/WIP branches and detached HEADs; and
+- cooldown and unavailable recency.
+
+Retirement integration tests cover successful local-only worktree and
+branch-only cleanup plus refusal on OID drift, lease loss, guard refusal, newly
+active ownership, changed GitHub evidence, and postcondition failure. Existing
+automatic-retirement tests must assert that `review-needed` is never selected.
+
+## Non-goals
+
+- Deleting remote branches.
+- Relaxing dirty-work, live-writer, recovery, uniqueness, or recency checks.
+- Automatically closing stale Beads.
+- Backfilling or fabricating lifecycle metadata.
+- Increasing automatic retirement batch size.

--- a/docs/superpowers/specs/2026-08-05-fixed-home-build-siderail-tabs-design.md
+++ b/docs/superpowers/specs/2026-08-05-fixed-home-build-siderail-tabs-design.md
@@ -1,0 +1,47 @@
+# Fixed Home and Build Siderail Tabs
+
+## Goal
+
+Keep the global section switcher in one stable location while moving between
+the Home and Build rooms. The switcher is the first interactive control inside
+the left siderail in both states.
+
+## User Interface
+
+- The two visible labels are `Home` and `Build`, in that order.
+- The existing segmented-control appearance, icons, active treatment, tooltips,
+  keyboard navigation, and collapsed-rail behavior remain unchanged.
+- The switcher renders before the familiar selector, New chat action, sidebar
+  options, destination rows, projects, and sessions in both siderail hosts.
+- Switching sections changes the selected tab and room content without changing
+  the switcher's top offset or DOM position within the siderail.
+
+## Implementation
+
+Use the existing `NavSectionTabs` component in both hosts:
+
+1. Move its `SidebarMinimal` render before the familiar selector and New chat
+   controls.
+2. Keep its `WorkspaceSidebar` render as the first child of the full sidebar.
+3. Change the `code` section descriptor's visible label from `Code` to `Build`.
+   Preserve the internal `code` section identifier and all routing semantics.
+4. Update comments and assertions that describe the visible `Home | Code`
+   control.
+
+No CSS ordering, new wrapper component, route rename, or data migration is
+needed.
+
+## Accessibility
+
+The existing tablist and roving-tab behavior remain authoritative. DOM order
+matches visual order, so keyboard and screen-reader users encounter Home and
+Build before room-specific controls.
+
+## Verification
+
+- Assert the registry exposes the visible labels `Home` and `Build`.
+- Assert both siderail hosts mount `NavSectionTabs` before their first
+  room-specific control.
+- Run the focused navigation-section and sidebar tests.
+- Confirm the switcher occupies the same top position in Home and Build in the
+  real app at expanded and collapsed widths.


### PR DESCRIPTION
## What changed
- restore the archived cave-jcdgb design and implementation plan exactly
- restore the archived cave-fv5ij approved design exactly
- require approved specs and plans to land independently on `main`, with archive tags treated only as recovery sources
- refresh the indexed superpowers document count

## Verification
- `node --test scripts/docs-index.test.mjs`
- archive blob hashes verified against their pushed archive tags
- `git diff --check`

Bead: `cave-usw4f`