### PR TITLE
docs(x6rw): re-land the approved waste-free half-splits design and plan

### DIFF
--- a/docs/superpowers/plans/2026-07-09-waste-free-half-splits.md
+++ b/docs/superpowers/plans/2026-07-09-waste-free-half-splits.md
@@ -1,0 +1,1184 @@
+# Waste-Free Half Splits Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Make every registered workspace page render in either half of the desktop detail area with pixel-exact, waste-free geometry, honest responsive behavior, and exhaustive rendered verification.
+
+**Architecture:** Add one pure page registry and one normalized pane-request contract, then route primary navigation, drag-to-split, promotion, footer destinations, role surfaces, and companion surfaces through that contract. `DetailSplitHost` owns pane geometry and uniform chrome; every page mounts inside a standard pane-root container, while a container-width fallback turns narrow splits into full-width tabs without unmounting either page.
+
+**Tech Stack:** Next.js 15, React 19, TypeScript, `react-resizable-panels`, CSS container queries, Node's built-in test runner, Playwright 1.61, Tauri 2.
+
+**Approved design:** `docs/superpowers/specs/2026-07-09-waste-free-half-splits-design.md`
+
+**Bead:** `cave-x6rw`
+
+## File structure
+
+New files:
+
+- `src/lib/workspace-page-registry.ts` — exhaustive page identities, aliases, variants, navigation metadata, and dynamic role-surface resolution.
+- `src/lib/workspace-page-registry.test.ts` — registry exhaustiveness, alias, split, and landmark contracts.
+- `src/lib/workspace-pane-request.ts` — normalized, stable per-pane requests and deduplication keys.
+- `src/lib/workspace-pane-request.test.ts` — normalization, coexistence, deduplication, and promotion tests.
+- `src/lib/split-geometry.ts` — integer-pixel two-pane geometry and narrow-container mode selection.
+- `src/lib/split-geometry.test.ts` — odd/even widths, seam ownership, and responsive thresholds.
+- `src/components/workspace-pane-page.tsx` — standard pane root, loading/unavailable state, and pane-local error boundary.
+- `src/components/workspace-pane-page.test.ts` — source contracts for fill behavior, landmarks, and isolation.
+- `src/components/dashboard/dashboard-surface.tsx` — embeddable dashboard client surface.
+- `src/app/api/dashboard/route.ts` — JSON view-model endpoint shared by the embedded surface.
+- `tests/workspace-half-split.spec.ts` — exhaustive desktop primary/secondary/left/right geometry matrix.
+- `tests/mobile/workspace-half-split.spec.ts` — narrow-container tab fallback and zero-geometry inactive-pane tests.
+
+Modified files:
+
+- `scripts/run-tests.mjs` — wire every new Node test into the app suite.
+- `src/lib/page-drag.ts` and `src/lib/page-drag.test.ts` — validate drag sources through the registry instead of exclusions.
+- `src/lib/workspace-tiles.ts` and `src/lib/workspace-tiles.test.ts` — key and retain normalized pane requests.
+- `src/components/sidebar-minimal.tsx`, `src/components/sidebar-footer.tsx`, and their tests — consume registry metadata and expose draggable footer destinations.
+- `src/components/workspace.tsx` — resolve every primary and secondary page through one renderer, mount Flow honestly, and support registry-backed split deep links.
+- `src/components/settings-shell.tsx` and `src/app/settings/page.tsx` — support route and embedded modes without route-only Escape/history behavior leaking into a pane.
+- `src/app/dashboard/page.tsx`, dashboard tests, and `src/app/api/api-contracts.test.ts` — preserve the standalone route while adding the embedded adapter.
+- `src/components/rail-terminal-panel.tsx` and its test — key terminal sessions by pane instance.
+- `src/components/detail-split-host.tsx`, `src/components/shell.tsx`, `src/components/detail-split-host.test.ts`, and `src/components/drag-to-split.test.ts` — symmetric pane chrome, integer geometry, container fallback, and no content floor.
+- `src/app/globals.css` plus surface styles/components named in Task 9 — standardized fill/min-size/container behavior and removal of horizontal dead-space policy.
+- `playwright.config.ts` — add explicit 1440, 1280, and 1024 desktop projects for the matrix.
+
+## Task 1: Establish the exhaustive page registry
+
+**Files:**
+
+- Create: `src/lib/workspace-page-registry.ts`
+- Create: `src/lib/workspace-page-registry.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write the failing registry test and wire it immediately**
+
+Add `src/lib/workspace-page-registry.test.ts` with these assertions:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  BUILT_IN_WORKSPACE_PAGE_IDS,
+  workspacePageDefinition,
+  workspacePageKey,
+} from "./workspace-page-registry.ts";
+
+const expected = [
+  "agents", "home", "chat", "groupchat", "board", "calendar", "inbox",
+  "browser", "github", "roles", "marketplace", "flow", "submissions",
+  "capabilities", "familiar-work-queue", "journal", "grimoire",
+  "settings", "dashboard", "salem", "memory", "terminal",
+] as const;
+
+test("registry enumerates every built-in page exactly once", () => {
+  assert.deepEqual(BUILT_IN_WORKSPACE_PAGE_IDS, expected);
+  assert.equal(new Set(BUILT_IN_WORKSPACE_PAGE_IDS).size, expected.length);
+});
+
+test("aliases preserve their requested variant", () => {
+  assert.deepEqual(workspacePageDefinition("groupchat"), {
+    id: "groupchat", title: "Group", canonicalId: "chat", variant: "group",
+    nav: "hidden", split: "contextual", landmark: "Chat / Group",
+  });
+  assert.equal(workspacePageDefinition("calendar")?.canonicalId, "inbox");
+  assert.equal(workspacePageDefinition("roles")?.canonicalId, "marketplace");
+  assert.equal(workspacePageDefinition("journal")?.canonicalId, "grimoire");
+});
+
+test("role surfaces are first-class split pages", () => {
+  const page = workspacePageDefinition("surface:researcher");
+  assert.equal(page.canonicalId, "surface:researcher");
+  assert.equal(page.split, true);
+  assert.equal(workspacePageKey(page), "surface:researcher:default");
+});
+```
+
+Append the test path beside the existing workspace library tests in `scripts/run-tests.mjs`:
+
+```js
+"src/lib/workspace-page-registry.test.ts",
+```
+
+- [ ] **Step 2: Run the test to verify it fails for the missing module**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/workspace-page-registry.test.ts
+```
+
+Expected: `ERR_MODULE_NOT_FOUND` for `workspace-page-registry.ts`.
+
+- [ ] **Step 3: Implement the typed registry**
+
+Create `src/lib/workspace-page-registry.ts` with these public contracts and a literal `satisfies Record<WorkspaceMode, WorkspacePageDefinition>` map:
+
+```ts
+import type { WorkspaceMode } from "./workspace-mode";
+import { isRoleSurfaceMode, type RoleSurfaceMode } from "./role-surfaces";
+
+export type BuiltInWorkspacePageId = WorkspaceMode | "settings" | "dashboard";
+export type CompanionPageId = "salem" | "memory" | "terminal";
+export type WorkspacePageId = BuiltInWorkspacePageId | CompanionPageId | RoleSurfaceMode;
+export type WorkspacePageVariant =
+  | "default" | "group" | "queue" | "calendar"
+  | "roles" | "capabilities" | "journal";
+
+export type WorkspacePageDefinition = {
+  id: WorkspacePageId;
+  title: string;
+  canonicalId: WorkspacePageId;
+  variant: WorkspacePageVariant;
+  nav: "daily" | "quiet" | "hidden" | "footer" | "companion" | "dynamic";
+  split: "always" | "contextual";
+  landmark: string;
+};
+
+const WORKSPACE_MODE_PAGES = {
+  agents: { id: "agents", title: "Familiars", canonicalId: "agents", variant: "default", nav: "hidden", split: "contextual", landmark: "Familiars" },
+  home: { id: "home", title: "Home", canonicalId: "home", variant: "default", nav: "daily", split: "always", landmark: "Home" },
+  chat: { id: "chat", title: "Chat", canonicalId: "chat", variant: "default", nav: "daily", split: "contextual", landmark: "Chat" },
+  groupchat: { id: "groupchat", title: "Group", canonicalId: "chat", variant: "group", nav: "hidden", split: "contextual", landmark: "Chat / Group" },
+  board: { id: "board", title: "Tasks", canonicalId: "board", variant: "default", nav: "daily", split: "always", landmark: "Tasks" },
+  calendar: { id: "calendar", title: "Calendar", canonicalId: "inbox", variant: "calendar", nav: "hidden", split: "always", landmark: "Schedules / Calendar" },
+  inbox: { id: "inbox", title: "Schedules", canonicalId: "inbox", variant: "default", nav: "daily", split: "always", landmark: "Schedules" },
+  browser: { id: "browser", title: "Browser", canonicalId: "browser", variant: "default", nav: "hidden", split: "contextual", landmark: "Browser" },
+  github: { id: "github", title: "GitHub", canonicalId: "github", variant: "default", nav: "quiet", split: "always", landmark: "GitHub" },
+  roles: { id: "roles", title: "Roles", canonicalId: "marketplace", variant: "roles", nav: "hidden", split: "always", landmark: "Marketplace / Roles" },
+  marketplace: { id: "marketplace", title: "Marketplace", canonicalId: "marketplace", variant: "default", nav: "quiet", split: "always", landmark: "Marketplace" },
+  flow: { id: "flow", title: "Flow", canonicalId: "flow", variant: "default", nav: "hidden", split: "always", landmark: "Flow" },
+  submissions: { id: "submissions", title: "Submissions", canonicalId: "submissions", variant: "default", nav: "hidden", split: "contextual", landmark: "Submissions" },
+  capabilities: { id: "capabilities", title: "Capabilities", canonicalId: "marketplace", variant: "capabilities", nav: "hidden", split: "always", landmark: "Marketplace / Capabilities" },
+  "familiar-work-queue": { id: "familiar-work-queue", title: "Queue", canonicalId: "board", variant: "queue", nav: "hidden", split: "contextual", landmark: "Tasks / Queue" },
+  journal: { id: "journal", title: "Journal", canonicalId: "grimoire", variant: "journal", nav: "quiet", split: "contextual", landmark: "Grimoire / Journal" },
+  grimoire: { id: "grimoire", title: "Grimoire", canonicalId: "grimoire", variant: "default", nav: "quiet", split: "contextual", landmark: "Grimoire" },
+} satisfies Record<WorkspaceMode, WorkspacePageDefinition>;
+
+const SUPPLEMENTAL_PAGES = {
+  settings: { id: "settings", title: "Settings", canonicalId: "settings", variant: "default", nav: "footer", split: "always", landmark: "Settings" },
+  dashboard: { id: "dashboard", title: "Dashboard", canonicalId: "dashboard", variant: "default", nav: "footer", split: "always", landmark: "Dashboard" },
+  salem: { id: "salem", title: "Salem", canonicalId: "salem", variant: "default", nav: "companion", split: "contextual", landmark: "Salem" },
+  memory: { id: "memory", title: "Memory", canonicalId: "memory", variant: "default", nav: "companion", split: "contextual", landmark: "Memory" },
+  terminal: { id: "terminal", title: "Terminal", canonicalId: "terminal", variant: "default", nav: "companion", split: "contextual", landmark: "Terminal" },
+} satisfies Record<"settings" | "dashboard" | CompanionPageId, WorkspacePageDefinition>;
+```
+
+Also export `BUILT_IN_WORKSPACE_PAGE_IDS`, `workspacePageDefinition(id)`, `workspacePageKey(definition)`, `isWorkspacePageId(value)`, and registry-derived nav/footer/companion lists. `workspacePageDefinition` must return a `nav: "dynamic"` definition only after `isRoleSurfaceMode(id)` succeeds; it must return `null` for unknown strings.
+
+- [ ] **Step 4: Run the focused test and test-wiring guard**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/workspace-page-registry.test.ts
+pnpm check:tests-wired
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 5: Commit the registry checkpoint**
+
+```bash
+git add scripts/run-tests.mjs src/lib/workspace-page-registry.ts src/lib/workspace-page-registry.test.ts
+git commit -S -m "feat(workspace): add exhaustive page registry (cave-x6rw)"
+```
+
+## Task 2: Normalize pane requests and tile identity
+
+**Files:**
+
+- Create: `src/lib/workspace-pane-request.ts`
+- Create: `src/lib/workspace-pane-request.test.ts`
+- Modify: `src/lib/workspace-tiles.ts`
+- Modify: `src/lib/workspace-tiles.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write failing normalization and identity tests**
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { normalizeWorkspacePaneRequest, workspacePaneRequestKey } from "./workspace-pane-request.ts";
+
+test("normalization retains aliases as explicit variants", () => {
+  const group = normalizeWorkspacePaneRequest("pane-group", "groupchat");
+  assert.deepEqual(group, {
+    instanceId: "pane-group",
+    pageId: "chat",
+    requestedPageId: "groupchat",
+    variant: "group",
+  });
+});
+
+test("exact page and variant dedupe while variants coexist", () => {
+  const direct = normalizeWorkspacePaneRequest("one", "chat");
+  const group = normalizeWorkspacePaneRequest("two", "groupchat");
+  assert.equal(workspacePaneRequestKey(direct), "chat:default");
+  assert.equal(workspacePaneRequestKey(group), "chat:group");
+  assert.notEqual(workspacePaneRequestKey(direct), workspacePaneRequestKey(group));
+});
+
+test("unknown page ids are rejected", () => {
+  assert.equal(normalizeWorkspacePaneRequest("bad", "definitely-missing"), null);
+});
+```
+
+Wire `src/lib/workspace-pane-request.test.ts` in the app suite.
+
+- [ ] **Step 2: Run the focused test and observe the missing-module failure**
+
+```bash
+node --experimental-strip-types --test src/lib/workspace-pane-request.test.ts
+```
+
+Expected: `ERR_MODULE_NOT_FOUND`.
+
+- [ ] **Step 3: Implement the request contract**
+
+```ts
+import type { WorkspacePageId, WorkspacePageVariant } from "./workspace-page-registry";
+import { workspacePageDefinition } from "./workspace-page-registry";
+
+export type WorkspacePaneRequest = {
+  instanceId: string;
+  pageId: WorkspacePageId;
+  requestedPageId: WorkspacePageId;
+  variant: WorkspacePageVariant;
+};
+
+export function normalizeWorkspacePaneRequest(
+  instanceId: string,
+  requestedPageId: string,
+): WorkspacePaneRequest | null {
+  const definition = workspacePageDefinition(requestedPageId);
+  if (!definition) return null;
+  return {
+    instanceId,
+    pageId: definition.canonicalId,
+    requestedPageId: definition.id,
+    variant: definition.variant,
+  };
+}
+
+export function workspacePaneRequestKey(request: WorkspacePaneRequest): string {
+  return `${request.pageId}:${request.variant}`;
+}
+```
+
+Update `addSecondaryWorkspaceTile` tests so two requests with the same key replace one another, while `chat:default` and `chat:group` remain separate entries. Keep the four-tile cap.
+
+- [ ] **Step 4: Run the focused suites**
+
+```bash
+node --experimental-strip-types --test src/lib/workspace-pane-request.test.ts
+node --experimental-strip-types --test src/lib/workspace-tiles.test.ts
+pnpm check:tests-wired
+```
+
+Expected: all exit 0.
+
+- [ ] **Step 5: Commit normalized pane identity**
+
+```bash
+git add scripts/run-tests.mjs src/lib/workspace-pane-request.ts src/lib/workspace-pane-request.test.ts src/lib/workspace-tiles.ts src/lib/workspace-tiles.test.ts
+git commit -S -m "feat(workspace): normalize pane requests (cave-x6rw)"
+```
+
+## Task 3: Make every navigation source registry-driven
+
+**Files:**
+
+- Modify: `src/lib/page-drag.ts`
+- Modify: `src/lib/page-drag.test.ts`
+- Modify: `src/components/sidebar-minimal.tsx`
+- Modify: `src/components/sidebar-minimal.test.ts`
+- Modify: `src/components/sidebar-footer.tsx`
+- Modify: `src/components/sidebar-footer.test.ts`
+- Modify: `src/components/command-palette.tsx`
+- Modify: `src/components/command-palette.test.ts`
+- Modify: `src/components/grimoire-view.test.ts`
+
+- [ ] **Step 1: Replace exclusion expectations with positive registry expectations**
+
+Add cases to `page-drag.test.ts`:
+
+```ts
+assert.equal(isSplittablePage("terminal"), true);
+assert.equal(isSplittablePage("journal"), true);
+assert.equal(isSplittablePage("settings"), true);
+assert.equal(isSplittablePage("dashboard"), true);
+assert.equal(isSplittablePage("surface:researcher"), true);
+assert.equal(isSplittablePage("unknown-page"), false);
+```
+
+Extend `sidebar-footer.test.ts` to require both footer destinations to use `PAGE_DRAG_MIME`, `emitPageDragStart`, and `emitPageDragEnd` without changing their click destinations.
+
+Extend `command-palette.test.ts` to forbid imports from `sidebar-minimal`, require registry-derived launcher definitions, and assert that hidden, footer, companion, and dynamic role pages can be represented by the `go-to-surface` intent.
+
+Replace `grimoire-view.test.ts`'s assertion about the deleted `FolderMode` union with an assertion that the registry contains both `grimoire` and the `journal` variant.
+
+- [ ] **Step 2: Run focused tests and verify the old exclusions fail**
+
+```bash
+node --experimental-strip-types --test src/lib/page-drag.test.ts
+node --experimental-strip-types --test src/components/sidebar-footer.test.ts
+```
+
+Expected: terminal, journal, role surface, and footer drag assertions fail.
+
+- [ ] **Step 3: Derive split eligibility from the registry**
+
+Replace `NON_SPLITTABLE` with:
+
+```ts
+import { workspacePageDefinition } from "./workspace-page-registry";
+
+export function isSplittablePage(mode: string): boolean {
+  return workspacePageDefinition(mode) !== null;
+}
+```
+
+Change `FolderMode` to `WorkspaceMode`, retain presentation-only icon/badge callbacks in `sidebar-minimal.tsx`, and assert each presentation entry resolves through `workspacePageDefinition`. Keep hidden launchers hidden; do not duplicate page identity or alias data.
+
+Extract a small `DraggablePageDestination` helper in `sidebar-footer.tsx`. Use `pageId="dashboard"` on the existing link and `pageId="settings"` on the existing button so clicks remain `/dashboard` and `onOpenSettings`, respectively, while drag data uses the registry ID.
+
+Change the command palette's `go-to-surface` intent to carry `WorkspacePageId`, and build launcher rows from the registry's exported palette definitions instead of importing `FOLDER_MODES`. The workspace intent handler will normalize the selected ID in Task 6.
+
+- [ ] **Step 4: Run all affected tests**
+
+```bash
+node --experimental-strip-types --test src/lib/page-drag.test.ts
+node --experimental-strip-types --test src/components/sidebar-minimal.test.ts
+node --experimental-strip-types --test src/components/sidebar-footer.test.ts
+node --experimental-strip-types --test src/components/command-palette.test.ts
+node --experimental-strip-types --test src/components/grimoire-view.test.ts
+node --experimental-strip-types --test src/components/drag-to-split.test.ts
+```
+
+Expected: all exit 0.
+
+- [ ] **Step 5: Commit navigation normalization**
+
+```bash
+git add src/lib/page-drag.ts src/lib/page-drag.test.ts src/components/sidebar-minimal.tsx src/components/sidebar-minimal.test.ts src/components/sidebar-footer.tsx src/components/sidebar-footer.test.ts src/components/command-palette.tsx src/components/command-palette.test.ts src/components/grimoire-view.test.ts
+git commit -S -m "refactor(workspace): drive split sources from registry (cave-x6rw)"
+```
+
+## Task 4: Add the standard pane root and local failure isolation
+
+**Files:**
+
+- Create: `src/components/workspace-pane-page.tsx`
+- Create: `src/components/workspace-pane-page.test.ts`
+- Modify: `scripts/run-tests.mjs`
+- Modify: `src/app/globals.css`
+
+- [ ] **Step 1: Write the failing pane-root source contract**
+
+```ts
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./workspace-pane-page.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+assert.match(source, /className="workspace-pane-page"/);
+assert.match(source, /aria-label=\{landmark\}/);
+assert.match(source, /WorkspacePaneErrorBoundary/);
+assert.match(source, /is unavailable in this pane/);
+assert.match(source, /Try again/);
+assert.match(source, /onRecover/);
+assert.match(css, /\.workspace-pane-page\s*\{[\s\S]*container:\s*workspace-pane\s*\/\s*inline-size/);
+assert.match(css, /\.workspace-pane-page\s*\{[\s\S]*min-width:\s*0/);
+```
+
+Wire it into `scripts/run-tests.mjs`.
+
+- [ ] **Step 2: Run the contract and observe the missing-file failure**
+
+```bash
+node --experimental-strip-types --test src/components/workspace-pane-page.test.ts
+```
+
+Expected: `ENOENT` for `workspace-pane-page.tsx`.
+
+- [ ] **Step 3: Implement the page root and class boundary**
+
+Create a class error boundary so a secondary page cannot replace the primary page with an error screen. Its fallback must name the registered landmark and provide a `Try again` button that clears only that boundary's error state:
+
+```tsx
+type WorkspacePanePageProps = {
+  instanceId: string;
+  landmark: string;
+  status?: "ready" | "loading";
+  unavailable?: {
+    reason: string;
+    recoveryLabel: string;
+    onRecover: () => void;
+  };
+  children: React.ReactNode;
+};
+
+export function WorkspacePanePage({
+  instanceId,
+  landmark,
+  status = "ready",
+  unavailable,
+  children,
+}: WorkspacePanePageProps) {
+  return (
+    <section
+      className="workspace-pane-page"
+      data-pane-instance={instanceId}
+      aria-label={landmark}
+    >
+      <WorkspacePaneErrorBoundary landmark={landmark}>
+        {status === "loading" ? <SkeletonRows count={6} /> : null}
+        {unavailable ? (
+          <div className="workspace-pane-page__state" role="status">
+            <strong>{landmark} is unavailable in this pane.</strong>
+            <span>{unavailable.reason}</span>
+            <Button onClick={unavailable.onRecover}>{unavailable.recoveryLabel}</Button>
+          </div>
+        ) : null}
+        {status === "ready" && !unavailable ? children : null}
+      </WorkspacePaneErrorBoundary>
+    </section>
+  );
+}
+```
+
+Add:
+
+```css
+.workspace-pane-page {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  container: workspace-pane / inline-size;
+}
+.workspace-pane-page > * {
+  min-width: 0;
+  min-height: 0;
+}
+```
+
+- [ ] **Step 4: Run the focused test and typecheck**
+
+```bash
+node --experimental-strip-types --test src/components/workspace-pane-page.test.ts
+pnpm typecheck
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 5: Commit the pane-root contract**
+
+```bash
+git add scripts/run-tests.mjs src/components/workspace-pane-page.tsx src/components/workspace-pane-page.test.ts src/app/globals.css
+git commit -S -m "feat(workspace): standardize pane roots (cave-x6rw)"
+```
+
+## Task 5: Add embeddable Settings, Dashboard, and Terminal adapters
+
+**Files:**
+
+- Modify: `src/components/settings-shell.tsx`
+- Modify: `src/app/settings/page.tsx`
+- Modify: `src/components/settings-shell-polish.test.ts`
+- Create: `src/components/dashboard/dashboard-surface.tsx`
+- Create: `src/app/api/dashboard/route.ts`
+- Modify: `src/app/api/api-contracts.test.ts`
+- Modify: `src/app/dashboard/page.tsx`
+- Modify: `src/app/dashboard-page.test.ts`
+- Modify: `src/app/dashboard-runtime-smoke.test.ts`
+- Modify: `src/components/rail-terminal-panel.tsx`
+- Modify: `src/components/rail-terminal-panel.test.ts`
+
+- [ ] **Step 1: Pin adapter behavior with failing source tests**
+
+Add assertions that:
+
+```ts
+assert.match(settings, /embedded\?: boolean/);
+assert.match(settings, /if \(!embedded && e\.key === "Escape"\)/);
+assert.match(dashboardPage, /<DashboardSurface initialModel=\{model\}/);
+assert.match(dashboardSurface, /fetch\("\/api\/dashboard"/);
+assert.match(terminal, /paneInstanceId\?: string/);
+assert.match(terminal, /`cave\.pane\.\$\{paneInstanceId\}`/);
+```
+
+Add `/api/dashboard` to the API contract table with `GET`, JSON success, and guarded server failure behavior.
+
+- [ ] **Step 2: Run the affected tests and see the missing adapter contracts fail**
+
+```bash
+node --experimental-strip-types --test src/components/settings-shell-polish.test.ts
+node --experimental-strip-types --test src/app/dashboard-page.test.ts
+node --experimental-strip-types --test src/components/rail-terminal-panel.test.ts
+node --experimental-strip-types --test src/app/api/api-contracts.test.ts
+```
+
+Expected: new embedded Settings, DashboardSurface, terminal instance, and API assertions fail.
+
+- [ ] **Step 3: Implement Settings embedded mode**
+
+Use a default-preserving prop:
+
+```tsx
+export function SettingsShell({ embedded = false }: { embedded?: boolean }) {
+```
+
+In embedded mode, do not call `router.back()` on Escape, do not replace route hashes, and use pane-local section state. Keep `<SettingsShell />` unchanged in `src/app/settings/page.tsx` so route behavior and metadata remain intact.
+
+- [ ] **Step 4: Implement the Dashboard adapter and endpoint**
+
+The endpoint must build the same model as the server page:
+
+```ts
+import { NextResponse } from "next/server";
+import { loadInbox } from "@/lib/cave-inbox";
+import { buildDashboardModel } from "@/lib/dashboard-model";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const inbox = await loadInbox();
+    return NextResponse.json({ ok: true, model: buildDashboardModel(inbox.items, new Date()) });
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: error instanceof Error ? error.message : "Dashboard unavailable" },
+      { status: 500 },
+    );
+  }
+}
+```
+
+`DashboardSurface` accepts `initialModel?: DashboardModel`, renders it synchronously when supplied by `/dashboard`, otherwise fetches `/api/dashboard`, and renders explicit loading/unavailable states. Define a wire type with `date: string` for the JSON response and hydrate it before rendering:
+
+```ts
+type DashboardModelWire = Omit<DashboardModel, "date"> & { date: string };
+
+function hydrateDashboardModel(model: DashboardModelWire): DashboardModel {
+  return { ...model, date: new Date(model.date) };
+}
+```
+
+The route must render the adapter after its unchanged top bar:
+
+```tsx
+<DashboardSurface initialModel={model} />
+```
+
+The embedded workspace mounts `<DashboardSurface />` without the route top bar.
+
+- [ ] **Step 5: Make terminal PTYs pane-stable**
+
+Add `paneInstanceId?: string` to `RailTerminalPanel`; derive its terminal thread ID as:
+
+```ts
+const terminalThreadId = paneInstanceId
+  ? `cave.pane.${paneInstanceId}`
+  : `cave.rail.${sessionId}`;
+```
+
+Pass `terminalThreadId` to `BottomTerminal`, leaving rail behavior unchanged when the prop is absent.
+
+- [ ] **Step 6: Run adapter and API verification**
+
+```bash
+node --experimental-strip-types --test src/components/settings-shell-polish.test.ts
+node --experimental-strip-types --test src/app/dashboard-page.test.ts
+node --experimental-strip-types --test src/app/dashboard-runtime-smoke.test.ts
+node --experimental-strip-types --test src/components/rail-terminal-panel.test.ts
+node --experimental-strip-types --test src/app/api/api-contracts.test.ts
+pnpm typecheck
+```
+
+Expected: all exit 0.
+
+- [ ] **Step 7: Commit embeddable adapters**
+
+```bash
+git add src/components/settings-shell.tsx src/app/settings/page.tsx src/components/settings-shell-polish.test.ts src/components/dashboard/dashboard-surface.tsx src/app/api/dashboard/route.ts src/app/api/api-contracts.test.ts src/app/dashboard/page.tsx src/app/dashboard-page.test.ts src/app/dashboard-runtime-smoke.test.ts src/components/rail-terminal-panel.tsx src/components/rail-terminal-panel.test.ts
+git commit -S -m "feat(workspace): embed route and companion pages (cave-x6rw)"
+```
+
+## Task 6: Route every primary and secondary page through one renderer
+
+**Files:**
+
+- Modify: `src/components/workspace.tsx`
+- Modify: `src/components/lazy-surfaces.tsx`
+- Modify: `src/components/chat-surface.tsx`
+- Modify: `src/components/chat-surface.test.ts`
+- Modify: `src/components/workspace-sidebar-wiring.test.ts`
+- Modify: `src/components/drag-to-split.test.ts`
+- Modify: `src/components/schedules-tabs.test.ts`
+
+- [ ] **Step 1: Add failing renderer coverage**
+
+Extend source tests to require:
+
+```ts
+assert.match(workspace, /normalizeWorkspacePaneRequest/);
+assert.match(workspace, /workspacePaneRequestKey/);
+assert.match(workspace, /case "flow":[\s\S]*<FlowView/);
+assert.match(workspace, /case "settings":[\s\S]*<SettingsShell embedded/);
+assert.match(workspace, /case "dashboard":[\s\S]*<DashboardSurface/);
+assert.match(workspace, /case "terminal":[\s\S]*paneInstanceId=\{request\.instanceId\}/);
+assert.match(workspace, /isRoleSurfaceMode\(request\.pageId\)/);
+assert.doesNotMatch(workspace, /m as WorkspaceMode/);
+assert.doesNotMatch(workspace, /const WORKSPACE_MODE_TITLES: Record/);
+assert.doesNotMatch(workspace, /const SURFACE_ORDER: WorkspaceMode\[\]/);
+assert.match(chatSurface, /initialScope\?: FamiliarsScope/);
+```
+
+Reverse the old Flow assertion in `schedules-tabs.test.ts`: Flow must render `FlowView`, never fall through to Home.
+
+- [ ] **Step 2: Run the source suites and see the old renderer fail**
+
+```bash
+node --experimental-strip-types --test src/components/drag-to-split.test.ts
+node --experimental-strip-types --test src/components/schedules-tabs.test.ts
+node --experimental-strip-types --test src/components/workspace-sidebar-wiring.test.ts
+```
+
+Expected: normalized request, Flow, adapters, role surface, and cast-removal assertions fail.
+
+- [ ] **Step 3: Replace `SplitTarget` with `WorkspacePaneRequest`**
+
+Use `crypto.randomUUID()` when available and a monotonic `useRef` fallback to create stable `instanceId` values. `openSplitPage` must reject unknown IDs before mutating state:
+
+```ts
+const openSplitPage = useCallback((pageId: string, side: "left" | "right") => {
+  const request = normalizeWorkspacePaneRequest(nextPaneInstanceId(), pageId);
+  if (!request) return;
+  setSplitSide(side);
+  setSplitTargets((current) =>
+    addSecondaryWorkspaceTile(current, request, workspacePaneRequestKey),
+  );
+}, [nextPaneInstanceId]);
+```
+
+Introduce a stable `primaryPaneRequest` state instead of deriving the primary exclusively from `mode`. Registry-backed navigation replaces that request; legacy session navigation may continue to update the existing mode state before replacing the request. Promotion assigns the complete secondary request as primary, so Settings, Dashboard, Terminal, companions, and aliases can all become the sole page. No path may cast an arbitrary string to `WorkspaceMode`.
+
+Remove `WORKSPACE_MODE_TITLES`, local `VALID_MODES`, and local `SURFACE_ORDER`. Use registry definitions for the hidden heading, URL validation, command-palette navigation, keyboard number shortcuts, and previous/next page cycling. Keep the current daily shortcut order as registry metadata.
+
+- [ ] **Step 4: Implement the exhaustive renderer**
+
+Create a local `renderPaneRequest(request)` switch over `request.pageId`. Before the switch, handle dynamic role surfaces. Every return must be wrapped by:
+
+```tsx
+const definition = workspacePageDefinition(request.requestedPageId);
+if (!definition) return null;
+return (
+  <WorkspacePanePage
+    instanceId={request.instanceId}
+    landmark={definition.landmark}
+  >
+    {renderRegisteredPage(request)}
+  </WorkspacePanePage>
+);
+```
+
+Map variants explicitly:
+
+- `chat/group` passes `initialScope="coven"` to `ChatSurface`; default Chat passes `initialScope="conversation"`. Add the optional prop to `ChatSurface` and use it as the initial scope so split mounting does not depend on a timeout or global event.
+- `board/queue` renders `FamiliarWorkQueueView`.
+- `inbox/calendar` renders `CalendarView`; default renders Schedules.
+- `marketplace/roles` and `marketplace/capabilities` pass their existing initial section.
+- `grimoire/journal` opens the Journal tab without routing to Settings.
+- `flow` renders the existing lazy `FlowView`.
+- `settings`, `dashboard`, and `terminal` render the adapters from Task 5.
+- `salem`, `memory`, and `browser` preserve their existing companion implementations.
+- a missing runtime dependency passes `unavailable={{ reason, recoveryLabel, onRecover }}` to `WorkspacePanePage`, with the registered landmark and a context-specific recovery action.
+
+- [ ] **Step 5: Add a registry-backed split deep link**
+
+Parse `mode=<page-id>`, `split=<page-id>`, and `splitSide=left|right` through the registry. `mode` creates the primary request even for Settings, Dashboard, Terminal, companions, and aliases; `split` creates the secondary once. When state changes, serialize each request's `requestedPageId` rather than its canonical alias. These are supported deep links and the deterministic entry point for the rendered matrix.
+
+- [ ] **Step 6: Run focused behavior and type verification**
+
+```bash
+node --experimental-strip-types --test src/components/drag-to-split.test.ts
+node --experimental-strip-types --test src/components/schedules-tabs.test.ts
+node --experimental-strip-types --test src/components/chat-surface.test.ts
+node --experimental-strip-types --test src/components/workspace-sidebar-wiring.test.ts
+node --experimental-strip-types --test src/lib/workspace-page-registry.test.ts
+node --experimental-strip-types --test src/lib/workspace-pane-request.test.ts
+pnpm typecheck
+```
+
+Expected: all exit 0.
+
+- [ ] **Step 7: Commit the unified renderer**
+
+```bash
+git add src/components/workspace.tsx src/components/lazy-surfaces.tsx src/components/chat-surface.tsx src/components/chat-surface.test.ts src/components/workspace-sidebar-wiring.test.ts src/components/drag-to-split.test.ts src/components/schedules-tabs.test.ts
+git commit -S -m "refactor(workspace): unify registered page rendering (cave-x6rw)"
+```
+
+## Task 7: Make two-pane geometry integer-exact and symmetric
+
+**Files:**
+
+- Create: `src/lib/split-geometry.ts`
+- Create: `src/lib/split-geometry.test.ts`
+- Modify: `scripts/run-tests.mjs`
+- Modify: `src/components/detail-split-host.tsx`
+- Modify: `src/components/shell.tsx`
+- Modify: `src/components/detail-split-host.test.ts`
+- Modify: `src/components/drag-to-split.test.ts`
+- Modify: `src/app/globals.css`
+
+- [ ] **Step 1: Write failing integer-geometry tests**
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { halfSplitGeometry, splitPresentation } from "./split-geometry.ts";
+
+test("half geometry consumes every pixel for odd and even hosts", () => {
+  for (const hostWidth of [501, 1024, 1279, 1440]) {
+    const geometry = halfSplitGeometry(hostWidth, 1);
+    assert.ok(Math.abs(geometry.left - geometry.right) <= 1);
+    assert.equal(geometry.left + geometry.separator + geometry.right, hostWidth);
+  }
+});
+
+test("narrow containers use tabs independent of viewport width", () => {
+  assert.equal(splitPresentation(719), "tabs");
+  assert.equal(splitPresentation(720), "panes");
+});
+```
+
+Wire `split-geometry.test.ts` in `scripts/run-tests.mjs`.
+
+- [ ] **Step 2: Run the focused test and observe the missing-module failure**
+
+```bash
+node --experimental-strip-types --test src/lib/split-geometry.test.ts
+```
+
+Expected: `ERR_MODULE_NOT_FOUND`.
+
+- [ ] **Step 3: Implement the geometry helper**
+
+```ts
+export const SPLIT_TABS_MAX_WIDTH = 719;
+
+export function halfSplitGeometry(hostWidth: number, separator: number) {
+  const usable = Math.max(0, Math.round(hostWidth) - separator);
+  const left = Math.floor(usable / 2);
+  return { left, separator, right: usable - left };
+}
+
+export function splitPresentation(hostWidth: number): "panes" | "tabs" {
+  return hostWidth <= SPLIT_TABS_MAX_WIDTH ? "tabs" : "panes";
+}
+```
+
+- [ ] **Step 4: Give both panes identical split-only chrome**
+
+Change `DetailSplitHostProps` to accept `primaryTile: DetailSplitTile` instead of a bare `primary`. Render both primary and secondary through one `renderPane(tile, options)` function. In solo mode, `Shell` renders the page without pane chrome; in split mode, both sides have the same header height, body class, title treatment, and action slot. Only secondary panes receive close buttons.
+
+Pass the normalized primary title and instance ID from `Workspace` through `Shell`; do not retain the hard-coded `Current` tile. Keep the separator as the sole seam, `SPLIT_DEFAULT_RATIO` at 0.5, double-click reset, resize snapping, close/promotion gestures, and the ResizeObserver refit.
+
+Use `halfSplitGeometry(groupWidth, separatorWidth)` whenever a split first opens and whenever the separator is double-clicked; resize the secondary panel to the returned left or right pixel width according to `secondarySide`. On host resize, use the integer helper only while the selected ratio is 0.5; for every user-selected ratio, reapply that ratio unchanged.
+
+- [ ] **Step 5: Replace viewport fallback with observed host width**
+
+Store the `DetailSplitHost` group width from its existing ResizeObserver and derive `splitPresentation(width)`. In tab mode:
+
+```tsx
+<div className="split-host__mobile-switcher" role="tablist" aria-label="Open pages">
+  {tiles.map((tile) => (
+    <button
+      key={tile.id}
+      role="tab"
+      aria-selected={tile.id === activeTileId}
+      onClick={() => setActiveTileId(tile.id)}
+    >
+      {tile.title}
+    </button>
+  ))}
+</div>
+```
+
+Keep every tile mounted; inactive tiles use `visibility: hidden`, `pointer-events: none`, `position: absolute`, `inline-size: 0`, `block-size: 0`, and `overflow: hidden`, while the active tile alone participates in layout. Do not use `display: none`.
+
+Give each switcher tab a minimum 44px block size and preserve the host's existing safe-area padding on phone-sized containers.
+
+- [ ] **Step 6: Remove the content-width floor**
+
+Delete `.split-host__pane-body > * { min-width: 300px; }`, remove `overflow-x: auto` from the generic pane body, and change multi-pane `Panel minSize="300px"` to a proportional minimum that does not force overflow. Update the old source tests to forbid those policies.
+
+- [ ] **Step 7: Run geometry, host, and type verification**
+
+```bash
+node --experimental-strip-types --test src/lib/split-geometry.test.ts
+node --experimental-strip-types --test src/components/detail-split-host.test.ts
+node --experimental-strip-types --test src/components/drag-to-split.test.ts
+pnpm typecheck
+```
+
+Expected: all exit 0.
+
+- [ ] **Step 8: Commit the geometry checkpoint**
+
+```bash
+git add scripts/run-tests.mjs src/lib/split-geometry.ts src/lib/split-geometry.test.ts src/components/detail-split-host.tsx src/components/shell.tsx src/components/detail-split-host.test.ts src/components/drag-to-split.test.ts src/app/globals.css
+git commit -S -m "fix(workspace): make half splits waste-free (cave-x6rw)"
+```
+
+## Task 8: Make split discovery complete and keyboard-accessible
+
+**Files:**
+
+- Modify: `src/components/detail-split-host.tsx`
+- Modify: `src/components/detail-split-host.test.ts`
+- Modify: `src/components/workspace.tsx`
+- Modify: `src/app/globals.css`
+
+- [ ] **Step 1: Add failing source assertions for the page chooser**
+
+Require `DetailSplitHost` to expose a button named `Open page in split`, a dialog/listbox backed by registry definitions, Escape close behavior, arrow-key navigation, and `onDropPage(page.id, "right")` selection. Require disabled options for exact page+variant duplicates and allow alias variants such as Chat and Group to coexist.
+
+- [ ] **Step 2: Run the host source test and see chooser assertions fail**
+
+```bash
+node --experimental-strip-types --test src/components/detail-split-host.test.ts
+```
+
+Expected: chooser button, registry options, and keyboard behavior assertions fail.
+
+- [ ] **Step 3: Implement registry-backed split discovery**
+
+Pass `availablePages` from `Workspace` to `DetailSplitHost`. The list combines built-in registry pages, currently registered role surfaces, and companion pages. Keep exact page+variant entries visible but disabled when already open; keep other variants enabled. Add the chooser action to the primary pane header in split mode and as a non-layout-impacting overlay button in solo mode. Selecting a page calls the same normalized `onDropPage` path as drag and deep links.
+
+The chooser must use existing popover/menu primitives, restore focus to its trigger, close on Escape, support ArrowUp/ArrowDown/Home/End, and expose page titles plus canonical variant labels.
+
+- [ ] **Step 4: Run host and accessibility source tests**
+
+```bash
+node --experimental-strip-types --test src/components/detail-split-host.test.ts
+node --experimental-strip-types --test src/components/drag-to-split.test.ts
+node --experimental-strip-types --test src/components/command-palette-a11y.test.ts
+pnpm typecheck
+```
+
+Expected: all exit 0.
+
+- [ ] **Step 5: Commit complete discovery**
+
+```bash
+git add src/components/detail-split-host.tsx src/components/detail-split-host.test.ts src/components/workspace.tsx src/app/globals.css
+git commit -S -m "feat(workspace): expose every page to split discovery (cave-x6rw)"
+```
+
+## Task 9: Audit every surface for pane-owned responsiveness
+
+**Files:**
+
+- Modify: `src/components/familiars-view.tsx`
+- Modify: `src/components/home-composer.tsx`
+- Modify: `src/components/chat-view.tsx`
+- Modify: `src/components/board-view.tsx`
+- Modify: `src/components/calendar-view.tsx`
+- Modify: `src/components/browser-pane.tsx`
+- Modify: `src/components/github-view.tsx`
+- Modify: `src/components/marketplace-view.tsx`
+- Modify: `src/components/flow/flow-view.tsx`
+- Modify: `src/components/opencoven-submission-panel.tsx`
+- Modify: `src/components/familiar-work-queue-view.tsx`
+- Modify: `src/components/grimoire-view.tsx`
+- Modify: `src/components/role-surface-host.tsx`
+- Modify: `src/components/role-surfaces/surface-room.tsx`
+- Modify: `src/components/dashboard/dashboard-cockpit.tsx`
+- Modify: `src/components/settings-shell.tsx`
+- Modify: `src/app/globals.css`
+- Modify: `src/components/drag-to-split.test.ts`
+
+- [ ] **Step 1: Turn the surface-fit source audit into a failing positive contract**
+
+In `drag-to-split.test.ts`, read each file above and assert its outer surface uses `h-full`, `min-h-0`, `min-w-0`, or the equivalent named CSS class. Assert no split-capable surface uses viewport breakpoints to choose columns or fixed content widths above 100%.
+
+For CSS-driven surfaces, require their root selector to include:
+
+```css
+width: 100%;
+height: 100%;
+min-width: 0;
+min-height: 0;
+```
+
+- [ ] **Step 2: Run the audit and record every named failing surface in the Bead**
+
+```bash
+node --experimental-strip-types --test src/components/drag-to-split.test.ts
+```
+
+Expected: failures name the exact surface files whose roots or grids still depend on the viewport.
+
+Append the resulting file list to `cave-x6rw` before editing those surfaces.
+
+- [ ] **Step 3: Apply the standard pane-root rules to every named surface**
+
+For each file in this task, make the root fill its `WorkspacePanePage`, set intermediate flex/grid wrappers to `min-width: 0; min-height: 0`, and move overflow to the content owner:
+
+- conversation/message lists scroll vertically; composers remain fixed;
+- board, schedules, marketplace, submissions, dashboard, and settings content regions scroll vertically;
+- Browser and Flow canvases clip to their pane and manage their own internal panning;
+- Grimoire editor/preview columns and role rooms collapse through container queries;
+- cards, grids, and toolbars use `@container workspace-pane` thresholds rather than viewport media queries.
+
+Use this form for responsive grids:
+
+```css
+.surface-grid { grid-template-columns: minmax(0, 1fr); }
+@container workspace-pane (min-width: 44rem) {
+  .surface-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+```
+
+Do not introduce generic horizontal scrolling on `.workspace-pane-page` or `.split-host__pane-body`.
+
+- [ ] **Step 4: Re-run the full source audit and typecheck**
+
+```bash
+node --experimental-strip-types --test src/components/drag-to-split.test.ts
+pnpm typecheck
+```
+
+Expected: all named surface contracts pass and TypeScript exits 0.
+
+- [ ] **Step 5: Commit the surface-fit checkpoint**
+
+```bash
+git add src/components/familiars-view.tsx src/components/home-composer.tsx src/components/chat-view.tsx src/components/board-view.tsx src/components/calendar-view.tsx src/components/browser-pane.tsx src/components/github-view.tsx src/components/marketplace-view.tsx src/components/flow/flow-view.tsx src/components/opencoven-submission-panel.tsx src/components/familiar-work-queue-view.tsx src/components/grimoire-view.tsx src/components/role-surface-host.tsx src/components/role-surfaces/surface-room.tsx src/components/dashboard/dashboard-cockpit.tsx src/components/settings-shell.tsx src/app/globals.css src/components/drag-to-split.test.ts
+git commit -S -m "fix(workspace): make surfaces pane-responsive (cave-x6rw)"
+```
+
+## Task 10: Build the exhaustive rendered geometry matrix
+
+**Files:**
+
+- Create: `tests/workspace-half-split.spec.ts`
+- Create: `tests/mobile/workspace-half-split.spec.ts`
+- Modify: `playwright.config.ts`
+- Modify: `src/components/role-surfaces/ids.ts`
+- Modify: `src/components/role-surfaces/register.tsx`
+- Modify: `src/lib/role-surfaces.test.ts`
+
+- [ ] **Step 1: Add explicit desktop viewport projects**
+
+Define projects with exact viewports:
+
+```ts
+{
+  name: "desktop-1440",
+  testMatch: /workspace-half-split\.spec\.ts/,
+  testIgnore: /mobile\//,
+  use: { ...devices["Desktop Chrome"], viewport: { width: 1440, height: 900 } },
+},
+{
+  name: "desktop-1280",
+  testMatch: /workspace-half-split\.spec\.ts/,
+  testIgnore: /mobile\//,
+  use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 800 } },
+},
+{
+  name: "desktop-1024",
+  testMatch: /workspace-half-split\.spec\.ts/,
+  testIgnore: /mobile\//,
+  use: { ...devices["Desktop Chrome"], viewport: { width: 1024, height: 768 } },
+},
+```
+
+Add `testIgnore: /workspace-half-split\.spec\.ts/` to the generic `desktop` project so the root matrix runs exactly three desktop widths. Leave the existing mobile projects scoped to `tests/mobile`.
+
+- [ ] **Step 2: Write the geometry assertion helper**
+
+```ts
+async function expectWasteFreeHalf(page: Page) {
+  const geometry = await page.locator(".split-host__group").evaluate((host) => {
+    const hostRect = host.getBoundingClientRect();
+    const panes = Array.from(host.querySelectorAll<HTMLElement>(":scope > [data-panel]"))
+      .map((node) => node.getBoundingClientRect());
+    const separator = host.querySelector<HTMLElement>(".split-host__sep")!.getBoundingClientRect();
+    return { hostRect, panes, separator };
+  });
+  expect(geometry.panes).toHaveLength(2);
+  expect(Math.abs(geometry.panes[0]!.width - geometry.panes[1]!.width)).toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.panes[0]!.left - geometry.hostRect.left)).toBeLessThanOrEqual(1);
+  expect(Math.abs(geometry.panes[1]!.right - geometry.hostRect.right)).toBeLessThanOrEqual(1);
+  expect(Math.abs(
+    geometry.panes[0]!.width + geometry.separator.width + geometry.panes[1]!.width
+      - geometry.hostRect.width,
+  )).toBeLessThanOrEqual(1);
+}
+```
+
+- [ ] **Step 3: Add the exhaustive desktop page matrix**
+
+Import `BUILT_IN_WORKSPACE_PAGE_IDS` into the Playwright spec and test every ID as:
+
+1. primary with a stable reference page as secondary on the right;
+2. primary with the reference page as secondary on the left;
+3. secondary beside the reference page on the right;
+4. secondary beside the reference page on the left.
+
+Use `home` as the reference for every request except `home`; use `github` for `home`. This keeps exact page+variant deduplication intact while preserving one deterministic comparison surface.
+
+For every case, navigate with supported query parameters, wait for both registered landmarks, call `expectWasteFreeHalf`, assert equal body heights, assert no pane-level horizontal scrollbar, and assert exactly one `.split-host__sep`. For each visible `button`, `a`, `input`, `textarea`, and `select` inside a pane, assert its rectangle stays inside the pane body; for touch-sized controls, retain the repository's existing 44px mobile target contract.
+
+Export the built-in role-room manifest from `src/components/role-surfaces/ids.ts` and make both registration tests and the rendered matrix consume it:
+
+```ts
+export const BUILT_IN_ROLE_SURFACE_IDS = [
+  RESEARCHER_SURFACE_ID,
+  MESSENGER_SURFACE_ID,
+  INDEXER_SURFACE_ID,
+] as const;
+```
+
+Add one case for every `surface:${id}` in that manifest. Seed deterministic familiar-role data so each room is visible, and mock API-heavy surfaces to deterministic empty/success responses. The existing role-surface unit suite must assert that every manifest ID is registered exactly once. The terminal case asserts its pane remains mounted while switching narrow tabs; Browser and Flow assert their canvas root stays inside the pane rectangle.
+
+- [ ] **Step 4: Add narrow-container lifecycle tests**
+
+In `tests/mobile/workspace-half-split.spec.ts`, open Home + Terminal, assert the tablist appears, assert the active page fills the host, and assert the inactive page remains mounted with zero interactive geometry. Switch tabs twice and assert the same terminal pane instance ID remains present.
+
+- [ ] **Step 5: Run the matrix and capture genuine failures**
+
+```bash
+pnpm exec playwright test tests/workspace-half-split.spec.ts --project=desktop-1440 --project=desktop-1280 --project=desktop-1024
+pnpm exec playwright test tests/mobile/workspace-half-split.spec.ts --project=pixel-5 --project=iphone-13
+node --experimental-strip-types --test src/lib/role-surfaces.test.ts
+```
+
+Expected on first run: any remaining page-specific overflow or landmark defect fails with the page ID in the test title. Fix only the named surface contract, then rerun the failing case and the entire matrix.
+
+- [ ] **Step 6: Verify all rendered cases pass**
+
+Run the three commands from Step 5 again.
+
+Expected: every project exits 0 with no retries required on the final run.
+
+- [ ] **Step 7: Commit the rendered matrix**
+
+```bash
+git add tests/workspace-half-split.spec.ts tests/mobile/workspace-half-split.spec.ts playwright.config.ts src/components/role-surfaces/ids.ts src/components/role-surfaces/register.tsx src/lib/role-surfaces.test.ts
+git commit -S -m "test(workspace): cover every half-split page (cave-x6rw)"
+```
+
+## Task 11: Run native desktop acceptance
+
+**Files:**
+
+- Modify only files implicated by a native acceptance failure.
+
+- [ ] **Step 1: Start the Tauri desktop app in the foreground**
+
+Run from the feature worktree:
+
+```bash
+bash scripts/dev-app.sh
+```
+
+Expected early output: a selected free port, `Ready on http://127.0.0.1:<port>`, and Cargo `Running DevCommand`. Compilation output is progress.
+
+- [ ] **Step 2: Exercise representative native-only cases**
+
+In the Tauri window verify:
+
+- Home + Terminal opens at a visually even seam and preserves the PTY through narrow tab switches;
+- Flow + Browser fill both halves without a trailing strip;
+- Settings + Dashboard scroll within their own panes;
+- a registered role surface opens on both left and right;
+- collapsing/expanding the navigation refits the split without changing the chosen ratio;
+- double-clicking the separator returns to exactly half;
+- dragging past close/promote thresholds preserves the intended page and variant.
+
+Capture the Tauri window only to `/tmp/cave-x6rw-native-split.png` using the macOS window-screenshot selector, inspect that image at original resolution, and confirm the outer edges, single seam, equal pane headers, and absence of a trailing strip. Do not capture the full desktop.
+
+- [ ] **Step 3: Record native evidence in the Bead and stop cleanly**
+
+Record chosen port, tested pairs, window size, and observed results in `cave-x6rw`. Stop the foreground wrapper with `Ctrl-C` and confirm both Next and Tauri child processes exit.
+
+- [ ] **Step 4: Commit any native-only correction**
+
+If Step 2 required a correction, stage only the implicated files and commit:
+
+```bash
+git commit -S -m "fix(desktop): preserve exact split geometry (cave-x6rw)"
+```
+
+If no correction was required, do not create an empty commit.
+
+## Task 12: Full verification, review, PR, merge, and cleanup
+
+**Files:**
+
+- Modify: Bead `cave-x6rw` metadata and notes only.
+
+- [ ] **Step 1: Run the complete local quality gate**
+
+```bash
+pnpm check:tests-wired
+pnpm typecheck
+pnpm test:app
+pnpm test:api
+pnpm test:mobile
+pnpm build
+pnpm test:e2e
+pnpm exec playwright test tests/workspace-half-split.spec.ts --project=desktop-1440 --project=desktop-1280 --project=desktop-1024
+pnpm exec playwright test tests/mobile/workspace-half-split.spec.ts --project=pixel-5 --project=iphone-13
+git diff --check origin/main...HEAD
+git status --short
+```
+
+Expected: every command exits 0; the final status contains no untracked generated assets or unstaged implementation files.
+
+- [ ] **Step 2: Use the required verification and review skills**
+
+Invoke `verification-before-completion`, then `requesting-code-review`. Review the full `origin/main...HEAD` diff against the approved design and this plan. Resolve every high- and medium-severity finding; rerun the focused test for each correction plus the complete gate from Step 1.
+
+- [ ] **Step 3: Update the Bead with delivery evidence**
+
+Record branch, worktree, commits, full gate output summary, rendered viewport matrix, native test evidence, and review disposition. Leave `cave-x6rw` open until merge.
+
+- [ ] **Step 4: Publish a PR-shaped branch**
+
+Fetch current `origin/main`, rebase only if required and safe, rerun the affected gate after any rebase, then push `feat/waste-free-half-splits` and open a draft PR. The PR body must link `cave-x6rw`, summarize registry/rendering/geometry changes, list all verification commands, and state that every registered page is covered in both split positions.
+
+- [ ] **Step 5: Wait for required checks and squash-merge under standing authorization**
+
+Inspect every required check to a terminal green state. Do not treat duplicate CI runs or transient flakes as proof of failure without reading their logs. Squash-merge only when all required checks are green; preserve any human contributor trailers in the squash message.
+
+- [ ] **Step 6: Verify merge from remote state**
+
+Run:
+
+```bash
+git fetch origin main
+git log -1 --oneline origin/main
+```
+
+Expected: `origin/main` contains the squash commit for this PR.
+
+- [ ] **Step 7: Close the Bead and remove PR transport**
+
+Close `cave-x6rw` with the merged PR and squash SHA as evidence. Delete the remote feature branch, remove `.worktrees/feat-waste-free-half-splits`, and delete the local feature branch. Do not mutate or clean unrelated files in the primary checkout.
+
+- [ ] **Step 8: Final handoff**
+
+Report the merged PR, squash SHA, closed Bead, verification summary, and cleanup result. Mark the persistent goal complete only after all four are confirmed from current state.

--- a/docs/superpowers/specs/2026-07-09-waste-free-half-splits-design.md
+++ b/docs/superpowers/specs/2026-07-09-waste-free-half-splits-design.md
@@ -1,0 +1,247 @@
+# Waste-Free Half Splits — Design
+
+**Date:** 2026-07-09
+**Status:** Approved
+**Bead:** `cave-x6rw`
+**Scope:** Every operator page registered in the CovenCave workspace can render as either half of an exact two-pane split without dead space, shell overflow, clipped controls, or viewport-dependent layout mistakes.
+
+## Problem
+
+CovenCave already has a shared `DetailSplitHost`, a magnetic 50% detent, and drag-to-split navigation. The implementation is not exhaustive:
+
+- `WorkspaceMode` has 17 built-in values, while the sidebar exposes only a subset and keeps a second hand-written mode type.
+- primary navigation canonicalizes `groupchat` to Chat and `journal` to Grimoire, but secondary rendering bypasses that path; the same request can therefore render a different page in a split.
+- `flow` and any unhandled mode silently fall through to `HomeComposer`, so a missing page looks valid.
+- `page-drag.ts` excludes `journal`, `terminal`, and every dynamic `surface:*` role room.
+- Settings and Dashboard are footer destinations outside the workspace registry, and Terminal is a context-bound rail panel rather than a page definition.
+- the pane body applies a global 300px content floor and horizontal scrolling. That prevents catastrophic crushing, but it can conceal viewport-keyed layouts instead of making each page genuinely half-width responsive.
+- source tests prove that split machinery exists, but no rendered matrix proves that every registered page fills either half without overlap or wasted strips.
+
+The result is a split system that is plausible for selected pages rather than a contract the whole application must satisfy.
+
+## Definition of “all pages”
+
+The split contract covers every operator surface the native Cave shell can present as a workspace page:
+
+1. all built-in `WorkspaceMode` values;
+2. every visible dynamic `surface:<id>` role room;
+3. split companions that behave as pages: Salem, Memory, Browser, and Terminal;
+4. the Settings and Dashboard footer destinations, exposed through embeddable workspace adapters while retaining their standalone routes.
+
+Aliases remain independently addressable requests but resolve to a live canonical surface and variant:
+
+| Request | Canonical surface | Variant |
+| --- | --- | --- |
+| `groupchat` | Chat | Group |
+| `familiar-work-queue` | Tasks | Queue |
+| `calendar` | Schedules | Calendar |
+| `roles` | Marketplace | Roles |
+| `capabilities` | Marketplace | Capabilities |
+| `journal` | Grimoire | Journal |
+
+`flow` is not an alias. It must render the existing lazy `FlowView`; it may not fall through to Home.
+
+Standalone drill-down documents reached from a registered page—individual analytics reports, daily-report documents, retro detail routes, and development mockups—remain standalone documents. Their owning workspace page must fit in a half; they are not additional workspace page identities.
+
+## Approaches considered
+
+### 1. Exhaustive registry plus shared pane contract — chosen
+
+Create one compile-time-exhaustive page registry and make navigation, drag eligibility, primary rendering, secondary rendering, titles, availability, and verification consume it. Patch individual surfaces only where rendered evidence shows a pane-width failure.
+
+This has the highest initial rigor but prevents future pages from shipping without declaring and testing split behavior.
+
+### 2. Blanket containment CSS
+
+Apply `min-width: 0`, `overflow: auto`, and `width: 100%` to all descendants. This is quick, but it converts many failures into hidden horizontal scrollbars and cannot catch dead aliases or inconsistent render paths.
+
+### 3. Independent per-page split implementations
+
+Give every surface its own two-column logic. This can look precise in isolation, but duplicates page identity, resize behavior, mobile fallback, accessibility, and tests. It would drift immediately.
+
+## 1. Authoritative page registry
+
+Add a pure, JSX-free `src/lib/workspace-page-registry.ts`. It owns page identity and resolution but not React components.
+
+```ts
+export const WORKSPACE_MODE_IDS = [/* all WorkspaceMode literals */] as const;
+
+export type BuiltInWorkspacePageId = WorkspaceMode | "settings" | "dashboard";
+export type CompanionPageId = "salem" | "memory" | "terminal";
+export type WorkspacePageId = BuiltInWorkspacePageId | CompanionPageId | RoleSurfaceMode;
+
+export type WorkspacePageVariant =
+  | "default"
+  | "group"
+  | "queue"
+  | "calendar"
+  | "roles"
+  | "capabilities"
+  | "journal";
+
+export type WorkspacePageDefinition = {
+  id: BuiltInWorkspacePageId | CompanionPageId;
+  title: string;
+  canonicalId: BuiltInWorkspacePageId | CompanionPageId;
+  variant: WorkspacePageVariant;
+  nav: "daily" | "quiet" | "hidden" | "footer" | "companion";
+  split: "always" | "contextual";
+  landmark: string;
+};
+```
+
+The built-in map must use `satisfies Record<WorkspaceMode, WorkspacePageDefinition>` so adding a mode is a compile error until the page declares its canonical surface and split behavior. Settings, Dashboard, and companions live in equally typed supplemental maps. Dynamic role surfaces resolve generically through the existing `surface:` prefix and role registry.
+
+`resolveWorkspacePage(request)` returns a normalized page request containing the canonical page, variant, title, and availability policy. It never returns Home for an unknown id.
+
+The sidebar, command palette, footer, keyboard shortcuts, and drag protocol use registry definitions instead of maintaining divergent unions and labels. Hidden pages remain reachable through the palette or their owning actions.
+
+## 2. One rendering path for every pane
+
+Replace `renderSurface(mode)` and the split-specific branches with one pane renderer:
+
+```ts
+type WorkspacePaneRequest = {
+  instanceId: string;
+  pageId: WorkspacePageId;
+  variant: WorkspacePageVariant;
+};
+
+renderWorkspacePane(request, context)
+```
+
+Primary navigation and split opening both resolve raw ids through the registry before creating a `WorkspacePaneRequest`. This removes the current difference between `setMode(...)` and direct split rendering.
+
+The request keeps a stable `instanceId`, so context-bound pages can own refs and local state without colliding with the primary instance. Exact duplicate page+variant requests remain deduplicated; different variants of one canonical surface, such as Chat Sessions and Chat Group, may coexist.
+
+Promotion from secondary to primary carries the complete normalized request, including its variant. Alias activation no longer depends on timeout events racing a newly mounted surface.
+
+### Embeddable adapters
+
+- **Settings:** give `SettingsShell` an `embedded` mode. It fills its pane, suppresses route-level back/Escape behavior, and keeps section state local to that pane. `/settings` continues to render the same shell in standalone mode.
+- **Dashboard:** extract the cockpit-loading boundary into an embeddable Dashboard surface. The standalone `/dashboard` route supplies the same model; the workspace adapter loads it through a dedicated API boundary rather than nesting a route or iframe.
+- **Terminal:** register a contextual page adapter around `RailTerminalPanel`. It receives the active session/project context and shows the existing explicit empty state when no session is available. Each pane gets a stable PTY thread id derived from its `instanceId` so opening a split does not steal or remount another terminal.
+- **Flow:** mount the existing lazy `FlowView` for `flow`; loading remains code-split.
+- **Role rooms:** allow `RoleSurfaceMode` in `WorkspacePaneRequest` and render through the existing generic `RoleSurfaceHost`.
+
+## 3. Exact pane geometry
+
+The two-pane path remains resizable, but opening or resetting a pair produces mathematically equal **usable** pane widths after the separator is accounted for.
+
+Rendered invariants, with a 1px rounding tolerance:
+
+1. `abs(left.width - right.width) <= 1` at the default/reset detent;
+2. `left.left == host.left`;
+3. `right.right == host.right`;
+4. `left.width + separator.width + right.width == host.width`;
+5. exactly one separator occupies the gap; there is no margin, padding gutter, or trailing strip;
+6. both pane frames and pane bodies have equal heights;
+7. every page root fills its pane body in both axes.
+
+When split, both primary and secondary panes use the same compact pane frame and title bar so their usable content starts at the same vertical coordinate. Solo mode renders no pane title bar.
+
+The divider keeps free resize, the magnetic 50% detent, double-click reset, close-at-near-edge, and promote-at-far-edge behavior. The existing three/four-pane feature remains, but this work does not redesign its ratios; it must still cover the full host with no dead area.
+
+The manual ResizeObserver refit remains as protection for Tauri webviews. The refit is tested against host-only width changes and must preserve the current ratio rather than forcing 50% after the user resizes.
+
+## 4. Pane-width surface contract
+
+Every registered page renders under a standard `.workspace-pane-page` root:
+
+```css
+.workspace-pane-page {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  container: workspace-pane / inline-size;
+  overflow: hidden;
+}
+```
+
+Page toolbars, grids, master-detail layouts, and side panels must respond to their owning container width rather than the browser viewport. The global `.split-host__pane-body > * { min-width: 300px }` fallback is removed once the page matrix is green.
+
+Intentional scrolling is allowed only on the component that owns overflow:
+
+- terminals and code viewers may scroll their content;
+- tables may expose an explicitly labelled horizontal scroller when columns cannot compact further;
+- lists and documents may scroll vertically;
+- the shell, split group, pane frame, and generic page root may not leak overflow.
+
+At narrow pane widths, controls wrap, collapse to icon/menu affordances, or switch from master-detail to one-pane detail navigation. They may not overlap, clip, shrink below existing touch-target contracts, or reserve blank columns.
+
+## 5. Responsive and native behavior
+
+Simultaneous halves are a desktop/native-window behavior when the split host has enough inline space. The fallback is driven by the split host's **container width**, not viewport width:
+
+- at or above the simultaneous-fit threshold, render the real two-pane group;
+- below it, keep both logical pages mounted according to their lifecycle needs but display one full-size pane at a time through the existing accessible tab switcher;
+- the active tab fills the entire host, inactive panes do not reserve geometry, and switching does not lose state;
+- phone controls retain 44px targets and safe-area handling.
+
+The native Tauri shell uses the same DOM and registry. Validation must include a real Tauri launch and macOS traffic-light/titlebar geometry; browser-only simulation is supporting evidence, not the sole native proof.
+
+## 6. Availability and failure isolation
+
+Unknown page ids, missing dynamic role rooms, and contextual pages without required state render an explicit full-pane unavailable state. The state identifies the requested page, explains the missing context, and offers an appropriate recovery action. No request silently renders Home.
+
+Each pane gets an error boundary. A failed lazy import or surface render replaces only that pane with a retryable error state; the sibling page, divider, and close/promote actions remain usable.
+
+Async surfaces use full-pane skeletons with stable geometry. Loading and failure states must satisfy the same fill and overflow contracts as successful content.
+
+## 7. Verification
+
+### Registry and unit contracts
+
+- `workspace-page-registry.test.ts` proves exact coverage of every `WorkspaceMode`, canonical alias/variant resolution, Settings/Dashboard/companion metadata, unknown-id rejection, and generic `surface:*` handling.
+- existing sidebar, command-palette, page-drag, and split tests consume the registry and forbid local duplicate mode lists.
+- page drag becomes positive-by-registry; no hard-coded `NON_SPLITTABLE` exceptions remain. Contextual availability is checked when the page opens, not by hiding the drag affordance.
+- split geometry helpers prove deterministic 50% rounding and ratio preservation.
+
+### Rendered exhaustive matrix
+
+A Playwright spec obtains the registry's test manifest and exercises every page definition:
+
+1. render the page as primary with a stable reference page as secondary;
+2. render it as secondary on the left and right;
+3. verify its success, loading, or honest-unavailable landmark;
+4. assert equal default pane widths, full host coverage, one seam, equal body heights, root fill, no pane/shell/document overflow, and no overlapping visible controls;
+5. repeat at representative 1440px, 1280px, and 1024px desktop/native widths;
+6. exercise dynamic role rooms with deterministic mocked role data;
+7. exercise the below-threshold switcher at tablet and phone widths and prove inactive panes reserve zero space.
+
+The matrix must fail if a registry entry has no test landmark. This makes “all pages” self-updating when future pages are registered.
+
+### Project gates
+
+- targeted registry, split, and surface tests;
+- `pnpm check:tests-wired`;
+- `pnpm typecheck`;
+- `pnpm test:app` and `pnpm test:mobile`;
+- the exhaustive Playwright matrix plus the existing E2E suite;
+- `pnpm build` and bundle budgets;
+- real Tauri startup and a captured/inspected native split at a representative window size;
+- independent code review with no unresolved Critical or Important findings.
+
+## 8. Delivery sequence
+
+1. land the exhaustive registry and normalized page requests behind source/unit tests;
+2. route primary navigation and split opening through the same resolver;
+3. make dynamic role rooms and existing built-ins split-addressable;
+4. add Settings, Dashboard, Terminal, and Flow adapters;
+5. enforce the standard pane root and exact two-pane geometry;
+6. run the exhaustive rendered matrix, patching each surface's container behavior until all entries pass;
+7. validate mobile/native behavior, complete review, and ship through the protected PR path.
+
+The work stays in one integration bead because the registry and matrix are the acceptance authority. If an individual surface requires a substantial independent redesign, create a child bead linked to `cave-x6rw`; the parent remains open until every registry entry passes.
+
+## Out of scope
+
+- redesigning the visual content or information architecture of otherwise fitting pages;
+- changing the maximum four visible workspace pages;
+- persisting split layouts across app restarts;
+- allowing two exact duplicates of the same page+variant;
+- converting standalone drill-down documents into new workspace identities.


### PR DESCRIPTION
Restores the two documents `cave-x6rw` depends on. Both were absent from `main`, which left an open **P1** unexecutable and caused repeated sweeps to record its design and plan as missing.

## They were not lost — they were unreachable

The documents were never written to `main`. They survived only in three commits reachable from **no branch and no tag**:

| commit | holds |
|---|---|
| `f6446179a` | design (247 lines) |
| `653cc9575` | plan (1184 lines) |
| `6de07aa08` | both, complete — descends from the other two |

Commits on no ref are exactly what garbage collection removes, so an **approved** design for an open P1 sat one `git gc` away from being gone.

## How they were found

A plain `git log --all` reports these files as *never authored*, because `--all` walks only existing refs. They were found by scanning the commits reported by `git fsck --unreachable`. That is the part worth remembering: if a design doc looks like it was never written, search unreachable commits before concluding it.

## Content is verbatim

Both blobs are taken unmodified from `6de07aa08`, and are independently preserved on the pushed tag `retention/cave-x6rw-waste-free-half-splits-6de07aa08`. The design carries `**Status:** Approved` and names `cave-x6rw` directly.

## Deliberately not included

`6de07aa08` also carries page-registry implementation work that never reached `main`. That is **not** in this PR — this change is docs-only. It is worth reviewing before anyone rebuilds it from scratch.