### PR TITLE
Render onboarding before the workspace

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,22 @@
-import { Workspace } from "@/components/workspace";
-import { WorkspaceSurfacePreferencesProvider } from "@/lib/surface-preferences";
+import { cookies } from "next/headers";
+import { OnboardingStartupGate } from "@/components/onboarding-startup-gate";
+import { WorkspaceApp } from "@/components/workspace-app";
+import { shouldAutoOpenOnboardingBootstrap } from "@/lib/onboarding-gate";
+import { onboardingBootstrapStatus } from "@/lib/server/onboarding-bootstrap";
 
-export default function Home() {
-  return (
-    <WorkspaceSurfacePreferencesProvider>
-      <Workspace />
-    </WorkspaceSurfacePreferencesProvider>
-  );
+export default async function Home() {
+  const [bootstrap, cookieStore] = await Promise.all([
+    onboardingBootstrapStatus(),
+    cookies(),
+  ]);
+  const dismissed = cookieStore.get("cave_onboarding_dismissed")?.value === "1";
+
+  if (
+    shouldAutoOpenOnboardingBootstrap(bootstrap) &&
+    (bootstrap.confirmed || !dismissed)
+  ) {
+    return <OnboardingStartupGate initialState={bootstrap} />;
+  }
+
+  return <WorkspaceApp />;
 }

--- a/src/components/chat-list-filter-defaults.test.ts
+++ b/src/components/chat-list-filter-defaults.test.ts
@@ -15,7 +15,7 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /const clearSessionFilters = useCallback\(\(\) => \{\s*setSearch\(""\);\s*setStatusFilter\("all"\);\s*setSelection\("all"\);\s*setShowArchived\(false\);\s*\}, \[\]\);/,
+  /const clearSessionFilters = useCallback\(\(\) => \{\s*setSearch\(""\);\s*setStatusFilter\("all"\);\s*onSelectionChange\("all"\);\s*setShowArchived\(false\);\s*\}, \[onSelectionChange\]\);/,
   "One reset should clear every non-familiar Sessions filter",
 );
 assert.match(

--- a/src/components/first-project-gate.test.ts
+++ b/src/components/first-project-gate.test.ts
@@ -89,7 +89,7 @@ test("workspace wires the first-project gate through pending-aware policy and re
     /const \{\s*projects: registeredProjects,\s*loading: projectsLoading,\s*error: projectsError,\s*loadedSuccessfully: projectsLoadedSuccessfully,\s*reload: reloadProjects,\s*createProjectOrThrow,\s*\} = useProjects\(\);/,
     "workspace destructures the unscoped projects hook with collision-safe names",
   );
-  assert.match(src, /const \[onboardingResolved, setOnboardingResolved\] = useState\(false\);/, "onboarding resolution starts false");
+  assert.match(src, /const onboardingResolved = true;/, "Workspace only mounts after the server resolves startup onboarding");
   assert.match(src, /const \[projectsInitiallyResolved, setProjectsInitiallyResolved\] = useState\(false\);/, "project-load resolution starts false");
   assert.match(src, /const archivedFamiliars = useArchivedFamiliars\(\);/, "workspace reads the archived familiar map");
   assert.match(

--- a/src/components/onboarding-bootstrap-overlay.test.ts
+++ b/src/components/onboarding-bootstrap-overlay.test.ts
@@ -14,6 +14,12 @@ const diagnostics = await readFile(
   new URL("./onboarding-setup-diagnostics.tsx", import.meta.url),
   "utf8",
 );
+const startupGate = await readFile(
+  new URL("./onboarding-startup-gate.tsx", import.meta.url),
+  "utf8",
+);
+const page = await readFile(new URL("../app/page.tsx", import.meta.url), "utf8");
+const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 
 assert.match(
   lazy,
@@ -74,6 +80,51 @@ assert.match(
   source,
   /requestQueueRef\.current\.then\(\(\) =>\s*performRequest\(method, body\)/,
   "status, confirmation, and resume requests are serialized instead of dropped",
+);
+assert.match(
+  source,
+  /initialState\?: OnboardingBootstrapState/,
+  "the server-resolved bootstrap state can hydrate the dialog",
+);
+assert.match(
+  source,
+  /\(\) => initialState \?\? createOnboardingBootstrapState\(\)/,
+  "the hydrated state is used before any client bootstrap request",
+);
+assert.match(
+  source,
+  /if \(!open \|\| initialState\) return;/,
+  "a server-hydrated dialog does not make an initial bootstrap GET",
+);
+assert.match(
+  source,
+  /document\.cookie = "cave_onboarding_dismissed=1;/,
+  "a first-run dismissal becomes available to the server on the next launch",
+);
+assert.match(
+  page,
+  /await Promise\.all\(\[\s*onboardingBootstrapStatus\(\),\s*cookies\(\),\s*\]\)/s,
+  "the root route resolves bootstrap state before choosing the first surface",
+);
+assert.match(
+  page,
+  /<OnboardingStartupGate initialState=\{bootstrap\} \/>/,
+  "unfinished setup renders its hydrated startup gate instead of Workspace",
+);
+assert.match(
+  startupGate,
+  /import\("@\/components\/workspace-app"\)/,
+  "the startup gate defers the Workspace bundle until setup exits",
+);
+assert.match(
+  startupGate,
+  /<OnboardingOverlay[\s\S]*initialState=\{initialState\}[\s\S]*onDismiss=\{\(\) => setShowWorkspace\(true\)\}/,
+  "the first surface is the hydrated dialog and dismissal releases Workspace",
+);
+assert.doesNotMatch(
+  workspace,
+  /fetch\("\/api\/onboarding\/bootstrap"/,
+  "Workspace no longer waits for a first-run bootstrap request after it mounts",
 );
 assert.doesNotMatch(
   source,

--- a/src/components/onboarding-bootstrap-overlay.tsx
+++ b/src/components/onboarding-bootstrap-overlay.tsx
@@ -18,6 +18,7 @@ type Props = {
   open: boolean;
   onDismiss: () => void;
   autoFinishWhenComplete?: boolean;
+  initialState?: OnboardingBootstrapState;
 };
 
 type BootstrapResponse = OnboardingBootstrapState & {
@@ -54,9 +55,10 @@ export function OnboardingOverlay({
   open,
   onDismiss,
   autoFinishWhenComplete = false,
+  initialState,
 }: Props) {
   const [state, setState] = useState<OnboardingBootstrapState>(
-    createOnboardingBootstrapState(),
+    () => initialState ?? createOnboardingBootstrapState(),
   );
   const [loading, setLoading] = useState(false);
   const [requestError, setRequestError] = useState<string | null>(null);
@@ -73,6 +75,11 @@ export function OnboardingOverlay({
       localStorage.setItem("cave:onboarding:dismissed", "1");
     } catch {
       /* private mode */
+    }
+    try {
+      document.cookie = "cave_onboarding_dismissed=1; Path=/; Max-Age=31536000; SameSite=Lax";
+    } catch {
+      /* embedded browser storage disabled */
     }
   }, []);
 
@@ -157,9 +164,9 @@ export function OnboardingOverlay({
   );
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || initialState) return;
     void request("GET");
-  }, [open, request]);
+  }, [initialState, open, request]);
 
   useEffect(() => {
     if (!open || !state.failure?.diagnostics) setDiagnosticsOpen(false);

--- a/src/components/onboarding-startup-gate.tsx
+++ b/src/components/onboarding-startup-gate.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+import { OnboardingOverlay } from "@/components/onboarding-bootstrap-overlay";
+import type { OnboardingBootstrapState } from "@/lib/onboarding-bootstrap";
+
+const WorkspaceApp = dynamic(
+  () => import("@/components/workspace-app").then((module) => module.WorkspaceApp),
+  { ssr: false, loading: () => null },
+);
+
+const ONBOARDING_DISMISSED_KEY = "cave:onboarding:dismissed";
+
+function wasDismissed(): boolean {
+  try {
+    return window.localStorage.getItem(ONBOARDING_DISMISSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The server has already established that setup is unfinished. Render its
+ * hydrated dialog as the first surface and defer the Workspace bundle until a
+ * user explicitly leaves setup. The localStorage check bridges dismissals made
+ * before the server-readable cookie was introduced.
+ */
+export function OnboardingStartupGate({
+  initialState,
+}: {
+  initialState: OnboardingBootstrapState;
+}) {
+  const [showWorkspace, setShowWorkspace] = useState(false);
+
+  useEffect(() => {
+    if (!initialState.confirmed && wasDismissed()) {
+      setShowWorkspace(true);
+    }
+  }, [initialState.confirmed]);
+
+  if (showWorkspace) return <WorkspaceApp />;
+
+  return (
+    <OnboardingOverlay
+      autoFinishWhenComplete
+      initialState={initialState}
+      open
+      onDismiss={() => setShowWorkspace(true)}
+    />
+  );
+}

--- a/src/components/workspace-app.tsx
+++ b/src/components/workspace-app.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { Workspace } from "@/components/workspace";
+import { WorkspaceSurfacePreferencesProvider } from "@/lib/surface-preferences";
+
+/** The normal application shell, kept out of first-run startup until setup exits. */
+export function WorkspaceApp() {
+  return (
+    <WorkspaceSurfacePreferencesProvider>
+      <Workspace />
+    </WorkspaceSurfacePreferencesProvider>
+  );
+}

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -97,43 +97,19 @@ assert.match(
 );
 assert.match(
   workspace,
-  /const \[autoFinishOnboarding, setAutoFinishOnboarding\] = useState\(false\);/,
-  "Workspace tracks whether startup-opened onboarding should auto-finish on completion",
+  /const openOnboarding = useCallback\(\(\) => \{\s*setOnboardingOpen\(true\);/s,
+  "shared openOnboarding opens onboarding manually after normal startup",
 );
 assert.match(
   workspace,
-  /const manualOnboardingOpenedRef = useRef\(false\);/,
-  "Workspace tracks whether onboarding was opened manually before the startup probe resolves",
+  /const openCreate = \(\) => \{\s*setOnboardingOpen\(true\);/s,
+  "the cave:onboarding-open bridge opens onboarding manually",
 );
+assert.doesNotMatch(workspace, /fetch\("\/api\/onboarding\/bootstrap"/, "Workspace does not repeat the server startup bootstrap request");
 assert.match(
   workspace,
-  /const openOnboarding = useCallback\(\(\) => \{\s*manualOnboardingOpenedRef\.current = true;\s*setAutoFinishOnboarding\(false\);\s*setOnboardingOpen\(true\);/s,
-  "shared openOnboarding marks manual intent before it clears auto-finish and opens the overlay",
-);
-assert.match(
-  workspace,
-  /const openCreate = \(\) => \{\s*manualOnboardingOpenedRef\.current = true;\s*setAutoFinishOnboarding\(false\);\s*setOnboardingOpen\(true\);/s,
-  "the cave:onboarding-open bridge clears auto-finish before opening the overlay",
-);
-assert.match(
-  workspace,
-  /import \{[\s\S]*shouldApplyStartupOnboardingBootstrap[\s\S]*\} from "@\/lib\/onboarding-gate"/,
-  "Workspace imports the shared bootstrap startup helper from onboarding-gate",
-);
-assert.match(
-  workspace,
-  /fetch\("\/api\/onboarding\/bootstrap"[\s\S]*shouldApplyStartupOnboardingBootstrap\(\{\s*status: json,\s*cancelled,\s*manuallyOpened: manualOnboardingOpenedRef\.current,\s*\}\)/s,
-  "a delayed bootstrap response delegates the manual/cancelled/status gate to the shared helper",
-);
-assert.match(
-  workspace,
-  /onDismiss=\{\(\) => \{\s*setAutoFinishOnboarding\(false\);[\s\S]*closeOnboarding\(\);/s,
-  "overlay dismissal clears auto-finish before closing onboarding",
-);
-assert.match(
-  workspace,
-  /<OnboardingOverlay[\s\S]*autoFinishWhenComplete=\{autoFinishOnboarding\}/,
-  "Workspace forwards the auto-finish flag into OnboardingOverlay",
+  /onDismiss=\{\(\) => \{\s*setOnboardingMounted\(true\);[\s\S]*closeOnboarding\(\);/s,
+  "manual overlay dismissal retains its lazy host before closing onboarding",
 );
 
 // The right companion rail was removed in favour of drag-to-split, so the

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -54,10 +54,6 @@ import type { CalendarDeadline } from "@/components/calendar-view";
 import { CaveBackdropLayer } from "@/components/cave-backdrop-layer";
 import { readMobileModeEnabled, writeMobileModeEnabled } from "@/lib/mobile-mode-pref";
 import { reconcileMobileModeRequest } from "@/lib/mobile-mode-reconcile";
-import {
-  shouldApplyStartupOnboardingBootstrap,
-  type OnboardingBootstrapStatusPayload,
-} from "@/lib/onboarding-gate";
 import { draftFromSlashArgs } from "@/lib/reminder-slash-draft";
 import { InboxToastStack, toastFromItem, type Toast } from "@/components/inbox-toast";
 import { MagicTriggers } from "@/components/magic-triggers";
@@ -823,7 +819,7 @@ export function Workspace() {
   const activeChatSessionIdRef = useRef<string | null>(null);
   activeChatSessionIdRef.current = activeChatSessionId;
   const [onboardingOpen, setOnboardingOpen] = useState(false);
-  const [onboardingResolved, setOnboardingResolved] = useState(false);
+  const onboardingResolved = true;
   const [autoFinishOnboarding, setAutoFinishOnboarding] = useState(false);
   // Lazy-load onboarding on first use, then keep its host mounted while closed.
   // Server-owned bootstrap progress persists independently; keeping the host
@@ -1881,40 +1877,6 @@ export function Workspace() {
     clearPendingFirstProjectAccessSnapshot();
     setPendingFirstProjectGrant(null);
   }, [canReconcilePendingFirstProjectGrant, pendingFirstProjectGrant, reconciledPendingFirstProjectGrant]);
-
-  // First-run uses the staged bootstrap state instead of the legacy technical
-  // readiness checklist. A confirmed interrupted job always resumes; before
-  // confirmation the existing dismissal flag still suppresses auto-open.
-  useEffect(() => {
-    let cancelled = false;
-    const skipped =
-      typeof window !== "undefined" && window.localStorage.getItem("cave:onboarding:dismissed") === "1";
-    void (async () => {
-      try {
-        const res = await fetch("/api/onboarding/bootstrap", { cache: "no-store" });
-        if (!res.ok || cancelled) return;
-        const json = (await res.json()) as OnboardingBootstrapStatusPayload;
-        if (
-          shouldApplyStartupOnboardingBootstrap({
-            status: json,
-            cancelled,
-            manuallyOpened: manualOnboardingOpenedRef.current,
-          }) &&
-          (!skipped || json.confirmed === true)
-        ) {
-          setAutoFinishOnboarding(true);
-          setOnboardingOpen(true);
-        }
-      } catch {
-        /* ignore — the daemon-offline banner surfaces transport issues */
-      } finally {
-        if (!cancelled) setOnboardingResolved(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   useEffect(() => {
     const isEditableTarget = (target: EventTarget | null): boolean => {

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -820,14 +820,12 @@ export function Workspace() {
   activeChatSessionIdRef.current = activeChatSessionId;
   const [onboardingOpen, setOnboardingOpen] = useState(false);
   const onboardingResolved = true;
-  const [autoFinishOnboarding, setAutoFinishOnboarding] = useState(false);
   // Lazy-load onboarding on first use, then keep its host mounted while closed.
   // Server-owned bootstrap progress persists independently; keeping the host
   // mounted makes close/reopen cheap and retains local focus/announcement refs.
   const [onboardingMounted, setOnboardingMounted] = useState(false);
   const [projectsInitiallyResolved, setProjectsInitiallyResolved] = useState(false);
   const [pendingFirstProjectGrant, setPendingFirstProjectGrant] = useState<PendingFirstProjectAccessSnapshot | null>(() => readPendingFirstProjectAccessSnapshot());
-  const manualOnboardingOpenedRef = useRef(false);
   const [inboxItems, setInboxItems] = useState<InboxItem[]>([]);
   const [escalationsUnresolved, setEscalationsUnresolved] = useState(0);
   // Open (not-done) board cards, kept with their familiar so the Tasks badge can
@@ -1155,8 +1153,6 @@ export function Workspace() {
   // for adding to an existing roster without re-running setup.
   useEffect(() => {
     const openCreate = () => {
-      manualOnboardingOpenedRef.current = true;
-      setAutoFinishOnboarding(false);
       setOnboardingOpen(true);
     };
     window.addEventListener("cave:onboarding-open", openCreate);
@@ -1844,8 +1840,6 @@ export function Workspace() {
   }, [inboxItems, sessionsLoaded, daemonOffline, familiars, activeId]);
 
   const openOnboarding = useCallback(() => {
-    manualOnboardingOpenedRef.current = true;
-    setAutoFinishOnboarding(false);
     setOnboardingOpen(true);
   }, []);
   const closeOnboarding = useCallback(() => {
@@ -3866,10 +3860,8 @@ export function Workspace() {
 
       {(onboardingOpen || onboardingMounted) && (
         <OnboardingOverlay
-          autoFinishWhenComplete={autoFinishOnboarding}
           open={onboardingOpen}
           onDismiss={() => {
-            setAutoFinishOnboarding(false);
             setOnboardingMounted(true);
             closeOnboarding();
           }}

--- a/src/lib/surface-preferences.test.ts
+++ b/src/lib/surface-preferences.test.ts
@@ -82,7 +82,7 @@ test("every remounting surface opts into the registry while searches remain tran
     browser: read("../components/browser-pane.tsx"),
     grimoire: read("../components/grimoire-view.tsx"),
     codeRail: read("../components/rail-files-panel.tsx"),
-    workspace: read("../app/page.tsx"),
+    workspace: read("../components/workspace-app.tsx"),
     workspaceShell: read("../components/workspace.tsx"),
   };
   for (const [name, source] of Object.entries(sources)) {

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -185,9 +185,16 @@ async function gotoApp(
       state: "visible",
       timeout: 30_000,
     });
-    await page.evaluate(() => {
-      window.dispatchEvent(new Event("cave:onboarding-open"));
-    });
+    // The search surface paints before Workspace installs the bridge listener.
+    // Re-dispatch until that listener has opened the shared overlay.
+    await expect
+      .poll(async () => {
+        await page.evaluate(() => {
+          window.dispatchEvent(new Event("cave:onboarding-open"));
+        });
+        return await setup(page).count();
+      }, { timeout: 30_000 })
+      .toBeGreaterThan(0);
   }
 }
 

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -154,7 +154,7 @@ async function baseRoutes(page: Page) {
 async function gotoApp(
   page: Page,
   handler: (route: Route) => Promise<unknown> | unknown,
-  options?: { dismissed?: boolean },
+  options?: { dismissed?: boolean; openOnboarding?: boolean },
 ) {
   await baseRoutes(page);
   await page.route("**/api/onboarding/bootstrap**", handler);
@@ -164,6 +164,19 @@ async function gotoApp(
     });
   }
   await page.goto("/");
+  // Startup state is now resolved by the server before this browser can
+  // intercept API requests. These interaction tests exercise the shared
+  // overlay through the Workspace's supported manual-open bridge; the server
+  // startup/hydration contract is covered by the focused app test.
+  if (options?.openOnboarding !== false) {
+    await page.getByRole("searchbox").first().waitFor({
+      state: "visible",
+      timeout: 30_000,
+    });
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("cave:onboarding-open"));
+    });
+  }
 }
 
 const setup = (page: Page) => page.getByRole("dialog", { name: "Set up Cave" });
@@ -575,6 +588,7 @@ test.describe("onboarding bootstrap", () => {
     });
     await gotoApp(page, (route) =>
       route.fulfill({ json: payload(complete) }),
+      { openOnboarding: false },
     );
     await page.getByRole("searchbox").first().waitFor({
       state: "visible",

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -163,6 +163,18 @@ async function gotoApp(
       window.localStorage.setItem("cave:onboarding:dismissed", "1");
     });
   }
+  // The root route resolves bootstrap state on the server, before Playwright
+  // can intercept its client API route. Seed the server-readable dismissal for
+  // these shared-overlay interaction tests, then use the supported manual-open
+  // bridge below. The startup gate itself is covered by the focused app test.
+  await page.goto("/");
+  await page.context().addCookies([
+    {
+      name: "cave_onboarding_dismissed",
+      value: "1",
+      url: page.url(),
+    },
+  ]);
   await page.goto("/");
   // Startup state is now resolved by the server before this browser can
   // intercept API requests. These interaction tests exercise the shared


### PR DESCRIPTION
Summary: resolve onboarding bootstrap before Workspace renders; hydrate the first-run dialog; defer Workspace until setup exits. Validation: focused onboarding tests, typecheck, design codemod check, diff check. Source lint awaits CI because this worktree dependency install stalled. Bead: cave-y7y.