### PR TITLE
Fix Research Improve duplicating prompt instructions

### DIFF
--- a/src/lib/prompt-enhancer.test.ts
+++ b/src/lib/prompt-enhancer.test.ts
@@ -131,4 +131,28 @@ assert.deepEqual(
 assert.equal(settleEnhance("draft", "draft"), "apply", "an unchanged draft applies in place");
 assert.equal(settleEnhance("draft", "draft edited"), "suggest", "a changed draft downgrades to a suggestion");
 
+// ── Research idempotency (#4628) ──────────────────────────────────────────────
+// Improve resends the input on every click, so a second pass re-wraps an
+// already-formatted Research prompt unless the formatter recovers the question.
+function countOccurrences(text: string, needle: string): number {
+  return text.split(needle).length - 1;
+}
+
+const researchOnce = buildPromptEnhancement({ draft: "compare local llm runtimes", mode: "research" });
+const researchTwice = buildPromptEnhancement({ draft: researchOnce.enhanced, mode: "research" });
+assert.equal(researchTwice.ok, true, "a second research pass should still succeed");
+assert.equal(
+  researchTwice.enhanced,
+  researchOnce.enhanced,
+  "formatting twice returns the same text as formatting once",
+);
+for (const section of ["Primary questions:", "Method:", "Sources and confidence:", "Output format:"]) {
+  assert.equal(countOccurrences(researchOnce.enhanced, section), 1, `one copy of "${section}" after the first pass`);
+  assert.equal(countOccurrences(researchTwice.enhanced, section), 1, `one copy of "${section}" after the second pass`);
+}
+// A question that already ended with a period is reconstructed verbatim.
+const dottedOnce = buildPromptEnhancement({ draft: "compare runtimes.", mode: "research" });
+const dottedTwice = buildPromptEnhancement({ draft: dottedOnce.enhanced, mode: "research" });
+assert.equal(dottedTwice.enhanced, dottedOnce.enhanced, "a trailing period in the question survives idempotency");
+
 console.log("prompt-enhancer.test.ts: ok");

--- a/src/lib/prompt-enhancer.ts
+++ b/src/lib/prompt-enhancer.ts
@@ -165,6 +165,40 @@ export function settleEnhance(baseDraft: string, currentDraft: string): "apply" 
   return baseDraft === currentDraft ? "apply" : "suggest";
 }
 
+// ── Research idempotency (#4628) ──────────────────────────────────────────────
+// Improve sends the full input back through the formatter on every click, so a
+// second click re-wraps an already-formatted Research prompt and duplicates the
+// generated sections. Recover the underlying question from a prior wrapper so a
+// second pass rebuilds the wrapper instead of nesting another copy inside it.
+
+const RESEARCH_PREFIX = "Research and compare: ";
+const RESEARCH_SECTION_HEADERS = [
+  "Primary questions:",
+  "Method:",
+  "Sources and confidence:",
+  "Output format:",
+] as const;
+
+/** Returns the original question embedded in a prior research-mode enhancement,
+ *  or null when `draft` is not a wrapped research prompt. The formatter appends
+ *  exactly one "." to the draft, so exactly one trailing "." is dropped — that
+ *  reconstructs a draft that already ended with a period verbatim. */
+function recoverResearchCore(draft: string): string | null {
+  if (!draft.startsWith(RESEARCH_PREFIX)) return null;
+  const body = draft.slice(RESEARCH_PREFIX.length);
+  // cleanDraft collapses whitespace, so sections may follow the question
+  // separated by a single space; the first generated header is the boundary.
+  let boundary = -1;
+  for (const header of RESEARCH_SECTION_HEADERS) {
+    const index = body.indexOf(header);
+    if (index >= 0 && (boundary < 0 || index < boundary)) boundary = index;
+  }
+  if (boundary < 0) return null;
+  const core = body.slice(0, boundary).trim();
+  if (!core) return null;
+  return core.endsWith(".") ? core.slice(0, -1).trim() : core;
+}
+
 export function buildPromptEnhancement(input: PromptEnhanceRequest): PromptEnhanceResult {
   const mode = normalizeEnhanceMode(input.mode);
   const draft = cleanDraft(input.draft);
@@ -212,12 +246,13 @@ export function buildPromptEnhancement(input: PromptEnhanceRequest): PromptEnhan
   }
 
   if (mode === "research") {
+    const question = recoverResearchCore(draft) ?? draft;
     return {
       ok: true,
       mode,
       label: "Research",
       enhanced: [
-        `Research and compare: ${draft}.`,
+        `Research and compare: ${question}.`,
         "Primary questions: identify the key claims, tradeoffs, and decision criteria to answer.",
         "Method: use current primary sources where possible, compare alternatives, and separate facts from inference.",
         "Sources and confidence: cite sources, note publication dates, and label confidence or uncertainty.",


### PR DESCRIPTION
Fixes #4628

## What changed

\src/lib/prompt-enhancer.ts\ now detects when a draft is already wrapped in the Research format and recovers the underlying question before rebuilding the prompt. A second (third, fourth…) click on \u201CImprove\u201D rewrites the same question instead of nesting another copy of the generated sections.

## Why

The composer's Improve button POSTs the current input (\intent\) back through \uildPromptEnhancement\ on every click. The Research branch wraps whatever it receives, so a second click produced:

\\\
Research and compare: Research and compare: Compare local LLM runtimes. Primary questions: … Method: … …
Primary questions: …
Method: …
Sources and confidence: …
Output format: …
\\\

The formatter is now idempotent for research mode.

## Tests

Added regression checks to \src/lib/prompt-enhancer.test.ts\:

- Formatting twice returns the same text as formatting once.
- One copy of each generated section (Primary questions, Method, Sources and confidence, Output format) after a second pass.
- A question that already ends with a period is reconstructed verbatim.

Verified locally: \
ode --experimental-strip-types src/lib/prompt-enhancer.test.ts\, \src/app/api/prompt/enhance/route.test.ts\, \src/components/role-surfaces/research-tab-prompt.test.ts\, \	sc --noEmit\, and \slint\ on the changed files.