### PR TITLE
Fix managed Node setup when Coven CLI is absent

### DIFF
--- a/src/app/api/onboarding/install/install-service.ts
+++ b/src/app/api/onboarding/install/install-service.ts
@@ -1031,7 +1031,10 @@ async function runManagedNodeInstallJob(job: InstallJob, npmLease?: NpmInstallLe
       onProgress: (line) => appendOutput(job, `${line}\n`),
     });
     if (result.ok && !job.cancelRequested) {
-      refreshCovenBin();
+      // Node setup is complete independently of the Coven CLI. On Windows,
+      // eagerly resolving the executable throws while the intentionally
+      // not-yet-installed CLI is absent, turning this success into a
+      // misleading installer_start_failed result.
       refreshCovenSpawnEnv();
       job.ok = true;
       job.code = 0;

--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -84,6 +84,16 @@ assert.match(source, /shell: false/, "installer spawns never use a shell");
 assert.match(source, /commandPath\("npm", \{ refresh: true, refreshOnMiss: true \}\)/, "Coven CLI repair falls back to verified host npm only for its detected prefix");
 assert.match(source, /installManagedNodeToolchain\(/, "managed Node installer is routed through the endpoint");
 assert.match(source, /controller\.abort\(\)/, "managed Node installation supports cancellation");
+assert.match(
+  source,
+  /async function runManagedNodeInstallJob[\s\S]*?if \(result\.ok && !job\.cancelRequested\) \{[\s\S]*?refreshCovenSpawnEnv\(\);[\s\S]*?job\.ok = true;[\s\S]*?\}/,
+  "a successful managed Node install refreshes PATH without requiring the not-yet-installed Coven CLI",
+);
+assert.doesNotMatch(
+  source.match(/async function runManagedNodeInstallJob[\s\S]*?(?=export async function startOnboardingInstall)/)?.[0] ?? "",
+  /refreshCovenBin\(\)/,
+  "managed Node success must not resolve Coven before the distinct CLI install step",
+);
 assert.match(source, /reserveGlobalNpmInstall\(targetName\)/, "managed toolchain and npm operations serialize");
 assert.match(source, /if \(body\.confirmInstall !== true\)/, "installation requires explicit confirmation");
 assert.equal(source.match(/rejectNonLocalRequest\(req\)/g)?.length, 3, "all route methods are local-only");


### PR DESCRIPTION
## Summary
- preserve a successful managed Node.js setup when Coven CLI is intentionally absent
- refresh only the child-process PATH before the separate Coven CLI step
- pin the Windows regression at the onboarding install boundary

## Validation
- `node --experimental-strip-types src/app/api/onboarding/install/route.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `pnpm test:api`

Bead: cave-8rx