### PR TITLE
Disable persistent Turbopack dev cache

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -107,6 +107,13 @@ const nextConfig: NextConfig = {
   // bundle-budget postbuild gate and the e2e suite guard the output.
   reactCompiler: true,
   experimental: {
+    // Next 16.2 enables Turbopack's persistent dev cache by default. In this
+    // app the cache reaches multiple gigabytes, then its SST compaction can
+    // starve the PostCSS child-process IPC until Turbopack panics while
+    // processing globals.css ("timeout while receiving message from process").
+    // Keep dev state in memory instead; a dev-server restart is an acceptable
+    // cache boundary and avoids the failing compaction path.
+    turbopackFileSystemCacheForDev: false,
     // Tree-shake the icon + syntax-highlight kitchens so the per-route
     // bundle only includes the icons and grammars actually referenced.
     // @iconify/react in particular has a flat icon-name surface that

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -220,6 +220,7 @@ export const SUITES = {
     "src-tauri/release-runtime.test.mjs",
     "src-tauri/notch-window-chrome.test.mjs",
     "scripts/react-compiler-config.test.mjs",
+    "scripts/turbopack-dev-cache.test.mjs",
     "scripts/codemods/tokenize-tsx-design.test.mjs",
     "scripts/eslint/design-system-plugin.test.mjs",
     "scripts/bundle-budget.test.mjs",

--- a/scripts/turbopack-dev-cache.test.mjs
+++ b/scripts/turbopack-dev-cache.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const nextConfig = await readFile(
+  new URL("../next.config.ts", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  nextConfig,
+  /turbopackFileSystemCacheForDev:\s*false/,
+  "dev must keep Turbopack's persistent filesystem cache disabled so multi-gigabyte compaction cannot stall the PostCSS worker",
+);
+
+console.log("turbopack-dev-cache.test.mjs: ok");


### PR DESCRIPTION
## Summary
- disable Next.js persistent Turbopack filesystem caching in development
- pin the setting with a dedicated regression test
- wire the regression into the app test suite

This cleanly re-lands the verified `cave-snxn4` fix onto current `main` without carrying unrelated source-worktree changes.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `node scripts/turbopack-dev-cache.test.mjs`
- `pnpm build`
- `git diff --check`

Bead: `cave-azz3k`