### PR TITLE
Fix Windows managed CLI path verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Fixed
+- Verify Cave’s private Coven CLI after first-run installation on Windows even
+  when the inherited environment spells `Path` with different casing.
+
 ## [0.3.7] - 2026-08-19
 
 > A calmer native iOS shell, clearer Chats, and a safer cross-platform foundation.

--- a/src/lib/server/managed-node-toolchain.test.ts
+++ b/src/lib/server/managed-node-toolchain.test.ts
@@ -193,6 +193,48 @@ test("managed Node paths are user-scoped and never point at a system installatio
   assert.equal(managedNodeRoot("linux", { XDG_DATA_HOME: "/home/sage/.local/share" } as unknown as NodeJS.ProcessEnv, "/home/sage"), "/home/sage/.local/share/opencoven/coven-cave/toolchains");
 });
 
+test("managed Node spawn environment replaces Windows PATH keys case-insensitively", () => {
+  const paths = managedNodePaths(
+    "win32",
+    "x64",
+    { LOCALAPPDATA: "C:\\Users\\Sage\\AppData\\Local" } as unknown as NodeJS.ProcessEnv,
+    "C:\\Users\\Sage",
+  );
+  assert.ok(paths);
+  const env = managedNodeSpawnEnv({
+    Path: "C:\\stale-user-path",
+    PATH: "C:\\stale-uppercase-path",
+  } as unknown as NodeJS.ProcessEnv, paths);
+  assert.ok(env);
+  assert.deepEqual(
+    Object.keys(env).filter((key) => key.toUpperCase() === "PATH"),
+    ["PATH"],
+  );
+  assert.deepEqual(
+    env.PATH?.split(";"),
+    [paths.npmBin, paths.installDir, "C:\\stale-uppercase-path"],
+  );
+});
+
+test("managed Node spawn environment preserves a mixed-case Windows Path value", () => {
+  const paths = managedNodePaths(
+    "win32",
+    "x64",
+    { LOCALAPPDATA: "C:\\Users\\Sage\\AppData\\Local" } as unknown as NodeJS.ProcessEnv,
+    "C:\\Users\\Sage",
+  );
+  assert.ok(paths);
+  const env = managedNodeSpawnEnv(
+    { Path: "C:\\Windows\\System32" } as unknown as NodeJS.ProcessEnv,
+    paths,
+  );
+  assert.ok(env);
+  assert.deepEqual(
+    env.PATH?.split(";"),
+    [paths.npmBin, paths.installDir, "C:\\Windows\\System32"],
+  );
+});
+
 test("managed Node probe distinguishes an absent toolchain from an unusable one", async () => {
   const missing = await probeManagedNodeToolchain({ platform: "linux", architecture: "x64", home: path.join(tmpdir(), "missing-coven-node") });
   assert.equal(missing.status, "missing");

--- a/src/lib/server/managed-node-toolchain.ts
+++ b/src/lib/server/managed-node-toolchain.ts
@@ -222,9 +222,20 @@ export function managedNodeSpawnEnv(
   if (!paths) return null;
   const pathOps = pathApi(paths.platform);
   const nodeBin = pathOps.dirname(paths.node);
-  const parts = [paths.npmBin, nodeBin, base.PATH].filter(Boolean);
+  const basePath =
+    base.PATH ??
+    (paths.platform === "win32"
+      ? Object.entries(base).find(([key]) => key.toUpperCase() === "PATH")?.[1]
+      : undefined);
+  const parts = [paths.npmBin, nodeBin, basePath].filter(Boolean);
+  const env = { ...base };
+  if (paths.platform === "win32") {
+    for (const key of Object.keys(env)) {
+      if (key.toUpperCase() === "PATH") delete env[key];
+    }
+  }
   return {
-    ...base,
+    ...env,
     PATH: parts.join(paths.platform === "win32" ? ";" : ":"),
     NPM_CONFIG_PREFIX: paths.npmPrefix,
     npm_config_prefix: paths.npmPrefix,


### PR DESCRIPTION
## Summary

- canonicalize case-insensitive Windows `PATH`/`Path` entries before managed CLI verification
- preserve the host path while prepending Cave managed npm and Node directories
- add regression coverage for duplicate and mixed-case-only Windows path keys

## Verification

- managed Node tests (34/34)
- Coven path tests
- install-service tests
- onboarding core-tools tests (15/15)
- onboarding install route contract
- ESLint
- TypeScript
- full app test suite
- full API suite (385 files)
- test wiring (1716 files)
- `git diff --check`

Bead: `cave-0fhfv`
