### PR TITLE
fix(deps): bump serde_with to 3.21.0 (Dependabot #19)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3797,9 +3797,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -3817,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
## Dependabot alert #19 (Moderate)

**Advisory:** `serde_with` — *KeyValueMap serialization panics on empty sequence or map entries*.
Vulnerable range `< 3.21.0`; patched in **3.21.0**. Detected in `src-tauri/Cargo.lock`.

**Change:** `serde_with` **3.20.0 → 3.21.0** (and `serde_with_macros` 3.20.0 → 3.21.0, which moves in lockstep because `serde_with` pins its macro crate to an exact version).

## What pulls `serde_with` in

It is entirely transitive — `src-tauri/Cargo.toml` never names it. `cargo tree -i serde_with` shows a single consumer:

```
serde_with v3.20.0
├── tauri-utils v2.9.2
│   ├── tauri-build v2.6.2  (build-dependency of app + tauri)
│   ├── tauri-codegen v2.6.2 → tauri-macros v2.6.2 → tauri v2.11.2
│   └── tauri-plugin v2.6.2 (build-dep of the log/notification/os/process/updater plugins)
└── tauri-utils v2.9.2
    ├── tauri v2.11.2
    ├── tauri-runtime v2.11.2
    └── tauri-runtime-wry v2.11.2
```

`tauri-utils` accepts the bump inside its existing semver range, so this is a lockfile-only patch bump with no manifest change.

## Diff scope

One file, 4 insertions / 4 deletions — only the two `serde_with` package entries (version + checksum each):

```
src-tauri/Cargo.lock | 8 ++++----
```

The update was run as `cargo update -p serde_with --precise 3.21.0` rather than a bare `cargo update`, to avoid churning the rest of the lockfile. One unrelated edge that the resolver re-picked (`tempfile`'s `getrandom 0.4.2` → `0.3.4`) was reverted so the diff stays limited to the advisory; `cargo metadata --locked` then exits 0, confirming the lockfile is still self-consistent.

`3.20.0` no longer appears anywhere in `src-tauri/Cargo.lock`.

## Validation

Run locally on **Windows 11** (native Tauri target):

| Command | Result |
| --- | --- |
| `cargo metadata --locked` | exit 0 — lockfile self-consistent, no re-resolution needed |
| `cargo check --locked` | ✅ `Finished dev profile` — only pre-existing `dead_code` warnings, no new diagnostics |
| `cargo test --locked` | ✅ **164 passed, 0 failed, 0 ignored** |

Linux-only members of the Tauri stack are not exercised by a Windows checkout; CI covers those.

## Dependabot alert

Resolves [alert #19](https://github.com/OpenCoven/coven-cave/security/dependabot/19) — `serde_with` ([GHSA advisory](https://github.com/advisories?query=serde_with)), `src-tauri/Cargo.lock`. The alert closes automatically once this lands on `main` and the vulnerable version is no longer resolved.
