### PR TITLE
Add familiar execution analytics

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1317,6 +1317,7 @@ export const SUITES = {
     "src/app/api/chat/conversation/[id]/route.test.ts",
     "src/app/api/sessions/[id]/route.test.ts",
     "src/app/api/canvas/route.test.ts",
+    "src/lib/server/familiar-execution-analytics.test.ts",
     "src/app/api/api-contracts.test.ts",
     "src/app/api/x/account-routes.test.ts",
     "src/app/api/x/research-routes.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -2,6 +2,19 @@
 import assert from "node:assert/strict";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
+import type { ConversationFile } from "../../lib/cave-conversations.ts";
+import {
+  buildFamiliarExecutionAnalytics,
+  EXECUTION_ATTEMPT_SCHEMA_VERSION,
+  normalizeExecutionAttemptSnapshot,
+  type ExecutionAttemptSnapshotV1,
+} from "../../lib/familiar-execution-analytics.ts";
+import { backfillFamiliarExecutionAttempts } from "../../lib/server/familiar-execution-analytics-backfill.ts";
+import {
+  deterministicExecutionAttemptId,
+  projectConversationExecutionAttempts,
+} from "../../lib/server/familiar-execution-analytics-projection.ts";
+import { serializeExecutionAttemptLedgerRecord } from "../../lib/server/familiar-execution-analytics-store.ts";
 
 const root = process.cwd();
 const apiRoot = path.join(root, "src", "app", "api");
@@ -87,6 +100,7 @@ const contracts: RouteContract[] = [
   { route: "/familiars/[id]/avatar", methods: ["GET", "POST", "DELETE"], kind: "stream", pathGuard: true },
   { route: "/familiars/[id]/backdrop", methods: ["GET", "PUT", "DELETE"], kind: "stream", localOriginGuard: true },
   { route: "/familiars/[id]/contract", methods: ["GET"], kind: "json", pathGuard: true },
+  { route: "/familiars/[id]/execution-analytics", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/familiars/[id]/icon", methods: ["PUT"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/familiars/[id]/notes", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
   { route: "/familiars/[id]/self-report", methods: ["POST", "GET"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
@@ -865,6 +879,291 @@ for (const contract of contracts) {
     projectFileSource,
     /const maxSize = imageMimeType \? MAX_IMAGE_SIZE : MAX_TEXT_SIZE;/,
     "/project-file: image previews should have their own bounded size cap instead of using the text-file cap",
+  );
+}
+
+{
+  const privateMarker = "PRIVATE-CONTENT-MUST-NOT-SURVIVE";
+  const snapshot = normalizeExecutionAttemptSnapshot({
+    schemaVersion: EXECUTION_ATTEMPT_SCHEMA_VERSION,
+    attemptId: "ea1_privacy",
+    familiarId: "cody",
+    sessionId: "session-private",
+    turnId: "turn-private",
+    attemptNumber: 1,
+    execution: {
+      kind: "assistant-response",
+      origin: "chat",
+      prompt: privateMarker,
+      cwd: `/private/${privateMarker}`,
+    },
+    harness: { id: "claude", version: "1.2.3", binaryPath: privateMarker },
+    models: {
+      requested: { kind: "model", id: "anthropic/claude-sonnet" },
+      forwarded: "claude-sonnet",
+      confirmed: "claude-sonnet",
+      response: privateMarker,
+    },
+    timing: {
+      completedAt: "2026-08-18T09:00:00.000Z",
+      durationMs: 1200,
+      rawEvent: privateMarker,
+    },
+    usage: { inputTokens: 10, outputTokens: 20, rawPayload: privateMarker },
+    costUsd: 0,
+    outcome: { status: "error", error: privateMarker },
+    tools: [{
+      name: "shell",
+      status: "error",
+      durationMs: 100,
+      input: privateMarker,
+      output: privateMarker,
+      path: `/private/${privateMarker}`,
+    }],
+    provenance: {
+      source: "live",
+      sourceSchema: "execution-attempt-v1",
+      capturedAt: "2026-08-18T09:00:00.000Z",
+      rawPayload: privateMarker,
+    },
+    coverage: { knownFields: ["tools"], arbitrary: privateMarker },
+    prompt: privateMarker,
+    response: privateMarker,
+    errorText: privateMarker,
+    path: `/private/${privateMarker}`,
+  });
+  assert.ok(snapshot, "metadata-only snapshots should accept the versioned allowlist");
+  const serialized = serializeExecutionAttemptLedgerRecord(snapshot);
+  assert.ok(serialized, "valid snapshots should serialize into a ledger record");
+  assert.doesNotMatch(
+    serialized,
+    new RegExp(privateMarker),
+    "snapshot normalization must discard prompt/response text, payloads, paths, and arbitrary errors",
+  );
+  assert.deepEqual(
+    snapshot.tools,
+    [{ name: "shell", status: "error", durationMs: 100 }],
+    "tools retain only name, status, and duration",
+  );
+  assert.equal(snapshot.costUsd, 0, "a known zero cost remains distinct from missing cost");
+}
+
+{
+  const conversation: ConversationFile = {
+    sessionId: "session-deterministic",
+    familiarId: "cody",
+    harness: "claude-code",
+    origin: "chat",
+    createdAt: "2026-08-18T08:00:00.000Z",
+    updatedAt: "2026-08-18T09:00:00.000Z",
+    turns: [
+      {
+        id: "user-secret",
+        role: "user",
+        text: "private prompt",
+        createdAt: "2026-08-18T08:00:00.000Z",
+      },
+      {
+        id: "assistant-result",
+        role: "assistant",
+        text: "private response",
+        reasoning: "private reasoning",
+        createdAt: "2026-08-18T08:00:05.000Z",
+        durationMs: 5000,
+        usage: { inputTokens: 11, outputTokens: 7 },
+        costUsd: 0.02,
+        tools: [{
+          id: "tool-1",
+          name: "shell",
+          input: "private tool input",
+          output: "private tool output",
+          status: "ok",
+          durationMs: 800,
+        }],
+        responseMetadata: {
+          familiarId: "cody",
+          harness: "claude-code",
+          model: "anthropic/claude-sonnet",
+          runtime: "local",
+          requestedModel: "anthropic/claude-sonnet",
+          forwardedModel: "claude-sonnet",
+          confirmedModel: "claude-sonnet",
+          requestedControls: { reasoning: "high" },
+          forwardedControls: { reasoning: "high" },
+          appliedControls: { reasoning: "high" },
+        },
+      },
+    ],
+  };
+  const first = projectConversationExecutionAttempts(conversation);
+  const second = projectConversationExecutionAttempts(conversation);
+  assert.deepEqual(first, second, "conversation projection must be deterministic");
+  assert.equal(first.length, 1);
+  assert.equal(
+    first[0].attemptId,
+    deterministicExecutionAttemptId({
+      familiarId: "cody",
+      sessionId: "session-deterministic",
+      turnId: "assistant-result",
+      attemptNumber: 1,
+    }),
+  );
+  assert.deepEqual(
+    first[0].harness,
+    { id: "claude" },
+    "historical projection canonicalizes the harness id without inventing a current version",
+  );
+  assert.equal("version" in (first[0].harness ?? {}), false);
+  assert.doesNotMatch(JSON.stringify(first[0]), /private prompt|private response|private reasoning|private tool/);
+
+  const deps = {
+    listConversations: async () => [{
+      sessionId: conversation.sessionId,
+      familiarId: conversation.familiarId,
+      harness: conversation.harness,
+      updatedAt: conversation.updatedAt,
+    }],
+    loadConversation: async () => conversation,
+  };
+  const initial = await backfillFamiliarExecutionAttempts({
+    familiarId: "cody",
+    existing: [],
+    dependencies: deps,
+  });
+  const replay = await backfillFamiliarExecutionAttempts({
+    familiarId: "cody",
+    existing: initial.attempts,
+    dependencies: deps,
+  });
+  assert.equal(initial.toAppend.length, 1);
+  assert.equal(replay.toAppend.length, 0, "replaying the same conversation must dedupe");
+  assert.deepEqual(replay.attempts, initial.attempts);
+}
+
+{
+  function attempt(
+    attemptId: string,
+    completedAt: string,
+    extras: Record<string, unknown> = {},
+  ): ExecutionAttemptSnapshotV1 {
+    const value = normalizeExecutionAttemptSnapshot({
+      schemaVersion: EXECUTION_ATTEMPT_SCHEMA_VERSION,
+      attemptId,
+      familiarId: "cody",
+      sessionId: `session-${attemptId}`,
+      turnId: `turn-${attemptId}`,
+      attemptNumber: 1,
+      execution: { kind: "assistant-response", origin: "chat" },
+      timing: { completedAt },
+      outcome: { status: "succeeded" },
+      provenance: {
+        source: "live",
+        sourceSchema: "execution-attempt-v1",
+        capturedAt: completedAt,
+      },
+      coverage: { knownFields: [] },
+      ...extras,
+    });
+    assert.ok(value);
+    return value;
+  }
+
+  const attempts = [
+    attempt("recent-known", "2026-08-17T10:00:00.000Z", {
+      harness: { id: "claude", version: "1.0.0" },
+      models: { confirmed: "claude-sonnet" },
+      timing: { completedAt: "2026-08-17T10:00:00.000Z", durationMs: 1000 },
+      usage: { inputTokens: 10, outputTokens: 20 },
+      costUsd: 0,
+      tools: [],
+    }),
+    attempt("recent-missing", "2026-08-16T10:00:00.000Z"),
+    attempt("old", "2026-06-01T10:00:00.000Z", {
+      outcome: { status: "error" },
+      timing: { completedAt: "2026-06-01T10:00:00.000Z", durationMs: 3000 },
+    }),
+  ];
+  const analytics = buildFamiliarExecutionAnalytics({
+    familiarId: "cody",
+    attempts,
+    now: new Date("2026-08-18T10:00:00.000Z"),
+    recentLimit: 1,
+  });
+  assert.equal(analytics.windows["7d"].attempts, 2);
+  assert.equal(analytics.windows.all.attempts, 3);
+  assert.deepEqual(
+    analytics.windows.all.coverage.duration,
+    { known: 2, total: 3, ratio: 2 / 3 },
+  );
+  assert.deepEqual(
+    analytics.windows.all.coverage.cost,
+    { known: 1, total: 3, ratio: 1 / 3 },
+  );
+  assert.equal(analytics.windows.all.costUsd, 0);
+  assert.deepEqual(
+    analytics.windows.all.coverage.harnessVersion,
+    { known: 1, total: 3, ratio: 1 / 3 },
+  );
+  assert.equal(analytics.recentAttempts.length, 1, "recent attempts are bounded");
+  assert.equal(
+    "cacheReadTokens" in analytics.recentAttempts[0],
+    false,
+    "an unknown recent-attempt metric remains absent",
+  );
+  assert.deepEqual(
+    Object.keys(analytics).sort(),
+    ["backfill", "generatedAt", "recentAttempts", "windows"],
+    "the analytics domain object contains only the response contract",
+  );
+}
+
+{
+  const routeSource = readFileSync(
+    path.join(apiRoot, "familiars", "[id]", "execution-analytics", "route.ts"),
+    "utf8",
+  );
+  const source = readFileSync(
+    path.join(root, "src", "lib", "server", "familiar-execution-analytics-source.ts"),
+    "utf8",
+  );
+  const projection = readFileSync(
+    path.join(root, "src", "lib", "server", "familiar-execution-analytics-projection.ts"),
+    "utf8",
+  );
+  assert.match(
+    routeSource,
+    /if \(!isValidFamiliarId\(id\)\)[\s\S]*?"path not allowed"[\s\S]*?status: 403/,
+    "/familiars/[id]/execution-analytics validates the familiar id before storage access",
+  );
+  assert.match(
+    routeSource,
+    /Math\.max\(0, Math\.min\(100, parsed\)\)/,
+    "/familiars/[id]/execution-analytics bounds recent attempts",
+  );
+  assert.match(
+    routeSource,
+    /__setFamiliarExecutionAnalyticsSourceForTests/,
+    "/familiars/[id]/execution-analytics exposes the established route test override",
+  );
+  assert.match(
+    routeSource,
+    /analytics: \{\s*generatedAt: analytics\.generatedAt,\s*windows: analytics\.windows,\s*recentAttempts: analytics\.recentAttempts,\s*backfill: analytics\.backfill,\s*\}/,
+    "/familiars/[id]/execution-analytics returns the exact public analytics shape",
+  );
+  assert.match(
+    source,
+    /listConversations[\s\S]*loadConversation[\s\S]*backfillFamiliarExecutionAttempts/,
+    "analytics source backfills from Cave-owned conversation files",
+  );
+  assert.match(
+    source,
+    /appendAttempts\(args\.familiarId, backfill\.toAppend\)[\s\S]*?\.catch\(\(\) => 0\)/,
+    "derived ledger persistence is best-effort",
+  );
+  assert.doesNotMatch(
+    projection,
+    /turn\.text|turn\.reasoning|tool\.input|tool\.output|conversation\.runtime|conversation\.branch|conversation\.prUrl/,
+    "conversation projection must not copy content, tool payloads, paths, or PR data",
   );
 }
 

--- a/src/app/api/familiars/[id]/execution-analytics/route.ts
+++ b/src/app/api/familiars/[id]/execution-analytics/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import type {
+  FamiliarExecutionAnalyticsErrorResponse,
+  FamiliarExecutionAnalyticsSuccessResponse,
+} from "@/lib/familiar-execution-analytics";
+import { isValidFamiliarId } from "@/lib/server/familiar-id";
+import { readFamiliarExecutionAnalytics } from "@/lib/server/familiar-execution-analytics-source";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type AnalyticsSource = typeof readFamiliarExecutionAnalytics;
+let analyticsSource: AnalyticsSource = readFamiliarExecutionAnalytics;
+
+export function __setFamiliarExecutionAnalyticsSourceForTests(
+  source?: AnalyticsSource,
+): void {
+  analyticsSource = source ?? readFamiliarExecutionAnalytics;
+}
+
+function recentLimit(req: Request): number {
+  const raw = new URL(req.url).searchParams.get("recent");
+  if (!raw) return 50;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? Math.max(0, Math.min(100, parsed)) : 50;
+}
+
+export async function GET(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  if (!isValidFamiliarId(id)) {
+    const response = {
+      ok: false,
+      error: "path not allowed",
+    } satisfies FamiliarExecutionAnalyticsErrorResponse;
+    return NextResponse.json(
+      response,
+      { status: 403 },
+    );
+  }
+
+  try {
+    const analytics = await analyticsSource({
+      familiarId: id,
+      recentLimit: recentLimit(req),
+    });
+    const response = {
+      ok: true,
+      analytics: {
+        generatedAt: analytics.generatedAt,
+        windows: analytics.windows,
+        recentAttempts: analytics.recentAttempts,
+        backfill: analytics.backfill,
+      },
+    } satisfies FamiliarExecutionAnalyticsSuccessResponse;
+    return NextResponse.json(
+      response,
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch {
+    const response = {
+      ok: false,
+      error: "Could not load familiar execution analytics.",
+    } satisfies FamiliarExecutionAnalyticsErrorResponse;
+    return NextResponse.json(
+      response,
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/familiar-analytics-content.tsx
+++ b/src/components/familiar-analytics-content.tsx
@@ -2,6 +2,11 @@
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { FamiliarAnalyticsModel } from "@/components/familiar-analytics-data";
+import type {
+  FamiliarExecutionAnalytics,
+  FamiliarExecutionAnalyticsWindow,
+  FamiliarExecutionSlice,
+} from "@/lib/familiar-execution-analytics";
 import type { FeedbackSliceStat, MessageFeedbackRollup } from "@/lib/message-feedback-rollup";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -52,6 +57,7 @@ import { SessionTraceOverlay, type TraceTarget } from "@/components/session-trac
 import { sessionDayKey, type PulseDay } from "@/lib/session-pulse";
 import { requestAgentsNewChat } from "@/lib/agents-new-chat";
 import { buildRehabilitationBrief } from "@/lib/familiar-rehabilitation";
+import { formatCost, formatTokens } from "@/lib/usage-format";
 import {
   aggregateThreadSignals,
   buildThreadSignalReviewQueue,
@@ -848,6 +854,210 @@ function ModelFeedbackSection({ rollup }: { rollup: MessageFeedbackRollup }) {
           {rollup.up} up · {rollup.down} down — older votes carry no model stamp; new votes bucket automatically.
         </p>
       ) : null}
+    </div>
+  );
+}
+
+const COVERAGE_LABELS: Record<string, string> = {
+  harnessVersion: "Harness version",
+  confirmedModel: "Confirmed model",
+  usage: "Token usage",
+  cost: "Reported cost",
+  duration: "Total duration",
+  firstOutput: "First output",
+  tools: "Tool activity",
+  quality: "Quality signal",
+};
+
+function formatRuntimePercent(value: number | null | undefined): string {
+  return typeof value === "number" ? `${Math.round(value * 100)}%` : "Unreported";
+}
+
+function formatRuntimeDuration(value: number | null | undefined): string {
+  if (typeof value !== "number") return "Unreported";
+  if (value < 1_000) return `${Math.round(value)} ms`;
+  if (value < 60_000) return `${(value / 1_000).toFixed(value < 10_000 ? 1 : 0)} s`;
+  return `${(value / 60_000).toFixed(1)} min`;
+}
+
+function RuntimeSliceList({ label, slices }: { label: string; slices: FamiliarExecutionSlice[] }) {
+  if (slices.length === 0) return null;
+  return (
+    <div className="fa-feedback-group">
+      <h3 className="fa-feedback-group__label">{label}</h3>
+      <ul className="fa-feedback-list">
+        {slices.map((slice) => {
+          const pct = typeof slice.successRate === "number" ? Math.round(slice.successRate * 100) : 0;
+          const name = slice.label ?? slice.key;
+          return (
+            <li key={slice.key} className="fa-feedback-row fa-runtime-row">
+              <span className="fa-feedback-row__name" title={slice.key}>{name}</span>
+              <span className="fa-feedback-row__bar" aria-hidden>
+                <i style={{ width: `${pct}%` }} />
+              </span>
+              <span className="fa-runtime-row__detail">
+                {slice.attempts} attempt{slice.attempts === 1 ? "" : "s"} ·{" "}
+                {formatRuntimePercent(slice.successRate)} success ·{" "}
+                {formatRuntimeDuration(slice.medianDurationMs)}
+              </span>
+              <span className="sr-only">
+                {`${name}: ${slice.attempts} attempts, ${formatRuntimePercent(slice.successRate)} success, median duration ${formatRuntimeDuration(slice.medianDurationMs)}`}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function RuntimeCoverage({ window }: { window: FamiliarExecutionAnalyticsWindow }) {
+  const coverage = Object.entries(window.coverage)
+    .filter(([, value]) => value.total > 0)
+    .sort((left, right) => left[1].ratio - right[1].ratio);
+  if (coverage.length === 0) return null;
+  return (
+    <div className="fa-feedback-group">
+      <h3 className="fa-feedback-group__label">Telemetry coverage</h3>
+      <ul className="fa-runtime-coverage">
+        {coverage.map(([key, value]) => (
+          <li key={key}>
+            <span>{COVERAGE_LABELS[key] ?? key}</span>
+            <b>{Math.round(value.ratio * 100)}%</b>
+            <small>{value.known} of {value.total}</small>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function RuntimeAttempts({
+  attempts,
+  onTrace,
+}: {
+  attempts: FamiliarExecutionAnalytics["recentAttempts"];
+  onTrace: (target: TraceTarget) => void;
+}) {
+  if (attempts.length === 0) return null;
+  return (
+    <div className="fa-feedback-group">
+      <h3 className="fa-feedback-group__label">Recent execution evidence</h3>
+      <ul className="fa-runtime-attempts">
+        {attempts.slice(0, 8).map((attempt) => {
+          const model = attempt.confirmedModel ?? attempt.forwardedModel ?? attempt.requestedModel ?? "Model unreported";
+          const harness = attempt.harnessVersion
+            ? `${attempt.harnessId} ${attempt.harnessVersion}`
+            : `${attempt.harnessId} · version unreported`;
+          const sessionId = attempt.sessionId;
+          return (
+            <li key={attempt.id} className="fa-runtime-attempt">
+              <span>
+                <b>{attempt.executionKind}</b>
+                <small>{model} · {harness}</small>
+              </span>
+              <span>
+                <b>{attempt.status}</b>
+                <small>
+                  {formatRuntimeDuration(attempt.durationMs)}
+                  {typeof attempt.totalTokens === "number" ? ` · ${formatTokens(attempt.totalTokens) ?? attempt.totalTokens} tokens` : ""}
+                  {typeof attempt.costUsd === "number" ? ` · ${formatCost(attempt.costUsd) ?? "reported cost"}` : ""}
+                </small>
+              </span>
+              {sessionId ? (
+                <button
+                  type="button"
+                  className="fa-primary-btn focus-ring"
+                  onClick={() => onTrace({ id: sessionId, title: `${attempt.executionKind} execution` })}
+                >
+                  Open trace
+                  <Icon name="ph:arrow-up-right" width={11} aria-hidden />
+                </button>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function RuntimePerformanceSection({
+  analytics,
+  rollup,
+  windowId,
+  now,
+  onTrace,
+}: {
+  analytics: FamiliarExecutionAnalytics | null;
+  rollup: MessageFeedbackRollup;
+  windowId: WindowId;
+  now: number;
+  onTrace: (target: TraceTarget) => void;
+}) {
+  if (!analytics) {
+    return (
+      <div className="fa-feedback">
+        <EmptyState
+          compact
+          icon="ph:chart-bar"
+          headline="Execution telemetry unavailable."
+          subtitle="Runtime evidence could not be loaded. Existing thumbs feedback is still shown below."
+        />
+        <ModelFeedbackSection rollup={rollup} />
+      </div>
+    );
+  }
+
+  const window = analytics.windows[windowId];
+  const recentAttempts = analytics.recentAttempts.filter((attempt) =>
+    withinWindow(attempt.occurredAt, windowId, now));
+  if (window.attempts === 0 && rollup.total === 0) {
+    return (
+      <EmptyState
+        compact
+        icon="ph:chart-bar"
+        headline="No runtime evidence yet."
+        subtitle="Run this familiar in Chat or Board; reported execution fields will appear here."
+      />
+    );
+  }
+
+  return (
+    <div className="fa-runtime-performance">
+      <div className="fa-foot-panel__stats">
+        <span className="fa-pulse-stat fa-pulse-stat--accent">
+          <b>{window.attempts}</b>
+          <span>Attempts</span>
+          <small>{window.completed} completed</small>
+        </span>
+        <span className="fa-pulse-stat fa-pulse-stat--good">
+          <b>{formatRuntimePercent(window.successRate)}</b>
+          <span>Success</span>
+          <small>{window.failed} failed · {window.cancelled} cancelled</small>
+        </span>
+        <span className="fa-pulse-stat fa-pulse-stat--accent">
+          <b>{formatRuntimeDuration(window.medianDurationMs)}</b>
+          <span>Median duration</span>
+          <small>p95 {formatRuntimeDuration(window.p95DurationMs)}</small>
+        </span>
+        <span className="fa-pulse-stat fa-pulse-stat--warn">
+          <b>{typeof window.totalTokens === "number" ? formatTokens(window.totalTokens) ?? window.totalTokens : "Unreported"}</b>
+          <span>Tokens</span>
+          <small>{typeof window.costUsd === "number" ? formatCost(window.costUsd) ?? "Reported" : "cost unreported"}</small>
+        </span>
+      </div>
+
+      <div className="fa-runtime-grid">
+        <RuntimeSliceList label="Models" slices={window.models} />
+        <RuntimeSliceList label="Harnesses and versions" slices={window.harnesses} />
+      </div>
+      <RuntimeCoverage window={window} />
+      <RuntimeAttempts attempts={recentAttempts} onTrace={onTrace} />
+      <div className="fa-feedback-group">
+        <h3 className="fa-feedback-group__label">Thumbs feedback</h3>
+        <ModelFeedbackSection rollup={rollup} />
+      </div>
     </div>
   );
 }
@@ -1965,10 +2175,11 @@ export function FamiliarAnalyticsContent({
             aria-expanded={deepDive === "model"}
             onClick={() => setDeepDive((prev) => (prev === "model" ? null : "model"))}
           >
-            <Icon name="ph:thumbs-up" width={13} aria-hidden />
-            <b>Model performance</b>
+            <Icon name="ph:chart-bar" width={13} aria-hidden />
+            <b>Runtime performance</b>
             <span className="fa-band-count">
-              {model.modelFeedback.total} vote{model.modelFeedback.total === 1 ? "" : "s"}
+              {model.executionAnalytics?.windows[windowId].attempts ?? 0} attempt
+              {(model.executionAnalytics?.windows[windowId].attempts ?? 0) === 1 ? "" : "s"}
             </span>
             <Icon name="ph:caret-up" className="fa-foot__caret" width={11} aria-hidden />
           </button>
@@ -2044,10 +2255,10 @@ export function FamiliarAnalyticsContent({
         {deepDive === "model" ? (
           <div className="fa-foot-panel">
             <div className="fa-foot-panel__head">
-              <Icon name="ph:thumbs-up" width={14} aria-hidden />
-              <b>Model performance — summary</b>
+              <Icon name="ph:chart-bar" width={14} aria-hidden />
+              <b>Runtime performance — summary</b>
               <span className="fa-band-hint">
-                thumbs votes on chat replies, netted per message
+                measured execution metadata with explicit coverage
               </span>
               <button type="button" className="fa-primary-btn focus-ring" onClick={() => openOverlay("model")}>
                 Open full view
@@ -2062,7 +2273,13 @@ export function FamiliarAnalyticsContent({
                 <Icon name="ph:caret-down" width={12} aria-hidden />
               </button>
             </div>
-            <ModelFeedbackSection rollup={model.modelFeedback} />
+            <RuntimePerformanceSection
+              analytics={model.executionAnalytics}
+              rollup={model.modelFeedback}
+              windowId={windowId}
+              now={now}
+              onTrace={setTraceTarget}
+            />
           </div>
         ) : null}
 
@@ -2087,21 +2304,28 @@ export function FamiliarAnalyticsContent({
 
         {overlay === "model" ? (
           <StageOverlay
-            label="Model performance"
+            label="Runtime performance"
             onClose={() => setOverlay(null)}
             head={
               <>
-                <h2 className="fa-overlay__title">Model performance</h2>
+                <h2 className="fa-overlay__title">Runtime performance</h2>
                 <span className="fa-band-count">
-                  {model.modelFeedback.total} vote{model.modelFeedback.total === 1 ? "" : "s"}
+                  {model.executionAnalytics?.windows[windowId].attempts ?? 0} attempt
+                  {(model.executionAnalytics?.windows[windowId].attempts ?? 0) === 1 ? "" : "s"}
                 </span>
                 <span className="fa-band-hint">
-                  thumbs votes on chat replies, netted per message — last vote wins
+                  local metadata only — unreported fields stay absent
                 </span>
               </>
             }
           >
-            <ModelFeedbackSection rollup={model.modelFeedback} />
+            <RuntimePerformanceSection
+              analytics={model.executionAnalytics}
+              rollup={model.modelFeedback}
+              windowId={windowId}
+              now={now}
+              onTrace={setTraceTarget}
+            />
           </StageOverlay>
         ) : null}
 

--- a/src/components/familiar-analytics-data.ts
+++ b/src/components/familiar-analytics-data.ts
@@ -22,6 +22,7 @@ import {
   EMPTY_FEEDBACK_ROLLUP,
   type MessageFeedbackRollup,
 } from "@/lib/message-feedback-rollup";
+import type { FamiliarExecutionAnalytics } from "@/lib/familiar-execution-analytics";
 import type { Familiar, SessionRow } from "@/lib/types";
 
 type FamiliarsResponse =
@@ -52,6 +53,10 @@ type MessageFeedbackResponse =
   | { ok: true; rollup: MessageFeedbackRollup }
   | { ok: false; rollup?: MessageFeedbackRollup; error?: string };
 
+type ExecutionAnalyticsResponse =
+  | { ok: true; analytics: FamiliarExecutionAnalytics }
+  | { ok: false; analytics?: FamiliarExecutionAnalytics; error?: string };
+
 export type FamiliarAnalyticsData = {
   familiarId: string;
   familiars: Familiar[];
@@ -65,6 +70,8 @@ export type FamiliarAnalyticsData = {
   metricSnapshots: ThreadMetricSnapshot[];
   /** Thumbs-vote aggregates by model/runtime (message-feedback-rollup). */
   modelFeedback: MessageFeedbackRollup;
+  /** Metadata-only model/harness execution analytics across Cave run surfaces. */
+  executionAnalytics: FamiliarExecutionAnalytics | null;
   errors: string[];
 };
 
@@ -83,6 +90,8 @@ export type FamiliarAnalyticsModel = {
   metricSnapshots: ThreadMetricSnapshot[];
   /** Thumbs-vote aggregates by model/runtime (message-feedback-rollup). */
   modelFeedback: MessageFeedbackRollup;
+  /** Metadata-only model/harness execution analytics across Cave run surfaces. */
+  executionAnalytics: FamiliarExecutionAnalytics | null;
   /**
    * Renown + ritual streak — the progression system's read of this familiar
    * (same derivation as the roster cards, so the surfaces always agree).
@@ -174,6 +183,7 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
     selfReportsJson,
     metricSnapshotsJson,
     feedbackJson,
+    executionAnalyticsJson,
   ] = await Promise.all([
     fetchResource<FamiliarsResponse>("/api/familiars", { ok: false, familiars: [] }),
     fetchResource<ContractResponse>(`/api/familiars/${encodedId}/contract`, { ok: false }),
@@ -189,6 +199,7 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
     fetchResource<SelfReportsResponse>(`/api/familiars/${encodedId}/self-reports?limit=all`, { ok: false, reports: [], total: 0 }),
     fetchResource<MetricSnapshotsResponse>(`/api/familiars/${encodedId}/self-reports/snapshots`, { ok: false, snapshots: [], total: 0 }),
     fetchResource<MessageFeedbackResponse>(`/api/feedback/message?familiarId=${encodedId}`, { ok: false }),
+    fetchResource<ExecutionAnalyticsResponse>(`/api/familiars/${encodedId}/execution-analytics`, { ok: false }),
   ]);
 
   const errors = [
@@ -201,6 +212,7 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
     responseError(retroJson, "retro runs unavailable"),
     responseError(metricSnapshotsJson, "metric snapshots unavailable"),
     responseError(feedbackJson, "message feedback unavailable"),
+    responseError(executionAnalyticsJson, "execution analytics unavailable"),
   ].filter((error): error is string => Boolean(error));
 
   return {
@@ -218,6 +230,7 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
     threadReports: Array.isArray(selfReportsJson.reports) ? selfReportsJson.reports : [],
     metricSnapshots: metricSnapshotsJson.ok ? metricSnapshotsJson.snapshots : [],
     modelFeedback: feedbackJson.ok ? feedbackJson.rollup : EMPTY_FEEDBACK_ROLLUP,
+    executionAnalytics: executionAnalyticsJson.ok ? executionAnalyticsJson.analytics : null,
     errors,
   };
 }
@@ -266,6 +279,7 @@ export function buildFamiliarAnalyticsModel(
     threadReports: data.threadReports,
     metricSnapshots: data.metricSnapshots,
     modelFeedback: data.modelFeedback,
+    executionAnalytics: data.executionAnalytics,
     progression: familiar
       ? {
           renown: deriveRenown({ sessionsTotal: stats.sessionsTotal, memoryCount: stats.memoryCount }),

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -67,10 +67,103 @@ function mockFetchFor(score: "low" | "trusted") {
           violations: [],
           warnings: [],
         };
+  const executionWindow = {
+    attempts: score === "trusted" ? 2 : 0,
+    completed: score === "trusted" ? 2 : 0,
+    failed: 0,
+    cancelled: 0,
+    successRate: score === "trusted" ? 1 : null,
+    medianDurationMs: score === "trusted" ? 1_200 : undefined,
+    p95DurationMs: score === "trusted" ? 1_800 : undefined,
+    totalTokens: score === "trusted" ? 2_400 : undefined,
+    costUsd: score === "trusted" ? 0.04 : undefined,
+    toolCalls: score === "trusted" ? 3 : 0,
+    toolFailures: 0,
+    coverage: {
+      harnessVersion: { known: score === "trusted" ? 2 : 0, total: score === "trusted" ? 2 : 0, ratio: score === "trusted" ? 1 : 0 },
+      confirmedModel: { known: score === "trusted" ? 2 : 0, total: score === "trusted" ? 2 : 0, ratio: score === "trusted" ? 1 : 0 },
+      usage: { known: score === "trusted" ? 1 : 0, total: score === "trusted" ? 2 : 0, ratio: score === "trusted" ? 0.5 : 0 },
+      cost: { known: score === "trusted" ? 1 : 0, total: score === "trusted" ? 2 : 0, ratio: score === "trusted" ? 0.5 : 0 },
+      duration: { known: score === "trusted" ? 2 : 0, total: score === "trusted" ? 2 : 0, ratio: score === "trusted" ? 1 : 0 },
+      tools: { known: score === "trusted" ? 2 : 0, total: score === "trusted" ? 2 : 0, ratio: score === "trusted" ? 1 : 0 },
+    },
+    models: score === "trusted"
+      ? [{
+          key: "claude-sonnet-4",
+          label: "claude-sonnet-4",
+          attempts: 2,
+          completed: 2,
+          failed: 0,
+          cancelled: 0,
+          successRate: 1,
+          medianDurationMs: 1_200,
+          totalTokens: 2_400,
+          costUsd: 0.04,
+          toolCalls: 3,
+          toolFailures: 0,
+        }]
+      : [],
+    harnesses: score === "trusted"
+      ? [{
+          key: "claude@1.0.0",
+          label: "claude 1.0.0",
+          attempts: 2,
+          completed: 2,
+          failed: 0,
+          cancelled: 0,
+          successRate: 1,
+          medianDurationMs: 1_200,
+          totalTokens: 2_400,
+          costUsd: 0.04,
+          toolCalls: 3,
+          toolFailures: 0,
+        }]
+      : [],
+  };
 
   const responses = new Map<string, unknown>([
     ["/api/familiars", { ok: true, familiars: [familiar] }],
     ["/api/familiars/cody/contract", { ok: true, report: contract }],
+    [
+      "/api/familiars/cody/execution-analytics",
+      {
+        ok: true,
+        analytics: {
+          generatedAt: "2026-06-25T12:00:00.000Z",
+          windows: {
+            "7d": executionWindow,
+            "14d": executionWindow,
+            "8w": executionWindow,
+            all: executionWindow,
+          },
+          recentAttempts: score === "trusted"
+            ? [{
+                id: "attempt-1",
+                sessionId: "session-1",
+                turnId: "turn-1",
+                executionKind: "chat",
+                occurredAt: "2026-06-25T12:00:00.000Z",
+                harnessId: "claude",
+                harnessVersion: "1.0.0",
+                requestedModel: "claude-sonnet-4",
+                forwardedModel: "claude-sonnet-4",
+                confirmedModel: "claude-sonnet-4",
+                status: "completed",
+                durationMs: 1_200,
+                totalTokens: 1_200,
+                costUsd: 0.02,
+                toolCalls: 1,
+                toolFailures: 0,
+                provenance: "backfilled",
+              }]
+            : [],
+          backfill: {
+            state: "complete",
+            imported: score === "trusted" ? 2 : 0,
+          },
+        },
+      },
+    ],
     [
       "/api/sessions/list?includeArchived=1&familiarId=cody",
       {
@@ -506,17 +599,22 @@ describe("FamiliarAnalyticsView", () => {
     assert.match(stageSource, /const pulse = model\.sessionPulse/, "pulse is wired to the model");
   });
 
-  it("surfaces thumbs-vote model/runtime performance from the feedback rollup", async () => {
+  it("surfaces execution telemetry and preserves thumbs feedback in runtime performance", async () => {
     mockFetchFor("trusted");
     const data = await loadFamiliarAnalyticsData("cody");
     const model = buildFamiliarAnalyticsModel(data);
 
+    assert.equal(model.executionAnalytics?.windows["14d"].attempts, 2);
+    assert.equal(model.executionAnalytics?.windows["14d"].coverage.usage.ratio, 0.5);
     assert.equal(model.modelFeedback.total, 3, "the rollup rides the model");
     assert.equal(model.modelFeedback.models[0].key, "claude-sonnet-4");
     assert.equal(model.modelFeedback.runtimes[0].up, 2);
-    assert.match(contentSource, /<b>Model performance<\/b>/, "the footer carries a Model performance deep dive");
+    assert.match(contentSource, /<b>Runtime performance<\/b>/, "the footer carries a Runtime performance deep dive");
     assert.match(contentSource, /openOverlay\("model"\)/, "the deep dive opens the full-stage view");
-    assert.match(source, /<ModelFeedbackSection rollup=\{model\.modelFeedback\}/, "the panel is wired to the rollup");
+    assert.match(source, /<RuntimePerformanceSection/, "the panel is wired to execution telemetry");
+    assert.match(source, /Telemetry coverage/, "missing-field coverage is explicit");
+    assert.match(source, /Recent execution evidence/, "recent attempts remain drillable");
+    assert.match(source, /Thumbs feedback/, "quality evidence remains visible");
     assert.match(source, /ph:thumbs-up/, "rows show up-vote counts");
     assert.match(source, /ph:thumbs-down/, "rows show down-vote counts");
   });

--- a/src/lib/familiar-execution-analytics.ts
+++ b/src/lib/familiar-execution-analytics.ts
@@ -1,0 +1,772 @@
+import type { ModelControlFamily, ModelControlValues } from "./model-control-capabilities.ts";
+import type { SessionOrigin } from "./types.ts";
+
+export const EXECUTION_ATTEMPT_SCHEMA_VERSION = 1 as const;
+export const EXECUTION_ATTEMPT_LEDGER_VERSION = 1 as const;
+export const FAMILIAR_EXECUTION_ANALYTICS_VERSION = 1 as const;
+
+export const EXECUTION_ANALYTICS_WINDOWS = ["7d", "14d", "8w", "all"] as const;
+export type ExecutionAnalyticsWindowKey = (typeof EXECUTION_ANALYTICS_WINDOWS)[number];
+
+export type ExecutionKind = "assistant-response";
+export type ExecutionOutcomeStatus = "succeeded" | "error" | "cancelled";
+export type ExecutionToolStatus = "running" | "ok" | "error";
+
+export type ExecutionModelSelection =
+  | { kind: "model"; id: string }
+  | { kind: "runtime-default" };
+
+export const EXECUTION_ATTEMPT_COVERAGE_FIELDS = [
+  "harness.id",
+  "harness.version",
+  "models.requested",
+  "models.forwarded",
+  "models.confirmed",
+  "controls.requested",
+  "controls.forwarded",
+  "controls.applied",
+  "timing.durationMs",
+  "usage.inputTokens",
+  "usage.outputTokens",
+  "usage.cacheReadTokens",
+  "usage.cacheCreationTokens",
+  "costUsd",
+  "tools",
+] as const;
+export type ExecutionAttemptCoverageField =
+  (typeof EXECUTION_ATTEMPT_COVERAGE_FIELDS)[number];
+
+export type ExecutionAttemptSnapshotV1 = {
+  schemaVersion: typeof EXECUTION_ATTEMPT_SCHEMA_VERSION;
+  attemptId: string;
+  /** Public drill-down alias retained alongside the explicit attempt identity. */
+  id: string;
+  familiarId: string;
+  sessionId: string;
+  turnId: string;
+  attemptNumber: number;
+  executionKind: string;
+  occurredAt: string;
+  origin?: SessionOrigin;
+  harnessId?: string;
+  harnessVersion?: string;
+  requestedModel?: string;
+  forwardedModel?: string;
+  confirmedModel?: string;
+  status: "completed" | "failed" | "cancelled";
+  durationMs?: number;
+  totalTokens?: number;
+  toolCalls?: number;
+  toolFailures?: number;
+  execution: {
+    kind: ExecutionKind;
+    origin?: SessionOrigin;
+  };
+  harness?: {
+    id?: string;
+    version?: string;
+  };
+  models?: {
+    requested?: ExecutionModelSelection;
+    forwarded?: string;
+    confirmed?: string;
+  };
+  controls?: {
+    requested?: ModelControlValues;
+    forwarded?: ModelControlValues;
+    applied?: ModelControlValues;
+    rejectedFamilies?: ModelControlFamily[];
+  };
+  timing: {
+    completedAt: string;
+    durationMs?: number;
+  };
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheCreationTokens?: number;
+  };
+  costUsd?: number;
+  outcome: {
+    status: ExecutionOutcomeStatus;
+  };
+  tools?: Array<{
+    name: string;
+    status: ExecutionToolStatus;
+    durationMs?: number;
+  }>;
+  provenance: {
+    source: "live" | "conversation-backfill";
+    sourceSchema: "execution-attempt-v1" | "cave-conversation-v1";
+    capturedAt: string;
+  };
+  coverage: {
+    knownFields: ExecutionAttemptCoverageField[];
+  };
+};
+
+export type ExecutionAttemptLedgerRecordV1 = {
+  ledgerVersion: typeof EXECUTION_ATTEMPT_LEDGER_VERSION;
+  snapshot: ExecutionAttemptSnapshotV1;
+};
+
+export type KnownDenominator = {
+  known: number;
+  total: number;
+};
+
+export type NumericAggregate = KnownDenominator & {
+  sum?: number;
+  average?: number;
+  min?: number;
+  max?: number;
+};
+
+export type DimensionAggregate = KnownDenominator & {
+  values: Array<{ value: string; attempts: number }>;
+};
+
+export type FamiliarExecutionSlice = {
+  key: string;
+  label?: string;
+  attempts: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+  successRate: number | null;
+  medianDurationMs?: number;
+  totalTokens?: number;
+  costUsd?: number;
+  toolCalls: number;
+  toolFailures: number;
+};
+
+export type FamiliarExecutionCoverage = KnownDenominator & {
+  ratio: number;
+};
+
+export type FamiliarExecutionAnalyticsWindow = {
+  attempts: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+  successRate: number | null;
+  medianDurationMs?: number;
+  p95DurationMs?: number;
+  totalTokens?: number;
+  costUsd?: number;
+  toolCalls: number;
+  toolFailures: number;
+  models: FamiliarExecutionSlice[];
+  harnesses: FamiliarExecutionSlice[];
+  coverage: Record<string, FamiliarExecutionCoverage>;
+};
+
+export type ExecutionAnalyticsWindow = FamiliarExecutionAnalyticsWindow;
+
+export type FamiliarExecutionAttemptProvenance = "live" | "backfilled";
+
+export type FamiliarExecutionAttemptSummary = {
+  id: string;
+  sessionId?: string;
+  turnId?: string;
+  executionKind: string;
+  occurredAt: string;
+  harnessId: string;
+  harnessVersion?: string;
+  requestedModel?: string;
+  forwardedModel?: string;
+  confirmedModel?: string;
+  status: "completed" | "failed" | "cancelled";
+  durationMs?: number;
+  totalTokens?: number;
+  costUsd?: number;
+  toolCalls: number;
+  toolFailures: number;
+  provenance: FamiliarExecutionAttemptProvenance;
+};
+
+export type FamiliarExecutionBackfillState = {
+  state: "complete" | "partial" | "not-started";
+  imported: number;
+  remaining?: number;
+};
+
+export type FamiliarExecutionAnalyticsWindows = Record<
+  ExecutionAnalyticsWindowKey,
+  FamiliarExecutionAnalyticsWindow
+>;
+
+export type FamiliarExecutionAnalytics = {
+  generatedAt: string;
+  windows: FamiliarExecutionAnalyticsWindows;
+  recentAttempts: FamiliarExecutionAttemptSummary[];
+  backfill: FamiliarExecutionBackfillState;
+};
+
+export type FamiliarExecutionAnalyticsSuccessResponse = {
+  ok: true;
+  analytics: FamiliarExecutionAnalytics;
+};
+
+export type FamiliarExecutionAnalyticsErrorResponse = {
+  ok: false;
+  error: string;
+};
+
+export type FamiliarExecutionAnalyticsResponse =
+  | FamiliarExecutionAnalyticsSuccessResponse
+  | FamiliarExecutionAnalyticsErrorResponse;
+
+const SESSION_ORIGINS = new Set<SessionOrigin>([
+  "chat",
+  "mention",
+  "board",
+  "cron",
+  "heartbeat",
+  "call",
+  "canvas",
+  "journal",
+  "enhance",
+]);
+const OUTCOMES = new Set<ExecutionOutcomeStatus>(["succeeded", "error", "cancelled"]);
+const TOOL_STATUSES = new Set<ExecutionToolStatus>(["running", "ok", "error"]);
+const CONTROL_FAMILIES = new Set<ModelControlFamily>([
+  "reasoning",
+  "performance",
+  "verbosity",
+  "output-limit",
+  "modalities",
+  "tool-support",
+]);
+const COVERAGE_FIELDS = new Set<ExecutionAttemptCoverageField>(
+  EXECUTION_ATTEMPT_COVERAGE_FIELDS,
+);
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function safeText(value: unknown, maxLength = 256): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, maxLength);
+}
+
+function nonNegative(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function isoInstant(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? new Date(time).toISOString() : undefined;
+}
+
+function normalizeControls(value: unknown): ModelControlValues | undefined {
+  const raw = record(value);
+  if (!raw) return undefined;
+  const controls: ModelControlValues = {};
+  for (const family of CONTROL_FAMILIES) {
+    const control = safeText(raw[family], 64);
+    if (control) controls[family] = control;
+  }
+  return Object.keys(controls).length ? controls : undefined;
+}
+
+function normalizeModelSelection(value: unknown): ExecutionModelSelection | undefined {
+  const raw = record(value);
+  if (!raw) return undefined;
+  if (raw.kind === "runtime-default") return { kind: "runtime-default" };
+  if (raw.kind !== "model") return undefined;
+  const id = safeText(raw.id);
+  return id ? { kind: "model", id } : undefined;
+}
+
+function modelSelectionLabel(value: ExecutionModelSelection): string {
+  return value.kind === "runtime-default" ? "runtime-default" : value.id;
+}
+
+function normalizeSnapshotTools(value: unknown): ExecutionAttemptSnapshotV1["tools"] {
+  if (!Array.isArray(value)) return undefined;
+  const tools: NonNullable<ExecutionAttemptSnapshotV1["tools"]> = [];
+  for (const item of value.slice(0, 100)) {
+    const raw = record(item);
+    if (!raw) continue;
+    const name = safeText(raw.name, 128);
+    const status = typeof raw.status === "string" &&
+      TOOL_STATUSES.has(raw.status as ExecutionToolStatus)
+      ? raw.status as ExecutionToolStatus
+      : undefined;
+    if (!name || !status) continue;
+    const durationMs = nonNegative(raw.durationMs);
+    tools.push({
+      name,
+      status,
+      ...(durationMs !== undefined ? { durationMs } : {}),
+    });
+  }
+  return tools;
+}
+
+function coverageForSnapshot(
+  snapshot: Omit<ExecutionAttemptSnapshotV1, "coverage">,
+): ExecutionAttemptCoverageField[] {
+  const known = new Set<ExecutionAttemptCoverageField>();
+  if (snapshot.harness?.id) known.add("harness.id");
+  if (snapshot.harness?.version) known.add("harness.version");
+  if (snapshot.models?.requested) known.add("models.requested");
+  if (snapshot.models?.forwarded) known.add("models.forwarded");
+  if (snapshot.models?.confirmed) known.add("models.confirmed");
+  if (snapshot.controls?.requested) known.add("controls.requested");
+  if (snapshot.controls?.forwarded) known.add("controls.forwarded");
+  if (snapshot.controls?.applied) known.add("controls.applied");
+  if (snapshot.timing.durationMs !== undefined) known.add("timing.durationMs");
+  if (snapshot.usage?.inputTokens !== undefined) known.add("usage.inputTokens");
+  if (snapshot.usage?.outputTokens !== undefined) known.add("usage.outputTokens");
+  if (snapshot.usage?.cacheReadTokens !== undefined) known.add("usage.cacheReadTokens");
+  if (snapshot.usage?.cacheCreationTokens !== undefined) known.add("usage.cacheCreationTokens");
+  if (snapshot.costUsd !== undefined) known.add("costUsd");
+  if (snapshot.tools !== undefined) known.add("tools");
+  return EXECUTION_ATTEMPT_COVERAGE_FIELDS.filter((field) => known.has(field));
+}
+
+/**
+ * Copy an untrusted value into the metadata-only execution snapshot contract.
+ * The allowlist is deliberate: transcript content, tool payloads, paths, raw
+ * errors, and unknown future payload fields cannot survive this boundary.
+ */
+export function normalizeExecutionAttemptSnapshot(
+  value: unknown,
+): ExecutionAttemptSnapshotV1 | null {
+  const raw = record(value);
+  if (!raw || raw.schemaVersion !== EXECUTION_ATTEMPT_SCHEMA_VERSION) return null;
+  const attemptId = safeText(raw.attemptId);
+  const familiarId = safeText(raw.familiarId, 64);
+  const sessionId = safeText(raw.sessionId);
+  const turnId = safeText(raw.turnId);
+  const attemptNumber = positiveInteger(raw.attemptNumber);
+  const executionRaw = record(raw.execution);
+  const timingRaw = record(raw.timing);
+  const outcomeRaw = record(raw.outcome);
+  const provenanceRaw = record(raw.provenance);
+  if (
+    !attemptId ||
+    !familiarId ||
+    !sessionId ||
+    !turnId ||
+    !attemptNumber ||
+    executionRaw?.kind !== "assistant-response" ||
+    !timingRaw ||
+    !outcomeRaw ||
+    !provenanceRaw
+  ) return null;
+
+  const completedAt = isoInstant(timingRaw.completedAt);
+  const capturedAt = isoInstant(provenanceRaw.capturedAt);
+  const outcomeStatus = typeof outcomeRaw.status === "string" &&
+    OUTCOMES.has(outcomeRaw.status as ExecutionOutcomeStatus)
+    ? outcomeRaw.status as ExecutionOutcomeStatus
+    : undefined;
+  const provenanceSource = provenanceRaw.source === "live" ||
+    provenanceRaw.source === "conversation-backfill"
+    ? provenanceRaw.source
+    : undefined;
+  const sourceSchema = provenanceRaw.sourceSchema === "execution-attempt-v1" ||
+    provenanceRaw.sourceSchema === "cave-conversation-v1"
+    ? provenanceRaw.sourceSchema
+    : undefined;
+  if (!completedAt || !capturedAt || !outcomeStatus || !provenanceSource || !sourceSchema) {
+    return null;
+  }
+
+  const origin = typeof executionRaw.origin === "string" &&
+    SESSION_ORIGINS.has(executionRaw.origin as SessionOrigin)
+    ? executionRaw.origin as SessionOrigin
+    : undefined;
+  const harnessRaw = record(raw.harness);
+  const harnessId = safeText(harnessRaw?.id, 128);
+  const harnessVersion = safeText(harnessRaw?.version, 128);
+  const harness = harnessId || harnessVersion
+    ? {
+        ...(harnessId ? { id: harnessId } : {}),
+        ...(harnessVersion ? { version: harnessVersion } : {}),
+      }
+    : undefined;
+
+  const modelsRaw = record(raw.models);
+  const requested = normalizeModelSelection(modelsRaw?.requested);
+  const forwarded = safeText(modelsRaw?.forwarded);
+  const confirmed = safeText(modelsRaw?.confirmed);
+  const models = requested || forwarded || confirmed
+    ? {
+        ...(requested ? { requested } : {}),
+        ...(forwarded ? { forwarded } : {}),
+        ...(confirmed ? { confirmed } : {}),
+      }
+    : undefined;
+
+  const controlsRaw = record(raw.controls);
+  const requestedControls = normalizeControls(controlsRaw?.requested);
+  const forwardedControls = normalizeControls(controlsRaw?.forwarded);
+  const appliedControls = normalizeControls(controlsRaw?.applied);
+  const rejectedFamilies = Array.isArray(controlsRaw?.rejectedFamilies)
+    ? [...new Set(controlsRaw.rejectedFamilies.filter(
+        (family): family is ModelControlFamily =>
+          typeof family === "string" && CONTROL_FAMILIES.has(family as ModelControlFamily),
+      ))]
+    : undefined;
+  const controls = requestedControls || forwardedControls || appliedControls ||
+    rejectedFamilies?.length
+    ? {
+        ...(requestedControls ? { requested: requestedControls } : {}),
+        ...(forwardedControls ? { forwarded: forwardedControls } : {}),
+        ...(appliedControls ? { applied: appliedControls } : {}),
+        ...(rejectedFamilies?.length ? { rejectedFamilies } : {}),
+      }
+    : undefined;
+
+  const usageRaw = record(raw.usage);
+  const inputTokens = nonNegative(usageRaw?.inputTokens);
+  const outputTokens = nonNegative(usageRaw?.outputTokens);
+  const cacheReadTokens = nonNegative(usageRaw?.cacheReadTokens);
+  const cacheCreationTokens = nonNegative(usageRaw?.cacheCreationTokens);
+  const usage = inputTokens !== undefined || outputTokens !== undefined ||
+    cacheReadTokens !== undefined || cacheCreationTokens !== undefined
+    ? {
+        ...(inputTokens !== undefined ? { inputTokens } : {}),
+        ...(outputTokens !== undefined ? { outputTokens } : {}),
+        ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+        ...(cacheCreationTokens !== undefined ? { cacheCreationTokens } : {}),
+      }
+    : undefined;
+  const durationMs = nonNegative(timingRaw.durationMs);
+  const costUsd = nonNegative(raw.costUsd);
+  const tools = normalizeSnapshotTools(raw.tools);
+  const totalTokens = usage &&
+    (usage.inputTokens !== undefined || usage.outputTokens !== undefined)
+    ? (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)
+    : undefined;
+  const publicStatus = outcomeStatus === "succeeded"
+    ? "completed"
+    : outcomeStatus === "error"
+      ? "failed"
+      : "cancelled";
+
+  const snapshotWithoutCoverage: Omit<ExecutionAttemptSnapshotV1, "coverage"> = {
+    schemaVersion: EXECUTION_ATTEMPT_SCHEMA_VERSION,
+    attemptId,
+    id: attemptId,
+    familiarId,
+    sessionId,
+    turnId,
+    attemptNumber,
+    executionKind: origin ?? "assistant-response",
+    occurredAt: completedAt,
+    ...(origin ? { origin } : {}),
+    ...(harnessId ? { harnessId } : {}),
+    ...(harnessVersion ? { harnessVersion } : {}),
+    ...(requested ? { requestedModel: modelSelectionLabel(requested) } : {}),
+    ...(forwarded ? { forwardedModel: forwarded } : {}),
+    ...(confirmed ? { confirmedModel: confirmed } : {}),
+    status: publicStatus,
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+    ...(tools !== undefined
+      ? {
+          toolCalls: tools.length,
+          toolFailures: tools.filter((tool) => tool.status === "error").length,
+        }
+      : {}),
+    execution: {
+      kind: "assistant-response",
+      ...(origin ? { origin } : {}),
+    },
+    ...(harness ? { harness } : {}),
+    ...(models ? { models } : {}),
+    ...(controls ? { controls } : {}),
+    timing: {
+      completedAt,
+      ...(durationMs !== undefined ? { durationMs } : {}),
+    },
+    ...(usage ? { usage } : {}),
+    ...(costUsd !== undefined ? { costUsd } : {}),
+    outcome: { status: outcomeStatus },
+    ...(tools !== undefined ? { tools } : {}),
+    provenance: {
+      source: provenanceSource,
+      sourceSchema,
+      capturedAt,
+    },
+  };
+  return {
+    ...snapshotWithoutCoverage,
+    coverage: { knownFields: coverageForSnapshot(snapshotWithoutCoverage) },
+  };
+}
+
+export function normalizeExecutionAttemptLedgerRecord(
+  value: unknown,
+): ExecutionAttemptLedgerRecordV1 | null {
+  const raw = record(value);
+  if (!raw || raw.ledgerVersion !== EXECUTION_ATTEMPT_LEDGER_VERSION) return null;
+  const snapshot = normalizeExecutionAttemptSnapshot(raw.snapshot);
+  return snapshot
+    ? { ledgerVersion: EXECUTION_ATTEMPT_LEDGER_VERSION, snapshot }
+    : null;
+}
+
+export function executionAttemptLedgerRecord(
+  snapshot: ExecutionAttemptSnapshotV1,
+): ExecutionAttemptLedgerRecordV1 {
+  return {
+    ledgerVersion: EXECUTION_ATTEMPT_LEDGER_VERSION,
+    snapshot,
+  };
+}
+
+function knownDenominator(
+  attempts: ExecutionAttemptSnapshotV1[],
+  known: (attempt: ExecutionAttemptSnapshotV1) => boolean,
+): KnownDenominator {
+  return {
+    known: attempts.filter(known).length,
+    total: attempts.length,
+  };
+}
+
+function reportedNumber(
+  attempts: ExecutionAttemptSnapshotV1[],
+  value: (attempt: ExecutionAttemptSnapshotV1) => number | undefined,
+): number | undefined {
+  const values = attempts
+    .map(value)
+    .filter((item): item is number => item !== undefined);
+  return values.length
+    ? values.reduce((total, item) => total + item, 0)
+    : undefined;
+}
+
+function percentile(values: number[], quantile: number): number | undefined {
+  if (!values.length) return undefined;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * quantile) - 1);
+  return sorted[Math.max(0, index)];
+}
+
+function coverageRatio(value: KnownDenominator): FamiliarExecutionCoverage {
+  return {
+    ...value,
+    ratio: value.total > 0 ? value.known / value.total : 0,
+  };
+}
+
+function executionSlice(
+  key: string,
+  label: string,
+  attempts: ExecutionAttemptSnapshotV1[],
+): FamiliarExecutionSlice {
+  const completed = attempts.filter((attempt) => attempt.outcome.status === "succeeded").length;
+  const failed = attempts.filter((attempt) => attempt.outcome.status === "error").length;
+  const cancelled = attempts.filter((attempt) => attempt.outcome.status === "cancelled").length;
+  const settled = completed + failed;
+  const durations = attempts
+    .map((attempt) => attempt.durationMs)
+    .filter((value): value is number => value !== undefined);
+  const tools = attempts.flatMap((attempt) => attempt.tools ?? []);
+  const medianDurationMs = percentile(durations, 0.5);
+  const totalTokens = reportedNumber(attempts, (attempt) => attempt.totalTokens);
+  const costUsd = reportedNumber(attempts, (attempt) => attempt.costUsd);
+  return {
+    key,
+    label,
+    attempts: attempts.length,
+    completed,
+    failed,
+    cancelled,
+    successRate: settled > 0 ? completed / settled : null,
+    ...(medianDurationMs !== undefined ? { medianDurationMs } : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+    ...(costUsd !== undefined ? { costUsd } : {}),
+    toolCalls: tools.length,
+    toolFailures: tools.filter((tool) => tool.status === "error").length,
+  };
+}
+
+function slices(
+  attempts: ExecutionAttemptSnapshotV1[],
+  keyFor: (attempt: ExecutionAttemptSnapshotV1) => string | undefined,
+  labelFor: (key: string) => string = (key) => key,
+): FamiliarExecutionSlice[] {
+  const groups = new Map<string, ExecutionAttemptSnapshotV1[]>();
+  for (const attempt of attempts) {
+    const key = keyFor(attempt);
+    if (!key) continue;
+    const group = groups.get(key) ?? [];
+    group.push(attempt);
+    groups.set(key, group);
+  }
+  return [...groups.entries()]
+    .map(([key, group]) => executionSlice(key, labelFor(key), group))
+    .sort((a, b) => b.attempts - a.attempts || a.key.localeCompare(b.key));
+}
+
+function aggregateWindow(
+  attempts: ExecutionAttemptSnapshotV1[],
+): FamiliarExecutionAnalyticsWindow {
+  const outcomeCounts = new Map<ExecutionOutcomeStatus, number>();
+  const toolStatuses = new Map<ExecutionToolStatus, number>();
+  let toolCalls = 0;
+  for (const attempt of attempts) {
+    outcomeCounts.set(
+      attempt.outcome.status,
+      (outcomeCounts.get(attempt.outcome.status) ?? 0) + 1,
+    );
+    for (const tool of attempt.tools ?? []) {
+      toolCalls += 1;
+      toolStatuses.set(tool.status, (toolStatuses.get(tool.status) ?? 0) + 1);
+    }
+  }
+  const completed = outcomeCounts.get("succeeded") ?? 0;
+  const failed = outcomeCounts.get("error") ?? 0;
+  const cancelled = outcomeCounts.get("cancelled") ?? 0;
+  const settled = completed + failed;
+  const durations = attempts
+    .map((attempt) => attempt.durationMs)
+    .filter((value): value is number => value !== undefined);
+  const totalTokens = reportedNumber(attempts, (attempt) => attempt.totalTokens);
+  const totalCost = reportedNumber(attempts, (attempt) => attempt.costUsd);
+  const medianDurationMs = percentile(durations, 0.5);
+  const p95DurationMs = percentile(durations, 0.95);
+
+  return {
+    attempts: attempts.length,
+    completed,
+    failed,
+    cancelled,
+    successRate: settled > 0 ? completed / settled : null,
+    ...(medianDurationMs !== undefined ? { medianDurationMs } : {}),
+    ...(p95DurationMs !== undefined ? { p95DurationMs } : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+    ...(totalCost !== undefined ? { costUsd: totalCost } : {}),
+    toolCalls,
+    toolFailures: toolStatuses.get("error") ?? 0,
+    models: slices(
+      attempts,
+      (attempt) => attempt.confirmedModel ??
+        attempt.forwardedModel ??
+        attempt.requestedModel,
+    ),
+    harnesses: slices(
+      attempts,
+      (attempt) => attempt.harnessId
+        ? `${attempt.harnessId}${attempt.harnessVersion ? `@${attempt.harnessVersion}` : ""}`
+        : undefined,
+      (key) => key.replace("@", " "),
+    ),
+    coverage: {
+      harnessVersion: coverageRatio(
+        knownDenominator(attempts, (attempt) => attempt.harnessVersion !== undefined),
+      ),
+      confirmedModel: coverageRatio(
+        knownDenominator(attempts, (attempt) => attempt.confirmedModel !== undefined),
+      ),
+      usage: coverageRatio(
+        knownDenominator(attempts, (attempt) => attempt.totalTokens !== undefined),
+      ),
+      cost: coverageRatio(
+        knownDenominator(attempts, (attempt) => attempt.costUsd !== undefined),
+      ),
+      duration: coverageRatio(
+        knownDenominator(attempts, (attempt) => attempt.durationMs !== undefined),
+      ),
+      tools: coverageRatio(
+        knownDenominator(attempts, (attempt) => attempt.tools !== undefined),
+      ),
+    },
+  };
+}
+
+function windowStart(nowMs: number, key: ExecutionAnalyticsWindowKey): number | undefined {
+  if (key === "all") return undefined;
+  const days = key === "7d" ? 7 : key === "14d" ? 14 : 56;
+  return nowMs - days * 24 * 60 * 60 * 1000;
+}
+
+function publicExecutionAttempt(
+  attempt: ExecutionAttemptSnapshotV1,
+): FamiliarExecutionAttemptSummary {
+  return {
+    id: attempt.attemptId,
+    ...(attempt.sessionId ? { sessionId: attempt.sessionId } : {}),
+    ...(attempt.turnId ? { turnId: attempt.turnId } : {}),
+    executionKind: attempt.executionKind,
+    occurredAt: attempt.occurredAt,
+    harnessId: attempt.harnessId ?? "unreported",
+    ...(attempt.harnessVersion ? { harnessVersion: attempt.harnessVersion } : {}),
+    ...(attempt.requestedModel ? { requestedModel: attempt.requestedModel } : {}),
+    ...(attempt.forwardedModel ? { forwardedModel: attempt.forwardedModel } : {}),
+    ...(attempt.confirmedModel ? { confirmedModel: attempt.confirmedModel } : {}),
+    status: attempt.status,
+    ...(attempt.durationMs !== undefined ? { durationMs: attempt.durationMs } : {}),
+    ...(attempt.totalTokens !== undefined ? { totalTokens: attempt.totalTokens } : {}),
+    ...(attempt.costUsd !== undefined ? { costUsd: attempt.costUsd } : {}),
+    toolCalls: attempt.toolCalls ?? 0,
+    toolFailures: attempt.toolFailures ?? 0,
+    provenance: attempt.provenance.source === "live" ? "live" : "backfilled",
+  };
+}
+
+export function buildFamiliarExecutionAnalytics(args: {
+  familiarId: string;
+  attempts: ExecutionAttemptSnapshotV1[];
+  now?: Date;
+  recentLimit?: number;
+  backfill?: FamiliarExecutionBackfillState;
+}): FamiliarExecutionAnalytics {
+  const now = args.now ?? new Date();
+  const nowMs = now.getTime();
+  const generatedAt = now.toISOString();
+  const attempts = args.attempts
+    .filter((attempt) => attempt.familiarId === args.familiarId)
+    .filter((attempt) => Date.parse(attempt.timing.completedAt) <= nowMs)
+    .sort((a, b) => (
+      Date.parse(b.timing.completedAt) - Date.parse(a.timing.completedAt) ||
+      a.attemptId.localeCompare(b.attemptId)
+    ));
+  const recentLimit = Math.max(0, Math.min(100, Math.floor(args.recentLimit ?? 50)));
+  const windows = Object.fromEntries(
+    EXECUTION_ANALYTICS_WINDOWS.map((key) => {
+      const startsAtMs = windowStart(nowMs, key);
+      const windowAttempts = startsAtMs === undefined
+        ? attempts
+        : attempts.filter((attempt) => Date.parse(attempt.timing.completedAt) >= startsAtMs);
+      return [key, aggregateWindow(windowAttempts)];
+    }),
+  ) as Record<ExecutionAnalyticsWindowKey, FamiliarExecutionAnalyticsWindow>;
+  return {
+    generatedAt,
+    windows,
+    recentAttempts: attempts.slice(0, recentLimit).map(publicExecutionAttempt),
+    backfill: args.backfill ?? { state: "not-started", imported: 0 },
+  };
+}
+
+export function isExecutionAttemptCoverageField(
+  value: unknown,
+): value is ExecutionAttemptCoverageField {
+  return typeof value === "string" &&
+    COVERAGE_FIELDS.has(value as ExecutionAttemptCoverageField);
+}

--- a/src/lib/server/familiar-execution-analytics-backfill.ts
+++ b/src/lib/server/familiar-execution-analytics-backfill.ts
@@ -1,0 +1,74 @@
+import type {
+  ConversationFile,
+  ConversationSummary,
+} from "../cave-conversations.ts";
+import type { ExecutionAttemptSnapshotV1 } from "../familiar-execution-analytics.ts";
+import { projectConversationExecutionAttempts } from "./familiar-execution-analytics-projection.ts";
+
+export type ExecutionAnalyticsBackfillDependencies = {
+  listConversations: () => Promise<ConversationSummary[]>;
+  loadConversation: (sessionId: string) => Promise<ConversationFile | null>;
+};
+
+export type ExecutionAnalyticsBackfillResult = {
+  attempts: ExecutionAttemptSnapshotV1[];
+  toAppend: ExecutionAttemptSnapshotV1[];
+  conversationsScanned: number;
+  conversationsLoaded: number;
+};
+
+function sameSnapshot(
+  left: ExecutionAttemptSnapshotV1,
+  right: ExecutionAttemptSnapshotV1,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+/**
+ * Merge best-effort conversation projections with the local ledger. Live
+ * snapshots remain authoritative; a newer deterministic backfill projection
+ * may replace only an older backfill row for the same attempt identity.
+ */
+export async function backfillFamiliarExecutionAttempts(args: {
+  familiarId: string;
+  existing: ExecutionAttemptSnapshotV1[];
+  dependencies: ExecutionAnalyticsBackfillDependencies;
+}): Promise<ExecutionAnalyticsBackfillResult> {
+  const summaries = (await args.dependencies.listConversations())
+    .filter((summary) => summary.familiarId === args.familiarId);
+  const byId = new Map(
+    args.existing
+      .filter((attempt) => attempt.familiarId === args.familiarId)
+      .map((attempt) => [attempt.attemptId, attempt]),
+  );
+  const toAppend: ExecutionAttemptSnapshotV1[] = [];
+  let conversationsLoaded = 0;
+
+  for (const summary of summaries) {
+    let conversation: ConversationFile | null = null;
+    try {
+      conversation = await args.dependencies.loadConversation(summary.sessionId);
+    } catch {
+      continue;
+    }
+    if (!conversation || conversation.familiarId !== args.familiarId) continue;
+    conversationsLoaded += 1;
+    for (const projected of projectConversationExecutionAttempts(conversation)) {
+      const current = byId.get(projected.attemptId);
+      if (current?.provenance.source === "live") continue;
+      if (current && sameSnapshot(current, projected)) continue;
+      byId.set(projected.attemptId, projected);
+      toAppend.push(projected);
+    }
+  }
+
+  return {
+    attempts: [...byId.values()].sort((a, b) => (
+      Date.parse(b.timing.completedAt) - Date.parse(a.timing.completedAt) ||
+      a.attemptId.localeCompare(b.attemptId)
+    )),
+    toAppend,
+    conversationsScanned: summaries.length,
+    conversationsLoaded,
+  };
+}

--- a/src/lib/server/familiar-execution-analytics-projection.ts
+++ b/src/lib/server/familiar-execution-analytics-projection.ts
@@ -1,0 +1,198 @@
+import { createHash } from "node:crypto";
+import type { ConversationFile } from "../cave-conversations.ts";
+import {
+  EXECUTION_ATTEMPT_SCHEMA_VERSION,
+  normalizeExecutionAttemptSnapshot,
+  type ExecutionAttemptSnapshotV1,
+  type ExecutionModelSelection,
+} from "../familiar-execution-analytics.ts";
+import { canonicalHarnessId } from "../harness-adapters.ts";
+import type {
+  ModelControlFamily,
+  ModelControlValues,
+} from "../model-control-capabilities.ts";
+import type { SessionOrigin } from "../types.ts";
+
+function text(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function nonNegative(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function requestedModelForTurn(
+  turn: ConversationFile["turns"][number],
+): ExecutionModelSelection | undefined {
+  const metadata = turn.responseMetadata;
+  if (typeof metadata?.requestedModel === "string") {
+    const requested = metadata.requestedModel.trim();
+    return requested
+      ? { kind: "model", id: requested }
+      : { kind: "runtime-default" };
+  }
+  const desired = text(metadata?.desiredModel);
+  if (desired) return { kind: "model", id: desired };
+  const override = text(turn.modelOverride);
+  if (override) return { kind: "model", id: override };
+  return turn.modelOverrideScope === "runtime-default"
+    ? { kind: "runtime-default" }
+    : undefined;
+}
+
+function controlsForTurn(
+  turn: ConversationFile["turns"][number],
+): ExecutionAttemptSnapshotV1["controls"] {
+  const metadata = turn.responseMetadata;
+  const requested = metadata?.requestedControls ?? turn.modelControls;
+  const forwarded = metadata?.forwardedControls;
+  const applied = metadata?.appliedControls;
+  const rejectedFamilies = metadata?.rejectedControlFamilies?.filter(
+    (family): family is ModelControlFamily =>
+      family === "reasoning" ||
+      family === "performance" ||
+      family === "verbosity" ||
+      family === "output-limit" ||
+      family === "modalities" ||
+      family === "tool-support",
+  );
+  if (!requested && !forwarded && !applied && !rejectedFamilies?.length) return undefined;
+  return {
+    ...(requested ? { requested: requested as ModelControlValues } : {}),
+    ...(forwarded ? { forwarded } : {}),
+    ...(applied ? { applied } : {}),
+    ...(rejectedFamilies?.length ? { rejectedFamilies } : {}),
+  };
+}
+
+function executionOrigin(
+  conversation: ConversationFile,
+  turn: ConversationFile["turns"][number],
+): SessionOrigin | undefined {
+  if (conversation.origin) return conversation.origin;
+  if (turn.origin === "voice") return "call";
+  if (turn.origin === "chat") return "chat";
+  return undefined;
+}
+
+export function deterministicExecutionAttemptId(args: {
+  familiarId: string;
+  sessionId: string;
+  turnId: string;
+  attemptNumber: number;
+}): string {
+  const digest = createHash("sha256")
+    .update([
+      `v${EXECUTION_ATTEMPT_SCHEMA_VERSION}`,
+      args.familiarId,
+      args.sessionId,
+      args.turnId,
+      String(args.attemptNumber),
+    ].join("\u001f"))
+    .digest("hex")
+    .slice(0, 32);
+  return `ea1_${digest}`;
+}
+
+/**
+ * Project historical Cave conversation turns into the content-free attempt
+ * contract. A transcript may contain one persisted assistant result per turn;
+ * retries inside the harness are not reconstructable, so historical rows use
+ * attemptNumber 1 rather than inventing additional attempts.
+ */
+export function projectConversationExecutionAttempts(
+  conversation: ConversationFile,
+): ExecutionAttemptSnapshotV1[] {
+  const attempts: ExecutionAttemptSnapshotV1[] = [];
+  for (const turn of conversation.turns) {
+    if (turn.role !== "assistant") continue;
+    if (!Number.isFinite(Date.parse(turn.createdAt))) continue;
+    const attemptNumber = 1;
+    const harnessId = text(turn.responseMetadata?.harness) ??
+      text(conversation.harness);
+    const requested = requestedModelForTurn(turn);
+    const forwarded = text(turn.responseMetadata?.forwardedModel);
+    const confirmed = text(turn.responseMetadata?.confirmedModel);
+    const controls = controlsForTurn(turn);
+    const durationMs = nonNegative(turn.durationMs);
+    const costUsd = nonNegative(turn.costUsd);
+    const tools = turn.tools?.map((tool) => {
+      const toolDurationMs = nonNegative(tool.durationMs);
+      return {
+        name: tool.name,
+        status: tool.status,
+        ...(toolDurationMs !== undefined ? { durationMs: toolDurationMs } : {}),
+      };
+    });
+    const usage = turn.usage
+      ? {
+          inputTokens: turn.usage.inputTokens,
+          outputTokens: turn.usage.outputTokens,
+          ...(turn.usage.cacheReadTokens !== undefined
+            ? { cacheReadTokens: turn.usage.cacheReadTokens }
+            : {}),
+          ...(turn.usage.cacheCreationTokens !== undefined
+            ? { cacheCreationTokens: turn.usage.cacheCreationTokens }
+            : {}),
+        }
+      : undefined;
+    const origin = executionOrigin(conversation, turn);
+    const candidate = {
+      schemaVersion: EXECUTION_ATTEMPT_SCHEMA_VERSION,
+      attemptId: deterministicExecutionAttemptId({
+        familiarId: conversation.familiarId,
+        sessionId: conversation.sessionId,
+        turnId: turn.id,
+        attemptNumber,
+      }),
+      familiarId: conversation.familiarId,
+      sessionId: conversation.sessionId,
+      turnId: turn.id,
+      attemptNumber,
+      execution: {
+        kind: "assistant-response",
+        ...(origin ? { origin } : {}),
+      },
+      ...(harnessId
+        ? { harness: { id: canonicalHarnessId(harnessId) } }
+        : {}),
+      ...(requested || forwarded || confirmed
+        ? {
+            models: {
+              ...(requested ? { requested } : {}),
+              ...(forwarded ? { forwarded } : {}),
+              ...(confirmed ? { confirmed } : {}),
+            },
+          }
+        : {}),
+      ...(controls ? { controls } : {}),
+      timing: {
+        completedAt: turn.createdAt,
+        ...(durationMs !== undefined ? { durationMs } : {}),
+      },
+      ...(usage ? { usage } : {}),
+      ...(costUsd !== undefined ? { costUsd } : {}),
+      outcome: {
+        status: turn.cancelled
+          ? "cancelled"
+          : turn.isError
+            ? "error"
+            : "succeeded",
+      },
+      ...(tools !== undefined ? { tools } : {}),
+      provenance: {
+        source: "conversation-backfill",
+        sourceSchema: "cave-conversation-v1",
+        capturedAt: turn.createdAt,
+      },
+      coverage: { knownFields: [] },
+    };
+    const snapshot = normalizeExecutionAttemptSnapshot(candidate);
+    if (snapshot) attempts.push(snapshot);
+  }
+  return attempts;
+}

--- a/src/lib/server/familiar-execution-analytics-source.ts
+++ b/src/lib/server/familiar-execution-analytics-source.ts
@@ -1,0 +1,74 @@
+import {
+  listConversations,
+  loadConversation,
+} from "../cave-conversations.ts";
+import {
+  buildFamiliarExecutionAnalytics,
+  type FamiliarExecutionAnalytics,
+} from "../familiar-execution-analytics.ts";
+import {
+  backfillFamiliarExecutionAttempts,
+  type ExecutionAnalyticsBackfillDependencies,
+} from "./familiar-execution-analytics-backfill.ts";
+import {
+  appendExecutionAttemptSnapshots,
+  listExecutionAttemptSnapshots,
+} from "./familiar-execution-analytics-store.ts";
+
+export type FamiliarExecutionAnalyticsSourceDependencies =
+  ExecutionAnalyticsBackfillDependencies & {
+    listStoredAttempts: typeof listExecutionAttemptSnapshots;
+    appendAttempts: typeof appendExecutionAttemptSnapshots;
+  };
+
+const DEFAULT_DEPENDENCIES: FamiliarExecutionAnalyticsSourceDependencies = {
+  listConversations,
+  loadConversation,
+  listStoredAttempts: listExecutionAttemptSnapshots,
+  appendAttempts: appendExecutionAttemptSnapshots,
+};
+
+export async function readFamiliarExecutionAnalytics(args: {
+  familiarId: string;
+  now?: Date;
+  recentLimit?: number;
+  dependencies?: Partial<FamiliarExecutionAnalyticsSourceDependencies>;
+}): Promise<FamiliarExecutionAnalytics> {
+  const dependencies = {
+    ...DEFAULT_DEPENDENCIES,
+    ...args.dependencies,
+  };
+  const existing = await dependencies.listStoredAttempts(args.familiarId);
+  const backfill = await backfillFamiliarExecutionAttempts({
+    familiarId: args.familiarId,
+    existing,
+    dependencies,
+  });
+  if (backfill.toAppend.length) {
+    // Derived persistence is a cache: a temporarily unwritable ledger must not
+    // hide analytics that can still be projected from local conversations.
+    await dependencies.appendAttempts(args.familiarId, backfill.toAppend)
+      .catch(() => 0);
+  }
+  const analytics = buildFamiliarExecutionAnalytics({
+    familiarId: args.familiarId,
+    attempts: backfill.attempts,
+    now: args.now,
+    recentLimit: args.recentLimit,
+  });
+  return {
+    ...analytics,
+    backfill: {
+      state: backfill.conversationsLoaded === backfill.conversationsScanned
+        ? "complete"
+        : "partial",
+      imported: backfill.toAppend.length,
+      ...(backfill.conversationsLoaded < backfill.conversationsScanned
+        ? {
+            remaining: backfill.conversationsScanned -
+              backfill.conversationsLoaded,
+          }
+        : {}),
+    },
+  };
+}

--- a/src/lib/server/familiar-execution-analytics-store.ts
+++ b/src/lib/server/familiar-execution-analytics-store.ts
@@ -1,0 +1,85 @@
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { caveHome } from "../coven-paths.ts";
+import {
+  executionAttemptLedgerRecord,
+  normalizeExecutionAttemptLedgerRecord,
+  normalizeExecutionAttemptSnapshot,
+  type ExecutionAttemptSnapshotV1,
+} from "../familiar-execution-analytics.ts";
+import { isValidFamiliarId } from "./familiar-id.ts";
+
+function ledgerDir(): string {
+  return path.join(caveHome(), "familiar-execution-analytics", "v1");
+}
+
+function ledgerFile(familiarId: string): string {
+  if (!isValidFamiliarId(familiarId)) throw new Error("path not allowed");
+  return path.join(ledgerDir(), `${familiarId}.jsonl`);
+}
+
+export function serializeExecutionAttemptLedgerRecord(
+  snapshot: ExecutionAttemptSnapshotV1,
+): string | null {
+  const normalized = normalizeExecutionAttemptSnapshot(snapshot);
+  return normalized
+    ? JSON.stringify(executionAttemptLedgerRecord(normalized))
+    : null;
+}
+
+export async function listExecutionAttemptSnapshots(
+  familiarId: string,
+): Promise<ExecutionAttemptSnapshotV1[]> {
+  const file = ledgerFile(familiarId);
+  let raw = "";
+  try {
+    raw = await readFile(file, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+
+  const byId = new Map<string, ExecutionAttemptSnapshotV1>();
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const record = normalizeExecutionAttemptLedgerRecord(JSON.parse(trimmed));
+      if (!record || record.snapshot.familiarId !== familiarId) continue;
+      byId.set(record.snapshot.attemptId, record.snapshot);
+    } catch {
+      // An append-only ledger remains readable when one historical line is bad.
+    }
+  }
+  return [...byId.values()].sort((a, b) => (
+    Date.parse(b.timing.completedAt) - Date.parse(a.timing.completedAt) ||
+    a.attemptId.localeCompare(b.attemptId)
+  ));
+}
+
+export async function appendExecutionAttemptSnapshots(
+  familiarId: string,
+  snapshots: ExecutionAttemptSnapshotV1[],
+): Promise<number> {
+  ledgerFile(familiarId);
+  const existing = new Map(
+    (await listExecutionAttemptSnapshots(familiarId))
+      .map((snapshot) => [snapshot.attemptId, JSON.stringify(snapshot)]),
+  );
+  const lines: string[] = [];
+  for (const snapshot of snapshots) {
+    const normalized = normalizeExecutionAttemptSnapshot(snapshot);
+    if (!normalized || normalized.familiarId !== familiarId) continue;
+    const serializedSnapshot = JSON.stringify(normalized);
+    if (existing.get(normalized.attemptId) === serializedSnapshot) continue;
+    const line = serializeExecutionAttemptLedgerRecord(normalized);
+    if (line) {
+      lines.push(line);
+      existing.set(normalized.attemptId, serializedSnapshot);
+    }
+  }
+  if (!lines.length) return 0;
+  await mkdir(ledgerDir(), { recursive: true });
+  await appendFile(ledgerFile(familiarId), `${lines.join("\n")}\n`, "utf8");
+  return lines.length;
+}

--- a/src/lib/server/familiar-execution-analytics.test.ts
+++ b/src/lib/server/familiar-execution-analytics.test.ts
@@ -1,0 +1,312 @@
+import assert from "node:assert/strict";
+import { appendFile, mkdir, readFile, rm } from "node:fs/promises";
+import path from "node:path";
+import { after, before, test } from "node:test";
+import type { ConversationFile } from "../cave-conversations.ts";
+import {
+  buildFamiliarExecutionAnalytics,
+  EXECUTION_ATTEMPT_LEDGER_VERSION,
+  EXECUTION_ATTEMPT_SCHEMA_VERSION,
+  executionAttemptLedgerRecord,
+  normalizeExecutionAttemptSnapshot,
+  type ExecutionAttemptSnapshotV1,
+} from "../familiar-execution-analytics.ts";
+import { backfillFamiliarExecutionAttempts } from "./familiar-execution-analytics-backfill.ts";
+import { projectConversationExecutionAttempts } from "./familiar-execution-analytics-projection.ts";
+import {
+  appendExecutionAttemptSnapshots,
+  listExecutionAttemptSnapshots,
+} from "./familiar-execution-analytics-store.ts";
+
+const originalCaveHome = process.env.COVEN_CAVE_HOME;
+const artifactRoot = path.join(
+  process.cwd(),
+  ".test-artifacts",
+  `familiar-execution-analytics-${process.pid}`,
+);
+
+before(async () => {
+  await rm(artifactRoot, { recursive: true, force: true });
+  await mkdir(artifactRoot, { recursive: true });
+  process.env.COVEN_CAVE_HOME = artifactRoot;
+});
+
+after(async () => {
+  if (originalCaveHome === undefined) delete process.env.COVEN_CAVE_HOME;
+  else process.env.COVEN_CAVE_HOME = originalCaveHome;
+  await rm(artifactRoot, { recursive: true, force: true });
+});
+
+function snapshot(overrides: Record<string, unknown> = {}): ExecutionAttemptSnapshotV1 {
+  const value = normalizeExecutionAttemptSnapshot({
+    schemaVersion: EXECUTION_ATTEMPT_SCHEMA_VERSION,
+    attemptId: "ea1_test",
+    familiarId: "cody",
+    sessionId: "session-test",
+    turnId: "turn-test",
+    attemptNumber: 1,
+    execution: { kind: "assistant-response", origin: "chat" },
+    timing: { completedAt: "2026-08-18T09:00:00.000Z" },
+    outcome: { status: "succeeded" },
+    provenance: {
+      source: "live",
+      sourceSchema: "execution-attempt-v1",
+      capturedAt: "2026-08-18T09:00:00.000Z",
+    },
+    coverage: { knownFields: [] },
+    ...overrides,
+  });
+  assert.ok(value);
+  return value;
+}
+
+function historicalConversation(): ConversationFile {
+  const privateMarker = "PRIVATE_EXECUTION_CONTENT";
+  return {
+    sessionId: "conversation-session",
+    familiarId: "cody",
+    harness: "claude-code",
+    runtime: `/private/worktree/${privateMarker}`,
+    branch: `feature/${privateMarker}`,
+    prUrl: `https://example.invalid/${privateMarker}`,
+    origin: "chat",
+    createdAt: "2026-08-17T08:00:00.000Z",
+    updatedAt: "2026-08-17T08:05:00.000Z",
+    turns: [
+      {
+        id: "user-turn",
+        role: "user",
+        text: `prompt ${privateMarker}`,
+        createdAt: "2026-08-17T08:00:00.000Z",
+      },
+      {
+        id: "assistant-known",
+        role: "assistant",
+        text: `response ${privateMarker}`,
+        reasoning: `reasoning ${privateMarker}`,
+        createdAt: "2026-08-17T08:00:05.000Z",
+        durationMs: 5_000,
+        usage: {
+          inputTokens: 100,
+          outputTokens: 40,
+          cacheReadTokens: 25,
+        },
+        costUsd: 0.03,
+        tools: [{
+          id: "tool-1",
+          name: "shell",
+          input: `args ${privateMarker}`,
+          output: `output ${privateMarker}`,
+          status: "ok",
+          durationMs: 750,
+        }],
+        responseMetadata: {
+          familiarId: "cody",
+          harness: "claude-code",
+          model: "anthropic/claude-sonnet",
+          runtime: `/private/runtime/${privateMarker}`,
+          requestedModel: "anthropic/claude-sonnet",
+          forwardedModel: "claude-sonnet",
+          confirmedModel: "claude-sonnet",
+        },
+      },
+      {
+        id: "assistant-unknown-metrics",
+        role: "assistant",
+        text: `second response ${privateMarker}`,
+        createdAt: "2026-08-17T08:01:00.000Z",
+      },
+    ],
+  };
+}
+
+test("append/read ledger is idempotent and ignores unsupported record versions", async () => {
+  const value = snapshot();
+  assert.equal(await appendExecutionAttemptSnapshots("cody", [value]), 1);
+  assert.equal(
+    await appendExecutionAttemptSnapshots("cody", [value]),
+    0,
+    "re-appending the same normalized snapshot is a no-op",
+  );
+
+  const ledger = path.join(
+    artifactRoot,
+    "familiar-execution-analytics",
+    "v1",
+    "cody.jsonl",
+  );
+  const firstRead = await listExecutionAttemptSnapshots("cody");
+  assert.deepEqual(firstRead.map((attempt) => attempt.attemptId), ["ea1_test"]);
+  assert.equal((await readFile(ledger, "utf8")).trim().split("\n").length, 1);
+
+  await appendFile(
+    ledger,
+    [
+      JSON.stringify({
+        ...executionAttemptLedgerRecord(value),
+        ledgerVersion: EXECUTION_ATTEMPT_LEDGER_VERSION + 1,
+      }),
+      JSON.stringify({
+        ledgerVersion: EXECUTION_ATTEMPT_LEDGER_VERSION,
+        snapshot: {
+          ...value,
+          schemaVersion: EXECUTION_ATTEMPT_SCHEMA_VERSION + 1,
+        },
+      }),
+      "not-json",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const afterUnsupportedRows = await listExecutionAttemptSnapshots("cody");
+  assert.deepEqual(
+    afterUnsupportedRows.map((attempt) => attempt.attemptId),
+    ["ea1_test"],
+    "unsupported ledger/snapshot versions and malformed lines are ignored",
+  );
+});
+
+test("conversation projection derives only safe execution metadata", () => {
+  const attempts = projectConversationExecutionAttempts(historicalConversation());
+  assert.equal(attempts.length, 2);
+  const known = attempts[0];
+  assert.equal(known.harnessId, "claude");
+  assert.equal(known.requestedModel, "anthropic/claude-sonnet");
+  assert.equal(known.forwardedModel, "claude-sonnet");
+  assert.equal(known.confirmedModel, "claude-sonnet");
+  assert.equal(known.durationMs, 5_000);
+  assert.deepEqual(known.usage, {
+    inputTokens: 100,
+    outputTokens: 40,
+    cacheReadTokens: 25,
+  });
+  assert.equal(known.costUsd, 0.03);
+  assert.deepEqual(known.tools, [{ name: "shell", status: "ok", durationMs: 750 }]);
+
+  const serialized = JSON.stringify(attempts);
+  assert.doesNotMatch(serialized, /PRIVATE_EXECUTION_CONTENT/);
+  assert.doesNotMatch(
+    serialized,
+    /"text"|"reasoning"|"input"|"output"|"runtime"|"branch"|"prUrl"|tool-1/,
+  );
+});
+
+test("historical unknown usage, cost, and harness version remain absent", () => {
+  const attempts = projectConversationExecutionAttempts(historicalConversation());
+  const unknown = attempts[1];
+  assert.equal("usage" in unknown, false);
+  assert.equal("totalTokens" in unknown, false);
+  assert.equal("costUsd" in unknown, false);
+  assert.equal("harnessVersion" in unknown, false);
+  assert.equal("version" in (unknown.harness ?? {}), false);
+  assert.equal(unknown.harnessId, "claude");
+});
+
+test("analytics projection builds windows, coverage, slices, and bounded recent rows", () => {
+  const historical = projectConversationExecutionAttempts(historicalConversation())[0];
+  const live = snapshot({
+    attemptId: "ea1_live",
+    sessionId: "session-live",
+    turnId: "turn-live",
+    execution: { kind: "assistant-response", origin: "board" },
+    harness: { id: "claude", version: "1.2.3" },
+    models: { confirmed: "claude-sonnet" },
+    timing: { completedAt: "2026-08-18T09:30:00.000Z" },
+    outcome: { status: "error" },
+  });
+  const old = snapshot({
+    attemptId: "ea1_old",
+    sessionId: "session-old",
+    turnId: "turn-old",
+    timing: { completedAt: "2026-06-01T09:00:00.000Z" },
+    outcome: { status: "cancelled" },
+  });
+
+  const analytics = buildFamiliarExecutionAnalytics({
+    familiarId: "cody",
+    attempts: [historical, live, old],
+    now: new Date("2026-08-18T10:00:00.000Z"),
+    recentLimit: 2,
+  });
+
+  assert.equal(analytics.windows["7d"].attempts, 2);
+  assert.equal(analytics.windows["7d"].completed, 1);
+  assert.equal(analytics.windows["7d"].failed, 1);
+  assert.equal(analytics.windows["7d"].cancelled, 0);
+  assert.equal(analytics.windows["7d"].successRate, 0.5);
+  assert.equal(analytics.windows.all.cancelled, 1);
+  assert.deepEqual(
+    analytics.windows["7d"].coverage.usage,
+    { known: 1, total: 2, ratio: 0.5 },
+  );
+  assert.deepEqual(
+    analytics.windows["7d"].coverage.harnessVersion,
+    { known: 1, total: 2, ratio: 0.5 },
+  );
+  assert.ok(
+    analytics.windows["7d"].models.some((slice) =>
+      slice.key === "claude-sonnet" &&
+      slice.attempts === 2 &&
+      slice.successRate === 0.5
+    ),
+  );
+  assert.ok(
+    analytics.windows["7d"].harnesses.some((slice) =>
+      slice.key === "claude@1.2.3" &&
+      slice.toolCalls === 0 &&
+      slice.toolFailures === 0
+    ),
+  );
+  assert.equal(analytics.recentAttempts.length, 2);
+  assert.deepEqual(
+    analytics.recentAttempts[0],
+    {
+      id: "ea1_live",
+      sessionId: "session-live",
+      turnId: "turn-live",
+      executionKind: "board",
+      occurredAt: "2026-08-18T09:30:00.000Z",
+      harnessId: "claude",
+      harnessVersion: "1.2.3",
+      confirmedModel: "claude-sonnet",
+      status: "failed",
+      toolCalls: 0,
+      toolFailures: 0,
+      provenance: "live",
+    },
+  );
+  assert.equal(analytics.backfill.state, "not-started");
+});
+
+test("repeated conversation backfill does not duplicate attempts", async () => {
+  const conversation = historicalConversation();
+  const dependencies = {
+    listConversations: async () => [{
+      sessionId: conversation.sessionId,
+      familiarId: conversation.familiarId,
+      harness: conversation.harness,
+      updatedAt: conversation.updatedAt,
+    }],
+    loadConversation: async () => conversation,
+  };
+  const initial = await backfillFamiliarExecutionAttempts({
+    familiarId: "cody",
+    existing: [],
+    dependencies,
+  });
+  const replay = await backfillFamiliarExecutionAttempts({
+    familiarId: "cody",
+    existing: initial.attempts,
+    dependencies,
+  });
+
+  assert.equal(initial.attempts.length, 2);
+  assert.equal(initial.toAppend.length, 2);
+  assert.equal(replay.attempts.length, 2);
+  assert.equal(replay.toAppend.length, 0);
+  assert.deepEqual(
+    replay.attempts.map((attempt) => attempt.attemptId),
+    initial.attempts.map((attempt) => attempt.attemptId),
+  );
+});

--- a/src/styles/familiar-analytics.css
+++ b/src/styles/familiar-analytics.css
@@ -2076,6 +2076,9 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+  max-height: calc(100% - 6rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: var(--space-3) var(--space-4);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, transparent);
   border-radius: var(--radius-card);
@@ -2533,6 +2536,91 @@
 .fa-feedback-row__down { display: inline-flex; align-items: center; gap: 3px; color: var(--color-danger); }
 .fa-feedback__unstamped { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }
 
+/* ── Runtime performance ────────────────────────────────────────────────── */
+.fa-runtime-performance {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.fa-runtime-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: var(--space-4);
+}
+.fa-runtime-row {
+  grid-template-columns: minmax(0, 10rem) minmax(5rem, 1fr) minmax(0, 14rem);
+}
+.fa-runtime-row__detail {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+  text-align: right;
+}
+.fa-runtime-coverage,
+.fa-runtime-attempts {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.fa-runtime-coverage {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: var(--space-2);
+}
+.fa-runtime-coverage li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--space-1) var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-subtle);
+}
+.fa-runtime-coverage span,
+.fa-runtime-coverage small {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+.fa-runtime-coverage b {
+  color: var(--text-primary);
+}
+.fa-runtime-coverage small {
+  grid-column: 1 / -1;
+}
+.fa-runtime-attempts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.fa-runtime-attempt {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr) auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+.fa-runtime-attempt > span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.fa-runtime-attempt b,
+.fa-runtime-attempt small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.fa-runtime-attempt b {
+  font-size: var(--text-xs);
+  color: var(--text-primary);
+}
+.fa-runtime-attempt small {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
 /* ── Responsive ─────────────────────────────────────────────────────────── */
 /* Tablet: the stage grid collapses to one column. The dock collapse itself is
    driven by matchMedia in the component, because the rail is a different tree
@@ -2543,6 +2631,7 @@
     flex: 0 0 auto;
     grid-template-columns: minmax(0, 1fr);
   }
+
   .fa-stage-grid > * { min-height: 320px; }
   .fa-stats { flex-wrap: wrap; height: auto; }
   .fa-stats > * { flex: 1 1 200px; }
@@ -2554,6 +2643,19 @@
   .fa-foot__meta { display: none; }
   .fa-pulse-panel { left: var(--space-4); }
   .fa-contract-panel { width: calc(100% - var(--space-6)); }
+}
+
+@media (max-width: 720px) {
+  .fa-runtime-row,
+  .fa-runtime-attempt {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .fa-runtime-row__detail {
+    text-align: left;
+  }
+  .fa-runtime-attempt .fa-primary-btn {
+    justify-self: start;
+  }
 }
 
 /* Narrow: one column everywhere and the frame scrolls as a page — a fixed


### PR DESCRIPTION
## Summary
- add a versioned metadata-only familiar execution ledger with idempotent conversation backfill
- project model, harness, reliability, latency, tool, usage, cost, coverage, and recent-attempt analytics
- replace the thumbs-only model panel with a runtime performance workbench while preserving feedback evidence

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` (1,232 files)
- `pnpm test:api` (381 files)
- `pnpm check:tests-wired`
- `pnpm build`
- browser verification on `/familiars/nova/analytics`

Bead: `cave-uadwk`