### PR TITLE
Release v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-08-19
+
+> A calmer native iOS shell, clearer Chats, and a safer cross-platform foundation.
+
+Patch release on top of v0.3.6.
+
+### Changes
+- Refine native iOS navigation, Chats chrome, Settings shelves, and accessibility
+  while retiring the native-only Terminal surface (#4729)
+- Layer native destination titles above app toolbars for clearer hierarchy
+  (#4727)
+- Require explicit Research cost approval and protect active Terminal missions
+  (#4726)
+- Publish a deterministic Client v1 contract with precise success and error
+  envelopes (#4717, #4725)
+- Preserve marketplace logos through shared transport handling (#4724)
+- Harden CI recovery, managed worktree retention, and release lifecycle guards
+  (#4719, #4720, #4721)
+- Improve Chat follow-up pills and session-toolbar alignment (#4718, #4707)
+- Add familiar execution analytics, durable local previews, direct podcast
+  rendering, and the inference-route foundation (#4710, #4714)
+- Restore compact Code-rail Terminal access and improve cross-theme Beautiful UI
+  legibility (#4713, #4702)
+- Honor `COVEN_BIN` in the desktop shell and retry transient managed Node
+  installation failures (#4703)
+
+
 ## [0.3.6] - 2026-08-17
 
 > Seamless familiar credential intake and a Chat panel that stays with you across the Cave.

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.3.6"
+    MARKETING_VERSION: "0.3.7"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026081702"
+    CURRENT_PROJECT_VERSION: "2026081908"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "block2",
  "discord-rich-presence",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.6"
+version = "0.3.7"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- stamp all canonical version locations to `0.3.7`
- advance the iOS App Store build number
- add curated release notes for changes since `v0.3.6`

## Verification
- `pnpm release:verify --version 0.3.7`
- focused stamp, App Store Connect, and release-note tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `pnpm test:mobile`

After merge, this release will be signed and tagged as `v0.3.7`, then dispatched through the repository iOS/TestFlight release workflow.

Bead: `cave-gueqr`