### PR TITLE
fix(research): explicit one-pass cost approval, protect terminal missions

### DIFF
--- a/docs/specs/2026-07-12-research-mission-desk-design.md
+++ b/docs/specs/2026-07-12-research-mission-desk-design.md
@@ -352,6 +352,9 @@ Autoresearch is a series of finite iterations, not one immortal process.
 - When reported cumulative cost reaches `maxSpendUsd`, the mission pauses.
 - If cost is unavailable and `stopWhenCostUnavailable` is true, the mission
   pauses before the next iteration with “Cost unavailable; approve continuation.”
+  Approval is explicit and applies to one iteration only; the policy remains
+  enabled for the following pass. A blocked attempt never downgrades an already
+  completed mission.
 - A complete decision disables the linked automation and publishes final
   artifacts.
 

--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -503,7 +503,7 @@ export function ResearchMissionDetail({
       size="xs"
       variant={
         action === "continue"
-          ? (continueInfo.gated ? "ghost" : "primary")
+          ? (continueInfo.costApprovalRequired ? "secondary" : continueInfo.gated ? "ghost" : "primary")
           : action === "retry"
             ? "primary"
             : action === "cancel"
@@ -512,13 +512,19 @@ export function ResearchMissionDetail({
                 ? "secondary"
                 : "ghost"
       }
-      disabled={busy}
-      {...(action === "continue"
+      disabled={busy || (action === "continue" && continueInfo.gated && !continueInfo.costApprovalRequired)}
+      {...(action === "continue" || (action === "resume" && continueInfo.costApprovalRequired)
         ? { "aria-label": continueInfo.description, title: continueInfo.description }
         : {})}
-      onClick={() => void runAction(action === "retry" ? plannedRetry : { action })}
+      onClick={() => void runAction(
+        action === "retry"
+          ? plannedRetry
+          : (action === "continue" || action === "resume") && continueInfo.costApprovalRequired
+            ? { action, approveCostUnavailable: true }
+            : { action },
+      )}
     >
-      {action === "continue"
+      {action === "continue" || (action === "resume" && continueInfo.costApprovalRequired)
         ? continueInfo.label
         : action === "retry" ? retryLabel : ACTION_LABELS[action] ?? action}
     </Button>
@@ -884,9 +890,19 @@ export function ResearchMissionDetail({
                   size="xs"
                   variant="secondary"
                   disabled={busy || directionDrafting || !direction.trim()}
-                  onClick={() => void runAction({ action: "refine", direction })}
+                  aria-label={continueInfo.costApprovalRequired
+                    ? `Refine and continue with unreported cost. ${continueInfo.description}`
+                    : undefined}
+                  title={continueInfo.costApprovalRequired ? continueInfo.description : undefined}
+                  onClick={() => void runAction({
+                    action: "refine",
+                    direction,
+                    ...(continueInfo.costApprovalRequired ? { approveCostUnavailable: true } : {}),
+                  })}
                 >
-                  Refine and continue
+                  {continueInfo.costApprovalRequired
+                    ? "Refine and continue with unreported cost"
+                    : "Refine and continue"}
                 </Button>
               </div>
               {directionDrafting ? (

--- a/src/components/role-surfaces/research-tab-desk.test.ts
+++ b/src/components/role-surfaces/research-tab-desk.test.ts
@@ -75,8 +75,10 @@ test("checkpoint direction can be drafted agentically without auto-continuing", 
   assert.match(detail, /direction\.length\.toLocaleString\(\)\} \/ \{RESEARCH_DIRECTION_MAX_LENGTH\.toLocaleString\(\)/);
   assert.match(
     detail,
-    /onClick=\{\(\) => void runAction\(\{ action: "refine", direction \}\)\}/,
+    /onClick=\{\(\) => void runAction\(\{[\s\S]{0,180}?action: "refine",[\s\S]{0,180}?direction,[\s\S]{0,180}?approveCostUnavailable/,
   );
+  assert.match(detail, /Refine and continue with unreported cost/);
+  assert.match(detail, /title=\{continueInfo\.costApprovalRequired \? continueInfo\.description : undefined\}/);
   assert.doesNotMatch(
     detail,
     /generateResearchRefineDirection\([\s\S]{0,800}?runAction\(\{ action: "refine"/,
@@ -359,9 +361,12 @@ test("the action bar stays decision-first, sticky, with end actions split right"
   const actionsIndex = detail.indexOf("research-mission-actions");
   assert.ok(bannerIndex !== -1 && actionsIndex !== -1 && bannerIndex < actionsIndex);
   // Actions still come from the shared gate, with the consequence-labeled
-  // Continue demoting itself when a stop gate refuses.
+  // Continue disabled at hard bounds while missing cost becomes an explicit,
+  // one-pass approval.
   assert.match(detail, /allowedResearchActions\(mission\)/);
-  assert.match(detail, /continueInfo\.gated \? "ghost" : "primary"/);
+  assert.match(detail, /continueInfo\.costApprovalRequired \? "secondary"/);
+  assert.match(detail, /continueInfo\.gated && !continueInfo\.costApprovalRequired/);
+  assert.match(detail, /approveCostUnavailable: true/);
   // Cancel/Archive detach to the right edge of the bar.
   assert.match(detail, /new Set\(\["cancel", "archive"\]\)/);
   assert.match(detail, /\{mainActions\.map\(renderActionButton\)\}/);

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -326,9 +326,12 @@ test("the action bar reads decision-first with a consequence-labeled Continue", 
   assert.ok(bannerIndex !== -1 && actionsIndex !== -1 && bannerIndex < actionsIndex);
   // Continue says which iteration it starts (researchContinueLabel is
   // behaviorally tested in the lib suite) and demotes itself when any runner
-  // stop gate — iteration, wall-clock, cost policy, spend — already refuses.
+  // hard stop gate — iteration, wall-clock, spend — already refuses. Missing
+  // cost instead gets an explicit one-pass approval payload.
   assert.match(detail, /researchContinueLabel\(mission\)/);
-  assert.match(detail, /continueInfo\.gated \? "ghost" : "primary"/);
+  assert.match(detail, /continueInfo\.costApprovalRequired \? "secondary"/);
+  assert.match(detail, /continueInfo\.gated && !continueInfo\.costApprovalRequired/);
+  assert.match(detail, /approveCostUnavailable: true/);
   assert.match(detail, /"aria-label": continueInfo\.description, title: continueInfo\.description/);
   assert.match(detail, /continueInfo\.label/);
 });
@@ -341,7 +344,7 @@ test("retry adapts to project-root failures with a visible config", () => {
   // …the button label says what the retry will actually do…
   assert.match(detail, /Retry in workspace/);
   assert.match(detail, /Retry with new root/);
-  assert.match(detail, /runAction\(action === "retry" \? plannedRetry : \{ action \}\)/);
+  assert.match(detail, /action === "retry"[\s\S]{0,120}?\? plannedRetry/);
   // …and the root is editable with an honest workspace fallback.
   assert.match(detail, /id="research-retry-root"/);
   assert.match(detail, /Leave empty to run in the mission workspace/);

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -1071,7 +1071,28 @@ test("Continue reports every runner stop gate, not just the iteration limit", ()
     Date.parse("2026-07-15T00:10:00Z"),
   );
   assert.equal(noCost.gated, true);
+  assert.equal(noCost.costApprovalRequired, true);
+  assert.match(noCost.label, /Continue with unreported cost/);
   assert.match(noCost.description, /finished without reporting cost/);
+
+  const spendBeforeApproval = researchContinueLabel(
+    {
+      iterations: [
+        { number: 1, status: "checkpoint" as const, finishedAt: "2026-07-15T00:05:00Z", costUsd: 5 },
+        { number: 2, status: "checkpoint" as const, finishedAt: "2026-07-15T00:10:00Z" },
+      ],
+      bounds: {
+        ...bounds,
+        maxIterations: 3,
+        maxSpendUsd: 5,
+        stopWhenCostUnavailable: true,
+      },
+      startedAt,
+    },
+    Date.parse("2026-07-15T00:10:00Z"),
+  );
+  assert.equal(spendBeforeApproval.costApprovalRequired, false);
+  assert.match(spendBeforeApproval.description, /reported spend has reached/);
 });
 
 // --- bound readings: a bar only where a denominator exists -----------------

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -31,6 +31,9 @@ export type ResearchMissionAction =
   | "cancel"
   | "archive";
 
+export const RESEARCH_COST_UNAVAILABLE_STOP_REASON =
+  "Cost unavailable; review before another iteration";
+
 export type ResearchBounds = {
   wallClockMinutes: number;
   maxIterations: number;
@@ -356,6 +359,8 @@ export type ResearchMissionActionInput =
   | {
     action: ResearchMissionAction;
     direction?: string;
+    /** One-pass approval to continue when the previous iteration reported no cost. */
+    approveCostUnavailable?: boolean;
     /**
      * Retry-only project root override: a path re-targets the retried
      * iteration (validated server-side against allowed project roots), null
@@ -987,6 +992,21 @@ export function allowedResearchActions(
   return [];
 }
 
+/** Repair the exact terminal-state downgrade produced by the old Continue gate. */
+export function repairResearchMissionState(mission: ResearchMission): ResearchMission {
+  const latest = mission.iterations.at(-1);
+  if (
+    mission.status === "paused" &&
+    mission.lastError === RESEARCH_COST_UNAVAILABLE_STOP_REASON &&
+    latest?.status === "completed" &&
+    latest.decision === "complete"
+  ) {
+    const { lastError: _lastError, ...completed } = mission;
+    return { ...completed, status: "completed" };
+  }
+  return mission;
+}
+
 export type ResearchPhaseStatus = "pending" | "running" | "succeeded" | "failed" | "skipped";
 
 type ResearchPhaseOutcome = "success" | "failure" | "cancelled" | null;
@@ -1145,6 +1165,8 @@ export type ResearchContinueLabel = {
   description: string;
   /** A stop gate already refuses the next iteration — pressing starts nothing. */
   gated: boolean;
+  /** Missing telemetry may be bypassed for exactly one explicitly approved pass. */
+  costApprovalRequired: boolean;
 };
 
 /**
@@ -1152,12 +1174,9 @@ export type ResearchContinueLabel = {
  *
  * The runner gates every new iteration on stopBeforeNextIteration
  * (src/lib/server/research-mission-runner.ts): iteration count, wall-clock
- * budget, missing-cost policy, and the reported-spend cap. A Continue past
- * any of those starts nothing — it re-settles the mission at the limit. This
- * mirrors those gates (same >= comparisons) so the button can say which gate
- * refuses instead of promising an iteration; keep the two in sync. Even when
- * no gate is known-exceeded, the description stays a request — the runner
- * re-checks with live clocks.
+ * budget, missing-cost policy, and the reported-spend cap. Hard bounds refuse
+ * the action; missing cost instead requires an explicit approval that applies
+ * to one pass only. Keep this in sync with stopBeforeNextIteration.
  */
 export function researchContinueLabel(
   mission: Pick<ResearchMission, "iterations" | "bounds" | "startedAt">,
@@ -1170,23 +1189,19 @@ export function researchContinueLabel(
     label,
     description: `Continue would ask for iteration ${next}, but ${why}`,
     gated: true,
+    costApprovalRequired: false,
   });
   if (next > max) {
     return {
       label,
       description: `Continue would ask for iteration ${next}, past the planned ${max} — the runner stops at the iteration limit instead of starting it.`,
       gated: true,
+      costApprovalRequired: false,
     };
   }
   const startedAt = mission.startedAt ? Date.parse(mission.startedAt) : Number.NaN;
   if (Number.isFinite(startedAt) && nowMs - startedAt >= mission.bounds.wallClockMinutes * 60_000) {
     return refusal(`the ${mission.bounds.wallClockMinutes}-minute wall-clock budget is spent — the runner pauses at the limit instead of starting it.`);
-  }
-  if (
-    mission.bounds.stopWhenCostUnavailable &&
-    mission.iterations.some((iteration) => iteration.finishedAt && iteration.costUsd === undefined)
-  ) {
-    return refusal("an iteration finished without reporting cost — the runner pauses for review instead of starting it.");
   }
   const reportedSpend = mission.iterations
     .map((iteration) => iteration.costUsd)
@@ -1195,10 +1210,22 @@ export function researchContinueLabel(
   if (mission.bounds.maxSpendUsd !== undefined && reportedSpend >= mission.bounds.maxSpendUsd) {
     return refusal(`reported spend has reached the $${mission.bounds.maxSpendUsd} cap — the runner pauses at the limit instead of starting it.`);
   }
+  if (
+    mission.bounds.stopWhenCostUnavailable &&
+    mission.iterations.some((iteration) => iteration.finishedAt && iteration.costUsd === undefined)
+  ) {
+    return {
+      label: `Continue with unreported cost (i${next}/${max})`,
+      description: `An iteration finished without reporting cost. Continue starts iteration ${next} with one-pass approval; the mission will ask again before another unmetered pass.`,
+      gated: true,
+      costApprovalRequired: true,
+    };
+  }
   return {
     label,
     description: `Continue asks the runner to start iteration ${next} of ${max} planned — stop gates are re-checked first.`,
     gated: false,
+    costApprovalRequired: false,
   };
 }
 

--- a/src/lib/server/research-mission-lifecycle.ts
+++ b/src/lib/server/research-mission-lifecycle.ts
@@ -8,6 +8,7 @@ import type {
 } from "./research-session-authority.ts";
 import {
   researchArtifactKindForMode,
+  RESEARCH_COST_UNAVAILABLE_STOP_REASON,
   RESEARCH_RUNTIME_DEFAULT_HARNESS,
   STANDARD_RESEARCH_ARTIFACTS,
 } from "../research-missions.ts";
@@ -158,7 +159,11 @@ export function withinStartupGrace(startedAt: string | undefined, now: Date): bo
   return Math.abs(now.getTime() - started) < SESSION_STARTUP_GRACE_MS;
 }
 
-export function stopBeforeNextIteration(mission: ResearchMission, now: Date): string | null {
+export function stopBeforeNextIteration(
+  mission: ResearchMission,
+  now: Date,
+  options: { allowCostUnavailable?: boolean } = {},
+): string | null {
   if (mission.iterations.length >= mission.bounds.maxIterations) return "Iteration limit reached";
   const startedAt = mission.startedAt ? Date.parse(mission.startedAt) : Number.NaN;
   if (Number.isFinite(startedAt) && now.getTime() - startedAt >= mission.bounds.wallClockMinutes * 60_000) {
@@ -167,11 +172,15 @@ export function stopBeforeNextIteration(mission: ResearchMission, now: Date): st
   const knownCosts = mission.iterations
     .map((iteration) => iteration.costUsd)
     .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
-  if (mission.bounds.stopWhenCostUnavailable && mission.iterations.some((iteration) => iteration.finishedAt && iteration.costUsd === undefined)) {
-    return "Cost unavailable; review before another iteration";
-  }
   if (mission.bounds.maxSpendUsd !== undefined && knownCosts.reduce((sum, value) => sum + value, 0) >= mission.bounds.maxSpendUsd) {
     return "Reported spend limit reached";
+  }
+  if (
+    !options.allowCostUnavailable &&
+    mission.bounds.stopWhenCostUnavailable &&
+    mission.iterations.some((iteration) => iteration.finishedAt && iteration.costUsd === undefined)
+  ) {
+    return RESEARCH_COST_UNAVAILABLE_STOP_REASON;
   }
   return null;
 }

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -920,6 +920,136 @@ test("cost-unavailable policy pauses before another iteration", async () => {
   assert.match(result.lastError ?? "", /Cost unavailable/);
 });
 
+test("one-pass cost approval starts the next iteration without weakening the policy", async () => {
+  let stored = checkpointMission({
+    bounds: {
+      ...checkpointMission().bounds,
+      stopWhenCostUnavailable: true,
+    },
+  });
+  let starts = 0;
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    startFlow: async (flow) => {
+      starts += 1;
+      return {
+        ok: true,
+        executor: "session",
+        sessionId: "session-2",
+        run: { ...RUN, id: "run-2", flowId: flow.id, sessionId: "session-2" },
+      };
+    },
+  }));
+  const result = await runner.act(stored.id, {
+    action: "continue",
+    approveCostUnavailable: true,
+  });
+  assert.equal(result.status, "running");
+  assert.equal(result.iterations.length, 2);
+  assert.equal(result.bounds.stopWhenCostUnavailable, true);
+  assert.equal(starts, 1);
+});
+
+test("one-pass cost approval cannot override the reported spend cap", async () => {
+  let stored = checkpointMission({
+    bounds: {
+      ...checkpointMission().bounds,
+      maxSpendUsd: 1,
+      stopWhenCostUnavailable: true,
+    },
+    iterations: [
+      {
+        ...checkpointMission().iterations[0],
+        costUsd: 1,
+      },
+      {
+        number: 2,
+        status: "checkpoint",
+        startedAt: NOW.toISOString(),
+        finishedAt: NOW.toISOString(),
+        decision: "checkpoint",
+        decisionReason: "Review before continuing",
+      },
+    ],
+  });
+  let starts = 0;
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    startFlow: async () => {
+      starts += 1;
+      return { ok: true, executor: "session", sessionId: "must-not-start" };
+    },
+  }));
+  const result = await runner.act(stored.id, {
+    action: "continue",
+    approveCostUnavailable: true,
+  });
+  assert.equal(result.status, "paused");
+  assert.match(result.lastError ?? "", /Reported spend limit reached/);
+  assert.equal(starts, 0);
+});
+
+test("a blocked Continue cannot downgrade a completed mission", async () => {
+  const finishedAt = NOW.toISOString();
+  let stored = checkpointMission({
+    status: "completed",
+    finishedAt,
+    bounds: {
+      ...checkpointMission().bounds,
+      stopWhenCostUnavailable: true,
+    },
+    iterations: [{
+      ...checkpointMission().iterations[0],
+      status: "completed",
+      decision: "complete",
+      decisionReason: "Enough evidence",
+    }],
+  });
+  let saves = 0;
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => {
+      saves += 1;
+      stored = structuredClone(mission);
+    },
+  }));
+  const result = await runner.act(stored.id, { action: "continue" });
+  assert.equal(result.status, "completed");
+  assert.equal(result.finishedAt, finishedAt);
+  assert.equal(result.lastError, undefined);
+  assert.equal(saves, 0);
+});
+
+test("Resume approves one unmetered pass for a legacy cost-paused mission", async () => {
+  let stored = checkpointMission({
+    status: "paused",
+    lastError: "Cost unavailable; review before another iteration",
+    bounds: {
+      ...checkpointMission().bounds,
+      stopWhenCostUnavailable: true,
+    },
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    startFlow: async (flow) => ({
+      ok: true,
+      executor: "session",
+      sessionId: "session-2",
+      run: { ...RUN, id: "run-2", flowId: flow.id, sessionId: "session-2" },
+    }),
+  }));
+  const result = await runner.act(stored.id, {
+    action: "resume",
+    approveCostUnavailable: true,
+  });
+  assert.equal(result.status, "running");
+  assert.equal(result.iterations.length, 2);
+  assert.equal(result.lastError, undefined);
+});
+
 test("cancel kills the active session and preserves artifacts", async () => {
   const killed: Array<[string, unknown, unknown]> = [];
   let cleared = 0;

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -16,6 +16,7 @@ import {
 import { buildResearchMissionFlow } from "../research-mission-flow.ts";
 import {
   allowedResearchActions,
+  RESEARCH_COST_UNAVAILABLE_STOP_REASON,
   RESEARCH_DIRECTION_MAX_LENGTH,
   RESEARCH_PROJECT_ROOT_MAX_LENGTH,
   researchArtifactKindForMode,
@@ -873,9 +874,15 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
     return { ...mission, projectRoot: resolved };
   };
 
-  const startNextIteration = async (mission: ResearchMission): Promise<ResearchMission> => {
-    const stopReason = stopBeforeNextIteration(mission, deps.now());
+  const startNextIteration = async (
+    mission: ResearchMission,
+    options: { allowCostUnavailable?: boolean } = {},
+  ): Promise<ResearchMission> => {
+    const stopReason = stopBeforeNextIteration(mission, deps.now(), options);
     if (stopReason) {
+      if (mission.status === "completed" || mission.status === "cancelled") {
+        return mission;
+      }
       const atIterationLimit = stopReason === "Iteration limit reached";
       return saveUpdated({
         ...mission,
@@ -1110,7 +1117,9 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
           throw new Error(`refined direction must be at most ${RESEARCH_DIRECTION_MAX_LENGTH} characters`);
         }
         mission = { ...mission, direction };
-        return startNextIteration(mission);
+        return startNextIteration(mission, {
+          allowCostUnavailable: input.approveCostUnavailable === true,
+        });
       }
       if (input.action === "retry") {
         if (input.projectRoot !== undefined) {
@@ -1119,7 +1128,9 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         return retryCurrentIteration(mission);
       }
       if (input.action === "continue") {
-        return startNextIteration(mission);
+        return startNextIteration(mission, {
+          allowCostUnavailable: input.approveCostUnavailable === true,
+        });
       }
       if (input.action === "cancel") {
         const current = mission.iterations.at(-1);
@@ -1210,6 +1221,12 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         return saveUpdated({ ...mission, status: "archived" });
       }
       if (input.action === "resume") {
+        if (
+          mission.lastError === RESEARCH_COST_UNAVAILABLE_STOP_REASON &&
+          input.approveCostUnavailable === true
+        ) {
+          return startNextIteration(mission, { allowCostUnavailable: true });
+        }
         return saveUpdated({ ...mission, status: "checkpoint", lastError: undefined });
       }
       return mission;

--- a/src/lib/server/research-mission-store.test.ts
+++ b/src/lib/server/research-mission-store.test.ts
@@ -340,3 +340,40 @@ test("loadResearchMission backfills standard artifact refs on legacy missions", 
     ["primary", "findings", "source-ledger", "research-log"],
   );
 });
+
+test("loadResearchMission repairs a completed mission downgraded by the missing-cost gate", async (t) => {
+  const legacyRoot = await mkdtemp(path.join(os.tmpdir(), "research-store-cost-pause-"));
+  const previousRoot = process.env.COVEN_RESEARCH_MISSIONS_DIR;
+  process.env.COVEN_RESEARCH_MISSIONS_DIR = legacyRoot;
+  t.after(async () => {
+    if (previousRoot === undefined) delete process.env.COVEN_RESEARCH_MISSIONS_DIR;
+    else process.env.COVEN_RESEARCH_MISSIONS_DIR = previousRoot;
+    await rm(legacyRoot, { recursive: true, force: true });
+  });
+  const corrupted = {
+    ...mission("cost-paused-complete"),
+    status: "paused",
+    finishedAt: "2026-08-15T04:51:00.510Z",
+    lastError: "Cost unavailable; review before another iteration",
+    bounds: {
+      ...mission("cost-paused-complete").bounds,
+      stopWhenCostUnavailable: true,
+    },
+    iterations: [{
+      number: 1,
+      status: "completed",
+      finishedAt: "2026-08-15T04:51:00.510Z",
+      decision: "complete",
+      decisionReason: "Decision-ready result published",
+    }],
+  };
+  await mkdir(path.join(legacyRoot, corrupted.id), { recursive: true });
+  await writeFile(
+    path.join(legacyRoot, corrupted.id, "mission.json"),
+    JSON.stringify(corrupted),
+  );
+  const loaded = await loadResearchMission(corrupted.id);
+  assert.equal(loaded?.status, "completed");
+  assert.equal(loaded?.lastError, undefined);
+  assert.equal(loaded?.finishedAt, corrupted.finishedAt);
+});

--- a/src/lib/server/research-mission-store.ts
+++ b/src/lib/server/research-mission-store.ts
@@ -12,6 +12,7 @@ import type { ResearchMission } from "../research-missions.ts";
 import {
   ensureStandardArtifactRefs,
   parseResearchMission,
+  repairResearchMissionState,
 } from "../research-missions.ts";
 import { hasUnpairedUtf16Surrogate } from "../utf16.ts";
 import { writeFileAtomic, writeJsonAtomic } from "./atomic-write.ts";
@@ -399,7 +400,7 @@ export async function loadResearchMission(id: string): Promise<ResearchMission |
     if (!parsed || parsed.id !== id) return null;
     // Additive read-time backfill: missions created before the standard refs
     // existed gain them on load; the refs persist on the next save.
-    return ensureStandardArtifactRefs(parsed);
+    return ensureStandardArtifactRefs(repairResearchMissionState(parsed));
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code === "ENOENT" || error instanceof SyntaxError) return null;


### PR DESCRIPTION
## Problem

A completed or checkpointed Research mission with a missing cost could be rewritten to `paused` by **Continue**, and **Resume** could not approve an unmetered next pass. Terminal mission state was not preserved when an attempt was blocked.

## Change

- Adds an explicit one-pass approval path so an unmetered next pass can be authorized deliberately.
- Preserves terminal mission state (`completed` / checkpointed) when a continuation attempt is blocked, instead of silently rewriting it to `paused`.
- Covers the behavior at both the UI and server layers.

11 files changed, +303 / -34.

## Provenance

This work was implemented and verified by an earlier session under bead `cave-jb0mm`, whose notes record *"192 focused tests pass, pnpm typecheck passes, targeted ESLint passes, full pnpm test:app passes"* and *"Awaiting commit/PR/merge; do not close before merge"* — but it was never committed. A worktree-reduction pass snapshotted the uncommitted tree to `fix/cave-jb0mm-research-cost-approval` as an explicitly **unreviewed** WIP commit marked *not proposed for merge*.

This PR re-validates that content against **current main** before proposing it, so it is no longer an unreviewed snapshot. Landing bead: `cave-ymcl7` (separate from `cave-jb0mm` because that bead's worktree record is stale and must not be hand-edited).

## Verification on current main

- `pnpm typecheck` — clean
- `pnpm lint` — clean, 0 design drift
- `research-missions`, `research-mission-store`, `research-mission-runner-lifecycle-actions`, `research-tab-desk`, `researcher-surface` suites — all pass

No files in this change were modified on `main` since the branch's fork point, so the merge is content-equivalent to a clean merge (verified with `git diff --name-only <base> origin/main -- <files>`, empty).