### PR TITLE
Fix familiar visual runtime resources

### DIFF
--- a/src/app/api/chat/send/harness-routing-attachments.test.ts
+++ b/src/app/api/chat/send/harness-routing-attachments.test.ts
@@ -121,8 +121,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /const runtimeResourceRoots = sshRuntime[\s\S]*?resolveRuntimeSkillRoots\([\s\S]*?readOnlyResourceRoots: runtimeResourceRoots/,
-  "Local skill sources should be declared as read-only runtime resources in the boundary prompt",
+  /const runtimeResourceRoots = sshRuntime[\s\S]*?resolveRuntimeResourceRoots\([\s\S]*?readOnlyResourceRoots: runtimeResourceRoots/,
+  "Local instruction and artifact sources should be declared as read-only runtime resources in the boundary prompt",
 );
 
 function extractAllowedRootsArrayFromCreateBoundarySentinel(source: string) {
@@ -169,10 +169,10 @@ const boundarySentinelAllowedRoots = extractAllowedRootsArrayFromCreateBoundaryS
   chatRoute,
 );
 
-assert.doesNotMatch(
+assert.match(
   boundarySentinelAllowedRoots,
   /\.\.\.runtimeResourceRoots/,
-  "Read-only skill resources must not be accepted by the write-boundary sentinel",
+  "Read-only runtime resources must not be falsely reported as out-of-boundary reads",
 );
 
 const grantDirsInitializerMatch = chatRoute.match(

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -181,7 +181,7 @@ import {
   projectlessGenerationLaunch,
 } from "@/lib/server/chat-project-launch";
 import { validateCaveProjectRoot } from "@/lib/server/project-paths";
-import { resolveRuntimeSkillRoots } from "@/lib/server/skill-scan";
+import { resolveRuntimeResourceRoots } from "@/lib/server/skill-scan";
 import { resolveBundledCopilotPluginDirs } from "@/lib/server/bundled-copilot-plugins";
 import { openClawLaunchCommand, openClawSpawnEnv } from "@/lib/openclaw-bin";
 import {
@@ -2544,7 +2544,7 @@ export async function POST(req: Request) {
   );
   const runtimeResourceRoots = sshRuntime
     ? []
-    : await resolveRuntimeSkillRoots({
+    : await resolveRuntimeResourceRoots({
         coveredRoots: [
           cwd,
           ...grantedProjectRoots,
@@ -2574,6 +2574,7 @@ export async function POST(req: Request) {
           cwd,
           ...grantedProjectRoots,
           ...(resolvedFamiliarWorkspace ? [resolvedFamiliarWorkspace] : []),
+          ...runtimeResourceRoots,
         ],
       });
   const responseMetadata: ChatResponseMetadata = {

--- a/src/lib/chat-boundary-sentinel.ts
+++ b/src/lib/chat-boundary-sentinel.ts
@@ -40,8 +40,10 @@ export type BoundarySentinel = {
 };
 
 type SentinelOptions = {
-  /** Roots the session may touch: runtime cwd, granted project roots, and
-   *  the familiar workspace (memory/identity writes are always in-scope). */
+  /** Roots the session may touch: runtime cwd, granted project roots, the
+   *  familiar workspace, and narrow read-only runtime resources. This
+   *  sentinel observes path access but does not infer read vs. write intent;
+   *  the prompt and harness sandbox retain that distinction. */
   allowedRoots: string[];
   homeDir?: string;
   tmpDir?: string;

--- a/src/lib/server/skill-scan.test.ts
+++ b/src/lib/server/skill-scan.test.ts
@@ -3,7 +3,11 @@ import assert from "node:assert/strict";
 import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { parseFrontmatter, resolveRuntimeSkillRoots } from "./skill-scan.ts";
+import {
+  parseFrontmatter,
+  resolveRuntimeResourceRoots,
+  resolveRuntimeSkillRoots,
+} from "./skill-scan.ts";
 
 // Regression: skill `description:` is almost always a YAML block scalar
 // (`description: |`). The old single-line parser captured just the "|"
@@ -99,6 +103,24 @@ description: |
       }),
       await Promise.all([covenSkillsRoot, codexSkills, pluginCache].map((root) => realpath(root))),
       "a skill root already covered by a project grant should not receive a contradictory read-only grant",
+    );
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+}
+
+// Codex image generation writes persistent outputs beside its skill roots.
+// That narrow directory must be advertised as a readable runtime resource so
+// a familiar can copy an approved result into its writable workspace.
+{
+  const home = await mkdtemp(path.join(tmpdir(), "cave-runtime-image-root-"));
+  const generatedImages = path.join(home, ".codex", "generated_images");
+  try {
+    await mkdir(generatedImages, { recursive: true });
+    assert.deepEqual(
+      await resolveRuntimeResourceRoots({ homeDir: home }),
+      [await realpath(generatedImages)],
+      "the existing Codex generated-image root should be a read-only runtime resource",
     );
   } finally {
     await rm(home, { recursive: true, force: true });

--- a/src/lib/server/skill-scan.ts
+++ b/src/lib/server/skill-scan.ts
@@ -45,6 +45,8 @@ type RuntimeSkillRootOptions = {
   coveredRoots?: string[];
 };
 
+type RuntimeResourceRootOptions = RuntimeSkillRootOptions;
+
 function isWithinRoot(candidate: string, root: string): boolean {
   const rel = path.relative(root, candidate);
   return rel === "" || (
@@ -88,6 +90,40 @@ export async function resolveRuntimeSkillRoots(
       if (!roots.includes(resolved)) roots.push(resolved);
     } catch {
       // An absent skill source advertises nothing and receives no grant.
+    }
+  }
+  return roots;
+}
+
+/**
+ * Narrow read-only roots a local harness may inspect without promoting an
+ * entire harness home directory. Skills are procedures; Codex's generated
+ * image directory is an artifact handoff surface that lets a familiar copy an
+ * approved output into its writable workspace.
+ */
+export async function resolveRuntimeResourceRoots(
+  options: RuntimeResourceRootOptions = {},
+): Promise<string[]> {
+  const roots = await resolveRuntimeSkillRoots(options);
+  const home = options.homeDir ?? homedir();
+  const candidates = [path.join(home, ".codex", "generated_images")];
+  const covered = await Promise.all(
+    (options.coveredRoots ?? []).map(async (root) => {
+      try {
+        return await realpath(root);
+      } catch {
+        return path.resolve(root);
+      }
+    }),
+  );
+  for (const candidate of candidates) {
+    try {
+      const resolved = await realpath(candidate);
+      if (!(await stat(resolved)).isDirectory()) continue;
+      if (covered.some((root) => isWithinRoot(resolved, root))) continue;
+      if (!roots.includes(resolved)) roots.push(resolved);
+    } catch {
+      // An absent generated-artifact root advertises nothing and receives no grant.
     }
   }
   return roots;


### PR DESCRIPTION
## Summary
- advertise Codex generated-image outputs as a narrow read-only runtime resource
- keep runtime-resource reads from producing false boundary violations
- preserve familiar-local skill precedence already injected by the familiar contract

## Verification
- `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/familiar-contract-context.test.ts` (26 passed)
- `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/app/api/chat/send/harness-routing-attachments.test.ts`
- `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/lib/chat-boundary-sentinel.test.ts`
- `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/lib/server/skill-scan.test.ts`
- `tsc --noEmit --project tsconfig.json`
- scoped ESLint on all five changed files

Bead: `cave-16uo9`