### PR TITLE
docs: plan Research Desk resource program

### DIFF
--- a/docs/superpowers/plans/2026-08-15-research-protocol-unit-0.md
+++ b/docs/superpowers/plans/2026-08-15-research-protocol-unit-0.md
@@ -1,0 +1,1669 @@
+# Research Protocol Unit 0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the provider-neutral Research Run Protocol v1 as authoritative JSON Schemas, hand-written TypeScript parsers, canonical SHA-256 digests, shared fixtures, and a cross-environment conformance suite.
+
+**Architecture:** Keep wire contracts in `schemas/research/v1/` and runtime code in small modules under `src/lib/research-protocol/`. JSON Schemas define the accepted wire shape; TypeScript parsers independently validate the same fixtures, preserve unknown additive fields, and enforce semantic rules that JSON Schema cannot express cleanly. Unit 0 does not modify Research Mission persistence, UI, local storage, device execution, or cloud APIs.
+
+**Tech Stack:** TypeScript 6, Node.js 24 test runner, `canonicalize@3.0.0` for RFC 8785 canonical JSON, `node:crypto` SHA-256, `typebox/value` for JSON Schema fixture checks, pnpm 10.
+
+**Source specification:** `docs/superpowers/specs/2026-08-15-externalized-research-desk-implementation-design.md` §§7-8, 20.1, and 21 Unit 0.
+
+---
+
+## File structure
+
+Create these focused modules:
+
+```text
+schemas/research/v1/
+  context-pack.schema.json
+  topic-discovery-job.schema.json
+  topic-proposal.schema.json
+  research-run.schema.json
+  run-event.schema.json
+  model-task.schema.json
+  model-task-result.schema.json
+  run-manifest.schema.json
+  fixtures/
+    valid/
+      context-pack.json
+      topic-discovery-job.json
+      topic-proposal.json
+      research-run.json
+      run-event.json
+      model-task.json
+      model-task-result.json
+      run-manifest-assembling.json
+      run-manifest-final-local.json
+      run-manifest-final-cloud.json
+      run-manifest-retention-update.json
+    invalid/
+      unknown-major.json
+      context-pack-retention.json
+      context-pack-pdf-selector.json
+      topic-proposal-score.json
+      research-run-waiting-phase.json
+      run-event-sequence.json
+      model-task-policy.json
+      model-task-result-usage.json
+      run-manifest-previous-digest.json
+      run-manifest-final-mutation.json
+      run-manifest-deletion-pair.json
+      run-manifest-private-title.json
+src/lib/research-protocol/
+  common.ts
+  digest.ts
+  context-pack.ts
+  topic-discovery.ts
+  research-run.ts
+  model-task.ts
+  run-manifest.ts
+  index.ts
+  digest.test.ts
+  context-pack.test.ts
+  topic-discovery.test.ts
+  research-run.test.ts
+  model-task.test.ts
+  run-manifest.test.ts
+scripts/
+  research-protocol-conformance.test.ts
+```
+
+Responsibilities:
+
+- `common.ts`: shared primitive guards, timestamp/id rules, parse result/error types, retention ordering, and unknown-field preservation.
+- `digest.ts`: RFC 8785 canonicalization and SHA-256 helpers.
+- `context-pack.ts`: selectors, resources, Context Pack types and parser.
+- `topic-discovery.ts`: model receipts, discovery jobs, evidence refs, proposals, and score recomputation.
+- `research-run.ts`: execution bindings, privacy policy, run, event, and bounds parsers.
+- `model-task.ts`: Model Task/result parsers and signed-payload projection.
+- `run-manifest.ts`: artifact/source/usage/retention/deletion parsing plus revision-chain validation.
+- `index.ts`: public exports and schema-string dispatcher.
+- `research-protocol-conformance.test.ts`: runs every fixture through both its JSON Schema and TypeScript parser.
+
+Do not add a generated-code step or a new dependency. Do not import server, React, mission-store, or provider modules into `src/lib/research-protocol/`.
+
+**Execution precondition:** Commit the amended specification and this plan,
+then execute Unit 0 in a dedicated worktree. Do not implement from the current
+dirty `main` worktree, and do not stage `.beads/interactions.jsonl`,
+`pnpm-lock.yaml`, or `WORKTREE-SWEEP-2026-08-15-READ-ME.md` unless a later task
+explicitly owns those files.
+
+### Task 1: Shared validation and canonical digests
+
+**Files:**
+- Create: `src/lib/research-protocol/common.ts`
+- Create: `src/lib/research-protocol/digest.ts`
+- Create: `src/lib/research-protocol/digest.test.ts`
+- Modify: `scripts/run-tests.mjs:1728-1733`
+
+- [ ] **Step 1: Write the failing digest tests**
+
+Create `src/lib/research-protocol/digest.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  canonicalJson,
+  digestProtocolObject,
+  sha256Digest,
+} from "./digest.ts";
+
+test("canonical JSON is stable across property insertion order", () => {
+  assert.equal(
+    canonicalJson({ z: 1, a: { y: 2, b: 3 } }),
+    canonicalJson({ a: { b: 3, y: 2 }, z: 1 }),
+  );
+});
+
+test("protocol object digest omits only its own digest field", () => {
+  const left = {
+    schema: "opencoven.context-pack/v1",
+    id: "ctx_1",
+    digest: "old-value",
+    child: { digest: "child-value" },
+  };
+  const right = {
+    schema: "opencoven.context-pack/v1",
+    id: "ctx_1",
+    child: { digest: "child-value" },
+  };
+  assert.equal(digestProtocolObject(left), digestProtocolObject(right));
+  assert.notEqual(
+    digestProtocolObject(left),
+    digestProtocolObject({ ...right, child: { digest: "changed" } }),
+  );
+});
+
+test("SHA-256 uses lowercase hexadecimal", () => {
+  assert.equal(
+    sha256Digest("hello"),
+    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+  );
+});
+
+test("non-JSON values fail canonicalization", () => {
+  assert.throws(() => canonicalJson({ value: undefined }), /canonical JSON/i);
+  assert.throws(() => canonicalJson({ value: Number.NaN }), /canonical JSON/i);
+});
+```
+
+- [ ] **Step 2: Wire the test and verify it fails**
+
+Append the test path to the `conformance` array in `scripts/run-tests.mjs`:
+
+```js
+conformance: [
+  "scripts/cross-environment.test.ts",
+  "scripts/daemon-connectivity-faults.test.ts",
+  "scripts/windows-native-browser-regression.test.mjs",
+  "scripts/cave-home-migration-windows.test.ts",
+  "src/lib/research-protocol/digest.test.ts",
+],
+```
+
+Run:
+
+```bash
+pnpm test:conformance
+```
+
+Expected: FAIL because `src/lib/research-protocol/digest.ts` does not exist.
+
+- [ ] **Step 3: Implement shared guards and parse errors**
+
+Create `src/lib/research-protocol/common.ts`:
+
+```ts
+export type UnknownFields = Record<string, unknown>;
+
+export type ProtocolErrorCode =
+  | "invalid_type"
+  | "invalid_value"
+  | "missing_field"
+  | "unknown_major"
+  | "digest_mismatch"
+  | "semantic_conflict";
+
+export type ProtocolParseError = {
+  code: ProtocolErrorCode;
+  path: string;
+  message: string;
+};
+
+export type ProtocolParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: ProtocolParseError };
+
+export const RETENTION_ORDER = {
+  "run-only": 0,
+  "7-days": 1,
+  project: 2,
+} as const;
+
+export type RetentionPolicyV1 = keyof typeof RETENTION_ORDER;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isUtcTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed)
+    && value.endsWith("Z")
+    && new Date(parsed).toISOString() === value;
+}
+
+export function isOpaqueId(value: unknown, prefix: string): value is string {
+  return typeof value === "string"
+    && value.startsWith(`${prefix}_`)
+    && /^[a-z0-9][a-z0-9_-]*$/i.test(value);
+}
+
+export function isSha256(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+}
+
+export function retentionDoesNotExceed(
+  requested: RetentionPolicyV1,
+  consented: RetentionPolicyV1,
+): boolean {
+  return RETENTION_ORDER[requested] <= RETENTION_ORDER[consented];
+}
+
+export function fail<T>(
+  code: ProtocolErrorCode,
+  path: string,
+  message: string,
+): ProtocolParseResult<T> {
+  return { ok: false, error: { code, path, message } };
+}
+
+export function pass<T>(value: T): ProtocolParseResult<T> {
+  return { ok: true, value };
+}
+
+export type ResearchContextBindingV1 = {
+  contextPackId: string;
+  contextPackDigest: string;
+  topicProposalId?: string;
+};
+```
+
+Parser modules must spread the source record first and validated known fields second:
+
+```ts
+return pass({
+  ...value,
+  schema: "opencoven.example/v1",
+  id: value.id,
+});
+```
+
+This preserves unknown additive fields while preventing unvalidated values from replacing known fields.
+
+- [ ] **Step 4: Implement canonicalization and hashing**
+
+Create `src/lib/research-protocol/digest.ts`:
+
+```ts
+import { createHash } from "node:crypto";
+import canonicalize from "canonicalize";
+import { isRecord } from "./common.ts";
+
+function assertJsonValue(value: unknown, path = "$"): void {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError(`${path} is not canonical JSON`);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertJsonValue(entry, `${path}[${index}]`));
+    return;
+  }
+  if (isRecord(value)) {
+    for (const [key, entry] of Object.entries(value)) {
+      assertJsonValue(entry, `${path}.${key}`);
+    }
+    return;
+  }
+  throw new TypeError(`${path} is not canonical JSON`);
+}
+
+export function canonicalJson(value: unknown): string {
+  assertJsonValue(value);
+  const canonical = canonicalize(value);
+  if (typeof canonical !== "string") {
+    throw new TypeError("Value cannot be represented as canonical JSON");
+  }
+  return canonical;
+}
+
+export function sha256Digest(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function digestProtocolObject(value: unknown): string {
+  if (!isRecord(value)) {
+    throw new TypeError("Protocol digest input must be an object");
+  }
+  const { digest: _ownDigest, ...digestInput } = value;
+  return sha256Digest(canonicalJson(digestInput));
+}
+```
+
+- [ ] **Step 5: Run the focused test and typecheck**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/research-protocol/digest.test.ts
+pnpm typecheck
+```
+
+Expected: all digest tests PASS; typecheck exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/research-protocol/common.ts \
+  src/lib/research-protocol/digest.ts \
+  src/lib/research-protocol/digest.test.ts \
+  scripts/run-tests.mjs
+git commit -m "feat(research): add protocol digest primitives"
+```
+
+### Task 2: Context Pack schema and parser
+
+**Files:**
+- Create: `schemas/research/v1/context-pack.schema.json`
+- Create: `schemas/research/v1/fixtures/valid/context-pack.json`
+- Create: `schemas/research/v1/fixtures/invalid/context-pack-retention.json`
+- Create: `schemas/research/v1/fixtures/invalid/context-pack-pdf-selector.json`
+- Create: `src/lib/research-protocol/context-pack.ts`
+- Create: `src/lib/research-protocol/context-pack.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Create one valid and one invalid fixture**
+
+The valid fixture must contain:
+
+```json
+{
+  "schema": "opencoven.context-pack/v1",
+  "id": "ctx_01",
+  "digest": "f1a36e4a3e458fbb62c3e868988c0b3ed735efca17b994216e1a78f050891d5f",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "createdBy": { "client": "coven-cave" },
+  "purpose": "research-run",
+  "subject": { "familiarId": "sage", "projectId": "project_01" },
+  "consent": {
+    "selectionMode": "explicit",
+    "allowRemoteQueries": true,
+    "allowRemoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days"
+  },
+  "resources": [
+    {
+      "id": "resource_01",
+      "kind": "session",
+      "uri": "coven://session/session_01",
+      "digest": "0b9c966e9a7c4831f255cebbba0e7726fc8410ed32998179b32221097b404f9b",
+      "localBlobDigest": "4b94f5f75ee88c0e995251afe98fb468499215b33bbb6c18d01b1dd583f69e9d",
+      "selector": { "type": "turn-range", "start": 2, "end": 5 },
+      "trust": "mixed-conversation",
+      "sensitivity": "private",
+      "capturedAt": "2026-08-15T19:59:00.000Z",
+      "title": "Selected research discussion",
+      "mediaType": "application/json"
+    }
+  ],
+  "policy": {
+    "treatResourceTextAsData": true,
+    "toolAuthority": "none",
+    "allowedPurposes": ["research-run"]
+  },
+  "transforms": { "secretScanVersion": "1" },
+  "futureExtension": { "preserve": true }
+}
+```
+
+Create `context-pack-retention.json` by copying the fixture and changing `consent.retention` to `"forever"`.
+
+Create `context-pack-pdf-selector.json` by copying the fixture, changing the
+resource kind to `"artifact"`, the media type to `"application/pdf"`, and the
+selector to:
+
+```json
+{ "type": "pdf-page-span", "page": 0, "start": 12, "end": 12 }
+```
+
+It is invalid because pages are one-based and evidence spans must be non-empty.
+
+- [ ] **Step 2: Write the failing parser tests**
+
+Create `src/lib/research-protocol/context-pack.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import invalidPdfSelector from "../../../schemas/research/v1/fixtures/invalid/context-pack-pdf-selector.json" with { type: "json" };
+import invalidRetention from "../../../schemas/research/v1/fixtures/invalid/context-pack-retention.json" with { type: "json" };
+import validContextPack from "../../../schemas/research/v1/fixtures/valid/context-pack.json" with { type: "json" };
+import {
+  parseContextPackV1,
+  parseContextSelectorV1,
+} from "./context-pack.ts";
+
+test("parses a Context Pack and preserves additive fields", () => {
+  const result = parseContextPackV1(validContextPack);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.deepEqual(result.value.futureExtension, { preserve: true });
+});
+
+test("rejects an unknown retention policy", () => {
+  const result = parseContextPackV1(invalidRetention);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.error.path, "$.consent.retention");
+});
+
+test("enforces selector-specific bounds", () => {
+  assert.equal(parseContextSelectorV1({ type: "turn-range", start: 2, end: 2 }).ok, false);
+  assert.equal(parseContextSelectorV1({ type: "turn-range", start: 2, end: 3 }).ok, true);
+  assert.equal(parseContextSelectorV1({ type: "turn-range", start: 3, end: 2 }).ok, false);
+  assert.equal(parseContextSelectorV1({ type: "json-pointer", pointer: "/items/0" }).ok, true);
+  assert.equal(parseContextSelectorV1({ type: "json-pointer", pointer: "items/0" }).ok, false);
+  assert.equal(parseContextSelectorV1({ type: "markdown-section", headingPath: [] }).ok, false);
+  assert.equal(
+    parseContextSelectorV1({ type: "text-span", start: 0, end: 12 }).ok,
+    true,
+  );
+  assert.equal(
+    parseContextSelectorV1({ type: "text-span", start: 12, end: 12 }).ok,
+    false,
+  );
+  assert.equal(
+    parseContextSelectorV1({ type: "pdf-page-span", page: 1, start: 0, end: 12 }).ok,
+    true,
+  );
+  assert.equal(
+    parseContextSelectorV1({ type: "pdf-page-span", page: 0, start: 0, end: 12 }).ok,
+    false,
+  );
+  assert.equal(parseContextPackV1(invalidPdfSelector).ok, false);
+});
+```
+
+Add `src/lib/research-protocol/context-pack.test.ts` to the conformance suite.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/research-protocol/context-pack.test.ts
+```
+
+Expected: FAIL because `context-pack.ts` does not exist.
+
+- [ ] **Step 4: Create the authoritative Context Pack schema**
+
+Create a Draft 2020-12 schema with `$id: "opencoven.context-pack/v1"` and:
+
+- `additionalProperties: true` on every object.
+- Required fields exactly matching §8.1.
+- `const` for `schema`, `createdBy.client`, `policy.treatResourceTextAsData`, and `policy.toolAuthority`.
+- SHA-256 strings constrained by `^[a-f0-9]{64}$`.
+- UTC timestamps constrained with `format: "date-time"` plus `pattern: "Z$"`.
+- Opaque ids constrained by the corresponding prefixes: `ctx_`, `resource_`.
+- Selector `oneOf` branches for all six selector types.
+- Non-negative integer selector positions and `minItems: 1` for `headingPath`.
+- `uniqueItems: true` and `minItems: 1` for `policy.allowedPurposes`.
+- Exact enums from §8.1 for purpose, selection mode, retention, resource kind, trust, and sensitivity.
+
+The schema cannot express `start < end`; the TypeScript parser must enforce it.
+
+- [ ] **Step 5: Implement Context Pack parsing**
+
+Create the exported types exactly as written in §8.1 and implement:
+
+```ts
+export function parseContextSelectorV1(
+  value: unknown,
+  path = "$.selector",
+): ProtocolParseResult<ContextSelectorV1>;
+
+export function parseContextPackResourceV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ContextPackResourceV1>;
+
+export function parseContextPackV1(
+  value: unknown,
+): ProtocolParseResult<ContextPackV1>;
+```
+
+Enforce:
+
+- Unknown `schema` major returns `unknown_major`.
+- All required booleans are real booleans, not truthy values.
+- `turn-range` uses zero-based safe non-negative turn indexes and `start < end`.
+- JSON pointers are `""` or begin with `/`.
+- `text-span` uses zero-based UTF-8 byte offsets and `start < end`.
+- Markdown heading paths contain at least one non-empty string.
+- `pdf-page-span` uses a one-based safe integer page and zero-based UTF-8 byte
+  offsets with `start < end`.
+- Resource arrays contain unique resource ids.
+- `allowedPurposes` contains the pack's own `purpose`.
+- Every digest is lowercase SHA-256.
+- Every timestamp passes `isUtcTimestamp`.
+- Unknown fields survive in the returned object.
+
+- [ ] **Step 6: Run focused tests and commit**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/research-protocol/context-pack.test.ts
+pnpm typecheck
+```
+
+Expected: PASS.
+
+```bash
+git add schemas/research/v1/context-pack.schema.json \
+  schemas/research/v1/fixtures/valid/context-pack.json \
+  schemas/research/v1/fixtures/invalid/context-pack-retention.json \
+  schemas/research/v1/fixtures/invalid/context-pack-pdf-selector.json \
+  src/lib/research-protocol/context-pack.ts \
+  src/lib/research-protocol/context-pack.test.ts \
+  scripts/run-tests.mjs
+git commit -m "feat(research): define Context Pack protocol"
+```
+
+### Task 3: Topic discovery schemas and parsers
+
+**Files:**
+- Create: `schemas/research/v1/topic-discovery-job.schema.json`
+- Create: `schemas/research/v1/topic-proposal.schema.json`
+- Create: `schemas/research/v1/fixtures/valid/topic-discovery-job.json`
+- Create: `schemas/research/v1/fixtures/valid/topic-proposal.json`
+- Create: `schemas/research/v1/fixtures/invalid/topic-proposal-score.json`
+- Create: `src/lib/research-protocol/topic-discovery.ts`
+- Create: `src/lib/research-protocol/topic-discovery.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write failing score and lifecycle tests**
+
+Create `src/lib/research-protocol/topic-discovery.test.ts` with:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parseTopicDiscoveryJobV1,
+  parseTopicProposalV1,
+  topicProposalVisibleTotal,
+} from "./topic-discovery.ts";
+
+const scores = {
+  groundability: 4,
+  decisionValue: 3,
+  unresolvedness: 2,
+  recurrence: 1,
+  novelty: 4,
+  timeliness: 2,
+  familiarFit: 4,
+  feasibility: 3,
+  humanResonance: 4,
+  riskPenalty: 2,
+  visibleTotal: 25,
+};
+
+test("recomputes the visible proposal score", () => {
+  assert.equal(topicProposalVisibleTotal(scores), 25);
+  assert.equal(parseTopicProposalV1({
+    schema: "opencoven.topic-proposal/v1",
+    id: "proposal_01",
+    discoveryJobId: "topicjob_01",
+    contextPackId: "ctx_01",
+    title: "A grounded question",
+    question: "Which evidence should guide the decision?",
+    whyNow: "The source set contains unresolved disagreement.",
+    evidence: [{
+      resourceId: "resource_01",
+      selector: { type: "text-span", start: 0, end: 20 },
+      excerpt: "Evidence excerpt",
+      excerptDigest: "84e3d621a6705b03cc38559364169efff401aa7155f85cecd46b51660dd1ae42",
+    }],
+    counterevidence: [],
+    scores,
+    suggested: {
+      mode: "brief",
+      deliverable: "Decision brief",
+      sourceTarget: 8,
+      wallClockMinutes: 30,
+    },
+    uncertainty: "One source may be stale.",
+    relatedMissionIds: [],
+    createdAt: "2026-08-15T20:05:00.000Z",
+  }).ok, true);
+});
+
+test("rejects a model-supplied total that does not recompute", () => {
+  const invalid = { ...scores, visibleTotal: 26 };
+  assert.equal(topicProposalVisibleTotal(invalid), 25);
+});
+
+test("requires lifecycle timestamps when their state has begun", () => {
+  const result = parseTopicDiscoveryJobV1({
+    schema: "opencoven.topic-discovery-job/v1",
+    id: "topicjob_01",
+    contextPackId: "ctx_01",
+    contextPackDigest: "f1a36e4a3e458fbb62c3e868988c0b3ed735efca17b994216e1a78f050891d5f",
+    familiarId: "sage",
+    status: "running",
+    requestedAt: "2026-08-15T20:00:00.000Z",
+    proposalIds: [],
+  });
+  assert.equal(result.ok, false);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Add the test to `conformance`, then run:
+
+```bash
+node --experimental-strip-types --test src/lib/research-protocol/topic-discovery.test.ts
+```
+
+Expected: FAIL because `topic-discovery.ts` does not exist.
+
+- [ ] **Step 3: Create both schemas and fixtures**
+
+Encode §8.2 and §8.3 exactly. Apply these additional constraints:
+
+- ids use `topicjob_`, `proposal_`, `ctx_`, `resource_`, and `mission_` prefixes;
+- all ten component scores are integers from 0 through 4;
+- evidence has `minItems: 1`;
+- excerpt digests are lowercase SHA-256;
+- suggested source target and wall-clock minutes are positive safe integers;
+- proposal ids and related mission ids are unique;
+- a running job requires `startedAt`;
+- completed, failed, or cancelled jobs require `finishedAt`;
+- a completed job has no `failure`;
+- a failed job requires `failure`;
+- `modelReceipt` uses the exact receipt shape in §8.7.
+
+Set the invalid score fixture's `groundability` to `5`.
+
+- [ ] **Step 4: Implement receipts, jobs, proposals, and score recomputation**
+
+Export:
+
+```ts
+export type ResearchModelReceiptV1 = {
+  familiarId: string;
+  runtime: string;
+  effectiveModel: string | null;
+  modelSource:
+    | "next-message"
+    | "session"
+    | "familiar-default"
+    | "runtime-default"
+    | "global-default";
+  providerBilling: "user-connected";
+  usage: {
+    inputTokens: number | null;
+    outputTokens: number | null;
+    costUsd: number | null;
+    reportedByRuntime: boolean;
+  };
+};
+
+export function parseResearchModelReceiptV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ResearchModelReceiptV1>;
+
+export function parseTopicDiscoveryJobV1(
+  value: unknown,
+): ProtocolParseResult<TopicDiscoveryJobV1>;
+
+export function topicProposalVisibleTotal(
+  scores: TopicProposalV1["scores"],
+): number;
+
+export function parseTopicProposalV1(
+  value: unknown,
+): ProtocolParseResult<TopicProposalV1>;
+```
+
+`topicProposalVisibleTotal` sums the nine positive dimensions and subtracts `riskPenalty`. `parseTopicProposalV1` rejects a mismatched `visibleTotal`; it does not silently replace it.
+
+For usage, enforce non-negative safe integer token counts, non-negative finite cost, and:
+
+- `reportedByRuntime: false` requires all three values to be `null`;
+- `reportedByRuntime: true` requires at least one non-null value.
+
+- [ ] **Step 5: Run focused tests and commit**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/research-protocol/topic-discovery.test.ts
+pnpm typecheck
+```
+
+Expected: PASS.
+
+```bash
+git add schemas/research/v1/topic-discovery-job.schema.json \
+  schemas/research/v1/topic-proposal.schema.json \
+  schemas/research/v1/fixtures/valid/topic-discovery-job.json \
+  schemas/research/v1/fixtures/valid/topic-proposal.json \
+  schemas/research/v1/fixtures/invalid/topic-proposal-score.json \
+  src/lib/research-protocol/topic-discovery.ts \
+  src/lib/research-protocol/topic-discovery.test.ts \
+  scripts/run-tests.mjs
+git commit -m "feat(research): define topic discovery protocol"
+```
+
+### Task 4: Research Run and ordered event contracts
+
+**Files:**
+- Create: `schemas/research/v1/research-run.schema.json`
+- Create: `schemas/research/v1/run-event.schema.json`
+- Create: `schemas/research/v1/fixtures/valid/research-run.json`
+- Create: `schemas/research/v1/fixtures/valid/run-event.json`
+- Create: `schemas/research/v1/fixtures/invalid/research-run-waiting-phase.json`
+- Create: `schemas/research/v1/fixtures/invalid/run-event-sequence.json`
+- Modify: `src/lib/research-protocol/common.ts`
+- Create: `src/lib/research-protocol/research-run.ts`
+- Create: `src/lib/research-protocol/research-run.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write failing semantic tests**
+
+Create tests covering:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  parseResearchRunV1,
+  parseRunEventV1,
+  validateRunEventSequence,
+} from "./research-run.ts";
+
+test("waiting_for_executor requires a resumable model phase", () => {
+  const result = parseResearchRunV1({
+    schema: "opencoven.research-run/v1",
+    id: "run_01",
+    acceptedTopic: {
+      question: "What should we research?",
+      editedByUser: false,
+    },
+    execution: {
+      location: "hosted",
+      modelExecution: "cave-device",
+      modelBinding: {
+        familiarId: "sage",
+        selection: "resolve-at-run-start",
+      },
+      strategy: "single-agent",
+    },
+    privacy: {
+      remoteQueries: true,
+      remoteContent: false,
+      artifactContentSync: false,
+      retention: "run-only",
+      allowMemoryPromotion: false,
+    },
+    bounds: {
+      wallClockMinutes: 30,
+      maxIterations: 1,
+      sourceTarget: 5,
+      checkpointEvery: 1,
+      stopWhenCostUnavailable: true,
+    },
+    status: "waiting_for_executor",
+    waitingReason: "executor",
+    createdAt: "2026-08-15T20:00:00.000Z",
+    updatedAt: "2026-08-15T20:01:00.000Z",
+    nextEventSequence: 2,
+  });
+  assert.equal(result.ok, false);
+});
+
+test("ordered events accept contiguous sequence and reject a gap", () => {
+  const first = {
+    schema: "opencoven.run-event/v1",
+    runId: "run_01",
+    sequence: 1,
+    type: "run.created",
+    at: "2026-08-15T20:00:00.000Z",
+    data: {},
+  } as const;
+  const second = { ...first, sequence: 2, type: "run.status" as const };
+  assert.equal(parseRunEventV1(first).ok, true);
+  assert.equal(validateRunEventSequence([first, second]).ok, true);
+  assert.equal(validateRunEventSequence([first, { ...second, sequence: 3 }]).ok, false);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Add the test to `conformance`, then run it directly. Expected: missing-module failure.
+
+- [ ] **Step 3: Create run and event schemas**
+
+Encode §§8.4-8.6 and:
+
+- allow `context` to be absent;
+- make `allowMemoryPromotion` a literal `false`;
+- require pinned model selection to include `model`;
+- reject a `model` field for `resolve-at-run-start`;
+- constrain all `ResearchBounds` counts to positive safe integers and `maxSpendUsd` to a non-negative finite number;
+- constrain `nextEventSequence` and event `sequence` to integers at least `1`;
+- allow `artifactManifest` through a `$ref` to `run-manifest.schema.json`;
+- require `waitingForPhase` exactly when status is `waiting_for_executor`;
+- allow `waitingReason: "checkpoint"` only with `awaiting_checkpoint`;
+- require `failure` only for `failed`;
+- leave event `data` open with `additionalProperties: true`.
+
+- [ ] **Step 4: Implement run and event parsing**
+
+Export the types from §§8.4-8.6. Add
+`parseResearchContextBindingV1` beside `ResearchContextBindingV1` in
+`common.ts` so `research-run.ts` and `run-manifest.ts` do not import each
+other in both directions:
+
+```ts
+export function parseResearchContextBindingV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ResearchContextBindingV1>;
+
+export function parseResearchExecutionProfileV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ResearchExecutionProfileV1>;
+
+export function parseResearchPrivacyPolicyV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ResearchPrivacyPolicyV1>;
+
+export function parseResearchRunV1(
+  value: unknown,
+): ProtocolParseResult<ResearchRunV1>;
+
+export function parseRunEventV1(
+  value: unknown,
+): ProtocolParseResult<RunEventV1>;
+
+export function validateRunEventSequence(
+  events: readonly RunEventV1[],
+): ProtocolParseResult<readonly RunEventV1[]>;
+```
+
+`validateRunEventSequence` must require one `runId`, start at sequence `1`, and increase by exactly one. It must return `semantic_conflict` at the first mismatch.
+
+- [ ] **Step 5: Run focused tests and commit**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/research-protocol/research-run.test.ts
+pnpm typecheck
+```
+
+Expected: PASS.
+
+```bash
+git add schemas/research/v1/research-run.schema.json \
+  schemas/research/v1/run-event.schema.json \
+  schemas/research/v1/fixtures/valid/research-run.json \
+  schemas/research/v1/fixtures/valid/run-event.json \
+  schemas/research/v1/fixtures/invalid/research-run-waiting-phase.json \
+  schemas/research/v1/fixtures/invalid/run-event-sequence.json \
+  src/lib/research-protocol/common.ts \
+  src/lib/research-protocol/research-run.ts \
+  src/lib/research-protocol/research-run.test.ts \
+  scripts/run-tests.mjs
+git commit -m "feat(research): define run and event protocol"
+```
+
+### Task 5: Model Task, result, and signature payload
+
+**Files:**
+- Create: `schemas/research/v1/model-task.schema.json`
+- Create: `schemas/research/v1/model-task-result.schema.json`
+- Create: `schemas/research/v1/fixtures/valid/model-task.json`
+- Create: `schemas/research/v1/fixtures/valid/model-task-result.json`
+- Create: `schemas/research/v1/fixtures/invalid/model-task-policy.json`
+- Create: `schemas/research/v1/fixtures/invalid/model-task-result-usage.json`
+- Create: `src/lib/research-protocol/model-task.ts`
+- Create: `src/lib/research-protocol/model-task.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write failing task/result tests**
+
+Create tests that assert:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  modelTaskResultSignaturePayload,
+  parseModelTaskResultV1,
+  parseModelTaskV1,
+} from "./model-task.ts";
+
+test("projects exactly the signed result fields", () => {
+  const result = {
+    schema: "opencoven.model-task-result/v1",
+    taskId: "modeltask_01",
+    runId: "run_01",
+    attempt: 1,
+    inputDigest: "89f8f6710042193f16a5cd49f3ae469f299f00a9efbee7f0bfa037dcae0efb97",
+    output: { decision: "continue" },
+    outputDigest: "91e75aca0a4f002ecb264c4d13e1e52ce4a584b709821b58f6c20db38127d8f6",
+    executorDeviceId: "device_01",
+    modelReceipt: {
+      familiarId: "sage",
+      runtime: "copilot",
+      effectiveModel: "gpt-5.6-sol",
+      modelSource: "session",
+      providerBilling: "user-connected",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        costUsd: null,
+        reportedByRuntime: true,
+      },
+    },
+    completedAt: "2026-08-15T20:10:00.000Z",
+    signature: "base64-signature",
+  } as const;
+  assert.equal(parseModelTaskResultV1(result).ok, true);
+  assert.deepEqual(modelTaskResultSignaturePayload(result), {
+    taskId: "modeltask_01",
+    runId: "run_01",
+    attempt: 1,
+    inputDigest: result.inputDigest,
+    outputDigest: result.outputDigest,
+    executorDeviceId: "device_01",
+    completedAt: "2026-08-15T20:10:00.000Z",
+  });
+});
+
+test("read permission is mandatory", () => {
+  assert.equal(parseModelTaskV1({
+    schema: "opencoven.model-task/v1",
+    id: "modeltask_01",
+    runId: "run_01",
+    phase: "scope",
+    attempt: 1,
+    inputDigest: "89f8f6710042193f16a5cd49f3ae469f299f00a9efbee7f0bfa037dcae0efb97",
+    input: {
+      contextPack: {
+        id: "ctx_01",
+        digest: "f1a36e4a3e458fbb62c3e868988c0b3ed735efca17b994216e1a78f050891d5f",
+        availability: "device-local",
+      },
+      publicEvidenceRefs: [],
+    },
+    modelBinding: {
+      familiarId: "sage",
+      selection: "resolve-at-run-start",
+    },
+    policy: {
+      permissionMode: "write",
+      allowedOutputs: ["scope"],
+      allowRemoteQueries: false,
+      maxOutputTokens: 1000,
+    },
+    outputSchema: "opencoven.scope-output/v1",
+    leaseExpiresAt: "2026-08-15T20:15:00.000Z",
+  }).ok, false);
+});
+```
+
+- [ ] **Step 2: Create schemas and fixtures**
+
+Encode §8.7 exactly and enforce:
+
+- `attempt` is an integer at least `1`;
+- `inputDigest` and `outputDigest` are lowercase SHA-256;
+- `permissionMode` is literal `"read"`;
+- `allowedOutputs` is a non-empty unique string array;
+- `maxOutputTokens` is a positive safe integer;
+- public evidence refs are unique opaque strings;
+- signature is a non-empty string;
+- output is an open object;
+- `leaseExpiresAt` and `completedAt` are UTC timestamps;
+- model receipt usage follows Task 3 semantics.
+
+- [ ] **Step 3: Implement parsers and signature projection**
+
+Export:
+
+```ts
+export type ModelTaskResultSignaturePayloadV1 = Pick<
+  ModelTaskResultV1,
+  | "taskId"
+  | "runId"
+  | "attempt"
+  | "inputDigest"
+  | "outputDigest"
+  | "executorDeviceId"
+  | "completedAt"
+>;
+
+export function parseModelTaskV1(
+  value: unknown,
+): ProtocolParseResult<ModelTaskV1>;
+
+export function parseModelTaskResultV1(
+  value: unknown,
+): ProtocolParseResult<ModelTaskResultV1>;
+
+export function modelTaskResultSignaturePayload(
+  value: ModelTaskResultV1,
+): ModelTaskResultSignaturePayloadV1 {
+  return {
+    taskId: value.taskId,
+    runId: value.runId,
+    attempt: value.attempt,
+    inputDigest: value.inputDigest,
+    outputDigest: value.outputDigest,
+    executorDeviceId: value.executorDeviceId,
+    completedAt: value.completedAt,
+  };
+}
+```
+
+The parser validates structure and digest syntax only. It does not verify the Ed25519 signature or recalculate `outputDigest`; those operations require executor keys and the declared output schema and belong to Unit 4.
+
+- [ ] **Step 4: Run focused tests and commit**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/research-protocol/model-task.test.ts
+pnpm typecheck
+```
+
+Expected: PASS.
+
+```bash
+git add schemas/research/v1/model-task.schema.json \
+  schemas/research/v1/model-task-result.schema.json \
+  schemas/research/v1/fixtures/valid/model-task.json \
+  schemas/research/v1/fixtures/valid/model-task-result.json \
+  schemas/research/v1/fixtures/invalid/model-task-policy.json \
+  schemas/research/v1/fixtures/invalid/model-task-result-usage.json \
+  src/lib/research-protocol/model-task.ts \
+  src/lib/research-protocol/model-task.test.ts \
+  scripts/run-tests.mjs
+git commit -m "feat(research): define model task protocol"
+```
+
+### Task 6: Run Manifest parsing and revision invariants
+
+**Files:**
+- Create: `schemas/research/v1/run-manifest.schema.json`
+- Create: `schemas/research/v1/fixtures/valid/run-manifest-assembling.json`
+- Create: `schemas/research/v1/fixtures/valid/run-manifest-final-local.json`
+- Create: `schemas/research/v1/fixtures/valid/run-manifest-final-cloud.json`
+- Create: `schemas/research/v1/fixtures/valid/run-manifest-retention-update.json`
+- Create: all five invalid Run Manifest fixtures listed in the file map
+- Create: `src/lib/research-protocol/run-manifest.ts`
+- Create: `src/lib/research-protocol/run-manifest.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write failing usage and deletion-state tests**
+
+Create tests for deterministic usage:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import finalManifestJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-final-local.json" with { type: "json" };
+import {
+  aggregateManifestUsage,
+  parseRunManifestV1,
+  validateRunManifestRevision,
+} from "./run-manifest.ts";
+
+test("classifies zero model executions as unreported", () => {
+  assert.deepEqual(aggregateManifestUsage([]), {
+    inputTokens: null,
+    outputTokens: null,
+    costUsd: null,
+    completeness: "unreported",
+  });
+});
+
+test("aggregates only reported values and marks gaps partial", () => {
+  const executions = [
+    {
+      taskId: "modeltask_01",
+      phase: "scope" as const,
+      attempt: 1,
+      inputDigest: "89f8f6710042193f16a5cd49f3ae469f299f00a9efbee7f0bfa037dcae0efb97",
+      outputDigest: "91e75aca0a4f002ecb264c4d13e1e52ce4a584b709821b58f6c20db38127d8f6",
+      receipt: {
+        familiarId: "sage",
+        runtime: "copilot",
+        effectiveModel: "gpt-5.6-sol",
+        modelSource: "session" as const,
+        providerBilling: "user-connected" as const,
+        usage: {
+          inputTokens: 100,
+          outputTokens: null,
+          costUsd: null,
+          reportedByRuntime: true,
+        },
+      },
+    },
+  ];
+  assert.deepEqual(aggregateManifestUsage(executions), {
+    inputTokens: 100,
+    outputTokens: null,
+    costUsd: null,
+    completeness: "partial",
+  });
+});
+
+test("rejects post-finalization artifact mutation", () => {
+  const parsed = parseRunManifestV1(finalManifestJson);
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  const previous = parsed.value;
+  const next = {
+    ...previous,
+    digest: "f2f086f40df9dc520fad5ecb0c9050c569d96bed108054b4c6f5cfbbd184e21d",
+    revision: previous.revision + 1,
+    previousDigest: previous.digest,
+    artifacts: [{ ...previous.artifacts[0], title: "Changed" }],
+  };
+  assert.equal(validateRunManifestRevision(previous, next).ok, false);
+});
+```
+
+- [ ] **Step 2: Create the Run Manifest schema**
+
+Encode §8.8 exactly. Include:
+
+- `revision` integer at least `1`;
+- revision `1` forbids `previousDigest`; later revisions require it;
+- assembling state forbids `finalizedAt`; final state requires it;
+- `context` remains optional;
+- `device-local`, `cloud-metadata`, and `cloud-content` placement enums;
+- all usage numbers nullable and non-negative;
+- all arrays default to no implied content and permit zero items;
+- required original and effective retention policies;
+- exact retention/deletion enums;
+- conditional required fields for scheduled, pending, partial-failure, and completed deletion receipts.
+
+JSON Schema conditionals must also enforce the status pairing table:
+
+```text
+active              <-> not_scheduled
+deletion_scheduled  <-> scheduled
+deletion_pending    <-> pending | partial_failure
+deleted             <-> completed
+```
+
+- [ ] **Step 3: Implement manifest parsing and aggregate usage**
+
+Export the §8.8 types and:
+
+```ts
+export function aggregateManifestUsage(
+  executions: readonly RunManifestModelExecutionV1[],
+): RunManifestUsageV1;
+
+export function parseRunManifestV1(
+  value: unknown,
+): ProtocolParseResult<RunManifestV1>;
+```
+
+`parseRunManifestV1` enforces:
+
+- manifest digest equals `digestProtocolObject(value)`;
+- aggregate usage equals `aggregateManifestUsage(modelExecutions)`;
+- unique source ids, artifact ids, and `taskId + attempt` execution pairs;
+- context/source correspondence from §8.8;
+- a cloud-content artifact cannot have `contentSync: "not-requested"`;
+- generic or user-approved titles are represented by requiring titles to reject `/`, `\`, URI schemes, control characters, and known secret prefixes (`sk-`, `ghp_`, `github_pat_`);
+- original and effective retention do not exceed bound Context Pack consent when the caller supplies that consent;
+- `contentExpiresAt` is null for active pre-clock state and for active project retention;
+- deletion status pairing and required receipt fields.
+
+Because the manifest does not embed Context Pack consent, expose:
+
+```ts
+export function validateManifestRetentionConsent(
+  manifest: RunManifestV1,
+  contextConsent: RetentionPolicyV1 | undefined,
+): ProtocolParseResult<RunManifestV1>;
+```
+
+When `manifest.context` is present, `contextConsent` is required. When no context is present, consent validation succeeds using the run's original policy as its ceiling.
+
+- [ ] **Step 4: Implement revision-chain validation**
+
+`validateRunManifestRevision` must reject unless all conditions hold:
+
+1. `next.revision === previous.revision + 1`.
+2. `next.previousDigest === previous.digest`.
+3. `id`, `runId`, and `createdAt` are unchanged.
+4. Both manifest digests recalculate correctly.
+5. An assembling revision may remain assembling or become final.
+6. A final revision remains final and preserves `finalizedAt`.
+7. After finalization, canonical values for `context`, `sources`, `artifacts`, `modelExecutions`, `usage`, and `retention.policy` are unchanged.
+8. After finalization, only `retention.effectivePolicy`, retention status/timestamps, deletion fields, `revision`, `previousDigest`, and `digest` may differ.
+9. Effective retention lengthening requires the caller to pass `freshConsent: true`.
+
+Use this signature for rule 9:
+
+```ts
+export type ManifestRevisionOptions = {
+  freshConsent?: boolean;
+  contextConsent?: RetentionPolicyV1;
+};
+
+export function validateRunManifestRevision(
+  previous: RunManifestV1,
+  next: RunManifestV1,
+  options?: ManifestRevisionOptions,
+): ProtocolParseResult<RunManifestV1>;
+```
+
+- [ ] **Step 5: Add fixtures for every manifest conformance case**
+
+The fixtures must cover:
+
+- revision-1 assembling;
+- revision-1 final early-terminal run with no model executions;
+- final local-only artifact;
+- final consented cloud-content artifact;
+- valid retention-update revision;
+- bad `previousDigest`;
+- final artifact mutation;
+- invalid retention/deletion pairing;
+- private filename in artifact title;
+- completed deletion without `eventSequence`.
+
+Every valid fixture's `digest` must be generated by a temporary one-line Node invocation of `digestProtocolObject`, then pasted into the fixture. Do not weaken digest validation to accommodate hand-written fixture values.
+
+- [ ] **Step 6: Run focused tests and commit**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/research-protocol/run-manifest.test.ts
+pnpm typecheck
+```
+
+Expected: PASS.
+
+```bash
+git add schemas/research/v1/run-manifest.schema.json \
+  schemas/research/v1/fixtures/valid/run-manifest-*.json \
+  schemas/research/v1/fixtures/invalid/run-manifest-*.json \
+  src/lib/research-protocol/run-manifest.ts \
+  src/lib/research-protocol/run-manifest.test.ts \
+  scripts/run-tests.mjs
+git commit -m "feat(research): define immutable run manifests"
+```
+
+### Task 7: Public protocol dispatcher and unknown-major behavior
+
+**Files:**
+- Create: `src/lib/research-protocol/index.ts`
+- Create: `schemas/research/v1/fixtures/invalid/unknown-major.json`
+- Modify: `src/lib/research-protocol/research-run.ts`
+- Modify: `src/lib/research-protocol/research-run.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write the failing dispatcher tests**
+
+Add:
+
+```ts
+import {
+  parseResearchProtocolObject,
+  RESEARCH_PROTOCOL_SCHEMAS,
+} from "./index.ts";
+
+test("dispatches every v1 schema and rejects unknown majors", () => {
+  assert.equal(RESEARCH_PROTOCOL_SCHEMAS.length, 8);
+  assert.equal(parseResearchProtocolObject({
+    schema: "opencoven.run-event/v1",
+    runId: "run_01",
+    sequence: 1,
+    type: "run.created",
+    at: "2026-08-15T20:00:00.000Z",
+    data: {},
+  }).ok, true);
+
+  const unknown = parseResearchProtocolObject({
+    schema: "opencoven.run-event/v2",
+  });
+  assert.equal(unknown.ok, false);
+  if (unknown.ok) return;
+  assert.equal(unknown.error.code, "unknown_major");
+});
+```
+
+- [ ] **Step 2: Implement the public exports and dispatcher**
+
+Create:
+
+```ts
+import { fail, isRecord, type ProtocolParseResult } from "./common.ts";
+import { parseContextPackV1, type ContextPackV1 } from "./context-pack.ts";
+import {
+  parseTopicDiscoveryJobV1,
+  parseTopicProposalV1,
+  type TopicDiscoveryJobV1,
+  type TopicProposalV1,
+} from "./topic-discovery.ts";
+import {
+  parseResearchRunV1,
+  parseRunEventV1,
+  type ResearchRunV1,
+  type RunEventV1,
+} from "./research-run.ts";
+import {
+  parseModelTaskResultV1,
+  parseModelTaskV1,
+  type ModelTaskResultV1,
+  type ModelTaskV1,
+} from "./model-task.ts";
+import { parseRunManifestV1, type RunManifestV1 } from "./run-manifest.ts";
+
+export * from "./common.ts";
+export * from "./context-pack.ts";
+export * from "./digest.ts";
+export * from "./model-task.ts";
+export * from "./research-run.ts";
+export * from "./run-manifest.ts";
+export * from "./topic-discovery.ts";
+
+export const RESEARCH_PROTOCOL_SCHEMAS = [
+  "opencoven.context-pack/v1",
+  "opencoven.topic-discovery-job/v1",
+  "opencoven.topic-proposal/v1",
+  "opencoven.research-run/v1",
+  "opencoven.run-event/v1",
+  "opencoven.model-task/v1",
+  "opencoven.model-task-result/v1",
+  "opencoven.run-manifest/v1",
+] as const;
+
+export type ResearchProtocolObjectV1 =
+  | ContextPackV1
+  | TopicDiscoveryJobV1
+  | TopicProposalV1
+  | ResearchRunV1
+  | RunEventV1
+  | ModelTaskV1
+  | ModelTaskResultV1
+  | RunManifestV1;
+
+export function parseResearchProtocolObject(
+  value: unknown,
+): ProtocolParseResult<ResearchProtocolObjectV1> {
+  if (!isRecord(value) || typeof value.schema !== "string") {
+    return fail("missing_field", "$.schema", "schema is required");
+  }
+  switch (value.schema) {
+    case "opencoven.context-pack/v1": return parseContextPackV1(value);
+    case "opencoven.topic-discovery-job/v1": return parseTopicDiscoveryJobV1(value);
+    case "opencoven.topic-proposal/v1": return parseTopicProposalV1(value);
+    case "opencoven.research-run/v1": return parseResearchRunV1(value);
+    case "opencoven.run-event/v1": return parseRunEventV1(value);
+    case "opencoven.model-task/v1": return parseModelTaskV1(value);
+    case "opencoven.model-task-result/v1": return parseModelTaskResultV1(value);
+    case "opencoven.run-manifest/v1": return parseRunManifestV1(value);
+    default: return fail("unknown_major", "$.schema", `Unsupported schema ${value.schema}`);
+  }
+}
+```
+
+- [ ] **Step 3: Run tests and commit**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/research-protocol/*.test.ts
+pnpm typecheck
+```
+
+Expected: PASS.
+
+```bash
+git add src/lib/research-protocol/index.ts \
+  src/lib/research-protocol/research-run.test.ts \
+  schemas/research/v1/fixtures/invalid/unknown-major.json
+git commit -m "feat(research): expose protocol dispatcher"
+```
+
+### Task 8: Cross-environment schema/parser conformance
+
+**Files:**
+- Create: `scripts/research-protocol-conformance.test.ts`
+- Modify: `scripts/run-tests.mjs:1728-1733`
+
+- [ ] **Step 1: Write the conformance runner**
+
+Create a test that:
+
+1. Reads `schemas/research/v1/fixtures/valid/*.json` and `invalid/*.json`.
+2. Maps each fixture's `schema` to the matching schema file and parser.
+3. Calls `Check(schemaContext, schema, fixture)` from `typebox/value`.
+4. Calls `parseResearchProtocolObject(fixture)`.
+5. Requires both validators to accept every valid fixture.
+6. Requires at least one validator to reject each invalid fixture.
+7. Requires semantic-only invalid fixtures to include `"expectedSchemaValid": true` at the fixture root; remove that marker before parser validation.
+8. Round-trips valid parsed objects through `JSON.stringify`/`JSON.parse` and verifies unknown additive fields remain.
+9. Recomputes digests for every digest-bearing valid fixture.
+
+Use:
+
+```ts
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { IsSchema, type TSchema } from "typebox";
+import { Check } from "typebox/value";
+import {
+  digestProtocolObject,
+  isRecord,
+  parseResearchProtocolObject,
+} from "../src/lib/research-protocol/index.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schemaRoot = path.join(root, "schemas/research/v1");
+
+const schemaFiles = new Map([
+  ["opencoven.context-pack/v1", "context-pack.schema.json"],
+  ["opencoven.topic-discovery-job/v1", "topic-discovery-job.schema.json"],
+  ["opencoven.topic-proposal/v1", "topic-proposal.schema.json"],
+  ["opencoven.research-run/v1", "research-run.schema.json"],
+  ["opencoven.run-event/v1", "run-event.schema.json"],
+  ["opencoven.model-task/v1", "model-task.schema.json"],
+  ["opencoven.model-task-result/v1", "model-task-result.schema.json"],
+  ["opencoven.run-manifest/v1", "run-manifest.schema.json"],
+]);
+
+function jsonObject(pathname: string): Record<string, unknown> {
+  const value: unknown = JSON.parse(readFileSync(pathname, "utf8"));
+  assert.ok(isRecord(value), pathname);
+  return value;
+}
+
+function jsonSchema(pathname: string): TSchema {
+  const value: unknown = JSON.parse(readFileSync(pathname, "utf8"));
+  assert.ok(IsSchema(value), pathname);
+  return value;
+}
+
+function fixtureFiles(kind: "valid" | "invalid"): string[] {
+  return readdirSync(path.join(schemaRoot, "fixtures", kind))
+    .filter((name) => name.endsWith(".json"))
+    .sort()
+    .map((name) => path.join(schemaRoot, "fixtures", kind, name));
+}
+
+const schemaContext = Object.fromEntries(
+  [...schemaFiles.entries()].map(([id, filename]) => [
+    id,
+    jsonSchema(path.join(schemaRoot, filename)),
+  ]),
+);
+
+test("all valid fixtures satisfy schema and parser", () => {
+  for (const fixturePath of fixtureFiles("valid")) {
+    const fixture = jsonObject(fixturePath);
+    const schemaFile = schemaFiles.get(String(fixture.schema));
+    assert.ok(schemaFile, fixturePath);
+    const schema = jsonSchema(path.join(schemaRoot, schemaFile));
+    assert.equal(Check(schemaContext, schema, fixture), true, fixturePath);
+    const parsed = parseResearchProtocolObject(fixture);
+    assert.equal(parsed.ok, true, fixturePath);
+    if (!parsed.ok) continue;
+    assert.deepEqual(JSON.parse(JSON.stringify(parsed.value)), parsed.value);
+    if (typeof fixture.digest === "string") {
+      assert.equal(digestProtocolObject(fixture), fixture.digest, fixturePath);
+    }
+  }
+});
+
+test("all invalid fixtures are rejected at the declared layer", () => {
+  for (const fixturePath of fixtureFiles("invalid")) {
+    const raw = jsonObject(fixturePath);
+    const expectedSchemaValid = raw.expectedSchemaValid === true;
+    const { expectedSchemaValid: _marker, ...fixture } = raw;
+    const schemaFile = schemaFiles.get(String(fixture.schema));
+    if (!schemaFile) {
+      assert.equal(parseResearchProtocolObject(fixture).ok, false, fixturePath);
+      continue;
+    }
+    const schema = jsonSchema(path.join(schemaRoot, schemaFile));
+    assert.equal(
+      Check(schemaContext, schema, fixture),
+      expectedSchemaValid,
+      fixturePath,
+    );
+    assert.equal(parseResearchProtocolObject(fixture).ok, false, fixturePath);
+  }
+});
+```
+
+- [ ] **Step 2: Wire the conformance runner**
+
+Append:
+
+```js
+"scripts/research-protocol-conformance.test.ts",
+```
+
+to the `conformance` suite.
+
+- [ ] **Step 3: Run all Unit 0 validation**
+
+Run:
+
+```bash
+pnpm test:conformance
+pnpm check:tests-wired
+pnpm typecheck
+pnpm lint:source
+```
+
+Expected:
+
+- every conformance test passes on the current OS;
+- every new test is reported as wired;
+- typecheck exits 0;
+- lint exits with zero warnings.
+
+- [ ] **Step 4: Check protocol-layer isolation**
+
+Run:
+
+```bash
+rg -n 'next/|react|server/|provider|openai|anthropic|cloudflare|@/' \
+  src/lib/research-protocol schemas/research/v1
+```
+
+Expected: no matches except the literal protocol field value `providerBilling` and privacy comments explaining why provider names are absent.
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; only Unit 0 paths and pre-existing unrelated worktree changes are present.
+
+- [ ] **Step 5: Commit the conformance suite**
+
+```bash
+git add scripts/research-protocol-conformance.test.ts scripts/run-tests.mjs
+git commit -m "test(research): add protocol conformance suite"
+```
+
+### Task 9: Unit 0 completion review
+
+**Files:**
+- Verify: `schemas/research/v1/**`
+- Verify: `src/lib/research-protocol/**`
+- Verify: `scripts/research-protocol-conformance.test.ts`
+- Verify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Confirm all eight schemas exist**
+
+Run:
+
+```bash
+find schemas/research/v1 -maxdepth 1 -name '*.schema.json' -print | sort
+```
+
+Expected: exactly eight schema files matching §7.2.
+
+- [ ] **Step 2: Confirm fixture coverage**
+
+Run:
+
+```bash
+find schemas/research/v1/fixtures -name '*.json' -print | sort
+```
+
+Expected: all valid and invalid fixtures listed in this plan, including assembling/final/revision manifest cases.
+
+- [ ] **Step 3: Confirm no protocol placeholders or implementation leakage**
+
+Run:
+
+```bash
+rg -n '\b(TBD|TODO|FIXME|REPLACE-ME)\b' \
+  schemas/research/v1 src/lib/research-protocol \
+  scripts/research-protocol-conformance.test.ts
+```
+
+Expected: no matches.
+
+- [ ] **Step 4: Run the final gate**
+
+Run:
+
+```bash
+pnpm test:conformance && \
+pnpm check:tests-wired && \
+pnpm typecheck && \
+pnpm lint:source
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 5: Record the implementation boundary**
+
+The Unit 0 pull request description must state:
+
+```text
+This change defines Research Protocol v1 schemas, parsers, canonical digests,
+fixtures, and conformance tests only. It does not enable Context Pack storage,
+topic discovery, mission v2 writes, hosted runs, device execution, or cloud
+deployment. Those remain gated by Units 1-5 of the approved specification.
+```
+
+- [ ] **Step 6: Commit any final test-only corrections**
+
+If the final gate required corrections, stage only Unit 0 files and commit:
+
+```bash
+git add schemas/research/v1 src/lib/research-protocol \
+  scripts/research-protocol-conformance.test.ts scripts/run-tests.mjs
+git commit -m "test(research): close Unit 0 conformance gaps"
+```
+
+If the working tree is clean for Unit 0 paths, do not create an empty commit.

--- a/docs/superpowers/plans/2026-08-16-externalized-research-desk-program.md
+++ b/docs/superpowers/plans/2026-08-16-externalized-research-desk-program.md
@@ -1,0 +1,600 @@
+# Externalized Research Desk Program Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the approved externalized Research Desk end to end through independently shippable protocol, local resource, Context Pack, discovery, gateway, executor, and optional hosted-cloud units.
+
+**Architecture:** Preserve the approved protocol-first, local-first design while inserting a local Research Resource layer before Context Pack creation. Authoritative resource manifests and immutable resource snapshots remain separate from operational job state; sealed Context Packs copy selected normalized bytes into their own content-addressed store so resource refresh, deletion, restore, and retention cannot mutate pack evidence. The useful local release ships before any cloud repository, account, Vectorize index, or executor is required.
+
+**Tech Stack:** TypeScript 6, Node.js 24, Next.js 16, React 19, `node:sqlite` with FTS5, RFC 8785 canonical JSON, SHA-256 content addressing, Cave JSON/atomic-file stores, Cloudflare Workers/D1/R2/Queues/Workflows/Durable Objects/Vectorize/Workers AI behind a separate decision gate.
+
+**Approved design:** `docs/superpowers/specs/2026-08-15-externalized-research-desk-implementation-design.md`
+
+**First executable plan:** `docs/superpowers/plans/2026-08-15-research-protocol-unit-0.md`
+
+---
+
+## 1. Program boundary
+
+This is an umbrella program, not one implementation branch. Every delivery unit
+gets its own Bead, managed worktree, detailed writing-plans document, protected
+pull request, focused validation, and merge evidence.
+
+The program has three release boundaries:
+
+1. **Local resource release:** saved resources become durable, versioned,
+   ingestible, searchable, backup-safe, and compatible with older Cave builds.
+2. **Local discovery release:** sealed Context Packs and grounded topic
+   discovery create editable mission drafts without cloud dependencies.
+3. **Hosted beta:** Research Cloud public retrieval and Cave Device Executor
+   work begin only after an explicit repository/account/operations decision.
+
+Cloud unavailability, a missing local embedding endpoint, or an offline Cave
+must never disable lexical local resource search, Context Pack reads, or
+existing local Research Missions.
+
+## 2. Non-negotiable trust boundaries
+
+1. Resource text, filenames, metadata, model output, and fetched pages are
+   untrusted data and never grant tools or authority.
+2. Resource manifests are authoritative user state. Ingest jobs, failure
+   records, FTS rows, and embeddings are operational or derivative state.
+3. A sealed Context Pack owns immutable selected bytes. It never relies on a
+   mutable resource snapshot remaining present.
+4. Private content, private embeddings, provider credentials, full prompts,
+   local paths, and raw sessions remain local by default.
+5. Every displayed evidence excerpt resolves to an exact selector over bytes
+   whose digest is verified at read time.
+6. Cancellation does not imply deletion. Retention, deletion, artifact
+   registration, and artifact-content synchronization remain distinct.
+7. Tenant identity comes from authentication and is re-applied at every D1,
+   R2, Vectorize, coordinator, event, and artifact boundary.
+8. Waiting is not running. Missing executor or quota produces a typed waiting
+   state with no false progress.
+
+## 3. Local storage ownership
+
+### 3.1 Resource catalog
+
+Authoritative and operational resource data lives under:
+
+```text
+<caveHome>/research-resources/
+  manifests/<resource-id>.json
+  snapshots/<snapshot-id>.json
+  blobs/sha256/<first-two-hex>/<digest>
+  jobs/<job-id>.json
+  failures/<job-id>.json
+  tombstones/<resource-id>.json
+  migration/research-links-projection.json
+  migration/research-links-journal.json
+  index/research-resources.sqlite
+```
+
+Ownership:
+
+- `manifests/`, `snapshots/`, `blobs/`, `tombstones/`, and migration projection
+  metadata are authoritative and included in Cave backup archives.
+- `jobs/` is durable operational intent but excluded from backups. The manifest
+  stores enough ingest intent to recreate a queued job after restore.
+- `failures/` contains bounded diagnostic records and is excluded from backups.
+  The manifest retains only a typed last-failure code and retryability.
+- `index/research-resources.sqlite`, `-wal`, and `-shm` are derivative and
+  excluded from backups. Restore and corruption recovery rebuild them.
+
+All directories are mode 0700; files are mode 0600. Stores refuse symlinked
+roots and entries, verify containment after `realpath`, write through
+temp-file-plus-atomic-rename, and verify every content digest on read.
+
+### 3.2 Context Pack store
+
+Sealed pack data remains physically separate:
+
+```text
+<caveHome>/research-context-packs/
+  manifests/<pack-id>.json
+  blobs/sha256/<first-two-hex>/<digest>
+  redactions/<redaction-map-digest>.json
+  topic-jobs/<job-id>.json
+  topic-proposals/<proposal-id>.json
+```
+
+Do not share the resource CAS with the pack CAS. Sharing would couple resource
+refresh/deletion, pack retention, backup repair, and corruption domains.
+Copying selected normalized bytes costs disk space but guarantees that a sealed
+pack remains readable after its source resource is refreshed or deleted.
+
+Pack deletion garbage-collects only pack-owned blobs. Resource deletion
+garbage-collects only resource-owned blobs.
+
+### 3.3 Authoritative resource contracts
+
+Local resource contracts are Cave-owned and are not added to the portable
+Research Run Protocol:
+
+```ts
+type ResourceManifestV1 = {
+  version: 1;
+  id: string;
+  revision: number;
+  kind:
+    | "saved-resource"
+    | "paper"
+    | "attachment"
+    | "mission-artifact"
+    | "session"
+    | "thread-self-report"
+    | "local-file";
+  canonicalIdentity: string;
+  title: string;
+  sourceUri?: string;
+  sourceType: string;
+  category?: "github" | "docs" | "paper" | "video" | "social" | "article" | "other";
+  publishedAt?: string;
+  legacySavedLink?: {
+    id: string;
+    url: string;
+    addedAt: string;
+    source: "chat" | "desk";
+  };
+  paper?: {
+    arxivId: string;
+    authors: string[];
+    abstract?: string;
+    publishedAt?: string;
+  };
+  subject: {
+    familiarId?: string;
+    projectId?: string;
+  };
+  sensitivity: "public" | "private" | "restricted";
+  ingest: {
+    desired: boolean;
+    state:
+      | "metadata_only"
+      | "queued"
+      | "ingesting"
+      | "ready"
+      | "partial"
+      | "failed"
+      | "deleting";
+    lastFailureCode?: string;
+    retryable?: boolean;
+  };
+  currentSnapshotId?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ResourceSnapshotV1 = {
+  version: 1;
+  id: string;
+  resourceId: string;
+  resourceRevision: number;
+  rawBlobDigest?: string;
+  normalizedBlobDigest: string;
+  normalizedMediaType: string;
+  normalizedBytes: number;
+  sourceSelector: ContextSelectorV1;
+  pageBoundaries?: Array<{
+    page: number;
+    start: number;
+    end: number;
+  }>;
+  fetchedAt?: string;
+  finalUrl?: string;
+  etag?: string;
+  lastModified?: string;
+  createdAt: string;
+};
+```
+
+`legacySavedLink`, `category`, `paper`, and `publishedAt` preserve landed
+Research Resources behavior, including `cave-cbz28`. They are local migration
+fields, not portable protocol fields.
+
+### 3.4 Selector coordinate contract
+
+Define selector coordinates before Protocol Unit 0 writes schemas:
+
+- `turn-range`: zero-based turn indexes, `start` inclusive, `end` exclusive,
+  and `start < end`.
+- `json-pointer`: RFC 6901 pointer evaluated against the exact normalized JSON
+  blob.
+- `text-span`: zero-based UTF-8 byte offsets over the exact normalized blob,
+  `start` inclusive, `end` exclusive, and `start < end`.
+- `markdown-section`: non-empty heading path evaluated against the exact
+  normalized Markdown blob.
+- `pdf-page-span`: one-based page number plus zero-based UTF-8 byte offsets
+  within that page's normalized text, `start` inclusive, `end` exclusive, and
+  `start < end`.
+- `whole-resource`: the complete exact normalized blob.
+
+PDF normalization persists a page-boundary table mapping each one-based page to
+its half-open range in the whole normalized blob. Rebuilds must reproduce the
+same normalized bytes and boundaries for the same extractor version.
+
+`ResourceSnapshotV1.sourceSelector` resolves against the immutable catalog
+snapshot. When a user selects a subset for a Context Pack, Cave copies the
+selected normalized bytes into a new pack-owned blob and writes the portable
+pack resource selector as `whole-resource`. The local pack build receipt keeps
+the original resource id, snapshot id, and `sourceSelector` for audit, but those
+local fields do not enter `ContextPackV1`.
+
+Topic Proposal evidence always points to the pack-owned selector. It never
+requires a catalog snapshot to remain present.
+
+## 4. Operational job state
+
+### 4.1 Main ingest job
+
+```ts
+type ResourceIngestJobV1 = {
+  version: 1;
+  id: string;
+  resourceId: string;
+  resourceRevision: number;
+  deletionRevision: number;
+  status:
+    | "queued"
+    | "claimed"
+    | "paused_quota"
+    | "retry_wait"
+    | "completed"
+    | "failed"
+    | "cancelled";
+  stage: "fetch" | "snapshot" | "extract" | "publish_lexical";
+  attempt: number;
+  availableAt: string;
+  lease?: {
+    owner: string;
+    expiresAt: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+};
+```
+
+`paused_quota` is resumable and does not consume a retry attempt. A claimed job
+may publish only when its resource manifest still exists, its resource revision
+matches, and its deletion revision equals the current tombstone/fence revision.
+
+### 4.2 Semantic task
+
+Embedding is a separate best-effort task, not a required main ingest stage:
+
+```ts
+type ResourceEmbeddingTaskV1 = {
+  version: 1;
+  resourceId: string;
+  snapshotId: string;
+  lexicalRevision: number;
+  providerId: string;
+  modelId: string;
+  dimensions: number;
+  status: "queued" | "building" | "ready" | "failed" | "unavailable";
+  updatedAt: string;
+};
+```
+
+Lexical publication makes a resource searchable. Missing, rebuilding, stale,
+or failed embeddings never hide lexical results.
+
+### 4.3 Crash recovery
+
+Startup reconciliation:
+
+1. Expires abandoned leases.
+2. Requeues `claimed` jobs whose manifest and revisions remain current.
+3. Recreates jobs for manifests with `ingest.desired: true` and no usable
+   snapshot or active job.
+4. Leaves non-retryable failures visible instead of silently requeueing.
+5. Rebuilds derivative lexical/vector rows from verified snapshots.
+6. Completes interrupted deletion before accepting new jobs for that id.
+
+## 5. Deletion fencing and tombstones
+
+Deletion is ordered:
+
+1. Acquire the resource lock.
+2. Increment and persist the deletion revision.
+3. Mark the manifest `deleting`.
+4. Cancel or fence all main and semantic jobs.
+5. Persist a minimal tombstone containing resource id, deletion revision,
+   deleted timestamp, and no title, URL, excerpt, or local path.
+6. Remove derivative lexical and semantic rows.
+7. Remove snapshot records.
+8. Garbage-collect unreferenced resource blobs.
+9. Remove the resource manifest last.
+10. Regenerate the legacy saved-link projection.
+
+Every publication step checks the tombstone/deletion revision immediately
+before commit. Startup repair resumes any interrupted deletion and never
+recreates a manifest from stale job output.
+
+Tombstones are authoritative, included in backup archives, and retained until a
+future explicit compaction design proves no supported archive or job can
+resurrect the deleted revision.
+
+## 6. Saved-link compatibility and downgrade safety
+
+`research-links.json` remains a complete reverse projection during migration:
+
+1. On first upgrade, lock and import every valid legacy row into the catalog.
+2. Preserve legacy id, URL, category, title, paper metadata, `addedAt`, and
+   `source`.
+3. Commit the catalog mutation.
+4. Write a migration journal naming the catalog revision and intended
+   projection digest.
+5. Regenerate the complete `research-links.json` from live compatible catalog
+   rows.
+6. Read the projection back and verify its digest before clearing the journal.
+7. On startup, finish any journaled projection before serving reads.
+8. Before regeneration after a downgrade/re-upgrade, compare the legacy file
+   digest with the last projected digest. If it changed, import legitimate
+   downgrade-era saves/deletes first instead of overwriting them.
+
+The compatibility API remains until all current writers and readers migrate.
+Older Cave builds see post-cutover saves/deletes through the projected file.
+Rollback disables new resource features but does not lose catalog-era link
+changes.
+
+## 7. Local retrieval
+
+Use a dedicated derivative database rather than coupling correctness to global
+search:
+
+```text
+resources
+snapshots
+chunks
+chunks_fts
+provider_state
+embedding_state
+chunk_embeddings
+```
+
+The request path:
+
+1. Validate a versioned Research retrieval query.
+2. Apply project, familiar, kind, sensitivity, status, date, and pack filters
+   before ranking.
+3. Produce exact-identity/title candidates.
+4. Query FTS5 for lexical candidates.
+5. Query compatible local embeddings when available.
+6. Fuse ranks deterministically, dedupe by resource/snapshot, and apply MMR.
+7. Re-resolve each result through the authoritative snapshot and verify the
+   blob digest before returning an excerpt.
+
+The first embedding adapter supports an explicitly configured loopback
+OpenAI-compatible/Ollama endpoint. It validates loopback origin, model id,
+dimensions, count, and response bounds. No local content is sent to a remote
+embedding service by this adapter.
+
+## 8. Backup and restore
+
+Backup archive v1 remains readable and writable. Add the authoritative Research
+directories to `src/lib/server/backup-manifest.ts` without changing the archive
+envelope version.
+
+Restore order:
+
+1. Validate every archive path and digest using existing archive-v1 rules.
+2. Restore authoritative files atomically.
+3. Reconcile tombstones and finish saved-link projection journals.
+4. Recreate missing ingest jobs from manifest intent.
+5. Rebuild derivative indexes.
+6. When Context Pack Unit 1 exists, validate every pack manifest against its
+   pack-owned blobs before exposing it.
+
+Resource backup support lands before Context Pack Unit 1. Pack manifests,
+pack-owned blobs, and redaction maps join backup only with Unit 1, so no plan
+references directories that do not exist yet.
+
+## 9. Feature-flag authority
+
+`src/lib/feature-flags.ts` is the single feature-flag authority. Add:
+
+```ts
+export function caveResearchResources(): boolean;
+export function caveResearchLocalIngestion(): boolean;
+export function caveResearchSemantic(): boolean;
+export function caveResearchContextPacks(): boolean;
+export function caveResearchTopicDiscovery(): boolean;
+export function caveResearchHostedRuns(): boolean;
+```
+
+Flags default off. Read and write migrations remain compatible while a flag is
+off. `caveResearchSemantic` controls only semantic work and UI; lexical search
+remains available. Hosted flags cannot enable without configured cloud account,
+repository, bindings, and auth policy.
+
+## 10. Cloud visibility and revision contract
+
+Cloud work is optional and begins only after Gate C0 in §12.
+
+For each cloud snapshot:
+
+```ts
+type CloudIndexPublicationV1 = {
+  tenantId: string;
+  resourceId: string;
+  snapshotId: string;
+  buildRevision: number;
+  lexicalState: "pending" | "ready" | "failed";
+  semanticState: "pending" | "ready" | "failed" | "disabled";
+  visibleRevision: number | null;
+  vectorRevision: number | null;
+};
+```
+
+Rules:
+
+- The D1 transaction that writes chunks and FTS rows sets
+  `lexicalState: "ready"` and advances `visibleRevision`.
+- `visibleRevision` is the only revision eligible for cloud lexical reads.
+- Vectorize lag or failure never hides lexically ready content.
+- Semantic candidates are eligible only when `semanticState: "ready"` and
+  `vectorRevision === visibleRevision`.
+- Stale vectors are ignored and may not resolve passages.
+- Vectorize stores a tenant-scoped D1 chunk id and bounded filter metadata, not
+  raw content or an externally usable R2 key.
+- Passage resolution rechecks tenant and revision through D1 before reading R2.
+
+## 11. Delivery graph
+
+### Approved portable protocol
+
+**A0 / Approved Unit 0 — Research Protocol v1**
+
+- Schemas, parsers, canonical digests, fixtures, and conformance.
+- Includes final selector coordinate semantics and `pdf-page-span`.
+- Detailed plan:
+  `docs/superpowers/plans/2026-08-15-research-protocol-unit-0.md`.
+
+### Local resource release
+
+**A1 — Local resource contracts and feature flags**
+
+- Cave-only manifest, snapshot, job, embedding-task, tombstone, migration, and
+  query contracts.
+- Depends on A0 selector types but does not alter portable schemas.
+
+**A2 — Resource snapshot and blob store**
+
+- Separate resource CAS, immutable snapshot records, digest verification,
+  normalization receipts, and deletion reference accounting.
+- Depends on A1.
+
+**A3 — Resource catalog and compatibility fields**
+
+- Authoritative manifests, revision locks, paper/date/category/legacy fields,
+  list/detail APIs, and existing Resources read model.
+- Depends on A1 and A2.
+
+**A4 — Saved-link migration and reverse projection**
+
+- First-run import, crash journal, complete reverse projection, downgrade-era
+  reconciliation, and compatibility API.
+- Depends on A3.
+
+**A5 — Durable local ingestion**
+
+- Public URL fetch, extraction adapters, main jobs, quota pause, retries,
+  lexical publication, deletion fencing, and startup repair.
+- Depends on A2, A3, and A4.
+
+**A6 — Optional local semantic retrieval**
+
+- Loopback embedding provider, embedding tasks, vector persistence, compatible
+  model revisions, and truthful unavailability.
+- Depends on A5. Nothing else requires A6.
+
+**A7 — Local Research retrieval and Resources UX**
+
+- Versioned search API, exact/FTS/hybrid ranking, evidence preview, ingest
+  status, retry/delete, and later global-search compatibility provider.
+- Depends on A5 and may consume A6 when available.
+
+**A8 — Resource backup, restore, deletion repair, and rollout**
+
+- Archive-v1 compatibility, authoritative inclusion/derivative exclusion,
+  restore reconciliation, tombstone repair, feature flags, and migration
+  rollback.
+- Depends on A4 and A5. A6 is optional.
+
+### Approved local discovery
+
+**Unit 1 — Local Context Packs**
+
+- Depends on A0, A5, A7, and A8.
+- Adds pack CAS backup/restore with the pack store itself.
+- A6 remains optional.
+
+**Unit 2 — Local Topic Discovery**
+
+- Depends on Unit 1.
+- Does not perform web search or writes and cannot create missions.
+
+**Unit 3 — Mission v2 and Research Run Gateway**
+
+- Depends on A0 and Unit 2.
+- Lands the dual v1/v2 parser before v2 writes.
+
+### Hosted path
+
+**Gate C0 — Cloud repository/account decision**
+
+- Depends on A7 and Unit 3.
+
+Required written decisions:
+
+- hosted repository and ownership;
+- Cloudflare account/environment;
+- authentication and tenant authority;
+- D1/R2/Queue/Workflow/Durable Object/Vectorize/Workers AI bindings;
+- budgets, quotas, retention, alerting, and operator responsibility;
+- staging and deletion-test tenants.
+
+No cloud resource is provisioned and no hosted endpoint is enabled before C0.
+
+**Unit 4 — Cave Device Executor**
+
+- Depends on Unit 3 and C0.
+- Uses the Unit 3 fake hosted adapter until Unit 5 staging is available.
+
+**Unit 5 — Hosted Research Cloud**
+
+- Depends on A0, A7, Unit 3, Unit 4, and C0.
+- D1 FTS5 lexical retrieval is independently useful.
+- Workers AI/Vectorize semantic retrieval is optional and revision-gated.
+
+## 12. Beads and pull-request structure
+
+Create one parent program Bead and one child Bead per A0-A8, Unit 1-5, and Gate
+C0. Dependencies must mirror §11 exactly. Each child records:
+
+- detailed plan path;
+- branch/worktree owner;
+- exact implementation boundary;
+- focused and full validation evidence;
+- PR and merge reference;
+- rollback/flag state;
+- next newly-ready child.
+
+Never mark multiple unrelated children `in_progress`. A child is
+`in_progress` only while actively worked.
+
+## 13. Program acceptance
+
+- [ ] Protocol schemas and TypeScript parsers pass the same valid/invalid
+      fixtures across supported runtimes.
+- [ ] Saved links, paper metadata, dates, categories, ids, and origins survive
+      migration, downgrade, re-upgrade, backup, and restore.
+- [ ] Resource refresh or deletion cannot mutate or break a sealed Context Pack.
+- [ ] Every evidence excerpt resolves to verified immutable bytes with exact
+      selector coordinates.
+- [ ] Job replay, quota pause, crash recovery, deletion fencing, and tombstone
+      repair do not duplicate or resurrect resources.
+- [ ] FTS-only local operation is complete and truthful without embeddings.
+- [ ] Context Pack and Topic Discovery releases require no cloud resource.
+- [ ] Existing v1 Research Missions remain readable and executable.
+- [ ] Hosted runs never accept provider credentials or private pack blobs by
+      default.
+- [ ] Cloud lexical results remain available during Vectorize lag or failure.
+- [ ] Cross-tenant tests produce zero unauthorized reads or writes.
+- [ ] Cancellation, retention, deletion, and artifact sync remain independent.
+- [ ] Backup archive v1 restores authoritative Research state and rebuilds
+      derivative state.
+- [ ] Relevance, selector-resolution, latency, recovery, and end-to-end
+      evaluation evidence is recorded before each feature flag is promoted.
+
+## 14. Immediate execution sequence
+
+- [ ] Land this umbrella plan, the amended approved design, and the corrected
+      Protocol Unit 0 plan through a docs-only PR.
+- [ ] Create the program/child Beads and dependency edges from §11.
+- [ ] Execute A0 in a fresh managed worktree from current `origin/main`.
+- [ ] Review A0 against this program and the approved design before merge.
+- [ ] Update `.copilot/goals.md` after merge with progress and the next ready
+      child.

--- a/docs/superpowers/specs/2026-08-15-externalized-research-desk-implementation-design.md
+++ b/docs/superpowers/specs/2026-08-15-externalized-research-desk-implementation-design.md
@@ -7,15 +7,19 @@
 **Owner:** Research Desk
 
 **Approval note:** Reviewed against `src/lib/research-missions.ts` and the
-existing Salem-style model-connection pattern. Two blocking findings from
-review are resolved in this text: (1) §11.1 requires the dual v1/v2
-`parseResearchMission` to ship in Unit 3 itself, with rollback keeping v2
-records readable; (2) §12.2/§13.3 add the `POST
-/v1/model-tasks/{id}/lease/renew` endpoint and its idempotency/conflict rules.
-Two non-blocking findings are also resolved: the pack/run retention
-precedence rule (§8.4) and the complete four-value `ModelTaskV1.phase` enum
-mapped to run states (§8.7). No open blocking issues remain; approved for
-implementation planning of Units 0-5 per §21-23.
+existing Salem-style model-connection pattern. Three blocking findings from
+review and implementation handoff are resolved in this text: (1) §11.1
+requires the dual v1/v2 `parseResearchMission` to ship in Unit 3 itself, with
+rollback keeping v2 records readable; (2) §12.2/§13.3 add the `POST
+/v1/model-tasks/{id}/lease/renew` endpoint and its idempotency/conflict rules;
+(3) §8.8 defines the previously referenced `RunManifestV1` wire contract,
+revision chain, usage semantics, retention state, and deletion receipt. Two
+non-blocking findings are also resolved: the pack/run retention precedence
+rule (§8.4) and the complete four-value `ModelTaskV1.phase` enum mapped to run
+states (§8.7). The Research Resource amendment also fixes selector coordinate
+semantics, adds deterministic PDF page selectors, and separates mutable
+resource snapshots from immutable pack-owned blobs. No open blocking issues
+remain; approved for implementation planning of Units 0-5 per §21-23.
 
 **Scope:** Coven Cave local discovery, portable Research Run Protocol, hosted
 Research Cloud, and Cave-side user-model execution
@@ -365,8 +369,29 @@ type ContextSelectorV1 =
   | { type: "json-pointer"; pointer: string }
   | { type: "text-span"; start: number; end: number }
   | { type: "markdown-section"; headingPath: string[] }
+  | { type: "pdf-page-span"; page: number; start: number; end: number }
   | { type: "whole-resource" };
 ```
+
+Selector coordinates are part of the v1 wire contract:
+
+- `turn-range` uses zero-based turn indexes with inclusive `start`, exclusive
+  `end`, and `start < end`.
+- `json-pointer` is an RFC 6901 pointer evaluated against the exact normalized
+  JSON blob.
+- `text-span` uses zero-based UTF-8 byte offsets over the exact normalized
+  blob, with inclusive `start`, exclusive `end`, and `start < end`.
+- `markdown-section` contains a non-empty heading path evaluated against the
+  exact normalized Markdown blob.
+- `pdf-page-span` uses a one-based page number and zero-based UTF-8 byte
+  offsets within that page's normalized text, with inclusive `start`,
+  exclusive `end`, and `start < end`.
+- `whole-resource` selects the complete exact normalized blob.
+
+PDF normalization persists a page-boundary table so a selector can be
+reconciled to the corresponding half-open range in the whole normalized blob.
+For a given source digest and extractor version, normalized bytes and page
+boundaries must be deterministic.
 
 `whole-resource` requires an explicit per-resource confirmation when the
 resource is private or restricted.
@@ -511,7 +536,7 @@ type ResearchRunV1 = {
   schema: "opencoven.research-run/v1";
   id: string;
   tenantOpaqueId?: string;
-  context: ResearchContextBindingV1;
+  context?: ResearchContextBindingV1;
   acceptedTopic: {
     proposalId?: string;
     question: string;
@@ -649,6 +674,200 @@ Model phases map to run states as follows:
 creates no Model Task. `publishing` registers manifests and opted-in artifact
 content and also creates no Model Task.
 
+### 8.8 Run Manifest and artifact registration
+
+A Run Manifest is an append-only completion receipt. Artifact registration,
+source registration, retention changes, and deletion progress create new
+manifest revisions; they never mutate an existing revision. The current
+revision is referenced by `ResearchRunV1.artifactManifest`.
+
+```ts
+type ArtifactRegistrationV1 = {
+  id: string;
+  kind: string;
+  title: string;
+  mediaType: string;
+  digest: string;
+  bytes: number;
+  placement: "device-local" | "cloud-metadata" | "cloud-content";
+  contentSync: "not-requested" | "pending" | "synced" | "failed";
+  createdAt: string;
+};
+
+type RunManifestSourceV1 =
+  | {
+      kind: "context-pack";
+      id: string;
+      digest: string;
+      availability: "device-local";
+    }
+  | {
+      kind: "public-evidence";
+      id: string;
+      contentDigest: string;
+      snapshotDigest: string;
+      canonicalUrl: string;
+      fetchedAt: string;
+    };
+
+type RunManifestModelExecutionV1 = {
+  taskId: string;
+  phase: "scope" | "challenge" | "synthesize" | "control";
+  attempt: number;
+  inputDigest: string;
+  outputDigest: string;
+  receipt: ResearchModelReceiptV1;
+};
+
+type RunManifestUsageV1 = {
+  inputTokens: number | null;
+  outputTokens: number | null;
+  costUsd: number | null;
+  completeness: "complete" | "partial" | "unreported";
+};
+
+type RunManifestRetentionV1 = {
+  policy: "run-only" | "7-days" | "project";
+  effectivePolicy: "run-only" | "7-days" | "project";
+  status:
+    | "active"
+    | "deletion_scheduled"
+    | "deletion_pending"
+    | "deleted";
+  contentExpiresAt: string | null;
+  updatedAt: string;
+};
+
+type RunManifestDeletionReceiptV1 = {
+  status:
+    | "not_scheduled"
+    | "scheduled"
+    | "pending"
+    | "completed"
+    | "partial_failure";
+  requestedAt?: string;
+  completedAt?: string;
+  deletedObjectCount?: number;
+  retainedAuditUntil?: string;
+  eventSequence?: number;
+};
+
+type RunManifestV1 = {
+  schema: "opencoven.run-manifest/v1";
+  id: string;
+  runId: string;
+  digest: string;
+  revision: number;
+  previousDigest?: string;
+  state: "assembling" | "final";
+  createdAt: string;
+  finalizedAt?: string;
+  context?: ResearchContextBindingV1;
+  sources: RunManifestSourceV1[];
+  artifacts: ArtifactRegistrationV1[];
+  modelExecutions: RunManifestModelExecutionV1[];
+  usage: RunManifestUsageV1;
+  retention: RunManifestRetentionV1;
+  deletion: RunManifestDeletionReceiptV1;
+};
+```
+
+Rules:
+
+- Manifest revisions begin at `1` and increase by one without gaps.
+- Revision `1` omits `previousDigest`; every later revision references the
+  immediately preceding manifest digest.
+- `id` and `runId` remain constant across every revision in a chain.
+- Each revision is immutable and content-addressed. Its `digest` is computed
+  using the canonical digest rules in §7.1.
+- Revision `1` may be either `assembling` or `final`; immediate cancellation,
+  failure, or expiry does not require a synthetic assembling revision.
+- `state: "assembling"` permits later revisions as sources, model executions,
+  artifacts, retention state, or deletion state are registered.
+- Entering a terminal run state creates the first `state: "final"` revision
+  exactly once.
+- Assembling revisions omit `finalizedAt`. The first final revision requires
+  it, and later revisions preserve it.
+- After the first final revision, no later revision may change sources,
+  artifacts, model executions, usage, or `retention.policy`.
+- Post-finalization revisions are permitted only for
+  `retention.effectivePolicy`, retention status/timestamps, and deletion
+  receipt updates. They retain `state: "final"` and preserve every other field
+  byte-for-byte after canonicalization.
+- `context` is present exactly when the run has a Context Pack binding. When
+  present, `sources` contains exactly one matching `context-pack` id and
+  digest; when absent, `sources` contains no `context-pack` entry.
+- Context Pack entries contain only opaque identity and digest metadata. They
+  never contain private excerpts, filenames, local paths, or blob contents.
+- Public-evidence entries identify the exact fetched snapshot. A changed live
+  URL does not alter an existing manifest.
+- `placement: "cloud-metadata"` records artifact metadata and digest only.
+  `placement: "cloud-content"` is valid only after separate artifact-content
+  sync consent.
+- `contentSync: "failed"` does not invalidate a locally durable artifact or
+  prevent manifest finalization; the failure remains inspectable.
+- Artifact titles persisted in a cloud manifest must be generic display labels
+  or explicitly user-approved. They must not contain private excerpts,
+  filenames, local paths, credentials, or object-store keys.
+- Usage values are copied only from runtime-supplied model receipts. Unknown
+  values remain `null`.
+- `usage.completeness` is:
+  - `complete` when at least one model execution exists and every execution
+    reports all three usage values;
+  - `partial` when at least one value is reported and at least one remains
+    unknown;
+  - `unreported` when no usage value is reported, including when there are no
+    model executions.
+- Aggregate token and cost fields sum reported values only. They remain `null`
+  when no corresponding value was reported.
+- `retention.policy` records the original run privacy policy and never changes.
+  It must not exceed the Context Pack consent defined in §8.4.
+- `retention.effectivePolicy` initially equals `retention.policy`. It may move
+  to a shorter policy; moving to a longer policy requires fresh consent and
+  still must not exceed the Context Pack consent.
+- `contentExpiresAt` is `null` before the deletion clock begins. It remains
+  `null` while the effective policy is `project`, until project deletion or a
+  shorter policy is explicitly approved.
+- Cancellation does not alter the effective retention policy.
+- Retention and deletion status pairs are constrained as follows:
+
+  | Retention status | Allowed deletion status |
+  | --- | --- |
+  | `active` | `not_scheduled` |
+  | `deletion_scheduled` | `scheduled` |
+  | `deletion_pending` | `pending`, `partial_failure` |
+  | `deleted` | `completed` |
+
+- `scheduled`, `pending`, and `partial_failure` deletion receipts require
+  `requestedAt`.
+- `deletion.status: "completed"` requires `completedAt`,
+  `requestedAt`, `deletedObjectCount`, and the sequence of the corresponding
+  `content.deleted` event.
+- Partial deletion failure sets both retention status `deletion_pending` and
+  deletion status `partial_failure`; retries create new manifest revisions.
+- Deletion receipts contain counts and timestamps only, never deleted content
+  or object-store keys.
+- A final manifest remains durable after content deletion as the minimized run
+  receipt required by §14.
+
+Conformance fixtures must cover:
+
+- initial assembling manifest;
+- revision-1 final manifest for an early-terminal run;
+- final manifest with local-only private artifacts;
+- final manifest with consented cloud artifact content;
+- deterministic revision-chain digests;
+- missing or incorrect `previousDigest`;
+- changed manifest or run id within a revision chain;
+- mutation of immutable fields after finalization;
+- complete, partial, and unreported usage;
+- invalid retention/deletion status pairs;
+- original or effective retention exceeding Context Pack consent;
+- effective retention shortening and consented lengthening;
+- scheduled, partial-failure, and completed deletion states;
+- completed deletion without a matching event sequence;
+- private path or private excerpt leakage in manifest fields.
+
 ## 9. Local Context Pack implementation
 
 ### 9.1 Storage
@@ -663,6 +882,13 @@ Use a dedicated local store:
   topic-jobs/<job-id>.json
   topic-proposals/<proposal-id>.json
 ```
+
+The Context Pack blob store is pack-owned and must not be shared with a mutable
+Research Resource snapshot store. When a selected resource subset is sealed,
+Cave copies the selected normalized bytes into a pack-owned blob and records a
+pack-local `whole-resource` selector over those exact bytes. This deliberate
+copy keeps a sealed pack readable after its source resource is refreshed,
+deleted, restored, or garbage-collected.
 
 Requirements:
 


### PR DESCRIPTION
## Summary
- amend the approved Research Desk design with exact selector coordinates, deterministic PDF selectors, a complete Run Manifest contract, and physically separate resource/pack blob stores
- add the blocker-free umbrella program with local-first storage, ingest, retrieval, backup, deletion, compatibility, and gated cloud delivery units
- add the executable Protocol Unit 0 plan and its cross-runtime conformance fixtures

## Validation
- `git diff --check`
- `pnpm check:conflict-markers`

Bead: `cave-pjqix`