### PR TITLE
Fix chat carousel image framing

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -920,6 +920,7 @@ export const SUITES = {
     "src/components/github-action-popover-chat-launch.test.ts",
     "src/components/github-card-wiring.test.ts",
     "src/components/image-carousel-wiring.test.ts",
+    "src/components/image-carousel-fill.test.ts",
     "src/components/chat-spec-card.test.ts",
     "src/components/chat-spec-card-wiring.test.ts",
     "src/lib/gh-card-commands.test.ts",

--- a/src/components/image-carousel-fill.test.ts
+++ b/src/components/image-carousel-fill.test.ts
@@ -6,7 +6,7 @@ const carousel = readFileSync(new URL("./image-carousel.tsx", import.meta.url), 
 
 assert.match(
   carousel,
-  /className=\{`focus-ring flex aspect-video w-full[\s\S]*?overflow-hidden/,
+  /className=\{`focus-ring flex aspect-video w-full[^$`]*\boverflow-hidden\b[^$`]*\$\{/,
   "each inline slide establishes a full-width frame that clips overflow",
 );
 assert.match(

--- a/src/components/image-carousel-fill.test.ts
+++ b/src/components/image-carousel-fill.test.ts
@@ -1,0 +1,23 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const carousel = readFileSync(new URL("./image-carousel.tsx", import.meta.url), "utf8");
+
+assert.match(
+  carousel,
+  /className=\{`focus-ring flex aspect-video w-full[\s\S]*?overflow-hidden/,
+  "each inline slide establishes a full-width frame that clips overflow",
+);
+assert.match(
+  carousel,
+  /className="block h-full w-full object-cover"/,
+  "inline carousel images fill the complete slide frame",
+);
+assert.match(
+  carousel,
+  /className="rounded-lg object-contain block \[max-height:75vh\]!/,
+  "the lightbox preserves an uncropped view of the complete image",
+);
+
+console.log("image-carousel-fill.test.ts: all assertions passed");

--- a/src/components/image-carousel.tsx
+++ b/src/components/image-carousel.tsx
@@ -219,7 +219,7 @@ export function ImageCarousel({ images, label }: Props) {
                   // through pictures nobody can see.
                   tabIndex={i === safeIndex ? 0 : -1}
                   aria-hidden={i === safeIndex ? undefined : true}
-                  className={`focus-ring flex w-full cursor-zoom-in items-center justify-center bg-transparent p-0 ${
+                  className={`focus-ring flex aspect-video w-full cursor-zoom-in items-center justify-center overflow-hidden bg-transparent p-0 ${
                     i === safeIndex
                       ? "relative opacity-100"
                       : "pointer-events-none absolute inset-0 opacity-0"
@@ -235,11 +235,11 @@ export function ImageCarousel({ images, label }: Props) {
                     alt={imageLabel(image, i, total)}
                     loading={i === 0 ? undefined : "lazy"}
                     fallback={
-                      <span className="flex h-40 w-full items-center justify-center text-[var(--text-muted)]">
+                      <span className="flex h-full w-full items-center justify-center text-[var(--text-muted)]">
                         <Icon name="ph:image-bold" width={24} />
                       </span>
                     }
-                    className="block max-h-96 w-full object-contain"
+                    className="block h-full w-full object-cover"
                   />
                 </button>
               ))}

--- a/tests/image-carousel-fill.spec.ts
+++ b/tests/image-carousel-fill.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const ISO = "2026-08-14T10:00:00.000Z";
+const LANDSCAPE = "https://images.example/landscape.png";
+const PORTRAIT = "https://images.example/portrait.png";
+const SESSION = {
+  id: "s-image-carousel",
+  title: "Image carousel",
+  status: "idle",
+  project_root: "/tmp/coven-cave",
+  harness: "claude",
+  familiarId: "nova",
+  exit_code: null,
+  archived_at: null,
+  created_at: ISO,
+  updated_at: ISO,
+};
+
+function svg(width: number, height: number, label: string, color: string): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+    <rect width="100%" height="100%" fill="${color}" />
+    <circle cx="${width / 2}" cy="${height / 2}" r="${Math.min(width, height) / 4}" fill="#ffffff" />
+    <text x="50%" y="52%" text-anchor="middle" font-family="sans-serif" font-size="${Math.min(width, height) / 12}" fill="#1f1729">${label}</text>
+  </svg>`;
+}
+
+async function setup(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("cave:active-familiar", "nova");
+    localStorage.setItem("cave:familiar:nova:last-surface", "chat");
+    localStorage.setItem("cave:onboarding:dismissed", "1");
+    localStorage.setItem("cave:shell:min-applied:cave.shell.widths.v3", "1");
+    localStorage.setItem("cave:shell:min-applied:cave.shell.widths.v3.two-pane", "1");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        familiars: [
+          {
+            id: "nova",
+            display_name: "Nova",
+            role: "Orchestrator",
+            status: "active",
+            icon: "ph:sparkle-fill",
+          },
+        ],
+      },
+    }),
+  );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions: [SESSION] } }),
+  );
+  await page.route("**/api/chat/conversation/**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        conversation: {
+          activeLeafId: "a1",
+          turns: [
+            { id: "u1", role: "user", text: "Show the images", createdAt: ISO },
+            {
+              id: "a1",
+              parentId: "u1",
+              role: "assistant",
+              text: `<coven:image src="${LANDSCAPE}" alt="Landscape sample" caption="Landscape" />
+<coven:image src="${PORTRAIT}" alt="Portrait sample" caption="Portrait" />`,
+              createdAt: ISO,
+            },
+          ],
+        },
+      },
+    }),
+  );
+  await page.route(LANDSCAPE, (route) =>
+    route.fulfill({ contentType: "image/svg+xml", body: svg(1200, 600, "LANDSCAPE", "#8f80c9") }),
+  );
+  await page.route(PORTRAIT, (route) =>
+    route.fulfill({ contentType: "image/svg+xml", body: svg(600, 1200, "PORTRAIT", "#6fa9a0") }),
+  );
+}
+
+test("carousel images fill the frame while the lightbox stays uncropped", async ({ page }) => {
+  await setup(page);
+  await page.goto("/?mode=chat#chat-s-image-carousel", { waitUntil: "domcontentloaded" });
+
+  const carousel = page.getByRole("group", { name: "Image carousel, 2 images" });
+  await expect(carousel).toBeVisible({ timeout: 30_000 });
+  const slide = carousel.locator('button[title^="View"]').first();
+  const image = slide.locator("img");
+  await expect(image).toBeVisible();
+
+  const frame = await slide.boundingBox();
+  const pixels = await image.boundingBox();
+  expect(frame).not.toBeNull();
+  expect(pixels).not.toBeNull();
+  expect(frame!.width / frame!.height).toBeCloseTo(16 / 9, 1);
+  expect(pixels!.width).toBeCloseTo(frame!.width, 0);
+  expect(pixels!.height).toBeCloseTo(frame!.height, 0);
+  await expect(image).toHaveCSS("object-fit", "cover");
+
+  await carousel.getByRole("button", { name: "Next image" }).click();
+  await expect(carousel.getByText("Portrait", { exact: true })).toBeVisible();
+  await carousel.locator('button[title^="View"][tabindex="0"]').click();
+
+  const lightbox = page.getByRole("dialog", { name: /Portrait sample/ });
+  await expect(lightbox).toBeVisible();
+  await expect(lightbox.locator("img")).toHaveCSS("object-fit", "contain");
+});


### PR DESCRIPTION
## Summary
- render inline chat carousel slides in a full-width 16:9 frame
- use object-cover inline while preserving the existing uncropped object-contain lightbox
- add source-contract and daemon-less Playwright coverage for landscape and portrait images

## Verification
- `node src/components/image-carousel-fill.test.ts`
- `pnpm check:tests-wired`
- `pnpm lint`
- `pnpm typecheck`
- `COVEN_CAVE_PORT=3101 COVEN_CAVE_E2E=1 pnpm exec playwright test tests/image-carousel-fill.spec.ts --project=desktop --no-deps --workers=1`
- `pnpm test:app` reached an unrelated host-load timing failure in `canonical-memory-smoke-lifecycle.test.mjs` (cleanup 2705ms vs 2500ms); an isolated rerun passed that assertion and then hit a different timing budget (2702ms vs 2000ms)

Bead: `cave-fhosx`