### PR TITLE
docs(security): record glib VariantStrIter constraint (Dependabot #18)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@ A document in `docs/` proper should be one somebody keeps current.
 
 ### Integrity and integrations
 
+- [`dependency-advisories.md`](dependency-advisories.md) — open Dependabot alerts whose patched version is unreachable from this dependency graph: the resolver refusal, the exposure assessment, and the upstream change that would lift each
 - [`project-permission-integrity.md`](project-permission-integrity.md) — reconciling stale grants against the project registry
 - [`discord-rich-presence.md`](discord-rich-presence.md) — privacy-safe local activity publishing
 

--- a/docs/dependency-advisories.md
+++ b/docs/dependency-advisories.md
@@ -1,0 +1,174 @@
+# Dependency advisories with no available fix
+
+Most Dependabot alerts close with a version bump. A few cannot, because the
+patched version is unreachable from this dependency graph — a transitive crate
+is pinned by an upstream generation that has not moved, or has stopped moving
+altogether. Those alerts stay open indefinitely, and every session that finds
+one re-derives the same constraint from scratch before concluding there is
+nothing to do.
+
+This file is where that derivation gets written down once. An entry records
+four things and nothing else:
+
+1. **The constraint** — the exact resolver refusal, quoted, not paraphrased.
+2. **The evidence** — the commands that produce it, so the next reader can
+   re-run them rather than trust this page.
+3. **The exposure** — whether the vulnerable code path is reachable from what
+   this repo actually builds and ships.
+4. **The condition that lifts it** — the specific upstream change that would
+   make a bump possible, so the entry can be retired deliberately.
+
+An entry is deleted when its alert closes, not edited into a historical note.
+The alert is the source of truth for state; this page only explains it.
+
+---
+
+## Dependabot #18 — `glib` `VariantStrIter` unsoundness
+
+| Field | Value |
+|---|---|
+| Alert | [#18](https://github.com/OpenCoven/coven-cave/security/dependabot/18) |
+| Advisory | [GHSA-wrw7-89jp-8q8g](https://github.com/advisories/GHSA-wrw7-89jp-8q8g) (no CVE) |
+| Severity | Moderate |
+| Package | `glib` (crates.io), transitive |
+| Manifest | `src-tauri/Cargo.lock` |
+| Vulnerable | `>= 0.15.0, < 0.20.0` |
+| Patched | `0.20.0` |
+| Resolved here | `0.18.5` |
+| Status | **Not fixable at this Tauri generation.** No exposure identified. |
+| Assessed | 2026-08-19 |
+
+### What the advisory is
+
+`VariantStrIter::impl_get` passed `&p` — an immutable reference to a
+`*mut libc::c_char` initialized to `NULL` — as a variadic out-argument to
+`glib_sys::g_variant_get_child`, which mutates the pointer in place. The
+mutability mismatch went uncaught because the C function is variadic. Recent
+Rust compilers disregard the unsound write when building with optimizations, so
+`CStr::from_ptr` then receives `NULL` and the process dereferences it.
+
+The failure mode is a **crash**, not a disclosure or code-execution primitive,
+and it only occurs on a code path that iterates a string-array `GVariant`.
+
+### The blocking constraint
+
+`glib` is not in `src-tauri/Cargo.toml`. It arrives entirely through the
+Linux/BSD GTK3 stack that `tauri` and `wry` depend on:
+
+```console
+$ cd src-tauri
+$ cargo tree -i glib --target x86_64-unknown-linux-gnu
+glib v0.18.5
+├── atk v0.18.2
+│   └── gtk v0.18.2
+│       ├── libappindicator v0.9.0
+│       │   └── tray-icon v0.23.1
+│       │       └── tauri v2.11.2
+│       ├── muda v0.19.2
+│       ├── tao v0.35.3
+│       │   └── tauri-runtime-wry v2.11.2
+│       ├── tauri v2.11.2
+│       ├── tauri-runtime v2.11.2
+│       ├── webkit2gtk v2.0.2
+│       │   └── wry v0.55.1
+│       └── wry v0.55.1
+├── cairo-rs v0.18.5
+├── gdk v0.18.2
+├── gdk-pixbuf v0.18.5
+├── gdkx11 v0.18.2
+├── gio v0.18.4
+├── gtk v0.18.2
+├── javascriptcore-rs v1.1.2
+├── libappindicator v0.9.0
+├── pango v0.18.3
+├── soup3 v0.5.0
+└── webkit2gtk v2.0.2
+```
+
+A plain `cargo update -p glib` reports `Locking 0 packages` — `0.18.5` is
+already the newest release in the `^0.18` range. Forcing the patched version
+names the pin directly:
+
+```console
+$ cargo update -p glib --precise 0.20.0
+error: failed to select a version for the requirement `glib = "^0.18"`
+candidate versions found which didn't match: 0.20.0
+location searched: crates.io index
+required by package `gtk v0.18.2`
+    ... which satisfies dependency `gtk = "^0.18"` (locked to 0.18.2) of package `tauri v2.11.2`
+    ... which satisfies dependency `tauri = "^2.11.2"` (locked to 2.11.2) of package `app v0.3.7`
+```
+
+### Why upgrading Tauri does not help
+
+The pin is not this project's Tauri version. It is the GTK3 Rust binding
+generation, which has stopped:
+
+- **`gtk` tops out at `0.18.2`**, published 2024-12-09. That is the highest
+  version the crate has ever had. `glib 0.20` belongs to the gtk4-rs
+  generation; there is no GTK3 binding release that consumes it.
+- **`webkit2gtk 2.0.2`** — the newest, and pinned exactly as `=2.0.2` by `wry`
+  — requires `glib ^0.18.0`, `gtk ^0.18.0`, `gio ^0.18.0`.
+- **`tauri 2.11.5`**, the latest release at time of writing, still declares
+  `gtk ^0.18` for `cfg(any(target_os = "linux", …bsd))`. So does
+  `wry 0.56.1`.
+
+Every Tauri v2 release therefore resolves `glib` to the `0.18` line on Linux.
+Bumping this project's `tauri` from `2.11.2` to `2.11.5` would change nothing
+about this alert.
+
+### Exposure
+
+**Linux/BSD only.** The whole GTK stack sits behind
+`cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd",
+target_os = "openbsd", target_os = "netbsd"))`. It is absent from the macOS and
+Windows builds, which is what `tauri.conf.json` bundles (`dmg`, `app`, `msi`).
+The Linux artifact is real, though — `.github/workflows/release.yml` builds an
+AppImage on `ubuntu-22.04` — so "Linux-only" narrows the blast radius rather
+than eliminating it.
+
+**No reachable call site was found.** `VariantStrIter` is only constructed by
+`glib::Variant::iter_str()`. Scanning the vendored sources of every crate in
+the tree that depends on `glib`:
+
+```console
+$ grep -rl 'iter_str\|VariantStrIter' ~/.cargo/registry/src/*/<crate>/
+```
+
+returns matches in `glib-0.18.5` itself and in **none** of `gtk-0.18.2`,
+`gdk-0.18.2`, `gdkx11-0.18.2`, `gdk-pixbuf-0.18.5`, `gio-0.18.4`, `atk-0.18.2`,
+`cairo-rs-0.18.5`, `pango-0.18.3`, `soup3-0.5.0`, `javascriptcore-rs-1.1.2`,
+`webkit2gtk-2.0.2`, `libappindicator-0.9.0`, `muda-0.19.2`, `tray-icon-0.23.1`,
+`tao-0.35.3`, `wry-0.55.1`, `tauri-2.11.2`, `tauri-runtime-2.11.2`, or
+`tauri-runtime-wry-2.11.2`.
+
+`src-tauri/src` contains no `glib`, `gio`, or `Variant` usage of its own.
+
+Assessed exposure: **none identified**, against a worst case of a null-pointer
+crash in the Linux AppImage.
+
+### What would lift this
+
+Either of:
+
+- **`wry` moving its Linux webview off GTK3.** A `webkit2gtk-6.0` / GTK4
+  generation would bring `glib 0.20+` with it. `wry` pins `webkit2gtk =2.0.2`
+  exactly, so this is visible as a change to that pin — watch it rather than
+  watching `glib`.
+- **An upstream backport to the `glib` 0.18 line.** The 0.18 series is not
+  receiving fixes, so treat this as unlikely.
+
+Nothing in this repository can accelerate either one. Do **not** hand-edit
+`Cargo.lock` to a `glib` version the resolver cannot reach; the build would
+fail and the alert would not close.
+
+### Re-checking
+
+```bash
+cd src-tauri
+cargo tree -i glib --target x86_64-unknown-linux-gnu
+cargo update -p glib --dry-run --precise 0.20.0   # expect the refusal quoted above
+```
+
+If that refusal no longer names `gtk v0.18.2`, the constraint has moved and
+this entry should be re-derived rather than trusted.


### PR DESCRIPTION
## Outcome: not fixable by a version bump

Dependabot alert [#18](https://github.com/OpenCoven/coven-cave/security/dependabot/18) (moderate, [GHSA-wrw7-89jp-8q8g](https://github.com/advisories/GHSA-wrw7-89jp-8q8g)) wants `glib >= 0.20.0`. `src-tauri/Cargo.lock` resolves `glib 0.18.5`, and **0.20.0 is unreachable from this dependency graph**. There is no lockfile change to make, so this PR ships the derivation instead of a fabricated bump. **`Cargo.lock` is untouched.**

### The constraint

`glib` is not in `src-tauri/Cargo.toml`. It arrives through the Linux/BSD GTK3 stack behind `tauri` and `wry`:

```
$ cd src-tauri && cargo tree -i glib --target x86_64-unknown-linux-gnu
glib v0.18.5
├── atk v0.18.2 → gtk v0.18.2 → { libappindicator → tray-icon → tauri v2.11.2,
│                                 muda, tao → tauri-runtime-wry,
│                                 webkit2gtk v2.0.2 → wry v0.55.1 }
├── cairo-rs, gdk, gdk-pixbuf, gdkx11, gio, gtk, javascriptcore-rs,
    libappindicator, pango, soup3, webkit2gtk
```

`cargo update -p glib` reports `Locking 0 packages` — 0.18.5 is already the newest in `^0.18`. Forcing the patched version names the pin:

```
$ cargo update -p glib --precise 0.20.0
error: failed to select a version for the requirement `glib = "^0.18"`
candidate versions found which didn't match: 0.20.0
required by package `gtk v0.18.2`
    ... which satisfies dependency `gtk = "^0.18"` (locked to 0.18.2) of package `tauri v2.11.2`
```

### Upgrading Tauri would not help

The pin is the GTK3 binding generation, not our Tauri version:

- `gtk` tops out at **0.18.2** (2024-12-09) — the highest version that crate has ever had. `glib 0.20` belongs to gtk4-rs; no GTK3 binding release consumes it.
- `webkit2gtk 2.0.2` (newest, and pinned `=2.0.2` by `wry`) requires `glib ^0.18.0` / `gtk ^0.18.0` / `gio ^0.18.0`.
- `tauri 2.11.5` (latest) and `wry 0.56.1` still declare `gtk ^0.18` for `cfg(any(target_os = "linux", …bsd))`.

So no Tauri v2 release resolves `glib` above the 0.18 line on Linux. Per the task scope, no major Tauri work was attempted — and it would not have mattered.

### Exposure: none identified

- **Linux/BSD only.** The GTK stack is `cfg`-gated off macOS and Windows. The Linux artifact is real, though — `release.yml` builds an AppImage on `ubuntu-22.04` — so this narrows the blast radius rather than eliminating it.
- **No reachable call site.** `VariantStrIter` is only constructed by `glib::Variant::iter_str()`. Grepping the vendored sources of all 19 crates in the tree that depend on `glib` finds `iter_str`/`VariantStrIter` in `glib-0.18.5` itself and **nowhere else** — not in gtk, gdk, gdkx11, gdk-pixbuf, gio, atk, cairo-rs, pango, soup3, javascriptcore-rs, webkit2gtk, libappindicator, muda, tray-icon, tao, wry, tauri, tauri-runtime, or tauri-runtime-wry. `src-tauri/src` uses no `glib`, `gio`, or `Variant` API of its own.
- **Failure mode is a crash.** Per the advisory, the unsound write is discarded under optimization and `CStr::from_ptr` then dereferences `NULL` — a null-pointer crash, not a disclosure or execution primitive.

### What would lift it

Either `wry` moving its Linux webview off GTK3 (visible as a change to its `webkit2gtk =2.0.2` pin, which would bring `glib 0.20+`), or an upstream backport to the unmaintained `glib` 0.18 line. Neither is actionable here. The doc records the re-check commands.

### The artifact

`docs/dependency-advisories.md` is deliberately general, not glib-specific: a frozen GTK3 stack will produce more alerts with no available fix, and each one currently costs a session the same derivation. Each entry records the resolver refusal verbatim, the commands that reproduce it, the exposure assessment, and the upstream condition that retires it. Entries are deleted when their alert closes — the alert stays the source of truth for state.

The repo has no `deny.toml`, no `audit.toml`, and no `.github/dependabot.yml`, so there was no existing suppression convention to extend. `docs/README.md` is updated under **Living → Integrity and integrations**, per that index's own "add its line to the right section" rule.

### Validation

- `node scripts/docs-index.test.mjs` → `index ok (49 documents classified, 62 links resolved)`. This is the check CI runs on the docs path.
- `cd src-tauri && cargo check --locked` → exit 0 in 1m25s (9 pre-existing dead-code warnings, unrelated). This confirms the lockfile still resolves; it does **not** compile the GTK stack, since this is a Windows machine and that code is `cfg`-gated out. The Linux path is only exercised in CI/release.
- `pnpm lint` was not run: its scripts only cover `src/**` TypeScript, and this change touches no source.

Closes nothing — alert #18 stays open by design. Tracked as `cave-13m`.
