### PR TITLE
fix(marketplace): share the logo transport projection

### DIFF
--- a/src/app/api/marketplace/route.ts
+++ b/src/app/api/marketplace/route.ts
@@ -22,17 +22,15 @@ import {
   type MarketplaceJsonPlugin,
   type PluginManifest,
 } from "@/lib/marketplace-catalog";
-import { resolveMarketplaceLogo } from "@/lib/marketplace-logo";
+import {
+  marketplaceLogoForTransport,
+  resolveMarketplaceLogo,
+} from "@/lib/marketplace-logo";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 const MARKETPLACE_DIR = path.join(process.cwd(), "marketplace");
-
-function toTransportMarketplaceLogo(logo: ReturnType<typeof resolveMarketplaceLogo>) {
-  const { svgPath: _svgPath, ...transportLogo } = logo;
-  return transportLogo;
-}
 
 export async function GET() {
   let marketplacePlugins: MarketplaceJsonPlugin[] = [];
@@ -76,7 +74,7 @@ export async function GET() {
     ...ownedCatalog,
   ].map((plugin) => ({
     ...plugin,
-    logo: toTransportMarketplaceLogo(
+    logo: marketplaceLogoForTransport(
       plugin.logo ?? resolveMarketplaceLogo(plugin.id, plugin.displayName),
     ),
   }));

--- a/src/components/marketplace/marketplace-logo.tsx
+++ b/src/components/marketplace/marketplace-logo.tsx
@@ -18,10 +18,10 @@ export function MarketplaceLogo({
   logo,
   size = "card",
 }: MarketplaceLogoProps) {
-  const resolved = {
-    ...resolveMarketplaceLogo(id, displayName),
-    ...logo,
-  };
+  const bundled = resolveMarketplaceLogo(id, displayName);
+  const resolved = logo?.kind === "brand" && !logo.svgPath && bundled.kind === "brand"
+    ? { ...logo, svgPath: bundled.svgPath }
+    : logo ?? bundled;
   return (
     <span
       className={`marketplace-logo marketplace-logo--${size}`}

--- a/src/lib/marketplace-logo.test.ts
+++ b/src/lib/marketplace-logo.test.ts
@@ -4,6 +4,7 @@ import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import {
   marketplaceLogoCoverage,
+  marketplaceLogoForTransport,
   marketplaceMonogram,
   resolveMarketplaceLogo,
 } from "./marketplace-logo.ts";
@@ -53,6 +54,15 @@ assert.equal(resolveMarketplaceLogo("unlisted-local-tool", "Unlisted Local Tool"
 assert.equal(marketplaceMonogram("Prompt Pack: Shipping"), "PS");
 assert.equal(marketplaceMonogram("GitHub"), "GH");
 assert.equal(marketplaceMonogram("OpenCoven"), "OC");
+const githubTransport = marketplaceLogoForTransport(resolveMarketplaceLogo("github", "GitHub"));
+assert.deepEqual(githubTransport, {
+  kind: "brand",
+  title: "GitHub",
+  monogram: "GH",
+  assetPath: "/marketplace-logos/github.png",
+});
+assert.equal("svgPath" in githubTransport, false, "API identities omit large inline SVG paths");
+assert.equal("source" in githubTransport, false, "API identities omit generator-only metadata");
 
 const expectedAssets = Object.entries(registry.entries)
   .filter(([, logo]) => logo.kind === "brand")
@@ -74,7 +84,7 @@ const componentSource = await readFile(
 assert.match(componentSource, /data-marketplace-logo-kind=\{resolved\.kind\}/);
 assert.match(componentSource, /resolved\.kind === "brand" && resolved\.svgPath/);
 assert.match(componentSource, /marketplace-logo__monogram/);
-assert.match(componentSource, /resolveMarketplaceLogo\(id, displayName\),\s+\.\.\.logo/s);
+assert.match(componentSource, /\{ \.\.\.logo, svgPath: bundled\.svgPath \}/);
 
 for (const file of [
   "src/components/marketplace/marketplace-card.tsx",
@@ -111,11 +121,6 @@ const marketplaceRoute = await readFile(
   path.join(root, "src/app/api/marketplace/route.ts"),
   "utf8",
 );
-assert.match(marketplaceRoute, /function toTransportMarketplaceLogo/);
-assert.match(marketplaceRoute, /const \{ svgPath: _svgPath, \.\.\.transportLogo \} = logo/);
-assert.match(
-  marketplaceRoute,
-  /logo: toTransportMarketplaceLogo\(\s+plugin\.logo \?\? resolveMarketplaceLogo\(plugin\.id, plugin\.displayName\),/s,
-);
+assert.match(marketplaceRoute, /logo: marketplaceLogoForTransport\(/);
 
 console.log(`marketplace-logo.test.ts: ${catalogIds.length} entries covered`);

--- a/src/lib/marketplace-logo.ts
+++ b/src/lib/marketplace-logo.ts
@@ -10,6 +10,11 @@ export type MarketplaceLogoIdentity = {
   source?: string;
 };
 
+export type MarketplaceLogoTransportIdentity = Pick<
+  MarketplaceLogoIdentity,
+  "kind" | "title" | "monogram" | "assetPath"
+>;
+
 type MarketplaceLogoRegistry = {
   schemaVersion: 1;
   catalogCount: number;
@@ -33,6 +38,17 @@ export function resolveMarketplaceLogo(id: string, displayName: string): Marketp
     kind: "monogram",
     title: displayName,
     monogram: marketplaceMonogram(displayName || id),
+  };
+}
+
+export function marketplaceLogoForTransport(
+  identity: MarketplaceLogoIdentity,
+): MarketplaceLogoTransportIdentity {
+  return {
+    kind: identity.kind,
+    title: identity.title,
+    monogram: identity.monogram,
+    ...(identity.assetPath ? { assetPath: identity.assetPath } : {}),
   };
 }
 

--- a/tests/marketplace-logos.spec.ts
+++ b/tests/marketplace-logos.spec.ts
@@ -78,9 +78,11 @@ test("marketplace cards and details show brand marks with resilient monograms", 
     await setTheme(page, theme.id, theme.mode);
     await expect(githubLogo).toBeVisible();
     await expect(fallbackLogo).toBeVisible();
-    const alpha = await githubLogo.evaluate((el) => {
-      const c = getComputedStyle(el).color;
-      return c === "transparent" ? 0 : Number(c.match(/rgba\(\d+, \d+, \d+, ([0-9.]+)\)/)?.[1] ?? 1);
+    const alpha = await githubLogo.evaluate((element) => {
+      const color = getComputedStyle(element).color.trim().toLowerCase();
+      if (color === "transparent") return 0;
+      const channels = color.match(/[\d.]+/g)?.map(Number) ?? [];
+      return color.startsWith("rgba") ? channels[3] ?? 1 : 1;
     });
     expect(alpha).toBeGreaterThan(0);
   }


### PR DESCRIPTION
Recovers reviewable follow-up work that was stranded on `feat/cave-k11i6-marketplace-logos-v2` after PR #4684 merged. That branch is 3 days behind `main` and its remaining commits are dominated by a worktree snapshot that would revert newer files, so this lands only the 5 files that carry real content, applied onto current `main`.

## What changed

- **Extract the transport projection.** `toTransportMarketplaceLogo` lived inside `src/app/api/marketplace/route.ts` and omitted `svgPath` by destructuring (`const { svgPath: _svgPath, ...rest } = logo`). That forwards every *other* field, including the generator-only `source`, to API consumers. It is now `marketplaceLogoForTransport` in `src/lib/marketplace-logo.ts`, returning an explicit allowlist typed as `MarketplaceLogoTransportIdentity`.
- **Fix the logo merge.** `MarketplaceLogo` spread `{ ...resolveMarketplaceLogo(id, displayName), ...logo }`. A transport logo has no `svgPath` by construction, so once a caller passed one through, the bundled brand SVG was lost and the mark degraded to a monogram. The bundled `svgPath` is now preserved when the incoming brand logo lacks one.
- **Harden the Playwright colour assertion** to parse `rgb()` as well as `rgba()`.

## Verification

- `node --experimental-strip-types src/lib/marketplace-logo.test.ts` — passes, 129 entries covered
- `pnpm typecheck` — clean
- `pnpm lint` — clean (incl. design codemod check, 0 drift)

Bead: cave-4y5q9. Original work by @BunsDev in `ed1ffad7fa` / `5e26dc4cee`; credited via `Co-authored-by`.