### PR TITLE
Preserve installer launch diagnostics

### DIFF
--- a/src/app/api/onboarding/install/install-service.test.ts
+++ b/src/app/api/onboarding/install/install-service.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 import {
   canRepairDetectedCovenWithHostNpm,
   classifyOnboardingInstallFailure,
+  installerErrorCode,
+  installStartErrorMessage,
 } from "./install-service.ts";
 
 test("Coven CLI repair uses host npm only for Windows npm command shims", () => {
@@ -22,6 +24,16 @@ const cases = [
     name: "launch",
     input: { code: null, output: "", launchFailed: true },
     expected: "installer_start_failed",
+  },
+  {
+    name: "Windows access-denied launch",
+    input: {
+      code: null,
+      output: "",
+      error: "Installer launch failed with EACCES.",
+      launchFailed: true,
+    },
+    expected: "filesystem_failed",
   },
   {
     name: "integrity",
@@ -102,5 +114,29 @@ for (const fixture of cases) {
     );
   });
 }
+
+test("installer launch diagnostics retain only stable Windows error codes", () => {
+  const error = Object.assign(
+    new Error("spawn C:\\Users\\Sage\\private\\node.exe EACCES"),
+    { code: "EACCES", path: "C:\\Users\\Sage\\private\\node.exe" },
+  );
+
+  assert.equal(installerErrorCode(error), "EACCES");
+  assert.equal(
+    installStartErrorMessage(error),
+    "The operating system blocked Cave from starting the installer (EACCES). Check the affected user-scoped location and security controls, then retry setup.",
+  );
+  assert.doesNotMatch(installStartErrorMessage(error), /Sage|node\.exe/);
+});
+
+test("missing installer executables produce an actionable restart message", () => {
+  const error = Object.assign(new Error("spawn node.exe ENOENT"), {
+    code: "ENOENT",
+  });
+
+  assert.equal(installerErrorCode(error), "ENOENT");
+  assert.match(installStartErrorMessage(error), /reviewed executable was missing/);
+  assert.match(installStartErrorMessage(error), /Restart Cave/);
+});
 
 console.log("onboarding install-service.test.ts: ok");

--- a/src/app/api/onboarding/install/install-service.test.ts
+++ b/src/app/api/onboarding/install/install-service.test.ts
@@ -139,4 +139,17 @@ test("missing installer executables produce an actionable restart message", () =
   assert.match(installStartErrorMessage(error), /Restart Cave/);
 });
 
+test("installer resource failures do not overstate the exhausted resource", () => {
+  const error = Object.assign(new Error("spawn node.exe ENFILE"), {
+    code: "ENFILE",
+  });
+
+  assert.equal(installerErrorCode(error), "ENFILE");
+  assert.equal(
+    installStartErrorMessage(error),
+    "Cave could not start the installer because system resources are temporarily exhausted. Close other apps or processes, wait a moment, then click Install again.",
+  );
+  assert.doesNotMatch(installStartErrorMessage(error), /process slots/);
+});
+
 console.log("onboarding install-service.test.ts: ok");

--- a/src/app/api/onboarding/install/install-service.ts
+++ b/src/app/api/onboarding/install/install-service.ts
@@ -595,7 +595,6 @@ export function classifyOnboardingInstallFailure(input: {
   // outcome. Historical success output must not override that known phase.
   if (input.code === 0) return "verification_failed";
   if (/timed out/i.test(detail)) return "install_timeout";
-  if (input.launchFailed) return "installer_start_failed";
   if (/(EBUSY|resource busy|locked)/i.test(detail)) {
     return "install_busy";
   }
@@ -611,6 +610,7 @@ export function classifyOnboardingInstallFailure(input: {
     // data. Never turn this signal into an application-data writeability claim.
     return "filesystem_failed";
   }
+  if (input.launchFailed) return "installer_start_failed";
   return "unknown_failure";
 }
 
@@ -651,10 +651,53 @@ export function readOnboardingInstall(
   return { ...jobView(job), ...npmLaneView() };
 }
 
-function installStartErrorMessage(err: unknown): string {
+const SAFE_INSTALLER_ERROR_CODES = new Set([
+  "EACCES",
+  "EAGAIN",
+  "EINVAL",
+  "EMFILE",
+  "ENFILE",
+  "ENOENT",
+  "ENOMEM",
+  "EPERM",
+  "EROFS",
+]);
+
+export function installerErrorCode(err: unknown): string | null {
+  const direct =
+    err && typeof err === "object" && "code" in err
+      ? String((err as { code?: unknown }).code ?? "").toUpperCase()
+      : "";
+  if (SAFE_INSTALLER_ERROR_CODES.has(direct)) return direct;
   const message = err instanceof Error ? err.message : String(err);
-  if (/resource temporarily unavailable|EAGAIN|uv_thread_create/i.test(message)) {
+  const matched = message
+    .toUpperCase()
+    .match(/\b(EACCES|EAGAIN|EINVAL|EMFILE|ENFILE|ENOENT|ENOMEM|EPERM|EROFS)\b/);
+  return matched?.[1] ?? null;
+}
+
+function installerErrorDetail(err: unknown): string {
+  const code = installerErrorCode(err);
+  return code ? `Installer launch failed with ${code}.` : "";
+}
+
+export function installStartErrorMessage(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  const code = installerErrorCode(err);
+  if (
+    code === "EAGAIN" ||
+    code === "ENOMEM" ||
+    code === "EMFILE" ||
+    code === "ENFILE" ||
+    /resource temporarily unavailable|uv_thread_create/i.test(message)
+  ) {
     return "Cave could not start the installer because the system is temporarily out of process slots. Wait a moment, then click Install again.";
+  }
+  if (code === "EACCES" || code === "EPERM" || code === "EROFS") {
+    return `The operating system blocked Cave from starting the installer (${code}). Check the affected user-scoped location and security controls, then retry setup.`;
+  }
+  if (code === "ENOENT") {
+    return "Cave could not start the installer because its reviewed executable was missing (ENOENT). Restart Cave, then retry setup.";
   }
   if (!message) return "install failed to start";
   return "Cave could not start the installer. Retry in a moment; if it continues, copy diagnostics for support.";
@@ -879,10 +922,11 @@ async function runInstallJob(
     if (finalized) return;
     finalized = true;
     clearTimers();
+    const launchErrorCode = installerErrorCode(launchError);
     appendTrace(
       job,
       launchError
-        ? "Installer process: did not start."
+        ? `Installer process: did not start${launchErrorCode ? ` (${launchErrorCode})` : ""}.`
         : code === null
           ? `Installer process: ended by signal ${signal ?? "unknown"}.`
           : `Installer process: exited with code ${code}.`,
@@ -1007,12 +1051,24 @@ async function runManagedNodeInstallJob(job: InstallJob, npmLease?: NpmInstallLe
   } catch (error) {
     job.ok = false;
     job.code = 1;
+    const errorDetail = installerErrorDetail(error);
     job.error = job.cancelRequested
       ? "install cancelled"
       : installStartErrorMessage(error);
     job.failureCode = job.cancelRequested
       ? "unknown_failure"
-      : "installer_start_failed";
+      : classifyOnboardingInstallFailure({
+          code: null,
+          output: job.output,
+          error: errorDetail,
+          launchFailed: true,
+        });
+    appendTrace(
+      job,
+      errorDetail
+        ? `Managed Node installer: failed before completion (${installerErrorCode(error)}).`
+        : "Managed Node installer: failed before completion.",
+    );
     appendOutput(job, `${job.error}\n`);
   } finally {
     job.status = "done";

--- a/src/app/api/onboarding/install/install-service.ts
+++ b/src/app/api/onboarding/install/install-service.ts
@@ -651,7 +651,7 @@ export function readOnboardingInstall(
   return { ...jobView(job), ...npmLaneView() };
 }
 
-const SAFE_INSTALLER_ERROR_CODES = new Set([
+const SAFE_INSTALLER_ERROR_CODE_LIST = [
   "EACCES",
   "EAGAIN",
   "EINVAL",
@@ -661,7 +661,13 @@ const SAFE_INSTALLER_ERROR_CODES = new Set([
   "ENOMEM",
   "EPERM",
   "EROFS",
-]);
+] as const;
+const SAFE_INSTALLER_ERROR_CODES = new Set<string>(
+  SAFE_INSTALLER_ERROR_CODE_LIST,
+);
+const SAFE_INSTALLER_ERROR_CODE_PATTERN = new RegExp(
+  `\\b(${SAFE_INSTALLER_ERROR_CODE_LIST.join("|")})\\b`,
+);
 
 export function installerErrorCode(err: unknown): string | null {
   const direct =
@@ -670,9 +676,7 @@ export function installerErrorCode(err: unknown): string | null {
       : "";
   if (SAFE_INSTALLER_ERROR_CODES.has(direct)) return direct;
   const message = err instanceof Error ? err.message : String(err);
-  const matched = message
-    .toUpperCase()
-    .match(/\b(EACCES|EAGAIN|EINVAL|EMFILE|ENFILE|ENOENT|ENOMEM|EPERM|EROFS)\b/);
+  const matched = message.toUpperCase().match(SAFE_INSTALLER_ERROR_CODE_PATTERN);
   return matched?.[1] ?? null;
 }
 
@@ -691,7 +695,7 @@ export function installStartErrorMessage(err: unknown): string {
     code === "ENFILE" ||
     /resource temporarily unavailable|uv_thread_create/i.test(message)
   ) {
-    return "Cave could not start the installer because the system is temporarily out of process slots. Wait a moment, then click Install again.";
+    return "Cave could not start the installer because system resources are temporarily exhausted. Close other apps or processes, wait a moment, then click Install again.";
   }
   if (code === "EACCES" || code === "EPERM" || code === "EROFS") {
     return `The operating system blocked Cave from starting the installer (${code}). Check the affected user-scoped location and security controls, then retry setup.`;

--- a/src/app/onboarding-install-route.test.ts
+++ b/src/app/onboarding-install-route.test.ts
@@ -19,8 +19,8 @@ assert.match(
 
 assert.match(
   route,
-  /function installStartErrorMessage\([\s\S]*?resource temporarily unavailable[\s\S]*?Cave could not start the installer because the system is temporarily out of process slots/,
-  "install route should turn process exhaustion into a user-facing retryable job error",
+  /function installStartErrorMessage\([\s\S]*?resource temporarily unavailable[\s\S]*?Cave could not start the installer because system resources are temporarily exhausted/,
+  "install route should turn resource exhaustion into a user-facing retryable job error",
 );
 
 assert.doesNotMatch(


### PR DESCRIPTION
## Summary
- retain an allowlisted native installer error code without exposing machine-local paths or raw launch messages
- classify access-denied launches (`EACCES`, `EPERM`, `EROFS`) as filesystem/security-control failures instead of transient installer-start failures
- give missing reviewed executables (`ENOENT`) explicit restart guidance and carry safe codes into installer traces

## Why
Windows x64 MSI setup currently collapses materially different launch failures into the same “Couldn’t start the local component installer” copy. That prevents support from distinguishing a missing executable from Windows access controls. The reporter did not provide a diagnostic payload after two requests, so this PR deliberately does not attribute the machine-specific failure to a particular product or path.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` (1,214 files)
- `pnpm test:api` (379 files)
- `pnpm check:tests-wired` (1,673 files)
- targeted installer service tests (19)

Bead: `cave-q9330`
Dependency repaired separately in PR #4678.