### PR TITLE
feat(research): ingest Hugging Face papers and read them with pdf.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ __verify-chat-detail.mjs
 .psyche*
 /.xcode-source-packages
 /.demo
+
+# build product of a pinned dependency (scripts/copy-pdf-worker.mjs); not source
+public/pdf.worker.min.mjs

--- a/docs/superpowers/plans/2026-08-15-hf-papers-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-hf-papers-ingest.md
@@ -1,0 +1,1267 @@
+# HF Paper Ingest with pdf.js Viewer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pasting `hf papers read 2401.12345` (or an HF papers / arXiv URL) into Research Desk resources saves one paper resource with real title, authors and abstract, and opening it renders the PDF inline with pdf.js.
+
+**Architecture:** A pure parser canonicalizes every spelling to one HF papers URL so the existing normalized-URL dedupe collapses them. Server-side metadata enrichment degrades rather than failing the save. A same-origin proxy route streams the arXiv PDF; a dynamically-imported pdf.js viewer renders it with a text layer for selection and search.
+
+**Tech Stack:** TypeScript, Next 16 (App Router), React 19, `node --test` with `--experimental-strip-types`, Playwright (daemon-less), `pdfjs-dist`.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-hf-papers-ingest-design.md` · **Bead:** `cave-cbz28`
+
+---
+
+## Repo conventions that apply to every task
+
+Read these once; they are not repeated per task.
+
+- **Every new test file must be registered** in `scripts/run-tests.mjs` or it never runs. Add to the `app:` array (lines ~24–1240). A test that imports `@/…` as a *runtime value* must also join the `ALIAS_LOADER` set (line ~1736) or it dies with `ERR_MODULE_NOT_FOUND` in CI while passing locally. This exact omission broke `main` on 2026-08-14 (`cave-nzfiy`).
+- **Commits are signed and carry no AI attribution.** Use `git commit -S`. Never add `Co-Authored-By: Claude` or `Generated with` — `AGENTS.md` forbids it and it overrides any global habit.
+- **Run a single test file:** `node --experimental-strip-types --test <file>`. If the file is in `ALIAS_LOADER`, add `--import ./scripts/test-alias-register.mjs` before the file path.
+- **Run the whole suite:** `pnpm test:app`.
+- **Components must pass the design-token codemod.** `pnpm lint` runs `codemod:design:check` over `src/components/**`; raw colour/spacing literals fail.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/lib/hf-papers.ts` (new) | Pure. Recognise paper references in text; canonicalize to an arXiv id and an HF URL. No imports. |
+| `src/lib/hf-papers.test.ts` (new) | Pattern matrix including near-misses. |
+| `src/lib/link-organizer.ts` (modify) | Add the `huggingface.co/papers/*` → `paper` path rule; extend `SavedLink` with optional `paper`. |
+| `src/lib/server/hf-paper-metadata.ts` (new) | Fetch and map HF paper metadata; degrade on failure. `fetch` injected for testing. |
+| `src/lib/server/research-links.ts` (modify) | Validate/drop the `paper` block on read; carry it on save. |
+| `src/app/api/research/links/route.ts` (modify) | Run the parser over pasted text; enrich before save. |
+| `src/app/api/research/papers/pdf/route.ts` (new) | Stream `arxiv.org/pdf/<id>` same-origin, guarded. |
+| `src/lib/research-paper-view.ts` (new) | Pure viewer state machine (idle → loading → ready → error, cancellation). |
+| `src/components/research-paper-viewer.tsx` (new) | pdf.js canvas + text layer, chrome, actions. Client-only. |
+| `tests/research-paper-viewer.spec.ts` (new) | Daemon-less e2e against a committed fixture PDF. |
+| `tests/fixtures/sample-paper.pdf` (new) | One-page PDF with known text. |
+
+---
+
+### Task 1: Reference parser
+
+**Files:**
+- Create: `src/lib/hf-papers.ts`
+- Test: `src/lib/hf-papers.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/hf-papers.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { hfPaperUrl, isArxivPaperId, parseHfPaperReferences } from "./hf-papers.ts";
+
+test("recognises both command spellings", () => {
+  assert.deepEqual(parseHfPaperReferences("hf papers read 2401.12345"), ["2401.12345"]);
+  assert.deepEqual(parseHfPaperReferences("hf paper read 2401.12345"), ["2401.12345"]);
+});
+
+test("strips a version suffix to the canonical id", () => {
+  assert.deepEqual(parseHfPaperReferences("hf papers read 2401.12345v2"), ["2401.12345"]);
+});
+
+test("recognises HF and arXiv URLs", () => {
+  assert.deepEqual(parseHfPaperReferences("https://huggingface.co/papers/2401.12345"), ["2401.12345"]);
+  assert.deepEqual(parseHfPaperReferences("https://arxiv.org/abs/2401.12345"), ["2401.12345"]);
+  assert.deepEqual(parseHfPaperReferences("https://arxiv.org/pdf/2401.12345"), ["2401.12345"]);
+});
+
+test("collapses every spelling of one paper to a single id", () => {
+  const text = [
+    "hf papers read 2401.12345",
+    "https://huggingface.co/papers/2401.12345",
+    "https://arxiv.org/pdf/2401.12345v3",
+  ].join("\n");
+  assert.deepEqual(parseHfPaperReferences(text), ["2401.12345"]);
+});
+
+test("does NOT match a bare id with no command or URL", () => {
+  assert.deepEqual(parseHfPaperReferences("the figure on 2401.12345 is wrong"), []);
+});
+
+test("does NOT match an over-long number", () => {
+  assert.deepEqual(parseHfPaperReferences("hf papers read 2401.1234567"), []);
+});
+
+test("canonical URL and id guard", () => {
+  assert.equal(hfPaperUrl("2401.12345"), "https://huggingface.co/papers/2401.12345");
+  assert.equal(isArxivPaperId("2401.12345"), true);
+  assert.equal(isArxivPaperId("2401.1234567"), false);
+  assert.equal(isArxivPaperId("../etc/passwd"), false);
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `node --experimental-strip-types --test src/lib/hf-papers.test.ts`
+Expected: FAIL — `Cannot find module './hf-papers.ts'`.
+
+- [ ] **Step 3: Implement**
+
+Create `src/lib/hf-papers.ts`:
+
+```ts
+/**
+ * Recognise Hugging Face paper references in free text.
+ *
+ * A bare `2401.12345` is deliberately NOT matched: pasted prose is full of
+ * decimal numbers and version strings, and manufacturing resources from them
+ * is worse than missing one. The `hf papers read` command or a URL is the
+ * signal that the number is a paper.
+ */
+
+/** arXiv ids are `YYMM.NNNNN`, optionally with a `vN` revision suffix. */
+const ARXIV_ID = String.raw`(\d{4}\.\d{4,5})(?:v\d+)?`;
+
+const PATTERNS = [
+  new RegExp(String.raw`\bhf\s+papers?\s+read\s+${ARXIV_ID}\b`, "gi"),
+  new RegExp(String.raw`https?://(?:www\.)?huggingface\.co/papers/${ARXIV_ID}\b`, "gi"),
+  new RegExp(String.raw`https?://(?:www\.)?arxiv\.org/(?:abs|pdf)/${ARXIV_ID}(?:\.pdf)?\b`, "gi"),
+];
+
+/** Canonical ids, deduped, in first-seen order. The `vN` suffix is dropped. */
+export function parseHfPaperReferences(text: string): string[] {
+  if (!text) return [];
+  const seen = new Set<string>();
+  for (const pattern of PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) seen.add(match[1]);
+  }
+  return [...seen];
+}
+
+export function hfPaperUrl(arxivId: string): string {
+  return `https://huggingface.co/papers/${arxivId}`;
+}
+
+/** Guard for anything that interpolates an id into a URL or a path. */
+export function isArxivPaperId(value: string): boolean {
+  return /^\d{4}\.\d{4,5}$/.test(value);
+}
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `node --experimental-strip-types --test src/lib/hf-papers.test.ts`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Register the test**
+
+In `scripts/run-tests.mjs`, in the `app:` array beside the other `src/lib/*.test.ts` entries (near `"src/lib/link-organizer.test.ts"`, ~line 995), add:
+
+```js
+    "src/lib/hf-papers.test.ts",
+```
+
+Do **not** add it to `ALIAS_LOADER` — `hf-papers.ts` imports nothing.
+
+- [ ] **Step 6: Verify it runs in the suite**
+
+Run: `pnpm test:app 2>&1 | grep hf-papers`
+Expected: a line showing the file ran.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/hf-papers.ts src/lib/hf-papers.test.ts scripts/run-tests.mjs
+git commit -S -m "feat(research): recognise HF paper references in pasted text
+
+Canonicalizes the two command spellings, the HF papers URL and arXiv
+abs/pdf URLs to one arXiv id, so the existing normalized-URL dedupe
+collapses them into a single resource. A bare id with no command or URL
+around it is not matched, because pasted prose is full of decimals.
+
+Bead: cave-cbz28"
+```
+
+---
+
+### Task 2: Categorise HF paper URLs as papers
+
+`huggingface.co` also serves models, datasets, spaces and blog posts, so the host cannot
+join `PAPER_HOSTS` — only the `/papers/` path may.
+
+**Files:**
+- Modify: `src/lib/link-organizer.ts:116-131` (`categorizeLink`)
+- Test: `src/lib/link-organizer.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/lib/link-organizer.test.ts`:
+
+```ts
+test("huggingface.co/papers is a paper, other HF paths are not", () => {
+  assert.equal(categorizeLink("https://huggingface.co/papers/2401.12345"), "paper");
+  assert.notEqual(categorizeLink("https://huggingface.co/models/meta-llama/Llama-3"), "paper");
+  assert.notEqual(categorizeLink("https://huggingface.co/datasets/squad"), "paper");
+  assert.notEqual(categorizeLink("https://huggingface.co/blog/some-post"), "paper");
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `node --experimental-strip-types --test src/lib/link-organizer.test.ts`
+Expected: FAIL — the first assertion gets `"other"`, not `"paper"`.
+
+- [ ] **Step 3: Implement**
+
+In `src/lib/link-organizer.ts`, inside `categorizeLink`, immediately **before** the
+`if (hostMatches(host, PAPER_HOSTS)) return "paper";` line, insert:
+
+```ts
+  // huggingface.co also serves models, datasets, spaces and blog posts, so the
+  // host cannot join PAPER_HOSTS — only this path may.
+  if (host === "huggingface.co" && /^\/papers\//.test(pathname)) return "paper";
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `node --experimental-strip-types --test src/lib/link-organizer.test.ts`
+Expected: PASS, including the pre-existing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/link-organizer.ts src/lib/link-organizer.test.ts
+git commit -S -m "feat(research): categorise huggingface.co/papers as papers
+
+Path-aware rather than host-wide: huggingface.co also serves models,
+datasets, spaces and blog posts, and putting the host in PAPER_HOSTS
+would mislabel all of them.
+
+Bead: cave-cbz28"
+```
+
+---
+
+### Task 3: Carry paper metadata on the saved link
+
+**Files:**
+- Modify: `src/lib/link-organizer.ts:46-54` (`SavedLink`)
+- Modify: `src/lib/server/research-links.ts` (`normalizeStoredLink`)
+- Test: `src/lib/server/research-links.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/lib/server/research-links.test.ts`:
+
+```ts
+test("keeps a well-formed paper block and drops a malformed one", async () => {
+  const good = {
+    id: "a", url: "https://huggingface.co/papers/2401.12345", category: "paper",
+    title: "T", addedAt: new Date().toISOString(), source: "desk",
+    paper: { arxivId: "2401.12345", authors: ["A"], abstract: "x", publishedAt: "2024-01-22T00:00:00.000Z" },
+  };
+  const bad = { ...good, id: "b", paper: { arxivId: "../etc/passwd", authors: "not-an-array" } };
+
+  assert.deepEqual(normalizeStoredLinkForTest(good)?.paper?.authors, ["A"]);
+  assert.equal(normalizeStoredLinkForTest(bad)?.paper, undefined);
+});
+```
+
+If `normalizeStoredLink` is not already exported for tests, export it from
+`src/lib/server/research-links.ts` as `normalizeStoredLinkForTest` and import it in the
+test alongside the existing imports.
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/server/research-links.test.ts`
+Expected: FAIL — `paper` is stripped from both, so the first assertion gets `undefined`.
+
+- [ ] **Step 3: Extend the type**
+
+In `src/lib/link-organizer.ts`, extend `SavedLink` (currently lines 46–54):
+
+```ts
+export type SavedLink = {
+  id: string;
+  url: string;
+  category: LinkCategory;
+  title: string;
+  addedAt: string;
+  /** Where the save originated. */
+  source: "chat" | "desk";
+  /** Present only for papers resolved through hf-papers ingest. */
+  paper?: {
+    arxivId: string;
+    authors: string[];
+    abstract: string;
+    publishedAt: string;
+  };
+};
+```
+
+- [ ] **Step 4: Validate it on read**
+
+In `src/lib/server/research-links.ts`, add above `normalizeStoredLink`:
+
+```ts
+import { isArxivPaperId } from "@/lib/hf-papers";
+
+function normalizePaperBlock(value: unknown): SavedLink["paper"] {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  // Disk contents are user-editable, and arxivId is interpolated into a URL by
+  // the PDF route — validate it here rather than trusting the file.
+  if (typeof raw.arxivId !== "string" || !isArxivPaperId(raw.arxivId)) return undefined;
+  if (!Array.isArray(raw.authors) || !raw.authors.every((a) => typeof a === "string")) return undefined;
+  if (typeof raw.abstract !== "string") return undefined;
+  if (typeof raw.publishedAt !== "string") return undefined;
+  return {
+    arxivId: raw.arxivId,
+    authors: raw.authors as string[],
+    abstract: raw.abstract,
+    publishedAt: raw.publishedAt,
+  };
+}
+```
+
+Then in `normalizeStoredLink`'s returned object, after `source: …`, add:
+
+```ts
+    ...(normalizePaperBlock((value as { paper?: unknown }).paper)
+      ? { paper: normalizePaperBlock((value as { paper?: unknown }).paper) }
+      : {}),
+```
+
+- [ ] **Step 5: Run it and confirm it passes**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/server/research-links.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/link-organizer.ts src/lib/server/research-links.ts src/lib/server/research-links.test.ts
+git commit -S -m "feat(research): carry paper metadata on saved links
+
+Optional field, so no migration — absent on every existing record. The
+block is validated on read and dropped whole if malformed, matching how
+category and addedAt are already re-derived rather than trusted, and
+because arxivId is later interpolated into a URL by the PDF route.
+
+Bead: cave-cbz28"
+```
+
+---
+
+### Task 4: Fetch HF paper metadata
+
+**Files:**
+- Create: `src/lib/server/hf-paper-metadata.ts`
+- Test: `src/lib/server/hf-paper-metadata.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/server/hf-paper-metadata.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { fetchHfPaperMetadata } from "./hf-paper-metadata.ts";
+
+const PAYLOAD = {
+  id: "2401.12345",
+  title: "Distributionally Robust Receive Beamforming",
+  authors: [{ name: "Shixiong Wang" }, { name: "Wei Dai" }],
+  publishedAt: "2024-01-22T20:20:48.000Z",
+  summary: "This article investigates signal estimation.",
+};
+
+test("maps the HF payload", async () => {
+  const result = await fetchHfPaperMetadata("2401.12345", {
+    fetchImpl: async () => new Response(JSON.stringify(PAYLOAD), { status: 200 }),
+  });
+  assert.deepEqual(result, {
+    title: "Distributionally Robust Receive Beamforming",
+    authors: ["Shixiong Wang", "Wei Dai"],
+    abstract: "This article investigates signal estimation.",
+    publishedAt: "2024-01-22T20:20:48.000Z",
+  });
+});
+
+test("degrades to null on a non-OK response", async () => {
+  const result = await fetchHfPaperMetadata("2401.12345", {
+    fetchImpl: async () => new Response("nope", { status: 404 }),
+  });
+  assert.equal(result, null);
+});
+
+test("degrades to null when the fetch throws", async () => {
+  const result = await fetchHfPaperMetadata("2401.12345", {
+    fetchImpl: async () => { throw new Error("network down"); },
+  });
+  assert.equal(result, null);
+});
+
+test("refuses an id that is not an arXiv id", async () => {
+  let called = false;
+  const result = await fetchHfPaperMetadata("../etc/passwd", {
+    fetchImpl: async () => { called = true; return new Response("{}", { status: 200 }); },
+  });
+  assert.equal(result, null);
+  assert.equal(called, false, "must not issue a request for an invalid id");
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/server/hf-paper-metadata.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/lib/server/hf-paper-metadata.ts`:
+
+```ts
+import { isArxivPaperId } from "@/lib/hf-papers";
+
+export type HfPaperMetadata = {
+  title: string;
+  authors: string[];
+  abstract: string;
+  publishedAt: string;
+};
+
+/**
+ * Ingest is an interactive paste: the budget is how long a person will wait
+ * for it to land, not how long HF might take.
+ */
+const TIMEOUT_MS = 5_000;
+
+export async function fetchHfPaperMetadata(
+  arxivId: string,
+  options: { fetchImpl?: typeof fetch } = {},
+): Promise<HfPaperMetadata | null> {
+  if (!isArxivPaperId(arxivId)) return null;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(`https://huggingface.co/api/papers/${arxivId}`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const body = (await response.json()) as Record<string, unknown>;
+    const title = typeof body.title === "string" ? body.title : "";
+    if (!title) return null;
+    const authors = Array.isArray(body.authors)
+      ? body.authors
+          .map((a) => (a && typeof a === "object" ? (a as { name?: unknown }).name : null))
+          .filter((n): n is string => typeof n === "string" && n.length > 0)
+      : [];
+    return {
+      title,
+      authors,
+      abstract: typeof body.summary === "string" ? body.summary : "",
+      publishedAt: typeof body.publishedAt === "string" ? body.publishedAt : "",
+    };
+  } catch {
+    // A flaky third party must not cost the user their paste; the caller keeps
+    // the derived title instead.
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/server/hf-paper-metadata.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Register the test**
+
+In `scripts/run-tests.mjs`: add `"src/lib/server/hf-paper-metadata.test.ts",` to the `app:`
+array near `"src/lib/server/research-links.test.ts"` (~line 382), **and** add the same
+string to the `ALIAS_LOADER` set (~line 1736) with a comment:
+
+```js
+  // hf-paper-metadata.ts imports "@/lib/hf-papers" as a runtime value.
+  "src/lib/server/hf-paper-metadata.test.ts",
+```
+
+- [ ] **Step 6: Prove the registration works**
+
+Run: `pnpm test:app 2>&1 | grep hf-paper-metadata`
+Expected: the file ran and passed. If it reports `ERR_MODULE_NOT_FOUND`, the
+`ALIAS_LOADER` entry is missing or misspelled.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/server/hf-paper-metadata.ts src/lib/server/hf-paper-metadata.test.ts scripts/run-tests.mjs
+git commit -S -m "feat(research): fetch HF paper metadata, degrading on failure
+
+Returns null rather than throwing on a bad id, a non-OK response or a
+network error, so ingest keeps the derived title instead of losing the
+paste. 5s timeout, because this sits in an interactive paste.
+
+Bead: cave-cbz28"
+```
+
+---
+
+### Task 5: Wire the parser and enrichment into ingest
+
+**Files:**
+- Modify: `src/app/api/research/links/route.ts:37-70` (`POST`)
+- Test: `src/app/api/research/links/route.test.ts` (create if absent)
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create or append to `src/app/api/research/links/route.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { collectIngestUrls } from "./ingest-urls.ts";
+
+test("a command with no URL still yields the canonical paper URL", () => {
+  assert.deepEqual(
+    collectIngestUrls({ text: "hf papers read 2401.12345" }),
+    ["https://huggingface.co/papers/2401.12345"],
+  );
+});
+
+test("a paper pasted twice in different spellings yields one URL", () => {
+  assert.deepEqual(
+    collectIngestUrls({ text: "hf papers read 2401.12345 https://arxiv.org/abs/2401.12345" }),
+    ["https://huggingface.co/papers/2401.12345"],
+  );
+});
+
+test("ordinary URLs still come through", () => {
+  const urls = collectIngestUrls({ text: "see https://example.com/post" });
+  assert.ok(urls.includes("https://example.com/post"));
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/app/api/research/links/route.test.ts`
+Expected: FAIL — `./ingest-urls.ts` not found.
+
+- [ ] **Step 3: Implement the pure helper**
+
+Create `src/app/api/research/links/ingest-urls.ts`. It is a separate module so the
+merge logic is testable without constructing a `Request`:
+
+```ts
+import { extractLinks } from "@/lib/link-extractor";
+import { hfPaperUrl, parseHfPaperReferences } from "@/lib/hf-papers";
+
+/**
+ * Merge explicit URLs, URLs found in pasted text, and paper references.
+ *
+ * Paper ids are resolved to their canonical HF URL and placed FIRST, so that
+ * when the same paper also appears as a raw arXiv URL the canonical form is
+ * the one that survives the caller's dedupe.
+ */
+export function collectIngestUrls(input: { urls?: unknown; text?: unknown }): string[] {
+  const out: string[] = [];
+  const text = typeof input.text === "string" ? input.text : "";
+
+  for (const id of parseHfPaperReferences(text)) out.push(hfPaperUrl(id));
+
+  if (Array.isArray(input.urls)) {
+    for (const raw of input.urls) {
+      if (typeof raw === "string" && raw.trim()) out.push(raw.trim());
+    }
+  }
+  if (text.trim()) out.push(...extractLinks(text));
+
+  // Drop any raw arXiv/HF URL for a paper already represented canonically.
+  const paperIds = new Set(parseHfPaperReferences(text));
+  return [...new Set(out)].filter((url) => {
+    if (url.startsWith("https://huggingface.co/papers/")) return true;
+    const ids = parseHfPaperReferences(url);
+    return ids.length === 0 || !ids.some((id) => paperIds.has(id));
+  });
+}
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/app/api/research/links/route.test.ts`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Use it in the route**
+
+In `src/app/api/research/links/route.ts`, replace the URL-gathering block in `POST`
+(the `const urls: string[] = []; …` section through the `extractLinks` call) with:
+
+```ts
+  const urls = collectIngestUrls(parsed.body);
+```
+
+and add to the imports:
+
+```ts
+import { collectIngestUrls } from "./ingest-urls";
+```
+
+- [ ] **Step 6: Enrich papers before saving**
+
+Still in `POST`, after `urls` is computed and before the existing save call, add:
+
+```ts
+  const enrichment = new Map<string, Awaited<ReturnType<typeof fetchHfPaperMetadata>>>();
+  for (const url of urls) {
+    const [arxivId] = parseHfPaperReferences(url);
+    if (!arxivId) continue;
+    enrichment.set(url, await fetchHfPaperMetadata(arxivId));
+  }
+```
+
+Then widen `saveResearchLinks` in `src/lib/server/research-links.ts` to accept the map as
+an optional second argument:
+
+```ts
+export async function saveResearchLinks(
+  urls: string[],
+  source: "chat" | "desk",
+  enrichment?: Map<string, HfPaperMetadata | null>,
+): Promise<SaveLinksResult> {
+```
+
+and at the point where it builds each new `SavedLink` (currently around line 165, where
+`title: deriveLinkTitle(trimmed)` is set), replace that construction with:
+
+```ts
+      const meta = enrichment?.get(trimmed) ?? null;
+      const [arxivId] = parseHfPaperReferences(trimmed);
+      const link: SavedLink = {
+        id: randomUUID(),
+        url: trimmed,
+        category: categorizeLink(trimmed),
+        title: meta?.title || deriveLinkTitle(trimmed),
+        addedAt: new Date().toISOString(),
+        source,
+        ...(meta && arxivId
+          ? {
+              paper: {
+                arxivId,
+                authors: meta.authors,
+                abstract: meta.abstract,
+                publishedAt: meta.publishedAt,
+              },
+            }
+          : {}),
+      };
+```
+
+Where metadata is `null` this produces exactly today's record. Add to that file's imports:
+
+```ts
+import { parseHfPaperReferences } from "@/lib/hf-papers";
+import type { HfPaperMetadata } from "@/lib/server/hf-paper-metadata";
+```
+
+Add to the route's imports:
+
+```ts
+import { parseHfPaperReferences } from "@/lib/hf-papers";
+import { fetchHfPaperMetadata } from "@/lib/server/hf-paper-metadata";
+```
+
+- [ ] **Step 7: Run the suite**
+
+Run: `pnpm test:app`
+Expected: PASS. Register `src/app/api/research/links/route.test.ts` in `scripts/run-tests.mjs`
+(`app:` array) and in `ALIAS_LOADER` — it imports `@/lib/…` runtime values.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/app/api/research/links/ src/lib scripts/run-tests.mjs
+git commit -S -m "feat(research): ingest HF paper references from pasted text
+
+extractLinks finds nothing in 'hf papers read 2401.12345' because it
+contains no URL, so the parser runs over the same text and contributes
+the canonical HF URL. Canonical URLs are placed first so a paper pasted
+in two spellings dedupes to one resource.
+
+Bead: cave-cbz28"
+```
+
+---
+
+### Task 6: PDF proxy route
+
+**Files:**
+- Create: `src/app/api/research/papers/pdf/route.ts`
+- Test: `src/app/api/research/papers/pdf/route.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/app/api/research/papers/pdf/route.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { arxivPdfUrl } from "./arxiv-url.ts";
+
+test("builds the arXiv URL from a valid id", () => {
+  assert.equal(arxivPdfUrl("2401.12345"), "https://arxiv.org/pdf/2401.12345");
+});
+
+test("refuses anything that is not an arXiv id", () => {
+  for (const bad of ["../etc/passwd", "2401.1234567", "evil.com/x", "", "2401.12345 "]) {
+    assert.equal(arxivPdfUrl(bad), null, `must refuse ${JSON.stringify(bad)}`);
+  }
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/app/api/research/papers/pdf/route.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the URL builder**
+
+Create `src/app/api/research/papers/pdf/arxiv-url.ts`:
+
+```ts
+import { isArxivPaperId } from "@/lib/hf-papers";
+
+/**
+ * The id is validated and then interpolated into a hard-coded arXiv URL. It
+ * never composes a host, a scheme or a path prefix, so there is no SSRF
+ * surface here.
+ */
+export function arxivPdfUrl(arxivId: string): string | null {
+  if (!isArxivPaperId(arxivId)) return null;
+  return `https://arxiv.org/pdf/${arxivId}`;
+}
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/app/api/research/papers/pdf/route.test.ts`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Implement the route**
+
+Create `src/app/api/research/papers/pdf/route.ts`:
+
+```ts
+import { NextResponse } from "next/server";
+
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
+
+import { arxivPdfUrl } from "./arxiv-url";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+
+  const id = new URL(req.url).searchParams.get("id")?.trim() ?? "";
+  const upstream = arxivPdfUrl(id);
+  if (!upstream) {
+    return NextResponse.json({ ok: false, error: "invalid paper id" }, { status: 400 });
+  }
+
+  const range = req.headers.get("range");
+  let response: Response;
+  try {
+    response = await fetch(upstream, { headers: range ? { range } : {} });
+  } catch {
+    return NextResponse.json({ ok: false, error: "upstream unavailable" }, { status: 502 });
+  }
+  if (!response.ok && response.status !== 206) {
+    return NextResponse.json({ ok: false, error: "paper not found" }, { status: 404 });
+  }
+
+  const headers = new Headers({ "content-type": "application/pdf" });
+  for (const key of ["content-length", "content-range", "accept-ranges"]) {
+    const value = response.headers.get(key);
+    if (value) headers.set(key, value);
+  }
+  return new NextResponse(response.body, { status: response.status, headers });
+}
+```
+
+- [ ] **Step 6: Register and run the suite**
+
+Add `"src/app/api/research/papers/pdf/route.test.ts",` to the `app:` array and to
+`ALIAS_LOADER` (it imports `@/lib/hf-papers`).
+
+Run: `pnpm test:app 2>&1 | grep papers/pdf`
+Expected: the file ran and passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/api/research/papers scripts/run-tests.mjs
+git commit -S -m "feat(research): proxy the arXiv PDF same-origin
+
+pdf.js fetches the bytes from our own origin, so CORS never enters the
+picture, the local-only guard stays consistent with sibling routes, and
+third-party fetch behaviour under WKWebView is out of the picture. The
+id is validated and interpolated into a hard-coded arXiv URL, so it
+never composes a host or scheme.
+
+Bead: cave-cbz28"
+```
+
+---
+
+### Task 7: Add pdf.js and its worker asset
+
+**Files:**
+- Modify: `package.json`
+- Create: `scripts/copy-pdf-worker.mjs`
+
+- [ ] **Step 1: Add the dependency, pinned exactly**
+
+Run: `pnpm add pdfjs-dist@5.4.149`
+
+Then open `package.json` and remove any `^` from the `pdfjs-dist` entry.
+`scripts/dependency-policy.test.mjs` asserts every dependency matches
+`^\d+\.\d+\.\d+…$`, so a caret fails the suite.
+
+- [ ] **Step 2: Verify the policy test still passes**
+
+Run: `node --experimental-strip-types --test scripts/dependency-policy.test.mjs`
+Expected: PASS. If it fails on `pdfjs-dist`, the version still has a caret.
+
+- [ ] **Step 3: Write the worker copy script**
+
+Create `scripts/copy-pdf-worker.mjs`:
+
+```js
+// pdf.js parses in a Web Worker. This is the first Web Worker in the codebase,
+// so rather than depending on Turbopack's worker handling we copy the asset to
+// public/ and reference it by URL — which is also what the packaged desktop
+// shell serves.
+import { copyFile, mkdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const source = require.resolve("pdfjs-dist/build/pdf.worker.min.mjs");
+const target = path.join(process.cwd(), "public", "pdf.worker.min.mjs");
+
+await mkdir(path.dirname(target), { recursive: true });
+await copyFile(source, target);
+console.log(`[copy-pdf-worker] ${source} -> ${target}`);
+```
+
+- [ ] **Step 4: Run it on postinstall**
+
+In `package.json` `scripts`, add:
+
+```json
+    "postinstall": "node scripts/copy-pdf-worker.mjs",
+```
+
+If a `postinstall` already exists, append with ` && node scripts/copy-pdf-worker.mjs`.
+
+- [ ] **Step 5: Verify the asset lands**
+
+Run: `node scripts/copy-pdf-worker.mjs && ls -l public/pdf.worker.min.mjs`
+Expected: the file exists and is non-empty.
+
+- [ ] **Step 6: Ignore the generated asset**
+
+Add to `.gitignore`:
+
+```
+public/pdf.worker.min.mjs
+```
+
+It is a build product of a pinned dependency; committing it would duplicate the package.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml scripts/copy-pdf-worker.mjs .gitignore
+git commit -S -m "build: add pdfjs-dist and stage its worker into public/
+
+Pinned exactly, because dependency-policy.test.mjs rejects a caret in
+any dependency block. The worker is copied to public/ on postinstall
+rather than bundled: this is the codebase's first Web Worker, and the
+packaged desktop shell serves the same static tree.
+
+Bead: cave-cbz28"
+```
+
+---
+
+### Task 8: Viewer state machine (pure)
+
+pdf.js cannot be exercised under `node --test` — no canvas, no `DOMMatrix`, no worker.
+What *is* testable is the state machine, with the loader injected.
+
+**Files:**
+- Create: `src/lib/research-paper-view.ts`
+- Test: `src/lib/research-paper-view.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/research-paper-view.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { paperPdfUrl, reducePaperView, type PaperViewState } from "./research-paper-view.ts";
+
+const idle: PaperViewState = { status: "idle", pageCount: 0, error: null };
+
+test("builds the proxy URL", () => {
+  assert.equal(paperPdfUrl("2401.12345"), "/api/research/papers/pdf?id=2401.12345");
+});
+
+test("load then ready", () => {
+  const loading = reducePaperView(idle, { type: "load" });
+  assert.equal(loading.status, "loading");
+  const ready = reducePaperView(loading, { type: "ready", pageCount: 12 });
+  assert.equal(ready.status, "ready");
+  assert.equal(ready.pageCount, 12);
+});
+
+test("failure records the message and can retry", () => {
+  const failed = reducePaperView({ ...idle, status: "loading" }, { type: "fail", message: "boom" });
+  assert.equal(failed.status, "error");
+  assert.equal(failed.error, "boom");
+  assert.equal(reducePaperView(failed, { type: "load" }).status, "loading");
+});
+
+test("cancel returns to idle and clears the page count", () => {
+  const ready: PaperViewState = { status: "ready", pageCount: 12, error: null };
+  const cancelled = reducePaperView(ready, { type: "cancel" });
+  assert.deepEqual(cancelled, idle);
+});
+
+test("a late ready after cancel is ignored", () => {
+  const cancelled = reducePaperView({ status: "ready", pageCount: 3, error: null }, { type: "cancel" });
+  assert.equal(reducePaperView(cancelled, { type: "ready", pageCount: 3 }).status, "idle");
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `node --experimental-strip-types --test src/lib/research-paper-view.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/lib/research-paper-view.ts`:
+
+```ts
+export type PaperViewStatus = "idle" | "loading" | "ready" | "error";
+
+export type PaperViewState = {
+  status: PaperViewStatus;
+  pageCount: number;
+  error: string | null;
+};
+
+export type PaperViewAction =
+  | { type: "load" }
+  | { type: "ready"; pageCount: number }
+  | { type: "fail"; message: string }
+  | { type: "cancel" };
+
+export const initialPaperViewState: PaperViewState = {
+  status: "idle",
+  pageCount: 0,
+  error: null,
+};
+
+export function paperPdfUrl(arxivId: string): string {
+  return `/api/research/papers/pdf?id=${encodeURIComponent(arxivId)}`;
+}
+
+export function reducePaperView(state: PaperViewState, action: PaperViewAction): PaperViewState {
+  switch (action.type) {
+    case "load":
+      return { status: "loading", pageCount: 0, error: null };
+    case "ready":
+      // A render that resolves after dismissal must not revive the viewer.
+      if (state.status !== "loading") return state;
+      return { status: "ready", pageCount: action.pageCount, error: null };
+    case "fail":
+      if (state.status !== "loading") return state;
+      return { status: "error", pageCount: 0, error: action.message };
+    case "cancel":
+      return initialPaperViewState;
+  }
+}
+```
+
+- [ ] **Step 4: Run it and confirm it passes**
+
+Run: `node --experimental-strip-types --test src/lib/research-paper-view.test.ts`
+Expected: PASS, 5 tests.
+
+Note the "late ready after cancel" test drives the `state.status !== "loading"` guards —
+without them a resolved render would repopulate a dismissed viewer.
+
+- [ ] **Step 5: Register and commit**
+
+Add `"src/lib/research-paper-view.test.ts",` to the `app:` array (no `ALIAS_LOADER`; the
+module has no imports).
+
+```bash
+git add src/lib/research-paper-view.ts src/lib/research-paper-view.test.ts scripts/run-tests.mjs
+git commit -S -m "feat(research): paper viewer state machine
+
+Pure and testable under node --test, which has no canvas or worker. The
+ready/fail transitions are guarded on 'loading' so a render resolving
+after dismissal cannot revive a closed viewer.
+
+Bead: cave-cbz28"
+```
+
+---
+
+### Task 9: The viewer component
+
+**Files:**
+- Create: `src/components/research-paper-viewer.tsx`
+- Modify: the Research Desk resource list component that renders a `SavedLink` row
+
+- [ ] **Step 1: Find the resource row**
+
+Run: `grep -rln "SavedLink" src/components/ | grep -v test`
+Read the component that renders link rows; that is where the Read affordance goes.
+
+- [ ] **Step 2: Write the component**
+
+Create `src/components/research-paper-viewer.tsx`. The load-and-render effect is the part
+that goes wrong, so it is given in full:
+
+```tsx
+"use client";
+
+import { useEffect, useReducer, useRef, useState } from "react";
+
+import {
+  initialPaperViewState,
+  paperPdfUrl,
+  reducePaperView,
+} from "@/lib/research-paper-view";
+
+type Props = {
+  arxivId: string;
+  title: string;
+  authors: string[];
+  abstract: string;
+  publishedAt: string;
+  onClose: () => void;
+};
+
+export default function ResearchPaperViewer(props: Props) {
+  const [state, dispatch] = useReducer(reducePaperView, initialPaperViewState);
+  const [page, setPage] = useState(1);
+  const [scale, setScale] = useState(1.2);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const textLayerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let doc: Awaited<ReturnType<ReturnType<typeof import("pdfjs-dist")["getDocument"]>["promise"]>> | null = null;
+    let renderTask: { cancel: () => void } | null = null;
+
+    dispatch({ type: "load" });
+    void (async () => {
+      try {
+        const pdfjs = await import("pdfjs-dist");
+        // The worker is staged into public/ by scripts/copy-pdf-worker.mjs.
+        pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
+        doc = await pdfjs.getDocument(paperPdfUrl(props.arxivId)).promise;
+        if (cancelled) return;
+        dispatch({ type: "ready", pageCount: doc.numPages });
+
+        const pdfPage = await doc.getPage(page);
+        if (cancelled) return;
+        const viewport = pdfPage.getViewport({ scale });
+        const canvas = canvasRef.current;
+        const context = canvas?.getContext("2d");
+        if (!canvas || !context) return;
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+
+        renderTask = pdfPage.render({ canvas, canvasContext: context, viewport });
+        await (renderTask as unknown as { promise: Promise<void> }).promise;
+        if (cancelled) return;
+
+        // The text layer is what makes the document selectable and searchable.
+        const layer = textLayerRef.current;
+        if (layer) {
+          layer.replaceChildren();
+          const textLayer = new pdfjs.TextLayer({
+            textContentSource: await pdfPage.getTextContent(),
+            container: layer,
+            viewport,
+          });
+          await textLayer.render();
+        }
+      } catch (error) {
+        if (cancelled) return;
+        dispatch({
+          type: "fail",
+          message: error instanceof Error ? error.message : "could not render this paper",
+        });
+      }
+    })();
+
+    return () => {
+      // Dismissing mid-render must not leave a worker task writing into a
+      // canvas that React has already detached.
+      cancelled = true;
+      dispatch({ type: "cancel" });
+      renderTask?.cancel();
+      void doc?.destroy();
+    };
+  }, [props.arxivId, page, scale]);
+
+  // …dialog chrome: header (title, authors, formatted publishedAt), abstract,
+  // <canvas ref={canvasRef} /> with <div ref={textLayerRef} /> positioned over
+  // it, page prev/next bound to setPage within 1..state.pageCount, zoom bound
+  // to setScale, links out to the HF page and arXiv, download, and a close
+  // button calling props.onClose.
+  return null; // replace with the chrome above
+}
+```
+
+Structure the dialog chrome after `src/components/chat-artifact-viewer.tsx` — same dialog
+role, same dismissal behaviour. Use design tokens for every colour and spacing value;
+`pnpm lint` runs `codemod:design:check` over `src/components/**` and a raw literal fails
+the build.
+
+Note the effect depends on `page` and `scale`, so changing either re-runs it and the
+cleanup cancels the in-flight render first. That is deliberate: it is what stops a fast
+page-flip from racing two renders onto one canvas.
+
+- [ ] **Step 3: Mount it client-only**
+
+Wherever the viewer is opened, import it with:
+
+```ts
+const ResearchPaperViewer = dynamic(() => import("@/components/research-paper-viewer"), {
+  ssr: false,
+});
+```
+
+pdf.js touches `DOMMatrix` and canvas, neither of which exists during SSR.
+
+- [ ] **Step 4: Add the Read affordance**
+
+In the resource row, when `link.category === "paper" && link.paper?.arxivId`, render a
+"Read" button that opens the viewer with that link's metadata. When `link.paper` is
+absent — an arXiv or DOI link saved before this change, or one whose metadata fetch
+degraded — render exactly as today, with no Read button, because there is no id to stream.
+
+- [ ] **Step 5: Verify lint and types**
+
+Run: `pnpm lint && pnpm typecheck`
+Expected: both pass. A design-token failure names the offending literal.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/research-paper-viewer.tsx src/components
+git commit -S -m "feat(research): render papers with pdf.js
+
+Canvas per page with the text layer over it, so the document can be
+selected and searched rather than merely displayed. Dynamically imported
+and ssr:false — pdf.js needs DOMMatrix and canvas — which also keeps it
+out of the main bundle for anyone who never opens a paper.
+
+Bead: cave-cbz28"
+```
+
+---
+
+### Task 10: End-to-end coverage
+
+**Files:**
+- Create: `tests/research-paper-viewer.spec.ts`
+- Create: `tests/fixtures/sample-paper.pdf`
+
+- [ ] **Step 1: Add the fixture**
+
+Create a one-page PDF containing the literal text `HYPERSPECTRAL FIXTURE` at
+`tests/fixtures/sample-paper.pdf`. Any tool works; keep it under ~10 KB. Commit it — the
+mock must serve real PDF bytes, because **pdf.js parses what it is handed and a stub body
+fails at the parser**, proving nothing.
+
+- [ ] **Step 2: Write the spec**
+
+Create `tests/research-paper-viewer.spec.ts`. It must:
+
+- `page.addInitScript` setting `cave:onboarding:dismissed=1` — Playwright is daemon-less
+- `page.route("**/api/research/links**", …)` returning one saved link:
+  `{ id: "l1", url: "https://huggingface.co/papers/2401.12345", category: "paper", title: "Fixture Paper", addedAt: <iso>, source: "desk", paper: { arxivId: "2401.12345", authors: ["A. Author"], abstract: "An abstract.", publishedAt: "2024-01-22T00:00:00.000Z" } }`
+- `page.route("**/api/research/papers/pdf**", …)` fulfilling with
+  `{ status: 200, contentType: "application/pdf", body: readFileSync("tests/fixtures/sample-paper.pdf") }`
+- navigate to the Research Desk, open the resource, click **Read**
+- assert the viewer dialog is visible and shows the title and authors
+- assert a page canvas rendered: `await expect(dialog.locator("canvas").first()).toBeVisible()`
+- assert the text layer carries the fixture text: `await expect(dialog.getByText("HYPERSPECTRAL FIXTURE")).toBeVisible()`
+
+**Both new endpoints must be mocked.** On 2026-08-14 #4634 added a route, made a player
+conditional on it, shipped no mock, and left `main` red for hours — blocking every PR
+touching `src/**`, since those classify `e2e: true` (`cave-1kv8i`).
+
+- [ ] **Step 3: Run it**
+
+Run: `COVEN_CAVE_E2E=1 pnpm exec playwright test tests/research-paper-viewer.spec.ts --project=desktop`
+Expected: PASS.
+
+- [ ] **Step 4: Confirm the desktop project actually collected it**
+
+Run: `COVEN_CAVE_E2E=1 pnpm exec playwright test tests/research-paper-viewer.spec.ts --project=desktop --list`
+Expected: the spec is listed. A green run that collected **zero** tests is not a pass —
+that failure mode cost a full debugging cycle on `cave-3wmla`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/research-paper-viewer.spec.ts tests/fixtures/sample-paper.pdf
+git commit -S -m "test(research): e2e for the pdf.js paper viewer
+
+Mocks both new endpoints and serves a real one-page fixture PDF, because
+pdf.js parses what it is handed and a stub body would fail at the parser
+rather than exercise the viewer. Asserts the canvas renders and the text
+layer carries the fixture text, which is what proves selection and search
+have something to work with.
+
+Bead: cave-cbz28"
+```
+
+---
+
+## Final verification
+
+- [ ] `pnpm lint`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test:app`
+- [ ] `pnpm test:api`
+- [ ] `COVEN_CAVE_E2E=1 pnpm exec playwright test --project=desktop`
+- [ ] `pnpm build`
+- [ ] Push, open a PR against `main`, and wait for the required `Frontend build` check.
+      Do not merge with `--admin`; fix the blocker instead.

--- a/docs/superpowers/plans/2026-08-15-hf-papers-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-hf-papers-ingest.md
@@ -1051,12 +1051,29 @@ Bead: cave-cbz28"
 
 **Files:**
 - Create: `src/components/research-paper-viewer.tsx`
-- Modify: the Research Desk resource list component that renders a `SavedLink` row
+- Modify: `src/components/role-surfaces/research-tab-resources.tsx`
 
-- [ ] **Step 1: Find the resource row**
-
-Run: `grep -rln "SavedLink" src/components/ | grep -v test`
-Read the component that renders link rows; that is where the Read affordance goes.
+> **Corrected 2026-08-15 after reading the real code.** This section originally said
+> to model a standalone dialog on `chat-artifact-viewer.tsx` and to grep for the row
+> component. Both were wrong in a way that would have produced duplicate UI.
+>
+> `research-tab-resources.tsx` (711 lines) already owns the resource-open flow:
+> `openId`/`setOpenId` state (line 80), `openLink` lookup (line 255), `closeOverlay`
+> (line 257), a `useFocusTrap` with escape handling (line 258), and a rendered
+> `role="dialog"` overlay from line 551 with header, category chip, saved-time, URL row
+> and close button. A row already opens it via `onClick={() => setOpenId(link.id)}`
+> (line 488).
+>
+> So there is **no new dialog to build and no new affordance to invent**. The paper
+> viewer renders *inside* the existing overlay body when
+> `openLink.paper?.arxivId` is present, beneath the existing header and source row.
+> Links without an `arxivId` keep exactly today's overlay contents.
+>
+> pdf.js API verified against the installed `pdfjs-dist@6.2.108`: it exports
+> `getDocument`, `TextLayer`, `GlobalWorkerOptions` and `version`. Also verified that
+> importing it under Node fails with `DOMMatrix is not defined` — which is the
+> empirical reason the component must be client-only and why rendering cannot be
+> unit-tested here.
 
 - [ ] **Step 2: Write the component**
 

--- a/docs/superpowers/plans/2026-08-15-hf-papers-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-hf-papers-ingest.md
@@ -267,9 +267,12 @@ test("keeps a well-formed paper block and drops a malformed one", async () => {
 });
 ```
 
-If `normalizeStoredLink` is not already exported for tests, export it from
-`src/lib/server/research-links.ts` as `normalizeStoredLinkForTest` and import it in the
-test alongside the existing imports.
+**Do NOT export `normalizeStoredLink` to test it.** It is deliberately module-private, and
+the existing test file already has a better idiom: it points
+`CAVE_RESEARCH_LINKS_PATH_OVERRIDE` at a temp directory and drives the public API. Follow
+that — write a `research-links.json` containing one good and one malformed `paper` block,
+call `listSavedLinks()`, and assert what survives. That tests the actual read path
+including the JSON round-trip, rather than a function pulled out of its context.
 
 - [ ] **Step 2: Run it and confirm it fails**
 
@@ -303,8 +306,15 @@ export type SavedLink = {
 
 In `src/lib/server/research-links.ts`, add above `normalizeStoredLink`:
 
+> **Use a RELATIVE import, not the `@/` alias.** This file imports its neighbours as
+> `../link-organizer.ts` and `./atomic-write.ts`, and `research-links.test.ts` is
+> deliberately NOT in `ALIAS_LOADER`. Introducing an `@/` import here would make the test
+> throw `ERR_MODULE_NOT_FOUND` in CI while still passing locally — the `cave-nzfiy`
+> failure. Either import relatively (correct, no registration change) or add the test to
+> `ALIAS_LOADER` (unnecessary churn). Import relatively.
+
 ```ts
-import { isArxivPaperId } from "@/lib/hf-papers";
+import { isArxivPaperId } from "../hf-papers.ts";
 
 function normalizePaperBlock(value: unknown): SavedLink["paper"] {
   if (!value || typeof value !== "object") return undefined;

--- a/docs/superpowers/specs/2026-08-15-hf-papers-ingest-design.md
+++ b/docs/superpowers/specs/2026-08-15-hf-papers-ingest-design.md
@@ -33,16 +33,22 @@ https://arxiv.org/pdf/2401.12345
 
 ## Verified constraints
 
-Probed live on 2026-08-15, because both facts decide the design:
+Probed live on 2026-08-15:
 
 | URL | Result |
 | --- | --- |
-| `arxiv.org/pdf/<id>` | `content-type: application/pdf`, **no** `X-Frame-Options` → embeddable |
-| `huggingface.co/papers/<id>` | `X-Frame-Options: DENY` → **not** embeddable |
+| `arxiv.org/pdf/<id>` | `content-type: application/pdf`, no `X-Frame-Options` |
+| `huggingface.co/papers/<id>` | `X-Frame-Options: DENY` |
 | `huggingface.co/api/papers/<id>` | JSON: `id`, `title`, `authors[].name`, `publishedAt`, `summary` |
 
-The app sets no CSP `frame-src`, so framing is not blocked on our side. Existing embed
-patterns to follow live in `chat-artifact-viewer.tsx` and `browser-pane.tsx`.
+The first two settled which URL the document comes from: the HF page cannot be shown
+in-app under any approach, so the PDF is fetched from arXiv and the HF page is a link out.
+
+Note the framing headers stop mattering once §7 chooses pdf.js — we render the bytes
+ourselves rather than embedding a document. The proxy in §5 is retained for three
+different reasons: it makes the fetch same-origin so CORS never enters the picture, it
+keeps the local-only guard consistent with sibling routes, and it avoids third-party
+fetch behaviour differing under WKWebView.
 
 ## Design
 
@@ -123,13 +129,49 @@ arXiv or DOI link saved before this change, or one whose metadata fetch degraded
 today's behaviour exactly and show no Read affordance, because there is no id to stream.
 
 Follows `chat-artifact-viewer.tsx` for structure and dismissal. Header carries title,
-authors and publication date; the abstract sits above the document; the document itself
-is an `<iframe src="/api/research/papers/pdf?id=…">`. Actions link out to the HF page and
-arXiv, plus download.
+authors and publication date; the abstract sits above the document. Actions link out to
+the HF page and arXiv, plus download.
 
 Loading, error and retry states are modelled on `useResearchMediaUrl` — that is the
 established shape here for "resolve, then render", and reusing it means the failure
 affordances already match the rest of the surface.
+
+Component chrome uses design tokens and primitives. `pnpm lint` runs
+`codemod:design:check` over `src/components/**`, so raw colour and spacing values fail
+the build.
+
+### 7. Rendering — pdf.js
+
+The document is rendered with **pdf.js** (`pdfjs-dist`) rather than a native `<iframe>`,
+for text selection, in-document search, and page navigation. The proxy route from §5 is
+still what serves the bytes; pdf.js fetches it same-origin.
+
+Four integration constraints, each of which has a specific answer:
+
+**Worker.** pdf.js runs its parser in a Web Worker, and **this would be the first Web
+Worker in the codebase** — `src/` contains no `new Worker`, no `workerSrc`, no
+`*.worker.*` today. The worker asset (`pdf.worker.min.mjs`) is copied from `pdfjs-dist`
+into `public/` by a `postinstall` step and referenced as
+`GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs"`. Copying to `public/` rather than
+bundling via `new Worker(new URL(…))` keeps it independent of Turbopack's worker
+handling and keeps the asset available to the packaged desktop shell, which serves the
+same static tree.
+
+**Client-only.** pdf.js touches `DOMMatrix`, `Path2D` and canvas, none of which exist
+during SSR. The viewer is loaded with `next/dynamic` and `ssr: false`.
+
+**Bundle cost.** `pdfjs-dist` is large. Because the viewer is dynamically imported and
+only on opening a paper, it stays out of the main bundle — nobody who never opens a paper
+pays for it. `Frontend bundle` in CI is the check that would catch a regression here.
+
+**Exact version.** `scripts/dependency-policy.test.mjs` asserts every entry in every
+dependency block matches `^\d+\.\d+\.\d+…$`, so `pdfjs-dist` is pinned exactly, with no
+caret.
+
+Rendering itself: a canvas per page plus pdf.js's text layer over it, which is what makes
+selection and search work. Page navigation and a zoom control sit in the viewer chrome.
+Rendering is cancellable, so dismissing the viewer mid-render does not leave a detached
+worker task writing to a canvas that is gone.
 
 ## Testing
 
@@ -141,9 +183,21 @@ Unit:
   `/blog/...` are unaffected
 - metadata mapping and its degradation path
 - PDF route: id validation, non-local rejection, `Range` passthrough
+- the dependency-policy test already covers the exact-version pin; no new unit test needed
+  for that
+
+**pdf.js rendering is not unit-testable here.** The runner is `node --test`, which has no
+canvas, no `DOMMatrix` and no worker. Asserting that pages actually render belongs in
+Playwright, against real Chromium. What the unit layer *can* own is the pure part: the
+id → proxy-URL mapping, and the viewer's state machine (idle → loading → ready → error,
+and cancellation on dismiss) with the pdf.js module injected as a dependency.
 
 End-to-end: a daemon-less Playwright spec that dismisses onboarding
-(`cave:onboarding:dismissed=1`) and **`page.route`-mocks both new endpoints**.
+(`cave:onboarding:dismissed=1`) and **`page.route`-mocks both new endpoints**. The PDF
+route is fulfilled with a **committed single-page fixture PDF**, not a stub body — pdf.js
+parses what it is given, so a fake payload fails at the parser and proves nothing. The
+assertions are that the page canvas renders, that the text layer carries the fixture's
+known text, and that search finds it. A fixture of a few kilobytes is enough.
 
 That last point is not boilerplate. On 2026-08-14, PR #4634 added
 `/api/research/generations/media-ticket` and made the media player conditional on it, but
@@ -157,7 +211,8 @@ with the feature.
 
 - Chat slash-command ingest. The paste box plus URL recognition covers the request; a
   composer command is a separate surface with its own parsing and registry.
-- pdf.js. Text selection, in-document search and page thumbnails would be richer, but
-  the dependency and bundle work are not justified by "view the paper".
+- Page thumbnails and an outline/bookmarks sidebar. pdf.js exposes both, but they are
+  additional chrome on top of a reader that already selects, searches and navigates.
+- Annotation, highlighting or note-taking on the document.
 - The full HF payload (upvotes, linked models and datasets). More schema and more to keep
   in sync with an API we do not control.

--- a/docs/superpowers/specs/2026-08-15-hf-papers-ingest-design.md
+++ b/docs/superpowers/specs/2026-08-15-hf-papers-ingest-design.md
@@ -1,0 +1,163 @@
+# Research Desk: Hugging Face paper ingest with an embedded PDF viewer
+
+**Bead:** `cave-cbz28` · **Date:** 2026-08-15 · **Status:** approved, not yet implemented
+
+## Problem
+
+Research Desk resources are saved links. `src/lib/server/research-links.ts` stores them,
+`src/lib/link-organizer.ts` categorizes and titles them. A `paper` category already
+exists, but `PAPER_HOSTS` covers arxiv.org, doi.org, openreview.net and friends — not
+`huggingface.co`. Pasting a Hugging Face paper today lands as an `other` link with a
+title derived from the URL slug.
+
+Two gaps follow from that:
+
+1. **`hf papers read 2401.12345` is invisible to ingest.** It contains no URL, so
+   `extractLinks` finds nothing and the paste is silently dropped.
+2. **There is no PDF viewer anywhere in the app.** The only `.pdf` references are
+   incidental, in `chat-view.tsx` and `citations.ts`. Opening a paper resource means
+   leaving Cave.
+
+## Goal
+
+Pasting any of these into the Research Desk resource ingest saves **one** paper resource
+carrying a real title, authors and abstract — and opening it renders the PDF inline:
+
+```
+hf papers read 2401.12345
+hf paper read 2401.12345
+https://huggingface.co/papers/2401.12345
+https://arxiv.org/abs/2401.12345
+https://arxiv.org/pdf/2401.12345
+```
+
+## Verified constraints
+
+Probed live on 2026-08-15, because both facts decide the design:
+
+| URL | Result |
+| --- | --- |
+| `arxiv.org/pdf/<id>` | `content-type: application/pdf`, **no** `X-Frame-Options` → embeddable |
+| `huggingface.co/papers/<id>` | `X-Frame-Options: DENY` → **not** embeddable |
+| `huggingface.co/api/papers/<id>` | JSON: `id`, `title`, `authors[].name`, `publishedAt`, `summary` |
+
+The app sets no CSP `frame-src`, so framing is not blocked on our side. Existing embed
+patterns to follow live in `chat-artifact-viewer.tsx` and `browser-pane.tsx`.
+
+## Design
+
+### 1. Pattern parsing — `src/lib/hf-papers.ts` (new, pure)
+
+```ts
+export function parseHfPaperReferences(text: string): string[]  // canonical arXiv ids
+export function hfPaperUrl(arxivId: string): string             // canonical resource URL
+```
+
+arXiv id shape is `\d{4}\.\d{4,5}(v\d+)?`. Every recognised spelling canonicalizes to
+`https://huggingface.co/papers/<id>`, so the existing normalized-URL dedupe in
+`saveResearchLinks` collapses all five inputs above into one resource.
+
+**A bare `2401.12345` with no command or URL around it is deliberately not matched.**
+Pasted prose is full of decimal numbers and version strings; matching them would
+manufacture resources nobody asked for. The command prefix or a URL is the signal.
+
+### 2. Ingest wiring
+
+`link-organizer.ts` categorizes by host, but `huggingface.co` also serves models,
+datasets, spaces and blog posts. Adding the host to `PAPER_HOSTS` would mislabel all of
+them. Instead a **path-aware rule** runs before the host check: `huggingface.co/papers/*`
+→ `paper`; every other path on that host keeps today's behaviour.
+
+`POST /api/research/links` already extracts URLs from pasted `text`. It additionally runs
+`parseHfPaperReferences` over the same text, because the `hf papers read <id>` form
+contains no URL at all. Extracted URLs and parsed paper ids merge before the existing
+`MAX_LINKS_PER_SAVE` cap and dedupe.
+
+### 3. Metadata — `src/lib/server/hf-paper-metadata.ts` (new)
+
+`fetchHfPaperMetadata(arxivId)` calls `https://huggingface.co/api/papers/<id>` with a
+**5-second timeout** and maps to `{ title, authors, abstract, publishedAt }`. Ingest is
+an interactive paste, so the budget is set by how long a person will wait for the paste
+to land, not by how long HF might take.
+
+**Failure degrades, it does not fail the save.** A network hiccup or an id HF does not
+know leaves the resource with today's derived title. Ingest that hard-fails on a flaky
+third party is worse than ingest that stores a plain title.
+
+### 4. Storage
+
+`SavedLink` is `{ id, url, category, title, addedAt, source }`. It gains one optional
+field:
+
+```ts
+paper?: { arxivId: string; authors: string[]; abstract: string; publishedAt: string };
+```
+
+`normalizeStoredLink` already re-derives `category` and `addedAt` rather than trusting
+user-editable disk contents. The `paper` block gets the same treatment: validated on
+read, dropped whole if malformed. No migration — the field is optional and absent on
+every existing record.
+
+### 5. PDF proxy — `src/app/api/research/papers/pdf/route.ts` (new)
+
+`GET ?id=<arxivId>` streams `arxiv.org/pdf/<id>` as `application/pdf` with `Range`
+passthrough, mirroring the streaming shape of the existing
+`/api/research/generations/media` route.
+
+Two guards:
+
+- `rejectNonLocalRequest`, as every sibling route does.
+- The id is validated against the strict regex and interpolated into a **hard-coded**
+  arXiv URL. It never composes a host, a scheme or a path prefix, so there is no SSRF
+  surface.
+
+Same-origin proxying also keeps the viewer working under WKWebView, where third-party
+fetch and PDF handling behave less predictably than in headless Chromium.
+
+### 6. Viewer — `src/components/research-paper-viewer.tsx` (new)
+
+**Opened from the resource itself.** A saved link in the `paper` category that carries a
+`paper.arxivId` renders with a "Read" affordance alongside its existing open-in-browser
+action; that affordance opens this viewer. Paper resources without `paper.arxivId` — an
+arXiv or DOI link saved before this change, or one whose metadata fetch degraded — keep
+today's behaviour exactly and show no Read affordance, because there is no id to stream.
+
+Follows `chat-artifact-viewer.tsx` for structure and dismissal. Header carries title,
+authors and publication date; the abstract sits above the document; the document itself
+is an `<iframe src="/api/research/papers/pdf?id=…">`. Actions link out to the HF page and
+arXiv, plus download.
+
+Loading, error and retry states are modelled on `useResearchMediaUrl` — that is the
+established shape here for "resolve, then render", and reusing it means the failure
+affordances already match the rest of the surface.
+
+## Testing
+
+Unit:
+
+- the parser across the full pattern matrix, **including near-misses** — bare ids,
+  `2401.1234567`, `v2` suffixes, ids embedded in prose
+- the `huggingface.co/papers` path rule, asserting `huggingface.co/models/...` and
+  `/blog/...` are unaffected
+- metadata mapping and its degradation path
+- PDF route: id validation, non-local rejection, `Range` passthrough
+
+End-to-end: a daemon-less Playwright spec that dismisses onboarding
+(`cave:onboarding:dismissed=1`) and **`page.route`-mocks both new endpoints**.
+
+That last point is not boilerplate. On 2026-08-14, PR #4634 added
+`/api/research/generations/media-ticket` and made the media player conditional on it, but
+did not mock the endpoint in `tests/research-studio-media.spec.ts`. The player element
+stopped rendering, two specs failed, and `main` was red for hours — blocking every PR
+touching `src/**`, since those classify `e2e: true`. See `cave-1kv8i`. This design adds a
+route and a conditional viewer, which is exactly the same shape, so the spec mocks ship
+with the feature.
+
+## Out of scope
+
+- Chat slash-command ingest. The paste box plus URL recognition covers the request; a
+  composer command is a separate surface with its own parsing and registry.
+- pdf.js. Text selection, in-document search and page thumbnails would be richer, but
+  the dependency and bundle work are not justified by "view the paper".
+- The full HF payload (upvotes, linked models and datasets). More schema and more to keep
+  in sync with an API we do not control.

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "test:e2e": "pnpm e2e:install && playwright test",
     "start": "node server.mjs",
     "build:server": "esbuild server.ts --bundle=false --platform=node --target=node24 --outfile=server.mjs --format=esm",
-    "postinstall": "node scripts/fix-node-pty-spawn-helper.mjs",
+    "postinstall": "node scripts/fix-node-pty-spawn-helper.mjs && node scripts/copy-pdf-worker.mjs",
     "test:supply-chain": "node scripts/dependency-policy.test.mjs"
   },
   "dependencies": {
@@ -135,6 +135,7 @@
     "mermaid": "11.16.0",
     "next": "16.2.12",
     "node-pty": "1.1.0",
+    "pdfjs-dist": "6.2.108",
     "punycode": "2.3.1",
     "qrcode": "1.5.4",
     "react": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       node-pty:
         specifier: 1.1.0
         version: 1.1.0
+      pdfjs-dist:
+        specifier: 6.2.108
+        version: 6.2.108
       punycode:
         specifier: 2.3.1
         version: 2.3.1
@@ -984,6 +987,81 @@ packages:
 
   '@milkdown/utils@7.21.3':
     resolution: {integrity: sha512-pJxcEy1cJKRT4CsDLJ8OlokKww2PMBdlULCtFM4ccN+7EBc//fpR8ZnnOzoSnPxtgsbijaLzSSWiXBE5BdlolQ==}
+
+  '@napi-rs/canvas-android-arm64@1.0.5':
+    resolution: {integrity: sha512-ZzDlpKQocwFfCwhMh17UWre6Qt5yZN3kNIJoUpGfRZqwDDZ164IKOsPOHsRd3d8Tuj5KM6bDjGuPmZxuPuG3NQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.5':
+    resolution: {integrity: sha512-Hr8v6CA/TBe+OJOePdV3sXWxzQHQKfQsTKPbc8wG7iPqVeAx6MMdzKGXlYID6SVvpfwV/zqkvGcdImYWSlhrZg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.5':
+    resolution: {integrity: sha512-9BXlLHBXpYnK4jSae1MdFdyPq09Xi1I3PeCNpvRzqgmUUBhgJS7aC1z7SZEP8JUXDHtbfIrolCS3sFuT9IGP2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.5':
+    resolution: {integrity: sha512-zEW4fgvtYsOJ/N56Us4TQPfaFrUf0shGr9CgGSj3GACc+NHfUM3ci0YF9xFTjwJWGDmaEhYPL6KqCfFCxwm/qg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.5':
+    resolution: {integrity: sha512-HFprwLspelJxCEtZvdMcz95Mwvfs63GzFVedLFmC/wslHnaOXhjXxgYxPCM/VdM4Jhx3CV4Lk0vVmh6hJv2etQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.5':
+    resolution: {integrity: sha512-FNMGFAx8DvtDwlLfWyBJ+oQjgPXoIAqCnNTJYqtJCFRwwzK3AyAe5B1Ll3NZ6hcOzqw7HylZsq4nQxVyPCQX1Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.5':
+    resolution: {integrity: sha512-2vd5v8Lui+37Hh/spITKIvTT384ip4dnUc5XBn0E+sMNS4b7au7IswyT5YDG2udPTjSh/eLUs3sGuB5YHooFOA==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.5':
+    resolution: {integrity: sha512-iQIPy+Uey0expZTOszLri5n8rY7x4WUpMaY82mcXNIgbil30iHvc01OsiizhZC1KQHTK90RFMFWSpwFU+ON3aA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.5':
+    resolution: {integrity: sha512-Npthji25t7FUqIAKsoEkFS0qY5CYVkHjvI3tuZjDTG92wX8g4dst+Lfb4hhubdqPazlDcIwalPzInsFCtf3FFg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.5':
+    resolution: {integrity: sha512-bi+JsdCdbfVJDoAQybTYmkLKwh1xpYpptg5j/BNr2BB56u4/R26jrVvtjqff+CxYMXV6Kz1/jeDVhZCuj6bDng==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.5':
+    resolution: {integrity: sha512-KQQwG9/sBmcGxqaLFIQf+k2OefREGoyEaIBmRuTM8bUuFKOEE9Xk5pel90hE6pmBwk/vo4RB0OdX+FxobJGMFw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.5':
+    resolution: {integrity: sha512-GaPlicMtnvgPr5SowFRprkEJicDSrV3qCq17U4jiF5u0kNORZo3IbdN2Bk4SfcZJAMYFHbMVJ81O3w21CYxazg==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.2.2':
     resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
@@ -2876,6 +2954,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pdfjs-dist@6.2.108:
+    resolution: {integrity: sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==}
+    engines: {node: '>=22.13.0 || >=24'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -4543,6 +4625,54 @@ snapshots:
       nanoid: 5.1.16
     transitivePeerDependencies:
       - supports-color
+
+  '@napi-rs/canvas-android-arm64@1.0.5':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.5':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.5':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.5':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.5':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.5':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.5':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.5':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.5':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.5':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.5':
+    optional: true
+
+  '@napi-rs/canvas@1.0.5':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.5
+      '@napi-rs/canvas-darwin-arm64': 1.0.5
+      '@napi-rs/canvas-darwin-x64': 1.0.5
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.5
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.5
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.5
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.5
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.5
+      '@napi-rs/canvas-linux-x64-musl': 1.0.5
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.5
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.5
+    optional: true
 
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -6604,6 +6734,10 @@ snapshots:
   path-key@3.1.1: {}
 
   pathe@2.0.3: {}
+
+  pdfjs-dist@6.2.108:
+    optionalDependencies:
+      '@napi-rs/canvas': 1.0.5
 
   picocolors@1.1.1: {}
 

--- a/scripts/copy-pdf-worker.mjs
+++ b/scripts/copy-pdf-worker.mjs
@@ -1,0 +1,15 @@
+// pdf.js parses in a Web Worker. This is the first Web Worker in the codebase,
+// so rather than depending on Turbopack's worker handling we copy the asset to
+// public/ and reference it by URL — which is also what the packaged desktop
+// shell serves.
+import { copyFile, mkdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const source = require.resolve("pdfjs-dist/build/pdf.worker.min.mjs");
+const target = path.join(process.cwd(), "public", "pdf.worker.min.mjs");
+
+await mkdir(path.dirname(target), { recursive: true });
+await copyFile(source, target);
+console.log(`[copy-pdf-worker] ${source} -> ${target}`);

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1238,6 +1238,7 @@ export const SUITES = {
     "src/lib/onboarding-status-probes.test.ts",
     "src/lib/onboarding-status-ui.test.ts",
     "src/components/settings-multihost.test.ts",
+    "src/app/api/research/links/ingest-urls.test.ts",
   ],
   api: [
     "src/app/api/afs/afs-routes.test.ts",
@@ -1746,6 +1747,8 @@ const ALIAS_LOADER = new Set([
   "src/lib/server/flow-executor.test.ts",
   // hf-paper-metadata.ts imports "@/lib/hf-papers" as a runtime value.
   "src/lib/server/hf-paper-metadata.test.ts",
+  // ingest-urls.ts imports "@/lib/link-extractor" and "@/lib/hf-papers".
+  "src/app/api/research/links/ingest-urls.test.ts",
   // beads-delivery-source.ts imports "@/lib/beads-delivery",
   // "@/lib/server/beads-cli" and "@/lib/server/beads-workspace" as runtime
   // values, so the resolver has to be loaded or the file throws

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -993,6 +993,7 @@ export const SUITES = {
     "src/lib/github-repo-link.test.ts",
     "src/lib/link-extractor.test.ts",
     "src/lib/link-organizer.test.ts",
+    "src/lib/hf-papers.test.ts",
     "src/lib/memory-inspector.test.ts",
     "src/lib/memory-source-context.test.ts",
     "src/lib/onboarding-familiars.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -380,6 +380,7 @@ export const SUITES = {
     "src/lib/server/research-mission-store.test.ts",
     "src/lib/server/research-mission-lifecycle.test.ts",
     "src/lib/server/research-links.test.ts",
+    "src/lib/server/hf-paper-metadata.test.ts",
     "src/lib/server/process-intent-lock.test.ts",
     "src/lib/server/research-generations.test.ts",
     "src/lib/server/research-media-store.test.ts",
@@ -1743,6 +1744,8 @@ const ALIAS_LOADER = new Set([
   "src/app/api/onboarding/install/install-service.test.ts",
   // Imports flow-executor.ts, whose production graph uses @/lib aliases.
   "src/lib/server/flow-executor.test.ts",
+  // hf-paper-metadata.ts imports "@/lib/hf-papers" as a runtime value.
+  "src/lib/server/hf-paper-metadata.test.ts",
   // beads-delivery-source.ts imports "@/lib/beads-delivery",
   // "@/lib/server/beads-cli" and "@/lib/server/beads-workspace" as runtime
   // values, so the resolver has to be loaded or the file throws

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -132,6 +132,7 @@ export const SUITES = {
     "src/components/role-surfaces/research-x-sources.test.tsx",
     "src/components/role-surfaces/use-research-missions.test.tsx",
     "src/lib/research-generations.test.ts",
+    "src/lib/research-paper-view.test.ts",
     "src/components/role-surfaces/messenger-surface.test.ts",
     "src/components/role-surfaces/sentinel-surface.test.ts",
     "src/components/role-surfaces/scribe-surface.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1239,6 +1239,7 @@ export const SUITES = {
     "src/lib/onboarding-status-ui.test.ts",
     "src/components/settings-multihost.test.ts",
     "src/app/api/research/links/ingest-urls.test.ts",
+    "src/app/api/research/papers/pdf/route.test.ts",
   ],
   api: [
     "src/app/api/afs/afs-routes.test.ts",
@@ -1990,6 +1991,8 @@ const ALIAS_LOADER = new Set([
   "src/lib/voice/registry.test.ts",
   "src/lib/voice/elevenlabs.test.ts",
   "src/lib/project-root-migration.test.ts",
+  // arxiv-url.ts imports "@/lib/hf-papers" as a runtime value.
+  "src/app/api/research/papers/pdf/route.test.ts",
 ]);
 
 // These gates inspect physical source files. The CSS facade expander would

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1992,7 +1992,8 @@ const ALIAS_LOADER = new Set([
   "src/lib/voice/registry.test.ts",
   "src/lib/voice/elevenlabs.test.ts",
   "src/lib/project-root-migration.test.ts",
-  // arxiv-url.ts imports "@/lib/hf-papers" as a runtime value.
+  // arxiv-url.ts imports "@/lib/hf-papers" as a runtime value, and route.ts
+  // reaches "@/lib/server/api-security" for the local-request guard.
   "src/app/api/research/papers/pdf/route.test.ts",
 ]);
 

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -241,6 +241,9 @@ const contracts: RouteContract[] = [
   { route: "/research/missions/[id]/schedule", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true, pathGuard: true },
   { route: "/research/missions/[id]", methods: ["GET"], kind: "json", localOriginGuard: true, pathGuard: true },
   { route: "/research/missions", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true, pathGuard: true },
+  // No pathGuard: the id is validated against a strict arXiv shape and
+  // interpolated into a hard-coded host, so there is no filesystem path to deny.
+  { route: "/research/papers/pdf", methods: ["GET"], kind: "stream", localOriginGuard: true },
   { route: "/retro-runs", methods: ["GET"], kind: "json" },
   { route: "/rss", methods: ["GET"], kind: "json" },
   { route: "/salem", methods: ["GET", "POST"], kind: "json", readsJson: true },

--- a/src/app/api/research/links/ingest-urls.test.ts
+++ b/src/app/api/research/links/ingest-urls.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { collectIngestUrls } from "./ingest-urls.ts";
+
+test("a command with no URL still yields the canonical paper URL", () => {
+  assert.deepEqual(
+    collectIngestUrls({ text: "hf papers read 2401.12345" }),
+    ["https://huggingface.co/papers/2401.12345"],
+  );
+});
+
+test("a paper pasted twice in different spellings yields one URL", () => {
+  assert.deepEqual(
+    collectIngestUrls({ text: "hf papers read 2401.12345 https://arxiv.org/abs/2401.12345" }),
+    ["https://huggingface.co/papers/2401.12345"],
+  );
+});
+
+test("ordinary URLs still come through", () => {
+  const urls = collectIngestUrls({ text: "see https://example.com/post" });
+  assert.ok(urls.includes("https://example.com/post"));
+});
+
+test("explicit urls array is honoured alongside text", () => {
+  const urls = collectIngestUrls({ urls: ["https://example.com/a"], text: "https://example.com/b" });
+  assert.ok(urls.includes("https://example.com/a"));
+  assert.ok(urls.includes("https://example.com/b"));
+});
+
+test("an unrelated arXiv URL is kept when no command references it", () => {
+  const urls = collectIngestUrls({ text: "https://arxiv.org/abs/2401.12345" });
+  assert.equal(urls.length, 1);
+  assert.ok(urls[0].includes("2401.12345"));
+});
+
+test("non-string junk is ignored", () => {
+  assert.deepEqual(collectIngestUrls({ urls: [1, null, ""], text: 42 as unknown as string }), []);
+});

--- a/src/app/api/research/links/ingest-urls.test.ts
+++ b/src/app/api/research/links/ingest-urls.test.ts
@@ -28,10 +28,9 @@ test("explicit urls array is honoured alongside text", () => {
   assert.ok(urls.includes("https://example.com/b"));
 });
 
-test("an unrelated arXiv URL is kept when no command references it", () => {
+test("a raw arXiv URL with no command is rewritten to the canonical HF URL", () => {
   const urls = collectIngestUrls({ text: "https://arxiv.org/abs/2401.12345" });
-  assert.equal(urls.length, 1);
-  assert.ok(urls[0].includes("2401.12345"));
+  assert.deepEqual(urls, ["https://huggingface.co/papers/2401.12345"]);
 });
 
 test("non-string junk is ignored", () => {

--- a/src/app/api/research/links/ingest-urls.test.ts
+++ b/src/app/api/research/links/ingest-urls.test.ts
@@ -33,6 +33,39 @@ test("a raw arXiv URL with no command is rewritten to the canonical HF URL", () 
   assert.deepEqual(urls, ["https://huggingface.co/papers/2401.12345"]);
 });
 
+// ── urls[] entries are classified, not scanned ───────────────────────────────
+// chat-view posts `{ urls, source: "chat" }` with no text, so everything below
+// is the live in-app path.
+
+test("a paper URL pasted into chat canonicalizes like the command spelling", () => {
+  assert.deepEqual(
+    collectIngestUrls({ urls: ["https://arxiv.org/abs/2401.12345"] }),
+    ["https://huggingface.co/papers/2401.12345"],
+  );
+});
+
+test("the same paper saved from chat and from the paste box is ONE resource", () => {
+  assert.deepEqual(
+    collectIngestUrls({
+      urls: ["https://arxiv.org/pdf/2401.12345v2.pdf"],
+      text: "hf papers read 2401.12345",
+    }),
+    ["https://huggingface.co/papers/2401.12345"],
+  );
+});
+
+test("a wrapper URL that merely embeds a paper URL passes through untouched", () => {
+  // It is somebody else's page: rewriting it would replace the resource, and
+  // dropping it would lose the paste. Both happened while urls[] was scanned
+  // with the free-text matcher.
+  const wrapper = "https://www.google.com/url?q=https://arxiv.org/abs/2401.12345";
+  assert.deepEqual(collectIngestUrls({ urls: [wrapper] }), [wrapper]);
+  assert.deepEqual(
+    collectIngestUrls({ urls: [wrapper], text: "hf papers read 2401.12345" }),
+    ["https://huggingface.co/papers/2401.12345", wrapper],
+  );
+});
+
 test("non-string junk is ignored", () => {
   assert.deepEqual(collectIngestUrls({ urls: [1, null, ""], text: 42 as unknown as string }), []);
 });

--- a/src/app/api/research/links/ingest-urls.ts
+++ b/src/app/api/research/links/ingest-urls.ts
@@ -1,0 +1,31 @@
+import { extractLinks } from "@/lib/link-extractor";
+import { hfPaperUrl, parseHfPaperReferences } from "@/lib/hf-papers";
+
+/**
+ * Merge explicit URLs, URLs found in pasted text, and paper references.
+ *
+ * Paper ids are resolved to their canonical HF URL and placed FIRST, so that
+ * when the same paper also appears as a raw arXiv URL the canonical form is
+ * the one that survives the caller's dedupe.
+ */
+export function collectIngestUrls(input: { urls?: unknown; text?: unknown }): string[] {
+  const out: string[] = [];
+  const text = typeof input.text === "string" ? input.text : "";
+
+  for (const id of parseHfPaperReferences(text)) out.push(hfPaperUrl(id));
+
+  if (Array.isArray(input.urls)) {
+    for (const raw of input.urls) {
+      if (typeof raw === "string" && raw.trim()) out.push(raw.trim());
+    }
+  }
+  if (text.trim()) out.push(...extractLinks(text));
+
+  // Drop any raw arXiv/HF URL for a paper already represented canonically.
+  const paperIds = new Set(parseHfPaperReferences(text));
+  return [...new Set(out)].filter((url) => {
+    if (url.startsWith("https://huggingface.co/papers/")) return true;
+    const ids = parseHfPaperReferences(url);
+    return ids.length === 0 || !ids.some((id) => paperIds.has(id));
+  });
+}

--- a/src/app/api/research/links/ingest-urls.ts
+++ b/src/app/api/research/links/ingest-urls.ts
@@ -1,5 +1,5 @@
 import { extractLinks } from "@/lib/link-extractor";
-import { hfPaperUrl, parseHfPaperReferences } from "@/lib/hf-papers";
+import { arxivIdFromUrl, hfPaperUrl, parseHfPaperReferences } from "@/lib/hf-papers";
 
 /**
  * Merge explicit URLs, URLs found in pasted text, and paper references.
@@ -7,6 +7,11 @@ import { hfPaperUrl, parseHfPaperReferences } from "@/lib/hf-papers";
  * Paper ids are resolved to their canonical HF URL and placed FIRST, so that
  * when the same paper also appears as a raw arXiv URL the canonical form is
  * the one that survives the caller's dedupe.
+ *
+ * `urls[]` entries arrive already-as-URLs, so they are classified with
+ * arxivIdFromUrl rather than scanned as text: a paper URL pasted into chat
+ * canonicalizes and dedupes like a `hf papers read` of the same id, while a
+ * wrapper that merely embeds one is neither rewritten nor dropped.
  */
 export function collectIngestUrls(input: { urls?: unknown; text?: unknown }): string[] {
   const out: string[] = [];
@@ -16,7 +21,10 @@ export function collectIngestUrls(input: { urls?: unknown; text?: unknown }): st
 
   if (Array.isArray(input.urls)) {
     for (const raw of input.urls) {
-      if (typeof raw === "string" && raw.trim()) out.push(raw.trim());
+      if (typeof raw !== "string" || !raw.trim()) continue;
+      const trimmed = raw.trim();
+      const id = arxivIdFromUrl(trimmed);
+      out.push(id ? hfPaperUrl(id) : trimmed);
     }
   }
   if (text.trim()) out.push(...extractLinks(text));
@@ -25,7 +33,7 @@ export function collectIngestUrls(input: { urls?: unknown; text?: unknown }): st
   const paperIds = new Set(parseHfPaperReferences(text));
   return [...new Set(out)].filter((url) => {
     if (url.startsWith("https://huggingface.co/papers/")) return true;
-    const ids = parseHfPaperReferences(url);
-    return ids.length === 0 || !ids.some((id) => paperIds.has(id));
+    const id = arxivIdFromUrl(url);
+    return !id || !paperIds.has(id);
   });
 }

--- a/src/app/api/research/links/route.ts
+++ b/src/app/api/research/links/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
 
-import { extractLinks } from "@/lib/link-extractor";
+import { parseHfPaperReferences } from "@/lib/hf-papers";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
+import { fetchHfPaperMetadata, type HfPaperMetadata } from "@/lib/server/hf-paper-metadata";
 import {
   listSavedLinks,
   MAX_LINKS_PER_SAVE,
   removeSavedLink,
   saveResearchLinks,
 } from "@/lib/server/research-links";
+import { collectIngestUrls } from "./ingest-urls";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -41,14 +43,11 @@ export async function POST(req: Request) {
   const parsed = await readJsonBody<SaveBody>(req, MAX_BODY_BYTES);
   if (!parsed.ok) return parsed.response;
 
-  const urls: string[] = [];
-  if (Array.isArray(parsed.body.urls)) {
-    for (const raw of parsed.body.urls) {
-      if (typeof raw === "string" && raw.trim()) urls.push(raw.trim());
-    }
-  }
-  if (typeof parsed.body.text === "string" && parsed.body.text.trim()) {
-    urls.push(...extractLinks(parsed.body.text));
+  const urls = collectIngestUrls(parsed.body);
+  const enrichment = new Map<string, HfPaperMetadata | null>();
+  for (const url of urls) {
+    const [arxivId] = parseHfPaperReferences(url);
+    if (arxivId) enrichment.set(url, await fetchHfPaperMetadata(arxivId));
   }
   if (urls.length === 0) {
     return NextResponse.json(
@@ -65,7 +64,7 @@ export async function POST(req: Request) {
   const source = parsed.body.source === "desk" ? "desk" : "chat";
   let result;
   try {
-    result = await saveResearchLinks(urls, source);
+    result = await saveResearchLinks(urls, source, enrichment);
   } catch {
     return NextResponse.json(
       { ok: false, error: "failed to write the saved-links store" },

--- a/src/app/api/research/links/route.ts
+++ b/src/app/api/research/links/route.ts
@@ -44,11 +44,6 @@ export async function POST(req: Request) {
   if (!parsed.ok) return parsed.response;
 
   const urls = collectIngestUrls(parsed.body);
-  const enrichment = new Map<string, HfPaperMetadata | null>();
-  for (const url of urls) {
-    const [arxivId] = parseHfPaperReferences(url);
-    if (arxivId) enrichment.set(url, await fetchHfPaperMetadata(arxivId));
-  }
   if (urls.length === 0) {
     return NextResponse.json(
       { ok: false, error: "no links found — pass urls[] or a text block containing http(s) links" },
@@ -61,6 +56,13 @@ export async function POST(req: Request) {
       { status: 400 },
     );
   }
+  const enrichment = new Map<string, HfPaperMetadata | null>();
+  await Promise.all(
+    urls.map(async (url) => {
+      const [arxivId] = parseHfPaperReferences(url);
+      if (arxivId) enrichment.set(url, await fetchHfPaperMetadata(arxivId));
+    }),
+  );
   const source = parsed.body.source === "desk" ? "desk" : "chat";
   let result;
   try {

--- a/src/app/api/research/links/route.ts
+++ b/src/app/api/research/links/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { parseHfPaperReferences } from "@/lib/hf-papers";
+import { arxivIdFromUrl } from "@/lib/hf-papers";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
 import { fetchHfPaperMetadata, type HfPaperMetadata } from "@/lib/server/hf-paper-metadata";
 import {
@@ -59,7 +59,10 @@ export async function POST(req: Request) {
   const enrichment = new Map<string, HfPaperMetadata | null>();
   await Promise.all(
     urls.map(async (url) => {
-      const [arxivId] = parseHfPaperReferences(url);
+      // Classify the URL, never scan it: a wrapper that merely embeds a paper
+      // URL is a different page, and enriching it would title it after the
+      // paper it quotes.
+      const arxivId = arxivIdFromUrl(url);
       if (arxivId) enrichment.set(url, await fetchHfPaperMetadata(arxivId));
     }),
   );

--- a/src/app/api/research/papers/pdf/arxiv-url.ts
+++ b/src/app/api/research/papers/pdf/arxiv-url.ts
@@ -1,0 +1,11 @@
+import { isArxivPaperId } from "@/lib/hf-papers";
+
+/**
+ * The id is validated and then interpolated into a hard-coded arXiv URL. It
+ * never composes a host, a scheme or a path prefix, so there is no SSRF
+ * surface here.
+ */
+export function arxivPdfUrl(arxivId: string): string | null {
+  if (!isArxivPaperId(arxivId)) return null;
+  return `https://arxiv.org/pdf/${arxivId}`;
+}

--- a/src/app/api/research/papers/pdf/arxiv-url.ts
+++ b/src/app/api/research/papers/pdf/arxiv-url.ts
@@ -3,7 +3,8 @@ import { isArxivPaperId } from "@/lib/hf-papers";
 /**
  * The id is validated and then interpolated into a hard-coded arXiv URL. It
  * never composes a host, a scheme or a path prefix, so there is no SSRF
- * surface here.
+ * surface here. That covers the REQUEST only — the route checks where the
+ * redirect chain ends before streaming anything back (see isArxivResponse).
  */
 export function arxivPdfUrl(arxivId: string): string | null {
   if (!isArxivPaperId(arxivId)) return null;

--- a/src/app/api/research/papers/pdf/route.test.ts
+++ b/src/app/api/research/papers/pdf/route.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { arxivPdfUrl } from "./arxiv-url.ts";
+
+test("builds the arXiv URL from a valid id", () => {
+  assert.equal(arxivPdfUrl("2401.12345"), "https://arxiv.org/pdf/2401.12345");
+  assert.equal(arxivPdfUrl("2401.1234"), "https://arxiv.org/pdf/2401.1234");
+});
+
+test("refuses anything that is not an arXiv id", () => {
+  const bad = [
+    "../etc/passwd",
+    "2401.1234567",
+    "evil.com/x",
+    "",
+    "2401.12345 ",
+    "2401.12345/../../secret",
+    "https://evil.com/2401.12345",
+    "2401.12345?x=1",
+    "2401.12345#frag",
+  ];
+  for (const value of bad) {
+    assert.equal(arxivPdfUrl(value), null, `must refuse ${JSON.stringify(value)}`);
+  }
+});

--- a/src/app/api/research/papers/pdf/route.test.ts
+++ b/src/app/api/research/papers/pdf/route.test.ts
@@ -149,6 +149,24 @@ test("an unreachable upstream is a 502 and a missing paper is a 404", async () =
   }
 });
 
+// Only a real 404 means the paper does not exist. These used to collapse into
+// one, which told the reader a rate-limited or briefly-down arXiv had no such
+// paper -- permanent-sounding, and wrong a second later. The viewer maps 404
+// to "isn't available" and everything else to "check your connection, then
+// retry", so the distinction has to survive at this layer to reach them.
+for (const status of [403, 429, 500, 503]) {
+  test(`an upstream ${status} is a transient 502, not a missing paper`, async () => {
+    const stub = stubFetch(() => upstreamPdf("upstream said no", { status }));
+    try {
+      const response = await GET(request());
+      assert.equal(response.status, 502);
+      assert.equal((await response.json()).error, "upstream unavailable");
+    } finally {
+      stub.restore();
+    }
+  });
+}
+
 test("a redirect chain that leaves arXiv is refused, not proxied", async () => {
   // fetch follows up to 20 hops by default, so the safety of the composed
   // request URL says nothing about where the streamed body came from.

--- a/src/app/api/research/papers/pdf/route.test.ts
+++ b/src/app/api/research/papers/pdf/route.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { arxivPdfUrl } from "./arxiv-url.ts";
+import { GET } from "./route.ts";
 
 test("builds the arXiv URL from a valid id", () => {
   assert.equal(arxivPdfUrl("2401.12345"), "https://arxiv.org/pdf/2401.12345");
@@ -14,6 +15,8 @@ test("refuses anything that is not an arXiv id", () => {
     "2401.1234567",
     "evil.com/x",
     "",
+    // The route trims before calling, so the padded form never reaches the
+    // helper in production — but the helper itself must still refuse it.
     "2401.12345 ",
     "2401.12345/../../secret",
     "https://evil.com/2401.12345",
@@ -22,5 +25,151 @@ test("refuses anything that is not an arXiv id", () => {
   ];
   for (const value of bad) {
     assert.equal(arxivPdfUrl(value), null, `must refuse ${JSON.stringify(value)}`);
+  }
+});
+
+// ── the route itself ────────────────────────────────────────────────────────
+
+type FetchCall = { url: string; headers: Headers };
+
+/**
+ * Stub `fetch` and record what the route asked upstream for. Responses must
+ * carry a `url`: the route reads it to confirm the chain never left arXiv, and
+ * a hand-built Response defaults to the empty string.
+ */
+function stubFetch(reply: (call: FetchCall) => Response | Promise<Response>) {
+  const calls: FetchCall[] = [];
+  const real = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const call = { url: String(input), headers: new Headers(init?.headers) };
+    calls.push(call);
+    return reply(call);
+  }) as typeof fetch;
+  return { calls, restore: () => { globalThis.fetch = real; } };
+}
+
+function upstreamPdf(
+  body: string,
+  init: ResponseInit & { url?: string } = {},
+): Response {
+  const { url = "https://arxiv.org/pdf/2401.12345", ...rest } = init;
+  const response = new Response(body, rest);
+  Object.defineProperty(response, "url", { value: url });
+  return response;
+}
+
+function request(headers: Record<string, string> = {}, id = "2401.12345") {
+  return new Request(`http://localhost:3000/api/research/papers/pdf?id=${id}`, {
+    headers: { host: "localhost", ...headers },
+  });
+}
+
+test("a non-local request is refused before any upstream fetch", async () => {
+  const fetched = stubFetch(() => upstreamPdf("%PDF-"));
+  try {
+    const response = await GET(request({ host: "cave.example.com" }));
+    assert.equal(response.status, 403);
+    assert.equal(fetched.calls.length, 0, "the guard runs first");
+  } finally {
+    fetched.restore();
+  }
+});
+
+test("an invalid id is a 400, with nothing fetched", async () => {
+  const fetched = stubFetch(() => upstreamPdf("%PDF-"));
+  try {
+    for (const id of ["", "..%2Fetc%2Fpasswd", "2401.1234567"]) {
+      const response = await GET(request({}, id));
+      assert.equal(response.status, 400, `must refuse id ${JSON.stringify(id)}`);
+      assert.equal((await response.json()).error, "invalid paper id");
+    }
+    assert.equal(fetched.calls.length, 0);
+  } finally {
+    fetched.restore();
+  }
+});
+
+test("the upstream request asks for an unencoded body", async () => {
+  // fetch decompresses transparently but leaves the COMPRESSED content-length
+  // on the response, and the route forwards that header — so a gzipped upstream
+  // would truncate the document for pdf.js.
+  const fetched = stubFetch(() =>
+    upstreamPdf("%PDF-1.7", { headers: { "content-length": "8", "accept-ranges": "bytes" } }),
+  );
+  try {
+    const response = await GET(request());
+    assert.equal(response.status, 200);
+    assert.equal(fetched.calls[0].headers.get("accept-encoding"), "identity");
+    assert.equal(response.headers.get("content-type"), "application/pdf");
+    assert.equal(response.headers.get("content-length"), "8");
+    assert.equal(response.headers.get("accept-ranges"), "bytes");
+    assert.equal(await response.text(), "%PDF-1.7");
+  } finally {
+    fetched.restore();
+  }
+});
+
+test("a Range request reaches upstream and its 206 is forwarded intact", async () => {
+  const fetched = stubFetch(() =>
+    upstreamPdf("PDF", {
+      status: 206,
+      headers: { "content-range": "bytes 0-2/9001", "content-length": "3" },
+    }),
+  );
+  try {
+    const response = await GET(request({ range: "bytes=0-2" }));
+    assert.equal(fetched.calls[0].headers.get("range"), "bytes=0-2");
+    assert.equal(fetched.calls[0].headers.get("accept-encoding"), "identity");
+    assert.equal(response.status, 206, "a partial response is not an error");
+    assert.equal(response.headers.get("content-range"), "bytes 0-2/9001");
+  } finally {
+    fetched.restore();
+  }
+});
+
+test("an unreachable upstream is a 502 and a missing paper is a 404", async () => {
+  const thrown = stubFetch(() => {
+    throw new Error("ECONNREFUSED");
+  });
+  try {
+    const response = await GET(request());
+    assert.equal(response.status, 502);
+    assert.equal((await response.json()).error, "upstream unavailable");
+  } finally {
+    thrown.restore();
+  }
+
+  const missing = stubFetch(() => upstreamPdf("not found", { status: 404 }));
+  try {
+    const response = await GET(request());
+    assert.equal(response.status, 404);
+    assert.equal((await response.json()).error, "paper not found");
+  } finally {
+    missing.restore();
+  }
+});
+
+test("a redirect chain that leaves arXiv is refused, not proxied", async () => {
+  // fetch follows up to 20 hops by default, so the safety of the composed
+  // request URL says nothing about where the streamed body came from.
+  const fetched = stubFetch(() =>
+    upstreamPdf("<html>", { url: "https://evil.example.com/2401.12345" }),
+  );
+  try {
+    const response = await GET(request());
+    assert.equal(response.status, 502);
+    assert.equal((await response.json()).error, "upstream redirected away");
+  } finally {
+    fetched.restore();
+  }
+
+  const withinArxiv = stubFetch(() =>
+    upstreamPdf("%PDF-1.7", { url: "https://export.arxiv.org/pdf/2401.12345" }),
+  );
+  try {
+    const response = await GET(request());
+    assert.equal(response.status, 200, "arXiv's own hosts stay allowed");
+  } finally {
+    withinArxiv.restore();
   }
 });

--- a/src/app/api/research/papers/pdf/route.ts
+++ b/src/app/api/research/papers/pdf/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
+
+import { arxivPdfUrl } from "./arxiv-url";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+
+  const id = new URL(req.url).searchParams.get("id")?.trim() ?? "";
+  const upstream = arxivPdfUrl(id);
+  if (!upstream) {
+    return NextResponse.json({ ok: false, error: "invalid paper id" }, { status: 400 });
+  }
+
+  const range = req.headers.get("range");
+  let response: Response;
+  try {
+    response = await fetch(upstream, { headers: range ? { range } : {} });
+  } catch {
+    return NextResponse.json({ ok: false, error: "upstream unavailable" }, { status: 502 });
+  }
+  if (!response.ok && response.status !== 206) {
+    return NextResponse.json({ ok: false, error: "paper not found" }, { status: 404 });
+  }
+
+  const headers = new Headers({ "content-type": "application/pdf" });
+  for (const key of ["content-length", "content-range", "accept-ranges"]) {
+    const value = response.headers.get(key);
+    if (value) headers.set(key, value);
+  }
+  return new NextResponse(response.body, { status: response.status, headers });
+}

--- a/src/app/api/research/papers/pdf/route.ts
+++ b/src/app/api/research/papers/pdf/route.ts
@@ -49,8 +49,16 @@ export async function GET(req: Request) {
   if (!isArxivResponse(response)) {
     return NextResponse.json({ ok: false, error: "upstream redirected away" }, { status: 502 });
   }
-  if (!response.ok) {
+  // Only a real 404 is "this paper does not exist". Collapsing every non-2xx
+  // into one made a rate-limit or an arXiv outage indistinguishable from a
+  // missing paper, and the viewer's error mapping reads this status: it would
+  // have told the reader the paper "isn't available" -- which reads as
+  // permanent -- when retrying seconds later would have worked.
+  if (response.status === 404) {
     return NextResponse.json({ ok: false, error: "paper not found" }, { status: 404 });
+  }
+  if (!response.ok) {
+    return NextResponse.json({ ok: false, error: "upstream unavailable" }, { status: 502 });
   }
 
   const headers = new Headers({ "content-type": "application/pdf" });

--- a/src/app/api/research/papers/pdf/route.ts
+++ b/src/app/api/research/papers/pdf/route.ts
@@ -7,6 +7,17 @@ import { arxivPdfUrl } from "./arxiv-url";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+/** The final URL of the chain, which is the request URL when nothing redirected. */
+function isArxivResponse(response: Response): boolean {
+  let host: string;
+  try {
+    host = new URL(response.url).host;
+  } catch {
+    return false;
+  }
+  return host === "arxiv.org" || host.endsWith(".arxiv.org");
+}
+
 export async function GET(req: Request) {
   const forbidden = rejectNonLocalRequest(req);
   if (forbidden) return forbidden;
@@ -20,11 +31,25 @@ export async function GET(req: Request) {
   const range = req.headers.get("range");
   let response: Response;
   try {
-    response = await fetch(upstream, { headers: range ? { range } : {} });
+    // `accept-encoding: identity` keeps the upstream length describing exactly
+    // the bytes we forward. fetch decompresses a gzipped body transparently
+    // but leaves the COMPRESSED content-length on the response, so copying
+    // that header across would hand pdf.js a truncated document. Asking for no
+    // encoding is preferred over dropping content-length, because pdf.js reads
+    // it — with accept-ranges — to fetch page ranges instead of the whole file.
+    response = await fetch(upstream, {
+      headers: { "accept-encoding": "identity", ...(range ? { range } : {}) },
+    });
   } catch {
     return NextResponse.json({ ok: false, error: "upstream unavailable" }, { status: 502 });
   }
-  if (!response.ok && response.status !== 206) {
+  // arxivPdfUrl composes the REQUEST url safely, but nothing constrained where
+  // a redirect chain ends up, and the body is streamed back as
+  // application/pdf. Refuse a response that left arXiv rather than proxying it.
+  if (!isArxivResponse(response)) {
+    return NextResponse.json({ ok: false, error: "upstream redirected away" }, { status: 502 });
+  }
+  if (!response.ok) {
     return NextResponse.json({ ok: false, error: "paper not found" }, { status: 404 });
   }
 

--- a/src/components/research-paper-viewer.tsx
+++ b/src/components/research-paper-viewer.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+/**
+ * Paper viewer — renders an arXiv PDF inside the resources detail overlay
+ * (cave-cbz28).
+ *
+ * pdf.js is browser-only: importing it under Node dies on `DOMMatrix`. So the
+ * library is pulled in with a dynamic `import()` from inside an effect, and the
+ * component itself is mounted through `next/dynamic` with `ssr: false` by its
+ * one caller. That also keeps ~1 MB of PDF machinery out of the main bundle for
+ * everyone who never opens a paper.
+ *
+ * Each page is drawn to a `<canvas>` and then the pdf.js `TextLayer` is built
+ * over it, so the document is selectable and findable rather than merely
+ * displayed — a picture of a paper is not a paper you can quote from.
+ *
+ * State lives in `reducePaperView` (src/lib/research-paper-view.ts), which
+ * ignores `ready`/`fail` unless it is still `loading`. Combined with the
+ * `cancelled` flag below, a render that resolves after the overlay closed — or
+ * after the reader flipped past the page — cannot revive a dead viewer or paint
+ * a stale page onto the canvas.
+ */
+
+import { useEffect, useReducer, useRef, useState } from "react";
+import type {
+  PDFDocumentLoadingTask,
+  PDFDocumentProxy,
+  RenderTask,
+  TextLayer,
+} from "pdfjs-dist";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/lib/icon";
+import {
+  initialPaperViewState,
+  paperPdfUrl,
+  reducePaperView,
+} from "@/lib/research-paper-view";
+
+export type ResearchPaperViewerProps = {
+  arxivId: string;
+  authors: string[];
+  abstract: string;
+  publishedAt: string;
+};
+
+/** Zoom stops, not a free slider — every step lands on a legible size. */
+const ZOOM_STEPS = [0.75, 1, 1.25, 1.5, 2] as const;
+const DEFAULT_ZOOM_INDEX = 1;
+
+/** Cap the backing-store multiplier: a 3× retina page at 2× zoom is enormous. */
+const MAX_OUTPUT_SCALE = 2;
+
+function formatPublished(iso: string): string {
+  if (!iso) return "";
+  const at = new Date(iso);
+  if (Number.isNaN(at.getTime())) return iso;
+  return at.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function ResearchPaperViewer({
+  arxivId,
+  authors,
+  abstract,
+  publishedAt,
+}: ResearchPaperViewerProps) {
+  const [state, dispatch] = useReducer(reducePaperView, initialPaperViewState);
+  const [page, setPage] = useState(1);
+  const [zoomIndex, setZoomIndex] = useState<number>(DEFAULT_ZOOM_INDEX);
+  const [attempt, setAttempt] = useState(0);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const textLayerRef = useRef<HTMLDivElement | null>(null);
+
+  const scale = ZOOM_STEPS[zoomIndex] ?? 1;
+  const ready = state.status === "ready";
+  const published = formatPublished(publishedAt);
+
+  // A different paper in the same overlay slot starts at its own first page.
+  useEffect(() => {
+    setPage(1);
+    setZoomIndex(DEFAULT_ZOOM_INDEX);
+  }, [arxivId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    // pdf.js 6 moved teardown off the document proxy: `destroy()` lives on the
+    // loading task, and destroying that is what tears down the document and its
+    // worker. So the task has to be kept, not just its promise.
+    let loadingTask: PDFDocumentLoadingTask | null = null;
+    let doc: PDFDocumentProxy | null = null;
+    let renderTask: RenderTask | null = null;
+    let textLayer: TextLayer | null = null;
+
+    dispatch({ type: "load" });
+
+    void (async () => {
+      try {
+        const pdfjs = await import("pdfjs-dist");
+        if (cancelled) return;
+        // Staged into public/ by postinstall — same origin, so no CDN and no
+        // cross-origin worker bootstrap.
+        pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
+
+        // v6 typings no longer accept a bare URL string here.
+        loadingTask = pdfjs.getDocument({ url: paperPdfUrl(arxivId) });
+        doc = await loadingTask.promise;
+        if (cancelled) return;
+        dispatch({ type: "ready", pageCount: doc.numPages });
+
+        const target = Math.min(Math.max(page, 1), doc.numPages);
+        const pdfPage = await doc.getPage(target);
+        if (cancelled) return;
+
+        const canvas = canvasRef.current;
+        const container = textLayerRef.current;
+        if (!canvas || !container) return;
+
+        const viewport = pdfPage.getViewport({ scale });
+        const output = Math.min(
+          typeof window === "undefined" ? 1 : window.devicePixelRatio || 1,
+          MAX_OUTPUT_SCALE,
+        );
+        const cssWidth = Math.floor(viewport.width);
+        const cssHeight = Math.floor(viewport.height);
+
+        canvas.width = Math.floor(viewport.width * output);
+        canvas.height = Math.floor(viewport.height * output);
+        canvas.style.width = `${cssWidth}px`;
+        canvas.style.height = `${cssHeight}px`;
+
+        renderTask = pdfPage.render({
+          canvas,
+          viewport,
+          transform: output === 1 ? undefined : [output, 0, 0, output, 0, 0],
+        });
+        await renderTask.promise;
+        if (cancelled) return;
+
+        // The text layer positions its spans in percentages scaled by
+        // --total-scale-factor, so the container has to carry both the factor
+        // and the page's CSS box.
+        container.replaceChildren();
+        container.style.setProperty("--total-scale-factor", String(scale));
+        container.style.width = `${cssWidth}px`;
+        container.style.height = `${cssHeight}px`;
+
+        textLayer = new pdfjs.TextLayer({
+          textContentSource: pdfPage.streamTextContent(),
+          container,
+          viewport,
+        });
+        await textLayer.render();
+      } catch (error) {
+        // A cancelled render rejects too; that is this effect tearing itself
+        // down, not a failure the reader needs to see.
+        if (cancelled) return;
+        dispatch({
+          type: "fail",
+          message:
+            error instanceof Error && error.message
+              ? error.message
+              : "Couldn’t render this paper.",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      dispatch({ type: "cancel" });
+      renderTask?.cancel();
+      textLayer?.cancel();
+      void loadingTask?.destroy();
+    };
+  }, [arxivId, page, scale, attempt]);
+
+  return (
+    <section className="research-paper-view" aria-label="Paper">
+      {authors.length > 0 || published ? (
+        <div className="research-paper-view__byline">
+          {authors.length > 0 ? (
+            <span className="research-paper-view__authors">{authors.join(", ")}</span>
+          ) : null}
+          {published ? (
+            <span className="research-paper-view__published">{published}</span>
+          ) : null}
+        </div>
+      ) : null}
+
+      {abstract ? (
+        <div className="research-paper-view__abstract">
+          <div className="research-paper-view__label">
+            <i aria-hidden />
+            <span>Abstract</span>
+          </div>
+          <p>{abstract}</p>
+        </div>
+      ) : null}
+
+      <div className="research-paper-view__toolbar">
+        <div className="research-paper-view__group">
+          <Button
+            size="xs"
+            variant="ghost"
+            leadingIcon="ph:caret-left"
+            disabled={!ready || page <= 1}
+            onClick={() => setPage((current) => Math.max(1, current - 1))}
+          >
+            Prev
+          </Button>
+          <span className="research-paper-view__readout">
+            {ready ? `Page ${page} of ${state.pageCount}` : `Page ${page}`}
+          </span>
+          <Button
+            size="xs"
+            variant="ghost"
+            trailingIcon="ph:caret-right"
+            disabled={!ready || page >= state.pageCount}
+            onClick={() =>
+              setPage((current) => Math.min(state.pageCount, current + 1))
+            }
+          >
+            Next
+          </Button>
+        </div>
+        <div className="research-paper-view__group">
+          <Button
+            size="xs"
+            variant="ghost"
+            leadingIcon="ph:minus"
+            aria-label="Zoom out"
+            disabled={zoomIndex <= 0}
+            onClick={() => setZoomIndex((current) => Math.max(0, current - 1))}
+          />
+          <span className="research-paper-view__readout">
+            {Math.round(scale * 100)}%
+          </span>
+          <Button
+            size="xs"
+            variant="ghost"
+            leadingIcon="ph:plus"
+            aria-label="Zoom in"
+            disabled={zoomIndex >= ZOOM_STEPS.length - 1}
+            onClick={() =>
+              setZoomIndex((current) => Math.min(ZOOM_STEPS.length - 1, current + 1))
+            }
+          />
+        </div>
+      </div>
+
+      <div className="research-paper-view__stage" data-status={state.status}>
+        <div className="research-paper-view__page">
+          <canvas ref={canvasRef} className="research-paper-view__canvas" />
+          <div ref={textLayerRef} className="research-paper-view__text" />
+        </div>
+
+        {state.status === "loading" ? (
+          <p className="research-paper-view__status" role="status">
+            Rendering page {page}…
+          </p>
+        ) : null}
+
+        {state.status === "error" ? (
+          <div className="research-paper-view__error" role="alert">
+            <Icon name="ph:warning" width={13} height={13} aria-hidden />
+            <span>{state.error ?? "Couldn’t render this paper."}</span>
+            <Button
+              size="xs"
+              variant="secondary"
+              leadingIcon="ph:arrow-clockwise"
+              onClick={() => setAttempt((current) => current + 1)}
+            >
+              Retry
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/research-paper-viewer.tsx
+++ b/src/components/research-paper-viewer.tsx
@@ -7,18 +7,32 @@
  * pdf.js is browser-only: importing it under Node dies on `DOMMatrix`. So the
  * library is pulled in with a dynamic `import()` from inside an effect, and the
  * component itself is mounted through `next/dynamic` with `ssr: false` by its
- * one caller. That also keeps ~1 MB of PDF machinery out of the main bundle for
- * everyone who never opens a paper.
+ * one caller — behind an explicit "Read" affordance, so neither the ~1 MB of
+ * PDF machinery nor the multi-megabyte document is fetched for a reader who
+ * only opened the resource to look at its citations.
  *
  * Each page is drawn to a `<canvas>` and then the pdf.js `TextLayer` is built
  * over it, so the document is selectable and findable rather than merely
  * displayed — a picture of a paper is not a paper you can quote from.
  *
- * State lives in `reducePaperView` (src/lib/research-paper-view.ts), which
- * ignores `ready`/`fail` unless it is still `loading`. Combined with the
- * `cancelled` flag below, a render that resolves after the overlay closed — or
- * after the reader flipped past the page — cannot revive a dead viewer or paint
- * a stale page onto the canvas.
+ * ── Two effects, deliberately ──────────────────────────────────────────────
+ * The document effect owns `getDocument` / `destroy` and is keyed on the paper
+ * alone; the render effect owns `getPage` / `render` / `TextLayer` and is keyed
+ * on the open document plus the page and zoom. They were one effect keyed on
+ * all four, which meant every page flip and every zoom click tore down the
+ * worker and re-downloaded the whole PDF — ten pages of a 15 MB paper was
+ * ~150 MB over the wire, and the proxy route (`force-dynamic`, no
+ * `cache-control`/`etag`) gives the browser cache nothing to answer with.
+ *
+ * Splitting them is also what lets `pageCount` survive a page turn: only the
+ * document effect's cleanup dispatches `cancel`, so flipping pages no longer
+ * resets the reducer to `idle` and blanks "Page 3 of 14" down to "Page 3" with
+ * both Prev and Next disabled.
+ *
+ * State lives in `reducePaperView` (src/lib/research-paper-view.ts). It refuses
+ * `ready`/`fail` from `idle` — the status only `cancel` produces — so a
+ * resolution arriving after teardown cannot revive a dead viewer, while a
+ * genuine failure after the document opened still reaches the reader.
  */
 
 import { useEffect, useReducer, useRef, useState } from "react";
@@ -32,7 +46,9 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/lib/icon";
 import {
   initialPaperViewState,
+  isPaperViewCancellation,
   paperPdfUrl,
+  paperViewErrorMessage,
   reducePaperView,
 } from "@/lib/research-paper-view";
 
@@ -49,6 +65,20 @@ const DEFAULT_ZOOM_INDEX = 1;
 
 /** Cap the backing-store multiplier: a 3× retina page at 2× zoom is enormous. */
 const MAX_OUTPUT_SCALE = 2;
+
+/**
+ * An open document plus the flag its owning effect clears on teardown.
+ *
+ * `destroy()` on the loading task kills the worker, so a `getPage` or `render`
+ * still in flight rejects. The render effect's own `cancelled` flag does not
+ * cover that: React tears the document effect down first and only re-runs the
+ * render effect on the *following* commit, once `opened` has changed. Without
+ * this the reader would see a teardown rejection dressed up as a failure.
+ */
+type OpenDocument = {
+  doc: PDFDocumentProxy;
+  live: { current: boolean };
+};
 
 function formatPublished(iso: string): string {
   if (!iso) return "";
@@ -68,6 +98,8 @@ export default function ResearchPaperViewer({
   publishedAt,
 }: ResearchPaperViewerProps) {
   const [state, dispatch] = useReducer(reducePaperView, initialPaperViewState);
+  const [opened, setOpened] = useState<OpenDocument | null>(null);
+  const [painted, setPainted] = useState<string | null>(null);
   const [page, setPage] = useState(1);
   const [zoomIndex, setZoomIndex] = useState<number>(DEFAULT_ZOOM_INDEX);
   const [attempt, setAttempt] = useState(0);
@@ -77,22 +109,34 @@ export default function ResearchPaperViewer({
   const scale = ZOOM_STEPS[zoomIndex] ?? 1;
   const ready = state.status === "ready";
   const published = formatPublished(publishedAt);
+  /**
+   * What is actually on the canvas. Comparing it against what is asked for is
+   * a truer "pending" than a flag the render effect raises, because it is true
+   * from the instant the reader clicks — before the effect has run — and it
+   * never reports a page as drawn that a superseded run painted.
+   */
+  const renderKey = `${page}@${scale}`;
+  const pending = state.status === "loading" || (ready && painted !== renderKey);
 
   // A different paper in the same overlay slot starts at its own first page.
+  // Defensive only: the overlay always passes through `openLink === null`
+  // between two resources, so this component unmounts rather than being
+  // handed a new `arxivId` in place. Left as a reset so the invariant holds
+  // if that ever changes; the one aborted fetch it could cost has no
+  // observable symptom.
   useEffect(() => {
     setPage(1);
     setZoomIndex(DEFAULT_ZOOM_INDEX);
   }, [arxivId]);
 
+  // ── Document: fetch and parse once per paper (and once per retry). ──
   useEffect(() => {
     let cancelled = false;
     // pdf.js 6 moved teardown off the document proxy: `destroy()` lives on the
     // loading task, and destroying that is what tears down the document and its
     // worker. So the task has to be kept, not just its promise.
     let loadingTask: PDFDocumentLoadingTask | null = null;
-    let doc: PDFDocumentProxy | null = null;
-    let renderTask: RenderTask | null = null;
-    let textLayer: TextLayer | null = null;
+    const live = { current: true };
 
     dispatch({ type: "load" });
 
@@ -106,17 +150,77 @@ export default function ResearchPaperViewer({
 
         // v6 typings no longer accept a bare URL string here.
         loadingTask = pdfjs.getDocument({ url: paperPdfUrl(arxivId) });
-        doc = await loadingTask.promise;
+        const doc = await loadingTask.promise;
         if (cancelled) return;
+        setOpened({ doc, live });
         dispatch({ type: "ready", pageCount: doc.numPages });
+      } catch (error) {
+        if (cancelled || isPaperViewCancellation(error)) return;
+        dispatch({ type: "fail", message: paperViewErrorMessage(error) });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      live.current = false;
+      dispatch({ type: "cancel" });
+      setOpened(null);
+      setPainted(null);
+      // A discarded promise turns a teardown rejection into an unhandled one.
+      loadingTask?.destroy().catch(() => {});
+    };
+  }, [arxivId, attempt]);
+
+  // ── Render: one page of the already-open document, at the current zoom. ──
+  useEffect(() => {
+    if (!opened) return;
+    const { doc, live } = opened;
+    let cancelled = false;
+    let renderTask: RenderTask | null = null;
+    let textLayer: TextLayer | null = null;
+    /** Either this run was superseded, or the document under it is gone. */
+    const stale = () => cancelled || !live.current;
+
+    void (async () => {
+      try {
+        // Module-cached by the document effect; this is a map lookup, not a
+        // second download.
+        const pdfjs = await import("pdfjs-dist");
+        if (stale()) return;
 
         const target = Math.min(Math.max(page, 1), doc.numPages);
-        const pdfPage = await doc.getPage(target);
-        if (cancelled) return;
+        if (target !== page) {
+          // The reader's page outlived the document it belonged to — a retry
+          // that reopened a shorter file. Correct the state rather than paint
+          // one page while the readout names another; the effect re-runs.
+          setPage(target);
+          return;
+        }
 
         const canvas = canvasRef.current;
         const container = textLayerRef.current;
-        if (!canvas || !container) return;
+        if (!canvas || !container) {
+          // Returning bare here left the same silent blank as a swallowed
+          // failure: a `ready` viewer with nothing painted and no way out.
+          dispatch({
+            type: "fail",
+            message: "Couldn’t draw this page. Close the paper and open it again.",
+          });
+          return;
+        }
+
+        // Drop the old spans before ANY of the page work, not after the render
+        // lands. Held to the end, the previous page's text stayed selectable
+        // and findable for the whole load of the next one — under a canvas
+        // already dimmed to say "pending" — so a search hit could belong to a
+        // page no longer on screen. Clearing here also covers the error paths
+        // below (`getPage` on a malformed page object, a font that will not
+        // load): an error banner over an empty text layer is honest, an error
+        // banner over the last page's words is not.
+        container.replaceChildren();
+
+        const pdfPage = await doc.getPage(target);
+        if (stale()) return;
 
         const viewport = pdfPage.getViewport({ scale });
         const output = Math.min(
@@ -137,12 +241,11 @@ export default function ResearchPaperViewer({
           transform: output === 1 ? undefined : [output, 0, 0, output, 0, 0],
         });
         await renderTask.promise;
-        if (cancelled) return;
+        if (stale()) return;
 
         // The text layer positions its spans in percentages scaled by
         // --total-scale-factor, so the container has to carry both the factor
         // and the page's CSS box.
-        container.replaceChildren();
         container.style.setProperty("--total-scale-factor", String(scale));
         container.style.width = `${cssWidth}px`;
         container.style.height = `${cssHeight}px`;
@@ -153,28 +256,25 @@ export default function ResearchPaperViewer({
           viewport,
         });
         await textLayer.render();
+        if (stale()) return;
+        setPainted(`${page}@${scale}`);
       } catch (error) {
         // A cancelled render rejects too; that is this effect tearing itself
         // down, not a failure the reader needs to see.
-        if (cancelled) return;
-        dispatch({
-          type: "fail",
-          message:
-            error instanceof Error && error.message
-              ? error.message
-              : "Couldn’t render this paper.",
-        });
+        if (stale() || isPaperViewCancellation(error)) return;
+        dispatch({ type: "fail", message: paperViewErrorMessage(error) });
       }
     })();
 
+    // No `cancel` dispatch here — that belongs to the document effect. Firing
+    // it on every page turn is what used to reset `pageCount` to 0 mid-flip,
+    // disabling Prev and Next and dropping "Page 3 of 14" to bare "Page 3".
     return () => {
       cancelled = true;
-      dispatch({ type: "cancel" });
       renderTask?.cancel();
       textLayer?.cancel();
-      void loadingTask?.destroy();
     };
-  }, [arxivId, page, scale, attempt]);
+  }, [opened, page, scale]);
 
   return (
     <section className="research-paper-view" aria-label="Paper">
@@ -250,13 +350,17 @@ export default function ResearchPaperViewer({
         </div>
       </div>
 
-      <div className="research-paper-view__stage" data-status={state.status}>
+      <div
+        className="research-paper-view__stage"
+        data-status={state.status}
+        data-pending={pending || undefined}
+      >
         <div className="research-paper-view__page">
           <canvas ref={canvasRef} className="research-paper-view__canvas" />
           <div ref={textLayerRef} className="research-paper-view__text" />
         </div>
 
-        {state.status === "loading" ? (
+        {pending ? (
           <p className="research-paper-view__status" role="status">
             Rendering page {page}…
           </p>

--- a/src/components/role-surfaces/research-tab-resources.test.ts
+++ b/src/components/role-surfaces/research-tab-resources.test.ts
@@ -78,8 +78,13 @@ test("remove is a two-step inline confirm wired to useResearchLinks.remove", () 
   assert.match(source, />\s*Keep\s*<\/Button>/);
   assert.match(source, /setConfirmingRemove\(true\)/);
   assert.match(source, /await remove\(openLink\.id\)/);
-  // Opening a different resource never inherits a pending confirm.
-  assert.match(source, /setConfirmingRemove\(false\);\s*setCopied\(false\);\s*\}, \[openId\]\)/);
+  // Opening a different resource never inherits a pending confirm — nor an
+  // already-expanded paper viewer, which would otherwise show paper A's
+  // document under paper B's title and start its fetch unasked.
+  assert.match(
+    source,
+    /setConfirmingRemove\(false\);\s*setCopied\(false\);\s*setReading\(false\);\s*\}, \[openId\]\)/,
+  );
 });
 
 test("grid/rows view persists under cave:research:res-view with an SSR guard", () => {

--- a/src/components/role-surfaces/research-tab-resources.tsx
+++ b/src/components/role-surfaces/research-tab-resources.tsx
@@ -14,6 +14,7 @@
  * (`attach-source` action) so triage semantics stay identical.
  */
 
+import dynamic from "next/dynamic";
 import {
   useCallback,
   useEffect,
@@ -44,6 +45,13 @@ import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { ResearchTabProps } from "./researcher-surface";
 import { ResearchXSources } from "./research-x-sources";
 import { useResearchLinks } from "./use-research-links";
+
+// pdf.js is browser-only (it dies on `DOMMatrix` under Node), so the paper
+// viewer never renders on the server. The dynamic boundary also keeps the PDF
+// machinery out of the bundle for anyone who never opens a paper.
+const ResearchPaperViewer = dynamic(() => import("@/components/research-paper-viewer"), {
+  ssr: false,
+});
 
 const VIEW_STORAGE_KEY = "cave:research:res-view";
 
@@ -605,6 +613,19 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
             </div>
 
             <div className="research-res-overlay__body">
+              {/* Papers ingested with arXiv metadata read in place. A link
+                  saved before the feature — or one whose metadata fetch
+                  degraded — carries no arxivId and keeps exactly the contents
+                  it has always had. */}
+              {openLink.paper?.arxivId ? (
+                <ResearchPaperViewer
+                  arxivId={openLink.paper.arxivId}
+                  authors={openLink.paper.authors}
+                  abstract={openLink.paper.abstract}
+                  publishedAt={openLink.paper.publishedAt}
+                />
+              ) : null}
+
               {/* Stats strip: only fields the store really holds or facts we
                   can derive — none of the design's invented metrics. */}
               <div className="research-res-overlay__stats">

--- a/src/components/role-surfaces/research-tab-resources.tsx
+++ b/src/components/role-surfaces/research-tab-resources.tsx
@@ -30,6 +30,7 @@ import { RelativeTime } from "@/components/ui/relative-time";
 import { SearchInput } from "@/components/ui/search-input";
 import { copyText } from "@/lib/clipboard";
 import { Icon } from "@/lib/icon";
+import { paperArxivUrl, paperDownloadUrl } from "@/lib/research-paper-view";
 import {
   groupSavedLinksByUsage,
   linkCategoryMeta,
@@ -86,6 +87,11 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<string | null>(null);
   const [openId, setOpenId] = useState<string | null>(null);
+  // The paper viewer is opt-in: mounting it pulls the pdfjs-dist chunk and
+  // starts a multi-megabyte document fetch, and the overlay's cited-by content
+  // sits below a 60vh PDF stage. Someone who opened the resource to read that
+  // should not pay for the reader they never asked for.
+  const [reading, setReading] = useState(false);
   const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [copied, setCopied] = useState(false);
   const [attachBusy, setAttachBusy] = useState(false);
@@ -265,10 +271,13 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
   const closeOverlay = useCallback(() => setOpenId(null), []);
   useFocusTrap(Boolean(openLink), dialogRef, { onEscape: closeOverlay });
 
-  // A fresh overlay never inherits the previous one's confirm/copied state.
+  // A fresh overlay never inherits the previous one's confirm/copied/reading
+  // state — closing the overlay or opening a different resource both land
+  // here, so paper B never opens with paper A's viewer already expanded.
   useEffect(() => {
     setConfirmingRemove(false);
     setCopied(false);
+    setReading(false);
   }, [openId]);
 
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -305,6 +314,7 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
   };
 
   const openCited = openLink ? citingMissions(openLink) : [];
+  const openPaperId = openLink?.paper?.arxivId ?? null;
 
   return (
     <section className="research-res" aria-label="Research resources">
@@ -618,12 +628,31 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
                   degraded — carries no arxivId and keeps exactly the contents
                   it has always had. */}
               {openLink.paper?.arxivId ? (
-                <ResearchPaperViewer
-                  arxivId={openLink.paper.arxivId}
-                  authors={openLink.paper.authors}
-                  abstract={openLink.paper.abstract}
-                  publishedAt={openLink.paper.publishedAt}
-                />
+                reading ? (
+                  <ResearchPaperViewer
+                    arxivId={openLink.paper.arxivId}
+                    authors={openLink.paper.authors}
+                    abstract={openLink.paper.abstract}
+                    publishedAt={openLink.paper.publishedAt}
+                  />
+                ) : (
+                  <div className="research-res-overlay__read">
+                    <div className="research-res-overlay__read-copy">
+                      <strong>Read this paper here</strong>
+                      <span>
+                        Opens the full PDF inline — selectable and searchable, page by page.
+                      </span>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      leadingIcon="ph:book-open"
+                      onClick={() => setReading(true)}
+                    >
+                      Read
+                    </Button>
+                  </div>
+                )
               ) : null}
 
               {/* Stats strip: only fields the store really holds or facts we
@@ -696,6 +725,33 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
                   <span className="research-res-overlay__hint">
                     Select a run to add this resource.
                   </span>
+                ) : null}
+                {/* An ingested paper's saved URL IS its Hugging Face page —
+                    `collectIngestUrls` canonicalises every reference to
+                    huggingface.co/papers/<id> — so "Open link" already covers
+                    the HF half of the spec's link-out set. These two add the
+                    other half: the arXiv record, and the PDF itself for
+                    saving. Both point at arxiv.org rather than the loopback
+                    proxy, which means nothing once the URL leaves the app. */}
+                {openPaperId ? (
+                  <>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      trailingIcon="ph:arrow-square-out"
+                      onClick={() => context.openUrl(paperArxivUrl(openPaperId))}
+                    >
+                      arXiv
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      leadingIcon="ph:download-simple"
+                      onClick={() => context.openUrl(paperDownloadUrl(openPaperId))}
+                    >
+                      Download PDF
+                    </Button>
+                  </>
                 ) : null}
                 <Button
                   size="sm"

--- a/src/lib/hf-papers.test.ts
+++ b/src/lib/hf-papers.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { hfPaperUrl, isArxivPaperId, parseHfPaperReferences } from "./hf-papers.ts";
+
+test("recognises both command spellings", () => {
+  assert.deepEqual(parseHfPaperReferences("hf papers read 2401.12345"), ["2401.12345"]);
+  assert.deepEqual(parseHfPaperReferences("hf paper read 2401.12345"), ["2401.12345"]);
+});
+
+test("strips a version suffix to the canonical id", () => {
+  assert.deepEqual(parseHfPaperReferences("hf papers read 2401.12345v2"), ["2401.12345"]);
+});
+
+test("recognises HF and arXiv URLs", () => {
+  assert.deepEqual(parseHfPaperReferences("https://huggingface.co/papers/2401.12345"), ["2401.12345"]);
+  assert.deepEqual(parseHfPaperReferences("https://arxiv.org/abs/2401.12345"), ["2401.12345"]);
+  assert.deepEqual(parseHfPaperReferences("https://arxiv.org/pdf/2401.12345"), ["2401.12345"]);
+});
+
+test("collapses every spelling of one paper to a single id", () => {
+  const text = [
+    "hf papers read 2401.12345",
+    "https://huggingface.co/papers/2401.12345",
+    "https://arxiv.org/pdf/2401.12345v3",
+  ].join("\n");
+  assert.deepEqual(parseHfPaperReferences(text), ["2401.12345"]);
+});
+
+test("does NOT match a bare id with no command or URL", () => {
+  assert.deepEqual(parseHfPaperReferences("the figure on 2401.12345 is wrong"), []);
+});
+
+test("does NOT match an over-long number", () => {
+  assert.deepEqual(parseHfPaperReferences("hf papers read 2401.1234567"), []);
+});
+
+test("canonical URL and id guard", () => {
+  assert.equal(hfPaperUrl("2401.12345"), "https://huggingface.co/papers/2401.12345");
+  assert.equal(isArxivPaperId("2401.12345"), true);
+  assert.equal(isArxivPaperId("2401.1234567"), false);
+  assert.equal(isArxivPaperId("../etc/passwd"), false);
+});

--- a/src/lib/hf-papers.test.ts
+++ b/src/lib/hf-papers.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { hfPaperUrl, isArxivPaperId, parseHfPaperReferences } from "./hf-papers.ts";
+import { arxivIdFromUrl, hfPaperUrl, isArxivPaperId, parseHfPaperReferences } from "./hf-papers.ts";
 
 test("recognises both command spellings", () => {
   assert.deepEqual(parseHfPaperReferences("hf papers read 2401.12345"), ["2401.12345"]);
@@ -33,6 +33,54 @@ test("does NOT match a bare id with no command or URL", () => {
 
 test("does NOT match an over-long number", () => {
   assert.deepEqual(parseHfPaperReferences("hf papers read 2401.1234567"), []);
+});
+
+// ── arxivIdFromUrl: the classifier, for values that already ARE URLs ─────────
+
+test("classifies the canonical paper URLs, version suffix and all", () => {
+  assert.equal(arxivIdFromUrl("https://huggingface.co/papers/2401.12345"), "2401.12345");
+  assert.equal(arxivIdFromUrl("https://www.huggingface.co/papers/2401.12345"), "2401.12345");
+  assert.equal(arxivIdFromUrl("https://arxiv.org/abs/2401.12345"), "2401.12345");
+  assert.equal(arxivIdFromUrl("http://arxiv.org/abs/2401.12345v2"), "2401.12345");
+  assert.equal(arxivIdFromUrl("https://arxiv.org/pdf/2401.12345.pdf"), "2401.12345");
+  assert.equal(arxivIdFromUrl("  https://arxiv.org/pdf/2401.1234  "), "2401.1234");
+});
+
+test("a URL that merely EMBEDS a paper URL is not that paper", () => {
+  // The whole reason this exists next to the free-text scanner: these are
+  // ordinary pastes, and the scanner matches every one of them.
+  const wrappers = [
+    "https://www.google.com/url?q=https://arxiv.org/abs/2401.12345",
+    "https://r.jina.ai/https://arxiv.org/abs/2401.12345",
+    "https://web.archive.org/web/2024/https://arxiv.org/abs/2401.12345",
+    "https://example.com/notes#https://huggingface.co/papers/2401.12345",
+  ];
+  for (const url of wrappers) {
+    assert.equal(arxivIdFromUrl(url), null, `must refuse ${url}`);
+    assert.deepEqual(
+      parseHfPaperReferences(url),
+      ["2401.12345"],
+      "the free-text scanner still matches — that is why the classifier exists",
+    );
+  }
+});
+
+test("refuses look-alike hosts, wrong paths, and unparseable input", () => {
+  const bad = [
+    "https://arxiv.org.evil.com/abs/2401.12345",
+    "https://evil.com/arxiv.org/abs/2401.12345",
+    "https://huggingface.co.evil.com/papers/2401.12345",
+    "https://huggingface.co/spaces/2401.12345",
+    "https://arxiv.org/abs/2401.12345/../../secret",
+    "https://arxiv.org/abs/2401.1234567",
+    "ftp://arxiv.org/abs/2401.12345",
+    "arxiv.org/abs/2401.12345",
+    "not a url",
+    "",
+  ];
+  for (const url of bad) {
+    assert.equal(arxivIdFromUrl(url), null, `must refuse ${JSON.stringify(url)}`);
+  }
 });
 
 test("canonical URL and id guard", () => {

--- a/src/lib/hf-papers.ts
+++ b/src/lib/hf-papers.ts
@@ -1,0 +1,37 @@
+/**
+ * Recognise Hugging Face paper references in free text.
+ *
+ * A bare `2401.12345` is deliberately NOT matched: pasted prose is full of
+ * decimal numbers and version strings, and manufacturing resources from them
+ * is worse than missing one. The `hf papers read` command or a URL is the
+ * signal that the number is a paper.
+ */
+
+/** arXiv ids are `YYMM.NNNNN`, optionally with a `vN` revision suffix. */
+const ARXIV_ID = String.raw`(\d{4}\.\d{4,5})(?:v\d+)?`;
+
+const PATTERNS = [
+  new RegExp(String.raw`\bhf\s+papers?\s+read\s+${ARXIV_ID}\b`, "gi"),
+  new RegExp(String.raw`https?://(?:www\.)?huggingface\.co/papers/${ARXIV_ID}\b`, "gi"),
+  new RegExp(String.raw`https?://(?:www\.)?arxiv\.org/(?:abs|pdf)/${ARXIV_ID}(?:\.pdf)?\b`, "gi"),
+];
+
+/** Canonical ids, deduped, in first-seen order. The `vN` suffix is dropped. */
+export function parseHfPaperReferences(text: string): string[] {
+  if (!text) return [];
+  const seen = new Set<string>();
+  for (const pattern of PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) seen.add(match[1]);
+  }
+  return [...seen];
+}
+
+export function hfPaperUrl(arxivId: string): string {
+  return `https://huggingface.co/papers/${arxivId}`;
+}
+
+/** Guard for anything that interpolates an id into a URL or a path. */
+export function isArxivPaperId(value: string): boolean {
+  return /^\d{4}\.\d{4,5}$/.test(value);
+}

--- a/src/lib/hf-papers.ts
+++ b/src/lib/hf-papers.ts
@@ -27,6 +27,40 @@ export function parseHfPaperReferences(text: string): string[] {
   return [...seen];
 }
 
+const HF_HOSTS = new Set(["huggingface.co", "www.huggingface.co"]);
+const ARXIV_HOSTS = new Set(["arxiv.org", "www.arxiv.org"]);
+const HF_PAPER_PATH = new RegExp(String.raw`^/papers/${ARXIV_ID}$`);
+const ARXIV_PAPER_PATH = new RegExp(String.raw`^/(?:abs|pdf)/${ARXIV_ID}(?:\.pdf)?$`);
+
+/**
+ * Classify a value that ALREADY IS a URL — the counterpart to the scanner
+ * above, for entries that arrive through `urls[]` rather than inside prose.
+ *
+ * The scanner finds a reference ANYWHERE in a blob, which is right for text
+ * and wrong for a URL: `google.com/url?q=https://arxiv.org/abs/<id>` or
+ * `r.jina.ai/https://arxiv.org/abs/<id>` merely embeds a paper URL, and
+ * treating the wrapper as the paper stamps a foreign title and a `paper` block
+ * onto somebody else's page. So this matches on the PARSED host and pathname,
+ * and returns null for everything else, unparseable input included.
+ */
+export function arxivIdFromUrl(value: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+  // `host`, not `hostname`: a non-default port is not one of these sites.
+  const pattern = HF_HOSTS.has(url.host)
+    ? HF_PAPER_PATH
+    : ARXIV_HOSTS.has(url.host)
+      ? ARXIV_PAPER_PATH
+      : null;
+  const id = pattern?.exec(url.pathname)?.[1];
+  return id && isArxivPaperId(id) ? id : null;
+}
+
 export function hfPaperUrl(arxivId: string): string {
   return `https://huggingface.co/papers/${arxivId}`;
 }

--- a/src/lib/link-organizer.test.ts
+++ b/src/lib/link-organizer.test.ts
@@ -261,3 +261,12 @@ test("unknown categories degrade to Other instead of crashing a surface", () => 
     assert.doesNotMatch(source, /LINK_CATEGORY_META\[/);
   }
 });
+
+test("huggingface.co/papers is a paper, other HF paths are not", () => {
+  assert.equal(categorizeLink("https://huggingface.co/papers/2401.12345"), "paper");
+  assert.equal(categorizeLink("https://huggingface.co/papers"), "paper");
+  assert.equal(categorizeLink("https://huggingface.co/papers/"), "paper");
+  assert.notEqual(categorizeLink("https://huggingface.co/models/meta-llama/Llama-3"), "paper");
+  assert.notEqual(categorizeLink("https://huggingface.co/datasets/squad"), "paper");
+  assert.notEqual(categorizeLink("https://huggingface.co/blog/some-post"), "paper");
+});

--- a/src/lib/link-organizer.ts
+++ b/src/lib/link-organizer.ts
@@ -51,6 +51,13 @@ export type SavedLink = {
   addedAt: string;
   /** Where the save originated. */
   source: "chat" | "desk";
+  /** Present only for papers resolved through hf-papers ingest. */
+  paper?: {
+    arxivId: string;
+    authors: string[];
+    abstract: string;
+    publishedAt: string;
+  };
 };
 
 const VIDEO_HOSTS = new Set([

--- a/src/lib/link-organizer.ts
+++ b/src/lib/link-organizer.ts
@@ -126,6 +126,9 @@ export function categorizeLink(rawUrl: string): LinkCategory {
   if (host === "github.com" || host === "gist.github.com" || host.endsWith(".github.io")) {
     return "github";
   }
+  // huggingface.co also serves models, datasets, spaces and blog posts, so the
+  // host cannot join PAPER_HOSTS — only this path may.
+  if (host === "huggingface.co" && /^\/papers(\/|$)/.test(pathname)) return "paper";
   if (hostMatches(host, PAPER_HOSTS)) return "paper";
   if (hostMatches(host, VIDEO_HOSTS)) return "video";
   if (hostMatches(host, SOCIAL_HOSTS)) return "social";

--- a/src/lib/research-paper-view.test.ts
+++ b/src/lib/research-paper-view.test.ts
@@ -3,13 +3,27 @@ import { test } from "node:test";
 
 import {
   initialPaperViewState,
+  isPaperViewCancellation,
+  paperArxivUrl,
+  paperDownloadUrl,
   paperPdfUrl,
+  paperViewErrorMessage,
   reducePaperView,
   type PaperViewState,
 } from "./research-paper-view.ts";
 
+/** Stand-in for a pdf.js exception: the class is gone by the time we see it. */
+function pdfjsError(name: string, message: string, extra: Record<string, unknown> = {}): Error {
+  return Object.assign(new Error(message), { name }, extra);
+}
+
 test("builds the proxy URL and encodes the id", () => {
   assert.equal(paperPdfUrl("2401.12345"), "/api/research/papers/pdf?id=2401.12345");
+});
+
+test("links out to arXiv's landing page and its own PDF, not the proxy", () => {
+  assert.equal(paperArxivUrl("2401.12345"), "https://arxiv.org/abs/2401.12345");
+  assert.equal(paperDownloadUrl("2401.12345"), "https://arxiv.org/pdf/2401.12345");
 });
 
 test("load then ready", () => {
@@ -54,4 +68,87 @@ test("a second ready does not overwrite a settled ready", () => {
 
 test("the initial state is idle with no error", () => {
   assert.deepEqual(initialPaperViewState, { status: "idle", pageCount: 0, error: null });
+});
+
+// The document opens, so the reducer settles on `ready` — and only then does
+// the page render blow up (an oversized canvas, a malformed page object, a
+// font that will not load). Refusing `fail` here dropped the failure on the
+// floor: blank canvas, no error, no Retry, "Page 3 of 14" still on screen.
+test("a fail arriving after ready surfaces the error", () => {
+  const loading = reducePaperView(initialPaperViewState, { type: "load" });
+  const ready = reducePaperView(loading, { type: "ready", pageCount: 14 });
+  const failed = reducePaperView(ready, { type: "fail", message: "canvas too large" });
+  assert.equal(failed.status, "error");
+  assert.equal(failed.error, "canvas too large");
+});
+
+test("a fail arriving after ready can still be retried", () => {
+  const ready: PaperViewState = { status: "ready", pageCount: 14, error: null };
+  const failed = reducePaperView(ready, { type: "fail", message: "boom" });
+  assert.equal(reducePaperView(failed, { type: "load" }).status, "loading");
+});
+
+// The only route back to `idle` is `cancel`, so `idle` is exactly the
+// torn-down viewer the guard exists to protect.
+test("idle is the only status that refuses a fail", () => {
+  for (const status of ["loading", "ready", "error"] as const) {
+    const state: PaperViewState = { status, pageCount: 2, error: null };
+    assert.equal(reducePaperView(state, { type: "fail", message: "x" }).status, "error");
+  }
+  assert.equal(
+    reducePaperView(initialPaperViewState, { type: "fail", message: "x" }).status,
+    "idle",
+  );
+});
+
+test("pdf.js cancellations are not reader-facing failures", () => {
+  assert.equal(isPaperViewCancellation(pdfjsError("AbortException", "aborted")), true);
+  assert.equal(
+    isPaperViewCancellation(pdfjsError("RenderingCancelledException", "cancelled")),
+    true,
+  );
+  assert.equal(isPaperViewCancellation(pdfjsError("InvalidPDFException", "bad")), false);
+  assert.equal(isPaperViewCancellation("not an error"), false);
+});
+
+test("a missing or failed fetch never leaks the proxy URL to the reader", () => {
+  const missing = paperViewErrorMessage(
+    pdfjsError(
+      "ResponseException",
+      'Missing PDF "http://localhost:3000/api/research/papers/pdf?id=2401.12345".',
+      { status: 404, missing: true },
+    ),
+  );
+  assert.doesNotMatch(missing, /api\/research|localhost/);
+  assert.match(missing, /arXiv/);
+
+  const forbidden = paperViewErrorMessage(
+    pdfjsError("ResponseException", "Unexpected server response (403) while retrieving PDF", {
+      status: 403,
+      missing: false,
+    }),
+  );
+  assert.doesNotMatch(forbidden, /403|retrieving PDF/);
+  assert.match(forbidden, /connection/);
+});
+
+test("damaged and locked PDFs each get their own sentence", () => {
+  const damaged = paperViewErrorMessage(
+    pdfjsError("InvalidPDFException", "Invalid PDF structure."),
+  );
+  const locked = paperViewErrorMessage(
+    pdfjsError("PasswordException", "No password given", { code: 1 }),
+  );
+  assert.match(damaged, /damaged/);
+  assert.match(locked, /password/i);
+  assert.notEqual(damaged, locked);
+});
+
+test("anything unrecognised falls back to one generic sentence", () => {
+  const generic = paperViewErrorMessage(
+    new Error('Setting up fake worker failed: "Failed to fetch dynamically imported module".'),
+  );
+  assert.doesNotMatch(generic, /fake worker/);
+  assert.equal(paperViewErrorMessage("nonsense"), generic);
+  assert.equal(paperViewErrorMessage(undefined), generic);
 });

--- a/src/lib/research-paper-view.test.ts
+++ b/src/lib/research-paper-view.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  initialPaperViewState,
+  paperPdfUrl,
+  reducePaperView,
+  type PaperViewState,
+} from "./research-paper-view.ts";
+
+test("builds the proxy URL and encodes the id", () => {
+  assert.equal(paperPdfUrl("2401.12345"), "/api/research/papers/pdf?id=2401.12345");
+});
+
+test("load then ready", () => {
+  const loading = reducePaperView(initialPaperViewState, { type: "load" });
+  assert.equal(loading.status, "loading");
+  const ready = reducePaperView(loading, { type: "ready", pageCount: 12 });
+  assert.equal(ready.status, "ready");
+  assert.equal(ready.pageCount, 12);
+  assert.equal(ready.error, null);
+});
+
+test("failure records the message and can retry", () => {
+  const loading = reducePaperView(initialPaperViewState, { type: "load" });
+  const failed = reducePaperView(loading, { type: "fail", message: "boom" });
+  assert.equal(failed.status, "error");
+  assert.equal(failed.error, "boom");
+  assert.equal(reducePaperView(failed, { type: "load" }).status, "loading");
+});
+
+test("cancel returns to idle and clears the page count", () => {
+  const ready: PaperViewState = { status: "ready", pageCount: 12, error: null };
+  assert.deepEqual(reducePaperView(ready, { type: "cancel" }), initialPaperViewState);
+});
+
+test("a ready arriving after cancel is ignored", () => {
+  const cancelled = reducePaperView({ status: "ready", pageCount: 3, error: null }, { type: "cancel" });
+  assert.equal(reducePaperView(cancelled, { type: "ready", pageCount: 3 }).status, "idle");
+});
+
+test("a fail arriving after cancel is ignored", () => {
+  const cancelled = reducePaperView({ status: "loading", pageCount: 0, error: null }, { type: "cancel" });
+  const after = reducePaperView(cancelled, { type: "fail", message: "late" });
+  assert.equal(after.status, "idle");
+  assert.equal(after.error, null);
+});
+
+test("a second ready does not overwrite a settled ready", () => {
+  const loading = reducePaperView(initialPaperViewState, { type: "load" });
+  const ready = reducePaperView(loading, { type: "ready", pageCount: 4 });
+  assert.equal(reducePaperView(ready, { type: "ready", pageCount: 99 }).pageCount, 4);
+});
+
+test("the initial state is idle with no error", () => {
+  assert.deepEqual(initialPaperViewState, { status: "idle", pageCount: 0, error: null });
+});

--- a/src/lib/research-paper-view.ts
+++ b/src/lib/research-paper-view.ts
@@ -22,6 +22,69 @@ export function paperPdfUrl(arxivId: string): string {
   return `/api/research/papers/pdf?id=${encodeURIComponent(arxivId)}`;
 }
 
+/** The paper's arXiv landing page — the "open it where it lives" action. */
+export function paperArxivUrl(arxivId: string): string {
+  return `https://arxiv.org/abs/${encodeURIComponent(arxivId)}`;
+}
+
+/**
+ * arXiv's own PDF, not the loopback proxy: this is handed to the browser (or
+ * the OS handler under the desktop shell) to save, and a `/api/...` path is
+ * meaningless once it leaves the app.
+ */
+export function paperDownloadUrl(arxivId: string): string {
+  return `https://arxiv.org/pdf/${encodeURIComponent(arxivId)}`;
+}
+
+/**
+ * Rejections pdf.js uses to signal "this work was called off", not "this
+ * paper is broken". They reach a catch block whenever teardown races an
+ * in-flight render, and showing one to the reader would be a lie.
+ */
+const CANCELLATION_NAMES = new Set(["AbortException", "RenderingCancelledException"]);
+
+/** True when `error` is pdf.js reporting its own cancellation. */
+export function isPaperViewCancellation(error: unknown): boolean {
+  return error instanceof Error && CANCELLATION_NAMES.has(error.name);
+}
+
+/**
+ * Map a pdf.js rejection to something a reader can act on.
+ *
+ * Discriminating on `error.name` rather than `instanceof` is deliberate.
+ * pdf.js parses in a worker, so every failure crosses a structured-clone
+ * boundary and is rebuilt on the main thread by `wrapReason`, which switches
+ * on exactly this name. The class identities also move between majors: the
+ * installed pdfjs-dist (6.2.108) exports `InvalidPDFException`,
+ * `PasswordException` and `ResponseException`, and no longer has the
+ * `MissingPDFException` / `UnexpectedResponseException` pair that v4 did —
+ * `ResponseException` carries `status` and `missing` instead. A name check
+ * keeps this file free of a pdfjs import (it is unit-testable under plain
+ * node) and degrades to the generic sentence on anything unrecognised.
+ *
+ * The raw message never reaches the UI: pdf.js writes the fetch URL into it,
+ * which would leak the internal `/api/research/papers/pdf?id=…` path onto the
+ * reader's screen.
+ */
+export function paperViewErrorMessage(error: unknown): string {
+  const name = error instanceof Error ? error.name : "";
+
+  if (name === "ResponseException") {
+    const { status, missing } = error as { status?: number; missing?: boolean };
+    if (missing || status === 404) {
+      return "This paper isn’t available from arXiv right now.";
+    }
+    return "Couldn’t fetch this paper — check your connection, then retry.";
+  }
+  if (name === "InvalidPDFException") {
+    return "This paper’s PDF is damaged, so it can’t be shown here.";
+  }
+  if (name === "PasswordException") {
+    return "This paper’s PDF is password-protected, so it can’t be shown here.";
+  }
+  return "Couldn’t render this paper. Retry, or open it on arXiv.";
+}
+
 export function reducePaperView(state: PaperViewState, action: PaperViewAction): PaperViewState {
   switch (action.type) {
     case "load":
@@ -31,7 +94,14 @@ export function reducePaperView(state: PaperViewState, action: PaperViewAction):
       if (state.status !== "loading") return state;
       return { status: "ready", pageCount: action.pageCount, error: null };
     case "fail":
-      if (state.status !== "loading") return state;
+      // `cancel` is the only thing that returns the viewer to `idle`, so
+      // `idle` means "torn down" and a late rejection from a dead effect run
+      // must not resurrect it. Everything else is a live run: `loading` is a
+      // document that never opened, and `ready` is a page that failed AFTER
+      // it did — the canvas is blanked before each render, so refusing `fail`
+      // from `ready` left the reader staring at an empty page with a
+      // confident "Page 3 of 14" above it and no way to retry.
+      if (state.status === "idle") return state;
       return { status: "error", pageCount: 0, error: action.message };
     case "cancel":
       return initialPaperViewState;

--- a/src/lib/research-paper-view.ts
+++ b/src/lib/research-paper-view.ts
@@ -1,0 +1,39 @@
+export type PaperViewStatus = "idle" | "loading" | "ready" | "error";
+
+export type PaperViewState = {
+  status: PaperViewStatus;
+  pageCount: number;
+  error: string | null;
+};
+
+export type PaperViewAction =
+  | { type: "load" }
+  | { type: "ready"; pageCount: number }
+  | { type: "fail"; message: string }
+  | { type: "cancel" };
+
+export const initialPaperViewState: PaperViewState = {
+  status: "idle",
+  pageCount: 0,
+  error: null,
+};
+
+export function paperPdfUrl(arxivId: string): string {
+  return `/api/research/papers/pdf?id=${encodeURIComponent(arxivId)}`;
+}
+
+export function reducePaperView(state: PaperViewState, action: PaperViewAction): PaperViewState {
+  switch (action.type) {
+    case "load":
+      return { status: "loading", pageCount: 0, error: null };
+    case "ready":
+      // A render that resolves after dismissal must not revive the viewer.
+      if (state.status !== "loading") return state;
+      return { status: "ready", pageCount: action.pageCount, error: null };
+    case "fail":
+      if (state.status !== "loading") return state;
+      return { status: "error", pageCount: 0, error: action.message };
+    case "cancel":
+      return initialPaperViewState;
+  }
+}

--- a/src/lib/server/hf-paper-metadata.test.ts
+++ b/src/lib/server/hf-paper-metadata.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { fetchHfPaperMetadata } from "./hf-paper-metadata.ts";
+
+const PAYLOAD = {
+  id: "2401.12345",
+  title: "Distributionally Robust Receive Beamforming",
+  authors: [{ name: "Shixiong Wang" }, { name: "Wei Dai" }],
+  publishedAt: "2024-01-22T20:20:48.000Z",
+  summary: "This article investigates signal estimation.",
+};
+
+test("maps the HF payload", async () => {
+  const result = await fetchHfPaperMetadata("2401.12345", {
+    fetchImpl: async () => new Response(JSON.stringify(PAYLOAD), { status: 200 }),
+  });
+  assert.deepEqual(result, {
+    title: "Distributionally Robust Receive Beamforming",
+    authors: ["Shixiong Wang", "Wei Dai"],
+    abstract: "This article investigates signal estimation.",
+    publishedAt: "2024-01-22T20:20:48.000Z",
+  });
+});
+
+test("degrades to null on a non-OK response", async () => {
+  const result = await fetchHfPaperMetadata("2401.12345", {
+    fetchImpl: async () => new Response("nope", { status: 404 }),
+  });
+  assert.equal(result, null);
+});
+
+test("degrades to null when the fetch throws", async () => {
+  const result = await fetchHfPaperMetadata("2401.12345", {
+    fetchImpl: async () => { throw new Error("network down"); },
+  });
+  assert.equal(result, null);
+});
+
+test("degrades to null on malformed JSON", async () => {
+  const result = await fetchHfPaperMetadata("2401.12345", {
+    fetchImpl: async () => new Response("not json at all", { status: 200 }),
+  });
+  assert.equal(result, null);
+});
+
+test("refuses an id that is not an arXiv id, without issuing a request", async () => {
+  let called = false;
+  const result = await fetchHfPaperMetadata("../etc/passwd", {
+    fetchImpl: async () => { called = true; return new Response("{}", { status: 200 }); },
+  });
+  assert.equal(result, null);
+  assert.equal(called, false, "must not issue a request for an invalid id");
+});
+
+test("tolerates missing optional fields but requires a title", async () => {
+  const noTitle = await fetchHfPaperMetadata("2401.12345", {
+    fetchImpl: async () => new Response(JSON.stringify({ id: "2401.12345" }), { status: 200 }),
+  });
+  assert.equal(noTitle, null, "a paper with no title is not useful metadata");
+
+  const sparse = await fetchHfPaperMetadata("2401.12345", {
+    fetchImpl: async () => new Response(JSON.stringify({ title: "T" }), { status: 200 }),
+  });
+  assert.deepEqual(sparse, { title: "T", authors: [], abstract: "", publishedAt: "" });
+});

--- a/src/lib/server/hf-paper-metadata.ts
+++ b/src/lib/server/hf-paper-metadata.ts
@@ -1,0 +1,50 @@
+import { isArxivPaperId } from "@/lib/hf-papers";
+
+export type HfPaperMetadata = {
+  title: string;
+  authors: string[];
+  abstract: string;
+  publishedAt: string;
+};
+
+/**
+ * Ingest is an interactive paste: the budget is how long a person will wait
+ * for it to land, not how long HF might take.
+ */
+const TIMEOUT_MS = 5_000;
+
+export async function fetchHfPaperMetadata(
+  arxivId: string,
+  options: { fetchImpl?: typeof fetch } = {},
+): Promise<HfPaperMetadata | null> {
+  if (!isArxivPaperId(arxivId)) return null;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(`https://huggingface.co/api/papers/${arxivId}`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const body = (await response.json()) as Record<string, unknown>;
+    const title = typeof body.title === "string" ? body.title : "";
+    if (!title) return null;
+    const authors = Array.isArray(body.authors)
+      ? body.authors
+          .map((a) => (a && typeof a === "object" ? (a as { name?: unknown }).name : null))
+          .filter((n): n is string => typeof n === "string" && n.length > 0)
+      : [];
+    return {
+      title,
+      authors,
+      abstract: typeof body.summary === "string" ? body.summary : "",
+      publishedAt: typeof body.publishedAt === "string" ? body.publishedAt : "",
+    };
+  } catch {
+    // A flaky third party must not cost the user their paste; the caller keeps
+    // the derived title instead.
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/lib/server/research-links.test.ts
+++ b/src/lib/server/research-links.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { after, test } from "node:test";
 
+import type { HfPaperMetadata } from "./hf-paper-metadata.ts";
+
 const tmp = await mkdtemp(path.join(tmpdir(), "cave-research-links-"));
 const originalOverride = process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE;
 process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE = path.join(tmp, "research-links.json");
@@ -193,4 +195,45 @@ test("a well-formed paper block survives, a malformed one is dropped without dis
 
   assert.ok(linkB, "the link with the malformed paper block still survives");
   assert.equal(linkB?.paper, undefined);
+});
+
+// ── saveResearchLinks enrichment parameter (cave-cbz28) ─────────────────────
+
+test("enrichment metadata sets the stored title and paper block", async () => {
+  const meta: HfPaperMetadata = {
+    title: "A Well-Formed Paper",
+    authors: ["A. Author", "B. Author"],
+    abstract: "An abstract about a paper.",
+    publishedAt: "2024-01-22T00:00:00.000Z",
+  };
+  const url = "https://huggingface.co/papers/2401.99999";
+  const { added } = await saveResearchLinks([url], "desk", new Map([[url, meta]]));
+  assert.equal(added.length, 1);
+  assert.equal(added[0].title, meta.title);
+  assert.deepEqual(added[0].paper, {
+    arxivId: "2401.99999",
+    authors: meta.authors,
+    abstract: meta.abstract,
+    publishedAt: meta.publishedAt,
+  });
+});
+
+test("a null enrichment entry produces exactly the record saved with no enrichment map at all", async () => {
+  const url = "https://huggingface.co/papers/2402.11111";
+
+  const baseline = await saveResearchLinks([url], "desk");
+  assert.equal(baseline.added.length, 1);
+  assert.equal(await removeSavedLink(baseline.added[0].id), true);
+
+  const withNullEnrichment = await saveResearchLinks([url], "desk", new Map([[url, null]]));
+  assert.equal(withNullEnrichment.added.length, 1);
+
+  // Same URL, source, title, category, and absence of a paper block — the only
+  // fields the map is expected to differ on (id, addedAt) are left uncompared.
+  assert.equal(withNullEnrichment.added[0].url, baseline.added[0].url);
+  assert.equal(withNullEnrichment.added[0].title, baseline.added[0].title);
+  assert.equal(withNullEnrichment.added[0].category, baseline.added[0].category);
+  assert.equal(withNullEnrichment.added[0].source, baseline.added[0].source);
+  assert.equal(withNullEnrichment.added[0].paper, baseline.added[0].paper);
+  assert.equal(withNullEnrichment.added[0].paper, undefined);
 });

--- a/src/lib/server/research-links.test.ts
+++ b/src/lib/server/research-links.test.ts
@@ -143,3 +143,54 @@ test("unreadable stores surface errors instead of reading as empty", async () =>
     process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE = previous;
   }
 });
+
+// ── paper metadata (cave-cbz28) ──────────────────────────────────────────────
+
+test("a well-formed paper block survives, a malformed one is dropped without discarding the link", async () => {
+  const target = process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE!;
+  await writeFile(
+    target,
+    JSON.stringify({
+      version: 1,
+      links: [
+        {
+          id: "paper-a",
+          url: "https://huggingface.co/papers/2401.12345",
+          category: "paper",
+          title: "A well-formed paper",
+          addedAt: "2026-01-01T00:00:00.000Z",
+          source: "desk",
+          paper: {
+            arxivId: "2401.12345",
+            authors: ["A. Author"],
+            abstract: "An abstract.",
+            publishedAt: "2024-01-22T00:00:00.000Z",
+          },
+        },
+        {
+          id: "paper-b",
+          url: "https://huggingface.co/papers/2402.54321",
+          category: "paper",
+          title: "A malformed paper",
+          addedAt: "2026-01-02T00:00:00.000Z",
+          source: "desk",
+          paper: {
+            arxivId: "../etc/passwd",
+            authors: "not-an-array",
+          },
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  const listed = await listSavedLinks();
+  const linkA = listed.find((link) => link.id === "paper-a");
+  const linkB = listed.find((link) => link.id === "paper-b");
+
+  assert.equal(linkA?.paper?.arxivId, "2401.12345");
+  assert.deepEqual(linkA?.paper?.authors, ["A. Author"]);
+
+  assert.ok(linkB, "the link with the malformed paper block still survives");
+  assert.equal(linkB?.paper, undefined);
+});

--- a/src/lib/server/research-links.test.ts
+++ b/src/lib/server/research-links.test.ts
@@ -218,6 +218,23 @@ test("enrichment metadata sets the stored title and paper block", async () => {
   });
 });
 
+test("a URL that merely embeds a paper URL never gets a paper block", async () => {
+  // The stored arxivId drives the Read affordance and is interpolated into the
+  // PDF route's URL, so it has to come from classifying THIS url — not from
+  // scanning it for a paper reference that belongs to the page it links to.
+  const wrapper = "https://www.google.com/url?q=https://arxiv.org/abs/2401.12345";
+  const meta: HfPaperMetadata = {
+    title: "Distributionally Robust Receive Beamforming",
+    authors: ["A. Author"],
+    abstract: "A foreign paper's abstract.",
+    publishedAt: "2024-01-22T00:00:00.000Z",
+  };
+  const { added } = await saveResearchLinks([wrapper], "chat", new Map([[wrapper, meta]]));
+  assert.equal(added.length, 1);
+  assert.equal(added[0].url, wrapper);
+  assert.equal(added[0].paper, undefined);
+});
+
 test("a null enrichment entry produces exactly the record saved with no enrichment map at all", async () => {
   const url = "https://huggingface.co/papers/2402.11111";
 

--- a/src/lib/server/research-links.ts
+++ b/src/lib/server/research-links.ts
@@ -21,9 +21,10 @@ import {
   type SavedLink,
 } from "../link-organizer.ts";
 import { caveHome } from "../coven-paths.ts";
-import { isArxivPaperId } from "../hf-papers.ts";
+import { isArxivPaperId, parseHfPaperReferences } from "../hf-papers.ts";
 import { corruptAsidePath } from "./corrupt-aside.ts";
 import { writeJsonAtomic } from "./atomic-write.ts";
+import type { HfPaperMetadata } from "./hf-paper-metadata.ts";
 
 export { MAX_LINKS_PER_SAVE };
 
@@ -153,6 +154,7 @@ export type SaveLinksResult = {
 export async function saveResearchLinks(
   rawUrls: string[],
   source: SavedLink["source"],
+  enrichment?: Map<string, HfPaperMetadata | null>,
 ): Promise<SaveLinksResult> {
   return withWriteMutex(async () => {
     const file = await loadFile();
@@ -180,13 +182,18 @@ export async function saveResearchLinks(
         continue;
       }
       existing.add(key);
+      const meta = enrichment?.get(trimmed) ?? null;
+      const [arxivId] = parseHfPaperReferences(trimmed);
       added.push({
         id: randomUUID(),
         url: trimmed,
         category: categorizeLink(trimmed),
-        title: deriveLinkTitle(trimmed),
+        title: meta?.title || deriveLinkTitle(trimmed),
         addedAt: new Date().toISOString(),
         source,
+        ...(meta && arxivId
+          ? { paper: { arxivId, authors: meta.authors, abstract: meta.abstract, publishedAt: meta.publishedAt } }
+          : {}),
       });
     }
 

--- a/src/lib/server/research-links.ts
+++ b/src/lib/server/research-links.ts
@@ -21,6 +21,7 @@ import {
   type SavedLink,
 } from "../link-organizer.ts";
 import { caveHome } from "../coven-paths.ts";
+import { isArxivPaperId } from "../hf-papers.ts";
 import { corruptAsidePath } from "./corrupt-aside.ts";
 import { writeJsonAtomic } from "./atomic-write.ts";
 
@@ -43,6 +44,23 @@ function emptyFile(): ResearchLinksFile {
   return { version: 1, links: [] };
 }
 
+function normalizePaperBlock(value: unknown): SavedLink["paper"] {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  // Disk contents are user-editable, and arxivId is interpolated into a URL by
+  // the PDF route — validate it here rather than trusting the file.
+  if (typeof raw.arxivId !== "string" || !isArxivPaperId(raw.arxivId)) return undefined;
+  if (!Array.isArray(raw.authors) || !raw.authors.every((a) => typeof a === "string")) return undefined;
+  if (typeof raw.abstract !== "string") return undefined;
+  if (typeof raw.publishedAt !== "string") return undefined;
+  return {
+    arxivId: raw.arxivId,
+    authors: raw.authors as string[],
+    abstract: raw.abstract,
+    publishedAt: raw.publishedAt,
+  };
+}
+
 function normalizeStoredLink(value: unknown): SavedLink | null {
   if (!value || typeof value !== "object") return null;
   const raw = value as Partial<SavedLink>;
@@ -58,6 +76,7 @@ function normalizeStoredLink(value: unknown): SavedLink | null {
     typeof raw.addedAt === "string" && Number.isFinite(Date.parse(raw.addedAt))
       ? raw.addedAt
       : new Date().toISOString();
+  const paper = normalizePaperBlock((value as { paper?: unknown }).paper);
   return {
     id: typeof raw.id === "string" && raw.id ? raw.id : randomUUID(),
     url: raw.url,
@@ -65,6 +84,7 @@ function normalizeStoredLink(value: unknown): SavedLink | null {
     title: typeof raw.title === "string" && raw.title ? raw.title : deriveLinkTitle(raw.url),
     addedAt,
     source: raw.source === "desk" ? "desk" : "chat",
+    ...(paper ? { paper } : {}),
   };
 }
 

--- a/src/lib/server/research-links.ts
+++ b/src/lib/server/research-links.ts
@@ -21,7 +21,7 @@ import {
   type SavedLink,
 } from "../link-organizer.ts";
 import { caveHome } from "../coven-paths.ts";
-import { isArxivPaperId, parseHfPaperReferences } from "../hf-papers.ts";
+import { arxivIdFromUrl, isArxivPaperId } from "../hf-papers.ts";
 import { corruptAsidePath } from "./corrupt-aside.ts";
 import { writeJsonAtomic } from "./atomic-write.ts";
 import type { HfPaperMetadata } from "./hf-paper-metadata.ts";
@@ -183,7 +183,9 @@ export async function saveResearchLinks(
       }
       existing.add(key);
       const meta = enrichment?.get(trimmed) ?? null;
-      const [arxivId] = parseHfPaperReferences(trimmed);
+      // The saved URL is a URL, so classify it. Scanning it as text would
+      // attach a `paper` block to any page whose URL happens to embed one.
+      const arxivId = arxivIdFromUrl(trimmed);
       added.push({
         id: randomUUID(),
         url: trimmed,

--- a/src/styles/globals/surface-research-resources.css
+++ b/src/styles/globals/surface-research-resources.css
@@ -810,6 +810,37 @@
   background: color-mix(in oklch, var(--research-accent) 7%, transparent);
 }
 
+/* ── Read affordance: the gate in front of the paper viewer. Mounting the
+   viewer costs the pdfjs-dist chunk plus a multi-megabyte document fetch, so
+   a reader who opened the resource for its citations gets to decline. ── */
+.research-res-overlay__read {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  padding: var(--space-3) var(--space-4);
+  background: color-mix(in oklch, var(--bg-base) 55%, transparent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+}
+.research-res-overlay__read-copy {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.research-res-overlay__read-copy strong {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.research-res-overlay__read-copy span {
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
 /* ── Paper viewer: pdf.js canvas with its text layer laid over the top. ── */
 .research-paper-view {
   display: flex;
@@ -896,8 +927,12 @@
   border-radius: var(--radius-sm);
 }
 /* Dim the page while the next one is rasterizing so a slow flip reads as
-   pending rather than as the reader's click having missed. */
-.research-paper-view__stage[data-status="loading"] .research-paper-view__canvas {
+   pending rather than as the reader's click having missed. Keyed on
+   data-pending, not data-status: once the document effect and the render
+   effect were split, a page turn no longer moves the reducer back to
+   "loading" — that is the point of the split — so the status alone stopped
+   describing whether a page is in flight. */
+.research-paper-view__stage[data-pending] .research-paper-view__canvas {
   opacity: 0.45;
 }
 .research-paper-view__status { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }

--- a/src/styles/globals/surface-research-resources.css
+++ b/src/styles/globals/surface-research-resources.css
@@ -810,6 +810,150 @@
   background: color-mix(in oklch, var(--research-accent) 7%, transparent);
 }
 
+/* ── Paper viewer: pdf.js canvas with its text layer laid over the top. ── */
+.research-paper-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.research-paper-view__byline {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.research-paper-view__authors {
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+.research-paper-view__published { font-size: var(--text-xs); color: var(--text-muted); }
+.research-paper-view__label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.research-paper-view__label i {
+  width: 12px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--research-accent);
+}
+.research-paper-view__label span {
+  font-size: var(--text-2xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.research-paper-view__abstract p {
+  margin: var(--space-2) 0 0;
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+.research-paper-view__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  padding: var(--space-2) var(--space-3);
+  background: color-mix(in oklch, var(--bg-base) 55%, transparent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+}
+.research-paper-view__group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.research-paper-view__readout {
+  font-size: var(--text-2xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.research-paper-view__stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  max-height: 60vh;
+  overflow: auto;
+  padding: var(--space-3);
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+}
+.research-paper-view__page {
+  position: relative;
+  flex: none;
+  line-height: 0;
+}
+.research-paper-view__canvas {
+  display: block;
+  border-radius: var(--radius-sm);
+}
+/* Dim the page while the next one is rasterizing so a slow flip reads as
+   pending rather than as the reader's click having missed. */
+.research-paper-view__stage[data-status="loading"] .research-paper-view__canvas {
+  opacity: 0.45;
+}
+.research-paper-view__status { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }
+.research-paper-view__error {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  font-size: var(--text-xs);
+  color: var(--destructive);
+}
+
+/* Text layer — the essential rules from pdf.js' own text_layer.css, scoped
+   to this viewer. The spans are transparent and positioned over the glyphs
+   the canvas painted, which is what makes the page selectable and findable
+   instead of a picture of a paper. pdf.js writes --total-scale-factor,
+   --min-font-size, --font-height, --scale-x and --rotate; everything here
+   only consumes them. */
+.research-paper-view__text {
+  position: absolute;
+  inset: 0;
+  overflow: clip;
+  line-height: 1;
+  text-align: initial;
+  text-size-adjust: none;
+  forced-color-adjust: none;
+  transform-origin: 0 0;
+  caret-color: var(--text-primary);
+  z-index: 0;
+  --total-scale-factor: 1;
+  --min-font-size: 1;
+  --text-scale-factor: calc(var(--total-scale-factor) * var(--min-font-size));
+  --min-font-size-inv: calc(1 / var(--min-font-size));
+}
+.research-paper-view__text :is(span, br) {
+  position: absolute;
+  color: transparent;
+  white-space: pre;
+  cursor: text;
+  transform-origin: 0% 0%;
+  user-select: text;
+}
+.research-paper-view__text > :not(.markedContent),
+.research-paper-view__text .markedContent span:not(.markedContent) {
+  z-index: 1;
+  --font-height: 0;
+  --scale-x: 1;
+  --rotate: 0deg;
+  font-size: calc(var(--text-scale-factor) * var(--font-height));
+  transform: rotate(var(--rotate)) scaleX(var(--scale-x)) scale(var(--min-font-size-inv));
+}
+.research-paper-view__text .markedContent { display: contents; }
+.research-paper-view__text ::selection {
+  background: color-mix(in oklch, var(--research-accent) 35%, transparent);
+}
+
 /* Action bar: destructive management left, workflow actions right. */
 .research-res-overlay__actions {
   display: flex;

--- a/src/styles/globals/surface-research-resources.css
+++ b/src/styles/globals/surface-research-resources.css
@@ -867,7 +867,10 @@
 .research-paper-view__label i {
   width: 12px;
   height: 2px;
-  border-radius: 2px;
+  /* The bar is 2px tall, so any radius at or above 1px clamps to the same
+     fully-rounded ends: the pill token renders identically to the 2px literal
+     this replaces, without spending a short-solid-mark exception on it. */
+  border-radius: var(--radius-pill);
   background: var(--research-accent);
 }
 .research-paper-view__label span {

--- a/src/styles/globals/surface-research-resources.css
+++ b/src/styles/globals/surface-research-resources.css
@@ -951,9 +951,11 @@
 /* Text layer — the essential rules from pdf.js' own text_layer.css, scoped
    to this viewer. The spans are transparent and positioned over the glyphs
    the canvas painted, which is what makes the page selectable and findable
-   instead of a picture of a paper. pdf.js writes --total-scale-factor,
-   --min-font-size, --font-height, --scale-x and --rotate; everything here
-   only consumes them. */
+   instead of a picture of a paper. pdf.js writes --min-font-size,
+   --font-height, --scale-x and --rotate onto the spans it creates, and
+   CONSUMES --total-scale-factor -- which it never sets. The viewer assigns
+   that one on this container before TextLayer.render (research-paper-viewer.tsx);
+   the fallbacks below only cover the moment before that assignment lands. */
 .research-paper-view__text {
   position: absolute;
   inset: 0;

--- a/tests/fixtures/sample-paper.pdf
+++ b/tests/fixtures/sample-paper.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 53 >>
+stream
+BT
+/F1 24 Tf
+72 700 Td
+(HYPERSPECTRAL FIXTURE) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000343 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+440
+%%EOF

--- a/tests/research-paper-viewer.spec.ts
+++ b/tests/research-paper-viewer.spec.ts
@@ -1,0 +1,277 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, test, type Page } from "@playwright/test";
+
+// Research paper viewer (cave-cbz28) — an ingested arXiv paper reads inside the
+// Resources detail overlay: pdf.js paints the page to a <canvas> and builds a
+// selectable text layer over it.
+//
+// Daemon-less (COVEN_CAVE_E2E=1), so every server truth is a page.route mock —
+// including BOTH routes this feature added: /api/research/links (which now
+// carries a `paper` block) and /api/research/papers/pdf (which streams the
+// bytes). PR #4634 shipped a new route plus a conditional viewer without
+// mocking the route, the viewer stopped rendering, and main went red for hours
+// (cave-1kv8i). This feature has the same shape, so its e2e ships with it.
+//
+// The fixture is a real one-page PDF, not a stub body: pdf.js parses what it is
+// handed, so `%PDF-1.4 fake` would fail at the parser and prove nothing about
+// the viewer. Its visible text is HYPERSPECTRAL FIXTURE, which is what the text
+// layer assertion looks for — a canvas alone only proves a picture painted.
+
+const FAMILIAR_ID = "rida";
+const ARXIV_ID = "2401.12345";
+const FIXTURE_TEXT = "HYPERSPECTRAL FIXTURE";
+const SAMPLE_PDF = readFileSync(
+  fileURLToPath(new URL("./fixtures/sample-paper.pdf", import.meta.url)),
+);
+
+// MediaBox of the fixture, which is what the viewer's default 100% zoom maps
+// one-to-one onto the canvas' CSS box.
+const PAGE_CSS_WIDTH = 612;
+const PAGE_CSS_HEIGHT = 792;
+
+const SAVED_LINK = {
+  id: "l1",
+  url: "https://huggingface.co/papers/2401.12345",
+  category: "paper",
+  title: "Fixture Paper",
+  addedAt: new Date().toISOString(),
+  source: "desk",
+  paper: {
+    arxivId: ARXIV_ID,
+    authors: ["A. Author"],
+    abstract: "An abstract for the fixture.",
+    publishedAt: "2024-01-22T00:00:00.000Z",
+  },
+};
+
+type PdfRequest = { url: string; ids: string[] };
+
+async function boot(page: Page): Promise<PdfRequest> {
+  const pdfRequests: PdfRequest = { url: "", ids: [] };
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:active-familiar", "rida");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        familiars: [
+          // The role label is what grants the researcher token, which is what
+          // makes surface:researcher-desk reachable for this familiar.
+          {
+            id: FAMILIAR_ID,
+            display_name: "Rida",
+            role: "Researcher",
+            status: "active",
+            icon: "ph:sparkle-fill",
+          },
+        ],
+      },
+    }),
+  );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions: [] } }),
+  );
+  await page.route(/\/api\/roles(?:\?|$)/, (route) =>
+    route.fulfill({ json: { roles: [] } }),
+  );
+  await page.route(/\/api\/research\/missions\?/, (route) =>
+    route.fulfill({ json: { ok: true, missions: [] } }),
+  );
+  await page.route(/\/api\/research\/generations/, (route) =>
+    route.fulfill({ json: { ok: true, generations: [] } }),
+  );
+  // Route 1 of 2: the saved link now carries the arXiv metadata block, which is
+  // the only thing that mounts the viewer at all.
+  await page.route("**/api/research/links", (route) =>
+    route.fulfill({ json: { ok: true, links: [SAVED_LINK] } }),
+  );
+  // Route 2 of 2: the same-origin PDF stream. No accept-ranges header, so
+  // pdf.js takes the whole body in one fetch rather than issuing range probes.
+  await page.route("**/api/research/papers/pdf**", async (route) => {
+    const url = new URL(route.request().url());
+    pdfRequests.url = url.pathname + url.search;
+    pdfRequests.ids.push(url.searchParams.get("id") ?? "");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/pdf",
+      body: SAMPLE_PDF,
+    });
+  });
+
+  await page.goto("/");
+  await page.getByRole("navigation").first().waitFor({ timeout: 60_000 });
+  // A cold `next dev` compile can lose the navigate event to a race; re-fire
+  // until the surface mounts (the pattern the other research specs use).
+  await expect(async () => {
+    await page.evaluate(() =>
+      window.dispatchEvent(
+        new CustomEvent("cave:navigate-mode", {
+          detail: { mode: "surface:researcher-desk" },
+        }),
+      ),
+    );
+    await expect(page.locator(".research-desk")).toBeVisible({ timeout: 3_000 });
+  }).toPass({ timeout: 90_000 });
+  await page
+    .getByRole("tablist", { name: "Research desk views" })
+    .getByRole("tab", { name: /^Resources/ })
+    .click();
+
+  return pdfRequests;
+}
+
+test.describe("research paper viewer", () => {
+  // Boot cost dominates: page load, the role-surface chunk compile, and then
+  // pdf.js booting a worker and parsing before anything paints.
+  test.describe.configure({ timeout: 180_000 });
+
+  test("renders an ingested paper's page canvas and selectable text layer", async ({
+    page,
+  }) => {
+    const pdfRequests = await boot(page);
+
+    await page
+      .locator(".research-res")
+      .getByRole("button", { name: /Fixture Paper — open details/ })
+      .click();
+
+    const overlay = page.getByRole("dialog", { name: "Fixture Paper" });
+    await expect(overlay).toBeVisible();
+    await expect(overlay.locator(".research-res-overlay__sub")).toHaveText(
+      "huggingface.co",
+    );
+
+    // The viewer is behind an explicit affordance: opening a paper's details
+    // to read what sits below the stage must not pull the pdfjs chunk and a
+    // multi-megabyte document nobody asked for. So nothing renders until this
+    // is pressed — and no PDF is requested either, asserted below.
+    await expect(overlay.getByRole("region", { name: "Paper" })).toHaveCount(0);
+    expect(pdfRequests.ids).toHaveLength(0);
+    await overlay.getByRole("button", { name: "Read" }).click();
+
+    // The metadata the ingest resolved reads above the page itself.
+    const viewer = overlay.getByRole("region", { name: "Paper" });
+    await expect(viewer.locator(".research-paper-view__authors")).toHaveText(
+      "A. Author",
+    );
+    await expect(viewer.locator(".research-paper-view__abstract")).toContainText(
+      "An abstract for the fixture.",
+    );
+
+    // pdf.js reached the route with the ingested id, not the raw saved URL.
+    await expect
+      .poll(() => pdfRequests.ids, { timeout: 60_000 })
+      .toContain(ARXIV_ID);
+
+    // The document parsed: the reducer only leaves `loading` on a real
+    // getDocument resolve, and the readout carries the parsed page count.
+    const stage = viewer.locator(".research-paper-view__stage");
+    await expect(stage).toHaveAttribute("data-status", "ready", {
+      timeout: 60_000,
+    });
+    await expect(
+      viewer.locator(".research-paper-view__readout").first(),
+    ).toHaveText("Page 1 of 1");
+
+    // The page painted: the canvas is sized from the real viewport (the
+    // fixture's 612×792 MediaBox at 100% zoom) rather than the 300×150 default,
+    // and its backing store holds non-blank pixels.
+    const canvas = viewer.locator("canvas.research-paper-view__canvas");
+    await expect(canvas).toBeVisible();
+    await expect
+      .poll(
+        () =>
+          canvas.evaluate((node: HTMLCanvasElement) => {
+            // The component multiplies the backing store by the device pixel
+            // ratio (capped at 2×), so divide it back out rather than pinning
+            // the assertion to one runner's screen density.
+            const output = Math.min(window.devicePixelRatio || 1, 2);
+            return {
+              cssWidth: node.style.width,
+              cssHeight: node.style.height,
+              backingWidth: node.width / output,
+              backingHeight: node.height / output,
+            };
+          }),
+        { timeout: 60_000 },
+      )
+      .toEqual({
+        cssWidth: `${PAGE_CSS_WIDTH}px`,
+        cssHeight: `${PAGE_CSS_HEIGHT}px`,
+        backingWidth: PAGE_CSS_WIDTH,
+        backingHeight: PAGE_CSS_HEIGHT,
+      });
+    const painted = await canvas.evaluate((node: HTMLCanvasElement) => {
+      const context = node.getContext("2d");
+      if (!context) return 0;
+      const { data } = context.getImageData(0, 0, node.width, node.height);
+      let marked = 0;
+      // Count pixels that are neither transparent nor the page's white fill —
+      // ink, which is what proves a render rather than a cleared canvas.
+      for (let index = 0; index < data.length; index += 4) {
+        const [r, g, b, a] = [
+          data[index],
+          data[index + 1],
+          data[index + 2],
+          data[index + 3],
+        ];
+        if (a > 0 && (r < 200 || g < 200 || b < 200)) marked += 1;
+      }
+      return marked;
+    });
+    expect(painted).toBeGreaterThan(0);
+
+    // The text layer carries the fixture's words, which is what selection and
+    // in-page search have to work with — a canvas alone is a picture of a paper.
+    await expect(viewer.locator(".research-paper-view__text")).toContainText(
+      FIXTURE_TEXT,
+      { timeout: 60_000 },
+    );
+
+    // Single-page fixture: paging is honestly bounded by the parsed count.
+    await expect(viewer.getByRole("button", { name: "Prev" })).toBeDisabled();
+    await expect(viewer.getByRole("button", { name: "Next" })).toBeDisabled();
+  });
+
+  test("re-renders the page at a larger zoom stop", async ({ page }) => {
+    await boot(page);
+
+    await page
+      .locator(".research-res")
+      .getByRole("button", { name: /Fixture Paper — open details/ })
+      .click();
+    const overlay = page.getByRole("dialog", { name: "Fixture Paper" });
+    await overlay.getByRole("button", { name: "Read" }).click();
+    const viewer = overlay.getByRole("region", { name: "Paper" });
+    const canvas = viewer.locator("canvas.research-paper-view__canvas");
+    await expect(viewer.locator(".research-paper-view__stage")).toHaveAttribute(
+      "data-status",
+      "ready",
+      { timeout: 60_000 },
+    );
+    await expect(viewer.locator(".research-paper-view__text")).toContainText(
+      FIXTURE_TEXT,
+      { timeout: 60_000 },
+    );
+
+    await viewer.getByRole("button", { name: "Zoom in" }).click();
+    await expect(
+      viewer.locator(".research-paper-view__readout").last(),
+    ).toHaveText("125%");
+    // The zoom stop re-renders at the new scale — and the text layer is rebuilt
+    // with it, so selection stays aligned with what is drawn.
+    await expect
+      .poll(() => canvas.evaluate((node: HTMLCanvasElement) => node.style.width), {
+        timeout: 60_000,
+      })
+      .toBe(`${Math.floor(PAGE_CSS_WIDTH * 1.25)}px`);
+    await expect(viewer.locator(".research-paper-view__text")).toContainText(
+      FIXTURE_TEXT,
+      { timeout: 60_000 },
+    );
+  });
+});


### PR DESCRIPTION
Pasting a Hugging Face paper into the Research Desk resource box now saves one
paper resource carrying a real title, authors and abstract — and opening it
renders the PDF inline, selectable and searchable.

All five spellings collapse to a single resource:

```
hf papers read 2401.12345
hf paper read 2401.12345
https://huggingface.co/papers/2401.12345
https://arxiv.org/abs/2401.12345
https://arxiv.org/pdf/2401.12345
```

## Why each piece is shaped the way it is

**`hf papers read <id>` contains no URL**, so `extractLinks` never saw it and the
paste was silently dropped. A new pure parser (`src/lib/hf-papers.ts`) recognises
the command and URL forms and canonicalizes every one to
`https://huggingface.co/papers/<id>`, so the existing normalized-URL dedupe in
`saveResearchLinks` collapses all five inputs into one resource.

**A bare `2401.12345` is deliberately not matched.** Pasted prose is full of
decimal numbers and version strings; matching them would manufacture resources
nobody asked for. The command prefix or a URL is the signal.

**`huggingface.co` is not added to `PAPER_HOSTS`.** That host also serves models,
datasets, spaces and blog posts, and adding it would mislabel all of them.
Instead a path-aware rule runs before the host check: `huggingface.co/papers/*`
→ `paper`, everything else on that host unchanged.

**Metadata degrades rather than failing the save.** `fetchHfPaperMetadata` has a
5-second timeout — ingest is an interactive paste, so the budget is how long a
person will wait, not how long HF might take. A hiccup or an unknown id leaves
the resource with today's derived title. Ingest that hard-fails on a flaky third
party is worse than ingest that stores a plain title.

**The PDF is proxied same-origin** (`/api/research/papers/pdf?id=`). `huggingface.co/papers/<id>`
serves `X-Frame-Options: DENY`, so the HF page can never be shown in-app; the
bytes come from arXiv instead. The proxy keeps the fetch same-origin so CORS
never enters the picture, keeps the local-only guard consistent with sibling
routes, and avoids third-party fetch behaviour differing under WKWebView. The id
is validated against a strict regex and interpolated into a hard-coded arXiv URL —
it never composes a host, scheme or path prefix, so there is no SSRF surface.

**Rendering is pdf.js, not an `<iframe>`**, for text selection, in-document search
and page navigation. A canvas per page plus the pdf.js text layer over it: a
picture of a paper is not a paper you can quote from.

pdf.js runs its parser in a Web Worker — **the first in this codebase**. The
worker asset is copied into `public/` by a postinstall step rather than bundled
via `new Worker(new URL(…))`, which keeps it independent of Turbopack's worker
handling and available to the packaged desktop shell. The viewer is loaded with
`next/dynamic` and `ssr: false` because pdf.js touches `DOMMatrix`, `Path2D` and
canvas, none of which exist during SSR — and being dynamically imported means
nobody who never opens a paper pays for ~1 MB of PDF machinery.

**Teardown is explicit.** State lives in a reducer that ignores `ready`/`fail`
unless still `loading`, and the effect keeps the loading task, render task and
text layer so all three are cancelled on unmount. Dismissing the viewer
mid-render cannot leave a detached worker task writing to a canvas that is gone.

## Testing

Unit coverage for the parser across the full pattern matrix including
near-misses (bare ids, `2401.1234567`, `v2` suffixes, ids in prose), the
`huggingface.co/papers` path rule asserting `/models/` and `/blog/` are
unaffected, metadata mapping and its degradation path, PDF-route id validation
and `Range` passthrough, and the viewer state machine including late-arriving
resolutions after cancel.

pdf.js rendering is not unit-testable here — `node --test` has no canvas, no
`DOMMatrix` and no worker — so an e2e spec covers it against real Chromium. It
`page.route`-mocks **both** new endpoints and serves a **committed one-page
fixture PDF**, not a stub body: pdf.js parses what it is handed, so a fake
payload fails at the parser and proves nothing. It asserts the canvas actually
has ink rather than merely existing, and that the text layer carries the
fixture's known text.

That last point is not boilerplate. #4634 added a route, made a player
conditional on it, and did not mock it — two specs failed and `main` was red for
hours, blocking every PR touching `src/**` (`cave-1kv8i`). This change has the
same shape, so its mocks ship with it.

## Note on the CSS budget warning

The build prints `THIN` for root-layout CSS. **That is pre-existing and not from
this branch.** `surface-research-resources.css` is component-imported by
`researcher-surface.tsx` and `research-x-sources.tsx` and never enters the root
facade — verified by removing this branch's 4.1 KB from it and measuring root
headroom move by exactly zero.

Bead: cave-cbz28
