### PR TITLE
Layer native title chrome above the app toolbar

### DIFF
--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -109,40 +109,6 @@ mod native_startup_terminal_tests {
     }
 }
 
-/// Show or hide the macOS traffic lights (close/minimize/zoom) on the
-/// invoking window. The main window's title bar is an Overlay (see the main
-/// window builder), so the buttons float over web content — when the app's
-/// side panel is closed the shell asks for them to disappear, Dia-style, and
-/// brings them back the moment the panel (or its hover-peek) opens. AppKit
-/// must be touched on the main thread; a no-op elsewhere.
-#[cfg(desktop)]
-#[tauri::command]
-fn set_traffic_lights_visible(window: tauri::WebviewWindow, visible: bool) {
-    #[cfg(target_os = "macos")]
-    {
-        let win = window.clone();
-        let _ = window.run_on_main_thread(move || {
-            let Ok(ns_ptr) = win.ns_window() else { return };
-            unsafe {
-                use objc2::msg_send;
-                use objc2::runtime::AnyObject;
-                let ns_window = ns_ptr as *mut AnyObject;
-                // NSWindowButton: close = 0, miniaturize = 1, zoom = 2.
-                for kind in 0u64..=2u64 {
-                    let button: *mut AnyObject = msg_send![&*ns_window, standardWindowButton: kind];
-                    if !button.is_null() {
-                        let _: () = msg_send![&*button, setHidden: !visible];
-                    }
-                }
-            }
-        });
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = (window, visible);
-    }
-}
-
 #[cfg(all(test, desktop))]
 #[path = "shell_open_tests.rs"]
 mod shell_open_tests;
@@ -299,7 +265,6 @@ pub fn run() {
             open_x_oauth_url,
             shell_open_path,
             shell_pick_directory,
-            set_traffic_lights_visible,
             #[cfg(target_os = "macos")]
             microphone::microphone_permission_request,
             #[cfg(target_os = "macos")]
@@ -498,14 +463,11 @@ pub fn run() {
                         // them.
                         .disable_drag_drop_handler();
                 // macOS: dissolve the seam between the native title bar and the
-                // app's top toolbar. `Overlay` lets the webview content fill to the
+                // app's title strip. `Overlay` lets the webview content fill to the
                 // very top (the traffic-light buttons float over it) and
-                // `hidden_title` drops the centered "CovenCave" label, so the
-                // toolbar reads as one continuous strip. The web side reserves room
-                // for the traffic lights (`[data-tauri-titlebar]` in globals.css)
-                // and marks the bar `data-tauri-drag-region="deep"`; the drag is
-                // an ACL-gated IPC call, granted to this loopback origin by
-                // capabilities/loopback-window-drag.json. No-op on Windows/Linux.
+                // `hidden_title` drops the native "CovenCave" label. The web side
+                // renders the centered Coven identity, reserves room for the
+                // traffic lights, and marks the strip as a deep drag region.
                 #[cfg(target_os = "macos")]
                 {
                     main_window = main_window

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -55,6 +55,6 @@ assert.match(css, /\.menu-bar__search \{[\s\S]*?border:\s*1px solid var\(--borde
 assert.match(css, /\.shell-top-history \{/, "history Back/Forward pair has its grouping styles");
 assert.match(css, /\.menu-bar__task-label \{\s*\n\s*display:\s*none/, "task labels are CSS-demoted — the bar shows icons only");
 assert.match(css, /\.menu-bar__task-label--live \{\s*\n\s*display:\s*inline/, "…except live enrich progress, which is information, not chrome");
-assert.match(css, /:root\[data-tauri-titlebar\] \.shell-top \{[\s\S]{0,300}?min-height: 29px/, "the desktop bar is a slim 29px — it hugs the 28px controls instead of towering over the macOS traffic lights");
-assert.match(css, /:root\[data-tauri-titlebar\] \.shell-top \.menu-bar \{[\s\S]{0,120}?min-height: 28px/, "the inner menu-bar must not prop the slim titlebar band back open at 34px");
+assert.match(css, /:root\[data-tauri-titlebar\] \.shell-window-titlebar \{[\s\S]{0,300}?flex: 0 0 30px/, "native macOS renders a dedicated 30px window title strip");
+assert.match(css, /:root\[data-tauri-titlebar\] \.shell-top \{[\s\S]{0,300}?min-height: 34px/, "the functional toolbar keeps its compact 34px row below the title strip");
 console.log("menu-bar-icon-size.test.ts passed");

--- a/src/components/shell-chrome-revamp.test.ts
+++ b/src/components/shell-chrome-revamp.test.ts
@@ -123,6 +123,11 @@ assert.match(
   /\.shell-top:has\(\.notification-bell__popover\) \{[^}]*z-index: 140;/,
   "an open notification dropdown lifts its title-bar stacking context above shell content",
 );
+assert.match(
+  desktopChrome,
+  /:root\[data-tauri-titlebar\] \.shell-window-titlebar \{[\s\S]{0,500}?border-bottom: 1px solid color-mix/,
+  "native macOS separates the centered identity strip from the functional toolbar with a quiet hairline",
+);
 
 // ── 3. Bottom status bar ─────────────────────────────────────────────────────
 assert.match(

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -39,8 +39,8 @@ assert.match(
 );
 assert.match(
   shell,
-  /<div className="shell-top" data-tauri-drag-region="deep">[\s\S]*?\{navToggle\}[\s\S]*?<div className="shell-top__bar" data-tauri-drag-region="deep">\{renderedTopBar\}<\/div>/,
-  "the top bar row leads with the nav toggle before the rendered top bar",
+  /<div className="shell-window-titlebar" data-tauri-drag-region="deep" aria-label="Coven window">[\s\S]*?<span className="shell-window-titlebar__title">Coven<\/span>[\s\S]*?<div className="shell-top" data-tauri-drag-region="deep">[\s\S]*?\{navToggle\}[\s\S]*?<div className="shell-top__bar" data-tauri-drag-region="deep">\{renderedTopBar\}<\/div>/,
+  "the native title strip precedes the functional toolbar and its nav toggle",
 );
 // `deep` (not the bare attribute) is load-bearing: Tauri drag.js only drags a
 // bare region on DIRECT presses on the attributed element, so empty chrome
@@ -53,7 +53,12 @@ assert.match(
 assert.equal(
   shell.match(/<div className="shell-top" data-tauri-drag-region="deep">/g)?.length,
   1,
-  "the hydration-stable shell should expose one deep Tauri drag region on the titlebar container",
+  "the hydration-stable shell should expose one deep Tauri drag region on the toolbar container",
+);
+assert.equal(
+  shell.match(/<div className="shell-window-titlebar" data-tauri-drag-region="deep"/g)?.length,
+  1,
+  "the hydration-stable shell should expose one dedicated native title strip",
 );
 assert.doesNotMatch(
   shell,
@@ -136,7 +141,7 @@ assert.match(
 );
 assert.match(
   css,
-  /:root\[data-tauri-titlebar\]\s+:is\(\s*\.shell-top,\s*\.shell-top__bar,\s*\.shell-top \.menu-bar,\s*\.shell-top \.top-bar,\s*\.shell-top \.menu-bar__group,\s*\.shell-top \.top-bar__lead,\s*\.shell-top \.top-bar__actions\s*\)\s*\{[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?app-region:\s*drag;/,
+  /:root\[data-tauri-titlebar\]\s+:is\(\s*\.shell-window-titlebar,\s*\.shell-top,\s*\.shell-top__bar,\s*\.shell-top \.menu-bar,\s*\.shell-top \.top-bar,\s*\.shell-top \.menu-bar__group,\s*\.shell-top \.top-bar__lead,\s*\.shell-top \.top-bar__actions\s*\)\s*\{[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?app-region:\s*drag;/,
   "macOS Tauri titlebar mode should keep the full rendered top-bar band draggable, including inert layout wrappers",
 );
 assert.doesNotMatch(
@@ -251,62 +256,12 @@ assert.doesNotMatch(
 );
 
 
-// ── Dia-style traffic lights follow the side panel (cave-9ja2) ──────────────
+// ── Native traffic lights stay with the dedicated title strip ───────────────
 {
   const tauriSetup = readFileSync(new URL("../../src-tauri/src/tauri_setup.rs", import.meta.url), "utf8");
-  assert.match(
-    shell,
-    /const navPeekVisible = navPeekEnabled && navPeeking;/,
-    "traffic-light visibility is fed by the synchronously gated visible-peek state",
-  );
-  assert.match(
-    shell,
-    /const trafficLightsVisible = navOpen \|\| navPeekVisible \|\| isMobile;/,
-    "lights show whenever the panel is open, visibly hover-peeked, or the layout is mobile",
-  );
-  assert.match(
-    shell,
-    /invoke\("set_traffic_lights_visible", \{ visible \}\)/,
-    "the shell drives the native buttons through the app command",
-  );
-  // Title-bar fit contract: the 78px inset is released only AFTER the native
-  // hide is confirmed — marking "hidden" optimistically slid the nav toggle +
-  // history chevrons under still-visible lights when the command failed.
-  assert.match(
-    shell,
-    /applyNative\(false\)\s*\.then\(\(\) => \{\s*if \(!cancelled\) root\.dataset\.trafficLights = "hidden";/,
-    "the root attribute flips to hidden only once the native hide resolves",
-  );
-  assert.match(
-    shell,
-    /\.catch\(\(\) => \{[\s\S]{0,220}?if \(!cancelled\) root\.dataset\.trafficLights = "visible";/,
-    "a failed native hide keeps the inset reserved for the still-visible lights",
-  );
-  assert.match(
-    shell,
-    /window\.addEventListener\("focus", onFocus\)/,
-    "focus re-asserts the hidden state after AppKit re-shows the buttons",
-  );
-  assert.match(
-    css,
-    /:root\[data-tauri-titlebar\]\[data-traffic-lights="hidden"\] \.shell-top \{[\s\S]*?padding-left: var\(--space-3\);/,
-    "hiding the lights releases the 78px title-bar inset",
-  );
-  assert.match(
-    tauriSetup,
-    /fn set_traffic_lights_visible\(window: tauri::WebviewWindow, visible: bool\)/,
-    "the Rust command exists",
-  );
-  assert.match(
-    tauriSetup,
-    /standardWindowButton: kind/,
-    "the command toggles NSWindow's standard buttons",
-  );
-  assert.match(
-    tauriSetup,
-    /shell_pick_directory,\s*set_traffic_lights_visible,/,
-    "the command is registered with the invoke handler",
-  );
+  assert.doesNotMatch(shell, /set_traffic_lights_visible/, "the workspace no longer hides native window controls with the siderail");
+  assert.doesNotMatch(tauriSetup, /set_traffic_lights_visible/, "the retired traffic-light mutation command is removed");
+  assert.doesNotMatch(css, /data-traffic-lights="hidden"/, "title-strip geometry no longer depends on hidden native controls");
 }
 
 // ── Title-bar fit is comprehensive (cave-i7wf follow-up) ────────────────────
@@ -328,17 +283,17 @@ assert.doesNotMatch(
     /dataset\.tauriTitlebar =/,
     "the workspace shell no longer sets the marker — it must survive shell unmount",
   );
-  assert.match(
-    shell,
-    /if \(!isMacDesktopShell\(\)\) return;/,
-    "the lights effect detects the platform directly instead of racing the marker mount",
-  );
-  // The shell-top reserve applies at every width (a sub-1024 window put the
-  // mobile top-bar's controls under the lights when it was media-gated).
+  // The dedicated title strip reserves the traffic-light inset while the
+  // functional toolbar beneath it uses ordinary app padding.
   assert.match(
     css,
-    /:root\[data-tauri-titlebar\] \.shell-top \{\s*padding-left: var\(--titlebar-lights-inset\);\s*\}/,
-    "the shell-top lights inset is not desktop-media-gated",
+    /:root\[data-tauri-titlebar\] \.shell-window-titlebar \{[\s\S]{0,240}?padding: 0 var\(--space-3\) 0 var\(--titlebar-lights-inset\);/,
+    "the native title strip reserves the traffic-light inset",
+  );
+  assert.match(
+    css,
+    /:root\[data-tauri-titlebar\] \.shell-top \{[\s\S]{0,180}?padding-left: var\(--space-3\);/,
+    "the functional toolbar starts at the normal app inset below native chrome",
   );
   // Full-window route bands reserve the same inset…
   for (const band of ["settings-shell__header", "dr-topbar", "fa-topbar"]) {
@@ -359,8 +314,8 @@ assert.doesNotMatch(
   // and no-backdrop-filter fallbacks.
   assert.match(
     css,
-    /:root\[data-tauri-titlebar\] \.shell-top \{[\s\S]{0,340}?backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);/,
-    "the native shell titlebar carries subtle glass",
+    /:root\[data-tauri-titlebar\] \.shell-window-titlebar \{[\s\S]{0,340}?backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);/,
+    "the native identity strip carries subtle glass",
   );
   const dashboardCss = readFileSync(new URL("../styles/dashboard.css", import.meta.url), "utf8");
   assert.match(

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -18,7 +18,6 @@ import { OpenCovenToolsBannerTrigger } from "@/components/open-coven-tools-updat
 import { CaveHomeMigrationBannerTrigger } from "@/components/cave-home-migration-banner";
 import { DesktopHistoryNav } from "@/components/desktop-history-nav";
 import { useIsMobile } from "@/lib/use-viewport";
-import { isMacDesktopShell } from "@/lib/tauri-platform";
 import { MobileDrawer, type MobileDrawerSlot } from "@/components/mobile-drawer";
 import { DetailSplitHost, type DetailSplitTile } from "@/components/detail-split-host";
 import { ShellPeelReveal } from "@/components/shell-peel-reveal";
@@ -633,64 +632,6 @@ function ShellInner({
   useEffect(() => {
     if (!navPeekEnabled) setNavPeeking(false);
   }, [navPeekEnabled]);
-
-  // Dia-style traffic lights: on the macOS desktop shell the native
-  // close/minimize/zoom buttons float over the side panel's top edge. With
-  // the panel fully closed (not even hover-peeked) they'd hover over page
-  // content, so they follow the panel — hidden with it, back the moment it
-  // opens or peeks. The root attribute lets globals.css release the 78px
-  // title-bar inset; the native call is an app command
-  // (set_traffic_lights_visible in lib.rs), so it needs no ACL entry. Mobile
-  // layouts keep their drawer chrome and never hide the lights.
-  //
-  // Fit contract (title-bar overlap bug): the inset is released ONLY after
-  // the native hide is confirmed. Showing is marked optimistically (worst
-  // case: a roomy bar), but marking "hidden" before the buttons actually
-  // vanish — pre-update shell without the command, an AppKit hiccup — slid
-  // the nav toggle + history chevrons underneath still-visible lights.
-  const trafficLightsVisible = navOpen || navPeekVisible || isMobile;
-  useEffect(() => {
-    const root = document.documentElement;
-    // Only the macOS desktop Tauri shell overlays the title bar; everywhere
-    // else there are no lights to manage. Detected directly (not via the
-    // root marker) so this effect can't race <TauriTitlebarMarker />'s mount.
-    if (!isMacDesktopShell()) return;
-    let cancelled = false;
-    const applyNative = (visible: boolean) =>
-      import("@tauri-apps/api/core").then(({ invoke }) =>
-        invoke("set_traffic_lights_visible", { visible }),
-      );
-    if (trafficLightsVisible) {
-      root.dataset.trafficLights = "visible";
-      void applyNative(true).catch(() => {});
-    } else {
-      void applyNative(false)
-        .then(() => {
-          if (!cancelled) root.dataset.trafficLights = "hidden";
-        })
-        .catch(() => {
-          // Pre-update shell without the command — the buttons stay put, so
-          // the bar must keep the 78px inset reserved for them.
-          if (!cancelled) root.dataset.trafficLights = "visible";
-        });
-    }
-    // macOS re-shows the standard buttons on its own after some window
-    // transitions (fullscreen round-trips, space changes). Re-assert the
-    // intended state whenever the window regains focus so the bar and the
-    // buttons can't drift apart mid-session.
-    const onFocus = () => {
-      if (trafficLightsVisible) return;
-      void applyNative(false).catch(() => {});
-    };
-    window.addEventListener("focus", onFocus);
-    return () => {
-      cancelled = true;
-      window.removeEventListener("focus", onFocus);
-      // If the shell ever unmounts mid-hide, leave the window usable.
-      delete root.dataset.trafficLights;
-      void applyNative(true).catch(() => {});
-    };
-  }, [trafficLightsVisible]);
 
   // Track the detail panel's REAL left/right viewport gaps (side panels +
   // separators + edge rails — everything between the detail box and the
@@ -1435,6 +1376,9 @@ function ShellInner({
       {/* Keyboard/SR users can jump straight past the chrome to the active
           surface. Visually hidden until focused (see .skip-link in globals). */}
       <a className="skip-link" href="#shell-main-content">Skip to main content</a>
+      <div className="shell-window-titlebar" data-tauri-drag-region="deep" aria-label="Coven window">
+        <span className="shell-window-titlebar__title">Coven</span>
+      </div>
       {/* `deep` (not the bare attribute) matters: drag.js's bare value only
           drags on DIRECT presses on the attributed element, so empty chrome
           inside .menu-bar / .top-bar wrappers would short-circuit the walk and

--- a/src/styles/globals/desktop-chrome.css
+++ b/src/styles/globals/desktop-chrome.css
@@ -72,6 +72,10 @@ button:active > .edge-rail-chip {
   display: none;
 }
 
+.shell-window-titlebar {
+  display: none;
+}
+
 .shell-top__bar {
   display: flex;
   align-items: center;
@@ -90,12 +94,10 @@ button:active > .edge-rail-chip {
 }
 
 /* ────────────────────────────────────────────────
-   Seamless macOS title bar (Tauri desktop)
+   Layered macOS title bar (Tauri desktop)
    The native title bar is set to `Overlay` (see src-tauri/src/lib.rs), so the
-   webview fills to the very top and the traffic-light buttons float over this
-   bar — there's no separate native title strip and no seam. We:
-     1. reserve room on the left so the toggle doesn't sit under the lights,
-     2. give the bar a touch more height to comfortably frame the lights.
+   webview fills to the very top and the traffic-light buttons float over a
+   dedicated identity strip. The functional toolbar sits beneath it.
    The actual window drag is NOT these `app-region` hints: WebKit ignores them
    on external-URL webviews (the app loads from http://127.0.0.1), so dragging
    is driven by the `data-tauri-drag-region="deep"` attributes in shell.tsx +
@@ -113,36 +115,48 @@ button:active > .edge-rail-chip {
   --titlebar-lights-inset: 78px;
 }
 
-/* Fit at EVERY window width: the lights float over the webview no matter how
-   narrow the window is, so the reserve can't be desktop-media-gated — in a
-   sub-1024 window the mobile top-bar's controls sat underneath the buttons. */
-:root[data-tauri-titlebar] .shell-top {
-  padding-left: var(--titlebar-lights-inset);
-}
-
-/* Dia-style: with the side panel closed the shell hides the traffic lights
-   (set_traffic_lights_visible in lib.rs, driven by shell.tsx — the attribute
-   flips to "hidden" only AFTER the native hide is confirmed), so the bar
-   releases the room reserved for them and slides back to the window edge. */
-:root[data-tauri-titlebar][data-traffic-lights="hidden"] .shell-top {
-  padding-left: var(--space-3);
-}
-
-/* Subtle titlebar glass (native shell only — the browser tab keeps the fully
-   seamless canvas): a whisper of translucent fill + blur so the band reads
-   as window chrome floating over the backdrop, macOS-native, not a painted
-   strip. Falls back to the seamless transparent band where glass can't
-   render legibly. */
-:root[data-tauri-titlebar] .shell-top {
+/* Native identity strip: the centered title is positioned against the whole
+   window rather than the traffic-light-safe content area. */
+:root[data-tauri-titlebar] .shell-window-titlebar {
+  position: relative;
+  display: grid;
+  place-items: center;
+  flex: 0 0 30px;
+  min-height: 30px;
+  padding: 0 var(--space-3) 0 var(--titlebar-lights-inset);
   background: color-mix(in oklch, var(--bg-base) 46%, transparent);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 45%, transparent);
+  -webkit-app-region: drag;
+  app-region: drag;
+}
+
+:root[data-tauri-titlebar] .shell-window-titlebar__title {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  pointer-events: none;
+  user-select: none;
+}
+
+/* Functional controls remain in their own compact row below native chrome. */
+:root[data-tauri-titlebar] .shell-top {
+  min-height: 34px;
+  padding-left: var(--space-3);
+  background: var(--bg-base);
+  backdrop-filter: none;
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 45%, transparent);
 }
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
-  :root[data-tauri-titlebar] .shell-top { background: transparent; }
+  :root[data-tauri-titlebar] .shell-window-titlebar { background: var(--bg-base); }
 }
 @media (prefers-reduced-transparency: reduce) {
-  :root[data-tauri-titlebar] .shell-top {
-    background: transparent;
+  :root[data-tauri-titlebar] .shell-window-titlebar {
+    background: var(--bg-base);
     backdrop-filter: none;
   }
 }
@@ -184,17 +198,6 @@ button:active > .edge-rail-chip {
     padding-left: var(--space-6);
   }
 
-  :root[data-tauri-titlebar] .shell-top {
-    /* The slim 29px band hugs the 28px controls so the bar doesn't tower
-       over the lights (was 36px — user asked for ~20% shorter). */
-    min-height: 29px;
-  }
-
-  /* The inner menu-bar would otherwise prop the band back open at 34px. */
-  :root[data-tauri-titlebar] .shell-top .menu-bar {
-    min-height: 28px;
-  }
-
   :root[data-tauri-titlebar] .shell-titlebar-drag-lane {
     position: absolute;
     inset: 0;
@@ -206,6 +209,7 @@ button:active > .edge-rail-chip {
   }
 
   :root[data-tauri-titlebar] :is(
+    .shell-window-titlebar,
     .shell-top,
     .shell-top__bar,
     .shell-top .menu-bar,


### PR DESCRIPTION
## What changed
- add a dedicated macOS title strip with centered Coven identity above the functional toolbar
- keep traffic lights persistently visible instead of coupling them to siderail collapse state
- preserve browser/mobile chrome while retaining draggable native title regions and compact toolbar controls
- update shell chrome contracts and remove the retired native traffic-light mutation command

## Verification
- `pnpm typecheck`
- `pnpm lint`
- focused shell chrome tests
- `cargo check --manifest-path src-tauri/Cargo.toml --quiet`
- `pnpm test:app` (1232 files)
- `pnpm test:api` (383 files)
- `pnpm check:tests-wired`
- `pnpm build`
- isolated native Tauri preview as **Coven Preview** on port 3007

Bead: `cave-ok7j5`