### PR TITLE
Clarify familiar runtime selection

### DIFF
--- a/src/components/familiar-summoning-circle.test.ts
+++ b/src/components/familiar-summoning-circle.test.ts
@@ -72,6 +72,36 @@ assert.match(
 );
 assert.match(
   source,
+  /active && v\.kind === "local" \? " summoning-vessel--expanded" : ""/,
+  "selecting the first local vessel expands it across the available panel width",
+);
+assert.match(
+  source,
+  /<span className="summoning-vessel__action" aria-hidden>[\s\S]*?\{active \? "Selected" : "Choose"\}/,
+  "vessel cards name the hovered and selected action instead of relying on a border-only cue",
+);
+assert.match(
+  source,
+  /<span className=\{labelClass\}>Available runtimes<\/span>[\s\S]*?className="summoning-runtime-grid"/,
+  "local and SSH vessel selections reveal a clearly labelled full-width runtime panel",
+);
+assert.match(
+  source,
+  /summoning-runtime-option--active[\s\S]*?ph:check-circle-fill/,
+  "the chosen runtime has a persistent checkmark in addition to its color treatment",
+);
+assert.match(
+  css,
+  /\.summoning-vessel:hover,[\s\S]*?background:[\s\S]*?box-shadow:/,
+  "hovered vessel cards receive a visible raised surface treatment",
+);
+assert.match(
+  css,
+  /\.summoning-runtime-panel \{[\s\S]*?width: 100%;[\s\S]*?\.summoning-runtime-grid \{[\s\S]*?width: 100%;/,
+  "the available-runtime panel and option grid consume the full working width",
+);
+assert.match(
+  source,
   /Runs on \$\{localHost\}, the host serving this Cave\./,
   "the local vessel explains what the hostname identifies",
 );

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -888,31 +888,44 @@ function StageVessel({
   return (
     <div className="flex flex-col gap-3">
       <div role="radiogroup" aria-label="Vessel" className="summoning-vessels">
-        {vessels.map((v) => (
-          <button
-            key={v.kind}
-            type="button"
-            role="radio"
-            aria-checked={vessel === v.kind}
-            onClick={() => {
-              setVessel(v.kind);
-              // A previously selected local Grok runtime must not survive a
-              // switch to SSH: native Grok sessions are deliberately local-only.
-              if (v.kind === "ssh" && harness === "grok") setHarness(null);
-              if (v.kind === "hermes") setHarness("hermes");
-            }}
-            className={`focus-ring summoning-vessel${vessel === v.kind ? " summoning-vessel--active" : ""}`}
-          >
-            <Icon name={v.icon} width={18} className="summoning-vessel__icon" />
-            <span className="summoning-vessel__title">{v.title}</span>
-            <span className="summoning-vessel__hint">{v.hint}</span>
-          </button>
-        ))}
+        {vessels.map((v) => {
+          const active = vessel === v.kind;
+          return (
+            <button
+              key={v.kind}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => {
+                setVessel(v.kind);
+                // A previously selected local Grok runtime must not survive a
+                // switch to SSH: native Grok sessions are deliberately local-only.
+                if (v.kind === "ssh" && harness === "grok") setHarness(null);
+                if (v.kind === "hermes") setHarness("hermes");
+              }}
+              className={`focus-ring summoning-vessel${active ? " summoning-vessel--active" : ""}${active && v.kind === "local" ? " summoning-vessel--expanded" : ""}`}
+            >
+              <Icon name={v.icon} width={18} className="summoning-vessel__icon" />
+              <span className="summoning-vessel__title">{v.title}</span>
+              <span className="summoning-vessel__hint">{v.hint}</span>
+              <span className="summoning-vessel__action" aria-hidden>
+                {active ? "Selected" : "Choose"}
+              </span>
+            </button>
+          );
+        })}
       </div>
 
       {vessel === "local" || vessel === "ssh" ? (
-        <div>
-          <span className={labelClass}>Runtime</span>
+        <div className="summoning-runtime-panel">
+          <div className="summoning-runtime-panel__heading">
+            <span className={labelClass}>Available runtimes</span>
+            <p className="summoning-runtime-panel__hint">
+              {vessel === "local"
+                ? `Choose what powers this familiar on ${localHost ?? "this Cave host"}.`
+                : "Choose the installed runtime to launch over SSH."}
+            </p>
+          </div>
           {harnesses === null ? (
             <p className="text-[length:var(--text-xs)] text-[var(--text-muted)]">Looking for installed runtimes…</p>
           ) : installedHarnesses.length === 0 ? (
@@ -932,7 +945,7 @@ function StageVessel({
               </button>
             </div>
           ) : (
-            <div role="radiogroup" aria-label="Runtime" className="summoning-chiprow">
+            <div role="radiogroup" aria-label="Runtime" className="summoning-runtime-grid">
               {installedHarnesses.map((h) => (
                 <button
                   key={h.id}
@@ -940,10 +953,13 @@ function StageVessel({
                   role="radio"
                   aria-checked={harness === h.id}
                   onClick={() => setHarness(h.id)}
-                  className={`focus-ring summoning-chip${harness === h.id ? " summoning-chip--active" : ""}`}
+                  className={`focus-ring summoning-runtime-option${harness === h.id ? " summoning-runtime-option--active" : ""}`}
                 >
-                  <Icon name="ph:terminal-window" width={12} />
-                  {h.label}
+                  <span className="summoning-runtime-option__identity">
+                    <Icon name="ph:terminal-window" width={14} />
+                    <span>{h.label}</span>
+                  </span>
+                  {harness === h.id ? <Icon name="ph:check-circle-fill" width={14} aria-hidden /> : null}
                 </button>
               ))}
             </div>

--- a/src/styles/summoning-circle.css
+++ b/src/styles/summoning-circle.css
@@ -237,6 +237,7 @@
 }
 
 .summoning-vessel {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -246,16 +247,43 @@
   border-radius: var(--radius-card);
   background: color-mix(in oklch, var(--bg-elevated) 40%, transparent);
   text-align: left;
+  transition:
+    transform var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard),
+    box-shadow var(--duration-fast) var(--ease-standard);
 }
 
-.summoning-vessel:hover {
-  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-strong));
+.summoning-vessel:hover,
+.summoning-vessel:focus-visible {
+  transform: translateY(-1px);
+  border-color: color-mix(in oklch, var(--accent-presence) 60%, var(--border-strong));
+  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-elevated));
+  box-shadow: 0 8px 20px color-mix(in oklch, var(--bg-panel) 55%, transparent);
 }
 
 .summoning-vessel--active {
   border-style: solid;
   border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-strong));
   background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+}
+
+.summoning-vessel--expanded {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: var(--space-3);
+}
+
+.summoning-vessel--expanded .summoning-vessel__icon {
+  grid-row: 1 / 3;
+}
+
+.summoning-vessel--expanded .summoning-vessel__action {
+  grid-column: 3;
+  grid-row: 1 / 3;
+  align-self: center;
 }
 
 .summoning-vessel__icon {
@@ -272,6 +300,104 @@
   font-size: var(--text-2xs);
   line-height: 1.35;
   color: var(--text-muted);
+}
+
+.summoning-vessel:hover .summoning-vessel__hint,
+.summoning-vessel:focus-visible .summoning-vessel__hint,
+.summoning-vessel--active .summoning-vessel__hint {
+  color: var(--text-secondary);
+}
+
+.summoning-vessel__action {
+  margin-top: auto;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-presence);
+  opacity: 0;
+  transform: translateY(2px);
+  transition:
+    opacity var(--duration-fast) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard);
+}
+
+.summoning-vessel:hover .summoning-vessel__action,
+.summoning-vessel:focus-visible .summoning-vessel__action,
+.summoning-vessel--active .summoning-vessel__action {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Selected local/SSH vessels reveal their launch choices as one associated,
+   full-width panel instead of a detached row of compact chips. */
+.summoning-runtime-panel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 32%, var(--border-hairline));
+  border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--accent-presence) 6%, var(--bg-raised));
+}
+
+.summoning-runtime-panel__heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.summoning-runtime-panel__hint {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+.summoning-runtime-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  width: 100%;
+  gap: var(--space-2);
+}
+
+.summoning-runtime-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 40px;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  text-align: left;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+.summoning-runtime-option:hover,
+.summoning-runtime-option:focus-visible {
+  border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border-strong));
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.summoning-runtime-option--active {
+  border-color: color-mix(in oklch, var(--accent-presence) 65%, var(--border-strong));
+  background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-base));
+  color: var(--text-primary);
+}
+
+.summoning-runtime-option__identity {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
 }
 
 /* Chips (runtime picker) */
@@ -750,6 +876,14 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .summoning-vessel--expanded {
+    grid-column: auto;
+  }
+
+  .summoning-runtime-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .summoning-glyphgrid {
     grid-template-columns: repeat(6, minmax(0, 1fr));
   }
@@ -759,6 +893,17 @@
 @media (prefers-reduced-motion: reduce) {
   .summoning-circle__runes {
     animation: none;
+  }
+
+  .summoning-vessel,
+  .summoning-vessel__action,
+  .summoning-runtime-option {
+    transition: none;
+  }
+
+  .summoning-vessel:hover,
+  .summoning-vessel:focus-visible {
+    transform: none;
   }
 
   .summoning-circle[data-flare] .summoning-circle__flare {


### PR DESCRIPTION
## Summary
- make vessel hover and focus states clearly identify the option under consideration
- expand the selected local host across the panel width
- show available runtimes in a full-width selection grid with persistent checkmarks

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `node --test --experimental-strip-types src/components/familiar-summoning-circle.test.ts`
- `git diff --check`
- browser validation at 1440x900

Bead: `cave-bawch`