### PR TITLE
fix(desktop): honor COVEN_BIN in the shell's coven resolver

### DIFF
--- a/docs/cross-environment.md
+++ b/docs/cross-environment.md
@@ -49,7 +49,7 @@ that diverge. It pairs with the conformance suite that enforces them.
 | E2E (Playwright) port | `3100` (fixed, avoids colliding with `pnpm dev`) | `PORT` env ([`playwright.config.ts`](../playwright.config.ts)) |
 | Config / state home | `~/.coven/` | `COVEN_HOME` env ([`src/lib/coven-paths.ts`](../src/lib/coven-paths.ts)) |
 | Familiar workspaces | `~/.coven/workspaces/familiars/<id>/` | via `COVEN_HOME` |
-| `coven` CLI binary | discovered on PATH / well-known install dirs | `COVEN_BIN` env ([`src/lib/coven-bin.ts`](../src/lib/coven-bin.ts)) |
+| `coven` CLI binary | discovered on PATH / well-known install dirs | `COVEN_BIN` env ([`src/lib/coven-bin.ts`](../src/lib/coven-bin.ts), [`src-tauri/src/sidecar_discovery.rs`](../src-tauri/src/sidecar_discovery.rs)) |
 | CI Node.js | `22` | — |
 
 ## Per-OS deltas

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -1549,7 +1549,7 @@ fn daemon_augmented_path(node: &Path) -> String {
         directories.push(directory.to_path_buf());
     }
     if let Some(coven) = find_coven() {
-        if let Some(directory) = coven.parent() {
+        if let Some(directory) = coven.path.parent() {
             directories.push(directory.to_path_buf());
         }
     }

--- a/src-tauri/src/sidecar_discovery.rs
+++ b/src-tauri/src/sidecar_discovery.rs
@@ -206,11 +206,267 @@ pub(super) fn find_node(resource_dir: &Path) -> Option<PathBuf> {
         None
     }
 }
+/// Which lane produced the resolved `coven`. Startup logs this alongside the
+/// path: `using coven at <path>` on its own cannot tell an operator whether
+/// their `COVEN_BIN` override was honored, which is the line people read while
+/// working out which CLI is in play.
+#[cfg(desktop)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CovenSource {
+    /// `COVEN_BIN` named it explicitly.
+    Override,
+    /// A known install location matched.
+    Candidate,
+    /// A PATH lookup (`where.exe`, or a login shell) found it.
+    PathLookup,
+}
+
+#[cfg(desktop)]
+impl CovenSource {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            CovenSource::Override => "COVEN_BIN override",
+            CovenSource::Candidate => "known install location",
+            CovenSource::PathLookup => "PATH lookup",
+        }
+    }
+}
+
+/// A resolved `coven` CLI plus the lane that produced it.
+#[cfg(desktop)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CovenBinary {
+    pub(super) path: PathBuf,
+    pub(super) source: CovenSource,
+}
+
+/// Why a `COVEN_BIN` value was not usable. Every variant is logged: an
+/// explicit override that silently falls through to discovery is what turns a
+/// one-line fix into an investigation.
+#[cfg(desktop)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum OverrideRejection {
+    NotAbsolute,
+    RemotePath,
+    Missing,
+    NotAFile,
+}
+
+#[cfg(desktop)]
+impl OverrideRejection {
+    pub(super) fn reason(self) -> &'static str {
+        match self {
+            OverrideRejection::NotAbsolute => "not an absolute path",
+            OverrideRejection::RemotePath => "refers to a remote UNC share",
+            OverrideRejection::Missing => "does not exist",
+            OverrideRejection::NotAFile => "is not a file",
+        }
+    }
+}
+
+/// What a filesystem probe found. Split out so the verification rules can be
+/// exercised on any host, including the Linux runner that runs `cargo test`.
+#[cfg(desktop)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PathProbe {
+    Missing,
+    NotAFile,
+    /// `canonical` is the symlink-resolved path, which is what the remote-share
+    /// check must run against — the literal path can be a local symlink whose
+    /// target sits on a share.
+    File { canonical: String },
+}
+
+/// Mirror of `isWindowsRemoteExecutablePath` in `src/lib/coven-bin.ts`: a
+/// Cave-owned local CLI must not be sourced from a remote UNC share. Besides
+/// crossing the local trust boundary, probing one can stall on an offline
+/// share. `\\?\` and `\\.\` device namespaces are local and stay eligible;
+/// `\\?\UNC\` is the extended spelling of a share and is not.
+#[cfg(desktop)]
+pub(super) fn is_windows_remote_executable_path(candidate: &str) -> bool {
+    let normalized: String = candidate
+        .chars()
+        .map(|c| if c == '/' { '\\' } else { c })
+        .collect();
+    if let Some(rest) = normalized.strip_prefix("\\\\") {
+        match rest.chars().next() {
+            Some('?') | Some('.') | Some('\\') | None => {}
+            Some(_) => return true,
+        }
+    }
+    normalized.to_ascii_lowercase().starts_with("\\\\?\\unc\\")
+}
+
+/// Host-independent `path.isAbsolute`. `Path::is_absolute` answers for the
+/// compile target only, which would make the Windows rules untestable on the
+/// Linux runner.
+#[cfg(desktop)]
+pub(super) fn is_absolute_binary_path(candidate: &str, windows: bool) -> bool {
+    if !windows {
+        return candidate.starts_with('/');
+    }
+    let normalized: String = candidate
+        .chars()
+        .map(|c| if c == '/' { '\\' } else { c })
+        .collect();
+    if normalized.starts_with('\\') {
+        return true;
+    }
+    let bytes = normalized.as_bytes();
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'\\'
+}
+
+/// Apply the same admission rules to `COVEN_BIN` that `verifiedAbsoluteBinary`
+/// applies on the TS side: absolute, existing, a file, and never a remote UNC
+/// path on Windows.
+///
+/// One deliberate difference from the TS resolver: the *literal* path is
+/// returned, not the canonical one. The result here is not executed directly —
+/// its parent directory is prepended to a PATH string — and Windows'
+/// `canonicalize` yields a `\\?\`-prefixed path that PATH search does not
+/// honor. The canonical form is still what the remote-share check runs
+/// against, so a symlink pointing at a share is rejected either way.
+#[cfg(desktop)]
+pub(super) fn verify_coven_override(
+    candidate: &str,
+    windows: bool,
+    probe: impl Fn(&str) -> PathProbe,
+) -> Result<String, OverrideRejection> {
+    if !is_absolute_binary_path(candidate, windows) {
+        return Err(OverrideRejection::NotAbsolute);
+    }
+    if windows && is_windows_remote_executable_path(candidate) {
+        return Err(OverrideRejection::RemotePath);
+    }
+    match probe(candidate) {
+        PathProbe::Missing => Err(OverrideRejection::Missing),
+        PathProbe::NotAFile => Err(OverrideRejection::NotAFile),
+        PathProbe::File { canonical } => {
+            if windows && is_windows_remote_executable_path(&canonical) {
+                return Err(OverrideRejection::RemotePath);
+            }
+            Ok(candidate.to_string())
+        }
+    }
+}
+
+#[cfg(desktop)]
+fn probe_filesystem(candidate: &str) -> PathProbe {
+    let path = Path::new(candidate);
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => {
+            let canonical = std::fs::canonicalize(path)
+                .map(|resolved| resolved.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| candidate.to_string());
+            PathProbe::File { canonical }
+        }
+        Ok(_) => PathProbe::NotAFile,
+        Err(_) => PathProbe::Missing,
+    }
+}
+
+/// Explicit override always wins, matching `covenBinaryFromEnvironment` and
+/// `covenBin` in `src/lib/coven-bin.ts`. Useful for local dev when a
+/// checkout-built CLI is newer than the npm-bundled one — which is the only
+/// way to reach a checkout build at all, since no candidate list names one.
+///
+/// `std::env::var` is already case-insensitive on Windows, so this matches the
+/// TS `environmentValue` lookup without a separate scan.
+#[cfg(desktop)]
+fn coven_override() -> Option<CovenBinary> {
+    let raw = std::env::var("COVEN_BIN").ok()?;
+    let candidate = raw.trim();
+    if candidate.is_empty() {
+        return None;
+    }
+    match verify_coven_override(candidate, cfg!(target_os = "windows"), probe_filesystem) {
+        Ok(path) => Some(CovenBinary {
+            path: PathBuf::from(path),
+            source: CovenSource::Override,
+        }),
+        Err(rejection) => {
+            log::warn!(
+                "[cave] ignoring COVEN_BIN={} - it {}; falling back to discovery",
+                candidate,
+                rejection.reason()
+            );
+            None
+        }
+    }
+}
+
+/// Root of Cave's own managed toolchain, mirroring `managedNodeRoot` in
+/// `src/lib/server/managed-node-toolchain.ts`. The TS resolver ranks this lane
+/// first; without it here the shell and the sidecar can disagree about which
+/// `coven` is canonical, with no diagnostic saying so.
+#[cfg(desktop)]
+fn managed_toolchain_root() -> Option<PathBuf> {
+    fn non_empty(key: &str) -> Option<String> {
+        std::env::var(key).ok().filter(|value| !value.is_empty())
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let local = non_empty("LOCALAPPDATA").map(PathBuf::from).or_else(|| {
+            non_empty("USERPROFILE").map(|home| PathBuf::from(home).join("AppData").join("Local"))
+        })?;
+        Some(local.join("OpenCoven").join("CovenCave").join("toolchains"))
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let home = non_empty("HOME")?;
+        Some(
+            PathBuf::from(home)
+                .join("Library")
+                .join("Application Support")
+                .join("OpenCoven")
+                .join("CovenCave")
+                .join("toolchains"),
+        )
+    }
+
+    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+    {
+        let data = non_empty("XDG_DATA_HOME").map(PathBuf::from).or_else(|| {
+            non_empty("HOME").map(|home| PathBuf::from(home).join(".local").join("share"))
+        })?;
+        Some(data.join("opencoven").join("coven-cave").join("toolchains"))
+    }
+}
+
+/// npm installs the Coven CLI into the managed prefix: a `.cmd` shim beside the
+/// prefix root on Windows, a `bin/` entry elsewhere.
+#[cfg(desktop)]
+fn managed_coven_candidates() -> Vec<PathBuf> {
+    let Some(root) = managed_toolchain_root() else {
+        return Vec::new();
+    };
+    let npm = root.join("npm");
+    #[cfg(target_os = "windows")]
+    {
+        vec![npm.join("coven.cmd"), npm.join("coven.exe")]
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        vec![npm.join("bin").join("coven")]
+    }
+}
+
 /// Find the `coven` CLI on disk so API routes spawned from the sidecar can
 /// reach it. Same GUI-launch PATH problem as `find_node`. Returns the full
-/// path to the binary so callers can prepend its parent directory to PATH.
+/// path to the binary so callers can prepend its parent directory to PATH,
+/// plus the lane that produced it so startup can log which one won.
 #[cfg(desktop)]
-pub(super) fn find_coven() -> Option<PathBuf> {
+pub(super) fn find_coven() -> Option<CovenBinary> {
+    if let Some(binary) = coven_override() {
+        return Some(binary);
+    }
+    find_coven_by_discovery()
+}
+
+#[cfg(desktop)]
+fn find_coven_by_discovery() -> Option<CovenBinary> {
     #[cfg(target_os = "windows")]
     {
         let home = std::env::var("USERPROFILE").unwrap_or_default();
@@ -221,16 +477,22 @@ pub(super) fn find_coven() -> Option<PathBuf> {
         // %USERPROFILE%\\AppData\\Roaming\\npm when APPDATA is unset.
         let appdata = std::env::var("APPDATA")
             .unwrap_or_else(|_| format!("{}\\AppData\\Roaming", home));
-        let candidates = [
+        // Cave's managed toolchain leads, as it does in `candidateDirs()` on the
+        // TS side: a Cave-installed CLI is preferred over a stale host binary.
+        let mut candidates = managed_coven_candidates();
+        candidates.extend([
             PathBuf::from(format!("{}\\npm\\coven.cmd", appdata)),
             PathBuf::from(format!("{}\\npm\\coven.exe", appdata)),
             PathBuf::from(format!("{}\\.volta\\bin\\coven.exe", home)),
             PathBuf::from(format!("{}\\.bun\\bin\\coven.exe", home)),
             PathBuf::from(format!("{}\\.cargo\\bin\\coven.exe", home)),
-        ];
+        ]);
         for c in candidates.iter() {
             if c.exists() {
-                return Some(c.clone());
+                return Some(CovenBinary {
+                    path: c.clone(),
+                    source: CovenSource::Candidate,
+                });
             }
         }
         if let Ok(out) = windows_command::hidden_system32_command("where.exe")
@@ -246,7 +508,10 @@ pub(super) fn find_coven() -> Option<PathBuf> {
             if !path.is_empty() {
                 let pb = PathBuf::from(&path);
                 if pb.exists() {
-                    return Some(pb);
+                    return Some(CovenBinary {
+                        path: pb,
+                        source: CovenSource::PathLookup,
+                    });
                 }
             }
         }
@@ -255,6 +520,17 @@ pub(super) fn find_coven() -> Option<PathBuf> {
 
     #[cfg(not(target_os = "windows"))]
     {
+        // Cave's managed toolchain leads, as it does in `candidateDirs()` on the
+        // TS side: a Cave-installed CLI is preferred over a stale host binary.
+        for c in managed_coven_candidates() {
+            if c.exists() {
+                return Some(CovenBinary {
+                    path: c,
+                    source: CovenSource::Candidate,
+                });
+            }
+        }
+
         let home = std::env::var("HOME").ok()?;
         let nvm_root = PathBuf::from(format!("{}/.nvm/versions/node", home));
         if let Ok(entries) = std::fs::read_dir(&nvm_root) {
@@ -267,7 +543,10 @@ pub(super) fn find_coven() -> Option<PathBuf> {
             if let Some(latest) = versions.into_iter().next_back() {
                 let coven = latest.join("bin").join("coven");
                 if coven.exists() {
-                    return Some(coven);
+                    return Some(CovenBinary {
+                        path: coven,
+                        source: CovenSource::Candidate,
+                    });
                 }
             }
         }
@@ -282,7 +561,10 @@ pub(super) fn find_coven() -> Option<PathBuf> {
         ];
         for c in candidates.iter() {
             if c.exists() {
-                return Some(c.clone());
+                return Some(CovenBinary {
+                    path: c.clone(),
+                    source: CovenSource::Candidate,
+                });
             }
         }
         if let Ok(out) = Command::new("/bin/zsh")
@@ -293,10 +575,168 @@ pub(super) fn find_coven() -> Option<PathBuf> {
             if !path.is_empty() {
                 let pb = PathBuf::from(path);
                 if pb.exists() {
-                    return Some(pb);
+                    return Some(CovenBinary {
+                        path: pb,
+                        source: CovenSource::PathLookup,
+                    });
                 }
             }
         }
         None
+    }
+}
+
+#[cfg(all(test, desktop))]
+mod coven_binary_tests {
+    use super::*;
+
+    fn file_probe(canonical: &str) -> impl Fn(&str) -> PathProbe + '_ {
+        move |_| PathProbe::File {
+            canonical: canonical.to_string(),
+        }
+    }
+
+    #[test]
+    fn absolute_paths_are_recognized_per_host() {
+        assert!(is_absolute_binary_path("/usr/local/bin/coven", false));
+        assert!(!is_absolute_binary_path("bin/coven", false));
+        assert!(!is_absolute_binary_path("C:\\bin\\coven.exe", false));
+
+        assert!(is_absolute_binary_path("C:\\bin\\coven.exe", true));
+        assert!(is_absolute_binary_path("c:/bin/coven.exe", true));
+        assert!(is_absolute_binary_path(
+            "\\\\server\\share\\coven.exe",
+            true
+        ));
+        assert!(!is_absolute_binary_path("bin\\coven.exe", true));
+        assert!(!is_absolute_binary_path("C:coven.exe", true));
+    }
+
+    #[test]
+    fn remote_share_paths_are_detected_in_both_spellings() {
+        assert!(is_windows_remote_executable_path(
+            "\\\\server\\share\\coven.exe"
+        ));
+        assert!(is_windows_remote_executable_path(
+            "//server/share/coven.exe"
+        ));
+        assert!(is_windows_remote_executable_path(
+            "\\\\?\\UNC\\server\\share\\coven.exe"
+        ));
+        assert!(is_windows_remote_executable_path(
+            "\\\\?\\unc\\server\\share\\coven.exe"
+        ));
+        // Local device namespaces are not shares.
+        assert!(!is_windows_remote_executable_path(
+            "\\\\?\\C:\\bin\\coven.exe"
+        ));
+        assert!(!is_windows_remote_executable_path(
+            "\\\\.\\C:\\bin\\coven.exe"
+        ));
+        assert!(!is_windows_remote_executable_path("C:\\bin\\coven.exe"));
+    }
+
+    #[test]
+    fn a_relative_override_is_rejected_rather_than_resolved_against_the_cwd() {
+        // Windows searches the child cwd before PATH, so a relative override is
+        // exactly the value a planted launcher would need.
+        assert_eq!(
+            verify_coven_override("coven.exe", true, file_probe("C:\\work\\coven.exe")),
+            Err(OverrideRejection::NotAbsolute)
+        );
+    }
+
+    #[test]
+    fn a_remote_override_is_rejected_before_the_filesystem_is_touched() {
+        let probe = |_: &str| -> PathProbe {
+            panic!("an offline share must not be probed");
+        };
+        assert_eq!(
+            verify_coven_override("\\\\server\\share\\coven.exe", true, probe),
+            Err(OverrideRejection::RemotePath)
+        );
+    }
+
+    #[test]
+    fn a_local_symlink_onto_a_share_is_rejected_by_its_canonical_target() {
+        assert_eq!(
+            verify_coven_override(
+                "C:\\links\\coven.exe",
+                true,
+                file_probe("\\\\?\\UNC\\server\\share\\coven.exe"),
+            ),
+            Err(OverrideRejection::RemotePath)
+        );
+    }
+
+    #[test]
+    fn missing_and_non_file_overrides_report_distinct_reasons() {
+        assert_eq!(
+            verify_coven_override("/opt/coven/bin/coven", false, |_| PathProbe::Missing),
+            Err(OverrideRejection::Missing)
+        );
+        assert_eq!(
+            verify_coven_override("/opt/coven/bin", false, |_| PathProbe::NotAFile),
+            Err(OverrideRejection::NotAFile)
+        );
+        // Each reason reaches the log with its own wording; a bare "ignored"
+        // would not tell an operator which part of the value to fix.
+        assert_ne!(
+            OverrideRejection::Missing.reason(),
+            OverrideRejection::NotAFile.reason()
+        );
+    }
+
+    #[test]
+    fn a_verified_override_keeps_the_literal_path_not_the_canonical_one() {
+        // The parent directory is prepended to a PATH string, and Windows PATH
+        // search does not honor the `\\?\` prefix `canonicalize` produces.
+        assert_eq!(
+            verify_coven_override(
+                "C:\\checkout\\target\\release\\coven.exe",
+                true,
+                file_probe("\\\\?\\C:\\checkout\\target\\release\\coven.exe"),
+            ),
+            Ok("C:\\checkout\\target\\release\\coven.exe".to_string())
+        );
+    }
+
+    #[test]
+    fn sources_are_labeled_distinctly_for_the_startup_log() {
+        let labels = [
+            CovenSource::Override.label(),
+            CovenSource::Candidate.label(),
+            CovenSource::PathLookup.label(),
+        ];
+        for (index, label) in labels.iter().enumerate() {
+            assert!(!label.is_empty());
+            assert!(
+                !labels[index + 1..].contains(label),
+                "each lane must be distinguishable in the log"
+            );
+        }
+    }
+
+    #[test]
+    fn the_managed_toolchain_lane_leads_discovery() {
+        // The TS resolver ranks its managed lane first; the Rust list had no
+        // entry for it at all, so the shell and the sidecar could disagree
+        // about which `coven` is canonical.
+        let managed = managed_coven_candidates();
+        assert!(
+            !managed.is_empty(),
+            "the managed toolchain lane must contribute at least one candidate"
+        );
+        for candidate in managed {
+            assert!(
+                candidate.to_string_lossy().contains("toolchains"),
+                "managed candidates live under the managed toolchain root"
+            );
+            assert!(
+                candidate.ends_with("coven")
+                    || candidate.ends_with("coven.cmd")
+                    || candidate.ends_with("coven.exe")
+            );
+        }
     }
 }

--- a/src-tauri/src/sidecar_startup.rs
+++ b/src-tauri/src/sidecar_startup.rs
@@ -680,8 +680,15 @@ fn run_sidecar_runtime(
     }
     match find_coven() {
         Some(coven) => {
-            log::info!("[cave] using coven at {}", coven.display());
-            if let Some(directory) = coven.parent() {
+            // Name the lane, not just the path: this is the line read while
+            // working out which CLI is in play, and a path alone cannot say
+            // whether a COVEN_BIN override was honored.
+            log::info!(
+                "[cave] using coven at {} (source: {})",
+                coven.path.display(),
+                coven.source.label()
+            );
+            if let Some(directory) = coven.path.parent() {
                 augmented_path = format!("{}{}{}", directory.display(), path_sep, augmented_path);
             }
         }

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -8,7 +8,7 @@ import { spawnSync } from "node:child_process";
 import { chmod, copyFile, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV, caveToolSpawnEnv, covenAdapterDirsEnvValue, covenBinaryFromEnvironment, covenLaunchCommandForBinary, covenSpawnEnv, covenWrapperSpawnEnv, isWindowsRemoteExecutablePath, pickWindowsLauncher, refreshCovenSpawnEnv, runnableNodeToolchainDirs, scrubSidecarInternalEnv, windowsPathFromRegQuery, withCovenWrapperWindowPolicy } from "./coven-bin.ts";
+import { COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV, caveToolSpawnEnv, covenAdapterDirsEnvValue, covenBinaryFromEnvironment, covenLaunchCommandForBinary, covenOverrideRejection, covenSpawnEnv, covenWrapperSpawnEnv, isWindowsRemoteExecutablePath, pickWindowsLauncher, refreshCovenSpawnEnv, runnableNodeToolchainDirs, scrubSidecarInternalEnv, windowsPathFromRegQuery, withCovenWrapperWindowPolicy } from "./coven-bin.ts";
 import { harnessSpawnEnv } from "./harness-spawn-env.ts";
 
 const source = await readFile(new URL("./coven-bin.ts", import.meta.url), "utf8");
@@ -813,6 +813,32 @@ assert.match(
   source,
   /process\.platform === "win32"\) throw new Error\(COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC\)/,
   "a missing Windows Coven CLI fails closed instead of returning a bare executable name",
+);
+
+// An explicit override that fails verification must not vanish: resolution
+// falls through to the managed copy, and without a line naming the reason the
+// only way to discover that is to read the resolver.
+assert.match(
+  source,
+  /console\.warn\([\s\S]{0,200}ignoring COVEN_BIN/,
+  "an unusable COVEN_BIN is reported instead of silently falling through to discovery",
+);
+assert.equal(
+  covenOverrideRejection("coven.exe", "linux"),
+  "it is not an absolute path",
+  "a relative override is named as such - Windows would resolve it against the child cwd",
+);
+assert.equal(
+  covenOverrideRejection("\\\\remote-host\\share\\coven.exe", "win32"),
+  "it refers to a remote UNC share",
+);
+assert.equal(
+  covenOverrideRejection(path.join(os.tmpdir(), "cave-coven-override-absent")),
+  "it does not exist",
+);
+assert.equal(
+  covenOverrideRejection(await realpath(os.tmpdir())),
+  "it is not a file",
 );
 
 if (process.platform === "win32") {

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -445,19 +445,55 @@ export function covenBinaryFromEnvironment(
   return null;
 }
 
+/**
+ * Explain a `COVEN_BIN` value that `verifiedAbsoluteBinary` refused, so the
+ * operator learns which part of it to fix. Only reached on the failure path.
+ */
+export function covenOverrideRejection(
+  candidate: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const pathApi = platform === "win32" ? path.win32 : path;
+  if (!pathApi.isAbsolute(candidate) && !path.isAbsolute(candidate)) {
+    return "it is not an absolute path";
+  }
+  if (platform === "win32" && isWindowsRemoteExecutablePath(candidate)) {
+    return "it refers to a remote UNC share";
+  }
+  try {
+    const canonical = realpathSync(/* turbopackIgnore: true */ candidate);
+    if (platform === "win32" && isWindowsRemoteExecutablePath(canonical)) {
+      return "it resolves onto a remote UNC share";
+    }
+    return statSync(/* turbopackIgnore: true */ canonical).isFile()
+      ? "it could not be verified"
+      : "it is not a file";
+  } catch {
+    return "it does not exist";
+  }
+}
+
 /** Resolve an existing absolute Coven launcher. Windows never returns a bare name. */
 export function covenBin(): string {
   if (cachedBin) return cachedBin;
 
   // Explicit override always wins. Useful for local dev when a checkout-built
   // ~/.cargo/bin/coven is newer than the npm-bundled one in ~/.nvm/.../bin.
-  const envBin = process.env.COVEN_BIN;
+  const envBin = process.env.COVEN_BIN?.trim();
   if (envBin) {
     const verified = verifiedAbsoluteBinary(envBin);
     if (verified) {
       cachedBin = verified;
       return cachedBin;
     }
+    // An override that fails verification used to vanish: resolution fell
+    // through to the managed copy with no error anywhere, so the only way to
+    // find out was to read the code. The warning stays on this cached,
+    // process-level entry point rather than inside `covenBinaryFromEnvironment`,
+    // which callers invoke per request with a supplied environment.
+    console.warn(
+      `[coven-bin] ignoring COVEN_BIN=${envBin} - ${covenOverrideRejection(envBin)}; falling back to discovery`,
+    );
   }
 
   const discovery = discoveryOptions();


### PR DESCRIPTION
Closes #4692.

## The problem

`COVEN_BIN` is the documented override for pointing Cave at a specific Coven CLI. Both TS resolvers honor it first — `covenBinaryFromEnvironment` (`src/lib/coven-bin.ts:414`) and `covenBin` (`:454`), the latter with a comment naming the exact use case.

The desktop shell has a **second, independent resolver that never consulted it**. `find_coven()` (`src-tauri/src/sidecar_discovery.rs:213`) probed a hardcoded candidate list and then shelled out to `where.exe` / `zsh -lic command -v`. There was no `COVEN_BIN` handling anywhere under `src-tauri/`.

That resolver does not execute Coven directly — it **prepends the resolved binary's parent directory** to the PATH handed to downstream processes:

- `src-tauri/src/sidecar_startup.rs:681` — the Next sidecar's augmented PATH, and the `[cave] using coven at {path}` startup log.
- `src-tauri/src/desktop_reachability.rs:1551` — the daemon's augmented PATH on macOS.

So with `COVEN_BIN` set, the startup log could name a binary the user did not choose, and a directory holding a stale Coven was front-loaded onto the sidecar's PATH ahead of the user's own entries.

The two resolvers also disagreed about what exists. The Rust list had no entry for Cave's own managed toolchain, which `candidateDirs()` (`src/lib/coven-bin.ts:218`) ranks **first**; the TS list has no entry for a checkout build and ranks `~/.cargo/bin` last, so `COVEN_BIN` is the only way to reach a locally built CLI — precisely the case the Rust side dropped.

## What changed

### 1. `COVEN_BIN` is consulted first, with the TS side's verification

`find_coven()` now checks the override before any candidate probing, applying the same admission rules `verifiedAbsoluteBinary` applies on the TS side: **absolute**, **exists**, **is a file**, and **never a remote UNC path on Windows** (both `\\server\share\…` and the extended `\\?\UNC\…` spelling; `\\?\` and `\\.\` device namespaces stay eligible because they are local).

One deliberate difference from the TS resolver, called out in the code: the **literal** path is returned, not the canonical one. This value is not executed — its parent directory is prepended to a PATH string — and Windows' `canonicalize` yields a `\\?\`-prefixed path that PATH search does not honor. The canonical form is still what the remote-share check runs against, so a local symlink whose target sits on a share is rejected either way.

`std::env::var` is already case-insensitive on Windows, which matches the TS `environmentValue` lookup without a separate scan.

### 2. The startup log names the lane that won

```diff
-log::info!("[cave] using coven at {}", coven.display());
+log::info!(
+    "[cave] using coven at {} (source: {})",
+    coven.path.display(),
+    coven.source.label()
+);
```

`find_coven()` now returns a `CovenBinary { path, source }` where `source` is one of `COVEN_BIN override` / `known install location` / `PATH lookup`. This is the line someone reads while working out which Coven is in play; a path on its own cannot answer whether the override was honored.

### 3. An ignored override says so — on both sides

Previously a `COVEN_BIN` that failed verification was discarded silently on *both* sides, with resolution falling through to the managed copy and no error anywhere.

- **Rust:** `[cave] ignoring COVEN_BIN=<value> - it <reason>; falling back to discovery`, where the reason is one of *not an absolute path* / *refers to a remote UNC share* / *does not exist* / *is not a file*.
- **TS:** a matching `console.warn` from `covenBin()`, backed by a new exported `covenOverrideRejection()` that classifies the value.

The TS warning sits on `covenBin()` — the cached, process-level entry point whose result feeds spawns — rather than inside `covenBinaryFromEnvironment`, which `/api/onboarding/status` and `opencoven-tools-status` invoke per request with a supplied environment. That boundary is noted in the code.

### 4. The managed toolchain lane is added to the Rust list

`managed_toolchain_root()` mirrors `managedNodeRoot` in `src/lib/server/managed-node-toolchain.ts` across all three platforms (`%LOCALAPPDATA%\OpenCoven\CovenCave\toolchains`, `~/Library/Application Support/OpenCoven/CovenCave/toolchains`, `$XDG_DATA_HOME/opencoven/coven-cave/toolchains`), and its `npm` prefix now leads the candidate list on both branches — matching the TS comment that *"`coven` intentionally prefers its managed install locations over a stale shell binary."*

This is the "at minimum" half of item 4 in the issue. Fully factoring one shared candidate list across the Rust and TS resolvers is left out deliberately: it is a larger change than the bug warrants, and the two lists still differ in ordering below the managed lane.

## Tests

Nine new Rust tests in `sidecar_discovery::coven_binary_tests`. The verification rules are split into **host-independent** helpers (`is_absolute_binary_path(candidate, windows)`, `is_windows_remote_executable_path`, and `verify_coven_override` taking an injected probe) specifically so the Windows paths are exercised by `cargo test --lib` on CI's Linux runner rather than only on a Windows machine:

- absolute-path recognition per host, including `C:\`, `c:/`, UNC, and the `C:coven.exe` drive-relative form
- remote-share detection in both spellings, and non-detection of the local `\\?\` / `\\.\` device namespaces
- a relative override is rejected rather than resolved against the cwd — Windows searches the child cwd before PATH, so that is exactly the value a planted launcher would need
- a remote override is rejected **before the filesystem is touched** (the probe panics if called, since an offline share can stall)
- a local symlink onto a share is rejected by its canonical target
- missing vs. not-a-file report distinct reasons
- a verified override keeps the literal path, not the `\\?\` canonical one
- the three source labels are distinct
- the managed toolchain lane contributes candidates and they live under the managed root

TS: four `covenOverrideRejection` cases plus a source assertion that the warn exists, in `src/lib/coven-bin.test.ts`.

## Validation

| Check | Result |
| --- | --- |
| `cargo test --lib` (Windows) | 163 passed, 0 failed — including the 9 new tests |
| `node --experimental-strip-types src/lib/coven-bin.test.ts` | ok |
| `node --experimental-strip-types src/app/api/onboarding/status/route.test.ts` | ok |
| `pnpm exec eslint src/lib/coven-bin.ts src/lib/coven-bin.test.ts --max-warnings=0` | clean |
| `pnpm typecheck` | clean apart from two stale `.next/types/validator.ts` entries for pages deleted on `main` |

One unrelated pre-existing failure: `scripts/check-conflict-markers.test.mjs` fails on this Windows machine on a **clean tree at this same base** (verified by stashing the change and re-running), so it is environmental and not caused by this PR.

## Not done

Full unification of the Rust and TS candidate lists (issue item 4, first half) — see the note above.
