### PR TITLE
build: exclude suffixed iOS build roots

### DIFF
--- a/scripts/standalone-budget.mjs
+++ b/scripts/standalone-budget.mjs
@@ -61,6 +61,7 @@ export const STANDALONE_FORBIDDEN_ROOTS = Object.freeze([
 ]);
 
 const STANDALONE_FORBIDDEN_ROOT_PREFIXES = Object.freeze([".worktree-lifecycle-fixture-"]);
+const IOS_BUILD_ROOT_PATTERN = /^(apps\/ios\/(?:[^/]+\/)*build(?:-[^/]+)?)(?:\/|$)/;
 
 function portable(relativePath) {
   return relativePath.split(path.sep).join("/");
@@ -72,6 +73,8 @@ export function forbiddenStandaloneRoot(relativePath) {
   if (STANDALONE_FORBIDDEN_ROOT_PREFIXES.some((prefix) => candidateRoot.startsWith(prefix))) {
     return candidateRoot;
   }
+  const iosBuildRoot = candidate.match(IOS_BUILD_ROOT_PATTERN)?.[1];
+  if (iosBuildRoot) return iosBuildRoot;
   return STANDALONE_FORBIDDEN_ROOTS.find(
     (root) => candidate === root || candidate.startsWith(`${root}/`),
   );

--- a/scripts/standalone-budget.test.mjs
+++ b/scripts/standalone-budget.test.mjs
@@ -55,6 +55,15 @@ try {
     forbiddenStandaloneRoot(".worktree-lifecycle-fixture-sample/repo/README.md"),
     ".worktree-lifecycle-fixture-sample",
   );
+  assert.equal(
+    forbiddenStandaloneRoot("apps/ios/CovenCave/build/Release/CovenCave.app"),
+    "apps/ios/CovenCave/build",
+  );
+  assert.equal(
+    forbiddenStandaloneRoot("apps/ios/CovenCave/build-cody-cma81/Release/CovenCave.app"),
+    "apps/ios/CovenCave/build-cody-cma81",
+  );
+  assert.equal(forbiddenStandaloneRoot("apps/ios/CovenCave/building-notes/file.txt"), undefined);
   assert.equal(forbiddenStandaloneRoot("node_modules/target/index.js"), undefined);
 
   const nextConfig = await readFile(new URL("../next.config.ts", import.meta.url), "utf8");
@@ -68,11 +77,24 @@ try {
     /"\.\/\.tmp\/\*\*\/\*"/,
     "Next tracing excludes checkout-local temporary artifacts",
   );
+  assert.match(
+    nextConfig,
+    /"\.\/apps\/ios\/\*\*\/build-\*\/\*\*\/\*"/,
+    "Next tracing excludes suffixed local iOS build roots",
+  );
 
   const leaked = path.join(fixture, "target-windows");
   await write(leaked, "debug/build.exe", "binary\n");
   await assert.rejects(verifyStandaloneArtifact(fixture), /forbidden root leaked.*target-windows/);
   await rm(leaked, { recursive: true, force: true });
+
+  const leakedIosBuild = path.join(fixture, "apps/ios/CovenCave/build-cody-cma81");
+  await write(leakedIosBuild, "Release/CovenCave.app", "binary\n");
+  await assert.rejects(
+    verifyStandaloneArtifact(fixture),
+    /forbidden root leaked.*apps\/ios\/CovenCave\/build-cody-cma81/,
+  );
+  await rm(path.join(fixture, "apps"), { recursive: true, force: true });
 
   try {
     await symlink("server.js", path.join(fixture, "server-link.js"));

--- a/scripts/standalone-budget.test.mjs
+++ b/scripts/standalone-budget.test.mjs
@@ -79,7 +79,7 @@ try {
   );
   assert.match(
     nextConfig,
-    /"\.\/apps\/ios\/\*\*\/build-\*\/\*\*\/\*"/,
+    /"\.\/apps\/ios\/\*\*\/build\*\/\*\*\/\*"/,
     "Next tracing excludes suffixed local iOS build roots",
   );
 


### PR DESCRIPTION
## Summary
- fail closed if standard or suffixed iOS build roots appear in Next standalone output
- cover both iOS build-root matching and artifact rejection with regression tests
- pin the broader `apps/ios/**/build*` tracing exclusion already landed on `main`

## Root cause
The primary checkout contained `apps/ios/CovenCave/build-cody-cma81` at 505 MiB / 4,503 files. The former tracing config excluded only directories literally named `build`, so the suffixed root inflated standalone to 884,895,805 bytes. Current `main` now excludes `build*`; this PR adds the independent postbuild guard so any future tracing regression fails closed instead of relying only on byte/file ceilings.

## Verification
- `node --test scripts/standalone-budget.test.mjs scripts/bundle-budget.test.mjs`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` — 1,225 test files passed
- `pnpm test:api` — 380 test files passed on isolated rerun after an unrelated dev-server port-bind teardown flake
- `pnpm check:tests-wired`
- `pnpm build` — 7,085 files / 403,916,220 bytes; no forbidden local build roots
- independent review: no significant issues

Bead: cave-otppj
