### PR TITLE
Mint a dev sidecar auth token

### DIFF
--- a/scripts/dev-app-teardown.test.mjs
+++ b/scripts/dev-app-teardown.test.mjs
@@ -79,6 +79,7 @@ writeFileSync(path.join(fakeScripts, "whisper-runtime-dev-env.sh"), "# stub for 
 const fakePnpm = (port, pidFile) => `#!/usr/bin/env bash
 if [ "$1" = "dev" ]; then
 echo "server $$" >>"${pidFile}"
+echo "server_token $COVEN_CAVE_AUTH_TOKEN" >>"${pidFile}"
 node -e '
   const http = require("http");
   const fs = require("fs");
@@ -95,6 +96,7 @@ child=$!
 wait "$child"
 else
 echo "tauri $$" >>"${pidFile}"
+echo "tauri_token $COVEN_CAVE_AUTH_TOKEN" >>"${pidFile}"
 node -e "setInterval(() => {}, 1000)" &
 child=$!
 wait "$child"
@@ -166,6 +168,16 @@ async function assertTeardown(signal) {
     });
     assert.ok(pids.tauri, "the launcher must actually start the Tauri child");
     assert.ok(pids.server, "the Tauri child must own the dev server process");
+    assert.match(
+      pids.server_token,
+      /^[0-9a-f]{64}$/,
+      "an absent dev sidecar token must be minted before the server starts",
+    );
+    assert.equal(
+      pids.tauri_token,
+      pids.server_token,
+      "the Tauri WebView and dev server must receive the same per-launch token",
+    );
 
     process.kill(wrapper.pid, signal);
 

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -151,6 +151,17 @@ trap cleanup EXIT
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM HUP
 
+# The packaged app always gives its sidecar and WebView the same ephemeral
+# credential. Mirror that contract in dev even when the caller did not provide
+# one: server.ts may re-arm the persisted mobile-access gate for this port, and
+# a tokenless WebView would otherwise receive 401s from every API route.
+if [ -z "${COVEN_CAVE_AUTH_TOKEN:-}" ]; then
+  COVEN_CAVE_AUTH_TOKEN="$(
+    node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))'
+  )"
+  export COVEN_CAVE_AUTH_TOKEN
+fi
+
 # The launcher starts both the Tauri dev process and its owned server with this
 # secret. Carry it into the browser-side bridge through the URL fragment so it
 # never participates in Next's module URL resolution or reaches the HTTP server.

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -86,8 +86,13 @@ assert.match(
 
 assert.match(
   source,
-  /if \[ -n "\$\{COVEN_CAVE_AUTH_TOKEN:-\}" \]; then[\s\S]*?encodeURIComponent\(process\.env\.COVEN_CAVE_AUTH_TOKEN\)[\s\S]*?dev_url\+="#covenCaveToken=\$\{sidecar_token_fragment\}"/,
-  "an inherited sidecar token must reach the desktop webview through the URL hash",
+  /if \[ -z "\$\{COVEN_CAVE_AUTH_TOKEN:-\}" \]; then[\s\S]*?randomBytes\(32\)\.toString\("hex"\)[\s\S]*?export COVEN_CAVE_AUTH_TOKEN[\s\S]*?if \[ -n "\$\{COVEN_CAVE_AUTH_TOKEN:-\}" \]; then[\s\S]*?encodeURIComponent\(process\.env\.COVEN_CAVE_AUTH_TOKEN\)[\s\S]*?dev_url\+="#covenCaveToken=\$\{sidecar_token_fragment\}"/,
+  "the launcher must mint a missing sidecar token and carry it into the desktop webview",
+);
+assert.ok(
+  source.indexOf("export COVEN_CAVE_AUTH_TOKEN") <
+    source.indexOf('HOSTNAME=127.0.0.1 PORT="$dev_port" pnpm dev &'),
+  "the minted token must be exported before the owned dev server starts",
 );
 assert.match(
   source,


### PR DESCRIPTION
## Summary
- mint a 256-bit sidecar token when the dev launcher receives none
- pass the same token to the dev server and Tauri WebView
- cover token propagation in launcher and teardown regressions

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `node scripts/dev-app.test.mjs`
- `node scripts/dev-app-teardown.test.mjs`
- `bash -n scripts/dev-app.sh`
- `git diff --check`

Bead: `cave-frsmb`