### PR TITLE
Skip blocked worktree retirement candidates

### DIFF
--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -4424,7 +4424,7 @@ exit 0
   assert.match(
     inventoryDrivenRemainingText,
     /Cleanup-ready but not processed \(0\): none/,
-    "the unprocessed section remains limited to candidates skipped by the batch bound",
+    "the unprocessed section remains limited to candidates skipped by a success or attempt bound",
   );
 
   const partialBlockedRetirement = {

--- a/scripts/worktree-lifecycle-retirement.test.mjs
+++ b/scripts/worktree-lifecycle-retirement.test.mjs
@@ -392,7 +392,7 @@ test("parseMaxRetire defaults and enforces exact bounds", () => {
   }
 });
 
-test("retireLifecycleUnits uses default batch size of three and leaves cleanupReady remainder", () => {
+test("retireLifecycleUnits stops after the default three successful retirements", () => {
   const items = [
     makeItem({ branch: "fix/d", ref: "refs/heads/fix/d", updatedAtMs: 40 }),
     makeItem({ branch: "fix/a", ref: "refs/heads/fix/a", updatedAtMs: 10 }),
@@ -420,6 +420,99 @@ test("retireLifecycleUnits uses default batch size of three and leaves cleanupRe
     calls.filter(([name]) => name === "heartbeatGate").length,
     12,
     "three worktree candidates should heartbeat before every destructive phase and after retirement",
+  );
+});
+
+test("retireLifecycleUnits bypasses blocked candidates until it reaches the successful-retirement limit", () => {
+  const items = ["a", "b", "c", "d", "e", "f"].map((branch, index) =>
+    makeItem({
+      kind: "branch-only",
+      path: null,
+      branch: `fix/${branch}`,
+      ref: `refs/heads/fix/${branch}`,
+      updatedAtMs: index,
+    }),
+  );
+  const { operations } = makeOperations({
+    reprobe(item) {
+      return item.ref === "refs/heads/fix/a" || item.ref === "refs/heads/fix/b"
+        ? { ok: false, reason: `fixture blocked ${item.ref}` }
+        : { ok: true, item };
+    },
+  });
+
+  const report = retireLifecycleUnits({
+    items,
+    gateHandle: { generation: 8, token: "gate" },
+    operations,
+  });
+
+  assert.deepEqual(
+    report.attempts.map((attempt) => [attempt.ref, attempt.outcome]),
+    [
+      ["refs/heads/fix/a", "blocked"],
+      ["refs/heads/fix/b", "blocked"],
+      ["refs/heads/fix/c", "retired"],
+      ["refs/heads/fix/d", "retired"],
+      ["refs/heads/fix/e", "retired"],
+    ],
+  );
+  assert.deepEqual(
+    report.retired.map((item) => item.ref),
+    ["refs/heads/fix/c", "refs/heads/fix/d", "refs/heads/fix/e"],
+  );
+  assert.deepEqual(
+    report.blocked.map((block) => block.ref),
+    ["refs/heads/fix/a", "refs/heads/fix/b"],
+  );
+  assert.deepEqual(
+    report.cleanupReady.map((item) => item.ref),
+    ["refs/heads/fix/f"],
+    "only the eligible candidate skipped after the successful-retirement limit is cleanup-ready",
+  );
+});
+
+test("retireLifecycleUnits leaves only unattempted candidates cleanup-ready when its attempt budget is exhausted", () => {
+  const items = ["a", "b", "c", "d", "e", "f", "g"].map((branch, index) =>
+    makeItem({
+      kind: "branch-only",
+      path: null,
+      branch: `fix/${branch}`,
+      ref: `refs/heads/fix/${branch}`,
+      updatedAtMs: index,
+    }),
+  );
+  const { operations } = makeOperations({
+    reprobe(item) {
+      return { ok: false, reason: `fixture blocked ${item.ref}` };
+    },
+  });
+
+  const report = retireLifecycleUnits({
+    items,
+    gateHandle: { generation: 8, token: "gate" },
+    operations,
+  });
+
+  assert.deepEqual(
+    report.attempts.map((attempt) => attempt.ref),
+    [
+      "refs/heads/fix/a",
+      "refs/heads/fix/b",
+      "refs/heads/fix/c",
+      "refs/heads/fix/d",
+      "refs/heads/fix/e",
+    ],
+  );
+  assert.deepEqual(
+    report.blocked.map((block) => block.ref),
+    report.attempts.map((attempt) => attempt.ref),
+    "each attempted failed candidate remains blocked",
+  );
+  assert.deepEqual(
+    report.cleanupReady.map((item) => item.ref),
+    ["refs/heads/fix/f", "refs/heads/fix/g"],
+    "the attempt budget leaves only untouched eligible candidates cleanup-ready",
   );
 });
 
@@ -539,10 +632,12 @@ test("branch-only retirement skips worktree removal", () => {
   ]);
 });
 
-test("initial gate heartbeat failure blocks the current and remaining selected candidates", () => {
+test("initial gate heartbeat failure blocks the current and every remaining eligible candidate", () => {
   const items = [
     makeItem({ branch: "fix/a", ref: "refs/heads/fix/a", path: null, kind: "branch-only" }),
     makeItem({ branch: "fix/b", ref: "refs/heads/fix/b", path: null, kind: "branch-only" }),
+    makeItem({ branch: "fix/c", ref: "refs/heads/fix/c", path: null, kind: "branch-only" }),
+    makeItem({ branch: "fix/d", ref: "refs/heads/fix/d", path: null, kind: "branch-only" }),
   ];
   const { operations } = makeOperations({
     heartbeatGate() {
@@ -554,7 +649,7 @@ test("initial gate heartbeat failure blocks the current and remaining selected c
     items,
     gateHandle: { generation: 2, token: "gate" },
     operations,
-    maxRetire: "10",
+    maxRetire: "1",
   });
 
   assert.equal(report.retired.length, 0);
@@ -576,8 +671,19 @@ test("initial gate heartbeat failure blocks the current and remaining selected c
         partial: false,
         reason: "maintenance gate unavailable after earlier retirement failure: maintenance gate heartbeat failed before retirement: expired",
       },
+      {
+        ref: "refs/heads/fix/c",
+        partial: false,
+        reason: "maintenance gate unavailable after earlier retirement failure: maintenance gate heartbeat failed before retirement: expired",
+      },
+      {
+        ref: "refs/heads/fix/d",
+        partial: false,
+        reason: "maintenance gate unavailable after earlier retirement failure: maintenance gate heartbeat failed before retirement: expired",
+      },
     ],
   );
+  assert.deepEqual(report.cleanupReady, []);
 });
 
 test("initial gate ownership drift blocks without mutating", () => {

--- a/scripts/worktree-lifecycle-retirement.ts
+++ b/scripts/worktree-lifecycle-retirement.ts
@@ -17,6 +17,13 @@ import {
 
 const DEFAULT_MAX_RETIRE = 3;
 const MAX_RETIRE_LIMIT = 10;
+// A retirement attempt includes a full candidate reprobe and several gate
+// checks, so it can be much slower than the local mutation it guards. Five
+// lets the scheduled default of three retirements bypass two blocked units,
+// while bounding an all-blocked sweep. Higher explicit success limits retain
+// at least that many attempts so a requested successful-retirement limit is
+// still attainable.
+const DEFAULT_RETIREMENT_ATTEMPT_BUDGET = 5;
 const ZERO_OID_40 = "0000000000000000000000000000000000000000";
 const ZERO_OID_64 =
   "0000000000000000000000000000000000000000000000000000000000000000";
@@ -157,15 +164,22 @@ export function retireLifecycleUnits({
     attempts: [],
     remoteDeletionProposals: [],
   };
-  const batchSize = parseMaxRetire(maxRetire);
+  const maxSuccessfulRetirements = parseMaxRetire(maxRetire);
+  const attemptBudget = retirementAttemptBudget(maxSuccessfulRetirements);
   const eligible = [...items]
     .filter((item) => item.lane === "retire-after-gate")
     .sort(compareRetirementCandidates);
-  const selected = eligible.slice(0, batchSize);
-  report.cleanupReady = eligible.slice(batchSize);
 
-  for (let index = 0; index < selected.length; index += 1) {
-    const item = selected[index]!;
+  let gateFailed = false;
+  let index = 0;
+  for (
+    ;
+    index < eligible.length &&
+    report.retired.length < maxSuccessfulRetirements &&
+    report.attempts.length < attemptBudget;
+    index += 1
+  ) {
+    const item = eligible[index]!;
     const attempt = beginAttempt(item);
     const state: RetirementState = {
       destructiveMutation: false,
@@ -178,7 +192,8 @@ export function retireLifecycleUnits({
     const initialGate = heartbeatThenVerify(operations, gateHandle, "before retirement");
     if (!initialGate.ok) {
       reportFailure(report, item, attempt, state, initialGate.reason);
-      cascadeRemainingBlocked(report, selected, index + 1, initialGate.reason);
+      cascadeRemainingBlocked(report, eligible, index + 1, initialGate.reason);
+      gateFailed = true;
       break;
     }
 
@@ -257,7 +272,8 @@ export function retireLifecycleUnits({
       const preCleanupGate = heartbeatThenVerify(operations, gateHandle, "before ignored cleanup");
       if (!preCleanupGate.ok) {
         reportFailure(report, item, attempt, state, preCleanupGate.reason);
-        cascadeRemainingBlocked(report, selected, index + 1, preCleanupGate.reason);
+        cascadeRemainingBlocked(report, eligible, index + 1, preCleanupGate.reason);
+        gateFailed = true;
         break;
       }
 
@@ -300,7 +316,8 @@ export function retireLifecycleUnits({
       );
       if (!preWorktreeGate.ok) {
         reportFailure(report, item, attempt, state, preWorktreeGate.reason);
-        cascadeRemainingBlocked(report, selected, index + 1, preWorktreeGate.reason);
+        cascadeRemainingBlocked(report, eligible, index + 1, preWorktreeGate.reason);
+        gateFailed = true;
         break;
       }
 
@@ -322,7 +339,8 @@ export function retireLifecycleUnits({
         state,
         midGate.reason,
       );
-      cascadeRemainingBlocked(report, selected, index + 1, midGate.reason);
+      cascadeRemainingBlocked(report, eligible, index + 1, midGate.reason);
+      gateFailed = true;
       break;
     }
 
@@ -357,7 +375,8 @@ export function retireLifecycleUnits({
       );
       reportFailure(report, item, attempt, handled.state, handled.reason);
       if (handled.lostGate) {
-        cascadeRemainingBlocked(report, selected, index + 1, handled.reason);
+        cascadeRemainingBlocked(report, eligible, index + 1, handled.reason);
+        gateFailed = true;
         break;
       }
       continue;
@@ -382,7 +401,8 @@ export function retireLifecycleUnits({
         );
         reportFailure(report, item, attempt, handled.state, handled.reason);
         if (handled.lostGate) {
-          cascadeRemainingBlocked(report, selected, index + 1, handled.reason);
+          cascadeRemainingBlocked(report, eligible, index + 1, handled.reason);
+          gateFailed = true;
           break;
         }
         continue;
@@ -392,7 +412,8 @@ export function retireLifecycleUnits({
     const finalGate = heartbeatThenVerify(operations, gateHandle, "after local retirement");
     if (!finalGate.ok) {
       reportFailure(report, item, attempt, state, finalGate.reason);
-      cascadeRemainingBlocked(report, selected, index + 1, finalGate.reason);
+      cascadeRemainingBlocked(report, eligible, index + 1, finalGate.reason);
+      gateFailed = true;
       break;
     }
 
@@ -409,6 +430,9 @@ export function retireLifecycleUnits({
         reason: "remote-deletion-requires-separate-authorization",
       });
     }
+  }
+  if (!gateFailed) {
+    report.cleanupReady = eligible.slice(index);
   }
 
   return report;
@@ -837,14 +861,18 @@ function reportFailure(
   });
 }
 
+function retirementAttemptBudget(maxSuccessfulRetirements: number): number {
+  return Math.max(DEFAULT_RETIREMENT_ATTEMPT_BUDGET, maxSuccessfulRetirements);
+}
+
 function cascadeRemainingBlocked(
   report: RetirementReport,
-  selected: WorktreeLifecycleItem[],
+  eligible: WorktreeLifecycleItem[],
   startIndex: number,
   reason: string,
 ): void {
-  for (let index = startIndex; index < selected.length; index += 1) {
-    const item = selected[index]!;
+  for (let index = startIndex; index < eligible.length; index += 1) {
+    const item = eligible[index]!;
     report.blocked.push({
       branch: item.branch,
       ref: item.ref,

--- a/scripts/worktree-sweep.sh
+++ b/scripts/worktree-sweep.sh
@@ -147,11 +147,12 @@ echo "[sweep] repo HEAD: $(git rev-parse --short HEAD 2>/dev/null) on $(git rev-
 echo "[sweep] registered worktrees: $before"
 echo "[sweep] --- lifecycle apply output follows ---"
 # The lifecycle command performs its own complete inventory and retires only
-# cleanup-ready units. --max-retire limits destructive local retirements; the
-# command may make a few additional bounded non-mutating attempts to reach
-# safe candidates behind blocks. The explicit override is audited by the
-# command; the local maintenance plane remains enforced. Keep the blast radius
-# bounded.
+# cleanup-ready units. --max-retire limits the number of local retirements per
+# run; the command may make additional attempts that can still include
+# destructive steps (e.g. ignored-path cleanup, worktree removal) before
+# reporting a unit as partially retired or blocked. The explicit override is
+# audited by the command; the local maintenance plane remains enforced. Keep
+# the blast radius bounded.
 pnpm beads:worktrees:apply --allow-unenforced-planes --max-retire 3
 status=$?
 

--- a/scripts/worktree-sweep.sh
+++ b/scripts/worktree-sweep.sh
@@ -3,9 +3,10 @@
 #
 # Runs the lifecycle tool directly. The tool owns the retirement guard rails:
 # cooldown, dirty-state and live-process checks, retention proof, the maintenance
-# fence, and the bounded retirement count. Do not put an unattended LLM between
-# this wrapper and that policy: lifecycle inventory contains untrusted text from
-# filenames and repository metadata.
+# fence, a bounded destructive-retirement count, and a separate bounded attempt
+# budget that can bypass blocked candidates. Do not put an unattended LLM
+# between this wrapper and that policy: lifecycle inventory contains untrusted
+# text from filenames and repository metadata.
 #
 # Machine-specific wiring — the launchd plist and, on macOS, an app bundle that
 # holds the Full Disk Access grant — stays out of the repo.
@@ -146,8 +147,11 @@ echo "[sweep] repo HEAD: $(git rev-parse --short HEAD 2>/dev/null) on $(git rev-
 echo "[sweep] registered worktrees: $before"
 echo "[sweep] --- lifecycle apply output follows ---"
 # The lifecycle command performs its own complete inventory and retires only
-# cleanup-ready units. The explicit override is audited by the command; the
-# local maintenance plane remains enforced. Keep the blast radius bounded.
+# cleanup-ready units. --max-retire limits destructive local retirements; the
+# command may make a few additional bounded non-mutating attempts to reach
+# safe candidates behind blocks. The explicit override is audited by the
+# command; the local maintenance plane remains enforced. Keep the blast radius
+# bounded.
 pnpm beads:worktrees:apply --allow-unenforced-planes --max-retire 3
 status=$?
 


### PR DESCRIPTION
## Summary
- treat `--max-retire` as a cap on successful destructive retirements
- continue past individually blocked candidates under a deterministic five-attempt budget
- preserve fail-closed gate cascades and report only unattempted candidates as cleanup-ready
- document the scheduled sweep bounded throughput behavior

## Verification
- worktree lifecycle retirement tests
- worktree lifecycle patrol tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `bash -n scripts/worktree-sweep.sh`
- `git diff --check`
- independent safety review approved

Bead: `cave-96rz8`