### PR TITLE
Stamp Coven Cave v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-08-16
+
+> Hardened iOS mutations and familiar avatars, now with corrected cross-platform packaging.
+
+Patch release on top of v0.3.4.
+
+v0.3.4 was tagged but stopped at release validation before any artifacts or
+TestFlight build were published. v0.3.5 supersedes it and carries its complete
+product payload.
+
+### Changes
+- Carry forward replay-safe iOS mutations and Familiar avatar management (#4695)
+- Restore cross-platform packaging with the measured sidecar runtime budget (#4698)
+- [Review every product change since v0.3.3](https://github.com/OpenCoven/coven-cave/compare/v0.3.3...v0.3.5)
+
+
 ## [0.3.4] - 2026-08-16
 
 > Faster iOS mutations, safer chat and research flows, and a more reliable first-run Cave.

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.3.4"
+    MARKETING_VERSION: "0.3.5"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026081607"
+    CURRENT_PROJECT_VERSION: "2026081610"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "block2",
  "discord-rich-presence",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.4"
+version = "0.3.5"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- stamp v0.3.5 consistently across desktop and native iOS release manifests
- advance the iOS build number to `2026081610`
- supersede the unpublished v0.3.4 tag while carrying forward its full product payload
- preserve transparent release notes for the corrected sidecar packaging gate

## Verification
- `pnpm release:verify --version 0.3.5`
- `node scripts/stamp-release.test.mjs`
- `pnpm test:mobile`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api` (380 files)
- `pnpm check:tests-wired` (1,686 files)
- optimized iOS Release simulator build (`BUILD SUCCEEDED`)

Bead: `cave-gmu7q`
Budget repair: #4698
Failed immutable v0.3.4 run: https://github.com/OpenCoven/coven-cave/actions/runs/31938681513