### PR TITLE
Clarify first-run setup progress

### DIFF
--- a/src/components/onboarding-bootstrap-overlay.test.ts
+++ b/src/components/onboarding-bootstrap-overlay.test.ts
@@ -168,7 +168,7 @@ assert.match(
 );
 assert.match(
   source,
-  /Next, Cave creates your defaults and starts its local service\./,
+  /Next, Cave checks your defaults, then checks the local service\./,
   "running local-component setup explains the remaining stages",
 );
 assert.match(

--- a/src/components/onboarding-bootstrap-overlay.test.ts
+++ b/src/components/onboarding-bootstrap-overlay.test.ts
@@ -163,8 +163,8 @@ assert.match(
 );
 assert.match(
   source,
-  /First-time setup can take a few minutes\. Cave keeps working if you run it in the background\./,
-  "running setup explains both the expected wait and safe backgrounding",
+  /Cave keeps working if you run setup in the background\./,
+  "running setup explains safe backgrounding without estimating completion",
 );
 assert.match(
   source,

--- a/src/components/onboarding-bootstrap-overlay.test.ts
+++ b/src/components/onboarding-bootstrap-overlay.test.ts
@@ -163,6 +163,16 @@ assert.match(
 );
 assert.match(
   source,
+  /First-time setup can take a few minutes\. Cave keeps working if you run it in the background\./,
+  "running setup explains both the expected wait and safe backgrounding",
+);
+assert.match(
+  source,
+  /Next, Cave creates your defaults and starts its local service\./,
+  "running local-component setup explains the remaining stages",
+);
+assert.match(
+  source,
   /does not create Cave defaults or start a familiar runtime/,
   "a local-components failure says which later work did not happen",
 );

--- a/src/components/onboarding-bootstrap-overlay.tsx
+++ b/src/components/onboarding-bootstrap-overlay.tsx
@@ -53,7 +53,7 @@ function stageTone(status: OnboardingBootstrapStageStatus): string {
 
 function nextSetupStep(activeStage: OnboardingBootstrapState["activeStage"]) {
   if (activeStage === "core-tools") {
-    return "Next, Cave creates your defaults and starts its local service.";
+    return "Next, Cave checks your defaults, then checks the local service.";
   }
   if (activeStage === "workspace") {
     return "Next, Cave starts its local service if it needs to.";

--- a/src/components/onboarding-bootstrap-overlay.tsx
+++ b/src/components/onboarding-bootstrap-overlay.tsx
@@ -299,7 +299,7 @@ export function OnboardingOverlay({
           {running ? (
             <div className="grid gap-1 rounded-[var(--radius-card)] border border-[var(--border-hairline)] bg-[var(--bg-subtle)] p-3 text-[length:var(--text-xs)] leading-4 text-[var(--text-secondary)]">
               <p className="font-medium text-[var(--text-primary)]">
-                First-time setup can take a few minutes. Cave keeps working if you run it in the background.
+                Cave keeps working if you run setup in the background.
               </p>
               <p>{nextSetupStep(state.activeStage)}</p>
             </div>

--- a/src/components/onboarding-bootstrap-overlay.tsx
+++ b/src/components/onboarding-bootstrap-overlay.tsx
@@ -51,6 +51,16 @@ function stageTone(status: OnboardingBootstrapStageStatus): string {
   return "border-[var(--border-hairline)] text-[var(--text-muted)]";
 }
 
+function nextSetupStep(activeStage: OnboardingBootstrapState["activeStage"]) {
+  if (activeStage === "core-tools") {
+    return "Next, Cave creates your defaults and starts its local service.";
+  }
+  if (activeStage === "workspace") {
+    return "Next, Cave starts its local service if it needs to.";
+  }
+  return "Cave is finishing its local setup.";
+}
+
 export function OnboardingOverlay({
   open,
   onDismiss,
@@ -285,6 +295,15 @@ export function OnboardingOverlay({
               </li>
             ))}
           </ol>
+
+          {running ? (
+            <div className="grid gap-1 rounded-[var(--radius-card)] border border-[var(--border-hairline)] bg-[var(--bg-subtle)] p-3 text-[length:var(--text-xs)] leading-4 text-[var(--text-secondary)]">
+              <p className="font-medium text-[var(--text-primary)]">
+                First-time setup can take a few minutes. Cave keeps working if you run it in the background.
+              </p>
+              <p>{nextSetupStep(state.activeStage)}</p>
+            </div>
+          ) : null}
 
           {state.failure ? (
             <div

--- a/src/lib/server/onboarding-core-tools.test.ts
+++ b/src/lib/server/onboarding-core-tools.test.ts
@@ -86,7 +86,9 @@ test("managed Node and the Coven CLI install through the reviewed serialized lan
   assert.equal(result.ok, true);
   assert.deepEqual(starts, ["managed-node", "coven-cli"]);
   assert.deepEqual(progress, [
-    "Setting up Cave’s private Node.js and npm runtime…",
+    "Checking Cave’s local Node.js, npm, and Coven CLI…",
+    "Preparing Cave’s private Node.js and npm runtime…",
+    "Checking Cave’s private Node.js and npm runtime…",
     "Installing and verifying the Coven CLI…",
     "Verifying the local runtime and Coven CLI…",
   ]);

--- a/src/lib/server/onboarding-core-tools.ts
+++ b/src/lib/server/onboarding-core-tools.ts
@@ -269,6 +269,7 @@ export async function ensureOnboardingCoreTools(
     return stageFailure({ code: "unsupported_platform", inspection });
   }
 
+  await onProgress("Checking Cave’s local Node.js, npm, and Coven CLI…");
   let inspection = await dependencies.inspect();
   if (inspection.runtimeReady && inspection.coreToolsReady) {
     return {
@@ -281,7 +282,7 @@ export async function ensureOnboardingCoreTools(
   let lastInstaller: ReturnType<typeof diagnosticInstaller> | undefined;
 
   if (!inspection.runtimeReady) {
-    await onProgress("Setting up Cave’s private Node.js and npm runtime…");
+    await onProgress("Preparing Cave’s private Node.js and npm runtime…");
     const result = await runReviewedInstall("managed-node", dependencies);
     lastInstaller = diagnosticInstaller(
       result.target,
@@ -314,9 +315,11 @@ export async function ensureOnboardingCoreTools(
         installer: lastInstaller,
       });
     }
+
+    await onProgress("Checking Cave’s private Node.js and npm runtime…");
+    inspection = await dependencies.inspect();
   }
 
-  inspection = await dependencies.inspect();
   if (!inspection.coreToolsReady) {
     await onProgress("Installing and verifying the Coven CLI…");
     const result = await runReviewedInstall("coven-cli", dependencies);

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -312,7 +312,7 @@ test.describe("onboarding bootstrap", () => {
 
     await expect(dialog.getByText(/private Node\.js and npm runtime/)).toBeVisible();
     await expect(dialog.getByText(/few minutes/)).toHaveCount(0);
-    await expect(dialog.getByText(/Next, Cave creates your defaults and starts its local service/)).toBeVisible();
+    await expect(dialog.getByText(/Next, Cave checks your defaults, then checks the local service/)).toBeVisible();
     await expect(dialog.getByText(/Waiting for local components/)).toBeVisible();
     await expect(dialog.getByText(/Provider sign-in is deferred/)).toBeVisible();
     await expect(dialog.getByText(/never asks for an administrator password/)).toBeVisible();

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -311,7 +311,7 @@ test.describe("onboarding bootstrap", () => {
     await expect.poll(() => confirmations).toBe(1);
 
     await expect(dialog.getByText(/private Node\.js and npm runtime/)).toBeVisible();
-    await expect(dialog.getByText(/First-time setup can take a few minutes/)).toBeVisible();
+    await expect(dialog.getByText(/few minutes/)).toHaveCount(0);
     await expect(dialog.getByText(/Next, Cave creates your defaults and starts its local service/)).toBeVisible();
     await expect(dialog.getByText(/Waiting for local components/)).toBeVisible();
     await expect(dialog.getByText(/Provider sign-in is deferred/)).toBeVisible();

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -293,7 +293,7 @@ test.describe("onboarding bootstrap", () => {
               id: "core-tools",
               label: "Prepare local components",
               status: "running",
-              detail: "Setting up Cave’s private Node.js and npm runtime…",
+              detail: "Preparing Cave’s private Node.js and npm runtime…",
             },
             ...state().stages.slice(1),
           ],
@@ -304,13 +304,15 @@ test.describe("onboarding bootstrap", () => {
 
     const dialog = setup(page);
     await dialog.getByRole("button", { name: "Set up Cave", exact: true }).click();
-    await expect(dialog.getByText("Setting up Cave’s private Node.js and npm runtime…")).toBeVisible();
+    await expect(dialog.getByText("Preparing Cave’s private Node.js and npm runtime…")).toBeVisible();
     await expect(dialog.locator('[aria-current="step"]')).toContainText(
       "Prepare local components",
     );
     await expect.poll(() => confirmations).toBe(1);
 
     await expect(dialog.getByText(/private Node\.js and npm runtime/)).toBeVisible();
+    await expect(dialog.getByText(/First-time setup can take a few minutes/)).toBeVisible();
+    await expect(dialog.getByText(/Next, Cave creates your defaults and starts its local service/)).toBeVisible();
     await expect(dialog.getByText(/Waiting for local components/)).toBeVisible();
     await expect(dialog.getByText(/Provider sign-in is deferred/)).toBeVisible();
     await expect(dialog.getByText(/never asks for an administrator password/)).toBeVisible();


### PR DESCRIPTION
## Summary
- show the real local-tools checkpoints while Cave checks, prepares, installs, and verifies first-run components
- explain the next setup stage and that backgrounding is safe
- cover the server progress sequence and running dialog copy

## Verification
- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/onboarding-core-tools.test.ts`
- `node --experimental-strip-types src/components/onboarding-bootstrap-overlay.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `pnpm codemod:design:check`

Not verified locally: `pnpm lint` cannot load the missing `eslint-plugin-react-hooks` package; the targeted Playwright run did not start its configured web server.

Bead: cave-jab