### PR TITLE
fix(shell): keep the outer frame solid under a backdrop

### DIFF
--- a/src/components/shell-inset-layout.test.ts
+++ b/src/components/shell-inset-layout.test.ts
@@ -10,16 +10,58 @@ const responsiveCss = readFileSync(
   new URL("../styles/globals/shell-responsive.css", import.meta.url),
   "utf8",
 );
+const foundationsCss = readFileSync(
+  new URL("../styles/globals/foundations.css", import.meta.url),
+  "utf8",
+);
+const backdropCss = readFileSync(
+  new URL("../styles/backdrop.css", import.meta.url),
+  "utf8",
+);
 
 assert.match(
   shellCss,
   /\.shell-body\s*\{[^}]*background:\s*var\(--bg-panel\);/,
-  "the sidebar and inset gutter should share the shell floor",
+  "the nav pane's ground stays --bg-panel — the rail's shade is that ground plus .shell-nav's translucent paint, and moving it would move the rail",
+);
+// The gutter is the frame, so it reads the rail's own rendered shade rather
+// than the bare ground beneath the rail. Pinned because the two used to be the
+// same token, which made the mismatch invisible in review.
+assert.match(
+  foundationsCss,
+  /--shell-floor:\s*color-mix\(in oklch, var\(--bg-raised\) 88%, var\(--bg-panel\)\);/,
+  "the frame token should be the flat equivalent of .shell-nav's 88% --bg-raised over --bg-panel",
 );
 assert.match(
   shellCss,
-  /@media \(min-width: 1024px\)\s*\{[\s\S]*?\.shell-detail-panel\s*\{[^}]*padding:\s*var\(--space-2\);[^}]*background:\s*var\(--bg-panel\);/,
-  "desktop detail should reserve an even tokenized inset around the main content",
+  /@media \(min-width: 1024px\)\s*\{[\s\S]*?\.shell-detail-panel\s*\{[^}]*padding:\s*var\(--space-2\);[^}]*background:\s*var\(--shell-floor\);/,
+  "desktop detail should reserve an even tokenized inset around the main content, painted in the frame color",
+);
+// With a backdrop up, the pane goes transparent so the image shows through the
+// content — which also handed the gutter to the fixed z-0 layer. The band is
+// repainted above it; without these the frame silently bleeds again.
+assert.match(
+  backdropCss,
+  /@media \(min-width: 1024px\)\s*\{[\s\S]*?html\[data-backdrop-on\] \.shell-detail-panel::before\s*\{[\s\S]*?background-image:[\s\S]*?linear-gradient\(var\(--shell-floor\) 0 0\)/,
+  "a backdrop-on gutter should be repainted in the frame color above the backdrop layer",
+);
+assert.match(
+  backdropCss,
+  /@media \(min-width: 1024px\)\s*\{[\s\S]*?html\[data-backdrop-on\] \.shell-detail-panel::before\s*\{[\s\S]*?background-size:\s*\n?\s*100% var\(--space-2\),\s*\n?\s*var\(--space-2\) 100%,\s*\n?\s*100% var\(--space-2\),\s*\n?\s*var\(--space-2\) 100%;/,
+  "the repaint must be four strips the width of the gutter, never a fill over the content box",
+);
+assert.match(
+  backdropCss,
+  /html\[data-backdrop-on\] \.shell-detail\s*\{\s*box-shadow:\s*\n?\s*0 0 0 var\(--space-2\) var\(--shell-floor\),/,
+  "the content's rounded corners need the same color spread behind them, or the image shows in the four wedges the strips cannot reach",
+);
+// The pane must stay transparent even though it is positioned for the strips:
+// positioning lifts it over the z-0 layer, so any opaque paint here covers the
+// image across the whole box, hero included.
+assert.match(
+  backdropCss,
+  /@media \(min-width: 1024px\)\s*\{[\s\S]*?html\[data-backdrop-on\] \.shell-detail-panel\s*\{[^}]*position:\s*relative;[^}]*background:\s*transparent;/,
+  "the positioned detail pane must paint nothing itself — the strips own the gutter",
 );
 assert.match(
   shellCss,

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -340,3 +340,68 @@ html[data-backdrop-on] .shell-list-panel {
   z-index: 1;
   background: var(--bg-panel);
 }
+
+/* ── The outer frame stays solid too (cave-0uzj0) ────────────────────────────
+   Only the CONTENT of the detail pane joins the backdrop. The pane's box is
+   content PLUS the inset gutter, though, and the gutter is chrome — the same
+   frame the nav rail is part of. Handing the whole box to the layer therefore
+   painted the image straight through the top, right and bottom edges: a solid
+   charcoal rail beside three bleeding gutters.
+
+   The panes above fix this by lifting themselves over the layer. The detail
+   pane cannot do that: lifting it would carry the content with it and hide the
+   image inside the panel, which is the one place it is supposed to show. So
+   the gutter BAND is painted instead — four strips on a pseudo-element, above
+   the layer, leaving the content box untouched. Strips rather than a masked
+   ring on purpose: no mask-composite dependency, and the corners stay square
+   where they meet the window edge (a rounded ring would leak the image back in
+   at exactly the four corners of the app).
+
+   No z-index: the strips paint over the layer because they come later in the
+   document, and staying at `auto` keeps them UNDER the pane's own content, so
+   a surface that deliberately paints into the gutter (the home composer's
+   translateX shift, which opens this pane's overflow) is not clipped by them. */
+@media (min-width: 1024px) {
+  html[data-backdrop-on] .shell-detail-panel {
+    /* Positioning context for the strips below — and transparent, which is
+       load-bearing rather than leftover: positioning the pane lifts it over
+       the z-0 layer, so an opaque paint here would cover the image across the
+       WHOLE box, content included (measured: the hero went flat charcoal).
+       The band is painted by ::before instead; the pane itself paints nothing. */
+    position: relative;
+    background: transparent;
+  }
+
+  html[data-backdrop-on] .shell-detail-panel::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+      linear-gradient(var(--shell-floor) 0 0),
+      linear-gradient(var(--shell-floor) 0 0),
+      linear-gradient(var(--shell-floor) 0 0),
+      linear-gradient(var(--shell-floor) 0 0);
+    background-repeat: no-repeat;
+    background-size:
+      100% var(--space-2),
+      var(--space-2) 100%,
+      100% var(--space-2),
+      var(--space-2) 100%;
+    /* top, right, bottom, left — the exact band .shell-detail-panel's padding
+       reserves, so the strips can never encroach on the content box. */
+    background-position: 0 0, 100% 0, 0 100%, 0 0;
+  }
+
+  /* The strips stop at the content's square box, but the content is a rounded
+     panel — four wedges inside that box, outside its rounded border, would
+     still show the image. An outer spread shadow paints precisely the region
+     outside the border shape, so it fills them in the same color. The
+     elevation shadow is restated because box-shadow does not cascade
+     per-layer. */
+  html[data-backdrop-on] .shell-detail {
+    box-shadow:
+      0 0 0 var(--space-2) var(--shell-floor),
+      0 14px 36px -28px var(--shadow-color);
+  }
+}

--- a/src/styles/globals/foundations.css
+++ b/src/styles/globals/foundations.css
@@ -251,6 +251,19 @@
   /* ---- Surface alphas ---- */
   --backdrop-scrim: oklch(0 0 0 / 60%);
 
+  /* ---- Shell frame ----
+     The nav rail's rendered surface, as one flat color. `.shell-nav` paints
+     color-mix(--bg-raised 88%, transparent) over the --bg-panel ground its
+     panel supplies, so the rail lands on this value — measured rgb(34,30,31)
+     on the Coven default against rgb(33,30,31) here, the 1/255 being the
+     rail's own saturate(140%). The inset gutter around the main content reads
+     from the same token, so the rail and the three outer gutters form ONE
+     continuous frame instead of two shades of dark meeting at the content
+     edge. Flat, not translucent: the gutter has to cover the backdrop layer
+     (see the frame rules in styles/backdrop.css), and a see-through fill is
+     exactly what let the image bleed through it. */
+  --shell-floor: color-mix(in oklch, var(--bg-raised) 88%, var(--bg-panel));
+
   /* ---- Glass (native-vibrancy translucency for overlay chrome) ----
      Derived from the theme's own surface tokens via color-mix, so every
      accent theme and light mode track automatically. Overlay surfaces only —

--- a/src/styles/globals/shell-navigation.css
+++ b/src/styles/globals/shell-navigation.css
@@ -193,7 +193,10 @@
 
   .shell-detail-panel {
     padding: var(--space-2);
-    background: var(--bg-panel);
+    /* The gutter this padding reserves IS the outer frame, so it takes the
+       rail's own rendered shade rather than the bare panel token — see
+       --shell-floor in globals/foundations.css. */
+    background: var(--shell-floor);
   }
 
   .shell-detail {
@@ -1158,7 +1161,7 @@
 
 /* The detail wrapper provides the shell floor around the inset content. */
 .shell-detail-panel {
-  background: var(--bg-panel);
+  background: var(--shell-floor);
 }
 
 .shell-detail-header {


### PR DESCRIPTION
Closes `cave-0uzj0`.

## The bug

With a backdrop up, `html[data-backdrop-on]` handed `.shell-detail-panel` to the fixed z-0 layer. That pane's box is the content **plus** the 8px inset gutter, so the image painted straight through the top, right and bottom edges — while the nav rail stayed solid, because the nav and list panes lift themselves over the layer. The result read as one charcoal rail beside three bleeding gutters instead of a single frame.

## The fix

The detail pane cannot use the lift trick: lifting it carries the content along and hides the image inside the panel, which is the one place it belongs. That is not a guess — it was measured mid-fix, and the hero went flat charcoal.

So the gutter **band** alone is repainted above the layer, as four strips on a pseudo-element:

- Strips rather than a masked ring — no `mask-composite` dependency, and the corners stay square where they meet the window edge. A rounded ring leaks the image back in at exactly the four corners of the app.
- No `z-index` on the strips: they paint over the layer by document order, and staying at `auto` keeps them *under* the pane's own content, so a surface that deliberately paints into the gutter (the home composer's `translateX` shift, which opens this pane's overflow) is not clipped.
- A `var(--space-2)` spread shadow on `.shell-detail` fills the four wedges the content's rounded corners leave inside the strips' square hole.

The color comes from a new `--shell-floor` token — the flat equivalent of `.shell-nav`'s 88% `--bg-raised` over its `--bg-panel` ground — so the rail and the three gutters are one continuous frame. The gutter reads it with **no** backdrop too, where it had been the bare panel token and sat visibly darker than the rail. `.shell-body` deliberately keeps `--bg-panel`: it is the ground the rail's translucent paint composites against, and moving it would move the rail.

## Verification

Driven at 1440x900 with a deliberately loud stand-in image in the backdrop layer, so any bleed is unmistakable.

| sample | before | after |
| --- | --- | --- |
| rail | rgb(34,30,31) | rgb(34,30,31) |
| top / right / bottom / left gutter | the image | rgb(33,30,31) |

The remaining 1/255 is the rail's own `saturate(140%)`, not a token mismatch.

- Corner crops at 4x: no bleed at the window corners, none against the content radius.
- Hero image, overlays, content border, radius, bottom status bar and spacing unchanged; the image still fills the content area.
- Checked with the backdrop off, on Home and on Chat, and the rules are scoped to `@media (min-width: 1024px)` so the full-bleed mobile layout is untouched.
- `pnpm lint` clean; `shell-inset-layout.test.ts` extended to pin the token, the strip geometry, the wedge shadow, and the fact that the positioned pane must paint nothing itself.