### PR TITLE
docs: cross-link the OpenCoven UI specimen browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ to describe current behavior. For deeper design context, start with
 [`docs/coven-design-language.md`](docs/coven-design-language.md), and
 [`docs/multi-session-coordination.md`](docs/multi-session-coordination.md).
 
+For interface direction explored outside this repository,
+[**OpenCoven UI**](https://ui.opencoven.ai) is a standalone, dependency-free
+browser of chat-surface specimens — composer, messages, context, and actions.
+It is an exploration workspace
+([`OpenCoven/ui`](https://github.com/OpenCoven/ui)), not a component library and
+not the canonical source for anything in `src/components/`; shipped Cave code
+and `docs/coven-design-language.md` remain authoritative.
+
 ---
 
 ## Development

--- a/docs/coven-design-language.md
+++ b/docs/coven-design-language.md
@@ -435,4 +435,6 @@ roster + voice samples) · `docs/superpowers/specs/` (per-surface `*-design.md`
 decisions; `docs/specs/` holds the frozen predecessors) ·
 `src/styles/globals/foundations.css` (the annotated token contract) ·
 `src/styles/globals/themes.css` (per-theme palettes) ·
-`src/styles/globals/primitives.css` (shared `.ui-*` classes).*
+`src/styles/globals/primitives.css` (shared `.ui-*` classes) ·
+[ui.opencoven.ai](https://ui.opencoven.ai) (standalone chat-surface specimens —
+exploratory direction only, never authoritative over shipped code).*


### PR DESCRIPTION
Cross-links the newly public specimen browser at https://ui.opencoven.ai from Cave's two natural design-context surfaces, without implying it is canonical.

## Changes

- `README.md` — a paragraph after the "Repository layout" design-context pointer linking https://ui.opencoven.ai and https://github.com/OpenCoven/ui, stating explicitly that it is an exploration workspace and **not** the canonical source for anything in `src/components/`.
- `docs/coven-design-language.md` — appended to the trailing *Related* line, labelled "exploratory direction only, never authoritative over shipped code", preserving the document's code-is-authoritative stance.

Docs only. No source, token, or component changes.

## Verification

- `node scripts/docs-index.test.mjs` → exit 0, "index ok (49 documents classified, 62 links resolved)"
- `node scripts/ui-consistency.test.mjs` → exit 0, "contract, scanner, and baseline ok (12 palettes, 334 icons)" — this is the job that pins factual claims in `docs/coven-design-language.md`
- Link targets return HTTP 200: https://ui.opencoven.ai and https://github.com/OpenCoven/ui