### PR TITLE
chore(release): stamp v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-08-17
+
+> Seamless familiar credential intake and a Chat panel that stays with you across the Cave.
+
+Patch release on top of v0.3.5.
+
+### Changes
+- Make familiar Vault credential intake dynamic, secure, and copy-paste friendly (#4700)
+- Add a global shell-owned right Chat panel (#4697)
+
 ## [0.3.5] - 2026-08-16
 
 > Hardened iOS mutations and familiar avatars, now with corrected cross-platform packaging.

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.3.5"
+    MARKETING_VERSION: "0.3.6"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026081610"
+    CURRENT_PROJECT_VERSION: "2026081702"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/scripts/standalone-budget.mjs
+++ b/scripts/standalone-budget.mjs
@@ -35,7 +35,11 @@ export const STANDALONE_BUDGETS = Object.freeze({
   //
   // Both ceilings still catch what this guard is for: a renewed repository-root
   // trace overshoots by gigabytes and thousands of entries, not by 8%.
-  fileCount: 7_600,
+  //
+  // 2026-08-17: release operators raised the file-count ceiling to 12,000.
+  // Keep the independent 480 MiB ceiling and forbidden-root checks intact so
+  // larger artifacts and known local build roots still fail closed.
+  fileCount: 12_000,
   unpackedBytes: 480 * 1024 * 1024,
 });
 

--- a/scripts/standalone-budget.test.mjs
+++ b/scripts/standalone-budget.test.mjs
@@ -6,9 +6,12 @@ import path from "node:path";
 import {
   forbiddenStandaloneRoot,
   standaloneMetrics,
+  STANDALONE_BUDGETS,
   STANDALONE_FORBIDDEN_ROOTS,
   verifyStandaloneArtifact,
 } from "./standalone-budget.mjs";
+
+assert.equal(STANDALONE_BUDGETS.fileCount, 12_000, "standalone output allows at most 12,000 files");
 
 async function write(root, relativePath, contents = "fixture\n") {
   const output = path.join(root, relativePath);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "block2",
  "discord-rich-presence",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.5"
+version = "0.3.6"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- stamp CovenCave 0.3.6 across web, Tauri, Cargo, and iOS release sources
- assign iOS build number 2026081702
- finalize release notes for dynamic familiar Vault intake and the global Chat panel
- raise the Next standalone file-count ceiling from 7,600 to 12,000 while preserving the 480 MiB and forbidden-root guards

## Verification
- `pnpm release:verify --version 0.3.6`
- `node --test scripts/stamp-release.test.mjs`
- `node --test scripts/standalone-budget.test.mjs scripts/bundle-budget.test.mjs`
- `pnpm build` (clean artifact: 7,083 files, 402,819,798 bytes)
- standalone verifier reports the requested 12,000-file limit
- independent reviews: no significant issues

Bead: cave-pubzg