### PR TITLE
Treat generated PDF worker as disposable during retirement

### DIFF
--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -87,6 +87,7 @@ assert.equal(
     "artifacts/report.json",
     "test-results/results.json",
     "public/sandbox/runtime.js",
+    "public/pdf.worker.min.mjs",
     "src-tauri/gen/schemas.json",
     "src-tauri/resources/server/server.mjs",
     "src-tauri/target/debug/app",
@@ -97,6 +98,11 @@ assert.equal(
     isDisposableIgnoredPath("docs/superpowers/plans/uncommitted-design.md"),
     false,
     "ignored authored work remains preservation evidence",
+  );
+  assert.equal(
+    isDisposableIgnoredPath("public/valuable-source.mjs"),
+    false,
+    "other ignored public assets remain preservation evidence",
   );
   assert.equal(
     isDisposableIgnoredPath("node_modules\\valuable/source.ts"),

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -345,6 +345,10 @@ const DISPOSABLE_IGNORED_ROOTS = [
   "test-results",
 ];
 
+const DISPOSABLE_IGNORED_FILES = new Set([
+  "public/pdf.worker.min.mjs",
+]);
+
 /** Hook artifacts written under `.claude/` that are machine-local bookkeeping,
  *  gitignored, and safe to discard during worktree retirement. */
 const DISPOSABLE_HOOK_ARTIFACTS = new Set([
@@ -381,6 +385,9 @@ export function isDisposableIgnoredPath(candidate: string): boolean {
     normalized === "next-env.d.ts" ||
     normalized.endsWith(".tsbuildinfo")
   ) {
+    return true;
+  }
+  if (DISPOSABLE_IGNORED_FILES.has(normalized)) {
     return true;
   }
   if (DISPOSABLE_HOOK_ARTIFACTS.has(normalized)) {


### PR DESCRIPTION
## Summary
- classify only `public/pdf.worker.min.mjs` as disposable generated state
- preserve every other ignored asset under `public/`
- add regression coverage for both cases

## Validation
- `node --test src/lib/worktree-lifecycle.test.ts`
- `git diff --check`

Bead: `cave-4pwuz`