### PR TITLE
docs(copy): replace plumbing-speak in the phone handoff modal

### DIFF
--- a/src/components/mobile-handoff-modal.tsx
+++ b/src/components/mobile-handoff-modal.tsx
@@ -217,13 +217,13 @@ export function MobileHandoffModal({
       if (controller.signal.aborted) return;
       const json = (await res.json()) as HandoffResponse;
       if (controller.signal.aborted) return;
-      if (!json.ok) setError(json.stderr || json.error || "Tailscale Serve reset failed.");
+      if (!json.ok) setError(json.stderr || json.error || "Couldn’t stop sharing.");
       setHandoff(null);
     } catch (err) {
       if (controller.signal.aborted || (err instanceof Error && err.name === "AbortError")) {
         return;
       }
-      setError(err instanceof Error ? err.message : "Tailscale Serve reset failed.");
+      setError(err instanceof Error ? err.message : "Couldn’t stop sharing.");
     } finally {
       if (!controller.signal.aborted) setLoading(false);
       if (startAbortRef.current === controller) startAbortRef.current = null;
@@ -238,7 +238,7 @@ export function MobileHandoffModal({
       footerActions={
         <>
           <Button variant="ghost" onClick={resetServe} disabled={loading}>
-            Reset Serve
+            Stop sharing
           </Button>
           {onMobileModeChange ? (
             <Button
@@ -250,7 +250,7 @@ export function MobileHandoffModal({
             </Button>
           ) : null}
           <Button variant="secondary" onClick={() => void start()} loading={loading}>
-            Refresh route
+            Refresh link
           </Button>
           <Button variant="secondary" onClick={() => void copyHost()} disabled={!handoff?.nativeHost || loading}>
             {copied === "host" ? "Host copied" : "Copy host"}


### PR DESCRIPTION
Completes the last outstanding deliverable on `cave-jr4r`, whose other three (guided Tailscale checklist, iOS explains the desktop model, install QR) all shipped via #3257, `4b11b1152d` and #3818, and whose two stale-docs items are already fixed on `main`.

## The change

The phone handoff modal used two implementation nouns as button labels, and `Reset Serve` was Title Case where every sibling control is sentence case.

| before | after |
|---|---|
| `Reset Serve` | `Stop sharing` |
| `Refresh route` | `Refresh link` |
| `"Tailscale Serve reset failed."` ×2 | `"Couldn't stop sharing."` |

## Why this wording

The neighbouring controls already read as plain intent in sentence case — `Turn on mobile mode`, `Copy host`, `Copy invite`, `Host copied`. The two odd ones out named the mechanism instead of the action.

- Tearing down Tailscale Serve is, from the user's side, **ending the phone's access** → `Stop sharing`.
- Refreshing the route mints a new invite URL, and **link** is the noun the adjacent Copy actions already use → `Refresh link`.

The same jargon had leaked into the failure path, so both user-facing error strings move with it. That follows the error tone in `docs/coven-design-language.md` §4 — gentle, specific, never blaming, sentence case, contractions, typographic punctuation (the doc's own example is *"Couldn't load projects"*). §4 also rules that a utility surface is **never in character**, so no flourish was added.

## Risk

- **No behaviour change.** Handlers, `disabled`/`loading` conditions and API calls are untouched; only string literals changed.
- **No test pins any of the three strings** — checked across `src`, `tests` and `scripts`; the only occurrences were in this component.

Unblocks `cave-f1wo` (Onboarding O4) and `cave-r1h6` (Onboarding O3), both of which list `cave-jr4r` as their blocker.