### PR TITLE
Safely unlink disposable symlink artifacts during retirement

### DIFF
--- a/scripts/worktree-lifecycle-retirement.test.mjs
+++ b/scripts/worktree-lifecycle-retirement.test.mjs
@@ -1869,7 +1869,7 @@ test("real git adapter reads tag retention from the remote, peeling annotated ta
   }
 });
 
-test("createGitRetirementOperations rejects path traversal, absolute paths, and symlink cleanup", () => {
+test("createGitRetirementOperations rejects unsafe paths and unlinks terminal symlinks", () => {
   const fixture = createGitFixture();
   try {
     const gate = withPathPrefix(fixture.bin, () =>
@@ -1924,16 +1924,31 @@ test("createGitRetirementOperations rejects path traversal, absolute paths, and 
 
     assert.deepEqual(operations.removeDisposableIgnored({
       ...baseItem,
-      ignoredPaths: ["target/linked"],
+      ignoredPaths: ["target/linked/owned.txt"],
     }), {
       ok: false,
-      reason: "refused disposable ignored cleanup through a symbolic link: target/linked",
+      reason: "refused disposable ignored cleanup through a symbolic link: target/linked/owned.txt",
     });
 
+    assert.equal(existsSync(path.join(worktree, "target", "linked")), true);
+    assert.deepEqual(
+      withPathPrefix(fixture.bin, () =>
+        operations.removeDisposableIgnored({
+          ...baseItem,
+          ignoredPaths: ["target/linked"],
+        }),
+      ),
+      { ok: true },
+    );
+    assert.equal(
+      existsSync(path.join(worktree, "target", "linked")),
+      false,
+      "terminal symlink cleanup removes only the link",
+    );
     assert.equal(
       existsSync(path.join(fixture.fixtureRoot, "outside", "owned.txt")),
       true,
-      "cleanup rejection must not delete the symlink target",
+      "symlink cleanup must not delete the target",
     );
 
     const released = withPathPrefix(fixture.bin, () => releaseMaintenanceGate(gate.handle));

--- a/scripts/worktree-lifecycle-retirement.ts
+++ b/scripts/worktree-lifecycle-retirement.ts
@@ -598,7 +598,9 @@ export function createGitRetirementOperations({
           process.execPath,
           [
             "-e",
-            "try { require('node:fs').rmSync(process.argv[1], { recursive: true, force: false, maxRetries: 8, retryDelay: 100 }) } catch (error) { if (error?.code !== 'ENOENT') throw error }",
+            resolved.unlinkOnly
+              ? "try { require('node:fs').unlinkSync(process.argv[1]) } catch (error) { if (error?.code !== 'ENOENT') throw error }"
+              : "try { require('node:fs').rmSync(process.argv[1], { recursive: true, force: false, maxRetries: 8, retryDelay: 100 }) } catch (error) { if (error?.code !== 'ENOENT') throw error }",
             resolved.target,
           ],
           normalizedRoot,
@@ -1107,7 +1109,7 @@ function parseWorktreeListPaths(raw: string): string[] | null {
 function resolveDisposableIgnoredTarget(
   worktreePath: string,
   rawCandidate: string,
-): OperationFailure | { ok: true; target: string } {
+): OperationFailure | { ok: true; target: string; unlinkOnly: boolean } {
   if (rawCandidate.includes("\0")) {
     return { ok: false, reason: `invalid ignored path contains NUL: ${rawCandidate}` };
   }
@@ -1133,7 +1135,7 @@ function resolveDisposableIgnoredTarget(
   }
 
   let current = worktreePath;
-  for (const segment of segments) {
+  for (const [index, segment] of segments.entries()) {
     current = path.join(current, segment);
     if (
       current !== worktreePath &&
@@ -1147,6 +1149,9 @@ function resolveDisposableIgnoredTarget(
     try {
       const stat = lstatSync(current);
       if (stat.isSymbolicLink()) {
+        if (index === segments.length - 1) {
+          return { ok: true, target: current, unlinkOnly: true };
+        }
         return {
           ok: false,
           reason: `refused disposable ignored cleanup through a symbolic link: ${rawCandidate}`,
@@ -1154,7 +1159,7 @@ function resolveDisposableIgnoredTarget(
       }
     } catch (error) {
       if (isErrno(error, "ENOENT")) {
-        return { ok: true, target: current };
+        return { ok: true, target: current, unlinkOnly: false };
       }
       return {
         ok: false,
@@ -1163,7 +1168,7 @@ function resolveDisposableIgnoredTarget(
     }
   }
 
-  return { ok: true, target: current };
+  return { ok: true, target: current, unlinkOnly: false };
 }
 
 function zeroOidFor(oid: string): string {

--- a/scripts/worktree-lifecycle-retirement.ts
+++ b/scripts/worktree-lifecycle-retirement.ts
@@ -598,9 +598,7 @@ export function createGitRetirementOperations({
           process.execPath,
           [
             "-e",
-            resolved.unlinkOnly
-              ? "try { require('node:fs').unlinkSync(process.argv[1]) } catch (error) { if (error?.code !== 'ENOENT') throw error }"
-              : "try { require('node:fs').rmSync(process.argv[1], { recursive: true, force: false, maxRetries: 8, retryDelay: 100 }) } catch (error) { if (error?.code !== 'ENOENT') throw error }",
+            "try { require('node:fs').rmSync(process.argv[1], { recursive: true, force: false, maxRetries: 8, retryDelay: 100 }) } catch (error) { if (error?.code !== 'ENOENT') throw error }",
             resolved.target,
           ],
           normalizedRoot,
@@ -1109,7 +1107,7 @@ function parseWorktreeListPaths(raw: string): string[] | null {
 function resolveDisposableIgnoredTarget(
   worktreePath: string,
   rawCandidate: string,
-): OperationFailure | { ok: true; target: string; unlinkOnly: boolean } {
+): OperationFailure | { ok: true; target: string } {
   if (rawCandidate.includes("\0")) {
     return { ok: false, reason: `invalid ignored path contains NUL: ${rawCandidate}` };
   }
@@ -1150,7 +1148,7 @@ function resolveDisposableIgnoredTarget(
       const stat = lstatSync(current);
       if (stat.isSymbolicLink()) {
         if (index === segments.length - 1) {
-          return { ok: true, target: current, unlinkOnly: true };
+          return { ok: true, target: current };
         }
         return {
           ok: false,
@@ -1159,7 +1157,7 @@ function resolveDisposableIgnoredTarget(
       }
     } catch (error) {
       if (isErrno(error, "ENOENT")) {
-        return { ok: true, target: current, unlinkOnly: false };
+        return { ok: true, target: current };
       }
       return {
         ok: false,
@@ -1168,7 +1166,7 @@ function resolveDisposableIgnoredTarget(
     }
   }
 
-  return { ok: true, target: current, unlinkOnly: false };
+  return { ok: true, target: current };
 }
 
 function zeroOidFor(oid: string): string {


### PR DESCRIPTION
## Summary
- allow only a terminal disposable symlink during retirement path validation
- unlink that exact path without traversing its target
- continue rejecting every intermediate symlink, traversal, and absolute path

## Validation
- `node --experimental-strip-types --test scripts/worktree-lifecycle-retirement.test.mjs` (46 cases)
- `pnpm typecheck`
- `git diff --check`

Bead: `cave-15bsj`