### PR TITLE
Harden dynamic familiar Vault intake

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -16,6 +16,8 @@
 // allowlisted there).
 
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -2073,17 +2075,34 @@ function main(argv) {
   }
   const list = names.flatMap((n) => SUITES[n]);
   console.log(`running ${list.length} test file(s) [${names.join(", ")}]`);
+  const secretRoot = mkdtempSync(path.join(tmpdir(), "coven-test-secrets-"));
+  const testEnv = {
+    ...process.env,
+    COVEN_VAULT_FILE: path.join(secretRoot, "vault.yaml"),
+    COVEN_CAVE_ENV_FILE: path.join(secretRoot, ".env.local"),
+    COVEN_CAVE_LOCAL_VAULT_FILE: path.join(secretRoot, "local-vault.enc.json"),
+    COVEN_CAVE_LOCAL_VAULT_KEY_FILE: path.join(secretRoot, "local-vault.key"),
+  };
   let passed = 0;
-  for (const file of list) {
-    const args = VITEST_TESTS.has(file)
-      ? ["./node_modules/vitest/vitest.mjs", "run", file]
-      : nodeArgsFor(file);
-    const res = spawnSync(process.execPath, args, { stdio: "inherit", cwd: root });
-    if (res.status !== 0) {
-      console.error(`\n✗ FAILED: ${file}  (${passed} passed before it)`);
-      process.exit(res.status ?? 1);
+  try {
+    for (const file of list) {
+      const args = VITEST_TESTS.has(file)
+        ? ["./node_modules/vitest/vitest.mjs", "run", file]
+        : nodeArgsFor(file);
+      const res = spawnSync(process.execPath, args, {
+        stdio: "inherit",
+        cwd: root,
+        env: testEnv,
+      });
+      if (res.status !== 0) {
+        console.error(`\n✗ FAILED: ${file}  (${passed} passed before it)`);
+        process.exitCode = res.status ?? 1;
+        return;
+      }
+      passed++;
     }
-    passed++;
+  } finally {
+    rmSync(secretRoot, { recursive: true, force: true });
   }
   console.log(`\n✓ ${passed} test file(s) passed [${names.join(", ")}]`);
 }

--- a/src/app/api/asana/pat/route.ts
+++ b/src/app/api/asana/pat/route.ts
@@ -17,11 +17,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
 import {
-  deleteLocalEncryptedSecret,
+  commitLocalEncryptedSecretBatch,
   hasLocalEncryptedSecret,
-  setLocalEncryptedSecret,
 } from "@/lib/local-encrypted-vault";
-import { loadVaultMap, resolveSecret, saveVaultMap } from "@/lib/vault";
+import {
+  loadVaultMapForMutation,
+  resolveSecret,
+  saveVaultMap,
+  type VaultMap,
+} from "@/lib/vault";
 import { envLocalPath, upsertEnvContent } from "@/lib/env-file";
 
 export const dynamic = "force-dynamic";
@@ -35,6 +39,16 @@ function applyEnvUpdates(updates: Record<string, string | null>): void {
   mkdirSync(dirname(envPath), { recursive: true });
   const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
   writeFileSync(envPath, upsertEnvContent(existing, updates), "utf8");
+}
+
+function mutationError(error: unknown) {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: error instanceof Error ? error.message : "failed to update Asana credentials",
+    },
+    { status: 500 },
+  );
 }
 
 async function validatePat(pat: string): Promise<{ valid: boolean; login: string | null; network?: boolean }> {
@@ -97,8 +111,13 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  setLocalEncryptedSecret(PAT_KEY, pat);
-  const map = loadVaultMap(true);
+  let map: VaultMap;
+  try {
+    map = loadVaultMapForMutation();
+  } catch (error) {
+    return mutationError(error);
+  }
+  const previousMap = structuredClone(map);
   map[PAT_KEY] = {
     storage: "encrypted",
     description: "Asana Personal Access Token",
@@ -106,7 +125,15 @@ export async function POST(req: NextRequest) {
     // Re-saving the PAT must not reset per-familiar grants back to shared.
     scope: map[PAT_KEY]?.scope,
   };
-  saveVaultMap(map);
+  try {
+    commitLocalEncryptedSecretBatch(
+      [{ key: PAT_KEY, value: pat }],
+      () => saveVaultMap(map),
+      () => saveVaultMap(previousMap),
+    );
+  } catch (error) {
+    return mutationError(error);
+  }
 
   const updates: Record<string, string | null> = { [PAT_KEY]: null };
   if (result.login) updates[USER_KEY] = result.login;
@@ -120,12 +147,25 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE() {
-  applyEnvUpdates({ [PAT_KEY]: null });
-  deleteLocalEncryptedSecret(PAT_KEY);
-  const map = loadVaultMap(true);
+  let map: VaultMap;
+  try {
+    map = loadVaultMapForMutation();
+  } catch (error) {
+    return mutationError(error);
+  }
+  const previousMap = structuredClone(map);
   if (map[PAT_KEY]?.storage === "encrypted") {
     delete map[PAT_KEY];
-    saveVaultMap(map);
+  }
+  try {
+    commitLocalEncryptedSecretBatch(
+      [{ key: PAT_KEY, value: null }],
+      () => saveVaultMap(map),
+      () => saveVaultMap(previousMap),
+    );
+    applyEnvUpdates({ [PAT_KEY]: null });
+  } catch (error) {
+    return mutationError(error);
   }
   delete process.env[PAT_KEY];
   return NextResponse.json({ ok: true });

--- a/src/app/api/github/pat/route.ts
+++ b/src/app/api/github/pat/route.ts
@@ -15,9 +15,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
-import { deleteLocalEncryptedSecret, getLocalEncryptedSecret, hasLocalEncryptedSecret, setLocalEncryptedSecret } from "@/lib/local-encrypted-vault";
+import {
+  commitLocalEncryptedSecretBatch,
+  getLocalEncryptedSecret,
+  hasLocalEncryptedSecret,
+} from "@/lib/local-encrypted-vault";
 import { resolveGitHubToken } from "@/lib/github-token";
-import { loadVaultMap, resolveSecret, saveVaultMap } from "@/lib/vault";
+import {
+  loadVaultMapForMutation,
+  resolveSecret,
+  saveVaultMap,
+  type VaultMap,
+} from "@/lib/vault";
 import { envLocalPath, readEnvLocalValue, upsertEnvContent } from "@/lib/env-file";
 
 export const dynamic = "force-dynamic";
@@ -46,6 +55,16 @@ function applyEnvUpdates(updates: Record<string, string | null>): void {
   mkdirSync(dirname(envPath), { recursive: true });
   const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
   writeFileSync(envPath, upsertEnvContent(existing, updates), "utf8");
+}
+
+function mutationError(error: unknown) {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: error instanceof Error ? error.message : "failed to update GitHub credentials",
+    },
+    { status: 500 },
+  );
 }
 
 async function validatePat(pat: string): Promise<{ valid: boolean; login: string | null; network?: boolean }> {
@@ -157,8 +176,13 @@ export async function POST(req: NextRequest) {
   const updates: Record<string, string | null> = {};
 
   if (pat) {
-    setLocalEncryptedSecret(PAT_KEY, pat);
-    const map = loadVaultMap(true);
+    let map: VaultMap;
+    try {
+      map = loadVaultMapForMutation();
+    } catch (error) {
+      return mutationError(error);
+    }
+    const previousMap = structuredClone(map);
     map[PAT_KEY] = {
       storage: "encrypted",
       description: "GitHub Personal Access Token",
@@ -166,7 +190,15 @@ export async function POST(req: NextRequest) {
       // Re-saving the PAT must not reset per-familiar grants back to shared.
       scope: map[PAT_KEY]?.scope,
     };
-    saveVaultMap(map);
+    try {
+      commitLocalEncryptedSecretBatch(
+        [{ key: PAT_KEY, value: pat }],
+        () => saveVaultMap(map),
+        () => saveVaultMap(previousMap),
+      );
+    } catch (error) {
+      return mutationError(error);
+    }
     updates[PAT_KEY] = null;
   }
   if (login) updates[LOGIN_KEY] = login;
@@ -181,6 +213,13 @@ export async function POST(req: NextRequest) {
 
 // DELETE — remove PAT
 export async function DELETE() {
+  let map: VaultMap;
+  try {
+    map = loadVaultMapForMutation();
+  } catch (error) {
+    return mutationError(error);
+  }
+
   // Preserve a launcher-provided GITHUB_PAT when it wins over an older local
   // value. resolveSecret caches local values in process.env, so clear only a
   // cached local token rather than blindly removing every inherited value.
@@ -191,12 +230,19 @@ export async function DELETE() {
   } catch {
     // Deletion still removes the malformed local entry below.
   }
-  applyEnvUpdates({ [PAT_KEY]: null });
-  deleteLocalEncryptedSecret(PAT_KEY);
-  const map = loadVaultMap(true);
+  const previousMap = structuredClone(map);
   if (map[PAT_KEY]?.storage === "encrypted") {
     delete map[PAT_KEY];
-    saveVaultMap(map);
+  }
+  try {
+    commitLocalEncryptedSecretBatch(
+      [{ key: PAT_KEY, value: null }],
+      () => saveVaultMap(map),
+      () => saveVaultMap(previousMap),
+    );
+    applyEnvUpdates({ [PAT_KEY]: null });
+  } catch (error) {
+    return mutationError(error);
   }
   const processPat = process.env[PAT_KEY]?.trim();
   if (processPat && (processPat === localEnvPat || processPat === encryptedPat)) {

--- a/src/app/api/vault/route.ts
+++ b/src/app/api/vault/route.ts
@@ -4,9 +4,9 @@
  * GET    — returns vault mappings + resolution status for each entry.
  *          Never returns secret values.
  *
- * POST   — adds or updates a mapping:
- *          { key, ref, description?, required? } for 1Password refs, or
- *          { key, storage: "encrypted", value, description?, required? } for local encrypted secrets.
+ * POST   — adds or updates one mapping, or an `entries` batch. Supports local
+ *          encrypted values, op:// and dl:// references, and environment-owned
+ *          metadata without copying external values.
  *
  * PATCH  — grants or revokes one familiar without rewriting the secret.
  *
@@ -15,14 +15,14 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import {
-  deleteLocalEncryptedSecret,
-  setLocalEncryptedSecret,
+  commitLocalEncryptedSecretBatch,
+  hasLocalEncryptedSecret,
 } from "@/lib/local-encrypted-vault";
 import {
-  canMirrorVaultKeyToProcessEnv,
-  getVaultStatuses,
+  clearMirroredVaultSecretFromProcessEnv,
+  getVaultMetadataStatuses,
   grantVaultScope,
-  loadVaultMap,
+  loadVaultMapForMutation,
   mirrorVaultSecretToProcessEnv,
   normalizeVaultScope,
   refStorage,
@@ -30,18 +30,34 @@ import {
   saveVaultMap,
   validateRef,
   type VaultEntry,
+  type VaultMap,
 } from "@/lib/vault";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
+import {
+  normalizeVaultKey,
+  VAULT_PASTE_MAX_ENTRIES,
+  VAULT_PASTE_MAX_VALUE_LENGTH,
+  VAULT_STORAGE_IDS,
+  vaultStorageForReference,
+  type VaultStorageId,
+} from "@/lib/vault-storage";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+function vaultError(error: unknown, fallback: string) {
+  return NextResponse.json(
+    { ok: false, error: error instanceof Error ? error.message : fallback },
+    { status: 500 },
+  );
+}
 
 // ── GET — list all mappings + live status ─────────────────────────────────────
 
 export async function GET() {
   try {
-    const statuses = getVaultStatuses();
-    const map = loadVaultMap();
+    const map = loadVaultMapForMutation();
+    const statuses = getVaultMetadataStatuses();
     return NextResponse.json({
       ok: true,
       mappings: statuses.map((status) => ({
@@ -50,71 +66,174 @@ export async function GET() {
       })),
     });
   } catch (e) {
-    return NextResponse.json({ ok: false, error: String(e) }, { status: 500 });
+    return vaultError(e, "failed to read Vault metadata");
   }
 }
 
 // ── POST — add / update a mapping ─────────────────────────────────────────────
 
 export async function POST(req: NextRequest) {
-  let body: {
-    key?: string;
-    ref?: string;
-    storage?: string;
-    value?: string;
-    description?: string;
-    required?: boolean;
-    scope?: unknown;
-  } = {};
+  let body: Record<string, unknown> = {};
   try { body = await req.json(); } catch { /**/ }
 
-  const key = typeof body.key === "string" ? body.key.trim().toUpperCase().replace(/[^A-Z0-9_]/g, "_") : "";
-  const ref = typeof body.ref === "string" ? body.ref.trim() : "";
-  const storage = body.storage === "encrypted" || typeof body.value === "string" ? "encrypted" : "1password";
-
-  if (!key) return NextResponse.json({ ok: false, error: "key is required" }, { status: 400 });
-
-  const map = loadVaultMap(true);
-
-  const baseEntry = {
-    description: typeof body.description === "string" ? body.description.trim() : undefined,
-    required: body.required ?? false,
-    // Grants are edited elsewhere (per-familiar Vault tab) — re-saving a
-    // mapping here must not silently reset a key back to shared.
-    scope: map[key]?.scope,
-  };
-  if (body.scope !== undefined) {
-    baseEntry.scope = normalizeVaultScope(body.scope);
+  const rawEntries = Array.isArray(body.entries) ? body.entries : [body];
+  if (rawEntries.length === 0 || rawEntries.length > VAULT_PASTE_MAX_ENTRIES) {
+    return NextResponse.json(
+      { ok: false, error: `save between 1 and ${VAULT_PASTE_MAX_ENTRIES} entries at once` },
+      { status: 400 },
+    );
   }
 
-  let entry: VaultEntry;
-  if (storage === "encrypted") {
-    const value = typeof body.value === "string" ? body.value : "";
-    if (!value) return NextResponse.json({ ok: false, error: "value is required" }, { status: 400 });
-    setLocalEncryptedSecret(key, value);
-    entry = { ...baseEntry, storage: "encrypted" };
-  } else {
-    const refError = validateRef(ref);
-    if (refError) return NextResponse.json({ ok: false, error: refError }, { status: 400 });
-    deleteLocalEncryptedSecret(key);
-    entry = { ...baseEntry, ref };
+  let map: VaultMap;
+  try {
+    map = loadVaultMapForMutation();
+  } catch (error) {
+    return vaultError(error, "failed to read Vault metadata");
+  }
+  const seen = new Set<string>();
+  const prepared: Array<{
+    key: string;
+    storage: VaultStorageId;
+    secret?: string;
+    entry: VaultEntry;
+  }> = [];
+
+  for (const rawEntry of rawEntries) {
+    if (!rawEntry || typeof rawEntry !== "object") {
+      return NextResponse.json({ ok: false, error: "each entry must be an object" }, { status: 400 });
+    }
+    const input = rawEntry as Record<string, unknown>;
+    const key = normalizeVaultKey(typeof input.key === "string" ? input.key : "");
+    if (!key) return NextResponse.json({ ok: false, error: "key is required" }, { status: 400 });
+    if (seen.has(key)) {
+      return NextResponse.json({ ok: false, error: `${key} appears more than once` }, { status: 400 });
+    }
+    seen.add(key);
+
+    const description = typeof input.description === "string"
+      ? input.description.trim()
+      : undefined;
+    if (
+      typeof input.storage === "string"
+      && !VAULT_STORAGE_IDS.includes(input.storage as VaultStorageId)
+    ) {
+      return NextResponse.json(
+        { ok: false, error: `${key} uses an unsupported storage provider` },
+        { status: 400 },
+      );
+    }
+    const explicitStorage = typeof input.storage === "string"
+      && VAULT_STORAGE_IDS.includes(input.storage as VaultStorageId)
+      ? input.storage as VaultStorageId
+      : null;
+    const ref = typeof input.ref === "string" ? input.ref.trim() : "";
+    const value = typeof input.value === "string" ? input.value : "";
+    const storage = explicitStorage ?? (ref ? vaultStorageForReference(ref) : "encrypted");
+    const baseEntry = {
+      description: description || undefined,
+      required: input.required === true,
+      // Grants are edited elsewhere. Re-saving a mapping must not silently
+      // reset it back to shared unless the caller provides a scope.
+      scope: input.scope === undefined
+        ? map[key]?.scope
+        : normalizeVaultScope(input.scope),
+    };
+
+    if (storage === "environment") {
+      if (ref || value) {
+        return NextResponse.json(
+          { ok: false, error: `${key} environment mappings do not accept a secret value` },
+          { status: 400 },
+        );
+      }
+      prepared.push({ key, storage, entry: { ...baseEntry, storage } });
+      continue;
+    }
+
+    if (storage === "1password" || storage === "dashlane") {
+      const reference = ref || value.trim();
+      const refError = validateRef(reference);
+      if (refError) {
+        return NextResponse.json({ ok: false, error: `${key}: ${refError}` }, { status: 400 });
+      }
+      if (refStorage(reference) !== storage) {
+        return NextResponse.json(
+          { ok: false, error: `${key} must use ${storage === "dashlane" ? "dl://" : "op://"}` },
+          { status: 400 },
+        );
+      }
+      prepared.push({ key, storage, entry: { ...baseEntry, ref: reference } });
+      continue;
+    }
+
+    if (value.length > VAULT_PASTE_MAX_VALUE_LENGTH) {
+      return NextResponse.json(
+        { ok: false, error: `${key} is too large to store in the Vault` },
+        { status: 400 },
+      );
+    }
+    const existingEntry = map[key];
+    const keepsExistingEncryptedValue = existingEntry?.storage === "encrypted" || (
+      existingEntry?.storage !== "environment"
+      && !existingEntry?.ref
+      && hasLocalEncryptedSecret(key)
+    );
+    if (!value && !keepsExistingEncryptedValue) {
+      return NextResponse.json({ ok: false, error: `${key} value is required` }, { status: 400 });
+    }
+    prepared.push({
+      key,
+      storage,
+      secret: value || undefined,
+      entry: { ...baseEntry, storage: "encrypted" },
+    });
   }
 
-  map[key] = entry;
-  saveVaultMap(map);
+  try {
+    const previousMap = structuredClone(map);
+    const nextMap = structuredClone(map);
+    for (const item of prepared) {
+      nextMap[item.key] = item.entry;
+    }
+    const secretChanges: Array<{ key: string; value: string | null }> = [];
+    for (const item of prepared) {
+      if (item.storage === "encrypted") {
+        if (item.secret) secretChanges.push({ key: item.key, value: item.secret });
+      } else {
+        secretChanges.push({ key: item.key, value: null });
+      }
+    }
+    commitLocalEncryptedSecretBatch(
+      secretChanges,
+      () => saveVaultMap(nextMap),
+      () => saveVaultMap(previousMap),
+    );
 
-  if (storage === "encrypted" && typeof body.value === "string") {
-    mirrorVaultSecretToProcessEnv(key, body.value, { source: "vault", storage: "encrypted" });
-  } else if (canMirrorVaultKeyToProcessEnv(key)) {
-    delete process.env[key];
+    for (const item of prepared) {
+      const clearedVaultValue = clearMirroredVaultSecretFromProcessEnv(item.key);
+      if (
+        item.storage === "encrypted"
+        && item.secret
+        && (clearedVaultValue || !process.env[item.key])
+      ) {
+        mirrorVaultSecretToProcessEnv(item.key, item.secret, {
+          source: "vault",
+          storage: "encrypted",
+        });
+      }
+    }
+  } catch (error) {
+    return vaultError(error, "failed to save Vault entries");
   }
 
-  return NextResponse.json({
-    ok: true,
+  const saved = prepared.map(({ key, storage, entry }) => ({
     key,
     ref: entry.ref ?? null,
-    storage: entry.storage ?? (entry.ref ? refStorage(entry.ref) : "1password"),
-  });
+    storage,
+  }));
+  return NextResponse.json(saved.length === 1
+    ? { ok: true, ...saved[0] }
+    : { ok: true, entries: saved });
 }
 
 // ── PATCH — update one familiar grant without touching the secret ────────────
@@ -127,9 +246,7 @@ export async function PATCH(req: NextRequest) {
   } = {};
   try { body = await req.json(); } catch { /**/ }
 
-  const key = typeof body.key === "string"
-    ? body.key.trim().toUpperCase().replace(/[^A-Z0-9_]/g, "_")
-    : "";
+  const key = normalizeVaultKey(typeof body.key === "string" ? body.key : "");
   const familiarId = typeof body.familiarId === "string"
     ? body.familiarId.trim().toLowerCase()
     : "";
@@ -145,7 +262,12 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ ok: false, error: "action must be grant or revoke" }, { status: 400 });
   }
 
-  const map = loadVaultMap(true);
+  let map: VaultMap;
+  try {
+    map = loadVaultMapForMutation();
+  } catch (error) {
+    return vaultError(error, "failed to read Vault metadata");
+  }
   const entry = map[key];
   if (!entry) {
     return NextResponse.json({ ok: false, error: "key not found" }, { status: 404 });
@@ -155,7 +277,11 @@ export async function PATCH(req: NextRequest) {
     ? grantVaultScope(entry.scope, familiarId)
     : revokeVaultScope(entry.scope, familiarId);
   map[key] = { ...entry, scope };
-  saveVaultMap(map);
+  try {
+    saveVaultMap(map);
+  } catch (error) {
+    return vaultError(error, "failed to save Vault grant");
+  }
 
   return NextResponse.json({ ok: true, key, scope });
 }
@@ -166,19 +292,30 @@ export async function DELETE(req: NextRequest) {
   let body: { key?: string } = {};
   try { body = await req.json(); } catch { /**/ }
 
-  const key = typeof body.key === "string" ? body.key.trim().toUpperCase() : "";
+  const key = normalizeVaultKey(typeof body.key === "string" ? body.key : "");
   if (!key) return NextResponse.json({ ok: false, error: "key is required" }, { status: 400 });
 
-  const map = loadVaultMap(true);
+  let map: VaultMap;
+  try {
+    map = loadVaultMapForMutation();
+  } catch (error) {
+    return vaultError(error, "failed to read Vault metadata");
+  }
   if (!map[key]) return NextResponse.json({ ok: false, error: "key not found" }, { status: 404 });
 
+  const previousMap = structuredClone(map);
   delete map[key];
-  saveVaultMap(map);
-  deleteLocalEncryptedSecret(key);
+  try {
+    commitLocalEncryptedSecretBatch(
+      [{ key, value: null }],
+      () => saveVaultMap(map),
+      () => saveVaultMap(previousMap),
+    );
+  } catch (error) {
+    return vaultError(error, "failed to delete Vault entry");
+  }
 
-  // Clear cached safe values so the next resolve is fresh. Denied keys may be
-  // inherited runtime configuration and are never owned by the vault.
-  if (canMirrorVaultKeyToProcessEnv(key)) delete process.env[key];
+  clearMirroredVaultSecretFromProcessEnv(key);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/components/marketplace/marketplace-configure.tsx
+++ b/src/components/marketplace/marketplace-configure.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Icon } from "@/lib/icon";
 import { useAnnouncer } from "@/components/ui/live-region";
+import { vaultStorageForValue } from "@/lib/vault-storage";
 
 type FieldStatus = {
   key: string;
@@ -129,8 +130,9 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
     setKeyBusy(field.key, true);
     setError(null);
     try {
-      const sensitiveBody = draft.startsWith("op://")
-        ? { key: field.env, ref: draft, required: true, description: field.title }
+      const storage = vaultStorageForValue(draft);
+      const sensitiveBody = storage !== "encrypted"
+        ? { key: field.env, storage, ref: draft, required: true, description: field.title }
         : { key: field.env, storage: "encrypted", value: draft, required: true, description: field.title };
       const res = field.sensitive
         ? await fetch("/api/vault", {
@@ -171,7 +173,7 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
         {!loaded || fields.length > 0 ? (
           <p className="text-[length:var(--text-sm)] text-[var(--text-muted)]">
             {displayName} needs the following before its tools can run. Secrets are saved in the
-            encrypted local vault or stored as 1Password references.
+            encrypted local Vault or stored as 1Password or Dashlane references.
           </p>
         ) : null}
         {error ? (
@@ -201,9 +203,9 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
                   type="text"
                   value={drafts[f.key] ?? ""}
                   onChange={(e) => setDrafts((d) => ({ ...d, [f.key]: e.target.value }))}
-                  placeholder={f.sensitive ? "Paste a secret or op://Vault/Item/field" : f.default ? `e.g. ${f.default}` : "Enter a value (e.g. a directory path)"}
+                  placeholder={f.sensitive ? "Paste a secret, op:// reference, or dl:// reference" : f.default ? `e.g. ${f.default}` : "Enter a value (e.g. a directory path)"}
                   aria-label={`${f.title} value`}
-                  className="min-w-0 flex-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 text-[length:var(--text-sm)] text-[var(--text-primary)] outline-none focus:border-[var(--border-strong)] [height:var(--space-8)]!"
+                  className="focus-ring min-w-0 flex-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 text-[length:var(--text-sm)] text-[var(--text-primary)] outline-none focus:border-[var(--border-strong)] [height:var(--space-8)]!"
                 />
                 <Button
                   variant="primary"
@@ -232,7 +234,7 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
               ) : null}
               {f.sensitive ? (
                 <p className="text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                  Raw values are saved encrypted on this machine. op:// refs still use 1Password.
+                  Raw values are encrypted on this machine. op:// uses 1Password; dl:// uses Dashlane.
                 </p>
               ) : null}
             </div>

--- a/src/components/settings-familiars-control-sheet.test.ts
+++ b/src/components/settings-familiars-control-sheet.test.ts
@@ -99,7 +99,11 @@ assert.match(
   /familiarId \?[\s\S]*?updateFamiliarGrant[\s\S]*?:[\s\S]*?handleDelete/,
   "The familiar-scoped action cannot invoke the global secret deletion path",
 );
-assert.match(vaultRoute, /normalizeVaultScope\(body\.scope\)/, "Vault writes can persist a familiar grant");
+assert.match(
+  vaultRoute,
+  /input\.scope === undefined[\s\S]*?normalizeVaultScope\(input\.scope\)/,
+  "Vault writes can persist a familiar grant while preserving existing scope by default",
+);
 assert.match(vaultRoute, /export async function PATCH/, "Vault exposes a scope-only mutation");
 
 // Preserve the four real Studio surfaces and the fixed autosave/offline footer.

--- a/src/components/surface-error-states.test.ts
+++ b/src/components/surface-error-states.test.ts
@@ -41,8 +41,8 @@ assert.match(
 );
 assert.match(
   vault,
-  /<EmptyState[\s\S]*?No mappings yet[\s\S]*?Add mapping/,
-  "Vault panel empty state has an Add mapping action, not bare text",
+  /<EmptyState[\s\S]*?No mappings yet[\s\S]*?Add secrets/,
+  "Vault panel empty state has an Add secrets action, not bare text",
 );
 
 console.log("surface-error-states.test.ts: ok");

--- a/src/components/vault-automations-filter.test.ts
+++ b/src/components/vault-automations-filter.test.ts
@@ -7,7 +7,7 @@ const read = (rel: string) => readFileSync(new URL(rel, import.meta.url), "utf8"
 // Both surfaces gain a text filter via the shared SearchInput primitive.
 const vault = read("./vault-panel.tsx");
 assert.match(vault, /import \{ SearchInput \} from "@\/components\/ui\/search-input"/, "vault imports SearchInput");
-assert.match(vault, /<SearchInput[\s\S]*?placeholder="Filter secrets…"/, "vault renders a secrets filter");
+assert.match(vault, /<SearchInput[\s\S]*?placeholder="Search secrets…"/, "vault renders canonical secret search");
 // Filter composes with the undo-pending hide and matches key / ref / storage / description.
 assert.match(vault, /\[m\.key, m\.ref \?\? "", m\.storage \?\? "", m\.description \?\? ""\]\.join\(" "\)\.toLowerCase\(\)\.includes\(q\)/, "vault filters by key/ref/storage/description");
 assert.match(vault, /No secrets match/, "vault shows a no-matches message");

--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "@/styles/vault-panel.css";
 import { useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { SearchInput } from "@/components/ui/search-input";
@@ -10,15 +11,30 @@ import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { UndoToast } from "@/components/ui/undo-toast";
 import { useUndoDelete } from "@/lib/use-undo-delete";
+import {
+  normalizeVaultKey,
+  parseVaultPaste,
+  VAULT_STORAGE_PROVIDERS,
+  vaultStorageForValue,
+  vaultStorageProvider,
+  type VaultStorageId,
+} from "@/lib/vault-storage";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type VaultStatus = "resolved" | "encrypted" | "env-only" | "unresolved" | "error" | "no-ref";
+type VaultStatus =
+  | "resolved"
+  | "configured"
+  | "encrypted"
+  | "env-only"
+  | "unresolved"
+  | "error"
+  | "no-ref";
 
 type Mapping = {
   key: string;
   ref: string | null;
-  storage: "1password" | "encrypted" | "dashlane" | null;
+  storage: VaultStorageId | null;
   scope: "shared" | string[];
   description: string | null;
   required: boolean;
@@ -29,24 +45,24 @@ type Mapping = {
 
 // ── Status badge ──────────────────────────────────────────────────────────────
 
-const STATUS_META: Record<VaultStatus, { label: string; color: string; icon: string }> = {
-  resolved:   { label: "1Password",   color: "var(--color-success)", icon: "ph:vault" },
-  encrypted:  { label: "encrypted",   color: "var(--accent-presence)", icon: "ph:lock-key" },
-  "env-only": { label: "env only",    color: "oklch(0.75 0.15 80)", icon: "ph:file-text" },
-  unresolved: { label: "unresolved",  color: "var(--color-warning)", icon: "ph:warning" },
-  error:      { label: "error",       color: "var(--color-danger)", icon: "ph:x-circle" },
-  "no-ref":   { label: "no ref",      color: "var(--text-muted)", icon: "ph:minus" },
+const STATUS_META: Record<VaultStatus, { label: string; icon: string }> = {
+  resolved:   { label: "resolved", icon: "ph:vault" },
+  configured: { label: "configured", icon: "ph:vault" },
+  encrypted:  { label: "encrypted", icon: "ph:lock-key" },
+  "env-only": { label: "environment", icon: "ph:file-text" },
+  unresolved: { label: "unresolved", icon: "ph:warning" },
+  error:      { label: "error", icon: "ph:x-circle" },
+  "no-ref":   { label: "no storage", icon: "ph:minus" },
 };
 
 function StatusBadge({ status, storage }: { status: VaultStatus; storage?: Mapping["storage"] }) {
   const meta = STATUS_META[status];
-  // "resolved" means a live ref read succeeded; label it by the backing
-  // provider (1Password op:// vs Dashlane dl://) rather than a fixed string.
-  const label = status === "resolved" && storage === "dashlane" ? "Dashlane" : meta.label;
+  const label = storage && (status === "resolved" || status === "configured")
+    ? vaultStorageProvider(storage).shortLabel
+    : meta.label;
   return (
     <span
-      className="vault-status-badge"
-      style={{ color: meta.color, borderColor: `${meta.color}40` }}
+      className={`vault-status-badge vault-status-badge--${status}`}
       title={status}
     >
       <Icon name={meta.icon as Parameters<typeof Icon>[0]["name"]} width={10} />
@@ -68,47 +84,114 @@ function AddMappingForm({
   onSaved: () => void;
   onCancel: () => void;
 }) {
-  const [key, setKey]         = useState(initial?.key ?? "");
-  const [ref, setRef]         = useState(initial?.ref ?? "op://");
-  const [storage, setStorage] = useState<"1password" | "encrypted" | "dashlane">(
-    initial?.storage === "encrypted" || initial?.status === "encrypted"
-      ? "encrypted"
-      : initial?.storage === "dashlane" || initial?.ref?.startsWith("dl://")
-        ? "dashlane"
-        : "1password",
+  const initialStorage = initial?.storage ?? (
+    initial?.ref ? vaultStorageForValue(initial.ref) : "encrypted"
   );
-  const [secret, setSecret]   = useState("");
+  const [key, setKey]         = useState(initial?.key ?? "");
+  const [input, setInput]     = useState(initial?.ref ?? "");
+  const [storage, setStorage] = useState<VaultStorageId>(initialStorage);
   const [desc, setDesc]       = useState(initial?.description ?? "");
   const [required, setReq]    = useState(initial?.required ?? false);
+  const [showInput, setShowInput] = useState(false);
   const [busy, setBusy]       = useState(false);
   const [err, setErr]         = useState<string | null>(null);
+  const { announce } = useAnnouncer();
+
+  const pasteResult = useMemo(
+    () => storage === "environment"
+      ? { entries: [], error: null, assignmentMode: false }
+      : parseVaultPaste(input, key),
+    [input, key, storage],
+  );
+  const isBatch = !initial && pasteResult.assignmentMode;
+  const detectedStorage = pasteResult.entries.length === 1
+    ? pasteResult.entries[0].storage
+    : null;
+  const activeStorage = storage === "environment"
+    ? "environment"
+    : detectedStorage ?? storage;
+
+  function selectStorage(next: VaultStorageId) {
+    setStorage(next);
+    setErr(null);
+    const provider = vaultStorageProvider(next);
+    if (next === "encrypted") {
+      setInput((current) => {
+        const trimmed = current.trim();
+        return trimmed.startsWith("op://") || trimmed.startsWith("dl://")
+          ? ""
+          : current;
+      });
+    }
+    if (provider.referencePrefix) {
+      setInput((current) => {
+        const trimmed = current.trim();
+        return trimmed.startsWith(provider.referencePrefix!)
+          ? current
+          : provider.referencePrefix!;
+      });
+    }
+  }
+
+  async function pasteFromClipboard() {
+    try {
+      const value = await navigator.clipboard.readText();
+      setInput(value);
+      announce("Pasted from clipboard.");
+    } catch {
+      setErr("Clipboard access is unavailable. Paste into the field instead.");
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    if (storage !== "environment" && pasteResult.error) {
+      setErr(pasteResult.error);
+      return;
+    }
     setBusy(true); setErr(null);
     try {
+      const scope = initial?.scope ?? (familiarId ? [familiarId] : undefined);
+      const common = {
+        description: desc || undefined,
+        required,
+        scope,
+      };
+      const singleEntry = pasteResult.entries[0];
+      const payload = storage === "environment"
+        ? {
+            key,
+            storage,
+            ...common,
+          }
+        : isBatch
+          ? {
+              entries: pasteResult.entries.map((entry) => ({
+                ...entry,
+                ...common,
+              })),
+            }
+          : {
+              key: normalizeVaultKey(key),
+              storage: activeStorage,
+              value: activeStorage === "encrypted"
+                ? singleEntry?.value ?? input
+                : undefined,
+              ref: activeStorage === "1password" || activeStorage === "dashlane"
+                ? singleEntry?.ref ?? input.trim()
+                : undefined,
+              ...common,
+            };
       const res = await fetch("/api/vault", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(storage === "encrypted"
-          ? {
-              key,
-              storage: "encrypted",
-              value: secret,
-              description: desc || undefined,
-              required,
-              scope: initial?.scope ?? (familiarId ? [familiarId] : undefined),
-            }
-          : {
-              key,
-              ref,
-              description: desc || undefined,
-              required,
-              scope: initial?.scope ?? (familiarId ? [familiarId] : undefined),
-            }),
+        body: JSON.stringify(payload),
       });
       const j = await res.json() as { ok: boolean; error?: string };
       if (!j.ok) throw new Error(j.error ?? "Failed to save");
+      announce(isBatch
+        ? `Saved ${pasteResult.entries.length} Vault entries.`
+        : `Saved ${normalizeVaultKey(key)}.`);
       onSaved();
     } catch (e) {
       setErr(e instanceof Error ? e.message : "Unknown error");
@@ -123,77 +206,96 @@ function AddMappingForm({
         <label className="vault-add-label">
           Env var name
           <input
-            className="vault-add-input"
+            className="vault-add-input focus-ring"
             value={key}
-            onChange={(e) => setKey(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, "_"))}
-            placeholder="GITHUB_PAT"
-            required
+            onChange={(e) => setKey(normalizeVaultKey(e.target.value))}
+            placeholder={isBatch ? "Detected from paste" : "GITHUB_PAT"}
+            required={!isBatch}
             disabled={!!initial}
           />
         </label>
         <div className="vault-add-label [flex:2]!">
           Storage
-          <div className="[display:flex]! [gap:6px]!">
-            <button
-              type="button"
-              className={`vault-btn${storage === "encrypted" ? " vault-btn--primary" : ""}`}
-              onClick={() => setStorage("encrypted")}
-            >
-              Local encrypted
-            </button>
-            <button
-              type="button"
-              className={`vault-btn${storage === "1password" ? " vault-btn--primary" : ""}`}
-              onClick={() => {
-                setStorage("1password");
-                if (!ref || ref === "dl://") setRef("op://");
-              }}
-            >
-              1Password
-            </button>
-            <button
-              type="button"
-              className={`vault-btn${storage === "dashlane" ? " vault-btn--primary" : ""}`}
-              onClick={() => {
-                setStorage("dashlane");
-                if (!ref || ref === "op://") setRef("dl://");
-              }}
-            >
-              Dashlane
-            </button>
+          <div className="vault-provider-list">
+            {VAULT_STORAGE_PROVIDERS.map((provider) => (
+              <button
+                key={provider.id}
+                type="button"
+                className={`vault-btn focus-ring${activeStorage === provider.id ? " vault-btn--primary" : ""}`}
+                onClick={() => selectStorage(provider.id)}
+                aria-pressed={activeStorage === provider.id}
+                title={provider.description}
+                disabled={isBatch}
+              >
+                {provider.shortLabel}
+              </button>
+            ))}
           </div>
+          {!isBatch ? (
+            <span className="vault-provider-description">
+              {vaultStorageProvider(activeStorage).description}
+            </span>
+          ) : null}
         </div>
       </div>
-      {storage === "encrypted" ? (
+      {storage !== "environment" ? (
         <label className="vault-add-label">
-          Secret value
-          <input
-            className="vault-add-input"
-            type="password"
-            value={secret}
-            onChange={(e) => setSecret(e.target.value)}
-            placeholder={initial ? "Enter a new value" : "Paste secret value"}
-            required
-          />
+          Secret, secure reference, or .env entries
+          <div className="vault-paste-field">
+            <textarea
+              className={`vault-add-input vault-paste-input focus-ring${showInput ? "" : " vault-paste-input--masked"}`}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder={initial?.storage === "encrypted"
+                ? "Leave blank to keep the current encrypted value"
+                : "Paste a value, op:// or dl:// reference, or KEY=value lines"}
+              required={!initial}
+              rows={isBatch ? Math.min(8, Math.max(3, pasteResult.entries.length)) : 3}
+              spellCheck={false}
+            />
+            <div className="vault-paste-actions">
+              <button
+                type="button"
+                className="vault-btn focus-ring vault-paste-button"
+                onClick={() => setShowInput((current) => !current)}
+                aria-pressed={showInput}
+              >
+                {showInput ? "Hide" : "Show"}
+              </button>
+              <button
+                type="button"
+                className="vault-btn focus-ring vault-paste-button"
+                onClick={() => void pasteFromClipboard()}
+              >
+                <Icon name="ph:clipboard-text" width={12} />
+                Paste
+              </button>
+            </div>
+          </div>
+          {pasteResult.error ? (
+            <span className="vault-err">{pasteResult.error}</span>
+          ) : isBatch ? (
+            <span className="vault-paste-summary">
+              Detected {pasteResult.entries.length} entries:{" "}
+              {pasteResult.entries.map((entry) => entry.key).join(", ")}
+            </span>
+          ) : detectedStorage ? (
+            <span className="vault-paste-summary">
+              Detected {vaultStorageProvider(detectedStorage).label}.
+            </span>
+          ) : null}
         </label>
       ) : (
-        <label className="vault-add-label">
-          {storage === "dashlane" ? "Dashlane reference" : "1Password reference"}
-          <input
-            className="vault-add-input vault-ref-input"
-            value={ref}
-            onChange={(e) => setRef(e.target.value)}
-            placeholder={storage === "dashlane"
-              ? "dl://GitHub PAT/username"
-              : "op://Personal/GitHub PAT/credential"}
-            required
-          />
-        </label>
+        <div className="vault-environment-note">
+          <Icon name="ph:terminal-window" width={14} />
+          The Vault stores only this key's access and metadata. Its value stays in the
+          launch environment or <code>.env.local</code>.
+        </div>
       )}
       <label className="vault-add-label">
         Description (optional)
         <input
-          className="vault-add-input"
+          className="vault-add-input focus-ring"
           value={desc}
           onChange={(e) => setDesc(e.target.value)}
           placeholder="What this secret is for"
@@ -201,14 +303,19 @@ function AddMappingForm({
       </label>
       <div className="vault-add-footer">
         <label className="vault-required-check">
-          <input type="checkbox" checked={required} onChange={(e) => setReq(e.target.checked)} />
+          <input
+            className="focus-ring"
+            type="checkbox"
+            checked={required}
+            onChange={(e) => setReq(e.target.checked)}
+          />
           Required
         </label>
         {err && <span className="vault-err">{err}</span>}
         <div className="[margin-left:auto]! [display:flex]! [gap:6px]!">
-          <button type="button" className="vault-btn" onClick={onCancel}>Cancel</button>
-          <button type="submit" className="vault-btn vault-btn--primary" disabled={busy}>
-            {busy ? "Saving…" : initial ? "Update" : "Add mapping"}
+          <button type="button" className="vault-btn focus-ring" onClick={onCancel}>Cancel</button>
+          <button type="submit" className="vault-btn vault-btn--primary focus-ring" disabled={busy}>
+            {busy ? "Saving…" : initial ? "Save changes" : isBatch ? "Save entries" : "Add mapping"}
           </button>
         </div>
       </div>
@@ -237,9 +344,10 @@ export function VaultPanel({ familiarId }: { familiarId?: string }) {
     try {
       await navigator.clipboard.writeText(ref);
       setCopiedKey(key);
+      announce(`Copied the secure reference for ${key}.`);
       window.setTimeout(() => setCopiedKey((k) => (k === key ? null : k)), 1600);
     } catch {
-      // Clipboard blocked (insecure context / permissions) — no-op.
+      announce(`Couldn't copy the secure reference for ${key}.`);
     }
   }
 
@@ -337,20 +445,20 @@ export function VaultPanel({ familiarId }: { familiarId?: string }) {
         <span className="vault-header-sub">
           {familiarId
             ? `shared, granted, and available keys for ${familiarId}`
-            : "env vars → encrypted local secrets, 1Password, or Dashlane references"}
+            : "Paste secrets, secure references, or .env entries; keep environment-owned values in place"}
         </span>
         <button
           type="button"
-          className="vault-btn vault-btn--primary [margin-left:auto]!"
+          className="vault-btn vault-btn--primary focus-ring [margin-left:auto]!"
           onClick={() => { setAdding(true); setEditing(null); }}
           disabled={adding}
         >
           <Icon name="ph:plus" width={12} />
-          Add mapping
+          Add secrets
         </button>
         <button
           type="button"
-          className="vault-btn"
+          className="vault-btn focus-ring"
           onClick={load}
           title="Refresh"
         >
@@ -391,7 +499,7 @@ export function VaultPanel({ familiarId }: { familiarId?: string }) {
           headline={familiarId ? "No secrets available" : "No mappings yet"}
           subtitle={familiarId
             ? "Add a secret scoped to this familiar."
-            : "Add one to store a local encrypted secret or pull from 1Password."}
+            : "Paste a value or .env block, link a secure reference, or recognize an environment-owned key."}
           actions={
             <Button
               size="xs"
@@ -399,7 +507,7 @@ export function VaultPanel({ familiarId }: { familiarId?: string }) {
               onClick={() => { setAdding(true); setEditing(null); }}
               disabled={adding}
             >
-              Add mapping
+              Add secrets
             </Button>
           }
         />
@@ -410,8 +518,8 @@ export function VaultPanel({ familiarId }: { familiarId?: string }) {
               value={query}
               onValueChange={setQuery}
               onClear={() => setQuery("")}
-              placeholder="Filter secrets…"
-              aria-label="Filter secrets"
+              placeholder="Search secrets…"
+              aria-label="Search secrets"
               containerClassName="vault-filter"
             />
           ) : null}
@@ -444,6 +552,9 @@ export function VaultPanel({ familiarId }: { familiarId?: string }) {
               {m.storage === "encrypted" && !m.ref && (
                 <div className="vault-row-ref">Local encrypted secret</div>
               )}
+              {m.storage === "environment" && !m.ref && (
+                <div className="vault-row-ref">Environment-owned value</div>
+              )}
               {m.description && (
                 <div className="vault-row-desc">{m.description}</div>
               )}
@@ -454,9 +565,9 @@ export function VaultPanel({ familiarId }: { familiarId?: string }) {
                 {m.ref && (
                   <button
                     type="button"
-                    className="vault-action-btn"
+                    className="vault-action-btn focus-ring"
                     title={copiedKey === m.key ? "Copied" : "Copy reference"}
-                    aria-label={`Copy the 1Password reference for ${m.key}`}
+                    aria-label={`Copy the secure reference for ${m.key}`}
                     onClick={() => void handleCopyRef(m.key, m.ref!)}
                   >
                     <Icon name={copiedKey === m.key ? "ph:check" : "ph:copy"} width={11} />
@@ -466,7 +577,7 @@ export function VaultPanel({ familiarId }: { familiarId?: string }) {
                   m.scope === "shared" ? null : (
                     <button
                       type="button"
-                      className="vault-action-btn"
+                      className="vault-action-btn focus-ring"
                       title={granted ? "Revoke from familiar" : "Grant to familiar"}
                       aria-label={`${granted ? "Revoke" : "Grant"} ${m.key} ${granted ? "from" : "to"} ${familiarId}`}
                       disabled={grantBusyKey === m.key}
@@ -482,7 +593,7 @@ export function VaultPanel({ familiarId }: { familiarId?: string }) {
                   <>
                     <button
                       type="button"
-                      className="vault-action-btn"
+                      className="vault-action-btn focus-ring"
                       title="Edit"
                       onClick={() => { setEditing(m); setAdding(false); }}
                     >
@@ -490,7 +601,7 @@ export function VaultPanel({ familiarId }: { familiarId?: string }) {
                     </button>
                     <button
                       type="button"
-                      className="vault-action-btn vault-action-btn--danger"
+                      className="vault-action-btn vault-action-btn--danger focus-ring"
                       title="Remove mapping"
                       onClick={() => handleDelete(m.key)}
                     >
@@ -509,8 +620,8 @@ export function VaultPanel({ familiarId }: { familiarId?: string }) {
 
       {/* Footer note */}
       <div className="vault-footer-note">
-        Local secrets are encrypted on disk with a machine-local Cave key. 1Password
-        entries are resolved live via <code>op read</code> and cached in process memory.
+        Local values are encrypted with a machine-local Cave key. Secure references resolve
+        through their provider CLI. Environment values stay where they already live.
       </div>
       {grantError ? (
         <div className="vault-row-error" role="alert">{grantError}</div>

--- a/src/lib/child-spawn-env.ts
+++ b/src/lib/child-spawn-env.ts
@@ -24,6 +24,25 @@ function comparableEnvKey(key: string, platform: NodeJS.Platform): string {
   return platform === "win32" ? key.toUpperCase() : key;
 }
 
+export function isForbiddenSpawnEnvKey(
+  key: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const comparableKey = comparableEnvKey(key, platform);
+  return (
+    isSidecarInternalEnvKey(key, platform) ||
+    FORBIDDEN_SPAWN_ENV_KEYS.some((forbidden) => comparableKey === forbidden)
+  );
+}
+
+export function isSidecarInternalEnvKey(
+  key: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const comparableKey = comparableEnvKey(key, platform);
+  return SIDECAR_INTERNAL_ENV_PREFIXES.some((prefix) => comparableKey.startsWith(prefix));
+}
+
 /**
  * Remove Cave/sidecar-internal variables (and forbidden token keys) from a
  * spawn env, in place.
@@ -33,13 +52,7 @@ export function scrubSidecarInternalEnv(
   platform: NodeJS.Platform = process.platform,
 ): NodeJS.ProcessEnv {
   for (const key of Object.keys(env)) {
-    const comparableKey = comparableEnvKey(key, platform);
-    if (
-      SIDECAR_INTERNAL_ENV_PREFIXES.some((prefix) => comparableKey.startsWith(prefix)) ||
-      FORBIDDEN_SPAWN_ENV_KEYS.some((forbidden) => comparableKey === forbidden)
-    ) {
-      delete env[key];
-    }
+    if (isForbiddenSpawnEnvKey(key, platform)) delete env[key];
   }
   return env;
 }

--- a/src/lib/harness-spawn-env.test.ts
+++ b/src/lib/harness-spawn-env.test.ts
@@ -1,11 +1,12 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import {
   canonicalProbeSpawnEnv,
   restoreAllowedGitHubTokenEnv,
+  restoreGrantedVaultEnv,
   restoreGrantedVaultGitHubTokenEnv,
   subtractScopedVaultKeys,
   vaultFreeDiscoveryEnv,
@@ -279,7 +280,11 @@ assert.match(
 assert.doesNotMatch(daemonStartSource, /covenSpawnEnv/);
 
 const vaultRouteSource = read("../app/api/vault/route.ts");
-assert.match(vaultRouteSource, /scope: map\[key\]\?\.scope/, "/api/vault edits preserve existing grants");
+assert.match(
+  vaultRouteSource,
+  /input\.scope === undefined[\s\S]*?\? map\[key\]\?\.scope[\s\S]*?: normalizeVaultScope\(input\.scope\)/,
+  "/api/vault edits preserve existing grants unless the caller supplies a scope",
+);
 
 const githubPatSource = read("../app/api/github/pat/route.ts");
 assert.match(githubPatSource, /scope: map\[PAT_KEY\]\?\.scope/, "GitHub PAT re-save preserves existing grants");
@@ -301,8 +306,13 @@ assert.match(
 );
 assert.match(
   helperSource,
-  /restoreGrantedVaultGitHubTokenEnv[\s\S]*isVaultKeyGrantedTo\(entry, familiarId\)[\s\S]*resolveVaultManagedSecret\(key, entry\)\?\.trim\(\)/,
+  /restoreGrantedVaultGitHubTokenEnv[\s\S]*isVaultKeyGrantedTo\(entry, familiarId\)[\s\S]*entry\.storage === "environment"[\s\S]*resolveVaultManagedSecret\(key, entry, resolution\)\?\.trim\(\)/,
   "a Vault-managed GitHub alias is restored only for the granted familiar after the generic child-env scrub",
+);
+assert.match(
+  helperSource,
+  /restoreGrantedVaultEnv[\s\S]*isForbiddenSpawnEnvKey\(key\)[\s\S]*canMirrorVaultKeyToProcessEnv\(key\)[\s\S]*isVaultKeyGrantedTo\(entry, familiarId\)[\s\S]*resolveCachedVaultManagedSecret\(key, entry, resolution\)\?\.trim\(\)/,
+  "every safe generic Vault key is materialized only for a granted familiar",
 );
 {
   const helperStart = helperSource.indexOf("export function canonicalProbeSpawnEnv");
@@ -311,7 +321,7 @@ assert.match(
   const probeHelperSource = helperSource.slice(helperStart, helperEnd);
   assert.doesNotMatch(
     probeHelperSource,
-    /restoreGrantedVaultGitHubTokenEnv|restoreAllowedGitHubTokenEnv|resolveVaultManagedSecret/,
+    /restoreGrantedVaultEnv|restoreGrantedVaultGitHubTokenEnv|restoreAllowedGitHubTokenEnv|resolveVaultManagedSecret/,
     "probe environment construction never restores or materializes familiar/shared credentials",
   );
 }
@@ -326,6 +336,12 @@ const tokenOriginal = {
   COVEN_CAVE_ENV_FILE: process.env.COVEN_CAVE_ENV_FILE,
   GITHUB_PAT: process.env.GITHUB_PAT,
   GH_TOKEN: process.env.GH_TOKEN,
+  COVEN_GENERIC_ENV: process.env.COVEN_GENERIC_ENV,
+  COVEN_CAVE_AUTH_TOKEN: process.env.COVEN_CAVE_AUTH_TOKEN,
+  __NEXT_PRIVATE_TEST_TOKEN: process.env.__NEXT_PRIVATE_TEST_TOKEN,
+  PATH: process.env.PATH,
+  COVEN_CAVE_REF_READ_TIMEOUT_MS: process.env.COVEN_CAVE_REF_READ_TIMEOUT_MS,
+  COVEN_CAVE_REF_READ_RETRY_TIMEOUT_MS: process.env.COVEN_CAVE_REF_READ_RETRY_TIMEOUT_MS,
 };
 process.env.COVEN_VAULT_FILE = join(tokenDir, "vault.yaml");
 process.env.COVEN_CAVE_LOCAL_VAULT_FILE = join(tokenDir, "local-vault.enc.json");
@@ -333,6 +349,9 @@ process.env.COVEN_CAVE_LOCAL_VAULT_KEY_FILE = join(tokenDir, "local-vault.key");
 process.env.COVEN_CAVE_ENV_FILE = join(tokenDir, ".env.local");
 process.env.GITHUB_PAT = "launcher-pat";
 process.env.GH_TOKEN = "launcher-token";
+process.env.COVEN_GENERIC_ENV = "launcher-generic";
+process.env.COVEN_CAVE_AUTH_TOKEN = "side";
+process.env.__NEXT_PRIVATE_TEST_TOKEN = "next";
 try {
   assert.equal(
     restoreAllowedGitHubTokenEnv({}, new Set(["GITHUB_PAT"]), new Set()).GITHUB_PAT,
@@ -360,6 +379,71 @@ try {
     restoreAllowedGitHubTokenEnv({}, new Set(["GITHUB_PAT"]), new Set(Object.keys(loadVaultMap(true)))).GITHUB_PAT,
     undefined,
     "an opt-in cannot replace a Vault-managed GitHub PAT with the launcher's same-named value",
+  );
+  saveVaultMap({
+    GH_TOKEN: { storage: "environment", scope: ["nova"] },
+  });
+  assert.equal(
+    restoreGrantedVaultGitHubTokenEnv({}, loadVaultMap(true), "nova").GH_TOKEN,
+    "launcher-token",
+    "a granted environment mapping keeps launcher custody while applying familiar scope",
+  );
+  assert.equal(
+    restoreGrantedVaultGitHubTokenEnv({}, loadVaultMap(true), "sage").GH_TOKEN,
+    undefined,
+    "an environment-owned GitHub token remains hidden from an ungranted familiar",
+  );
+  saveVaultMap({
+    COVEN_GENERIC_ENV: { storage: "environment", scope: ["nova"] },
+    COVEN_GENERIC_SECRET: { storage: "encrypted", scope: ["nova"] },
+    COVEN_CAVE_AUTH_TOKEN: { storage: "environment", scope: ["nova"] },
+    __NEXT_PRIVATE_TEST_TOKEN: { storage: "environment", scope: ["nova"] },
+    NODE_OPTIONS: { storage: "environment", scope: ["nova"] },
+  });
+  setLocalEncryptedSecret("COVEN_GENERIC_SECRET", "safe");
+  assert.deepEqual(
+    restoreGrantedVaultEnv({}, loadVaultMap(true), "nova"),
+    {
+      COVEN_GENERIC_ENV: "launcher-generic",
+      COVEN_GENERIC_SECRET: "safe",
+    },
+    "generic granted environment and encrypted keys materialize without runtime-control keys",
+  );
+  assert.deepEqual(
+    restoreGrantedVaultEnv({}, loadVaultMap(true), "sage"),
+    {},
+    "generic Vault keys remain hidden from an ungranted familiar",
+  );
+
+  const fakeBin = join(tokenDir, "bin");
+  const fakeOp = join(fakeBin, "op");
+  await import("node:fs/promises").then(({ mkdir }) => mkdir(fakeBin));
+  writeFileSync(
+    fakeOp,
+    "#!/usr/bin/env node\nsetTimeout(() => process.stdout.write('late-secret\\n'), 2000);\n",
+  );
+  chmodSync(fakeOp, 0o755);
+  process.env.PATH = `${fakeBin}${delimiter}${process.env.PATH ?? ""}`;
+  process.env.COVEN_CAVE_REF_READ_TIMEOUT_MS = "5000";
+  process.env.COVEN_CAVE_REF_READ_RETRY_TIMEOUT_MS = "5000";
+  const providerMap = {
+    FIRST_PROVIDER_SECRET: { ref: "op://Dev/First/credential", scope: ["nova"] },
+    SECOND_PROVIDER_SECRET: { ref: "op://Dev/Second/credential", scope: ["nova"] },
+  };
+  const providerStartedAt = Date.now();
+  assert.deepEqual(
+    restoreGrantedVaultEnv(
+      {},
+      providerMap,
+      "nova",
+      { deadlineMs: providerStartedAt + 150 },
+    ),
+    {},
+    "provider timeouts fail closed without injecting partial credentials",
+  );
+  assert.ok(
+    Date.now() - providerStartedAt < 1_000,
+    "one aggregate deadline bounds all provider resolution during harness startup",
   );
 } finally {
   for (const [key, value] of Object.entries(tokenOriginal)) {

--- a/src/lib/harness-spawn-env.ts
+++ b/src/lib/harness-spawn-env.ts
@@ -20,11 +20,22 @@ import {
   covenSpawnEnv,
   type CovenSpawnEnvOptions,
 } from "./coven-bin.ts";
-import { vaultFreeDiscoveryEnv } from "./child-spawn-env.ts";
+import {
+  isForbiddenSpawnEnvKey,
+  vaultFreeDiscoveryEnv,
+} from "./child-spawn-env.ts";
 import { readEnvLocalValue } from "./env-file.ts";
 import { GITHUB_HARNESS_TOKEN_ENV_KEYS } from "./github-token-env.ts";
 import { hasLocalEncryptedSecret } from "./local-encrypted-vault.ts";
-import { isVaultKeyGrantedTo, loadVaultMap, resolveVaultManagedSecret, type VaultMap } from "./vault.ts";
+import {
+  canMirrorVaultKeyToProcessEnv,
+  isVaultKeyGrantedTo,
+  loadVaultMap,
+  resolveCachedVaultManagedSecret,
+  resolveVaultManagedSecret,
+  type VaultMap,
+  type VaultResolutionOptions,
+} from "./vault.ts";
 
 export { vaultFreeDiscoveryEnv } from "./child-spawn-env.ts";
 
@@ -80,6 +91,7 @@ export function restoreGrantedVaultGitHubTokenEnv(
   env: NodeJS.ProcessEnv,
   map: VaultMap,
   familiarId?: string | null,
+  resolution: VaultResolutionOptions = {},
 ): NodeJS.ProcessEnv {
   for (const key of GITHUB_HARNESS_TOKEN_ENV_KEYS) {
     const entry = map[key];
@@ -88,10 +100,35 @@ export function restoreGrantedVaultGitHubTokenEnv(
     // Vault mapping again so that security boundary does not prevent a
     // configured Codex, Hermes, OpenCode, or other harness from receiving
     // its own scoped credential.
-    // Do not take a same-named launcher variable here. A managed mapping
-    // must retain its Vault value and scope; launcher values need the explicit
-    // COVEN_HARNESS_ALLOW_ENV_KEYS opt-in handled above.
-    const value = resolveVaultManagedSecret(key, entry)?.trim();
+    // Environment mappings deliberately retain launcher/.env.local custody
+    // while still applying the Vault's familiar scope at this boundary.
+    const value = entry.storage === "environment"
+      ? process.env[key]?.trim() || readEnvLocalValue(key)?.trim()
+      : resolveVaultManagedSecret(key, entry, resolution)?.trim();
+    if (value) env[key] = value;
+  }
+  return env;
+}
+
+/** Materialize every non-GitHub Vault key granted to this familiar. */
+export function restoreGrantedVaultEnv(
+  env: NodeJS.ProcessEnv,
+  map: VaultMap,
+  familiarId?: string | null,
+  resolution: VaultResolutionOptions = {},
+): NodeJS.ProcessEnv {
+  for (const [key, entry] of Object.entries(map)) {
+    if (
+      GITHUB_HARNESS_TOKEN_ENV_KEYS.includes(
+        key as (typeof GITHUB_HARNESS_TOKEN_ENV_KEYS)[number],
+      )
+      || isForbiddenSpawnEnvKey(key)
+      || !canMirrorVaultKeyToProcessEnv(key)
+      || !isVaultKeyGrantedTo(entry, familiarId)
+    ) continue;
+    const value = entry.storage === "environment"
+      ? process.env[key]?.trim() || readEnvLocalValue(key)?.trim()
+      : resolveCachedVaultManagedSecret(key, entry, resolution)?.trim();
     if (value) env[key] = value;
   }
   return env;
@@ -145,6 +182,11 @@ export function harnessSpawnEnv(
   discovery: Pick<CovenSpawnEnvOptions, "discoveryDeadline" | "now"> = {},
 ): NodeJS.ProcessEnv {
   const map = loadVaultMap(true);
+  const configuredBudget = Number(process.env.COVEN_CAVE_HARNESS_VAULT_TIMEOUT_MS);
+  const budgetMs = Number.isFinite(configuredBudget) && configuredBudget >= 0
+    ? configuredBudget
+    : 15_000;
+  const resolution = { deadlineMs: Date.now() + budgetMs };
   const env = subtractScopedVaultKeys(
     covenSpawnEnv({
       discoveryEnv: vaultFreeDiscoveryEnv(process.env, map),
@@ -154,6 +196,7 @@ export function harnessSpawnEnv(
     map,
     familiarId,
   );
-  restoreGrantedVaultGitHubTokenEnv(env, map, familiarId);
+  restoreGrantedVaultEnv(env, map, familiarId, resolution);
+  restoreGrantedVaultGitHubTokenEnv(env, map, familiarId, resolution);
   return restoreAllowedGitHubTokenEnv(env, undefined, new Set(Object.keys(map)));
 }

--- a/src/lib/local-encrypted-vault.test.ts
+++ b/src/lib/local-encrypted-vault.test.ts
@@ -79,6 +79,7 @@ try {
   );
 
   const {
+    commitLocalEncryptedSecretBatch,
     deleteLocalEncryptedSecret,
     getLocalEncryptedSecret,
     getLocalEncryptedSecretSnapshot,
@@ -466,6 +467,52 @@ try {
     "vault mutation contention leaves no store temp files",
   );
 
+  setLocalEncryptedSecret("SYNTHETIC_BATCH_A", "batch-a-before");
+  setLocalEncryptedSecret("SYNTHETIC_BATCH_B", "batch-b-before");
+  assert.throws(
+    () => commitLocalEncryptedSecretBatch(
+      [
+        { key: "SYNTHETIC_BATCH_A", value: "batch-a-after" },
+        { key: "SYNTHETIC_BATCH_B", value: "batch-b-after" },
+      ],
+      () => {
+        throw new Error("synthetic metadata failure");
+      },
+      () => {
+        assert.fail("metadata rollback is unnecessary when metadata never committed");
+      },
+    ),
+    /local encrypted vault is unavailable/,
+    "a failed metadata commit aborts the whole encrypted-value batch",
+  );
+  valueMatches(
+    getLocalEncryptedSecret("SYNTHETIC_BATCH_A"),
+    "batch-a-before",
+    "the first encrypted value is preserved after a failed batch",
+  );
+  valueMatches(
+    getLocalEncryptedSecret("SYNTHETIC_BATCH_B"),
+    "batch-b-before",
+    "the second encrypted value is preserved after a failed batch",
+  );
+  assert.throws(
+    () => commitLocalEncryptedSecretBatch(
+      [
+        { key: "SYNTHETIC_BATCH_A", value: "must-not-write" },
+        { key: "SYNTHETIC_BATCH_B", value: "" },
+      ],
+      () => assert.fail("invalid batches are rejected before metadata commit"),
+      () => assert.fail("invalid batches never need rollback"),
+    ),
+    /secret value is required/,
+    "batch validation completes before any encrypted value is changed",
+  );
+  valueMatches(
+    getLocalEncryptedSecret("SYNTHETIC_BATCH_A"),
+    "batch-a-before",
+    "a later invalid item cannot partially overwrite an earlier item",
+  );
+
   const rawFile = await readFile(vaultFile, "utf8");
   const plaintextTestValues = [
     INITIAL_VALUE,
@@ -478,6 +525,11 @@ try {
     "synthetic-test-cas-race-initial",
     casAValue,
     casBValue,
+    "batch-a-before",
+    "batch-b-before",
+    "batch-a-after",
+    "batch-b-after",
+    "must-not-write",
   ];
   assert.equal(
     plaintextTestValues.some((value) => rawFile.includes(value)),
@@ -501,6 +553,19 @@ try {
   deleteLocalEncryptedSecret(SECRET_KEY);
   assert.equal(getLocalEncryptedSecret(SECRET_KEY), null);
   assert.equal(hasLocalEncryptedSecret(SECRET_KEY), false);
+
+  const malformedStore = "{not valid json";
+  await writeFile(vaultFile, malformedStore, { mode: 0o600 });
+  assert.throws(
+    () => setLocalEncryptedSecret("SYNTHETIC_AFTER_CORRUPTION", "must-not-write"),
+    /local encrypted vault is unavailable/,
+    "a malformed encrypted store fails closed instead of being replaced",
+  );
+  assert.equal(
+    await readFile(vaultFile, "utf8"),
+    malformedStore,
+    "failed mutation preserves the malformed store for recovery",
+  );
 
   console.log("local-encrypted-vault.test.ts: ok");
 } finally {

--- a/src/lib/local-encrypted-vault.ts
+++ b/src/lib/local-encrypted-vault.ts
@@ -232,12 +232,26 @@ function readStore(): LocalVaultStore {
       parsed.version !== 1
       || !parsed.secrets
       || typeof parsed.secrets !== "object"
+      || Array.isArray(parsed.secrets)
     ) {
-      return { version: 1, secrets: {} };
+      throw fixedVaultError("local encrypted vault is unavailable");
+    }
+    for (const entry of Object.values(parsed.secrets)) {
+      if (
+        !entry
+        || entry.v !== 1
+        || entry.alg !== "aes-256-gcm"
+        || typeof entry.iv !== "string"
+        || typeof entry.tag !== "string"
+        || typeof entry.ciphertext !== "string"
+        || typeof entry.updatedAt !== "string"
+      ) {
+        throw fixedVaultError("local encrypted vault is unavailable");
+      }
     }
     return { version: 1, secrets: parsed.secrets };
-  } catch {
-    return { version: 1, secrets: {} };
+  } catch (error) {
+    return sanitizedVaultError(error);
   }
 }
 
@@ -345,6 +359,49 @@ export function setLocalEncryptedSecret(key: string, value: string): void {
     const store = readStore();
     store.secrets[normalized] = encryptSecret(normalized, value, vaultKey);
     writeStore(store);
+  });
+}
+
+export function commitLocalEncryptedSecretBatch(
+  changes: ReadonlyArray<{ key: string; value: string | null }>,
+  commitMetadata: () => void,
+  rollbackMetadata: () => void,
+): void {
+  const prepared = changes.map(({ key, value }) => {
+    const normalized = requireNormalizedKey(key);
+    if (value !== null) requireSecretValue(value);
+    return { normalized, value };
+  });
+
+  withVaultMutationLock(() => {
+    const store = readStore();
+    let changed = false;
+    let vaultKey: Buffer | null = null;
+    for (const { normalized, value } of prepared) {
+      if (value === null) {
+        if (store.secrets[normalized]) {
+          delete store.secrets[normalized];
+          changed = true;
+        }
+        continue;
+      }
+      vaultKey ??= readOrCreateKey();
+      store.secrets[normalized] = encryptSecret(normalized, value, vaultKey);
+      changed = true;
+    }
+
+    commitMetadata();
+    if (!changed) return;
+    try {
+      writeStore(store);
+    } catch (error) {
+      try {
+        rollbackMetadata();
+      } catch {
+        throw fixedVaultError("local encrypted vault is unavailable");
+      }
+      throw error;
+    }
   });
 }
 

--- a/src/lib/vault-storage.ts
+++ b/src/lib/vault-storage.ts
@@ -1,0 +1,178 @@
+export const VAULT_STORAGE_IDS = [
+  "encrypted",
+  "1password",
+  "dashlane",
+  "environment",
+] as const;
+
+export type VaultStorageId = (typeof VAULT_STORAGE_IDS)[number];
+
+export type VaultStorageProvider = {
+  id: VaultStorageId;
+  label: string;
+  shortLabel: string;
+  description: string;
+  referencePrefix: string | null;
+  acceptsValue: boolean;
+};
+
+export const VAULT_STORAGE_PROVIDERS: readonly VaultStorageProvider[] = [
+  {
+    id: "encrypted",
+    label: "Local encrypted",
+    shortLabel: "Encrypted",
+    description: "Paste a value. Cave encrypts it with this machine's local Vault key.",
+    referencePrefix: null,
+    acceptsValue: true,
+  },
+  {
+    id: "1password",
+    label: "1Password",
+    shortLabel: "1Password",
+    description: "Store an op:// reference and resolve it through the authenticated 1Password CLI.",
+    referencePrefix: "op://",
+    acceptsValue: true,
+  },
+  {
+    id: "dashlane",
+    label: "Dashlane",
+    shortLabel: "Dashlane",
+    description: "Store a dl:// reference and resolve it through the authenticated Dashlane CLI.",
+    referencePrefix: "dl://",
+    acceptsValue: true,
+  },
+  {
+    id: "environment",
+    label: "Environment",
+    shortLabel: "Environment",
+    description: "Use a value already supplied by the launcher or writable .env.local file.",
+    referencePrefix: null,
+    acceptsValue: false,
+  },
+] as const;
+
+export const VAULT_PASTE_MAX_ENTRIES = 50;
+export const VAULT_PASTE_MAX_VALUE_LENGTH = 65_536;
+
+const ENV_ASSIGNMENT_PATTERN =
+  /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/;
+
+export function normalizeVaultKey(key: string): string {
+  return key.trim().toUpperCase().replace(/[^A-Z0-9_]/g, "_");
+}
+
+export function vaultStorageProvider(
+  storage: VaultStorageId,
+): VaultStorageProvider {
+  return VAULT_STORAGE_PROVIDERS.find((provider) => provider.id === storage)
+    ?? VAULT_STORAGE_PROVIDERS[0];
+}
+
+export function vaultStorageForValue(value: string): Exclude<
+  VaultStorageId,
+  "environment"
+> {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("op://")) return "1password";
+  if (trimmed.startsWith("dl://")) return "dashlane";
+  return "encrypted";
+}
+
+export function vaultStorageForReference(
+  ref: string,
+): "1password" | "dashlane" {
+  return ref.trim().startsWith("dl://") ? "dashlane" : "1password";
+}
+
+export type ParsedVaultPasteEntry = {
+  key: string;
+  storage: "encrypted" | "1password" | "dashlane";
+  value?: string;
+  ref?: string;
+};
+
+export type VaultPasteResult = {
+  entries: ParsedVaultPasteEntry[];
+  error: string | null;
+  assignmentMode: boolean;
+};
+
+function unquoteEnvValue(value: string): string {
+  if (value.length < 2) return value;
+  const first = value[0];
+  const last = value[value.length - 1];
+  return (first === '"' && last === '"') || (first === "'" && last === "'")
+    ? value.slice(1, -1)
+    : value;
+}
+
+function parsedEntry(key: string, rawValue: string): ParsedVaultPasteEntry {
+  const value = unquoteEnvValue(rawValue.trim());
+  const storage = vaultStorageForValue(value);
+  return storage === "encrypted"
+    ? { key, storage, value }
+    : { key, storage, ref: value };
+}
+
+function validateParsedEntries(
+  entries: ParsedVaultPasteEntry[],
+): string | null {
+  if (entries.length > VAULT_PASTE_MAX_ENTRIES) {
+    return `Paste at most ${VAULT_PASTE_MAX_ENTRIES} secrets at once.`;
+  }
+
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (!entry.key) return "Every pasted secret needs an environment variable name.";
+    const value = entry.storage === "encrypted" ? entry.value : entry.ref;
+    if (!value) return `${entry.key} needs a value or secure reference.`;
+    if (value.length > VAULT_PASTE_MAX_VALUE_LENGTH) {
+      return `${entry.key} is too large to store in the Vault.`;
+    }
+    if (seen.has(entry.key)) return `${entry.key} appears more than once.`;
+    seen.add(entry.key);
+  }
+  return null;
+}
+
+export function parseVaultPaste(
+  input: string,
+  fallbackKey = "",
+): VaultPasteResult {
+  const meaningfulLines = input
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+
+  if (meaningfulLines.length === 0) {
+    return { entries: [], error: null, assignmentMode: false };
+  }
+
+  const assignments = meaningfulLines.map((line) => line.match(ENV_ASSIGNMENT_PATTERN));
+  const assignmentMode = assignments.some((match) => match !== null);
+
+  if (assignmentMode) {
+    if (assignments.some((match) => match === null)) {
+      return {
+        entries: [],
+        error: "Paste one KEY=value assignment per line.",
+        assignmentMode: true,
+      };
+    }
+    const entries = assignments.map((match) =>
+      parsedEntry(normalizeVaultKey(match![1]), match![2]));
+    return {
+      entries,
+      error: validateParsedEntries(entries),
+      assignmentMode: true,
+    };
+  }
+
+  const key = normalizeVaultKey(fallbackKey);
+  const entries = [parsedEntry(key, input.trim())];
+  return {
+    entries,
+    error: validateParsedEntries(entries),
+    assignmentMode: false,
+  };
+}

--- a/src/lib/vault.test.ts
+++ b/src/lib/vault.test.ts
@@ -273,15 +273,21 @@ try {
   });
   setLocalEncryptedSecret("COVEN_STATUS_STORED", "stored-value");
   setLocalEncryptedSecret("COVEN_STATUS_CACHE", "cached-value");
-  assert.equal(
-    vaultModule.resolveCachedVaultManagedSecret("COVEN_STATUS_CACHE"),
-    "cached-value",
+  mirrorVaultSecretToProcessEnv(
+    "COVEN_STATUS_CACHE",
+    "cached-value\n",
+    { source: "vault", storage: "encrypted" },
   );
   setLocalEncryptedSecret("COVEN_STATUS_CACHE", "updated-value");
   assert.equal(
     vaultModule.resolveCachedVaultManagedSecret("COVEN_STATUS_CACHE"),
     "cached-value",
-    "Vault-owned provider cache is reused across harness environment builds",
+    "Vault-owned cache provenance survives trailing newlines while consumers receive a trimmed value",
+  );
+  assert.equal(
+    process.env.COVEN_STATUS_CACHE,
+    "cached-value\n",
+    "provenance checks do not rewrite the exact mirrored process value",
   );
   process.env.COVEN_STATUS_EXTERNAL = "launcher-owned";
   setLocalEncryptedSecret("COVEN_STATUS_EXTERNAL", "vault-owned");
@@ -314,6 +320,18 @@ try {
   assert.equal(statuses.COVEN_STATUS_MISSING.hasValue, false);
   assert.equal(statuses.COVEN_STATUS_REF.status, "resolved");
   assert.equal(statuses.COVEN_STATUS_REF.hasValue, true);
+  assert.equal(
+    statuses.COVEN_STATUS_CACHE.status,
+    "encrypted",
+    "metadata status keeps newline-terminated mirrored values Vault-owned",
+  );
+  assert.equal(
+    Object.fromEntries(
+      vaultModule.getVaultStatuses().map((status) => [status.key, status]),
+    ).COVEN_STATUS_CACHE.status,
+    "encrypted",
+    "materializing status keeps newline-terminated mirrored values Vault-owned",
+  );
 
   writeFileSync(process.env.COVEN_CAVE_LOCAL_VAULT_FILE, "{not valid json");
   const corrupt = Object.fromEntries(

--- a/src/lib/vault.test.ts
+++ b/src/lib/vault.test.ts
@@ -1,12 +1,20 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import * as vaultModule from "./vault.ts";
+import { setLocalEncryptedSecret } from "./local-encrypted-vault.ts";
 import {
   canMirrorVaultKeyToProcessEnv,
+  clearMirroredVaultSecretFromProcessEnv,
   mirrorVaultSecretToProcessEnv,
   validateOpRef,
 } from "./vault.ts";
+import {
+  parseVaultPaste,
+  vaultStorageForValue,
+} from "./vault-storage.ts";
 
 assert.equal(
   typeof vaultModule.grantVaultScope,
@@ -46,6 +54,35 @@ assert.equal(validateOpRef({ ref: "op://Personal/GitHub/token" }), "ref must be 
 assert.equal(validateOpRef("https://example.test"), "ref must start with op://");
 assert.equal(validateOpRef("op://Personal/GitHub"), "ref must include vault, item, and field segments");
 assert.equal(validateOpRef("op://Personal/GitHub/token;rm -rf"), "ref contains invalid characters");
+assert.equal(vaultStorageForValue("op://Personal/GitHub/token"), "1password");
+assert.equal(vaultStorageForValue("dl://GitHub PAT/token"), "dashlane");
+assert.equal(vaultStorageForValue("plain-secret"), "encrypted");
+assert.deepEqual(
+  parseVaultPaste("raw", "github pat").entries,
+  [{ key: "GITHUB_PAT", storage: "encrypted", value: "raw" }],
+  "raw paste uses the normalized fallback key and encrypted storage",
+);
+assert.deepEqual(
+  parseVaultPaste("line one\nline two", "multiline secret").entries,
+  [{ key: "MULTILINE_SECRET", storage: "encrypted", value: "line one\nline two" }],
+  "multiline raw values remain one encrypted secret when no assignments are present",
+);
+assert.deepEqual(
+  parseVaultPaste(
+    "OPENAI_API_KEY='openai'\nexport GITHUB_PAT=op://Personal/GitHub/token\nDASHLANE_TOKEN=dl://GitHub PAT/token",
+  ).entries,
+  [
+    { key: "OPENAI_API_KEY", storage: "encrypted", value: "openai" },
+    { key: "GITHUB_PAT", storage: "1password", ref: "op://Personal/GitHub/token" },
+    { key: "DASHLANE_TOKEN", storage: "dashlane", ref: "dl://GitHub PAT/token" },
+  ],
+  "multiline .env paste detects encrypted values and both reference providers",
+);
+assert.match(
+  parseVaultPaste("TOKEN=one\nTOKEN=two").error ?? "",
+  /appears more than once/,
+  "bulk paste rejects duplicate normalized keys",
+);
 
 for (const key of [
   "NODE_OPTIONS",
@@ -55,6 +92,8 @@ for (const key of [
   "Shell",
   "coven_bin",
   "Coven_Vault_File",
+  "COVEN_CAVE_AUTH_TOKEN",
+  "__NEXT_PRIVATE_INTERNAL",
 ]) {
   assert.equal(
     canMirrorVaultKeyToProcessEnv(key),
@@ -86,6 +125,23 @@ try {
     "safe vault keys remain cacheable",
   );
   assert.equal(process.env.COVEN_TEST_SAFE_SECRET, "safe-value");
+  mirrorVaultSecretToProcessEnv(
+    "COVEN_TEST_SAFE_SECRET",
+    "vault-value",
+    { source: "vault", storage: "encrypted" },
+  );
+  assert.equal(
+    clearMirroredVaultSecretFromProcessEnv("COVEN_TEST_SAFE_SECRET"),
+    true,
+    "Vault-owned process values can be cleared safely",
+  );
+  process.env.COVEN_TEST_SAFE_SECRET = "owned";
+  assert.equal(
+    clearMirroredVaultSecretFromProcessEnv("COVEN_TEST_SAFE_SECRET"),
+    false,
+    "external process values are never deleted without matching Vault provenance",
+  );
+  assert.equal(process.env.COVEN_TEST_SAFE_SECRET, "owned");
 } finally {
   if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
   else process.env.NODE_OPTIONS = previousNodeOptions;
@@ -96,14 +152,24 @@ try {
 const vaultSource = readFileSync(new URL("./vault.ts", import.meta.url), "utf8");
 const routeSource = readFileSync(new URL("../app/api/vault/route.ts", import.meta.url), "utf8");
 const githubPatRouteSource = readFileSync(new URL("../app/api/github/pat/route.ts", import.meta.url), "utf8");
+const asanaPatRouteSource = readFileSync(new URL("../app/api/asana/pat/route.ts", import.meta.url), "utf8");
 const panelSource = readFileSync(new URL("../components/vault-panel.tsx", import.meta.url), "utf8");
 const marketplaceConfigureSource = readFileSync(new URL("../components/marketplace/marketplace-configure.tsx", import.meta.url), "utf8");
 const themesSource = readFileSync(new URL("../styles/globals/themes.css", import.meta.url), "utf8");
+const panelStylesSource = readFileSync(new URL("../styles/vault-panel.css", import.meta.url), "utf8");
 
 assert.match(vaultSource, /getLocalEncryptedSecret/, "vault resolver can load locally encrypted secrets");
 assert.match(vaultSource, /"encrypted"/, "vault statuses include encrypted local storage");
-assert.match(routeSource, /setLocalEncryptedSecret/, "/api/vault can save encrypted local secrets");
-assert.match(routeSource, /deleteLocalEncryptedSecret/, "/api/vault deletes encrypted local secrets");
+assert.match(
+  routeSource,
+  /commitLocalEncryptedSecretBatch[\s\S]*saveVaultMap\(nextMap\)[\s\S]*saveVaultMap\(previousMap\)/,
+  "/api/vault commits encrypted batches with metadata rollback",
+);
+assert.match(
+  routeSource,
+  /loadVaultMapForMutation/,
+  "/api/vault refuses to overwrite corrupt Vault metadata",
+);
 assert.match(
   routeSource,
   /export async function PATCH[\s\S]*?action === "grant"[\s\S]*?grantVaultScope[\s\S]*?revokeVaultScope/,
@@ -111,14 +177,27 @@ assert.match(
 );
 assert.match(
   routeSource,
-  /mirrorVaultSecretToProcessEnv\(key, body\.value, \{ source: "vault", storage: "encrypted" \}\)/,
+  /clearMirroredVaultSecretFromProcessEnv\(item\.key\)[\s\S]*?mirrorVaultSecretToProcessEnv\(item\.key, item\.secret/,
   "/api/vault routes encrypted values through the process-env safety gate",
 );
+assert.match(routeSource, /Array\.isArray\(body\.entries\)/, "/api/vault accepts validated batch intake");
+assert.match(routeSource, /storage === "environment"/, "/api/vault supports metadata-only environment mappings");
 assert.doesNotMatch(routeSource, /applyEnvUpdates/, "/api/vault must not persist encrypted secrets to .env.local");
-assert.match(githubPatRouteSource, /setLocalEncryptedSecret\(PAT_KEY, pat\)/, "GitHub PAT setup stores tokens in the encrypted local vault");
+assert.match(
+  githubPatRouteSource,
+  /loadVaultMapForMutation[\s\S]*commitLocalEncryptedSecretBatch/,
+  "GitHub PAT setup validates metadata before transactionally storing tokens",
+);
+assert.match(
+  asanaPatRouteSource,
+  /loadVaultMapForMutation[\s\S]*commitLocalEncryptedSecretBatch/,
+  "Asana PAT setup validates metadata before transactionally storing tokens",
+);
 assert.doesNotMatch(githubPatRouteSource, /updates\[PAT_KEY\] = pat/, "GitHub PAT setup does not write tokens to .env.local");
 assert.match(panelSource, /Local encrypted/, "Vault panel exposes local encrypted storage as a first-class option");
-assert.match(panelSource, /type="password"/, "Vault panel uses a password input for raw local secrets");
+assert.match(panelSource, /parseVaultPaste/, "Vault panel uses the shared smart-paste parser");
+assert.match(panelSource, /navigator\.clipboard\.readText/, "Vault panel supports direct clipboard intake");
+assert.match(panelSource, /Detected \{pasteResult\.entries\.length\} entries/, "Vault panel previews bulk .env intake");
 assert.match(
   panelSource,
   /method: "PATCH"[\s\S]*?action: granted \? "revoke" : "grant"/,
@@ -130,19 +209,19 @@ assert.match(
   "The scoped Vault action cannot call the global delete path",
 );
 assert.match(
-  panelSource,
-  /unresolved:\s*\{[^}]*color:\s*"var\(--color-warning\)"[^}]*icon:\s*"ph:warning"/,
-  "Vault unresolved status uses the warning token",
-);
-assert.match(
-  panelSource,
-  /error:\s*\{[^}]*color:\s*"var\(--color-danger\)"/,
-  "Vault error status keeps the danger token",
-);
-assert.match(
   themesSource,
   /\.vault-row--warn\s*\{\s*border-color:\s*color-mix\(in oklch,\s*var\(--color-warning\)\s+35%,\s*transparent\);\s*\}/,
   "Vault warning rows use the warning token",
+);
+assert.match(
+  panelStylesSource,
+  /\.vault-status-badge--unresolved\s*\{[^}]*var\(--color-warning\)/,
+  "Vault unresolved status uses the warning token",
+);
+assert.match(
+  panelStylesSource,
+  /\.vault-status-badge--error\s*\{[^}]*var\(--color-danger\)/,
+  "Vault error status keeps the danger token",
 );
 assert.match(
   themesSource,
@@ -150,6 +229,7 @@ assert.match(
   "Vault row errors keep the danger token",
 );
 assert.match(marketplaceConfigureSource, /storage: "encrypted", value: draft/, "Marketplace sensitive config can save raw values through the encrypted vault");
+assert.match(marketplaceConfigureSource, /vaultStorageForValue\(draft\)/, "Marketplace sensitive config shares provider detection with the Vault");
 
 assert.match(
   vaultSource,
@@ -162,5 +242,104 @@ assert.match(
   "configured checks use vault metadata instead of resolving secret values",
 );
 assert.doesNotMatch(marketplaceConfigureSource, /enter a 1Password reference/, "Marketplace sensitive config no longer requires 1Password");
+
+const statusRoot = mkdtempSync(join(tmpdir(), "cave-vault-status-"));
+const statusOriginal = {
+  COVEN_VAULT_FILE: process.env.COVEN_VAULT_FILE,
+  COVEN_CAVE_LOCAL_VAULT_FILE: process.env.COVEN_CAVE_LOCAL_VAULT_FILE,
+  COVEN_CAVE_LOCAL_VAULT_KEY_FILE: process.env.COVEN_CAVE_LOCAL_VAULT_KEY_FILE,
+  COVEN_STATUS_ENV: process.env.COVEN_STATUS_ENV,
+  COVEN_STATUS_STORED: process.env.COVEN_STATUS_STORED,
+  COVEN_STATUS_REF: process.env.COVEN_STATUS_REF,
+  COVEN_STATUS_CACHE: process.env.COVEN_STATUS_CACHE,
+  COVEN_STATUS_EXTERNAL: process.env.COVEN_STATUS_EXTERNAL,
+};
+const restoreStatusEnv = (key: string, value: string | undefined) => {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+};
+try {
+  process.env.COVEN_VAULT_FILE = join(statusRoot, "vault.yaml");
+  process.env.COVEN_CAVE_LOCAL_VAULT_FILE = join(statusRoot, "local-vault.enc.json");
+  process.env.COVEN_CAVE_LOCAL_VAULT_KEY_FILE = join(statusRoot, "local-vault.key");
+  process.env.COVEN_STATUS_ENV = "launcher-value";
+  vaultModule.saveVaultMap({
+    COVEN_STATUS_ENV: { storage: "environment" },
+    COVEN_STATUS_STORED: { storage: "encrypted" },
+    COVEN_STATUS_MISSING: { storage: "encrypted" },
+    COVEN_STATUS_REF: { ref: "op://Personal/Test/token" },
+    COVEN_STATUS_CACHE: { storage: "encrypted" },
+    COVEN_STATUS_EXTERNAL: { storage: "encrypted" },
+  });
+  setLocalEncryptedSecret("COVEN_STATUS_STORED", "stored-value");
+  setLocalEncryptedSecret("COVEN_STATUS_CACHE", "cached-value");
+  assert.equal(
+    vaultModule.resolveCachedVaultManagedSecret("COVEN_STATUS_CACHE"),
+    "cached-value",
+  );
+  setLocalEncryptedSecret("COVEN_STATUS_CACHE", "updated-value");
+  assert.equal(
+    vaultModule.resolveCachedVaultManagedSecret("COVEN_STATUS_CACHE"),
+    "cached-value",
+    "Vault-owned provider cache is reused across harness environment builds",
+  );
+  process.env.COVEN_STATUS_EXTERNAL = "launcher-owned";
+  setLocalEncryptedSecret("COVEN_STATUS_EXTERNAL", "vault-owned");
+  assert.equal(
+    vaultModule.resolveCachedVaultManagedSecret("COVEN_STATUS_EXTERNAL"),
+    "vault-owned",
+  );
+  assert.equal(
+    process.env.COVEN_STATUS_EXTERNAL,
+    "launcher-owned",
+    "Vault caching never overwrites an externally owned process value",
+  );
+  mirrorVaultSecretToProcessEnv(
+    "COVEN_STATUS_STORED",
+    "stored-value",
+    { source: "vault", storage: "encrypted" },
+  );
+  mirrorVaultSecretToProcessEnv(
+    "COVEN_STATUS_REF",
+    "resolved-value",
+    { source: "vault", storage: "1password" },
+  );
+  const statuses = Object.fromEntries(
+    vaultModule.getVaultMetadataStatuses().map((status) => [status.key, status]),
+  );
+  assert.equal(statuses.COVEN_STATUS_ENV.status, "env-only");
+  assert.equal(statuses.COVEN_STATUS_STORED.status, "encrypted");
+  assert.equal(statuses.COVEN_STATUS_STORED.hasValue, true);
+  assert.equal(statuses.COVEN_STATUS_MISSING.status, "unresolved");
+  assert.equal(statuses.COVEN_STATUS_MISSING.hasValue, false);
+  assert.equal(statuses.COVEN_STATUS_REF.status, "resolved");
+  assert.equal(statuses.COVEN_STATUS_REF.hasValue, true);
+
+  writeFileSync(process.env.COVEN_CAVE_LOCAL_VAULT_FILE, "{not valid json");
+  const corrupt = Object.fromEntries(
+    vaultModule.getVaultMetadataStatuses().map((status) => [status.key, status]),
+  );
+  assert.equal(corrupt.COVEN_STATUS_STORED.status, "error");
+  assert.equal(corrupt.COVEN_STATUS_STORED.hasValue, false);
+
+  const invalidMetadata = "BROKEN: [\n";
+  writeFileSync(process.env.COVEN_VAULT_FILE, invalidMetadata);
+  assert.throws(
+    () => vaultModule.loadVaultMapForMutation(),
+    /Vault metadata is invalid/,
+    "mutations fail closed when vault.yaml cannot be parsed",
+  );
+  assert.equal(
+    readFileSync(process.env.COVEN_VAULT_FILE, "utf8"),
+    invalidMetadata,
+    "failed strict loading preserves corrupt Vault metadata for recovery",
+  );
+} finally {
+  for (const [key, value] of Object.entries(statusOriginal)) {
+    restoreStatusEnv(key, value);
+  }
+  vaultModule.loadVaultMap(true);
+  rmSync(statusRoot, { recursive: true, force: true });
+}
 
 console.log("vault.test.ts: ok");

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -538,8 +538,13 @@ export function resolveCachedVaultManagedSecret(
   options?: VaultResolutionOptions,
 ): string | undefined {
   if (!entry || entry.storage === "environment") return undefined;
-  const current = process.env[key]?.trim();
-  if (current && currentMirroredMetadata(key, current)?.source === "vault") {
+  const rawCurrent = process.env[key];
+  const current = rawCurrent?.trim();
+  if (
+    current
+    && rawCurrent
+    && currentMirroredMetadata(key, rawCurrent)?.source === "vault"
+  ) {
     return current;
   }
 
@@ -564,9 +569,12 @@ type ResolvedSecret = {
 
 /** Resolve one key with the same precedence used by every secret consumer. */
 function resolveSecretWithSource(key: string, map = loadVaultMap()): ResolvedSecret | undefined {
-  const fromProcess = process.env[key]?.trim();
+  const rawProcessValue = process.env[key];
+  const fromProcess = rawProcessValue?.trim();
   if (fromProcess) {
-    const mirrored = currentMirroredMetadata(key, fromProcess);
+    const mirrored = rawProcessValue
+      ? currentMirroredMetadata(key, rawProcessValue)
+      : null;
     return {
       value: fromProcess,
       source: mirrored?.source ?? "process-env",
@@ -711,8 +719,11 @@ export function getVaultMetadataStatuses(): VaultMappingStatus[] {
   const map = loadVaultMap(true); // always fresh for status checks
   const envLocal = readEnvLocalAll(); // read once for all entries
   return Object.entries(map).map(([key, entry]) => {
-    const processValue = process.env[key]?.trim();
-    const mirrored = processValue ? currentMirroredMetadata(key, processValue) : null;
+    const rawProcessValue = process.env[key];
+    const processValue = rawProcessValue?.trim();
+    const mirrored = rawProcessValue
+      ? currentMirroredMetadata(key, rawProcessValue)
+      : null;
     const externallyOwnedEnv =
       key in envLocal
       || (!!processValue && mirrored?.source !== "vault");
@@ -797,8 +808,11 @@ export function getVaultMetadataStatuses(): VaultMappingStatus[] {
 export function getVaultStatuses(): VaultMappingStatus[] {
   const map = loadVaultMap(true); // always fresh for status checks
   return Object.entries(map).map(([key, entry]) => {
-    const processValue = process.env[key]?.trim();
-    const mirrored = processValue ? currentMirroredMetadata(key, processValue) : null;
+    const rawProcessValue = process.env[key];
+    const processValue = rawProcessValue?.trim();
+    const mirrored = rawProcessValue
+      ? currentMirroredMetadata(key, rawProcessValue)
+      : null;
     const fromEnvFile = processValue ? undefined : readEnvLocalValue(key);
     if (fromEnvFile) {
       mirrorVaultSecretToProcessEnv(key, fromEnvFile, { source: "env-local", storage: null });

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,13 +1,13 @@
 /**
- * Cave Vault — resolves env vars from encrypted local secrets or 1Password references
+ * Cave Vault — resolves environment-owned, encrypted, and provider-backed secrets
  *
- * vault.yaml maps ENV_VAR_NAME → { storage: "encrypted" } or { ref: "op://Vault/Item/field", ... }
+ * vault.yaml maps ENV_VAR_NAME to storage metadata or an op:// / dl:// reference.
  *
  * Resolution priority:
  *   1. Already in process.env (e.g. set by .env.local or OS env) → use as-is
  *   2. Writable .env.local legacy fallback → use as-is
  *   3. Local encrypted vault → decrypt into process memory
- *   4. vault.yaml has a ref for this key → resolve via `op read`
+ *   4. vault.yaml has a ref for this key → resolve through its provider CLI
  *   5. undefined
  *
  * The vault.yaml mapping declares which backend a key uses: when it carries a
@@ -21,15 +21,24 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
-import { scrubSidecarInternalEnv } from "./child-spawn-env.ts";
+import { isSidecarInternalEnvKey, scrubSidecarInternalEnv } from "./child-spawn-env.ts";
 import { caveHome } from "./coven-paths.ts";
 import { readEnvLocalAll, readEnvLocalValue } from "./env-file.ts";
 import { getLocalEncryptedSecret, hasLocalEncryptedSecret } from "./local-encrypted-vault.ts";
+import { vaultStorageForReference, type VaultStorageId } from "./vault-storage.ts";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -43,7 +52,7 @@ export type VaultScope = "shared" | string[];
 
 export type VaultEntry = {
   ref?: string;
-  storage?: "1password" | "encrypted" | "dashlane";
+  storage?: VaultStorageId;
   description?: string;
   required?: boolean;
   scope?: VaultScope;
@@ -55,7 +64,7 @@ export type VaultSecretSource = "process-env" | "env-local" | "vault" | null;
 
 type MirroredSecretMetadata = {
   source: Exclude<VaultSecretSource, "process-env" | null>;
-  storage: "1password" | "encrypted" | "dashlane" | null;
+  storage: Exclude<VaultStorageId, "environment"> | null;
 };
 
 const mirroredSecretMetadata = new Map<string, MirroredSecretMetadata & { digest: string }>();
@@ -85,7 +94,10 @@ const VAULT_PROCESS_ENV_DENYLIST = new Set([
 ]);
 
 export function canMirrorVaultKeyToProcessEnv(key: string): boolean {
-  return !VAULT_PROCESS_ENV_DENYLIST.has(key.trim().toUpperCase());
+  return (
+    !VAULT_PROCESS_ENV_DENYLIST.has(key.trim().toUpperCase()) &&
+    !isSidecarInternalEnvKey(key)
+  );
 }
 
 /** Cache a resolved vault value only when the key cannot steer this process. */
@@ -101,6 +113,16 @@ export function mirrorVaultSecretToProcessEnv(
   } else {
     mirroredSecretMetadata.delete(key);
   }
+  return true;
+}
+
+/** Remove only a value this process previously mirrored from the Vault. */
+export function clearMirroredVaultSecretFromProcessEnv(key: string): boolean {
+  const current = process.env[key];
+  const mirrored = current ? currentMirroredMetadata(key, current) : null;
+  mirroredSecretMetadata.delete(key);
+  if (!current || !mirrored || mirrored.source !== "vault") return false;
+  delete process.env[key];
   return true;
 }
 
@@ -155,7 +177,7 @@ export type VaultStatus = "resolved" | "configured" | "encrypted" | "env-only" |
 export type VaultMappingStatus = {
   key: string;
   ref: string | null;
-  storage: "1password" | "encrypted" | "dashlane" | null;
+  storage: VaultStorageId | null;
   description: string | null;
   required: boolean;
   status: VaultStatus;
@@ -227,36 +249,60 @@ function seedVaultIfNeeded(): void {
 
 let _vaultMap: VaultMap | null = null;
 
+function readVaultMap(strict: boolean): VaultMap {
+  const vaultYaml = vaultYamlPath();
+  if (!existsSync(/* turbopackIgnore: true */ vaultYaml)) return {};
+  try {
+    const raw = readFileSync(/* turbopackIgnore: true */ vaultYaml, "utf8");
+    const parsed = parseYaml(raw) as unknown;
+    if (
+      parsed == null
+      || typeof parsed !== "object"
+      || Array.isArray(parsed)
+      || Object.values(parsed).some(
+        (entry) => !entry || typeof entry !== "object" || Array.isArray(entry),
+      )
+    ) {
+      throw new Error("invalid Vault metadata shape");
+    }
+    return parsed as VaultMap;
+  } catch {
+    if (strict) {
+      throw new Error("Vault metadata is invalid; repair vault.yaml before saving changes");
+    }
+    return {};
+  }
+}
+
 export function loadVaultMap(force = false): VaultMap {
   if (_vaultMap && !force) return _vaultMap;
   seedVaultIfNeeded();
-  const vaultYaml = vaultYamlPath();
-  if (!existsSync(/* turbopackIgnore: true */ vaultYaml)) { _vaultMap = {}; return {}; }
-  try {
-    const raw = readFileSync(/* turbopackIgnore: true */ vaultYaml, "utf8");
-    const parsed = parseYaml(raw) as VaultMap | null;
-    _vaultMap = parsed ?? {};
-    return _vaultMap;
-  } catch {
-    _vaultMap = {};
-    return {};
-  }
+  _vaultMap = readVaultMap(false);
+  return _vaultMap;
+}
+
+export function loadVaultMapForMutation(): VaultMap {
+  seedVaultIfNeeded();
+  _vaultMap = readVaultMap(true);
+  return _vaultMap;
 }
 
 export function saveVaultMap(map: VaultMap): void {
   // Serialise back to YAML manually (keeps comments stripped but structure clean)
   const lines = [
-    "# Cave Vault — env var → encrypted local secret or 1Password reference map",
+    "# Cave Vault — env var → encrypted secret, external reference, or environment mapping",
     "#",
     "# Format:",
     '#   ENV_VAR_NAME:',
     '#     storage: "encrypted"',
     "#   ANOTHER_ENV_VAR:",
     '#     ref: "op://VaultName/ItemTitle/field"',
+    "#   ENVIRONMENT_OWNED_VAR:",
+    '#     storage: "environment"',
     '#     description: "human-readable note"',
     "#     required: false",
     "#",
-    "# Secrets are NEVER stored here — only storage metadata or an op:// reference.",
+    "# Secrets are NEVER stored here — only storage metadata or secure references.",
     "# Safe to commit; contains no credentials.",
     "",
   ];
@@ -264,6 +310,8 @@ export function saveVaultMap(map: VaultMap): void {
     lines.push(`${key}:`);
     if (entry.storage === "encrypted") {
       lines.push('  storage: "encrypted"');
+    } else if (entry.storage === "environment") {
+      lines.push('  storage: "environment"');
     } else if (entry.ref) {
       lines.push(`  ref: "${entry.ref}"`);
     }
@@ -280,7 +328,23 @@ export function saveVaultMap(map: VaultMap): void {
   }
   const vaultYaml = vaultYamlPath();
   mkdirSync(/* turbopackIgnore: true */ dirname(vaultYaml), { recursive: true });
-  writeFileSync(/* turbopackIgnore: true */ vaultYaml, lines.join("\n"), "utf8");
+  const temporary = `${vaultYaml}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  try {
+    writeFileSync(/* turbopackIgnore: true */ temporary, lines.join("\n"), {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    renameSync(
+      /* turbopackIgnore: true */ temporary,
+      /* turbopackIgnore: true */ vaultYaml,
+    );
+  } finally {
+    try {
+      unlinkSync(/* turbopackIgnore: true */ temporary);
+    } catch {
+      // Rename removes the temporary path.
+    }
+  }
   _vaultMap = map; // bust cache
 }
 
@@ -343,26 +407,45 @@ function refReadRetryTimeoutMs(): number {
   return Number.isFinite(raw) && raw > 0 ? raw : 30_000;
 }
 
+function refFailureCacheMs(): number {
+  const raw = Number(process.env.COVEN_CAVE_REF_FAILURE_CACHE_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 5_000;
+}
+
+export type VaultResolutionOptions = {
+  deadlineMs?: number;
+};
+
+const failedRefUntil = new Map<string, number>();
+
 function isTimeoutError(e: unknown): boolean {
   return !!e && typeof e === "object" && (e as NodeJS.ErrnoException).code === "ETIMEDOUT";
 }
 
 /** Run `<cli> read <ref>`, retrying once with a longer timeout if the first
  *  attempt was killed by the base timeout. Returns null on failure. */
-function cliRead(cli: "op" | "dcli", ref: string): string | null {
+function cliRead(
+  cli: "op" | "dcli",
+  ref: string,
+  options: VaultResolutionOptions = {},
+): string | null {
+  const remainingMs = () => options.deadlineMs === undefined
+    ? Number.POSITIVE_INFINITY
+    : Math.max(0, options.deadlineMs - Date.now());
   const run = (timeout: number) =>
     String(Reflect.apply(execFileSync, undefined, [cli, ["read", ref], {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
-      timeout,
+      timeout: Math.max(1, Math.min(timeout, remainingMs())),
       env: resolverEnv(),
       windowsHide: true,
     }])).trim();
 
+  if (remainingMs() <= 0) return null;
   try {
     return run(refReadTimeoutMs()) || null;
   } catch (e) {
-    if (!isTimeoutError(e)) return null;
+    if (!isTimeoutError(e) || remainingMs() <= 0) return null;
     try {
       return run(refReadRetryTimeoutMs()) || null;
     } catch {
@@ -372,9 +455,9 @@ function cliRead(cli: "op" | "dcli", ref: string): string | null {
 }
 
 /** Call `op read` to fetch a secret reference. Returns null on failure. */
-function opRead(ref: string): string | null {
+function opRead(ref: string, options?: VaultResolutionOptions): string | null {
   if (validateOpRef(ref)) return null;
-  return cliRead("op", ref);
+  return cliRead("op", ref, options);
 }
 
 // ── dashlane (dcli) resolver ────────────────────────────────────────────────
@@ -400,14 +483,14 @@ export function validateDashlaneRef(ref: unknown): string | null {
 }
 
 /** Call `dcli read` to fetch a Dashlane secret reference. Returns null on failure. */
-function dcliRead(ref: string): string | null {
+function dcliRead(ref: string, options?: VaultResolutionOptions): string | null {
   if (validateDashlaneRef(ref)) return null;
-  return cliRead("dcli", ref);
+  return cliRead("dcli", ref, options);
 }
 
 /** The storage backend a reference resolves through, implied by its scheme. */
 export function refStorage(ref: string): "1password" | "dashlane" {
-  return ref.startsWith(DL_REF_PREFIX) ? "dashlane" : "1password";
+  return vaultStorageForReference(ref);
 }
 
 /** Validate a secret reference, dispatching by scheme (op:// vs dl://). */
@@ -418,20 +501,59 @@ export function validateRef(ref: unknown): string | null {
 }
 
 /** Resolve a secret reference via the appropriate CLI, dispatching by scheme. */
-function readRef(ref: string): string | null {
-  return ref.startsWith(DL_REF_PREFIX) ? dcliRead(ref) : opRead(ref);
+function readRef(ref: string, options?: VaultResolutionOptions): string | null {
+  if ((failedRefUntil.get(ref) ?? 0) > Date.now()) return null;
+  const value = ref.startsWith(DL_REF_PREFIX)
+    ? dcliRead(ref, options)
+    : opRead(ref, options);
+  if (value) {
+    failedRefUntil.delete(ref);
+  } else {
+    failedRefUntil.set(ref, Date.now() + refFailureCacheMs());
+  }
+  return value;
 }
 
 /** Resolve a mapped secret without reading or changing process.env. */
-export function resolveVaultManagedSecret(key: string, entry = loadVaultMap()[key]): string | undefined {
+export function resolveVaultManagedSecret(
+  key: string,
+  entry = loadVaultMap()[key],
+  options?: VaultResolutionOptions,
+): string | undefined {
   if (!entry) return undefined;
+  if (entry.storage === "environment") return undefined;
 
   // The map's declared backend wins: a ref mapping is never shadowed by a
   // stale/orphaned entry in the local encrypted store.
   if (entry.storage === "encrypted") {
     return getLocalEncryptedSecret(key)?.trim() || undefined;
   }
-  return entry.ref ? readRef(entry.ref) || undefined : undefined;
+  return entry.ref ? readRef(entry.ref, options) || undefined : undefined;
+}
+
+/** Resolve one declared Vault backend and reuse only values cached by the Vault. */
+export function resolveCachedVaultManagedSecret(
+  key: string,
+  entry = loadVaultMap()[key],
+  options?: VaultResolutionOptions,
+): string | undefined {
+  if (!entry || entry.storage === "environment") return undefined;
+  const current = process.env[key]?.trim();
+  if (current && currentMirroredMetadata(key, current)?.source === "vault") {
+    return current;
+  }
+
+  const value = resolveVaultManagedSecret(key, entry, options);
+  if (!value || current) return value;
+  const storage = entry.storage === "encrypted"
+    ? "encrypted"
+    : entry.ref
+      ? refStorage(entry.ref)
+      : null;
+  if (storage) {
+    mirrorVaultSecretToProcessEnv(key, value, { source: "vault", storage });
+  }
+  return value;
 }
 
 type ResolvedSecret = {
@@ -464,12 +586,16 @@ function resolveSecretWithSource(key: string, map = loadVaultMap()): ResolvedSec
   }
 
   const entry = map[key];
+  if (entry?.storage === "environment") return undefined;
   const value = entry
     ? resolveVaultManagedSecret(key, entry)
     : hasLocalEncryptedSecret(key) ? getLocalEncryptedSecret(key)?.trim() : undefined;
   if (!value) return undefined;
 
-  const storage = entry?.storage === "encrypted" || (!entry?.ref && hasLocalEncryptedSecret(key))
+  const storage = entry?.storage === "encrypted" || (
+    !entry?.ref
+    && hasLocalEncryptedSecret(key)
+  )
     ? "encrypted"
     : entry?.ref
       ? refStorage(entry.ref)
@@ -516,7 +642,11 @@ export function getSecretStatus(key: string): VaultSecretStatus {
       key,
       status: "error",
       hasValue: false,
-      storage: entry?.storage === "encrypted" || (!entry?.ref && hasLocalEncryptedSecret(key))
+      storage: entry?.storage === "encrypted" || (
+        entry?.storage !== "environment"
+        && !entry?.ref
+        && hasLocalEncryptedSecret(key)
+      )
         ? "encrypted"
         : entry?.ref
           ? refStorage(entry.ref)
@@ -526,7 +656,11 @@ export function getSecretStatus(key: string): VaultSecretStatus {
     };
   }
 
-  const storage = entry?.storage === "encrypted" || (!entry?.ref && hasLocalEncryptedSecret(key))
+  const storage = entry?.storage === "encrypted" || (
+    entry?.storage !== "environment"
+    && !entry?.ref
+    && hasLocalEncryptedSecret(key)
+  )
     ? "encrypted"
     : entry?.ref
       ? refStorage(entry.ref)
@@ -566,6 +700,7 @@ export function hasConfiguredSecretMetadata(key: string): boolean {
 
   const map = loadVaultMap();
   const entry = map[key];
+  if (entry?.storage === "environment") return true;
   if (entry?.storage === "encrypted" || hasLocalEncryptedSecret(key)) return true;
   return !!entry?.ref;
 }
@@ -576,12 +711,20 @@ export function getVaultMetadataStatuses(): VaultMappingStatus[] {
   const map = loadVaultMap(true); // always fresh for status checks
   const envLocal = readEnvLocalAll(); // read once for all entries
   return Object.entries(map).map(([key, entry]) => {
-    const inEnv = !!(process.env[key]?.trim()) || key in envLocal;
+    const processValue = process.env[key]?.trim();
+    const mirrored = processValue ? currentMirroredMetadata(key, processValue) : null;
+    const externallyOwnedEnv =
+      key in envLocal
+      || (!!processValue && mirrored?.source !== "vault");
     // A ref mapping reports its ref backend even if an orphaned encrypted
     // entry lingers in the local store (cave-6iee).
-    const hasEncrypted = entry.storage === "encrypted" || (!entry.ref && hasLocalEncryptedSecret(key));
+    const encryptedMapping = entry.storage === "encrypted";
+    const legacyEncryptedCandidate =
+      entry.storage !== "environment"
+      && !entry.ref
+      && entry.storage !== "encrypted";
 
-    if (inEnv) {
+    if (externallyOwnedEnv) {
       return {
         key, ref: entry.ref ?? null, description: entry.description ?? null,
         storage: entry.storage ?? (entry.ref ? refStorage(entry.ref) : null),
@@ -590,16 +733,46 @@ export function getVaultMetadataStatuses(): VaultMappingStatus[] {
       };
     }
 
-    if (hasEncrypted) {
-      return {
-        key, ref: entry.ref ?? null, description: entry.description ?? null,
-        storage: "encrypted",
-        required: entry.required ?? false,
-        status: "encrypted" as VaultStatus, hasValue: true,
-      };
+    if (encryptedMapping || legacyEncryptedCandidate) {
+      try {
+        if (!hasLocalEncryptedSecret(key)) {
+          if (encryptedMapping) {
+            return {
+              key, ref: entry.ref ?? null, description: entry.description ?? null,
+              storage: "encrypted",
+              required: entry.required ?? false,
+              status: "unresolved" as VaultStatus, hasValue: false,
+              error: "encrypted local secret is missing",
+            };
+          }
+        } else {
+          return {
+            key, ref: entry.ref ?? null, description: entry.description ?? null,
+            storage: "encrypted",
+            required: entry.required ?? false,
+            status: "encrypted" as VaultStatus, hasValue: true,
+          };
+        }
+      } catch (error) {
+        return {
+          key, ref: entry.ref ?? null, description: entry.description ?? null,
+          storage: "encrypted",
+          required: entry.required ?? false,
+          status: "error" as VaultStatus, hasValue: false,
+          error: error instanceof Error ? error.message : "local encrypted vault is unavailable",
+        };
+      }
     }
 
     if (entry.ref) {
+      if (processValue && mirrored?.source === "vault") {
+        return {
+          key, ref: entry.ref, description: entry.description ?? null,
+          storage: refStorage(entry.ref),
+          required: entry.required ?? false,
+          status: "resolved" as VaultStatus, hasValue: true,
+        };
+      }
       return {
         key, ref: entry.ref, description: entry.description ?? null,
         storage: refStorage(entry.ref),
@@ -612,7 +785,11 @@ export function getVaultMetadataStatuses(): VaultMappingStatus[] {
       key, ref: null, description: entry.description ?? null,
       storage: entry.storage ?? null,
       required: entry.required ?? false,
-      status: "no-ref" as VaultStatus, hasValue: false,
+      status: entry.storage === "environment" ? "unresolved" as VaultStatus : "no-ref" as VaultStatus,
+      hasValue: false,
+      error: entry.storage === "environment"
+        ? "not present in the process environment or .env.local"
+        : undefined,
     };
   });
 }
@@ -627,7 +804,11 @@ export function getVaultStatuses(): VaultMappingStatus[] {
       mirrorVaultSecretToProcessEnv(key, fromEnvFile, { source: "env-local", storage: null });
     }
 
-    const storage = entry.storage === "encrypted" || (!entry.ref && hasLocalEncryptedSecret(key))
+    const storage = entry.storage === "encrypted" || (
+      entry.storage !== "environment"
+      && !entry.ref
+      && hasLocalEncryptedSecret(key)
+    )
       ? "encrypted"
       : entry.ref
         ? refStorage(entry.ref)
@@ -654,7 +835,14 @@ export function getVaultStatuses(): VaultMappingStatus[] {
 
     // Same backend-priority rule as resolveSecret: an orphaned encrypted
     // entry must not make a ref mapping report (or resolve) as "encrypted".
-    if (entry.storage === "encrypted" || (!entry.ref && hasLocalEncryptedSecret(key))) {
+    if (
+      entry.storage === "encrypted"
+      || (
+        entry.storage !== "environment"
+        && !entry.ref
+        && hasLocalEncryptedSecret(key)
+      )
+    ) {
       try {
         const value = getLocalEncryptedSecret(key);
         if (value) {
@@ -689,7 +877,11 @@ export function getVaultStatuses(): VaultMappingStatus[] {
         key, ref: null, description: entry.description ?? null,
         storage: entry.storage ?? null,
         required: entry.required ?? false,
-        status: "no-ref" as VaultStatus, hasValue: false,
+        status: entry.storage === "environment" ? "unresolved" as VaultStatus : "no-ref" as VaultStatus,
+        hasValue: false,
+        error: entry.storage === "environment"
+          ? "not present in the process environment or .env.local"
+          : undefined,
       };
     }
 

--- a/src/styles/vault-panel.css
+++ b/src/styles/vault-panel.css
@@ -1,0 +1,96 @@
+.vault-row:focus-within .vault-row-actions {
+  opacity: 1;
+}
+
+.vault-status-badge {
+  color: var(--text-muted);
+  border-color: color-mix(in oklch, var(--text-muted) 35%, transparent);
+}
+
+.vault-status-badge--resolved,
+.vault-status-badge--configured {
+  color: var(--color-success);
+  border-color: color-mix(in oklch, var(--color-success) 38%, transparent);
+}
+
+.vault-status-badge--encrypted {
+  color: var(--accent-presence);
+  border-color: color-mix(in oklch, var(--accent-presence) 38%, transparent);
+}
+
+.vault-status-badge--env-only {
+  color: var(--color-info);
+  border-color: color-mix(in oklch, var(--color-info) 38%, transparent);
+}
+
+.vault-status-badge--unresolved {
+  color: var(--color-warning);
+  border-color: color-mix(in oklch, var(--color-warning) 38%, transparent);
+}
+
+.vault-status-badge--error {
+  color: var(--color-danger);
+  border-color: var(--danger-border);
+}
+
+.vault-provider-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.vault-provider-description {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  font-weight: 400;
+  line-height: var(--leading-normal);
+}
+
+.vault-paste-field {
+  position: relative;
+}
+
+.vault-paste-input {
+  min-height: calc(var(--space-4) * 4);
+  padding-right: calc(var(--space-4) * 6);
+  resize: vertical;
+  font-family: var(--font-mono, monospace);
+  line-height: var(--leading-normal);
+}
+
+.vault-paste-input--masked {
+  -webkit-text-security: disc;
+}
+
+.vault-paste-actions {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  display: flex;
+  gap: var(--space-1);
+}
+
+.vault-paste-summary {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  font-weight: 400;
+  overflow-wrap: anywhere;
+}
+
+.vault-environment-note {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid color-mix(in oklch, var(--color-info) 38%, transparent);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--color-info) 14%, transparent);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+.vault-btn:disabled {
+  opacity: var(--opacity-disabled);
+  cursor: default;
+}


### PR DESCRIPTION
## Summary
- add provider-driven smart paste for encrypted values, environment mappings, 1Password, and Dashlane references
- enforce familiar scope at spawn time without leaking protected sidecar credentials
- fail closed on corrupt Vault metadata and commit encrypted/map mutations transactionally
- isolate test suites from real local Vault and environment credentials

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `pnpm build`
- exact diff secret preflight

Bead: `cave-kaknb`