### PR TITLE
fix(research): state Research Desk iteration progress unambiguously

### DIFF
--- a/src/components/role-surfaces/research-evidence-ledger.tsx
+++ b/src/components/role-surfaces/research-evidence-ledger.tsx
@@ -25,10 +25,10 @@ type Props = {
    * content and never its own tabs.
    */
   tab: ResearchOutputTab;
-  /** One line of run context above the visible pane (pass state, bound progress). */
+  /** One line of run context above the visible pane (iteration state, bound progress). */
   hint?: ReactNode;
   /**
-   * Checkpoint triage: offer Keep / Reject / Verify next pass on the sources
+   * Checkpoint triage: offer Keep / Reject / Verify next iteration on the sources
    * still awaiting a verdict, alongside the always-available status control.
    */
   triage?: boolean;
@@ -43,8 +43,13 @@ const SOURCE_STATUSES: ResearchSourceRef["status"][] = [
   "rejected",
 ];
 
-/** Appended to a source note so "verify next pass" survives into the next run. */
-export const VERIFY_NOTE = "Verify next pass";
+/** Appended to a source note so the verification request survives the next run. */
+export const VERIFY_NOTE = "Verify next iteration";
+const LEGACY_VERIFY_NOTE = "Verify next pass";
+
+function hasVerificationRequest(note: string | undefined): boolean {
+  return [VERIFY_NOTE, LEGACY_VERIFY_NOTE].some((marker) => (note ?? "").includes(marker));
+}
 
 export function ResearchEvidenceLedger({
   mission,
@@ -299,9 +304,9 @@ export function ResearchEvidenceLedger({
                 {source.id === latestSourceId ? (
                   <span className="sr-only">Most recently added</span>
                 ) : null}
-                {/* Checkpoint triage: the verdicts the pass is actually waiting
-                    on, as one-tap buttons. The status control below stays for
-                    revisiting any source at any time. */}
+                {/* Checkpoint triage: the verdicts the iteration is actually
+                    waiting on, as one-tap buttons. The status control below
+                    stays for revisiting any source at any time. */}
                 {triage && (source.status === "candidate" || source.status === "conflicting") ? (
                   <div className="research-desk-delta__actions">
                     <Button
@@ -332,7 +337,7 @@ export function ResearchEvidenceLedger({
                       <Button
                         size="xs"
                         variant="ghost"
-                        disabled={busy || (source.note ?? "").includes(VERIFY_NOTE)}
+                        disabled={busy || hasVerificationRequest(source.note)}
                         onClick={() => void act({
                           action: "update-source",
                           sourceId: source.id,
@@ -342,7 +347,7 @@ export function ResearchEvidenceLedger({
                           },
                         })}
                       >
-                        Verify next pass
+                        Verify next iteration
                       </Button>
                     ) : null}
                   </div>

--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -101,8 +101,8 @@ const ACTION_LABELS: Partial<Record<ResearchMissionAction, string>> = {
 /** End-of-run actions sit right-aligned in the bar, per the design. */
 const END_ACTIONS: ReadonlySet<ResearchMissionAction> = new Set(["cancel", "archive"]);
 
-/** Note marker appended by "Verify next pass" — the source stays conflicting
- *  so the agent re-checks it, and the marker records the request. */
+/** Note marker appended by "Verify next iteration" — the source stays
+ *  conflicting so the familiar re-checks it, and the marker records the request. */
 
 const LIVE_STATUSES = new Set<ResearchMission["status"]>(["queued", "planning", "running"]);
 
@@ -245,11 +245,9 @@ export function ResearchMissionDetail({
   const mainActions = actions.filter((action) => action !== "refine" && !END_ACTIONS.has(action));
   const endActions = actions.filter((action) => END_ACTIONS.has(action));
   const sourceCounts = researchSourceStatusCounts(mission.sources);
-  const passNote = mission.status === "completed"
-    ? "final"
-    : iteration
-      ? `pass ${iteration.number} of ${mission.bounds.maxIterations}`
-      : `0 of ${mission.bounds.maxIterations} passes`;
+  const iterationNote = iteration
+    ? `Iteration ${iteration.number} of ${mission.bounds.maxIterations}${mission.status === "completed" ? " · final" : ""}`
+    : `No iteration started · ${mission.bounds.maxIterations} planned`;
   const phaseStatuses = researchPhaseStatuses(mission, PHASE_IDS);
   const phaseMeta = researchPhaseMeta(mission, PHASE_IDS);
   // Wash width = settled phases. "Settled" counts skipped alongside succeeded:
@@ -258,12 +256,12 @@ export function ResearchMissionDetail({
   const phaseProgress =
     phaseStatuses.filter((status) => status === "succeeded" || status === "skipped").length
     / PHASES.length;
-  // One dot per allowed pass, capped so a 40-iteration budget stays a row and
+  // One dot per allowed iteration, capped so a 40-iteration budget stays a row and
   // not a ribbon. The count text next to it carries the exact numbers.
-  const passCount = Math.max(1, Math.min(8, mission.bounds.maxIterations));
-  const currentPass = iteration?.number ?? 0;
-  const passDots = Array.from({ length: passCount }, (_, index) =>
-    index < currentPass - 1 ? "done" : index === currentPass - 1 ? "current" : "pending");
+  const iterationCount = Math.max(1, Math.min(8, mission.bounds.maxIterations));
+  const currentIteration = iteration?.number ?? 0;
+  const iterationDots = Array.from({ length: iterationCount }, (_, index) =>
+    index < currentIteration - 1 ? "done" : index === currentIteration - 1 ? "current" : "pending");
   // The design's "draft synthesis updated · vN" tile — only when the primary
   // deliverable is still a working draft; its version is the iteration that
   // wrote it. Every mission now also carries the 3 standard refs (findings,
@@ -280,7 +278,7 @@ export function ResearchMissionDetail({
   const diagnostics = [
     ["Error", mission.lastError ?? "No current error"],
     ["Status", mission.status],
-    ["Pass", iteration ? `${iteration.number} of ${mission.bounds.maxIterations}` : "No pass recorded"],
+    ["Iteration", iteration ? `${iteration.number} of ${mission.bounds.maxIterations}` : "No iteration recorded"],
     ["Control", iteration?.decisionReason ?? "No control decision recorded"],
     ["Flow run", iteration?.flowRunId ?? "No flow run recorded"],
     ["Session", sessionId ?? "No session recorded"],
@@ -299,12 +297,12 @@ export function ResearchMissionDetail({
   // rail panels used to carry in their titles and hints.
   const railHint = railTab === "sources"
     ? isCheckpointLike
-      ? `Evidence delta — pass ${iteration?.number ?? 0}. Triage now or leave it for the agent to resolve next pass.`
+      ? `Evidence delta — iteration ${iteration?.number ?? 0}. Triage now or leave it for the familiar to resolve next iteration.`
       : isLive
         ? `${mission.sources.length} of ${mission.bounds.sourceTarget} targeted — streaming in, review anytime.`
         : null
     : mission.status === "failed" && iteration
-      ? `From pass ${iteration.number}.`
+      ? `From iteration ${iteration.number}.`
       : null;
   // Archived missions are read-only: automation controls gate on this the
   // same way "Create schedule" already does.
@@ -545,7 +543,7 @@ export function ResearchMissionDetail({
             <div>
               <span className="research-mission-detail__eyebrow">
                 {mission.mode} · {mission.status}
-                {iteration ? ` · pass ${iteration.number}/${mission.bounds.maxIterations}` : ""}
+                {iteration ? ` · iteration ${iteration.number} of ${mission.bounds.maxIterations}` : " · not started"}
                 {" · "}
                 <time dateTime={mission.updatedAt}>updated {relativeTime(mission.updatedAt) || "just now"}</time>
               </span>
@@ -641,14 +639,14 @@ export function ResearchMissionDetail({
                   </div>
                 ))}
               </dl>
-              <span className="research-desk-stepper__pass" title={passNote}>
-                <span className="research-desk-stepper__pass-label">Pass</span>
-                <span className="research-desk-stepper__dots" aria-hidden>
-                  {passDots.map((state, index) => (
+              <span className="research-desk-stepper__iteration" title={iterationNote}>
+                <span className="research-desk-stepper__iteration-label">Iteration</span>
+                <span className="research-desk-stepper__iteration-dots" aria-hidden>
+                  {iterationDots.map((state, index) => (
                     <i key={index} data-state={state} />
                   ))}
                 </span>
-                <span className="research-desk-stepper__pass-text">{passNote}</span>
+                <span className="research-desk-stepper__iteration-text">{iterationNote}</span>
               </span>
             </div>
           </div>
@@ -724,9 +722,9 @@ export function ResearchMissionDetail({
                 design's "+N new sources" tile ships as the honest ledger
                 total instead. ── */}
           {isCheckpointLike ? (
-            <section className="research-desk-block" aria-label={`What changed in pass ${iteration?.number ?? 0}`}>
+            <section className="research-desk-block" aria-label={`What changed in iteration ${iteration?.number ?? 0}`}>
               <span className="research-desk-block__kicker">
-                What changed in pass {iteration?.number ?? 0}
+                What changed in iteration {iteration?.number ?? 0}
               </span>
               <div className="research-desk-tiles">
                 {mission.sources.length > 0 ? (
@@ -768,8 +766,8 @@ export function ResearchMissionDetail({
                 <span className="research-desk-block__kicker">Live activity</span>
                 <span className="research-desk-block__aside">
                   {mission.bounds.checkpointEvery === 1
-                    ? "checkpoint after this pass"
-                    : `checkpoint every ${mission.bounds.checkpointEvery} passes`}
+                    ? "checkpoint after this iteration"
+                    : `checkpoint every ${mission.bounds.checkpointEvery} iterations`}
                 </span>
               </div>
               {iteration?.steps?.length ? (
@@ -783,7 +781,7 @@ export function ResearchMissionDetail({
                 </ul>
               ) : (
                 <p className="research-desk-block__empty">
-                  No step detail reported yet — activity appears as the pass advances.
+                  No step detail reported yet — activity appears as the iteration advances.
                 </p>
               )}
             </section>
@@ -797,7 +795,7 @@ export function ResearchMissionDetail({
                 <span className="research-desk-block__kicker">Findings · published</span>
                 <span className="research-desk-block__aside">
                   {mission.sources.length} sources · {sourceCounts.used} used ·{" "}
-                  {mission.iterations.length} pass{mission.iterations.length === 1 ? "" : "es"}
+                  {mission.iterations.length} iteration{mission.iterations.length === 1 ? "" : "s"}
                 </span>
               </div>
               {iteration?.summary ? (
@@ -853,7 +851,7 @@ export function ResearchMissionDetail({
             </div>
           ) : null}
 
-          {/* ── Refine box: the familiar may propose the next-pass direction,
+          {/* ── Refine box: the familiar may propose the next-iteration direction,
                 but only the separate reviewed action continues the mission. ── */}
           {actions.includes("refine") ? (
             <div className="research-desk-refine">
@@ -907,7 +905,7 @@ export function ResearchMissionDetail({
               </div>
               {directionDrafting ? (
                 <p className="research-desk-refine__status" role="status">
-                  Reading the checkpoint and choosing the highest-value next pass…
+                  Reading the checkpoint and choosing the highest-value next iteration…
                 </p>
               ) : null}
               {directionSuggestion ? (

--- a/src/components/role-surfaces/research-mission-list.tsx
+++ b/src/components/role-surfaces/research-mission-list.tsx
@@ -152,7 +152,11 @@ export function ResearchMissionList({
           <span className="research-mission-row__meta">
             <span>{mission.mode}</span>
             <span>{mission.status}</span>
-            {iteration ? <span>i{iteration.number}/{mission.bounds.maxIterations}</span> : null}
+            {iteration ? (
+              <span>Iteration {iteration.number}/{mission.bounds.maxIterations}</span>
+            ) : (
+              <span>Not started</span>
+            )}
             <time dateTime={mission.updatedAt}>{relativeTime(mission.updatedAt) || "just now"}</time>
           </span>
         </button>

--- a/src/components/role-surfaces/research-tab-desk.test.ts
+++ b/src/components/role-surfaces/research-tab-desk.test.ts
@@ -37,9 +37,10 @@ test("bounds row keeps the shared readings with not-color-only badges", () => {
   assert.match(detail, /research-bound--\$\{reading\.tone\}/);
   assert.match(detail, /research-bound-badge/);
   assert.match(detail, /<span className="sr-only"> — \{reading\.detail\}<\/span>/);
-  // Pass note sits with the bounds row and derives from real iteration data.
-  assert.match(detail, /research-desk-stepper__pass/);
-  assert.match(detail, /pass \$\{iteration\.number\} of \$\{mission\.bounds\.maxIterations\}/);
+  // Iteration state sits with the bounds row and derives from real mission data.
+  assert.match(detail, /research-desk-stepper__iteration/);
+  assert.match(detail, /Iteration \$\{iteration\.number\} of \$\{mission\.bounds\.maxIterations\}/);
+  assert.match(detail, /No iteration started · \$\{mission\.bounds\.maxIterations\} planned/);
 });
 
 // ── Checkpoint delta: derived-only tiles, omit when missing ─────────────────
@@ -65,7 +66,7 @@ test("checkpoint direction can be drafted agentically without auto-continuing", 
   assert.match(detail, /generateResearchRefineDirection/);
   assert.match(detail, /Draft with familiar/);
   assert.match(detail, /Redraft with familiar/);
-  assert.match(detail, /Reading the checkpoint and choosing the highest-value next pass…/);
+  assert.match(detail, /Reading the checkpoint and choosing the highest-value next iteration…/);
   assert.match(detail, /directionRef\.current === baseDraft/);
   assert.match(detail, /Direction ready — your edits were kept\./);
   assert.match(detail, /Apply direction/);
@@ -139,8 +140,11 @@ test("Keep/Reject/Verify map onto the ledger's update-source action", () => {
   // Verify keeps the source conflicting and appends a note instead of
   // changing status.
   assert.match(ledger, /status: "conflicting",\s*note: source\.note \? `\$\{source\.note\}\\n\$\{VERIFY_NOTE\}` : VERIFY_NOTE/);
-  // Re-verifying is inert: the button disables once the marker is present.
-  assert.match(ledger, /\(source\.note \?\? ""\)\.includes\(VERIFY_NOTE\)/);
+  // Re-verifying is inert for both the current marker and persisted legacy
+  // notes written before the Desk adopted explicit iteration terminology.
+  assert.match(ledger, /const LEGACY_VERIFY_NOTE = "Verify next pass"/);
+  assert.match(ledger, /hasVerificationRequest\(source\.note\)/);
+  assert.match(ledger, />\s*Verify next iteration\s*<\/Button>/);
   // Triage actions only appear at a checkpoint, on sources still awaiting a
   // verdict; the status control below them stays available always.
   assert.match(ledger, /triage && \(source\.status === "candidate" \|\| source\.status === "conflicting"\)/);
@@ -236,6 +240,12 @@ test("planning missions read as active work in the runs rail", () => {
   assert.match(list, /queued: "busy"/);
 });
 
+test("the run rail states the current iteration without terse iN shorthand", () => {
+  assert.match(list, />Iteration \{iteration\.number\}\/\{mission\.bounds\.maxIterations\}</);
+  assert.match(list, />Not started</);
+  assert.doesNotMatch(list, />i\{iteration\.number\}/);
+});
+
 test("mission navigation composes text scope and priority groups", () => {
   assert.match(list, /scope: ResearchMissionScope/);
   assert.match(list, /matchesResearchMissionScope\(mission, scope\)/);
@@ -322,7 +332,7 @@ test("run state picks the opening pane and the pane's context line", () => {
   assert.match(detail, /\? "sources"\s*: "artifacts"/);
   assert.match(detail, /if \(railTabMission !== missionId\) \{\s*setRailTabMission\(missionId\);\s*setRailTab\(defaultRailTab\);\s*\}/);
   // The context the stacked panel titles used to carry survives as one hint.
-  assert.match(detail, /Evidence delta — pass/);
+  assert.match(detail, /Evidence delta — iteration/);
   assert.match(detail, /targeted — streaming in, review anytime/);
   assert.match(detail, /highlightLatest=\{isLive\}/);
   // The streaming highlight marks the newest ledger entry without faking times.

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -23,6 +23,7 @@ import {
   RESEARCH_MODEL_MAX_LENGTH,
   RESEARCH_RUNTIME_DEFAULT_HARNESS,
   RESEARCH_TITLE_MAX_LENGTH,
+  nextResearchIterationNumber,
   researchArtifactKindForMode,
   researchBoundReadings,
   researchContinueLabel,
@@ -1012,7 +1013,7 @@ test("Continue is labeled with its real consequence", () => {
     { iterations: [{ number: 1, status: "checkpoint" }], bounds, startedAt },
     tenMinutesIn,
   );
-  assert.equal(withinPlan.label, "Continue (i2/3)");
+  assert.equal(withinPlan.label, "Continue to iteration 2 of 3");
   assert.equal(withinPlan.gated, false);
   // Even ungated, the sentence is a request, not a promise — the runner
   // re-checks its stop gates with live clocks.
@@ -1029,10 +1030,21 @@ test("Continue is labeled with its real consequence", () => {
     },
     tenMinutesIn,
   );
-  assert.equal(beyond.label, "Continue (i2/1)");
+  assert.equal(beyond.label, "Iteration limit reached");
   assert.equal(beyond.gated, true);
   assert.match(beyond.description, /past the planned 1/);
   assert.match(beyond.description, /iteration limit/);
+
+  assert.equal(
+    nextResearchIterationNumber({
+      iterations: [
+        { number: 1, status: "completed" },
+        { number: 3, status: "checkpoint" },
+      ],
+    }),
+    4,
+    "the next iteration follows the latest persisted iteration number, not the array length",
+  );
 });
 
 test("Continue reports every runner stop gate, not just the iteration limit", () => {

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -359,7 +359,7 @@ export type ResearchMissionActionInput =
   | {
     action: ResearchMissionAction;
     direction?: string;
-    /** One-pass approval to continue when the previous iteration reported no cost. */
+    /** One-iteration approval to continue when the previous iteration reported no cost. */
     approveCostUnavailable?: boolean;
     /**
      * Retry-only project root override: a path re-targets the retried
@@ -1165,7 +1165,7 @@ export type ResearchContinueLabel = {
   description: string;
   /** A stop gate already refuses the next iteration — pressing starts nothing. */
   gated: boolean;
-  /** Missing telemetry may be bypassed for exactly one explicitly approved pass. */
+  /** Missing telemetry may be bypassed for exactly one explicitly approved iteration. */
   costApprovalRequired: boolean;
 };
 
@@ -1182,7 +1182,7 @@ export function nextResearchIterationNumber(
  * (src/lib/server/research-mission-runner.ts): iteration count, wall-clock
  * budget, missing-cost policy, and the reported-spend cap. Hard bounds refuse
  * the action; missing cost instead requires an explicit approval that applies
- * to one pass only. Keep this in sync with stopBeforeNextIteration.
+ * to one iteration only. Keep this in sync with stopBeforeNextIteration.
  */
 export function researchContinueLabel(
   mission: Pick<ResearchMission, "iterations" | "bounds" | "startedAt">,
@@ -1222,7 +1222,7 @@ export function researchContinueLabel(
   ) {
     return {
       label: `Continue with unreported cost, iteration ${next} of ${max}`,
-      description: `An iteration finished without reporting cost. Continue starts iteration ${next} with one-pass approval; the mission will ask again before another unmetered pass.`,
+      description: `An iteration finished without reporting cost. Continue starts iteration ${next} with approval for that one iteration; the mission will ask again before another unmetered iteration.`,
       gated: true,
       costApprovalRequired: true,
     };

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -1221,7 +1221,7 @@ export function researchContinueLabel(
     mission.iterations.some((iteration) => iteration.finishedAt && iteration.costUsd === undefined)
   ) {
     return {
-      label: `Continue with unreported cost (i${next}/${max})`,
+      label: `Continue with unreported cost, iteration ${next} of ${max}`,
       description: `An iteration finished without reporting cost. Continue starts iteration ${next} with one-pass approval; the mission will ask again before another unmetered pass.`,
       gated: true,
       costApprovalRequired: true,

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -1159,7 +1159,7 @@ export function researchSourceStatusCounts(
 }
 
 export type ResearchContinueLabel = {
-  /** Compact button text in the desk's iN/M vocabulary. */
+  /** Explicit button text naming the iteration the runner will evaluate. */
   label: string;
   /** Full-sentence consequence for the button's aria-label and title. */
   description: string;
@@ -1168,6 +1168,12 @@ export type ResearchContinueLabel = {
   /** Missing telemetry may be bypassed for exactly one explicitly approved pass. */
   costApprovalRequired: boolean;
 };
+
+export function nextResearchIterationNumber(
+  mission: Pick<ResearchMission, "iterations">,
+): number {
+  return (mission.iterations.at(-1)?.number ?? 0) + 1;
+}
 
 /**
  * What pressing Continue will actually do.
@@ -1182,9 +1188,9 @@ export function researchContinueLabel(
   mission: Pick<ResearchMission, "iterations" | "bounds" | "startedAt">,
   nowMs: number = Date.now(),
 ): ResearchContinueLabel {
-  const next = mission.iterations.length + 1;
+  const next = nextResearchIterationNumber(mission);
   const max = mission.bounds.maxIterations;
-  const label = `Continue (i${next}/${max})`;
+  const label = `Continue to iteration ${next} of ${max}`;
   const refusal = (why: string) => ({
     label,
     description: `Continue would ask for iteration ${next}, but ${why}`,
@@ -1193,7 +1199,7 @@ export function researchContinueLabel(
   });
   if (next > max) {
     return {
-      label,
+      label: "Iteration limit reached",
       description: `Continue would ask for iteration ${next}, past the planned ${max} — the runner stops at the iteration limit instead of starting it.`,
       gated: true,
       costApprovalRequired: false,

--- a/src/lib/research-refine-direction.test.ts
+++ b/src/lib/research-refine-direction.test.ts
@@ -68,6 +68,7 @@ test("refine prompt asks for a decisive agentic direction grounded in mission ev
   assert.match(prompt, /lead with imperative verbs/);
   assert.match(prompt, /Do not broaden the mission/);
   assert.match(prompt, /ask a question, request approval/);
+  assert.match(prompt, /Next iteration: 2 of 4/);
   assert.match(prompt, /Latest synthesis: The first pass found incompatible vendor throughput claims/);
   assert.match(prompt, /Control decision: The benchmark methods are not comparable yet/);
   assert.match(prompt, /Operator draft to strengthen: Verify the throughput comparison/);

--- a/src/lib/research-refine-direction.ts
+++ b/src/lib/research-refine-direction.ts
@@ -1,5 +1,5 @@
 /**
- * Agentic next-pass direction drafting for Research Desk checkpoints.
+ * Agentic next-iteration direction drafting for Research Desk checkpoints.
  *
  * The familiar proposes one execution-ready direction from persisted mission
  * evidence. It never continues the mission itself: the proposal lands in the
@@ -10,6 +10,7 @@
 import { streamFamiliarText } from "@/lib/familiar-stream";
 import { extractNextPaths } from "@/lib/next-paths";
 import {
+  nextResearchIterationNumber,
   RESEARCH_DIRECTION_MAX_LENGTH,
   type ResearchMission,
   type ResearchSourceRef,
@@ -68,7 +69,7 @@ export function buildResearchRefineDirectionPrompt(
     mission.constraints.length
       ? `Constraints: ${mission.constraints.map((constraint) => compact(constraint, 240)).join("; ")}`
       : "Constraints: none beyond the mission bounds.",
-    `Next pass: ${mission.iterations.length + 1} of ${mission.bounds.maxIterations}`,
+    `Next iteration: ${nextResearchIterationNumber(mission)} of ${mission.bounds.maxIterations}`,
     `Remaining source target: ${Math.max(0, mission.bounds.sourceTarget - mission.sources.length)}`,
     iteration?.summary ? `Latest synthesis: ${compact(iteration.summary, 900)}` : "",
     iteration?.decisionReason ? `Control decision: ${compact(iteration.decisionReason, 700)}` : "",
@@ -80,7 +81,7 @@ export function buildResearchRefineDirectionPrompt(
   ].filter(Boolean);
 
   return [
-    "You are the mission familiar choosing the highest-value next bounded research pass.",
+    "You are the mission familiar choosing the highest-value next bounded research iteration.",
     "Produce one execution-ready refined direction that can be passed verbatim to the next iteration. Do not perform the research and do not summarize the checkpoint.",
     "Write agentically: lead with imperative verbs, commit to one coherent course, and state what evidence to gather or verify, which uncertainty to resolve, and what the updated artifact must establish.",
     "Prefer the highest-impact unresolved conflict or evidence gap. Preserve every explicit operator priority and mission constraint. Do not broaden the mission, offer a menu of options, ask a question, request approval, or use hedges such as “consider”, “could”, or “might”.",

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -904,6 +904,38 @@ test("two Continue calls create exactly one next iteration", async () => {
   assert.equal(starts, 1);
 });
 
+test("Continue advances from the latest persisted iteration number", async () => {
+  let stored = checkpointMission({
+    bounds: {
+      ...checkpointMission().bounds,
+      maxIterations: 5,
+    },
+    iterations: [
+      { number: 1, status: "completed" },
+      { number: 3, status: "checkpoint" },
+    ],
+  });
+  let startedFlowId = "";
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    startFlow: async (flow) => {
+      startedFlowId = flow.id;
+      return {
+        ok: true,
+        executor: "session",
+        sessionId: "session-4",
+        run: { ...RUN, id: "run-4", flowId: flow.id, sessionId: "session-4" },
+      };
+    },
+  }));
+
+  const result = await runner.act(stored.id, { action: "continue" });
+
+  assert.equal(result.iterations.at(-1)?.number, 4);
+  assert.match(startedFlowId, /iteration-4$/);
+});
+
 test("cost-unavailable policy pauses before another iteration", async () => {
   let stored = checkpointMission({
     bounds: {

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -16,6 +16,7 @@ import {
 import { buildResearchMissionFlow } from "../research-mission-flow.ts";
 import {
   allowedResearchActions,
+  nextResearchIterationNumber,
   RESEARCH_COST_UNAVAILABLE_STOP_REASON,
   RESEARCH_DIRECTION_MAX_LENGTH,
   RESEARCH_PROJECT_ROOT_MAX_LENGTH,
@@ -891,7 +892,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         lastError: stopReason,
       });
     }
-    const number = mission.iterations.length + 1;
+    const number = nextResearchIterationNumber(mission);
     const timestamp = deps.now().toISOString();
     const workingArtifact = mission.artifacts[0]?.state === "rejected" ? {
       ...mission.artifacts[0],
@@ -1404,7 +1405,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
     }
 
     const timestamp = deps.now().toISOString();
-    const number = mission.iterations.length + 1;
+    const number = nextResearchIterationNumber(mission);
     let status: ResearchMission["status"] = control.decision === "complete" ? "completed" : "checkpoint";
     let stopReason = control.decision === "complete" ? "Research marked complete" : null;
     let reconciled: ResearchMission = {

--- a/src/styles/globals/surface-research-desk.css
+++ b/src/styles/globals/surface-research-desk.css
@@ -445,7 +445,7 @@
 
 /* ── Stepper card: six nodes on a connecting rail, each reporting what it
    found, over a wash that widens as phases settle. Bounds row sits under a
-   divider with the pass dots right-aligned. ── */
+   divider with the iteration dots right-aligned. ── */
 .research-desk-stepper {
   position: relative;
   overflow: hidden;
@@ -634,7 +634,7 @@
 .research-bound--over .research-bound-bar::before { background: var(--color-warning); }
 .research-bound--met .research-bound-bar::before { background: var(--color-success); }
 
-.research-desk-stepper__pass {
+.research-desk-stepper__iteration {
   flex: none;
   margin-left: auto;
   display: inline-flex;
@@ -643,33 +643,33 @@
   font-size: var(--text-2xs);
   color: var(--text-muted);
 }
-.research-desk-stepper__pass-label {
+.research-desk-stepper__iteration-label {
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: var(--text-2xs);
   font-weight: 600;
   letter-spacing: 0.09em;
   text-transform: uppercase;
 }
-.research-desk-stepper__dots {
+.research-desk-stepper__iteration-dots {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
 }
-.research-desk-stepper__dots i {
+.research-desk-stepper__iteration-dots i {
   width: 5px;
   height: 5px;
   border-radius: var(--radius-pill);
   background: color-mix(in oklch, var(--text-primary) 15%, transparent);
 }
-.research-desk-stepper__dots i[data-state="done"] {
+.research-desk-stepper__iteration-dots i[data-state="done"] {
   background: color-mix(in oklch, var(--research-accent) 55%, transparent);
 }
-.research-desk-stepper__dots i[data-state="current"] {
+.research-desk-stepper__iteration-dots i[data-state="current"] {
   width: 7px;
   height: 7px;
   background: var(--research-accent);
 }
-.research-desk-stepper__pass-text {
+.research-desk-stepper__iteration-text {
   font-family: var(--font-mono, ui-monospace, monospace);
   font-weight: 600;
   color: var(--text-secondary);
@@ -1026,7 +1026,7 @@
     padding-bottom: var(--space-1);
   }
   .research-desk-stepper__bounds .research-bound-meter { gap: var(--space-3); }
-  .research-desk-stepper__pass { margin-left: 0; }
+  .research-desk-stepper__iteration { margin-left: 0; }
   .research-desk-tiles { grid-template-columns: 1fr; }
 }
 

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -467,12 +467,13 @@ test.describe("research desk tabs", () => {
     await expect(desk.locator(".research-desk-stepper__track")).not.toContainText("Trigger");
 
     // Checkpoint mission is selected (first unarchived) → checkpoint action
-    // bar: Continue (i2/4) + Finish now on the left, Cancel/Archive on the right.
+    // bar: Continue to iteration 2 of 4 + Finish now on the left, Cancel/Archive
+    // on the right.
     await expect(desk.locator("#research-mission-title")).toHaveText(CHECKPOINT_MISSION.title);
     const actions = desk.locator(".research-mission-actions");
     // Continue's accessible name is its full-consequence aria-label, so match
-    // the visible i2/4 text instead of the role name.
-    const continueButton = actions.locator("button", { hasText: "Continue (i2/4)" });
+    // the visible iteration text instead of the role name.
+    const continueButton = actions.locator("button", { hasText: "Continue to iteration 2 of 4" });
     await expect(continueButton).toBeVisible();
     await expect(continueButton).toHaveAttribute("aria-label", /start iteration 2 of 4/);
     await expect(actions.getByRole("button", { name: "Finish now" })).toBeVisible();
@@ -501,7 +502,7 @@ test.describe("research desk tabs", () => {
     await expect(railTabs.getByRole("tab", { name: /^Sources/ })).toHaveAttribute("aria-selected", "true");
     const sourcesPane = desk.getByRole("tabpanel", { name: /^Sources/ });
     await expect(sourcesPane.getByRole("button", { name: /^Vendor benchmarks blog/ })).toBeVisible();
-    await expect(sourcesPane.getByRole("button", { name: "Verify next pass" })).toBeVisible();
+    await expect(sourcesPane.getByRole("button", { name: "Verify next iteration" })).toBeVisible();
 
     // Toggling shows the artifacts in the same pane — one list at a time, both
     // complete, with no second copy stacked below.


### PR DESCRIPTION
## Problem

The Research Desk mixed `pass` and `iN` labels, so the current iteration was stated inconsistently and continue/refine actions gave no clear signal about which iteration they advanced to.

## Change

- The Desk now uses explicit **"Iteration N of M"** language throughout.
- A shared `nextResearchIterationNumber` drives Continue, refine prompts, manual starts, and automation reconciliation, so every path agrees on what comes next.
- Legacy "Verify next pass" notes remain recognized, so existing missions keep working.

11 files changed, +136 / -66.

## Provenance

Implemented and verified by an earlier session under bead `cave-ld0at`, whose notes record targeted Research Desk/mission/refine/runner tests passing (29 + 53 + 3 + 60), `pnpm typecheck` and `pnpm lint` green, and *"Pending protected commit/PR/merge; do not close before merge"* — but it was never committed. A worktree-reduction pass snapshotted the uncommitted tree to `fix/cave-ld0at-research-desk-iteration` as an explicitly **unreviewed** WIP commit marked *not proposed for merge*.

This PR re-validates that content against **current main** before proposing it. Landing bead: `cave-56fkj` (separate from `cave-ld0at` because that bead's worktree record is stale and must not be hand-edited).

## Conflict resolution

Rebasing onto main after #4726 produced exactly one conflict, in `src/lib/server/research-mission-runner.ts`: both changes add a different named import to the same import block (`RESEARCH_COST_UNAVAILABLE_STOP_REASON` from #4726, `nextResearchIterationNumber` from this change). Both are needed and independent, so both are kept, in the file's existing case-insensitive alphabetical order. No logic was resolved away.

## Verification on current main (post-rebase)

- `pnpm typecheck` — clean
- `pnpm lint` — clean, 0 design drift
- `research-missions`, `research-tab-desk`, `research-mission-runner-lifecycle-actions` — pass
- `research-refine-direction` — 3/3 under **vitest** (it is on `run-tests.mjs`'s alias-resolution list, so bare `node --experimental-strip-types` cannot resolve its `@/lib` imports and fails with `ERR_MODULE_NOT_FOUND` on `main` too — not a regression)
- #4726's own suites re-run here to confirm the shared-file resolution is sound: `research-mission-store`, `researcher-surface` — pass
