### PR TITLE
Show Terminal in the compact Code rail

### DIFF
--- a/src/components/workspace-rail.test.ts
+++ b/src/components/workspace-rail.test.ts
@@ -19,8 +19,10 @@ assert.match(src, /projectRoot=\{projectRoot\}/, "threads projectRoot into the f
 assert.match(src, /RailTerminalPanel/, "Terminal tab renders RailTerminalPanel");
 assert.match(src, /isFullscreen,\s*setIsFullscreen/, "rail tracks fullscreen expansion state");
 assert.match(src, /aria-label=\{isFullscreen \? "Exit code rail fullscreen" : "Expand code rail fullscreen"\}/, "rail exposes a fullscreen toggle");
-assert.match(src, /isFullscreen && \(\s*<button[\s\S]*?aria-label="Terminal"/, "Terminal tab is only available while the rail is fullscreen");
-assert.match(src, /terminalEverOpened && isFullscreen/, "terminal host is gated behind fullscreen expansion");
+assert.doesNotMatch(src, /isFullscreen && \(\s*<button[\s\S]*?aria-label="Terminal"/, "Terminal tab stays available before fullscreen expansion");
+assert.match(src, /aria-label="Files"[\s\S]*aria-label="Terminal"/, "Terminal is listed below Files in the rail strip");
+assert.doesNotMatch(src, /terminalEverOpened && isFullscreen/, "terminal host is not gated behind fullscreen expansion");
+assert.match(src, /\{terminalEverOpened \? \(/, "terminal host mounts after its first selection at any rail size");
 assert.match(src, /terminalEverOpened/, "lazy gate: terminal not mounted until first opened");
 assert.match(src, /setTerminalEverOpened\(true\)/, "flips the lazy gate once the Terminal tab opens");
 assert.match(src, /workspace-rail__terminal/, "terminal wrapper class for keepalive hide/show");

--- a/src/components/workspace-rail.tsx
+++ b/src/components/workspace-rail.tsx
@@ -45,17 +45,14 @@ export function WorkspaceRail({
 }) {
   const [isFullscreen, setIsFullscreen] = useState(false);
   // Lazy pty: the terminal (and its shell) is not mounted until the Terminal tab
-  // is first selected from the fullscreen rail. Once opened it stays mounted
-  // (keepalive) while fullscreen but is hidden when another tab is active.
+  // is first selected. Once opened it stays mounted (keepalive) but is hidden
+  // when another tab is active.
   const [terminalEverOpened, setTerminalEverOpened] = useState(false);
   useEffect(() => {
-    if (!isFullscreen && activeTab === "terminal") onSelectTab("files");
-  }, [activeTab, isFullscreen, onSelectTab]);
-  useEffect(() => {
-    if (isFullscreen && activeTab === "terminal") setTerminalEverOpened(true);
-  }, [activeTab, isFullscreen]);
-  const terminalVisible = isFullscreen && activeTab === "terminal";
-  const title = activeTab === "terminal" && !isFullscreen ? TAB_TITLE.files : TAB_TITLE[activeTab];
+    if (activeTab === "terminal") setTerminalEverOpened(true);
+  }, [activeTab]);
+  const terminalVisible = activeTab === "terminal";
+  const title = TAB_TITLE[activeTab];
 
   return (
     <section
@@ -83,17 +80,15 @@ export function WorkspaceRail({
         >
           <Icon name="ph:folder" width={16} aria-hidden />
         </button>
-        {isFullscreen && (
-          <button
-            type="button"
-            aria-label="Terminal"
-            aria-pressed={activeTab === "terminal"}
-            className={`workspace-rail__tab focus-ring${activeTab === "terminal" ? " is-active" : ""}`}
-            onClick={() => onSelectTab("terminal")}
-          >
-            <Icon name="ph:terminal-window" width={16} aria-hidden />
-          </button>
-        )}
+        <button
+          type="button"
+          aria-label="Terminal"
+          aria-pressed={activeTab === "terminal"}
+          className={`workspace-rail__tab focus-ring${activeTab === "terminal" ? " is-active" : ""}`}
+          onClick={() => onSelectTab("terminal")}
+        >
+          <Icon name="ph:terminal-window" width={16} aria-hidden />
+        </button>
       </nav>
       <div className="workspace-rail__body">
         {/* Progressive disclosure (§8): pin + fullscreen are occasional-use —
@@ -158,7 +153,7 @@ export function WorkspaceRail({
           ) : null}
           {/* Terminal: mounted lazily on first selection, then kept mounted but
               visually hidden when another tab is active so the pty persists. */}
-          {terminalEverOpened && isFullscreen ? (
+          {terminalEverOpened ? (
             <div
               className={`workspace-rail__terminal workspace-rail__panel${terminalVisible ? "" : " is-hidden"}`}
               hidden={!terminalVisible}

--- a/tests/code-rail.spec.ts
+++ b/tests/code-rail.spec.ts
@@ -195,7 +195,7 @@ test.describe("code rail beside chat", () => {
     await rail.getByRole("button", { name: "Exit code rail fullscreen" }).click();
     await expect(rail).not.toHaveAttribute("data-fullscreen", "true");
     await expect(rail.locator(".workspace-rail__files--ide")).toHaveCount(0);
-    await expect(rail.getByRole("button", { name: "Terminal" })).toHaveCount(0);
+    await expect(rail.getByRole("button", { name: "Terminal" })).toBeVisible();
   });
 
   // PR 3 / Task 3: below the mobile breakpoint there's no room for the
@@ -221,7 +221,7 @@ test.describe("code rail beside chat", () => {
   // under tests/mobile/ (see playwright.config.ts testMatch). A mobile-only test
   // placed here would only ever run under the desktop project and self-skip.
 
-  test("(f) Terminal tab → fullscreen-only lazy pty host", async ({ page }) => {
+  test("(f) Terminal tab → compact-rail lazy pty host", async ({ page }) => {
     const filesRef = { count: 0 };
     await routeChanges(page, filesRef);
 
@@ -233,27 +233,21 @@ test.describe("code rail beside chat", () => {
     const rail = page.locator(".workspace-rail");
     await expect(rail).toBeVisible({ timeout: 15_000 });
 
-    // The normal side rail has Changes/Files only; Terminal is reserved for
-    // the user-expanded fullscreen rail.
-    await expect(rail.getByRole("button", { name: "Terminal" })).toHaveCount(0);
-    await expect(rail.locator(".workspace-rail__terminal")).toHaveCount(0);
-
-    await rail.getByRole("button", { name: "Expand code rail fullscreen" }).click();
-    await expect(rail).toHaveAttribute("data-fullscreen", "true");
-
-    // The Terminal tab button appears only after fullscreen expansion…
+    // Terminal stays visible below Files in the compact rail.
     const terminalTab = rail.getByRole("button", { name: "Terminal" });
     await expect(terminalTab).toBeVisible();
+    await expect(rail).not.toHaveAttribute("data-fullscreen", "true");
 
-    // …but its host container is ABSENT before the first click (genuine
-    // laziness — the pty must not start early).
+    // Its host container is absent before the first click (genuine laziness —
+    // the pty must not start early).
     await expect(rail.locator(".workspace-rail__terminal")).toHaveCount(0);
 
-    // Clicking Terminal mounts the host wrapper. In daemon-less e2e there is no
-    // live pty websocket bridge, so we assert the host wrapper mounts (not a
-    // working shell) and that the "next step" placeholder is gone.
+    // Clicking Terminal mounts the host without forcing fullscreen. In
+    // daemon-less e2e there is no live pty websocket bridge, so assert the host
+    // wrapper mounts (not a working shell) and the placeholder is gone.
     await terminalTab.click();
     await expect(rail.locator(".workspace-rail__terminal")).toBeVisible({ timeout: 15_000 });
+    await expect(rail).not.toHaveAttribute("data-fullscreen", "true");
     await expect(rail.locator(".workspace-rail__soon")).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Summary
- keep Terminal visible below Files in the compact Code rail
- allow the lazy terminal host to open without forcing fullscreen
- update source and Playwright regression coverage for the compact behavior

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `pnpm exec playwright test tests/code-rail.spec.ts --workers=1` (10 passed)

A full local `pnpm test:e2e` attempt encountered shared `cave-home-reconciliation` lock timeouts across unrelated research, onboarding, split-layout, and mobile suites; the focused Code rail lane passed. The required PR check remains authoritative for the exact head.

Bead: `cave-zaf7b`