### PR TITLE
fix(client-v1): make the public envelopes a precise discriminated union

### DIFF
--- a/src/lib/server/client-v1/contract.test.ts
+++ b/src/lib/server/client-v1/contract.test.ts
@@ -22,8 +22,11 @@ import {
   renderClientV1ContractFixture,
   sortClientV1JsonKeys,
   type ClientV1Cursor,
+  type ClientV1ErrorEnvelope,
   type ClientV1Identity,
   type ClientV1Revision,
+  type ClientV1StatusRecord,
+  type ClientV1SuccessEnvelope,
 } from "./contract.ts";
 import {
   clientV1Error,
@@ -33,6 +36,28 @@ import {
   clientV1SuccessResponse,
   httpStatusForClientV1ErrorCode,
 } from "./responses.ts";
+
+// Type-only compile-time assertions: the public envelope types must form a
+// precise discriminated union. Without `error?: never` / `data?: never`,
+// ClientV1Record's string index signature would let `error` and `data`
+// type-check on either envelope, so `Equal` here would resolve to `false` and
+// `Assert` would fail to compile.
+type Equal<Actual, Expected> =
+  (<Value>() => Value extends Actual ? 1 : 2) extends
+  (<Value>() => Value extends Expected ? 1 : 2)
+    ? (<Value>() => Value extends Expected ? 1 : 2) extends
+      (<Value>() => Value extends Actual ? 1 : 2)
+      ? true
+      : false
+    : false;
+type Assert<Condition extends true> = Condition;
+
+export type ClientV1SuccessEnvelopeExcludesErrorIsExact = Assert<
+  Equal<ClientV1SuccessEnvelope<ClientV1StatusRecord>["error"], undefined>
+>;
+export type ClientV1ErrorEnvelopeExcludesDataIsExact = Assert<
+  Equal<ClientV1ErrorEnvelope["data"], undefined>
+>;
 
 function parseJson<T>(value: string): T {
   return JSON.parse(value) as T;

--- a/src/lib/server/client-v1/contract.ts
+++ b/src/lib/server/client-v1/contract.ts
@@ -118,10 +118,15 @@ export type ClientV1Error = {
 
 export type ClientV1SuccessEnvelope<TData extends ClientV1Record = ClientV1Record> = ClientV1EnvelopeBase & {
   data: TData;
+  // Excludes `error` at the type level so success and error envelopes stay a
+  // precise discriminated union instead of both accepting either field via
+  // ClientV1Record's string index signature.
+  error?: never;
 };
 
 export type ClientV1ErrorEnvelope = ClientV1EnvelopeBase & {
   error: ClientV1Error;
+  data?: never;
 };
 
 export type ClientV1ContractManifest = {


### PR DESCRIPTION
## The defect

`ClientV1EnvelopeBase` is intersected with `ClientV1Record`, which is `JsonObject` — a type with a **string index signature**:

```ts
export type ClientV1EnvelopeBase = { … } & ClientV1Record;   // ClientV1Record = JsonObject
export type ClientV1SuccessEnvelope<TData …> = ClientV1EnvelopeBase & { data: TData };
export type ClientV1ErrorEnvelope        = ClientV1EnvelopeBase & { error: ClientV1Error };
```

That index signature means `ClientV1SuccessEnvelope` structurally accepts an `error` field and `ClientV1ErrorEnvelope` accepts `data`. The two are therefore **not** a discriminated union, and narrowing on either field does not behave the way callers of a public API contract expect.

## The fix

- `error?: never` on the success envelope, `data?: never` on the error envelope.
- Compile-time `Equal`/`Assert` type assertions in `contract.test.ts` pinning both.

## Verification — the assertions have teeth

Reverting **only** `contract.ts` and leaving the assertions in place fails typecheck at both sites, which is the evidence that `main` really did carry the imprecise union rather than this being documentation of an already-correct state:

```text
src/lib/server/client-v1/contract.test.ts(56,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/lib/server/client-v1/contract.test.ts(59,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```

With the fix applied:

- `pnpm typecheck` — clean
- `node --experimental-strip-types --test src/lib/server/client-v1/contract.test.ts` — 20 pass, 0 fail
- `pnpm lint` — clean

The wire contract is unchanged: this is type-level only, and `contract-fixture.sha256` is untouched.

## Provenance

Recovered from the stranded branch `fix/client-v1-contract-spec-freeze`, which holds this fix but is otherwise 521 lines behind `main` (it predates the `cloneClientV1JsonValue` hardening that #4717 landed) and so cannot be landed wholesale. Only the union fix is taken here, applied onto current `main`.

Bead: cave-7hw34. Original work by @BunsDev; credited via `Co-authored-by`.