### PR TITLE
fix(cave-t57kr): stop managed worktree creation from tracking origin/main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -602,6 +602,50 @@ in-app instead. A dev-only recovery overlay replaces the raw `ChunkLoadError` /
 `ERR_CONNECTION_REFUSED` page, polls the origin, and hard-reloads the window as
 soon as the server answers so no stale chunk ids survive the restart.
 
+## Local remote hygiene — keep the Desktop branch list honest
+
+GitHub Desktop lists every remote-tracking ref in this checkout, so anything
+stale or foreign shows up as branch-list noise. Three rules keep it accurate.
+
+**One remote: `origin`.** A fork remote mirrors branches nobody here maintains.
+`snowopsdev` sat in this checkout contributing three refs, none of which any
+local branch tracked, long after its only contribution (`#4596`, closed
+unmerged, later re-landed on `main`) was superseded. Removing a remote is
+local-only and lossless — the fork keeps its own branches — so drop one as soon
+as its PR is resolved:
+
+```bash
+git remote -v                    # expect exactly origin (fetch + push)
+git remote remove <fork>
+```
+
+**`fetch.prune = true`.** Without it, deleted remote branches linger as
+tracking refs forever, and this repository deletes branches constantly
+(`delete_branch_on_merge` plus `branch-cap.yml`). Set once per checkout:
+
+```bash
+git config fetch.prune true
+git config fetch.pruneTags false   # tags are the retention store; never prune them
+```
+
+⚠️ Keep `pruneTags` off. `archive/*` and `retention/*` tags are what the
+worktree guard reads as proof a head is retained, and pruning them locally
+would make retained work look at-risk.
+
+**No feature branch tracks a remote branch.** Only `main` and the Beads dolt
+sync branch should have an upstream. Audit with:
+
+```bash
+git for-each-ref --format='%(refname:short) -> %(upstream:short)' refs/heads \
+  | grep -v ' -> $'
+```
+
+Anything else listed is a branch that will render as "behind N" against a ref
+it is not a view of, and whose bare `git push` git answers by suggesting
+`git push origin HEAD:main`. Clear it with `git branch --unset-upstream
+<branch>`. Managed creation stopped producing these in `cave-t57kr`, but
+branches made before that fix still carry one.
+
 ## Diagnosing concurrent sessions
 
 If git operations keep colliding with surprise pulls/merges, multiple Claude sessions are likely on the same checkout. Diagnose:
@@ -685,8 +729,18 @@ something the others do not (`cave-xjuup`):
 
 - `refs/remotes/origin/<branch>`, written by a push. Survives the remote
   dropping the branch, but **not** a `fetch --prune`.
-- `branch.<name>.remote`, written only by `push -u`. Lives in `.git/config`, so
+- `branch.<name>.remote`, written by `push -u`. Lives in `.git/config`, so
   a prune cannot touch it — but plenty of branches never get one.
+
+  ⚠️ It was **also** written by managed worktree creation until `cave-t57kr`:
+  `git worktree add -b <branch> <path> origin/main` tracks its remote start
+  point by default, so this key was true from birth for every canonical
+  worktree. That made the "three signals" below effectively one — the test
+  never reached the log, always read "was deleted", and so always archived a
+  tag instead of the readable branch the paragraph after this one promises.
+  `worktree-lifecycle-create.ts` now passes `--no-track`. A branch created
+  before that fix still carries the stale key; clear it with
+  `git branch --unset-upstream <branch>`.
 - **the hook's own log**, which records that *it* pushed the branch. Survives
   everything short of deleting the file.
 

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1042,6 +1042,37 @@ await withFixture({}, async (fixture) => {
   assert.match(report.metadata.coven.worktree.createdAt, /^\d{4}-\d{2}-\d{2}T/);
   assert.equal(registeredAt(fixture.repo, expectedPath).length, 1);
   assert.equal(refState(fixture.repo, report.fullRef).oid, report.head);
+
+  // A managed branch must NOT track its remote start point. Git's default
+  // `branch.autoSetupMerge` would set `origin/main` as the upstream of every
+  // worktree branch, which renders each one as "behind N" against `main` in
+  // GitHub Desktop and makes a bare `git push` suggest `git push origin
+  // HEAD:main` — the direct-to-main move the repository forbids.
+  //
+  // It also writes `branch.<name>.remote`, which `worktree-retention-push.mjs`
+  // reads as proof that a push once happened. That key was therefore true from
+  // birth for every canonically-created worktree, collapsing that hook's
+  // three-signal "deleted or never pushed?" test into an unconditional "was
+  // deleted" and so never taking the readable-branch route it promises for a
+  // branch that has genuinely never left the machine (cave-t57kr).
+  //
+  // Assert on the observable git state rather than the flag, so a refactor that
+  // drops `--no-track` fails here rather than silently restoring the defect.
+  for (const [key, label] of [
+    ["remote", "the retention hook's `was it ever pushed?` signal"],
+    ["merge", "the upstream shown by GitHub Desktop"],
+  ]) {
+    assert.equal(
+      run(realGit, ["config", "--get", `branch.${report.branch}.${key}`], fixture.repo).status,
+      1,
+      `a managed worktree branch must not set branch.<name>.${key} — it corrupts ${label}`,
+    );
+  }
+  assert.equal(
+    git(["for-each-ref", "--format=%(upstream)", report.fullRef], fixture.repo).trim(),
+    "",
+    "a managed worktree branch must have no upstream",
+  );
   const state = readJson(fixture.stateFile);
   assert.deepEqual(Object.keys(state.updates.at(-1)), ["coven"], "bd update merges only coven");
   const covenFence = readJson(fixture.covenStateFile);

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -1837,6 +1837,19 @@ function execute(
     [
       "worktree",
       "add",
+      // `--start-point` is a remote-tracking ref (`origin/main` by default), and
+      // git's default `branch.autoSetupMerge` would make the new branch TRACK
+      // it: `branch.<name>.remote=origin`, `branch.<name>.merge=refs/heads/main`.
+      // That upstream is wrong in every case — the branch is not a local view of
+      // `main` — and it costs twice over. It renders every managed worktree as
+      // "behind N" against `main` in GitHub Desktop, and a bare `git push` from
+      // one is refused with git's own suggestion to run `git push origin
+      // HEAD:main`, the direct-to-main move this repository forbids. It also
+      // writes the `branch.<name>.remote` key that `worktree-retention-push.mjs`
+      // reads as proof a push once happened, which would be true from birth for
+      // every canonically-created worktree and would collapse that hook's
+      // three-signal test into "always archive as a tag".
+      "--no-track",
       "-b",
       options.branch,
       worktreePath,

--- a/scripts/worktree-retention-push.mjs
+++ b/scripts/worktree-retention-push.mjs
@@ -213,10 +213,18 @@ export function hadRemoteTracking(worktreePath, branch) {
  * Did a push ever configure an upstream for this branch?
  *
  * `branch.<name>.remote` lives in `.git/config`, not in the ref store, so
- * unlike the remote-tracking ref it SURVIVES `fetch --prune`. Only `push -u`
- * (or an explicit `--set-upstream`) writes it, so it is a partial signal —
- * present for some branches and not others — which is exactly why it is one of
- * several rather than the answer.
+ * unlike the remote-tracking ref it SURVIVES `fetch --prune`. `push -u` (or an
+ * explicit `--set-upstream`) writes it, so it is a partial signal — present for
+ * some branches and not others — which is exactly why it is one of several
+ * rather than the answer.
+ *
+ * One other thing writes it: `git worktree add -b <branch> <path> origin/main`,
+ * whose default `branch.autoSetupMerge` tracks the remote start point. That
+ * made the key true from birth for every canonically-created worktree, so this
+ * signal was silently unconditional and `deletedUpstream` below always took the
+ * archive-tag route — never the readable-branch route it promises for a
+ * never-pushed branch (cave-t57kr). `worktree-lifecycle-create.ts` now passes
+ * `--no-track`, which restores the key to meaning what this doc comment says.
  */
 export function hasUpstreamConfig(worktreePath, branch) {
   if (!branch) return false;
@@ -375,7 +383,8 @@ function main() {
     // do not (cave-xjuup):
     //
     //   - the remote-tracking ref, which a `fetch --prune` erases;
-    //   - `branch.<name>.remote`, which only `push -u` writes;
+    //   - `branch.<name>.remote`, which `push -u` writes (and which worktree
+    //     creation no longer writes — see hasUpstreamConfig, cave-t57kr);
     //   - this hook's own log, which records that IT pushed the branch.
     //
     // One signal was not enough. GitHub Desktop prunes routinely here, so the


### PR DESCRIPTION
Closes cave-t57kr.

## The defect

`worktree-lifecycle-create.ts` runs `git worktree add -b <branch> <path> origin/main`. The start point is a remote-tracking ref, so git's default `branch.autoSetupMerge` makes the new branch **track** it — every canonically-created worktree branch got `branch.<name>.remote=origin` and `branch.<name>.merge=refs/heads/main`.

Reproduced from first principles in a scratch repo:

```
feat/tracked   -> [origin/main]   # git worktree add -b … origin/main
feat/untracked -> []              # … --no-track
```

## Why it matters twice

**Visible half.** GitHub Desktop renders every feature branch as "behind N" against a ref it is not a view of — the branch-list noise this started from. And a bare `git push` from such a branch is refused by `push.default=simple` with git's own suggestion to run `git push origin HEAD:main`, the direct-to-main move `CLAUDE.md` forbids. Five live branches were in this state when the bug was found, plus a sixth created by another session mid-investigation.

**Quiet half, and the more serious one.** `scripts/worktree-retention-push.mjs` reads `branch.<name>.remote` as one of three signals proving a push once happened. Its doc comment asserted *"Only `push -u` (or an explicit `--set-upstream`) writes it, so it is a partial signal — present for some branches and not others"*. That was false: worktree creation wrote it too, so the key was true **from birth for every managed worktree**.

The three-signal test in `deletedUpstream()` therefore collapsed to an unconditional "was deleted" — it never reached the log, and always took the archive-tag route. The behaviour the surrounding comment promises, *"a never-pushed branch is still retained as a readable branch"*, was unreachable for exactly the branches this repository creates canonically.

## The fix

Pass `--no-track`. That restores `branch.<name>.remote` to meaning what the retention hook documents, and leaves the key intact for its real writer (`push -u`).

The regression test asserts the **observable git state** rather than the flag — no `branch.<name>.remote`, no `branch.<name>.merge`, no upstream — so a refactor that drops `--no-track` fails here instead of silently restoring the defect.

`CLAUDE.md` is corrected in the same change (its `cave-xjuup` three-signal list repeated the same false claim), and gains a short **Local remote hygiene** section covering the two other sources of Desktop branch-list noise found alongside this: a stale fork remote, and `fetch.prune` being unset.

## Verification

| Suite | Result |
| --- | --- |
| `worktree-lifecycle-create.test.mjs` | ok |
| `worktree-retention-push.test.mjs` | 23/23 pass |
| `beads-familiar-workflow.test.mjs` | pass |
| `branch-curator-manual-cleanup-contract.test.mjs` | pass |
| `branch-to-merge-contract.test.mjs` | pass |

## Note for existing branches

Branches created before this fix keep the stale upstream; it is cleared per branch with `git branch --unset-upstream <branch>`. Already done for the six in this checkout.