### PR TITLE
Repair Chat filter reset contract

### DIFF
--- a/src/components/chat-list-filter-defaults.test.ts
+++ b/src/components/chat-list-filter-defaults.test.ts
@@ -15,7 +15,7 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /const clearSessionFilters = useCallback\(\(\) => \{\s*setSearch\(""\);\s*setStatusFilter\("all"\);\s*setSelection\("all"\);\s*setShowArchived\(false\);\s*\}, \[\]\);/,
+  /const clearSessionFilters = useCallback\(\(\) => \{\s*setSearch\(""\);\s*setStatusFilter\("all"\);\s*onSelectionChange\("all"\);\s*setShowArchived\(false\);\s*\}, \[onSelectionChange\]\);/,
   "One reset should clear every non-familiar Sessions filter",
 );
 assert.match(


### PR DESCRIPTION
## Summary
- update the Chat filter reset source contract for the controlled project-selection prop
- keep the baseline suite aligned with the production `onSelectionChange` callback and dependency

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` (1,214 files; isolated Chromium timing flake passed on rerun, then full suite passed)
- `pnpm test:api` (379 files)
- `pnpm check:tests-wired`

Bead: `cave-p2qlk`