### PR TITLE
fix(deps): bump nanoid to 3.3.18 (Dependabot #17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
   "pnpm": {
     "overrides": {
       "enhanced-resolve": "5.23.0",
+      "nanoid@3": "3.3.18",
       "postcss@<8.5.23": "^8.5.26",
       "sharp": "0.35.3"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   enhanced-resolve: 5.23.0
+  nanoid@3: 3.3.18
   postcss@<8.5.23: ^8.5.26
   sharp: 0.35.3
 
@@ -2865,8 +2866,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6678,7 +6679,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -6801,7 +6802,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## What

Resolves **Dependabot alert #17** (High): `nanoid` 3.3.17 — *custom generators can loop indefinitely when size is zero*. Patched in **3.3.18**.

`nanoid` is not a direct dependency. `pnpm-lock.yaml` carried two copies:

- `nanoid@3.3.17` — vulnerable, pulled in transitively by `postcss`
- `nanoid@5.1.16` — unaffected, untouched

postcss declares a `^3.3.x` range, so 3.3.18 is already admissible. A scoped pnpm override (`"nanoid@3": "3.3.18"`) pins the transitive resolution so it lands on the patched release and no future resolution drifts back. The existing overrides are left intact.

## Change

| File | Change |
| --- | --- |
| `package.json` | +1 line: `"nanoid@3": "3.3.18"` added to `pnpm.overrides` |
| `pnpm-lock.yaml` | The `overrides` entry, the `nanoid@3.3.17` → `3.3.18` package + snapshot entries, and the `postcss@8.5.26` snapshot reference |

Total: 6 insertions, 4 deletions across 2 files. No unrelated lockfile churn.

Rebased onto current `main` after the sibling dependency PRs (#4741 postcss, #4742 sharp, #4737 serde_with) landed. That rebase collapsed the second `postcss@8.4.31` copy into `postcss@8.5.26`, so only one postcss snapshot reference remains to update.

## Validation

Run from a clean checkout of this branch at `51a5dc9`:

- `pnpm install --frozen-lockfile` — passes (lockfile consistent with `package.json`)
- `pnpm lint` — passes (design codemod check: 0 files with drift; eslint `--max-warnings=0` clean)
- `pnpm typecheck` — passes (`tsc --noEmit`, no errors)
- `pnpm build` — passes, including the `bundle-budget` and `standalone-budget` postbuild gates
- `grep -n "nanoid" pnpm-lock.yaml` — no `3.3.17` anywhere; `nanoid@3: 3.3.18` in `overrides`, `nanoid@3.3.18` in packages + snapshots, the postcss snapshot on `3.3.18`
- `node -e "require('./node_modules/.pnpm/postcss@8.5.26/node_modules/nanoid/package.json').version"` → `3.3.18` in the installed tree

CI on this head is fully green across all ten jobs, including the required `Frontend build` (Playwright: 282 passed, 3 skipped).
