### PR TITLE
Refresh the sidecar runtime budget

### DIFF
--- a/scripts/sidecar-runtime-budget.json
+++ b/scripts/sidecar-runtime-budget.json
@@ -1,14 +1,15 @@
 {
   "note": "Single source of truth for the sidecar runtime file-count budget. Edit fileCount HERE and nowhere else: scripts/sidecar-runtime-closure.mjs reads this file, scripts/sidecar-runtime-smoke.mjs derives from that, and src-tauri/build.rs generates the Rust MAX_FILE_COUNT const from it. Before cave-0ia8h the same number was hand-synced across six places and drifted; sidecar-bundle-deps.test.mjs now fails if a literal reappears.",
   "raising": "Raising this is a deliberate, reviewed act, not a reflex when CI goes red. Set it from the GOVERNING platform measurement (Windows runs a few files above Ubuntu; a budget set from an Ubuntu-only figure has reddened windows-latest more than once) and record that measurement below. The reasoning history lives beside SIDECAR_RUNTIME_BUDGETS in scripts/sidecar-runtime-closure.mjs.",
-  "fileCount": 6109,
+  "fileCount": 6306,
   "measurement": {
-    "on": "2026-08-06",
+    "on": "2026-08-16",
     "governingPlatform": "windows",
-    "windows": 5959,
-    "ubuntu": 5957,
+    "windows": 6156,
+    "ubuntu": 6154,
+    "macos": 6150,
     "headroom": 150,
-    "headroomRationale": "About one week of the measured ~21 closure-files/day drift. At this headroom the gate no longer notices organic drift and is not meant to; what it still catches is a single change dragging a whole subtree in, which is hundreds of files at once.",
-    "bead": "cave-oqawv"
+    "headroomRationale": "About one week of organic drift. The 197-file increase over the ten days since the 5,959-file Windows baseline is ~19.7 files/day, consistent with the previously measured ~21 files/day. Intermediate release runs measured 5,960 Windows files on August 9, 6,036 on August 11, and 6,035 on August 12, so this is gradual closure growth rather than one sudden subtree inclusion. At this headroom the gate ignores expected drift but still catches a single change adding hundreds of files.",
+    "bead": "cave-boem6"
   }
 }

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -268,6 +268,15 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // Next's traced output following new routes, at roughly two to four files
   // each. There is no subtree to prune — the closure grows because the app
   // does — which is why this is a tracked budget rather than a fixed one.
+  //
+  // 2026-08-16 (cave-boem6): v0.3.4 release validation measured 6,150 files
+  // on macOS, 6,154 on Ubuntu, and 6,156 on Windows. That is +197 over the
+  // governing 5,959-file Windows baseline in ten days (~19.7 files/day),
+  // consistent with the ~21/day rate above. Intermediate Windows release
+  // measurements were 5,960 on August 9, 6,036 on August 11, and 6,035 on
+  // August 12, confirming gradual growth rather than a sudden subtree inclusion.
+  // Restore the same one-week, 150-file headroom from the Windows maximum;
+  // leave the expanded-byte ceiling unchanged.
   fileCount: readSidecarFileCountBudget(),
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });


### PR DESCRIPTION
## Summary
- raise the sidecar file-count ceiling from 6,109 to 6,306 using the v0.3.4 release\u2019s governing 6,156-file Windows measurement
- record the macOS, Ubuntu, Windows, and intermediate release-run evidence showing gradual ~19.7 files/day growth
- preserve 150 files of weekly headroom without changing the 200 MiB expanded-byte ceiling

## Verification
- packaged macOS sidecar: 6,150 files, 113,678,101 bytes
- `node scripts/sidecar-runtime-closure.test.mjs`
- `node scripts/sidecar-bundle-deps.test.mjs`
- `pnpm test:sidecar-runtime`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api` (380 files)
- `pnpm check:tests-wired` (1,686 files)

Bead: `cave-boem6`
Failed release evidence: https://github.com/OpenCoven/coven-cave/actions/runs/31938681513