### PR TITLE
fix(ci): stop one bad candidate from disabling CI recovery

### DIFF
--- a/.github/workflows/ci-recovery.yml
+++ b/.github/workflows/ci-recovery.yml
@@ -37,4 +37,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+        # A red run here no longer means "nothing was recovered". Every
+        # recoverable PR is dispatched first; the non-zero exit reports only the
+        # candidates dropped for a reason a human should fix — an ambiguous
+        # guard contract (`workflow_contract_partial`, usually an un-rebased
+        # branch carrying an older ci.yml shape) or a REST failure. Read the
+        # `#<pr> skipped <reason>` lines to see which. Recovery for every other
+        # open PR already happened in this same run.
         run: node scripts/ci-recovery.mjs --apply

--- a/scripts/ci-recovery.mjs
+++ b/scripts/ci-recovery.mjs
@@ -4,6 +4,12 @@ import { parse } from "yaml";
 export const RECOVERY_GRACE_MS = 15 * 60 * 1000;
 export const RECOVERY_COOLDOWN_MS = 60 * 60 * 1000;
 
+/** That head's ci.yml cannot be dispatched by anyone. Routine; not an alarm. */
+export const NOT_DISPATCHABLE = "workflow_not_dispatchable";
+
+/** That head's guard contract is ambiguous, so it is never dispatched. Alarm. */
+export const CONTRACT_PARTIAL = "workflow_contract_partial";
+
 const WORKFLOW_FILE = "ci.yml";
 const MAX_PULL_PAGES = 10;
 const EXPECTED_RUN_NAME = "CI ${{ github.event_name }} ${{ inputs.expected_sha || github.sha }}";
@@ -43,6 +49,11 @@ export async function runCiRecovery({
   const pulls = await listOpenPulls(context);
   const eligible = [];
   const skipped = [];
+  // Set when a candidate was dropped for a reason a human should look at — a
+  // misconfigured guard contract or a REST failure — rather than a routine
+  // "nothing to do". The scan still recovers everything else; this only decides
+  // whether the process exits non-zero at the end.
+  let degraded = false;
 
   for (const rawPull of pulls) {
     const pull = parsePull(rawPull);
@@ -52,8 +63,18 @@ export async function runCiRecovery({
       continue;
     }
 
-    const runs = await listWorkflowRuns(context, pull.sha);
-    const decision = await decideRecovery(context, runs, now);
+    let decision;
+    try {
+      const runs = await listWorkflowRuns(context, pull.sha);
+      decision = await decideRecovery(context, runs, now);
+    } catch (cause) {
+      // One unreadable pull request is one unreadable pull request. Letting it
+      // propagate ended the whole scan, so every OTHER open PR with missing CI
+      // stayed missing until someone noticed by hand.
+      skipped.push({ number: pull.number, reason: failureReason(cause) });
+      degraded = true;
+      continue;
+    }
     if (!decision.recover) {
       skipped.push({ number: pull.number, reason: decision.reason });
       continue;
@@ -73,15 +94,23 @@ export async function runCiRecovery({
     // Complete every candidate read before the first mutation. A later REST
     // failure must never leave the repository with a partially applied scan.
     for (const recovery of eligible) {
-      const current = await getPull(context, recovery.number);
-      const drift = dispatchSkipReason(current, recovery, repository, now);
-      if (drift) {
-        skipped.push({ number: recovery.number, reason: drift });
+      let contract;
+      try {
+        const current = await getPull(context, recovery.number);
+        const drift = dispatchSkipReason(current, recovery, repository, now);
+        if (drift) {
+          skipped.push({ number: recovery.number, reason: drift });
+          continue;
+        }
+        contract = await inspectRecoveryDispatch(context, recovery.sha);
+      } catch (cause) {
+        skipped.push({ number: recovery.number, reason: failureReason(cause) });
+        degraded = true;
         continue;
       }
-      const contract = await inspectRecoveryDispatch(context, recovery.sha);
       if (!contract.dispatchable) {
-        skipped.push({ number: recovery.number, reason: "workflow_not_dispatchable" });
+        skipped.push({ number: recovery.number, reason: contract.reason });
+        if (contract.reason === CONTRACT_PARTIAL) degraded = true;
         continue;
       }
       dispatchable.push({ recovery, supportsExpectedSha: contract.supportsExpectedSha });
@@ -90,7 +119,15 @@ export async function runCiRecovery({
 
   const recoveries = apply ? [] : eligible.map((recovery) => ({ ...recovery, dispatched: false }));
   for (const { recovery, supportsExpectedSha } of dispatchable) {
-    await dispatchWorkflow(context, recovery.ref, recovery.sha, supportsExpectedSha);
+    try {
+      await dispatchWorkflow(context, recovery.ref, recovery.sha, supportsExpectedSha);
+    } catch (cause) {
+      // A refused dispatch is that PR's problem. Throwing here abandoned every
+      // dispatch still queued behind it.
+      skipped.push({ number: recovery.number, reason: failureReason(cause) });
+      degraded = true;
+      continue;
+    }
     recoveries.push({ ...recovery, dispatched: true });
   }
 
@@ -99,6 +136,7 @@ export async function runCiRecovery({
     scanned: pulls.length,
     recoveries,
     skipped,
+    degraded,
   };
   for (const recovery of recoveries) {
     log(
@@ -115,7 +153,8 @@ export async function runCiRecovery({
   log(
     `CI recovery: ${result.scanned} open PR${result.scanned === 1 ? "" : "s"} scanned; ` +
       `${recoveries.length} ${apply ? "dispatched" : "eligible"}` +
-      `${skipped.length > 0 ? `; ${skipped.length} skipped` : ""}.`,
+      `${skipped.length > 0 ? `; ${skipped.length} skipped` : ""}` +
+      `${degraded ? "; needs attention" : ""}.`,
   );
   return result;
 }
@@ -292,14 +331,23 @@ async function workflowJobCount(context, runId) {
 /** Inspect the CI workflow at an exact head and decide how it may be dispatched.
  *
  *  Three outcomes, and keeping them distinct is the whole point:
- *  - `{dispatchable: false}` — that head's ci.yml has no `workflow_dispatch`
- *    trigger, so it cannot be dispatched by anyone. A permanent fact about the
- *    branch, not an ambiguity, so the caller skips this candidate and continues.
+ *  - `{dispatchable: false, reason: NOT_DISPATCHABLE}` — that head's ci.yml has
+ *    no `workflow_dispatch` trigger, so it cannot be dispatched by anyone. A
+ *    permanent fact about the branch, not an ambiguity, so the caller skips
+ *    this candidate and continues.
  *  - `{dispatchable: true, supportsExpectedSha}` — dispatch it, with the SHA
  *    guard when the head carries the complete guarded contract.
- *  - throws — the guard contract is only PARTIALLY configured. That one stays
- *    fatal: we cannot tell whether the exact-SHA guard will be honoured, so a
- *    dispatch might silently test a different commit than the one we checked.
+ *  - `{dispatchable: false, reason: CONTRACT_PARTIAL}` — the guard contract is
+ *    only PARTIALLY configured. We cannot tell whether the exact-SHA guard will
+ *    be honoured, so a dispatch might silently test a different commit than the
+ *    one we checked: THIS head is never dispatched, and that safety property is
+ *    unchanged. What changed is blast radius. It used to throw, which killed
+ *    the whole apply — so a single un-rebased branch carrying an older ci.yml
+ *    shape disabled recovery for every other open pull request, which is the
+ *    exact failure already fixed for the un-dispatchable case (cave-qibp6).
+ *    Observed twice in ten days: runs 31393882802 (2026-08-10) and 31618670601
+ *    (2026-08-12) aborted on this path. The scan now finishes, recovers
+ *    everything else, and exits non-zero so the misconfiguration stays visible.
  */
 async function inspectRecoveryDispatch(context, sha) {
   const url =
@@ -333,7 +381,7 @@ async function inspectRecoveryDispatch(context, sha) {
     // WHOLE apply — so a single stale branch whose ci.yml predates dispatch
     // support disabled recovery for every other PR in the repository
     // (cave-qibp6: #4646 blocked #4643 and #4641, and nothing was dispatched).
-    return { dispatchable: false, supportsExpectedSha: false };
+    return { dispatchable: false, reason: NOT_DISPATCHABLE, supportsExpectedSha: false };
   }
   const inputs = workflow?.on?.workflow_dispatch?.inputs;
   const expectedInput =
@@ -369,7 +417,7 @@ async function inspectRecoveryDispatch(context, sha) {
   const hasGuardedProtocolMarker =
     hasExpectedInput || JSON.stringify(workflow).includes("inputs.expected_sha");
   if (hasGuardedProtocolMarker) {
-    throw new Error("CI workflow recovery contract was partially configured");
+    return { dispatchable: false, reason: CONTRACT_PARTIAL, supportsExpectedSha: false };
   }
   return { dispatchable: true, supportsExpectedSha: false };
 }
@@ -516,8 +564,17 @@ function isPullInventoryUrl(value, context) {
   }
 }
 
-function requiredEnv(env, name) {
-  const value = env[name]?.trim();
+/** Render a per-candidate failure as a one-line skip reason.
+ *
+ * Kept on one line because these are printed one per line, and a multi-line
+ * reason would break a log a human scans for what was dropped.
+ */
+function failureReason(cause) {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  return `error: ${message.replace(/\s+/g, " ").trim() || "unknown failure"}`;
+}
+
+function requiredEnv(env, name) {  const value = env[name]?.trim();
   if (!value) throw new Error(`${name} is required`);
   return value;
 }
@@ -557,6 +614,10 @@ if (isDirectRun) {
         log: options.json ? () => {} : console.log,
       });
       if (options.json) console.log(JSON.stringify(result, null, 2));
+      // Every recoverable PR has already been dispatched by this point. A
+      // non-zero exit reports the candidates that were dropped for a reason a
+      // human should fix; it no longer means recovery was skipped.
+      if (result.degraded) process.exitCode = 1;
     }
   } catch (cause) {
     const message = cause instanceof Error ? cause.message : String(cause);

--- a/scripts/ci-recovery.test.mjs
+++ b/scripts/ci-recovery.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  CONTRACT_PARTIAL,
+  NOT_DISPATCHABLE,
   RECOVERY_COOLDOWN_MS,
   RECOVERY_GRACE_MS,
   runCiRecovery,
@@ -266,23 +268,49 @@ test("apply omits expected_sha only for a legacy head workflow without that inpu
   );
 });
 
-test("apply fails closed when expected_sha exists without the REST-visible run stamp", async () => {
-  const pr = pull();
+test("a partial guard contract is skipped without blocking the other candidates", async () => {
+  // The safety property is unchanged: a partial contract is ambiguous rather
+  // than un-dispatchable, so the exact-SHA guard may not be honoured and THIS
+  // head is never dispatched. What changed is blast radius — it used to abort
+  // the whole apply, so one un-rebased branch disabled recovery for every other
+  // open PR (runs 31393882802 and 31618670601 died exactly here).
+  const partial = pull({ number: 1, sha: "e".repeat(40), branch: "fix/partial" });
+  const healthy = pull({ number: 2, sha: "f".repeat(40), branch: "fix/healthy" });
   const fixture = githubFixture({
-    pulls: [pr],
+    pulls: [partial, healthy],
     workflowsBySha: {
-      [pr.head.sha]: GUARDED_CI_WORKFLOW.replace(`run-name: ${GUARDED_RUN_NAME}\n`, ""),
+      [partial.head.sha]: GUARDED_CI_WORKFLOW.replace(`run-name: ${GUARDED_RUN_NAME}\n`, ""),
+      [healthy.head.sha]: GUARDED_CI_WORKFLOW,
     },
   });
+  const messages = [];
 
-  await assert.rejects(
-    runCiRecovery(options(fixture.fetchImpl, true)),
-    /CI workflow recovery contract was partially configured/,
+  const result = await runCiRecovery(
+    options(fixture.fetchImpl, true, { log: (message) => messages.push(message) }),
   );
-  assert.equal(fixture.requests.some((request) => request.method === "POST"), false);
+
+  assert.deepEqual(
+    result.recoveries.map((recovery) => recovery.number),
+    [healthy.number],
+  );
+  assert.deepEqual(result.skipped, [{ number: partial.number, reason: CONTRACT_PARTIAL }]);
+  // The ambiguous head is never dispatched — only the healthy one is.
+  assert.deepEqual(
+    fixture.requests.filter((request) => request.method === "POST"),
+    [
+      {
+        method: "POST",
+        path: `/repos/${REPOSITORY}/actions/workflows/ci.yml/dispatches`,
+        body: { ref: healthy.head.ref, inputs: { expected_sha: healthy.head.sha } },
+      },
+    ],
+  );
+  // A misconfigured contract still has to reach a human.
+  assert.equal(result.degraded, true);
+  assert.equal(messages.some((message) => message.includes("needs attention")), true);
 });
 
-test("apply fails closed when the required job lacks the expected SHA guard", async () => {
+test("a job missing the expected SHA guard is skipped, never dispatched", async () => {
   const pr = pull();
   const fixture = githubFixture({
     pulls: [pr],
@@ -294,11 +322,27 @@ test("apply fails closed when the required job lacks the expected SHA guard", as
     },
   });
 
-  await assert.rejects(
-    runCiRecovery(options(fixture.fetchImpl, true)),
-    /CI workflow recovery contract was partially configured/,
-  );
+  const result = await runCiRecovery(options(fixture.fetchImpl, true));
+
+  assert.deepEqual(result.recoveries, []);
+  assert.deepEqual(result.skipped, [{ number: pr.number, reason: CONTRACT_PARTIAL }]);
+  assert.equal(result.degraded, true);
   assert.equal(fixture.requests.some((request) => request.method === "POST"), false);
+});
+
+test("an un-dispatchable head is skipped without raising the attention flag", async () => {
+  // A branch whose ci.yml predates dispatch support is normal, not a
+  // misconfiguration: it must not turn the scheduled run red every ten minutes.
+  const stale = pull({ number: 4646, sha: "c".repeat(40), branch: "codex/stale-workflow" });
+  const fixture = githubFixture({
+    pulls: [stale],
+    workflowsBySha: { [stale.head.sha]: "name: CI\non:\n  pull_request:\n" },
+  });
+
+  const result = await runCiRecovery(options(fixture.fetchImpl, true));
+
+  assert.deepEqual(result.skipped, [{ number: stale.number, reason: NOT_DISPATCHABLE }]);
+  assert.equal(result.degraded, false);
 });
 
 test("an un-dispatchable head is skipped without blocking the other candidates", async () => {
@@ -306,8 +350,7 @@ test("an un-dispatchable head is skipped without blocking the other candidates",
   // that used to abort everything: its ci.yml predates workflow_dispatch, so it
   // can never be dispatched by anyone, and throwing for it stranded every other
   // eligible PR in the repository (cave-qibp6).
-  const stale = pull({ number: 4646, sha: "c".repeat(40), branch: "codex/stale-workflow" });
-  const healthy = pull({ number: 4643, sha: "d".repeat(40), branch: "codex/current-workflow" });
+  const stale = pull({ number: 4646, sha: "c".repeat(40), branch: "codex/stale-workflow" });  const healthy = pull({ number: 4643, sha: "d".repeat(40), branch: "codex/current-workflow" });
   const fixture = githubFixture({
     pulls: [stale, healthy],
     workflowsBySha: {
@@ -346,26 +389,62 @@ test("an un-dispatchable head is skipped without blocking the other candidates",
   assert.equal(messages.some((message) => message.includes("1 skipped")), true);
 });
 
-test("a partial guard contract still aborts every dispatch, even beside a healthy candidate", async () => {
-  // The safety property the skip above must not have weakened. A partial
-  // contract is ambiguous rather than un-dispatchable: the exact-SHA guard may
-  // not be honoured, so the dispatch could test a different commit. That stays
-  // fatal for the whole run, before any mutation.
-  const partial = pull({ number: 1, sha: "e".repeat(40), branch: "fix/partial" });
-  const healthy = pull({ number: 2, sha: "f".repeat(40), branch: "fix/healthy" });
-  const fixture = githubFixture({
-    pulls: [partial, healthy],
-    workflowsBySha: {
-      [partial.head.sha]: GUARDED_CI_WORKFLOW.replace(`run-name: ${GUARDED_RUN_NAME}\n`, ""),
-      [healthy.head.sha]: GUARDED_CI_WORKFLOW,
-    },
-  });
 
-  await assert.rejects(
-    runCiRecovery(options(fixture.fetchImpl, true)),
-    /CI workflow recovery contract was partially configured/,
+
+test("one unreadable pull request does not strand the rest of the scan", async () => {
+  // A 404 on a deleted/garbage-collected head, or one flaky 5xx, used to
+  // propagate out of the scan loop and end the run. Every other open PR with
+  // missing CI then stayed missing — the same "recovery never fired" report,
+  // from a different cause.
+  const broken = pull({ number: 11, sha: "1".repeat(40), branch: "fix/broken" });
+  const healthy = pull({ number: 12, sha: "2".repeat(40), branch: "fix/healthy" });
+  const fixture = githubFixture({ pulls: [broken, healthy] });
+  const failing = async (url, init) => {
+    const parsed = new URL(url);
+    if (
+      parsed.pathname.endsWith("/actions/workflows/ci.yml/runs") &&
+      parsed.searchParams.get("head_sha") === broken.head.sha
+    ) {
+      return new Response("", { status: 502 });
+    }
+    return fixture.fetchImpl(url, init);
+  };
+
+  const result = await runCiRecovery(options(failing, true));
+
+  assert.deepEqual(
+    result.recoveries.map((recovery) => recovery.number),
+    [healthy.number],
   );
-  assert.equal(fixture.requests.some((request) => request.method === "POST"), false);
+  assert.deepEqual(result.skipped, [
+    {
+      number: broken.number,
+      reason: "error: failed to list CI runs for a pull request head (HTTP 502)",
+    },
+  ]);
+  assert.equal(result.degraded, true);
+});
+
+test("one refused dispatch does not abandon the dispatches queued behind it", async () => {
+  const refused = pull({ number: 21, sha: "3".repeat(40), branch: "fix/refused" });
+  const healthy = pull({ number: 22, sha: "4".repeat(40), branch: "fix/healthy" });
+  const fixture = githubFixture({ pulls: [refused, healthy] });
+  const failing = async (url, init) => {
+    const body = init?.body ? JSON.parse(init.body) : null;
+    if (body?.ref === refused.head.ref) return new Response("", { status: 403 });
+    return fixture.fetchImpl(url, init);
+  };
+
+  const result = await runCiRecovery(options(failing, true));
+
+  assert.deepEqual(
+    result.recoveries.map((recovery) => recovery.number),
+    [healthy.number],
+  );
+  assert.deepEqual(result.skipped, [
+    { number: refused.number, reason: "error: failed to dispatch CI recovery (HTTP 403)" },
+  ]);
+  assert.equal(result.degraded, true);
 });
 
 test("a legacy dispatchable head is still dispatched without inputs", async () => {
@@ -494,17 +573,39 @@ test("apply completes every candidate read before dispatching any recovery", asy
       }
       return jsonResponse({ message: "service unavailable" }, 503);
     }
+    if (parsed.pathname.endsWith(`/pulls/${first.number}`)) return jsonResponse(first);
+    if (parsed.pathname.endsWith(`/pulls/${second.number}`)) return jsonResponse(second);
+    if (parsed.pathname.endsWith("/contents/.github/workflows/ci.yml")) {
+      return jsonResponse({
+        encoding: "base64",
+        content: Buffer.from(GUARDED_CI_WORKFLOW).toString("base64"),
+      });
+    }
     if (parsed.pathname.endsWith("/actions/workflows/ci.yml/dispatches")) {
       return new Response(null, { status: 204 });
     }
     throw new Error(`unexpected request: ${parsed.pathname}`);
   };
 
-  await assert.rejects(
-    runCiRecovery(options(fetchImpl, true)),
-    /failed to list CI runs for a pull request head \(HTTP 503\)/,
+  const result = await runCiRecovery(options(fetchImpl, true));
+
+  // The ordering invariant is unchanged: no mutation is issued until every
+  // candidate read has finished. What changed is that a failed read now costs
+  // that ONE candidate instead of the whole scan.
+  const firstPost = requests.findIndex((request) => request.method === "POST");
+  const lastRead = requests.findLastIndex((request) => request.method === "GET");
+  assert.notEqual(firstPost, -1);
+  assert.equal(firstPost > lastRead, true);
+  assert.deepEqual(
+    result.recoveries.map((recovery) => recovery.number),
+    [first.number],
   );
-  assert.equal(requests.some((request) => request.method === "POST"), false);
+  assert.deepEqual(result.skipped, [
+    {
+      number: second.number,
+      reason: "error: failed to list CI runs for a pull request head (HTTP 503)",
+    },
+  ]);
 });
 
 test("apply inspects every exact-head workflow contract before dispatching any recovery", async () => {
@@ -535,11 +636,22 @@ test("apply inspects every exact-head workflow contract before dispatching any r
     throw new Error(`unexpected request: ${parsed.pathname}`);
   };
 
-  await assert.rejects(
-    runCiRecovery(options(fetchImpl, true)),
-    /failed to inspect the CI workflow contract \(HTTP 503\)/,
+  const result = await runCiRecovery(options(fetchImpl, true));
+
+  const firstPost = requests.findIndex((request) => request.method === "POST");
+  const lastRead = requests.findLastIndex((request) => request.method === "GET");
+  assert.notEqual(firstPost, -1);
+  assert.equal(firstPost > lastRead, true);
+  assert.deepEqual(
+    result.recoveries.map((recovery) => recovery.number),
+    [first.number],
   );
-  assert.equal(requests.some((request) => request.method === "POST"), false);
+  assert.deepEqual(result.skipped, [
+    {
+      number: second.number,
+      reason: "error: failed to inspect the CI workflow contract (HTTP 503)",
+    },
+  ]);
 });
 
 test("apply skips a recovery when the pull request head moves before dispatch", async () => {


### PR DESCRIPTION
## Problem

PRs intermittently land with **no check runs at all** on their head commit because GitHub never delivers the `pull_request` event (#4400, #4391, #4581). `ci-recovery.yml` exists to catch that, but the scan **aborted on the first candidate it could not resolve** — so one un-rebased branch, or one flaky REST call, cancelled recovery for *every other open PR in the same run*.

Evidence: recovery runs [31393882802](https://github.com/OpenCoven/coven-cave/actions/runs/31393882802) (2026-08-10) and [31618670601](https://github.com/OpenCoven/coven-cave/actions/runs/31618670601) (2026-08-12) both exited 1 with `CI workflow recovery contract was partially configured` and dispatched nothing.

This is the same failure already fixed for the un-dispatchable case (cave-qibp6). The partial-contract and REST-failure paths were left fatal.

The underlying GitHub gap is still live and recovery is still load-bearing: head `e2cf70d24af7f49b720be1a5dd5ce3fcb04dc138` (2026-08-17) has **only** a `workflow_dispatch` run — recovery was its sole source of CI.

## Change

- A partial guard contract is **still never dispatched** — that safety property is unchanged, since the exact-SHA guard may not be honoured. It is now a per-PR skip (`workflow_contract_partial`) instead of a whole-scan abort.
- Per-candidate read failures and refused dispatches are isolated the same way, so a dispatch already queued behind a failing one is no longer abandoned.
- Dropped candidates that need a human still surface: the scan finishes, logs each `#<pr> skipped <reason>`, and exits non-zero via a new `degraded` flag. A stale branch that simply predates `workflow_dispatch` stays green, so the ten-minute schedule is not turned red by a routine condition.

## Verification

- `node --test scripts/ci-recovery.test.mjs scripts/ci-recovery-workflow.test.mjs` — 30/30 pass.
- New tests: partial contract skipped beside a healthy candidate (healthy one still dispatched, ambiguous one never dispatched, `degraded` set); un-dispatchable head does **not** set `degraded`; one 502 read and one 403 dispatch each cost only their own PR.
- Existing read-before-mutate ordering tests rewritten to assert the invariant directly (first POST after last GET) rather than via a fatal throw.
- Live report-only run against this repo: `{"scanned":0,"recoveries":[],"skipped":[],"degraded":false}`, exit 0.