### PR TITLE
Promote primary blockers with an audit trail

### DIFF
--- a/docs/orchestration-ready-tasks.md
+++ b/docs/orchestration-ready-tasks.md
@@ -9,9 +9,10 @@ This is the shared operating contract for Cave tasks. The spec explains *why* an
 task shape. Read it before writing anything that creates, blocks, unblocks, or
 dispatches a task.
 
-Status: approved design. The fields described here are the target contract, not
-yet shipped — until they land, treat this as the shape to design toward and do
-not invent a competing one.
+Status: the canonical fields, mutator enforcement, lifecycle blockers, primary
+blocker promotion, and promotion audit are implemented. Board and Chart Room
+editing surfaces, Enhance proposals, and overlay retirement remain phased work;
+do not invent a competing task shape while those surfaces migrate.
 
 ## The one rule
 

--- a/docs/superpowers/specs/2026-08-03-orchestration-ready-task-shape-design.md
+++ b/docs/superpowers/specs/2026-08-03-orchestration-ready-task-shape-design.md
@@ -1,6 +1,6 @@
 # Orchestration-Ready Task Shape Design
 
-**Date:** 2026-08-03 · **Bead:** `cave-wqzf2` · **Status:** approved design, not yet implemented
+**Date:** 2026-08-03 · **Bead:** `cave-wqzf2` · **Status:** core contract, enforcement, and promotion implemented; surface migration remains
 **Reviewers:** Astra (implementation alignment), Sage (research and best practice)
 
 Cave tasks are the unit of work every familiar, surface, and orchestrator reads.

--- a/src/lib/cave-board-orchestration.test.ts
+++ b/src/lib/cave-board-orchestration.test.ts
@@ -53,6 +53,16 @@ assert.ok(
   orchestration.repairRecommendations(legacy, initial.cards).length >= 2,
   "legacy cards expose concrete repair recommendations",
 );
+await assert.rejects(
+  board.updateCard(legacy.id, { dependencies: [] }),
+  (error) => {
+    assert.ok(
+      errorCodes(error).includes("blocked_requires_dependency"),
+      "an unchanged dependency patch still enforces the blocked contract",
+    );
+    return true;
+  },
+);
 
 await assert.rejects(
   board.createCard({ title: "Invalid blocked task", status: "blocked" }),
@@ -132,23 +142,34 @@ const blocked = await board.createCard({
 assert.equal(blocked.needsHuman, true, "approval-gated next steps set needsHuman");
 
 await assert.rejects(
-  board.updateCard(blocked.id, { dependencies: [] }, { automated: true }),
+  board.updateCard(blocked.id, { dependencies: [null] as never }),
   (error) => {
-    const codes = errorCodes(error);
-    assert.ok(codes.includes("dependency_authorship"), "automation cannot remove human dependencies");
-    assert.ok(codes.includes("blocked_requires_dependency"), "projected blocked state is validated");
+    assert.ok(
+      errorCodes(error).includes("dependency_invalid"),
+      "malformed dependency patches reach structured validation before promotion",
+    );
+    return true;
+  },
+);
+await assert.rejects(
+  board.updateCard(blocked.id, {
+    dependencies: [...(blocked.dependencies ?? []), null] as never,
+  }),
+  (error) => {
+    assert.ok(
+      errorCodes(error).includes("dependency_invalid"),
+      "malformed entries cannot hide behind repeat-resolution detection",
+    );
     return true;
   },
 );
 
 await assert.rejects(
-  board.updateCard(blocked.id, {
-    dependencies: [{ ...blocker, state: "resolved", evidence: "Decision recorded" }],
-  }),
+  board.updateCard(blocked.id, { dependencies: [] }, { automated: true }),
   (error) => {
     const codes = errorCodes(error);
-    assert.ok(codes.includes("blocked_requires_dependency"));
-    assert.ok(codes.includes("blocked_requires_primary"));
+    assert.ok(codes.includes("dependency_authorship"), "automation cannot remove human dependencies");
+    assert.ok(codes.includes("blocked_requires_dependency"), "projected blocked state is validated");
     return true;
   },
 );
@@ -161,6 +182,430 @@ await assert.rejects(
     assert.ok(errorCodes(error).includes("blocked_requires_next_step"));
     return true;
   },
+);
+
+const resolvedHumanBlocker = {
+  ...blocker,
+  state: "resolved" as const,
+  resolvedAt: new Date().toISOString(),
+  resolvedBy: "cody",
+  evidence: "Maintainer chose the implementation",
+};
+const readyBlocked = await board.updateCard(
+  blocked.id,
+  { dependencies: [resolvedHumanBlocker] },
+  { actor: "cody" },
+);
+assert.ok(readyBlocked);
+assert.equal(readyBlocked.status, "blocked", "resolution does not move the card out of Blocked");
+assert.equal(readyBlocked.primaryBlockerId, null, "the resolved final primary is cleared");
+assert.deepEqual(readyBlocked.nextStep, humanNextStep, "a human-authored next step is preserved");
+assert.equal(orchestration.deriveReadiness(readyBlocked, (await board.loadBoard()).cards), "ready");
+assert.deepEqual(readyBlocked.orchestrationAudit, [{
+  taskId: blocked.id,
+  resolvedDependencyId: blocker.id,
+  previousNextStep: humanNextStep,
+  nextStep: humanNextStep,
+  at: readyBlocked.updatedAt,
+  actor: "cody",
+}]);
+
+const settledUpdatedAt = readyBlocked.updatedAt;
+const repeatedResolution = await board.updateCard(
+  blocked.id,
+  { dependencies: [resolvedHumanBlocker] },
+  { actor: "cody" },
+);
+assert.equal(repeatedResolution?.updatedAt, settledUpdatedAt, "repeat resolution is a storage no-op");
+assert.equal(repeatedResolution?.orchestrationAudit?.length, 1, "repeat resolution does not duplicate audit");
+
+await new Promise((resolve) => setTimeout(resolve, 2));
+const reorderedRepeat = await board.updateCard(
+  blocked.id,
+  {
+    dependencies: [{
+      evidence: resolvedHumanBlocker.evidence,
+      resolvedBy: resolvedHumanBlocker.resolvedBy,
+      resolvedAt: "2099-01-01T00:00:00.000Z",
+      createdAt: resolvedHumanBlocker.createdAt,
+      origin: resolvedHumanBlocker.origin,
+      state: resolvedHumanBlocker.state,
+      label: resolvedHumanBlocker.label,
+      kind: resolvedHumanBlocker.kind,
+      id: resolvedHumanBlocker.id,
+    }],
+  },
+  { actor: "cody" },
+);
+assert.equal(
+  reorderedRepeat?.updatedAt,
+  settledUpdatedAt,
+  "repeat resolution ignores regenerated resolution timestamps and property order",
+);
+assert.equal(reorderedRepeat?.orchestrationAudit?.length, 1);
+
+const editedReadyBlocked = await board.updateCard(blocked.id, {
+  notes: "Ready for an explicit move out of Blocked",
+});
+assert.equal(editedReadyBlocked?.notes, "Ready for an explicit move out of Blocked");
+assert.equal(
+  orchestration.deriveReadiness(editedReadyBlocked, (await board.loadBoard()).cards),
+  "ready",
+  "a persisted ready-blocked card remains editable",
+);
+
+const primaryDependency = {
+  id: "system-primary",
+  kind: "service" as const,
+  label: "Restore the build service",
+  ref: "svc:build",
+  state: "unresolved" as const,
+  origin: "system" as const,
+  createdAt: now,
+};
+const secondaryDependency = {
+  id: "system-secondary",
+  kind: "github" as const,
+  label: "Merge the follow-up pull request",
+  ref: "OpenCoven/coven-cave#9999",
+  state: "unresolved" as const,
+  origin: "system" as const,
+  createdAt: now,
+};
+const systemNextStep = {
+  summary: primaryDependency.label,
+  requiresApproval: false,
+  origin: "system" as const,
+  updatedAt: now,
+};
+const promotable = await board.createCard({
+  title: "Promote blockers deterministically",
+  status: "blocked",
+  dependencies: [primaryDependency, secondaryDependency],
+  primaryBlockerId: primaryDependency.id,
+  nextStep: systemNextStep,
+});
+const promoted = await board.updateCard(
+  promotable.id,
+  {
+    dependencies: [
+      {
+        ...primaryDependency,
+        state: "resolved",
+        resolvedAt: new Date().toISOString(),
+        resolvedBy: "cody",
+        evidence: "Build service health check passed",
+      },
+      secondaryDependency,
+    ],
+  },
+  { automated: true, actor: "cody" },
+);
+assert.ok(promoted);
+assert.equal(promoted.primaryBlockerId, secondaryDependency.id, "array order chooses the next primary");
+assert.equal(promoted.nextStep?.summary, secondaryDependency.label, "the derived next step follows the promoted blocker");
+assert.equal(promoted.nextStep?.origin, "system");
+assert.deepEqual(promoted.orchestrationAudit?.[0], {
+  taskId: promotable.id,
+  resolvedDependencyId: primaryDependency.id,
+  previousNextStep: systemNextStep,
+  nextStep: promoted.nextStep,
+  at: promoted.updatedAt,
+  actor: "cody",
+});
+
+const approvalPrimary = {
+  ...primaryDependency,
+  id: "approval-primary",
+  kind: "human" as const,
+  label: "Approve the deployment approach",
+};
+const nonApprovalSecondary = {
+  ...secondaryDependency,
+  id: "non-approval-secondary",
+  kind: "service" as const,
+  label: "Restore the deployment service",
+};
+const approvalPromotion = await board.createCard({
+  title: "Clear resolved approval attention",
+  status: "blocked",
+  dependencies: [approvalPrimary, nonApprovalSecondary],
+  primaryBlockerId: approvalPrimary.id,
+  nextStep: {
+    summary: approvalPrimary.label,
+    requiresApproval: true,
+    origin: "system",
+    updatedAt: now,
+  },
+});
+assert.equal(approvalPromotion.needsHuman, true);
+const approvalResolved = await board.updateCard(approvalPromotion.id, {
+  dependencies: [
+    {
+      ...approvalPrimary,
+      state: "resolved",
+      resolvedAt: new Date().toISOString(),
+      evidence: "Maintainer approved the approach",
+    },
+    nonApprovalSecondary,
+  ],
+});
+assert.equal(approvalResolved?.primaryBlockerId, nonApprovalSecondary.id);
+assert.equal(approvalResolved?.nextStep?.requiresApproval, false);
+assert.equal(
+  approvalResolved?.needsHuman,
+  false,
+  "promotion clears attention derived from a resolved approval-gated step",
+);
+
+const preservedAttention = await board.createCard({
+  title: "Preserve independent human attention",
+  status: "blocked",
+  dependencies: [
+    { ...approvalPrimary, id: "attention-primary" },
+    { ...nonApprovalSecondary, id: "attention-secondary" },
+  ],
+  primaryBlockerId: "attention-primary",
+  nextStep: {
+    summary: approvalPrimary.label,
+    requiresApproval: true,
+    origin: "system",
+    updatedAt: now,
+  },
+});
+const attentionResolved = await board.updateCard(preservedAttention.id, {
+  dependencies: [
+    {
+      ...approvalPrimary,
+      id: "attention-primary",
+      state: "resolved",
+      resolvedAt: new Date().toISOString(),
+      evidence: "Approval recorded",
+    },
+    { ...nonApprovalSecondary, id: "attention-secondary" },
+  ],
+  needsHuman: true,
+});
+assert.equal(
+  attentionResolved?.needsHuman,
+  true,
+  "an explicit independent attention flag survives approval-step promotion",
+);
+
+const auditOverwriteAttempt = await board.updateCard(promotable.id, {
+  orchestrationAudit: [],
+});
+assert.equal(
+  auditOverwriteAttempt?.orchestrationAudit?.length,
+  1,
+  "callers cannot replace the append-only promotion audit",
+);
+
+const pinnedPromotion = await board.createCard({
+  title: "Pinned primary stays operator-controlled",
+  status: "blocked",
+  dependencies: [
+    { ...primaryDependency, id: "pinned-promotion-primary" },
+    { ...secondaryDependency, id: "pinned-promotion-secondary" },
+  ],
+  primaryBlockerId: "pinned-promotion-primary",
+  primaryBlockerPinned: true,
+  nextStep: systemNextStep,
+});
+await assert.rejects(
+  board.updateCard(pinnedPromotion.id, {
+    dependencies: [
+      {
+        ...primaryDependency,
+        id: "pinned-promotion-primary",
+        state: "resolved",
+        resolvedAt: new Date().toISOString(),
+        evidence: "Operator resolved the service",
+      },
+      { ...secondaryDependency, id: "pinned-promotion-secondary" },
+    ],
+  }),
+  (error) => {
+    assert.ok(errorCodes(error).includes("blocked_requires_primary"));
+    return true;
+  },
+);
+const stillPinned = (await board.loadBoard()).cards.find((card) => card.id === pinnedPromotion.id);
+assert.equal(stillPinned?.primaryBlockerId, "pinned-promotion-primary");
+assert.equal(stillPinned?.dependencies?.[0]?.state, "unresolved", "a rejected pinned resolution is not saved");
+assert.equal(stillPinned?.orchestrationAudit?.length, 0);
+
+const deletedUpstream = await board.createCard({ title: "Upstream task to delete" });
+const taskDependency = {
+  id: "deleted-task-dependency",
+  kind: "task" as const,
+  label: "Finish the upstream task",
+  taskId: deletedUpstream.id,
+  state: "unresolved" as const,
+  origin: "human" as const,
+  createdAt: now,
+};
+const deletionSecondary = {
+  ...secondaryDependency,
+  id: "deletion-human-secondary",
+  kind: "human" as const,
+  label: "Ask the maintainer to approve the fallback",
+  ref: null,
+};
+const dependent = await board.createCard({
+  title: "Repair references after deletion",
+  status: "blocked",
+  dependencies: [taskDependency, deletionSecondary],
+  primaryBlockerId: taskDependency.id,
+  nextStep: {
+    summary: taskDependency.label,
+    requiresApproval: false,
+    origin: "system",
+    updatedAt: now,
+  },
+});
+assert.equal(await board.deleteCard(deletedUpstream.id, { actor: "cody" }), "deleted");
+const repairedDependent = (await board.loadBoard()).cards.find((card) => card.id === dependent.id);
+assert.ok(repairedDependent);
+assert.equal(
+  repairedDependent.dependencies?.some(
+    (dependency) => dependency.kind === "task" && dependency.taskId === deletedUpstream.id,
+  ),
+  false,
+  "deletion leaves no dangling task edge",
+);
+assert.equal(repairedDependent.primaryBlockerId, deletionSecondary.id);
+assert.equal(repairedDependent.nextStep?.summary, deletionSecondary.label);
+assert.equal(
+  repairedDependent.needsHuman,
+  true,
+  "deletion-promoted approval blockers stay visible in the Decisions queue",
+);
+assert.equal(repairedDependent.orchestrationAudit?.at(-1)?.resolvedDependencyId, taskDependency.id);
+assert.equal(repairedDependent.orchestrationAudit?.at(-1)?.actor, "cody");
+
+const soleUpstream = await board.createCard({ title: "Only upstream task" });
+const soleDependency = {
+  ...taskDependency,
+  id: "sole-task-dependency",
+  taskId: soleUpstream.id,
+};
+const soleDependent = await board.createCard({
+  title: "Stay blocked for explicit unblocking",
+  status: "blocked",
+  dependencies: [soleDependency],
+  primaryBlockerId: soleDependency.id,
+  nextStep: {
+    summary: soleDependency.label,
+    requiresApproval: false,
+    origin: "system",
+    updatedAt: now,
+  },
+});
+assert.equal(await board.deleteCard(soleUpstream.id, { actor: "cody" }), "deleted");
+const readyAfterDelete = (await board.loadBoard()).cards.find((card) => card.id === soleDependent.id);
+assert.ok(readyAfterDelete);
+assert.equal(readyAfterDelete.status, "blocked");
+assert.equal(readyAfterDelete.primaryBlockerId, null);
+assert.equal(orchestration.deriveReadiness(readyAfterDelete, (await board.loadBoard()).cards), "ready");
+assert.equal(
+  readyAfterDelete.dependencies?.some(
+    (dependency) => dependency.kind === "task" && dependency.taskId === soleUpstream.id,
+  ),
+  false,
+);
+assert.deepEqual(
+  orchestration.repairRecommendations(readyAfterDelete, (await board.loadBoard()).cards)
+    .map((recommendation) => recommendation.code),
+  ["blocked_requires_dependency"],
+  "ready-blocked cards recommend unblocking without asking for a new next step",
+);
+
+const legacyUpstream = await board.createCard({ title: "Legacy upstream task" });
+const legacyDependentBase = await board.createCard({ title: "Legacy dependent task" });
+const beforeLegacySeed = await board.loadBoard();
+await board.saveBoard({
+  version: beforeLegacySeed.version,
+  cards: beforeLegacySeed.cards.map((card) =>
+    card.id === legacyDependentBase.id
+      ? {
+          ...card,
+          status: "blocked",
+          lifecycle: "failed",
+          dependencies: [
+            {
+              ...taskDependency,
+              id: "legacy-task-dependency",
+              taskId: legacyUpstream.id,
+            },
+            {
+              ...secondaryDependency,
+              id: "legacy-resolved-without-evidence",
+              state: "resolved",
+            },
+          ],
+          primaryBlockerId: null,
+          nextStep: null,
+        }
+      : card),
+});
+assert.equal(
+  await board.deleteCard(legacyUpstream.id, { actor: "cody" }),
+  "deleted",
+  "pre-existing legacy errors do not block dangling-edge cleanup",
+);
+const repairedLegacy = (await board.loadBoard()).cards.find(
+  (card) => card.id === legacyDependentBase.id,
+);
+assert.equal(
+  repairedLegacy?.dependencies?.some(
+    (dependency) => dependency.kind === "task" && dependency.taskId === legacyUpstream.id,
+  ),
+  false,
+);
+
+const malformedUpstream = await board.createCard({ title: "Malformed dependency upstream" });
+const malformedObjectCard = await board.createCard({ title: "Non-array legacy dependencies" });
+const malformedEntryCard = await board.createCard({ title: "Mixed legacy dependencies" });
+const beforeMalformedSeed = await board.loadBoard();
+await board.saveBoard({
+  version: beforeMalformedSeed.version,
+  cards: beforeMalformedSeed.cards.map((card) => {
+    if (card.id === malformedObjectCard.id) {
+      return { ...card, dependencies: { broken: true } as never };
+    }
+    if (card.id === malformedEntryCard.id) {
+      return {
+        ...card,
+        dependencies: [
+          null,
+          {
+            ...taskDependency,
+            id: "mixed-legacy-task-dependency",
+            taskId: malformedUpstream.id,
+          },
+        ] as never,
+        primaryBlockerId: "mixed-legacy-task-dependency",
+      };
+    }
+    return card;
+  }),
+});
+assert.equal(
+  await board.deleteCard(malformedUpstream.id, { actor: "cody" }),
+  "deleted",
+  "malformed legacy dependency payloads cannot crash deletion",
+);
+const repairedMalformed = (await board.loadBoard()).cards.find(
+  (card) => card.id === malformedEntryCard.id,
+);
+assert.equal(
+  Array.isArray(repairedMalformed?.dependencies) &&
+    repairedMalformed.dependencies.some(
+      (dependency) =>
+        dependency?.kind === "task" && dependency.taskId === malformedUpstream.id,
+    ),
+  false,
 );
 
 const enhanceTarget = await board.createCard({ title: "Enhance target" });

--- a/src/lib/cave-board-types.ts
+++ b/src/lib/cave-board-types.ts
@@ -83,6 +83,15 @@ export type TaskNextStep = {
   updatedAt: string;
 };
 
+export type TaskOrchestrationAuditEntry = {
+  taskId: string;
+  resolvedDependencyId: string;
+  previousNextStep: TaskNextStep | null;
+  nextStep: TaskNextStep | null;
+  at: string;
+  actor: string;
+};
+
 /** Derived on read from dependencies + primary blocker + next step. Never stored. */
 export type TaskReadiness = "ready" | "waiting" | "incomplete" | "cyclic";
 
@@ -221,6 +230,8 @@ export type Card = {
   /** Freezes the operator's choice so promotion never moves it. */
   primaryBlockerPinned?: boolean;
   nextStep?: TaskNextStep | null;
+  /** Append-only explanation of automatic primary-blocker promotions. */
+  orchestrationAudit?: TaskOrchestrationAuditEntry[];
   /** Files carried in from the composer when the card was created. Stored lean:
    * metadata + inlined text, but image `dataUrl`/`mimeType` are stripped so the
    * board JSON doesn't bloat with base64 payloads. Absent when none were staged. */

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -14,6 +14,7 @@ import {
   type CardStatus,
   type TaskDependency,
   type TaskNextStep,
+  type TaskOrchestrationAuditEntry,
 } from "@/lib/cave-board-types";
 import {
   mergeLinksWithGitHub,
@@ -35,7 +36,11 @@ import {
 } from "@/lib/chat-attachments";
 import { applyCardOps, hasCardOps, type CardPatch } from "@/lib/board-card-ops";
 import { canonicalHarnessId } from "@/lib/harness-adapters";
-import { assertValidOrchestration } from "@/lib/task-orchestration";
+import {
+  assertValidOrchestration,
+  dependenciesOf,
+  validateOrchestration,
+} from "@/lib/task-orchestration";
 
 export {
   DEFAULT_MAX_RETRIES,
@@ -52,6 +57,7 @@ export {
   type CardStatus,
   type TaskDependency,
   type TaskNextStep,
+  type TaskOrchestrationAuditEntry,
 } from "@/lib/cave-board-types";
 export { OrchestrationValidationError } from "@/lib/task-orchestration";
 
@@ -283,6 +289,7 @@ function backfillCard(c: Card | LegacyCard): Card {
     primaryBlockerPinned:
       typeof c.primaryBlockerPinned === "boolean" ? c.primaryBlockerPinned : false,
     nextStep: c.nextStep ?? null,
+    orchestrationAudit: Array.isArray(c.orchestrationAudit) ? c.orchestrationAudit : [],
   } as Card;
 }
 
@@ -436,6 +443,7 @@ export async function createCard(input: NewCardInput): Promise<Card> {
     primaryBlockerPinned:
       input.primaryBlockerPinned === undefined ? false : input.primaryBlockerPinned,
     nextStep: input.nextStep ?? null,
+    orchestrationAudit: [],
   };
   if (card.nextStep?.requiresApproval) card.needsHuman = true;
   const attachments = boardAttachments(input.attachments);
@@ -447,10 +455,201 @@ export async function createCard(input: NewCardInput): Promise<Card> {
   });
 }
 
+function resolutionActor(
+  options: { automated?: boolean; actor?: string },
+  dependency?: TaskDependency,
+): string {
+  return (
+    options.actor?.trim() ||
+    dependency?.resolvedBy?.trim() ||
+    (options.automated ? "system" : "human")
+  );
+}
+
+function nextStepForDependency(dependency: TaskDependency, now: string): TaskNextStep {
+  const target = dependency.url ?? dependency.ref ?? dependency.taskId;
+  return {
+    summary: dependency.label,
+    ...(target ? { target } : {}),
+    requiresApproval: dependency.kind === "human" || dependency.kind === "credential",
+    origin: "system",
+    updatedAt: now,
+  };
+}
+
+function appendPromotionAudit(
+  card: Card,
+  resolvedDependencyId: string,
+  previousNextStep: TaskNextStep | null,
+  nextStep: TaskNextStep | null,
+  now: string,
+  actor: string,
+): void {
+  const entry: TaskOrchestrationAuditEntry = {
+    taskId: card.id,
+    resolvedDependencyId,
+    previousNextStep,
+    nextStep,
+    at: now,
+    actor,
+  };
+  card.orchestrationAudit = [...(card.orchestrationAudit ?? []), entry];
+}
+
+function syncPromotionAttention(
+  next: Card,
+  previousNextStep: TaskNextStep | null,
+  preserveExistingAttention = false,
+): void {
+  if (next.nextStep?.requiresApproval) {
+    next.needsHuman = true;
+  } else if (previousNextStep?.requiresApproval && !preserveExistingAttention) {
+    next.needsHuman = false;
+  }
+}
+
+function promoteResolvedPrimary(
+  current: Card,
+  next: Card,
+  patch: Partial<Omit<Card, "id" | "createdAt">>,
+  now: string,
+  options: { automated?: boolean; actor?: string },
+): { promoted: boolean; readyBlocked: boolean } {
+  if (
+    current.primaryBlockerPinned ||
+    !current.primaryBlockerId ||
+    next.primaryBlockerId !== current.primaryBlockerId
+  ) {
+    return { promoted: false, readyBlocked: false };
+  }
+
+  const before = dependenciesOf(current).find(
+    (dependency) => dependency.id === current.primaryBlockerId,
+  );
+  const nextDependencies = dependenciesOf(next);
+  const resolved = nextDependencies.find(
+    (dependency) => dependency.id === current.primaryBlockerId,
+  );
+  if (
+    before?.state !== "unresolved" ||
+    !resolved ||
+    (resolved.state !== "resolved" && resolved.state !== "waived")
+  ) {
+    return { promoted: false, readyBlocked: false };
+  }
+
+  const promoted = nextDependencies.find(
+    (dependency) => dependency.state === "unresolved",
+  );
+  const previousNextStep = current.nextStep ?? null;
+  next.primaryBlockerId = promoted?.id ?? null;
+  if (!("nextStep" in patch)) {
+    next.nextStep =
+      previousNextStep?.origin === "human"
+        ? previousNextStep
+        : promoted
+          ? nextStepForDependency(promoted, now)
+          : null;
+    if (previousNextStep?.origin !== "human") {
+      syncPromotionAttention(next, previousNextStep, "needsHuman" in patch);
+    }
+  }
+  appendPromotionAudit(
+    next,
+    resolved.id,
+    previousNextStep,
+    next.nextStep ?? null,
+    now,
+    resolutionActor(options, resolved),
+  );
+  return { promoted: true, readyBlocked: promoted == null };
+}
+
+function isRepeatResolutionNoop(
+  left: Card,
+  right: Card,
+  patch: Partial<Omit<Card, "id" | "createdAt">>,
+): boolean {
+  if (!("dependencies" in patch)) return false;
+  const orchestrationFields = new Set([
+    "dependencies",
+    "primaryBlockerId",
+    "primaryBlockerPinned",
+    "nextStep",
+  ]);
+  if (Object.keys(patch).some((field) => !orchestrationFields.has(field))) return false;
+  const leftRaw = (left as { dependencies?: unknown }).dependencies;
+  const rightRaw = (right as { dependencies?: unknown }).dependencies;
+  if (!Array.isArray(leftRaw) || !Array.isArray(rightRaw)) return false;
+  const leftDependencies = dependenciesOf(left);
+  const rightDependencies = dependenciesOf(right);
+  if (
+    leftDependencies.length !== leftRaw.length ||
+    rightDependencies.length !== rightRaw.length
+  ) {
+    return false;
+  }
+  return (
+    leftDependencies.length === rightDependencies.length &&
+    leftDependencies.every((dependency, index) =>
+      sameDependencyForRepeat(dependency, rightDependencies[index])) &&
+    left.primaryBlockerId === right.primaryBlockerId &&
+    left.primaryBlockerPinned === right.primaryBlockerPinned &&
+    sameNextStepValue(left.nextStep, right.nextStep)
+  );
+}
+
+function sameOptionalValue(
+  left: string | null | undefined,
+  right: string | null | undefined,
+): boolean {
+  return (left ?? null) === (right ?? null);
+}
+
+function sameDependencyForRepeat(
+  left: TaskDependency,
+  right: TaskDependency | undefined,
+): boolean {
+  return (
+    right != null &&
+    left.id === right.id &&
+    left.kind === right.kind &&
+    left.label === right.label &&
+    sameOptionalValue(left.taskId, right.taskId) &&
+    sameOptionalValue(left.ref, right.ref) &&
+    sameOptionalValue(left.url, right.url) &&
+    left.state === right.state &&
+    left.origin === right.origin &&
+    left.createdAt === right.createdAt &&
+    sameOptionalValue(left.resolvedBy, right.resolvedBy) &&
+    sameOptionalValue(left.evidence, right.evidence) &&
+    (left.state !== "unresolved" ||
+      sameOptionalValue(left.resolvedAt, right.resolvedAt))
+  );
+}
+
+function sameNextStepValue(
+  left: TaskNextStep | null | undefined,
+  right: TaskNextStep | null | undefined,
+): boolean {
+  if (left == null || right == null) return left == null && right == null;
+  return (
+    left.summary === right.summary &&
+    sameOptionalValue(left.actorFamiliarId, right.actorFamiliarId) &&
+    sameOptionalValue(left.capability, right.capability) &&
+    sameOptionalValue(left.target, right.target) &&
+    (left.inputs?.length ?? 0) === (right.inputs?.length ?? 0) &&
+    (left.inputs ?? []).every((input, index) => input === right.inputs?.[index]) &&
+    left.requiresApproval === right.requiresApproval &&
+    left.origin === right.origin &&
+    left.updatedAt === right.updatedAt
+  );
+}
+
 export async function updateCard(
   id: string,
   patchWithOps: CardPatch,
-  options: { automated?: boolean } = {},
+  options: { automated?: boolean; actor?: string } = {},
 ): Promise<Card | null> {
   return withBoardLock(async () => {
   const board = await loadBoard();
@@ -547,7 +746,9 @@ export async function updateCard(
         : patch.primaryBlockerPinned
       : current.primaryBlockerPinned ?? false,
     nextStep: "nextStep" in patch ? patch.nextStep ?? null : current.nextStep ?? null,
+    orchestrationAudit: current.orchestrationAudit ?? [],
   };
+  const promotion = promoteResolvedPrimary(current, next, patch, now, options);
   if (statusChanged) next.needsHuman = next.status === "blocked";
   if (next.nextStep?.requiresApproval) next.needsHuman = true;
   if (next.lifecycle === "running" && !next.runningSince) {
@@ -555,10 +756,23 @@ export async function updateCard(
   } else if (next.lifecycle !== "running") {
     delete next.runningSince;
   }
+  if (isRepeatResolutionNoop(current, next, patch)) {
+    assertValidOrchestration(current, {
+      cards: board.cards,
+      previous: current,
+      automated: options.automated,
+      allowReadyBlocked:
+        current.status === "blocked" &&
+        hasOnlySettledDependencies(current) &&
+        current.primaryBlockerId == null,
+    });
+    return current;
+  }
   assertValidOrchestration(next, {
     cards: board.cards,
     previous: current,
     automated: options.automated,
+    allowReadyBlocked: promotion.readyBlocked,
   });
   board.cards[idx] = next;
   await saveBoard(board);
@@ -721,6 +935,99 @@ export async function transitionCard(
  *  it. `linked` is refused rather than silently skipped so the caller can say so. */
 export type DeleteCardOutcome = "deleted" | "not-found" | "linked";
 
+function repairDeletedTaskReferences(
+  card: Card,
+  deleted: Card,
+  now: string,
+  actor: string,
+): Card {
+  const rawDependencies = (card as { dependencies?: unknown }).dependencies;
+  if (!Array.isArray(rawDependencies)) return card;
+  const references = rawDependencies.filter(
+    (dependency): dependency is TaskDependency =>
+      dependency != null &&
+      typeof dependency === "object" &&
+      (dependency as { kind?: unknown }).kind === "task" &&
+      (dependency as { taskId?: unknown }).taskId === deleted.id,
+  );
+  if (references.length === 0) return card;
+
+  const removedPrimary = references.find(
+    (dependency) => dependency.id === card.primaryBlockerId,
+  );
+  const dependencies = rawDependencies.map((dependency): TaskDependency => {
+    if (
+      dependency == null ||
+      typeof dependency !== "object" ||
+      (dependency as { kind?: unknown }).kind !== "task" ||
+      (dependency as { taskId?: unknown }).taskId !== deleted.id
+    ) {
+      return dependency as TaskDependency;
+    }
+    return {
+      ...(dependency as TaskDependency),
+      kind: "external",
+      taskId: null,
+      ref: dependency.ref ?? `deleted-task:${deleted.id}`,
+      state: "waived",
+      resolvedAt: now,
+      resolvedBy: actor,
+      evidence: `Referenced task "${deleted.title}" was deleted.`,
+    };
+  });
+  const next: Card = {
+    ...card,
+    dependencies,
+    orchestrationAudit: card.orchestrationAudit ?? [],
+    updatedAt: now,
+  };
+
+  if (removedPrimary) {
+    const promoted = dependenciesOf({ dependencies }).find(
+      (dependency) => dependency.state === "unresolved",
+    );
+    const previousNextStep = card.nextStep ?? null;
+    next.primaryBlockerId = promoted?.id ?? null;
+    next.primaryBlockerPinned = false;
+    next.nextStep =
+      previousNextStep?.origin === "human"
+        ? previousNextStep
+        : promoted
+          ? nextStepForDependency(promoted, now)
+          : null;
+    if (previousNextStep?.origin !== "human") {
+      syncPromotionAttention(next, previousNextStep);
+    }
+    appendPromotionAudit(
+      next,
+      removedPrimary.id,
+      previousNextStep,
+      next.nextStep ?? null,
+      now,
+      actor,
+    );
+  }
+
+  return next;
+}
+
+function hasOnlySettledDependencies(card: Card): boolean {
+  const raw = (card as { dependencies?: unknown }).dependencies;
+  return (
+    Array.isArray(raw) &&
+    raw.length > 0 &&
+    raw.every(
+      (dependency) =>
+        dependency != null &&
+        typeof dependency === "object" &&
+        (
+          (dependency as { state?: unknown }).state === "resolved" ||
+          (dependency as { state?: unknown }).state === "waived"
+        ),
+    )
+  );
+}
+
 /**
  * Delete a card.
  *
@@ -732,14 +1039,41 @@ export type DeleteCardOutcome = "deleted" | "not-found" | "linked";
  */
 export async function deleteCard(
   id: string,
-  options: { allowLinked?: boolean } = {},
+  options: { allowLinked?: boolean; actor?: string } = {},
 ): Promise<DeleteCardOutcome> {
   return withBoardLock(async () => {
   const board = await loadBoard();
   const card = board.cards.find((c) => c.id === id);
   if (!card) return "not-found";
   if (card.beadRef && !options.allowLinked) return "linked";
-  board.cards = board.cards.filter((c) => c.id !== id);
+  const now = new Date().toISOString();
+  const actor = options.actor?.trim() || "human";
+  const remaining = board.cards.filter((candidate) => candidate.id !== id);
+  const repaired = remaining.map((candidate) =>
+    repairDeletedTaskReferences(candidate, card, now, actor));
+  for (let index = 0; index < repaired.length; index += 1) {
+    const next = repaired[index];
+    const previous = remaining[index];
+    if (next === previous) continue;
+    const previousErrors = validateOrchestration(previous, {
+      cards: board.cards,
+      allowReadyBlocked:
+        previous.status === "blocked" &&
+        hasOnlySettledDependencies(previous) &&
+        previous.primaryBlockerId == null,
+    });
+    if (previousErrors.length === 0) {
+      assertValidOrchestration(next, {
+        cards: repaired,
+        previous,
+        allowReadyBlocked:
+          next.status === "blocked" &&
+          hasOnlySettledDependencies(next) &&
+          next.primaryBlockerId == null,
+      });
+    }
+  }
+  board.cards = repaired;
   await saveBoard(board);
   return "deleted";
   });

--- a/src/lib/task-orchestration.ts
+++ b/src/lib/task-orchestration.ts
@@ -300,6 +300,8 @@ export type OrchestrationContext = {
   previous?: Card | null;
   /** True when the writer is automation (Enhance or a system transition). */
   automated?: boolean;
+  /** Internal resolution transaction that leaves a ready card in Blocked for explicit unblocking. */
+  allowReadyBlocked?: boolean;
 };
 
 export class OrchestrationValidationError extends Error {
@@ -460,7 +462,20 @@ export function validateOrchestration(
   // I1 — the blocked triple. Legacy cards are read-only-tolerated (I8); this is
   // the write path, so the contract is strict here.
   if (card.status === "blocked") {
-    if (unresolved.length === 0) {
+    const readyBlocked =
+      deps.length > 0 &&
+      unresolved.length === 0 &&
+      card.primaryBlockerId == null &&
+      (
+        ctx.allowReadyBlocked === true ||
+        (
+          ctx.previous?.status === "blocked" &&
+          dependenciesOf(ctx.previous).length > 0 &&
+          unresolvedOf(ctx.previous).length === 0 &&
+          ctx.previous.primaryBlockerId == null
+        )
+      );
+    if (unresolved.length === 0 && !readyBlocked) {
       errors.push({
         code: "blocked_requires_dependency",
         field: "dependencies",
@@ -469,7 +484,10 @@ export function validateOrchestration(
     }
 
     const primary = deps.find((dep) => dep.id === card.primaryBlockerId);
-    if (!isNonEmpty(card.primaryBlockerId) || !primary) {
+    if (readyBlocked) {
+      // Resolution deliberately does not move the card. Readiness becomes
+      // `ready`, and the operator gets an explicit unblocking recommendation.
+    } else if (!isNonEmpty(card.primaryBlockerId) || !primary) {
       if (unresolved.length > 0) {
         errors.push({
           code: "blocked_requires_primary",
@@ -486,7 +504,7 @@ export function validateOrchestration(
       });
     }
 
-    if (!isValidNextStep(card.nextStep)) {
+    if (!readyBlocked && !isValidNextStep(card.nextStep)) {
       errors.push({
         code: "blocked_requires_next_step",
         field: "nextStep",
@@ -548,6 +566,11 @@ export function deriveReadiness(
 
   const unresolved = unresolvedOf(card);
   if (card.status === "blocked") {
+    if (unresolved.length === 0) {
+      return dependenciesOf(card).length > 0 && card.primaryBlockerId == null
+        ? "ready"
+        : "incomplete";
+    }
     const primary = dependenciesOf(card).find((dep) => dep.id === card.primaryBlockerId);
     const complete =
       unresolved.length > 0 && primary?.state === "unresolved" && isValidNextStep(card.nextStep);
@@ -610,7 +633,7 @@ export function repairRecommendations(
       }
     }
 
-    if (!isValidNextStep(card.nextStep)) {
+    if ((unresolved.length > 0 || deps.length === 0) && !isValidNextStep(card.nextStep)) {
       out.push({
         code: "blocked_requires_next_step",
         field: "nextStep",


### PR DESCRIPTION
## Summary
- Promote the first unresolved dependency in operator-defined array order when the primary blocker resolves.
- Preserve pinned blockers and human-authored next steps while keeping repeat resolution storage-idempotent.
- Append immutable promotion audit entries and derive explicit unblocking recommendations when no blocker remains.
- Repair task dependency references during deletion without losing legacy boards or human-decision visibility.

## Verification
- env -u NPM_CONFIG_PREFIX -u npm_config_prefix pnpm test:app (1,225 test files)
- pnpm test:api
- pnpm typecheck
- pnpm lint
- pnpm check:tests-wired (1,686 wired test files)
- Focused cave-board orchestration, task-orchestration, and retention tests
- Independent code review with all pre-commit blockers resolved

Bead: cave-6jpum