### PR TITLE
Harden iOS mutation recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Fixed
+
+- Native iOS task, reminder, session, theme, and avatar mutations now retry
+  transient network failures only when the operation is explicitly replay-safe,
+  stay within the existing 20-second request budget, and treat a repeated delete
+  as already complete. The missing Familiar avatar mutation client required by
+  the shipped XCTest contract is now implemented as well (cave-ioswipe.1).
+
 ## [0.3.3] - 2026-08-12
 
 > Closes an access-gate bypass on mobile, keeps chat attachments and skills

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -17,10 +17,16 @@ protocol CaveBootstrapClient: Sendable {
 struct CaveClient {
     var connection: CaveConnection
     private let injectedSession: URLSession?
+    private let idempotentMutationRetryBudget: Duration
 
-    init(connection: CaveConnection, session: URLSession? = nil) {
+    init(
+        connection: CaveConnection,
+        session: URLSession? = nil,
+        idempotentMutationRetryBudget: Duration = Self.defaultIdempotentMutationRetryBudget
+    ) {
         self.connection = connection
         self.injectedSession = session
+        self.idempotentMutationRetryBudget = idempotentMutationRetryBudget
     }
 
     /// `POST /api/voice/session` request. The desktop resolves the familiar's
@@ -119,21 +125,116 @@ struct CaveClient {
 
     private var session: URLSession { Self.restSession }
 
-    func data(for req: URLRequest) async throws -> (Data, URLResponse) {
-        let method = (req.httpMethod ?? "GET").uppercased()
-        let retryDelays: [Duration] = ["GET", "HEAD"].contains(method)
-            ? [.milliseconds(350), .seconds(1)]
-            : []
+    static let defaultIdempotentMutationRetryBudget: Duration = .seconds(20)
+
+    func data(
+        for req: URLRequest,
+        retryingIdempotentMutation: Bool = false
+    ) async throws -> (Data, URLResponse) {
+        let retryPlan = Self.retryPlan(
+            for: req,
+            retryingIdempotentMutation: retryingIdempotentMutation,
+            idempotentMutationRetryBudget: idempotentMutationRetryBudget
+        )
         let session = injectedSession ?? self.session
+        let result: RequestResult
+        if let budget = retryPlan.budget {
+            result = try await Self.data(
+                for: req,
+                using: session,
+                retryDelays: retryPlan.delays,
+                within: budget
+            )
+        } else {
+            result = try await Self.performData(
+                for: req,
+                using: session,
+                retryDelays: retryPlan.delays
+            )
+        }
+        return (result.data, result.response)
+    }
+
+    private struct RequestResult: @unchecked Sendable {
+        var data: Data
+        var response: URLResponse
+    }
+
+    private static func data(
+        for req: URLRequest,
+        using session: URLSession,
+        retryDelays: [Duration],
+        within budget: Duration
+    ) async throws -> RequestResult {
+        try await withThrowingTaskGroup(of: RequestResult.self) { group in
+            group.addTask {
+                try await performData(for: req, using: session, retryDelays: retryDelays)
+            }
+            group.addTask {
+                try await Task.sleep(for: budget)
+                throw URLError(.timedOut)
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw CaveError.transport("Network request failed.")
+            }
+            return result
+        }
+    }
+
+    private static func performData(
+        for req: URLRequest,
+        using session: URLSession,
+        retryDelays: [Duration]
+    ) async throws -> RequestResult {
         for attempt in 0...retryDelays.count {
             do {
-                return try await session.data(for: req)
+                let (data, response) = try await session.data(for: req)
+                return RequestResult(data: data, response: response)
             } catch {
-                guard attempt < retryDelays.count, Self.isTransient(error) else { throw error }
+                guard attempt < retryDelays.count, isTransient(error) else { throw error }
                 try await Task.sleep(for: retryDelays[attempt])
             }
         }
         throw CaveError.transport("Network request failed.")
+    }
+
+    private struct RetryPlan {
+        var delays: [Duration]
+        var budget: Duration?
+    }
+
+    private static func retryPlan(
+        for req: URLRequest,
+        retryingIdempotentMutation: Bool,
+        idempotentMutationRetryBudget: Duration
+    ) -> RetryPlan {
+        let method = (req.httpMethod ?? "GET").uppercased()
+        switch method {
+        case "GET", "HEAD":
+            return RetryPlan(delays: [.milliseconds(350), .seconds(1)], budget: nil)
+        case "DELETE", "PATCH", "PUT":
+            guard retryingIdempotentMutation else {
+                return RetryPlan(delays: [], budget: nil)
+            }
+            return RetryPlan(
+                delays: [.milliseconds(350), .seconds(1), .seconds(3)],
+                budget: idempotentMutationRetryBudget
+            )
+        case "POST":
+            // POST is never replayed unless its caller and server explicitly
+            // share an idempotency key.
+            let key = req.value(forHTTPHeaderField: "Idempotency-Key")?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return key?.isEmpty == false
+                ? RetryPlan(
+                    delays: [.milliseconds(350), .seconds(1), .seconds(3)],
+                    budget: idempotentMutationRetryBudget
+                )
+                : RetryPlan(delays: [], budget: nil)
+        default:
+            return RetryPlan(delays: [], budget: nil)
+        }
     }
 
     private static func isTransient(_ error: Error) -> Bool {
@@ -231,6 +332,58 @@ struct CaveClient {
         guard let path = familiar.avatarUrl, let base = connection.baseURL else { return nil }
         if path.hasPrefix("http") { return URL(string: path) }
         return URL(string: path, relativeTo: base)?.absoluteURL
+    }
+
+    struct FamiliarAvatarMutation: Decodable {
+        var ok: Bool
+        var avatarUrl: String?
+        var revision: Int?
+        var removed: Bool?
+        var error: String?
+    }
+
+    func uploadFamiliarAvatar(
+        id: String,
+        imageData: Data,
+        contentType: String
+    ) async throws -> FamiliarAvatarMutation {
+        let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        var req = try request(
+            "api/familiars/\(escaped)/avatar",
+            method: "POST",
+            body: imageData
+        )
+        req.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        return try await familiarAvatarMutation(for: req)
+    }
+
+    func deleteFamiliarAvatar(id: String) async throws -> FamiliarAvatarMutation {
+        let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        let req = try request("api/familiars/\(escaped)/avatar", method: "DELETE")
+        return try await familiarAvatarMutation(for: req)
+    }
+
+    private func familiarAvatarMutation(for req: URLRequest) async throws -> FamiliarAvatarMutation {
+        let method = (req.httpMethod ?? "").uppercased()
+        let (data, resp) = try await data(
+            for: req,
+            retryingIdempotentMutation: method == "DELETE"
+        )
+        guard let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let status = (resp as? HTTPURLResponse)?.statusCode ?? 0
+            throw Self.serverResponseError(statusCode: status, data: data)
+        }
+        do {
+            let mutation = try JSONDecoder().decode(FamiliarAvatarMutation.self, from: data)
+            guard mutation.ok else {
+                throw CaveError.transport(mutation.error ?? "The avatar change was not accepted.")
+            }
+            return mutation
+        } catch let error as CaveError {
+            throw error
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
     }
 
     // MARK: - Voice
@@ -476,7 +629,7 @@ struct CaveClient {
         let escaped = sessionId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? sessionId
         let payload = try JSONEncoder().encode(SessionFlagsPatch(archived: archived, pinned: pinned))
         let req = try request("api/sessions/\(escaped)", method: "PATCH", body: payload)
-        let (_, resp) = try await data(for: req)
+        let (_, resp) = try await data(for: req, retryingIdempotentMutation: true)
         try Self.check(resp)
     }
 
@@ -485,20 +638,20 @@ struct CaveClient {
     func deleteSession(sessionId: String) async throws {
         let escaped = sessionId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? sessionId
         let req = try request("api/sessions/\(escaped)", method: "DELETE")
-        let (_, resp) = try await data(for: req)
-        try Self.check(resp)
+        let (_, resp) = try await data(for: req, retryingIdempotentMutation: true)
+        try Self.checkDelete(resp)
     }
 
     /// `DELETE /api/board/{id}` — remove a task.
     func deleteTask(cardId: String) async throws {
         let req = try request("api/board/\(cardId)", method: "DELETE")
-        let (_, resp) = try await data(for: req)
-        try Self.check(resp)
+        let (_, resp) = try await data(for: req, retryingIdempotentMutation: true)
+        try Self.checkDelete(resp)
     }
 
     private func patchTask(cardId: String, payload: Data) async throws -> BoardCard {
         let req = try request("api/board/\(cardId)", method: "PATCH", body: payload)
-        let (data, resp) = try await data(for: req)
+        let (data, resp) = try await data(for: req, retryingIdempotentMutation: true)
         try Self.check(resp)
         let decoded = try JSONDecoder().decode(BoardPatchResponse.self, from: data)
         if let card = decoded.card { return card }
@@ -571,7 +724,7 @@ struct CaveClient {
         let payload = try JSONEncoder().encode(
             Body(familiarId: familiarId, sessionId: sessionId, model: model, scope: scope))
         let req = try request("api/chat/model-state", method: "PATCH", body: payload)
-        let (data, resp) = try await data(for: req)
+        let (data, resp) = try await data(for: req, retryingIdempotentMutation: true)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(ChatModelStateResponse.self, from: data)
@@ -817,7 +970,7 @@ struct CaveClient {
         struct Body: Encodable { let themeId: String; let mode: String }
         let payload = try JSONEncoder().encode(Body(themeId: themeId, mode: mode))
         let req = try request("api/theme", method: "PUT", body: payload)
-        let (data, resp) = try await data(for: req)
+        let (data, resp) = try await data(for: req, retryingIdempotentMutation: true)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(ThemeResponse.self, from: data).theme
@@ -857,8 +1010,8 @@ struct CaveClient {
     func deleteReminder(id: String) async throws {
         let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
         let req = try request("api/inbox/\(escaped)", method: "DELETE")
-        let (_, resp) = try await data(for: req)
-        try Self.check(resp)
+        let (_, resp) = try await data(for: req, retryingIdempotentMutation: true)
+        try Self.checkDelete(resp)
     }
 
     struct ReminderActionResponse: Decodable { var ok: Bool; var error: String?; var item: Reminder? }
@@ -930,6 +1083,11 @@ struct CaveClient {
         guard (200..<300).contains(http.statusCode) else {
             throw CaveError.badResponse(http.statusCode)
         }
+    }
+
+    private static func checkDelete(_ resp: URLResponse) throws {
+        if (resp as? HTTPURLResponse)?.statusCode == 404 { return }
+        try check(resp)
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -18,6 +18,9 @@ struct CaveClient {
     var connection: CaveConnection
     private let injectedSession: URLSession?
     private let idempotentMutationRetryBudget: Duration
+    private static let pathSegmentAllowed = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    )
 
     init(
         connection: CaveConnection,
@@ -347,7 +350,7 @@ struct CaveClient {
         imageData: Data,
         contentType: String
     ) async throws -> FamiliarAvatarMutation {
-        let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        let escaped = try Self.encodedPathSegment(id)
         var req = try request(
             "api/familiars/\(escaped)/avatar",
             method: "POST",
@@ -358,9 +361,16 @@ struct CaveClient {
     }
 
     func deleteFamiliarAvatar(id: String) async throws -> FamiliarAvatarMutation {
-        let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        let escaped = try Self.encodedPathSegment(id)
         let req = try request("api/familiars/\(escaped)/avatar", method: "DELETE")
         return try await familiarAvatarMutation(for: req)
+    }
+
+    private static func encodedPathSegment(_ value: String) throws -> String {
+        guard let encoded = value.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed) else {
+            throw CaveError.transport("Could not encode the familiar identifier.")
+        }
+        return encoded
     }
 
     private func familiarAvatarMutation(for req: URLRequest) async throws -> FamiliarAvatarMutation {

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -1797,6 +1797,11 @@ final class AppModel {
         }
     }
 
+    func applyFamiliarAvatarMutation(id: String, avatarUrl: String?) {
+        guard let index = familiars.firstIndex(where: { $0.id == id }) else { return }
+        familiars[index].avatarUrl = avatarUrl
+    }
+
     // MARK: - Unread tracking
 
     /// True when a familiar has activity newer than the last time its chats were

--- a/apps/ios/CovenCave/CovenCaveTests/CaveClientRetryTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/CaveClientRetryTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import XCTest
+@testable import CovenCave
+
+private final class CaveClientRetryURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        do {
+            let handler = try XCTUnwrap(Self.handler)
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private final class CaveClientHangingURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {}
+    override func stopLoading() {}
+}
+
+final class CaveClientRetryTests: XCTestCase {
+    override func tearDown() {
+        CaveClientRetryURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    private func client() -> CaveClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CaveClientRetryURLProtocol.self]
+        return CaveClient(
+            connection: CaveConnection(host: "http://cave.test:3000"),
+            session: URLSession(configuration: configuration)
+        )
+    }
+
+    private func response(for request: URLRequest, status: Int = 200) throws -> HTTPURLResponse {
+        try XCTUnwrap(
+            HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: status,
+                httpVersion: nil,
+                headerFields: nil
+            )
+        )
+    }
+
+    func testDeleteRetriesTransientFailureAndAcceptsAlreadyDeletedResource() async throws {
+        var attempts = 0
+        CaveClientRetryURLProtocol.handler = { [self] request in
+            attempts += 1
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            if attempts == 1 {
+                throw URLError(.networkConnectionLost)
+            }
+            return (try response(for: request, status: 404), Data())
+        }
+
+        try await client().deleteTask(cardId: "task-42")
+
+        XCTAssertEqual(attempts, 2)
+    }
+
+    func testPatchRetriesTransientFailure() async throws {
+        var attempts = 0
+        CaveClientRetryURLProtocol.handler = { [self] request in
+            attempts += 1
+            if attempts == 1 {
+                throw URLError(.notConnectedToInternet)
+            }
+            return (try response(for: request), Data())
+        }
+        var request = URLRequest(url: try XCTUnwrap(URL(string: "http://cave.test:3000/api/board/task-42")))
+        request.httpMethod = "PATCH"
+
+        _ = try await client().data(for: request, retryingIdempotentMutation: true)
+
+        XCTAssertEqual(attempts, 2)
+    }
+
+    func testPostWithoutIdempotencyKeyDoesNotRetry() async throws {
+        var attempts = 0
+        CaveClientRetryURLProtocol.handler = { _ in
+            attempts += 1
+            throw URLError(.networkConnectionLost)
+        }
+        var request = URLRequest(url: try XCTUnwrap(URL(string: "http://cave.test:3000/api/inbox")))
+        request.httpMethod = "POST"
+
+        do {
+            _ = try await client().data(for: request)
+            XCTFail("Expected the transport error to propagate")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .networkConnectionLost)
+        }
+
+        XCTAssertEqual(attempts, 1)
+    }
+
+    func testMutationWithoutExplicitOptInDoesNotRetry() async throws {
+        var attempts = 0
+        CaveClientRetryURLProtocol.handler = { _ in
+            attempts += 1
+            throw URLError(.networkConnectionLost)
+        }
+        var request = URLRequest(url: try XCTUnwrap(URL(string: "http://cave.test:3000/api/example")))
+        request.httpMethod = "PATCH"
+
+        do {
+            _ = try await client().data(for: request)
+            XCTFail("Expected the transport error to propagate")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .networkConnectionLost)
+        }
+
+        XCTAssertEqual(attempts, 1)
+    }
+
+    func testIdempotencyKeyAllowsPostRetry() async throws {
+        var attempts = 0
+        CaveClientRetryURLProtocol.handler = { [self] request in
+            attempts += 1
+            if attempts == 1 {
+                throw URLError(.timedOut)
+            }
+            return (try response(for: request), Data())
+        }
+        var request = URLRequest(url: try XCTUnwrap(URL(string: "http://cave.test:3000/api/example")))
+        request.httpMethod = "POST"
+        request.setValue("stable-operation-42", forHTTPHeaderField: "Idempotency-Key")
+
+        _ = try await client().data(for: request)
+
+        XCTAssertEqual(attempts, 2)
+    }
+
+    func testIdempotentMutationRetriesAreBounded() async throws {
+        var attempts = 0
+        CaveClientRetryURLProtocol.handler = { _ in
+            attempts += 1
+            throw URLError(.cannotConnectToHost)
+        }
+        var request = URLRequest(url: try XCTUnwrap(URL(string: "http://cave.test:3000/api/board/task-42")))
+        request.httpMethod = "DELETE"
+
+        do {
+            _ = try await client().data(for: request, retryingIdempotentMutation: true)
+            XCTFail("Expected the transport error to propagate")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .cannotConnectToHost)
+        }
+
+        XCTAssertEqual(attempts, 4)
+    }
+
+    func testNonTransientMutationFailureDoesNotRetry() async throws {
+        var attempts = 0
+        CaveClientRetryURLProtocol.handler = { _ in
+            attempts += 1
+            throw URLError(.badURL)
+        }
+        var request = URLRequest(url: try XCTUnwrap(URL(string: "http://cave.test:3000/api/board/task-42")))
+        request.httpMethod = "PATCH"
+
+        do {
+            _ = try await client().data(for: request, retryingIdempotentMutation: true)
+            XCTFail("Expected the transport error to propagate")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .badURL)
+        }
+
+        XCTAssertEqual(attempts, 1)
+    }
+
+    func testMutationRetryBudgetMatchesTheExistingRequestTimeout() {
+        XCTAssertEqual(CaveClient.defaultIdempotentMutationRetryBudget, .seconds(20))
+    }
+
+    func testMutationRetryBudgetCancelsARequestThatNeverCompletes() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CaveClientHangingURLProtocol.self]
+        let client = CaveClient(
+            connection: CaveConnection(host: "http://cave.test:3000"),
+            session: URLSession(configuration: configuration),
+            idempotentMutationRetryBudget: .milliseconds(100)
+        )
+        var request = URLRequest(url: try XCTUnwrap(URL(string: "http://cave.test:3000/api/board/task-42")))
+        request.httpMethod = "DELETE"
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+
+        do {
+            _ = try await client.data(for: request, retryingIdempotentMutation: true)
+            XCTFail("Expected the request budget to expire")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .timedOut)
+        }
+
+        XCTAssertLessThan(startedAt.duration(to: clock.now), .seconds(1))
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/FamiliarAvatarClientTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/FamiliarAvatarClientTests.swift
@@ -32,7 +32,7 @@ private extension URLRequest {
         defer { stream.close() }
         var body = Data()
         var buffer = [UInt8](repeating: 0, count: 4_096)
-        while stream.hasBytesAvailable {
+        while true {
             let count = stream.read(&buffer, maxLength: buffer.count)
             if count < 0 {
                 throw stream.streamError ?? URLError(.cannotDecodeRawData)
@@ -62,7 +62,10 @@ final class FamiliarAvatarClientTests: XCTestCase {
     func testUploadSendsRawImageAndReturnsRevisionedURL() async throws {
         let image = Data([0x89, 0x50, 0x4e, 0x47])
         FamiliarAvatarURLProtocol.handler = { request in
-            XCTAssertEqual(request.url?.path, "/api/familiars/nova/avatar")
+            XCTAssertEqual(
+                URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath,
+                "/api/familiars/nova%2Ffamiliar/avatar"
+            )
             XCTAssertEqual(request.httpMethod, "POST")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "image/png")
             XCTAssertNil(request.value(forHTTPHeaderField: "Idempotency-Key"))
@@ -83,7 +86,7 @@ final class FamiliarAvatarClientTests: XCTestCase {
         }
 
         let mutation = try await client().uploadFamiliarAvatar(
-            id: "nova",
+            id: "nova/familiar",
             imageData: image,
             contentType: "image/png"
         )
@@ -94,7 +97,10 @@ final class FamiliarAvatarClientTests: XCTestCase {
 
     func testDeleteUsesIdempotentAvatarContract() async throws {
         FamiliarAvatarURLProtocol.handler = { request in
-            XCTAssertEqual(request.url?.path, "/api/familiars/nova/avatar")
+            XCTAssertEqual(
+                URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.percentEncodedPath,
+                "/api/familiars/nova%2Ffamiliar/avatar"
+            )
             XCTAssertEqual(request.httpMethod, "DELETE")
             let response = try XCTUnwrap(HTTPURLResponse(
                 url: try XCTUnwrap(request.url),
@@ -107,7 +113,7 @@ final class FamiliarAvatarClientTests: XCTestCase {
             """.utf8))
         }
 
-        let mutation = try await client().deleteFamiliarAvatar(id: "nova")
+        let mutation = try await client().deleteFamiliarAvatar(id: "nova/familiar")
 
         XCTAssertNil(mutation.avatarUrl)
         XCTAssertNil(mutation.revision)

--- a/apps/ios/CovenCave/CovenCaveTests/FamiliarAvatarClientTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/FamiliarAvatarClientTests.swift
@@ -23,6 +23,27 @@ private final class FamiliarAvatarURLProtocol: URLProtocol {
     override func stopLoading() {}
 }
 
+private extension URLRequest {
+    func capturedBody() throws -> Data? {
+        if let httpBody { return httpBody }
+        guard let stream = httpBodyStream else { return nil }
+
+        stream.open()
+        defer { stream.close() }
+        var body = Data()
+        var buffer = [UInt8](repeating: 0, count: 4_096)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count < 0 {
+                throw stream.streamError ?? URLError(.cannotDecodeRawData)
+            }
+            if count == 0 { break }
+            body.append(contentsOf: buffer.prefix(count))
+        }
+        return body
+    }
+}
+
 final class FamiliarAvatarClientTests: XCTestCase {
     override func tearDown() {
         FamiliarAvatarURLProtocol.handler = nil
@@ -44,7 +65,8 @@ final class FamiliarAvatarClientTests: XCTestCase {
             XCTAssertEqual(request.url?.path, "/api/familiars/nova/avatar")
             XCTAssertEqual(request.httpMethod, "POST")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "image/png")
-            XCTAssertEqual(request.httpBody, image)
+            XCTAssertNil(request.value(forHTTPHeaderField: "Idempotency-Key"))
+            XCTAssertEqual(try request.capturedBody(), image)
             let response = try XCTUnwrap(HTTPURLResponse(
                 url: try XCTUnwrap(request.url),
                 statusCode: 200,

--- a/scripts/ios-self-healing-sync.test.mjs
+++ b/scripts/ios-self-healing-sync.test.mjs
@@ -88,11 +88,25 @@ assert.doesNotMatch(
   /URLSessionConfiguration|URLSession\(/,
   "developer API requests should not bypass the resilient client with a private session",
 );
-assert.match(client, /func data\(for req: URLRequest\) async throws -> \(Data, URLResponse\)/, "CaveClient should centralize resilient request data loading");
+assert.match(
+  client,
+  /func data\([\s\S]{0,120}?for req: URLRequest,[\s\S]{0,120}?retryingIdempotentMutation: Bool = false[\s\S]{0,80}?\) async throws -> \(Data, URLResponse\)/,
+  "CaveClient should centralize resilient request data loading with explicit mutation retry opt-in",
+);
 assert.match(
   client,
   /for attempt in 0\.\.\.retryDelays\.count[\s\S]*?session\.data\(for: req\)[\s\S]*?Task\.sleep/,
   "resilient data loading should retry transient failures with bounded backoff",
+);
+assert.match(
+  client,
+  /defaultIdempotentMutationRetryBudget: Duration = \.seconds\(20\)/,
+  "mutation retries should remain inside the existing 20-second request budget",
+);
+assert.match(
+  client,
+  /withThrowingTaskGroup\(of: RequestResult\.self\)[\s\S]*?Task\.sleep\(for: budget\)[\s\S]*?group\.cancelAll\(\)/,
+  "the mutation budget should cancel the active URLSession operation at its wall-clock deadline",
 );
 
 console.log("ios-self-healing-sync: OK");


### PR DESCRIPTION
## Summary
- bound replay-safe iOS mutations to explicit retries with a 20-second wall-clock deadline
- restore Familiar avatar upload/delete client and immediate state updates
- cover transient recovery, POST replay safety, exhaustion, deletion replay, and cancellation

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `node scripts/run-tests.mjs app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `pnpm test:mobile`
- full CovenCave XCTest/UI test scheme
- optimized iOS Release simulator build

Bead: `cave-ioswipe.1`