### PR TITLE
fix(cave-a245b): release auto-locks once the risk they name is gone

### DIFF
--- a/scripts/worktree-autolock.mjs
+++ b/scripts/worktree-autolock.mjs
@@ -18,6 +18,15 @@
 // locking it would only force an unlock during routine cleanup. Same
 // philosophy as the guard, which lets clean+pushed cleanup pass silently.
 //
+// A lock is re-evaluated on later passes and RELEASED once the risk it names no
+// longer holds — the tree is clean and its head is retained on a remote branch
+// or a remote tag. Without that, a lock taken while work was genuinely at risk
+// outlived the risk and permanently blocked automated retirement: the nightly
+// sweep failed with `retirement-blocked` on units that were in fact safe,
+// registered worktrees climbed 14 -> 55, and both budgets blew, which blocks
+// worktree creation for every session (cave-a245b). Only this hook's own locks
+// are released; see `isAutoLock`.
+//
 // Advisory only: this never blocks a tool call and always exits 0.
 
 import { execFileSync } from "node:child_process";
@@ -50,12 +59,15 @@ export function parseWorktrees(porcelain) {
   for (const rawLine of porcelain.split("\n")) {
     const line = rawLine.trimEnd();
     if (line.startsWith("worktree ")) {
-      current = { path: line.slice("worktree ".length), locked: false, bare: false };
+      current = { path: line.slice("worktree ".length), locked: false, bare: false, lockReason: "" };
       records.push(current);
       continue;
     }
     if (!current) continue;
-    if (line === "locked" || line.startsWith("locked ")) current.locked = true;
+    if (line === "locked" || line.startsWith("locked ")) {
+      current.locked = true;
+      current.lockReason = line === "locked" ? "" : line.slice("locked ".length);
+    }
     if (line === "bare") current.bare = true;
   }
   return records;
@@ -83,12 +95,28 @@ export function parseWorktrees(porcelain) {
 // would count LOCAL tags, and a local-only tag is not retention — it dies with
 // the checkout, which is the hole the guard exists to close.
 export function riskOf(worktreePath, tagRetained = () => false) {
+  const verdict = evaluateRisk(worktreePath, tagRetained);
+  if (verdict.status !== "at-risk") return null;
+  return { dirty: verdict.dirty, unpushed: verdict.unpushed };
+}
+
+// The same measurement as `riskOf`, but it distinguishes the two cases `riskOf`
+// deliberately flattens into `null`.
+//
+// For LOCKING, "no risk" and "unreadable" are interchangeable — both mean don't
+// lock, and neither can destroy anything. For RELEASING they are opposites: a
+// tree we cannot read must stay locked, because "I could not measure this" is
+// not evidence the work is safe. Collapsing them would turn a git hiccup, a
+// half-created worktree, or a dead registration into the one verdict that
+// permits destruction — the exact inversion the tag blind spot caused in
+// cave-qbr34. So the release path consumes this, and only `clear` unlocks.
+export function evaluateRisk(worktreePath, tagRetained = () => false) {
   let dirty = 0;
   let unpushed = 0;
   try {
     dirty = git(["status", "--porcelain"], worktreePath).split("\n").filter(Boolean).length;
   } catch {
-    return null; // unreadable (mid-creation, or a dead registration) — leave it alone
+    return { status: "unreadable" }; // mid-creation, or a dead registration
   }
   try {
     unpushed = Number(
@@ -104,8 +132,29 @@ export function riskOf(worktreePath, tagRetained = () => false) {
   // unanswerable question as "retained" hands out the one verdict that permits
   // destruction.
   if (unpushed > 0 && tagRetained(worktreePath)) unpushed = 0;
-  if (dirty === 0 && unpushed === 0) return null;
-  return { dirty, unpushed };
+  if (dirty === 0 && unpushed === 0) return { status: "clear" };
+  return { status: "at-risk", dirty, unpushed };
+}
+
+// Did THIS hook take the lock? Only its own locks may be released.
+//
+// A lock reason is a point-in-time claim, and nothing re-evaluated it: a tree
+// locked while genuinely at risk stayed locked after the retention-push hook
+// pushed its branch or tag, and `beads:worktrees:apply` then failed with
+// `retirement-blocked` on a unit that was in fact safe. Registered worktrees
+// climbed 14 -> 55 that way and both budgets blew, which blocks worktree
+// creation for every session (cave-a245b).
+//
+// The prefix test is the whole safety boundary. A human — or another tool —
+// who locks a tree is making a claim this hook cannot evaluate ("active
+// cave-1c8zf PR completion" says nothing about dirtiness), so those locks are
+// never touched, only reported. `git worktree list --porcelain` C-quotes a
+// reason containing anything unusual, and ours always does (an em dash), so the
+// opening quote is stripped before the prefix is compared.
+export function isAutoLock(reason) {
+  if (typeof reason !== "string") return false;
+  const unquoted = reason.trim().replace(/^"/, "");
+  return unquoted.startsWith(REASON_PREFIX);
 }
 
 // Commit oids the REMOTE holds under a tag, HEAD included when a tag points at
@@ -204,10 +253,31 @@ function main() {
 
   // The first record is the main working tree; git refuses to lock it.
   for (const wt of worktrees.slice(1)) {
-    if (wt.locked || wt.bare) continue;
+    if (wt.bare) continue;
+    const today = new Date().toISOString().slice(0, 10);
+
+    if (wt.locked) {
+      // Someone else's claim — this hook cannot evaluate it, so it stands.
+      if (!isAutoLock(wt.lockReason)) continue;
+      const verdict = evaluateRisk(wt.path, tagRetained);
+      // Anything but a positive all-clear keeps the lock: still at risk, or
+      // unreadable and therefore unproven.
+      if (verdict.status !== "clear") continue;
+      try {
+        git(["worktree", "unlock", wt.path], root);
+        record(root, { verdict: "released", worktree: wt.path, was: wt.lockReason });
+      } catch (error) {
+        record(root, {
+          verdict: "release-failed",
+          worktree: wt.path,
+          error: String(error?.message ?? error),
+        });
+      }
+      continue;
+    }
+
     const risk = riskOf(wt.path, tagRetained);
     if (!risk) continue;
-    const today = new Date().toISOString().slice(0, 10);
     try {
       git(["worktree", "lock", "--reason", reasonFor(risk, today), wt.path], root);
       record(root, { verdict: "locked", worktree: wt.path, ...risk });

--- a/scripts/worktree-autolock.test.mjs
+++ b/scripts/worktree-autolock.test.mjs
@@ -14,7 +14,9 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  evaluateRisk,
   headShaOf,
+  isAutoLock,
   parseWorktrees,
   reasonFor,
   remoteTagCommits,
@@ -331,6 +333,94 @@ try {
   } finally {
     rmSync(scratch, { recursive: true, force: true });
   }
+}
+
+// --- a lock is released once the risk it named is gone (cave-a245b) ----------
+// A lock reason is a point-in-time claim. Nothing re-evaluated it, so a tree
+// locked while genuinely at risk stayed locked after its branch was pushed, and
+// `beads:worktrees:apply` then failed `retirement-blocked` on units that were
+// in fact safe — registered worktrees climbed 14 -> 55 and both budgets blew.
+{
+  const box = mkdtempSync(path.join(tmpdir(), "autolock-release-"));
+  try {
+    const hook = fileURLToPath(new URL("./worktree-autolock.mjs", import.meta.url));
+    const origin = path.join(box, "origin.git");
+    git(["init", "--quiet", "--bare", "-b", "main", origin], box);
+
+    const repo = path.join(box, "repo");
+    git(["init", "--quiet", "-b", "main", repo], box);
+    writeFileSync(path.join(repo, "seed.txt"), "seed\n");
+    git(["add", "."], repo);
+    git(["commit", "--quiet", "--no-gpg-sign", "-m", "seed"], repo);
+    git(["remote", "add", "origin", origin], repo);
+    git(["push", "--quiet", "origin", "main"], repo);
+
+    const wt = path.join(repo, "wt");
+    git(["worktree", "add", "--quiet", "-b", "risky", wt], repo);
+    writeFileSync(path.join(wt, "unsaved.txt"), "would be lost\n");
+
+    const runHook = () => {
+      // The 60s throttle stamp would make a second pass a no-op, and the whole
+      // point here is what the NEXT pass does.
+      rmSync(path.join(repo, ".claude", "worktree-autolock.stamp"), { force: true });
+      execFileSync(process.execPath, [hook], {
+        cwd: repo,
+        env: { ...process.env, CLAUDE_PROJECT_DIR: repo },
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 30_000,
+      });
+      return parseWorktrees(
+        execFileSync("git", ["worktree", "list", "--porcelain"], { cwd: repo, encoding: "utf8" }),
+      ).find((w) => w.path.endsWith("wt"));
+    };
+
+    const locked = runHook();
+    assert.equal(locked.locked, true, "untracked work is at risk, so the hook locks it");
+    assert.ok(isAutoLock(locked.lockReason), "the hook's own lock is recognizable as its own");
+
+    // Still at risk → the lock must survive re-evaluation. Without this, a
+    // release path could simply unlock everything and still pass the test below.
+    assert.equal(runHook().locked, true, "a lock whose risk still holds is not released");
+
+    // Commit and push: the risk the reason names no longer holds.
+    git(["add", "."], wt);
+    git(["commit", "--quiet", "--no-gpg-sign", "-m", "save"], wt);
+    git(["push", "--quiet", "origin", "risky"], wt);
+    assert.equal(runHook().locked, false, "the lock is released once the head is retained");
+
+    // Fail closed on anything unproven: an unreadable tree keeps its lock,
+    // because "I could not measure this" is not evidence the work is safe.
+    assert.equal(
+      evaluateRisk(path.join(box, "does-not-exist")).status,
+      "unreadable",
+      "a missing path is unreadable, never 'clear'",
+    );
+    assert.equal(evaluateRisk(wt).status, "clear", "a clean, pushed tree measures clear");
+
+    // A lock this hook did not take is somebody else's claim it cannot
+    // evaluate, so it must stand even when nothing is at risk.
+    git(["worktree", "lock", "--reason", "active cave-1c8zf PR completion", wt], repo);
+    assert.equal(runHook().locked, true, "a human lock is never released by the hook");
+    git(["worktree", "unlock", wt], repo);
+  } finally {
+    rmSync(box, { recursive: true, force: true });
+  }
+}
+
+// --- only this hook's own locks are releasable -------------------------------
+// The prefix test is the entire safety boundary, and porcelain C-quotes any
+// reason containing something unusual — ours always does (an em dash).
+{
+  assert.equal(isAutoLock('"auto-locked 2026-08-14: 1 commit not on any remote"'), true);
+  assert.equal(isAutoLock("auto-locked 2026-08-14: 3 uncommitted paths"), true);
+  assert.equal(isAutoLock('"active cave-1c8zf PR completion"'), false);
+  assert.equal(isAutoLock(""), false, "a bare `locked` line carries no claim of ours");
+  assert.equal(isAutoLock(undefined), false);
+  assert.equal(
+    isAutoLock('"manual: auto-locked look-alike"'),
+    false,
+    "the prefix must lead the reason, not merely appear in it",
+  );
 }
 
 console.log("worktree-autolock.test.mjs: ok");


### PR DESCRIPTION
Fixes the root cause in `cave-a245b` — the nightly worktree sweep stalling on stale locks.

## The bug

`scripts/worktree-autolock.mjs` skipped every already-locked worktree outright:

```js
for (const wt of worktrees.slice(1)) {
  if (wt.locked || wt.bare) continue;
```

So a lock reason is a **point-in-time claim that nothing ever re-evaluates**. A tree locked while work was genuinely at risk stayed locked after the retention-push hook later pushed its branch or tag — the risk was gone, the lock was not.

That permanently blocks automated retirement. The sweep exits 1 with `retirement-blocked` on units that are in fact clean and retained, and because blocked units still consume the `--max-retire` budget a run can retire **nothing**. Registered worktrees climbed 14 → 55 and both budgets blew, which blocks worktree creation for *every* session.

Both stale locks named in the bead were exactly this shape — e.g. `docs/cave-qphen-daily-report-backfill`, locked `1 commit not on any remote`, whose head was by then retained by `archive/` **and** `retention/` tags on origin.

## The fix

The hook re-evaluates its own locks and releases one whose stated risk no longer holds. Two deliberate boundaries:

- **Only its own locks.** A reason it did not write is a claim it cannot evaluate — `active cave-1c8zf PR completion` says nothing about dirtiness — so those stand and are left to a human. The `auto-locked` prefix test is the whole safety boundary; porcelain C-quotes the reason (ours always contains an em dash), so the opening quote is stripped before comparing.
- **Only a positive all-clear.** `riskOf` collapsed *no risk* and *unreadable* into `null`. That is correct for locking — both mean don't lock, and neither can destroy anything — and wrong for releasing, where they are opposites. New `evaluateRisk` returns `unreadable | clear | at-risk`, so a git hiccup, a half-created worktree, or an unreachable remote **keeps** its lock rather than earning the one verdict that permits destruction.

Retention still counts a pushed tag, not just a branch (`cave-qbr34`), so a unit archived the documented way becomes releasable instead of re-locked forever.

## Verification

- `node scripts/worktree-autolock.test.mjs` — ok. New coverage: full lock → still-at-risk → released cycle end-to-end through the real hook binary; a human lock is never released; `unreadable` is never `clear`; the prefix must *lead* the reason.
- Sibling suites green: `worktree-retention-push`, `worktree-status`, `worktree-guard`.
- Read-only simulation against this checkout: all six dirty worktrees **keep** their locks, nothing released indiscriminately.

## Not in scope

The bead's other two proposals, filed separately — (a) surface stale locks distinctly in the patrol, (b) stop charging blocked units against `--max-retire`. Both are defence-in-depth; this PR removes what generates the stale locks in the first place.