### PR TITLE
Implement Research Protocol v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
             command: typecheck
           - name: test wiring
             command: check:tests-wired
+          - name: protocol conformance
+            command: test:conformance
           - name: app tests
             command: test:app
           - name: API tests

--- a/docs/superpowers/plans/2026-08-15-research-protocol-unit-0.md
+++ b/docs/superpowers/plans/2026-08-15-research-protocol-unit-0.md
@@ -584,11 +584,11 @@ const scores = {
   feasibility: 3,
   humanResonance: 4,
   riskPenalty: 2,
-  visibleTotal: 25,
+  visibleTotal: 2.64,
 };
 
 test("recomputes the visible proposal score", () => {
-  assert.equal(topicProposalVisibleTotal(scores), 25);
+  assert.equal(topicProposalVisibleTotal(scores), 2.64);
   assert.equal(parseTopicProposalV1({
     schema: "opencoven.topic-proposal/v1",
     id: "proposal_01",
@@ -618,8 +618,8 @@ test("recomputes the visible proposal score", () => {
 });
 
 test("rejects a model-supplied total that does not recompute", () => {
-  const invalid = { ...scores, visibleTotal: 26 };
-  assert.equal(topicProposalVisibleTotal(invalid), 25);
+  const invalid = { ...scores, visibleTotal: 2.65 };
+  assert.equal(topicProposalVisibleTotal(invalid), 2.64);
 });
 
 test("requires lifecycle timestamps when their state has begun", () => {
@@ -707,7 +707,7 @@ export function parseTopicProposalV1(
 ): ProtocolParseResult<TopicProposalV1>;
 ```
 
-`topicProposalVisibleTotal` sums the nine positive dimensions and subtracts `riskPenalty`. `parseTopicProposalV1` rejects a mismatched `visibleTotal`; it does not silently replace it.
+`topicProposalVisibleTotal` applies the §10.3 decimal weights to the nine positive integer component scores and the `-0.20` risk-penalty weight, yielding `2.64` for the fixture above. `parseTopicProposalV1` rejects a mismatched `visibleTotal`; it does not silently replace it.
 
 For usage, enforce non-negative safe integer token counts, non-negative finite cost, and:
 
@@ -836,7 +836,9 @@ Encode §§8.4-8.6 and:
 - constrain `nextEventSequence` and event `sequence` to integers at least `1`;
 - allow `artifactManifest` through a `$ref` to `run-manifest.schema.json`;
 - require `waitingForPhase` exactly when status is `waiting_for_executor`;
-- allow `waitingReason: "checkpoint"` only with `awaiting_checkpoint`;
+- allow `waitingReason: "checkpoint"` only in active phases: `scoping`,
+  `gathering_public_sources`, `challenging`, `synthesizing`, `controlling`,
+  `awaiting_checkpoint`, or `publishing`;
 - require `failure` only for `failed`;
 - leave event `data` open with `additionalProperties: true`.
 
@@ -1235,13 +1237,15 @@ When `manifest.context` is present, `contextConsent` is required. When no contex
 6. A final revision remains final and preserves `finalizedAt`.
 7. After finalization, canonical values for `context`, `sources`, `artifacts`, `modelExecutions`, `usage`, and `retention.policy` are unchanged.
 8. After finalization, only `retention.effectivePolicy`, retention status/timestamps, deletion fields, `revision`, `previousDigest`, and `digest` may differ.
-9. Effective retention lengthening requires the caller to pass `freshConsent: true`.
+9. Effective retention or deadline lengthening requires `freshConsent: true`
+   and a `freshConsentAt` timestamp newer than the prior revision.
 
 Use this signature for rule 9:
 
 ```ts
 export type ManifestRevisionOptions = {
   freshConsent?: boolean;
+  freshConsentAt?: string;
   contextConsent?: RetentionPolicyV1;
 };
 

--- a/docs/superpowers/specs/2026-08-15-externalized-research-desk-implementation-design.md
+++ b/docs/superpowers/specs/2026-08-15-externalized-research-desk-implementation-design.md
@@ -251,6 +251,10 @@ opencoven.model-task-result/v1
 opencoven.run-manifest/v1
 ```
 
+The Run Manifest JSON Schema document uses the absolute identifier
+`urn:opencoven:schema:research:run-manifest:v1`; cross-schema references use
+that identifier while wire objects retain `opencoven.run-manifest/v1`.
+
 Rules:
 
 - A consumer rejects an unknown major version.

--- a/schemas/research/v1/context-pack.schema.json
+++ b/schemas/research/v1/context-pack.schema.json
@@ -1,0 +1,314 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "opencoven.context-pack/v1",
+  "title": "OpenCoven Context Pack v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "id",
+    "digest",
+    "createdAt",
+    "createdBy",
+    "purpose",
+    "subject",
+    "consent",
+    "resources",
+    "policy",
+    "transforms"
+  ],
+  "properties": {
+    "schema": { "const": "opencoven.context-pack/v1" },
+    "id": { "$ref": "#/$defs/contextPackId" },
+    "digest": { "$ref": "#/$defs/sha256" },
+    "createdAt": { "$ref": "#/$defs/utcTimestamp" },
+    "createdBy": { "$ref": "#/$defs/createdBy" },
+    "purpose": { "$ref": "#/$defs/purpose" },
+    "subject": { "$ref": "#/$defs/subject" },
+    "consent": { "$ref": "#/$defs/consent" },
+    "resources": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/resource" }
+    },
+    "policy": { "$ref": "#/$defs/policy" },
+    "transforms": { "$ref": "#/$defs/transforms" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "purpose": {
+            "const": "topic-discovery"
+          }
+        },
+        "required": [
+          "purpose"
+        ]
+      },
+      "then": {
+        "properties": {
+          "policy": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "allowedPurposes"
+            ],
+            "properties": {
+              "allowedPurposes": {
+                "contains": {
+                  "const": "topic-discovery"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "purpose": {
+            "const": "research-run"
+          }
+        },
+        "required": [
+          "purpose"
+        ]
+      },
+      "then": {
+        "properties": {
+          "policy": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "allowedPurposes"
+            ],
+            "properties": {
+              "allowedPurposes": {
+                "contains": {
+                  "const": "research-run"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "utcTimestamp": {
+      "type": "string",
+      "format": "date-time",
+      "minLength": 20,
+      "maxLength": 30,
+      "pattern": "^(?:(?:\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d)|(?:1972-(?:06-30|12-31)|197[3-9]-12-31|198[1235]-06-30|198[79]-12-31|1990-12-31|199[2347]-06-30|199[58]-12-31|200[58]-12-31|201[25]-06-30|2016-12-31)T23:59:60)(?:\\.\\d{1,9})?Z$"
+    },
+    "contextPackId": {
+      "type": "string",
+      "pattern": "^ctx_[A-Za-z0-9_-]+$"
+    },
+    "resourceId": {
+      "type": "string",
+      "pattern": "^resource_[A-Za-z0-9_-]+$"
+    },
+    "purpose": {
+      "enum": ["topic-discovery", "research-run"]
+    },
+    "selectionMode": {
+      "enum": ["explicit", "saved-view"]
+    },
+    "retention": {
+      "enum": ["run-only", "7-days", "project"]
+    },
+    "resourceKind": {
+      "enum": [
+        "session",
+        "thread-self-report",
+        "mission",
+        "artifact",
+        "attachment",
+        "saved-resource",
+        "metric-snapshot"
+      ]
+    },
+    "resourceTrust": {
+      "enum": [
+        "user-authored",
+        "agent-output",
+        "mixed-conversation",
+        "model-derived",
+        "imported-source"
+      ]
+    },
+    "resourceSensitivity": {
+      "enum": ["public", "private", "restricted"]
+    },
+    "createdBy": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["client"],
+      "properties": {
+        "client": { "const": "coven-cave" },
+        "userId": { "type": "string" }
+      }
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["familiarId"],
+      "properties": {
+        "familiarId": { "type": "string" },
+        "projectId": { "type": "string" }
+      }
+    },
+    "consent": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "selectionMode",
+        "allowRemoteQueries",
+        "allowRemoteContent",
+        "artifactContentSync",
+        "retention"
+      ],
+      "properties": {
+        "selectionMode": { "$ref": "#/$defs/selectionMode" },
+        "allowRemoteQueries": { "type": "boolean" },
+        "allowRemoteContent": { "type": "boolean" },
+        "artifactContentSync": { "type": "boolean" },
+        "retention": { "$ref": "#/$defs/retention" }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["treatResourceTextAsData", "toolAuthority", "allowedPurposes"],
+      "properties": {
+        "treatResourceTextAsData": { "const": true },
+        "toolAuthority": { "const": "none" },
+        "allowedPurposes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/purpose" },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      }
+    },
+    "transforms": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["secretScanVersion"],
+      "properties": {
+        "secretScanVersion": { "type": "string" },
+        "redactionMapDigest": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "selector": {
+      "oneOf": [
+        { "$ref": "#/$defs/turnRangeSelector" },
+        { "$ref": "#/$defs/jsonPointerSelector" },
+        { "$ref": "#/$defs/textSpanSelector" },
+        { "$ref": "#/$defs/markdownSectionSelector" },
+        { "$ref": "#/$defs/pdfPageSpanSelector" },
+        { "$ref": "#/$defs/wholeResourceSelector" }
+      ]
+    },
+    "turnRangeSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "start", "end"],
+      "properties": {
+        "type": { "const": "turn-range" },
+        "start": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
+        "end": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 }
+      }
+    },
+    "jsonPointerSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "pointer"],
+      "properties": {
+        "type": { "const": "json-pointer" },
+        "pointer": {
+          "type": "string",
+          "pattern": "^(?:$|/(?:[^~/]|~0|~1)*(?:/(?:[^~/]|~0|~1)*)*)$"
+        }
+      }
+    },
+    "textSpanSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "start", "end"],
+      "properties": {
+        "type": { "const": "text-span" },
+        "start": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
+        "end": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 }
+      }
+    },
+    "markdownSectionSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "headingPath"],
+      "properties": {
+        "type": { "const": "markdown-section" },
+        "headingPath": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "pdfPageSpanSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "page", "start", "end"],
+      "properties": {
+        "type": { "const": "pdf-page-span" },
+        "page": { "type": "integer", "minimum": 1, "maximum": 9007199254740991 },
+        "start": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
+        "end": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 }
+      }
+    },
+    "wholeResourceSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "whole-resource" }
+      }
+    },
+    "resource": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "id",
+        "kind",
+        "uri",
+        "digest",
+        "localBlobDigest",
+        "selector",
+        "trust",
+        "sensitivity",
+        "capturedAt",
+        "mediaType"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/resourceId" },
+        "kind": { "$ref": "#/$defs/resourceKind" },
+        "uri": { "type": "string" },
+        "digest": { "$ref": "#/$defs/sha256" },
+        "localBlobDigest": { "$ref": "#/$defs/sha256" },
+        "selector": { "$ref": "#/$defs/selector" },
+        "trust": { "$ref": "#/$defs/resourceTrust" },
+        "sensitivity": { "$ref": "#/$defs/resourceSensitivity" },
+        "capturedAt": { "$ref": "#/$defs/utcTimestamp" },
+        "title": { "type": "string" },
+        "mediaType": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/context-pack-pdf-selector.json
+++ b/schemas/research/v1/fixtures/invalid/context-pack-pdf-selector.json
@@ -1,0 +1,36 @@
+{
+  "schema": "opencoven.context-pack/v1",
+  "id": "ctx_01",
+  "digest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "createdBy": { "client": "coven-cave" },
+  "purpose": "research-run",
+  "subject": { "familiarId": "sage", "projectId": "project_01" },
+  "consent": {
+    "selectionMode": "explicit",
+    "allowRemoteQueries": true,
+    "allowRemoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days"
+  },
+  "resources": [{
+    "id": "resource_01",
+    "kind": "artifact",
+    "uri": "coven://session/session_01",
+    "digest": "0b9c966e9a7c4831f255cebbba0e7726fc8410ed32998179b32221097b404f9b",
+    "localBlobDigest": "4b94f5f75ee88c0e995251afe98fb468499215b33bbb6c18d01b1dd583f69e9d",
+    "selector": { "type": "pdf-page-span", "page": 0, "start": 12, "end": 12 },
+    "trust": "mixed-conversation",
+    "sensitivity": "private",
+    "capturedAt": "2026-08-15T19:59:00.000Z",
+    "title": "Selected research discussion",
+    "mediaType": "application/pdf"
+  }],
+  "policy": {
+    "treatResourceTextAsData": true,
+    "toolAuthority": "none",
+    "allowedPurposes": ["research-run"]
+  },
+  "transforms": { "secretScanVersion": "1" },
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/invalid/context-pack-retention.json
+++ b/schemas/research/v1/fixtures/invalid/context-pack-retention.json
@@ -1,0 +1,36 @@
+{
+  "schema": "opencoven.context-pack/v1",
+  "id": "ctx_01",
+  "digest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "createdBy": { "client": "coven-cave" },
+  "purpose": "research-run",
+  "subject": { "familiarId": "sage", "projectId": "project_01" },
+  "consent": {
+    "selectionMode": "explicit",
+    "allowRemoteQueries": true,
+    "allowRemoteContent": false,
+    "artifactContentSync": false,
+    "retention": "forever"
+  },
+  "resources": [{
+    "id": "resource_01",
+    "kind": "session",
+    "uri": "coven://session/session_01",
+    "digest": "0b9c966e9a7c4831f255cebbba0e7726fc8410ed32998179b32221097b404f9b",
+    "localBlobDigest": "4b94f5f75ee88c0e995251afe98fb468499215b33bbb6c18d01b1dd583f69e9d",
+    "selector": { "type": "turn-range", "start": 2, "end": 5 },
+    "trust": "mixed-conversation",
+    "sensitivity": "private",
+    "capturedAt": "2026-08-15T19:59:00.000Z",
+    "title": "Selected research discussion",
+    "mediaType": "application/json"
+  }],
+  "policy": {
+    "treatResourceTextAsData": true,
+    "toolAuthority": "none",
+    "allowedPurposes": ["research-run"]
+  },
+  "transforms": { "secretScanVersion": "1" },
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/invalid/model-task-policy.json
+++ b/schemas/research/v1/fixtures/invalid/model-task-policy.json
@@ -1,0 +1,33 @@
+{
+  "schema": "opencoven.model-task/v1",
+  "id": "modeltask_01",
+  "runId": "run_01",
+  "phase": "scope",
+  "attempt": 1,
+  "inputDigest": "a7a21a3895e180dfcce5b4aa1c7827bb7985a406b378399f6655d4f1a01229d5",
+  "input": {
+    "contextPack": {
+      "id": "ctx_01",
+      "digest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+      "availability": "device-local",
+      "futureExtension": { "preserve": true }
+    },
+    "publicEvidenceRefs": [],
+    "futureExtension": { "preserve": true }
+  },
+  "modelBinding": {
+    "familiarId": "sage",
+    "selection": "resolve-at-run-start",
+    "futureExtension": { "preserve": true }
+  },
+  "policy": {
+    "permissionMode": "write",
+    "allowedOutputs": ["scope"],
+    "allowRemoteQueries": false,
+    "maxOutputTokens": 1000,
+    "futureExtension": { "preserve": true }
+  },
+  "outputSchema": "opencoven.scope-output/v1",
+  "leaseExpiresAt": "2026-08-15T20:15:00.000Z",
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/invalid/model-task-result-usage.json
+++ b/schemas/research/v1/fixtures/invalid/model-task-result-usage.json
@@ -1,0 +1,31 @@
+{
+  "schema": "opencoven.model-task-result/v1",
+  "taskId": "modeltask_01",
+  "runId": "run_01",
+  "attempt": 1,
+  "inputDigest": "a7a21a3895e180dfcce5b4aa1c7827bb7985a406b378399f6655d4f1a01229d5",
+  "output": {
+    "decision": "continue",
+    "futureExtension": { "preserve": true }
+  },
+  "outputDigest": "0919f42fd41098c197abbe957594805f531ff4f7b9bccc68316c5f9db3adee17",
+  "executorDeviceId": "device_01",
+  "modelReceipt": {
+    "familiarId": "sage",
+    "runtime": "copilot",
+    "effectiveModel": "gpt-5.6-sol",
+    "modelSource": "session",
+    "providerBilling": "user-connected",
+    "usage": {
+      "inputTokens": 100,
+      "outputTokens": 20,
+      "costUsd": null,
+      "reportedByRuntime": false,
+      "futureExtension": { "preserve": true }
+    },
+    "futureExtension": { "preserve": true }
+  },
+  "completedAt": "2026-08-15T20:10:00.000Z",
+  "signature": "base64-signature",
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/invalid/research-run-checkpoint-queued.json
+++ b/schemas/research/v1/fixtures/invalid/research-run-checkpoint-queued.json
@@ -1,0 +1,36 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_bad_checkpoint_01",
+  "acceptedTopic": {
+    "question": "Can a queued run claim it is checkpoint-paused?",
+    "editedByUser": true
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "resolve-at-run-start"
+    },
+    "strategy": "single-agent"
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "run-only",
+    "allowMemoryPromotion": false
+  },
+  "bounds": {
+    "wallClockMinutes": 15,
+    "maxIterations": 1,
+    "sourceTarget": 2,
+    "checkpointEvery": 1,
+    "stopWhenCostUnavailable": true
+  },
+  "status": "queued",
+  "waitingReason": "checkpoint",
+  "createdAt": "2026-08-17T19:00:00.000Z",
+  "updatedAt": "2026-08-17T19:00:00.000Z",
+  "nextEventSequence": 1
+}

--- a/schemas/research/v1/fixtures/invalid/research-run-chronology-reversed.json
+++ b/schemas/research/v1/fixtures/invalid/research-run-chronology-reversed.json
@@ -1,0 +1,67 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "context": {
+    "contextPackId": "ctx_01",
+    "contextPackDigest": "1111111111111111111111111111111111111111111111111111111111111111",
+    "topicProposalId": "proposal_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "acceptedTopic": {
+    "proposalId": "proposal_01",
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "waiting_for_executor",
+  "waitingReason": "executor",
+  "waitingForPhase": "challenge",
+  "createdAt": "2026-08-15T20:00:00Z",
+  "updatedAt": "2026-08-15T19:59:59.999999999Z",
+  "nextEventSequence": 2,
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/research-run-local-tenant.json
+++ b/schemas/research/v1/fixtures/invalid/research-run-local-tenant.json
@@ -1,0 +1,36 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_local_tenant_01",
+  "tenantOpaqueId": "tenant_alpha",
+  "acceptedTopic": {
+    "question": "How should local execution coordinate this run?",
+    "editedByUser": false
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "resolve-at-run-start"
+    },
+    "strategy": "single-agent"
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "run-only",
+    "allowMemoryPromotion": false
+  },
+  "bounds": {
+    "wallClockMinutes": 30,
+    "maxIterations": 3,
+    "sourceTarget": 6,
+    "checkpointEvery": 1,
+    "stopWhenCostUnavailable": true
+  },
+  "status": "queued",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:01:00.000Z",
+  "nextEventSequence": 1
+}

--- a/schemas/research/v1/fixtures/invalid/research-run-topic-provenance-accepted-missing.json
+++ b/schemas/research/v1/fixtures/invalid/research-run-topic-provenance-accepted-missing.json
@@ -1,0 +1,65 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "context": {
+    "contextPackId": "ctx_01",
+    "contextPackDigest": "1111111111111111111111111111111111111111111111111111111111111111",
+    "topicProposalId": "proposal_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "acceptedTopic": {
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "waiting_for_executor",
+  "waitingReason": "executor",
+  "waitingForPhase": "challenge",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:01:00.000Z",
+  "nextEventSequence": 2,
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/research-run-topic-provenance-context-missing.json
+++ b/schemas/research/v1/fixtures/invalid/research-run-topic-provenance-context-missing.json
@@ -1,0 +1,65 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "context": {
+    "contextPackId": "ctx_01",
+    "contextPackDigest": "1111111111111111111111111111111111111111111111111111111111111111",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "acceptedTopic": {
+    "proposalId": "proposal_01",
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "waiting_for_executor",
+  "waitingReason": "executor",
+  "waitingForPhase": "challenge",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:01:00.000Z",
+  "nextEventSequence": 2,
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/research-run-topic-provenance-mismatch.json
+++ b/schemas/research/v1/fixtures/invalid/research-run-topic-provenance-mismatch.json
@@ -1,0 +1,67 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "context": {
+    "contextPackId": "ctx_01",
+    "contextPackDigest": "1111111111111111111111111111111111111111111111111111111111111111",
+    "topicProposalId": "proposal_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "acceptedTopic": {
+    "proposalId": "proposal_other",
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "waiting_for_executor",
+  "waitingReason": "executor",
+  "waitingForPhase": "challenge",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:01:00.000Z",
+  "nextEventSequence": 2,
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/research-run-waiting-phase.json
+++ b/schemas/research/v1/fixtures/invalid/research-run-waiting-phase.json
@@ -1,0 +1,37 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "tenantOpaqueId": "tenant_alpha",
+  "acceptedTopic": {
+    "question": "How should the research executor resume this run?",
+    "editedByUser": false
+  },
+  "execution": {
+    "location": "hosted",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "resolve-at-run-start"
+    },
+    "strategy": "orchestrator-workers"
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "run-only",
+    "allowMemoryPromotion": false
+  },
+  "bounds": {
+    "wallClockMinutes": 30,
+    "maxIterations": 3,
+    "sourceTarget": 6,
+    "checkpointEvery": 1,
+    "stopWhenCostUnavailable": true
+  },
+  "status": "waiting_for_executor",
+  "waitingReason": "executor",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:01:00.000Z",
+  "nextEventSequence": 1
+}

--- a/schemas/research/v1/fixtures/invalid/run-event-default-ignorable-deletion-extension.json
+++ b/schemas/research/v1/fixtures/invalid/run-event-default-ignorable-deletion-extension.json
@@ -1,0 +1,15 @@
+{
+  "expectedSchemaValid": false,
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_deletion_default_ignorable_01",
+  "sequence": 1,
+  "type": "content.deleted",
+  "at": "2026-08-17T19:30:00.000Z",
+  "data": {
+    "deletedObjectCount": 3,
+    "manifestStatus": "deleted",
+    "audit\u2060Trail": {
+      "outcome": "complete"
+    }
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-event-deleted-content-payload.json
+++ b/schemas/research/v1/fixtures/invalid/run-event-deleted-content-payload.json
@@ -1,0 +1,12 @@
+{
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_deleted_content_payload_01",
+  "sequence": 2,
+  "type": "content.deleted",
+  "at": "2026-08-17T19:30:00.000Z",
+  "deletedContent": "private material",
+  "data": {
+    "deletedObjectCount": 3,
+    "manifestStatus": "deleted"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-event-invalid-future-leap-second.json
+++ b/schemas/research/v1/fixtures/invalid/run-event-invalid-future-leap-second.json
@@ -1,0 +1,10 @@
+{
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_invalid_future_leap_second_01",
+  "sequence": 1,
+  "type": "run.created",
+  "at": "2030-12-31T23:59:60Z",
+  "data": {
+    "status": "queued"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-event-invalid-leap-second-date.json
+++ b/schemas/research/v1/fixtures/invalid/run-event-invalid-leap-second-date.json
@@ -1,0 +1,10 @@
+{
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_invalid_leap_second_date_01",
+  "sequence": 1,
+  "type": "run.created",
+  "at": "2026-08-15T23:59:60Z",
+  "data": {
+    "status": "queued"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-event-invalid-leap-second-placement.json
+++ b/schemas/research/v1/fixtures/invalid/run-event-invalid-leap-second-placement.json
@@ -1,0 +1,10 @@
+{
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_leap_second_01",
+  "sequence": 1,
+  "type": "run.created",
+  "at": "2016-12-31T23:58:60Z",
+  "data": {
+    "status": "queued"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-event-non-ascii-deletion-extension.json
+++ b/schemas/research/v1/fixtures/invalid/run-event-non-ascii-deletion-extension.json
@@ -1,0 +1,16 @@
+{
+  "expectedSchemaValid": false,
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_01",
+  "sequence": 1,
+  "type": "content.deleted",
+  "at": "2026-08-17T19:30:00.000Z",
+  "data": {
+    "deletedObjectCount": 3,
+    "manifestStatus": "deleted",
+    "deletedCоntentPayload": "private material"
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-event-sequence.json
+++ b/schemas/research/v1/fixtures/invalid/run-event-sequence.json
@@ -1,0 +1,8 @@
+{
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_01",
+  "sequence": 0,
+  "type": "run.created",
+  "at": "2026-08-15T20:00:00.000Z",
+  "data": {}
+}

--- a/schemas/research/v1/fixtures/invalid/run-event-split-object-store-key.json
+++ b/schemas/research/v1/fixtures/invalid/run-event-split-object-store-key.json
@@ -1,0 +1,19 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_split_object_store_key_01",
+  "sequence": 2,
+  "type": "content.deleted",
+  "at": "2026-08-17T19:30:00.000Z",
+  "data": {
+    "deletedObjectCount": 3,
+    "manifestStatus": "deleted",
+    "audit": {
+      "object": {
+        "store": {
+          "key": "tenant/private/object"
+        }
+      }
+    }
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-event-unicode-sensitive-extension.json
+++ b/schemas/research/v1/fixtures/invalid/run-event-unicode-sensitive-extension.json
@@ -1,0 +1,16 @@
+{
+  "expectedSchemaValid": false,
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_01",
+  "sequence": 1,
+  "type": "content.deleted",
+  "at": "2026-08-17T19:30:00.000Z",
+  "data": {
+    "deletedObjectCount": 3,
+    "manifestStatus": "deleted",
+    "deletedCon\u2060tentPayload": "private material"
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-artifact-after-finalized.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-artifact-after-finalized.json
@@ -1,0 +1,99 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_artifact_after_finalized_01",
+  "runId": "run_artifact_after_finalized_01",
+  "digest": "6ea9ee71730020cd923450532c221a0635eaedb4b225db38e15150de44249656",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:10:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_01",
+      "contentDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "snapshotDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "canonicalUrl": "https://www.iana.org/research",
+      "fetchedAt": "2026-08-16T20:07:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_cloud_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T20:10:00.000000001Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_cloud_01",
+      "phase": "synthesize",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1200,
+          "outputTokens": 300,
+          "costUsd": 0.42,
+          "reportedByRuntime": true,
+          "futureExtension": {
+            "preserve": true
+          }
+        },
+        "futureExtension": {
+          "preserve": true
+        }
+      },
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "usage": {
+    "inputTokens": 1200,
+    "outputTokens": 300,
+    "costUsd": 0.42,
+    "completeness": "complete",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:10:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-artifact-before-created.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-artifact-before-created.json
@@ -1,0 +1,99 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_artifact_before_created_01",
+  "runId": "run_artifact_before_created_01",
+  "digest": "bf94f9a886a9cbef3765d0d03196c88294d0e9b13efeca8453748f8449118f67",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:10:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_01",
+      "contentDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "snapshotDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "canonicalUrl": "https://www.iana.org/research",
+      "fetchedAt": "2026-08-16T20:07:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_cloud_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T19:59:59.999999999Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_cloud_01",
+      "phase": "synthesize",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1200,
+          "outputTokens": 300,
+          "costUsd": 0.42,
+          "reportedByRuntime": true,
+          "futureExtension": {
+            "preserve": true
+          }
+        },
+        "futureExtension": {
+          "preserve": true
+        }
+      },
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "usage": {
+    "inputTokens": 1200,
+    "outputTokens": 300,
+    "costUsd": 0.42,
+    "completeness": "complete",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:10:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-content-expires-before-created.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-content-expires-before-created.json
@@ -1,0 +1,60 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_content_expires_before_created_01",
+  "runId": "run_content_expires_before_created_01",
+  "digest": "d4862a2e835ce93df4ea0e4828840891c09a8e762a7a096d7e2e84d1b8a39822",
+  "revision": 1,
+  "state": "assembling",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2026-08-16T19:59:59.999999999Z",
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "scheduled",
+    "requestedAt": "2026-08-16T20:00:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-content-expires-before-finalized.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-content-expires-before-finalized.json
@@ -1,0 +1,76 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_content_expires_before_finalized_01",
+  "runId": "run_content_expires_before_finalized_01",
+  "digest": "4d671f0a69c70d8c4f8bb9bc3f66932e7d8301af082e65c8a068d21ef7156128",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2026-08-16T20:03:59.999999999Z",
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "scheduled",
+    "requestedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-cost-binary-drift.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-cost-binary-drift.json
@@ -1,0 +1,123 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_exact_decimal_01",
+  "runId": "run_final_cloud_01",
+  "digest": "ec41a6a597517601ed143ff630255114423847894ab1f374b9fdfc037df22690",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:10:00.000Z",
+  "context": {
+    "contextPackId": "ctx_cloud_01",
+    "contextPackDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_cloud_01",
+      "digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_01",
+      "contentDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "snapshotDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "canonicalUrl": "https://www.iana.org/research",
+      "fetchedAt": "2026-08-16T20:07:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_cloud_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T20:09:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_decimal_01",
+      "phase": "scope",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1,
+          "outputTokens": 1,
+          "costUsd": 0.1,
+          "reportedByRuntime": true
+        }
+      }
+    },
+    {
+      "taskId": "modeltask_decimal_02",
+      "phase": "scope",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1,
+          "outputTokens": 1,
+          "costUsd": 0.2,
+          "reportedByRuntime": true
+        }
+      }
+    }
+  ],
+  "usage": {
+    "inputTokens": 2,
+    "outputTokens": 2,
+    "costUsd": 0.30000000000000004,
+    "completeness": "complete"
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:10:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-deleted-content-payload.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-deleted-content-payload.json
@@ -1,0 +1,32 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_deleted_content_payload_01",
+  "runId": "run_deleted_content_payload_01",
+  "digest": "e267701e8a514545784b1c1c63740a65065bd5ab2f29812c362eaf0a219dc405",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "run-only",
+    "effectivePolicy": "run-only",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z"
+  },
+  "deletion": {
+    "status": "not_scheduled"
+  },
+  "extensionMetadata": {
+    "deletedcontentpayload": "private material"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-deletion-event.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-deletion-event.json
@@ -1,0 +1,74 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_final_local_01",
+  "runId": "run_final_local_01",
+  "digest": "80c3554a81fc87c98a3058de450e8e97cd19145e79fca5691cb1c63f76d2632f",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deleted",
+    "contentExpiresAt": "2026-08-16T20:08:00.000Z",
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "completed",
+    "requestedAt": "2026-08-16T20:06:00.000Z",
+    "completedAt": "2026-08-16T20:08:00.000Z",
+    "deletedObjectCount": 1
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-deletion-homoglyph-array.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-deletion-homoglyph-array.json
@@ -1,0 +1,79 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_deletion_homoglyph_array_01",
+  "runId": "run_deletion_homoglyph_array_01",
+  "digest": "3b6463ad0df324bad896c856ead79bb7d2c75af24c92310ab1131ca150400b42",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    },
+    "auditEnvelope": [
+      {
+        "objectKеy": "redacted"
+      }
+    ]
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-deletion-homoglyph-nested.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-deletion-homoglyph-nested.json
@@ -1,0 +1,77 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_deletion_homoglyph_nested_01",
+  "runId": "run_deletion_homoglyph_nested_01",
+  "digest": "090db093b442881dcd0b8b60d27d2c44dc30d1f07f52680b5eaeb835a2ba3e8c",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    },
+    "auditEnvelope": {
+      "objectKеy": "redacted"
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-deletion-homoglyph-root.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-deletion-homoglyph-root.json
@@ -1,0 +1,75 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_deletion_homoglyph_root_01",
+  "runId": "run_deletion_homoglyph_root_01",
+  "digest": "1540cd6fed83b2ba8692a3fd73207cb65153f334a94fafe66daaf60c45973dbc",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    },
+    "objectKеy": "redacted"
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-deletion-pair.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-deletion-pair.json
@@ -1,0 +1,75 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_final_local_01",
+  "runId": "run_final_local_01",
+  "digest": "8c81bb43dc3e950bf10cf0d4fed314ba86b6aea321d1171d04c2ca92327d8650",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2026-08-23T20:04:00.000Z",
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "requestedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-finalized-before-created.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-finalized-before-created.json
@@ -1,0 +1,99 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_finalized_before_created_01",
+  "runId": "run_finalized_before_created_01",
+  "digest": "a66c2e62cc7a92376874d497a5eed48b56888386a3631e8f98faf8436647a1fb",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T19:59:59.999999999Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_01",
+      "contentDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "snapshotDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "canonicalUrl": "https://www.iana.org/research",
+      "fetchedAt": "2026-08-16T20:07:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_cloud_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T20:09:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_cloud_01",
+      "phase": "synthesize",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1200,
+          "outputTokens": 300,
+          "costUsd": 0.42,
+          "reportedByRuntime": true,
+          "futureExtension": {
+            "preserve": true
+          }
+        },
+        "futureExtension": {
+          "preserve": true
+        }
+      },
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "usage": {
+    "inputTokens": 1200,
+    "outputTokens": 300,
+    "costUsd": 0.42,
+    "completeness": "complete",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:10:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-model-raw-prompt.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-model-raw-prompt.json
@@ -1,0 +1,51 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_model_raw_prompt_01",
+  "runId": "run_model_raw_prompt_01",
+  "digest": "718f5a036c474135977292dec29a41402ced49d3659c6bd6cc03ee9828d034ba",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_raw_prompt_01",
+      "phase": "scope",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": null,
+          "outputTokens": null,
+          "costUsd": null,
+          "reportedByRuntime": false
+        }
+      },
+      "rawPrompt": "private model input"
+    }
+  ],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "run-only",
+    "effectivePolicy": "run-only",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z"
+  },
+  "deletion": {
+    "status": "not_scheduled"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-nested-privacy-storage-keys.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-nested-privacy-storage-keys.json
@@ -1,0 +1,36 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_nested_privacy_storage_keys_01",
+  "runId": "run_nested_privacy_storage_keys_01",
+  "digest": "11a40ee3d3fa53c763baae2edf453c5f295d1e1447a4bf027751cd0a67952fa3",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "run-only",
+    "effectivePolicy": "run-only",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "extensionMetadata": {
+      "items": [
+        {
+          "privacyStorageKeys": ["tenant/private/object"]
+        }
+      ]
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-nested-private-extension.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-nested-private-extension.json
@@ -1,0 +1,73 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_nested_private_01",
+  "runId": "run_nested_private_01",
+  "digest": "79e4b345621ed9b72672d1ab42bdf2b42de4577ca1c0658c34595ecf5139f36f",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_nested_private_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_nested_private_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "metadata": {
+        "items": [
+          {
+            "privateExcerpt": "private material",
+            "private_contentValue": "private material",
+            "privateCONTENTvalue": "private material",
+            "rawTEXTvalue": "private material",
+            "private_storageKeyValue": "tenant/private/object"
+          }
+        ]
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_nested_private_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "metadata": {
+        "nested": {
+          "local_file_path": "/private/report.md"
+        }
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z"
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "auditMetadata": [
+      {
+        "credentialHint": "tenant/private/object"
+      }
+    ]
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-private-title.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-private-title.json
@@ -1,0 +1,75 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_final_local_01",
+  "runId": "run_final_local_01",
+  "digest": "b9f6aa8b513515c3abb96aae8e6a50d126f0c4cb640e1535620ed39f65ccee3a",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "file：／／Users／alice／secret.txt",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-public-url-empty.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-public-url-empty.json
@@ -1,0 +1,38 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_public_url_empty_01",
+  "runId": "run_public_url_empty_01",
+  "digest": "b1b420ae92e55f48131fbf25e018c492db309d72e52d748c8f59fa905dc560f1",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_url_empty_01",
+      "contentDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "snapshotDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "canonicalUrl": "",
+      "fetchedAt": "2026-08-16T20:03:00.000Z"
+    }
+  ],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:04:00.000Z"
+  },
+  "deletion": {
+    "status": "not_scheduled"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-public-url-file.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-public-url-file.json
@@ -1,0 +1,38 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_public_url_file_01",
+  "runId": "run_public_url_file_01",
+  "digest": "5ae9d535784a0b6ea690cebb4aae653db60b8a4396be9cb32ecbec956beb7205",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_url_file_01",
+      "contentDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "snapshotDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "canonicalUrl": "file:///Users/example/report.html",
+      "fetchedAt": "2026-08-16T20:03:00.000Z"
+    }
+  ],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:04:00.000Z"
+  },
+  "deletion": {
+    "status": "not_scheduled"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-public-url-localhost.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-public-url-localhost.json
@@ -1,0 +1,39 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_public_url_localhost_01",
+  "runId": "run_public_url_localhost_01",
+  "digest": "2e48c5eb179c2b36d744a53e9c3a4497bf59b59c3de8d509fe6c2ffab19cb87c",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_url_localhost_01",
+      "contentDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "snapshotDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "canonicalUrl": "http://localhost/report",
+      "fetchedAt": "2026-08-16T20:03:00.000Z"
+    }
+  ],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:04:00.000Z"
+  },
+  "deletion": {
+    "status": "not_scheduled"
+  },
+  "expectedSchemaValid": true
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-public-url-malformed-authority.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-public-url-malformed-authority.json
@@ -1,0 +1,38 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_public_url_malformed_authority_01",
+  "runId": "run_public_url_malformed_authority_01",
+  "digest": "20b140ac8b06283c3657d476de166dd3692c9b66cf19050b1c7261bb715a1b6c",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_url_malformed_authority_01",
+      "contentDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "snapshotDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "canonicalUrl": "http:////www.iana.org/path",
+      "fetchedAt": "2026-08-16T20:03:00.000Z"
+    }
+  ],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:04:00.000Z"
+  },
+  "deletion": {
+    "status": "not_scheduled"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-public-url-userinfo.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-public-url-userinfo.json
@@ -1,0 +1,38 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_public_url_userinfo_01",
+  "runId": "run_public_url_userinfo_01",
+  "digest": "4caeaa91e4f54467327334e2fa0defa2fbd8fa815319376f15b7eb8c0c9b249c",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_url_userinfo_01",
+      "contentDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "snapshotDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "canonicalUrl": "https://analyst:secret@example.com/report",
+      "fetchedAt": "2026-08-16T20:03:00.000Z"
+    }
+  ],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:04:00.000Z"
+  },
+  "deletion": {
+    "status": "not_scheduled"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-retention-7-days-leap-overflow.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-retention-7-days-leap-overflow.json
@@ -1,0 +1,31 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_7_days_leap_overflow",
+  "runId": "run_7_days_leap_overflow",
+  "digest": "6fb5a1d00f7496956bce1cd9029fcd1ba17d7db3e18e310df83fa824010f1490",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2016-12-31T11:59:00Z",
+  "finalizedAt": "2016-12-31T12:00:00Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2017-01-07T12:00:00Z",
+    "updatedAt": "2016-12-31T12:00:00Z"
+  },
+  "deletion": {
+    "status": "scheduled",
+    "requestedAt": "2016-12-31T12:00:00Z"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-retention-7-days-overflow.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-retention-7-days-overflow.json
@@ -1,0 +1,31 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_7_days_overflow",
+  "runId": "run_7_days_overflow",
+  "digest": "69de801feb8f0b00465a9bc3247f23f3f0cdd5fcda4fe10374f330cb6fb7134e",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2099-01-01T00:00:00.000Z",
+    "updatedAt": "2026-08-16T20:04:00.000Z"
+  },
+  "deletion": {
+    "status": "scheduled",
+    "requestedAt": "2026-08-16T20:04:00.000Z"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-retention-before-created.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-retention-before-created.json
@@ -1,0 +1,99 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_retention_before_created_01",
+  "runId": "run_retention_before_created_01",
+  "digest": "ed1a17327ac8ac2ffbd6edd6e30ee211e4b089919d1068bab4e1023bd2bbcb40",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:10:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_01",
+      "contentDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "snapshotDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "canonicalUrl": "https://www.iana.org/research",
+      "fetchedAt": "2026-08-16T20:07:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_cloud_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T20:09:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_cloud_01",
+      "phase": "synthesize",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1200,
+          "outputTokens": 300,
+          "costUsd": 0.42,
+          "reportedByRuntime": true,
+          "futureExtension": {
+            "preserve": true
+          }
+        },
+        "futureExtension": {
+          "preserve": true
+        }
+      },
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "usage": {
+    "inputTokens": 1200,
+    "outputTokens": 300,
+    "costUsd": 0.42,
+    "completeness": "complete",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T19:59:59.999999999Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-retention-before-finalized.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-retention-before-finalized.json
@@ -1,0 +1,99 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_retention_before_finalized_01",
+  "runId": "run_retention_before_finalized_01",
+  "digest": "381637125504ce9faf42b03345cfdf0486d93e05d965e62f3c65091e1121358b",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:10:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_01",
+      "contentDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "snapshotDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "canonicalUrl": "https://www.iana.org/research",
+      "fetchedAt": "2026-08-16T20:07:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_cloud_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T20:09:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_cloud_01",
+      "phase": "synthesize",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1200,
+          "outputTokens": 300,
+          "costUsd": 0.42,
+          "reportedByRuntime": true,
+          "futureExtension": {
+            "preserve": true
+          }
+        },
+        "futureExtension": {
+          "preserve": true
+        }
+      },
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "usage": {
+    "inputTokens": 1200,
+    "outputTokens": 300,
+    "costUsd": 0.42,
+    "completeness": "complete",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:09:59.999999999Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-retention-run-only-leap-overflow.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-retention-run-only-leap-overflow.json
@@ -1,0 +1,31 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_run_only_leap_overflow",
+  "runId": "run_run_only_leap_overflow",
+  "digest": "0551ff710d831e6df9fce9b3668ca668be609aae466885f2aa03a7bb6771815f",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2016-12-31T11:59:00Z",
+  "finalizedAt": "2016-12-31T12:00:00Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "run-only",
+    "effectivePolicy": "run-only",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2017-01-01T12:00:00Z",
+    "updatedAt": "2016-12-31T12:00:00Z"
+  },
+  "deletion": {
+    "status": "scheduled",
+    "requestedAt": "2016-12-31T12:00:00Z"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-retention-run-only-overflow.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-retention-run-only-overflow.json
@@ -1,0 +1,31 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_run_only_overflow",
+  "runId": "run_run_only_overflow",
+  "digest": "168550bb4ff07605a3c4af9e3f44c55329271896f50107355d23e17669f73a8e",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "run-only",
+    "effectivePolicy": "run-only",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2026-08-17T20:04:00.000000001Z",
+    "updatedAt": "2026-08-16T20:04:00.000Z"
+  },
+  "deletion": {
+    "status": "scheduled",
+    "requestedAt": "2026-08-16T20:04:00.000Z"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-root-private-excerpts.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-root-private-excerpts.json
@@ -1,0 +1,30 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_root_private_excerpts_01",
+  "runId": "run_root_private_excerpts_01",
+  "digest": "a048a605623c299345c686adfc7c754fce7947fc8f969d230ca00b69170d7098",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "run-only",
+    "effectivePolicy": "run-only",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z"
+  },
+  "deletion": {
+    "status": "not_scheduled"
+  },
+  "privateExcerpts": ["private material"]
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-scheduled-null-expiry.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-scheduled-null-expiry.json
@@ -1,0 +1,42 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_scheduled_null_expiry_01",
+  "runId": "run_scheduled_null_expiry_01",
+  "digest": "2b901c88fa5a524785f3b34e363be0326faa1b88e398b95b8ea19b81d0325143",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [],
+  "artifacts": [
+    {
+      "id": "artifact_scheduled_null_expiry_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z"
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:06:00.000Z"
+  },
+  "deletion": {
+    "status": "scheduled",
+    "requestedAt": "2026-08-16T20:06:00.000Z"
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-source-after-finalized.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-source-after-finalized.json
@@ -1,0 +1,99 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_source_after_finalized_01",
+  "runId": "run_source_after_finalized_01",
+  "digest": "b342e4d454f2d16b068aa4e273666a6a9eeb2647e8d525fde479f991951410e0",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:10:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_01",
+      "contentDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "snapshotDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "canonicalUrl": "https://www.iana.org/research",
+      "fetchedAt": "2026-08-16T20:10:00.000000001Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_cloud_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T20:09:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_cloud_01",
+      "phase": "synthesize",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1200,
+          "outputTokens": 300,
+          "costUsd": 0.42,
+          "reportedByRuntime": true,
+          "futureExtension": {
+            "preserve": true
+          }
+        },
+        "futureExtension": {
+          "preserve": true
+        }
+      },
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "usage": {
+    "inputTokens": 1200,
+    "outputTokens": 300,
+    "costUsd": 0.42,
+    "completeness": "complete",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:10:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-source-before-created.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-source-before-created.json
@@ -1,0 +1,99 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_source_before_created_01",
+  "runId": "run_source_before_created_01",
+  "digest": "0ea74af1874a5a93b7c53e4f7b3526c994c7c3a63424aed788c06c8913ce8343",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:10:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_01",
+      "contentDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "snapshotDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "canonicalUrl": "https://www.iana.org/research",
+      "fetchedAt": "2026-08-16T19:59:59.999999999Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_cloud_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T20:09:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_cloud_01",
+      "phase": "synthesize",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1200,
+          "outputTokens": 300,
+          "costUsd": 0.42,
+          "reportedByRuntime": true,
+          "futureExtension": {
+            "preserve": true
+          }
+        },
+        "futureExtension": {
+          "preserve": true
+        }
+      },
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "usage": {
+    "inputTokens": 1200,
+    "outputTokens": 300,
+    "costUsd": 0.42,
+    "completeness": "complete",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:10:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-split-object-store-key.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-split-object-store-key.json
@@ -1,0 +1,39 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_split_object_store_key_01",
+  "runId": "run_split_object_store_key_01",
+  "digest": "05dbe11c25b4ed1ba588a39a7c13da6349acc66cdfc511c80af1f59e73e5689b",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "run-only",
+    "effectivePolicy": "run-only",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z"
+  },
+  "deletion": {
+    "status": "not_scheduled"
+  },
+  "extensionMetadata": {
+    "audit": {
+      "object": {
+        "store": {
+          "key": "tenant/private/object"
+        }
+      }
+    }
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/run-manifest-unicode-sensitive-extension.json
+++ b/schemas/research/v1/fixtures/invalid/run-manifest-unicode-sensitive-extension.json
@@ -1,0 +1,76 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_unicode_sensitive_extension_01",
+  "runId": "run_unicode_sensitive_extension_01",
+  "digest": "776448a5a7225799f94b0ce1072c9a457d84e7eb708b0377dcfbc6e6660f9e5e",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  },
+  "ｒａｗＰｒｏｍｐｔ": "private material"
+}

--- a/schemas/research/v1/fixtures/invalid/topic-discovery-job-eight.json
+++ b/schemas/research/v1/fixtures/invalid/topic-discovery-job-eight.json
@@ -1,0 +1,21 @@
+{
+  "schema": "opencoven.topic-discovery-job/v1",
+  "id": "topicjob_eight_01",
+  "contextPackId": "ctx_01",
+  "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "familiarId": "sage",
+  "status": "completed",
+  "requestedAt": "2026-08-15T20:00:00.000Z",
+  "startedAt": "2026-08-15T20:01:00.000Z",
+  "finishedAt": "2026-08-15T20:06:00.000Z",
+  "proposalIds": [
+    "proposal_01",
+    "proposal_02",
+    "proposal_03",
+    "proposal_04",
+    "proposal_05",
+    "proposal_06",
+    "proposal_07",
+    "proposal_08"
+  ]
+}

--- a/schemas/research/v1/fixtures/invalid/topic-discovery-job-finished-before-started.json
+++ b/schemas/research/v1/fixtures/invalid/topic-discovery-job-finished-before-started.json
@@ -1,0 +1,36 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.topic-discovery-job/v1",
+  "id": "topicjob_01",
+  "contextPackId": "ctx_01",
+  "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "familiarId": "sage",
+  "status": "completed",
+  "requestedAt": "2026-08-15T20:00:00Z",
+  "startedAt": "2026-08-15T20:01:00Z",
+  "finishedAt": "2026-08-15T20:00:59.999999999Z",
+  "proposalIds": [
+    "proposal_01",
+    "proposal_02",
+    "proposal_03"
+  ],
+  "modelReceipt": {
+    "familiarId": "sage",
+    "runtime": "coven-cave",
+    "effectiveModel": "gpt-5-mini",
+    "modelSource": "runtime-default",
+    "providerBilling": "user-connected",
+    "usage": {
+      "inputTokens": 1200,
+      "outputTokens": 450,
+      "costUsd": 0.0125,
+      "reportedByRuntime": true
+    },
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/topic-discovery-job-one.json
+++ b/schemas/research/v1/fixtures/invalid/topic-discovery-job-one.json
@@ -1,0 +1,12 @@
+{
+  "schema": "opencoven.topic-discovery-job/v1",
+  "id": "topicjob_one_01",
+  "contextPackId": "ctx_01",
+  "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "familiarId": "sage",
+  "status": "completed",
+  "requestedAt": "2026-08-15T20:00:00.000Z",
+  "startedAt": "2026-08-15T20:01:00.000Z",
+  "finishedAt": "2026-08-15T20:06:00.000Z",
+  "proposalIds": ["proposal_01"]
+}

--- a/schemas/research/v1/fixtures/invalid/topic-discovery-job-receipt-familiar.json
+++ b/schemas/research/v1/fixtures/invalid/topic-discovery-job-receipt-familiar.json
@@ -1,0 +1,30 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.topic-discovery-job/v1",
+  "id": "topicjob_01",
+  "contextPackId": "ctx_01",
+  "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "familiarId": "sage",
+  "status": "completed",
+  "requestedAt": "2026-08-15T20:00:00.000Z",
+  "startedAt": "2026-08-15T20:01:00.000Z",
+  "finishedAt": "2026-08-15T20:06:00.000Z",
+  "proposalIds": [
+    "proposal_01",
+    "proposal_02",
+    "proposal_03"
+  ],
+  "modelReceipt": {
+    "familiarId": "other-familiar",
+    "runtime": "coven-cave",
+    "effectiveModel": "gpt-5-mini",
+    "modelSource": "runtime-default",
+    "providerBilling": "user-connected",
+    "usage": {
+      "inputTokens": 1200,
+      "outputTokens": 450,
+      "costUsd": 0.0125,
+      "reportedByRuntime": true
+    }
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/topic-discovery-job-started-before-requested.json
+++ b/schemas/research/v1/fixtures/invalid/topic-discovery-job-started-before-requested.json
@@ -1,0 +1,36 @@
+{
+  "expectedSchemaValid": true,
+  "schema": "opencoven.topic-discovery-job/v1",
+  "id": "topicjob_01",
+  "contextPackId": "ctx_01",
+  "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "familiarId": "sage",
+  "status": "completed",
+  "requestedAt": "2026-08-15T20:00:00Z",
+  "startedAt": "2026-08-15T19:59:59.999999999Z",
+  "finishedAt": "2026-08-15T20:06:00Z",
+  "proposalIds": [
+    "proposal_01",
+    "proposal_02",
+    "proposal_03"
+  ],
+  "modelReceipt": {
+    "familiarId": "sage",
+    "runtime": "coven-cave",
+    "effectiveModel": "gpt-5-mini",
+    "modelSource": "runtime-default",
+    "providerBilling": "user-connected",
+    "usage": {
+      "inputTokens": 1200,
+      "outputTokens": 450,
+      "costUsd": 0.0125,
+      "reportedByRuntime": true
+    },
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/invalid/topic-discovery-job-two.json
+++ b/schemas/research/v1/fixtures/invalid/topic-discovery-job-two.json
@@ -1,0 +1,12 @@
+{
+  "schema": "opencoven.topic-discovery-job/v1",
+  "id": "topicjob_two_01",
+  "contextPackId": "ctx_01",
+  "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "familiarId": "sage",
+  "status": "completed",
+  "requestedAt": "2026-08-15T20:00:00.000Z",
+  "startedAt": "2026-08-15T20:01:00.000Z",
+  "finishedAt": "2026-08-15T20:06:00.000Z",
+  "proposalIds": ["proposal_01", "proposal_02"]
+}

--- a/schemas/research/v1/fixtures/invalid/topic-proposal-score.json
+++ b/schemas/research/v1/fixtures/invalid/topic-proposal-score.json
@@ -1,0 +1,41 @@
+{
+  "schema": "opencoven.topic-proposal/v1",
+  "id": "proposal_01",
+  "discoveryJobId": "topicjob_01",
+  "contextPackId": "ctx_01",
+  "title": "A grounded question",
+  "question": "Which evidence should guide the decision?",
+  "whyNow": "The source set contains unresolved disagreement.",
+  "evidence": [
+    {
+      "resourceId": "resource_01",
+      "selector": { "type": "text-span", "start": 0, "end": 20 },
+      "excerpt": "Evidence excerpt",
+      "excerptDigest": "84e3d621a6705b03cc38559364169efff401aa7155f85cecd46b51660dd1ae42"
+    }
+  ],
+  "counterevidence": [],
+  "scores": {
+    "groundability": 5,
+    "decisionValue": 3,
+    "unresolvedness": 2,
+    "recurrence": 1,
+    "novelty": 4,
+    "timeliness": 2,
+    "familiarFit": 4,
+    "feasibility": 3,
+    "humanResonance": 4,
+    "riskPenalty": 2,
+    "visibleTotal": 2.82
+  },
+  "suggested": {
+    "mode": "brief",
+    "deliverable": "Decision brief",
+    "sourceTarget": 8,
+    "wallClockMinutes": 30
+  },
+  "uncertainty": "One source may be stale.",
+  "relatedMissionIds": ["mission_01"],
+  "createdAt": "2026-08-15T20:05:00.000Z",
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/invalid/unknown-major.json
+++ b/schemas/research/v1/fixtures/invalid/unknown-major.json
@@ -1,0 +1,12 @@
+{
+  "schema": "opencoven.run-event/v2",
+  "runId": "run_01",
+  "sequence": 1,
+  "type": "run.created",
+  "at": "2026-08-15T20:00:00.000Z",
+  "data": {
+    "status": "queued",
+    "futureExtension": { "preserve": true }
+  },
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/scenarios/manifest-retention-consent.scenario.json
+++ b/schemas/research/v1/fixtures/scenarios/manifest-retention-consent.scenario.json
@@ -1,0 +1,75 @@
+{
+  "format": "opencoven.research-protocol-scenarios/v1",
+  "family": "manifest-retention-consent",
+  "objects": {
+    "context-bound-manifest": {
+      "fixture": "valid/run-manifest-final-local.json"
+    },
+    "contextless-manifest": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "context": null,
+        "sources": []
+      },
+      "digestTargets": [""]
+    }
+  },
+  "scenarios": [
+    {
+      "id": "manifest-consent.valid-context-consent",
+      "description": "A context-bound manifest accepts retention within the supplied Context Pack consent.",
+      "validator": "manifest-retention-consent",
+      "inputs": {
+        "manifest": "context-bound-manifest"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest-consent.missing-context-consent",
+      "description": "A context-bound manifest requires its Context Pack retention consent.",
+      "validator": "manifest-retention-consent",
+      "inputs": {
+        "manifest": "context-bound-manifest"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.policy"
+      }
+    },
+    {
+      "id": "manifest-consent.retention-above-consent",
+      "description": "A context-bound manifest cannot exceed its Context Pack retention consent.",
+      "validator": "manifest-retention-consent",
+      "inputs": {
+        "manifest": "context-bound-manifest"
+      },
+      "options": {
+        "contextConsent": "run-only"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.policy"
+      }
+    },
+    {
+      "id": "manifest-consent.contextless-without-consent",
+      "description": "A contextless manifest uses its original retention policy as its ceiling.",
+      "validator": "manifest-retention-consent",
+      "inputs": {
+        "manifest": "contextless-manifest"
+      },
+      "expected": {
+        "ok": true
+      }
+    }
+  ]
+}

--- a/schemas/research/v1/fixtures/scenarios/model-task-result.scenario.json
+++ b/schemas/research/v1/fixtures/scenarios/model-task-result.scenario.json
@@ -1,0 +1,166 @@
+{
+  "format": "opencoven.research-protocol-scenarios/v1",
+  "family": "model-task-result",
+  "objects": {
+    "pinned-task": {
+      "fixture": "valid/model-task.json",
+      "mergePatch": {
+        "modelBinding": {
+          "familiarId": "sage",
+          "selection": "pinned",
+          "model": "gpt-5.6-sol"
+        }
+      }
+    },
+    "result": {
+      "fixture": "valid/model-task-result.json"
+    },
+    "task": {
+      "fixture": "valid/model-task.json"
+    },
+    "wrong-attempt-result": {
+      "fixture": "valid/model-task-result.json",
+      "mergePatch": {
+        "attempt": 2
+      }
+    },
+    "wrong-effective-model-result": {
+      "fixture": "valid/model-task-result.json",
+      "mergePatch": {
+        "modelReceipt": {
+          "effectiveModel": "other-model"
+        }
+      }
+    },
+    "wrong-familiar-result": {
+      "fixture": "valid/model-task-result.json",
+      "mergePatch": {
+        "modelReceipt": {
+          "familiarId": "other-familiar"
+        }
+      }
+    },
+    "wrong-input-digest-result": {
+      "fixture": "valid/model-task-result.json",
+      "mergePatch": {
+        "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    },
+    "wrong-run-result": {
+      "fixture": "valid/model-task-result.json",
+      "mergePatch": {
+        "runId": "run_other_01"
+      }
+    },
+    "wrong-task-result": {
+      "fixture": "valid/model-task-result.json",
+      "mergePatch": {
+        "taskId": "modeltask_other_01"
+      }
+    }
+  },
+  "scenarios": [
+    {
+      "id": "model-task.valid-pair",
+      "description": "The canonical Model Task and Model Task Result form a valid pair.",
+      "validator": "model-task-result",
+      "inputs": {
+        "task": "task",
+        "result": "result"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "model-task.wrong-task-id",
+      "description": "The result must name the task that produced it.",
+      "validator": "model-task-result",
+      "inputs": {
+        "task": "task",
+        "result": "wrong-task-result"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.taskId"
+      }
+    },
+    {
+      "id": "model-task.wrong-run-id",
+      "description": "Task and result must belong to the same run.",
+      "validator": "model-task-result",
+      "inputs": {
+        "task": "task",
+        "result": "wrong-run-result"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.runId"
+      }
+    },
+    {
+      "id": "model-task.wrong-attempt",
+      "description": "The result attempt must equal the leased task attempt.",
+      "validator": "model-task-result",
+      "inputs": {
+        "task": "task",
+        "result": "wrong-attempt-result"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.attempt"
+      }
+    },
+    {
+      "id": "model-task.wrong-input-digest",
+      "description": "The result must echo the task input digest.",
+      "validator": "model-task-result",
+      "inputs": {
+        "task": "task",
+        "result": "wrong-input-digest-result"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.inputDigest"
+      }
+    },
+    {
+      "id": "model-task.wrong-familiar-id",
+      "description": "The result receipt must identify the task-bound familiar.",
+      "validator": "model-task-result",
+      "inputs": {
+        "task": "task",
+        "result": "wrong-familiar-result"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.modelReceipt.familiarId"
+      }
+    },
+    {
+      "id": "model-task.wrong-effective-model",
+      "description": "A pinned task requires the exact effective model in the result receipt.",
+      "validator": "model-task-result",
+      "inputs": {
+        "task": "pinned-task",
+        "result": "wrong-effective-model-result"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.modelReceipt.effectiveModel"
+      }
+    }
+  ]
+}

--- a/schemas/research/v1/fixtures/scenarios/objects/completed-deletion-run.json
+++ b/schemas/research/v1/fixtures/scenarios/objects/completed-deletion-run.json
@@ -1,0 +1,101 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "acceptedTopic": {
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "completed",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-17T20:00:00.000Z",
+  "nextEventSequence": 4,
+  "artifactManifest": {
+    "schema": "opencoven.run-manifest/v1",
+    "id": "manifest_deleted_01",
+    "runId": "run_01",
+    "digest": "46465b06099663bdcea155c00fa7e17383b69a5413781aa96507780b3cc491b7",
+    "revision": 2,
+    "previousDigest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "state": "final",
+    "createdAt": "2026-08-15T20:00:00.000Z",
+    "finalizedAt": "2026-08-15T20:10:00.000Z",
+    "sources": [],
+    "artifacts": [
+      {
+        "id": "artifact_deleted_01",
+        "kind": "research-notes",
+        "title": "Deleted research notes",
+        "mediaType": "text/markdown",
+        "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "bytes": 128,
+        "placement": "device-local",
+        "contentSync": "not-requested",
+        "createdAt": "2026-08-15T20:08:00.000Z"
+      }
+    ],
+    "modelExecutions": [],
+    "usage": {
+      "inputTokens": null,
+      "outputTokens": null,
+      "costUsd": null,
+      "completeness": "unreported"
+    },
+    "retention": {
+      "policy": "7-days",
+      "effectivePolicy": "7-days",
+      "status": "deleted",
+      "contentExpiresAt": "2026-08-17T20:00:00.000Z",
+      "updatedAt": "2026-08-17T20:00:00.000Z"
+    },
+    "deletion": {
+      "status": "completed",
+      "requestedAt": "2026-08-17T19:00:00.000Z",
+      "completedAt": "2026-08-17T20:00:00.000Z",
+      "deletedObjectCount": 3,
+      "eventSequence": 2
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/scenarios/objects/context-bound-extended-run.json
+++ b/schemas/research/v1/fixtures/scenarios/objects/context-bound-extended-run.json
@@ -1,0 +1,121 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "context": {
+    "contextPackId": "ctx_01",
+    "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+    "topicProposalId": "proposal_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "acceptedTopic": {
+    "proposalId": "proposal_01",
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "completed",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:10:00.000Z",
+  "nextEventSequence": 2,
+  "artifactManifest": {
+    "schema": "opencoven.run-manifest/v1",
+    "id": "manifest_context_01",
+    "runId": "run_01",
+    "digest": "e91b15a1dc1b1dcea2358a6307cf1820574019510e0bbc687465b97bddd2c04d",
+    "revision": 2,
+    "previousDigest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "state": "final",
+    "createdAt": "2026-08-15T20:00:00.000Z",
+    "finalizedAt": "2026-08-15T20:09:00.000Z",
+    "context": {
+      "contextPackId": "ctx_01",
+      "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+      "topicProposalId": "proposal_01",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "sources": [
+      {
+        "kind": "context-pack",
+        "id": "ctx_01",
+        "digest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+        "availability": "device-local"
+      }
+    ],
+    "artifacts": [
+      {
+        "id": "artifact_context_01",
+        "kind": "research-notes",
+        "title": "Context-bound research notes",
+        "mediaType": "text/markdown",
+        "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "bytes": 128,
+        "placement": "device-local",
+        "contentSync": "not-requested",
+        "createdAt": "2026-08-15T20:08:00.000Z"
+      }
+    ],
+    "modelExecutions": [],
+    "usage": {
+      "inputTokens": null,
+      "outputTokens": null,
+      "costUsd": null,
+      "completeness": "unreported"
+    },
+    "retention": {
+      "policy": "7-days",
+      "effectivePolicy": "7-days",
+      "status": "active",
+      "contentExpiresAt": null,
+      "updatedAt": "2026-08-15T20:09:00.000Z"
+    },
+    "deletion": {
+      "status": "not_scheduled"
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/scenarios/objects/replay-consent-run.json
+++ b/schemas/research/v1/fixtures/scenarios/objects/replay-consent-run.json
@@ -1,0 +1,134 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "context": {
+    "contextPackId": "ctx_01",
+    "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+    "topicProposalId": "proposal_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "acceptedTopic": {
+    "proposalId": "proposal_01",
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "completed",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-16T20:09:00.000Z",
+  "nextEventSequence": 2,
+  "artifactManifest": {
+    "schema": "opencoven.run-manifest/v1",
+    "id": "manifest_replay_01",
+    "runId": "run_01",
+    "digest": "a1c0f7f199dfa5b0d4f95b8b5f4ad9ddc4fc99a506dc6372b6dbba280e84e87e",
+    "revision": 4,
+    "previousDigest": "0449d175c0b8c19640c597eb7693bf7e9f2178efbf16a0a426653331bee6eacb",
+    "state": "final",
+    "createdAt": "2026-08-16T20:00:00.000Z",
+    "finalizedAt": "2026-08-16T20:04:00.000Z",
+    "context": {
+      "contextPackId": "ctx_01",
+      "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+      "topicProposalId": "proposal_01",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "sources": [
+      {
+        "kind": "context-pack",
+        "id": "ctx_01",
+        "digest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+        "availability": "device-local"
+      }
+    ],
+    "artifacts": [
+      {
+        "id": "artifact_local_01",
+        "kind": "research-notes",
+        "title": "Research notes",
+        "mediaType": "text/markdown",
+        "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "bytes": 128,
+        "placement": "device-local",
+        "contentSync": "not-requested",
+        "createdAt": "2026-08-16T20:03:00.000Z",
+        "futureExtension": {
+          "preserve": true
+        }
+      }
+    ],
+    "modelExecutions": [],
+    "usage": {
+      "inputTokens": null,
+      "outputTokens": null,
+      "costUsd": null,
+      "completeness": "unreported",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "retention": {
+      "policy": "7-days",
+      "effectivePolicy": "7-days",
+      "status": "deletion_scheduled",
+      "contentExpiresAt": "2026-08-22T20:07:30.000Z",
+      "updatedAt": "2026-08-16T20:08:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "deletion": {
+      "status": "scheduled",
+      "requestedAt": "2026-08-16T20:05:00.000Z"
+    },
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/scenarios/objects/research-run-device-local-failed-consent-true.json
+++ b/schemas/research/v1/fixtures/scenarios/objects/research-run-device-local-failed-consent-true.json
@@ -1,0 +1,96 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "acceptedTopic": {
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": true,
+    "retention": "run-only",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "completed",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:10:00.000Z",
+  "nextEventSequence": 2,
+  "artifactManifest": {
+    "schema": "opencoven.run-manifest/v1",
+    "id": "manifest_context_01",
+    "runId": "run_01",
+    "digest": "cf06a3bc67052feda1cc4c7fb7d1a60aeca02a3d6d0aeb4504e73ff65990feb3",
+    "revision": 1,
+    "state": "final",
+    "createdAt": "2026-08-15T20:00:00.000Z",
+    "finalizedAt": "2026-08-15T20:09:00.000Z",
+    "sources": [],
+    "artifacts": [
+      {
+        "id": "artifact_context_01",
+        "kind": "research-notes",
+        "title": "Context-bound research notes",
+        "mediaType": "text/markdown",
+        "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "bytes": 128,
+        "placement": "device-local",
+        "contentSync": "failed",
+        "createdAt": "2026-08-15T20:08:00.000Z"
+      }
+    ],
+    "modelExecutions": [],
+    "usage": {
+      "inputTokens": null,
+      "outputTokens": null,
+      "costUsd": null,
+      "completeness": "unreported"
+    },
+    "retention": {
+      "policy": "run-only",
+      "effectivePolicy": "run-only",
+      "status": "active",
+      "contentExpiresAt": null,
+      "updatedAt": "2026-08-15T20:09:00.000Z"
+    },
+    "deletion": {
+      "status": "not_scheduled"
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/scenarios/objects/research-run-device-local-pending-consent-true.json
+++ b/schemas/research/v1/fixtures/scenarios/objects/research-run-device-local-pending-consent-true.json
@@ -1,0 +1,96 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "acceptedTopic": {
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": true,
+    "retention": "run-only",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "completed",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:10:00.000Z",
+  "nextEventSequence": 2,
+  "artifactManifest": {
+    "schema": "opencoven.run-manifest/v1",
+    "id": "manifest_context_01",
+    "runId": "run_01",
+    "digest": "9f900b4ed3fd795e528103930b8b49ebe356a5a3da95c457126fc2c16582beed",
+    "revision": 1,
+    "state": "final",
+    "createdAt": "2026-08-15T20:00:00.000Z",
+    "finalizedAt": "2026-08-15T20:09:00.000Z",
+    "sources": [],
+    "artifacts": [
+      {
+        "id": "artifact_context_01",
+        "kind": "research-notes",
+        "title": "Context-bound research notes",
+        "mediaType": "text/markdown",
+        "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "bytes": 128,
+        "placement": "device-local",
+        "contentSync": "pending",
+        "createdAt": "2026-08-15T20:08:00.000Z"
+      }
+    ],
+    "modelExecutions": [],
+    "usage": {
+      "inputTokens": null,
+      "outputTokens": null,
+      "costUsd": null,
+      "completeness": "unreported"
+    },
+    "retention": {
+      "policy": "run-only",
+      "effectivePolicy": "run-only",
+      "status": "active",
+      "contentExpiresAt": null,
+      "updatedAt": "2026-08-15T20:09:00.000Z"
+    },
+    "deletion": {
+      "status": "not_scheduled"
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/scenarios/objects/research-run-device-local-synced-consent-true.json
+++ b/schemas/research/v1/fixtures/scenarios/objects/research-run-device-local-synced-consent-true.json
@@ -1,0 +1,96 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "acceptedTopic": {
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": true,
+    "retention": "run-only",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "completed",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:10:00.000Z",
+  "nextEventSequence": 2,
+  "artifactManifest": {
+    "schema": "opencoven.run-manifest/v1",
+    "id": "manifest_context_01",
+    "runId": "run_01",
+    "digest": "63be90af7d81b088b588c14bb94fe6db407f9a83c1c678bca160209cf6f81a52",
+    "revision": 1,
+    "state": "final",
+    "createdAt": "2026-08-15T20:00:00.000Z",
+    "finalizedAt": "2026-08-15T20:09:00.000Z",
+    "sources": [],
+    "artifacts": [
+      {
+        "id": "artifact_context_01",
+        "kind": "research-notes",
+        "title": "Context-bound research notes",
+        "mediaType": "text/markdown",
+        "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "bytes": 128,
+        "placement": "device-local",
+        "contentSync": "synced",
+        "createdAt": "2026-08-15T20:08:00.000Z"
+      }
+    ],
+    "modelExecutions": [],
+    "usage": {
+      "inputTokens": null,
+      "outputTokens": null,
+      "costUsd": null,
+      "completeness": "unreported"
+    },
+    "retention": {
+      "policy": "run-only",
+      "effectivePolicy": "run-only",
+      "status": "active",
+      "contentExpiresAt": null,
+      "updatedAt": "2026-08-15T20:09:00.000Z"
+    },
+    "deletion": {
+      "status": "not_scheduled"
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/scenarios/objects/research-run-receipt-valid.json
+++ b/schemas/research/v1/fixtures/scenarios/objects/research-run-receipt-valid.json
@@ -1,0 +1,117 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "acceptedTopic": {
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "openai/gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "run-only",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "completed",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:10:00.000Z",
+  "nextEventSequence": 2,
+  "artifactManifest": {
+    "schema": "opencoven.run-manifest/v1",
+    "id": "manifest_context_01",
+    "runId": "run_01",
+    "digest": "e06749b7b512392b045f6b3db71ae2950df85d1ce4c10d501f0e4e42f6d9a65a",
+    "revision": 1,
+    "state": "final",
+    "createdAt": "2026-08-15T20:00:00.000Z",
+    "finalizedAt": "2026-08-15T20:09:00.000Z",
+    "sources": [],
+    "artifacts": [
+      {
+        "id": "artifact_context_01",
+        "kind": "research-notes",
+        "title": "Context-bound research notes",
+        "mediaType": "text/markdown",
+        "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "bytes": 128,
+        "placement": "device-local",
+        "contentSync": "not-requested",
+        "createdAt": "2026-08-15T20:08:00.000Z"
+      }
+    ],
+    "modelExecutions": [
+      {
+        "taskId": "modeltask_receipt_01",
+        "phase": "scope",
+        "attempt": 1,
+        "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "receipt": {
+          "familiarId": "sage",
+          "runtime": "copilot",
+          "effectiveModel": "openai/gpt-5.6-sol",
+          "modelSource": "session",
+          "providerBilling": "user-connected",
+          "usage": {
+            "inputTokens": 10,
+            "outputTokens": 5,
+            "costUsd": 0.1,
+            "reportedByRuntime": true
+          }
+        }
+      }
+    ],
+    "usage": {
+      "inputTokens": 10,
+      "outputTokens": 5,
+      "costUsd": 0.1,
+      "completeness": "complete"
+    },
+    "retention": {
+      "policy": "run-only",
+      "effectivePolicy": "run-only",
+      "status": "active",
+      "contentExpiresAt": null,
+      "updatedAt": "2026-08-15T20:09:00.000Z"
+    },
+    "deletion": {
+      "status": "not_scheduled"
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/scenarios/objects/run-manifest-final-mutation.json
+++ b/schemas/research/v1/fixtures/scenarios/objects/run-manifest-final-mutation.json
@@ -1,0 +1,76 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_final_local_01",
+  "runId": "run_final_local_01",
+  "digest": "f50b8f269b77bc498121030d1eb08ef1c8e388191afbf0ba26f65b7f16080c86",
+  "revision": 2,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Changed immutable artifact",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2026-08-23T20:04:00.000Z",
+    "updatedAt": "2026-08-16T20:06:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "scheduled",
+    "futureExtension": {
+      "preserve": true
+    },
+    "requestedAt": "2026-08-16T20:06:00.000Z"
+  },
+  "futureExtension": {
+    "preserve": true
+  },
+  "previousDigest": "4c7161996cbbcb51d3e13f7a27f0cac88a389e5765c9f6706898ef5329080579"
+}

--- a/schemas/research/v1/fixtures/scenarios/objects/run-manifest-previous-digest.json
+++ b/schemas/research/v1/fixtures/scenarios/objects/run-manifest-previous-digest.json
@@ -1,0 +1,76 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_final_local_01",
+  "runId": "run_final_local_01",
+  "digest": "cb80ae02f07dffa08975a400db994747679f027dea633a8d7b7c885ee42d338b",
+  "revision": 2,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2026-08-23T20:04:00.000Z",
+    "updatedAt": "2026-08-16T20:06:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "scheduled",
+    "futureExtension": {
+      "preserve": true
+    },
+    "requestedAt": "2026-08-16T20:06:00.000Z"
+  },
+  "futureExtension": {
+    "preserve": true
+  },
+  "previousDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}

--- a/schemas/research/v1/fixtures/scenarios/research-run-context-pack.scenario.json
+++ b/schemas/research/v1/fixtures/scenarios/research-run-context-pack.scenario.json
@@ -1,0 +1,834 @@
+{
+  "format": "opencoven.research-protocol-scenarios/v1",
+  "family": "research-run-context-pack",
+  "objects": {
+    "context-pack": {
+      "fixture": "valid/context-pack.json"
+    },
+    "contextless-run": {
+      "fixture": "valid/research-run.json",
+      "mergePatch": {
+        "context": null,
+        "acceptedTopic": {
+          "proposalId": null
+        }
+      }
+    },
+    "device-local-failed-consent-false": {
+      "fixture": "scenarios/objects/research-run-device-local-failed-consent-true.json",
+      "mergePatch": {
+        "privacy": {
+          "artifactContentSync": false
+        }
+      }
+    },
+    "device-local-failed-consent-true": {
+      "fixture": "scenarios/objects/research-run-device-local-failed-consent-true.json"
+    },
+    "device-local-pending-consent-false": {
+      "fixture": "scenarios/objects/research-run-device-local-pending-consent-true.json",
+      "mergePatch": {
+        "privacy": {
+          "artifactContentSync": false
+        }
+      }
+    },
+    "device-local-pending-consent-true": {
+      "fixture": "scenarios/objects/research-run-device-local-pending-consent-true.json"
+    },
+    "device-local-synced-consent-false": {
+      "fixture": "scenarios/objects/research-run-device-local-synced-consent-true.json",
+      "mergePatch": {
+        "privacy": {
+          "artifactContentSync": false
+        }
+      }
+    },
+    "device-local-synced-consent-true": {
+      "fixture": "scenarios/objects/research-run-device-local-synced-consent-true.json"
+    },
+    "receipt-valid": {
+      "fixture": "scenarios/objects/research-run-receipt-valid.json"
+    },
+    "receipt-wrong-familiar": {
+      "fixture": "scenarios/objects/research-run-receipt-valid.json",
+      "mergePatch": {
+        "execution": {
+          "modelBinding": {
+            "familiarId": "other-familiar"
+          }
+        }
+      }
+    },
+    "receipt-wrong-model": {
+      "fixture": "scenarios/objects/research-run-receipt-valid.json",
+      "mergePatch": {
+        "execution": {
+          "modelBinding": {
+            "model": "openai/gpt-5-mini"
+          }
+        }
+      }
+    },
+    "receipt-wrong-provider": {
+      "fixture": "scenarios/objects/research-run-receipt-valid.json",
+      "mergePatch": {
+        "execution": {
+          "modelBinding": {
+            "model": "anthropic/gpt-5.6-sol"
+          }
+        }
+      }
+    },
+    "contextless-lengthened-run": {
+      "fixture": "scenarios/objects/context-bound-extended-run.json",
+      "mergePatch": {
+        "context": null,
+        "acceptedTopic": {
+          "proposalId": null
+        },
+        "privacy": {
+          "retention": "run-only"
+        },
+        "artifactManifest": {
+          "context": null,
+          "sources": [],
+          "retention": {
+            "policy": "run-only"
+          }
+        }
+      },
+      "digestTargets": ["/artifactManifest"]
+    },
+    "embedded-retention-above-consent-run": {
+      "fixture": "scenarios/objects/context-bound-extended-run.json",
+      "mergePatch": {
+        "artifactManifest": {
+          "digest": "b207c051bd22df4394f2afa81a938ea16d1ead516f3a17344e0f483f66a089cd",
+          "retention": {
+            "effectivePolicy": "project"
+          }
+        }
+      }
+    },
+    "matching-run": {
+      "fixture": "scenarios/objects/context-bound-extended-run.json",
+      "mergePatch": {
+        "artifactManifest": {
+          "revision": 1,
+          "previousDigest": null
+        }
+      },
+      "digestTargets": ["/artifactManifest"]
+    },
+    "run-retention-above-consent": {
+      "fixture": "valid/research-run.json",
+      "mergePatch": {
+        "context": {
+          "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118"
+        },
+        "privacy": {
+          "retention": "project"
+        }
+      }
+    },
+    "replay-run": {
+      "fixture": "scenarios/objects/replay-consent-run.json"
+    },
+    "replay-root": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "id": "manifest_replay_01",
+        "runId": "run_01",
+        "context": {
+          "contextPackId": "ctx_01",
+          "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+          "topicProposalId": "proposal_01"
+        },
+        "sources": [
+          {
+            "kind": "context-pack",
+            "id": "ctx_01",
+            "digest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+            "availability": "device-local"
+          }
+        ],
+        "retention": {
+          "policy": "7-days",
+          "effectivePolicy": "7-days",
+          "status": "deletion_scheduled",
+          "contentExpiresAt": "2026-08-20T20:05:00.000Z",
+          "updatedAt": "2026-08-16T20:05:00.000Z"
+        },
+        "deletion": {
+          "status": "scheduled",
+          "requestedAt": "2026-08-16T20:05:00.000Z",
+          "futureExtension": null
+        }
+      },
+      "digestTargets": [""]
+    },
+    "replay-first-lengthening": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "id": "manifest_replay_01",
+        "runId": "run_01",
+        "revision": 2,
+        "previousDigest": "02d819908b8025038608e563ae1356e401d86fb7b3ec30888fe64cb657510998",
+        "context": {
+          "contextPackId": "ctx_01",
+          "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+          "topicProposalId": "proposal_01"
+        },
+        "sources": [
+          {
+            "kind": "context-pack",
+            "id": "ctx_01",
+            "digest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+            "availability": "device-local"
+          }
+        ],
+        "retention": {
+          "policy": "7-days",
+          "effectivePolicy": "7-days",
+          "status": "deletion_scheduled",
+          "contentExpiresAt": "2026-08-21T20:05:30.000Z",
+          "updatedAt": "2026-08-16T20:06:00.000Z"
+        },
+        "deletion": {
+          "status": "scheduled",
+          "requestedAt": "2026-08-16T20:05:00.000Z",
+          "futureExtension": null
+        }
+      },
+      "digestTargets": [""]
+    },
+    "replay-unchanged": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "id": "manifest_replay_01",
+        "runId": "run_01",
+        "revision": 3,
+        "previousDigest": "abf045c85ee6837f0f27e7afc04bb4c378bf9854801e7eb3dda607d4fbbbaa86",
+        "context": {
+          "contextPackId": "ctx_01",
+          "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+          "topicProposalId": "proposal_01"
+        },
+        "sources": [
+          {
+            "kind": "context-pack",
+            "id": "ctx_01",
+            "digest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+            "availability": "device-local"
+          }
+        ],
+        "retention": {
+          "policy": "7-days",
+          "effectivePolicy": "7-days",
+          "status": "deletion_scheduled",
+          "contentExpiresAt": "2026-08-21T20:05:30.000Z",
+          "updatedAt": "2026-08-16T20:07:00.000Z"
+        },
+        "deletion": {
+          "status": "scheduled",
+          "requestedAt": "2026-08-16T20:05:00.000Z",
+          "futureExtension": null
+        }
+      },
+      "digestTargets": [""]
+    },
+    "replay-second-lengthening": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "id": "manifest_replay_01",
+        "runId": "run_01",
+        "revision": 4,
+        "previousDigest": "0449d175c0b8c19640c597eb7693bf7e9f2178efbf16a0a426653331bee6eacb",
+        "context": {
+          "contextPackId": "ctx_01",
+          "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+          "topicProposalId": "proposal_01"
+        },
+        "sources": [
+          {
+            "kind": "context-pack",
+            "id": "ctx_01",
+            "digest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+            "availability": "device-local"
+          }
+        ],
+        "retention": {
+          "policy": "7-days",
+          "effectivePolicy": "7-days",
+          "status": "deletion_scheduled",
+          "contentExpiresAt": "2026-08-22T20:07:30.000Z",
+          "updatedAt": "2026-08-16T20:08:00.000Z"
+        },
+        "deletion": {
+          "status": "scheduled",
+          "requestedAt": "2026-08-16T20:05:00.000Z",
+          "futureExtension": null
+        }
+      },
+      "digestTargets": [""]
+    }
+  },
+  "scenarios": [
+    {
+      "id": "research-run.valid-context-pack",
+      "description": "A research run matches its Context Pack binding and consent.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "matching-run",
+        "contextPack": "context-pack"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "research-run.missing-context-pack",
+      "description": "A context-bound research run rejects validation without its Context Pack.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "matching-run"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.context"
+      }
+    },
+    {
+      "id": "research-run.contextless-without-pack",
+      "description": "A contextless research run validates without a Context Pack.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "contextless-run"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "research-run.contextless-with-pack",
+      "description": "A contextless research run rejects an unrelated Context Pack.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "contextless-run",
+        "contextPack": "context-pack"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.context"
+      }
+    },
+    {
+      "id": "research-run.retention-ceiling",
+      "description": "Run retention cannot exceed Context Pack consent.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "run-retention-above-consent",
+        "contextPack": "context-pack"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.privacy.retention"
+      }
+    },
+    {
+      "id": "research-run.embedded-manifest-retention-ceiling",
+      "description": "A later embedded manifest above Context Pack consent must first supply its authenticated revision-1-rooted history.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "embedded-retention-above-consent-run",
+        "contextPack": "context-pack"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.artifactManifest.revision"
+      }
+    },
+    {
+      "id": "research-run.contextless-manifest-lengthening",
+      "description": "A contextless embedded manifest cannot lengthen beyond run retention.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "contextless-lengthened-run",
+        "contextPack": "context-pack"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "run",
+        "code": "semantic_conflict",
+        "path": "$.artifactManifest.retention.effectivePolicy"
+      }
+    },
+    {
+      "id": "research-run.replay-explicit-transition-consent",
+      "description": "A multi-lengthening replay consumes independently keyed fresh consent for each lengthening successor.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "replay-run",
+        "contextPack": "context-pack",
+        "manifestHistory": [
+          "replay-root",
+          "replay-first-lengthening",
+          "replay-unchanged",
+          "replay-second-lengthening"
+        ]
+      },
+      "options": {
+        "manifestRevisionOptions": [
+          {
+            "successorRevision": 4,
+            "successorDigest": "a1c0f7f199dfa5b0d4f95b8b5f4ad9ddc4fc99a506dc6372b6dbba280e84e87e",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:07:30.000Z",
+            "contextConsent": "7-days"
+          },
+          {
+            "successorRevision": 2,
+            "successorDigest": "abf045c85ee6837f0f27e7afc04bb4c378bf9854801e7eb3dda607d4fbbbaa86",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:05:30.000Z",
+            "contextConsent": "7-days"
+          }
+        ]
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "research-run.replay-missing-transition-consent",
+      "description": "Every lengthening successor requires its own explicit replay consent entry.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "replay-run",
+        "contextPack": "context-pack",
+        "manifestHistory": [
+          "replay-root",
+          "replay-first-lengthening",
+          "replay-unchanged",
+          "replay-second-lengthening"
+        ]
+      },
+      "options": {
+        "manifestRevisionOptions": [
+          {
+            "successorRevision": 2,
+            "successorDigest": "abf045c85ee6837f0f27e7afc04bb4c378bf9854801e7eb3dda607d4fbbbaa86",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:05:30.000Z",
+            "contextConsent": "7-days"
+          }
+        ]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.manifestHistory[3].retention.contentExpiresAt"
+      }
+    },
+    {
+      "id": "research-run.replay-duplicate-transition-consent",
+      "description": "A replay rejects duplicate options for one successor revision and digest.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "replay-run",
+        "contextPack": "context-pack",
+        "manifestHistory": [
+          "replay-root",
+          "replay-first-lengthening",
+          "replay-unchanged",
+          "replay-second-lengthening"
+        ]
+      },
+      "options": {
+        "manifestRevisionOptions": [
+          {
+            "successorRevision": 2,
+            "successorDigest": "abf045c85ee6837f0f27e7afc04bb4c378bf9854801e7eb3dda607d4fbbbaa86",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:05:30.000Z",
+            "contextConsent": "7-days"
+          },
+          {
+            "successorRevision": 2,
+            "successorDigest": "abf045c85ee6837f0f27e7afc04bb4c378bf9854801e7eb3dda607d4fbbbaa86",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:05:45.000Z",
+            "contextConsent": "7-days"
+          },
+          {
+            "successorRevision": 4,
+            "successorDigest": "a1c0f7f199dfa5b0d4f95b8b5f4ad9ddc4fc99a506dc6372b6dbba280e84e87e",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:07:30.000Z",
+            "contextConsent": "7-days"
+          }
+        ]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.manifestRevisionOptions[1].successorRevision"
+      }
+    },
+    {
+      "id": "research-run.replay-unknown-transition-consent",
+      "description": "A replay rejects an option keyed to no history successor.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "replay-run",
+        "contextPack": "context-pack",
+        "manifestHistory": [
+          "replay-root",
+          "replay-first-lengthening",
+          "replay-unchanged",
+          "replay-second-lengthening"
+        ]
+      },
+      "options": {
+        "manifestRevisionOptions": [
+          {
+            "successorRevision": 2,
+            "successorDigest": "abf045c85ee6837f0f27e7afc04bb4c378bf9854801e7eb3dda607d4fbbbaa86",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:05:30.000Z",
+            "contextConsent": "7-days"
+          },
+          {
+            "successorRevision": 4,
+            "successorDigest": "a1c0f7f199dfa5b0d4f95b8b5f4ad9ddc4fc99a506dc6372b6dbba280e84e87e",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:07:30.000Z",
+            "contextConsent": "7-days"
+          },
+          {
+            "successorRevision": 5,
+            "successorDigest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:08:30.000Z",
+            "contextConsent": "7-days"
+          }
+        ]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.manifestRevisionOptions[2].successorRevision"
+      }
+    },
+    {
+      "id": "research-run.replay-extra-non-lengthening-consent",
+      "description": "A replay rejects an extra option for a non-lengthening successor.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "replay-run",
+        "contextPack": "context-pack",
+        "manifestHistory": [
+          "replay-root",
+          "replay-first-lengthening",
+          "replay-unchanged",
+          "replay-second-lengthening"
+        ]
+      },
+      "options": {
+        "manifestRevisionOptions": [
+          {
+            "successorRevision": 2,
+            "successorDigest": "abf045c85ee6837f0f27e7afc04bb4c378bf9854801e7eb3dda607d4fbbbaa86",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:05:30.000Z",
+            "contextConsent": "7-days"
+          },
+          {
+            "successorRevision": 3,
+            "successorDigest": "0449d175c0b8c19640c597eb7693bf7e9f2178efbf16a0a426653331bee6eacb",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:06:30.000Z",
+            "contextConsent": "7-days"
+          },
+          {
+            "successorRevision": 4,
+            "successorDigest": "a1c0f7f199dfa5b0d4f95b8b5f4ad9ddc4fc99a506dc6372b6dbba280e84e87e",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:07:30.000Z",
+            "contextConsent": "7-days"
+          }
+        ]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.manifestRevisionOptions[1].successorRevision"
+      }
+    },
+    {
+      "id": "research-run.replay-stale-transition-consent",
+      "description": "Fresh replay consent must postdate prior retention and deletion authority.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "replay-run",
+        "contextPack": "context-pack",
+        "manifestHistory": [
+          "replay-root",
+          "replay-first-lengthening",
+          "replay-unchanged",
+          "replay-second-lengthening"
+        ]
+      },
+      "options": {
+        "manifestRevisionOptions": [
+          {
+            "successorRevision": 2,
+            "successorDigest": "abf045c85ee6837f0f27e7afc04bb4c378bf9854801e7eb3dda607d4fbbbaa86",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:05:00.000Z",
+            "contextConsent": "7-days"
+          },
+          {
+            "successorRevision": 4,
+            "successorDigest": "a1c0f7f199dfa5b0d4f95b8b5f4ad9ddc4fc99a506dc6372b6dbba280e84e87e",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:07:30.000Z",
+            "contextConsent": "7-days"
+          }
+        ]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.manifestRevisionOptions[0].freshConsentAt"
+      }
+    },
+    {
+      "id": "research-run.replay-future-transition-consent",
+      "description": "Fresh replay consent cannot postdate its successor retention update.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "replay-run",
+        "contextPack": "context-pack",
+        "manifestHistory": [
+          "replay-root",
+          "replay-first-lengthening",
+          "replay-unchanged",
+          "replay-second-lengthening"
+        ]
+      },
+      "options": {
+        "manifestRevisionOptions": [
+          {
+            "successorRevision": 2,
+            "successorDigest": "abf045c85ee6837f0f27e7afc04bb4c378bf9854801e7eb3dda607d4fbbbaa86",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:06:00.000000001Z",
+            "contextConsent": "7-days"
+          },
+          {
+            "successorRevision": 4,
+            "successorDigest": "a1c0f7f199dfa5b0d4f95b8b5f4ad9ddc4fc99a506dc6372b6dbba280e84e87e",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:07:30.000Z",
+            "contextConsent": "7-days"
+          }
+        ]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.manifestRevisionOptions[0].freshConsentAt"
+      }
+    },
+    {
+      "id": "research-run.replay-misbound-transition-consent",
+      "description": "Replay consent must carry the authenticated Context Pack retention ceiling.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "replay-run",
+        "contextPack": "context-pack",
+        "manifestHistory": [
+          "replay-root",
+          "replay-first-lengthening",
+          "replay-unchanged",
+          "replay-second-lengthening"
+        ]
+      },
+      "options": {
+        "manifestRevisionOptions": [
+          {
+            "successorRevision": 2,
+            "successorDigest": "abf045c85ee6837f0f27e7afc04bb4c378bf9854801e7eb3dda607d4fbbbaa86",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:05:30.000Z",
+            "contextConsent": "project"
+          },
+          {
+            "successorRevision": 4,
+            "successorDigest": "a1c0f7f199dfa5b0d4f95b8b5f4ad9ddc4fc99a506dc6372b6dbba280e84e87e",
+            "freshConsent": true,
+            "freshConsentAt": "2026-08-16T20:07:30.000Z",
+            "contextConsent": "7-days"
+          }
+        ]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.manifestRevisionOptions[0].contextConsent"
+      }
+    },
+    {
+      "id": "research-run.device-local-pending-without-consent",
+      "description": "Device-local pending content sync requires run consent.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "device-local-pending-consent-false"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "run",
+        "code": "semantic_conflict",
+        "path": "$.artifactManifest.artifacts[0].contentSync"
+      }
+    },
+    {
+      "id": "research-run.device-local-pending-with-consent",
+      "description": "Device-local pending content sync accepts explicit run consent.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "device-local-pending-consent-true"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "research-run.device-local-synced-without-consent",
+      "description": "Device-local completed content sync requires run consent.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "device-local-synced-consent-false"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "run",
+        "code": "semantic_conflict",
+        "path": "$.artifactManifest.artifacts[0].contentSync"
+      }
+    },
+    {
+      "id": "research-run.device-local-synced-with-consent",
+      "description": "Device-local completed content sync accepts explicit run consent.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "device-local-synced-consent-true"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "research-run.device-local-failed-without-consent",
+      "description": "Device-local failed content sync still requires run consent.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "device-local-failed-consent-false"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "run",
+        "code": "semantic_conflict",
+        "path": "$.artifactManifest.artifacts[0].contentSync"
+      }
+    },
+    {
+      "id": "research-run.device-local-failed-with-consent",
+      "description": "Device-local failed content sync accepts explicit run consent.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "device-local-failed-consent-true"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "research-run.receipt-valid-binding",
+      "description": "A single-agent pinned receipt matches its selected familiar and provider/model.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "receipt-valid"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "research-run.receipt-wrong-familiar",
+      "description": "A single-agent receipt cannot attribute execution to another familiar.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "receipt-wrong-familiar"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "run",
+        "code": "semantic_conflict",
+        "path": "$.artifactManifest.modelExecutions[0].receipt.familiarId"
+      }
+    },
+    {
+      "id": "research-run.receipt-wrong-provider",
+      "description": "A pinned receipt cannot report a model from another provider.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "receipt-wrong-provider"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "run",
+        "code": "semantic_conflict",
+        "path": "$.artifactManifest.modelExecutions[0].receipt.effectiveModel"
+      }
+    },
+    {
+      "id": "research-run.receipt-wrong-model",
+      "description": "A pinned receipt cannot report another model from the selected provider.",
+      "validator": "research-run-context-pack",
+      "inputs": {
+        "run": "receipt-wrong-model"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "run",
+        "code": "semantic_conflict",
+        "path": "$.artifactManifest.modelExecutions[0].receipt.effectiveModel"
+      }
+    }
+  ]
+}

--- a/schemas/research/v1/fixtures/scenarios/run-event-deletion.scenario.json
+++ b/schemas/research/v1/fixtures/scenarios/run-event-deletion.scenario.json
@@ -1,0 +1,545 @@
+{
+  "format": "opencoven.research-protocol-scenarios/v1",
+  "family": "run-event-deletion",
+  "objects": {
+    "completed-deletion-run": {
+      "fixture": "scenarios/objects/completed-deletion-run.json"
+    },
+    "completed-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "sequence": 3,
+        "type": "run.status",
+        "data": {
+          "status": "completed"
+        }
+      }
+    },
+    "completed-event-other-run": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "runId": "run_other_01",
+        "sequence": 3,
+        "type": "run.status",
+        "data": {
+          "status": "completed"
+        }
+      }
+    },
+    "created-event": {
+      "fixture": "valid/run-event.json"
+    },
+    "created-event-other-run": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "runId": "run_other_01"
+      }
+    },
+    "deleted-count-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "at": "2026-08-17T19:30:00.000Z",
+        "sequence": 2,
+        "type": "content.deleted",
+        "data": {
+          "status": null,
+          "deletedObjectCount": 4,
+          "manifestStatus": "deleted"
+        }
+      }
+    },
+    "deleted-duplicate-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "at": "2026-08-17T19:30:00.000Z",
+        "sequence": 1,
+        "type": "content.deleted",
+        "data": {
+          "status": null,
+          "deletedObjectCount": 3,
+          "manifestStatus": "deleted"
+        }
+      }
+    },
+    "deleted-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "at": "2026-08-17T19:30:00.000Z",
+        "sequence": 2,
+        "type": "content.deleted",
+        "data": {
+          "status": null,
+          "deletedObjectCount": 3,
+          "manifestStatus": "deleted"
+        }
+      }
+    },
+    "deleted-event-other-run": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "at": "2026-08-17T19:30:00.000Z",
+        "runId": "run_other_01",
+        "sequence": 2,
+        "type": "content.deleted",
+        "data": {
+          "status": null,
+          "deletedObjectCount": 3,
+          "manifestStatus": "deleted"
+        }
+      }
+    },
+    "deleted-gap-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "at": "2026-08-17T19:30:00.000Z",
+        "sequence": 3,
+        "type": "content.deleted",
+        "data": {
+          "status": null,
+          "deletedObjectCount": 3,
+          "manifestStatus": "deleted"
+        }
+      }
+    },
+    "deleted-status-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "at": "2026-08-17T19:30:00.000Z",
+        "sequence": 2,
+        "type": "content.deleted",
+        "data": {
+          "status": null,
+          "deletedObjectCount": 3,
+          "manifestStatus": "active"
+        }
+      }
+    },
+    "deleted-content-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "at": "2026-08-17T19:30:00.000Z",
+        "sequence": 2,
+        "type": "content.deleted",
+        "data": {
+          "status": null,
+          "deletedObjectCount": 3,
+          "manifestStatus": "deleted",
+          "deletedcontentpayload": "private material"
+        }
+      }
+    },
+    "deleted-object-store-key-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "at": "2026-08-17T19:30:00.000Z",
+        "sequence": 2,
+        "type": "content.deleted",
+        "data": {
+          "status": null,
+          "deletedObjectCount": 3,
+          "manifestStatus": "deleted",
+          "audit": {
+            "object": {
+              "store": {
+                "key": "tenant/private/object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "deleted-nested-array-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "at": "2026-08-17T19:30:00.000Z",
+        "sequence": 2,
+        "type": "content.deleted",
+        "data": {
+          "status": null,
+          "deletedObjectCount": 3,
+          "manifestStatus": "deleted",
+          "auditTrail": [
+            {
+              "nested": {
+                "deletedContents": ["private material"]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "deleted-benign-audit-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "at": "2026-08-17T19:30:00.000Z",
+        "sequence": 2,
+        "type": "content.deleted",
+        "data": {
+          "status": null,
+          "deletedObjectCount": 3,
+          "manifestStatus": "deleted",
+          "audit": {
+            "context": "retention worker",
+            "contentment": "complete",
+            "objectives": "met",
+            "storefront": "closed",
+            "storagelike": "audit-only",
+            "bucketed": true,
+            "keystone": "retention",
+            "deletedcontentmentpayload": "benign",
+            "items": [
+              {
+                "retryDisposition": "not-needed"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "extra-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "sequence": 4,
+        "type": "run.status",
+        "data": {
+          "status": "completed"
+        }
+      }
+    },
+    "midstream-status-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "sequence": 2,
+        "type": "run.status",
+        "data": {
+          "status": "scoping"
+        }
+      }
+    },
+    "no-manifest-run": {
+      "fixture": "valid/research-run.json",
+      "mergePatch": {
+        "status": "scoping",
+        "waitingReason": null,
+        "waitingForPhase": null,
+        "nextEventSequence": 3
+      }
+    },
+    "partial-failure-run": {
+      "fixture": "scenarios/objects/completed-deletion-run.json",
+      "mergePatch": {
+        "artifactManifest": {
+          "retention": {
+            "status": "deletion_pending"
+          },
+          "deletion": {
+            "status": "partial_failure",
+            "completedAt": null,
+            "deletedObjectCount": null,
+            "eventSequence": null
+          }
+        }
+      },
+      "digestTargets": ["/artifactManifest"]
+    },
+    "scoping-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "sequence": 2,
+        "type": "run.status",
+        "data": {
+          "status": "scoping"
+        }
+      }
+    },
+    "wrong-receipt-run": {
+      "fixture": "scenarios/objects/completed-deletion-run.json",
+      "mergePatch": {
+        "artifactManifest": {
+          "deletion": {
+            "eventSequence": 4
+          }
+        }
+      },
+      "digestTargets": ["/artifactManifest"]
+    },
+    "wrong-type-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "sequence": 2,
+        "type": "run.status",
+        "data": {
+          "status": "completed"
+        }
+      }
+    }
+  },
+  "scenarios": [
+    {
+      "id": "run-deletion.valid-completed",
+      "description": "A complete ordered stream contains the content.deleted event named by the completed receipt.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-event", "completed-event"]
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "run-deletion.valid-benign-audit-extension",
+      "description": "A content.deleted event preserves recursively safe additive audit fields.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-benign-audit-event", "completed-event"]
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "run-deletion.rejects-deleted-content",
+      "description": "A content.deleted event cannot carry deleted content.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-content-event", "completed-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "events[1]",
+        "code": "semantic_conflict",
+        "path": "$.data.deletedcontentpayload"
+      }
+    },
+    {
+      "id": "run-deletion.rejects-object-store-key",
+      "description": "A content.deleted event cannot carry an object-store key.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-object-store-key-event", "completed-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "events[1]",
+        "code": "semantic_conflict",
+        "path": "$.data.audit.object.store.key"
+      }
+    },
+    {
+      "id": "run-deletion.rejects-nested-array-content",
+      "description": "A content.deleted event rejects sensitive keys nested through arrays.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-nested-array-event", "completed-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "events[1]",
+        "code": "semantic_conflict",
+        "path": "$.data.auditTrail[0].nested.deletedContents"
+      }
+    },
+    {
+      "id": "run-deletion.valid-no-manifest",
+      "description": "A non-completed run without a manifest accepts its complete ordered event stream.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "no-manifest-run",
+        "events": ["created-event", "scoping-event"]
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "run-deletion.partial-failure-retryable",
+      "description": "A partial-failure deletion remains valid and retryable without a completed deletion event.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "partial-failure-run",
+        "events": ["created-event", "midstream-status-event", "completed-event"]
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "run-deletion.partial-failure-incomplete-stream",
+      "description": "A partial-failure receipt does not permit an incomplete event stream.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "partial-failure-run",
+        "events": ["created-event", "midstream-status-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$"
+      }
+    },
+    {
+      "id": "run-deletion.truncated-stream",
+      "description": "A complete stream cannot omit its final persisted event.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$"
+      }
+    },
+    {
+      "id": "run-deletion.extra-stream",
+      "description": "A complete stream cannot contain an event beyond nextEventSequence.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-event", "completed-event", "extra-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$"
+      }
+    },
+    {
+      "id": "run-deletion.duplicate-sequence",
+      "description": "An event stream cannot repeat a sequence number.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-duplicate-event", "completed-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$[1].sequence"
+      }
+    },
+    {
+      "id": "run-deletion.gapped-sequence",
+      "description": "An event stream cannot skip a contiguous sequence number.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-gap-event", "completed-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$[1].sequence"
+      }
+    },
+    {
+      "id": "run-deletion.wrong-run-stream",
+      "description": "The event stream must belong to the enclosing run.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": [
+          "created-event-other-run",
+          "deleted-event-other-run",
+          "completed-event-other-run"
+        ]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$[0].runId"
+      }
+    },
+    {
+      "id": "run-deletion.mixed-run-stream",
+      "description": "Every event in one stream must identify the same run.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-event-other-run", "completed-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$[1].runId"
+      }
+    },
+    {
+      "id": "run-deletion.wrong-event-type",
+      "description": "The deletion receipt sequence must identify content.deleted.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "wrong-type-event", "completed-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$[1].type"
+      }
+    },
+    {
+      "id": "run-deletion.wrong-object-count",
+      "description": "The deletion event object count must match the receipt.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-count-event", "completed-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$[1].data.deletedObjectCount"
+      }
+    },
+    {
+      "id": "run-deletion.wrong-manifest-status",
+      "description": "The deletion event manifestStatus must be deleted.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "completed-deletion-run",
+        "events": ["created-event", "deleted-status-event", "completed-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "events[1]",
+        "code": "invalid_value",
+        "path": "$.data.manifestStatus"
+      }
+    },
+    {
+      "id": "run-deletion.wrong-receipt-sequence",
+      "description": "The deletion receipt eventSequence must identify its matching stream event.",
+      "validator": "run-event-deletion",
+      "inputs": {
+        "run": "wrong-receipt-run",
+        "events": ["created-event", "deleted-event", "completed-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.artifactManifest.deletion.eventSequence"
+      }
+    }
+  ]
+}

--- a/schemas/research/v1/fixtures/scenarios/run-event-sequence.scenario.json
+++ b/schemas/research/v1/fixtures/scenarios/run-event-sequence.scenario.json
@@ -1,0 +1,95 @@
+{
+  "format": "opencoven.research-protocol-scenarios/v1",
+  "family": "run-event-sequence",
+  "objects": {
+    "first-event": {
+      "fixture": "valid/run-event.json"
+    },
+    "gapped-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "sequence": 3,
+        "type": "run.status",
+        "data": {
+          "status": "scoping"
+        }
+      }
+    },
+    "other-run-second-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "runId": "run_other_01",
+        "sequence": 2,
+        "type": "run.status",
+        "data": {
+          "status": "scoping"
+        }
+      }
+    },
+    "second-event": {
+      "fixture": "valid/run-event.json",
+      "mergePatch": {
+        "sequence": 2,
+        "type": "run.status",
+        "data": {
+          "status": "scoping"
+        }
+      }
+    }
+  },
+  "scenarios": [
+    {
+      "id": "run-events.valid-sequence",
+      "description": "A direct event-sequence validation accepts one run's contiguous ordered stream.",
+      "validator": "run-event-sequence",
+      "inputs": {
+        "events": ["first-event", "second-event"]
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "run-events.empty-sequence",
+      "description": "A direct event-sequence validation rejects an empty stream.",
+      "validator": "run-event-sequence",
+      "inputs": {
+        "events": []
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$"
+      }
+    },
+    {
+      "id": "run-events.gapped-sequence",
+      "description": "A direct event-sequence validation rejects a gap in persisted sequence numbers.",
+      "validator": "run-event-sequence",
+      "inputs": {
+        "events": ["first-event", "gapped-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$[1].sequence"
+      }
+    },
+    {
+      "id": "run-events.mixed-run-sequence",
+      "description": "A direct event-sequence validation rejects events from another run.",
+      "validator": "run-event-sequence",
+      "inputs": {
+        "events": ["first-event", "other-run-second-event"]
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$[1].runId"
+      }
+    }
+  ]
+}

--- a/schemas/research/v1/fixtures/scenarios/run-manifest-revision.scenario.json
+++ b/schemas/research/v1/fixtures/scenarios/run-manifest-revision.scenario.json
@@ -1,0 +1,1081 @@
+{
+  "format": "opencoven.research-protocol-scenarios/v1",
+  "family": "run-manifest-revision",
+  "objects": {
+    "assembling": {
+      "fixture": "valid/run-manifest-assembling.json"
+    },
+    "active-shortening-next": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "revision": 3,
+        "previousDigest": "7bb2d0a7636bcf1b52b110f9d351cb8c7badfc3c89ace6cfeaecb75ae71ce1aa",
+        "retention": {
+          "policy": "7-days",
+          "effectivePolicy": "run-only",
+          "status": "active",
+          "updatedAt": "2026-08-16T20:07:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "active-shortening-previous": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "revision": 2,
+        "previousDigest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "retention": {
+          "policy": "7-days",
+          "effectivePolicy": "7-days",
+          "status": "active",
+          "updatedAt": "2026-08-16T20:06:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "broken-previous-digest": {
+      "fixture": "scenarios/objects/run-manifest-previous-digest.json"
+    },
+    "changed-manifest-id": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "id": "manifest_other_01"
+      },
+      "digestTargets": [""]
+    },
+    "changed-run-id": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "runId": "run_other_01"
+      },
+      "digestTargets": [""]
+    },
+    "completed-deletion-previous": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "retention": {
+          "status": "deleted",
+          "contentExpiresAt": "2026-08-17T20:00:00.000Z",
+          "updatedAt": "2026-08-17T20:00:00.000Z"
+        },
+        "deletion": {
+          "status": "completed",
+          "requestedAt": "2026-08-17T19:00:00.000Z",
+          "completedAt": "2026-08-17T20:00:00.000Z",
+          "deletedObjectCount": 3,
+          "eventSequence": 2
+        }
+      },
+      "digestTargets": [""]
+    },
+    "deadline-2099": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "retention": {
+          "contentExpiresAt": "2099-01-01T00:00:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "deadline-cleared": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "revision": 3,
+        "previousDigest": "242559b199acf0bd3277f9f3e7f0c27486ba3b50a44d130f7ff8a9f67807a2d8",
+        "retention": {
+          "updatedAt": "2026-08-17T20:01:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "deadline-extended": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "revision": 3,
+        "previousDigest": "242559b199acf0bd3277f9f3e7f0c27486ba3b50a44d130f7ff8a9f67807a2d8",
+        "retention": {
+          "contentExpiresAt": "2026-08-24T20:00:00.000Z",
+          "updatedAt": "2026-08-17T20:01:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "deadline-extended-beyond-consent": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "revision": 3,
+        "previousDigest": "242559b199acf0bd3277f9f3e7f0c27486ba3b50a44d130f7ff8a9f67807a2d8",
+        "retention": {
+          "contentExpiresAt": "2026-08-24T20:00:00.000000001Z",
+          "updatedAt": "2026-08-17T20:01:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "deadline-shortened": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "revision": 3,
+        "previousDigest": "242559b199acf0bd3277f9f3e7f0c27486ba3b50a44d130f7ff8a9f67807a2d8",
+        "retention": {
+          "contentExpiresAt": "2026-08-22T20:04:00.000Z",
+          "updatedAt": "2026-08-16T20:07:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "deletion-cancelled": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "revision": 2,
+        "previousDigest": "f24b9bbae5824bc848ab050c62056f8dcf73bd0c3a9bf8975d35b4cc8b8ab09c",
+        "retention": {
+          "contentExpiresAt": "2026-08-17T20:00:00.000Z",
+          "updatedAt": "2026-08-17T20:01:00.000Z"
+        },
+        "deletion": {
+          "requestedAt": "2026-08-17T19:00:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "final": {
+      "fixture": "valid/run-manifest-final-local.json"
+    },
+    "final-from-assembling": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "revision": 2,
+        "previousDigest": "7dcce4ad6b5ab349f157675f29310f23633e3fc05b383b1e931475b0c1bfb32d"
+      },
+      "digestTargets": [""]
+    },
+    "gapped-revision": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "revision": 3
+      },
+      "digestTargets": [""]
+    },
+    "lengthened-retention": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "retention": {
+          "effectivePolicy": "project"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "partial-usage-final": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "revision": 2,
+        "previousDigest": "7dcce4ad6b5ab349f157675f29310f23633e3fc05b383b1e931475b0c1bfb32d",
+        "modelExecutions": [
+          {
+            "taskId": "modeltask_partial_01",
+            "phase": "scope",
+            "attempt": 1,
+            "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "receipt": {
+              "familiarId": "sage",
+              "runtime": "copilot",
+              "effectiveModel": "gpt-5.6-sol",
+              "modelSource": "session",
+              "providerBilling": "user-connected",
+              "usage": {
+                "inputTokens": 100,
+                "outputTokens": null,
+                "costUsd": null,
+                "reportedByRuntime": true
+              }
+            }
+          }
+        ],
+        "usage": {
+          "inputTokens": 100,
+          "completeness": "partial"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "partial-failure-next": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "previousDigest": "f24b9bbae5824bc848ab050c62056f8dcf73bd0c3a9bf8975d35b4cc8b8ab09c",
+        "retention": {
+          "status": "deletion_pending",
+          "contentExpiresAt": "2026-08-17T20:00:00.000Z",
+          "updatedAt": "2026-08-17T20:01:00.000Z"
+        },
+        "deletion": {
+          "status": "pending",
+          "requestedAt": "2026-08-17T19:00:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "partial-failure-previous": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "retention": {
+          "status": "deletion_pending",
+          "contentExpiresAt": "2026-08-17T20:00:00.000Z",
+          "updatedAt": "2026-08-17T20:00:00.000Z"
+        },
+        "deletion": {
+          "status": "partial_failure",
+          "requestedAt": "2026-08-17T19:00:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "post-final-mutation": {
+      "fixture": "scenarios/objects/run-manifest-final-mutation.json"
+    },
+    "post-completed-pending": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "previousDigest": "73d4928072341a118a4c5d4b9e9d2d7180dd7ec80ed3dc46612a8d5ddf3026a9",
+        "retention": {
+          "status": "deletion_pending",
+          "contentExpiresAt": "2026-08-17T20:00:00.000Z",
+          "updatedAt": "2026-08-17T20:01:00.000Z"
+        },
+        "deletion": {
+          "status": "pending",
+          "requestedAt": "2026-08-17T19:00:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "scheduled": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "predecessor": "final"
+    },
+    "shortened-retention": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "retention": {
+          "effectivePolicy": "run-only",
+          "contentExpiresAt": "2026-08-17T20:04:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "shortened-retention-compliant-successor": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "revision": 3,
+        "previousDigest": "242559b199acf0bd3277f9f3e7f0c27486ba3b50a44d130f7ff8a9f67807a2d8",
+        "retention": {
+          "effectivePolicy": "run-only",
+          "contentExpiresAt": "2026-08-17T20:04:00.000Z",
+          "updatedAt": "2026-08-16T20:07:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "shortened-retention-over-ceiling": {
+      "fixture": "valid/run-manifest-retention-update.json",
+      "mergePatch": {
+        "revision": 3,
+        "previousDigest": "242559b199acf0bd3277f9f3e7f0c27486ba3b50a44d130f7ff8a9f67807a2d8",
+        "retention": {
+          "effectivePolicy": "run-only",
+          "updatedAt": "2026-08-16T20:07:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "contextless-original": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "context": null,
+        "sources": []
+      },
+      "digestTargets": [""]
+    },
+    "contextless-restoration-previous": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "predecessor": "contextless-original",
+      "mergePatch": {
+        "context": null,
+        "sources": [],
+        "revision": 2,
+        "previousDigest": "34e8bae7a9f6527d9d9e23dd97efb6ef3a61f712e1cb8becedf664c0d202eb6f",
+        "retention": {
+          "effectivePolicy": "run-only",
+          "status": "deletion_scheduled",
+          "contentExpiresAt": "2026-08-17T20:04:00.000Z",
+          "updatedAt": "2026-08-16T20:06:00.000Z"
+        },
+        "deletion": {
+          "status": "scheduled",
+          "requestedAt": "2026-08-16T20:06:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "contextless-restoration-next": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "context": null,
+        "sources": [],
+        "revision": 3,
+        "previousDigest": "ebdb999920883bb27d0998adf8ccf880c654a8bfeca9ca001dfe5ca7ceb4f7c4",
+        "retention": {
+          "status": "deletion_scheduled",
+          "contentExpiresAt": "2026-08-23T20:04:00.000Z",
+          "updatedAt": "2026-08-16T20:08:00.000Z"
+        },
+        "deletion": {
+          "status": "scheduled",
+          "requestedAt": "2026-08-16T20:06:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "contextless-beyond-original": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "context": null,
+        "sources": [],
+        "revision": 3,
+        "previousDigest": "ebdb999920883bb27d0998adf8ccf880c654a8bfeca9ca001dfe5ca7ceb4f7c4",
+        "retention": {
+          "effectivePolicy": "project",
+          "updatedAt": "2026-08-16T20:08:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "scheduled-project-previous": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "retention": {
+          "policy": "project",
+          "effectivePolicy": "project",
+          "status": "deletion_scheduled",
+          "contentExpiresAt": "2026-08-20T20:04:00.000Z",
+          "updatedAt": "2026-08-16T20:06:00.000Z"
+        },
+        "deletion": {
+          "status": "scheduled",
+          "requestedAt": "2026-08-16T20:06:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "scheduled-project-restoration": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "revision": 2,
+        "previousDigest": "b39c000b6bb145c1b49e9c137baa9fc2b9c0865ac595a1aa79005e00c08bc843",
+        "retention": {
+          "policy": "project",
+          "effectivePolicy": "project",
+          "updatedAt": "2026-08-16T20:08:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "pending-project-previous": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "retention": {
+          "policy": "project",
+          "effectivePolicy": "project",
+          "status": "deletion_pending",
+          "contentExpiresAt": "2026-08-20T20:04:00.000Z",
+          "updatedAt": "2026-08-16T20:06:00.000Z"
+        },
+        "deletion": {
+          "status": "pending",
+          "requestedAt": "2026-08-16T20:06:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "pending-project-restoration": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "revision": 2,
+        "previousDigest": "415ff350a8f461e2ced2d8a659ee6052ab2ed9ccad5d0b35588171284ba4de4e",
+        "retention": {
+          "policy": "project",
+          "effectivePolicy": "project",
+          "updatedAt": "2026-08-16T20:08:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "partial-failure-project-previous": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "retention": {
+          "policy": "project",
+          "effectivePolicy": "project",
+          "status": "deletion_pending",
+          "contentExpiresAt": "2026-08-20T20:04:00.000Z",
+          "updatedAt": "2026-08-16T20:06:00.000Z"
+        },
+        "deletion": {
+          "status": "partial_failure",
+          "requestedAt": "2026-08-16T20:06:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "partial-failure-project-restoration": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "revision": 2,
+        "previousDigest": "e4be85cea1c9566fe08b5a15647a2b7d6e3ff8295d5e9226f862b125b5c39f79",
+        "retention": {
+          "policy": "project",
+          "effectivePolicy": "project",
+          "updatedAt": "2026-08-16T20:08:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    },
+    "completed-project-previous": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "retention": {
+          "policy": "project",
+          "effectivePolicy": "project",
+          "status": "deleted",
+          "contentExpiresAt": "2026-08-20T20:04:00.000Z",
+          "updatedAt": "2026-08-16T20:07:00.000Z"
+        },
+        "deletion": {
+          "status": "completed",
+          "requestedAt": "2026-08-16T20:06:00.000Z",
+          "completedAt": "2026-08-16T20:07:00.000Z",
+          "deletedObjectCount": 1,
+          "eventSequence": 2
+        }
+      },
+      "digestTargets": [""]
+    },
+    "completed-project-restoration": {
+      "fixture": "valid/run-manifest-final-local.json",
+      "mergePatch": {
+        "revision": 2,
+        "previousDigest": "00959c9b7ae9b728e3ff7c51b9f8364a3cc14bc9a12f750ccb7f32d30a32145a",
+        "retention": {
+          "policy": "project",
+          "effectivePolicy": "project",
+          "updatedAt": "2026-08-16T20:09:00.000Z"
+        }
+      },
+      "digestTargets": [""]
+    }
+  },
+  "scenarios": [
+    {
+      "id": "manifest.assembling-to-final",
+      "description": "A valid assembling manifest advances to a linked final revision.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "assembling",
+        "next": "final-from-assembling"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest.partial-usage",
+      "description": "A linked final manifest accepts correct partial usage completeness and accounting.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "assembling",
+        "next": "partial-usage-final"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest.changed-manifest-id",
+      "description": "A linked revision cannot change the manifest identity.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "final",
+        "next": "changed-manifest-id"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.id"
+      }
+    },
+    {
+      "id": "manifest.changed-run-id",
+      "description": "A linked revision cannot move to another run.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "final",
+        "next": "changed-run-id"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.runId"
+      }
+    },
+    {
+      "id": "manifest.broken-previous-digest",
+      "description": "A linked revision must identify the immediately preceding manifest digest.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "final",
+        "next": "broken-previous-digest"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.previousDigest"
+      }
+    },
+    {
+      "id": "manifest.gapped-revision",
+      "description": "A linked manifest revision must advance by exactly one.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "final",
+        "next": "gapped-revision"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.revision"
+      }
+    },
+    {
+      "id": "manifest.post-final-mutation",
+      "description": "A final manifest cannot mutate immutable artifact metadata.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "final",
+        "next": "post-final-mutation"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.artifacts"
+      }
+    },
+    {
+      "id": "manifest.policy-shortening",
+      "description": "Effective retention may be shortened within the Context Pack ceiling.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "final",
+        "next": "shortened-retention"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest.policy-shortening-preserves-deletion-schedule",
+      "description": "A run-only-compliant successor preserves its required deletion schedule.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "scheduled",
+        "next": "shortened-retention-compliant-successor"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest.policy-shortening-revalidates-deadline",
+      "description": "A shortened effective policy revalidates an inherited deadline against its stricter ceiling.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "scheduled",
+        "next": "shortened-retention-over-ceiling"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.contentExpiresAt"
+      }
+    },
+    {
+      "id": "manifest.active-shortening",
+      "description": "A final revision that shortens effective retention must start a deletion clock.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "active-shortening-previous",
+        "next": "active-shortening-next"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "parse",
+        "input": "next",
+        "code": "semantic_conflict",
+        "path": "$.retention.status"
+      }
+    },
+    {
+      "id": "manifest.lengthening-without-fresh-consent",
+      "description": "Effective retention cannot be lengthened without fresh Context Pack consent.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "final",
+        "next": "lengthened-retention"
+      },
+      "options": {
+        "contextConsent": "project"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.effectivePolicy"
+      }
+    },
+    {
+      "id": "manifest.lengthening-with-fresh-consent",
+      "description": "Fresh consent permits effective retention lengthening within the Context Pack ceiling.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "final",
+        "next": "lengthened-retention"
+      },
+      "options": {
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-16T20:05:30.000Z",
+        "contextConsent": "project"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest.retention-ceiling",
+      "description": "Effective retention cannot exceed the Context Pack consent ceiling.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "final",
+        "next": "lengthened-retention"
+      },
+      "options": {
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-16T20:05:30.000Z",
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.effectivePolicy"
+      }
+    },
+    {
+      "id": "manifest.contextless-shortening",
+      "description": "A contextless manifest may shorten retention while preserving its original policy ceiling.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "contextless-original",
+        "next": "contextless-restoration-previous"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest.contextless-restoration-with-fresh-consent",
+      "description": "Fresh consent restores contextless retention up to its immutable original run policy.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "contextless-restoration-previous",
+        "next": "contextless-restoration-next"
+      },
+      "options": {
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-16T20:07:00.000Z"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest.contextless-restoration-without-fresh-consent",
+      "description": "A contextless retention restoration still requires explicit fresh consent.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "contextless-restoration-previous",
+        "next": "contextless-restoration-next"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.effectivePolicy"
+      }
+    },
+    {
+      "id": "manifest.contextless-restoration-with-stale-consent",
+      "description": "Consent at the prior contextless revision timestamp is stale.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "contextless-restoration-previous",
+        "next": "contextless-restoration-next"
+      },
+      "options": {
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-16T20:06:00.000Z"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.effectivePolicy"
+      }
+    },
+    {
+      "id": "manifest.contextless-restoration-beyond-original-policy",
+      "description": "An unrelated caller-supplied Context Pack cannot authorize contextless retention beyond the original run policy.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "contextless-restoration-previous",
+        "next": "contextless-beyond-original"
+      },
+      "options": {
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-16T20:07:00.000Z",
+        "contextConsent": "project"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.effectivePolicy"
+      }
+    },
+    {
+      "id": "manifest.scheduled-project-restoration-with-fresh-consent",
+      "description": "Fresh consent may cancel a merely scheduled project deletion and remove its deadline.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "scheduled-project-previous",
+        "next": "scheduled-project-restoration"
+      },
+      "options": {
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-16T20:07:00.000Z",
+        "contextConsent": "project"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest.scheduled-project-restoration-without-fresh-consent",
+      "description": "Removing a scheduled project deadline requires explicit fresh consent.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "scheduled-project-previous",
+        "next": "scheduled-project-restoration"
+      },
+      "options": {
+        "contextConsent": "project"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.contentExpiresAt"
+      }
+    },
+    {
+      "id": "manifest.scheduled-project-restoration-with-stale-consent",
+      "description": "Consent at the scheduled project revision timestamp is stale.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "scheduled-project-previous",
+        "next": "scheduled-project-restoration"
+      },
+      "options": {
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-16T20:06:00.000Z",
+        "contextConsent": "project"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.contentExpiresAt"
+      }
+    },
+    {
+      "id": "manifest.pending-project-restoration-with-fresh-consent",
+      "description": "Fresh consent cannot restore project retention after deletion enters pending work.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "pending-project-previous",
+        "next": "pending-project-restoration"
+      },
+      "options": {
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-16T20:07:00.000Z",
+        "contextConsent": "project"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.contentExpiresAt"
+      }
+    },
+    {
+      "id": "manifest.partial-failure-project-restoration-with-fresh-consent",
+      "description": "Fresh consent cannot restore project retention after a partial deletion failure.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "partial-failure-project-previous",
+        "next": "partial-failure-project-restoration"
+      },
+      "options": {
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-16T20:07:00.000Z",
+        "contextConsent": "project"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.contentExpiresAt"
+      }
+    },
+    {
+      "id": "manifest.completed-project-restoration-with-fresh-consent",
+      "description": "Fresh consent cannot restore project retention after deletion completed.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "completed-project-previous",
+        "next": "completed-project-restoration"
+      },
+      "options": {
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-16T20:08:00.000Z",
+        "contextConsent": "project"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.deletion.status"
+      }
+    },
+    {
+      "id": "manifest.partial-failure-continues",
+      "description": "A partial deletion failure may return to pending work in a linked revision.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "partial-failure-previous",
+        "next": "partial-failure-next"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest.deadline-2099",
+      "description": "A finite seven-day policy cannot schedule deletion in 2099.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "final",
+        "next": "deadline-2099"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.contentExpiresAt"
+      }
+    },
+    {
+      "id": "manifest.deadline-cleared",
+      "description": "A scheduled finite deletion deadline cannot be cleared.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "scheduled",
+        "next": "deadline-cleared"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.contentExpiresAt"
+      }
+    },
+    {
+      "id": "manifest.deletion-cancellation",
+      "description": "A deletion in partial failure cannot move back to scheduled.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "partial-failure-previous",
+        "next": "deletion-cancelled"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.status"
+      }
+    },
+    {
+      "id": "manifest.deadline-shortening",
+      "description": "A scheduled finite deletion deadline may move earlier.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "scheduled",
+        "next": "deadline-shortened"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest.deadline-extension-without-fresh-consent",
+      "description": "An unchanged finite policy cannot extend its deadline without fresh consent.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "scheduled",
+        "next": "deadline-extended"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.contentExpiresAt"
+      }
+    },
+    {
+      "id": "manifest.deadline-extension-with-stale-consent",
+      "description": "Consent at the prior revision timestamp is not fresh.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "scheduled",
+        "next": "deadline-extended"
+      },
+      "options": {
+        "contextConsent": "7-days",
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-16T20:06:00.000Z"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.contentExpiresAt"
+      }
+    },
+    {
+      "id": "manifest.deadline-extension-with-fresh-consent",
+      "description": "Newer explicit consent may extend a deadline within its new seven-day ceiling.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "scheduled",
+        "next": "deadline-extended"
+      },
+      "options": {
+        "contextConsent": "7-days",
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-17T20:00:00.000Z"
+      },
+      "expected": {
+        "ok": true
+      }
+    },
+    {
+      "id": "manifest.deadline-extension-exceeds-fresh-ceiling",
+      "description": "Fresh consent does not permit a deadline beyond its newly consented ceiling.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "scheduled",
+        "next": "deadline-extended-beyond-consent"
+      },
+      "options": {
+        "contextConsent": "7-days",
+        "freshConsent": true,
+        "freshConsentAt": "2026-08-17T20:00:00.000Z"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.retention.contentExpiresAt"
+      }
+    },
+    {
+      "id": "manifest.completed-deletion-terminal",
+      "description": "A completed deletion cannot return to pending in a later revision.",
+      "validator": "run-manifest-revision",
+      "inputs": {
+        "previous": "completed-deletion-previous",
+        "next": "post-completed-pending"
+      },
+      "options": {
+        "contextConsent": "7-days"
+      },
+      "expected": {
+        "ok": false,
+        "stage": "composition",
+        "code": "semantic_conflict",
+        "path": "$.deletion.status"
+      }
+    }
+  ]
+}

--- a/schemas/research/v1/fixtures/valid/context-pack.json
+++ b/schemas/research/v1/fixtures/valid/context-pack.json
@@ -1,0 +1,36 @@
+{
+  "schema": "opencoven.context-pack/v1",
+  "id": "ctx_01",
+  "digest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "createdBy": { "client": "coven-cave" },
+  "purpose": "research-run",
+  "subject": { "familiarId": "sage", "projectId": "project_01" },
+  "consent": {
+    "selectionMode": "explicit",
+    "allowRemoteQueries": true,
+    "allowRemoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days"
+  },
+  "resources": [{
+    "id": "resource_01",
+    "kind": "session",
+    "uri": "coven://session/session_01",
+    "digest": "0b9c966e9a7c4831f255cebbba0e7726fc8410ed32998179b32221097b404f9b",
+    "localBlobDigest": "4b94f5f75ee88c0e995251afe98fb468499215b33bbb6c18d01b1dd583f69e9d",
+    "selector": { "type": "turn-range", "start": 2, "end": 5 },
+    "trust": "mixed-conversation",
+    "sensitivity": "private",
+    "capturedAt": "2026-08-15T19:59:00.000Z",
+    "title": "Selected research discussion",
+    "mediaType": "application/json"
+  }],
+  "policy": {
+    "treatResourceTextAsData": true,
+    "toolAuthority": "none",
+    "allowedPurposes": ["research-run"]
+  },
+  "transforms": { "secretScanVersion": "1" },
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/valid/model-task-result.json
+++ b/schemas/research/v1/fixtures/valid/model-task-result.json
@@ -1,0 +1,32 @@
+{
+  "schema": "opencoven.model-task-result/v1",
+  "taskId": "modeltask_01",
+  "runId": "run_01",
+  "attempt": 1,
+  "inputDigest": "6a28b9d62b79b42a133d52fe51636c161c67722929efa5f6178e2940c9136597",
+  "output": {
+    "decision": "continue",
+    "digest": "output-field-is-canonical-data",
+    "futureExtension": { "preserve": true }
+  },
+  "outputDigest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "executorDeviceId": "device_01",
+  "modelReceipt": {
+    "familiarId": "sage",
+    "runtime": "copilot",
+    "effectiveModel": "gpt-5.6-sol",
+    "modelSource": "session",
+    "providerBilling": "user-connected",
+    "usage": {
+      "inputTokens": 100,
+      "outputTokens": 20,
+      "costUsd": null,
+      "reportedByRuntime": true,
+      "futureExtension": { "preserve": true }
+    },
+    "futureExtension": { "preserve": true }
+  },
+  "completedAt": "2026-08-15T20:10:00.000Z",
+  "signature": "base64-signature",
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/valid/model-task.json
+++ b/schemas/research/v1/fixtures/valid/model-task.json
@@ -1,0 +1,34 @@
+{
+  "schema": "opencoven.model-task/v1",
+  "id": "modeltask_01",
+  "runId": "run_01",
+  "phase": "scope",
+  "attempt": 1,
+  "inputDigest": "6a28b9d62b79b42a133d52fe51636c161c67722929efa5f6178e2940c9136597",
+  "input": {
+    "contextPack": {
+      "id": "ctx_01",
+      "digest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+      "availability": "device-local",
+      "futureExtension": { "preserve": true }
+    },
+    "publicEvidenceRefs": [],
+    "digest": "input-field-is-canonical-data",
+    "futureExtension": { "preserve": true }
+  },
+  "modelBinding": {
+    "familiarId": "sage",
+    "selection": "resolve-at-run-start",
+    "futureExtension": { "preserve": true }
+  },
+  "policy": {
+    "permissionMode": "read",
+    "allowedOutputs": ["scope"],
+    "allowRemoteQueries": false,
+    "maxOutputTokens": 1000,
+    "futureExtension": { "preserve": true }
+  },
+  "outputSchema": "opencoven.scope-output/v1",
+  "leaseExpiresAt": "2026-08-15T20:15:00.000Z",
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/valid/research-run-chronology-boundary.json
+++ b/schemas/research/v1/fixtures/valid/research-run-chronology-boundary.json
@@ -1,0 +1,66 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "context": {
+    "contextPackId": "ctx_01",
+    "contextPackDigest": "1111111111111111111111111111111111111111111111111111111111111111",
+    "topicProposalId": "proposal_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "acceptedTopic": {
+    "proposalId": "proposal_01",
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "waiting_for_executor",
+  "waitingReason": "executor",
+  "waitingForPhase": "challenge",
+  "createdAt": "2016-12-31T23:59:60Z",
+  "updatedAt": "2016-12-31T23:59:60Z",
+  "nextEventSequence": 2,
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/valid/research-run-embedded-retention-7-days-provisional.json
+++ b/schemas/research/v1/fixtures/valid/research-run-embedded-retention-7-days-provisional.json
@@ -1,0 +1,137 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "context": {
+    "contextPackId": "ctx_01",
+    "contextPackDigest": "1111111111111111111111111111111111111111111111111111111111111111",
+    "topicProposalId": "proposal_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "acceptedTopic": {
+    "proposalId": "proposal_01",
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "completed",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-20T20:04:00.000Z",
+  "nextEventSequence": 2,
+  "futureExtension": {
+    "preserve": true
+  },
+  "artifactManifest": {
+    "schema": "opencoven.run-manifest/v1",
+    "id": "manifest_final_local_01",
+    "runId": "run_01",
+    "digest": "edd1b15c77b6684cf9010cef9c4f90445fa5adafcfb461802f1b03f2d1057c4b",
+    "revision": 2,
+    "state": "final",
+    "createdAt": "2026-08-16T20:00:00.000Z",
+    "finalizedAt": "2026-08-16T20:04:00.000Z",
+    "context": {
+      "contextPackId": "ctx_01",
+      "contextPackDigest": "1111111111111111111111111111111111111111111111111111111111111111",
+      "topicProposalId": "proposal_01",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "sources": [
+      {
+        "kind": "context-pack",
+        "id": "ctx_01",
+        "digest": "1111111111111111111111111111111111111111111111111111111111111111",
+        "availability": "device-local",
+        "futureExtension": {
+          "preserve": true
+        }
+      }
+    ],
+    "artifacts": [
+      {
+        "id": "artifact_local_01",
+        "kind": "research-notes",
+        "title": "Research notes",
+        "mediaType": "text/markdown",
+        "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "bytes": 128,
+        "placement": "device-local",
+        "contentSync": "not-requested",
+        "createdAt": "2026-08-16T20:03:00.000Z",
+        "futureExtension": {
+          "preserve": true
+        }
+      }
+    ],
+    "modelExecutions": [],
+    "usage": {
+      "inputTokens": null,
+      "outputTokens": null,
+      "costUsd": null,
+      "completeness": "unreported",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "retention": {
+      "policy": "7-days",
+      "effectivePolicy": "7-days",
+      "status": "deletion_scheduled",
+      "contentExpiresAt": "2026-08-27T20:04:00.000Z",
+      "updatedAt": "2026-08-20T20:04:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "deletion": {
+      "status": "scheduled",
+      "requestedAt": "2026-08-20T20:04:00.000Z"
+    },
+    "futureExtension": {
+      "preserve": true
+    },
+    "previousDigest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  }
+}

--- a/schemas/research/v1/fixtures/valid/research-run-embedded-retention-run-only-provisional.json
+++ b/schemas/research/v1/fixtures/valid/research-run-embedded-retention-run-only-provisional.json
@@ -1,0 +1,137 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "context": {
+    "contextPackId": "ctx_01",
+    "contextPackDigest": "1111111111111111111111111111111111111111111111111111111111111111",
+    "topicProposalId": "proposal_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "acceptedTopic": {
+    "proposalId": "proposal_01",
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "run-only",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "completed",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-20T20:04:00.000Z",
+  "nextEventSequence": 2,
+  "futureExtension": {
+    "preserve": true
+  },
+  "artifactManifest": {
+    "schema": "opencoven.run-manifest/v1",
+    "id": "manifest_final_local_01",
+    "runId": "run_01",
+    "digest": "7b65013ebf9b45f81f668672f158d1cba3202b54ea6a547c223b4a0d75c1e17f",
+    "revision": 2,
+    "state": "final",
+    "createdAt": "2026-08-16T20:00:00.000Z",
+    "finalizedAt": "2026-08-16T20:04:00.000Z",
+    "context": {
+      "contextPackId": "ctx_01",
+      "contextPackDigest": "1111111111111111111111111111111111111111111111111111111111111111",
+      "topicProposalId": "proposal_01",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "sources": [
+      {
+        "kind": "context-pack",
+        "id": "ctx_01",
+        "digest": "1111111111111111111111111111111111111111111111111111111111111111",
+        "availability": "device-local",
+        "futureExtension": {
+          "preserve": true
+        }
+      }
+    ],
+    "artifacts": [
+      {
+        "id": "artifact_local_01",
+        "kind": "research-notes",
+        "title": "Research notes",
+        "mediaType": "text/markdown",
+        "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "bytes": 128,
+        "placement": "device-local",
+        "contentSync": "not-requested",
+        "createdAt": "2026-08-16T20:03:00.000Z",
+        "futureExtension": {
+          "preserve": true
+        }
+      }
+    ],
+    "modelExecutions": [],
+    "usage": {
+      "inputTokens": null,
+      "outputTokens": null,
+      "costUsd": null,
+      "completeness": "unreported",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "retention": {
+      "policy": "run-only",
+      "effectivePolicy": "run-only",
+      "status": "deletion_scheduled",
+      "contentExpiresAt": "2026-08-21T20:04:00.000Z",
+      "updatedAt": "2026-08-20T20:04:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "deletion": {
+      "status": "scheduled",
+      "requestedAt": "2026-08-20T20:04:00.000Z"
+    },
+    "futureExtension": {
+      "preserve": true
+    },
+    "previousDigest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  }
+}

--- a/schemas/research/v1/fixtures/valid/research-run-hosted-without-tenant.json
+++ b/schemas/research/v1/fixtures/valid/research-run-hosted-without-tenant.json
@@ -1,0 +1,35 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_hosted_without_tenant_01",
+  "acceptedTopic": {
+    "question": "How should hosted execution coordinate this run?",
+    "editedByUser": false
+  },
+  "execution": {
+    "location": "hosted",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "resolve-at-run-start"
+    },
+    "strategy": "orchestrator-workers"
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "run-only",
+    "allowMemoryPromotion": false
+  },
+  "bounds": {
+    "wallClockMinutes": 30,
+    "maxIterations": 3,
+    "sourceTarget": 6,
+    "checkpointEvery": 1,
+    "stopWhenCostUnavailable": true
+  },
+  "status": "queued",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:01:00.000Z",
+  "nextEventSequence": 1
+}

--- a/schemas/research/v1/fixtures/valid/research-run-hosted.json
+++ b/schemas/research/v1/fixtures/valid/research-run-hosted.json
@@ -1,0 +1,37 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_hosted_01",
+  "tenantOpaqueId": "tenant_alpha",
+  "acceptedTopic": {
+    "question": "How should hosted execution coordinate this run?",
+    "editedByUser": false
+  },
+  "execution": {
+    "location": "hosted",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "resolve-at-run-start"
+    },
+    "strategy": "orchestrator-workers"
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "run-only",
+    "allowMemoryPromotion": false
+  },
+  "bounds": {
+    "wallClockMinutes": 30,
+    "maxIterations": 3,
+    "sourceTarget": 6,
+    "checkpointEvery": 1,
+    "stopWhenCostUnavailable": true
+  },
+  "status": "queued",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:01:00.000Z",
+  "nextEventSequence": 1,
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/valid/research-run-paused.json
+++ b/schemas/research/v1/fixtures/valid/research-run-paused.json
@@ -1,0 +1,47 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_paused_01",
+  "context": {
+    "contextPackId": "ctx_01",
+    "contextPackDigest": "1111111111111111111111111111111111111111111111111111111111111111",
+    "topicProposalId": "proposal_01"
+  },
+  "acceptedTopic": {
+    "proposalId": "proposal_01",
+    "question": "How should checkpoint pauses preserve an active phase?",
+    "editedByUser": true
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol"
+    },
+    "strategy": "single-agent"
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true
+  },
+  "status": "publishing",
+  "waitingReason": "checkpoint",
+  "createdAt": "2026-08-17T19:00:00.000Z",
+  "updatedAt": "2026-08-17T19:01:00.000Z",
+  "nextEventSequence": 2,
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/valid/research-run-topic-provenance-absent.json
+++ b/schemas/research/v1/fixtures/valid/research-run-topic-provenance-absent.json
@@ -1,0 +1,57 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "acceptedTopic": {
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    "strategy": "single-agent",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "status": "waiting_for_executor",
+  "waitingReason": "executor",
+  "waitingForPhase": "challenge",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:01:00.000Z",
+  "nextEventSequence": 2,
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/valid/research-run.json
+++ b/schemas/research/v1/fixtures/valid/research-run.json
@@ -1,0 +1,52 @@
+{
+  "schema": "opencoven.research-run/v1",
+  "id": "run_01",
+  "context": {
+    "contextPackId": "ctx_01",
+    "contextPackDigest": "1111111111111111111111111111111111111111111111111111111111111111",
+    "topicProposalId": "proposal_01",
+    "futureExtension": { "preserve": true }
+  },
+  "acceptedTopic": {
+    "proposalId": "proposal_01",
+    "question": "How should the research executor resume this run?",
+    "editedByUser": true,
+    "futureExtension": { "preserve": true }
+  },
+  "execution": {
+    "location": "local",
+    "modelExecution": "cave-device",
+    "modelBinding": {
+      "familiarId": "sage",
+      "selection": "pinned",
+      "model": "gpt-5.6-sol",
+      "futureExtension": { "preserve": true }
+    },
+    "strategy": "single-agent",
+    "futureExtension": { "preserve": true }
+  },
+  "privacy": {
+    "remoteQueries": false,
+    "remoteContent": false,
+    "artifactContentSync": false,
+    "retention": "7-days",
+    "allowMemoryPromotion": false,
+    "futureExtension": { "preserve": true }
+  },
+  "bounds": {
+    "wallClockMinutes": 45,
+    "maxIterations": 4,
+    "sourceTarget": 8,
+    "maxSpendUsd": 0,
+    "checkpointEvery": 2,
+    "stopWhenCostUnavailable": true,
+    "futureExtension": { "preserve": true }
+  },
+  "status": "waiting_for_executor",
+  "waitingReason": "executor",
+  "waitingForPhase": "challenge",
+  "createdAt": "2026-08-15T20:00:00.000Z",
+  "updatedAt": "2026-08-15T20:01:00.000Z",
+  "nextEventSequence": 2,
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/valid/run-event-deletion-benign-extension.json
+++ b/schemas/research/v1/fixtures/valid/run-event-deletion-benign-extension.json
@@ -1,0 +1,23 @@
+{
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_deletion_benign_01",
+  "sequence": 2,
+  "type": "content.deleted",
+  "at": "2026-08-17T19:30:00.000Z",
+  "auditDisposition": {
+    "outcome": "complete",
+    "retryCount": 0
+  },
+  "data": {
+    "deletedObjectCount": 3,
+    "manifestStatus": "deleted",
+    "audit": {
+      "objectives": "met",
+      "storefront": "closed",
+      "storagelike": "audit-only",
+      "bucketed": true,
+      "keystone": "retention",
+      "deletedcontentmentpayload": "benign"
+    }
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-event-leap-second-historical.json
+++ b/schemas/research/v1/fixtures/valid/run-event-leap-second-historical.json
@@ -1,0 +1,11 @@
+{
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_leap_second_historical_01",
+  "sequence": 1,
+  "type": "run.created",
+  "at": "1972-06-30T23:59:60.123456789Z",
+  "data": {
+    "status": "queued",
+    "futureExtension": { "preserve": true }
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-event-leap-second.json
+++ b/schemas/research/v1/fixtures/valid/run-event-leap-second.json
@@ -1,0 +1,12 @@
+{
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_leap_second_01",
+  "sequence": 1,
+  "type": "run.created",
+  "at": "2016-12-31T23:59:60Z",
+  "data": {
+    "status": "queued",
+    "futureExtension": { "preserve": true }
+  },
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/valid/run-event-unicode-extension.json
+++ b/schemas/research/v1/fixtures/valid/run-event-unicode-extension.json
@@ -1,0 +1,20 @@
+{
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_01",
+  "sequence": 1,
+  "type": "run.status",
+  "at": "2026-08-17T19:30:00.000Z",
+  "data": {
+    "deletedObjectCount": 3,
+    "manifestStatus": "deleted",
+    "監査": {
+      "résumé": "préservé",
+      "аudit": {
+        "状態": "complete"
+      }
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-event.json
+++ b/schemas/research/v1/fixtures/valid/run-event.json
@@ -1,0 +1,12 @@
+{
+  "schema": "opencoven.run-event/v1",
+  "runId": "run_01",
+  "sequence": 1,
+  "type": "run.created",
+  "at": "2026-08-15T20:00:00.000Z",
+  "data": {
+    "status": "queued",
+    "futureExtension": { "preserve": true }
+  },
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-assembling.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-assembling.json
@@ -1,0 +1,58 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_final_local_01",
+  "runId": "run_final_local_01",
+  "digest": "7dcce4ad6b5ab349f157675f29310f23633e3fc05b383b1e931475b0c1bfb32d",
+  "revision": 1,
+  "state": "assembling",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-chronology-boundaries.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-chronology-boundaries.json
@@ -1,0 +1,102 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_chronology_boundaries_01",
+  "runId": "run_chronology_boundaries_01",
+  "digest": "0b2dd02956301097546bc67e75d5497139345dd81144073906afe44377325f52",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:10:00.000Z",
+  "sources": [
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_01",
+      "contentDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "snapshotDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "canonicalUrl": "https://www.iana.org/research",
+      "fetchedAt": "2026-08-16T20:00:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_cloud_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T20:10:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_cloud_01",
+      "phase": "synthesize",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1200,
+          "outputTokens": 300,
+          "costUsd": 0.42,
+          "reportedByRuntime": true,
+          "futureExtension": {
+            "preserve": true
+          }
+        },
+        "futureExtension": {
+          "preserve": true
+        }
+      },
+      "futureExtension": {
+        "preserve": true
+      },
+      "completedAt": "2099-12-31T23:59:59.000Z"
+    }
+  ],
+  "usage": {
+    "inputTokens": 1200,
+    "outputTokens": 300,
+    "costUsd": 0.42,
+    "completeness": "complete",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:10:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  },
+  "extensionMetadata": {
+    "recordedAt": "1900-01-01T00:00:00.000Z"
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-cost-exact-decimal.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-cost-exact-decimal.json
@@ -1,0 +1,122 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_exact_decimal_01",
+  "runId": "run_final_cloud_01",
+  "digest": "ae92a7f67ece618afbd02c1f14b8b0b7e9255eb5d8fe085c0142649d2eca9c69",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:10:00.000Z",
+  "context": {
+    "contextPackId": "ctx_cloud_01",
+    "contextPackDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_cloud_01",
+      "digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_01",
+      "contentDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "snapshotDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "canonicalUrl": "https://www.iana.org/research",
+      "fetchedAt": "2026-08-16T20:07:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_cloud_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T20:09:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_decimal_01",
+      "phase": "scope",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1,
+          "outputTokens": 1,
+          "costUsd": 0.1,
+          "reportedByRuntime": true
+        }
+      }
+    },
+    {
+      "taskId": "modeltask_decimal_02",
+      "phase": "scope",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1,
+          "outputTokens": 1,
+          "costUsd": 0.2,
+          "reportedByRuntime": true
+        }
+      }
+    }
+  ],
+  "usage": {
+    "inputTokens": 2,
+    "outputTokens": 2,
+    "costUsd": 0.3,
+    "completeness": "complete"
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:10:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-deletion-ascii-extension.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-deletion-ascii-extension.json
@@ -1,0 +1,83 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_deletion_ascii_extension_01",
+  "runId": "run_deletion_ascii_extension_01",
+  "digest": "ffce933725c3f88756e6153b50138b633ac3b57d20586d0cce97bcfb7b8f1325",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    },
+    "auditEnvelope": {
+      "disposition": "complete",
+      "batches": [
+        {
+          "attemptCount": 1,
+          "regionCode": "us-central"
+        }
+      ]
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-extension-boundaries.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-extension-boundaries.json
@@ -1,0 +1,120 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_extension_boundaries_01",
+  "runId": "run_extension_boundaries_01",
+  "digest": "a3e2072dd05a74aecb6df4bffe3583e9f3e59208e6de333f068e4fb7072107fb",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:10:00.000Z",
+  "context": {
+    "contextPackId": "ctx_extension_boundaries_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "extensionMetadata": {
+      "items": [{ "label": "context" }]
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_extension_boundaries_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "extensionMetadata": {
+        "items": [{ "label": "context source" }]
+      }
+    },
+    {
+      "kind": "public-evidence",
+      "id": "evidence_extension_boundaries_01",
+      "contentDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "snapshotDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "canonicalUrl": "http://www.iana.org/evidence",
+      "fetchedAt": "2026-08-16T20:07:00.000Z",
+      "extensionMetadata": {
+        "items": [{ "label": "public source" }]
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_extension_boundaries_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T20:09:00.000Z",
+      "extensionMetadata": {
+        "items": [{ "label": "artifact" }]
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_extension_boundaries_01",
+      "phase": "synthesize",
+      "attempt": 1,
+      "inputDigest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "outputDigest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": null,
+          "outputTokens": null,
+          "costUsd": null,
+          "reportedByRuntime": false,
+          "extensionMetadata": {
+            "items": [{ "label": "receipt usage" }]
+          }
+        },
+        "extensionMetadata": {
+          "items": [{ "label": "receipt" }]
+        }
+      },
+      "extensionMetadata": {
+        "items": [{ "label": "model execution" }]
+      }
+    }
+  ],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "extensionMetadata": {
+      "items": [{ "label": "manifest usage" }]
+    }
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:10:00.000Z",
+    "extensionMetadata": {
+      "items": [{ "label": "retention" }]
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "extensionMetadata": {
+      "items": [{ "label": "deletion" }]
+    }
+  },
+  "extensionMetadata": {
+    "context": "benign audit metadata",
+    "contentment": "benign audit metadata",
+    "textile": "benign audit metadata",
+    "pathology": "benign audit metadata",
+    "secretary": "benign audit metadata",
+    "credentialed": "benign audit metadata",
+    "items": [{ "label": "manifest root" }]
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-final-cloud.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-final-cloud.json
@@ -1,0 +1,114 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_final_cloud_01",
+  "runId": "run_final_cloud_01",
+  "digest": "b93f97eab4c93f58cdbfd72f1dc5abecc8070c6a7f2eba1f0e0c429edab39f78",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:10:00.000Z",
+  "context": {
+    "contextPackId": "ctx_cloud_01",
+    "contextPackDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_cloud_01",
+      "digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    },
+    {
+      "kind": "public-evidence",
+      "id": "evidence_public_01",
+      "contentDigest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "snapshotDigest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "canonicalUrl": "https://www.iana.org/research",
+      "fetchedAt": "2026-08-16T20:07:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_cloud_01",
+      "kind": "research-report",
+      "title": "Research report",
+      "mediaType": "text/markdown",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "bytes": 1024,
+      "placement": "cloud-content",
+      "contentSync": "synced",
+      "createdAt": "2026-08-16T20:09:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [
+    {
+      "taskId": "modeltask_cloud_01",
+      "phase": "synthesize",
+      "attempt": 1,
+      "inputDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "outputDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "receipt": {
+        "familiarId": "sage",
+        "runtime": "copilot",
+        "effectiveModel": "gpt-5.6-sol",
+        "modelSource": "session",
+        "providerBilling": "user-connected",
+        "usage": {
+          "inputTokens": 1200,
+          "outputTokens": 300,
+          "costUsd": 0.42,
+          "reportedByRuntime": true,
+          "futureExtension": {
+            "preserve": true
+          }
+        },
+        "futureExtension": {
+          "preserve": true
+        }
+      },
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "usage": {
+    "inputTokens": 1200,
+    "outputTokens": 300,
+    "costUsd": 0.42,
+    "completeness": "complete",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "project",
+    "effectivePolicy": "project",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:10:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-final-local.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-final-local.json
@@ -1,0 +1,74 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_final_local_01",
+  "runId": "run_final_local_01",
+  "digest": "4c7161996cbbcb51d3e13f7a27f0cac88a389e5765c9f6706898ef5329080579",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-nested-benign-extension.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-nested-benign-extension.json
@@ -1,0 +1,90 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_nested_benign_01",
+  "runId": "run_nested_benign_01",
+  "digest": "7867636d4db3680460fd6c659b8f0fe7c50eb4ab3a0083a131208de33822e507",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_nested_benign_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_nested_benign_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "metadata": {
+        "contextMetadata": {
+          "summaryLabel": "privateExcerpt"
+        },
+        "items": [
+          null,
+          true,
+          1,
+          {
+            "label": "local_file_path"
+          }
+        ]
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_nested_benign_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "metadata": {
+        "nested": [
+          {
+            "label": "safe",
+            "examples": [
+              "credentialHint",
+              "deletedContent"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z"
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "metadata": {
+      "objectives": "met",
+      "storefront": "closed",
+      "storagelike": "audit-only",
+      "bucketed": true,
+      "keystone": "retention",
+      "deletedcontentmentpayload": "benign",
+      "nested": [
+        {
+          "label": "safe",
+          "note": "objectKey"
+        }
+      ]
+    }
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-retention-7-days-boundary.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-retention-7-days-boundary.json
@@ -1,0 +1,30 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_7_days_boundary",
+  "runId": "run_7_days_boundary",
+  "digest": "abed97148673b646fb8cb1510e1c139ecb73cc15a0092b552bb7104dafcbe72f",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2026-08-23T20:04:00.000Z",
+    "updatedAt": "2026-08-16T20:04:00.000Z"
+  },
+  "deletion": {
+    "status": "scheduled",
+    "requestedAt": "2026-08-16T20:04:00.000Z"
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-retention-7-days-leap-boundary.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-retention-7-days-leap-boundary.json
@@ -1,0 +1,30 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_7_days_leap_boundary",
+  "runId": "run_7_days_leap_boundary",
+  "digest": "76767440497509b42a7a940fb6e782111542932e78db6e1aa9e2ebfd63d83b62",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2016-12-31T11:59:00Z",
+  "finalizedAt": "2016-12-31T12:00:00Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2017-01-07T11:59:59Z",
+    "updatedAt": "2016-12-31T12:00:00Z"
+  },
+  "deletion": {
+    "status": "scheduled",
+    "requestedAt": "2016-12-31T12:00:00Z"
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-retention-run-only-boundary.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-retention-run-only-boundary.json
@@ -1,0 +1,30 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_run_only_boundary",
+  "runId": "run_run_only_boundary",
+  "digest": "7d1f14b750cafb24364d221ededeee8baa41892a03bdfcb44721be3e5ba2bb22",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "run-only",
+    "effectivePolicy": "run-only",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2026-08-17T20:04:00.000Z",
+    "updatedAt": "2026-08-16T20:04:00.000Z"
+  },
+  "deletion": {
+    "status": "scheduled",
+    "requestedAt": "2026-08-16T20:04:00.000Z"
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-retention-run-only-leap-boundary.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-retention-run-only-leap-boundary.json
@@ -1,0 +1,30 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_run_only_leap_boundary",
+  "runId": "run_run_only_leap_boundary",
+  "digest": "fe969a82ee73c0a0a5ba53b9347ab7ca55ef552d41ad83720846225b8c144e08",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2016-12-31T11:59:00Z",
+  "finalizedAt": "2016-12-31T12:00:00Z",
+  "sources": [],
+  "artifacts": [],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported"
+  },
+  "retention": {
+    "policy": "run-only",
+    "effectivePolicy": "run-only",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2017-01-01T11:59:59Z",
+    "updatedAt": "2016-12-31T12:00:00Z"
+  },
+  "deletion": {
+    "status": "scheduled",
+    "requestedAt": "2016-12-31T12:00:00Z"
+  }
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-retention-update.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-retention-update.json
@@ -1,0 +1,76 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_final_local_01",
+  "runId": "run_final_local_01",
+  "digest": "242559b199acf0bd3277f9f3e7f0c27486ba3b50a44d130f7ff8a9f67807a2d8",
+  "revision": 2,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Research notes",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "deletion_scheduled",
+    "contentExpiresAt": "2026-08-23T20:04:00.000Z",
+    "updatedAt": "2026-08-16T20:06:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "scheduled",
+    "futureExtension": {
+      "preserve": true
+    },
+    "requestedAt": "2026-08-16T20:06:00.000Z"
+  },
+  "futureExtension": {
+    "preserve": true
+  },
+  "previousDigest": "4c7161996cbbcb51d3e13f7a27f0cac88a389e5765c9f6706898ef5329080579"
+}

--- a/schemas/research/v1/fixtures/valid/run-manifest-unicode-extension.json
+++ b/schemas/research/v1/fixtures/valid/run-manifest-unicode-extension.json
@@ -1,0 +1,80 @@
+{
+  "schema": "opencoven.run-manifest/v1",
+  "id": "manifest_unicode_extension_01",
+  "runId": "run_unicode_extension_01",
+  "digest": "bf1e40ae620a8c98d521875ae23d11221c7324161c70256989ab6ab42d06db4f",
+  "revision": 1,
+  "state": "final",
+  "createdAt": "2026-08-16T20:00:00.000Z",
+  "finalizedAt": "2026-08-16T20:04:00.000Z",
+  "context": {
+    "contextPackId": "ctx_local_01",
+    "contextPackDigest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topicProposalId": "proposal_local_01",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "sources": [
+    {
+      "kind": "context-pack",
+      "id": "ctx_local_01",
+      "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "availability": "device-local",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "id": "artifact_local_01",
+      "kind": "research-notes",
+      "title": "Résumé — 研究ノート",
+      "mediaType": "text/markdown",
+      "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "bytes": 128,
+      "placement": "device-local",
+      "contentSync": "not-requested",
+      "createdAt": "2026-08-16T20:03:00.000Z",
+      "futureExtension": {
+        "preserve": true
+      }
+    }
+  ],
+  "modelExecutions": [],
+  "usage": {
+    "inputTokens": null,
+    "outputTokens": null,
+    "costUsd": null,
+    "completeness": "unreported",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "retention": {
+    "policy": "7-days",
+    "effectivePolicy": "7-days",
+    "status": "active",
+    "contentExpiresAt": null,
+    "updatedAt": "2026-08-16T20:05:00.000Z",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "deletion": {
+    "status": "not_scheduled",
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  },
+  "研究メタデータ": {
+    "café": "préservé",
+    "аudit": {
+      "状態": "complete"
+    }
+  }
+}

--- a/schemas/research/v1/fixtures/valid/topic-discovery-job-chronology-boundary.json
+++ b/schemas/research/v1/fixtures/valid/topic-discovery-job-chronology-boundary.json
@@ -1,0 +1,35 @@
+{
+  "schema": "opencoven.topic-discovery-job/v1",
+  "id": "topicjob_01",
+  "contextPackId": "ctx_01",
+  "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "familiarId": "sage",
+  "status": "completed",
+  "requestedAt": "2016-12-31T23:59:60Z",
+  "startedAt": "2016-12-31T23:59:60Z",
+  "finishedAt": "2016-12-31T23:59:60Z",
+  "proposalIds": [
+    "proposal_01",
+    "proposal_02",
+    "proposal_03"
+  ],
+  "modelReceipt": {
+    "familiarId": "sage",
+    "runtime": "coven-cave",
+    "effectiveModel": "gpt-5-mini",
+    "modelSource": "runtime-default",
+    "providerBilling": "user-connected",
+    "usage": {
+      "inputTokens": 1200,
+      "outputTokens": 450,
+      "costUsd": 0.0125,
+      "reportedByRuntime": true
+    },
+    "futureExtension": {
+      "preserve": true
+    }
+  },
+  "futureExtension": {
+    "preserve": true
+  }
+}

--- a/schemas/research/v1/fixtures/valid/topic-discovery-job-seven.json
+++ b/schemas/research/v1/fixtures/valid/topic-discovery-job-seven.json
@@ -1,0 +1,20 @@
+{
+  "schema": "opencoven.topic-discovery-job/v1",
+  "id": "topicjob_seven_01",
+  "contextPackId": "ctx_01",
+  "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "familiarId": "sage",
+  "status": "completed",
+  "requestedAt": "2026-08-15T20:00:00.000Z",
+  "startedAt": "2026-08-15T20:01:00.000Z",
+  "finishedAt": "2026-08-15T20:06:00.000Z",
+  "proposalIds": [
+    "proposal_01",
+    "proposal_02",
+    "proposal_03",
+    "proposal_04",
+    "proposal_05",
+    "proposal_06",
+    "proposal_07"
+  ]
+}

--- a/schemas/research/v1/fixtures/valid/topic-discovery-job.json
+++ b/schemas/research/v1/fixtures/valid/topic-discovery-job.json
@@ -1,0 +1,27 @@
+{
+  "schema": "opencoven.topic-discovery-job/v1",
+  "id": "topicjob_01",
+  "contextPackId": "ctx_01",
+  "contextPackDigest": "db34941f93689f6d425cf48e7e046b885f6cee80c2e9790d1ad97cb26b3cd118",
+  "familiarId": "sage",
+  "status": "completed",
+  "requestedAt": "2026-08-15T20:00:00.000Z",
+  "startedAt": "2026-08-15T20:01:00.000Z",
+  "finishedAt": "2026-08-15T20:06:00.000Z",
+  "proposalIds": ["proposal_01", "proposal_02", "proposal_03"],
+  "modelReceipt": {
+    "familiarId": "sage",
+    "runtime": "coven-cave",
+    "effectiveModel": "gpt-5-mini",
+    "modelSource": "runtime-default",
+    "providerBilling": "user-connected",
+    "usage": {
+      "inputTokens": 1200,
+      "outputTokens": 450,
+      "costUsd": 0.0125,
+      "reportedByRuntime": true
+    },
+    "futureExtension": { "preserve": true }
+  },
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/fixtures/valid/topic-proposal.json
+++ b/schemas/research/v1/fixtures/valid/topic-proposal.json
@@ -1,0 +1,41 @@
+{
+  "schema": "opencoven.topic-proposal/v1",
+  "id": "proposal_01",
+  "discoveryJobId": "topicjob_01",
+  "contextPackId": "ctx_01",
+  "title": "A grounded question",
+  "question": "Which evidence should guide the decision?",
+  "whyNow": "The source set contains unresolved disagreement.",
+  "evidence": [
+    {
+      "resourceId": "resource_01",
+      "selector": { "type": "text-span", "start": 0, "end": 20 },
+      "excerpt": "Evidence excerpt",
+      "excerptDigest": "84e3d621a6705b03cc38559364169efff401aa7155f85cecd46b51660dd1ae42"
+    }
+  ],
+  "counterevidence": [],
+  "scores": {
+    "groundability": 4,
+    "decisionValue": 3,
+    "unresolvedness": 2,
+    "recurrence": 1,
+    "novelty": 4,
+    "timeliness": 2,
+    "familiarFit": 4,
+    "feasibility": 3,
+    "humanResonance": 4,
+    "riskPenalty": 2,
+    "visibleTotal": 2.64
+  },
+  "suggested": {
+    "mode": "brief",
+    "deliverable": "Decision brief",
+    "sourceTarget": 8,
+    "wallClockMinutes": 30
+  },
+  "uncertainty": "One source may be stale.",
+  "relatedMissionIds": ["mission_01"],
+  "createdAt": "2026-08-15T20:05:00.000Z",
+  "futureExtension": { "preserve": true }
+}

--- a/schemas/research/v1/model-task-result.schema.json
+++ b/schemas/research/v1/model-task-result.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "opencoven.model-task-result/v1",
+  "title": "OpenCoven Model Task Result v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "taskId",
+    "runId",
+    "attempt",
+    "inputDigest",
+    "output",
+    "outputDigest",
+    "executorDeviceId",
+    "modelReceipt",
+    "completedAt",
+    "signature"
+  ],
+  "properties": {
+    "schema": { "const": "opencoven.model-task-result/v1" },
+    "taskId": { "$ref": "#/$defs/modelTaskId" },
+    "runId": { "$ref": "#/$defs/runId" },
+    "attempt": { "$ref": "#/$defs/positiveSafeInteger" },
+    "inputDigest": { "$ref": "#/$defs/sha256" },
+    "output": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "outputDigest": { "$ref": "#/$defs/sha256" },
+    "executorDeviceId": { "$ref": "#/$defs/deviceId" },
+    "modelReceipt": { "$ref": "#/$defs/modelReceipt" },
+    "completedAt": { "$ref": "#/$defs/utcTimestamp" },
+    "signature": { "$ref": "#/$defs/nonEmptyString" }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "utcTimestamp": {
+      "type": "string",
+      "format": "date-time",
+      "minLength": 20,
+      "maxLength": 30,
+      "pattern": "^(?:(?:\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d)|(?:1972-(?:06-30|12-31)|197[3-9]-12-31|198[1235]-06-30|198[79]-12-31|1990-12-31|199[2347]-06-30|199[58]-12-31|200[58]-12-31|201[25]-06-30|2016-12-31)T23:59:60)(?:\\.\\d{1,9})?Z$"
+    },
+    "modelTaskId": {
+      "type": "string",
+      "pattern": "^modeltask_[A-Za-z0-9_-]+$"
+    },
+    "runId": {
+      "type": "string",
+      "pattern": "^run_[A-Za-z0-9_-]+$"
+    },
+    "deviceId": {
+      "type": "string",
+      "pattern": "^device_[A-Za-z0-9_-]+$"
+    },
+    "positiveSafeInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "nullableSafeInteger": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "nullableNonNegativeNumber": {
+      "type": ["number", "null"],
+      "minimum": 0
+    },
+    "modelUsage": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["inputTokens", "outputTokens", "costUsd", "reportedByRuntime"],
+      "properties": {
+        "inputTokens": { "$ref": "#/$defs/nullableSafeInteger" },
+        "outputTokens": { "$ref": "#/$defs/nullableSafeInteger" },
+        "costUsd": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "reportedByRuntime": { "type": "boolean" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "reportedByRuntime": { "const": false } },
+            "required": ["reportedByRuntime"]
+          },
+          "then": {
+            "properties": {
+              "inputTokens": { "const": null },
+              "outputTokens": { "const": null },
+              "costUsd": { "const": null }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "reportedByRuntime": { "const": true } },
+            "required": ["reportedByRuntime"]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": { "inputTokens": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 } },
+                "required": ["inputTokens"]
+              },
+              {
+                "properties": { "outputTokens": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 } },
+                "required": ["outputTokens"]
+              },
+              {
+                "properties": { "costUsd": { "type": "number", "minimum": 0 } },
+                "required": ["costUsd"]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "modelReceipt": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "familiarId",
+        "runtime",
+        "effectiveModel",
+        "modelSource",
+        "providerBilling",
+        "usage"
+      ],
+      "properties": {
+        "familiarId": { "type": "string" },
+        "runtime": { "type": "string" },
+        "effectiveModel": { "type": ["string", "null"] },
+        "modelSource": {
+          "enum": [
+            "next-message",
+            "session",
+            "familiar-default",
+            "runtime-default",
+            "global-default"
+          ]
+        },
+        "providerBilling": { "const": "user-connected" },
+        "usage": { "$ref": "#/$defs/modelUsage" }
+      }
+    }
+  }
+}

--- a/schemas/research/v1/model-task.schema.json
+++ b/schemas/research/v1/model-task.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "opencoven.model-task/v1",
+  "title": "OpenCoven Model Task v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "id",
+    "runId",
+    "phase",
+    "attempt",
+    "inputDigest",
+    "input",
+    "modelBinding",
+    "policy",
+    "outputSchema",
+    "leaseExpiresAt"
+  ],
+  "properties": {
+    "schema": { "const": "opencoven.model-task/v1" },
+    "id": { "$ref": "#/$defs/modelTaskId" },
+    "runId": { "$ref": "#/$defs/runId" },
+    "phase": { "enum": ["scope", "challenge", "synthesize", "control"] },
+    "attempt": { "$ref": "#/$defs/positiveSafeInteger" },
+    "inputDigest": { "$ref": "#/$defs/sha256" },
+    "input": { "$ref": "#/$defs/input" },
+    "modelBinding": { "$ref": "#/$defs/modelBinding" },
+    "policy": { "$ref": "#/$defs/policy" },
+    "outputSchema": { "type": "string" },
+    "leaseExpiresAt": { "$ref": "#/$defs/utcTimestamp" }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "utcTimestamp": {
+      "type": "string",
+      "format": "date-time",
+      "minLength": 20,
+      "maxLength": 30,
+      "pattern": "^(?:(?:\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d)|(?:1972-(?:06-30|12-31)|197[3-9]-12-31|198[1235]-06-30|198[79]-12-31|1990-12-31|199[2347]-06-30|199[58]-12-31|200[58]-12-31|201[25]-06-30|2016-12-31)T23:59:60)(?:\\.\\d{1,9})?Z$"
+    },
+    "modelTaskId": {
+      "type": "string",
+      "pattern": "^modeltask_[A-Za-z0-9_-]+$"
+    },
+    "runId": {
+      "type": "string",
+      "pattern": "^run_[A-Za-z0-9_-]+$"
+    },
+    "contextPackId": {
+      "type": "string",
+      "pattern": "^ctx_[A-Za-z0-9_-]+$"
+    },
+    "topicProposalId": {
+      "type": "string",
+      "pattern": "^proposal_[A-Za-z0-9_-]+$"
+    },
+    "positiveSafeInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["contextPack", "publicEvidenceRefs"],
+      "properties": {
+        "topicProposalId": { "$ref": "#/$defs/topicProposalId" },
+        "contextPack": { "$ref": "#/$defs/contextPack" },
+        "publicEvidenceRefs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nonEmptyString" },
+          "uniqueItems": true
+        }
+      }
+    },
+    "contextPack": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["id", "digest", "availability"],
+      "properties": {
+        "id": { "$ref": "#/$defs/contextPackId" },
+        "digest": { "$ref": "#/$defs/sha256" },
+        "availability": { "const": "device-local" }
+      }
+    },
+    "modelBinding": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["familiarId", "selection"],
+      "properties": {
+        "familiarId": { "type": "string" },
+        "selection": { "enum": ["resolve-at-run-start", "pinned"] },
+        "model": { "type": "string" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "selection": { "const": "pinned" } },
+            "required": ["selection"]
+          },
+          "then": {
+            "required": ["model"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "selection": { "const": "resolve-at-run-start" } },
+            "required": ["selection"]
+          },
+          "then": {
+            "not": { "required": ["model"] }
+          }
+        }
+      ]
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["permissionMode", "allowedOutputs", "allowRemoteQueries", "maxOutputTokens"],
+      "properties": {
+        "permissionMode": { "const": "read" },
+        "allowedOutputs": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" },
+          "uniqueItems": true
+        },
+        "allowRemoteQueries": { "type": "boolean" },
+        "maxOutputTokens": { "$ref": "#/$defs/positiveSafeInteger" }
+      }
+    }
+  }
+}

--- a/schemas/research/v1/research-run.schema.json
+++ b/schemas/research/v1/research-run.schema.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "opencoven.research-run/v1",
+  "title": "OpenCoven Research Run v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "id",
+    "acceptedTopic",
+    "execution",
+    "privacy",
+    "bounds",
+    "status",
+    "createdAt",
+    "updatedAt",
+    "nextEventSequence"
+  ],
+  "properties": {
+    "schema": { "const": "opencoven.research-run/v1" },
+    "id": { "$ref": "#/$defs/runId" },
+    "tenantOpaqueId": { "type": "string" },
+    "context": { "$ref": "#/$defs/contextBinding" },
+    "acceptedTopic": { "$ref": "#/$defs/acceptedTopic" },
+    "execution": { "$ref": "#/$defs/execution" },
+    "privacy": { "$ref": "#/$defs/privacy" },
+    "bounds": { "$ref": "#/$defs/bounds" },
+    "status": { "$ref": "#/$defs/status" },
+    "waitingReason": { "$ref": "#/$defs/waitingReason" },
+    "waitingForPhase": { "$ref": "#/$defs/waitingForPhase" },
+    "createdAt": { "$ref": "#/$defs/utcTimestamp" },
+    "updatedAt": { "$ref": "#/$defs/utcTimestamp" },
+    "nextEventSequence": { "$ref": "#/$defs/positiveSafeInteger" },
+    "artifactManifest": {
+      "$ref": "urn:opencoven:schema:research:run-manifest:v1"
+    },
+    "failure": { "$ref": "#/$defs/failure" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "execution": {
+            "properties": { "location": { "const": "local" } },
+            "required": ["location"]
+          }
+        },
+        "required": ["execution"]
+      },
+      "then": {
+        "not": { "required": ["tenantOpaqueId"] }
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "const": "waiting_for_executor" } },
+        "required": ["status"]
+      },
+      "then": {
+        "required": ["waitingForPhase"]
+      },
+      "else": {
+        "not": { "required": ["waitingForPhase"] }
+      }
+    },
+    {
+      "if": {
+        "properties": { "waitingReason": { "const": "checkpoint" } },
+        "required": ["waitingReason"]
+      },
+      "then": {
+        "properties": {
+          "status": {
+            "enum": [
+              "scoping",
+              "gathering_public_sources",
+              "challenging",
+              "synthesizing",
+              "controlling",
+              "awaiting_checkpoint",
+              "publishing"
+            ]
+          }
+        },
+        "required": ["status"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "waitingReason": {
+            "enum": ["executor", "provider-attention"]
+          }
+        },
+        "required": ["waitingReason"]
+      },
+      "then": {
+        "properties": { "status": { "const": "waiting_for_executor" } },
+        "required": ["status"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "const": "failed" } },
+        "required": ["status"]
+      },
+      "then": {
+        "required": ["failure"]
+      },
+      "else": {
+        "not": { "required": ["failure"] }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "enum": ["completed", "failed", "cancelled", "expired"]
+          }
+        },
+        "required": ["status"]
+      },
+      "then": {
+        "required": ["artifactManifest"],
+        "properties": {
+          "artifactManifest": {
+            "type": "object",
+            "properties": { "state": { "const": "final" } },
+            "required": ["state"]
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "artifactManifest": {
+            "type": "object",
+            "properties": { "state": { "const": "assembling" } },
+            "required": ["state"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "acceptedTopic": {
+            "required": ["proposalId"]
+          }
+        },
+        "required": ["acceptedTopic"]
+      },
+      "then": {
+        "properties": {
+          "context": {
+            "required": ["topicProposalId"]
+          }
+        },
+        "required": ["context"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "context": {
+            "required": ["topicProposalId"]
+          }
+        },
+        "required": ["context"]
+      },
+      "then": {
+        "properties": {
+          "acceptedTopic": {
+            "required": ["proposalId"]
+          }
+        },
+        "required": ["acceptedTopic"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "artifactManifest": {
+            "properties": {
+              "artifacts": {
+                "contains": {
+                  "properties": {
+                    "contentSync": {
+                      "enum": ["pending", "synced", "failed"]
+                    }
+                  },
+                  "required": ["contentSync"]
+                }
+              }
+            },
+            "required": ["artifacts"]
+          }
+        },
+        "required": ["artifactManifest"]
+      },
+      "then": {
+        "properties": {
+          "privacy": {
+            "properties": {
+              "artifactContentSync": { "const": true }
+            },
+            "required": ["artifactContentSync"]
+          }
+        },
+        "required": ["privacy"]
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "utcTimestamp": {
+      "type": "string",
+      "format": "date-time",
+      "minLength": 20,
+      "maxLength": 30,
+      "pattern": "^(?:(?:\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d)|(?:1972-(?:06-30|12-31)|197[3-9]-12-31|198[1235]-06-30|198[79]-12-31|1990-12-31|199[2347]-06-30|199[58]-12-31|200[58]-12-31|201[25]-06-30|2016-12-31)T23:59:60)(?:\\.\\d{1,9})?Z$"
+    },
+    "runId": {
+      "type": "string",
+      "pattern": "^run_[A-Za-z0-9_-]+$"
+    },
+    "contextPackId": {
+      "type": "string",
+      "pattern": "^ctx_[A-Za-z0-9_-]+$"
+    },
+    "topicProposalId": {
+      "type": "string",
+      "pattern": "^proposal_[A-Za-z0-9_-]+$"
+    },
+    "positiveSafeInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "nonNegativeNumber": {
+      "type": "number",
+      "minimum": 0
+    },
+    "status": {
+      "enum": [
+        "queued",
+        "scoping",
+        "gathering_public_sources",
+        "waiting_for_executor",
+        "challenging",
+        "synthesizing",
+        "controlling",
+        "awaiting_checkpoint",
+        "publishing",
+        "completed",
+        "failed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "waitingReason": {
+      "enum": ["executor", "checkpoint", "provider-attention"]
+    },
+    "waitingForPhase": {
+      "enum": ["scope", "challenge", "synthesize", "control"]
+    },
+    "contextBinding": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["contextPackId", "contextPackDigest"],
+      "properties": {
+        "contextPackId": { "$ref": "#/$defs/contextPackId" },
+        "contextPackDigest": { "$ref": "#/$defs/sha256" },
+        "topicProposalId": { "$ref": "#/$defs/topicProposalId" }
+      }
+    },
+    "acceptedTopic": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["question", "editedByUser"],
+      "properties": {
+        "proposalId": { "$ref": "#/$defs/topicProposalId" },
+        "question": { "type": "string" },
+        "editedByUser": { "type": "boolean" }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["location", "modelExecution", "modelBinding", "strategy"],
+      "properties": {
+        "location": { "enum": ["local", "hosted"] },
+        "modelExecution": { "enum": ["cave-device", "user-hosted-executor"] },
+        "modelBinding": { "$ref": "#/$defs/modelBinding" },
+        "strategy": { "enum": ["single-agent", "orchestrator-workers"] }
+      }
+    },
+    "modelBinding": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["familiarId", "selection"],
+      "properties": {
+        "familiarId": { "type": "string" },
+        "selection": { "enum": ["resolve-at-run-start", "pinned"] },
+        "model": { "type": "string" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "selection": { "const": "pinned" } },
+            "required": ["selection"]
+          },
+          "then": {
+            "required": ["model"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "selection": { "const": "resolve-at-run-start" } },
+            "required": ["selection"]
+          },
+          "then": {
+            "not": { "required": ["model"] }
+          }
+        }
+      ]
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "remoteQueries",
+        "remoteContent",
+        "artifactContentSync",
+        "retention",
+        "allowMemoryPromotion"
+      ],
+      "properties": {
+        "remoteQueries": { "type": "boolean" },
+        "remoteContent": { "type": "boolean" },
+        "artifactContentSync": { "type": "boolean" },
+        "retention": { "enum": ["run-only", "7-days", "project"] },
+        "allowMemoryPromotion": { "const": false }
+      }
+    },
+    "bounds": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "wallClockMinutes",
+        "maxIterations",
+        "sourceTarget",
+        "checkpointEvery",
+        "stopWhenCostUnavailable"
+      ],
+      "properties": {
+        "wallClockMinutes": { "$ref": "#/$defs/positiveSafeInteger" },
+        "maxIterations": { "$ref": "#/$defs/positiveSafeInteger" },
+        "sourceTarget": { "$ref": "#/$defs/positiveSafeInteger" },
+        "maxSpendUsd": { "$ref": "#/$defs/nonNegativeNumber" },
+        "checkpointEvery": { "$ref": "#/$defs/positiveSafeInteger" },
+        "stopWhenCostUnavailable": { "type": "boolean" }
+      }
+    },
+    "failure": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["code", "message", "retryable"],
+      "properties": {
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "retryable": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/schemas/research/v1/run-event.schema.json
+++ b/schemas/research/v1/run-event.schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "opencoven.run-event/v1",
+  "title": "OpenCoven Run Event v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["schema", "runId", "sequence", "type", "at", "data"],
+  "properties": {
+    "schema": { "const": "opencoven.run-event/v1" },
+    "runId": { "$ref": "#/$defs/runId" },
+    "sequence": { "$ref": "#/$defs/positiveSafeInteger" },
+    "type": { "$ref": "#/$defs/eventType" },
+    "at": { "$ref": "#/$defs/utcTimestamp" },
+    "data": { "$ref": "#/$defs/data" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "type": { "const": "content.deleted" } },
+        "required": ["type"]
+      },
+      "then": {
+        "propertyNames": {
+          "anyOf": [
+            {
+              "enum": ["schema", "runId", "sequence", "type", "at", "data"]
+            },
+            { "$ref": "#/$defs/deletionExtensionPropertyName" }
+          ]
+        },
+        "properties": {
+          "data": { "$ref": "#/$defs/contentDeletedData" }
+        },
+        "additionalProperties": {
+          "$ref": "#/$defs/deletionSafeExtensionValue"
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "runId": {
+      "type": "string",
+      "pattern": "^run_[A-Za-z0-9_-]+$"
+    },
+    "positiveSafeInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "utcTimestamp": {
+      "type": "string",
+      "format": "date-time",
+      "minLength": 20,
+      "maxLength": 30,
+      "pattern": "^(?:(?:\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d)|(?:1972-(?:06-30|12-31)|197[3-9]-12-31|198[1235]-06-30|198[79]-12-31|1990-12-31|199[2347]-06-30|199[58]-12-31|200[58]-12-31|201[25]-06-30|2016-12-31)T23:59:60)(?:\\.\\d{1,9})?Z$"
+    },
+    "eventType": {
+      "enum": [
+        "run.created",
+        "run.status",
+        "phase.started",
+        "phase.completed",
+        "model-task.available",
+        "model-task.leased",
+        "model-task.completed",
+        "checkpoint.required",
+        "artifact.registered",
+        "run.completed",
+        "run.failed",
+        "run.cancelled",
+        "retention.changed",
+        "content.deleted"
+      ]
+    },
+    "nonNegativeSafeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "sensitivePropertyName": {
+      "type": "string",
+      "allOf": [
+        {
+          "not": {
+            "pattern": "^(?:(?:[pP][rR][iI][vV][aA][tT][eE]|[pP][rR][iI][vV][aA][cC][yY]|[rR][aA][wW])[_.-]*)?(?:[pP][rR][oO][mM][pP][tT][sS]?|[eE][xX][cC][eE][rR][pP][tT][sS]?|[tT][eE][xX][tT][sS]?|[cC][oO][nN][tT][eE][nN][tT][sS]?|[bB][lL][oO][bB][sS]?|[fF][iI][lL][eE][nN][aA][mM][eE][sS]?|[pP][aA][tT][hH][sS]?|[cC][rR][eE][dD][eE][nN][tT][iI][aA][lL][sS]?|[sS][eE][cC][rR][eE][tT][sS]?|[lL][oO][cC][aA][lL][_.-]*[pP][aA][tT][hH][sS]?|[fF][iI][lL][eE][_.-]*[pP][aA][tT][hH][sS]?|[oO][bB][jJ][eE][cC][tT][_.-]*[kK][eE][yY][sS]?|[oO][bB][jJ][eE][cC][tT][_.-]*[sS][tT][oO][rR][eE][_.-]*[kK][eE][yY][sS]?|[sS][tT][oO][rR][aA][gG][eE][_.-]*[kK][eE][yY][sS]?|[bB][uU][cC][kK][eE][tT][_.-]*[kK][eE][yY][sS]?|[dD][eE][lL][eE][tT][eE][dD][_.-]*[cC][oO][nN][tT][eE][nN][tT][sS]?)(?:[_.-]*(?:[vV][aA][lL][uU][eE]|[vV][aA][lL][uU][eE][sS]|[dD][aA][tT][aA]|[fF][iI][eE][lL][dD]|[fF][iI][eE][lL][dD][sS]|[iI][tT][eE][mM]|[iI][tT][eE][mM][sS]|[lL][iI][sS][tT]|[mM][aA][pP]|[mM][eE][tT][aA][dD][aA][tT][aA]|[hH][iI][nN][tT]|[hH][iI][nN][tT][sS]|[rR][eE][fF]|[rR][eE][fF][sS]))?$"
+          }
+        },
+        {
+          "not": {
+            "pattern": "^(?:(?:[pP][rR][iI][vV][aA][tT][eE]|[pP][rR][iI][vV][aA][cC][yY]|[rR][aA][wW])[_.-]*)?(?:[pP][rR][oO][mM][pP][tT][sS]?|[eE][xX][cC][eE][rR][pP][tT][sS]?|[tT][eE][xX][tT][sS]?|[cC][oO][nN][tT][eE][nN][tT][sS]?|[bB][lL][oO][bB][sS]?|[fF][iI][lL][eE][nN][aA][mM][eE][sS]?|[pP][aA][tT][hH][sS]?|[cC][rR][eE][dD][eE][nN][tT][iI][aA][lL][sS]?|[sS][eE][cC][rR][eE][tT][sS]?|[lL][oO][cC][aA][lL][pP][aA][tT][hH][sS]?|[fF][iI][lL][eE][pP][aA][tT][hH][sS]?|[oO][bB][jJ][eE][cC][tT][kK][eE][yY][sS]?|[oO][bB][jJ][eE][cC][tT][sS][tT][oO][rR][eE][kK][eE][yY][sS]?|[sS][tT][oO][rR][aA][gG][eE][kK][eE][yY][sS]?|[bB][uU][cC][kK][eE][tT][kK][eE][yY][sS]?|[dD][eE][lL][eE][tT][eE][dD][cC][oO][nN][tT][eE][nN][tT][sS]?)(?:[pP][aA][yY][lL][oO][aA][dD])[sS]?$"
+          }
+        }
+      ],
+      "not": {
+        "pattern": "(?:(?:^|[_.-])(?:[pP][rR][oO][mM][pP][tT][sS]?|[eE][xX][cC][eE][rR][pP][tT][sS]?|[tT][eE][xX][tT][sS]?|[cC][oO][nN][tT][eE][nN][tT][sS]?|[bB][lL][oO][bB][sS]?|[fF][iI][lL][eE][nN][aA][mM][eE][sS]?|[pP][aA][tT][hH][sS]?|[cC][rR][eE][dD][eE][nN][tT][iI][aA][lL][sS]?|[sS][eE][cC][rR][eE][tT][sS]?|[lL][oO][cC][aA][lL][_.-]*[pP][aA][tT][hH][sS]?|[fF][iI][lL][eE][_.-]*[pP][aA][tT][hH][sS]?|[oO][bB][jJ][eE][cC][tT][_.-]*[kK][eE][yY][sS]?|[oO][bB][jJ][eE][cC][tT][_.-]*[sS][tT][oO][rR][eE][_.-]*[kK][eE][yY][sS]?|[sS][tT][oO][rR][aA][gG][eE][_.-]*[kK][eE][yY][sS]?|[bB][uU][cC][kK][eE][tT][_.-]*[kK][eE][yY][sS]?|[dD][eE][lL][eE][tT][eE][dD][_.-]*[cC][oO][nN][tT][eE][nN][tT][sS]?)(?:$|[_.-]|[A-Z0-9])|(?:^|[_.-]|[a-z0-9])(?:P[rR][oO][mM][pP][tT][sS]?|E[xX][cC][eE][rR][pP][tT][sS]?|T[eE][xX][tT][sS]?|C[oO][nN][tT][eE][nN][tT][sS]?|B[lL][oO][bB][sS]?|F[iI][lL][eE][nN][aA][mM][eE][sS]?|P[aA][tT][hH][sS]?|C[rR][eE][dD][eE][nN][tT][iI][aA][lL][sS]?|S[eE][cC][rR][eE][tT][sS]?|L[oO][cC][aA][lL][pP][aA][tT][hH][sS]?|F[iI][lL][eE][pP][aA][tT][hH][sS]?|O[bB][jJ][eE][cC][tT][kK][eE][yY][sS]?|O[bB][jJ][eE][cC][tT][sS][tT][oO][rR][eE][kK][eE][yY][sS]?|S[tT][oO][rR][aA][gG][eE][kK][eE][yY][sS]?|B[uU][cC][kK][eE][tT][kK][eE][yY][sS]?|D[eE][lL][eE][tT][eE][dD][cC][oO][nN][tT][eE][nN][tT][sS]?)(?:$|[_.-]|[A-Z0-9])|(?:^|[_.-]|[a-z0-9])(?:PROMPTS?|EXCERPTS?|TEXTS?|CONTENTS?|BLOBS?|FILENAMES?|PATHS?|CREDENTIALS?|SECRETS?|LOCALPATHS?|FILEPATHS?|OBJECTKEYS?|OBJECTSTOREKEYS?|STORAGEKEYS?|BUCKETKEYS?|DELETEDCONTENTS?)(?:$|[_.-]|[A-Za-z0-9]))"
+      }
+    },
+    "safeExtensionValue": {
+      "anyOf": [
+        {
+          "type": ["string", "number", "boolean", "null"]
+        },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/safeExtensionValue" }
+        },
+        {
+          "type": "object",
+          "propertyNames": { "$ref": "#/$defs/sensitivePropertyName" },
+          "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" }
+        }
+      ]
+    },
+    "deletionExtensionPropertyName": {
+      "type": "string",
+      "pattern": "^[\\x00-\\x7f]+$",
+      "allOf": [
+        { "$ref": "#/$defs/sensitivePropertyName" }
+      ]
+    },
+    "deletionSafeExtensionValue": {
+      "anyOf": [
+        {
+          "type": ["string", "number", "boolean", "null"]
+        },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/deletionSafeExtensionValue" }
+        },
+        {
+          "type": "object",
+          "propertyNames": {
+            "$ref": "#/$defs/deletionExtensionPropertyName"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/deletionSafeExtensionValue"
+          }
+        }
+      ]
+    },
+    "contentDeletedData": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/deletionSafeExtensionValue"
+      },
+      "propertyNames": {
+        "anyOf": [
+          { "enum": ["deletedObjectCount", "manifestStatus"] },
+          { "$ref": "#/$defs/deletionExtensionPropertyName" }
+        ]
+      },
+      "required": ["deletedObjectCount", "manifestStatus"],
+      "properties": {
+        "deletedObjectCount": { "$ref": "#/$defs/nonNegativeSafeInteger" },
+        "manifestStatus": { "const": "deleted" }
+      }
+    },
+    "data": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/research/v1/run-manifest.schema.json
+++ b/schemas/research/v1/run-manifest.schema.json
@@ -1,0 +1,817 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:opencoven:schema:research:run-manifest:v1",
+  "title": "OpenCoven Run Manifest v1",
+  "type": "object",
+  "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" },
+  "propertyNames": {
+    "anyOf": [
+      {
+        "enum": [
+          "schema",
+          "id",
+          "runId",
+          "digest",
+          "revision",
+          "previousDigest",
+          "state",
+          "createdAt",
+          "finalizedAt",
+          "context",
+          "sources",
+          "artifacts",
+          "modelExecutions",
+          "usage",
+          "retention",
+          "deletion"
+        ]
+      },
+      { "$ref": "#/$defs/sensitivePropertyName" }
+    ]
+  },
+  "required": [
+    "schema",
+    "id",
+    "runId",
+    "digest",
+    "revision",
+    "state",
+    "createdAt",
+    "sources",
+    "artifacts",
+    "modelExecutions",
+    "usage",
+    "retention",
+    "deletion"
+  ],
+  "properties": {
+    "schema": { "const": "opencoven.run-manifest/v1" },
+    "id": { "$ref": "#/$defs/manifestId" },
+    "runId": { "$ref": "#/$defs/runId" },
+    "digest": { "$ref": "#/$defs/sha256" },
+    "revision": { "$ref": "#/$defs/positiveSafeInteger" },
+    "previousDigest": { "$ref": "#/$defs/sha256" },
+    "state": { "enum": ["assembling", "final"] },
+    "createdAt": { "$ref": "#/$defs/utcTimestamp" },
+    "finalizedAt": { "$ref": "#/$defs/utcTimestamp" },
+    "context": { "$ref": "#/$defs/contextBinding" },
+    "sources": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/source" }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifact" }
+    },
+    "modelExecutions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/modelExecution" }
+    },
+    "usage": { "$ref": "#/$defs/usage" },
+    "retention": { "$ref": "#/$defs/retention" },
+    "deletion": { "$ref": "#/$defs/deletion" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "revision": { "const": 1 } },
+        "required": ["revision"]
+      },
+      "then": {
+        "not": { "required": ["previousDigest"] }
+      },
+      "else": {
+        "required": ["previousDigest"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "state": { "const": "assembling" } },
+        "required": ["state"]
+      },
+      "then": {
+        "not": { "required": ["finalizedAt"] }
+      },
+      "else": {
+        "required": ["finalizedAt"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "retention": {
+            "properties": { "status": { "const": "active" } },
+            "required": ["status"]
+          }
+        },
+        "required": ["retention"]
+      },
+      "then": {
+        "properties": {
+          "deletion": {
+            "properties": { "status": { "const": "not_scheduled" } },
+            "required": ["status"]
+          },
+          "retention": {
+            "properties": { "contentExpiresAt": { "const": null } },
+            "required": ["contentExpiresAt"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "retention": {
+            "properties": {
+              "status": {
+                "enum": ["deletion_scheduled", "deletion_pending", "deleted"]
+              }
+            },
+            "required": ["status"]
+          }
+        },
+        "required": ["retention"]
+      },
+      "then": {
+        "properties": {
+          "retention": {
+            "properties": {
+              "contentExpiresAt": { "$ref": "#/$defs/utcTimestamp" }
+            },
+            "required": ["contentExpiresAt"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "retention": {
+            "properties": { "status": { "const": "deletion_scheduled" } },
+            "required": ["status"]
+          }
+        },
+        "required": ["retention"]
+      },
+      "then": {
+        "properties": {
+          "deletion": {
+            "properties": { "status": { "const": "scheduled" } },
+            "required": ["status"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": { "const": "final" },
+          "retention": {
+            "anyOf": [
+              {
+                "properties": {
+                  "policy": { "const": "7-days" },
+                  "effectivePolicy": { "const": "run-only" }
+                },
+                "required": ["policy", "effectivePolicy"]
+              },
+              {
+                "properties": {
+                  "policy": { "const": "project" },
+                  "effectivePolicy": { "enum": ["run-only", "7-days"] }
+                },
+                "required": ["policy", "effectivePolicy"]
+              }
+            ]
+          }
+        },
+        "required": ["state", "retention"]
+      },
+      "then": {
+        "properties": {
+          "retention": {
+            "properties": {
+              "status": {
+                "enum": ["deletion_scheduled", "deletion_pending", "deleted"]
+              },
+              "contentExpiresAt": { "$ref": "#/$defs/utcTimestamp" }
+            },
+            "required": ["status", "contentExpiresAt"]
+          },
+          "deletion": {
+            "properties": {
+              "status": {
+                "enum": ["scheduled", "pending", "partial_failure", "completed"]
+              }
+            },
+            "required": ["status"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "retention": {
+            "properties": { "status": { "const": "deletion_pending" } },
+            "required": ["status"]
+          }
+        },
+        "required": ["retention"]
+      },
+      "then": {
+        "properties": {
+          "deletion": {
+            "properties": {
+              "status": { "enum": ["pending", "partial_failure"] }
+            },
+            "required": ["status"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "retention": {
+            "properties": { "status": { "const": "deleted" } },
+            "required": ["status"]
+          }
+        },
+        "required": ["retention"]
+      },
+      "then": {
+        "properties": {
+          "deletion": {
+            "properties": { "status": { "const": "completed" } },
+            "required": ["status"]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "deletion": {
+            "properties": {
+              "status": { "enum": ["scheduled", "pending", "partial_failure"] }
+            },
+            "required": ["status"]
+          }
+        },
+        "required": ["deletion"]
+      },
+      "then": {
+        "properties": {
+          "deletion": { "required": ["requestedAt"] }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "deletion": {
+            "properties": { "status": { "const": "completed" } },
+            "required": ["status"]
+          }
+        },
+        "required": ["deletion"]
+      },
+      "then": {
+        "properties": {
+          "deletion": {
+            "required": [
+              "requestedAt",
+              "completedAt",
+              "deletedObjectCount",
+              "eventSequence"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "sensitivePropertyName": {
+      "type": "string",
+      "allOf": [
+        {
+          "not": {
+            "pattern": "^(?:(?:[pP][rR][iI][vV][aA][tT][eE]|[pP][rR][iI][vV][aA][cC][yY]|[rR][aA][wW])[_.-]*)?(?:[pP][rR][oO][mM][pP][tT][sS]?|[eE][xX][cC][eE][rR][pP][tT][sS]?|[tT][eE][xX][tT][sS]?|[cC][oO][nN][tT][eE][nN][tT][sS]?|[bB][lL][oO][bB][sS]?|[fF][iI][lL][eE][nN][aA][mM][eE][sS]?|[pP][aA][tT][hH][sS]?|[cC][rR][eE][dD][eE][nN][tT][iI][aA][lL][sS]?|[sS][eE][cC][rR][eE][tT][sS]?|[lL][oO][cC][aA][lL][_.-]*[pP][aA][tT][hH][sS]?|[fF][iI][lL][eE][_.-]*[pP][aA][tT][hH][sS]?|[oO][bB][jJ][eE][cC][tT][_.-]*[kK][eE][yY][sS]?|[oO][bB][jJ][eE][cC][tT][_.-]*[sS][tT][oO][rR][eE][_.-]*[kK][eE][yY][sS]?|[sS][tT][oO][rR][aA][gG][eE][_.-]*[kK][eE][yY][sS]?|[bB][uU][cC][kK][eE][tT][_.-]*[kK][eE][yY][sS]?|[dD][eE][lL][eE][tT][eE][dD][_.-]*[cC][oO][nN][tT][eE][nN][tT][sS]?)(?:[_.-]*(?:[vV][aA][lL][uU][eE]|[vV][aA][lL][uU][eE][sS]|[dD][aA][tT][aA]|[fF][iI][eE][lL][dD]|[fF][iI][eE][lL][dD][sS]|[iI][tT][eE][mM]|[iI][tT][eE][mM][sS]|[lL][iI][sS][tT]|[mM][aA][pP]|[mM][eE][tT][aA][dD][aA][tT][aA]|[hH][iI][nN][tT]|[hH][iI][nN][tT][sS]|[rR][eE][fF]|[rR][eE][fF][sS]))?$"
+          }
+        },
+        {
+          "not": {
+            "pattern": "^(?:(?:[pP][rR][iI][vV][aA][tT][eE]|[pP][rR][iI][vV][aA][cC][yY]|[rR][aA][wW])[_.-]*)?(?:[pP][rR][oO][mM][pP][tT][sS]?|[eE][xX][cC][eE][rR][pP][tT][sS]?|[tT][eE][xX][tT][sS]?|[cC][oO][nN][tT][eE][nN][tT][sS]?|[bB][lL][oO][bB][sS]?|[fF][iI][lL][eE][nN][aA][mM][eE][sS]?|[pP][aA][tT][hH][sS]?|[cC][rR][eE][dD][eE][nN][tT][iI][aA][lL][sS]?|[sS][eE][cC][rR][eE][tT][sS]?|[lL][oO][cC][aA][lL][pP][aA][tT][hH][sS]?|[fF][iI][lL][eE][pP][aA][tT][hH][sS]?|[oO][bB][jJ][eE][cC][tT][kK][eE][yY][sS]?|[oO][bB][jJ][eE][cC][tT][sS][tT][oO][rR][eE][kK][eE][yY][sS]?|[sS][tT][oO][rR][aA][gG][eE][kK][eE][yY][sS]?|[bB][uU][cC][kK][eE][tT][kK][eE][yY][sS]?|[dD][eE][lL][eE][tT][eE][dD][cC][oO][nN][tT][eE][nN][tT][sS]?)(?:[pP][aA][yY][lL][oO][aA][dD])[sS]?$"
+          }
+        }
+      ],
+      "not": {
+        "pattern": "(?:(?:^|[_.-])(?:[pP][rR][oO][mM][pP][tT][sS]?|[eE][xX][cC][eE][rR][pP][tT][sS]?|[tT][eE][xX][tT][sS]?|[cC][oO][nN][tT][eE][nN][tT][sS]?|[bB][lL][oO][bB][sS]?|[fF][iI][lL][eE][nN][aA][mM][eE][sS]?|[pP][aA][tT][hH][sS]?|[cC][rR][eE][dD][eE][nN][tT][iI][aA][lL][sS]?|[sS][eE][cC][rR][eE][tT][sS]?|[lL][oO][cC][aA][lL][_.-]*[pP][aA][tT][hH][sS]?|[fF][iI][lL][eE][_.-]*[pP][aA][tT][hH][sS]?|[oO][bB][jJ][eE][cC][tT][_.-]*[kK][eE][yY][sS]?|[oO][bB][jJ][eE][cC][tT][_.-]*[sS][tT][oO][rR][eE][_.-]*[kK][eE][yY][sS]?|[sS][tT][oO][rR][aA][gG][eE][_.-]*[kK][eE][yY][sS]?|[bB][uU][cC][kK][eE][tT][_.-]*[kK][eE][yY][sS]?|[dD][eE][lL][eE][tT][eE][dD][_.-]*[cC][oO][nN][tT][eE][nN][tT][sS]?)(?:$|[_.-]|[A-Z0-9])|(?:^|[_.-]|[a-z0-9])(?:P[rR][oO][mM][pP][tT][sS]?|E[xX][cC][eE][rR][pP][tT][sS]?|T[eE][xX][tT][sS]?|C[oO][nN][tT][eE][nN][tT][sS]?|B[lL][oO][bB][sS]?|F[iI][lL][eE][nN][aA][mM][eE][sS]?|P[aA][tT][hH][sS]?|C[rR][eE][dD][eE][nN][tT][iI][aA][lL][sS]?|S[eE][cC][rR][eE][tT][sS]?|L[oO][cC][aA][lL][pP][aA][tT][hH][sS]?|F[iI][lL][eE][pP][aA][tT][hH][sS]?|O[bB][jJ][eE][cC][tT][kK][eE][yY][sS]?|O[bB][jJ][eE][cC][tT][sS][tT][oO][rR][eE][kK][eE][yY][sS]?|S[tT][oO][rR][aA][gG][eE][kK][eE][yY][sS]?|B[uU][cC][kK][eE][tT][kK][eE][yY][sS]?|D[eE][lL][eE][tT][eE][dD][cC][oO][nN][tT][eE][nN][tT][sS]?)(?:$|[_.-]|[A-Z0-9])|(?:^|[_.-]|[a-z0-9])(?:PROMPTS?|EXCERPTS?|TEXTS?|CONTENTS?|BLOBS?|FILENAMES?|PATHS?|CREDENTIALS?|SECRETS?|LOCALPATHS?|FILEPATHS?|OBJECTKEYS?|OBJECTSTOREKEYS?|STORAGEKEYS?|BUCKETKEYS?|DELETEDCONTENTS?)(?:$|[_.-]|[A-Za-z0-9]))"
+      }
+    },
+    "safeExtensionValue": {
+      "anyOf": [
+        {
+          "type": ["string", "number", "boolean", "null"]
+        },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/safeExtensionValue" }
+        },
+        {
+          "type": "object",
+          "propertyNames": { "$ref": "#/$defs/sensitivePropertyName" },
+          "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" }
+        }
+      ]
+    },
+    "deletionExtensionPropertyName": {
+      "type": "string",
+      "pattern": "^[\\x00-\\x7f]+$",
+      "allOf": [
+        { "$ref": "#/$defs/sensitivePropertyName" }
+      ]
+    },
+    "deletionSafeExtensionValue": {
+      "anyOf": [
+        {
+          "type": ["string", "number", "boolean", "null"]
+        },
+        {
+          "type": "array",
+          "items": { "$ref": "#/$defs/deletionSafeExtensionValue" }
+        },
+        {
+          "type": "object",
+          "propertyNames": {
+            "$ref": "#/$defs/deletionExtensionPropertyName"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/deletionSafeExtensionValue"
+          }
+        }
+      ]
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "utcTimestamp": {
+      "type": "string",
+      "format": "date-time",
+      "minLength": 20,
+      "maxLength": 30,
+      "pattern": "^(?:(?:\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d)|(?:1972-(?:06-30|12-31)|197[3-9]-12-31|198[1235]-06-30|198[79]-12-31|1990-12-31|199[2347]-06-30|199[58]-12-31|200[58]-12-31|201[25]-06-30|2016-12-31)T23:59:60)(?:\\.\\d{1,9})?Z$"
+    },
+    "manifestId": {
+      "type": "string",
+      "pattern": "^manifest_[A-Za-z0-9_-]+$"
+    },
+    "runId": {
+      "type": "string",
+      "pattern": "^run_[A-Za-z0-9_-]+$"
+    },
+    "contextPackId": {
+      "type": "string",
+      "pattern": "^ctx_[A-Za-z0-9_-]+$"
+    },
+    "topicProposalId": {
+      "type": "string",
+      "pattern": "^proposal_[A-Za-z0-9_-]+$"
+    },
+    "evidenceId": {
+      "type": "string",
+      "pattern": "^evidence_[A-Za-z0-9_-]+$"
+    },
+    "artifactId": {
+      "type": "string",
+      "pattern": "^artifact_[A-Za-z0-9_-]+$"
+    },
+    "modelTaskId": {
+      "type": "string",
+      "pattern": "^modeltask_[A-Za-z0-9_-]+$"
+    },
+    "positiveSafeInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "nonNegativeSafeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "nonNegativeNumber": {
+      "type": "number",
+      "minimum": 0
+    },
+    "nullableSafeInteger": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "nullableNonNegativeNumber": {
+      "type": ["number", "null"],
+      "minimum": 0
+    },
+    "nullableTimestamp": {
+      "anyOf": [
+        { "$ref": "#/$defs/utcTimestamp" },
+        { "type": "null" }
+      ]
+    },
+    "contextBinding": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" },
+      "propertyNames": {
+        "anyOf": [
+          { "enum": ["contextPackId", "contextPackDigest", "topicProposalId"] },
+          { "$ref": "#/$defs/sensitivePropertyName" }
+        ]
+      },
+      "required": ["contextPackId", "contextPackDigest"],
+      "properties": {
+        "contextPackId": { "$ref": "#/$defs/contextPackId" },
+        "contextPackDigest": { "$ref": "#/$defs/sha256" },
+        "topicProposalId": { "$ref": "#/$defs/topicProposalId" }
+      }
+    },
+    "source": {
+      "oneOf": [
+        { "$ref": "#/$defs/contextPackSource" },
+        { "$ref": "#/$defs/publicEvidenceSource" }
+      ]
+    },
+    "contextPackSource": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" },
+      "propertyNames": {
+        "anyOf": [
+          { "enum": ["kind", "id", "digest", "availability"] },
+          { "$ref": "#/$defs/sensitivePropertyName" }
+        ]
+      },
+      "required": ["kind", "id", "digest", "availability"],
+      "properties": {
+        "kind": { "const": "context-pack" },
+        "id": { "$ref": "#/$defs/contextPackId" },
+        "digest": { "$ref": "#/$defs/sha256" },
+        "availability": { "const": "device-local" }
+      }
+    },
+    "publicEvidenceSource": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "enum": [
+              "kind",
+              "id",
+              "contentDigest",
+              "snapshotDigest",
+              "canonicalUrl",
+              "fetchedAt"
+            ]
+          },
+          { "$ref": "#/$defs/sensitivePropertyName" }
+        ]
+      },
+      "required": [
+        "kind",
+        "id",
+        "contentDigest",
+        "snapshotDigest",
+        "canonicalUrl",
+        "fetchedAt"
+      ],
+      "properties": {
+        "kind": { "const": "public-evidence" },
+        "id": { "$ref": "#/$defs/evidenceId" },
+        "contentDigest": { "$ref": "#/$defs/sha256" },
+        "snapshotDigest": { "$ref": "#/$defs/sha256" },
+        "canonicalUrl": {
+          "type": "string",
+          "minLength": 1,
+          "description": "A canonical public URL whose stored value exactly equals WHATWG URL.href serialization, including the root slash.",
+          "allOf": [
+            {
+              "pattern": "^https?://[^\\s\\\\/?#@]+(?:[/?][^\\s\\\\#]*)?$"
+            },
+            {
+              "not": {
+                "pattern": "^https?://[^/?#]*@"
+              }
+            },
+            { "not": { "pattern": "#" } }
+          ]
+        },
+        "fetchedAt": { "$ref": "#/$defs/utcTimestamp" }
+      }
+    },
+    "artifactTitle": {
+      "type": "string",
+      "allOf": [
+        { "not": { "pattern": "[/\\\\]" } },
+        {
+          "not": {
+            "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:"
+          }
+        },
+        {
+          "not": {
+            "pattern": "[\\u0000-\\u001f\\u007f-\\u009f]"
+          }
+        },
+        { "not": { "pattern": "(?:sk-|ghp_|github_pat_)" } }
+      ]
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "enum": [
+              "id",
+              "kind",
+              "title",
+              "mediaType",
+              "digest",
+              "bytes",
+              "placement",
+              "contentSync",
+              "createdAt"
+            ]
+          },
+          { "$ref": "#/$defs/sensitivePropertyName" }
+        ]
+      },
+      "required": [
+        "id",
+        "kind",
+        "title",
+        "mediaType",
+        "digest",
+        "bytes",
+        "placement",
+        "contentSync",
+        "createdAt"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/artifactId" },
+        "kind": { "type": "string" },
+        "title": { "$ref": "#/$defs/artifactTitle" },
+        "mediaType": { "type": "string" },
+        "digest": { "$ref": "#/$defs/sha256" },
+        "bytes": { "$ref": "#/$defs/nonNegativeSafeInteger" },
+        "placement": {
+          "enum": ["device-local", "cloud-metadata", "cloud-content"]
+        },
+        "contentSync": {
+          "enum": ["not-requested", "pending", "synced", "failed"]
+        },
+        "createdAt": { "$ref": "#/$defs/utcTimestamp" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "placement": { "const": "cloud-content" } },
+            "required": ["placement"]
+          },
+          "then": {
+            "properties": {
+              "contentSync": {
+                "not": { "const": "not-requested" }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "modelUsage": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "enum": [
+              "inputTokens",
+              "outputTokens",
+              "costUsd",
+              "reportedByRuntime"
+            ]
+          },
+          { "$ref": "#/$defs/sensitivePropertyName" }
+        ]
+      },
+      "required": ["inputTokens", "outputTokens", "costUsd", "reportedByRuntime"],
+      "properties": {
+        "inputTokens": { "$ref": "#/$defs/nullableSafeInteger" },
+        "outputTokens": { "$ref": "#/$defs/nullableSafeInteger" },
+        "costUsd": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "reportedByRuntime": { "type": "boolean" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "reportedByRuntime": { "const": false } },
+            "required": ["reportedByRuntime"]
+          },
+          "then": {
+            "properties": {
+              "inputTokens": { "const": null },
+              "outputTokens": { "const": null },
+              "costUsd": { "const": null }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "reportedByRuntime": { "const": true } },
+            "required": ["reportedByRuntime"]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": { "inputTokens": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 } },
+                "required": ["inputTokens"]
+              },
+              {
+                "properties": { "outputTokens": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 } },
+                "required": ["outputTokens"]
+              },
+              {
+                "properties": { "costUsd": { "type": "number", "minimum": 0 } },
+                "required": ["costUsd"]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "modelReceipt": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "enum": [
+              "familiarId",
+              "runtime",
+              "effectiveModel",
+              "modelSource",
+              "providerBilling",
+              "usage"
+            ]
+          },
+          { "$ref": "#/$defs/sensitivePropertyName" }
+        ]
+      },
+      "required": [
+        "familiarId",
+        "runtime",
+        "effectiveModel",
+        "modelSource",
+        "providerBilling",
+        "usage"
+      ],
+      "properties": {
+        "familiarId": { "type": "string" },
+        "runtime": { "type": "string" },
+        "effectiveModel": { "type": ["string", "null"] },
+        "modelSource": {
+          "enum": [
+            "next-message",
+            "session",
+            "familiar-default",
+            "runtime-default",
+            "global-default"
+          ]
+        },
+        "providerBilling": { "const": "user-connected" },
+        "usage": { "$ref": "#/$defs/modelUsage" }
+      }
+    },
+    "modelExecution": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "enum": [
+              "taskId",
+              "phase",
+              "attempt",
+              "inputDigest",
+              "outputDigest",
+              "receipt"
+            ]
+          },
+          { "$ref": "#/$defs/sensitivePropertyName" }
+        ]
+      },
+      "required": [
+        "taskId",
+        "phase",
+        "attempt",
+        "inputDigest",
+        "outputDigest",
+        "receipt"
+      ],
+      "properties": {
+        "taskId": { "$ref": "#/$defs/modelTaskId" },
+        "phase": { "enum": ["scope", "challenge", "synthesize", "control"] },
+        "attempt": { "$ref": "#/$defs/positiveSafeInteger" },
+        "inputDigest": { "$ref": "#/$defs/sha256" },
+        "outputDigest": { "$ref": "#/$defs/sha256" },
+        "receipt": { "$ref": "#/$defs/modelReceipt" }
+      }
+    },
+    "usage": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" },
+      "propertyNames": {
+        "anyOf": [
+          { "enum": ["inputTokens", "outputTokens", "costUsd", "completeness"] },
+          { "$ref": "#/$defs/sensitivePropertyName" }
+        ]
+      },
+      "required": ["inputTokens", "outputTokens", "costUsd", "completeness"],
+      "properties": {
+        "inputTokens": { "$ref": "#/$defs/nullableSafeInteger" },
+        "outputTokens": { "$ref": "#/$defs/nullableSafeInteger" },
+        "costUsd": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "completeness": {
+          "enum": ["complete", "partial", "unreported"]
+        }
+      }
+    },
+    "retention": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/safeExtensionValue" },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "enum": [
+              "policy",
+              "effectivePolicy",
+              "status",
+              "contentExpiresAt",
+              "updatedAt"
+            ]
+          },
+          { "$ref": "#/$defs/sensitivePropertyName" }
+        ]
+      },
+      "required": [
+        "policy",
+        "effectivePolicy",
+        "status",
+        "contentExpiresAt",
+        "updatedAt"
+      ],
+      "properties": {
+        "policy": { "enum": ["run-only", "7-days", "project"] },
+        "effectivePolicy": { "enum": ["run-only", "7-days", "project"] },
+        "status": {
+          "enum": ["active", "deletion_scheduled", "deletion_pending", "deleted"]
+        },
+        "contentExpiresAt": { "$ref": "#/$defs/nullableTimestamp" },
+        "updatedAt": { "$ref": "#/$defs/utcTimestamp" }
+      }
+    },
+    "deletion": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/deletionSafeExtensionValue" },
+      "propertyNames": {
+        "anyOf": [
+          {
+            "enum": [
+              "status",
+              "requestedAt",
+              "completedAt",
+              "deletedObjectCount",
+              "retainedAuditUntil",
+              "eventSequence"
+            ]
+          },
+          { "$ref": "#/$defs/deletionExtensionPropertyName" }
+        ]
+      },
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "enum": ["not_scheduled", "scheduled", "pending", "completed", "partial_failure"]
+        },
+        "requestedAt": { "$ref": "#/$defs/utcTimestamp" },
+        "completedAt": { "$ref": "#/$defs/utcTimestamp" },
+        "deletedObjectCount": { "$ref": "#/$defs/nonNegativeSafeInteger" },
+        "retainedAuditUntil": { "$ref": "#/$defs/utcTimestamp" },
+        "eventSequence": { "$ref": "#/$defs/positiveSafeInteger" }
+      }
+    }
+  }
+}

--- a/schemas/research/v1/topic-discovery-job.schema.json
+++ b/schemas/research/v1/topic-discovery-job.schema.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "opencoven.topic-discovery-job/v1",
+  "title": "OpenCoven Topic Discovery Job v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "id",
+    "contextPackId",
+    "contextPackDigest",
+    "familiarId",
+    "status",
+    "requestedAt",
+    "proposalIds"
+  ],
+  "properties": {
+    "schema": { "const": "opencoven.topic-discovery-job/v1" },
+    "id": { "$ref": "#/$defs/topicDiscoveryJobId" },
+    "contextPackId": { "$ref": "#/$defs/contextPackId" },
+    "contextPackDigest": { "$ref": "#/$defs/sha256" },
+    "familiarId": { "type": "string" },
+    "status": { "$ref": "#/$defs/jobStatus" },
+    "requestedAt": { "$ref": "#/$defs/utcTimestamp" },
+    "startedAt": { "$ref": "#/$defs/utcTimestamp" },
+    "finishedAt": { "$ref": "#/$defs/utcTimestamp" },
+    "proposalIds": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/topicProposalId" },
+      "uniqueItems": true
+    },
+    "modelReceipt": { "$ref": "#/$defs/modelReceipt" },
+    "failure": { "$ref": "#/$defs/failure" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "status": { "const": "running" } },
+        "required": ["status"]
+      },
+      "then": {
+        "required": ["startedAt"],
+        "not": {
+          "anyOf": [
+            { "required": ["finishedAt"] },
+            { "required": ["failure"] }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "const": "queued" } },
+        "required": ["status"]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            { "required": ["finishedAt"] },
+            { "required": ["failure"] }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "const": "completed" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "proposalIds": {
+            "minItems": 3,
+            "maxItems": 7
+          }
+        },
+        "not": { "required": ["failure"] }
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "const": "failed" } },
+        "required": ["status"]
+      },
+      "then": {
+        "required": ["failure"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "const": "cancelled" } },
+        "required": ["status"]
+      },
+      "then": {
+        "not": { "required": ["failure"] }
+      }
+    },
+    {
+      "if": {
+        "properties": { "status": { "enum": ["completed", "failed", "cancelled"] } },
+        "required": ["status"]
+      },
+      "then": { "required": ["finishedAt"] }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "utcTimestamp": {
+      "type": "string",
+      "format": "date-time",
+      "minLength": 20,
+      "maxLength": 30,
+      "pattern": "^(?:(?:\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d)|(?:1972-(?:06-30|12-31)|197[3-9]-12-31|198[1235]-06-30|198[79]-12-31|1990-12-31|199[2347]-06-30|199[58]-12-31|200[58]-12-31|201[25]-06-30|2016-12-31)T23:59:60)(?:\\.\\d{1,9})?Z$"
+    },
+    "contextPackId": {
+      "type": "string",
+      "pattern": "^ctx_[A-Za-z0-9_-]+$"
+    },
+    "topicDiscoveryJobId": {
+      "type": "string",
+      "pattern": "^topicjob_[A-Za-z0-9_-]+$"
+    },
+    "topicProposalId": {
+      "type": "string",
+      "pattern": "^proposal_[A-Za-z0-9_-]+$"
+    },
+    "jobStatus": {
+      "enum": ["queued", "running", "completed", "failed", "cancelled"]
+    },
+    "nullableSafeInteger": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "nullableNonNegativeNumber": {
+      "type": ["number", "null"],
+      "minimum": 0
+    },
+    "modelUsage": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["inputTokens", "outputTokens", "costUsd", "reportedByRuntime"],
+      "properties": {
+        "inputTokens": { "$ref": "#/$defs/nullableSafeInteger" },
+        "outputTokens": { "$ref": "#/$defs/nullableSafeInteger" },
+        "costUsd": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "reportedByRuntime": { "type": "boolean" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "reportedByRuntime": { "const": false } },
+            "required": ["reportedByRuntime"]
+          },
+          "then": {
+            "properties": {
+              "inputTokens": { "const": null },
+              "outputTokens": { "const": null },
+              "costUsd": { "const": null }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "reportedByRuntime": { "const": true } },
+            "required": ["reportedByRuntime"]
+          },
+          "then": {
+            "anyOf": [
+              { "properties": { "inputTokens": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 } }, "required": ["inputTokens"] },
+              { "properties": { "outputTokens": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 } }, "required": ["outputTokens"] },
+              { "properties": { "costUsd": { "type": "number", "minimum": 0 } }, "required": ["costUsd"] }
+            ]
+          }
+        }
+      ]
+    },
+    "modelReceipt": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "familiarId",
+        "runtime",
+        "effectiveModel",
+        "modelSource",
+        "providerBilling",
+        "usage"
+      ],
+      "properties": {
+        "familiarId": { "type": "string" },
+        "runtime": { "type": "string" },
+        "effectiveModel": { "type": ["string", "null"] },
+        "modelSource": {
+          "enum": [
+            "next-message",
+            "session",
+            "familiar-default",
+            "runtime-default",
+            "global-default"
+          ]
+        },
+        "providerBilling": { "const": "user-connected" },
+        "usage": { "$ref": "#/$defs/modelUsage" }
+      }
+    },
+    "failure": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["code", "message", "retryable"],
+      "properties": {
+        "code": { "type": "string" },
+        "message": { "type": "string" },
+        "retryable": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/schemas/research/v1/topic-proposal.schema.json
+++ b/schemas/research/v1/topic-proposal.schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "opencoven.topic-proposal/v1",
+  "title": "OpenCoven Topic Proposal v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "id",
+    "discoveryJobId",
+    "contextPackId",
+    "title",
+    "question",
+    "whyNow",
+    "evidence",
+    "counterevidence",
+    "scores",
+    "suggested",
+    "uncertainty",
+    "relatedMissionIds",
+    "createdAt"
+  ],
+  "properties": {
+    "schema": { "const": "opencoven.topic-proposal/v1" },
+    "id": { "$ref": "#/$defs/topicProposalId" },
+    "discoveryJobId": { "$ref": "#/$defs/topicDiscoveryJobId" },
+    "contextPackId": { "$ref": "#/$defs/contextPackId" },
+    "title": { "type": "string" },
+    "question": { "type": "string" },
+    "whyNow": { "type": "string" },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/topicEvidenceRef" }
+    },
+    "counterevidence": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/topicEvidenceRef" }
+    },
+    "scores": { "$ref": "#/$defs/scores" },
+    "suggested": { "$ref": "#/$defs/suggested" },
+    "uncertainty": { "type": "string" },
+    "relatedMissionIds": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/missionId" },
+      "uniqueItems": true
+    },
+    "createdAt": { "$ref": "#/$defs/utcTimestamp" }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "utcTimestamp": {
+      "type": "string",
+      "format": "date-time",
+      "minLength": 20,
+      "maxLength": 30,
+      "pattern": "^(?:(?:\\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d)|(?:1972-(?:06-30|12-31)|197[3-9]-12-31|198[1235]-06-30|198[79]-12-31|1990-12-31|199[2347]-06-30|199[58]-12-31|200[58]-12-31|201[25]-06-30|2016-12-31)T23:59:60)(?:\\.\\d{1,9})?Z$"
+    },
+    "contextPackId": {
+      "type": "string",
+      "pattern": "^ctx_[A-Za-z0-9_-]+$"
+    },
+    "resourceId": {
+      "type": "string",
+      "pattern": "^resource_[A-Za-z0-9_-]+$"
+    },
+    "missionId": {
+      "type": "string",
+      "pattern": "^mission_[A-Za-z0-9_-]+$"
+    },
+    "topicDiscoveryJobId": {
+      "type": "string",
+      "pattern": "^topicjob_[A-Za-z0-9_-]+$"
+    },
+    "topicProposalId": {
+      "type": "string",
+      "pattern": "^proposal_[A-Za-z0-9_-]+$"
+    },
+    "score": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 4
+    },
+    "selector": {
+      "oneOf": [
+        { "$ref": "#/$defs/turnRangeSelector" },
+        { "$ref": "#/$defs/jsonPointerSelector" },
+        { "$ref": "#/$defs/textSpanSelector" },
+        { "$ref": "#/$defs/markdownSectionSelector" },
+        { "$ref": "#/$defs/pdfPageSpanSelector" },
+        { "$ref": "#/$defs/wholeResourceSelector" }
+      ]
+    },
+    "turnRangeSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "start", "end"],
+      "properties": {
+        "type": { "const": "turn-range" },
+        "start": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
+        "end": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 }
+      }
+    },
+    "jsonPointerSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "pointer"],
+      "properties": {
+        "type": { "const": "json-pointer" },
+        "pointer": {
+          "type": "string",
+          "pattern": "^(?:$|/(?:[^~/]|~0|~1)*(?:/(?:[^~/]|~0|~1)*)*)$"
+        }
+      }
+    },
+    "textSpanSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "start", "end"],
+      "properties": {
+        "type": { "const": "text-span" },
+        "start": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
+        "end": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 }
+      }
+    },
+    "markdownSectionSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "headingPath"],
+      "properties": {
+        "type": { "const": "markdown-section" },
+        "headingPath": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "pdfPageSpanSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "page", "start", "end"],
+      "properties": {
+        "type": { "const": "pdf-page-span" },
+        "page": { "type": "integer", "minimum": 1, "maximum": 9007199254740991 },
+        "start": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
+        "end": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 }
+      }
+    },
+    "wholeResourceSelector": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "whole-resource" }
+      }
+    },
+    "topicEvidenceRef": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["resourceId", "selector", "excerpt", "excerptDigest"],
+      "properties": {
+        "resourceId": { "$ref": "#/$defs/resourceId" },
+        "selector": { "$ref": "#/$defs/selector" },
+        "excerpt": { "type": "string" },
+        "excerptDigest": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "scores": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "groundability",
+        "decisionValue",
+        "unresolvedness",
+        "recurrence",
+        "novelty",
+        "timeliness",
+        "familiarFit",
+        "feasibility",
+        "humanResonance",
+        "riskPenalty",
+        "visibleTotal"
+      ],
+      "properties": {
+        "groundability": { "$ref": "#/$defs/score" },
+        "decisionValue": { "$ref": "#/$defs/score" },
+        "unresolvedness": { "$ref": "#/$defs/score" },
+        "recurrence": { "$ref": "#/$defs/score" },
+        "novelty": { "$ref": "#/$defs/score" },
+        "timeliness": { "$ref": "#/$defs/score" },
+        "familiarFit": { "$ref": "#/$defs/score" },
+        "feasibility": { "$ref": "#/$defs/score" },
+        "humanResonance": { "$ref": "#/$defs/score" },
+        "riskPenalty": { "$ref": "#/$defs/score" },
+        "visibleTotal": {
+          "type": "number",
+          "minimum": -0.8,
+          "maximum": 4,
+          "multipleOf": 0.01
+        }
+      }
+    },
+    "suggested": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["mode", "deliverable", "sourceTarget", "wallClockMinutes"],
+      "properties": {
+        "mode": { "enum": ["brief", "sweep", "paper", "autoresearch"] },
+        "deliverable": { "type": "string" },
+        "sourceTarget": { "type": "integer", "minimum": 1, "maximum": 9007199254740991 },
+        "wallClockMinutes": { "type": "integer", "minimum": 1, "maximum": 9007199254740991 }
+      }
+    }
+  }
+}

--- a/scripts/ci-paths.mjs
+++ b/scripts/ci-paths.mjs
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
 const FRONTEND_PATH =
-  /^(?:src\/|public\/|server\.(?:mjs|ts)$|scripts\/|tests\/|package\.json$|pnpm-lock\.yaml$|next\.config|playwright\.config|tsconfig|eslint\.config|postcss\.config|\.github\/workflows\/)/;
+  /^(?:src\/|public\/|schemas\/research\/|server\.(?:mjs|ts)$|scripts\/|tests\/|package\.json$|pnpm-lock\.yaml$|next\.config|playwright\.config|tsconfig|eslint\.config|postcss\.config|\.github\/workflows\/)/;
 const RUST_PATH = /^(?:src-tauri\/|Cargo\.(?:toml|lock)$|rust-toolchain)/;
 const ROOT_RUNTIME_PATH = /^[^/]+\.(?:[cm]?[jt]s|tsx?)$/;
 const E2E_PATH =

--- a/scripts/ci-paths.test.mjs
+++ b/scripts/ci-paths.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { classifyCiPaths } from "./ci-paths.mjs";
@@ -25,6 +26,28 @@ test("workflow and script changes run frontend validation", () => {
   });
   assert.equal(classifyCiPaths(["scripts/run-tests.mjs"]).frontend, true);
   assert.equal(classifyCiPaths(["scripts/run-tests.mjs"]).ios, false);
+});
+
+test("protocol changes run conformance in normal Linux pull-request CI", () => {
+  assert.equal(
+    classifyCiPaths(["schemas/research/v1/run-manifest.schema.json"]).frontend,
+    true,
+  );
+
+  const workflow = readFileSync(
+    new URL("../.github/workflows/ci.yml", import.meta.url),
+    "utf8",
+  );
+  const frontendValidation = workflow.match(
+    /^  frontend-validation:\n[\s\S]*?(?=^  [a-z][a-z-]+:\n)/m,
+  )?.[0];
+  assert.ok(frontendValidation, "CI must retain the frontend validation job");
+  assert.match(workflow, /^  pull_request:\n/m);
+  assert.match(frontendValidation, /^    runs-on: ubuntu-latest$/m);
+  assert.match(
+    frontendValidation,
+    /^          - name: protocol conformance\n            command: test:conformance$/m,
+  );
 });
 
 test("Rust-only changes avoid frontend and E2E work", () => {

--- a/scripts/ci-recovery-workflow.test.mjs
+++ b/scripts/ci-recovery-workflow.test.mjs
@@ -53,6 +53,7 @@ assert.deepEqual(ciWorkflow.jobs["frontend-validation"].strategy.matrix.validati
   { name: "lint", command: "lint" },
   { name: "typecheck", command: "typecheck" },
   { name: "test wiring", command: "check:tests-wired" },
+  { name: "protocol conformance", command: "test:conformance" },
   { name: "app tests", command: "test:app" },
   { name: "API tests", command: "test:api" },
   { name: "mobile tests", command: "test:mobile" },

--- a/scripts/research-protocol-conformance.test.ts
+++ b/scripts/research-protocol-conformance.test.ts
@@ -1,0 +1,502 @@
+// Fixture-level conformance suite for Research Protocol v1 (Unit 0, #8).
+//
+// This suite is deliberately generic: it reads every `.json` fixture out of
+// `schemas/research/v1/fixtures/{valid,invalid}` from disk (sorted for
+// filesystem-order independence) and checks each one against BOTH layers of
+// the protocol at once:
+//   - the authoritative TypeBox/JSON Schema file for its `schema` string
+//   - the hand-written parser reached through `parseResearchProtocolObject`
+//
+// Standalone fixture filenames are intentionally ratcheted below. Any addition,
+// deletion, or rename must update that inventory explicitly. JSON Schema cannot
+// express every cross-object revision rule the protocol enforces. Persistent
+// cross-object cases live in
+// `schemas/research/v1/fixtures/scenarios/*.scenario.json`; the focused sibling
+// runner keeps this suite limited to agreement for individual wire objects.
+
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { test, type TestContext } from "node:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { IsSchema, type TSchema } from "typebox";
+import { Check } from "typebox/value";
+
+import {
+  isRecord,
+  UTC_TIMESTAMP_PATTERN,
+} from "../src/lib/research-protocol/common.ts";
+import { digestProtocolObject } from "../src/lib/research-protocol/digest.ts";
+import {
+  RESEARCH_PROTOCOL_SCHEMAS,
+  parseResearchProtocolObject,
+} from "../src/lib/research-protocol/index.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const schemasDir = path.join(repoRoot, "schemas/research/v1");
+const fixturesDir = path.join(schemasDir, "fixtures");
+
+const EXPECTED_VALID_STANDALONE_FIXTURES = [
+  "context-pack.json",
+  "model-task-result.json",
+  "model-task.json",
+  "research-run-chronology-boundary.json",
+  "research-run-embedded-retention-7-days-provisional.json",
+  "research-run-embedded-retention-run-only-provisional.json",
+  "research-run-hosted-without-tenant.json",
+  "research-run-hosted.json",
+  "research-run-paused.json",
+  "research-run-topic-provenance-absent.json",
+  "research-run.json",
+  "run-event-deletion-benign-extension.json",
+  "run-event-leap-second-historical.json",
+  "run-event-leap-second.json",
+  "run-event-unicode-extension.json",
+  "run-event.json",
+  "run-manifest-assembling.json",
+  "run-manifest-chronology-boundaries.json",
+  "run-manifest-cost-exact-decimal.json",
+  "run-manifest-deletion-ascii-extension.json",
+  "run-manifest-extension-boundaries.json",
+  "run-manifest-final-cloud.json",
+  "run-manifest-final-local.json",
+  "run-manifest-nested-benign-extension.json",
+  "run-manifest-retention-7-days-boundary.json",
+  "run-manifest-retention-7-days-leap-boundary.json",
+  "run-manifest-retention-run-only-boundary.json",
+  "run-manifest-retention-run-only-leap-boundary.json",
+  "run-manifest-retention-update.json",
+  "run-manifest-unicode-extension.json",
+  "topic-discovery-job-chronology-boundary.json",
+  "topic-discovery-job-seven.json",
+  "topic-discovery-job.json",
+  "topic-proposal.json",
+] as const;
+
+const EXPECTED_INVALID_STANDALONE_FIXTURES = [
+  "context-pack-pdf-selector.json",
+  "context-pack-retention.json",
+  "model-task-policy.json",
+  "model-task-result-usage.json",
+  "research-run-checkpoint-queued.json",
+  "research-run-chronology-reversed.json",
+  "research-run-local-tenant.json",
+  "research-run-topic-provenance-accepted-missing.json",
+  "research-run-topic-provenance-context-missing.json",
+  "research-run-topic-provenance-mismatch.json",
+  "research-run-waiting-phase.json",
+  "run-event-default-ignorable-deletion-extension.json",
+  "run-event-deleted-content-payload.json",
+  "run-event-invalid-future-leap-second.json",
+  "run-event-invalid-leap-second-date.json",
+  "run-event-invalid-leap-second-placement.json",
+  "run-event-non-ascii-deletion-extension.json",
+  "run-event-sequence.json",
+  "run-event-split-object-store-key.json",
+  "run-event-unicode-sensitive-extension.json",
+  "run-manifest-artifact-after-finalized.json",
+  "run-manifest-artifact-before-created.json",
+  "run-manifest-content-expires-before-created.json",
+  "run-manifest-content-expires-before-finalized.json",
+  "run-manifest-cost-binary-drift.json",
+  "run-manifest-deleted-content-payload.json",
+  "run-manifest-deletion-event.json",
+  "run-manifest-deletion-homoglyph-array.json",
+  "run-manifest-deletion-homoglyph-nested.json",
+  "run-manifest-deletion-homoglyph-root.json",
+  "run-manifest-deletion-pair.json",
+  "run-manifest-finalized-before-created.json",
+  "run-manifest-model-raw-prompt.json",
+  "run-manifest-nested-privacy-storage-keys.json",
+  "run-manifest-nested-private-extension.json",
+  "run-manifest-private-title.json",
+  "run-manifest-public-url-empty.json",
+  "run-manifest-public-url-file.json",
+  "run-manifest-public-url-localhost.json",
+  "run-manifest-public-url-malformed-authority.json",
+  "run-manifest-public-url-userinfo.json",
+  "run-manifest-retention-7-days-leap-overflow.json",
+  "run-manifest-retention-7-days-overflow.json",
+  "run-manifest-retention-before-created.json",
+  "run-manifest-retention-before-finalized.json",
+  "run-manifest-retention-run-only-leap-overflow.json",
+  "run-manifest-retention-run-only-overflow.json",
+  "run-manifest-root-private-excerpts.json",
+  "run-manifest-scheduled-null-expiry.json",
+  "run-manifest-source-after-finalized.json",
+  "run-manifest-source-before-created.json",
+  "run-manifest-split-object-store-key.json",
+  "run-manifest-unicode-sensitive-extension.json",
+  "topic-discovery-job-eight.json",
+  "topic-discovery-job-finished-before-started.json",
+  "topic-discovery-job-one.json",
+  "topic-discovery-job-receipt-familiar.json",
+  "topic-discovery-job-started-before-requested.json",
+  "topic-discovery-job-two.json",
+  "topic-proposal-score.json",
+  "unknown-major.json",
+] as const;
+
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function requireString(value: unknown, filePath: string, label: string): string {
+  if (typeof value !== "string") {
+    assert.fail(`${filePath}: ${label} must be a string`);
+  }
+  return value;
+}
+
+// Every approved schema id follows `opencoven.<name>/v1`, and its
+// authoritative file lives right beside this suite as `<name>.schema.json`.
+// The mapping is derived from `RESEARCH_PROTOCOL_SCHEMAS` (the dispatcher's
+// own source of truth) rather than hand-listed, so a renamed file or a 9th
+// schema fails loudly here instead of silently going unchecked.
+const SCHEMA_ID_PATTERN = /^opencoven\.([a-z-]+)\/v1$/;
+const SCHEMA_DOCUMENT_ID_BY_PROTOCOL_ID: Readonly<Record<string, string>> = {
+  "opencoven.run-manifest/v1":
+    "urn:opencoven:schema:research:run-manifest:v1",
+};
+
+function schemaFileNameFor(schemaId: string): string {
+  const match = SCHEMA_ID_PATTERN.exec(schemaId);
+  assert.ok(match, `schema id ${schemaId} does not match the opencoven.<name>/v1 pattern`);
+  const [, name] = match;
+  return `${name}.schema.json`;
+}
+
+// Populated by the "loads and validates" test below, then read by every
+// fixture test that follows. `node:test` registers callbacks and runs them
+// only after this module's synchronous top level finishes, so the load test
+// (added first) always completes before any fixture test body runs.
+//
+// A `Map` is used (rather than a plain object plus `in`/property lookups) so
+// that an attacker-controlled or coincidental schema id equal to an inherited
+// `Object.prototype` name (e.g. `toString`, `constructor`, `hasOwnProperty`)
+// can never be mistaken for a registered schema.
+const schemaContext = new Map<string, TSchema>();
+
+// `Check` (from typebox/value) expects a schema-id -> schema lookup object,
+// not a `Map`, for resolving `$ref`s across schemas. Build that object with a
+// null prototype so it carries no inherited properties either.
+const schemaCheckContext: Record<string, TSchema> = Object.create(null);
+
+test("loads and validates all eight authoritative Research Protocol v1 schema files", () => {
+  assert.equal(RESEARCH_PROTOCOL_SCHEMAS.length, 8);
+  for (const schemaId of RESEARCH_PROTOCOL_SCHEMAS) {
+    const fileName = schemaFileNameFor(schemaId);
+    const filePath = path.join(schemasDir, fileName);
+    const loaded: unknown = readJsonFile(filePath);
+    assert.ok(isRecord(loaded), `${filePath}: schema file root must be an object`);
+    assert.ok(IsSchema(loaded), `${filePath}: schema file must be a valid JSON Schema object`);
+    const documentId = SCHEMA_DOCUMENT_ID_BY_PROTOCOL_ID[schemaId] ?? schemaId;
+    assert.equal(loaded.$id, documentId, `${filePath}: $id must equal ${documentId}`);
+    assert.ok(isRecord(loaded.$defs), `${filePath}: $defs must be an object`);
+    assert.ok(
+      isRecord(loaded.$defs.utcTimestamp),
+      `${filePath}: $defs.utcTimestamp must be an object`,
+    );
+    assert.equal(
+      loaded.$defs.utcTimestamp.pattern,
+      UTC_TIMESTAMP_PATTERN,
+      `${filePath}: UTC timestamp pattern must match the shared protocol convention`,
+    );
+    schemaContext.set(schemaId, loaded);
+    schemaCheckContext[documentId] = loaded;
+  }
+});
+
+test("cross-schema references are absolute and resolve by schema document id", () => {
+  const visit = (value: unknown, sourceId: string): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, sourceId);
+      return;
+    }
+    if (!isRecord(value)) return;
+    if (typeof value.$ref === "string" && !value.$ref.startsWith("#")) {
+      const reference = new URL(value.$ref);
+      assert.ok(
+        Object.hasOwn(schemaCheckContext, reference.href),
+        `${sourceId}: unresolved cross-schema reference ${reference.href}`,
+      );
+    }
+    for (const child of Object.values(value)) visit(child, sourceId);
+  };
+
+  for (const [protocolId, schema] of schemaContext) {
+    visit(schema, protocolId);
+  }
+});
+
+test("schema lookup does not resolve inherited Object.prototype names as registered schemas", () => {
+  for (const name of ["toString", "constructor", "hasOwnProperty", "__proto__", "valueOf"]) {
+    assert.equal(
+      schemaContext.has(name),
+      false,
+      `${name} must not resolve as a registered schema id`,
+    );
+    assert.equal(
+      schemaContext.get(name),
+      undefined,
+      `${name} must not resolve to a schema value`,
+    );
+  }
+});
+
+function listFixtureFiles(
+  kind: "valid" | "invalid",
+  rootDirectory = fixturesDir,
+): string[] {
+  const dir = path.join(rootDirectory, kind);
+  const directoryStats = lstatSync(dir, { throwIfNoEntry: false });
+  assert.ok(directoryStats, `${dir}: standalone fixture directory is missing`);
+  assert.ok(
+    !directoryStats.isSymbolicLink() && directoryStats.isDirectory(),
+    `${dir}: standalone fixture root must be a real directory`,
+  );
+
+  const files: string[] = [];
+  for (const name of readdirSync(dir).sort()) {
+    const filePath = path.join(dir, name);
+    const stats = lstatSync(filePath, { throwIfNoEntry: false });
+    assert.ok(stats, `${filePath}: standalone fixture entry disappeared`);
+    assert.ok(
+      !stats.isSymbolicLink() &&
+        stats.isFile() &&
+        /^[a-z0-9]+(?:-[a-z0-9]+)*\.json$/.test(name),
+      `${filePath}: every standalone fixture entry must be a regular JSON file with a lowercase kebab-case name`,
+    );
+    files.push(name);
+  }
+  return files;
+}
+
+function assertStandaloneFixtureInventory(
+  kind: "valid" | "invalid",
+  expected: readonly string[],
+  rootDirectory = fixturesDir,
+): string[] {
+  assert.equal(
+    new Set(expected).size,
+    expected.length,
+    `${kind} standalone fixture ratchet must not contain duplicates`,
+  );
+  const discovered = listFixtureFiles(kind, rootDirectory);
+  assert.deepEqual(
+    discovered,
+    [...expected],
+    `${kind} standalone fixture inventory must exactly match its ratchet`,
+  );
+  return discovered;
+}
+
+const validFixtureFiles = assertStandaloneFixtureInventory(
+  "valid",
+  EXPECTED_VALID_STANDALONE_FIXTURES,
+);
+const invalidFixtureFiles = assertStandaloneFixtureInventory(
+  "invalid",
+  EXPECTED_INVALID_STANDALONE_FIXTURES,
+);
+
+test("standalone fixture inventories are exact and duplicate-free", () => {
+  assert.equal(EXPECTED_VALID_STANDALONE_FIXTURES.length, 34);
+  assert.equal(EXPECTED_INVALID_STANDALONE_FIXTURES.length, 61);
+  assert.deepEqual(validFixtureFiles, [...EXPECTED_VALID_STANDALONE_FIXTURES]);
+  assert.deepEqual(invalidFixtureFiles, [...EXPECTED_INVALID_STANDALONE_FIXTURES]);
+});
+
+function withTemporaryFixtureTree<T>(
+  callback: (rootDirectory: string) => T,
+): T {
+  const cacheDirectory = path.join(repoRoot, "node_modules", ".cache");
+  mkdirSync(cacheDirectory, { recursive: true });
+  const rootDirectory = mkdtempSync(
+    path.join(cacheDirectory, "research-protocol-standalone-fixtures-"),
+  );
+  mkdirSync(path.join(rootDirectory, "valid"));
+  mkdirSync(path.join(rootDirectory, "invalid"));
+  try {
+    return callback(rootDirectory);
+  } finally {
+    rmSync(rootDirectory, { recursive: true, force: true });
+  }
+}
+
+function createSymlinkOrSkip(
+  context: TestContext,
+  targetPath: string,
+  linkPath: string,
+): boolean {
+  try {
+    symlinkSync(targetPath, linkPath, "file");
+    return true;
+  } catch (error) {
+    const code =
+      typeof error === "object" && error !== null && "code" in error
+        ? String(error.code)
+        : "unknown";
+    if (["EACCES", "ENOSYS", "ENOTSUP", "EOPNOTSUPP", "EPERM"].includes(code)) {
+      context.skip(`symlink creation is unavailable (${code})`);
+      return false;
+    }
+    throw error;
+  }
+}
+
+test("standalone fixture inventory rejects directories and non-JSON files", () => {
+  withTemporaryFixtureTree((rootDirectory) => {
+    mkdirSync(path.join(rootDirectory, "valid", "nested"));
+    assert.throws(
+      () => assertStandaloneFixtureInventory("valid", [], rootDirectory),
+      /regular JSON file/i,
+    );
+  });
+  withTemporaryFixtureTree((rootDirectory) => {
+    writeFileSync(path.join(rootDirectory, "invalid", "notes.txt"), "not JSON");
+    assert.throws(
+      () => assertStandaloneFixtureInventory("invalid", [], rootDirectory),
+      /regular JSON file/i,
+    );
+  });
+});
+
+test("standalone fixture inventory rejects symlinks", (context) => {
+  withTemporaryFixtureTree((rootDirectory) => {
+    const targetPath = path.join(rootDirectory, "target.json");
+    writeFileSync(targetPath, "{}");
+    if (
+      !createSymlinkOrSkip(
+        context,
+        targetPath,
+        path.join(rootDirectory, "valid", "linked.json"),
+      )
+    ) {
+      return;
+    }
+    assert.throws(
+      () => assertStandaloneFixtureInventory("valid", [], rootDirectory),
+      /regular JSON file/i,
+    );
+  });
+});
+
+test("standalone fixture inventory rejects unexpected JSON names", () => {
+  withTemporaryFixtureTree((rootDirectory) => {
+    writeFileSync(path.join(rootDirectory, "valid", "unexpected.json"), "{}");
+    assert.throws(
+      () => assertStandaloneFixtureInventory("valid", [], rootDirectory),
+      /exactly match its ratchet/i,
+    );
+  });
+});
+
+for (const fileName of validFixtureFiles) {
+  const filePath = path.join(fixturesDir, "valid", fileName);
+
+  test(`valid fixture ${filePath} passes schema and parser`, () => {
+    const loaded: unknown = readJsonFile(filePath);
+    assert.ok(isRecord(loaded), `${filePath}: fixture root must be an object`);
+
+    const schemaId = requireString(loaded.schema, filePath, "$.schema");
+    const schema = schemaContext.get(schemaId);
+    assert.ok(
+      schema !== undefined,
+      `${filePath}: schema ${schemaId} is not one of the eight approved schemas`,
+    );
+    assert.equal(
+      Check(schemaCheckContext, schema, loaded),
+      true,
+      `${filePath}: expected schema validation to pass`,
+    );
+
+    const parsed = parseResearchProtocolObject(loaded);
+    if (!parsed.ok) {
+      assert.fail(`${filePath}: expected parser to accept fixture (${parsed.error.path}: ${parsed.error.message})`);
+    }
+
+    // Every valid fixture is expected to be lossless: the parser must return
+    // exactly what was on disk, including any additive fields it does not
+    // itself inspect, so this compares against the original loaded JSON
+    // rather than just the parser's own serialization of itself.
+    assert.deepEqual(
+      parsed.value,
+      loaded,
+      `${filePath}: parser result must be deeply equal to the original fixture (lossless)`,
+    );
+
+    const roundTripped: unknown = JSON.parse(JSON.stringify(parsed.value));
+    assert.deepEqual(roundTripped, parsed.value, `${filePath}: parser result must round-trip through JSON`);
+
+    if (typeof loaded.digest === "string") {
+      const recomputed = digestProtocolObject(parsed.value);
+      assert.equal(recomputed, loaded.digest, `${filePath}: recomputed digest must equal fixture digest`);
+    }
+  });
+}
+
+for (const fileName of invalidFixtureFiles) {
+  const filePath = path.join(fixturesDir, "invalid", fileName);
+
+  test(`invalid fixture ${filePath} is rejected by the parser`, () => {
+    const loaded: unknown = readJsonFile(filePath);
+    assert.ok(isRecord(loaded), `${filePath}: fixture root must be an object`);
+
+    // Strip the root `expectedSchemaValid` marker before validating: it is a
+    // conformance-suite instruction, not part of the protocol object, and
+    // must not reach the schema check or the parser.
+    const { expectedSchemaValid: marker, ...fixture } = loaded;
+    let expectedSchemaValid = false;
+    if (marker !== undefined) {
+      assert.equal(
+        typeof marker,
+        "boolean",
+        `${filePath}: expectedSchemaValid marker must be a boolean when present`,
+      );
+      expectedSchemaValid = marker === true;
+    }
+
+    const schemaId = requireString(fixture.schema, filePath, "$.schema");
+    const schema = schemaContext.get(schemaId);
+
+    if (schema === undefined) {
+      // No registered schema for this family/major (e.g. the unknown-major
+      // fixture's `opencoven.run-event/v2`): the dispatcher must reject it
+      // outright, without this suite ever attempting schema validation.
+      assert.equal(
+        expectedSchemaValid,
+        false,
+        `${filePath}: an unregistered schema id must not claim expectedSchemaValid`,
+      );
+    } else {
+      const schemaValid = Check(schemaCheckContext, schema, fixture);
+      assert.equal(
+        schemaValid,
+        expectedSchemaValid,
+        `${filePath}: expected schema validity ${expectedSchemaValid}, got ${schemaValid}`,
+      );
+    }
+
+    const parsed = parseResearchProtocolObject(fixture);
+    assert.equal(parsed.ok, false, `${filePath}: expected parser to reject fixture`);
+    if (schema === undefined && !parsed.ok) {
+      assert.equal(
+        parsed.error.code,
+        "unknown_major",
+        `${filePath}: dispatcher must reject an unregistered schema as unknown_major without trying schema validation`,
+      );
+    }
+  });
+}

--- a/scripts/research-protocol-scenario-conformance.test.ts
+++ b/scripts/research-protocol-scenario-conformance.test.ts
@@ -1,0 +1,2243 @@
+// Structured cross-object conformance for Research Protocol v1.
+//
+// Scenario behavior lives in JSON under
+// `schemas/research/v1/fixtures/scenarios/*.scenario.json`, with authoritative
+// support objects directly beneath `scenarios/objects/`. Each corpus names a
+// format/family, declares reusable objects (fixture or inline value, optional
+// RFC 7396 mergePatch, optional digestTargets, and optional manifest predecessor
+// links), then lists stable scenario ids, descriptions, input references,
+// validator options, and exact expected code/path outcomes. This runner owns
+// assembly and strict format validation; protocol behavior stays in the public
+// parsers and composition validators.
+
+import assert from "node:assert/strict";
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { test, type TestContext } from "node:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { IsSchema, type TSchema } from "typebox";
+import { Check } from "typebox/value";
+
+import {
+  RESEARCH_PROTOCOL_SCHEMAS,
+  digestProtocolObject,
+  isRecord,
+  isSha256,
+  isUtcTimestamp,
+  parseResearchProtocolObject,
+  validateManifestRetentionConsent,
+  validateModelTaskResultV1,
+  validateResearchRunContextPackV1,
+  validateRunEventSequence,
+  validateRunManifestDeletionEventV1,
+  validateRunManifestRevisionV1,
+  type ContextPackV1,
+  type ManifestRevisionOptions,
+  type ModelTaskResultV1,
+  type ModelTaskV1,
+  type ProtocolParseResult,
+  type ResearchProtocolObjectV1,
+  type ResearchRunManifestRevisionOptionsV1,
+  type ResearchRunV1,
+  type RunEventV1,
+  type RunManifestV1,
+} from "../src/lib/research-protocol/index.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const schemasDir = path.join(repoRoot, "schemas/research/v1");
+const fixturesDir = path.join(schemasDir, "fixtures");
+const scenariosDir = path.join(fixturesDir, "scenarios");
+
+const SCENARIO_FORMAT = "opencoven.research-protocol-scenarios/v1";
+const SCHEMA_ID_PATTERN = /^opencoven\.([a-z-]+)\/v1$/;
+const SCENARIO_ID_PATTERN = /^[a-z0-9]+(?:[.-][a-z0-9]+)*$/;
+const RETENTION_POLICIES = new Set(["run-only", "7-days", "project"]);
+const PROTOCOL_ERROR_CODES = new Set([
+  "invalid_type",
+  "invalid_value",
+  "missing_field",
+  "unknown_major",
+  "digest_mismatch",
+  "semantic_conflict",
+]);
+// Keep this independent from the action registry so an omitted action cannot
+// make the registry's own coverage assertion pass.
+const PUBLIC_VALIDATOR_ENTRY_POINTS = [
+  "validateManifestRetentionConsent",
+  "validateModelTaskResultV1",
+  "validateResearchRunContextPackV1",
+  "validateRunEventSequence",
+  "validateRunManifestDeletionEventV1",
+  "validateRunManifestRevisionV1",
+] as const;
+
+const VALIDATOR_ENTRY_POINT_BY_ACTION = {
+  "manifest-retention-consent": "validateManifestRetentionConsent",
+  "model-task-result": "validateModelTaskResultV1",
+  "research-run-context-pack": "validateResearchRunContextPackV1",
+  "run-event-deletion": "validateRunManifestDeletionEventV1",
+  "run-event-sequence": "validateRunEventSequence",
+  "run-manifest-revision": "validateRunManifestRevisionV1",
+} as const satisfies Record<string, (typeof PUBLIC_VALIDATOR_ENTRY_POINTS)[number]>;
+
+type ValidatorKind = keyof typeof VALIDATOR_ENTRY_POINT_BY_ACTION;
+const VALIDATORS = Object.keys(VALIDATOR_ENTRY_POINT_BY_ACTION) as ValidatorKind[];
+const DIGEST_TARGET_SCHEMA_BY_CONTAINER: Readonly<
+  Record<string, Readonly<Record<string, string>>>
+> = {
+  "opencoven.context-pack/v1": {
+    "": "opencoven.context-pack/v1",
+  },
+  "opencoven.research-run/v1": {
+    "/artifactManifest": "opencoven.run-manifest/v1",
+  },
+  "opencoven.run-manifest/v1": {
+    "": "opencoven.run-manifest/v1",
+  },
+};
+type ExpectedResult =
+  | { ok: true }
+  | {
+      ok: false;
+      stage: "parse" | "composition";
+      input?: string;
+      code: string;
+      path: string;
+    };
+
+type ObjectSpec = {
+  fixture?: string;
+  value?: Record<string, unknown>;
+  mergePatch?: Record<string, unknown>;
+  digestTargets?: string[];
+  predecessor?: string;
+};
+
+type ScenarioDefinition = {
+  id: string;
+  description: string;
+  validator: ValidatorKind;
+  inputs: Record<string, unknown>;
+  options?: ManifestRevisionOptions & {
+    manifestRevisionOptions?: readonly ResearchRunManifestRevisionOptionsV1[];
+  };
+  expected: ExpectedResult;
+};
+
+type ScenarioInputEntry = {
+  name: string;
+  reference: string;
+  schema: ResearchProtocolObjectV1["schema"];
+};
+
+type ScenarioCorpus = {
+  filePath: string;
+  family: ValidatorKind;
+  objects: Record<string, ObjectSpec>;
+  scenarios: ScenarioDefinition[];
+};
+
+type ScenarioTreeEntryKind = "file" | "directory" | "symlink" | "other";
+type ScenarioTreeClassification = "corpus" | "support" | "directory";
+type ScenarioInventoryFile = {
+  relativePath: string;
+  filePath: string;
+};
+type ScenarioInventory = {
+  corpusFiles: ScenarioInventoryFile[];
+  supportObjectFiles: ScenarioInventoryFile[];
+};
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function withTemporaryDirectory<T>(callback: (directory: string) => T): T {
+  const cacheDirectory = path.join(repoRoot, "node_modules", ".cache");
+  mkdirSync(cacheDirectory, { recursive: true });
+  const temporaryDirectory = mkdtempSync(
+    path.join(cacheDirectory, "research-protocol-scenario-conformance-"),
+  );
+  try {
+    return callback(temporaryDirectory);
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function createSymlinkOrSkip(
+  context: TestContext,
+  targetPath: string,
+  linkPath: string,
+  type: "file" | "dir",
+): boolean {
+  try {
+    symlinkSync(
+      targetPath,
+      linkPath,
+      process.platform === "win32" && type === "dir" ? "junction" : type,
+    );
+    return true;
+  } catch (error) {
+    const code =
+      typeof error === "object" && error !== null && "code" in error
+        ? String(error.code)
+        : "unknown";
+    if (["EACCES", "ENOSYS", "ENOTSUP", "EOPNOTSUPP", "EPERM"].includes(code)) {
+      context.skip(`symlink creation is unavailable (${code})`);
+      return false;
+    }
+    throw error;
+  }
+}
+
+function classifyScenarioTreeEntry(
+  relativePath: string,
+  kind: ScenarioTreeEntryKind,
+): ScenarioTreeClassification {
+  if (kind === "symlink") {
+    assert.fail(`${relativePath}: symlinks are not allowed under the scenario fixture tree`);
+  }
+  if (kind === "other") {
+    assert.fail(`${relativePath}: must be a regular file or directory`);
+  }
+
+  const isInObjectsDirectory = relativePath.startsWith("objects/");
+  const isDirectObject =
+    isInObjectsDirectory && !relativePath.slice("objects/".length).includes("/");
+  if (kind === "directory") {
+    if (relativePath === "objects") return "directory";
+    assert.fail(
+      `${relativePath}: unexpected directory; only the top-level objects directory is allowed`,
+    );
+  }
+
+  if (!relativePath.includes("/") && relativePath.endsWith(".scenario.json")) {
+    return "corpus";
+  }
+  if (isDirectObject && relativePath.endsWith(".json")) {
+    return "support";
+  }
+  if (isInObjectsDirectory && !isDirectObject) {
+    assert.fail(`${relativePath}: nested support object paths are not allowed`);
+  }
+  if (relativePath.endsWith(".json")) {
+    assert.fail(`${relativePath}: JSON file is outside the objects directory and is not a top-level corpus`);
+  }
+  assert.fail(
+    `${relativePath}: unexpected file extension; expected a top-level .scenario.json corpus or an objects/*.json support object`,
+  );
+}
+
+function inventoryScenarioTree(rootDirectory: string): ScenarioInventory {
+  const rootStats = lstatSync(rootDirectory, { throwIfNoEntry: false });
+  assert.ok(rootStats, `${rootDirectory}: scenario fixture root does not exist`);
+  assert.ok(
+    !rootStats.isSymbolicLink(),
+    `${rootDirectory}: scenario fixture root must not be a symlink`,
+  );
+  assert.ok(rootStats.isDirectory(), `${rootDirectory}: scenario fixture root must be a directory`);
+
+  const corpusFiles: ScenarioInventoryFile[] = [];
+  const supportObjectFiles: ScenarioInventoryFile[] = [];
+  let foundObjectsDirectory = false;
+
+  function visit(directoryPath: string, relativeDirectory: string): void {
+    const entryNames = readdirSync(directoryPath).sort(compareCodeUnits);
+    for (const entryName of entryNames) {
+      const relativePath =
+        relativeDirectory === "" ? entryName : `${relativeDirectory}/${entryName}`;
+      const filePath = path.join(directoryPath, entryName);
+      const stats = lstatSync(filePath, { throwIfNoEntry: false });
+      assert.ok(stats, `${filePath}: scenario inventory entry disappeared`);
+
+      const kind: ScenarioTreeEntryKind = stats.isSymbolicLink()
+        ? "symlink"
+        : stats.isFile()
+          ? "file"
+          : stats.isDirectory()
+            ? "directory"
+            : "other";
+      const classification = classifyScenarioTreeEntry(relativePath, kind);
+      if (classification === "directory") {
+        assert.equal(relativePath, "objects");
+        foundObjectsDirectory = true;
+        visit(filePath, relativePath);
+      } else if (classification === "corpus") {
+        corpusFiles.push({ relativePath, filePath });
+      } else {
+        supportObjectFiles.push({ relativePath, filePath });
+      }
+    }
+  }
+
+  visit(rootDirectory, "");
+  assert.ok(
+    foundObjectsDirectory,
+    `${rootDirectory}: required objects directory is missing`,
+  );
+  corpusFiles.sort((left, right) => compareCodeUnits(left.relativePath, right.relativePath));
+  supportObjectFiles.sort((left, right) =>
+    compareCodeUnits(left.relativePath, right.relativePath),
+  );
+  return { corpusFiles, supportObjectFiles };
+}
+
+function readJsonFile(filePath: string): unknown {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"));
+  } catch (error) {
+    assert.fail(
+      `${filePath}: must contain valid JSON (${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+}
+
+function requireRecord(value: unknown, location: string): Record<string, unknown> {
+  assert.ok(isRecord(value), `${location}: must be an object`);
+  return value;
+}
+
+function requireString(value: unknown, location: string): string {
+  if (typeof value !== "string") {
+    assert.fail(`${location}: must be a string`);
+  }
+  assert.notEqual(value, "", `${location}: must not be empty`);
+  return value;
+}
+
+function assertAllowedKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  location: string,
+): void {
+  const allowedSet = new Set(allowed);
+  for (const key of Object.keys(value)) {
+    assert.ok(allowedSet.has(key), `${location}: unknown field ${key}`);
+  }
+}
+
+function requireExactInputKeys(
+  inputs: Record<string, unknown>,
+  expectedKeys: readonly string[],
+  location: string,
+): void {
+  assertAllowedKeys(inputs, expectedKeys, location);
+  for (const key of expectedKeys) {
+    assert.ok(Object.hasOwn(inputs, key), `${location}: missing field ${key}`);
+  }
+}
+
+function requireObjectReference(
+  value: unknown,
+  objects: Record<string, ObjectSpec>,
+  location: string,
+): string {
+  const reference = requireString(value, location);
+  assert.ok(Object.hasOwn(objects, reference), `${location}: unknown object reference ${reference}`);
+  return reference;
+}
+
+function validateObjectSpec(value: unknown, location: string): ObjectSpec {
+  const spec = requireRecord(value, location);
+  assertAllowedKeys(
+    spec,
+    ["fixture", "value", "mergePatch", "digestTargets", "predecessor"],
+    location,
+  );
+
+  const hasFixture = Object.hasOwn(spec, "fixture");
+  const hasValue = Object.hasOwn(spec, "value");
+  assert.notEqual(hasFixture, hasValue, `${location}: exactly one of fixture or value is required`);
+
+  const validated: ObjectSpec = {};
+  if (hasFixture) {
+    validated.fixture = requireString(spec.fixture, `${location}.fixture`);
+  } else {
+    validated.value = requireRecord(spec.value, `${location}.value`);
+  }
+  if (Object.hasOwn(spec, "mergePatch")) {
+    validated.mergePatch = requireRecord(spec.mergePatch, `${location}.mergePatch`);
+  }
+  if (Object.hasOwn(spec, "digestTargets")) {
+    assert.ok(Array.isArray(spec.digestTargets), `${location}.digestTargets: must be an array`);
+    validated.digestTargets = spec.digestTargets.map((target, index) => {
+      assert.equal(
+        typeof target,
+        "string",
+        `${location}.digestTargets[${index}]: must be a JSON Pointer string`,
+      );
+      assert.ok(
+        target === "" || target.startsWith("/"),
+        `${location}.digestTargets[${index}]: must be an empty root pointer or start with /`,
+      );
+      return target;
+    });
+    assert.equal(
+      new Set(validated.digestTargets).size,
+      validated.digestTargets.length,
+      `${location}.digestTargets: duplicate pointers are not allowed`,
+    );
+  }
+  if (Object.hasOwn(spec, "predecessor")) {
+    validated.predecessor = requireString(spec.predecessor, `${location}.predecessor`);
+  }
+
+  return validated;
+}
+
+function validateExpected(
+  value: unknown,
+  inputNames: readonly string[],
+  location: string,
+): ExpectedResult {
+  const expected = requireRecord(value, location);
+  assert.equal(typeof expected.ok, "boolean", `${location}.ok: must be a boolean`);
+
+  if (expected.ok === true) {
+    assertAllowedKeys(expected, ["ok"], location);
+    return { ok: true };
+  }
+
+  assertAllowedKeys(expected, ["ok", "stage", "input", "code", "path"], location);
+  assert.ok(
+    expected.stage === "parse" || expected.stage === "composition",
+    `${location}.stage: must be parse or composition`,
+  );
+  const code = requireString(expected.code, `${location}.code`);
+  assert.ok(PROTOCOL_ERROR_CODES.has(code), `${location}.code: unknown protocol error code ${code}`);
+  const expectedPath = requireString(expected.path, `${location}.path`);
+  assert.ok(expectedPath.startsWith("$"), `${location}.path: must start with $`);
+
+  if (expected.stage === "parse") {
+    const input = requireString(expected.input, `${location}.input`);
+    assert.ok(inputNames.includes(input), `${location}.input: unknown input ${input}`);
+    return {
+      ok: false,
+      stage: "parse",
+      input,
+      code,
+      path: expectedPath,
+    };
+  }
+
+  assert.equal(expected.input, undefined, `${location}.input: is only valid for parse failures`);
+  return {
+    ok: false,
+    stage: "composition",
+    code,
+    path: expectedPath,
+  };
+}
+
+function scenarioInputEntries(
+  scenario: Pick<ScenarioDefinition, "validator" | "inputs">,
+  objects: Record<string, ObjectSpec>,
+  location: string,
+): ScenarioInputEntry[] {
+  const entries: ScenarioInputEntry[] = [];
+
+  switch (scenario.validator) {
+    case "run-manifest-revision":
+      requireExactInputKeys(scenario.inputs, ["previous", "next"], location);
+      entries.push(
+        {
+          name: "previous",
+          reference: requireObjectReference(scenario.inputs.previous, objects, `${location}.previous`),
+          schema: "opencoven.run-manifest/v1",
+        },
+        {
+          name: "next",
+          reference: requireObjectReference(scenario.inputs.next, objects, `${location}.next`),
+          schema: "opencoven.run-manifest/v1",
+        },
+      );
+      break;
+    case "research-run-context-pack":
+      assertAllowedKeys(
+        scenario.inputs,
+        ["run", "contextPack", "manifestHistory"],
+        location,
+      );
+      assert.ok(Object.hasOwn(scenario.inputs, "run"), `${location}: missing field run`);
+      entries.push({
+        name: "run",
+        reference: requireObjectReference(scenario.inputs.run, objects, `${location}.run`),
+        schema: "opencoven.research-run/v1",
+      });
+      if (Object.hasOwn(scenario.inputs, "contextPack")) {
+        entries.push({
+          name: "contextPack",
+          reference: requireObjectReference(
+            scenario.inputs.contextPack,
+            objects,
+            `${location}.contextPack`,
+          ),
+          schema: "opencoven.context-pack/v1",
+        });
+      }
+      if (Object.hasOwn(scenario.inputs, "manifestHistory")) {
+        assert.ok(
+          Array.isArray(scenario.inputs.manifestHistory),
+          `${location}.manifestHistory: must be an array`,
+        );
+        assert.ok(
+          scenario.inputs.manifestHistory.length > 0,
+          `${location}.manifestHistory: must not be empty`,
+        );
+        for (const [index, manifest] of scenario.inputs.manifestHistory.entries()) {
+          entries.push({
+            name: `manifestHistory[${index}]`,
+            reference: requireObjectReference(
+              manifest,
+              objects,
+              `${location}.manifestHistory[${index}]`,
+            ),
+            schema: "opencoven.run-manifest/v1",
+          });
+        }
+      }
+      break;
+    case "manifest-retention-consent":
+      requireExactInputKeys(scenario.inputs, ["manifest"], location);
+      entries.push({
+        name: "manifest",
+        reference: requireObjectReference(
+          scenario.inputs.manifest,
+          objects,
+          `${location}.manifest`,
+        ),
+        schema: "opencoven.run-manifest/v1",
+      });
+      break;
+    case "model-task-result":
+      requireExactInputKeys(scenario.inputs, ["task", "result"], location);
+      entries.push(
+        {
+          name: "task",
+          reference: requireObjectReference(scenario.inputs.task, objects, `${location}.task`),
+          schema: "opencoven.model-task/v1",
+        },
+        {
+          name: "result",
+          reference: requireObjectReference(scenario.inputs.result, objects, `${location}.result`),
+          schema: "opencoven.model-task-result/v1",
+        },
+      );
+      break;
+    case "run-event-deletion": {
+      requireExactInputKeys(scenario.inputs, ["run", "events"], location);
+      entries.push({
+        name: "run",
+        reference: requireObjectReference(scenario.inputs.run, objects, `${location}.run`),
+        schema: "opencoven.research-run/v1",
+      });
+      assert.ok(Array.isArray(scenario.inputs.events), `${location}.events: must be an array`);
+      for (const [index, event] of scenario.inputs.events.entries()) {
+        entries.push({
+          name: `events[${index}]`,
+          reference: requireObjectReference(event, objects, `${location}.events[${index}]`),
+          schema: "opencoven.run-event/v1",
+        });
+      }
+      break;
+    }
+    case "run-event-sequence": {
+      requireExactInputKeys(scenario.inputs, ["events"], location);
+      assert.ok(Array.isArray(scenario.inputs.events), `${location}.events: must be an array`);
+      for (const [index, event] of scenario.inputs.events.entries()) {
+        entries.push({
+          name: `events[${index}]`,
+          reference: requireObjectReference(event, objects, `${location}.events[${index}]`),
+          schema: "opencoven.run-event/v1",
+        });
+      }
+      break;
+    }
+  }
+
+  return entries;
+}
+
+function validateScenario(
+  value: unknown,
+  family: ValidatorKind,
+  objects: Record<string, ObjectSpec>,
+  location: string,
+): ScenarioDefinition {
+  const scenario = requireRecord(value, location);
+  assertAllowedKeys(
+    scenario,
+    ["id", "description", "validator", "inputs", "options", "expected"],
+    location,
+  );
+
+  const id = requireString(scenario.id, `${location}.id`);
+  assert.match(id, SCENARIO_ID_PATTERN, `${location}.id: must use lowercase dot/kebab segments`);
+  const description = requireString(scenario.description, `${location}.description`);
+  const validator = requireString(scenario.validator, `${location}.validator`);
+  assert.ok(
+    VALIDATORS.includes(validator as ValidatorKind),
+    `${location}.validator: unknown validator ${validator}`,
+  );
+  assert.equal(validator, family, `${location}.validator: must match corpus family ${family}`);
+  const inputs = requireRecord(scenario.inputs, `${location}.inputs`);
+  const inputEntries = scenarioInputEntries(
+    { validator: validator as ValidatorKind, inputs },
+    objects,
+    `${location}.inputs`,
+  );
+
+  let options: ScenarioDefinition["options"];
+  if (
+    validator === "run-manifest-revision" ||
+    validator === "manifest-retention-consent"
+  ) {
+    if (scenario.options !== undefined) {
+      const rawOptions = requireRecord(scenario.options, `${location}.options`);
+      assertAllowedKeys(
+        rawOptions,
+        validator === "run-manifest-revision"
+          ? ["contextConsent", "freshConsent", "freshConsentAt"]
+          : ["contextConsent"],
+        `${location}.options`,
+      );
+      if (rawOptions.contextConsent !== undefined) {
+        assert.ok(
+          RETENTION_POLICIES.has(rawOptions.contextConsent as string),
+          `${location}.options.contextConsent: must be run-only, 7-days, or project`,
+        );
+      }
+      if (rawOptions.freshConsent !== undefined) {
+        assert.equal(
+          typeof rawOptions.freshConsent,
+          "boolean",
+          `${location}.options.freshConsent: must be a boolean`,
+        );
+      }
+      if (rawOptions.freshConsentAt !== undefined) {
+        assert.equal(
+          isUtcTimestamp(rawOptions.freshConsentAt),
+          true,
+          `${location}.options.freshConsentAt: must be a UTC RFC 3339 timestamp`,
+        );
+      }
+      options = {
+        ...(rawOptions.contextConsent === undefined
+          ? {}
+          : {
+              contextConsent: rawOptions.contextConsent as ManifestRevisionOptions["contextConsent"],
+            }),
+        ...(rawOptions.freshConsent === undefined
+          ? {}
+          : { freshConsent: rawOptions.freshConsent as boolean }),
+        ...(rawOptions.freshConsentAt === undefined
+          ? {}
+          : { freshConsentAt: rawOptions.freshConsentAt as string }),
+      };
+    }
+  } else if (validator === "research-run-context-pack") {
+    if (scenario.options !== undefined) {
+      const rawOptions = requireRecord(scenario.options, `${location}.options`);
+      requireExactInputKeys(
+        rawOptions,
+        ["manifestRevisionOptions"],
+        `${location}.options`,
+      );
+      assert.ok(
+        Array.isArray(rawOptions.manifestRevisionOptions),
+        `${location}.options.manifestRevisionOptions: must be an array`,
+      );
+      const manifestRevisionOptions = rawOptions.manifestRevisionOptions.map(
+        (rawEntry, index) => {
+          const entryLocation =
+            `${location}.options.manifestRevisionOptions[${index}]`;
+          const entry = requireRecord(rawEntry, entryLocation);
+          requireExactInputKeys(
+            entry,
+            [
+              "successorRevision",
+              "successorDigest",
+              "freshConsent",
+              "freshConsentAt",
+              "contextConsent",
+            ],
+            entryLocation,
+          );
+          assert.ok(
+            Number.isSafeInteger(entry.successorRevision) &&
+              (entry.successorRevision as number) >= 2,
+            `${entryLocation}.successorRevision: must be a safe integer of at least 2`,
+          );
+          assert.equal(
+            isSha256(entry.successorDigest),
+            true,
+            `${entryLocation}.successorDigest: must be a lowercase SHA-256 digest`,
+          );
+          assert.equal(
+            entry.freshConsent,
+            true,
+            `${entryLocation}.freshConsent: must equal true`,
+          );
+          assert.equal(
+            isUtcTimestamp(entry.freshConsentAt),
+            true,
+            `${entryLocation}.freshConsentAt: must be a UTC RFC 3339 timestamp`,
+          );
+          assert.ok(
+            RETENTION_POLICIES.has(entry.contextConsent as string),
+            `${entryLocation}.contextConsent: must be run-only, 7-days, or project`,
+          );
+          return {
+            successorRevision: entry.successorRevision as number,
+            successorDigest: entry.successorDigest as string,
+            freshConsent: true as const,
+            freshConsentAt: entry.freshConsentAt as string,
+            contextConsent:
+              entry.contextConsent as ResearchRunManifestRevisionOptionsV1["contextConsent"],
+          };
+        },
+      );
+      options = { manifestRevisionOptions };
+    }
+  } else {
+    assert.equal(
+      scenario.options,
+      undefined,
+      `${location}.options: is only valid for manifest retention consent or revisions`,
+    );
+  }
+
+  const expected = validateExpected(
+    scenario.expected,
+    inputEntries.map((entry) => entry.name),
+    `${location}.expected`,
+  );
+  return {
+    id,
+    description,
+    validator: validator as ValidatorKind,
+    inputs,
+    ...(options === undefined ? {} : { options }),
+    expected,
+  };
+}
+
+function validateCorpus(value: unknown, filePath: string): ScenarioCorpus {
+  const corpus = requireRecord(value, filePath);
+  assertAllowedKeys(corpus, ["format", "family", "objects", "scenarios"], filePath);
+  assert.equal(corpus.format, SCENARIO_FORMAT, `${filePath}: unsupported scenario format`);
+
+  const family = requireString(corpus.family, `${filePath}.family`);
+  assert.ok(VALIDATORS.includes(family as ValidatorKind), `${filePath}.family: unknown family ${family}`);
+
+  const rawObjects = requireRecord(corpus.objects, `${filePath}.objects`);
+  assert.ok(Object.keys(rawObjects).length > 0, `${filePath}.objects: must not be empty`);
+  const objects: Record<string, ObjectSpec> = Object.create(null);
+  for (const name of Object.keys(rawObjects).sort(compareCodeUnits)) {
+    requireString(name, `${filePath}.objects key`);
+    objects[name] = validateObjectSpec(rawObjects[name], `${filePath}.objects.${name}`);
+  }
+  for (const [name, spec] of Object.entries(objects)) {
+    if (spec.predecessor === undefined) continue;
+    assert.equal(
+      family,
+      "run-manifest-revision",
+      `${filePath}.objects.${name}.predecessor: is only valid for manifest revision scenarios`,
+    );
+    assert.notEqual(
+      spec.predecessor,
+      name,
+      `${filePath}.objects.${name}.predecessor: cannot reference itself`,
+    );
+    assert.ok(
+      Object.hasOwn(objects, spec.predecessor),
+      `${filePath}.objects.${name}.predecessor: unknown object ${spec.predecessor}`,
+    );
+  }
+
+  assert.ok(Array.isArray(corpus.scenarios), `${filePath}.scenarios: must be an array`);
+  assert.ok(corpus.scenarios.length > 0, `${filePath}.scenarios: must not be empty`);
+  const scenarios = corpus.scenarios.map((scenario, index) =>
+    validateScenario(scenario, family as ValidatorKind, objects, `${filePath}.scenarios[${index}]`),
+  );
+
+  const ids = scenarios.map((scenario) => scenario.id);
+  assert.equal(new Set(ids).size, ids.length, `${filePath}: duplicate scenario id`);
+
+  const usedObjects = new Set<string>();
+  for (const scenario of scenarios) {
+    for (const entry of scenarioInputEntries(
+      scenario,
+      objects,
+      `${filePath}:${scenario.id}.inputs`,
+    )) {
+      usedObjects.add(entry.reference);
+    }
+  }
+  for (const spec of Object.values(objects)) {
+    if (spec.predecessor !== undefined) usedObjects.add(spec.predecessor);
+  }
+  for (const objectName of Object.keys(objects)) {
+    assert.ok(
+      usedObjects.has(objectName),
+      `${filePath}.objects.${objectName}: object is not referenced by any scenario`,
+    );
+  }
+
+  return {
+    filePath,
+    family: family as ValidatorKind,
+    objects,
+    scenarios,
+  };
+}
+
+function applyMergePatch(target: unknown, patch: unknown): unknown {
+  if (!isRecord(patch)) {
+    return structuredClone(patch);
+  }
+  const merged: Record<string, unknown> = isRecord(target) ? structuredClone(target) : {};
+  for (const key of Object.keys(patch)) {
+    const patchValue = Object.hasOwn(patch, key) ? patch[key] : undefined;
+    if (patchValue === null) {
+      delete merged[key];
+    } else {
+      const targetValue = Object.hasOwn(merged, key) ? merged[key] : undefined;
+      Object.defineProperty(merged, key, {
+        configurable: true,
+        enumerable: true,
+        value: applyMergePatch(targetValue, patchValue),
+        writable: true,
+      });
+    }
+  }
+  return merged;
+}
+
+function decodeJsonPointer(pointer: string, location: string): string[] {
+  if (pointer === "") return [];
+  assert.ok(pointer.startsWith("/"), `${location}: JSON Pointer must start with /`);
+  return pointer.slice(1).split("/").map((part) => {
+    assert.ok(!/~(?:[^01]|$)/.test(part), `${location}: invalid JSON Pointer escape`);
+    return part.replaceAll("~1", "/").replaceAll("~0", "~");
+  });
+}
+
+function resolveJsonPointer(
+  value: Record<string, unknown>,
+  pointer: string,
+  location: string,
+): Record<string, unknown> {
+  let current: unknown = value;
+  for (const part of decodeJsonPointer(pointer, location)) {
+    const record = requireRecord(current, location);
+    assert.ok(Object.hasOwn(record, part), `${location}: pointer does not exist`);
+    current = record[part];
+  }
+  return requireRecord(current, location);
+}
+
+function recomputeDigestTarget(
+  value: Record<string, unknown>,
+  pointer: string,
+  location: string,
+  deferManifestRevisionComposition = false,
+): void {
+  const containerSchema = requireString(value.schema, `${location}.container.schema`);
+  const targetSchema = DIGEST_TARGET_SCHEMA_BY_CONTAINER[containerSchema]?.[pointer];
+  assert.ok(
+    targetSchema !== undefined,
+    `${location}: does not identify a recognized self-digest-bearing protocol object`,
+  );
+
+  const target = resolveJsonPointer(value, pointer, location);
+  assert.equal(
+    target.schema,
+    targetSchema,
+    `${location}: digest target must declare schema ${targetSchema}`,
+  );
+  assert.ok(
+    isSha256(target.digest),
+    `${location}: digest target must already contain a valid digest field`,
+  );
+  target.digest = digestProtocolObject(target);
+  if (
+    !deferManifestRevisionComposition ||
+    targetSchema !== "opencoven.run-manifest/v1"
+  ) {
+    validateAuthoritativeProtocolObject(target, `${location} synthesized target`);
+  }
+}
+
+function resolveFixturePath(
+  relativePath: string,
+  location: string,
+  fixtureRoot: string = fixturesDir,
+): string {
+  assert.ok(relativePath !== "", `${location}: fixture path must not be empty`);
+  assert.ok(!relativePath.includes("\0"), `${location}: fixture path must not contain NUL bytes`);
+  assert.ok(
+    !path.posix.isAbsolute(relativePath) && !path.win32.isAbsolute(relativePath),
+    `${location}: fixture path must be a repository-relative POSIX path beneath the fixture root`,
+  );
+  assert.ok(
+    !/^[A-Za-z]:/.test(relativePath),
+    `${location}: fixture path must not use platform-specific path syntax`,
+  );
+  assert.ok(
+    !relativePath.includes("\\"),
+    `${location}: fixture path must use POSIX separators, not backslashes`,
+  );
+  assert.ok(
+    !/%[0-9A-Fa-f]{2}/.test(relativePath),
+    `${location}: fixture path must not use percent-encoded path syntax`,
+  );
+
+  const segments = relativePath.split("/");
+  assert.ok(
+    !segments.includes(""),
+    `${location}: fixture path must not contain empty segments`,
+  );
+  assert.ok(
+    !segments.some((segment) => segment === "." || segment === ".."),
+    `${location}: fixture path must not contain dot or traversal segments`,
+  );
+  assert.equal(
+    path.posix.normalize(relativePath),
+    relativePath,
+    `${location}: fixture path must already be in normalized POSIX form`,
+  );
+  assert.ok(
+    relativePath.endsWith(".json"),
+    `${location}: fixture path must end in .json`,
+  );
+
+  const absoluteFixtureRoot = path.resolve(fixtureRoot);
+  const rootStats = lstatSync(absoluteFixtureRoot, { throwIfNoEntry: false });
+  assert.ok(rootStats, `${absoluteFixtureRoot}: fixture root does not exist`);
+  assert.ok(
+    !rootStats.isSymbolicLink(),
+    `${absoluteFixtureRoot}: fixture root must not be a symlink`,
+  );
+  assert.ok(
+    rootStats.isDirectory(),
+    `${absoluteFixtureRoot}: fixture root must be a directory`,
+  );
+  const realFixtureRoot = realpathSync(absoluteFixtureRoot);
+
+  let resolved = absoluteFixtureRoot;
+  for (const [index, segment] of segments.entries()) {
+    assert.ok(
+      readdirSync(resolved).includes(segment),
+      `${location}: fixture does not exist (${segments.slice(0, index + 1).join("/")})`,
+    );
+    resolved = path.join(resolved, segment);
+    const stats = lstatSync(resolved, { throwIfNoEntry: false });
+    const traversedPath = segments.slice(0, index + 1).join("/");
+    assert.ok(stats, `${location}: fixture does not exist (${traversedPath})`);
+    assert.ok(
+      !stats.isSymbolicLink(),
+      `${location}: fixture path component ${traversedPath} is a symlink; symlinks are not allowed`,
+    );
+    if (index === segments.length - 1) {
+      assert.ok(stats.isFile(), `${location}: fixture path must identify a regular file`);
+    } else {
+      assert.ok(
+        stats.isDirectory(),
+        `${location}: fixture path component ${traversedPath} must be a directory`,
+      );
+    }
+  }
+
+  const realResolved = realpathSync(resolved);
+  const relative = path.relative(realFixtureRoot, realResolved);
+  assert.ok(
+    relative !== "" &&
+      !relative.startsWith(`..${path.sep}`) &&
+      relative !== ".." &&
+      !path.isAbsolute(relative),
+    `${location}: fixture path must stay beneath ${absoluteFixtureRoot}`,
+  );
+  return resolved;
+}
+
+function materializeObject(
+  spec: ObjectSpec,
+  location: string,
+  deferManifestRevisionComposition = false,
+): Record<string, unknown> {
+  const source =
+    spec.fixture === undefined
+      ? structuredClone(spec.value)
+      : readJsonFile(resolveFixturePath(spec.fixture, `${location}.fixture`));
+  const rawSupportObject = requireRecord(source, `${location}.raw`);
+  validateAuthoritativeProtocolObject(rawSupportObject, `${location}.raw`);
+
+  let materialized = structuredClone(rawSupportObject);
+  if (spec.mergePatch !== undefined) {
+    materialized = requireRecord(applyMergePatch(materialized, spec.mergePatch), location);
+  }
+  for (const [index, targetPointer] of (spec.digestTargets ?? []).entries()) {
+    recomputeDigestTarget(
+      materialized,
+      targetPointer,
+      `${location}.digestTargets[${index}]`,
+      deferManifestRevisionComposition,
+    );
+  }
+  return materialized;
+}
+
+function schemaFileNameFor(schemaId: string): string {
+  const match = SCHEMA_ID_PATTERN.exec(schemaId);
+  assert.ok(match, `schema id ${schemaId} does not match opencoven.<name>/v1`);
+  return `${match[1]}.schema.json`;
+}
+
+const schemaContext = new Map<string, TSchema>();
+const schemaCheckContext: Record<string, TSchema> = Object.create(null);
+for (const schemaId of RESEARCH_PROTOCOL_SCHEMAS) {
+  const schemaPath = path.join(schemasDir, schemaFileNameFor(schemaId));
+  const schema = readJsonFile(schemaPath);
+  assert.ok(IsSchema(schema), `${schemaPath}: must be a valid JSON Schema`);
+  const schemaDocumentId = (schema as TSchema & { $id?: unknown }).$id;
+  assert.ok(
+    typeof schemaDocumentId === "string",
+    `${schemaPath}: must declare a schema document id`,
+  );
+  schemaContext.set(schemaId, schema);
+  schemaCheckContext[schemaDocumentId] = schema;
+}
+
+function validateProtocolObjectSchema(
+  value: unknown,
+  location: string,
+  expectedSchema?: ResearchProtocolObjectV1["schema"],
+  allowSchemaInvalid = false,
+): Record<string, unknown> {
+  const protocolObject = requireRecord(value, location);
+  const declaredSchema = requireString(protocolObject.schema, `${location}.schema`);
+  if (expectedSchema !== undefined) {
+    assert.equal(
+      declaredSchema,
+      expectedSchema,
+      `${location}: input must declare expected protocol role schema ${expectedSchema}`,
+    );
+  }
+  const schemaId = expectedSchema ?? declaredSchema;
+  const schema = schemaContext.get(schemaId);
+  assert.ok(schema !== undefined, `${location}: schema ${schemaId} is not an approved v1 schema`);
+  if (!allowSchemaInvalid) {
+    assert.equal(
+      Check(schemaCheckContext, schema, protocolObject),
+      true,
+      expectedSchema === undefined
+        ? `${location}: object must pass its authoritative schema before parsing or composition`
+        : `${location}: input must pass expected protocol role schema ${expectedSchema} before parsing or composition`,
+    );
+  }
+  return protocolObject;
+}
+
+function invokeParserWithSnapshot<T>(
+  protocolObject: Record<string, unknown>,
+  parser: (value: unknown) => ProtocolParseResult<T>,
+  location: string,
+): ProtocolParseResult<T> {
+  const snapshot = structuredClone(protocolObject);
+  const parsed = parser(protocolObject);
+  assert.deepEqual(
+    protocolObject,
+    snapshot,
+    `${location}: public parser must not mutate its input`,
+  );
+  if (parsed.ok) {
+    assert.deepEqual(
+      parsed.value,
+      snapshot,
+      `${location}: public parser must preserve protocol data losslessly`,
+    );
+  }
+  return parsed;
+}
+
+function validateAuthoritativeProtocolObject(
+  value: unknown,
+  location: string,
+): ResearchProtocolObjectV1 {
+  const protocolObject = validateProtocolObjectSchema(value, location);
+  const parsed = invokeParserWithSnapshot(
+    protocolObject,
+    parseResearchProtocolObject,
+    location,
+  );
+  if (!parsed.ok) {
+    assert.fail(
+      `${location}: support object must pass the public parser (${parsed.error.code} at ${parsed.error.path}: ${parsed.error.message})`,
+    );
+  }
+  return parsed.value;
+}
+
+function materializeScenarioInput(
+  corpus: ScenarioCorpus,
+  entry: ScenarioInputEntry,
+  allowSchemaInvalid = false,
+): Record<string, unknown> {
+  const location = `${corpus.filePath}.objects.${entry.reference} (input ${entry.name})`;
+  return validateProtocolObjectSchema(
+    materializeObject(
+      corpus.objects[entry.reference],
+      location,
+      (corpus.family === "run-manifest-revision" && entry.name === "next") ||
+        allowSchemaInvalid,
+    ),
+    location,
+    entry.schema,
+    allowSchemaInvalid,
+  );
+}
+
+function requireParsedSchema<T extends ResearchProtocolObjectV1>(
+  parsed: ResearchProtocolObjectV1,
+  schema: T["schema"],
+  location: string,
+): T {
+  assert.equal(parsed.schema, schema, `${location}: expected ${schema}, got ${parsed.schema}`);
+  return parsed as T;
+}
+
+function replayScenarioManifestPredecessor(
+  corpus: ScenarioCorpus,
+  scenario: ScenarioDefinition,
+  parsedInputs: Map<string, ResearchProtocolObjectV1>,
+): void {
+  if (scenario.validator !== "run-manifest-revision") return;
+
+  const targetReference = scenario.inputs.previous as string;
+  if (corpus.objects[targetReference].predecessor === undefined) return;
+
+  const reverseChain = [targetReference];
+  const seen = new Set(reverseChain);
+  let cursor: string | undefined = corpus.objects[targetReference].predecessor;
+  while (cursor !== undefined) {
+    assert.ok(
+      !seen.has(cursor),
+      `${corpus.filePath}.objects.${targetReference}.predecessor: cycle detected`,
+    );
+    seen.add(cursor);
+    reverseChain.push(cursor);
+    cursor = corpus.objects[cursor].predecessor;
+  }
+  const chain = reverseChain.reverse();
+  const rootReference = chain[0];
+  const rootLocation = `${corpus.filePath}.objects.${rootReference} (revision history root)`;
+  const root = requireParsedSchema<RunManifestV1>(
+    validateAuthoritativeProtocolObject(
+      materializeObject(corpus.objects[rootReference], rootLocation),
+      rootLocation,
+    ),
+    "opencoven.run-manifest/v1",
+    rootLocation,
+  );
+  assert.equal(root.revision, 1, `${rootLocation}: revision history must start at revision 1`);
+
+  let replayed = root;
+  for (const reference of chain.slice(1)) {
+    const candidate =
+      reference === targetReference
+        ? requireParsedSchema<RunManifestV1>(
+            parsedInputs.get("previous")!,
+            "opencoven.run-manifest/v1",
+            `${scenario.id}.previous`,
+          )
+        : (validateProtocolObjectSchema(
+            materializeObject(
+              corpus.objects[reference],
+              `${corpus.filePath}.objects.${reference} (revision history)`,
+              true,
+            ),
+            `${corpus.filePath}.objects.${reference} (revision history)`,
+            "opencoven.run-manifest/v1",
+          ) as RunManifestV1);
+    const result = validateRunManifestRevisionV1(replayed, candidate, scenario.options);
+    if (!result.ok) {
+      assert.fail(
+        `${corpus.filePath}.objects.${reference}.predecessor: history replay failed (${result.error.code} at ${result.error.path}: ${result.error.message})`,
+      );
+    }
+    replayed = result.value;
+  }
+  parsedInputs.set("previous", replayed);
+}
+
+function executeComposition(
+  scenario: ScenarioDefinition,
+  parsedInputs: ReadonlyMap<string, ResearchProtocolObjectV1>,
+): {
+  result: ProtocolParseResult<ResearchProtocolObjectV1 | readonly RunEventV1[]>;
+  expectedValue: ResearchProtocolObjectV1 | readonly RunEventV1[];
+} {
+  switch (scenario.validator) {
+    case "manifest-retention-consent": {
+      const manifest = requireParsedSchema<RunManifestV1>(
+        parsedInputs.get("manifest")!,
+        "opencoven.run-manifest/v1",
+        `${scenario.id}.manifest`,
+      );
+      return {
+        result: validateManifestRetentionConsent(manifest, scenario.options?.contextConsent),
+        expectedValue: manifest,
+      };
+    }
+    case "run-manifest-revision": {
+      const previous = requireParsedSchema<RunManifestV1>(
+        parsedInputs.get("previous")!,
+        "opencoven.run-manifest/v1",
+        `${scenario.id}.previous`,
+      );
+      const next = requireParsedSchema<RunManifestV1>(
+        parsedInputs.get("next")!,
+        "opencoven.run-manifest/v1",
+        `${scenario.id}.next`,
+      );
+      return {
+        result: validateRunManifestRevisionV1(previous, next, scenario.options),
+        expectedValue: next,
+      };
+    }
+    case "research-run-context-pack": {
+      const run = requireParsedSchema<ResearchRunV1>(
+        parsedInputs.get("run")!,
+        "opencoven.research-run/v1",
+        `${scenario.id}.run`,
+      );
+      const parsedContextPack = parsedInputs.get("contextPack");
+      const contextPack =
+        parsedContextPack === undefined
+          ? undefined
+          : requireParsedSchema<ContextPackV1>(
+              parsedContextPack,
+              "opencoven.context-pack/v1",
+              `${scenario.id}.contextPack`,
+            );
+      const historyReferences = scenario.inputs.manifestHistory;
+      const manifestHistory =
+        historyReferences === undefined
+          ? undefined
+          : (historyReferences as unknown[]).map((_, index) =>
+              requireParsedSchema<RunManifestV1>(
+                parsedInputs.get(`manifestHistory[${index}]`)!,
+                "opencoven.run-manifest/v1",
+                `${scenario.id}.manifestHistory[${index}]`,
+              ),
+            );
+      return {
+        result: validateResearchRunContextPackV1(run, contextPack, {
+          ...(manifestHistory === undefined ? {} : { manifestHistory }),
+          ...(scenario.options?.manifestRevisionOptions === undefined
+            ? {}
+            : {
+                manifestRevisionOptions:
+                  scenario.options.manifestRevisionOptions,
+              }),
+        }),
+        expectedValue: run,
+      };
+    }
+    case "model-task-result": {
+      const task = requireParsedSchema<ModelTaskV1>(
+        parsedInputs.get("task")!,
+        "opencoven.model-task/v1",
+        `${scenario.id}.task`,
+      );
+      const result = requireParsedSchema<ModelTaskResultV1>(
+        parsedInputs.get("result")!,
+        "opencoven.model-task-result/v1",
+        `${scenario.id}.result`,
+      );
+      return {
+        result: validateModelTaskResultV1(task, result),
+        expectedValue: result,
+      };
+    }
+    case "run-event-deletion": {
+      const run = requireParsedSchema<ResearchRunV1>(
+        parsedInputs.get("run")!,
+        "opencoven.research-run/v1",
+        `${scenario.id}.run`,
+      );
+      const events: RunEventV1[] = [];
+      const rawEvents = scenario.inputs.events as unknown[];
+      for (const index of rawEvents.keys()) {
+        events.push(
+          requireParsedSchema<RunEventV1>(
+            parsedInputs.get(`events[${index}]`)!,
+            "opencoven.run-event/v1",
+            `${scenario.id}.events[${index}]`,
+          ),
+        );
+      }
+      const eventsBefore = structuredClone(events);
+      const result = validateRunManifestDeletionEventV1(run, events);
+      assert.deepEqual(events, eventsBefore, "deletion composition must not reorder or mutate events");
+      return {
+        result,
+        expectedValue: run,
+      };
+    }
+    case "run-event-sequence": {
+      const events: RunEventV1[] = [];
+      const rawEvents = scenario.inputs.events as unknown[];
+      for (const index of rawEvents.keys()) {
+        events.push(
+          requireParsedSchema<RunEventV1>(
+            parsedInputs.get(`events[${index}]`)!,
+            "opencoven.run-event/v1",
+            `${scenario.id}.events[${index}]`,
+          ),
+        );
+      }
+      const eventsBefore = structuredClone(events);
+      const result = validateRunEventSequence(events);
+      assert.deepEqual(events, eventsBefore, "sequence composition must not reorder or mutate events");
+      return {
+        result,
+        expectedValue: events,
+      };
+    }
+  }
+}
+
+function executeScenario(corpus: ScenarioCorpus, scenario: ScenarioDefinition): void {
+  const entries = scenarioInputEntries(
+    scenario,
+    corpus.objects,
+    `${corpus.filePath}:${scenario.id}.inputs`,
+  );
+  const parsedInputs = new Map<string, ResearchProtocolObjectV1>();
+  let expectedParseFailureSeen = false;
+  const materializedInputs = entries.map((entry) => ({
+    entry,
+    location: `${corpus.filePath}.objects.${entry.reference} (input ${entry.name})`,
+    materialized: materializeScenarioInput(
+      corpus,
+      entry,
+      !scenario.expected.ok &&
+        scenario.expected.stage === "parse" &&
+        scenario.expected.input === entry.name,
+    ),
+  }));
+
+  for (const { entry, location, materialized } of materializedInputs) {
+    const expectsThisParseFailure =
+      !scenario.expected.ok &&
+      scenario.expected.stage === "parse" &&
+      scenario.expected.input === entry.name;
+    if (
+      scenario.validator === "run-manifest-revision" &&
+      (entry.name === "next" ||
+        (entry.name === "previous" &&
+          corpus.objects[entry.reference].predecessor !== undefined)) &&
+      !expectsThisParseFailure
+    ) {
+      parsedInputs.set(entry.name, materialized as ResearchProtocolObjectV1);
+      continue;
+    }
+    const parsed =
+      invokeParserWithSnapshot(
+        materialized,
+        parseResearchProtocolObject,
+        location,
+      );
+    if (!parsed.ok) {
+      assert.equal(
+        scenario.expected.ok,
+        false,
+        `${entry.name}: parser rejected an input for a scenario expected to pass`,
+      );
+      if (scenario.expected.ok) return;
+      assert.equal(scenario.expected.stage, "parse", `${entry.name}: unexpected parser failure`);
+      assert.equal(scenario.expected.input, entry.name, `${entry.name}: wrong input failed parsing`);
+      assert.equal(parsed.error.code, scenario.expected.code, `${entry.name}: wrong protocol error code`);
+      assert.equal(parsed.error.path, scenario.expected.path, `${entry.name}: wrong protocol error path`);
+      expectedParseFailureSeen = true;
+      continue;
+    }
+
+    parsedInputs.set(entry.name, parsed.value);
+  }
+
+  if (!scenario.expected.ok && scenario.expected.stage === "parse") {
+    assert.equal(expectedParseFailureSeen, true, "expected parser failure was not observed");
+    return;
+  }
+  assert.equal(expectedParseFailureSeen, false);
+
+  replayScenarioManifestPredecessor(corpus, scenario, parsedInputs);
+  const before = structuredClone(Object.fromEntries(parsedInputs));
+  const { result, expectedValue } = executeComposition(scenario, parsedInputs);
+  assert.deepEqual(
+    Object.fromEntries(parsedInputs),
+    before,
+    "composition validator must not mutate any parsed scenario input",
+  );
+
+  if (scenario.expected.ok) {
+    if (!result.ok) {
+      assert.fail(
+        `${result.error.path}: expected composition success, got ${result.error.code}: ${result.error.message}`,
+      );
+    }
+    assert.deepEqual(result.value, expectedValue, "successful composition must not lose protocol data");
+    return;
+  }
+
+  assert.equal(scenario.expected.stage, "composition");
+  assert.equal(result.ok, false, "expected composition failure");
+  if (result.ok) return;
+  assert.equal(result.error.code, scenario.expected.code, "wrong protocol error code");
+  assert.equal(result.error.path, scenario.expected.path, "wrong protocol error path");
+}
+
+function collectFixtureReferences(
+  scenarioCorpora: readonly ScenarioCorpus[],
+  fixtureRoot: string = fixturesDir,
+): Map<string, string[]> {
+  const references = new Map<string, string[]>();
+  for (const corpus of scenarioCorpora) {
+    for (const objectName of Object.keys(corpus.objects).sort(compareCodeUnits)) {
+      const fixture = corpus.objects[objectName].fixture;
+      if (fixture === undefined) continue;
+
+      const location = `${corpus.filePath}.objects.${objectName}.fixture`;
+      resolveFixturePath(fixture, location, fixtureRoot);
+      const locations = references.get(fixture) ?? [];
+      locations.push(location);
+      references.set(fixture, locations);
+    }
+  }
+  return references;
+}
+
+function assertSupportObjectsReferenced(
+  supportRelativePaths: readonly string[],
+  fixtureReferences: ReadonlyMap<string, readonly string[]>,
+  scenarioRootLocation: string,
+): void {
+  for (const relativePath of [...supportRelativePaths].sort(compareCodeUnits)) {
+    const fixtureReference = `scenarios/${relativePath}`;
+    const locations = fixtureReferences.get(fixtureReference);
+    assert.ok(
+      locations !== undefined && locations.length > 0,
+      `${scenarioRootLocation}/${relativePath}: support object is not referenced by any corpus`,
+    );
+  }
+}
+
+const scenarioInventory = inventoryScenarioTree(scenariosDir);
+for (const supportObject of scenarioInventory.supportObjectFiles) {
+  validateAuthoritativeProtocolObject(readJsonFile(supportObject.filePath), supportObject.filePath);
+}
+
+const corpora = scenarioInventory.corpusFiles.map(({ filePath }) =>
+  validateCorpus(readJsonFile(filePath), filePath),
+);
+const fixtureReferenceLocations = collectFixtureReferences(corpora);
+assertSupportObjectsReferenced(
+  scenarioInventory.supportObjectFiles.map((file) => file.relativePath),
+  fixtureReferenceLocations,
+  scenariosDir,
+);
+
+test("discovers every structured Research Protocol scenario fixture deterministically", () => {
+  const corpusRelativePaths = scenarioInventory.corpusFiles.map((file) => file.relativePath);
+  const supportRelativePaths = scenarioInventory.supportObjectFiles.map((file) => file.relativePath);
+  assert.ok(corpusRelativePaths.length > 0, `${scenariosDir}: no .scenario.json fixtures found`);
+  assert.ok(supportRelativePaths.length > 0, `${scenariosDir}: no support object fixtures found`);
+  assert.deepEqual(
+    corpusRelativePaths,
+    [...corpusRelativePaths].sort(compareCodeUnits),
+    `${scenariosDir}: corpus inventory must use code-unit ordering`,
+  );
+  assert.deepEqual(
+    supportRelativePaths,
+    [...supportRelativePaths].sort(compareCodeUnits),
+    `${scenariosDir}: support object inventory must use code-unit ordering`,
+  );
+  assert.deepEqual(
+    [...new Set(corpora.map((corpus) => corpus.family))].sort(compareCodeUnits),
+    [...VALIDATORS].sort(compareCodeUnits),
+    "scenario corpus must cover every public composition validator family",
+  );
+});
+
+test("maps actions onto the complete intended public validator surface", () => {
+  assert.deepEqual(
+    [...new Set(Object.values(VALIDATOR_ENTRY_POINT_BY_ACTION))].sort(compareCodeUnits),
+    [...PUBLIC_VALIDATOR_ENTRY_POINTS].sort(compareCodeUnits),
+    "scenario action registry must cover every intended public cross-object/stream validator",
+  );
+});
+
+test("rejects malformed scenario definitions before protocol execution", () => {
+  assert.throws(
+    () =>
+      validateCorpus(
+        {
+          format: SCENARIO_FORMAT,
+          family: "model-task-result",
+          objects: {
+            task: { fixture: "valid/model-task.json", unexpected: true },
+          },
+          scenarios: [],
+        },
+        "malformed.scenario.json",
+      ),
+    /unknown field unexpected/,
+  );
+  assert.throws(
+    () =>
+      validateExpected(
+        {
+          ok: false,
+          stage: "composition",
+          code: "not_a_protocol_error",
+          path: "$",
+        },
+        [],
+        "malformed.expected",
+      ),
+    /unknown protocol error code/,
+  );
+  assert.throws(
+    () =>
+      validateCorpus(
+        {
+          format: SCENARIO_FORMAT,
+          family: "model-task-result",
+          objects: {
+            task: { fixture: "valid/model-task.json" },
+          },
+          scenarios: [],
+        },
+        "empty-family.scenario.json",
+      ),
+    /scenarios: must not be empty/,
+  );
+  assert.throws(
+    () => resolveFixturePath("valid/missing-scenario-fixture.json", "missing.fixture"),
+    /missing\.fixture: fixture does not exist/,
+  );
+});
+
+test("preserves own __proto__ keys through nested RFC 7396 merge patches", () => {
+  const target = requireRecord(
+    JSON.parse(
+      '{"nested":{"retained":true,"__proto__":{"retainedOwnProto":true}}}',
+    ),
+    "merge target",
+  );
+  const patch = requireRecord(
+    JSON.parse(
+      '{"__proto__":{"topLevelPolluted":true},"nested":{"__proto__":{"nestedPolluted":true},"added":true}}',
+    ),
+    "merge patch",
+  );
+
+  const merged = requireRecord(applyMergePatch(target, patch), "merged result");
+  const nested = requireRecord(merged.nested, "merged result.nested");
+  const topLevelProtoValue = requireRecord(merged["__proto__"], "merged result.__proto__");
+  const nestedProtoValue = requireRecord(nested["__proto__"], "merged result.nested.__proto__");
+
+  assert.deepEqual(
+    merged,
+    JSON.parse(
+      '{"nested":{"retained":true,"__proto__":{"retainedOwnProto":true,"nestedPolluted":true},"added":true},"__proto__":{"topLevelPolluted":true}}',
+    ),
+  );
+  assert.ok(Object.hasOwn(merged, "__proto__"));
+  assert.ok(Object.hasOwn(nested, "__proto__"));
+  assert.equal(Object.getPrototypeOf(merged), Object.prototype);
+  assert.equal(Object.getPrototypeOf(nested), Object.prototype);
+  assert.equal(Object.getPrototypeOf(topLevelProtoValue), Object.prototype);
+  assert.equal(Object.getPrototypeOf(nestedProtoValue), Object.prototype);
+  assert.equal(({} as Record<string, unknown>).topLevelPolluted, undefined);
+  assert.equal(({} as Record<string, unknown>).nestedPolluted, undefined);
+});
+
+test("detects public parser mutation on every result and data loss on success", () => {
+  for (const outcome of ["success", "failure"] as const) {
+    const input = {
+      schema: "opencoven.injected/v1",
+      nested: { retained: true },
+    };
+
+    assert.throws(
+      () =>
+        invokeParserWithSnapshot(
+          input,
+          (value) => {
+            const record = requireRecord(value, `${outcome} parser input`);
+            const nested = requireRecord(record.nested, `${outcome} parser input.nested`);
+            nested.mutated = true;
+            if (outcome === "success") {
+              return { ok: true, value: structuredClone(record) } as const;
+            }
+            return {
+              ok: false,
+              error: {
+                code: "invalid_value",
+                path: "$",
+                message: "Injected parser failure",
+              },
+            } as const;
+          },
+          `${outcome} parser`,
+        ),
+      /public parser must not mutate its input/,
+    );
+  }
+
+  const losslessInput = {
+    schema: "opencoven.injected/v1",
+    retained: true,
+  };
+  assert.throws(
+    () =>
+      invokeParserWithSnapshot(
+        losslessInput,
+        () => ({
+          ok: true,
+          value: { schema: "opencoven.injected/v1" },
+        }),
+        "lossy success parser",
+      ),
+    /public parser must preserve protocol data losslessly/,
+  );
+});
+
+test("validates raw support objects through the authoritative schema and public parser", () => {
+  const filePath = path.join(scenariosDir, "objects/context-bound-extended-run.json");
+  const supportObject = requireRecord(readJsonFile(filePath), filePath);
+  assert.deepEqual(validateAuthoritativeProtocolObject(supportObject, filePath), supportObject);
+
+  const parserInvalid = structuredClone(supportObject);
+  const manifest = requireRecord(parserInvalid.artifactManifest, `${filePath}.artifactManifest`);
+  manifest.digest = "0".repeat(64);
+  assert.throws(
+    () => validateAuthoritativeProtocolObject(parserInvalid, "parser-invalid-support.json"),
+    /public parser.*digest_mismatch.*\$\.artifactManifest\.digest/,
+  );
+});
+
+test("rejects an invalid raw digest before declarative recomputation can repair it", () => {
+  const filePath = path.join(fixturesDir, "valid/run-manifest-final-local.json");
+  const invalidManifest = requireRecord(readJsonFile(filePath), filePath);
+  invalidManifest.digest = "0".repeat(64);
+
+  assert.throws(
+    () =>
+      materializeObject(
+        {
+          value: invalidManifest,
+          mergePatch: {
+            retention: {
+              effectivePolicy: "run-only",
+            },
+          },
+          digestTargets: [""],
+        },
+        "invalid-raw-digest",
+      ),
+    /support object must pass the public parser.*digest_mismatch.*\$\.digest/,
+  );
+});
+
+test("restricts digest targets to recognized self-digest-bearing protocol records", () => {
+  const runPath = path.join(fixturesDir, "valid/research-run.json");
+  const run = requireRecord(readJsonFile(runPath), runPath);
+  assert.throws(
+    () => materializeObject({ value: run, digestTargets: [""] }, "research-run-root"),
+    /digestTargets\[0\].*does not identify a recognized self-digest-bearing protocol object/,
+  );
+
+  const manifestPath = path.join(fixturesDir, "valid/run-manifest-final-local.json");
+  const manifest = requireRecord(readJsonFile(manifestPath), manifestPath);
+  assert.throws(
+    () =>
+      materializeObject(
+        {
+          value: manifest,
+          mergePatch: {
+            retention: {
+              digest: "0".repeat(64),
+            },
+          },
+          digestTargets: ["/retention"],
+        },
+        "manifest-retention-record",
+      ),
+    /digestTargets\[0\].*does not identify a recognized self-digest-bearing protocol object/,
+  );
+  assert.throws(
+    () =>
+      materializeObject(
+        {
+          value: manifest,
+          mergePatch: {
+            digest: "not-a-digest",
+          },
+          digestTargets: [""],
+        },
+        "invalid-target-digest",
+      ),
+    /digestTargets\[0\].*must already contain a valid digest field/,
+  );
+  assert.throws(
+    () =>
+      materializeObject(
+        {
+          value: manifest,
+          mergePatch: {
+            digest: null,
+          },
+          digestTargets: [""],
+        },
+        "missing-target-digest",
+      ),
+    /digestTargets\[0\].*must already contain a valid digest field/,
+  );
+});
+
+test("classifies only top-level corpora and direct JSON support objects under objects", () => {
+  assert.equal(classifyScenarioTreeEntry("model-task-result.scenario.json", "file"), "corpus");
+  assert.equal(classifyScenarioTreeEntry("objects", "directory"), "directory");
+  assert.equal(classifyScenarioTreeEntry("objects/base.json", "file"), "support");
+
+  assert.throws(
+    () => classifyScenarioTreeEntry("nested/base.json", "file"),
+    /JSON file is outside the objects directory/,
+  );
+  assert.throws(
+    () => classifyScenarioTreeEntry("notes.txt", "file"),
+    /unexpected file extension/,
+  );
+  assert.throws(
+    () => classifyScenarioTreeEntry("extra", "directory"),
+    /unexpected directory/,
+  );
+  assert.throws(
+    () => classifyScenarioTreeEntry("objects/nested", "directory"),
+    /unexpected directory/,
+  );
+  assert.throws(
+    () => classifyScenarioTreeEntry("objects/nested/base.json", "file"),
+    /nested support object/,
+  );
+  assert.throws(
+    () => classifyScenarioTreeEntry("objects/link.json", "symlink"),
+    /symlinks are not allowed/,
+  );
+  assert.throws(
+    () => classifyScenarioTreeEntry("objects/socket.json", "other"),
+    /must be a regular file or directory/,
+  );
+});
+
+test("rejects nested directories, unexpected files, and a missing objects directory", () => {
+  withTemporaryDirectory((temporaryDirectory) => {
+    const scenarioRoot = path.join(temporaryDirectory, "scenarios");
+    mkdirSync(path.join(scenarioRoot, "objects"), { recursive: true });
+    mkdirSync(path.join(scenarioRoot, "nested"), { recursive: true });
+    writeFileSync(path.join(scenarioRoot, "nested", "hidden.scenario.json"), "{}\n");
+    assert.throws(() => inventoryScenarioTree(scenarioRoot), /nested: unexpected directory/);
+  });
+
+  withTemporaryDirectory((temporaryDirectory) => {
+    const scenarioRoot = path.join(temporaryDirectory, "scenarios");
+    mkdirSync(path.join(scenarioRoot, "objects", "nested"), { recursive: true });
+    writeFileSync(path.join(scenarioRoot, "objects", "nested", "hidden.json"), "{}\n");
+    assert.throws(
+      () => inventoryScenarioTree(scenarioRoot),
+      /objects\/nested: unexpected directory/,
+    );
+  });
+
+  withTemporaryDirectory((temporaryDirectory) => {
+    const scenarioRoot = path.join(temporaryDirectory, "scenarios");
+    mkdirSync(path.join(scenarioRoot, "objects"), { recursive: true });
+    writeFileSync(path.join(scenarioRoot, "unexpected.json"), "{}\n");
+    assert.throws(
+      () => inventoryScenarioTree(scenarioRoot),
+      /unexpected\.json: JSON file is outside the objects directory/,
+    );
+  });
+
+  withTemporaryDirectory((temporaryDirectory) => {
+    const scenarioRoot = path.join(temporaryDirectory, "scenarios");
+    mkdirSync(scenarioRoot, { recursive: true });
+    writeFileSync(path.join(scenarioRoot, "only.scenario.json"), "{}\n");
+    assert.throws(() => inventoryScenarioTree(scenarioRoot), /required objects directory/);
+  });
+});
+
+test("rejects symlink entries in isolated scenario trees", (context) => {
+  withTemporaryDirectory((temporaryDirectory) => {
+    const scenarioRoot = path.join(temporaryDirectory, "scenarios");
+    const targetPath = path.join(temporaryDirectory, "target.json");
+    mkdirSync(path.join(scenarioRoot, "objects"), { recursive: true });
+    writeFileSync(targetPath, "{}\n");
+    if (
+      !createSymlinkOrSkip(
+        context,
+        targetPath,
+        path.join(scenarioRoot, "objects", "linked.json"),
+        "file",
+      )
+    ) {
+      return;
+    }
+    assert.throws(() => inventoryScenarioTree(scenarioRoot), /symlinks are not allowed/);
+  });
+});
+
+test("rejects non-portable fixture references before filesystem lookup", () => {
+  for (const [fixture, expected] of [
+    [path.join(fixturesDir, "valid/model-task.json"), /relative POSIX path/],
+    ["C:/checkout/model-task.json", /relative POSIX path/],
+    ["C:checkout/model-task.json", /platform-specific path syntax/],
+    ["valid\\model-task.json", /POSIX separators/],
+    ["./valid/model-task.json", /dot or traversal segments/],
+    ["valid/../valid/model-task.json", /dot or traversal segments/],
+    ["valid//model-task.json", /empty segments/],
+    ["valid/model-task.json/", /empty segments/],
+    ["%2e%2e/valid/model-task.json", /percent-encoded path syntax/],
+    ["valid%2fmodel-task.json", /percent-encoded path syntax/],
+    ["valid%5Cmodel-task.json", /percent-encoded path syntax/],
+    ["valid/model-task.json\0", /NUL bytes/],
+    ["valid/model-task.txt", /end in \.json/],
+  ] as const) {
+    assert.throws(
+      () => resolveFixturePath(fixture, `fixture ${JSON.stringify(fixture)}`),
+      expected,
+    );
+  }
+
+  assert.equal(
+    resolveFixturePath("valid/model-task.json", "portable.fixture"),
+    path.join(fixturesDir, "valid/model-task.json"),
+  );
+  assert.equal(
+    resolveFixturePath(
+      "scenarios/objects/completed-deletion-run.json",
+      "shared-object.fixture",
+    ),
+    path.join(fixturesDir, "scenarios/objects/completed-deletion-run.json"),
+  );
+
+  withTemporaryDirectory((temporaryDirectory) => {
+    const isolatedFixtures = path.join(temporaryDirectory, "fixtures");
+    mkdirSync(path.join(isolatedFixtures, "valid"), { recursive: true });
+    writeFileSync(path.join(isolatedFixtures, "valid", "model-task.json"), "{}\n");
+    assert.equal(
+      resolveFixturePath("valid/model-task.json", "isolated.fixture", isolatedFixtures),
+      path.join(isolatedFixtures, "valid", "model-task.json"),
+    );
+  });
+});
+
+test("rejects an inventoried support object not referenced by any corpus", () => {
+  withTemporaryDirectory((temporaryDirectory) => {
+    const isolatedFixtures = path.join(temporaryDirectory, "fixtures");
+    const scenarioRoot = path.join(isolatedFixtures, "scenarios");
+    const objectsDirectory = path.join(scenarioRoot, "objects");
+    mkdirSync(objectsDirectory, { recursive: true });
+    writeFileSync(path.join(scenarioRoot, "corpus.scenario.json"), "{}\n");
+    writeFileSync(path.join(objectsDirectory, "used.json"), "{}\n");
+    writeFileSync(path.join(objectsDirectory, "orphan.json"), "{}\n");
+
+    const inventory = inventoryScenarioTree(scenarioRoot);
+    const corpus: ScenarioCorpus = {
+      filePath: path.join(scenarioRoot, "corpus.scenario.json"),
+      family: "model-task-result",
+      objects: {
+        used: { fixture: "scenarios/objects/used.json" },
+      },
+      scenarios: [],
+    };
+    const references = collectFixtureReferences([corpus], isolatedFixtures);
+    assert.throws(
+      () =>
+        assertSupportObjectsReferenced(
+          inventory.supportObjectFiles.map((file) => file.relativePath),
+          references,
+          scenarioRoot,
+        ),
+      /objects\/orphan\.json: support object is not referenced by any corpus/,
+    );
+  });
+});
+
+test("rejects an intermediate fixture symlink escape", (context) => {
+  withTemporaryDirectory((temporaryDirectory) => {
+    const isolatedFixtures = path.join(temporaryDirectory, "fixtures");
+    const outsideDirectory = path.join(temporaryDirectory, "outside");
+    mkdirSync(isolatedFixtures, { recursive: true });
+    mkdirSync(outsideDirectory, { recursive: true });
+    writeFileSync(path.join(outsideDirectory, "escaped.json"), "{}\n");
+    if (
+      !createSymlinkOrSkip(
+        context,
+        outsideDirectory,
+        path.join(isolatedFixtures, "escape"),
+        "dir",
+      )
+    ) {
+      return;
+    }
+    assert.throws(
+      () => resolveFixturePath("escape/escaped.json", "escaped.fixture", isolatedFixtures),
+      /fixture path component escape is a symlink/,
+    );
+  });
+});
+
+test("rejects a final fixture file symlink", (context) => {
+  withTemporaryDirectory((temporaryDirectory) => {
+    const isolatedFixtures = path.join(temporaryDirectory, "fixtures");
+    const targetPath = path.join(temporaryDirectory, "target.json");
+    mkdirSync(isolatedFixtures, { recursive: true });
+    writeFileSync(targetPath, "{}\n");
+    if (
+      !createSymlinkOrSkip(
+        context,
+        targetPath,
+        path.join(isolatedFixtures, "linked.json"),
+        "file",
+      )
+    ) {
+      return;
+    }
+    assert.throws(
+      () => resolveFixturePath("linked.json", "linked.fixture", isolatedFixtures),
+      /fixture path component linked\.json is a symlink/,
+    );
+  });
+});
+
+test("rejects a fixture root symlink", (context) => {
+  withTemporaryDirectory((temporaryDirectory) => {
+    const actualFixtures = path.join(temporaryDirectory, "actual-fixtures");
+    const linkedFixtures = path.join(temporaryDirectory, "linked-fixtures");
+    mkdirSync(actualFixtures, { recursive: true });
+    writeFileSync(path.join(actualFixtures, "fixture.json"), "{}\n");
+    if (!createSymlinkOrSkip(context, actualFixtures, linkedFixtures, "dir")) {
+      return;
+    }
+    assert.throws(
+      () => resolveFixturePath("fixture.json", "root-link.fixture", linkedFixtures),
+      /fixture root must not be a symlink/,
+    );
+  });
+});
+
+test("rejects unknown scenario kinds, duplicate ids, and incomplete expected errors", () => {
+  const objects = {
+    task: { fixture: "valid/model-task.json" },
+    result: { fixture: "valid/model-task-result.json" },
+  };
+  const scenario = {
+    id: "model.valid-pair",
+    description: "A valid task and result pair.",
+    validator: "model-task-result",
+    inputs: { task: "task", result: "result" },
+    expected: { ok: true },
+  };
+
+  assert.throws(
+    () =>
+      validateCorpus(
+        {
+          format: SCENARIO_FORMAT,
+          family: "model-task-result",
+          objects,
+          scenarios: [scenario, { ...scenario }],
+        },
+        "duplicate-id.scenario.json",
+      ),
+    /duplicate scenario id/i,
+  );
+
+  assert.throws(
+    () =>
+      validateCorpus(
+        {
+          format: SCENARIO_FORMAT,
+          family: "model-task-result",
+          objects,
+          scenarios: [{ ...scenario, validator: "unknown-kind" }],
+        },
+        "unknown-kind.scenario.json",
+      ),
+    /unknown validator unknown-kind/i,
+  );
+
+  assert.throws(
+    () =>
+      validateCorpus(
+        {
+          format: SCENARIO_FORMAT,
+          family: "model-task-result",
+          objects,
+          scenarios: [
+            {
+              ...scenario,
+              expected: {
+                ok: false,
+                stage: "composition",
+                code: "semantic_conflict",
+              },
+            },
+          ],
+        },
+        "missing-path.scenario.json",
+      ),
+    /expected\.path.*must be a string/i,
+  );
+});
+
+test("fails when declared success, error code, or error path differs from the actual result", () => {
+  const corpus = corpora.find((candidate) => candidate.family === "model-task-result");
+  assert.ok(corpus);
+  const success = corpus.scenarios.find((scenario) => scenario.id === "model-task.valid-pair");
+  const failure = corpus.scenarios.find((scenario) => scenario.id === "model-task.wrong-task-id");
+  assert.ok(success);
+  assert.ok(failure && !failure.expected.ok);
+  if (failure.expected.ok) assert.fail("expected a declared failure scenario");
+  const expectedFailure = failure.expected;
+
+  assert.throws(
+    () =>
+      executeScenario(corpus, {
+        ...success,
+        expected: {
+          ok: false,
+          stage: "composition",
+          code: "semantic_conflict",
+          path: "$.taskId",
+        },
+      }),
+    /expected composition failure/i,
+  );
+  assert.throws(
+    () =>
+      executeScenario(corpus, {
+        ...failure,
+        expected: {
+          ...expectedFailure,
+          code: "digest_mismatch",
+        },
+      }),
+    /wrong protocol error code/i,
+  );
+  assert.throws(
+    () =>
+      executeScenario(corpus, {
+        ...failure,
+        expected: {
+          ...expectedFailure,
+          path: "$.wrongPath",
+        },
+      }),
+    /wrong protocol error path/i,
+  );
+});
+
+test("validates optional and event-array input roles before honoring a parse failure", () => {
+  const corpus = corpora.find(
+    (candidate) => candidate.family === "research-run-context-pack",
+  );
+  assert.ok(corpus);
+  const scenario = corpus.scenarios.find(
+    (candidate) => candidate.id === "research-run.contextless-manifest-lengthening",
+  );
+  assert.ok(scenario && !scenario.expected.ok && scenario.expected.stage === "parse");
+
+  assert.throws(
+    () =>
+      executeScenario(corpus, {
+        ...scenario,
+        inputs: {
+          ...scenario.inputs,
+          contextPack: "matching-run",
+        },
+      }),
+    /input contextPack.*opencoven\.context-pack\/v1/i,
+  );
+
+  const eventCorpus = corpora.find(
+    (candidate) => candidate.family === "run-event-deletion",
+  );
+  const parseFailingRun = corpus.objects["contextless-lengthened-run"];
+  assert.ok(eventCorpus);
+  assert.ok(parseFailingRun);
+  const malformedEventCorpus: ScenarioCorpus = {
+    ...eventCorpus,
+    objects: {
+      ...eventCorpus.objects,
+      "parse-failing-run": parseFailingRun,
+    },
+  };
+  assert.throws(
+    () =>
+      executeScenario(malformedEventCorpus, {
+        id: "run-deletion.malformed-event-role",
+        description: "An expected run parse failure must not hide a malformed event role.",
+        validator: "run-event-deletion",
+        inputs: {
+          run: "parse-failing-run",
+          events: ["completed-deletion-run"],
+        },
+        expected: scenario.expected,
+      }),
+    /input events\[0\].*opencoven\.run-event\/v1/i,
+  );
+});
+
+const allScenarioIds = new Set<string>();
+for (const corpus of corpora) {
+  for (const scenario of corpus.scenarios) {
+    assert.ok(
+      !allScenarioIds.has(scenario.id),
+      `${corpus.filePath}: duplicate scenario id ${scenario.id}`,
+    );
+    allScenarioIds.add(scenario.id);
+    test(`${corpus.family}: ${scenario.id} — ${scenario.description}`, () => {
+      executeScenario(corpus, scenario);
+    });
+  }
+}
+
+const REQUIRED_UNIT_0_SCENARIO_IDS = [
+    "manifest.assembling-to-final",
+    "manifest.partial-usage",
+    "manifest.changed-manifest-id",
+    "manifest.changed-run-id",
+    "manifest.broken-previous-digest",
+    "manifest.gapped-revision",
+    "manifest.post-final-mutation",
+    "manifest.retention-ceiling",
+    "manifest.policy-shortening",
+    "manifest.policy-shortening-preserves-deletion-schedule",
+    "manifest.policy-shortening-revalidates-deadline",
+    "manifest.active-shortening",
+    "manifest.contextless-shortening",
+    "manifest.lengthening-without-fresh-consent",
+    "manifest.lengthening-with-fresh-consent",
+    "manifest.contextless-restoration-with-fresh-consent",
+    "manifest.contextless-restoration-without-fresh-consent",
+    "manifest.contextless-restoration-with-stale-consent",
+    "manifest.contextless-restoration-beyond-original-policy",
+    "manifest.scheduled-project-restoration-with-fresh-consent",
+    "manifest.scheduled-project-restoration-without-fresh-consent",
+    "manifest.scheduled-project-restoration-with-stale-consent",
+    "manifest.pending-project-restoration-with-fresh-consent",
+    "manifest.partial-failure-project-restoration-with-fresh-consent",
+    "manifest.completed-project-restoration-with-fresh-consent",
+    "manifest.partial-failure-continues",
+    "manifest.deadline-2099",
+    "manifest.deadline-cleared",
+    "manifest.deletion-cancellation",
+    "manifest.deadline-shortening",
+    "manifest.deadline-extension-without-fresh-consent",
+    "manifest.deadline-extension-with-stale-consent",
+    "manifest.deadline-extension-with-fresh-consent",
+    "manifest.deadline-extension-exceeds-fresh-ceiling",
+    "manifest.completed-deletion-terminal",
+    "manifest-consent.valid-context-consent",
+    "manifest-consent.missing-context-consent",
+    "manifest-consent.retention-above-consent",
+    "manifest-consent.contextless-without-consent",
+    "research-run.valid-context-pack",
+    "research-run.missing-context-pack",
+    "research-run.contextless-without-pack",
+    "research-run.contextless-with-pack",
+    "research-run.retention-ceiling",
+    "research-run.embedded-manifest-retention-ceiling",
+    "research-run.contextless-manifest-lengthening",
+    "research-run.replay-explicit-transition-consent",
+    "research-run.replay-missing-transition-consent",
+    "research-run.replay-duplicate-transition-consent",
+    "research-run.replay-unknown-transition-consent",
+    "research-run.replay-extra-non-lengthening-consent",
+    "research-run.replay-stale-transition-consent",
+    "research-run.replay-future-transition-consent",
+    "research-run.replay-misbound-transition-consent",
+    "research-run.device-local-pending-without-consent",
+    "research-run.device-local-pending-with-consent",
+    "research-run.device-local-synced-without-consent",
+    "research-run.device-local-synced-with-consent",
+    "research-run.device-local-failed-without-consent",
+    "research-run.device-local-failed-with-consent",
+    "research-run.receipt-valid-binding",
+    "research-run.receipt-wrong-familiar",
+    "research-run.receipt-wrong-provider",
+    "research-run.receipt-wrong-model",
+    "model-task.valid-pair",
+    "model-task.wrong-task-id",
+    "model-task.wrong-run-id",
+    "model-task.wrong-attempt",
+    "model-task.wrong-input-digest",
+    "model-task.wrong-familiar-id",
+    "model-task.wrong-effective-model",
+    "run-deletion.valid-completed",
+    "run-deletion.valid-benign-audit-extension",
+    "run-deletion.rejects-deleted-content",
+    "run-deletion.rejects-object-store-key",
+    "run-deletion.rejects-nested-array-content",
+    "run-deletion.valid-no-manifest",
+    "run-deletion.partial-failure-retryable",
+    "run-deletion.partial-failure-incomplete-stream",
+    "run-deletion.truncated-stream",
+    "run-deletion.extra-stream",
+    "run-deletion.duplicate-sequence",
+    "run-deletion.gapped-sequence",
+    "run-deletion.wrong-run-stream",
+    "run-deletion.mixed-run-stream",
+    "run-deletion.wrong-event-type",
+    "run-deletion.wrong-object-count",
+    "run-deletion.wrong-manifest-status",
+    "run-deletion.wrong-receipt-sequence",
+    "run-events.valid-sequence",
+    "run-events.empty-sequence",
+    "run-events.gapped-sequence",
+    "run-events.mixed-run-sequence",
+  ] as const;
+
+test("required Unit 0 scenario inventory exactly matches the corpus", () => {
+  assert.equal(REQUIRED_UNIT_0_SCENARIO_IDS.length, 93);
+  assert.equal(
+    new Set(REQUIRED_UNIT_0_SCENARIO_IDS).size,
+    REQUIRED_UNIT_0_SCENARIO_IDS.length,
+    "required scenario inventory must not contain duplicates",
+  );
+  assert.deepEqual(
+    [...allScenarioIds].sort(compareCodeUnits),
+    [...REQUIRED_UNIT_0_SCENARIO_IDS].sort(compareCodeUnits),
+    "required scenario inventory must exactly match discovered scenario ids",
+  );
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1760,12 +1760,21 @@ export const SUITES = {
     "src/components/chat-list-mobile-rail-port.test.ts",
     "src/components/chat-artifact-viewer.test.ts",
   ],
-  // Cross-environment conformance (#1990). Runs on the ubuntu/windows/macos CI
-  // matrix via `pnpm test:conformance` — the SAME assertions on every OS. Kept
-  // out of the app/api/mobile suites (the neutral Linux baseline) on purpose;
-  // the matrix is where per-OS behavior is verified.
+  // Cross-environment conformance (#1990). Release CI runs the SAME assertions
+  // on ubuntu/windows/macos, and normal pull-request CI runs them on Ubuntu.
+  // Keep this separate from the broader app/api/mobile suites.
   conformance: [
     "scripts/cross-environment.test.ts",
+    "scripts/research-protocol-conformance.test.ts",
+    "scripts/research-protocol-scenario-conformance.test.ts",
+    "src/lib/research-protocol/common.test.ts",
+    "src/lib/research-protocol/digest.test.ts",
+    "src/lib/research-protocol/context-pack.test.ts",
+    "src/lib/research-protocol/topic-discovery.test.ts",
+    "src/lib/research-protocol/research-run.test.ts",
+    "src/lib/research-protocol/model-task.test.ts",
+    "src/lib/research-protocol/run-manifest.test.ts",
+    "src/lib/research-protocol/index.test.ts",
     "scripts/daemon-connectivity-faults.test.ts",
     "scripts/windows-native-browser-regression.test.mjs",
     "scripts/cave-home-migration-windows.test.ts",

--- a/src/lib/research-protocol/common.test.ts
+++ b/src/lib/research-protocol/common.test.ts
@@ -1,0 +1,284 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  compareUtcTimestamps,
+  isUtcTimestamp,
+  utcTimestampToProtocolNanoseconds,
+} from "./common.ts";
+import {
+  snapshotProtocolArrayElements,
+  snapshotProtocolObjectProperties,
+} from "./option-shell.ts";
+
+test("UTC RFC 3339 timestamps accept ordinary timestamps and historical leap seconds", () => {
+  for (const value of [
+    "2026-08-15T20:00:00Z",
+    "2026-08-15T20:00:00.1Z",
+    "2026-08-15T20:00:00.123456789Z",
+    "2024-02-29T23:59:59.000000000Z",
+    "1972-06-30T23:59:60Z",
+    "1972-12-31T23:59:60Z",
+    "1973-12-31T23:59:60Z",
+    "1974-12-31T23:59:60Z",
+    "1975-12-31T23:59:60Z",
+    "1976-12-31T23:59:60Z",
+    "1977-12-31T23:59:60Z",
+    "1978-12-31T23:59:60Z",
+    "1979-12-31T23:59:60Z",
+    "1981-06-30T23:59:60Z",
+    "1982-06-30T23:59:60Z",
+    "1983-06-30T23:59:60Z",
+    "1985-06-30T23:59:60Z",
+    "1987-12-31T23:59:60Z",
+    "1989-12-31T23:59:60Z",
+    "1990-12-31T23:59:60Z",
+    "1992-06-30T23:59:60Z",
+    "1993-06-30T23:59:60Z",
+    "1994-06-30T23:59:60Z",
+    "1995-12-31T23:59:60Z",
+    "1997-06-30T23:59:60Z",
+    "1998-12-31T23:59:60Z",
+    "2005-12-31T23:59:60Z",
+    "2008-12-31T23:59:60Z",
+    "2012-06-30T23:59:60Z",
+    "2015-06-30T23:59:60Z",
+    "2016-12-31T23:59:60Z",
+    "2016-12-31T23:59:60.123456789Z",
+  ]) {
+    assert.equal(isUtcTimestamp(value), true, value);
+  }
+});
+
+test("UTC RFC 3339 timestamps reject non-UTC syntax and invalid calendar or time values", () => {
+  for (const value of [
+    "2026-08-15T20:00:00+00:00",
+    "2026-08-15T20:00:00-05:00",
+    "2026-08-15T20:00:00z",
+    "2026-08-15 20:00:00Z",
+    "2026-08-15T20:00:00.1234567890Z",
+    "2023-02-29T20:00:00Z",
+    "2026-04-31T20:00:00Z",
+    "2026-13-01T20:00:00Z",
+    "2026-08-15T24:00:00Z",
+    "2026-08-15T20:60:00Z",
+    "2026-08-15T20:00:60Z",
+    "1972-06-29T23:59:60Z",
+    "2016-06-30T23:59:60Z",
+    "2026-08-15T23:59:60Z",
+    "2030-12-31T23:59:60Z",
+    "2016-12-31T22:59:60Z",
+    "2016-12-31T23:58:60Z",
+    "2016-12-31T23:59:61Z",
+    "2016-12-31T23:59:60.1234567890Z",
+    "2016-12-31T23:59:60z",
+    "2016-12-31T23:59:60+00:00",
+    "2016-12-31 23:59:60Z",
+  ]) {
+    assert.equal(isUtcTimestamp(value), false, value);
+  }
+});
+
+test("UTC RFC 3339 comparison is exact across fractions and leap seconds", () => {
+  assert.equal(
+    compareUtcTimestamps("2026-08-15T20:00:00.1Z", "2026-08-15T20:00:00.100000000Z"),
+    0,
+  );
+  assert.equal(
+    compareUtcTimestamps("2026-08-15T20:00:00.099999999Z", "2026-08-15T20:00:00.1Z"),
+    -1,
+  );
+  assert.equal(
+    compareUtcTimestamps("2016-12-31T23:59:59.999999999Z", "2016-12-31T23:59:60Z"),
+    -1,
+  );
+  assert.equal(
+    compareUtcTimestamps("2016-12-31T23:59:60.999999999Z", "2017-01-01T00:00:00Z"),
+    -1,
+  );
+  assert.equal(
+    compareUtcTimestamps("2017-01-01T00:00:00Z", "2016-12-31T23:59:60.999999999Z"),
+    1,
+  );
+});
+
+test("UTC RFC 3339 comparison rejects invalid inputs", () => {
+  assert.throws(
+    () => compareUtcTimestamps("2026-08-15T20:00:00Z", "not-a-timestamp"),
+    /valid UTC RFC 3339 timestamps/,
+  );
+});
+
+test("the protocol timeline counts positive leap seconds in elapsed durations", () => {
+  const second = BigInt(1_000_000_000);
+  assert.equal(
+    utcTimestampToProtocolNanoseconds("2017-01-01T00:00:00Z") -
+      utcTimestampToProtocolNanoseconds("2016-12-31T23:59:59Z"),
+    BigInt(2) * second,
+  );
+  assert.equal(
+    utcTimestampToProtocolNanoseconds("2017-01-01T00:00:00Z") -
+      utcTimestampToProtocolNanoseconds("2016-12-31T23:59:60Z"),
+    second,
+  );
+  assert.equal(
+    utcTimestampToProtocolNanoseconds("2017-01-01T11:59:59Z") -
+      utcTimestampToProtocolNanoseconds("2016-12-31T12:00:00Z"),
+    BigInt(86_400) * second,
+  );
+});
+
+test("protocol option shells accept only ordinary data containers", () => {
+  assert.equal(
+    snapshotProtocolObjectProperties(
+      Object.freeze({ freshConsent: true }),
+      "$.options",
+      "options",
+    ).ok,
+    true,
+  );
+  assert.equal(
+    snapshotProtocolArrayElements(
+      Object.freeze([{ freshConsent: true }]),
+      "$.options",
+      "options",
+    ).ok,
+    true,
+  );
+
+  for (const value of [
+    new Map([["freshConsent", true]]),
+    Object.create({ freshConsent: true }),
+    Object.defineProperty({}, "freshConsent", {
+      enumerable: true,
+      get() {
+        throw new Error("must not execute");
+      },
+    }),
+    Object.defineProperty({}, Symbol("hidden"), {
+      enumerable: true,
+      value: true,
+    }),
+    new Proxy({}, {
+      ownKeys() {
+        throw new Error("must not execute");
+      },
+    }),
+  ]) {
+    assert.equal(
+      snapshotProtocolObjectProperties(value, "$.options", "options").ok,
+      false,
+    );
+  }
+});
+
+test("protocol option shells reject frozen Web intrinsics after prototype spoofing", () => {
+  const factories: Array<readonly [string, () => object]> = [
+    ["URLSearchParams", () => new URLSearchParams("freshConsent=true")],
+    ["Headers", () => new Headers({ accept: "application/json" })],
+    ["Request", () => new Request("https://example.com/research")],
+    ["Response", () => new Response(null, { status: 204 })],
+    ["FormData", () => new FormData()],
+    ["Blob", () => new Blob(["research"])],
+    ["AbortController", () => new AbortController()],
+    ["AbortSignal", () => new AbortController().signal],
+    ["ReadableStream", () => new ReadableStream()],
+    ["WritableStream", () => new WritableStream()],
+    ["TransformStream", () => new TransformStream()],
+    ["TextEncoder", () => new TextEncoder()],
+    ["TextDecoder", () => new TextDecoder()],
+    ["DOMException", () => new DOMException("research", "DataError")],
+    ["Intl.Collator", () => new Intl.Collator()],
+    ["Intl.DateTimeFormat", () => new Intl.DateTimeFormat()],
+    ["Intl.NumberFormat", () => new Intl.NumberFormat()],
+    ["Intl.PluralRules", () => new Intl.PluralRules()],
+    ["Intl.RelativeTimeFormat", () => new Intl.RelativeTimeFormat()],
+  ];
+  if (typeof Intl.DisplayNames === "function") {
+    factories.push([
+      "Intl.DisplayNames",
+      () => new Intl.DisplayNames(["en"], { type: "language" }),
+    ]);
+  }
+  if (typeof Intl.ListFormat === "function") {
+    factories.push(["Intl.ListFormat", () => new Intl.ListFormat()]);
+  }
+  if (typeof Intl.Segmenter === "function") {
+    factories.push(["Intl.Segmenter", () => new Intl.Segmenter()]);
+  }
+  factories.push(
+    [
+      "WebAssembly.Module",
+      () => new WebAssembly.Module(
+        Uint8Array.of(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00),
+      ),
+    ],
+    ["WebAssembly.Memory", () => new WebAssembly.Memory({ initial: 1 })],
+    [
+      "WebAssembly.Table",
+      () => new WebAssembly.Table({ element: "externref", initial: 0 }),
+    ],
+    [
+      "WebAssembly.Global",
+      () => new WebAssembly.Global({ value: "i32" }, 0),
+    ],
+  );
+
+  for (const [label, create] of factories) {
+    for (const prototype of [Object.prototype, null]) {
+      const value = create();
+      Object.setPrototypeOf(value, prototype);
+      Object.assign(value, { freshConsent: true });
+      Object.freeze(value);
+      const result = snapshotProtocolObjectProperties(
+        value,
+        "$.options",
+        "options",
+      );
+      assert.equal(result.ok, false, label);
+    }
+  }
+});
+
+test("protocol option probing fails closed on nested proxies and preserves fetch state", () => {
+  const nestedProxy = new Proxy({}, {
+    ownKeys() {
+      throw new Error("must not execute");
+    },
+  });
+  assert.equal(
+    snapshotProtocolObjectProperties(
+      { manifestHistory: [nestedProxy] },
+      "$.options",
+      "options",
+    ).ok,
+    false,
+  );
+
+  let deep: Record<string, unknown> = { leaf: true };
+  for (let index = 0; index < 1_000; index += 1) {
+    deep = { nested: deep };
+  }
+  assert.equal(
+    snapshotProtocolObjectProperties(
+      { manifestHistory: [deep] },
+      "$.options",
+      "options",
+    ).ok,
+    true,
+  );
+
+  const request = new Request("https://example.com/research", {
+    method: "POST",
+    body: "research",
+  });
+  const originalPrototype = Object.getPrototypeOf(request);
+  const result = snapshotProtocolObjectProperties(
+    request,
+    "$.options",
+    "options",
+  );
+  assert.equal(result.ok, false);
+  assert.equal(Object.getPrototypeOf(request), originalPrototype);
+  assert.equal(request.bodyUsed, false);
+});

--- a/src/lib/research-protocol/common.ts
+++ b/src/lib/research-protocol/common.ts
@@ -1,0 +1,358 @@
+import { copyCanonicalJsonValue } from "./digest.ts";
+
+export type UnknownFields = Record<string, unknown>;
+
+export type ProtocolErrorCode =
+  | "invalid_type"
+  | "invalid_value"
+  | "missing_field"
+  | "unknown_major"
+  | "digest_mismatch"
+  | "semantic_conflict";
+
+export type ProtocolParseError = {
+  code: ProtocolErrorCode;
+  path: string;
+  message: string;
+};
+
+export type ProtocolParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: ProtocolParseError };
+
+export const RETENTION_ORDER = {
+  "run-only": 0,
+  "7-days": 1,
+  project: 2,
+} as const;
+
+export type RetentionPolicyV1 = keyof typeof RETENTION_ORDER;
+
+const SHA256_RE = /^[a-f0-9]{64}$/;
+const OPAQUE_ID_BODY_RE = /^[A-Za-z0-9_-]+$/;
+export const UTC_TIMESTAMP_PATTERN =
+  String.raw`^(?:(?:\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d)|(?:1972-(?:06-30|12-31)|197[3-9]-12-31|198[1235]-06-30|198[79]-12-31|1990-12-31|199[2347]-06-30|199[58]-12-31|200[58]-12-31|201[25]-06-30|2016-12-31)T23:59:60)(?:\.\d{1,9})?Z$`;
+const UTC_TIMESTAMP_RE = new RegExp(UTC_TIMESTAMP_PATTERN);
+const JSON_POINTER_RE = /^(?:$|\/(?:[^~/]|~0|~1)*(?:\/(?:[^~/]|~0|~1)*)*)$/;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isUtcTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  if (!UTC_TIMESTAMP_RE.test(value)) return false;
+
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  const hour = Number(value.slice(11, 13));
+  const minute = Number(value.slice(14, 16));
+  const second = Number(value.slice(17, 19));
+  if (
+    month < 1 ||
+    month > 12 ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 60 ||
+    (second === 60 && (hour !== 23 || minute !== 59))
+  ) {
+    return false;
+  }
+
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [
+    31,
+    leapYear ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+  return day >= 1 && day <= daysInMonth[month - 1]!;
+}
+
+export function compareUtcTimestamps(left: string, right: string): -1 | 0 | 1 {
+  if (!isUtcTimestamp(left) || !isUtcTimestamp(right)) {
+    throw new TypeError("compareUtcTimestamps requires valid UTC RFC 3339 timestamps");
+  }
+
+  const components = (value: string): readonly number[] => {
+    const fractionStart = value.indexOf(".");
+    const fraction =
+      fractionStart === -1
+        ? 0
+        : Number(value.slice(fractionStart + 1, -1).padEnd(9, "0"));
+    return [
+      Number(value.slice(0, 4)),
+      Number(value.slice(5, 7)),
+      Number(value.slice(8, 10)),
+      Number(value.slice(11, 13)),
+      Number(value.slice(14, 16)),
+      Number(value.slice(17, 19)),
+      fraction,
+    ];
+  };
+
+  const leftComponents = components(left);
+  const rightComponents = components(right);
+  for (let index = 0; index < leftComponents.length; index += 1) {
+    if (leftComponents[index]! < rightComponents[index]!) return -1;
+    if (leftComponents[index]! > rightComponents[index]!) return 1;
+  }
+  return 0;
+}
+
+const POSITIVE_LEAP_SECOND_EFFECTIVE_TIMESTAMPS = [
+  "1972-07-01T00:00:00Z",
+  "1973-01-01T00:00:00Z",
+  "1974-01-01T00:00:00Z",
+  "1975-01-01T00:00:00Z",
+  "1976-01-01T00:00:00Z",
+  "1977-01-01T00:00:00Z",
+  "1978-01-01T00:00:00Z",
+  "1979-01-01T00:00:00Z",
+  "1980-01-01T00:00:00Z",
+  "1981-07-01T00:00:00Z",
+  "1982-07-01T00:00:00Z",
+  "1983-07-01T00:00:00Z",
+  "1985-07-01T00:00:00Z",
+  "1988-01-01T00:00:00Z",
+  "1990-01-01T00:00:00Z",
+  "1991-01-01T00:00:00Z",
+  "1992-07-01T00:00:00Z",
+  "1993-07-01T00:00:00Z",
+  "1994-07-01T00:00:00Z",
+  "1996-01-01T00:00:00Z",
+  "1997-07-01T00:00:00Z",
+  "1999-01-01T00:00:00Z",
+  "2006-01-01T00:00:00Z",
+  "2009-01-01T00:00:00Z",
+  "2012-07-01T00:00:00Z",
+  "2015-07-01T00:00:00Z",
+  "2017-01-01T00:00:00Z",
+] as const;
+const DAYS_BEFORE_MONTH = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334] as const;
+
+export function utcTimestampToProtocolNanoseconds(value: string): bigint {
+  if (!isUtcTimestamp(value)) {
+    throw new TypeError(
+      "utcTimestampToProtocolNanoseconds requires a valid UTC RFC 3339 timestamp",
+    );
+  }
+
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  const hour = Number(value.slice(11, 13));
+  const minute = Number(value.slice(14, 16));
+  const second = Number(value.slice(17, 19));
+  const fractionStart = value.indexOf(".");
+  const fraction =
+    fractionStart === -1
+      ? BigInt(0)
+      : BigInt(value.slice(fractionStart + 1, -1).padEnd(9, "0"));
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const leapYearsBeforeYear =
+    Math.floor((year + 3) / 4) -
+    Math.floor((year + 99) / 100) +
+    Math.floor((year + 399) / 400);
+  const daysBeforeYear = 365 * year + leapYearsBeforeYear;
+  const daysBeforeDate =
+    daysBeforeYear +
+    DAYS_BEFORE_MONTH[month - 1]! +
+    (leapYear && month > 2 ? 1 : 0) +
+    day -
+    1;
+  const nominalSeconds =
+    BigInt(daysBeforeDate) * BigInt(86_400) +
+    BigInt(hour * 3_600 + minute * 60 + second);
+  const completedLeapSeconds = POSITIVE_LEAP_SECOND_EFFECTIVE_TIMESTAMPS.filter(
+    (effectiveAt) => compareUtcTimestamps(value, effectiveAt) >= 0,
+  ).length;
+  return (
+    (nominalSeconds + BigInt(completedLeapSeconds)) * BigInt(1_000_000_000) +
+    fraction
+  );
+}
+
+export function isJsonPointer(value: unknown): value is string {
+  return typeof value === "string" && JSON_POINTER_RE.test(value);
+}
+
+export function isOpaqueId(value: unknown, prefix: string): value is string {
+  if (typeof value !== "string") return false;
+  if (!value.startsWith(`${prefix}_`)) return false;
+  const body = value.slice(prefix.length + 1);
+  return body.length > 0 && OPAQUE_ID_BODY_RE.test(body);
+}
+
+export function isSha256(value: unknown): value is string {
+  return typeof value === "string" && SHA256_RE.test(value);
+}
+
+export function retentionDoesNotExceed(
+  requested: RetentionPolicyV1,
+  consented: RetentionPolicyV1,
+): boolean {
+  return RETENTION_ORDER[requested] <= RETENTION_ORDER[consented];
+}
+
+export function fail<T>(
+  code: ProtocolErrorCode,
+  path: string,
+  message: string,
+): ProtocolParseResult<T> {
+  return { ok: false, error: { code, path, message } };
+}
+
+export function pass<T>(value: T): ProtocolParseResult<T> {
+  return { ok: true, value };
+}
+
+function toOrdinaryJsonValue(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) {
+    return value.map((entry) => toOrdinaryJsonValue(entry));
+  }
+
+  const copy: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    Object.defineProperty(copy, key, {
+      value: toOrdinaryJsonValue((value as Record<string, unknown>)[key]),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return copy;
+}
+
+export function copyProtocolJsonValue<T>(
+  value: T,
+  path = "$",
+): ProtocolParseResult<T> {
+  try {
+    return pass(toOrdinaryJsonValue(copyCanonicalJsonValue(value)) as T);
+  } catch {
+    return fail(
+      "invalid_value",
+      path,
+      "Protocol value must contain only canonical JSON data",
+    );
+  }
+}
+
+export type ResearchContextBindingV1 = {
+  contextPackId: string;
+  contextPackDigest: string;
+  topicProposalId?: string;
+} & UnknownFields;
+
+function childPath(path: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${path}.${key}`
+    : `${path}[${JSON.stringify(key)}]`;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function parseObject(value: unknown, path: string): ProtocolParseResult<Record<string, unknown>> {
+  if (!isRecord(value)) {
+    return fail("invalid_type", path, "Expected an object");
+  }
+  return pass(value);
+}
+
+function parseRequiredField(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): ProtocolParseResult<unknown> {
+  if (!hasOwn(record, key)) {
+    return fail("missing_field", childPath(path, key), `Missing required field ${key}`);
+  }
+  return pass(record[key]);
+}
+
+function parseOpaqueIdentifier(
+  value: unknown,
+  prefix: string,
+  path: string,
+  label: string,
+): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isOpaqueId(value, prefix)) {
+    return fail("invalid_value", path, `${label} must match ${prefix}_...`);
+  }
+  return pass(value);
+}
+
+function parseSha256(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isSha256(value)) {
+    return fail("invalid_value", path, `${label} must be a lowercase SHA-256 digest`);
+  }
+  return pass(value);
+}
+
+export function parseResearchContextBindingV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ResearchContextBindingV1> {
+  const wireValue = copyProtocolJsonValue(value, path);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, path);
+  if (!object.ok) return object;
+
+  const contextPackIdField = parseRequiredField(object.value, "contextPackId", path);
+  if (!contextPackIdField.ok) return contextPackIdField;
+  const contextPackId = parseOpaqueIdentifier(
+    contextPackIdField.value,
+    "ctx",
+    childPath(path, "contextPackId"),
+    "contextPackId",
+  );
+  if (!contextPackId.ok) return contextPackId;
+
+  const contextPackDigestField = parseRequiredField(object.value, "contextPackDigest", path);
+  if (!contextPackDigestField.ok) return contextPackDigestField;
+  const contextPackDigest = parseSha256(
+    contextPackDigestField.value,
+    childPath(path, "contextPackDigest"),
+    "contextPackDigest",
+  );
+  if (!contextPackDigest.ok) return contextPackDigest;
+
+  let topicProposalId: string | undefined;
+  if (hasOwn(object.value, "topicProposalId")) {
+    const parsedTopicProposalId = parseOpaqueIdentifier(
+      object.value.topicProposalId,
+      "proposal",
+      childPath(path, "topicProposalId"),
+      "topicProposalId",
+    );
+    if (!parsedTopicProposalId.ok) return parsedTopicProposalId;
+    topicProposalId = parsedTopicProposalId.value;
+  }
+
+  return pass({
+    ...object.value,
+    contextPackId: contextPackId.value,
+    contextPackDigest: contextPackDigest.value,
+    ...(typeof topicProposalId === "string" ? { topicProposalId } : {}),
+  });
+}

--- a/src/lib/research-protocol/context-pack.test.ts
+++ b/src/lib/research-protocol/context-pack.test.ts
@@ -1,0 +1,542 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Value } from "typebox/value";
+
+import invalidPdfSelectorPack from "../../../schemas/research/v1/fixtures/invalid/context-pack-pdf-selector.json" with { type: "json" };
+import invalidRetentionPack from "../../../schemas/research/v1/fixtures/invalid/context-pack-retention.json" with { type: "json" };
+import contextPackSchema from "../../../schemas/research/v1/context-pack.schema.json" with { type: "json" };
+import validContextPack from "../../../schemas/research/v1/fixtures/valid/context-pack.json" with { type: "json" };
+
+import { digestProtocolObject } from "./digest.ts";
+import {
+  parseContextPackResourceV1,
+  parseContextPackV1,
+  parseContextSelectorV1,
+} from "./context-pack.ts";
+
+const SAFE_INTEGER_OVERFLOW = 9007199254740992;
+
+function expectOk<T>(result: { ok: true; value: T } | { ok: false; error: { path: string; message: string } }): T {
+  if (!result.ok) {
+    assert.fail(`${result.error.path}: ${result.error.message}`);
+  }
+  return result.value;
+}
+
+function expectError(
+  result: { ok: true; value: unknown } | { ok: false; error: { path: string; code: string; message: string } },
+  path: string,
+  code?: string,
+): { path: string; code: string; message: string } {
+  if (result.ok) {
+    assert.fail("expected parse failure");
+  }
+  assert.equal(result.error.path, path);
+  if (code) {
+    assert.equal(result.error.code, code);
+  }
+  return result.error;
+}
+
+test("valid Context Pack parses and preserves unknown additive fields", () => {
+  const parsed = expectOk(parseContextPackV1(validContextPack));
+  assert.equal((parsed.futureExtension as { preserve: boolean }).preserve, true);
+
+  const nestedPack = {
+    ...validContextPack,
+    createdBy: { ...validContextPack.createdBy, nickname: "archivist" },
+    subject: { ...validContextPack.subject, lane: "shared" },
+    consent: { ...validContextPack.consent, extraConsent: true },
+    resources: [
+      {
+        ...validContextPack.resources[0],
+        note: "kept",
+        selector: { type: "whole-resource", marker: 1 },
+      },
+    ],
+    policy: { ...validContextPack.policy, note: "strict" },
+    transforms: { ...validContextPack.transforms, marker: "preserved" },
+  };
+  nestedPack.digest = digestProtocolObject(nestedPack);
+  const nested = expectOk(parseContextPackV1(nestedPack));
+
+  assert.equal(nested.createdBy.nickname, "archivist");
+  assert.equal(nested.subject.lane, "shared");
+  assert.equal(nested.consent.extraConsent, true);
+  assert.equal(nested.resources[0].note, "kept");
+  assert.equal(nested.resources[0].selector.marker, 1);
+  assert.equal(nested.policy.note, "strict");
+  assert.equal(nested.transforms.marker, "preserved");
+});
+
+test("valid Context Pack fixture digest matches implementation", () => {
+  assert.equal(validContextPack.digest, digestProtocolObject(validContextPack));
+});
+
+test("Context Pack parsing rejects a structurally valid object with a stale root digest", () => {
+  const tampered = {
+    ...validContextPack,
+    subject: { ...validContextPack.subject, familiarId: "tampered-familiar" },
+  };
+
+  expectError(parseContextPackV1(tampered), "$.digest", "digest_mismatch");
+});
+
+test("Context Pack rejects symbol keys, hidden data, and hidden or accessor toJSON", () => {
+  const symbolKeyed = { ...validContextPack };
+  Object.defineProperty(symbolKeyed, Symbol("hidden"), {
+    value: "not-json",
+    enumerable: true,
+  });
+  expectError(parseContextPackV1(symbolKeyed), "$", "invalid_value");
+
+  const hidden = { ...validContextPack };
+  Object.defineProperty(hidden, "hidden", {
+    value: "not-json",
+    enumerable: false,
+  });
+  expectError(parseContextPackV1(hidden), "$", "invalid_value");
+
+  let calls = 0;
+  const hiddenToJson = { ...validContextPack };
+  Object.defineProperty(hiddenToJson, "toJSON", {
+    value() {
+      calls += 1;
+      return validContextPack;
+    },
+    enumerable: false,
+  });
+  expectError(parseContextPackV1(hiddenToJson), "$", "invalid_value");
+
+  const accessorToJson = { ...validContextPack };
+  Object.defineProperty(accessorToJson, "toJSON", {
+    get() {
+      calls += 1;
+      return () => validContextPack;
+    },
+    enumerable: true,
+  });
+  expectError(parseContextPackV1(accessorToJson), "$", "invalid_value");
+  assert.equal(calls, 0);
+});
+
+test("Context Pack rejects sparse and custom arrays in additive data", () => {
+  class CustomArray<T> extends Array<T> {}
+  const extraProperty = [1, 2, 3];
+  Object.defineProperty(extraProperty, "extra", {
+    value: true,
+    enumerable: true,
+  });
+
+  for (const values of [[1, , 3], CustomArray.from([1, 2, 3]), extraProperty]) {
+    expectError(
+      parseContextPackV1({
+        ...validContextPack,
+        futureExtension: { values },
+      }),
+      "$",
+      "invalid_value",
+    );
+  }
+});
+
+test("Context Pack parsing accepts an ordinary deeply frozen wire object", () => {
+  const deepFreeze = (value: unknown): unknown => {
+    if (value === null || typeof value !== "object") return value;
+    for (const child of Object.values(value)) {
+      deepFreeze(child);
+    }
+    return Object.freeze(value);
+  };
+  const frozen = deepFreeze(
+    structuredClone(validContextPack),
+  ) as typeof validContextPack;
+
+  const parsed = expectOk(parseContextPackV1(frozen));
+  assert.deepEqual(parsed, validContextPack);
+  assert.notStrictEqual(parsed, frozen);
+  assert.notStrictEqual(parsed.resources, frozen.resources);
+});
+
+test("Context Pack accepts safe canonical extensions", () => {
+  const extension = Object.create(null) as Record<string, unknown>;
+  Object.defineProperty(extension, "__proto__", {
+    value: { preserve: true },
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+  extension.values = [1, 2, 3];
+  extension.label = "research-🔬";
+
+  const pack = {
+    ...validContextPack,
+    futureExtension: extension,
+  };
+  pack.digest = digestProtocolObject(pack);
+  const parsed = expectOk(parseContextPackV1(pack));
+  const parsedExtension = parsed.futureExtension as Record<string, unknown>;
+
+  assert.equal(Object.getPrototypeOf(parsedExtension), Object.prototype);
+  assert.equal(Object.hasOwn(parsedExtension, "__proto__"), true);
+  assert.equal(Object.getPrototypeOf(parsedExtension.__proto__ as object), Object.prototype);
+  assert.equal((parsedExtension.__proto__ as { preserve: boolean }).preserve, true);
+  assert.deepEqual(parsedExtension.values, [1, 2, 3]);
+  assert.equal(parsedExtension.label, "research-🔬");
+});
+
+test("Context Pack returns detached additive objects and arrays", () => {
+  const extension = {
+    nested: { state: "original" },
+    items: [{ value: 1 }],
+  };
+  const pack = {
+    ...validContextPack,
+    futureExtension: extension,
+  };
+  pack.digest = digestProtocolObject(pack);
+
+  const parsed = expectOk(parseContextPackV1(pack));
+  const parsedExtension = parsed.futureExtension as {
+    nested: { state: string };
+    items: Array<{ value: number }>;
+  };
+
+  assert.notStrictEqual(parsedExtension, extension);
+  assert.notStrictEqual(parsedExtension.nested, extension.nested);
+  assert.notStrictEqual(parsedExtension.items, extension.items);
+  assert.notStrictEqual(parsedExtension.items[0], extension.items[0]);
+
+  extension.nested.state = "mutated";
+  extension.items[0].value = 99;
+  extension.items.push({ value: 2 });
+  assert.equal(parsedExtension.nested.state, "original");
+  assert.equal(parsedExtension.items[0].value, 1);
+  assert.equal(parsedExtension.items.length, 1);
+});
+
+test("Context Pack JSON Schema validates the valid fixture and purpose contract", () => {
+  assert.ok(Value.Check(contextPackSchema, validContextPack));
+  assert.equal(
+    Value.Check(contextPackSchema, {
+      ...validContextPack,
+      purpose: "topic-discovery",
+      policy: { ...validContextPack.policy, allowedPurposes: ["research-run"] },
+    }),
+    false,
+  );
+  assert.equal(
+    Value.Check(contextPackSchema, {
+      ...validContextPack,
+      resources: [
+        {
+          ...validContextPack.resources[0],
+          selector: { type: "json-pointer", pointer: "items/0" },
+        },
+      ],
+    }),
+    false,
+  );
+});
+
+test("protocol timestamps accept UTC RFC 3339 with zero through nine fractional digits", () => {
+  for (const timestamp of [
+    "2026-08-15T20:00:00Z",
+    "2026-08-15T20:00:00.1Z",
+    "2026-08-15T20:00:00.123456789Z",
+    "2016-12-31T23:59:60Z",
+    "2016-12-31T23:59:60.123456789Z",
+  ]) {
+    const pack = {
+      ...validContextPack,
+      createdAt: timestamp,
+      resources: [{ ...validContextPack.resources[0], capturedAt: timestamp }],
+    };
+    pack.digest = digestProtocolObject(pack);
+
+    assert.equal(Value.Check(contextPackSchema, pack), true, timestamp);
+    const parsed = expectOk(parseContextPackV1(pack));
+    assert.equal(parsed.createdAt, timestamp);
+    assert.equal(parsed.resources[0].capturedAt, timestamp);
+  }
+});
+
+test("protocol timestamps reject offsets, invalid values, noncanonical syntax, and excessive precision", () => {
+  for (const timestamp of [
+    "2026-08-15T20:00:00+00:00",
+    "2026-08-15T20:00:00-05:00",
+    "2026-08-15T20:00:00z",
+    "2026-08-15 20:00:00Z",
+    "2026-08-15T20:00:00.1234567890Z",
+    "2023-02-29T20:00:00Z",
+    "2026-04-31T20:00:00Z",
+    "2026-08-15T24:00:00Z",
+    "2026-08-15T20:60:00Z",
+    "2026-08-15T20:00:60Z",
+    "2016-12-31T22:59:60Z",
+    "2016-12-31T23:58:60Z",
+    "2016-12-31T23:59:61Z",
+    "2016-12-31T23:59:60.1234567890Z",
+    "2016-12-31T23:59:60z",
+    "2016-12-31T23:59:60+00:00",
+    "2016-12-31 23:59:60Z",
+  ]) {
+    const pack = { ...validContextPack, createdAt: timestamp };
+    pack.digest = digestProtocolObject(pack);
+
+    assert.equal(Value.Check(contextPackSchema, pack), false, timestamp);
+    expectError(parseContextPackV1(pack), "$.createdAt", "invalid_value");
+  }
+});
+
+test("empty plain-string fields are accepted", () => {
+  const pack = {
+    ...validContextPack,
+    createdBy: { ...validContextPack.createdBy, userId: "" },
+    subject: { familiarId: "", projectId: "" },
+    resources: [
+      {
+        ...validContextPack.resources[0],
+        uri: "",
+        title: "",
+        mediaType: "",
+      },
+    ],
+    transforms: { ...validContextPack.transforms, secretScanVersion: "" },
+  };
+  pack.digest = digestProtocolObject(pack);
+  const parsed = expectOk(parseContextPackV1(pack));
+
+  assert.equal(parsed.createdBy.userId, "");
+  assert.equal(parsed.subject.familiarId, "");
+  assert.equal(parsed.subject.projectId, "");
+  assert.equal(parsed.resources[0].uri, "");
+  assert.equal(parsed.resources[0].title, "");
+  assert.equal(parsed.resources[0].mediaType, "");
+  assert.equal(parsed.transforms.secretScanVersion, "");
+});
+
+test("unsupported schema major returns unknown_major", () => {
+  expectError(
+    parseContextPackV1({ ...validContextPack, schema: "opencoven.context-pack/v2" }),
+    "$.schema",
+    "unknown_major",
+  );
+});
+
+test("unknown retention fails at $.consent.retention", () => {
+  expectError(parseContextPackV1(invalidRetentionPack), "$.consent.retention", "invalid_value");
+});
+
+test("custom-prototype Context Packs are rejected", () => {
+  const prototypePack = Object.create({ schema: validContextPack.schema });
+  Object.assign(prototypePack, {
+    id: validContextPack.id,
+    digest: validContextPack.digest,
+    createdAt: validContextPack.createdAt,
+    createdBy: validContextPack.createdBy,
+    purpose: validContextPack.purpose,
+    subject: validContextPack.subject,
+    consent: validContextPack.consent,
+    resources: validContextPack.resources,
+    policy: validContextPack.policy,
+    transforms: validContextPack.transforms,
+  });
+
+  expectError(parseContextPackV1(prototypePack), "$", "invalid_value");
+});
+
+test("policy.allowedPurposes must include the pack purpose", () => {
+  expectError(
+    parseContextPackV1({
+      ...validContextPack,
+      policy: { ...validContextPack.policy, allowedPurposes: ["topic-discovery"] },
+    }),
+    "$.policy.allowedPurposes",
+    "semantic_conflict",
+  );
+});
+
+test("resource ids must be unique", () => {
+  expectError(
+    parseContextPackV1({
+      ...validContextPack,
+      resources: [
+        validContextPack.resources[0],
+        { ...validContextPack.resources[0], uri: "coven://session/session_02" },
+      ],
+    }),
+    "$.resources[1].id",
+    "semantic_conflict",
+  );
+});
+
+test("turn-range accepts 2..3 and rejects empty or reversed spans", () => {
+  const parsed = expectOk(parseContextSelectorV1({ type: "turn-range", start: 2, end: 3, extra: true }));
+  assert.equal(parsed.type, "turn-range");
+  assert.equal(parsed.start, 2);
+  assert.equal(parsed.end, 3);
+  assert.equal(parsed.extra, true);
+
+  expectError(parseContextSelectorV1({ type: "turn-range", start: 2, end: 2 }), "$.selector", "semantic_conflict");
+  expectError(parseContextSelectorV1({ type: "turn-range", start: 3, end: 2 }), "$.selector", "semantic_conflict");
+});
+
+test("standalone Context Pack child parsers reject accessors without invoking them", () => {
+  let calls = 0;
+  const selector = { type: "whole-resource" };
+  Object.defineProperty(selector, "type", {
+    get() {
+      calls += 1;
+      return "whole-resource";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  expectError(parseContextSelectorV1(selector), "$.selector", "invalid_value");
+
+  const resource = { ...validContextPack.resources[0] };
+  Object.defineProperty(resource, "id", {
+    get() {
+      calls += 1;
+      return validContextPack.resources[0].id;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  expectError(parseContextPackResourceV1(resource, "$.resource"), "$.resource", "invalid_value");
+  assert.equal(calls, 0);
+});
+
+test("json-pointer accepts RFC 6901 pointers and rejects malformed escapes", () => {
+  for (const pointer of ["", "/items/0", "/foo/~0bar/~1baz"]) {
+    assert.equal(expectOk(parseContextSelectorV1({ type: "json-pointer", pointer })).pointer, pointer);
+    assert.equal(
+      Value.Check(contextPackSchema, {
+        ...validContextPack,
+        resources: [{ ...validContextPack.resources[0], selector: { type: "json-pointer", pointer } }],
+      }),
+      true,
+    );
+  }
+
+  for (const pointer of ["items/0", "/foo/~2bar", "/foo/~"]) {
+    expectError(parseContextSelectorV1({ type: "json-pointer", pointer }), "$.selector.pointer", "invalid_value");
+    assert.equal(
+      Value.Check(contextPackSchema, {
+        ...validContextPack,
+        resources: [{ ...validContextPack.resources[0], selector: { type: "json-pointer", pointer } }],
+      }),
+      false,
+    );
+  }
+});
+
+test("markdown-section rejects an empty heading path", () => {
+  const selector = expectOk(
+    parseContextSelectorV1({ type: "markdown-section", headingPath: ["Intro", "Findings"] }),
+  );
+  assert.deepEqual(selector.headingPath, ["Intro", "Findings"]);
+  expectError(parseContextSelectorV1({ type: "markdown-section", headingPath: [] }), "$.selector.headingPath", "invalid_value");
+});
+
+test("text-span accepts 0..12 and rejects empty spans", () => {
+  const selector = expectOk(parseContextSelectorV1({ type: "text-span", start: 0, end: 12 }));
+  assert.equal(selector.start, 0);
+  assert.equal(selector.end, 12);
+  expectError(parseContextSelectorV1({ type: "text-span", start: 4, end: 4 }), "$.selector", "semantic_conflict");
+});
+
+test("pdf-page-span accepts page 1 and rejects page 0, empty, or reversed spans", () => {
+  const selector = expectOk(parseContextSelectorV1({ type: "pdf-page-span", page: 1, start: 0, end: 12 }));
+  assert.equal(selector.page, 1);
+  assert.equal(selector.start, 0);
+  assert.equal(selector.end, 12);
+
+  expectError(parseContextSelectorV1({ type: "pdf-page-span", page: 0, start: 0, end: 12 }), "$.selector.page", "invalid_value");
+  expectError(parseContextSelectorV1({ type: "pdf-page-span", page: 1, start: 12, end: 12 }), "$.selector", "semantic_conflict");
+  expectError(parseContextSelectorV1({ type: "pdf-page-span", page: 1, start: 13, end: 12 }), "$.selector", "semantic_conflict");
+});
+
+test("selector coordinates above the safe integer limit are rejected by schema and parser", () => {
+  const cases = [
+    {
+      selector: { type: "turn-range", start: SAFE_INTEGER_OVERFLOW, end: 1 },
+      path: "$.resources[0].selector.start",
+    },
+    {
+      selector: { type: "turn-range", start: 1, end: SAFE_INTEGER_OVERFLOW },
+      path: "$.resources[0].selector.end",
+    },
+    {
+      selector: { type: "text-span", start: SAFE_INTEGER_OVERFLOW, end: 1 },
+      path: "$.resources[0].selector.start",
+    },
+    {
+      selector: { type: "text-span", start: 1, end: SAFE_INTEGER_OVERFLOW },
+      path: "$.resources[0].selector.end",
+    },
+    {
+      selector: { type: "pdf-page-span", page: SAFE_INTEGER_OVERFLOW, start: 0, end: 1 },
+      path: "$.resources[0].selector.page",
+    },
+    {
+      selector: { type: "pdf-page-span", page: 1, start: SAFE_INTEGER_OVERFLOW, end: 1 },
+      path: "$.resources[0].selector.start",
+    },
+    {
+      selector: { type: "pdf-page-span", page: 1, start: 0, end: SAFE_INTEGER_OVERFLOW },
+      path: "$.resources[0].selector.end",
+    },
+  ] as const;
+
+  for (const { selector, path } of cases) {
+    const pack = {
+      ...validContextPack,
+      resources: [{ ...validContextPack.resources[0], selector }],
+    };
+
+    assert.equal(Value.Check(contextPackSchema, pack), false);
+    expectError(parseContextPackV1(pack), path, "invalid_value");
+  }
+});
+
+test("invalid PDF fixture rejects", () => {
+  expectError(parseContextPackV1(invalidPdfSelectorPack), "$.resources[0].selector.page", "invalid_value");
+});
+
+test("resource parser preserves unknown fields", () => {
+  const resource = expectOk(
+    parseContextPackResourceV1(
+      {
+        ...validContextPack.resources[0],
+        marker: "resource",
+        selector: { type: "whole-resource", nestedMarker: true },
+      },
+      "$.resources[0]",
+    ),
+  );
+
+  assert.equal(resource.marker, "resource");
+  assert.equal(resource.selector.nestedMarker, true);
+});
+
+test("custom-prototype nested objects are rejected", () => {
+  const subject = Object.create({ projectId: "proto-project" });
+  subject.familiarId = validContextPack.subject.familiarId;
+
+  const transforms = Object.create({
+    redactionMapDigest: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  });
+  transforms.secretScanVersion = validContextPack.transforms.secretScanVersion;
+
+  expectError(
+    parseContextPackV1({
+      ...validContextPack,
+      subject,
+      transforms,
+    }),
+    "$",
+    "invalid_value",
+  );
+});

--- a/src/lib/research-protocol/context-pack.ts
+++ b/src/lib/research-protocol/context-pack.ts
@@ -1,0 +1,845 @@
+import {
+  copyProtocolJsonValue,
+  fail,
+  isJsonPointer,
+  isOpaqueId,
+  isRecord,
+  isSha256,
+  isUtcTimestamp,
+  pass,
+  type ProtocolParseResult,
+  type UnknownFields,
+} from "./common.ts";
+import { digestProtocolObject } from "./digest.ts";
+
+const CONTEXT_PACK_SCHEMA = "opencoven.context-pack/v1";
+const CONTEXT_PACK_SCHEMA_RE = /^opencoven\.context-pack\/v(\d+)$/;
+
+const PURPOSES = ["topic-discovery", "research-run"] as const;
+const SELECTION_MODES = ["explicit", "saved-view"] as const;
+const RETENTION_POLICIES = ["run-only", "7-days", "project"] as const;
+const RESOURCE_KINDS = [
+  "session",
+  "thread-self-report",
+  "mission",
+  "artifact",
+  "attachment",
+  "saved-resource",
+  "metric-snapshot",
+] as const;
+const RESOURCE_TRUST_LEVELS = [
+  "user-authored",
+  "agent-output",
+  "mixed-conversation",
+  "model-derived",
+  "imported-source",
+] as const;
+const RESOURCE_SENSITIVITIES = ["public", "private", "restricted"] as const;
+const SELECTOR_TYPES = [
+  "turn-range",
+  "json-pointer",
+  "text-span",
+  "markdown-section",
+  "pdf-page-span",
+  "whole-resource",
+] as const;
+
+type ContextPackPurposeV1 = (typeof PURPOSES)[number];
+type ContextSelectionModeV1 = (typeof SELECTION_MODES)[number];
+type ContextRetentionPolicyV1 = (typeof RETENTION_POLICIES)[number];
+type ContextPackResourceKindV1 = (typeof RESOURCE_KINDS)[number];
+type ContextPackResourceTrustV1 = (typeof RESOURCE_TRUST_LEVELS)[number];
+type ContextPackResourceSensitivityV1 = (typeof RESOURCE_SENSITIVITIES)[number];
+
+type ContextPackCreatedByV1 = {
+  client: "coven-cave";
+  userId?: string;
+} & UnknownFields;
+
+type ContextPackSubjectV1 = {
+  familiarId: string;
+  projectId?: string;
+} & UnknownFields;
+
+type ContextPackConsentV1 = {
+  selectionMode: ContextSelectionModeV1;
+  allowRemoteQueries: boolean;
+  allowRemoteContent: boolean;
+  artifactContentSync: boolean;
+  retention: ContextRetentionPolicyV1;
+} & UnknownFields;
+
+type ContextPackPolicyV1 = {
+  treatResourceTextAsData: true;
+  toolAuthority: "none";
+  allowedPurposes: ContextPackPurposeV1[];
+} & UnknownFields;
+
+type ContextPackTransformsV1 = {
+  secretScanVersion: string;
+  redactionMapDigest?: string;
+} & UnknownFields;
+
+type TurnRangeSelectorV1 = {
+  type: "turn-range";
+  start: number;
+  end: number;
+} & UnknownFields;
+
+type JsonPointerSelectorV1 = {
+  type: "json-pointer";
+  pointer: string;
+} & UnknownFields;
+
+type TextSpanSelectorV1 = {
+  type: "text-span";
+  start: number;
+  end: number;
+} & UnknownFields;
+
+type MarkdownSectionSelectorV1 = {
+  type: "markdown-section";
+  headingPath: string[];
+} & UnknownFields;
+
+type PdfPageSpanSelectorV1 = {
+  type: "pdf-page-span";
+  page: number;
+  start: number;
+  end: number;
+} & UnknownFields;
+
+type WholeResourceSelectorV1 = {
+  type: "whole-resource";
+} & UnknownFields;
+
+export type ContextSelectorV1 =
+  | TurnRangeSelectorV1
+  | JsonPointerSelectorV1
+  | TextSpanSelectorV1
+  | MarkdownSectionSelectorV1
+  | PdfPageSpanSelectorV1
+  | WholeResourceSelectorV1;
+
+export type ContextPackResourceV1 = {
+  id: string;
+  kind: ContextPackResourceKindV1;
+  uri: string;
+  digest: string;
+  localBlobDigest: string;
+  selector: ContextSelectorV1;
+  trust: ContextPackResourceTrustV1;
+  sensitivity: ContextPackResourceSensitivityV1;
+  capturedAt: string;
+  title?: string;
+  mediaType: string;
+} & UnknownFields;
+
+export type ContextPackV1 = {
+  schema: "opencoven.context-pack/v1";
+  id: string;
+  digest: string;
+  createdAt: string;
+  createdBy: ContextPackCreatedByV1;
+  purpose: ContextPackPurposeV1;
+  subject: ContextPackSubjectV1;
+  consent: ContextPackConsentV1;
+  resources: ContextPackResourceV1[];
+  policy: ContextPackPolicyV1;
+  transforms: ContextPackTransformsV1;
+} & UnknownFields;
+
+function childPath(path: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${path}.${key}`
+    : `${path}[${JSON.stringify(key)}]`;
+}
+
+function indexPath(path: string, index: number): string {
+  return `${path}[${index}]`;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function parseObject(value: unknown, path: string): ProtocolParseResult<Record<string, unknown>> {
+  if (!isRecord(value)) {
+    return fail("invalid_type", path, "Expected an object");
+  }
+  return pass(value);
+}
+
+function parseRequiredField(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): ProtocolParseResult<unknown> {
+  if (!hasOwn(record, key)) {
+    return fail("missing_field", childPath(path, key), `Missing required field ${key}`);
+  }
+  return pass(record[key]);
+}
+
+function parseEnumValue<const T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  path: string,
+  label: string,
+): ProtocolParseResult<T[number]> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!allowed.includes(value as T[number])) {
+    return fail("invalid_value", path, `${label} must be one of ${allowed.join(", ")}`);
+  }
+  return pass(value as T[number]);
+}
+
+function parseBoolean(value: unknown, path: string, label: string): ProtocolParseResult<boolean> {
+  if (typeof value !== "boolean") {
+    return fail("invalid_type", path, `${label} must be a boolean`);
+  }
+  return pass(value);
+}
+
+function parseString(
+  value: unknown,
+  path: string,
+  label: string,
+  { allowEmpty = false }: { allowEmpty?: boolean } = {},
+): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!allowEmpty && value.length === 0) {
+    return fail("invalid_value", path, `${label} must not be empty`);
+  }
+  return pass(value);
+}
+
+function parseOptionalString(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): ProtocolParseResult<string | undefined> {
+  if (!hasOwn(record, key)) {
+    return pass(undefined);
+  }
+  return parseString(record[key], childPath(path, key), key, { allowEmpty: true });
+}
+
+function parseSha256(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isSha256(value)) {
+    return fail("invalid_value", path, `${label} must be a lowercase SHA-256 digest`);
+  }
+  return pass(value);
+}
+
+function parseUtc(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isUtcTimestamp(value)) {
+    return fail("invalid_value", path, `${label} must be a UTC RFC 3339 timestamp`);
+  }
+  return pass(value);
+}
+
+function parseOpaqueIdentifier(
+  value: unknown,
+  prefix: string,
+  path: string,
+  label: string,
+): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isOpaqueId(value, prefix)) {
+    return fail("invalid_value", path, `${label} must match ${prefix}_...`);
+  }
+  return pass(value);
+}
+
+function parseSafeInteger(
+  value: unknown,
+  path: string,
+  label: string,
+  minimum = 0,
+): ProtocolParseResult<number> {
+  if (typeof value !== "number") {
+    return fail("invalid_type", path, `${label} must be a number`);
+  }
+  if (!Number.isSafeInteger(value)) {
+    return fail("invalid_value", path, `${label} must be a safe integer`);
+  }
+  if (value < minimum) {
+    return fail("invalid_value", path, `${label} must be >= ${minimum}`);
+  }
+  return pass(value);
+}
+
+function parseRange(
+  start: number,
+  end: number,
+  path: string,
+  label: string,
+): ProtocolParseResult<void> {
+  if (start >= end) {
+    return fail("semantic_conflict", path, `${label} requires start < end`);
+  }
+  return pass(undefined);
+}
+
+function parseHeadingPath(value: unknown, path: string): ProtocolParseResult<string[]> {
+  if (!Array.isArray(value)) {
+    return fail("invalid_type", path, "headingPath must be an array");
+  }
+  if (value.length === 0) {
+    return fail("invalid_value", path, "headingPath must not be empty");
+  }
+  const headings: string[] = [];
+  for (const [index, heading] of value.entries()) {
+    const parsedHeading = parseString(heading, indexPath(path, index), "headingPath item");
+    if (!parsedHeading.ok) return parsedHeading;
+    headings.push(parsedHeading.value);
+  }
+  return pass(headings);
+}
+
+function parseJsonPointer(value: unknown, path: string): ProtocolParseResult<string> {
+  const pointer = parseString(value, path, "pointer", { allowEmpty: true });
+  if (!pointer.ok) return pointer;
+  if (!isJsonPointer(pointer.value)) {
+    return fail("invalid_value", path, "pointer must be empty or a valid RFC 6901 JSON Pointer");
+  }
+  return pointer;
+}
+
+function parseSchema(value: unknown): ProtocolParseResult<"opencoven.context-pack/v1"> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", "$.schema", "schema must be a string");
+  }
+  if (value === CONTEXT_PACK_SCHEMA) {
+    return pass(CONTEXT_PACK_SCHEMA);
+  }
+  const match = CONTEXT_PACK_SCHEMA_RE.exec(value);
+  if (match) {
+    return fail("unknown_major", "$.schema", `Unsupported Context Pack schema major v${match[1]}`);
+  }
+  return fail("invalid_value", "$.schema", `schema must equal ${CONTEXT_PACK_SCHEMA}`);
+}
+
+export function parseContextSelectorV1(
+  value: unknown,
+  path = "$.selector",
+): ProtocolParseResult<ContextSelectorV1> {
+  const wireValue = copyProtocolJsonValue(value, path);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, path);
+  if (!object.ok) return object;
+
+  const typeField = parseRequiredField(object.value, "type", path);
+  if (!typeField.ok) return typeField;
+
+  const type = parseEnumValue(typeField.value, SELECTOR_TYPES, childPath(path, "type"), "selector type");
+  if (!type.ok) return type;
+
+  switch (type.value) {
+    case "turn-range": {
+      const startField = parseRequiredField(object.value, "start", path);
+      if (!startField.ok) return startField;
+      const start = parseSafeInteger(startField.value, childPath(path, "start"), "start");
+      if (!start.ok) return start;
+
+      const endField = parseRequiredField(object.value, "end", path);
+      if (!endField.ok) return endField;
+      const end = parseSafeInteger(endField.value, childPath(path, "end"), "end");
+      if (!end.ok) return end;
+
+      const range = parseRange(start.value, end.value, path, "turn-range");
+      if (!range.ok) return range;
+
+      return pass({ ...object.value, type: "turn-range", start: start.value, end: end.value });
+    }
+    case "json-pointer": {
+      const pointerField = parseRequiredField(object.value, "pointer", path);
+      if (!pointerField.ok) return pointerField;
+      const pointer = parseJsonPointer(pointerField.value, childPath(path, "pointer"));
+      if (!pointer.ok) return pointer;
+
+      return pass({ ...object.value, type: "json-pointer", pointer: pointer.value });
+    }
+    case "text-span": {
+      const startField = parseRequiredField(object.value, "start", path);
+      if (!startField.ok) return startField;
+      const start = parseSafeInteger(startField.value, childPath(path, "start"), "start");
+      if (!start.ok) return start;
+
+      const endField = parseRequiredField(object.value, "end", path);
+      if (!endField.ok) return endField;
+      const end = parseSafeInteger(endField.value, childPath(path, "end"), "end");
+      if (!end.ok) return end;
+
+      const range = parseRange(start.value, end.value, path, "text-span");
+      if (!range.ok) return range;
+
+      return pass({ ...object.value, type: "text-span", start: start.value, end: end.value });
+    }
+    case "markdown-section": {
+      const headingPathField = parseRequiredField(object.value, "headingPath", path);
+      if (!headingPathField.ok) return headingPathField;
+      const headingPath = parseHeadingPath(headingPathField.value, childPath(path, "headingPath"));
+      if (!headingPath.ok) return headingPath;
+
+      return pass({ ...object.value, type: "markdown-section", headingPath: headingPath.value });
+    }
+    case "pdf-page-span": {
+      const pageField = parseRequiredField(object.value, "page", path);
+      if (!pageField.ok) return pageField;
+      const page = parseSafeInteger(pageField.value, childPath(path, "page"), "page", 1);
+      if (!page.ok) return page;
+
+      const startField = parseRequiredField(object.value, "start", path);
+      if (!startField.ok) return startField;
+      const start = parseSafeInteger(startField.value, childPath(path, "start"), "start");
+      if (!start.ok) return start;
+
+      const endField = parseRequiredField(object.value, "end", path);
+      if (!endField.ok) return endField;
+      const end = parseSafeInteger(endField.value, childPath(path, "end"), "end");
+      if (!end.ok) return end;
+
+      const range = parseRange(start.value, end.value, path, "pdf-page-span");
+      if (!range.ok) return range;
+
+      return pass({
+        ...object.value,
+        type: "pdf-page-span",
+        page: page.value,
+        start: start.value,
+        end: end.value,
+      });
+    }
+    case "whole-resource":
+      return pass({ ...object.value, type: "whole-resource" });
+  }
+}
+
+export function parseContextPackResourceV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ContextPackResourceV1> {
+  const wireValue = copyProtocolJsonValue(value, path);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, path);
+  if (!object.ok) return object;
+
+  const idField = parseRequiredField(object.value, "id", path);
+  if (!idField.ok) return idField;
+  const id = parseOpaqueIdentifier(idField.value, "resource", childPath(path, "id"), "id");
+  if (!id.ok) return id;
+
+  const kindField = parseRequiredField(object.value, "kind", path);
+  if (!kindField.ok) return kindField;
+  const kind = parseEnumValue(kindField.value, RESOURCE_KINDS, childPath(path, "kind"), "kind");
+  if (!kind.ok) return kind;
+
+  const uriField = parseRequiredField(object.value, "uri", path);
+  if (!uriField.ok) return uriField;
+  const uri = parseString(uriField.value, childPath(path, "uri"), "uri", { allowEmpty: true });
+  if (!uri.ok) return uri;
+
+  const digestField = parseRequiredField(object.value, "digest", path);
+  if (!digestField.ok) return digestField;
+  const digest = parseSha256(digestField.value, childPath(path, "digest"), "digest");
+  if (!digest.ok) return digest;
+
+  const localBlobDigestField = parseRequiredField(object.value, "localBlobDigest", path);
+  if (!localBlobDigestField.ok) return localBlobDigestField;
+  const localBlobDigest = parseSha256(
+    localBlobDigestField.value,
+    childPath(path, "localBlobDigest"),
+    "localBlobDigest",
+  );
+  if (!localBlobDigest.ok) return localBlobDigest;
+
+  const selectorField = parseRequiredField(object.value, "selector", path);
+  if (!selectorField.ok) return selectorField;
+  const selector = parseContextSelectorV1(selectorField.value, childPath(path, "selector"));
+  if (!selector.ok) return selector;
+
+  const trustField = parseRequiredField(object.value, "trust", path);
+  if (!trustField.ok) return trustField;
+  const trust = parseEnumValue(trustField.value, RESOURCE_TRUST_LEVELS, childPath(path, "trust"), "trust");
+  if (!trust.ok) return trust;
+
+  const sensitivityField = parseRequiredField(object.value, "sensitivity", path);
+  if (!sensitivityField.ok) return sensitivityField;
+  const sensitivity = parseEnumValue(
+    sensitivityField.value,
+    RESOURCE_SENSITIVITIES,
+    childPath(path, "sensitivity"),
+    "sensitivity",
+  );
+  if (!sensitivity.ok) return sensitivity;
+
+  const capturedAtField = parseRequiredField(object.value, "capturedAt", path);
+  if (!capturedAtField.ok) return capturedAtField;
+  const capturedAt = parseUtc(capturedAtField.value, childPath(path, "capturedAt"), "capturedAt");
+  if (!capturedAt.ok) return capturedAt;
+
+  const title = parseOptionalString(object.value, "title", path);
+  if (!title.ok) return title;
+
+  const mediaTypeField = parseRequiredField(object.value, "mediaType", path);
+  if (!mediaTypeField.ok) return mediaTypeField;
+  const mediaType = parseString(
+    mediaTypeField.value,
+    childPath(path, "mediaType"),
+    "mediaType",
+    { allowEmpty: true },
+  );
+  if (!mediaType.ok) return mediaType;
+
+  return pass({
+    ...object.value,
+    id: id.value,
+    kind: kind.value,
+    uri: uri.value,
+    digest: digest.value,
+    localBlobDigest: localBlobDigest.value,
+    selector: selector.value,
+    trust: trust.value,
+    sensitivity: sensitivity.value,
+    capturedAt: capturedAt.value,
+    ...(typeof title.value === "string" ? { title: title.value } : {}),
+    mediaType: mediaType.value,
+  });
+}
+
+function parseCreatedBy(value: unknown, path: string): ProtocolParseResult<ContextPackCreatedByV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const clientField = parseRequiredField(object.value, "client", path);
+  if (!clientField.ok) return clientField;
+  const client = parseString(clientField.value, childPath(path, "client"), "client");
+  if (!client.ok) return client;
+  if (client.value !== "coven-cave") {
+    return fail("invalid_value", childPath(path, "client"), "client must be coven-cave");
+  }
+
+  const userId = parseOptionalString(object.value, "userId", path);
+  if (!userId.ok) return userId;
+
+  return pass({
+    ...object.value,
+    client: "coven-cave",
+    ...(typeof userId.value === "string" ? { userId: userId.value } : {}),
+  });
+}
+
+function parseSubject(value: unknown, path: string): ProtocolParseResult<ContextPackSubjectV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const familiarIdField = parseRequiredField(object.value, "familiarId", path);
+  if (!familiarIdField.ok) return familiarIdField;
+  const familiarId = parseString(
+    familiarIdField.value,
+    childPath(path, "familiarId"),
+    "familiarId",
+    { allowEmpty: true },
+  );
+  if (!familiarId.ok) return familiarId;
+
+  const projectId = parseOptionalString(object.value, "projectId", path);
+  if (!projectId.ok) return projectId;
+
+  return pass({
+    ...object.value,
+    familiarId: familiarId.value,
+    ...(typeof projectId.value === "string" ? { projectId: projectId.value } : {}),
+  });
+}
+
+function parseConsent(value: unknown, path: string): ProtocolParseResult<ContextPackConsentV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const selectionModeField = parseRequiredField(object.value, "selectionMode", path);
+  if (!selectionModeField.ok) return selectionModeField;
+  const selectionMode = parseEnumValue(
+    selectionModeField.value,
+    SELECTION_MODES,
+    childPath(path, "selectionMode"),
+    "selectionMode",
+  );
+  if (!selectionMode.ok) return selectionMode;
+
+  const allowRemoteQueriesField = parseRequiredField(object.value, "allowRemoteQueries", path);
+  if (!allowRemoteQueriesField.ok) return allowRemoteQueriesField;
+  const allowRemoteQueries = parseBoolean(
+    allowRemoteQueriesField.value,
+    childPath(path, "allowRemoteQueries"),
+    "allowRemoteQueries",
+  );
+  if (!allowRemoteQueries.ok) return allowRemoteQueries;
+
+  const allowRemoteContentField = parseRequiredField(object.value, "allowRemoteContent", path);
+  if (!allowRemoteContentField.ok) return allowRemoteContentField;
+  const allowRemoteContent = parseBoolean(
+    allowRemoteContentField.value,
+    childPath(path, "allowRemoteContent"),
+    "allowRemoteContent",
+  );
+  if (!allowRemoteContent.ok) return allowRemoteContent;
+
+  const artifactContentSyncField = parseRequiredField(object.value, "artifactContentSync", path);
+  if (!artifactContentSyncField.ok) return artifactContentSyncField;
+  const artifactContentSync = parseBoolean(
+    artifactContentSyncField.value,
+    childPath(path, "artifactContentSync"),
+    "artifactContentSync",
+  );
+  if (!artifactContentSync.ok) return artifactContentSync;
+
+  const retentionField = parseRequiredField(object.value, "retention", path);
+  if (!retentionField.ok) return retentionField;
+  const retention = parseEnumValue(
+    retentionField.value,
+    RETENTION_POLICIES,
+    childPath(path, "retention"),
+    "retention",
+  );
+  if (!retention.ok) return retention;
+
+  return pass({
+    ...object.value,
+    selectionMode: selectionMode.value,
+    allowRemoteQueries: allowRemoteQueries.value,
+    allowRemoteContent: allowRemoteContent.value,
+    artifactContentSync: artifactContentSync.value,
+    retention: retention.value,
+  });
+}
+
+function parsePolicy(
+  value: unknown,
+  path: string,
+  purpose: ContextPackPurposeV1,
+): ProtocolParseResult<ContextPackPolicyV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const treatField = parseRequiredField(object.value, "treatResourceTextAsData", path);
+  if (!treatField.ok) return treatField;
+  if (treatField.value !== true) {
+    return fail(
+      typeof treatField.value === "boolean" ? "invalid_value" : "invalid_type",
+      childPath(path, "treatResourceTextAsData"),
+      "treatResourceTextAsData must be true",
+    );
+  }
+
+  const toolAuthorityField = parseRequiredField(object.value, "toolAuthority", path);
+  if (!toolAuthorityField.ok) return toolAuthorityField;
+  const toolAuthority = parseString(toolAuthorityField.value, childPath(path, "toolAuthority"), "toolAuthority");
+  if (!toolAuthority.ok) return toolAuthority;
+  if (toolAuthority.value !== "none") {
+    return fail("invalid_value", childPath(path, "toolAuthority"), "toolAuthority must be none");
+  }
+
+  const allowedPurposesField = parseRequiredField(object.value, "allowedPurposes", path);
+  if (!allowedPurposesField.ok) return allowedPurposesField;
+  if (!Array.isArray(allowedPurposesField.value)) {
+    return fail("invalid_type", childPath(path, "allowedPurposes"), "allowedPurposes must be an array");
+  }
+  if (allowedPurposesField.value.length === 0) {
+    return fail("invalid_value", childPath(path, "allowedPurposes"), "allowedPurposes must not be empty");
+  }
+
+  const allowedPurposes: ContextPackPurposeV1[] = [];
+  const seenPurposes = new Set<ContextPackPurposeV1>();
+  for (const [index, rawPurpose] of allowedPurposesField.value.entries()) {
+    const parsedPurpose = parseEnumValue(
+      rawPurpose,
+      PURPOSES,
+      indexPath(childPath(path, "allowedPurposes"), index),
+      "allowedPurposes item",
+    );
+    if (!parsedPurpose.ok) return parsedPurpose;
+    if (seenPurposes.has(parsedPurpose.value)) {
+      return fail(
+        "semantic_conflict",
+        indexPath(childPath(path, "allowedPurposes"), index),
+        `Duplicate allowed purpose ${parsedPurpose.value}`,
+      );
+    }
+    seenPurposes.add(parsedPurpose.value);
+    allowedPurposes.push(parsedPurpose.value);
+  }
+
+  if (!seenPurposes.has(purpose)) {
+    return fail(
+      "semantic_conflict",
+      childPath(path, "allowedPurposes"),
+      `allowedPurposes must include the pack purpose ${purpose}`,
+    );
+  }
+
+  return pass({
+    ...object.value,
+    treatResourceTextAsData: true,
+    toolAuthority: "none",
+    allowedPurposes,
+  });
+}
+
+function parseTransforms(value: unknown, path: string): ProtocolParseResult<ContextPackTransformsV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const secretScanVersionField = parseRequiredField(object.value, "secretScanVersion", path);
+  if (!secretScanVersionField.ok) return secretScanVersionField;
+  const secretScanVersion = parseString(
+    secretScanVersionField.value,
+    childPath(path, "secretScanVersion"),
+    "secretScanVersion",
+    { allowEmpty: true },
+  );
+  if (!secretScanVersion.ok) return secretScanVersion;
+
+  let redactionMapDigest: string | undefined;
+  if (hasOwn(object.value, "redactionMapDigest")) {
+    const parsedDigest = parseSha256(
+      object.value.redactionMapDigest,
+      childPath(path, "redactionMapDigest"),
+      "redactionMapDigest",
+    );
+    if (!parsedDigest.ok) return parsedDigest;
+    redactionMapDigest = parsedDigest.value;
+  }
+
+  return pass({
+    ...object.value,
+    secretScanVersion: secretScanVersion.value,
+    ...(redactionMapDigest ? { redactionMapDigest } : {}),
+  });
+}
+
+export function parseContextPackV1(value: unknown): ProtocolParseResult<ContextPackV1> {
+  const wireValue = copyProtocolJsonValue(value);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, "$");
+  if (!object.ok) return object;
+
+  const schemaField = parseRequiredField(object.value, "schema", "$");
+  if (!schemaField.ok) return schemaField;
+  const schema = parseSchema(schemaField.value);
+  if (!schema.ok) return schema;
+
+  const idField = parseRequiredField(object.value, "id", "$");
+  if (!idField.ok) return idField;
+  const id = parseOpaqueIdentifier(idField.value, "ctx", "$.id", "id");
+  if (!id.ok) return id;
+
+  const digestField = parseRequiredField(object.value, "digest", "$");
+  if (!digestField.ok) return digestField;
+  const digest = parseSha256(digestField.value, "$.digest", "digest");
+  if (!digest.ok) return digest;
+
+  const createdAtField = parseRequiredField(object.value, "createdAt", "$");
+  if (!createdAtField.ok) return createdAtField;
+  const createdAt = parseUtc(createdAtField.value, "$.createdAt", "createdAt");
+  if (!createdAt.ok) return createdAt;
+
+  const createdByField = parseRequiredField(object.value, "createdBy", "$");
+  if (!createdByField.ok) return createdByField;
+  const createdBy = parseCreatedBy(createdByField.value, "$.createdBy");
+  if (!createdBy.ok) return createdBy;
+
+  const purposeField = parseRequiredField(object.value, "purpose", "$");
+  if (!purposeField.ok) return purposeField;
+  const purpose = parseEnumValue(purposeField.value, PURPOSES, "$.purpose", "purpose");
+  if (!purpose.ok) return purpose;
+
+  const subjectField = parseRequiredField(object.value, "subject", "$");
+  if (!subjectField.ok) return subjectField;
+  const subject = parseSubject(subjectField.value, "$.subject");
+  if (!subject.ok) return subject;
+
+  const consentField = parseRequiredField(object.value, "consent", "$");
+  if (!consentField.ok) return consentField;
+  const consent = parseConsent(consentField.value, "$.consent");
+  if (!consent.ok) return consent;
+
+  const resourcesField = parseRequiredField(object.value, "resources", "$");
+  if (!resourcesField.ok) return resourcesField;
+  if (!Array.isArray(resourcesField.value)) {
+    return fail("invalid_type", "$.resources", "resources must be an array");
+  }
+  const resources: ContextPackResourceV1[] = [];
+  const seenResourceIds = new Set<string>();
+  for (const [index, resourceValue] of resourcesField.value.entries()) {
+    const resource = parseContextPackResourceV1(resourceValue, indexPath("$.resources", index));
+    if (!resource.ok) return resource;
+    if (seenResourceIds.has(resource.value.id)) {
+      return fail(
+        "semantic_conflict",
+        childPath(indexPath("$.resources", index), "id"),
+        `Duplicate resource id ${resource.value.id}`,
+      );
+    }
+    seenResourceIds.add(resource.value.id);
+    resources.push(resource.value);
+  }
+
+  const policyField = parseRequiredField(object.value, "policy", "$");
+  if (!policyField.ok) return policyField;
+  const policy = parsePolicy(policyField.value, "$.policy", purpose.value);
+  if (!policy.ok) return policy;
+
+  const transformsField = parseRequiredField(object.value, "transforms", "$");
+  if (!transformsField.ok) return transformsField;
+  const transforms = parseTransforms(transformsField.value, "$.transforms");
+  if (!transforms.ok) return transforms;
+
+  const parsed = {
+    ...object.value,
+    schema: CONTEXT_PACK_SCHEMA,
+    id: id.value,
+    digest: digest.value,
+    createdAt: createdAt.value,
+    createdBy: createdBy.value,
+    purpose: purpose.value,
+    subject: subject.value,
+    consent: consent.value,
+    resources,
+    policy: policy.value,
+    transforms: transforms.value,
+  } as ContextPackV1;
+
+  let expectedDigest: string;
+  try {
+    expectedDigest = digestProtocolObject(parsed);
+  } catch (error) {
+    return fail(
+      "invalid_value",
+      "$",
+      error instanceof Error ? error.message : "Context Pack must be canonical JSON",
+    );
+  }
+  if (parsed.digest !== expectedDigest) {
+    return fail("digest_mismatch", "$.digest", `digest must equal recomputed digest ${expectedDigest}`);
+  }
+
+  return pass(parsed);
+}

--- a/src/lib/research-protocol/digest.test.ts
+++ b/src/lib/research-protocol/digest.test.ts
@@ -1,0 +1,383 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  canonicalJson,
+  copyCanonicalJsonValue,
+  digestProtocolObject,
+  sha256Digest,
+} from "./digest.ts";
+
+test("canonical JSON is stable across property insertion order", () => {
+  const left = { z: 1, a: { c: 3, b: 2 } };
+  const right = { a: { b: 2, c: 3 }, z: 1 };
+
+  assert.equal(canonicalJson(left), canonicalJson(right));
+});
+
+test("digestProtocolObject only omits the root digest field", () => {
+  const rootA = {
+    digest: "root-a",
+    nested: { digest: "nested-a", value: 1 },
+  };
+  const rootB = {
+    digest: "root-b",
+    nested: { digest: "nested-a", value: 1 },
+  };
+  const nestedB = {
+    digest: "root-a",
+    nested: { digest: "nested-b", value: 1 },
+  };
+
+  assert.equal(digestProtocolObject(rootA), digestProtocolObject(rootB));
+  assert.notEqual(digestProtocolObject(rootA), digestProtocolObject(nestedB));
+});
+
+test("sha256Digest returns lowercase hex", () => {
+  assert.equal(
+    sha256Digest("hello"),
+    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+  );
+});
+
+test("canonicalization rejects undefined and NaN", () => {
+  assert.throws(() => canonicalJson({ value: undefined }), /canonical JSON/i);
+  assert.throws(() => canonicalJson({ value: NaN }), /canonical JSON/i);
+});
+
+test("canonicalization rejects symbol-keyed and non-enumerable state", () => {
+  const symbolKeyed = { visible: true };
+  Object.defineProperty(symbolKeyed, Symbol("hidden"), {
+    value: "not-json",
+    enumerable: true,
+  });
+  assert.throws(() => canonicalJson(symbolKeyed), /symbol-keyed own properties/i);
+
+  const hidden = { digest: "ignored", visible: true };
+  Object.defineProperty(hidden, "secret", {
+    value: "not-json",
+    enumerable: false,
+  });
+  assert.throws(() => canonicalJson(hidden), /non-enumerable own properties/i);
+  assert.throws(() => digestProtocolObject(hidden), /non-enumerable own properties/i);
+});
+
+test("canonicalization rejects accessors and toJSON functions without invoking them", () => {
+  let calls = 0;
+  const accessor = {};
+  Object.defineProperty(accessor, "value", {
+    get() {
+      calls += 1;
+      return "not-json";
+    },
+    enumerable: true,
+  });
+  assert.throws(() => canonicalJson(accessor), /accessor properties/i);
+
+  const hiddenToJson = { visible: true };
+  Object.defineProperty(hiddenToJson, "toJSON", {
+    value() {
+      calls += 1;
+      return { replaced: true };
+    },
+    enumerable: false,
+  });
+  assert.throws(() => canonicalJson(hiddenToJson), /non-enumerable own properties/i);
+
+  const accessorToJson = { visible: true };
+  Object.defineProperty(accessorToJson, "toJSON", {
+    get() {
+      calls += 1;
+      return () => ({ replaced: true });
+    },
+    enumerable: true,
+  });
+  assert.throws(() => canonicalJson(accessorToJson), /accessor properties/i);
+
+  const enumerableToJson = {
+    toJSON() {
+      calls += 1;
+      return { replaced: true };
+    },
+  };
+  assert.throws(() => canonicalJson(enumerableToJson), /functions are not allowed/i);
+  assert.equal(calls, 0);
+});
+
+test("canonicalization enforces exact dense JSON arrays", () => {
+  const sparse = [1, , 3];
+  assert.throws(() => canonicalJson(sparse), /sparse array holes/i);
+
+  const extraProperty = [1];
+  Object.defineProperty(extraProperty, "extra", {
+    value: 2,
+    enumerable: true,
+  });
+  assert.throws(() => canonicalJson(extraProperty), /extra string properties/i);
+
+  const symbolProperty = [1];
+  Object.defineProperty(symbolProperty, Symbol("extra"), {
+    value: 2,
+    enumerable: true,
+  });
+  assert.throws(() => canonicalJson(symbolProperty), /symbol-keyed own properties/i);
+
+  let accessorCalls = 0;
+  const accessorIndex = new Array<unknown>(1);
+  Object.defineProperty(accessorIndex, "0", {
+    get() {
+      accessorCalls += 1;
+      return "not-json";
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  assert.throws(() => canonicalJson(accessorIndex), /array indices must be data properties/i);
+
+  const hiddenIndex = new Array<unknown>(1);
+  Object.defineProperty(hiddenIndex, "0", {
+    value: "not-json",
+    enumerable: false,
+    configurable: true,
+  });
+  assert.throws(() => canonicalJson(hiddenIndex), /array indices must be enumerable/i);
+
+  class CustomArray<T> extends Array<T> {}
+  const customPrototype = CustomArray.from([1, 2, 3]);
+  assert.throws(() => canonicalJson(customPrototype), /exact Array\.prototype/i);
+  assert.equal(accessorCalls, 0);
+});
+
+test("canonicalization accepts deeply frozen ordinary arrays without invoking getters", () => {
+  const frozen = Object.freeze([
+    Object.freeze({
+      label: "frozen",
+      values: Object.freeze([1, 2, 3]),
+    }),
+  ]);
+
+  assert.equal(
+    canonicalJson(frozen),
+    '[{"label":"frozen","values":[1,2,3]}]',
+  );
+  assert.equal(
+    canonicalJson(copyCanonicalJsonValue(frozen)),
+    '[{"label":"frozen","values":[1,2,3]}]',
+  );
+
+  let getterCalls = 0;
+  const frozenAccessor = new Array<unknown>(1);
+  Object.defineProperty(frozenAccessor, "0", {
+    get() {
+      getterCalls += 1;
+      return "not-json";
+    },
+    enumerable: true,
+    configurable: false,
+  });
+  Object.freeze(frozenAccessor);
+
+  assert.throws(
+    () => canonicalJson(frozenAccessor),
+    /array indices must be data properties/i,
+  );
+  assert.equal(getterCalls, 0);
+});
+
+test("canonicalization safely accepts own __proto__, null-prototype objects, and normal arrays", () => {
+  const value = Object.create(null) as Record<string, unknown>;
+  Object.defineProperty(value, "__proto__", {
+    value: { polluted: true },
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+  value.items = [1, { ok: true }];
+  value.label = "familiar-🧙";
+
+  assert.equal(
+    canonicalJson(value),
+    "{\"__proto__\":{\"polluted\":true},\"items\":[1,{\"ok\":true}],\"label\":\"familiar-🧙\"}",
+  );
+  assert.equal(({} as { polluted?: boolean }).polluted, undefined);
+});
+
+test("canonicalization rejects lone high and low surrogates in string values", () => {
+  assert.throws(
+    () => canonicalJson({ value: "\uD800" }),
+    /unpaired UTF-16 surrogate/i,
+  );
+  assert.throws(
+    () => canonicalJson({ nested: ["\uDC00"] }),
+    /unpaired UTF-16 surrogate/i,
+  );
+});
+
+test("canonicalization rejects lone high and low surrogates in object keys", () => {
+  assert.throws(
+    () => canonicalJson({ ["\uD800"]: "high" }),
+    /unpaired UTF-16 surrogate/i,
+  );
+  assert.throws(
+    () => canonicalJson({ nested: { ["\uDC00"]: "low" } }),
+    /unpaired UTF-16 surrogate/i,
+  );
+});
+
+test("canonicalization and digests accept paired supplementary characters", () => {
+  const value = { "familiar-🧙": "research-🔬", nested: ["𐐷"] };
+
+  assert.equal(
+    canonicalJson(value),
+    "{\"familiar-🧙\":\"research-🔬\",\"nested\":[\"𐐷\"]}",
+  );
+  assert.equal(digestProtocolObject({ digest: "ignored", ...value }), sha256Digest(canonicalJson(value)));
+});
+
+test("copyCanonicalJsonValue detaches objects and arrays without mistaking shared references for cycles", () => {
+  const shared = { label: "shared-🧙", values: [1, 2] };
+  const source = {
+    left: shared,
+    right: shared,
+  };
+
+  const copy = copyCanonicalJsonValue(source);
+
+  assert.equal(Object.getPrototypeOf(copy), null);
+  assert.equal(Object.getPrototypeOf(copy.left), null);
+  assert.equal(Object.getPrototypeOf(copy.left.values), Array.prototype);
+  assert.notStrictEqual(copy, source);
+  assert.notStrictEqual(copy.left, shared);
+  assert.notStrictEqual(copy.right, shared);
+  assert.notStrictEqual(copy.left, copy.right);
+  assert.notStrictEqual(copy.left.values, shared.values);
+
+  shared.label = "mutated";
+  shared.values[0] = 99;
+  assert.equal(copy.left.label, "shared-🧙");
+  assert.deepEqual(copy.left.values, [1, 2]);
+});
+
+test("copyCanonicalJsonValue preserves own __proto__ as detached null-prototype data", () => {
+  const source = Object.create(null) as Record<string, unknown>;
+  const protoValue = { preserve: true };
+  Object.defineProperty(source, "__proto__", {
+    value: protoValue,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+
+  const copy = copyCanonicalJsonValue(source);
+
+  assert.equal(Object.getPrototypeOf(copy), null);
+  assert.equal(Object.hasOwn(copy, "__proto__"), true);
+  assert.notStrictEqual(copy.__proto__, protoValue);
+  assert.equal(Object.getPrototypeOf(copy.__proto__ as object), null);
+  assert.equal((copy.__proto__ as { preserve: boolean }).preserve, true);
+  assert.equal(({} as { preserve?: boolean }).preserve, undefined);
+});
+
+test("canonical JSON and digests ignore inherited Object and Array toJSON pollution", () => {
+  const objectToJson = Object.getOwnPropertyDescriptor(Object.prototype, "toJSON");
+  const arrayToJson = Object.getOwnPropertyDescriptor(Array.prototype, "toJSON");
+  let calls = 0;
+
+  try {
+    Object.defineProperty(Object.prototype, "toJSON", {
+      value() {
+        calls += 1;
+        return { polluted: "object" };
+      },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(Array.prototype, "toJSON", {
+      value() {
+        calls += 1;
+        return ["polluted-array"];
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const value = { z: [2, { a: "🧙" }], a: 1 };
+    assert.equal(canonicalJson(value), "{\"a\":1,\"z\":[2,{\"a\":\"🧙\"}]}");
+    assert.equal(
+      digestProtocolObject({ digest: "ignored", ...value }),
+      sha256Digest("{\"a\":1,\"z\":[2,{\"a\":\"🧙\"}]}"),
+    );
+    assert.equal(calls, 0);
+  } finally {
+    if (objectToJson) {
+      Object.defineProperty(Object.prototype, "toJSON", objectToJson);
+    } else {
+      Reflect.deleteProperty(Object.prototype, "toJSON");
+    }
+    if (arrayToJson) {
+      Object.defineProperty(Array.prototype, "toJSON", arrayToJson);
+    } else {
+      Reflect.deleteProperty(Array.prototype, "toJSON");
+    }
+  }
+});
+
+test("descriptor classification ignores inherited value pollution for objects and arrays", () => {
+  const previousValue = Object.getOwnPropertyDescriptor(Object.prototype, "value");
+  let getterCalls = 0;
+
+  try {
+    Object.defineProperty(Object.prototype, "value", {
+      value: "polluted-descriptor-value",
+      configurable: true,
+      writable: true,
+    });
+
+    const objectAccessor = {};
+    const objectAccessorDescriptor = Object.create(null) as PropertyDescriptor;
+    objectAccessorDescriptor.get = () => {
+      getterCalls += 1;
+      return "getter-result";
+    };
+    objectAccessorDescriptor.enumerable = true;
+    objectAccessorDescriptor.configurable = true;
+    Object.defineProperty(objectAccessor, "field", objectAccessorDescriptor);
+    assert.throws(() => canonicalJson(objectAccessor), /accessor properties/i);
+
+    const arrayAccessor = new Array<unknown>(1);
+    const arrayAccessorDescriptor = Object.create(null) as PropertyDescriptor;
+    arrayAccessorDescriptor.get = () => {
+      getterCalls += 1;
+      return "getter-result";
+    };
+    arrayAccessorDescriptor.enumerable = true;
+    arrayAccessorDescriptor.configurable = true;
+    Object.defineProperty(arrayAccessor, "0", arrayAccessorDescriptor);
+    assert.throws(() => canonicalJson(arrayAccessor), /array indices must be data properties/i);
+
+    const objectData = {};
+    Object.defineProperty(objectData, "field", {
+      value: "actual-object-value",
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    const arrayData = new Array<unknown>(1);
+    Object.defineProperty(arrayData, "0", {
+      value: "actual-array-value",
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+
+    assert.equal(canonicalJson(objectData), '{"field":"actual-object-value"}');
+    assert.equal(canonicalJson(arrayData), '["actual-array-value"]');
+    assert.equal(getterCalls, 0);
+  } finally {
+    if (previousValue) {
+      Object.defineProperty(Object.prototype, "value", previousValue);
+    } else {
+      Reflect.deleteProperty(Object.prototype, "value");
+    }
+  }
+});

--- a/src/lib/research-protocol/digest.ts
+++ b/src/lib/research-protocol/digest.ts
@@ -1,0 +1,253 @@
+import { createHash } from "node:crypto";
+
+function jsonPathForProperty(path: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${path}.${key}`
+    : `${path}[${JSON.stringify(key)}]`;
+}
+
+function jsonPathForIndex(path: string, index: number): string {
+  return `${path}[${index}]`;
+}
+
+function createCanonicalJsonError(path: string, reason: string): TypeError {
+  return new TypeError(`Value at ${path} is not canonical JSON: ${reason}`);
+}
+
+function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function assertPairedUtf16Surrogates(value: string, path: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const nextCodeUnit = value.charCodeAt(index + 1);
+      if (index + 1 >= value.length || nextCodeUnit < 0xdc00 || nextCodeUnit > 0xdfff) {
+        throw createCanonicalJsonError(path, "unpaired UTF-16 surrogate is not allowed");
+      }
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      throw createCanonicalJsonError(path, "unpaired UTF-16 surrogate is not allowed");
+    }
+  }
+}
+
+function isCanonicalArrayIndex(key: string): boolean {
+  if (!/^(?:0|[1-9]\d*)$/.test(key)) return false;
+  const index = Number(key);
+  return Number.isInteger(index) && index >= 0 && index < 0xffffffff;
+}
+
+function copyCanonicalJsonValueAtPath(
+  value: unknown,
+  path: string,
+  stack: WeakSet<object>,
+): unknown {
+  if (typeof value === "string") {
+    assertPairedUtf16Surrogates(value, path);
+    return value;
+  }
+  if (value === null || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw createCanonicalJsonError(path, "non-finite numbers are not allowed");
+    }
+    return value;
+  }
+  if (typeof value === "undefined") {
+    throw createCanonicalJsonError(path, "undefined is not allowed");
+  }
+  if (typeof value === "bigint") {
+    throw createCanonicalJsonError(path, "bigint is not allowed");
+  }
+  if (typeof value === "function") {
+    throw createCanonicalJsonError(path, "functions are not allowed");
+  }
+  if (typeof value === "symbol") {
+    throw createCanonicalJsonError(path, "symbols are not allowed");
+  }
+  if (Array.isArray(value)) {
+    if (Object.getPrototypeOf(value) !== Array.prototype) {
+      throw createCanonicalJsonError(path, "arrays must use exact Array.prototype");
+    }
+    if (stack.has(value)) {
+      throw createCanonicalJsonError(path, "cyclic structures are not allowed");
+    }
+
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+    if (
+      !lengthDescriptor
+      || !Object.hasOwn(lengthDescriptor, "value")
+      || lengthDescriptor.enumerable
+      || lengthDescriptor.configurable
+    ) {
+      throw createCanonicalJsonError(path, "arrays must have the standard length property");
+    }
+    const length = lengthDescriptor.value;
+    if (
+      typeof length !== "number"
+      || !Number.isInteger(length)
+      || length < 0
+      || length >= 0x100000000
+    ) {
+      throw createCanonicalJsonError(path, "arrays must have a valid length");
+    }
+
+    const entries: Array<{
+      descriptor: PropertyDescriptor;
+      index: number;
+      key: string;
+    }> = [];
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key === "symbol") {
+        throw createCanonicalJsonError(path, "symbol-keyed own properties are not allowed");
+      }
+      if (key === "length") continue;
+      const propertyPath = jsonPathForProperty(path, key);
+      if (!isCanonicalArrayIndex(key)) {
+        throw createCanonicalJsonError(propertyPath, "arrays may not have extra string properties");
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor) {
+        throw createCanonicalJsonError(propertyPath, "array index descriptor is missing");
+      }
+      if (!descriptor.enumerable) {
+        throw createCanonicalJsonError(propertyPath, "array indices must be enumerable");
+      }
+      if (!Object.hasOwn(descriptor, "value")) {
+        throw createCanonicalJsonError(propertyPath, "array indices must be data properties");
+      }
+      entries.push({ descriptor, index: Number(key), key });
+    }
+    entries.sort((left, right) => left.index - right.index);
+    for (let expectedIndex = 0; expectedIndex < entries.length; expectedIndex += 1) {
+      if (entries[expectedIndex].index !== expectedIndex) {
+        throw createCanonicalJsonError(
+          jsonPathForIndex(path, expectedIndex),
+          "sparse array holes are not allowed",
+        );
+      }
+    }
+    if (entries.length !== length) {
+      throw createCanonicalJsonError(
+        jsonPathForIndex(path, entries.length),
+        "sparse array holes are not allowed",
+      );
+    }
+
+    const copy = new Array<unknown>(length);
+    stack.add(value);
+    try {
+      for (const entry of entries) {
+        Object.defineProperty(copy, entry.key, {
+          value: copyCanonicalJsonValueAtPath(
+            entry.descriptor.value,
+            jsonPathForIndex(path, entry.index),
+            stack,
+          ),
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+      }
+    } finally {
+      stack.delete(value);
+    }
+    return copy;
+  }
+  if (!isPlainJsonObject(value)) {
+    throw createCanonicalJsonError(path, "only JSON objects and arrays are allowed");
+  }
+  if (stack.has(value)) {
+    throw createCanonicalJsonError(path, "cyclic structures are not allowed");
+  }
+
+  const copy = Object.create(null) as Record<string, unknown>;
+  stack.add(value);
+  try {
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key === "symbol") {
+        throw createCanonicalJsonError(path, "symbol-keyed own properties are not allowed");
+      }
+      const propertyPath = jsonPathForProperty(path, key);
+      assertPairedUtf16Surrogates(key, propertyPath);
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor) {
+        throw createCanonicalJsonError(propertyPath, "property descriptor is missing");
+      }
+      if (!descriptor.enumerable) {
+        throw createCanonicalJsonError(propertyPath, "non-enumerable own properties are not allowed");
+      }
+      if (!Object.hasOwn(descriptor, "value")) {
+        throw createCanonicalJsonError(propertyPath, "accessor properties are not allowed");
+      }
+      Object.defineProperty(copy, key, {
+        value: copyCanonicalJsonValueAtPath(descriptor.value, propertyPath, stack),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+  } finally {
+    stack.delete(value);
+  }
+  return copy;
+}
+
+export function copyCanonicalJsonValue<T>(value: T): T {
+  return copyCanonicalJsonValueAtPath(value, "$", new WeakSet<object>()) as T;
+}
+
+export function copyCanonicalJson(value: unknown): unknown {
+  return copyCanonicalJsonValue(value);
+}
+
+function stringifyJsonPrimitive(value: string | number): string {
+  const serialized = JSON.stringify(value);
+  if (typeof serialized !== "string") {
+    throw new TypeError("Value at $ is not canonical JSON: serialization failed");
+  }
+  return serialized;
+}
+
+function serializeCanonicalJson(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "string" || typeof value === "number") {
+    return stringifyJsonPrimitive(value);
+  }
+  if (Array.isArray(value)) {
+    const entries: string[] = [];
+    for (let index = 0; index < value.length; index += 1) {
+      entries.push(serializeCanonicalJson(value[index]));
+    }
+    return `[${entries.join(",")}]`;
+  }
+
+  const object = value as Record<string, unknown>;
+  const entries: string[] = [];
+  for (const key of Object.keys(object).sort()) {
+    entries.push(`${stringifyJsonPrimitive(key)}:${serializeCanonicalJson(object[key])}`);
+  }
+  return `{${entries.join(",")}}`;
+}
+
+export function canonicalJson(value: unknown): string {
+  return serializeCanonicalJson(copyCanonicalJsonValue(value));
+}
+
+export function sha256Digest(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function digestProtocolObject(value: unknown): string {
+  if (!isPlainJsonObject(value)) {
+    throw new TypeError("digestProtocolObject expects a JSON record");
+  }
+  const copy = copyCanonicalJsonValue(value);
+  Reflect.deleteProperty(copy, "digest");
+  return sha256Digest(serializeCanonicalJson(copy));
+}

--- a/src/lib/research-protocol/index.test.ts
+++ b/src/lib/research-protocol/index.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import validContextPack from "../../../schemas/research/v1/fixtures/valid/context-pack.json" with { type: "json" };
+import validModelTask from "../../../schemas/research/v1/fixtures/valid/model-task.json" with { type: "json" };
+import validModelTaskResult from "../../../schemas/research/v1/fixtures/valid/model-task-result.json" with { type: "json" };
+import validResearchRun from "../../../schemas/research/v1/fixtures/valid/research-run.json" with { type: "json" };
+import validRunEvent from "../../../schemas/research/v1/fixtures/valid/run-event.json" with { type: "json" };
+import validRunManifest from "../../../schemas/research/v1/fixtures/valid/run-manifest-assembling.json" with { type: "json" };
+import validFinalRunManifest from "../../../schemas/research/v1/fixtures/valid/run-manifest-final-local.json" with { type: "json" };
+import validTopicDiscoveryJob from "../../../schemas/research/v1/fixtures/valid/topic-discovery-job.json" with { type: "json" };
+import validTopicProposal from "../../../schemas/research/v1/fixtures/valid/topic-proposal.json" with { type: "json" };
+import invalidContextPackPdfSelector from "../../../schemas/research/v1/fixtures/invalid/context-pack-pdf-selector.json" with { type: "json" };
+import unknownMajorRunEvent from "../../../schemas/research/v1/fixtures/invalid/unknown-major.json" with { type: "json" };
+
+import { parseContextPackV1 } from "./context-pack.ts";
+import { digestProtocolObject } from "./digest.ts";
+import * as researchProtocol from "./index.ts";
+import {
+  RESEARCH_PROTOCOL_SCHEMAS,
+  parseResearchProtocolObject,
+  type ResearchProtocolObjectV1,
+} from "./index.ts";
+
+type ParseResult =
+  | { ok: true; value: ResearchProtocolObjectV1 }
+  | { ok: false; error: { path: string; code: string; message: string } };
+
+function expectOk(result: ParseResult): ResearchProtocolObjectV1 {
+  if (!result.ok) {
+    assert.fail(`${result.error.path}: ${result.error.message}`);
+  }
+  return result.value;
+}
+
+function expectError(result: ParseResult, path: string, code: string): void {
+  if (result.ok) {
+    assert.fail("expected parse failure");
+  }
+  assert.equal(result.error.path, path);
+  assert.equal(result.error.code, code);
+}
+
+function recalculate<T extends Record<string, unknown>>(value: T): T {
+  return { ...value, digest: digestProtocolObject(value) };
+}
+
+test("RESEARCH_PROTOCOL_SCHEMAS lists all eight v1 schema identifiers in order", () => {
+  assert.deepEqual(RESEARCH_PROTOCOL_SCHEMAS, [
+    "opencoven.context-pack/v1",
+    "opencoven.topic-discovery-job/v1",
+    "opencoven.topic-proposal/v1",
+    "opencoven.research-run/v1",
+    "opencoven.run-event/v1",
+    "opencoven.model-task/v1",
+    "opencoven.model-task-result/v1",
+    "opencoven.run-manifest/v1",
+  ]);
+  assert.equal(RESEARCH_PROTOCOL_SCHEMAS.length, 8);
+});
+
+const VALID_FIXTURES: Array<[string, unknown]> = [
+  ["opencoven.context-pack/v1", validContextPack],
+  ["opencoven.topic-discovery-job/v1", validTopicDiscoveryJob],
+  ["opencoven.topic-proposal/v1", validTopicProposal],
+  ["opencoven.research-run/v1", validResearchRun],
+  ["opencoven.run-event/v1", validRunEvent],
+  ["opencoven.model-task/v1", validModelTask],
+  ["opencoven.model-task-result/v1", validModelTaskResult],
+  ["opencoven.run-manifest/v1", validRunManifest],
+];
+
+test("dispatches every RESEARCH_PROTOCOL_SCHEMAS entry to its parser", () => {
+  assert.deepEqual(
+    VALID_FIXTURES.map(([schema]) => schema),
+    [...RESEARCH_PROTOCOL_SCHEMAS],
+  );
+  for (const [schema, fixture] of VALID_FIXTURES) {
+    const parsed = expectOk(parseResearchProtocolObject(fixture));
+    assert.equal(parsed.schema, schema);
+  }
+});
+
+test("missing schema field fails with missing_field at $.schema", () => {
+  const { schema: _schema, ...withoutSchema } = validRunEvent as Record<string, unknown>;
+  expectError(parseResearchProtocolObject(withoutSchema), "$.schema", "missing_field");
+});
+
+test("non-string schema field fails with missing_field at $.schema", () => {
+  expectError(
+    parseResearchProtocolObject({ ...validRunEvent, schema: 1 }),
+    "$.schema",
+    "missing_field",
+  );
+});
+
+test("non-object input fails with missing_field at $.schema", () => {
+  expectError(parseResearchProtocolObject(null), "$.schema", "missing_field");
+  expectError(parseResearchProtocolObject("opencoven.run-event/v1"), "$.schema", "missing_field");
+  expectError(parseResearchProtocolObject([validRunEvent]), "$.schema", "missing_field");
+});
+
+test("unknown schema major fails with unknown_major at $.schema, without parsing the payload", () => {
+  assert.equal(unknownMajorRunEvent.schema, "opencoven.run-event/v2");
+  expectError(parseResearchProtocolObject(unknownMajorRunEvent), "$.schema", "unknown_major");
+});
+
+test("a schema string outside the known family also fails with unknown_major", () => {
+  expectError(
+    parseResearchProtocolObject({ ...validRunEvent, schema: "opencoven.made-up/v1" }),
+    "$.schema",
+    "unknown_major",
+  );
+});
+
+test("dispatch preserves the underlying parser's result exactly", () => {
+  const direct = parseContextPackV1(invalidContextPackPdfSelector);
+  const dispatched = parseResearchProtocolObject(invalidContextPackPdfSelector);
+  assert.deepEqual(dispatched, direct);
+});
+
+test("public manifest dispatch rejects unvalidated policy and deadline extensions", () => {
+  const policyExtension = recalculate({
+    ...validRunManifest,
+    revision: 2,
+    previousDigest: validRunManifest.digest,
+    retention: {
+      ...validRunManifest.retention,
+      effectivePolicy: "project" as const,
+    },
+  });
+  expectError(
+    parseResearchProtocolObject(policyExtension),
+    "$.retention.effectivePolicy",
+    "semantic_conflict",
+  );
+
+  const deadlineExtension = recalculate({
+    ...validFinalRunManifest,
+    revision: 2,
+    previousDigest: validFinalRunManifest.digest,
+    retention: {
+      ...validFinalRunManifest.retention,
+      status: "deletion_scheduled" as const,
+      contentExpiresAt: "2026-08-24T20:04:00.000Z",
+      updatedAt: "2026-08-17T20:04:00.000Z",
+    },
+    deletion: {
+      status: "scheduled" as const,
+      requestedAt: "2026-08-17T20:04:00.000Z",
+    },
+  });
+  expectError(
+    parseResearchProtocolObject(deadlineExtension),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+});
+
+test("public protocol exports do not expose a permissive manifest candidate parser", () => {
+  assert.equal("parseRunManifestRevisionCandidateV1" in researchProtocol, false);
+  assert.equal("parseEmbeddedRunManifestCandidateV1" in researchProtocol, false);
+});
+
+test("dispatcher rejects non-canonical wire data for discovery, proposal, run, and event families", () => {
+  class CustomArray<T> extends Array<T> {}
+
+  const fixtures = [
+    validTopicDiscoveryJob,
+    validTopicProposal,
+    validResearchRun,
+    validRunEvent,
+  ] as ReadonlyArray<Record<string, unknown>>;
+
+  for (const fixture of fixtures) {
+    const hidden = { ...fixture };
+    Object.defineProperty(hidden, "hidden", {
+      value: "not-json",
+      enumerable: false,
+    });
+    expectError(parseResearchProtocolObject(hidden), "$", "invalid_value");
+
+    const symbolKeyed = { ...fixture };
+    Object.defineProperty(symbolKeyed, Symbol("hidden"), {
+      value: "not-json",
+      enumerable: true,
+    });
+    expectError(parseResearchProtocolObject(symbolKeyed), "$", "invalid_value");
+
+    const hiddenToJson = { ...fixture };
+    Object.defineProperty(hiddenToJson, "toJSON", {
+      value() {
+        return fixture;
+      },
+      enumerable: false,
+    });
+    expectError(parseResearchProtocolObject(hiddenToJson), "$", "invalid_value");
+
+    const extraProperty = [1, 2];
+    Object.defineProperty(extraProperty, "extra", {
+      value: true,
+      enumerable: true,
+    });
+    for (const values of [[1, , 3], CustomArray.from([1, 2]), extraProperty]) {
+      expectError(
+        parseResearchProtocolObject({ ...fixture, wireExtension: { values } }),
+        "$",
+        "invalid_value",
+      );
+    }
+  }
+});
+
+test("dispatcher rejects a schema accessor without invoking it", () => {
+  let calls = 0;
+  const value = { ...validRunEvent } as Record<string, unknown>;
+  Object.defineProperty(value, "schema", {
+    get() {
+      calls += 1;
+      return validRunEvent.schema;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+
+  expectError(parseResearchProtocolObject(value), "$", "invalid_value");
+  assert.equal(calls, 0);
+});
+
+test("dispatcher returns detached additive data", () => {
+  const extension = {
+    nested: { state: "original" },
+    items: [{ value: 1 }],
+  };
+  const parsed = expectOk(
+    parseResearchProtocolObject({
+      ...validRunEvent,
+      wireExtension: extension,
+    }),
+  ) as Record<string, unknown>;
+  const parsedExtension = parsed.wireExtension as typeof extension;
+
+  assert.notStrictEqual(parsedExtension, extension);
+  assert.notStrictEqual(parsedExtension.nested, extension.nested);
+  assert.notStrictEqual(parsedExtension.items, extension.items);
+  assert.notStrictEqual(parsedExtension.items[0], extension.items[0]);
+
+  extension.nested.state = "mutated";
+  extension.items[0].value = 99;
+  extension.items.push({ value: 2 });
+  assert.equal(parsedExtension.nested.state, "original");
+  assert.equal(parsedExtension.items[0].value, 1);
+  assert.equal(parsedExtension.items.length, 1);
+});

--- a/src/lib/research-protocol/index.ts
+++ b/src/lib/research-protocol/index.ts
@@ -1,0 +1,119 @@
+import {
+  copyProtocolJsonValue,
+  fail,
+  isRecord,
+  type ProtocolParseResult,
+} from "./common.ts";
+import { parseContextPackV1, type ContextPackV1 } from "./context-pack.ts";
+import {
+  parseModelTaskResultV1,
+  parseModelTaskV1,
+  type ModelTaskResultV1,
+  type ModelTaskV1,
+} from "./model-task.ts";
+import {
+  parseResearchRunV1,
+  parseRunEventV1,
+  type ResearchRunV1,
+  type RunEventV1,
+} from "./research-run.ts";
+import { parseRunManifestV1, type RunManifestV1 } from "./run-manifest.ts";
+import {
+  parseTopicDiscoveryJobV1,
+  parseTopicProposalV1,
+  type TopicDiscoveryJobV1,
+  type TopicProposalV1,
+} from "./topic-discovery.ts";
+
+export * from "./common.ts";
+export * from "./context-pack.ts";
+export * from "./digest.ts";
+export * from "./model-task.ts";
+export * from "./research-run.ts";
+export {
+  aggregateManifestUsage,
+  parseRunManifestV1,
+  SENSITIVE_EXTENSION_COMPONENT_KEY_PATTERN,
+  SENSITIVE_EXTENSION_COMPOUND_KEY_PATTERN,
+  SENSITIVE_EXTENSION_KEY_PATTERN,
+  SENSITIVE_EXTENSION_VARIANT_KEY_PATTERN,
+  validateManifestRetentionConsent,
+  validateRunManifestRevision,
+  validateRunManifestRevisionV1,
+  type ArtifactRegistrationV1,
+  type ManifestRevisionOptions,
+  type RunManifestDeletionReceiptV1,
+  type RunManifestModelExecutionV1,
+  type RunManifestRetentionV1,
+  type RunManifestSourceV1,
+  type RunManifestUsageV1,
+  type RunManifestV1,
+} from "./run-manifest.ts";
+export * from "./topic-discovery.ts";
+
+/**
+ * Every Research Protocol v1 schema identifier, in the fixed order the
+ * protocol defines them. This is the single source of truth for "which
+ * schemas exist" — keep it in sync with the object types dispatched below.
+ */
+export const RESEARCH_PROTOCOL_SCHEMAS = [
+  "opencoven.context-pack/v1",
+  "opencoven.topic-discovery-job/v1",
+  "opencoven.topic-proposal/v1",
+  "opencoven.research-run/v1",
+  "opencoven.run-event/v1",
+  "opencoven.model-task/v1",
+  "opencoven.model-task-result/v1",
+  "opencoven.run-manifest/v1",
+] as const;
+
+export type ResearchProtocolObjectV1 =
+  | ContextPackV1
+  | TopicDiscoveryJobV1
+  | TopicProposalV1
+  | ResearchRunV1
+  | RunEventV1
+  | ModelTaskV1
+  | ModelTaskResultV1
+  | RunManifestV1;
+
+/**
+ * Dispatches a value to the parser for its exact `schema` string. This is a
+ * thin router: it first applies the protocol JSON boundary, then inspects the
+ * detached `schema` value and dispatches it to the matching parser. Any schema
+ * string that isn't one of `RESEARCH_PROTOCOL_SCHEMAS` exactly — including a
+ * different major version of a known family, such as
+ * `opencoven.run-event/v2` — is rejected as `unknown_major` without reaching a
+ * schema parser.
+ */
+export function parseResearchProtocolObject(
+  value: unknown,
+): ProtocolParseResult<ResearchProtocolObjectV1> {
+  const wireValue = copyProtocolJsonValue(value);
+  if (!wireValue.ok) return wireValue;
+
+  if (!isRecord(wireValue.value) || typeof wireValue.value.schema !== "string") {
+    return fail("missing_field", "$.schema", "Missing required field schema");
+  }
+
+  switch (wireValue.value.schema) {
+    case "opencoven.context-pack/v1":
+      return parseContextPackV1(wireValue.value);
+    case "opencoven.topic-discovery-job/v1":
+      return parseTopicDiscoveryJobV1(wireValue.value);
+    case "opencoven.topic-proposal/v1":
+      return parseTopicProposalV1(wireValue.value);
+    case "opencoven.research-run/v1":
+      return parseResearchRunV1(wireValue.value);
+    case "opencoven.run-event/v1":
+      return parseRunEventV1(wireValue.value);
+    case "opencoven.model-task/v1":
+      return parseModelTaskV1(wireValue.value);
+    case "opencoven.model-task-result/v1":
+      return parseModelTaskResultV1(wireValue.value);
+    case "opencoven.run-manifest/v1":
+      return parseRunManifestV1(wireValue.value);
+    default:
+      return fail("unknown_major", "$.schema", `Unsupported schema ${wireValue.value.schema}`);
+  }
+}

--- a/src/lib/research-protocol/model-task.test.ts
+++ b/src/lib/research-protocol/model-task.test.ts
@@ -1,0 +1,814 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Value } from "typebox/value";
+
+import invalidModelTaskPolicy from "../../../schemas/research/v1/fixtures/invalid/model-task-policy.json" with { type: "json" };
+import invalidModelTaskResultUsage from "../../../schemas/research/v1/fixtures/invalid/model-task-result-usage.json" with { type: "json" };
+import validModelTask from "../../../schemas/research/v1/fixtures/valid/model-task.json" with { type: "json" };
+import validModelTaskResult from "../../../schemas/research/v1/fixtures/valid/model-task-result.json" with { type: "json" };
+import modelTaskResultSchema from "../../../schemas/research/v1/model-task-result.schema.json" with { type: "json" };
+import modelTaskSchema from "../../../schemas/research/v1/model-task.schema.json" with { type: "json" };
+
+import { canonicalJson, sha256Digest } from "./digest.ts";
+import {
+  modelTaskResultSignaturePayload,
+  parseModelTaskResultV1,
+  parseModelTaskV1,
+  validateModelTaskResultV1,
+} from "./model-task.ts";
+
+const SAFE_INTEGER_OVERFLOW = 9007199254740992;
+const FIXTURE_EXECUTOR_DEVICE_ID = "device_01";
+const VALID_SHA256_MISMATCH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const VALID_SHA256_MISMATCH_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+function expectOk<T>(result: { ok: true; value: T } | { ok: false; error: { path: string; message: string } }): T {
+  if (!result.ok) {
+    assert.fail(`${result.error.path}: ${result.error.message}`);
+  }
+  return result.value;
+}
+
+function expectError(
+  result: { ok: true; value: unknown } | { ok: false; error: { path: string; code: string; message: string } },
+  path: string,
+  code?: string,
+): { path: string; code: string; message: string } {
+  if (result.ok) {
+    assert.fail("expected parse failure");
+  }
+  assert.equal(result.error.path, path);
+  if (code) {
+    assert.equal(result.error.code, code);
+  }
+  return result.error;
+}
+
+test("valid fixtures satisfy schemas, parse, and preserve additive fields", () => {
+  assert.ok(Value.Check(modelTaskSchema, validModelTask));
+  assert.ok(Value.Check(modelTaskResultSchema, validModelTaskResult));
+
+  const task = expectOk(parseModelTaskV1(validModelTask));
+  assert.equal((task.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((task.input.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((task.input.contextPack.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((task.modelBinding.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((task.policy.futureExtension as { preserve: boolean }).preserve, true);
+
+  const result = expectOk(parseModelTaskResultV1(validModelTaskResult));
+  assert.equal((result.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((result.output.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((result.modelReceipt.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((result.modelReceipt.usage.futureExtension as { preserve: boolean }).preserve, true);
+});
+
+test("Model Task and Result reject non-canonical wire data before invoking accessors", () => {
+  class CustomArray<T> extends Array<T> {}
+  let accessorCalls = 0;
+
+  const parsers = [
+    {
+      base: validModelTask as Record<string, unknown>,
+      parse: (value: unknown) => parseModelTaskV1(value),
+    },
+    {
+      base: validModelTaskResult as Record<string, unknown>,
+      parse: (value: unknown) => parseModelTaskResultV1(value),
+    },
+  ];
+
+  for (const { base, parse } of parsers) {
+    const accessor = { ...base };
+    Object.defineProperty(accessor, "schema", {
+      get() {
+        accessorCalls += 1;
+        return base.schema;
+      },
+      enumerable: true,
+      configurable: true,
+    });
+    expectError(parse(accessor), "$", "invalid_value");
+
+    const hidden = { ...base };
+    Object.defineProperty(hidden, "hidden", {
+      value: "not-json",
+      enumerable: false,
+    });
+    expectError(parse(hidden), "$", "invalid_value");
+
+    const symbolKeyed = { ...base };
+    Object.defineProperty(symbolKeyed, Symbol("hidden"), {
+      value: "not-json",
+      enumerable: true,
+    });
+    expectError(parse(symbolKeyed), "$", "invalid_value");
+
+    const hiddenToJson = { ...base };
+    Object.defineProperty(hiddenToJson, "toJSON", {
+      value() {
+        accessorCalls += 1;
+        return base;
+      },
+      enumerable: false,
+    });
+    expectError(parse(hiddenToJson), "$", "invalid_value");
+
+    const extraProperty = [1, 2];
+    Object.defineProperty(extraProperty, "extra", {
+      value: true,
+      enumerable: true,
+    });
+    for (const values of [[1, , 3], CustomArray.from([1, 2]), extraProperty]) {
+      expectError(parse({ ...base, wireExtension: { values } }), "$", "invalid_value");
+    }
+  }
+
+  assert.equal(accessorCalls, 0);
+});
+
+test("Model Task and Result detach additive wire objects and arrays", () => {
+  for (const { base, parse } of [
+    {
+      base: validModelTask as Record<string, unknown>,
+      parse: (value: unknown) => parseModelTaskV1(value),
+    },
+    {
+      base: validModelTaskResult as Record<string, unknown>,
+      parse: (value: unknown) => parseModelTaskResultV1(value),
+    },
+  ]) {
+    const extension = {
+      nested: { state: "original" },
+      items: [{ value: 1 }],
+    };
+    const result = parse({ ...base, wireExtension: extension });
+    if (!result.ok) {
+      assert.fail(`${result.error.path}: ${result.error.message}`);
+    }
+    const parsed = result.value as unknown as Record<string, unknown>;
+    const parsedExtension = parsed.wireExtension as typeof extension;
+
+    assert.notStrictEqual(parsedExtension, extension);
+    assert.notStrictEqual(parsedExtension.nested, extension.nested);
+    assert.notStrictEqual(parsedExtension.items, extension.items);
+    assert.notStrictEqual(parsedExtension.items[0], extension.items[0]);
+
+    extension.nested.state = "mutated";
+    extension.items[0].value = 99;
+    extension.items.push({ value: 2 });
+    assert.equal(parsedExtension.nested.state, "original");
+    assert.equal(parsedExtension.items[0].value, 1);
+    assert.equal(parsedExtension.items.length, 1);
+  }
+});
+
+test("modelTaskResultSignaturePayload returns exactly the signed fields", () => {
+  const parsed = expectOk(parseModelTaskResultV1(validModelTaskResult));
+  const payload = modelTaskResultSignaturePayload(parsed);
+
+  assert.deepEqual(payload, {
+    taskId: "modeltask_01",
+    runId: "run_01",
+    attempt: 1,
+    inputDigest: "6a28b9d62b79b42a133d52fe51636c161c67722929efa5f6178e2940c9136597",
+    outputDigest: validModelTaskResult.outputDigest,
+    executorDeviceId: "device_01",
+    completedAt: "2026-08-15T20:10:00.000Z",
+  });
+  assert.deepEqual(Object.keys(payload).sort(), [
+    "attempt",
+    "completedAt",
+    "executorDeviceId",
+    "inputDigest",
+    "outputDigest",
+    "runId",
+    "taskId",
+  ]);
+  assert.equal("output" in payload, false);
+  assert.equal("modelReceipt" in payload, false);
+  assert.equal("signature" in payload, false);
+});
+
+test("permissionMode write rejects in schema and parser", () => {
+  assert.equal(Value.Check(modelTaskSchema, invalidModelTaskPolicy), false);
+  expectError(parseModelTaskV1(invalidModelTaskPolicy), "$.policy.permissionMode", "invalid_value");
+});
+
+test("model task identifier and context pack constraints reject in schema and parser", () => {
+  const cases = [
+    {
+      label: "model task id prefix",
+      schema: modelTaskSchema,
+      value: { ...validModelTask, id: "task_01" },
+      path: "$.id",
+    },
+    {
+      label: "model task run id prefix",
+      schema: modelTaskSchema,
+      value: { ...validModelTask, runId: "job_01" },
+      path: "$.runId",
+    },
+    {
+      label: "context pack id prefix",
+      schema: modelTaskSchema,
+      value: {
+        ...validModelTask,
+        input: {
+          ...validModelTask.input,
+          contextPack: { ...validModelTask.input.contextPack, id: "context_01" },
+        },
+      },
+      path: "$.input.contextPack.id",
+    },
+    {
+      label: "topic proposal id prefix",
+      schema: modelTaskSchema,
+      value: {
+        ...validModelTask,
+        input: {
+          ...validModelTask.input,
+          topicProposalId: "topic_01",
+        },
+      },
+      path: "$.input.topicProposalId",
+    },
+    {
+      label: "context pack availability",
+      schema: modelTaskSchema,
+      value: {
+        ...validModelTask,
+        input: {
+          ...validModelTask.input,
+          contextPack: { ...validModelTask.input.contextPack, availability: "browser-cache" },
+        },
+      },
+      path: "$.input.contextPack.availability",
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    assert.equal(Value.Check(testCase.schema, testCase.value), false, `${testCase.label}: schema should reject`);
+    expectError(parseModelTaskV1(testCase.value), testCase.path, "invalid_value");
+  }
+});
+
+test("invalid usage fixture rejects in schema and parser", () => {
+  assert.equal(Value.Check(modelTaskResultSchema, invalidModelTaskResultUsage), false);
+  expectError(parseModelTaskResultV1(invalidModelTaskResultUsage), "$.modelReceipt.usage", "semantic_conflict");
+});
+
+test("result outputDigest remains opaque while task input digest is verifiable", () => {
+  assert.equal(validModelTask.inputDigest, sha256Digest(canonicalJson(validModelTask.input)));
+  assert.equal(validModelTaskResult.inputDigest, validModelTask.inputDigest);
+  assert.equal(validModelTaskResult.inputDigest, sha256Digest(canonicalJson(validModelTask.input)));
+  assert.match(validModelTaskResult.outputDigest, /^[a-f0-9]{64}$/);
+  assert.notEqual(
+    validModelTaskResult.outputDigest,
+    sha256Digest(canonicalJson(validModelTaskResult.output)),
+  );
+  assert.equal(validModelTaskResult.executorDeviceId, FIXTURE_EXECUTOR_DEVICE_ID);
+});
+
+test("task parser verifies inputDigest while result parser defers outputDigest verification", () => {
+  expectError(
+    parseModelTaskV1({
+      ...validModelTask,
+      input: {
+        ...validModelTask.input,
+        publicEvidenceRefs: ["evidence://new"],
+      },
+    }),
+    "$.inputDigest",
+    "digest_mismatch",
+  );
+
+  assert.deepEqual(
+    expectOk(parseModelTaskResultV1({
+      ...validModelTaskResult,
+      output: { decision: "stop" },
+    })).output,
+    { decision: "stop" },
+  );
+});
+
+test("validateModelTaskResultV1 accepts matching replays and rejects conflicting associations", () => {
+  const task = expectOk(parseModelTaskV1(validModelTask));
+  const result = expectOk(parseModelTaskResultV1(validModelTaskResult));
+
+  assert.equal(result.executorDeviceId, "device_01");
+  assert.strictEqual(expectOk(validateModelTaskResultV1(task, result)), result);
+  assert.strictEqual(expectOk(validateModelTaskResultV1(task, result)), result);
+
+  for (const testCase of [
+    { field: "taskId", value: "modeltask_other", path: "$.taskId" },
+    { field: "runId", value: "run_other", path: "$.runId" },
+    { field: "attempt", value: 2, path: "$.attempt" },
+    { field: "inputDigest", value: VALID_SHA256_MISMATCH, path: "$.inputDigest" },
+  ] as const) {
+    expectError(
+      validateModelTaskResultV1(task, { ...result, [testCase.field]: testCase.value }),
+      testCase.path,
+      "semantic_conflict",
+    );
+  }
+});
+
+test("association validation verifies task input but defers result output digest semantics", () => {
+  const mutatedTask = expectOk(parseModelTaskV1(validModelTask));
+  const matchingResult = expectOk(parseModelTaskResultV1(validModelTaskResult));
+  mutatedTask.input.publicEvidenceRefs.push("evidence://mutated");
+  expectError(
+    validateModelTaskResultV1(mutatedTask, matchingResult),
+    "$.inputDigest",
+    "digest_mismatch",
+  );
+
+  const matchingTask = expectOk(parseModelTaskV1(validModelTask));
+  const mutatedResult = expectOk(parseModelTaskResultV1(validModelTaskResult));
+  mutatedResult.output.decision = "mutated";
+  assert.strictEqual(
+    expectOk(validateModelTaskResultV1(matchingTask, mutatedResult)),
+    mutatedResult,
+  );
+});
+
+test("validateModelTaskResultV1 binds the result receipt to the task familiar", () => {
+  const task = expectOk(parseModelTaskV1(validModelTask));
+  const result = expectOk(parseModelTaskResultV1(validModelTaskResult));
+
+  expectError(
+    validateModelTaskResultV1(task, {
+      ...result,
+      modelReceipt: { ...result.modelReceipt, familiarId: "other-familiar" },
+    }),
+    "$.modelReceipt.familiarId",
+    "semantic_conflict",
+  );
+});
+
+test("validateModelTaskResultV1 binds pinned models but allows run-start resolution", () => {
+  const pinnedTask = expectOk(
+    parseModelTaskV1({
+      ...validModelTask,
+      modelBinding: {
+        familiarId: "sage",
+        selection: "pinned",
+        model: "gpt-5.6-sol",
+      },
+    }),
+  );
+  const result = expectOk(parseModelTaskResultV1(validModelTaskResult));
+
+  assert.strictEqual(expectOk(validateModelTaskResultV1(pinnedTask, result)), result);
+  for (const effectiveModel of ["other-model", null]) {
+    expectError(
+      validateModelTaskResultV1(pinnedTask, {
+        ...result,
+        modelReceipt: { ...result.modelReceipt, effectiveModel },
+      }),
+      "$.modelReceipt.effectiveModel",
+      "semantic_conflict",
+    );
+  }
+
+  const resolvingTask = expectOk(parseModelTaskV1(validModelTask));
+  for (const effectiveModel of ["runtime-selected-model", null]) {
+    const resolvingResult = {
+      ...result,
+      modelReceipt: { ...result.modelReceipt, effectiveModel },
+    };
+    assert.strictEqual(
+      expectOk(validateModelTaskResultV1(resolvingTask, resolvingResult)),
+      resolvingResult,
+    );
+  }
+});
+
+test("pinned model requires own model and resolve-at-run-start forbids model", () => {
+  expectError(
+    parseModelTaskV1({
+      ...validModelTask,
+      modelBinding: { familiarId: "sage", selection: "pinned" as const },
+    }),
+    "$.modelBinding.model",
+    "missing_field",
+  );
+
+  expectError(
+    parseModelTaskV1({
+      ...validModelTask,
+      modelBinding: { familiarId: "sage", selection: "resolve-at-run-start" as const, model: "gpt-5.6-sol" },
+    }),
+    "$.modelBinding.model",
+    "semantic_conflict",
+  );
+});
+
+test("attempt and maxOutputTokens enforce positive safe integers", () => {
+  const taskCases = [
+    { field: "attempt", value: 0 },
+    { field: "attempt", value: SAFE_INTEGER_OVERFLOW },
+    { field: "policy", value: { ...validModelTask.policy, maxOutputTokens: 0 }, path: "$.policy.maxOutputTokens" },
+    { field: "policy", value: { ...validModelTask.policy, maxOutputTokens: SAFE_INTEGER_OVERFLOW }, path: "$.policy.maxOutputTokens" },
+  ] as const;
+
+  for (const caseItem of taskCases) {
+    if (caseItem.field === "attempt") {
+      expectError(
+        parseModelTaskV1({ ...validModelTask, attempt: caseItem.value }),
+        "$.attempt",
+        "invalid_value",
+      );
+    } else {
+      expectError(
+        parseModelTaskV1({ ...validModelTask, policy: caseItem.value }),
+        caseItem.path,
+        "invalid_value",
+      );
+    }
+  }
+
+  expectError(parseModelTaskResultV1({ ...validModelTaskResult, attempt: 0 }), "$.attempt", "invalid_value");
+  expectError(
+    parseModelTaskResultV1({ ...validModelTaskResult, attempt: SAFE_INTEGER_OVERFLOW }),
+    "$.attempt",
+    "invalid_value",
+  );
+});
+
+test("digests require lowercase sha256 and timestamps require UTC RFC 3339", () => {
+  expectError(
+    parseModelTaskV1({ ...validModelTask, inputDigest: "A7a21a3895e180dfcce5b4aa1c7827bb7985a406b378399f6655d4f1a01229d5" }),
+    "$.inputDigest",
+    "invalid_value",
+  );
+  expectError(
+    parseModelTaskV1({
+      ...validModelTask,
+      input: {
+        ...validModelTask.input,
+        contextPack: { ...validModelTask.input.contextPack, digest: "DB34941F93689F6D425CF48E7E046B885F6CEE80C2E9790D1AD97CB26B3CD118" },
+      },
+    }),
+    "$.input.contextPack.digest",
+    "invalid_value",
+  );
+  expectError(
+    parseModelTaskV1({ ...validModelTask, leaseExpiresAt: "2026-08-15T20:15:00+00:00" }),
+    "$.leaseExpiresAt",
+    "invalid_value",
+  );
+
+  expectError(
+    parseModelTaskResultV1({ ...validModelTaskResult, outputDigest: "0919F42FD41098C197ABBE957594805F531FF4F7B9BCCC68316C5F9DB3ADEE17" }),
+    "$.outputDigest",
+    "invalid_value",
+  );
+  expectError(
+    parseModelTaskResultV1({ ...validModelTaskResult, completedAt: "2026-08-15T20:10:00.1234567890Z" }),
+    "$.completedAt",
+    "invalid_value",
+  );
+});
+
+test("executorDeviceId uses the shared opaque device identifier grammar", () => {
+  for (const executorDeviceId of ["device_01", "device_A-b_9"]) {
+    const candidate = { ...validModelTaskResult, executorDeviceId };
+    assert.equal(Value.Check(modelTaskResultSchema, candidate), true);
+    assert.equal(
+      expectOk(parseModelTaskResultV1(candidate)).executorDeviceId,
+      executorDeviceId,
+    );
+  }
+
+  for (const executorDeviceId of [
+    "",
+    "device_",
+    "executor_01",
+    "630dcd2966c4336691125448bbb25b4ff412a49c732db2c8abc1b8581bd710dd",
+    "device_unsafe/value",
+    "device_unsafe value",
+    "device_é",
+  ]) {
+    const candidate = { ...validModelTaskResult, executorDeviceId };
+    assert.equal(
+      Value.Check(modelTaskResultSchema, candidate),
+      false,
+      executorDeviceId,
+    );
+    expectError(
+      parseModelTaskResultV1(candidate),
+      "$.executorDeviceId",
+      "invalid_value",
+    );
+  }
+});
+
+test("allowedOutputs must be non-empty unique non-empty strings", () => {
+  const emptyAllowedOutputs = {
+    ...validModelTask,
+    policy: { ...validModelTask.policy, allowedOutputs: [] },
+  };
+  assert.equal(Value.Check(modelTaskSchema, emptyAllowedOutputs), false);
+  expectError(parseModelTaskV1(emptyAllowedOutputs), "$.policy.allowedOutputs", "invalid_value");
+
+  expectError(
+    parseModelTaskV1({
+      ...validModelTask,
+      policy: { ...validModelTask.policy, allowedOutputs: ["scope", "scope"] },
+    }),
+    "$.policy.allowedOutputs[1]",
+    "semantic_conflict",
+  );
+
+  expectError(
+    parseModelTaskV1({
+      ...validModelTask,
+      policy: { ...validModelTask.policy, allowedOutputs: [""] },
+    }),
+    "$.policy.allowedOutputs[0]",
+    "invalid_value",
+  );
+});
+
+test("publicEvidenceRefs must be unique non-empty opaque strings", () => {
+  const duplicateEvidenceRefs = {
+    ...validModelTask,
+    input: { ...validModelTask.input, publicEvidenceRefs: ["ref://one", "ref://one"] },
+  };
+  assert.equal(Value.Check(modelTaskSchema, duplicateEvidenceRefs), false);
+  expectError(parseModelTaskV1(duplicateEvidenceRefs), "$.input.publicEvidenceRefs[1]", "semantic_conflict");
+
+  const emptyEvidenceRef = {
+    ...validModelTask,
+    input: { ...validModelTask.input, publicEvidenceRefs: [""] },
+  };
+  assert.equal(Value.Check(modelTaskSchema, emptyEvidenceRef), false);
+  expectError(parseModelTaskV1(emptyEvidenceRef), "$.input.publicEvidenceRefs[0]", "invalid_value");
+});
+
+test("signature must be non-empty and output must be an object", () => {
+  const emptySignature = { ...validModelTaskResult, signature: "" };
+  assert.equal(Value.Check(modelTaskResultSchema, emptySignature), false);
+  expectError(parseModelTaskResultV1(emptySignature), "$.signature", "invalid_value");
+
+  const arrayOutput = { ...validModelTaskResult, output: [] };
+  assert.equal(Value.Check(modelTaskResultSchema, arrayOutput), false);
+  expectError(parseModelTaskResultV1(arrayOutput), "$.output", "invalid_type");
+});
+
+test("model task result identifier prefixes reject in schema and parser", () => {
+  const cases = [
+    {
+      label: "model task result task id prefix",
+      value: { ...validModelTaskResult, taskId: "task_01" },
+      path: "$.taskId",
+    },
+    {
+      label: "model task result run id prefix",
+      value: { ...validModelTaskResult, runId: "job_01" },
+      path: "$.runId",
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    assert.equal(Value.Check(modelTaskResultSchema, testCase.value), false, `${testCase.label}: schema should reject`);
+    expectError(parseModelTaskResultV1(testCase.value), testCase.path, "invalid_value");
+  }
+});
+
+test("parser preserves nested canonical JSON output as deep own-property data", () => {
+  const output = {
+    decision: "continue",
+    findings: [
+      {
+        id: "finding_01",
+        score: 1,
+        tags: ["public"],
+      },
+    ],
+    metadata: {
+      ok: true,
+      notes: null,
+      futureExtension: { preserve: true },
+    },
+  };
+
+  const parsed = expectOk(parseModelTaskResultV1({
+    ...validModelTaskResult,
+    output,
+    outputDigest: sha256Digest(canonicalJson(output)),
+  }));
+  assert.deepEqual(parsed.output, output);
+  assert.notStrictEqual(parsed.output, output);
+  assert.notStrictEqual(parsed.output.findings, output.findings);
+  assert.notStrictEqual(parsed.output.metadata, output.metadata);
+});
+
+test("Model Result rejects symbol keys, hidden data, and hidden or accessor toJSON", () => {
+  const symbolKeyed = { ...validModelTaskResult.output };
+  Object.defineProperty(symbolKeyed, Symbol("hidden"), {
+    value: "not-json",
+    enumerable: true,
+  });
+  expectError(
+    parseModelTaskResultV1({ ...validModelTaskResult, output: symbolKeyed }),
+    "$",
+    "invalid_value",
+  );
+
+  const hidden = { ...validModelTaskResult.output };
+  Object.defineProperty(hidden, "hidden", {
+    value: "not-json",
+    enumerable: false,
+  });
+  expectError(
+    parseModelTaskResultV1({ ...validModelTaskResult, output: hidden }),
+    "$",
+    "invalid_value",
+  );
+
+  let calls = 0;
+  const hiddenToJson = { ...validModelTaskResult.output };
+  Object.defineProperty(hiddenToJson, "toJSON", {
+    value() {
+      calls += 1;
+      return validModelTaskResult.output;
+    },
+    enumerable: false,
+  });
+  expectError(
+    parseModelTaskResultV1({ ...validModelTaskResult, output: hiddenToJson }),
+    "$",
+    "invalid_value",
+  );
+
+  const accessorToJson = { ...validModelTaskResult.output };
+  Object.defineProperty(accessorToJson, "toJSON", {
+    get() {
+      calls += 1;
+      return () => validModelTaskResult.output;
+    },
+    enumerable: true,
+  });
+  expectError(
+    parseModelTaskResultV1({ ...validModelTaskResult, output: accessorToJson }),
+    "$",
+    "invalid_value",
+  );
+  assert.equal(calls, 0);
+});
+
+test("Model Result rejects sparse and custom arrays in output", () => {
+  class CustomArray<T> extends Array<T> {}
+
+  expectError(
+    parseModelTaskResultV1({
+      ...validModelTaskResult,
+      output: { ...validModelTaskResult.output, values: [1, , 3] },
+    }),
+    "$",
+    "invalid_value",
+  );
+  expectError(
+    parseModelTaskResultV1({
+      ...validModelTaskResult,
+      output: {
+        ...validModelTaskResult.output,
+        values: CustomArray.from([1, 2, 3]),
+      },
+    }),
+    "$",
+    "invalid_value",
+  );
+});
+
+test("Model Result accepts safe canonical output", () => {
+  const output = Object.create(null) as Record<string, unknown>;
+  Object.assign(output, validModelTaskResult.output);
+  Object.defineProperty(output, "__proto__", {
+    value: { preserve: true },
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+  output.values = [1, 2, 3];
+  output.label = "result-𐐷";
+
+  const parsed = expectOk(
+    parseModelTaskResultV1({
+      ...validModelTaskResult,
+      output,
+      outputDigest: sha256Digest(canonicalJson(output)),
+    }),
+  );
+
+  assert.equal(Object.hasOwn(parsed.output, "__proto__"), true);
+  assert.deepEqual(parsed.output.__proto__, { preserve: true });
+  assert.deepEqual(parsed.output.values, [1, 2, 3]);
+  assert.equal(parsed.output.label, "result-𐐷");
+  assert.equal(({} as { preserve?: boolean }).preserve, undefined);
+});
+
+test("Model Result preserves negative zero in detached additive output", () => {
+  const output = {
+    score: -0,
+    nested: { delta: -0 },
+    values: [-0],
+  };
+  const parsed = expectOk(
+    parseModelTaskResultV1({
+      ...validModelTaskResult,
+      output,
+      outputDigest: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    }),
+  );
+
+  assert.equal(Object.is(parsed.output.score, -0), true);
+  assert.equal(
+    Object.is((parsed.output.nested as { delta: number }).delta, -0),
+    true,
+  );
+  assert.equal(Object.is((parsed.output.values as number[])[0], -0), true);
+  assert.notStrictEqual(parsed.output, output);
+});
+
+test("parser rejects nested output custom-prototype objects and non-json values", () => {
+  const nestedCustomPrototype = {
+    ...validModelTaskResult,
+    output: {
+      nested: Object.assign(Object.create({ inherited: true }), { ok: true }),
+    },
+  };
+  expectError(parseModelTaskResultV1(nestedCustomPrototype), "$", "invalid_value");
+
+  const nestedNaN = {
+    ...validModelTaskResult,
+    output: {
+      metrics: {
+        score: Number.NaN,
+      },
+    },
+  };
+  expectError(parseModelTaskResultV1(nestedNaN), "$", "invalid_value");
+});
+
+test("custom-prototype top-level objects are rejected", () => {
+  const inheritedTask = Object.create({ schema: validModelTask.schema });
+  Object.assign(inheritedTask, {
+    id: validModelTask.id,
+    runId: validModelTask.runId,
+    phase: validModelTask.phase,
+    attempt: validModelTask.attempt,
+    inputDigest: validModelTask.inputDigest,
+    input: validModelTask.input,
+    modelBinding: validModelTask.modelBinding,
+    policy: validModelTask.policy,
+    outputSchema: validModelTask.outputSchema,
+    leaseExpiresAt: validModelTask.leaseExpiresAt,
+  });
+  expectError(parseModelTaskV1(inheritedTask), "$", "invalid_value");
+
+  const inheritedResult = Object.create({ taskId: validModelTaskResult.taskId });
+  Object.assign(inheritedResult, {
+    schema: validModelTaskResult.schema,
+    runId: validModelTaskResult.runId,
+    attempt: validModelTaskResult.attempt,
+    inputDigest: validModelTaskResult.inputDigest,
+    output: validModelTaskResult.output,
+    outputDigest: validModelTaskResult.outputDigest,
+    executorDeviceId: validModelTaskResult.executorDeviceId,
+    modelReceipt: validModelTaskResult.modelReceipt,
+    completedAt: validModelTaskResult.completedAt,
+    signature: validModelTaskResult.signature,
+  });
+  expectError(parseModelTaskResultV1(inheritedResult), "$", "invalid_value");
+});
+
+test("parser verifies task input but leaves result output and signature verification to Unit 4", () => {
+  const changedDigestTask = {
+    ...validModelTask,
+    inputDigest: VALID_SHA256_MISMATCH_B,
+  };
+  assert.ok(Value.Check(modelTaskSchema, changedDigestTask));
+  expectError(parseModelTaskV1(changedDigestTask), "$.inputDigest", "digest_mismatch");
+
+  const changedDigestResult = {
+    ...validModelTaskResult,
+    output: { decision: "stop" },
+    outputDigest: VALID_SHA256_MISMATCH,
+    signature: "still-not-verified",
+  };
+
+  assert.ok(Value.Check(modelTaskResultSchema, changedDigestResult));
+  assert.deepEqual(
+    expectOk(parseModelTaskResultV1(changedDigestResult)).output,
+    { decision: "stop" },
+  );
+
+  const parsed = expectOk(parseModelTaskResultV1({
+    ...validModelTaskResult,
+    signature: "still-not-verified",
+  }));
+  assert.equal(parsed.signature, "still-not-verified");
+});

--- a/src/lib/research-protocol/model-task.ts
+++ b/src/lib/research-protocol/model-task.ts
@@ -1,0 +1,707 @@
+import {
+  copyProtocolJsonValue,
+  fail,
+  isOpaqueId,
+  isRecord,
+  isSha256,
+  isUtcTimestamp,
+  pass,
+  type ProtocolParseResult,
+  type UnknownFields,
+} from "./common.ts";
+import {
+  parseResearchModelReceiptV1,
+  type ResearchModelReceiptV1,
+} from "./topic-discovery.ts";
+import { canonicalJson, sha256Digest } from "./digest.ts";
+
+const MODEL_TASK_SCHEMA = "opencoven.model-task/v1";
+const MODEL_TASK_SCHEMA_RE = /^opencoven\.model-task\/v(\d+)$/;
+const MODEL_TASK_RESULT_SCHEMA = "opencoven.model-task-result/v1";
+const MODEL_TASK_RESULT_SCHEMA_RE = /^opencoven\.model-task-result\/v(\d+)$/;
+const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
+
+const TASK_PHASES = ["scope", "challenge", "synthesize", "control"] as const;
+const MODEL_SELECTIONS = ["resolve-at-run-start", "pinned"] as const;
+const DEVICE_LOCAL_AVAILABILITY = ["device-local"] as const;
+
+type ModelTaskInputContextPackV1 = {
+  id: string;
+  digest: string;
+  availability: "device-local";
+} & UnknownFields;
+
+type ModelTaskInputV1 = {
+  topicProposalId?: string;
+  contextPack: ModelTaskInputContextPackV1;
+  publicEvidenceRefs: string[];
+} & UnknownFields;
+
+type ModelTaskModelBindingV1 = {
+  familiarId: string;
+  selection: "resolve-at-run-start" | "pinned";
+  model?: string;
+} & UnknownFields;
+
+type ModelTaskPolicyV1 = {
+  permissionMode: "read";
+  allowedOutputs: string[];
+  allowRemoteQueries: boolean;
+  maxOutputTokens: number;
+} & UnknownFields;
+
+export type ModelTaskV1 = {
+  schema: "opencoven.model-task/v1";
+  id: string;
+  runId: string;
+  phase: "scope" | "challenge" | "synthesize" | "control";
+  attempt: number;
+  inputDigest: string;
+  input: ModelTaskInputV1;
+  modelBinding: ModelTaskModelBindingV1;
+  policy: ModelTaskPolicyV1;
+  outputSchema: string;
+  leaseExpiresAt: string;
+} & UnknownFields;
+
+export type ModelTaskResultV1 = {
+  schema: "opencoven.model-task-result/v1";
+  taskId: string;
+  runId: string;
+  attempt: number;
+  inputDigest: string;
+  output: Record<string, unknown>;
+  outputDigest: string;
+  executorDeviceId: string;
+  modelReceipt: ResearchModelReceiptV1;
+  completedAt: string;
+  signature: string;
+} & UnknownFields;
+
+export type ModelTaskResultSignaturePayloadV1 = Pick<
+  ModelTaskResultV1,
+  | "taskId"
+  | "runId"
+  | "attempt"
+  | "inputDigest"
+  | "outputDigest"
+  | "executorDeviceId"
+  | "completedAt"
+>;
+
+function childPath(path: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${path}.${key}`
+    : `${path}[${JSON.stringify(key)}]`;
+}
+
+function indexPath(path: string, index: number): string {
+  return `${path}[${index}]`;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function parseObject(value: unknown, path: string): ProtocolParseResult<Record<string, unknown>> {
+  if (!isRecord(value)) {
+    return fail("invalid_type", path, "Expected an object");
+  }
+  return pass(value);
+}
+
+function parseRequiredField(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): ProtocolParseResult<unknown> {
+  if (!hasOwn(record, key)) {
+    return fail("missing_field", childPath(path, key), `Missing required field ${key}`);
+  }
+  return pass(record[key]);
+}
+
+function parseString(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  return pass(value);
+}
+
+function parseNonEmptyString(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  const stringValue = parseString(value, path, label);
+  if (!stringValue.ok) return stringValue;
+  if (stringValue.value.length === 0) {
+    return fail("invalid_value", path, `${label} must be a non-empty string`);
+  }
+  return stringValue;
+}
+
+function parseBoolean(value: unknown, path: string, label: string): ProtocolParseResult<boolean> {
+  if (typeof value !== "boolean") {
+    return fail("invalid_type", path, `${label} must be a boolean`);
+  }
+  return pass(value);
+}
+
+function parseEnumValue<const T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  path: string,
+  label: string,
+): ProtocolParseResult<T[number]> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!allowed.includes(value as T[number])) {
+    return fail("invalid_value", path, `${label} must be one of ${allowed.join(", ")}`);
+  }
+  return pass(value as T[number]);
+}
+
+function parseSchema<const T extends string>(
+  value: unknown,
+  exact: T,
+  re: RegExp,
+  path: string,
+  label: string,
+): ProtocolParseResult<T> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (value === exact) {
+    return pass(exact);
+  }
+  const match = re.exec(value);
+  if (match) {
+    return fail("unknown_major", path, `Unsupported ${label} major v${match[1]}`);
+  }
+  return fail("invalid_value", path, `${label} must equal ${exact}`);
+}
+
+function parseSafeIntegerInRange(
+  value: unknown,
+  path: string,
+  label: string,
+  minimum: number,
+  maximum: number,
+): ProtocolParseResult<number> {
+  if (typeof value !== "number") {
+    return fail("invalid_type", path, `${label} must be a number`);
+  }
+  if (!Number.isSafeInteger(value)) {
+    return fail("invalid_value", path, `${label} must be a safe integer`);
+  }
+  if (value < minimum || value > maximum) {
+    return fail("invalid_value", path, `${label} must be between ${minimum} and ${maximum}`);
+  }
+  return pass(value);
+}
+
+function parsePositiveSafeInteger(value: unknown, path: string, label: string): ProtocolParseResult<number> {
+  return parseSafeIntegerInRange(value, path, label, 1, MAX_SAFE_INTEGER);
+}
+
+function parseOpaqueIdentifier(
+  value: unknown,
+  prefix: string,
+  path: string,
+  label: string,
+): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isOpaqueId(value, prefix)) {
+    return fail("invalid_value", path, `${label} must match ${prefix}_...`);
+  }
+  return pass(value);
+}
+
+function parseSha256(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isSha256(value)) {
+    return fail("invalid_value", path, `${label} must be a lowercase SHA-256 digest`);
+  }
+  return pass(value);
+}
+
+function parseUtc(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isUtcTimestamp(value)) {
+    return fail(
+      "invalid_value",
+      path,
+      `${label} must be a UTC RFC 3339 timestamp`,
+    );
+  }
+  return pass(value);
+}
+
+function parseUniqueNonEmptyStringArray(
+  value: unknown,
+  path: string,
+  label: string,
+  minimumLength: number,
+): ProtocolParseResult<string[]> {
+  if (!Array.isArray(value)) {
+    return fail("invalid_type", path, `${label} must be an array`);
+  }
+  if (value.length < minimumLength) {
+    return fail("invalid_value", path, `${label} must contain at least ${minimumLength} item(s)`);
+  }
+
+  const seen = new Set<string>();
+  const parsed: string[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const itemPath = indexPath(path, index);
+    const item = parseNonEmptyString(value[index], itemPath, `${label} item`);
+    if (!item.ok) return item;
+    if (seen.has(item.value)) {
+      return fail("semantic_conflict", itemPath, `${label} must not contain duplicate values`);
+    }
+    seen.add(item.value);
+    parsed.push(item.value);
+  }
+
+  return pass(parsed);
+}
+
+function parseContextPackInput(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ModelTaskInputContextPackV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const idField = parseRequiredField(object.value, "id", path);
+  if (!idField.ok) return idField;
+  const id = parseOpaqueIdentifier(idField.value, "ctx", childPath(path, "id"), "id");
+  if (!id.ok) return id;
+
+  const digestField = parseRequiredField(object.value, "digest", path);
+  if (!digestField.ok) return digestField;
+  const digest = parseSha256(digestField.value, childPath(path, "digest"), "digest");
+  if (!digest.ok) return digest;
+
+  const availabilityField = parseRequiredField(object.value, "availability", path);
+  if (!availabilityField.ok) return availabilityField;
+  const availability = parseEnumValue(
+    availabilityField.value,
+    DEVICE_LOCAL_AVAILABILITY,
+    childPath(path, "availability"),
+    "availability",
+  );
+  if (!availability.ok) return availability;
+
+  return pass({
+    ...object.value,
+    id: id.value,
+    digest: digest.value,
+    availability: availability.value,
+  });
+}
+
+function parseModelTaskInput(value: unknown, path: string): ProtocolParseResult<ModelTaskInputV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  let topicProposalId: string | undefined;
+  if (hasOwn(object.value, "topicProposalId")) {
+    const parsedTopicProposalId = parseOpaqueIdentifier(
+      object.value.topicProposalId,
+      "proposal",
+      childPath(path, "topicProposalId"),
+      "topicProposalId",
+    );
+    if (!parsedTopicProposalId.ok) return parsedTopicProposalId;
+    topicProposalId = parsedTopicProposalId.value;
+  }
+
+  const contextPackField = parseRequiredField(object.value, "contextPack", path);
+  if (!contextPackField.ok) return contextPackField;
+  const contextPack = parseContextPackInput(contextPackField.value, childPath(path, "contextPack"));
+  if (!contextPack.ok) return contextPack;
+
+  const publicEvidenceRefsField = parseRequiredField(object.value, "publicEvidenceRefs", path);
+  if (!publicEvidenceRefsField.ok) return publicEvidenceRefsField;
+  const publicEvidenceRefs = parseUniqueNonEmptyStringArray(
+    publicEvidenceRefsField.value,
+    childPath(path, "publicEvidenceRefs"),
+    "publicEvidenceRefs",
+    0,
+  );
+  if (!publicEvidenceRefs.ok) return publicEvidenceRefs;
+
+  return pass({
+    ...object.value,
+    ...(typeof topicProposalId === "string" ? { topicProposalId } : {}),
+    contextPack: contextPack.value,
+    publicEvidenceRefs: publicEvidenceRefs.value,
+  });
+}
+
+function parseModelBinding(value: unknown, path: string): ProtocolParseResult<ModelTaskModelBindingV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const familiarIdField = parseRequiredField(object.value, "familiarId", path);
+  if (!familiarIdField.ok) return familiarIdField;
+  const familiarId = parseString(familiarIdField.value, childPath(path, "familiarId"), "familiarId");
+  if (!familiarId.ok) return familiarId;
+
+  const selectionField = parseRequiredField(object.value, "selection", path);
+  if (!selectionField.ok) return selectionField;
+  const selection = parseEnumValue(
+    selectionField.value,
+    MODEL_SELECTIONS,
+    childPath(path, "selection"),
+    "selection",
+  );
+  if (!selection.ok) return selection;
+
+  let model: string | undefined;
+  if (selection.value === "pinned") {
+    if (!hasOwn(object.value, "model")) {
+      return fail("missing_field", childPath(path, "model"), "pinned model selection requires model");
+    }
+    const parsedModel = parseString(object.value.model, childPath(path, "model"), "model");
+    if (!parsedModel.ok) return parsedModel;
+    model = parsedModel.value;
+  } else if (hasOwn(object.value, "model")) {
+    return fail(
+      "semantic_conflict",
+      childPath(path, "model"),
+      "resolve-at-run-start model selection must not include model",
+    );
+  }
+
+  return pass({
+    ...object.value,
+    familiarId: familiarId.value,
+    selection: selection.value,
+    ...(typeof model === "string" ? { model } : {}),
+  });
+}
+
+function parsePolicy(value: unknown, path: string): ProtocolParseResult<ModelTaskPolicyV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const permissionModeField = parseRequiredField(object.value, "permissionMode", path);
+  if (!permissionModeField.ok) return permissionModeField;
+  const permissionMode = parseString(
+    permissionModeField.value,
+    childPath(path, "permissionMode"),
+    "permissionMode",
+  );
+  if (!permissionMode.ok) return permissionMode;
+  if (permissionMode.value !== "read") {
+    return fail("invalid_value", childPath(path, "permissionMode"), "permissionMode must be read");
+  }
+
+  const allowedOutputsField = parseRequiredField(object.value, "allowedOutputs", path);
+  if (!allowedOutputsField.ok) return allowedOutputsField;
+  const allowedOutputs = parseUniqueNonEmptyStringArray(
+    allowedOutputsField.value,
+    childPath(path, "allowedOutputs"),
+    "allowedOutputs",
+    1,
+  );
+  if (!allowedOutputs.ok) return allowedOutputs;
+
+  const allowRemoteQueriesField = parseRequiredField(object.value, "allowRemoteQueries", path);
+  if (!allowRemoteQueriesField.ok) return allowRemoteQueriesField;
+  const allowRemoteQueries = parseBoolean(
+    allowRemoteQueriesField.value,
+    childPath(path, "allowRemoteQueries"),
+    "allowRemoteQueries",
+  );
+  if (!allowRemoteQueries.ok) return allowRemoteQueries;
+
+  const maxOutputTokensField = parseRequiredField(object.value, "maxOutputTokens", path);
+  if (!maxOutputTokensField.ok) return maxOutputTokensField;
+  const maxOutputTokens = parsePositiveSafeInteger(
+    maxOutputTokensField.value,
+    childPath(path, "maxOutputTokens"),
+    "maxOutputTokens",
+  );
+  if (!maxOutputTokens.ok) return maxOutputTokens;
+
+  return pass({
+    ...object.value,
+    permissionMode: "read",
+    allowedOutputs: allowedOutputs.value,
+    allowRemoteQueries: allowRemoteQueries.value,
+    maxOutputTokens: maxOutputTokens.value,
+  });
+}
+
+function parseOutputObject(value: unknown, path: string): ProtocolParseResult<Record<string, unknown>> {
+  const detached = copyProtocolJsonValue(value, path);
+  if (!detached.ok) return detached;
+  return parseObject(detached.value, path);
+}
+
+export function parseModelTaskV1(value: unknown): ProtocolParseResult<ModelTaskV1> {
+  const wireValue = copyProtocolJsonValue(value);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, "$");
+  if (!object.ok) return object;
+
+  const schemaField = parseRequiredField(object.value, "schema", "$");
+  if (!schemaField.ok) return schemaField;
+  const schema = parseSchema(schemaField.value, MODEL_TASK_SCHEMA, MODEL_TASK_SCHEMA_RE, "$.schema", "schema");
+  if (!schema.ok) return schema;
+
+  const idField = parseRequiredField(object.value, "id", "$");
+  if (!idField.ok) return idField;
+  const id = parseOpaqueIdentifier(idField.value, "modeltask", "$.id", "id");
+  if (!id.ok) return id;
+
+  const runIdField = parseRequiredField(object.value, "runId", "$");
+  if (!runIdField.ok) return runIdField;
+  const runId = parseOpaqueIdentifier(runIdField.value, "run", "$.runId", "runId");
+  if (!runId.ok) return runId;
+
+  const phaseField = parseRequiredField(object.value, "phase", "$");
+  if (!phaseField.ok) return phaseField;
+  const phase = parseEnumValue(phaseField.value, TASK_PHASES, "$.phase", "phase");
+  if (!phase.ok) return phase;
+
+  const attemptField = parseRequiredField(object.value, "attempt", "$");
+  if (!attemptField.ok) return attemptField;
+  const attempt = parsePositiveSafeInteger(attemptField.value, "$.attempt", "attempt");
+  if (!attempt.ok) return attempt;
+
+  const inputDigestField = parseRequiredField(object.value, "inputDigest", "$");
+  if (!inputDigestField.ok) return inputDigestField;
+  const inputDigest = parseSha256(inputDigestField.value, "$.inputDigest", "inputDigest");
+  if (!inputDigest.ok) return inputDigest;
+
+  const inputField = parseRequiredField(object.value, "input", "$");
+  if (!inputField.ok) return inputField;
+  const input = parseModelTaskInput(inputField.value, "$.input");
+  if (!input.ok) return input;
+
+  const modelBindingField = parseRequiredField(object.value, "modelBinding", "$");
+  if (!modelBindingField.ok) return modelBindingField;
+  const modelBinding = parseModelBinding(modelBindingField.value, "$.modelBinding");
+  if (!modelBinding.ok) return modelBinding;
+
+  const policyField = parseRequiredField(object.value, "policy", "$");
+  if (!policyField.ok) return policyField;
+  const policy = parsePolicy(policyField.value, "$.policy");
+  if (!policy.ok) return policy;
+
+  const outputSchemaField = parseRequiredField(object.value, "outputSchema", "$");
+  if (!outputSchemaField.ok) return outputSchemaField;
+  const outputSchema = parseString(outputSchemaField.value, "$.outputSchema", "outputSchema");
+  if (!outputSchema.ok) return outputSchema;
+
+  const leaseExpiresAtField = parseRequiredField(object.value, "leaseExpiresAt", "$");
+  if (!leaseExpiresAtField.ok) return leaseExpiresAtField;
+  const leaseExpiresAt = parseUtc(leaseExpiresAtField.value, "$.leaseExpiresAt", "leaseExpiresAt");
+  if (!leaseExpiresAt.ok) return leaseExpiresAt;
+
+  const parsed = {
+    ...object.value,
+    schema: schema.value,
+    id: id.value,
+    runId: runId.value,
+    phase: phase.value,
+    attempt: attempt.value,
+    inputDigest: inputDigest.value,
+    input: input.value,
+    modelBinding: modelBinding.value,
+    policy: policy.value,
+    outputSchema: outputSchema.value,
+    leaseExpiresAt: leaseExpiresAt.value,
+  } as ModelTaskV1;
+
+  let expectedInputDigest: string;
+  try {
+    expectedInputDigest = sha256Digest(canonicalJson(parsed.input));
+  } catch (error) {
+    return fail(
+      "invalid_value",
+      "$.input",
+      error instanceof Error ? error.message : "input must be canonical JSON",
+    );
+  }
+  if (parsed.inputDigest !== expectedInputDigest) {
+    return fail(
+      "digest_mismatch",
+      "$.inputDigest",
+      `inputDigest must equal recomputed digest ${expectedInputDigest}`,
+    );
+  }
+
+  return pass(parsed);
+}
+
+export function parseModelTaskResultV1(value: unknown): ProtocolParseResult<ModelTaskResultV1> {
+  const wireValue = copyProtocolJsonValue(value);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, "$");
+  if (!object.ok) return object;
+
+  const schemaField = parseRequiredField(object.value, "schema", "$");
+  if (!schemaField.ok) return schemaField;
+  const schema = parseSchema(
+    schemaField.value,
+    MODEL_TASK_RESULT_SCHEMA,
+    MODEL_TASK_RESULT_SCHEMA_RE,
+    "$.schema",
+    "schema",
+  );
+  if (!schema.ok) return schema;
+
+  const taskIdField = parseRequiredField(object.value, "taskId", "$");
+  if (!taskIdField.ok) return taskIdField;
+  const taskId = parseOpaqueIdentifier(taskIdField.value, "modeltask", "$.taskId", "taskId");
+  if (!taskId.ok) return taskId;
+
+  const runIdField = parseRequiredField(object.value, "runId", "$");
+  if (!runIdField.ok) return runIdField;
+  const runId = parseOpaqueIdentifier(runIdField.value, "run", "$.runId", "runId");
+  if (!runId.ok) return runId;
+
+  const attemptField = parseRequiredField(object.value, "attempt", "$");
+  if (!attemptField.ok) return attemptField;
+  const attempt = parsePositiveSafeInteger(attemptField.value, "$.attempt", "attempt");
+  if (!attempt.ok) return attempt;
+
+  const inputDigestField = parseRequiredField(object.value, "inputDigest", "$");
+  if (!inputDigestField.ok) return inputDigestField;
+  const inputDigest = parseSha256(inputDigestField.value, "$.inputDigest", "inputDigest");
+  if (!inputDigest.ok) return inputDigest;
+
+  const outputField = parseRequiredField(object.value, "output", "$");
+  if (!outputField.ok) return outputField;
+  const output = parseOutputObject(outputField.value, "$.output");
+  if (!output.ok) return output;
+
+  const outputDigestField = parseRequiredField(object.value, "outputDigest", "$");
+  if (!outputDigestField.ok) return outputDigestField;
+  const outputDigest = parseSha256(outputDigestField.value, "$.outputDigest", "outputDigest");
+  if (!outputDigest.ok) return outputDigest;
+
+  const executorDeviceIdField = parseRequiredField(object.value, "executorDeviceId", "$");
+  if (!executorDeviceIdField.ok) return executorDeviceIdField;
+  const executorDeviceId = parseOpaqueIdentifier(
+    executorDeviceIdField.value,
+    "device",
+    "$.executorDeviceId",
+    "executorDeviceId",
+  );
+  if (!executorDeviceId.ok) return executorDeviceId;
+
+  const modelReceiptField = parseRequiredField(object.value, "modelReceipt", "$");
+  if (!modelReceiptField.ok) return modelReceiptField;
+  const modelReceipt = parseResearchModelReceiptV1(modelReceiptField.value, "$.modelReceipt");
+  if (!modelReceipt.ok) return modelReceipt;
+
+  const completedAtField = parseRequiredField(object.value, "completedAt", "$");
+  if (!completedAtField.ok) return completedAtField;
+  const completedAt = parseUtc(completedAtField.value, "$.completedAt", "completedAt");
+  if (!completedAt.ok) return completedAt;
+
+  const signatureField = parseRequiredField(object.value, "signature", "$");
+  if (!signatureField.ok) return signatureField;
+  const signature = parseNonEmptyString(signatureField.value, "$.signature", "signature");
+  if (!signature.ok) return signature;
+
+  const parsed = {
+    ...object.value,
+    schema: schema.value,
+    taskId: taskId.value,
+    runId: runId.value,
+    attempt: attempt.value,
+    inputDigest: inputDigest.value,
+    output: output.value,
+    outputDigest: outputDigest.value,
+    executorDeviceId: executorDeviceId.value,
+    modelReceipt: modelReceipt.value,
+    completedAt: completedAt.value,
+    signature: signature.value,
+  } as ModelTaskResultV1;
+
+  return pass(parsed);
+}
+
+/**
+ * Validates one parsed task/result association. Matching replays remain valid;
+ * comparing a result with an already persisted receipt is a later storage
+ * boundary concern. Unit 4 verifies outputDigest against the declared output
+ * schema.
+ */
+export function validateModelTaskResultV1(
+  task: ModelTaskV1,
+  result: ModelTaskResultV1,
+): ProtocolParseResult<ModelTaskResultV1> {
+  let expectedInputDigest: string;
+  try {
+    expectedInputDigest = sha256Digest(canonicalJson(task.input));
+  } catch {
+    return fail("invalid_value", "$.input", "Model Task input must be canonical JSON");
+  }
+
+  if (task.inputDigest !== expectedInputDigest) {
+    return fail(
+      "digest_mismatch",
+      "$.inputDigest",
+      `Model Task inputDigest must equal recomputed digest ${expectedInputDigest}`,
+    );
+  }
+  if (result.taskId !== task.id) {
+    return fail("semantic_conflict", "$.taskId", "taskId must equal the Model Task id");
+  }
+  if (result.runId !== task.runId) {
+    return fail("semantic_conflict", "$.runId", "runId must equal the Model Task runId");
+  }
+  if (result.attempt !== task.attempt) {
+    return fail("semantic_conflict", "$.attempt", "attempt must equal the Model Task attempt");
+  }
+  if (result.inputDigest !== task.inputDigest) {
+    return fail("semantic_conflict", "$.inputDigest", "inputDigest must equal the Model Task inputDigest");
+  }
+  if (result.modelReceipt.familiarId !== task.modelBinding.familiarId) {
+    return fail(
+      "semantic_conflict",
+      "$.modelReceipt.familiarId",
+      "modelReceipt familiarId must equal the Model Task familiarId",
+    );
+  }
+  if (
+    task.modelBinding.selection === "pinned"
+    && result.modelReceipt.effectiveModel !== task.modelBinding.model
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.modelReceipt.effectiveModel",
+      "modelReceipt effectiveModel must equal the pinned Model Task model",
+    );
+  }
+
+  return pass(result);
+}
+
+export function modelTaskResultSignaturePayload(
+  value: ModelTaskResultV1,
+): ModelTaskResultSignaturePayloadV1 {
+  return {
+    taskId: value.taskId,
+    runId: value.runId,
+    attempt: value.attempt,
+    inputDigest: value.inputDigest,
+    outputDigest: value.outputDigest,
+    executorDeviceId: value.executorDeviceId,
+    completedAt: value.completedAt,
+  };
+}

--- a/src/lib/research-protocol/option-shell.ts
+++ b/src/lib/research-protocol/option-shell.ts
@@ -1,0 +1,359 @@
+import { types as nodeUtilTypes } from "node:util";
+
+import {
+  fail,
+  pass,
+  type ProtocolParseResult,
+} from "./common.ts";
+
+const arrayIsArray = Array.isArray;
+const arrayPrototype = Array.prototype;
+const objectPrototype = Object.prototype;
+const getPrototypeOf = Object.getPrototypeOf;
+const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const defineProperty = Object.defineProperty;
+const ownKeys = Reflect.ownKeys;
+const apply = Reflect.apply;
+const hasOwn = Object.hasOwn;
+const isProxy = nodeUtilTypes.isProxy;
+const objectToString = Object.prototype.toString;
+
+type BrandProbe = (value: object) => "match" | "non-match" | "failure";
+
+function canStructuredCloneWithoutUserCode(value: object): boolean {
+  const seen = new WeakSet<object>();
+  const pending = [value];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    if (isProxy(current)) return false;
+
+    const isArray = arrayIsArray(current);
+    const prototype = getPrototypeOf(current);
+    if (
+      isArray
+        ? prototype !== arrayPrototype
+        : prototype !== objectPrototype && prototype !== null
+    ) {
+      return false;
+    }
+    if (nodeIntrinsicBrandChecks.some((check) => check(current))) return false;
+
+    for (const key of ownKeys(current)) {
+      if (isArray && key === "length") continue;
+      if (typeof key === "symbol") return false;
+      const descriptor = getOwnPropertyDescriptor(current, key);
+      if (
+        !descriptor ||
+        !descriptor.enumerable ||
+        !hasOwn(descriptor, "value")
+      ) {
+        return false;
+      }
+      const propertyValue = descriptor.value;
+      if (
+        typeof propertyValue === "function" ||
+        typeof propertyValue === "symbol"
+      ) {
+        return false;
+      }
+      if (typeof propertyValue === "object" && propertyValue !== null) {
+        pending.push(propertyValue);
+      }
+    }
+  }
+  return true;
+}
+
+function dataProperty(object: object, key: PropertyKey): unknown {
+  const descriptor = getOwnPropertyDescriptor(object, key);
+  return descriptor && hasOwn(descriptor, "value")
+    ? descriptor.value
+    : undefined;
+}
+
+function receiverProbe(
+  container: object,
+  constructorName: string,
+  memberName: PropertyKey,
+  memberKind: "get" | "value",
+): BrandProbe | undefined {
+  const Constructor = dataProperty(container, constructorName);
+  if (typeof Constructor !== "function") return undefined;
+  const prototype = dataProperty(Constructor, "prototype");
+  if (typeof prototype !== "object" || prototype === null) return undefined;
+  const member = getOwnPropertyDescriptor(prototype, memberName)?.[memberKind];
+  if (typeof member !== "function") return undefined;
+  return (value) => {
+    try {
+      apply(member, value, []);
+      return "match";
+    } catch (error) {
+      return error instanceof TypeError ? "non-match" : "failure";
+    }
+  };
+}
+
+function argumentProbe(
+  container: object,
+  constructorName: string,
+  memberName: PropertyKey,
+): BrandProbe | undefined {
+  const Constructor = dataProperty(container, constructorName);
+  if (typeof Constructor !== "function") return undefined;
+  const member = dataProperty(Constructor, memberName);
+  if (typeof member !== "function") return undefined;
+  return (value) => {
+    try {
+      apply(member, Constructor, [value]);
+      return "match";
+    } catch (error) {
+      return error instanceof TypeError ? "non-match" : "failure";
+    }
+  };
+}
+
+function webBrandProbes(): readonly BrandProbe[] {
+  const probes: BrandProbe[] = [];
+  for (const [constructorName, memberName, memberKind] of [
+    ["URL", "href", "get"],
+    ["URLSearchParams", "entries", "value"],
+    ["Request", "method", "get"],
+    ["Response", "status", "get"],
+    ["Headers", "entries", "value"],
+    ["FormData", "entries", "value"],
+    ["Blob", "size", "get"],
+    ["File", "name", "get"],
+    ["AbortController", "signal", "get"],
+    ["AbortSignal", "aborted", "get"],
+    ["ReadableStream", "locked", "get"],
+    ["WritableStream", "locked", "get"],
+    ["TransformStream", "readable", "get"],
+    ["TextEncoder", "encoding", "get"],
+    ["TextDecoder", "encoding", "get"],
+    ["DOMException", "name", "get"],
+  ] as const) {
+    const probe = receiverProbe(
+      globalThis,
+      constructorName,
+      memberName,
+      memberKind,
+    );
+    if (probe) probes.push(probe);
+  }
+  const intl = dataProperty(globalThis, "Intl");
+  if (typeof intl === "object" && intl !== null) {
+    for (const constructorName of [
+      "Collator",
+      "DateTimeFormat",
+      "DisplayNames",
+      "DurationFormat",
+      "ListFormat",
+      "NumberFormat",
+      "PluralRules",
+      "RelativeTimeFormat",
+      "Segmenter",
+    ]) {
+      const probe = receiverProbe(
+        intl,
+        constructorName,
+        "resolvedOptions",
+        "value",
+      );
+      if (probe) probes.push(probe);
+    }
+  }
+  const webAssembly = dataProperty(globalThis, "WebAssembly");
+  if (typeof webAssembly === "object" && webAssembly !== null) {
+    const moduleProbe = argumentProbe(webAssembly, "Module", "exports");
+    if (moduleProbe) probes.push(moduleProbe);
+    for (const [constructorName, memberName] of [
+      ["Instance", "exports"],
+      ["Memory", "buffer"],
+      ["Table", "length"],
+      ["Global", "value"],
+    ] as const) {
+      const probe = receiverProbe(
+        webAssembly,
+        constructorName,
+        memberName,
+        "get",
+      );
+      if (probe) probes.push(probe);
+    }
+  }
+  const structuredClone = dataProperty(globalThis, "structuredClone");
+  if (typeof structuredClone === "function") {
+    let dataCloneErrorPrototype: object | undefined;
+    try {
+      apply(structuredClone, undefined, [webBrandProbes]);
+    } catch (error) {
+      if (typeof error === "object" && error !== null) {
+        dataCloneErrorPrototype = getPrototypeOf(error);
+      }
+    }
+    if (dataCloneErrorPrototype) {
+      probes.push((value) => {
+        if (!canStructuredCloneWithoutUserCode(value)) return "failure";
+        try {
+          apply(structuredClone, undefined, [value]);
+        } catch (error) {
+          return typeof error === "object" &&
+            error !== null &&
+            getPrototypeOf(error) === dataCloneErrorPrototype
+            ? "match"
+            : "failure";
+        }
+        return "non-match";
+      });
+    }
+  }
+  return probes;
+}
+
+const webIntrinsicBrandProbes = webBrandProbes();
+const nodeIntrinsicBrandChecks = Object.values(nodeUtilTypes).filter(
+  (check): check is (value: unknown) => boolean =>
+    typeof check === "function" && check !== isProxy,
+);
+
+function isCanonicalArrayIndex(key: string): boolean {
+  if (!/^(?:0|[1-9]\d*)$/.test(key)) return false;
+  const index = Number(key);
+  return Number.isInteger(index) && index >= 0 && index < 0xffffffff;
+}
+
+export function snapshotProtocolArrayElements(
+  value: unknown,
+  path: string,
+  label: string,
+): ProtocolParseResult<readonly unknown[]> {
+  if (typeof value !== "object" || value === null) {
+    return fail("invalid_type", path, `${label} must be an array`);
+  }
+  if (isProxy(value)) {
+    return fail("invalid_value", path, `${label} must be an ordinary array`);
+  }
+  if (!arrayIsArray(value)) {
+    return fail("invalid_type", path, `${label} must be an array`);
+  }
+  if (getPrototypeOf(value) !== arrayPrototype) {
+    return fail("invalid_value", path, `${label} must use the standard Array prototype`);
+  }
+
+  const lengthDescriptor = getOwnPropertyDescriptor(value, "length");
+  const length = lengthDescriptor?.value;
+  if (
+    !lengthDescriptor ||
+    !hasOwn(lengthDescriptor, "value") ||
+    lengthDescriptor.enumerable ||
+    lengthDescriptor.configurable ||
+    typeof length !== "number" ||
+    !Number.isInteger(length) ||
+    length < 0 ||
+    length >= 0x100000000
+  ) {
+    return fail("invalid_value", path, `${label} must have a valid array length`);
+  }
+
+  let indexedKeyCount = 0;
+  for (const key of ownKeys(value)) {
+    if (typeof key === "symbol") {
+      return fail("invalid_value", path, `${label} must not have symbol properties`);
+    }
+    if (key === "length") continue;
+    if (!isCanonicalArrayIndex(key) || Number(key) >= length) {
+      return fail("invalid_value", path, `${label} must not have extra properties`);
+    }
+    indexedKeyCount += 1;
+  }
+  if (indexedKeyCount !== length) {
+    return fail("invalid_value", path, `${label} must not contain sparse holes`);
+  }
+
+  const snapshot = new Array<unknown>(length);
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = getOwnPropertyDescriptor(value, String(index));
+    if (
+      !descriptor ||
+      !descriptor.enumerable ||
+      !hasOwn(descriptor, "value")
+    ) {
+      return fail(
+        "invalid_value",
+        path,
+        `${label} indices must be enumerable data properties`,
+      );
+    }
+    defineProperty(snapshot, index, {
+      value: descriptor.value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return pass(snapshot);
+}
+
+export function snapshotProtocolObjectProperties(
+  value: unknown,
+  path: string,
+  label: string,
+): ProtocolParseResult<Record<string, unknown>> {
+  if (typeof value !== "object" || value === null) {
+    return fail("invalid_type", path, `${label} must be an object`);
+  }
+  if (isProxy(value)) {
+    return fail("invalid_value", path, `${label} must be an ordinary object`);
+  }
+  if (arrayIsArray(value)) {
+    return fail("invalid_type", path, `${label} must be an object`);
+  }
+  const prototype = getPrototypeOf(value);
+  if (prototype !== objectPrototype && prototype !== null) {
+    return fail("invalid_value", path, `${label} must be an ordinary object`);
+  }
+  if (
+    nodeIntrinsicBrandChecks.some((check) => check(value)) ||
+    apply(objectToString, value, []) !== "[object Object]"
+  ) {
+    return fail("invalid_value", path, `${label} must be an ordinary object`);
+  }
+  for (const probe of webIntrinsicBrandProbes) {
+    if (probe(value) !== "non-match") {
+      return fail("invalid_value", path, `${label} must be an ordinary object`);
+    }
+  }
+
+  const properties: Array<readonly [string, PropertyDescriptor]> = [];
+  for (const key of ownKeys(value)) {
+    if (typeof key === "symbol") {
+      return fail("invalid_value", path, `${label} must not have symbol properties`);
+    }
+    const descriptor = getOwnPropertyDescriptor(value, key);
+    if (
+      !descriptor ||
+      !descriptor.enumerable ||
+      !hasOwn(descriptor, "value")
+    ) {
+      return fail(
+        "invalid_value",
+        path,
+        `${label} fields must be enumerable data properties`,
+      );
+    }
+    properties.push([key, descriptor]);
+  }
+
+  const snapshot = Object.create(null) as Record<string, unknown>;
+  for (const [key, descriptor] of properties) {
+    defineProperty(snapshot, key, {
+      value: descriptor.value,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return pass(snapshot);
+}

--- a/src/lib/research-protocol/privacy-extension.ts
+++ b/src/lib/research-protocol/privacy-extension.ts
@@ -1,0 +1,262 @@
+import {
+  fail,
+  isRecord,
+  pass,
+  type ProtocolParseResult,
+} from "./common.ts";
+
+const SENSITIVE_WORD_SEQUENCES = [
+  ["prompt"],
+  ["excerpt"],
+  ["text"],
+  ["content"],
+  ["blob"],
+  ["filename"],
+  ["path"],
+  ["credential"],
+  ["secret"],
+  ["local", "path"],
+  ["file", "path"],
+  ["object", "key"],
+  ["object", "store", "key"],
+  ["storage", "key"],
+  ["bucket", "key"],
+  ["deleted", "content"],
+] as const;
+const SENSITIVE_PREFIXES = ["private", "privacy", "raw"] as const;
+const EXTENSION_SUFFIXES = [
+  "value",
+  "values",
+  "data",
+  "field",
+  "fields",
+  "item",
+  "items",
+  "list",
+  "map",
+  "metadata",
+  "hint",
+  "hints",
+  "ref",
+  "refs",
+] as const;
+const DANGEROUS_COMPONENTS = [
+  "object",
+  "store",
+  "storage",
+  "bucket",
+  "key",
+] as const;
+const DANGEROUS_PATH_SEQUENCES = [
+  ["object", "key"],
+  ["object", "store", "key"],
+  ["store", "key"],
+  ["storage", "key"],
+  ["bucket", "key"],
+] as const;
+const DANGEROUS_PATH_COMPONENTS = new Set<string>(DANGEROUS_COMPONENTS);
+
+function caseInsensitiveWord(word: string): string {
+  return [...word]
+    .map((character) => `[${character}${character.toUpperCase()}]`)
+    .join("");
+}
+
+function sequencePattern(
+  words: readonly string[],
+  separator: string,
+): string {
+  return words.map(caseInsensitiveWord).join(separator);
+}
+
+const TOKEN_PATTERN = SENSITIVE_WORD_SEQUENCES
+  .map((words) => `${sequencePattern(words, "[_.-]*")}[sS]?`)
+  .join("|");
+const CAMEL_TOKEN_PATTERN = SENSITIVE_WORD_SEQUENCES
+  .map((words) => {
+    const compact = words.join("");
+    return `${compact[0]!.toUpperCase()}${caseInsensitiveWord(compact.slice(1))}[sS]?`;
+  })
+  .join("|");
+const UPPER_TOKEN_PATTERN = SENSITIVE_WORD_SEQUENCES
+  .map((words) => `${words.join("").toUpperCase()}S?`)
+  .join("|");
+const PREFIX_PATTERN = SENSITIVE_PREFIXES.map(caseInsensitiveWord).join("|");
+const SUFFIX_PATTERN = EXTENSION_SUFFIXES.map(caseInsensitiveWord).join("|");
+const DANGEROUS_COMPONENT_PATTERN = DANGEROUS_COMPONENTS
+  .map(caseInsensitiveWord)
+  .join("|");
+const COMPACT_TOKEN_PATTERN = SENSITIVE_WORD_SEQUENCES
+  .map((words) => `${sequencePattern(words, "")}[sS]?`)
+  .join("|");
+
+export const SENSITIVE_EXTENSION_KEY_PATTERN =
+  `(?:` +
+  `(?:^|[_.-])(?:${TOKEN_PATTERN})(?:$|[_.-]|[A-Z0-9])|` +
+  `(?:^|[_.-]|[a-z0-9])(?:${CAMEL_TOKEN_PATTERN})(?:$|[_.-]|[A-Z0-9])|` +
+  `(?:^|[_.-]|[a-z0-9])(?:${UPPER_TOKEN_PATTERN})(?:$|[_.-]|[A-Za-z0-9])` +
+  `)`;
+
+export const SENSITIVE_EXTENSION_VARIANT_KEY_PATTERN =
+  `^(?:(?:${PREFIX_PATTERN})[_.-]*)?` +
+  `(?:${TOKEN_PATTERN})` +
+  `(?:[_.-]*(?:${SUFFIX_PATTERN}))?$`;
+
+export const SENSITIVE_EXTENSION_COMPONENT_KEY_PATTERN =
+  `^(?:${DANGEROUS_COMPONENT_PATTERN})[sS]?$`;
+
+export const SENSITIVE_EXTENSION_COMPOUND_KEY_PATTERN =
+  `^(?:(?:${PREFIX_PATTERN})[_.-]*)?` +
+  `(?:${COMPACT_TOKEN_PATTERN})` +
+  `(?:${caseInsensitiveWord("payload")})[sS]?$`;
+
+const SENSITIVE_EXTENSION_KEY_RE = new RegExp(
+  `(?:${SENSITIVE_EXTENSION_KEY_PATTERN})|` +
+    `(?:${SENSITIVE_EXTENSION_VARIANT_KEY_PATTERN})|` +
+    `(?:${SENSITIVE_EXTENSION_COMPOUND_KEY_PATTERN})`,
+);
+const NO_DECLARED_FIELDS: ReadonlySet<string> = new Set();
+const DEFAULT_IGNORABLE_CODE_POINT_RE =
+  /\p{Default_Ignorable_Code_Point}/gu;
+const ASCII_EXTENSION_KEY_RE = /^[\x00-\x7f]+$/;
+
+function removeDefaultIgnorableCodePoints(value: string): string {
+  return value.replace(DEFAULT_IGNORABLE_CODE_POINT_RE, "");
+}
+
+export function normalizeUnicodeSecurityText(value: string): string {
+  return removeDefaultIgnorableCodePoints(value)
+    .normalize("NFKC")
+    .replace(DEFAULT_IGNORABLE_CODE_POINT_RE, "");
+}
+
+export function isSensitiveExtensionKey(key: string): boolean {
+  const normalizedKey = normalizeUnicodeSecurityText(key);
+  return (
+    SENSITIVE_EXTENSION_KEY_RE.test(normalizedKey) ||
+    extensionPathComponents(normalizedKey).some((component) =>
+      SENSITIVE_EXTENSION_KEY_RE.test(component),
+    )
+  );
+}
+
+function childPath(path: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${path}.${key}`
+    : `${path}[${JSON.stringify(key)}]`;
+}
+
+function extensionPathComponents(key: string): string[] {
+  return normalizeUnicodeSecurityText(key)
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .split(/[^A-Za-z0-9]+/)
+    .filter((component) => component.length > 0)
+    .map((component) => component.toLowerCase())
+    .map((component) => {
+      if (
+        component.endsWith("s") &&
+        DANGEROUS_PATH_COMPONENTS.has(component.slice(0, -1))
+      ) {
+        return component.slice(0, -1);
+      }
+      return component;
+    });
+}
+
+function hasDangerousPathSuffix(components: readonly string[]): boolean {
+  return DANGEROUS_PATH_SEQUENCES.some((sequence) => {
+    if (sequence.length > components.length) return false;
+    const offset = components.length - sequence.length;
+    return sequence.every(
+      (component, index) => components[offset + index] === component,
+    );
+  });
+}
+
+function validateSafeExtensionKeysAtPath(
+  value: unknown,
+  path: string,
+  declaredFields: ReadonlySet<string>,
+  extensionPath: readonly string[],
+  asciiOnly: boolean,
+): ProtocolParseResult<void> {
+  if (Array.isArray(value)) {
+    for (const [index, entry] of value.entries()) {
+      const nested = validateSafeExtensionKeysAtPath(
+        entry,
+        `${path}[${index}]`,
+        NO_DECLARED_FIELDS,
+        extensionPath,
+        asciiOnly,
+      );
+      if (!nested.ok) return nested;
+    }
+    return pass(undefined);
+  }
+  if (!isRecord(value)) return pass(undefined);
+
+  for (const key of Object.keys(value)) {
+    if (declaredFields.has(key)) continue;
+    const keyPath = childPath(path, key);
+    if (asciiOnly && !ASCII_EXTENSION_KEY_RE.test(key)) {
+      return fail(
+        "semantic_conflict",
+        keyPath,
+        "Deletion extension keys must use raw ASCII spelling",
+      );
+    }
+    const normalizedKey = normalizeUnicodeSecurityText(key);
+    const nestedExtensionPath = [
+      ...extensionPath,
+      ...extensionPathComponents(normalizedKey),
+    ];
+    if (
+      isSensitiveExtensionKey(normalizedKey) ||
+      hasDangerousPathSuffix(nestedExtensionPath)
+    ) {
+      return fail(
+        "semantic_conflict",
+        keyPath,
+        `Sensitive protocol extensions must not contain ${key}`,
+      );
+    }
+    const nested = validateSafeExtensionKeysAtPath(
+      value[key],
+      keyPath,
+      NO_DECLARED_FIELDS,
+      nestedExtensionPath,
+      asciiOnly,
+    );
+    if (!nested.ok) return nested;
+  }
+  return pass(undefined);
+}
+
+export function validateSafeExtensionKeys(
+  value: unknown,
+  path: string,
+  declaredFields: ReadonlySet<string> = NO_DECLARED_FIELDS,
+): ProtocolParseResult<void> {
+  return validateSafeExtensionKeysAtPath(
+    value,
+    path,
+    declaredFields,
+    [],
+    false,
+  );
+}
+
+export function validateSafeDeletionExtensionKeys(
+  value: unknown,
+  path: string,
+  declaredFields: ReadonlySet<string> = NO_DECLARED_FIELDS,
+): ProtocolParseResult<void> {
+  return validateSafeExtensionKeysAtPath(
+    value,
+    path,
+    declaredFields,
+    [],
+    true,
+  );
+}

--- a/src/lib/research-protocol/research-run.test.ts
+++ b/src/lib/research-protocol/research-run.test.ts
@@ -1,0 +1,3023 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { TSchema } from "typebox";
+import { Check, Value } from "typebox/value";
+
+import researchRunSchema from "../../../schemas/research/v1/research-run.schema.json" with { type: "json" };
+import runEventSchema from "../../../schemas/research/v1/run-event.schema.json" with { type: "json" };
+import runManifestSchema from "../../../schemas/research/v1/run-manifest.schema.json" with { type: "json" };
+import invalidLocalResearchRun from "../../../schemas/research/v1/fixtures/invalid/research-run-local-tenant.json" with { type: "json" };
+import provisionalEmbeddedSevenDayRetention from "../../../schemas/research/v1/fixtures/valid/research-run-embedded-retention-7-days-provisional.json" with { type: "json" };
+import provisionalEmbeddedRunOnlyRetention from "../../../schemas/research/v1/fixtures/valid/research-run-embedded-retention-run-only-provisional.json" with { type: "json" };
+import invalidResearchRunWaitingPhase from "../../../schemas/research/v1/fixtures/invalid/research-run-waiting-phase.json" with { type: "json" };
+import invalidResearchRunTopicAcceptedMissing from "../../../schemas/research/v1/fixtures/invalid/research-run-topic-provenance-accepted-missing.json" with { type: "json" };
+import invalidResearchRunTopicContextMissing from "../../../schemas/research/v1/fixtures/invalid/research-run-topic-provenance-context-missing.json" with { type: "json" };
+import invalidResearchRunTopicMismatch from "../../../schemas/research/v1/fixtures/invalid/research-run-topic-provenance-mismatch.json" with { type: "json" };
+import invalidRunEventSequence from "../../../schemas/research/v1/fixtures/invalid/run-event-sequence.json" with { type: "json" };
+import validContextPack from "../../../schemas/research/v1/fixtures/valid/context-pack.json" with { type: "json" };
+import validHostedResearchRun from "../../../schemas/research/v1/fixtures/valid/research-run-hosted.json" with { type: "json" };
+import validHostedResearchRunWithoutTenant from "../../../schemas/research/v1/fixtures/valid/research-run-hosted-without-tenant.json" with { type: "json" };
+import validResearchRun from "../../../schemas/research/v1/fixtures/valid/research-run.json" with { type: "json" };
+import validResearchRunTopicProvenanceAbsent from "../../../schemas/research/v1/fixtures/valid/research-run-topic-provenance-absent.json" with { type: "json" };
+import validDeletionBenignRunEvent from "../../../schemas/research/v1/fixtures/valid/run-event-deletion-benign-extension.json" with { type: "json" };
+import validRunEvent from "../../../schemas/research/v1/fixtures/valid/run-event.json" with { type: "json" };
+import validUnicodeRunEvent from "../../../schemas/research/v1/fixtures/valid/run-event-unicode-extension.json" with { type: "json" };
+import invalidDefaultIgnorableDeletionExtension from "../../../schemas/research/v1/fixtures/invalid/run-event-default-ignorable-deletion-extension.json" with { type: "json" };
+import invalidNonAsciiDeletionExtension from "../../../schemas/research/v1/fixtures/invalid/run-event-non-ascii-deletion-extension.json" with { type: "json" };
+import invalidUnicodeSensitiveRunEvent from "../../../schemas/research/v1/fixtures/invalid/run-event-unicode-sensitive-extension.json" with { type: "json" };
+import assemblingRunManifest from "../../../schemas/research/v1/fixtures/valid/run-manifest-assembling.json" with { type: "json" };
+import validCloudRunManifest from "../../../schemas/research/v1/fixtures/valid/run-manifest-final-cloud.json" with { type: "json" };
+import validRunManifest from "../../../schemas/research/v1/fixtures/valid/run-manifest-final-local.json" with { type: "json" };
+
+import { digestProtocolObject } from "./digest.ts";
+import { parseContextPackV1, type ContextPackV1 } from "./context-pack.ts";
+import { parseRunManifestV1 } from "./run-manifest.ts";
+import {
+  parseResearchExecutionProfileV1,
+  parseResearchPrivacyPolicyV1,
+  parseResearchRunV1,
+  parseRunEventV1,
+  validateResearchRunContextPackV1,
+  validateRunManifestDeletionEventV1,
+  validateRunEventSequence,
+  type ResearchRunV1,
+  type ResearchRunStatusV1,
+  type RunEventV1,
+} from "./research-run.ts";
+import { parseResearchContextBindingV1 } from "./common.ts";
+
+function expectOk<T>(result: { ok: true; value: T } | { ok: false; error: { path: string; message: string } }): T {
+  if (!result.ok) {
+    assert.fail(`${result.error.path}: ${result.error.message}`);
+  }
+  return result.value;
+}
+
+function expectError(
+  result: { ok: true; value: unknown } | { ok: false; error: { path: string; code: string; message: string } },
+  path: string,
+  code?: string,
+): { path: string; code: string; message: string } {
+  if (result.ok) {
+    assert.fail("expected parse failure");
+  }
+  assert.equal(result.error.path, path);
+  if (code) {
+    assert.equal(result.error.code, code);
+  }
+  return result.error;
+}
+
+const researchSchemaContext: Record<string, TSchema> = {
+  [runManifestSchema.$id]: runManifestSchema as TSchema,
+};
+
+function checkResearchRunSchema(value: unknown): boolean {
+  return Check(researchSchemaContext, researchRunSchema as TSchema, value);
+}
+
+function linkedManifest(
+  manifest: Record<string, unknown> & { sources: Array<Record<string, unknown>> },
+  context: {
+    contextPackId: string;
+    contextPackDigest: string;
+    topicProposalId?: string;
+    [key: string]: unknown;
+  } = validResearchRun.context,
+): Record<string, unknown> {
+  const linked: Record<string, unknown> = {
+    ...manifest,
+    runId: validResearchRun.id,
+    context,
+    sources: manifest.sources.map((source) =>
+      source.kind === "context-pack"
+        ? {
+            ...source,
+            id: context.contextPackId,
+            digest: context.contextPackDigest,
+          }
+        : source,
+    ),
+  };
+  linked.digest = digestProtocolObject(linked);
+  return linked;
+}
+
+function recalculateContextPack(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...value, digest: digestProtocolObject(value) };
+}
+
+function replayConsent(
+  successor: Record<string, unknown>,
+  freshConsentAt: string,
+  contextConsent: "run-only" | "7-days" | "project",
+) {
+  const { revision, digest } = successor;
+  assert.ok(typeof revision === "number");
+  assert.ok(typeof digest === "string");
+  return {
+    successorRevision: revision,
+    successorDigest: digest,
+    freshConsent: true as const,
+    freshConsentAt,
+    contextConsent,
+  };
+}
+
+function runBoundToPack(
+  run: ResearchRunV1,
+  contextPack: ContextPackV1,
+): ResearchRunV1 {
+  assert.ok(run.context);
+  return {
+    ...run,
+    context: {
+      ...run.context,
+      contextPackId: contextPack.id,
+      contextPackDigest: contextPack.digest,
+    },
+  };
+}
+
+function boundRetentionComposition(): { run: ResearchRunV1; contextPack: ContextPackV1 } {
+  const contextPack = expectOk(parseContextPackV1(validContextPack));
+  const context = {
+    ...validResearchRun.context,
+    contextPackId: contextPack.id,
+    contextPackDigest: contextPack.digest,
+  };
+  const manifest = linkedManifest(
+    {
+      ...validRunManifest,
+      retention: {
+        ...validRunManifest.retention,
+        policy: "7-days",
+        effectivePolicy: "7-days",
+      },
+    },
+    context,
+  );
+  const run = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", manifest),
+      context,
+      privacy: {
+        ...validResearchRun.privacy,
+        retention: "7-days",
+      },
+    }),
+  );
+  return { run, contextPack };
+}
+
+function runForStatus(
+  status: ResearchRunStatusV1,
+  artifactManifest?: Record<string, unknown>,
+): Record<string, unknown> {
+  const run: Record<string, unknown> = {
+    ...validResearchRun,
+    status,
+    ...(artifactManifest
+      ? {
+          artifactManifest,
+          updatedAt: "2026-08-18T00:00:00.000Z",
+        }
+      : {}),
+  };
+  delete run.waitingReason;
+  delete run.waitingForPhase;
+  delete run.failure;
+  if (status === "waiting_for_executor") {
+    run.waitingReason = "executor";
+    run.waitingForPhase = "scope";
+  }
+  if (status === "failed") {
+    run.failure = { code: "runtime_error", message: "failed", retryable: false };
+  }
+  return run;
+}
+
+function manifestWithReceipt(
+  familiarId: string,
+  effectiveModel: string | null,
+): Record<string, unknown> {
+  return linkedManifest({
+    ...validRunManifest,
+    modelExecutions: [
+      {
+        taskId: "modeltask_receipt_01",
+        phase: "scope",
+        attempt: 1,
+        inputDigest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        outputDigest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        receipt: {
+          familiarId,
+          runtime: "copilot",
+          effectiveModel,
+          modelSource: "session",
+          providerBilling: "user-connected",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            costUsd: 0.1,
+            reportedByRuntime: true,
+          },
+        },
+      },
+    ],
+    usage: {
+      inputTokens: 10,
+      outputTokens: 5,
+      costUsd: 0.1,
+      completeness: "complete",
+    },
+  });
+}
+
+function parsedEvent(
+  sequence: number,
+  type: RunEventV1["type"],
+  data: Record<string, unknown>,
+  runId = validResearchRun.id,
+  at = type === "content.deleted"
+    ? "2026-08-17T19:30:00.000Z"
+    : validRunEvent.at,
+): RunEventV1 {
+  return expectOk(
+    parseRunEventV1({
+      ...validRunEvent,
+      runId,
+      sequence,
+      type,
+      at,
+      data,
+    }),
+  );
+}
+
+function runWithCompletedDeletion(
+  nextEventSequence = 4,
+  eventSequence = 2,
+  requestedAt = "2026-08-17T19:00:00.000Z",
+  completedAt = "2026-08-17T20:00:00.000Z",
+  createdAt = validRunManifest.createdAt,
+  finalizedAt = validRunManifest.finalizedAt,
+): ResearchRunV1 {
+  const finalManifest = linkedManifest({
+    ...validRunManifest,
+    createdAt,
+    finalizedAt,
+    artifacts: validRunManifest.artifacts.map((artifact) => ({
+      ...artifact,
+      createdAt: finalizedAt,
+    })),
+  });
+  const deletedManifest: Record<string, unknown> = {
+    ...finalManifest,
+    retention: {
+      ...(finalManifest.retention as Record<string, unknown>),
+      status: "deleted",
+      contentExpiresAt: completedAt,
+      updatedAt: completedAt,
+    },
+    deletion: {
+      status: "completed",
+      requestedAt,
+      completedAt,
+      deletedObjectCount: 3,
+      eventSequence,
+    },
+  };
+  deletedManifest.digest = digestProtocolObject(deletedManifest);
+  return expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", deletedManifest),
+      nextEventSequence,
+      createdAt,
+      updatedAt: completedAt,
+    }),
+  );
+}
+
+test("waiting_for_executor without waitingForPhase rejects", () => {
+  assert.equal(Value.Check(researchRunSchema, invalidResearchRunWaitingPhase), false);
+  expectError(parseResearchRunV1(invalidResearchRunWaitingPhase), "$.waitingForPhase", "missing_field");
+});
+
+test("valid waiting_for_executor run with resumable phase accepts", () => {
+  assert.ok(Value.Check(researchRunSchema, validResearchRun));
+  const parsed = expectOk(parseResearchRunV1(validResearchRun));
+  assert.equal(parsed.status, "waiting_for_executor");
+  assert.equal(parsed.waitingForPhase, "challenge");
+});
+
+test("local runs forbid the cloud-only tenantOpaqueId", () => {
+  assert.equal(Object.hasOwn(validResearchRun, "tenantOpaqueId"), false);
+  assert.equal(checkResearchRunSchema(validResearchRun), true);
+  assert.deepEqual(expectOk(parseResearchRunV1(validResearchRun)), validResearchRun);
+
+  assert.equal(checkResearchRunSchema(invalidLocalResearchRun), false);
+  expectError(
+    parseResearchRunV1(invalidLocalResearchRun),
+    "$.tenantOpaqueId",
+    "semantic_conflict",
+  );
+});
+
+test("hosted runs may include or omit tenantOpaqueId", () => {
+  assert.equal(checkResearchRunSchema(validHostedResearchRun), true);
+  const hosted = expectOk(parseResearchRunV1(validHostedResearchRun));
+  assert.deepEqual(hosted, validHostedResearchRun);
+  assert.equal(hosted.tenantOpaqueId, "tenant_alpha");
+
+  assert.equal(checkResearchRunSchema(validHostedResearchRunWithoutTenant), true);
+  assert.deepEqual(
+    expectOk(parseResearchRunV1(validHostedResearchRunWithoutTenant)),
+    validHostedResearchRunWithoutTenant,
+  );
+});
+
+test("Research Run and Run Event reject schema accessors without invoking them", () => {
+  let calls = 0;
+  for (const { base, parse } of [
+    {
+      base: validResearchRun as Record<string, unknown>,
+      parse: (value: unknown) => parseResearchRunV1(value),
+    },
+    {
+      base: validRunEvent as Record<string, unknown>,
+      parse: (value: unknown) => parseRunEventV1(value),
+    },
+  ]) {
+    const value = { ...base };
+    Object.defineProperty(value, "schema", {
+      get() {
+        calls += 1;
+        return base.schema;
+      },
+      enumerable: true,
+      configurable: true,
+    });
+    expectError(parse(value), "$", "invalid_value");
+  }
+  assert.equal(calls, 0);
+});
+
+test("waitingForPhase is absent for every non waiting_for_executor status", () => {
+  for (const status of [
+    "queued",
+    "scoping",
+    "gathering_public_sources",
+    "challenging",
+    "synthesizing",
+    "controlling",
+    "awaiting_checkpoint",
+    "publishing",
+    "completed",
+    "failed",
+    "cancelled",
+    "expired",
+  ] as const) {
+    const run = { ...validResearchRun, status, waitingForPhase: "scope" as const };
+    assert.equal(Value.Check(researchRunSchema, run), false);
+    expectError(parseResearchRunV1(run), "$.waitingForPhase", "semantic_conflict");
+  }
+});
+
+test("checkpoint pauses preserve active phases and reject inactive phases", () => {
+  for (const status of [
+    "scoping",
+    "gathering_public_sources",
+    "challenging",
+    "synthesizing",
+    "controlling",
+    "awaiting_checkpoint",
+    "publishing",
+  ] as const) {
+    const checkpointRun = runForStatus(status);
+    checkpointRun.waitingReason = "checkpoint";
+    assert.ok(Value.Check(researchRunSchema, checkpointRun), status);
+    assert.equal(expectOk(parseResearchRunV1(checkpointRun)).waitingReason, "checkpoint");
+  }
+
+  for (const status of [
+    "queued",
+    "waiting_for_executor",
+    "completed",
+    "failed",
+    "cancelled",
+    "expired",
+  ] as const) {
+    const checkpointRun = runForStatus(status);
+    checkpointRun.waitingReason = "checkpoint";
+    assert.equal(Value.Check(researchRunSchema, checkpointRun), false, status);
+    expectError(parseResearchRunV1(checkpointRun), "$.waitingReason", "semantic_conflict");
+  }
+});
+
+test("executor and provider attention waiting reasons remain exclusive to waiting_for_executor", () => {
+  for (const waitingReason of ["executor", "provider-attention"] as const) {
+    const run = { ...validResearchRun, status: "awaiting_checkpoint" as const, waitingReason };
+    delete (run as Record<string, unknown>).waitingForPhase;
+    assert.equal(Value.Check(researchRunSchema, run), false);
+    expectError(parseResearchRunV1(run), "$.waitingReason", "semantic_conflict");
+  }
+});
+
+test("failure is required exactly for failed and absent otherwise", () => {
+  const failedWithoutFailure = { ...validResearchRun, status: "failed" as const, waitingReason: undefined, waitingForPhase: undefined };
+  delete (failedWithoutFailure as Record<string, unknown>).waitingReason;
+  delete (failedWithoutFailure as Record<string, unknown>).waitingForPhase;
+  assert.equal(Value.Check(researchRunSchema, failedWithoutFailure), false);
+  expectError(parseResearchRunV1(failedWithoutFailure), "$.failure", "missing_field");
+
+  const validFailed = {
+    ...failedWithoutFailure,
+    failure: { code: "runtime_error", message: "try again", retryable: true },
+    artifactManifest: linkedManifest(validRunManifest),
+    updatedAt: "2026-08-18T00:00:00.000Z",
+  };
+  assert.ok(checkResearchRunSchema(validFailed));
+  assert.equal(expectOk(parseResearchRunV1(validFailed)).failure?.retryable, true);
+
+  const nonFailedWithFailure = {
+    ...validResearchRun,
+    failure: { code: "runtime_error", message: "try again", retryable: true },
+  };
+  assert.equal(Value.Check(researchRunSchema, nonFailedWithFailure), false);
+  expectError(parseResearchRunV1(nonFailedWithFailure), "$.failure", "semantic_conflict");
+});
+
+test("pinned selection requires own model and resolve-at-run-start forbids model", () => {
+  const pinnedWithoutModel = {
+    ...validResearchRun.execution,
+    modelBinding: { familiarId: "sage", selection: "pinned" as const },
+  };
+  expectError(
+    parseResearchExecutionProfileV1(pinnedWithoutModel, "$.execution"),
+    "$.execution.modelBinding.model",
+    "missing_field",
+  );
+
+  const resolveWithModel = {
+    ...validResearchRun.execution,
+    modelBinding: { familiarId: "sage", selection: "resolve-at-run-start" as const, model: "gpt-5.6-sol" },
+  };
+  expectError(
+    parseResearchExecutionProfileV1(resolveWithModel, "$.execution"),
+    "$.execution.modelBinding.model",
+    "semantic_conflict",
+  );
+});
+
+test("booleans stay booleans and allowMemoryPromotion is literal false", () => {
+  expectError(
+    parseResearchPrivacyPolicyV1(
+      { ...validResearchRun.privacy, remoteQueries: "false" },
+      "$.privacy",
+    ),
+    "$.privacy.remoteQueries",
+    "invalid_type",
+  );
+
+  expectError(
+    parseResearchPrivacyPolicyV1(
+      { ...validResearchRun.privacy, allowMemoryPromotion: true },
+      "$.privacy",
+    ),
+    "$.privacy.allowMemoryPromotion",
+    "invalid_value",
+  );
+});
+
+test("standalone research child parsers reject accessors without invoking them", () => {
+  let calls = 0;
+  for (const testCase of [
+    {
+      value: { ...validResearchRun.context },
+      key: "contextPackId",
+      path: "$.context",
+      parse: (value: unknown) => parseResearchContextBindingV1(value, "$.context"),
+    },
+    {
+      value: { ...validResearchRun.execution },
+      key: "location",
+      path: "$.execution",
+      parse: (value: unknown) => parseResearchExecutionProfileV1(value, "$.execution"),
+    },
+    {
+      value: { ...validResearchRun.privacy },
+      key: "remoteQueries",
+      path: "$.privacy",
+      parse: (value: unknown) => parseResearchPrivacyPolicyV1(value, "$.privacy"),
+    },
+  ]) {
+    const original = testCase.value[testCase.key as keyof typeof testCase.value];
+    Object.defineProperty(testCase.value, testCase.key, {
+      get() {
+        calls += 1;
+        return original;
+      },
+      enumerable: true,
+      configurable: true,
+    });
+    expectError(testCase.parse(testCase.value), testCase.path, "invalid_value");
+  }
+  assert.equal(calls, 0);
+});
+
+test("bounds and nextEventSequence enforce safe integer and spend constraints", () => {
+  const boundsCases = [
+    { field: "wallClockMinutes", value: 0, code: "invalid_value" },
+    { field: "maxIterations", value: Number.MAX_SAFE_INTEGER + 1, code: "invalid_value" },
+    { field: "sourceTarget", value: 1.5, code: "invalid_value" },
+    { field: "checkpointEvery", value: -1, code: "invalid_value" },
+  ] as const;
+
+  for (const { field, value, code } of boundsCases) {
+    const run = {
+      ...validResearchRun,
+      bounds: { ...validResearchRun.bounds, [field]: value },
+    };
+    expectError(parseResearchRunV1(run), `$.bounds.${field}`, code);
+  }
+
+  expectError(
+    parseResearchRunV1({
+      ...validResearchRun,
+      bounds: { ...validResearchRun.bounds, maxSpendUsd: -0.01 },
+    }),
+    "$.bounds.maxSpendUsd",
+    "invalid_value",
+  );
+
+  expectError(
+    parseResearchRunV1({
+      ...validResearchRun,
+      nextEventSequence: 0,
+    }),
+    "$.nextEventSequence",
+    "invalid_value",
+  );
+});
+
+test("context parser validates ids and digest, preserves additive fields, and rejects custom prototypes", () => {
+  const context = expectOk(
+    parseResearchContextBindingV1(
+      {
+        ...validResearchRun.context,
+        futureExtension: { preserve: true },
+      },
+      "$.context",
+    ),
+  );
+  assert.equal((context.futureExtension as { preserve: boolean }).preserve, true);
+
+  expectError(
+    parseResearchContextBindingV1(
+      { ...validResearchRun.context, contextPackId: "bad_01" },
+      "$.context",
+    ),
+    "$.context.contextPackId",
+    "invalid_value",
+  );
+  expectError(
+    parseResearchContextBindingV1(
+      { ...validResearchRun.context, topicProposalId: "bad_01" },
+      "$.context",
+    ),
+    "$.context.topicProposalId",
+    "invalid_value",
+  );
+  expectError(
+    parseResearchContextBindingV1(
+      { ...validResearchRun.context, contextPackDigest: "BAD" },
+      "$.context",
+    ),
+    "$.context.contextPackDigest",
+    "invalid_value",
+  );
+
+  const inheritedOptional = Object.create({ topicProposalId: "proposal_inherited" });
+  Object.assign(inheritedOptional, {
+    contextPackId: validResearchRun.context.contextPackId,
+    contextPackDigest: validResearchRun.context.contextPackDigest,
+  });
+  expectError(
+    parseResearchContextBindingV1(inheritedOptional, "$.context"),
+    "$.context",
+    "invalid_value",
+  );
+});
+
+test("accepted-topic provenance is co-present and equal to context provenance", () => {
+  for (const [candidate, path, schemaValid] of [
+    [
+      invalidResearchRunTopicContextMissing,
+      "$.context.topicProposalId",
+      false,
+    ],
+    [
+      invalidResearchRunTopicAcceptedMissing,
+      "$.acceptedTopic.proposalId",
+      false,
+    ],
+    [
+      invalidResearchRunTopicMismatch,
+      "$.acceptedTopic.proposalId",
+      true,
+    ],
+  ] as const) {
+    expectError(parseResearchRunV1(candidate), path, "semantic_conflict");
+    assert.equal(checkResearchRunSchema(candidate), schemaValid);
+  }
+
+  for (const candidate of [
+    validResearchRun,
+    validResearchRunTopicProvenanceAbsent,
+  ]) {
+    assert.equal(checkResearchRunSchema(candidate), true);
+    expectOk(parseResearchRunV1(candidate));
+  }
+});
+
+test("run and embedded manifest chronology is inclusive and leap-second aware", () => {
+  expectError(
+    parseResearchRunV1({
+      ...validResearchRun,
+      updatedAt: "2026-08-15T19:59:59.999999999Z",
+    }),
+    "$.updatedAt",
+    "semantic_conflict",
+  );
+
+  const lower = "2016-12-31T23:59:60Z";
+  const upper = "2017-01-01T00:00:00Z";
+  const boundaryManifest = linkedManifest({
+    ...validRunManifest,
+    createdAt: lower,
+    finalizedAt: upper,
+    artifacts: validRunManifest.artifacts.map((artifact) => ({
+      ...artifact,
+      createdAt: lower,
+    })),
+    retention: {
+      ...validRunManifest.retention,
+      updatedAt: upper,
+    },
+  });
+  const boundaryRun = {
+    ...runForStatus("completed", boundaryManifest),
+    createdAt: lower,
+    updatedAt: upper,
+  };
+  const parsedBoundary = expectOk(parseResearchRunV1(boundaryRun));
+  assert.equal(parsedBoundary.artifactManifest?.createdAt, lower);
+  assert.equal(parsedBoundary.artifactManifest?.retention.updatedAt, upper);
+
+  const assemblingBase = {
+    ...assemblingRunManifest,
+    createdAt: lower,
+    retention: {
+      ...assemblingRunManifest.retention,
+      updatedAt: lower,
+    },
+  };
+  const publicEvidence = {
+    kind: "public-evidence",
+    id: "evidence_chronology_01",
+    contentDigest:
+      "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    snapshotDigest:
+      "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    canonicalUrl: "https://www.iana.org/evidence",
+    fetchedAt: "2017-01-01T00:00:00.000000001Z",
+  };
+  const futureArtifact = {
+    ...validRunManifest.artifacts[0],
+    createdAt: "2017-01-01T00:00:00.000000001Z",
+  };
+  const scheduledDeletion = linkedManifest({
+    ...validRunManifest,
+    createdAt: lower,
+    finalizedAt: upper,
+    artifacts: validRunManifest.artifacts.map((artifact) => ({
+      ...artifact,
+      createdAt: lower,
+    })),
+    retention: {
+      ...validRunManifest.retention,
+      status: "deletion_scheduled",
+      contentExpiresAt: "2017-01-08T00:00:00Z",
+      updatedAt: upper,
+    },
+    deletion: {
+      status: "scheduled",
+      requestedAt: "2017-01-01T00:00:00.000000001Z",
+    },
+  });
+  const completedDeletion = linkedManifest({
+    ...validRunManifest,
+    createdAt: lower,
+    finalizedAt: upper,
+    artifacts: validRunManifest.artifacts.map((artifact) => ({
+      ...artifact,
+      createdAt: lower,
+    })),
+    retention: {
+      ...validRunManifest.retention,
+      status: "deleted",
+      contentExpiresAt: "2017-01-08T00:00:00Z",
+      updatedAt: upper,
+    },
+    deletion: {
+      status: "completed",
+      requestedAt: upper,
+      completedAt: "2017-01-01T00:00:00.000000001Z",
+      deletedObjectCount: 1,
+      retainedAuditUntil: "2017-02-01T00:00:00Z",
+      eventSequence: 1,
+    },
+  });
+
+  const cases = [
+    [
+      "manifest createdAt",
+      linkedManifest({
+        ...validRunManifest,
+        createdAt: "2016-12-31T23:59:59.999999999Z",
+        finalizedAt: upper,
+        artifacts: validRunManifest.artifacts.map((artifact) => ({
+          ...artifact,
+          createdAt: lower,
+        })),
+        retention: { ...validRunManifest.retention, updatedAt: upper },
+      }),
+      "completed",
+      "$.artifactManifest.createdAt",
+    ],
+    [
+      "manifest finalizedAt",
+      linkedManifest({
+        ...validRunManifest,
+        createdAt: lower,
+        finalizedAt: "2017-01-01T00:00:00.000000001Z",
+        artifacts: validRunManifest.artifacts.map((artifact) => ({
+          ...artifact,
+          createdAt: lower,
+        })),
+        retention: {
+          ...validRunManifest.retention,
+          updatedAt: "2017-01-01T00:00:00.000000001Z",
+        },
+      }),
+      "completed",
+      "$.artifactManifest.finalizedAt",
+    ],
+    [
+      "public evidence fetchedAt",
+      linkedManifest({
+        ...assemblingBase,
+        sources: [...assemblingRunManifest.sources, publicEvidence],
+      }),
+      "scoping",
+      "$.artifactManifest.sources[1].fetchedAt",
+    ],
+    [
+      "artifact createdAt",
+      linkedManifest({
+        ...assemblingBase,
+        artifacts: [futureArtifact],
+      }),
+      "scoping",
+      "$.artifactManifest.artifacts[0].createdAt",
+    ],
+    [
+      "retention updatedAt",
+      linkedManifest({
+        ...assemblingBase,
+        retention: {
+          ...assemblingRunManifest.retention,
+          updatedAt: "2017-01-01T00:00:00.000000001Z",
+        },
+      }),
+      "scoping",
+      "$.artifactManifest.retention.updatedAt",
+    ],
+    [
+      "deletion requestedAt",
+      scheduledDeletion,
+      "completed",
+      "$.artifactManifest.deletion.requestedAt",
+    ],
+    [
+      "deletion completedAt",
+      completedDeletion,
+      "completed",
+      "$.artifactManifest.deletion.completedAt",
+    ],
+  ] as const;
+
+  for (const [label, manifest, status, path] of cases) {
+    const error = expectError(
+      parseResearchRunV1({
+        ...runForStatus(status, manifest),
+        createdAt: lower,
+        updatedAt: upper,
+      }),
+      path,
+      "semantic_conflict",
+    );
+    assert.match(error.message, /run chronology/i, label);
+  }
+});
+
+test("run and Context Pack composition requires matching presence and binding", () => {
+  const pack = expectOk(parseContextPackV1(validContextPack));
+  const boundRun = expectOk(
+    parseResearchRunV1({
+      ...validResearchRun,
+      context: {
+        ...validResearchRun.context,
+        contextPackId: pack.id,
+        contextPackDigest: pack.digest,
+      },
+    }),
+  );
+  assert.equal(expectOk(validateResearchRunContextPackV1(boundRun, pack)), boundRun);
+
+  const contextlessValue: Record<string, unknown> = { ...validResearchRun };
+  delete contextlessValue.context;
+  contextlessValue.acceptedTopic = { ...validResearchRun.acceptedTopic };
+  delete (contextlessValue.acceptedTopic as Record<string, unknown>).proposalId;
+  const contextlessRun = expectOk(parseResearchRunV1(contextlessValue));
+  assert.equal(expectOk(validateResearchRunContextPackV1(contextlessRun)), contextlessRun);
+  expectError(
+    validateResearchRunContextPackV1(contextlessRun, pack),
+    "$.context",
+    "semantic_conflict",
+  );
+  expectError(
+    validateResearchRunContextPackV1(boundRun),
+    "$.context",
+    "semantic_conflict",
+  );
+
+  expectError(
+    validateResearchRunContextPackV1(
+      {
+        ...boundRun,
+        context: { ...boundRun.context!, contextPackId: "ctx_other" },
+      },
+      pack,
+    ),
+    "$.context.contextPackId",
+    "semantic_conflict",
+  );
+  expectError(
+    validateResearchRunContextPackV1(
+      {
+        ...boundRun,
+        context: {
+          ...boundRun.context!,
+          contextPackDigest: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        },
+      },
+      pack,
+    ),
+    "$.context.contextPackDigest",
+    "semantic_conflict",
+  );
+});
+
+test("run and Context Pack composition requires research-run purpose and policy", () => {
+  const pack = expectOk(parseContextPackV1(validContextPack));
+  const boundRun = expectOk(
+    parseResearchRunV1({
+      ...validResearchRun,
+      context: {
+        ...validResearchRun.context,
+        contextPackId: pack.id,
+        contextPackDigest: pack.digest,
+      },
+    }),
+  );
+
+  const discoveryPack = expectOk(
+    parseContextPackV1(
+      recalculateContextPack({
+        ...pack,
+        purpose: "topic-discovery",
+        policy: {
+          ...pack.policy,
+          allowedPurposes: ["topic-discovery"],
+        },
+      }),
+    ),
+  );
+  expectError(
+    validateResearchRunContextPackV1(
+      runBoundToPack(boundRun, discoveryPack),
+      discoveryPack,
+    ),
+    "$.contextPack.purpose",
+    "semantic_conflict",
+  );
+  const disallowedPack = recalculateContextPack({
+    ...pack,
+    policy: {
+      ...pack.policy,
+      allowedPurposes: ["topic-discovery"],
+    },
+  }) as unknown as ContextPackV1;
+  expectError(
+    validateResearchRunContextPackV1(
+      runBoundToPack(boundRun, disallowedPack),
+      disallowedPack,
+    ),
+    "$.contextPack.policy.allowedPurposes",
+    "semantic_conflict",
+  );
+});
+
+test("run privacy cannot exceed Context Pack consent", () => {
+  const pack = expectOk(parseContextPackV1(validContextPack));
+  const boundRun = expectOk(
+    parseResearchRunV1({
+      ...validResearchRun,
+      context: {
+        ...validResearchRun.context,
+        contextPackId: pack.id,
+        contextPackDigest: pack.digest,
+      },
+    }),
+  );
+
+  for (const [runKey, consentKey] of [
+    ["remoteQueries", "allowRemoteQueries"],
+    ["remoteContent", "allowRemoteContent"],
+    ["artifactContentSync", "artifactContentSync"],
+  ] as const) {
+    const deniedPack = expectOk(
+      parseContextPackV1(
+        recalculateContextPack({
+          ...pack,
+          consent: { ...pack.consent, [consentKey]: false },
+        }),
+      ),
+    );
+    expectError(
+      validateResearchRunContextPackV1(
+        {
+          ...runBoundToPack(boundRun, deniedPack),
+          privacy: { ...boundRun.privacy, [runKey]: true },
+        },
+        deniedPack,
+      ),
+      `$.privacy.${runKey}`,
+      "semantic_conflict",
+    );
+  }
+
+  expectError(
+    validateResearchRunContextPackV1(
+      {
+        ...boundRun,
+        privacy: { ...boundRun.privacy, retention: "project" },
+      },
+      pack,
+    ),
+    "$.privacy.retention",
+    "semantic_conflict",
+  );
+
+  const permissivePack = expectOk(
+    parseContextPackV1(
+      recalculateContextPack({
+        ...pack,
+        consent: {
+          ...pack.consent,
+          allowRemoteQueries: true,
+          allowRemoteContent: true,
+          artifactContentSync: true,
+        },
+      }),
+    ),
+  );
+  assert.equal(
+    expectOk(
+      validateResearchRunContextPackV1(
+        {
+          ...runBoundToPack(boundRun, permissivePack),
+          privacy: {
+            ...boundRun.privacy,
+            remoteQueries: true,
+            remoteContent: true,
+            artifactContentSync: true,
+            retention: "run-only",
+          },
+        },
+        permissivePack,
+      ),
+    ).privacy.retention,
+    "run-only",
+  );
+});
+
+test("composition revalidates mutable parsed Context Packs at its trust boundary", () => {
+  const consentPack = expectOk(parseContextPackV1(validContextPack));
+  const consentRun = expectOk(
+    parseResearchRunV1({
+      ...validResearchRun,
+      context: {
+        ...validResearchRun.context,
+        contextPackId: consentPack.id,
+        contextPackDigest: consentPack.digest,
+      },
+    }),
+  );
+  assert.equal(
+    validateResearchRunContextPackV1(consentRun, consentPack).ok,
+    true,
+  );
+
+  consentPack.consent.retention = "run-only";
+  expectError(
+    validateResearchRunContextPackV1(consentRun, consentPack),
+    "$.contextPack.digest",
+    "digest_mismatch",
+  );
+
+  const sourcePack = expectOk(parseContextPackV1(validContextPack));
+  sourcePack.resources[0].localBlobDigest =
+    "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+  expectError(
+    validateResearchRunContextPackV1(consentRun, sourcePack),
+    "$.contextPack.digest",
+    "digest_mismatch",
+  );
+});
+
+test("context-bound manifest accepts retention within the Context Pack ceiling", () => {
+  const { run, contextPack } = boundRetentionComposition();
+
+  assert.deepEqual(
+    expectOk(validateResearchRunContextPackV1(run, contextPack)),
+    run,
+  );
+});
+
+test("every embedded later manifest requires a complete revision-1-rooted replay", () => {
+  const contextPack = expectOk(parseContextPackV1(validContextPack));
+  const context = {
+    ...validResearchRun.context,
+    contextPackId: contextPack.id,
+    contextPackDigest: contextPack.digest,
+  };
+  const root = linkedManifest(
+    {
+      ...validRunManifest,
+      sources: validRunManifest.sources,
+    },
+    context,
+  );
+  const next = linkedManifest(
+    {
+      ...root,
+      sources: root.sources as Array<Record<string, unknown>>,
+      revision: 2,
+      previousDigest: root.digest,
+      retention: {
+        ...(root.retention as Record<string, unknown>),
+        updatedAt: "2026-08-16T20:06:00.000Z",
+      },
+    },
+    context,
+  );
+  assert.equal(parseRunManifestV1(next).ok, true, "the later manifest is standalone-valid");
+  const run = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", next),
+      context,
+    }),
+  );
+
+  expectError(
+    validateResearchRunContextPackV1(run, contextPack),
+    "$.artifactManifest.revision",
+    "semantic_conflict",
+  );
+  assert.deepEqual(
+    expectOk(
+      validateResearchRunContextPackV1(run, contextPack, {
+        manifestHistory: [root, next],
+      }),
+    ),
+    run,
+  );
+  expectError(
+    validateResearchRunContextPackV1(run, contextPack, {
+      manifestHistory: [root],
+    }),
+    "$.artifactManifest.digest",
+    "semantic_conflict",
+  );
+
+  const fabricatedRoot = linkedManifest(
+    {
+      ...root,
+      sources: root.sources as Array<Record<string, unknown>>,
+      futureExtension: { preserve: false },
+    },
+    context,
+  );
+  expectError(
+    validateResearchRunContextPackV1(run, contextPack, {
+      manifestHistory: [fabricatedRoot, next],
+    }),
+    "$.manifestHistory[1].previousDigest",
+    "semantic_conflict",
+  );
+
+  const divergentTip = linkedManifest(
+    {
+      ...next,
+      sources: next.sources as Array<Record<string, unknown>>,
+      retention: {
+        ...(next.retention as Record<string, unknown>),
+        updatedAt: "2026-08-16T20:07:00.000Z",
+      },
+    },
+    context,
+  );
+  expectError(
+    validateResearchRunContextPackV1(run, contextPack, {
+      manifestHistory: [root, divergentTip],
+    }),
+    "$.artifactManifest.digest",
+    "semantic_conflict",
+  );
+
+  const contextlessRoot: Record<string, unknown> = {
+    ...validRunManifest,
+    runId: validResearchRun.id,
+    sources: [],
+  };
+  delete contextlessRoot.context;
+  contextlessRoot.digest = digestProtocolObject(contextlessRoot);
+  const contextlessNext: Record<string, unknown> = {
+    ...contextlessRoot,
+    revision: 2,
+    previousDigest: contextlessRoot.digest,
+    retention: {
+      ...(contextlessRoot.retention as Record<string, unknown>),
+      updatedAt: "2026-08-16T20:06:00.000Z",
+    },
+  };
+  contextlessNext.digest = digestProtocolObject(contextlessNext);
+  assert.equal(
+    parseRunManifestV1(contextlessNext).ok,
+    true,
+    "the contextless later manifest is standalone-valid",
+  );
+  const contextlessRunValue: Record<string, unknown> = runForStatus(
+    "completed",
+    contextlessNext,
+  );
+  delete contextlessRunValue.context;
+  contextlessRunValue.acceptedTopic = { ...validResearchRun.acceptedTopic };
+  delete (contextlessRunValue.acceptedTopic as Record<string, unknown>).proposalId;
+  const contextlessRun = expectOk(parseResearchRunV1(contextlessRunValue));
+
+  expectError(
+    validateResearchRunContextPackV1(contextlessRun),
+    "$.artifactManifest.revision",
+    "semantic_conflict",
+  );
+  assert.deepEqual(
+    expectOk(
+      validateResearchRunContextPackV1(contextlessRun, undefined, {
+        manifestHistory: [contextlessRoot, contextlessNext],
+      }),
+    ),
+    contextlessRun,
+  );
+
+  const revisionOneRun = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", root),
+      context,
+    }),
+  );
+  assert.deepEqual(
+    expectOk(validateResearchRunContextPackV1(revisionOneRun, contextPack)),
+    revisionOneRun,
+  );
+});
+
+test("embedded replay rejects stale mutations and returns the detached trusted history tip", () => {
+  const contextPack = expectOk(
+    parseContextPackV1(
+      recalculateContextPack({
+        ...validContextPack,
+        consent: {
+          ...validContextPack.consent,
+          artifactContentSync: true,
+        },
+      }),
+    ),
+  );
+  const context = {
+    ...validResearchRun.context,
+    contextPackId: contextPack.id,
+    contextPackDigest: contextPack.digest,
+  };
+  const root = linkedManifest(
+    {
+      ...validRunManifest,
+      sources: validRunManifest.sources,
+    },
+    context,
+  );
+  const tip = linkedManifest(
+    {
+      ...root,
+      sources: root.sources as Array<Record<string, unknown>>,
+      revision: 2,
+      previousDigest: root.digest,
+      retention: {
+        ...(root.retention as Record<string, unknown>),
+        updatedAt: "2026-08-16T20:06:00.000Z",
+      },
+    },
+    context,
+  );
+  const history = structuredClone([root, tip]);
+  const makeRun = () =>
+    expectOk(
+      parseResearchRunV1({
+        ...runForStatus("completed", tip),
+        context,
+        privacy: {
+          ...validResearchRun.privacy,
+          artifactContentSync: true,
+        },
+      }),
+    );
+
+  const run = makeRun();
+  const composed = expectOk(
+    validateResearchRunContextPackV1(run, contextPack, {
+      manifestHistory: history,
+    }),
+  );
+  assert.notStrictEqual(composed, run);
+  assert.notStrictEqual(composed.artifactManifest, run.artifactManifest);
+  assert.deepEqual(composed.artifactManifest, tip);
+  run.artifactManifest!.futureExtension = { preserve: false };
+  assert.deepEqual(composed.artifactManifest, tip);
+
+  const mutations: Array<
+    [string, (manifest: NonNullable<ResearchRunV1["artifactManifest"]>) => void]
+  > = [
+    [
+      "artifacts",
+      (manifest) => {
+        manifest.artifacts = manifest.artifacts.map((artifact, index) =>
+          index === 0
+            ? {
+                ...artifact,
+                placement: "cloud-content" as const,
+                contentSync: "synced" as const,
+              }
+            : artifact,
+        );
+      },
+    ],
+    [
+      "retention",
+      (manifest) => {
+        manifest.retention.updatedAt = "2026-08-16T20:07:00.000Z";
+      },
+    ],
+    [
+      "extensions",
+      (manifest) => {
+        manifest.futureExtension = { preserve: false };
+      },
+    ],
+    [
+      "digest",
+      (manifest) => {
+        manifest.digest =
+          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+      },
+    ],
+  ];
+
+  for (const [label, mutate] of mutations) {
+    const mutatedRun = makeRun();
+    assert.ok(mutatedRun.artifactManifest);
+    mutate(mutatedRun.artifactManifest);
+    const error = expectError(
+      validateResearchRunContextPackV1(mutatedRun, contextPack, {
+        manifestHistory: history,
+      }),
+      "$.artifactManifest.digest",
+      "digest_mismatch",
+    );
+    assert.match(error.message, /digest/i, label);
+  }
+  (history[1] as Record<string, unknown>).futureExtension = {
+    preserve: false,
+  };
+  assert.deepEqual(composed.artifactManifest, tip);
+});
+
+test("embedded replay binds every historical revision to its enclosing run authority", () => {
+  type ManifestRecord = Record<string, unknown> & {
+    digest: string;
+    sources: Array<Record<string, unknown>>;
+    retention: Record<string, unknown>;
+  };
+  const contextPack = expectOk(parseContextPackV1(validContextPack));
+  const context = {
+    ...validResearchRun.context,
+    contextPackId: contextPack.id,
+    contextPackDigest: contextPack.digest,
+  };
+  const validRoot = linkedManifest(
+    {
+      ...assemblingRunManifest,
+      sources: assemblingRunManifest.sources,
+    },
+    context,
+  ) as ManifestRecord;
+  const finalFromRoot = (
+    root: ManifestRecord,
+  ) =>
+    linkedManifest(
+      {
+        ...root,
+        revision: 2,
+        previousDigest: root.digest,
+        state: "final",
+        finalizedAt: "2026-08-16T20:06:00.000Z",
+        sources: root.sources,
+        artifacts: [{ ...validRunManifest.artifacts[0] }],
+        retention: {
+          ...root.retention,
+          policy: "7-days",
+          effectivePolicy: "7-days",
+          updatedAt: "2026-08-16T20:06:00.000Z",
+        },
+      },
+      context,
+    );
+  const validateHistory = (
+    root: ManifestRecord,
+  ) => {
+    const tip = finalFromRoot(root);
+    const run = expectOk(
+      parseResearchRunV1({
+        ...runForStatus("completed", tip),
+        context,
+      }),
+    );
+    return validateResearchRunContextPackV1(run, contextPack, {
+      manifestHistory: [root, tip],
+    });
+  };
+
+  assert.equal(expectOk(validateHistory(validRoot)).artifactManifest?.state, "final");
+
+  const foreignRunRoot: ManifestRecord = {
+    ...validRoot,
+    runId: "run_foreign",
+  };
+  foreignRunRoot.digest = digestProtocolObject(foreignRunRoot);
+
+  const foreignContext = {
+    ...context,
+    contextPackId: "ctx_foreign",
+    contextPackDigest:
+      "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  };
+  const foreignContextRoot = linkedManifest(
+    {
+      ...assemblingRunManifest,
+      sources: assemblingRunManifest.sources,
+    },
+    foreignContext,
+  ) as ManifestRecord;
+
+  const foreignRetentionRoot = linkedManifest(
+    {
+      ...assemblingRunManifest,
+      sources: assemblingRunManifest.sources,
+      retention: {
+        ...assemblingRunManifest.retention,
+        policy: "project",
+        effectivePolicy: "project",
+      },
+    },
+    context,
+  ) as ManifestRecord;
+
+  const cloudContentRoot = linkedManifest(
+    {
+      ...assemblingRunManifest,
+      sources: assemblingRunManifest.sources,
+      artifacts: [
+        {
+          ...validRunManifest.artifacts[0],
+          placement: "cloud-content",
+          contentSync: "synced",
+        },
+      ],
+    },
+    context,
+  ) as ManifestRecord;
+  const futureArtifactRoot = linkedManifest(
+    {
+      ...assemblingRunManifest,
+      sources: assemblingRunManifest.sources,
+      artifacts: [
+        {
+          ...validRunManifest.artifacts[0],
+          createdAt: "2026-08-18T00:00:00.000000001Z",
+        },
+      ],
+    },
+    context,
+  ) as ManifestRecord;
+
+  for (const [root, path] of [
+    [foreignRunRoot, "$.manifestHistory[0].runId"],
+    [foreignContextRoot, "$.manifestHistory[0].context"],
+    [foreignRetentionRoot, "$.manifestHistory[0].retention.policy"],
+    [cloudContentRoot, "$.manifestHistory[0].artifacts[0].contentSync"],
+    [futureArtifactRoot, "$.manifestHistory[0].artifacts[0].createdAt"],
+  ] as const) {
+    expectError(validateHistory(root), path, "semantic_conflict");
+  }
+
+  const wrongReceiptManifest = manifestWithReceipt(
+    "other-familiar",
+    "gpt-5.6-sol",
+  );
+  const wrongReceiptRoot = linkedManifest(
+    {
+      ...assemblingRunManifest,
+      sources: assemblingRunManifest.sources,
+      modelExecutions: wrongReceiptManifest.modelExecutions as unknown[],
+      usage: wrongReceiptManifest.usage as Record<string, unknown>,
+    },
+    context,
+  ) as ManifestRecord;
+  const receiptFreeTip = linkedManifest(
+    {
+      ...finalFromRoot(wrongReceiptRoot),
+      sources: wrongReceiptRoot.sources,
+      modelExecutions: [],
+      usage: {
+        inputTokens: null,
+        outputTokens: null,
+        costUsd: null,
+        completeness: "unreported",
+      },
+    },
+    context,
+  );
+  const receiptFreeRun = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", receiptFreeTip),
+      context,
+    }),
+  );
+  expectError(
+    validateResearchRunContextPackV1(receiptFreeRun, contextPack, {
+      manifestHistory: [wrongReceiptRoot, receiptFreeTip],
+    }),
+    "$.manifestHistory[0].modelExecutions[0].receipt.familiarId",
+    "semantic_conflict",
+  );
+});
+
+test("context-bound manifest effective retention cannot exceed the Context Pack ceiling", () => {
+  const { run, contextPack } = boundRetentionComposition();
+  const longerManifestRun = {
+    ...run,
+    artifactManifest: {
+      ...run.artifactManifest!,
+      retention: {
+        ...run.artifactManifest!.retention,
+        effectivePolicy: "project" as const,
+      },
+    },
+  };
+
+  expectError(
+    validateResearchRunContextPackV1(longerManifestRun, contextPack),
+    "$.artifactManifest.retention.effectivePolicy",
+    "semantic_conflict",
+  );
+});
+
+test("embedded retention lengthening requires revision-1-rooted replay and authentic fresh consent", () => {
+  const freshPack = expectOk(
+    parseContextPackV1(
+      recalculateContextPack({
+        ...validContextPack,
+        createdAt: "2026-08-16T20:04:30.000Z",
+        consent: {
+          ...validContextPack.consent,
+          retention: "project",
+        },
+      }),
+    ),
+  );
+  const freshContext = {
+    ...validResearchRun.context,
+    contextPackId: freshPack.id,
+    contextPackDigest: freshPack.digest,
+  };
+  const rootManifest = linkedManifest(
+    {
+      ...validRunManifest,
+      revision: 1,
+      retention: {
+        ...validRunManifest.retention,
+        policy: "7-days",
+        effectivePolicy: "7-days",
+      },
+    },
+    freshContext,
+  );
+  const extendedManifest = linkedManifest(
+    {
+      ...rootManifest,
+      sources: rootManifest.sources as Array<Record<string, unknown>>,
+      revision: 2,
+      previousDigest: rootManifest.digest,
+      retention: {
+        ...(rootManifest.retention as Record<string, unknown>),
+        policy: "7-days",
+        effectivePolicy: "project",
+        updatedAt: "2026-08-16T20:06:00.000Z",
+      },
+    },
+    freshContext,
+  );
+
+  expectError(
+    parseRunManifestV1(extendedManifest),
+    "$.retention.effectivePolicy",
+    "semantic_conflict",
+  );
+  const parsedRun = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", extendedManifest),
+      context: freshContext,
+      privacy: {
+        ...validResearchRun.privacy,
+        retention: "7-days",
+      },
+    }),
+  );
+  expectError(
+    validateResearchRunContextPackV1(parsedRun, freshPack),
+    "$.artifactManifest.revision",
+    "semantic_conflict",
+  );
+  const serializedHistory = JSON.parse(
+    JSON.stringify([rootManifest, extendedManifest]),
+  ) as unknown[];
+  assert.equal(
+    expectOk(
+      validateResearchRunContextPackV1(parsedRun, freshPack, {
+        manifestHistory: serializedHistory,
+        manifestRevisionOptions: [
+          replayConsent(
+            extendedManifest,
+            "2026-08-16T20:05:30.000Z",
+            "project",
+          ),
+        ],
+      }),
+    ).artifactManifest?.retention.effectivePolicy,
+    "project",
+  );
+  expectError(
+    validateResearchRunContextPackV1(parsedRun, freshPack, {
+      manifestHistory: serializedHistory,
+      manifestRevisionOptions: [
+        replayConsent(
+          extendedManifest,
+          "2026-08-16T20:05:00.000Z",
+          "project",
+        ),
+      ],
+    }),
+    "$.manifestRevisionOptions[0].freshConsentAt",
+    "semantic_conflict",
+  );
+  expectError(
+    validateResearchRunContextPackV1(parsedRun, freshPack, {
+      manifestHistory: serializedHistory,
+      manifestRevisionOptions: [
+        replayConsent(
+          extendedManifest,
+          "2026-08-16T20:06:00.000000001Z",
+          "project",
+        ),
+      ],
+    }),
+    "$.manifestRevisionOptions[0].freshConsentAt",
+    "semantic_conflict",
+  );
+  const laterCreatedRun = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", extendedManifest),
+      context: freshContext,
+      privacy: {
+        ...validResearchRun.privacy,
+        retention: "7-days",
+      },
+      createdAt: "2026-08-16T20:00:00.000Z",
+      updatedAt: "2026-08-16T20:06:00.000Z",
+    }),
+  );
+  expectError(
+    validateResearchRunContextPackV1(laterCreatedRun, freshPack, {
+      manifestHistory: serializedHistory,
+      manifestRevisionOptions: [
+        replayConsent(
+          extendedManifest,
+          "2026-08-16T19:59:59.999999999Z",
+          "project",
+        ),
+      ],
+    }),
+    "$.manifestRevisionOptions[0].freshConsentAt",
+    "semantic_conflict",
+  );
+  expectError(
+    validateResearchRunContextPackV1(parsedRun),
+    "$.context",
+    "semantic_conflict",
+  );
+
+  const mismatchedTip = linkedManifest(
+    {
+      ...extendedManifest,
+      sources: extendedManifest.sources as Array<Record<string, unknown>>,
+      retention: {
+        ...(extendedManifest.retention as Record<string, unknown>),
+        updatedAt: "2026-08-16T20:06:30.000Z",
+      },
+    },
+    freshContext,
+  );
+  expectError(
+    validateResearchRunContextPackV1(parsedRun, freshPack, {
+      manifestHistory: [rootManifest, mismatchedTip],
+      manifestRevisionOptions: [
+        replayConsent(
+          mismatchedTip,
+          "2026-08-16T20:05:30.000Z",
+          "project",
+        ),
+      ],
+    }),
+    "$.artifactManifest.digest",
+    "semantic_conflict",
+  );
+  expectError(
+    validateResearchRunContextPackV1(parsedRun, freshPack, {
+      manifestHistory: [extendedManifest],
+    }),
+    "$.manifestHistory[0].revision",
+    "semantic_conflict",
+  );
+
+  const stalePack = expectOk(parseContextPackV1(validContextPack));
+  const staleContext = {
+    ...freshContext,
+    contextPackDigest: stalePack.digest,
+  };
+  const staleRoot = linkedManifest(
+    {
+      ...rootManifest,
+      sources: rootManifest.sources as Array<Record<string, unknown>>,
+      revision: 1,
+    },
+    staleContext,
+  );
+  const staleManifest = linkedManifest(
+    {
+      ...extendedManifest,
+      sources: extendedManifest.sources as Array<Record<string, unknown>>,
+      previousDigest: staleRoot.digest,
+    },
+    staleContext,
+  );
+  const staleRun = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", staleManifest),
+      context: staleContext,
+      privacy: {
+        ...validResearchRun.privacy,
+        retention: "7-days",
+      },
+    }),
+  );
+  expectError(
+    validateResearchRunContextPackV1(staleRun, stalePack, {
+      manifestHistory: [staleRoot, staleManifest],
+      manifestRevisionOptions: [
+        replayConsent(
+          staleManifest,
+          "2026-08-16T20:05:30.000Z",
+          "7-days",
+        ),
+      ],
+    }),
+    "$.manifestHistory[1].retention.effectivePolicy",
+    "semantic_conflict",
+  );
+
+  freshPack.consent.retention = "7-days";
+  expectError(
+    validateResearchRunContextPackV1(parsedRun, freshPack),
+    "$.contextPack.digest",
+    "digest_mismatch",
+  );
+});
+
+test("embedded deadline extension replays from serialized history at the fresh-consent boundary", () => {
+  const freshPack = expectOk(
+    parseContextPackV1(
+      recalculateContextPack({
+        ...validContextPack,
+        createdAt: "2026-08-16T20:05:30.000Z",
+      }),
+    ),
+  );
+  const context = {
+    ...validResearchRun.context,
+    contextPackId: freshPack.id,
+    contextPackDigest: freshPack.digest,
+  };
+  const root = linkedManifest(
+    {
+      ...validRunManifest,
+      revision: 1,
+      retention: {
+        ...validRunManifest.retention,
+        policy: "7-days",
+        effectivePolicy: "7-days",
+        status: "deletion_scheduled",
+        contentExpiresAt: "2026-08-20T20:04:00.000Z",
+        updatedAt: "2026-08-16T20:05:00.000Z",
+      },
+      deletion: {
+        status: "scheduled",
+        requestedAt: "2026-08-16T20:05:00.000Z",
+      },
+    },
+    context,
+  );
+  const extended = linkedManifest(
+    {
+      ...root,
+      sources: root.sources as Array<Record<string, unknown>>,
+      revision: 2,
+      previousDigest: root.digest,
+      retention: {
+        ...(root.retention as Record<string, unknown>),
+        contentExpiresAt: "2026-08-23T20:05:30.000Z",
+        updatedAt: "2026-08-16T20:06:00.000Z",
+      },
+    },
+    context,
+  );
+  expectError(
+    parseRunManifestV1(extended),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+
+  const run = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", extended),
+      context,
+      privacy: {
+        ...validResearchRun.privacy,
+        retention: "7-days",
+      },
+    }),
+  );
+  expectError(
+    validateResearchRunContextPackV1(run, freshPack),
+    "$.artifactManifest.revision",
+    "semantic_conflict",
+  );
+  assert.equal(
+    expectOk(
+      validateResearchRunContextPackV1(run, freshPack, {
+        manifestHistory: JSON.parse(JSON.stringify([root, extended])) as unknown[],
+        manifestRevisionOptions: [
+          replayConsent(
+            extended,
+            "2026-08-16T20:05:30.000Z",
+            "7-days",
+          ),
+        ],
+      }),
+    ).artifactManifest?.retention.contentExpiresAt,
+    "2026-08-23T20:05:30.000Z",
+  );
+});
+
+test("embedded replay consumes one explicit keyed option per lengthening transition", () => {
+  const contextPack = expectOk(parseContextPackV1(validContextPack));
+  const context = {
+    ...validResearchRun.context,
+    contextPackId: contextPack.id,
+    contextPackDigest: contextPack.digest,
+  };
+  const root = linkedManifest(
+    {
+      ...validRunManifest,
+      retention: {
+        ...validRunManifest.retention,
+        policy: "7-days",
+        effectivePolicy: "7-days",
+        status: "deletion_scheduled",
+        contentExpiresAt: "2026-08-20T20:05:00.000Z",
+        updatedAt: "2026-08-16T20:05:00.000Z",
+      },
+      deletion: {
+        status: "scheduled",
+        requestedAt: "2026-08-16T20:05:00.000Z",
+      },
+    },
+    context,
+  );
+  const successor = (
+    previous: Record<string, unknown>,
+    revision: number,
+    contentExpiresAt: string,
+    updatedAt: string,
+  ) =>
+    linkedManifest(
+      {
+        ...previous,
+        sources: previous.sources as Array<Record<string, unknown>>,
+        revision,
+        previousDigest: previous.digest,
+        retention: {
+          ...(previous.retention as Record<string, unknown>),
+          contentExpiresAt,
+          updatedAt,
+        },
+      },
+      context,
+    );
+  const firstLengthening = successor(
+    root,
+    2,
+    "2026-08-21T20:05:30.000Z",
+    "2026-08-16T20:06:00.000Z",
+  );
+  const unchanged = successor(
+    firstLengthening,
+    3,
+    "2026-08-21T20:05:30.000Z",
+    "2026-08-16T20:07:00.000Z",
+  );
+  const secondLengthening = successor(
+    unchanged,
+    4,
+    "2026-08-22T20:07:30.000Z",
+    "2026-08-16T20:08:00.000Z",
+  );
+  const run = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", secondLengthening),
+      context,
+      privacy: {
+        ...validResearchRun.privacy,
+        retention: "7-days",
+      },
+    }),
+  );
+  const manifestHistory = JSON.parse(
+    JSON.stringify([root, firstLengthening, unchanged, secondLengthening]),
+  ) as unknown[];
+  const firstOption = replayConsent(
+    firstLengthening,
+    "2026-08-16T20:05:30.000Z",
+    "7-days",
+  );
+  const secondOption = replayConsent(
+    secondLengthening,
+    "2026-08-16T20:07:30.000Z",
+    "7-days",
+  );
+
+  expectError(
+    validateResearchRunContextPackV1(run, contextPack, { manifestHistory }),
+    "$.manifestHistory[1].retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+  expectError(
+    validateResearchRunContextPackV1(run, contextPack, {
+      manifestHistory,
+      manifestRevisionOptions: [firstOption],
+    }),
+    "$.manifestHistory[3].retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+  assert.equal(
+    expectOk(
+      validateResearchRunContextPackV1(run, contextPack, {
+        manifestHistory,
+        manifestRevisionOptions: [secondOption, firstOption],
+      }),
+    ).artifactManifest?.digest,
+    secondLengthening.digest,
+  );
+
+  expectError(
+    validateResearchRunContextPackV1(run, contextPack, {
+      manifestHistory,
+      manifestRevisionOptions: [firstOption, firstOption, secondOption],
+    }),
+    "$.manifestRevisionOptions[1].successorRevision",
+    "semantic_conflict",
+  );
+  expectError(
+    validateResearchRunContextPackV1(run, contextPack, {
+      manifestHistory,
+      manifestRevisionOptions: [
+        firstOption,
+        secondOption,
+        {
+          ...secondOption,
+          successorRevision: 5,
+          successorDigest:
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        },
+      ],
+    }),
+    "$.manifestRevisionOptions[2].successorRevision",
+    "semantic_conflict",
+  );
+  expectError(
+    validateResearchRunContextPackV1(run, contextPack, {
+      manifestHistory,
+      manifestRevisionOptions: [
+        firstOption,
+        replayConsent(unchanged, "2026-08-16T20:06:30.000Z", "7-days"),
+        secondOption,
+      ],
+    }),
+    "$.manifestRevisionOptions[1].successorRevision",
+    "semantic_conflict",
+  );
+
+  for (const [firstConsentAt, path] of [
+    [
+      "2026-08-16T20:05:00.000Z",
+      "$.manifestRevisionOptions[0].freshConsentAt",
+    ],
+    [
+      "2026-08-16T20:06:00.000000001Z",
+      "$.manifestRevisionOptions[0].freshConsentAt",
+    ],
+  ] as const) {
+    expectError(
+      validateResearchRunContextPackV1(run, contextPack, {
+        manifestHistory,
+        manifestRevisionOptions: [
+          replayConsent(firstLengthening, firstConsentAt, "7-days"),
+          secondOption,
+        ],
+      }),
+      path,
+      "semantic_conflict",
+    );
+  }
+
+  expectError(
+    validateResearchRunContextPackV1(run, contextPack, {
+      manifestHistory,
+      manifestRevisionOptions: [
+        replayConsent(firstLengthening, "2026-08-16T20:05:30.000Z", "project"),
+        secondOption,
+      ],
+    }),
+    "$.manifestRevisionOptions[0].contextConsent",
+    "semantic_conflict",
+  );
+});
+
+test("events parse and validateRunEventSequence enforces contiguous same-run sequences", () => {
+  assert.ok(Value.Check(runEventSchema, validRunEvent));
+  const parsedEvent = expectOk(parseRunEventV1(validRunEvent));
+  assert.equal(parsedEvent.sequence, 1);
+
+  assert.equal(Value.Check(runEventSchema, invalidRunEventSequence), false);
+  expectError(parseRunEventV1(invalidRunEventSequence), "$.sequence", "invalid_value");
+
+  const second: RunEventV1 = {
+    ...parsedEvent,
+    sequence: 2,
+    type: "run.status",
+  };
+  assert.equal(expectOk(validateRunEventSequence([parsedEvent, second])).length, 2);
+
+  expectError(validateRunEventSequence([{ ...parsedEvent, sequence: 2 }]), "$[0].sequence", "semantic_conflict");
+  expectError(validateRunEventSequence([parsedEvent, { ...second, sequence: 3 }]), "$[1].sequence", "semantic_conflict");
+  expectError(validateRunEventSequence([parsedEvent, { ...second, runId: "run_other" }]), "$[1].runId", "semantic_conflict");
+  expectError(
+    validateRunEventSequence([
+      parsedEvent,
+      { ...second, sequence: Number.MAX_SAFE_INTEGER + 1 } as unknown as RunEventV1,
+    ]),
+    "$[1].sequence",
+    "semantic_conflict",
+  );
+});
+
+test("schema and parser agree on expressible constraints and additive fields survive", () => {
+  const run = expectOk(parseResearchRunV1(validResearchRun));
+  assert.equal((run.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((run.context?.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((run.execution.modelBinding.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((run.privacy.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((run.bounds.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal("artifactManifest" in run, false);
+  assert.equal(run.artifactManifest, undefined);
+
+  const event = expectOk(parseRunEventV1(validRunEvent));
+  assert.equal((event.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((event.data.futureExtension as { preserve: boolean }).preserve, true);
+
+  assert.equal(
+    Value.Check(researchRunSchema, { ...validResearchRun, schema: "opencoven.research-run/v2" }),
+    false,
+  );
+  expectError(parseResearchRunV1({ ...validResearchRun, schema: "opencoven.research-run/v2" }), "$.schema", "unknown_major");
+
+  assert.equal(Value.Check(runEventSchema, { ...validRunEvent, schema: "opencoven.run-event/v2" }), false);
+  expectError(parseRunEventV1({ ...validRunEvent, schema: "opencoven.run-event/v2" }), "$.schema", "unknown_major");
+});
+
+test("artifactManifest uses the run-manifest absolute schema document identifier", () => {
+  const artifactManifestSchema = researchRunSchema.properties
+    .artifactManifest as { $ref: string };
+  const reference = new URL(artifactManifestSchema.$ref);
+  const targetIdentifier = new URL(runManifestSchema.$id);
+
+  assert.equal(reference.href, targetIdentifier.href);
+  const standardsRegistry = new Map([
+    [targetIdentifier.href, runManifestSchema],
+  ]);
+  assert.equal(standardsRegistry.get(reference.href), runManifestSchema);
+
+  const run = runForStatus(
+    "completed",
+    linkedManifest(validRunManifest),
+  );
+  assert.equal(checkResearchRunSchema(run), true);
+});
+
+test("content.deleted data permits only declared audit fields and safe recursive extensions", () => {
+  const event = {
+    ...validRunEvent,
+    type: "content.deleted",
+    at: "2026-08-17T19:30:00.000Z",
+    auditDisposition: {
+      outcome: "complete",
+      retryCount: 0,
+    },
+    data: {
+      deletedObjectCount: 3,
+      manifestStatus: "deleted",
+      audit: {
+        retry: 1,
+        objectives: "met",
+        storefront: "closed",
+        storagelike: "audit-only",
+        bucketed: true,
+        keystone: "retention",
+        deletedcontentmentpayload: "benign",
+        flags: [true, null, { disposition: "complete" }],
+      },
+    },
+  };
+  assert.equal(Value.Check(runEventSchema, event), true);
+  assert.deepEqual(expectOk(parseRunEventV1(event)).data, event.data);
+  assert.deepEqual(
+    expectOk(parseRunEventV1(event)).auditDisposition,
+    event.auditDisposition,
+  );
+
+  for (const [key, value] of [
+    ["deletedContent", "private material"],
+    ["objectStoreKey", "tenant/private/object"],
+  ] as const) {
+    const invalid = { ...event, [key]: value };
+    assert.equal(Value.Check(runEventSchema, invalid), false, key);
+    expectError(parseRunEventV1(invalid), `$.${key}`, "semantic_conflict");
+  }
+
+  const splitTopLevelPath = {
+    ...event,
+    auditEnvelope: {
+      object: {
+        store: {
+          key: "tenant/private/object",
+        },
+      },
+    },
+  };
+  assert.equal(Value.Check(runEventSchema, splitTopLevelPath), true);
+  expectError(
+    parseRunEventV1(splitTopLevelPath),
+    "$.auditEnvelope.object.store.key",
+    "semantic_conflict",
+  );
+
+  for (const [data, path, expectedSchemaValid] of [
+    [
+      {
+        deletedObjectCount: 3,
+        manifestStatus: "deleted",
+        deletedContent: "private material",
+      },
+      "$.data.deletedContent",
+      false,
+    ],
+    [
+      {
+        deletedObjectCount: 3,
+        manifestStatus: "deleted",
+        objectStoreKey: "tenant/private/object",
+      },
+      "$.data.objectStoreKey",
+      false,
+    ],
+    [
+      {
+        deletedObjectCount: 3,
+        manifestStatus: "deleted",
+        audit: { deletedcontentpayload: "private material" },
+      },
+      "$.data.audit.deletedcontentpayload",
+      false,
+    ],
+    [
+      {
+        deletedObjectCount: 3,
+        manifestStatus: "deleted",
+        audit: { object: { store: { key: "tenant/private/object" } } },
+      },
+      "$.data.audit.object.store.key",
+      true,
+    ],
+    [
+      {
+        deletedObjectCount: 3,
+        manifestStatus: "deleted",
+        audit: [{ storage: { key: "tenant/private/object" } }],
+      },
+      "$.data.audit[0].storage.key",
+      true,
+    ],
+    [
+      {
+        deletedObjectCount: 3,
+        manifestStatus: "deleted",
+        audit: { bucket: { key: "tenant/private/object" } },
+      },
+      "$.data.audit.bucket.key",
+      true,
+    ],
+    [
+      {
+        deletedObjectCount: 3,
+        manifestStatus: "deleted",
+        audit: { rawTEXTvalue: "private material" },
+      },
+      "$.data.audit.rawTEXTvalue",
+      false,
+    ],
+    [
+      {
+        deletedObjectCount: 3,
+        manifestStatus: "deleted",
+        audit: [{ private_contentValue: "private material" }],
+      },
+      "$.data.audit[0].private_contentValue",
+      false,
+    ],
+  ] as const) {
+    const invalid = { ...event, data };
+    assert.equal(Value.Check(runEventSchema, invalid), expectedSchemaValid, path);
+    expectError(parseRunEventV1(invalid), path, "semantic_conflict");
+  }
+
+  const benignKey = {
+    ...event,
+    data: {
+      ...event.data,
+      audit: { key: "benign standalone key" },
+    },
+  };
+  assert.equal(Value.Check(runEventSchema, benignKey), true);
+  assert.equal(
+    ((expectOk(parseRunEventV1(benignKey)).data.audit as { key: string }).key),
+    "benign standalone key",
+  );
+
+  const missingCount = {
+    ...event,
+    data: { manifestStatus: "deleted" },
+  };
+  assert.equal(Value.Check(runEventSchema, missingCount), false);
+  expectError(
+    parseRunEventV1(missingCount),
+    "$.data.deletedObjectCount",
+    "missing_field",
+  );
+});
+
+test("non-deletion events preserve benign Unicode extension keys", () => {
+  assert.equal(Value.Check(runEventSchema, validUnicodeRunEvent), true);
+  assert.deepEqual(
+    expectOk(parseRunEventV1(validUnicodeRunEvent)),
+    validUnicodeRunEvent,
+  );
+});
+
+test("content.deleted checks raw extension-key ASCII before Unicode normalization", () => {
+  const { expectedSchemaValid, ...invalidEvent } =
+    invalidDefaultIgnorableDeletionExtension;
+  assert.equal(expectedSchemaValid, false);
+  assert.equal(Value.Check(runEventSchema, invalidEvent), false);
+  expectError(
+    parseRunEventV1(invalidEvent),
+    '$.data["audit\u2060Trail"]',
+    "semantic_conflict",
+  );
+
+  assert.equal(Value.Check(runEventSchema, validDeletionBenignRunEvent), true);
+  assert.deepEqual(
+    expectOk(parseRunEventV1(validDeletionBenignRunEvent)),
+    validDeletionBenignRunEvent,
+  );
+});
+
+test("content.deleted extensions require raw ASCII keys", () => {
+  const { expectedSchemaValid: nonAsciiSchemaValid, ...nonAsciiEvent } =
+    invalidNonAsciiDeletionExtension;
+  assert.equal(nonAsciiSchemaValid, false);
+  assert.equal(Value.Check(runEventSchema, nonAsciiEvent), false);
+  expectError(
+    parseRunEventV1(nonAsciiEvent),
+    '$.data["deletedCоntentPayload"]',
+    "semantic_conflict",
+  );
+
+  const { expectedSchemaValid, ...invalidEvent } =
+    invalidUnicodeSensitiveRunEvent;
+  assert.equal(expectedSchemaValid, false);
+  assert.equal(Value.Check(runEventSchema, invalidEvent), false);
+  expectError(
+    parseRunEventV1(invalidEvent),
+    '$.data["deletedCon\u2060tentPayload"]',
+    "semantic_conflict",
+  );
+
+  const base = {
+    ...validRunEvent,
+    type: "content.deleted",
+    data: {
+      deletedObjectCount: 3,
+      manifestStatus: "deleted",
+    },
+  };
+  for (const [candidate, path] of [
+    [{ ...base, аudit: true }, '$["аudit"]'],
+    [
+      {
+        ...base,
+        data: { ...base.data, 監査: true },
+      },
+      '$.data["監査"]',
+    ],
+    [
+      {
+        ...base,
+        data: { ...base.data, ａｕｄｉｔ: true },
+      },
+      '$.data["ａｕｄｉｔ"]',
+    ],
+    [
+      {
+        ...base,
+        data: { ...base.data, audit: { résumé: "complete" } },
+      },
+      '$.data.audit["résumé"]',
+    ],
+  ] as const) {
+    assert.equal(Value.Check(runEventSchema, candidate), false, path);
+    expectError(parseRunEventV1(candidate), path, "semantic_conflict");
+  }
+});
+
+test("run event rejects custom-prototype nested data", () => {
+  const inheritedData = Object.create({ inheritedField: "drop-me" });
+  Object.assign(inheritedData, {
+    status: "queued",
+    customField: "kept",
+    futureExtension: { preserve: true },
+  });
+
+  expectError(
+    parseRunEventV1({
+      ...validRunEvent,
+      data: inheritedData,
+    }),
+    "$",
+    "invalid_value",
+  );
+});
+
+test("embedded manifests bind original run privacy retention and cloud-content consent", () => {
+  const finalManifest = linkedManifest(validRunManifest);
+
+  expectError(
+    parseResearchRunV1({
+      ...runForStatus("completed", finalManifest),
+      privacy: { ...validResearchRun.privacy, retention: "run-only" },
+    }),
+    "$.artifactManifest.retention.policy",
+    "semantic_conflict",
+  );
+
+  const longerEffectivePolicy = linkedManifest({
+    ...validRunManifest,
+    revision: 2,
+    previousDigest: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    retention: {
+      ...validRunManifest.retention,
+      policy: "run-only",
+      effectivePolicy: "7-days",
+    },
+  });
+  const provisionallyParsed = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", longerEffectivePolicy),
+      privacy: { ...validResearchRun.privacy, retention: "run-only" },
+    }),
+  );
+  assert.equal(
+    provisionallyParsed.artifactManifest?.retention.effectivePolicy,
+    "7-days",
+  );
+
+  const cloudManifest = linkedManifest(validCloudRunManifest);
+  expectError(
+    parseResearchRunV1({
+      ...runForStatus("completed", cloudManifest),
+      privacy: {
+        ...validResearchRun.privacy,
+        retention: "project",
+        artifactContentSync: false,
+      },
+    }),
+    "$.artifactManifest.artifacts[0].contentSync",
+    "semantic_conflict",
+  );
+  assert.equal(
+    expectOk(
+      parseResearchRunV1({
+        ...runForStatus("completed", cloudManifest),
+        privacy: {
+          ...validResearchRun.privacy,
+          retention: "project",
+          artifactContentSync: true,
+        },
+      }),
+    ).artifactManifest?.artifacts[0].placement,
+    "cloud-content",
+  );
+
+  const cloudMetadataManifest = linkedManifest({
+    ...validCloudRunManifest,
+    artifacts: validCloudRunManifest.artifacts.map((artifact) => ({
+      ...artifact,
+      placement: "cloud-metadata",
+      contentSync: "not-requested",
+    })),
+  });
+  const cloudMetadataRun = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", cloudMetadataManifest),
+      privacy: {
+        ...validResearchRun.privacy,
+        retention: "project",
+        artifactContentSync: false,
+      },
+    }),
+  );
+  assert.equal(cloudMetadataRun.artifactManifest?.artifacts[0].placement, "cloud-metadata");
+
+  const shortenedEffectivePolicy = linkedManifest({
+    ...validRunManifest,
+    revision: 2,
+    previousDigest: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    retention: {
+      ...validRunManifest.retention,
+      effectivePolicy: "run-only",
+      status: "deletion_scheduled",
+      contentExpiresAt: "2026-08-16T20:10:00.000Z",
+    },
+    deletion: {
+      status: "scheduled",
+      requestedAt: "2026-08-16T20:06:00.000Z",
+    },
+  });
+  assert.equal(
+    expectOk(
+      parseResearchRunV1(runForStatus("completed", shortenedEffectivePolicy)),
+    ).artifactManifest?.retention.effectivePolicy,
+    "run-only",
+  );
+});
+
+test("every requested artifact content sync requires run consent regardless of placement", () => {
+  for (const contentSync of ["pending", "synced", "failed"] as const) {
+    const manifest = linkedManifest({
+      ...validRunManifest,
+      artifacts: validRunManifest.artifacts.map((artifact) => ({
+        ...artifact,
+        placement: "device-local",
+        contentSync,
+      })),
+    });
+    const deniedRun = {
+      ...runForStatus("completed", manifest),
+      privacy: {
+        ...validResearchRun.privacy,
+        artifactContentSync: false,
+      },
+    };
+
+    assert.equal(checkResearchRunSchema(deniedRun), false);
+    expectError(
+      parseResearchRunV1(deniedRun),
+      "$.artifactManifest.artifacts[0].contentSync",
+      "semantic_conflict",
+    );
+
+    const allowed = expectOk(
+      parseResearchRunV1({
+        ...deniedRun,
+        privacy: {
+          ...validResearchRun.privacy,
+          artifactContentSync: true,
+        },
+      }),
+    );
+    assert.equal(checkResearchRunSchema(allowed), true);
+    assert.equal(allowed.artifactManifest?.artifacts[0].contentSync, contentSync);
+  }
+});
+
+test("single-agent manifest receipts bind the selected familiar and pinned provider/model", () => {
+  const execution = {
+    ...validResearchRun.execution,
+    modelBinding: {
+      ...validResearchRun.execution.modelBinding,
+      model: "openai/gpt-5.6-sol",
+    },
+  };
+  const cases = [
+    ["wrong familiar", "other-familiar", "openai/gpt-5.6-sol", "$.artifactManifest.modelExecutions[0].receipt.familiarId"],
+    ["wrong provider", "sage", "anthropic/gpt-5.6-sol", "$.artifactManifest.modelExecutions[0].receipt.effectiveModel"],
+    ["wrong model", "sage", "openai/gpt-5-mini", "$.artifactManifest.modelExecutions[0].receipt.effectiveModel"],
+  ] as const;
+
+  for (const [label, familiarId, effectiveModel, path] of cases) {
+    const result = parseResearchRunV1({
+      ...runForStatus("completed", manifestWithReceipt(familiarId, effectiveModel)),
+      execution,
+    });
+    const error = expectError(result, path, "semantic_conflict");
+    assert.match(error.message, /receipt/i, label);
+  }
+
+  const valid = expectOk(
+    parseResearchRunV1({
+      ...runForStatus(
+        "completed",
+        manifestWithReceipt("sage", "openai/gpt-5.6-sol"),
+      ),
+      execution,
+    }),
+  );
+  assert.equal(
+    valid.artifactManifest?.modelExecutions[0].receipt.effectiveModel,
+    "openai/gpt-5.6-sol",
+  );
+
+  const resolvedAtStart = expectOk(
+    parseResearchRunV1({
+      ...runForStatus(
+        "completed",
+        manifestWithReceipt("sage", "runtime/resolved-model"),
+      ),
+      execution: {
+        ...execution,
+        modelBinding: {
+          familiarId: "sage",
+          selection: "resolve-at-run-start",
+        },
+      },
+    }),
+  );
+  assert.equal(
+    resolvedAtStart.artifactManifest?.modelExecutions[0].receipt.effectiveModel,
+    "runtime/resolved-model",
+  );
+});
+
+test("contextless embedded manifests cannot extend effective retention beyond the run policy", () => {
+  const contextlessManifest: Record<string, unknown> = {
+    ...validRunManifest,
+    runId: validResearchRun.id,
+    revision: 2,
+    previousDigest: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    sources: validRunManifest.sources.filter((source) => source.kind !== "context-pack"),
+    retention: {
+      ...validRunManifest.retention,
+      policy: "run-only",
+      effectivePolicy: "7-days",
+    },
+  };
+  delete contextlessManifest.context;
+  contextlessManifest.digest = digestProtocolObject(contextlessManifest);
+
+  const contextlessRun: Record<string, unknown> = {
+    ...runForStatus("completed", contextlessManifest),
+    privacy: { ...validResearchRun.privacy, retention: "run-only" },
+  };
+  delete contextlessRun.context;
+  contextlessRun.acceptedTopic = { ...validResearchRun.acceptedTopic };
+  delete (contextlessRun.acceptedTopic as Record<string, unknown>).proposalId;
+
+  expectError(
+    parseResearchRunV1(contextlessRun),
+    "$.artifactManifest.retention.effectivePolicy",
+    "semantic_conflict",
+  );
+});
+
+test("embedded later deadline extensions decode provisionally but remain outside standalone authority", () => {
+  for (const run of [
+    provisionalEmbeddedRunOnlyRetention,
+    provisionalEmbeddedSevenDayRetention,
+  ]) {
+    assert.equal(checkResearchRunSchema(run), true);
+    assert.equal(
+      run.artifactManifest.digest,
+      digestProtocolObject(run.artifactManifest),
+    );
+    const parsed = expectOk(parseResearchRunV1(run));
+    assert.equal(
+      parsed.artifactManifest?.retention.contentExpiresAt,
+      run.artifactManifest.retention.contentExpiresAt,
+    );
+    expectError(
+      parseRunManifestV1(run.artifactManifest),
+      "$.retention.contentExpiresAt",
+      "semantic_conflict",
+    );
+  }
+});
+
+test("terminal runs require final manifests and nonterminal runs permit only assembling manifests", () => {
+  const finalManifest = linkedManifest(validRunManifest);
+  const assemblingManifest = linkedManifest(assemblingRunManifest);
+  const terminalStatuses = ["completed", "failed", "cancelled", "expired"] as const;
+  const nonterminalStatuses = [
+    "queued",
+    "scoping",
+    "gathering_public_sources",
+    "waiting_for_executor",
+    "challenging",
+    "synthesizing",
+    "controlling",
+    "awaiting_checkpoint",
+    "publishing",
+  ] as const;
+
+  for (const status of terminalStatuses) {
+    expectError(
+      parseResearchRunV1(runForStatus(status)),
+      "$.artifactManifest",
+      "missing_field",
+    );
+    expectError(
+      parseResearchRunV1(runForStatus(status, assemblingManifest)),
+      "$.artifactManifest.state",
+      "semantic_conflict",
+    );
+    assert.equal(
+      expectOk(parseResearchRunV1(runForStatus(status, finalManifest))).artifactManifest?.state,
+      "final",
+    );
+  }
+
+  for (const status of nonterminalStatuses) {
+    expectError(
+      parseResearchRunV1(runForStatus(status, finalManifest)),
+      "$.artifactManifest.state",
+      "semantic_conflict",
+    );
+    assert.equal(
+      expectOk(parseResearchRunV1(runForStatus(status, assemblingManifest))).artifactManifest?.state,
+      "assembling",
+    );
+  }
+
+  assert.deepEqual(
+    researchRunSchema.properties.artifactManifest,
+    { $ref: "urn:opencoven:schema:research:run-manifest:v1" },
+  );
+});
+
+test("research runs parse full run manifests and reject invalid embedded manifests", () => {
+  const manifest = linkedManifest(validRunManifest);
+  const valid = expectOk(
+    parseResearchRunV1(runForStatus("completed", manifest)),
+  );
+  assert.equal(valid.artifactManifest?.id, manifest.id);
+  assert.equal((valid.artifactManifest?.futureExtension as { preserve: boolean }).preserve, true);
+
+  const invalidManifest: Record<string, unknown> = {
+    ...manifest,
+    retention: {
+      ...(manifest.retention as Record<string, unknown>),
+      status: "deleted",
+    },
+    deletion: {
+      ...(manifest.deletion as Record<string, unknown>),
+      status: "not_scheduled",
+    },
+  };
+  invalidManifest.digest = digestProtocolObject(invalidManifest);
+  const invalid = parseResearchRunV1(runForStatus("completed", invalidManifest));
+  expectError(invalid, "$.artifactManifest.retention.status", "semantic_conflict");
+});
+
+test("research runs reject independently parsed embedded manifests above their retention ceiling", () => {
+  const overflowManifest = linkedManifest({
+    ...validRunManifest,
+    retention: {
+      ...validRunManifest.retention,
+      policy: "7-days",
+      effectivePolicy: "7-days",
+      contentExpiresAt: "2099-01-01T00:00:00.000Z",
+    },
+  });
+
+  expectError(
+    parseResearchRunV1({
+      ...runForStatus("completed", overflowManifest),
+      privacy: { ...validResearchRun.privacy, retention: "7-days" },
+    }),
+    "$.artifactManifest.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+});
+
+test("research runs reject embedded manifests for another run or context", () => {
+  const manifest = linkedManifest(validRunManifest);
+
+  const wrongRun: Record<string, unknown> = { ...manifest, runId: "run_other" };
+  wrongRun.digest = digestProtocolObject(wrongRun);
+  expectError(
+    parseResearchRunV1(runForStatus("completed", wrongRun)),
+    "$.artifactManifest.runId",
+    "semantic_conflict",
+  );
+
+  const wrongContext: Record<string, unknown> = {
+    ...manifest,
+    context: {
+      ...(manifest.context as Record<string, unknown>),
+      contextPackDigest: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    },
+    sources: (manifest.sources as Array<Record<string, unknown>>).map((source) => ({
+      ...source,
+      digest: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    })),
+  };
+  wrongContext.digest = digestProtocolObject(wrongContext);
+  expectError(
+    parseResearchRunV1(runForStatus("completed", wrongContext)),
+    "$.artifactManifest.context",
+    "semantic_conflict",
+  );
+});
+
+test("completed deletion requires a final manifest and its exact event in the complete run stream", () => {
+  const deletedRun = runWithCompletedDeletion();
+  const first = parsedEvent(1, "run.created", { status: "queued" });
+  const deletion = parsedEvent(2, "content.deleted", {
+    deletedObjectCount: 3,
+    manifestStatus: "deleted",
+  }, validResearchRun.id, "2026-08-17T19:30:00.000Z");
+  const completed = parsedEvent(3, "run.status", { status: "completed" });
+
+  assert.equal(
+    expectOk(validateRunManifestDeletionEventV1(deletedRun, [first, deletion, completed])),
+    deletedRun,
+  );
+
+  const activeRun = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("completed", linkedManifest(validRunManifest)),
+      nextEventSequence: 2,
+    }),
+  );
+  assert.equal(
+    expectOk(validateRunManifestDeletionEventV1(activeRun, [first])),
+    activeRun,
+  );
+
+  const runWithoutManifest = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("scoping"),
+      nextEventSequence: 2,
+    }),
+  );
+  assert.equal(
+    expectOk(validateRunManifestDeletionEventV1(runWithoutManifest, [first])),
+    runWithoutManifest,
+  );
+
+  const newRun = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("queued"),
+      nextEventSequence: 1,
+    }),
+  );
+  assert.equal(expectOk(validateRunManifestDeletionEventV1(newRun, [])), newRun);
+
+  const nonFinalRun: ResearchRunV1 = {
+    ...deletedRun,
+    artifactManifest: {
+      ...deletedRun.artifactManifest!,
+      state: "assembling",
+    },
+  };
+  expectError(
+    validateRunManifestDeletionEventV1(nonFinalRun, [first, deletion, completed]),
+    "$.artifactManifest.state",
+    "semantic_conflict",
+  );
+
+  expectError(
+    validateRunManifestDeletionEventV1(deletedRun, [
+      first,
+      parsedEvent(2, "run.status", { status: "completed" }),
+      completed,
+    ]),
+    "$[1].type",
+    "semantic_conflict",
+  );
+  expectError(
+    parseRunEventV1({
+      ...validRunEvent,
+      type: "content.deleted",
+      data: { manifestStatus: "deleted" },
+    }),
+    "$.data.deletedObjectCount",
+    "missing_field",
+  );
+  expectError(
+    validateRunManifestDeletionEventV1(deletedRun, [
+      first,
+      parsedEvent(2, "content.deleted", {
+        deletedObjectCount: 4,
+        manifestStatus: "deleted",
+      }),
+      completed,
+    ]),
+    "$[1].data.deletedObjectCount",
+    "semantic_conflict",
+  );
+  expectError(
+    parseRunEventV1({
+      ...validRunEvent,
+      type: "content.deleted",
+      data: { deletedObjectCount: 3 },
+    }),
+    "$.data.manifestStatus",
+    "missing_field",
+  );
+  expectError(
+    parseRunEventV1({
+      ...validRunEvent,
+      type: "content.deleted",
+      data: {
+        deletedObjectCount: 3,
+        manifestStatus: "active",
+      },
+    }),
+    "$.data.manifestStatus",
+    "invalid_value",
+  );
+});
+
+test("completed deletion event chronology is inclusive and leap-second aware", () => {
+  const first = parsedEvent(1, "run.created", { status: "queued" });
+  const completed = parsedEvent(3, "run.status", { status: "completed" });
+
+  const reversedRun = runWithCompletedDeletion();
+  for (const at of [
+    "2026-08-17T18:59:59.999999999Z",
+    "2026-08-17T20:00:00.000000001Z",
+  ]) {
+    const deletion = parsedEvent(
+      2,
+      "content.deleted",
+      { deletedObjectCount: 3, manifestStatus: "deleted" },
+      validResearchRun.id,
+      at,
+    );
+    expectError(
+      validateRunManifestDeletionEventV1(reversedRun, [first, deletion, completed]),
+      "$[1].at",
+      "semantic_conflict",
+    );
+  }
+
+  const equalAt = "2026-08-17T19:00:00.000Z";
+  const equalRun = runWithCompletedDeletion(4, 2, equalAt, equalAt);
+  const equalDeletion = parsedEvent(
+    2,
+    "content.deleted",
+    { deletedObjectCount: 3, manifestStatus: "deleted" },
+    validResearchRun.id,
+    equalAt,
+  );
+  assert.equal(
+    expectOk(validateRunManifestDeletionEventV1(equalRun, [first, equalDeletion, completed])),
+    equalRun,
+  );
+
+  const leapRun = runWithCompletedDeletion(
+    4,
+    2,
+    "2016-12-31T23:59:59.999999999Z",
+    "2017-01-01T00:00:00Z",
+    "2016-12-31T23:59:58Z",
+    "2016-12-31T23:59:59Z",
+  );
+  const leapDeletion = parsedEvent(
+    2,
+    "content.deleted",
+    { deletedObjectCount: 3, manifestStatus: "deleted" },
+    validResearchRun.id,
+    "2016-12-31T23:59:60.5Z",
+  );
+  assert.equal(
+    expectOk(validateRunManifestDeletionEventV1(leapRun, [first, leapDeletion, completed])),
+    leapRun,
+  );
+});
+
+test("deletion event composition rejects incomplete, malformed, and wrong-run streams", () => {
+  const deletedRun = runWithCompletedDeletion();
+  const first = parsedEvent(1, "run.created", { status: "queued" });
+  const deletion = parsedEvent(2, "content.deleted", {
+    deletedObjectCount: 3,
+    manifestStatus: "deleted",
+  });
+  const completed = parsedEvent(3, "run.status", { status: "completed" });
+
+  expectError(
+    validateRunManifestDeletionEventV1(deletedRun, [first, deletion]),
+    "$",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestDeletionEventV1(deletedRun, [
+      first,
+      deletion,
+      completed,
+      parsedEvent(4, "run.status", { status: "completed" }),
+    ]),
+    "$",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestDeletionEventV1(deletedRun, [
+      { ...first, runId: "run_other" },
+      { ...deletion, runId: "run_other" },
+      { ...completed, runId: "run_other" },
+    ]),
+    "$[0].runId",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestDeletionEventV1(deletedRun, [
+      first,
+      { ...deletion, sequence: 1 },
+      completed,
+    ]),
+    "$[1].sequence",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestDeletionEventV1(deletedRun, [
+      first,
+      { ...deletion, sequence: 3 },
+      completed,
+    ]),
+    "$[1].sequence",
+    "semantic_conflict",
+  );
+
+  const wrongReceiptRun = runWithCompletedDeletion(4, 4);
+  expectError(
+    validateRunManifestDeletionEventV1(wrongReceiptRun, [first, deletion, completed]),
+    "$.artifactManifest.deletion.eventSequence",
+    "semantic_conflict",
+  );
+
+  const runWithoutManifest = expectOk(
+    parseResearchRunV1({
+      ...runForStatus("scoping"),
+      nextEventSequence: 3,
+    }),
+  );
+  expectError(
+    validateRunManifestDeletionEventV1(runWithoutManifest, [first]),
+    "$",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestDeletionEventV1(runWithoutManifest, [
+      first,
+      { ...parsedEvent(2, "run.status", { status: "scoping" }), sequence: 3 },
+    ]),
+    "$[1].sequence",
+    "semantic_conflict",
+  );
+});
+
+test("run composition rejects exotic option shells before reading protocol inputs", () => {
+  const params = new URLSearchParams("manifestHistory=value");
+  Object.setPrototypeOf(params, Object.prototype);
+  Object.freeze(params);
+
+  expectError(
+    validateResearchRunContextPackV1(
+      {} as ResearchRunV1,
+      undefined,
+      params as unknown as Parameters<
+        typeof validateResearchRunContextPackV1
+      >[2],
+    ),
+    "$.options",
+    "invalid_value",
+  );
+
+  const options = Object.defineProperty({}, "manifestHistory", {
+    enumerable: true,
+    get() {
+      throw new Error("option getter must not execute");
+    },
+  });
+  expectError(
+    validateResearchRunContextPackV1(
+      {} as ResearchRunV1,
+      undefined,
+      options,
+    ),
+    "$.options",
+    "invalid_value",
+  );
+});

--- a/src/lib/research-protocol/research-run.ts
+++ b/src/lib/research-protocol/research-run.ts
@@ -1,0 +1,2092 @@
+import {
+  compareUtcTimestamps,
+  copyProtocolJsonValue,
+  fail,
+  isOpaqueId,
+  isRecord,
+  isSha256,
+  isUtcTimestamp,
+  parseResearchContextBindingV1,
+  pass,
+  RETENTION_ORDER,
+  retentionDoesNotExceed,
+  type ProtocolParseResult,
+  type ResearchContextBindingV1,
+  type RetentionPolicyV1,
+  type UnknownFields,
+} from "./common.ts";
+import {
+  parseContextPackV1,
+  type ContextPackV1,
+} from "./context-pack.ts";
+import { canonicalJson } from "./digest.ts";
+import {
+  parseEmbeddedRunManifestCandidateV1,
+  parseRunManifestV1,
+  validateRunManifestRevisionV1,
+  type ManifestRevisionOptions,
+  type RunManifestV1,
+} from "./run-manifest.ts";
+import {
+  validateSafeDeletionExtensionKeys,
+} from "./privacy-extension.ts";
+import {
+  snapshotProtocolArrayElements,
+  snapshotProtocolObjectProperties,
+} from "./option-shell.ts";
+
+const RESEARCH_RUN_SCHEMA = "opencoven.research-run/v1";
+const RESEARCH_RUN_SCHEMA_RE = /^opencoven\.research-run\/v(\d+)$/;
+const RUN_EVENT_SCHEMA = "opencoven.run-event/v1";
+const RUN_EVENT_SCHEMA_RE = /^opencoven\.run-event\/v(\d+)$/;
+const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
+
+const EXECUTION_LOCATIONS = ["local", "hosted"] as const;
+const MODEL_EXECUTIONS = ["cave-device", "user-hosted-executor"] as const;
+const MODEL_SELECTIONS = ["resolve-at-run-start", "pinned"] as const;
+const EXECUTION_STRATEGIES = ["single-agent", "orchestrator-workers"] as const;
+const RETENTION_POLICIES = ["run-only", "7-days", "project"] as const;
+const RUN_STATUSES = [
+  "queued",
+  "scoping",
+  "gathering_public_sources",
+  "waiting_for_executor",
+  "challenging",
+  "synthesizing",
+  "controlling",
+  "awaiting_checkpoint",
+  "publishing",
+  "completed",
+  "failed",
+  "cancelled",
+  "expired",
+] as const;
+const WAITING_REASONS = ["executor", "checkpoint", "provider-attention"] as const;
+const WAITING_PHASES = ["scope", "challenge", "synthesize", "control"] as const;
+const CHECKPOINT_WAITING_STATUSES = new Set([
+  "scoping",
+  "gathering_public_sources",
+  "challenging",
+  "synthesizing",
+  "controlling",
+  "awaiting_checkpoint",
+  "publishing",
+]);
+const TERMINAL_RUN_STATUSES = new Set(["completed", "failed", "cancelled", "expired"]);
+const RUN_EVENT_TYPES = [
+  "run.created",
+  "run.status",
+  "phase.started",
+  "phase.completed",
+  "model-task.available",
+  "model-task.leased",
+  "model-task.completed",
+  "checkpoint.required",
+  "artifact.registered",
+  "run.completed",
+  "run.failed",
+  "run.cancelled",
+  "retention.changed",
+  "content.deleted",
+] as const;
+const CONTENT_DELETED_DATA_FIELDS = new Set([
+  "deletedObjectCount",
+  "manifestStatus",
+]);
+const RUN_EVENT_FIELDS = new Set([
+  "schema",
+  "runId",
+  "sequence",
+  "type",
+  "at",
+  "data",
+]);
+
+type ResearchModelBindingV1 = {
+  familiarId: string;
+  selection: "resolve-at-run-start" | "pinned";
+  model?: string;
+} & UnknownFields;
+
+type ResearchAcceptedTopicV1 = {
+  proposalId?: string;
+  question: string;
+  editedByUser: boolean;
+} & UnknownFields;
+
+type ResearchRunFailureV1 = {
+  code: string;
+  message: string;
+  retryable: boolean;
+} & UnknownFields;
+
+export type ResearchExecutionProfileV1 = {
+  location: "local" | "hosted";
+  modelExecution: "cave-device" | "user-hosted-executor";
+  modelBinding: ResearchModelBindingV1;
+  strategy: "single-agent" | "orchestrator-workers";
+} & UnknownFields;
+
+export type ResearchPrivacyPolicyV1 = {
+  remoteQueries: boolean;
+  remoteContent: boolean;
+  artifactContentSync: boolean;
+  retention: "run-only" | "7-days" | "project";
+  allowMemoryPromotion: false;
+} & UnknownFields;
+
+export type ResearchBounds = {
+  wallClockMinutes: number;
+  maxIterations: number;
+  sourceTarget: number;
+  maxSpendUsd?: number;
+  checkpointEvery: number;
+  stopWhenCostUnavailable: boolean;
+} & UnknownFields;
+
+export type ResearchRunStatusV1 = (typeof RUN_STATUSES)[number];
+type WaitingReasonV1 = (typeof WAITING_REASONS)[number];
+type WaitingForPhaseV1 = (typeof WAITING_PHASES)[number];
+type RunEventTypeV1 = (typeof RUN_EVENT_TYPES)[number];
+
+export type ResearchRunV1 = {
+  schema: "opencoven.research-run/v1";
+  id: string;
+  tenantOpaqueId?: string;
+  context?: ResearchContextBindingV1;
+  acceptedTopic: ResearchAcceptedTopicV1;
+  execution: ResearchExecutionProfileV1;
+  privacy: ResearchPrivacyPolicyV1;
+  bounds: ResearchBounds;
+  status: ResearchRunStatusV1;
+  waitingReason?: WaitingReasonV1;
+  waitingForPhase?: WaitingForPhaseV1;
+  createdAt: string;
+  updatedAt: string;
+  nextEventSequence: number;
+  artifactManifest?: RunManifestV1;
+  failure?: ResearchRunFailureV1;
+} & UnknownFields;
+
+export type ResearchRunContextPackValidationOptionsV1 = {
+  /** Serialized revision-1-to-tip chain, including the embedded manifest. */
+  manifestHistory?: readonly unknown[];
+  /** Explicit fresh-consent authority keyed to each lengthening successor. */
+  manifestRevisionOptions?: readonly ResearchRunManifestRevisionOptionsV1[];
+};
+
+export type ResearchRunManifestRevisionOptionsV1 = Omit<
+  ManifestRevisionOptions,
+  "freshConsent" | "freshConsentAt"
+> & {
+  successorRevision: number;
+  successorDigest: string;
+  freshConsent: true;
+  freshConsentAt: string;
+};
+
+export type RunEventV1 = {
+  schema: "opencoven.run-event/v1";
+  runId: string;
+  sequence: number;
+  type: RunEventTypeV1;
+  at: string;
+  data: Record<string, unknown>;
+} & UnknownFields;
+
+function childPath(path: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${path}.${key}`
+    : `${path}[${JSON.stringify(key)}]`;
+}
+
+function indexPath(path: string, index: number): string {
+  return `${path}[${index}]`;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function contextBindingsMatch(
+  runContext: ResearchContextBindingV1 | undefined,
+  manifestContext: ResearchContextBindingV1 | undefined,
+): boolean {
+  if (runContext === undefined || manifestContext === undefined) {
+    return runContext === manifestContext;
+  }
+  return (
+    runContext.contextPackId === manifestContext.contextPackId &&
+    runContext.contextPackDigest === manifestContext.contextPackDigest &&
+    runContext.topicProposalId === manifestContext.topicProposalId
+  );
+}
+
+function prefixProtocolErrorPath(path: string, prefix: string): string {
+  return path === "$" ? prefix : `${prefix}${path.slice(1)}`;
+}
+
+type ParsedReplayRevisionOptions = {
+  index: number;
+  successorRevision: number;
+  successorDigest: string;
+  options: ManifestRevisionOptions;
+};
+
+const REPLAY_REVISION_OPTION_FIELDS = new Set([
+  "successorRevision",
+  "successorDigest",
+  "freshConsent",
+  "freshConsentAt",
+  "contextConsent",
+]);
+
+function parseReplayRevisionOptions(
+  value: readonly ResearchRunManifestRevisionOptionsV1[] | undefined,
+): ProtocolParseResult<ParsedReplayRevisionOptions[]> {
+  if (value === undefined) return pass([]);
+  const wireValue = snapshotProtocolArrayElements(
+    value,
+    "$.manifestRevisionOptions",
+    "manifestRevisionOptions",
+  );
+  if (!wireValue.ok) return wireValue;
+
+  const parsed: ParsedReplayRevisionOptions[] = [];
+  const revisions = new Set<number>();
+  const digests = new Set<string>();
+  for (const [index, entryValue] of wireValue.value.entries()) {
+    const entryPath = `$.manifestRevisionOptions[${index}]`;
+    const entry = snapshotProtocolObjectProperties(
+      entryValue,
+      entryPath,
+      "A manifest revision option",
+    );
+    if (!entry.ok) return entry;
+    const entryRecord = entry.value;
+    for (const key of Object.keys(entryRecord)) {
+      if (!REPLAY_REVISION_OPTION_FIELDS.has(key)) {
+        return fail(
+          "invalid_value",
+          childPath(entryPath, key),
+          `Unknown manifest revision option field ${key}`,
+        );
+      }
+    }
+
+    const successorRevision = entryRecord.successorRevision;
+    if (
+      typeof successorRevision !== "number" ||
+      !Number.isSafeInteger(successorRevision) ||
+      successorRevision < 2
+    ) {
+      return fail(
+        "invalid_value",
+        `${entryPath}.successorRevision`,
+        "successorRevision must be a safe integer of at least 2",
+      );
+    }
+    const successorDigest = entryRecord.successorDigest;
+    if (!isSha256(successorDigest)) {
+      return fail(
+        "invalid_value",
+        `${entryPath}.successorDigest`,
+        "successorDigest must be a lowercase SHA-256 digest",
+      );
+    }
+    if (revisions.has(successorRevision)) {
+      return fail(
+        "semantic_conflict",
+        `${entryPath}.successorRevision`,
+        "Each successor revision may have only one replay option",
+      );
+    }
+    if (digests.has(successorDigest)) {
+      return fail(
+        "semantic_conflict",
+        `${entryPath}.successorDigest`,
+        "Each successor digest may have only one replay option",
+      );
+    }
+    revisions.add(successorRevision);
+    digests.add(successorDigest);
+
+    const revisionOptions: ManifestRevisionOptions = {};
+    if (Object.hasOwn(entryRecord, "freshConsent")) {
+      if (typeof entryRecord.freshConsent !== "boolean") {
+        return fail(
+          "invalid_type",
+          `${entryPath}.freshConsent`,
+          "freshConsent must be a boolean",
+        );
+      }
+      revisionOptions.freshConsent = entryRecord.freshConsent;
+    }
+    if (Object.hasOwn(entryRecord, "freshConsentAt")) {
+      if (!isUtcTimestamp(entryRecord.freshConsentAt)) {
+        return fail(
+          "invalid_value",
+          `${entryPath}.freshConsentAt`,
+          "freshConsentAt must be a UTC RFC 3339 timestamp",
+        );
+      }
+      revisionOptions.freshConsentAt = entryRecord.freshConsentAt;
+    }
+    if (Object.hasOwn(entryRecord, "contextConsent")) {
+      if (
+        typeof entryRecord.contextConsent !== "string" ||
+        !RETENTION_POLICIES.includes(
+          entryRecord.contextConsent as RetentionPolicyV1,
+        )
+      ) {
+        return fail(
+          "invalid_value",
+          `${entryPath}.contextConsent`,
+          "contextConsent must be run-only, 7-days, or project",
+        );
+      }
+      revisionOptions.contextConsent =
+        entryRecord.contextConsent as RetentionPolicyV1;
+    }
+
+    parsed.push({
+      index,
+      successorRevision,
+      successorDigest,
+      options: revisionOptions,
+    });
+  }
+  return pass(parsed);
+}
+
+function retentionLengtheningPath(
+  previous: RunManifestV1,
+  next: RunManifestV1,
+): "$.retention.effectivePolicy" | "$.retention.contentExpiresAt" | undefined {
+  if (
+    RETENTION_ORDER[next.retention.effectivePolicy] >
+    RETENTION_ORDER[previous.retention.effectivePolicy]
+  ) {
+    return "$.retention.effectivePolicy";
+  }
+  const previousDeadline = previous.retention.contentExpiresAt;
+  const nextDeadline = next.retention.contentExpiresAt;
+  if (
+    previousDeadline !== null &&
+    (
+      nextDeadline === null ||
+      compareUtcTimestamps(nextDeadline, previousDeadline) > 0
+    )
+  ) {
+    return "$.retention.contentExpiresAt";
+  }
+  return undefined;
+}
+
+function validateReplayConsentCreationChronology(
+  entry: ParsedReplayRevisionOptions,
+  run: ResearchRunV1,
+  contextPack: ContextPackV1 | undefined,
+  previous: RunManifestV1,
+  successor: RunManifestV1,
+): ProtocolParseResult<void> {
+  const entryPath = `$.manifestRevisionOptions[${entry.index}]`;
+  if (
+    entry.options.freshConsent !== true ||
+    entry.options.freshConsentAt === undefined
+  ) {
+    return fail(
+      "semantic_conflict",
+      `${entryPath}.freshConsent`,
+      "A lengthening replay transition requires explicit fresh consent",
+    );
+  }
+  if (
+    compareUtcTimestamps(entry.options.freshConsentAt, run.createdAt) < 0 ||
+    (
+      contextPack !== undefined &&
+      compareUtcTimestamps(
+        entry.options.freshConsentAt,
+        contextPack.createdAt,
+      ) < 0
+    )
+  ) {
+    return fail(
+      "semantic_conflict",
+      `${entryPath}.freshConsentAt`,
+      "Fresh consent must not predate run or Context Pack creation",
+    );
+  }
+  if (
+    contextPack !== undefined &&
+    entry.options.contextConsent !== contextPack.consent.retention
+  ) {
+    return fail(
+      "semantic_conflict",
+      `${entryPath}.contextConsent`,
+      "Replay contextConsent must equal the authenticated Context Pack retention ceiling",
+    );
+  }
+  const latestPriorAuthority =
+    previous.deletion.requestedAt !== undefined &&
+    compareUtcTimestamps(
+      previous.deletion.requestedAt,
+      previous.retention.updatedAt,
+    ) > 0
+      ? previous.deletion.requestedAt
+      : previous.retention.updatedAt;
+  if (
+    compareUtcTimestamps(
+      entry.options.freshConsentAt,
+      latestPriorAuthority,
+    ) <= 0 ||
+    compareUtcTimestamps(
+      entry.options.freshConsentAt,
+      successor.retention.updatedAt,
+    ) > 0
+  ) {
+    return fail(
+      "semantic_conflict",
+      `${entryPath}.freshConsentAt`,
+      "Fresh consent must postdate prior retention and deletion-request authority and be no later than the new revision",
+    );
+  }
+  return pass(undefined);
+}
+
+function validateManifestRunChronology(
+  manifest: RunManifestV1,
+  runCreatedAt: string,
+  runUpdatedAt: string,
+): ProtocolParseResult<void> {
+  const timestamps: Array<readonly [string, string]> = [
+    [manifest.createdAt, "$.createdAt"],
+  ];
+  if (manifest.finalizedAt !== undefined) {
+    timestamps.push([manifest.finalizedAt, "$.finalizedAt"]);
+  }
+  for (const [index, source] of manifest.sources.entries()) {
+    if (source.kind === "public-evidence") {
+      timestamps.push([source.fetchedAt, `$.sources[${index}].fetchedAt`]);
+    }
+  }
+  for (const [index, artifact] of manifest.artifacts.entries()) {
+    timestamps.push([
+      artifact.createdAt,
+      `$.artifacts[${index}].createdAt`,
+    ]);
+  }
+  timestamps.push([manifest.retention.updatedAt, "$.retention.updatedAt"]);
+  if (manifest.deletion.requestedAt !== undefined) {
+    timestamps.push([
+      manifest.deletion.requestedAt,
+      "$.deletion.requestedAt",
+    ]);
+  }
+  if (manifest.deletion.completedAt !== undefined) {
+    timestamps.push([
+      manifest.deletion.completedAt,
+      "$.deletion.completedAt",
+    ]);
+  }
+
+  for (const [timestamp, path] of timestamps) {
+    if (
+      compareUtcTimestamps(timestamp, runCreatedAt) < 0 ||
+      compareUtcTimestamps(timestamp, runUpdatedAt) > 0
+    ) {
+      return fail(
+        "semantic_conflict",
+        path,
+        "Authoritative timestamp must fall within the enclosing run chronology",
+      );
+    }
+  }
+  return pass(undefined);
+}
+
+function validateManifestRunAuthority(
+  manifest: RunManifestV1,
+  run: ResearchRunV1,
+  contextPack: ContextPackV1 | undefined,
+): ProtocolParseResult<void> {
+  if (manifest.runId !== run.id) {
+    return fail(
+      "semantic_conflict",
+      "$.runId",
+      "Manifest runId must match the enclosing run id",
+    );
+  }
+  const chronology = validateManifestRunChronology(
+    manifest,
+    run.createdAt,
+    run.updatedAt,
+  );
+  if (!chronology.ok) return chronology;
+  for (const [index, execution] of manifest.modelExecutions.entries()) {
+    if (
+      run.execution.strategy === "single-agent" &&
+      execution.receipt.familiarId !== run.execution.modelBinding.familiarId
+    ) {
+      return fail(
+        "semantic_conflict",
+        `$.modelExecutions[${index}].receipt.familiarId`,
+        "Single-agent manifest receipt familiarId must equal the selected run familiarId",
+      );
+    }
+    if (
+      run.execution.modelBinding.selection === "pinned" &&
+      execution.receipt.effectiveModel !== run.execution.modelBinding.model
+    ) {
+      return fail(
+        "semantic_conflict",
+        `$.modelExecutions[${index}].receipt.effectiveModel`,
+        "Manifest receipt effectiveModel must equal the pinned run model",
+      );
+    }
+  }
+  if (!contextBindingsMatch(run.context, manifest.context)) {
+    return fail(
+      "semantic_conflict",
+      "$.context",
+      "Manifest context must match the enclosing run context",
+    );
+  }
+  if (
+    contextPack !== undefined &&
+    (
+      manifest.context?.contextPackId !== contextPack.id ||
+      manifest.context.contextPackDigest !== contextPack.digest
+    )
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.context",
+      "Manifest context must identify the composed Context Pack",
+    );
+  }
+  if (manifest.retention.policy !== run.privacy.retention) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.policy",
+      "Manifest retention policy must match the original run privacy retention",
+    );
+  }
+  const retentionCeiling =
+    contextPack?.consent.retention ?? run.privacy.retention;
+  if (
+    !retentionDoesNotExceed(
+      manifest.retention.effectivePolicy,
+      retentionCeiling,
+    )
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.effectivePolicy",
+      "Manifest effective retention exceeds enclosing consent",
+    );
+  }
+  const contentSyncIndex = manifest.artifacts.findIndex(
+    (artifact) => artifact.contentSync !== "not-requested",
+  );
+  if (
+    contentSyncIndex >= 0 &&
+    (
+      !run.privacy.artifactContentSync ||
+      contextPack?.consent.artifactContentSync === false
+    )
+  ) {
+    return fail(
+      "semantic_conflict",
+      `$.artifacts[${contentSyncIndex}].contentSync`,
+      "Requested artifact content sync requires enclosing artifactContentSync consent",
+    );
+  }
+  return pass(undefined);
+}
+
+function validateEmbeddedManifestAuthority(
+  manifest: RunManifestV1,
+  run: ResearchRunV1,
+  contextPack: ContextPackV1 | undefined,
+  history: readonly unknown[] | undefined,
+  revisionOptions: readonly ParsedReplayRevisionOptions[],
+): ProtocolParseResult<RunManifestV1> {
+  const embedded = parseEmbeddedRunManifestCandidateV1(manifest);
+  if (!embedded.ok) {
+    return {
+      ok: false,
+      error: {
+        ...embedded.error,
+        path: prefixProtocolErrorPath(
+          embedded.error.path,
+          "$.artifactManifest",
+        ),
+      },
+    };
+  }
+  if (embedded.value.revision === 1) {
+    if (revisionOptions.length > 0) {
+      return fail(
+        "semantic_conflict",
+        `$.manifestRevisionOptions[${revisionOptions[0]!.index}].successorRevision`,
+        "Manifest replay options do not identify a history transition",
+      );
+    }
+    const standalone = parseRunManifestV1(embedded.value);
+    if (!standalone.ok) {
+      return {
+        ok: false,
+        error: {
+          ...standalone.error,
+          path: prefixProtocolErrorPath(
+            standalone.error.path,
+            "$.artifactManifest",
+          ),
+        },
+      };
+    }
+    const binding = validateManifestRunAuthority(
+      standalone.value,
+      run,
+      contextPack,
+    );
+    if (!binding.ok) {
+      return {
+        ok: false,
+        error: {
+          ...binding.error,
+          path: prefixProtocolErrorPath(
+            binding.error.path,
+            "$.artifactManifest",
+          ),
+        },
+      };
+    }
+    return standalone;
+  }
+  if (history === undefined || history.length === 0) {
+    return fail(
+      "semantic_conflict",
+      "$.artifactManifest.revision",
+      "Embedded manifest revisions after 1 require revision-1-rooted manifest history",
+    );
+  }
+
+  const rootCandidate = parseEmbeddedRunManifestCandidateV1(history[0]);
+  if (!rootCandidate.ok) {
+    return {
+      ok: false,
+      error: {
+        ...rootCandidate.error,
+        path: prefixProtocolErrorPath(
+          rootCandidate.error.path,
+          "$.manifestHistory[0]",
+        ),
+      },
+    };
+  }
+  if (rootCandidate.value.revision !== 1) {
+    return fail(
+      "semantic_conflict",
+      "$.manifestHistory[0].revision",
+      "Manifest history must begin with revision 1",
+    );
+  }
+  const root = parseRunManifestV1(history[0]);
+  if (!root.ok) {
+    return {
+      ok: false,
+      error: {
+        ...root.error,
+        path: prefixProtocolErrorPath(root.error.path, "$.manifestHistory[0]"),
+      },
+    };
+  }
+  const rootBinding = validateManifestRunAuthority(
+    root.value,
+    run,
+    contextPack,
+  );
+  if (!rootBinding.ok) {
+    return {
+      ok: false,
+      error: {
+        ...rootBinding.error,
+        path: prefixProtocolErrorPath(
+          rootBinding.error.path,
+          "$.manifestHistory[0]",
+        ),
+      },
+    };
+  }
+
+  let replayed = root.value;
+  const optionsByRevision = new Map(
+    revisionOptions.map((entry) => [entry.successorRevision, entry]),
+  );
+  const optionsByDigest = new Map(
+    revisionOptions.map((entry) => [entry.successorDigest, entry]),
+  );
+  const consumedOptions = new Set<number>();
+  for (let index = 1; index < history.length; index += 1) {
+    const candidate = parseEmbeddedRunManifestCandidateV1(history[index]);
+    if (!candidate.ok) {
+      return {
+        ok: false,
+        error: {
+          ...candidate.error,
+          path: prefixProtocolErrorPath(
+            candidate.error.path,
+            `$.manifestHistory[${index}]`,
+          ),
+        },
+      };
+    }
+    const revisionEntry = optionsByRevision.get(candidate.value.revision);
+    const digestEntry = optionsByDigest.get(candidate.value.digest);
+    if (
+      revisionEntry !== undefined &&
+      revisionEntry.successorDigest !== candidate.value.digest
+    ) {
+      return fail(
+        "semantic_conflict",
+        `$.manifestRevisionOptions[${revisionEntry.index}].successorDigest`,
+        "Replay option successorDigest does not match its history revision",
+      );
+    }
+    if (
+      digestEntry !== undefined &&
+      digestEntry.successorRevision !== candidate.value.revision
+    ) {
+      return fail(
+        "semantic_conflict",
+        `$.manifestRevisionOptions[${digestEntry.index}].successorRevision`,
+        "Replay option successorRevision does not match its history digest",
+      );
+    }
+    const transitionOptions =
+      revisionEntry !== undefined && revisionEntry === digestEntry
+        ? revisionEntry
+        : undefined;
+    const lengtheningPath = retentionLengtheningPath(
+      replayed,
+      candidate.value,
+    );
+    if (lengtheningPath === undefined && transitionOptions !== undefined) {
+      return fail(
+        "semantic_conflict",
+        `$.manifestRevisionOptions[${transitionOptions.index}].successorRevision`,
+        "Replay options are not allowed for a non-lengthening transition",
+      );
+    }
+    if (lengtheningPath !== undefined && transitionOptions === undefined) {
+      return fail(
+        "semantic_conflict",
+        prefixProtocolErrorPath(
+          lengtheningPath,
+          `$.manifestHistory[${index}]`,
+        ),
+        "A lengthening history transition requires its own explicit replay consent",
+      );
+    }
+
+    let directOptions: ManifestRevisionOptions =
+      contextPack === undefined
+        ? {}
+        : { contextConsent: contextPack.consent.retention };
+    if (transitionOptions !== undefined) {
+      const chronology = validateReplayConsentCreationChronology(
+        transitionOptions,
+        run,
+        contextPack,
+        replayed,
+        candidate.value,
+      );
+      if (!chronology.ok) return chronology;
+      directOptions = transitionOptions.options;
+      consumedOptions.add(transitionOptions.index);
+    }
+    const next = validateRunManifestRevisionV1(
+      replayed,
+      candidate.value,
+      directOptions,
+    );
+    if (!next.ok) {
+      return {
+        ok: false,
+        error: {
+          ...next.error,
+          path: prefixProtocolErrorPath(
+            next.error.path,
+            `$.manifestHistory[${index}]`,
+          ),
+        },
+      };
+    }
+    replayed = next.value;
+    const binding = validateManifestRunAuthority(
+      replayed,
+      run,
+      contextPack,
+    );
+    if (!binding.ok) {
+      return {
+        ok: false,
+        error: {
+          ...binding.error,
+          path: prefixProtocolErrorPath(
+            binding.error.path,
+            `$.manifestHistory[${index}]`,
+          ),
+        },
+      };
+    }
+  }
+
+  const unusedOption = revisionOptions.find(
+    (entry) => !consumedOptions.has(entry.index),
+  );
+  if (unusedOption !== undefined) {
+    return fail(
+      "semantic_conflict",
+      `$.manifestRevisionOptions[${unusedOption.index}].successorRevision`,
+      "Replay option does not identify a lengthening history transition",
+    );
+  }
+  if (replayed.digest !== embedded.value.digest) {
+    return fail(
+      "semantic_conflict",
+      "$.artifactManifest.digest",
+      "Manifest history tip must match the embedded artifactManifest digest",
+    );
+  }
+  if (canonicalJson(replayed) !== canonicalJson(embedded.value)) {
+    return fail(
+      "semantic_conflict",
+      "$.artifactManifest",
+      "Manifest history tip must canonically equal the embedded artifactManifest",
+    );
+  }
+  return pass(replayed);
+}
+
+/**
+ * Revalidates and detaches the supplied Context Pack before composition.
+ * Run-field errors use run JSON paths; pack-only errors use the synthetic
+ * `$.contextPack` path.
+ * Parsing a context-bound run is provisional; callers must compose it with its
+ * Context Pack here before use, including when it embeds a manifest.
+ */
+export function validateResearchRunContextPackV1(
+  run: ResearchRunV1,
+  contextPack?: ContextPackV1,
+  options: ResearchRunContextPackValidationOptionsV1 = {},
+): ProtocolParseResult<ResearchRunV1> {
+  const wireOptions = snapshotProtocolObjectProperties(
+    options,
+    "$.options",
+    "Research Run composition options",
+  );
+  if (!wireOptions.ok) return wireOptions;
+  for (const key of Object.keys(wireOptions.value)) {
+    if (key !== "manifestHistory" && key !== "manifestRevisionOptions") {
+      return fail(
+        "invalid_value",
+        childPath("$.options", key),
+        `Unknown Research Run composition option ${key}`,
+      );
+    }
+  }
+  let manifestHistory: readonly unknown[] | undefined;
+  if (Object.hasOwn(wireOptions.value, "manifestHistory")) {
+    const history = snapshotProtocolArrayElements(
+      wireOptions.value.manifestHistory,
+      "$.manifestHistory",
+      "manifestHistory",
+    );
+    if (!history.ok) return history;
+    manifestHistory = history.value;
+  }
+  const revisionOptions = parseReplayRevisionOptions(
+    wireOptions.value.manifestRevisionOptions as
+      | readonly ResearchRunManifestRevisionOptionsV1[]
+      | undefined,
+  );
+  if (!revisionOptions.ok) return revisionOptions;
+  if (!run.context) {
+    if (contextPack !== undefined) {
+      return fail(
+        "semantic_conflict",
+        "$.context",
+        "A Context Pack must not be supplied when the run has no context binding",
+      );
+    }
+    if (run.artifactManifest) {
+      const authority = validateEmbeddedManifestAuthority(
+        run.artifactManifest,
+        run,
+        undefined,
+        manifestHistory,
+        revisionOptions.value,
+      );
+      if (!authority.ok) return authority;
+      return pass({
+        ...run,
+        artifactManifest: authority.value,
+      });
+    }
+    if (revisionOptions.value.length > 0) {
+      return fail(
+        "semantic_conflict",
+        `$.manifestRevisionOptions[${revisionOptions.value[0]!.index}].successorRevision`,
+        "Manifest replay options require an embedded manifest history",
+      );
+    }
+    return pass(run);
+  }
+  if (contextPack === undefined) {
+    return fail(
+      "semantic_conflict",
+      "$.context",
+      "A run context binding requires its parsed Context Pack",
+    );
+  }
+  const parsedContextPack = parseContextPackV1(contextPack);
+  if (!parsedContextPack.ok) {
+    return {
+      ok: false,
+      error: {
+        ...parsedContextPack.error,
+        path:
+          parsedContextPack.error.path === "$"
+            ? "$.contextPack"
+            : `$.contextPack${parsedContextPack.error.path.slice(1)}`,
+      },
+    };
+  }
+  const trustedContextPack = parsedContextPack.value;
+  if (run.context.contextPackId !== trustedContextPack.id) {
+    return fail(
+      "semantic_conflict",
+      "$.context.contextPackId",
+      "Run contextPackId must match the Context Pack id",
+    );
+  }
+  if (run.context.contextPackDigest !== trustedContextPack.digest) {
+    return fail(
+      "semantic_conflict",
+      "$.context.contextPackDigest",
+      "Run contextPackDigest must match the Context Pack digest",
+    );
+  }
+  if (trustedContextPack.purpose !== "research-run") {
+    return fail(
+      "semantic_conflict",
+      "$.contextPack.purpose",
+      "Context Pack purpose must be research-run",
+    );
+  }
+  if (!trustedContextPack.policy.allowedPurposes.includes("research-run")) {
+    return fail(
+      "semantic_conflict",
+      "$.contextPack.policy.allowedPurposes",
+      "Context Pack allowedPurposes must include research-run",
+    );
+  }
+
+  for (const [runKey, consentKey] of [
+    ["remoteQueries", "allowRemoteQueries"],
+    ["remoteContent", "allowRemoteContent"],
+    ["artifactContentSync", "artifactContentSync"],
+  ] as const) {
+    if (run.privacy[runKey] && !trustedContextPack.consent[consentKey]) {
+      return fail(
+        "semantic_conflict",
+        `$.privacy.${runKey}`,
+        `${runKey} exceeds Context Pack consent`,
+      );
+    }
+  }
+  if (
+    !retentionDoesNotExceed(
+      run.privacy.retention,
+      trustedContextPack.consent.retention,
+    )
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.privacy.retention",
+      "Run retention exceeds Context Pack consent",
+    );
+  }
+  if (run.artifactManifest) {
+    const authority = validateEmbeddedManifestAuthority(
+      run.artifactManifest,
+      run,
+      trustedContextPack,
+      manifestHistory,
+      revisionOptions.value,
+    );
+    if (!authority.ok) return authority;
+    return pass({
+      ...run,
+      artifactManifest: authority.value,
+    });
+  }
+
+  if (revisionOptions.value.length > 0) {
+    return fail(
+      "semantic_conflict",
+      `$.manifestRevisionOptions[${revisionOptions.value[0]!.index}].successorRevision`,
+      "Manifest replay options require an embedded manifest history",
+    );
+  }
+  return pass(run);
+}
+
+function parseObject(value: unknown, path: string): ProtocolParseResult<Record<string, unknown>> {
+  if (!isRecord(value)) {
+    return fail("invalid_type", path, "Expected an object");
+  }
+  return pass(value);
+}
+
+function parseRequiredField(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): ProtocolParseResult<unknown> {
+  if (!hasOwn(record, key)) {
+    return fail("missing_field", childPath(path, key), `Missing required field ${key}`);
+  }
+  return pass(record[key]);
+}
+
+function parseString(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  return pass(value);
+}
+
+function parseBoolean(value: unknown, path: string, label: string): ProtocolParseResult<boolean> {
+  if (typeof value !== "boolean") {
+    return fail("invalid_type", path, `${label} must be a boolean`);
+  }
+  return pass(value);
+}
+
+function parseEnumValue<const T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  path: string,
+  label: string,
+): ProtocolParseResult<T[number]> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!allowed.includes(value as T[number])) {
+    return fail("invalid_value", path, `${label} must be one of ${allowed.join(", ")}`);
+  }
+  return pass(value as T[number]);
+}
+
+function parseSafeIntegerInRange(
+  value: unknown,
+  path: string,
+  label: string,
+  minimum: number,
+  maximum: number,
+): ProtocolParseResult<number> {
+  if (typeof value !== "number") {
+    return fail("invalid_type", path, `${label} must be a number`);
+  }
+  if (!Number.isSafeInteger(value)) {
+    return fail("invalid_value", path, `${label} must be a safe integer`);
+  }
+  if (value < minimum || value > maximum) {
+    return fail("invalid_value", path, `${label} must be between ${minimum} and ${maximum}`);
+  }
+  return pass(value);
+}
+
+function parsePositiveSafeInteger(value: unknown, path: string, label: string): ProtocolParseResult<number> {
+  return parseSafeIntegerInRange(value, path, label, 1, MAX_SAFE_INTEGER);
+}
+
+function parseNonNegativeFiniteNumber(
+  value: unknown,
+  path: string,
+  label: string,
+): ProtocolParseResult<number> {
+  if (typeof value !== "number") {
+    return fail("invalid_type", path, `${label} must be a number`);
+  }
+  if (!Number.isFinite(value) || value < 0) {
+    return fail("invalid_value", path, `${label} must be a finite number >= 0`);
+  }
+  return pass(value);
+}
+
+function parseSchema<const T extends string>(
+  value: unknown,
+  exact: T,
+  re: RegExp,
+  path: string,
+  label: string,
+): ProtocolParseResult<T> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (value === exact) {
+    return pass(exact);
+  }
+  const match = re.exec(value);
+  if (match) {
+    return fail("unknown_major", path, `Unsupported ${label} major v${match[1]}`);
+  }
+  return fail("invalid_value", path, `${label} must equal ${exact}`);
+}
+
+function parseUtc(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isUtcTimestamp(value)) {
+    return fail("invalid_value", path, `${label} must be a UTC RFC 3339 timestamp`);
+  }
+  return pass(value);
+}
+
+function parseOpaqueIdentifier(
+  value: unknown,
+  prefix: string,
+  path: string,
+  label: string,
+): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isOpaqueId(value, prefix)) {
+    return fail("invalid_value", path, `${label} must match ${prefix}_...`);
+  }
+  return pass(value);
+}
+
+function parseAcceptedTopic(value: unknown, path: string): ProtocolParseResult<ResearchAcceptedTopicV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  let proposalId: string | undefined;
+  if (hasOwn(object.value, "proposalId")) {
+    const parsedProposalId = parseOpaqueIdentifier(
+      object.value.proposalId,
+      "proposal",
+      childPath(path, "proposalId"),
+      "proposalId",
+    );
+    if (!parsedProposalId.ok) return parsedProposalId;
+    proposalId = parsedProposalId.value;
+  }
+
+  const questionField = parseRequiredField(object.value, "question", path);
+  if (!questionField.ok) return questionField;
+  const question = parseString(questionField.value, childPath(path, "question"), "question");
+  if (!question.ok) return question;
+
+  const editedByUserField = parseRequiredField(object.value, "editedByUser", path);
+  if (!editedByUserField.ok) return editedByUserField;
+  const editedByUser = parseBoolean(
+    editedByUserField.value,
+    childPath(path, "editedByUser"),
+    "editedByUser",
+  );
+  if (!editedByUser.ok) return editedByUser;
+
+  return pass({
+    ...object.value,
+    ...(typeof proposalId === "string" ? { proposalId } : {}),
+    question: question.value,
+    editedByUser: editedByUser.value,
+  });
+}
+
+function parseModelBinding(value: unknown, path: string): ProtocolParseResult<ResearchModelBindingV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const familiarIdField = parseRequiredField(object.value, "familiarId", path);
+  if (!familiarIdField.ok) return familiarIdField;
+  const familiarId = parseString(familiarIdField.value, childPath(path, "familiarId"), "familiarId");
+  if (!familiarId.ok) return familiarId;
+
+  const selectionField = parseRequiredField(object.value, "selection", path);
+  if (!selectionField.ok) return selectionField;
+  const selection = parseEnumValue(
+    selectionField.value,
+    MODEL_SELECTIONS,
+    childPath(path, "selection"),
+    "selection",
+  );
+  if (!selection.ok) return selection;
+
+  let model: string | undefined;
+  if (selection.value === "pinned") {
+    if (!hasOwn(object.value, "model")) {
+      return fail("missing_field", childPath(path, "model"), "pinned model selection requires model");
+    }
+    const parsedModel = parseString(object.value.model, childPath(path, "model"), "model");
+    if (!parsedModel.ok) return parsedModel;
+    model = parsedModel.value;
+  } else if (hasOwn(object.value, "model")) {
+    return fail(
+      "semantic_conflict",
+      childPath(path, "model"),
+      "resolve-at-run-start model selection must not include model",
+    );
+  }
+
+  return pass({
+    ...object.value,
+    familiarId: familiarId.value,
+    selection: selection.value,
+    ...(typeof model === "string" ? { model } : {}),
+  });
+}
+
+export function parseResearchExecutionProfileV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ResearchExecutionProfileV1> {
+  const wireValue = copyProtocolJsonValue(value, path);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, path);
+  if (!object.ok) return object;
+
+  const locationField = parseRequiredField(object.value, "location", path);
+  if (!locationField.ok) return locationField;
+  const location = parseEnumValue(
+    locationField.value,
+    EXECUTION_LOCATIONS,
+    childPath(path, "location"),
+    "location",
+  );
+  if (!location.ok) return location;
+
+  const modelExecutionField = parseRequiredField(object.value, "modelExecution", path);
+  if (!modelExecutionField.ok) return modelExecutionField;
+  const modelExecution = parseEnumValue(
+    modelExecutionField.value,
+    MODEL_EXECUTIONS,
+    childPath(path, "modelExecution"),
+    "modelExecution",
+  );
+  if (!modelExecution.ok) return modelExecution;
+
+  const modelBindingField = parseRequiredField(object.value, "modelBinding", path);
+  if (!modelBindingField.ok) return modelBindingField;
+  const modelBinding = parseModelBinding(modelBindingField.value, childPath(path, "modelBinding"));
+  if (!modelBinding.ok) return modelBinding;
+
+  const strategyField = parseRequiredField(object.value, "strategy", path);
+  if (!strategyField.ok) return strategyField;
+  const strategy = parseEnumValue(
+    strategyField.value,
+    EXECUTION_STRATEGIES,
+    childPath(path, "strategy"),
+    "strategy",
+  );
+  if (!strategy.ok) return strategy;
+
+  return pass({
+    ...object.value,
+    location: location.value,
+    modelExecution: modelExecution.value,
+    modelBinding: modelBinding.value,
+    strategy: strategy.value,
+  });
+}
+
+export function parseResearchPrivacyPolicyV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ResearchPrivacyPolicyV1> {
+  const wireValue = copyProtocolJsonValue(value, path);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, path);
+  if (!object.ok) return object;
+
+  const remoteQueriesField = parseRequiredField(object.value, "remoteQueries", path);
+  if (!remoteQueriesField.ok) return remoteQueriesField;
+  const remoteQueries = parseBoolean(
+    remoteQueriesField.value,
+    childPath(path, "remoteQueries"),
+    "remoteQueries",
+  );
+  if (!remoteQueries.ok) return remoteQueries;
+
+  const remoteContentField = parseRequiredField(object.value, "remoteContent", path);
+  if (!remoteContentField.ok) return remoteContentField;
+  const remoteContent = parseBoolean(
+    remoteContentField.value,
+    childPath(path, "remoteContent"),
+    "remoteContent",
+  );
+  if (!remoteContent.ok) return remoteContent;
+
+  const artifactContentSyncField = parseRequiredField(object.value, "artifactContentSync", path);
+  if (!artifactContentSyncField.ok) return artifactContentSyncField;
+  const artifactContentSync = parseBoolean(
+    artifactContentSyncField.value,
+    childPath(path, "artifactContentSync"),
+    "artifactContentSync",
+  );
+  if (!artifactContentSync.ok) return artifactContentSync;
+
+  const retentionField = parseRequiredField(object.value, "retention", path);
+  if (!retentionField.ok) return retentionField;
+  const retention = parseEnumValue(
+    retentionField.value,
+    RETENTION_POLICIES,
+    childPath(path, "retention"),
+    "retention",
+  );
+  if (!retention.ok) return retention;
+
+  const allowMemoryPromotionField = parseRequiredField(object.value, "allowMemoryPromotion", path);
+  if (!allowMemoryPromotionField.ok) return allowMemoryPromotionField;
+  const allowMemoryPromotion = parseBoolean(
+    allowMemoryPromotionField.value,
+    childPath(path, "allowMemoryPromotion"),
+    "allowMemoryPromotion",
+  );
+  if (!allowMemoryPromotion.ok) return allowMemoryPromotion;
+  if (allowMemoryPromotion.value !== false) {
+    return fail(
+      "invalid_value",
+      childPath(path, "allowMemoryPromotion"),
+      "allowMemoryPromotion must equal false",
+    );
+  }
+
+  return pass({
+    ...object.value,
+    remoteQueries: remoteQueries.value,
+    remoteContent: remoteContent.value,
+    artifactContentSync: artifactContentSync.value,
+    retention: retention.value,
+    allowMemoryPromotion: false,
+  });
+}
+
+function parseResearchBounds(value: unknown, path: string): ProtocolParseResult<ResearchBounds> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const wallClockMinutesField = parseRequiredField(object.value, "wallClockMinutes", path);
+  if (!wallClockMinutesField.ok) return wallClockMinutesField;
+  const wallClockMinutes = parsePositiveSafeInteger(
+    wallClockMinutesField.value,
+    childPath(path, "wallClockMinutes"),
+    "wallClockMinutes",
+  );
+  if (!wallClockMinutes.ok) return wallClockMinutes;
+
+  const maxIterationsField = parseRequiredField(object.value, "maxIterations", path);
+  if (!maxIterationsField.ok) return maxIterationsField;
+  const maxIterations = parsePositiveSafeInteger(
+    maxIterationsField.value,
+    childPath(path, "maxIterations"),
+    "maxIterations",
+  );
+  if (!maxIterations.ok) return maxIterations;
+
+  const sourceTargetField = parseRequiredField(object.value, "sourceTarget", path);
+  if (!sourceTargetField.ok) return sourceTargetField;
+  const sourceTarget = parsePositiveSafeInteger(
+    sourceTargetField.value,
+    childPath(path, "sourceTarget"),
+    "sourceTarget",
+  );
+  if (!sourceTarget.ok) return sourceTarget;
+
+  let maxSpendUsd: number | undefined;
+  if (hasOwn(object.value, "maxSpendUsd")) {
+    const parsedMaxSpendUsd = parseNonNegativeFiniteNumber(
+      object.value.maxSpendUsd,
+      childPath(path, "maxSpendUsd"),
+      "maxSpendUsd",
+    );
+    if (!parsedMaxSpendUsd.ok) return parsedMaxSpendUsd;
+    maxSpendUsd = parsedMaxSpendUsd.value;
+  }
+
+  const checkpointEveryField = parseRequiredField(object.value, "checkpointEvery", path);
+  if (!checkpointEveryField.ok) return checkpointEveryField;
+  const checkpointEvery = parsePositiveSafeInteger(
+    checkpointEveryField.value,
+    childPath(path, "checkpointEvery"),
+    "checkpointEvery",
+  );
+  if (!checkpointEvery.ok) return checkpointEvery;
+
+  const stopWhenCostUnavailableField = parseRequiredField(object.value, "stopWhenCostUnavailable", path);
+  if (!stopWhenCostUnavailableField.ok) return stopWhenCostUnavailableField;
+  const stopWhenCostUnavailable = parseBoolean(
+    stopWhenCostUnavailableField.value,
+    childPath(path, "stopWhenCostUnavailable"),
+    "stopWhenCostUnavailable",
+  );
+  if (!stopWhenCostUnavailable.ok) return stopWhenCostUnavailable;
+
+  return pass({
+    ...object.value,
+    wallClockMinutes: wallClockMinutes.value,
+    maxIterations: maxIterations.value,
+    sourceTarget: sourceTarget.value,
+    ...(typeof maxSpendUsd === "number" ? { maxSpendUsd } : {}),
+    checkpointEvery: checkpointEvery.value,
+    stopWhenCostUnavailable: stopWhenCostUnavailable.value,
+  });
+}
+
+function parseResearchRunFailureV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ResearchRunFailureV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const codeField = parseRequiredField(object.value, "code", path);
+  if (!codeField.ok) return codeField;
+  const code = parseString(codeField.value, childPath(path, "code"), "code");
+  if (!code.ok) return code;
+
+  const messageField = parseRequiredField(object.value, "message", path);
+  if (!messageField.ok) return messageField;
+  const message = parseString(messageField.value, childPath(path, "message"), "message");
+  if (!message.ok) return message;
+
+  const retryableField = parseRequiredField(object.value, "retryable", path);
+  if (!retryableField.ok) return retryableField;
+  const retryable = parseBoolean(retryableField.value, childPath(path, "retryable"), "retryable");
+  if (!retryable.ok) return retryable;
+
+  return pass({
+    ...object.value,
+    code: code.value,
+    message: message.value,
+    retryable: retryable.value,
+  });
+}
+
+export function parseResearchRunV1(value: unknown): ProtocolParseResult<ResearchRunV1> {
+  const wireValue = copyProtocolJsonValue(value);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, "$");
+  if (!object.ok) return object;
+
+  const schemaField = parseRequiredField(object.value, "schema", "$");
+  if (!schemaField.ok) return schemaField;
+  const schema = parseSchema(
+    schemaField.value,
+    RESEARCH_RUN_SCHEMA,
+    RESEARCH_RUN_SCHEMA_RE,
+    "$.schema",
+    "schema",
+  );
+  if (!schema.ok) return schema;
+
+  const idField = parseRequiredField(object.value, "id", "$");
+  if (!idField.ok) return idField;
+  const id = parseOpaqueIdentifier(idField.value, "run", "$.id", "id");
+  if (!id.ok) return id;
+
+  let context: ResearchContextBindingV1 | undefined;
+  if (hasOwn(object.value, "context")) {
+    const parsedContext = parseResearchContextBindingV1(object.value.context, "$.context");
+    if (!parsedContext.ok) return parsedContext;
+    context = parsedContext.value;
+  }
+
+  const acceptedTopicField = parseRequiredField(object.value, "acceptedTopic", "$");
+  if (!acceptedTopicField.ok) return acceptedTopicField;
+  const acceptedTopic = parseAcceptedTopic(acceptedTopicField.value, "$.acceptedTopic");
+  if (!acceptedTopic.ok) return acceptedTopic;
+  const contextTopicProposalId = context?.topicProposalId;
+  const acceptedTopicProposalId = acceptedTopic.value.proposalId;
+  if (
+    contextTopicProposalId === undefined &&
+    acceptedTopicProposalId !== undefined
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.context.topicProposalId",
+      "context.topicProposalId must be present with acceptedTopic.proposalId",
+    );
+  }
+  if (
+    contextTopicProposalId !== undefined &&
+    acceptedTopicProposalId === undefined
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.acceptedTopic.proposalId",
+      "acceptedTopic.proposalId must be present with context.topicProposalId",
+    );
+  }
+  if (
+    contextTopicProposalId !== undefined &&
+    acceptedTopicProposalId !== contextTopicProposalId
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.acceptedTopic.proposalId",
+      "acceptedTopic.proposalId must equal context.topicProposalId",
+    );
+  }
+
+  const executionField = parseRequiredField(object.value, "execution", "$");
+  if (!executionField.ok) return executionField;
+  const execution = parseResearchExecutionProfileV1(executionField.value, "$.execution");
+  if (!execution.ok) return execution;
+
+  let tenantOpaqueId: string | undefined;
+  if (execution.value.location === "local") {
+    if (hasOwn(object.value, "tenantOpaqueId")) {
+      return fail(
+        "semantic_conflict",
+        "$.tenantOpaqueId",
+        "local runs must not include tenantOpaqueId",
+      );
+    }
+  } else if (hasOwn(object.value, "tenantOpaqueId")) {
+    const parsedTenantOpaqueId = parseString(
+      object.value.tenantOpaqueId,
+      "$.tenantOpaqueId",
+      "tenantOpaqueId",
+    );
+    if (!parsedTenantOpaqueId.ok) return parsedTenantOpaqueId;
+    tenantOpaqueId = parsedTenantOpaqueId.value;
+  }
+
+  const privacyField = parseRequiredField(object.value, "privacy", "$");
+  if (!privacyField.ok) return privacyField;
+  const privacy = parseResearchPrivacyPolicyV1(privacyField.value, "$.privacy");
+  if (!privacy.ok) return privacy;
+
+  const boundsField = parseRequiredField(object.value, "bounds", "$");
+  if (!boundsField.ok) return boundsField;
+  const bounds = parseResearchBounds(boundsField.value, "$.bounds");
+  if (!bounds.ok) return bounds;
+
+  const statusField = parseRequiredField(object.value, "status", "$");
+  if (!statusField.ok) return statusField;
+  const status = parseEnumValue(statusField.value, RUN_STATUSES, "$.status", "status");
+  if (!status.ok) return status;
+
+  let waitingReason: WaitingReasonV1 | undefined;
+  if (hasOwn(object.value, "waitingReason")) {
+    const parsedWaitingReason = parseEnumValue(
+      object.value.waitingReason,
+      WAITING_REASONS,
+      "$.waitingReason",
+      "waitingReason",
+    );
+    if (!parsedWaitingReason.ok) return parsedWaitingReason;
+    waitingReason = parsedWaitingReason.value;
+  }
+
+  let waitingForPhase: WaitingForPhaseV1 | undefined;
+  if (status.value === "waiting_for_executor") {
+    if (!hasOwn(object.value, "waitingForPhase")) {
+      return fail("missing_field", "$.waitingForPhase", "waiting_for_executor runs require waitingForPhase");
+    }
+    const parsedWaitingForPhase = parseEnumValue(
+      object.value.waitingForPhase,
+      WAITING_PHASES,
+      "$.waitingForPhase",
+      "waitingForPhase",
+    );
+    if (!parsedWaitingForPhase.ok) return parsedWaitingForPhase;
+    waitingForPhase = parsedWaitingForPhase.value;
+  } else if (hasOwn(object.value, "waitingForPhase")) {
+    return fail(
+      "semantic_conflict",
+      "$.waitingForPhase",
+      "waitingForPhase is only valid with waiting_for_executor",
+    );
+  }
+
+  if (
+    waitingReason === "checkpoint" &&
+    !CHECKPOINT_WAITING_STATUSES.has(status.value)
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.waitingReason",
+      "waitingReason checkpoint is only valid while an active phase is paused or awaiting a checkpoint",
+    );
+  }
+  if (
+    (waitingReason === "executor" || waitingReason === "provider-attention") &&
+    status.value !== "waiting_for_executor"
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.waitingReason",
+      "waitingReason executor/provider-attention is only valid with waiting_for_executor",
+    );
+  }
+
+  const createdAtField = parseRequiredField(object.value, "createdAt", "$");
+  if (!createdAtField.ok) return createdAtField;
+  const createdAt = parseUtc(createdAtField.value, "$.createdAt", "createdAt");
+  if (!createdAt.ok) return createdAt;
+
+  const updatedAtField = parseRequiredField(object.value, "updatedAt", "$");
+  if (!updatedAtField.ok) return updatedAtField;
+  const updatedAt = parseUtc(updatedAtField.value, "$.updatedAt", "updatedAt");
+  if (!updatedAt.ok) return updatedAt;
+  if (compareUtcTimestamps(updatedAt.value, createdAt.value) < 0) {
+    return fail(
+      "semantic_conflict",
+      "$.updatedAt",
+      "updatedAt must not be earlier than createdAt",
+    );
+  }
+
+  const nextEventSequenceField = parseRequiredField(object.value, "nextEventSequence", "$");
+  if (!nextEventSequenceField.ok) return nextEventSequenceField;
+  const nextEventSequence = parsePositiveSafeInteger(
+    nextEventSequenceField.value,
+    "$.nextEventSequence",
+    "nextEventSequence",
+  );
+  if (!nextEventSequence.ok) return nextEventSequence;
+
+  let artifactManifest: RunManifestV1 | undefined;
+  if (hasOwn(object.value, "artifactManifest")) {
+    const parsedArtifactManifest = parseEmbeddedRunManifestCandidateV1(
+      object.value.artifactManifest,
+    );
+    if (!parsedArtifactManifest.ok) {
+      return {
+        ok: false,
+        error: {
+          ...parsedArtifactManifest.error,
+          path:
+            parsedArtifactManifest.error.path === "$"
+              ? "$.artifactManifest"
+              : `$.artifactManifest${parsedArtifactManifest.error.path.slice(1)}`,
+        },
+      };
+    }
+    artifactManifest = parsedArtifactManifest.value;
+    if (artifactManifest.runId !== id.value) {
+      return fail(
+        "semantic_conflict",
+        "$.artifactManifest.runId",
+        "artifactManifest.runId must match the enclosing run id",
+      );
+    }
+    const manifestChronology = validateManifestRunChronology(
+      artifactManifest,
+      createdAt.value,
+      updatedAt.value,
+    );
+    if (!manifestChronology.ok) {
+      return {
+        ok: false,
+        error: {
+          ...manifestChronology.error,
+          path: prefixProtocolErrorPath(
+            manifestChronology.error.path,
+            "$.artifactManifest",
+          ),
+        },
+      };
+    }
+    for (const [index, manifestExecution] of artifactManifest.modelExecutions.entries()) {
+      if (
+        execution.value.strategy === "single-agent" &&
+        manifestExecution.receipt.familiarId !==
+          execution.value.modelBinding.familiarId
+      ) {
+        return fail(
+          "semantic_conflict",
+          `$.artifactManifest.modelExecutions[${index}].receipt.familiarId`,
+          "Single-agent manifest receipt familiarId must equal the selected run familiarId",
+        );
+      }
+      if (
+        execution.value.modelBinding.selection === "pinned" &&
+        manifestExecution.receipt.effectiveModel !==
+          execution.value.modelBinding.model
+      ) {
+        return fail(
+          "semantic_conflict",
+          `$.artifactManifest.modelExecutions[${index}].receipt.effectiveModel`,
+          "Manifest receipt effectiveModel must equal the pinned run model",
+        );
+      }
+    }
+    if (!contextBindingsMatch(context, artifactManifest.context)) {
+      return fail(
+        "semantic_conflict",
+        "$.artifactManifest.context",
+        "artifactManifest context must match the enclosing run context",
+      );
+    }
+    if (artifactManifest.retention.policy !== privacy.value.retention) {
+      return fail(
+        "semantic_conflict",
+        "$.artifactManifest.retention.policy",
+        "artifactManifest retention policy must match run privacy retention",
+      );
+    }
+    if (
+      !context &&
+      !retentionDoesNotExceed(
+        artifactManifest.retention.effectivePolicy,
+        privacy.value.retention,
+      )
+    ) {
+      return fail(
+        "semantic_conflict",
+        "$.artifactManifest.retention.effectivePolicy",
+        "artifactManifest effective retention must not exceed run privacy retention",
+      );
+    }
+    if (!context) {
+      const standaloneManifest = parseRunManifestV1(artifactManifest);
+      if (!standaloneManifest.ok) {
+        return {
+          ok: false,
+          error: {
+            ...standaloneManifest.error,
+            path: prefixProtocolErrorPath(
+              standaloneManifest.error.path,
+              "$.artifactManifest",
+            ),
+          },
+        };
+      }
+      artifactManifest = standaloneManifest.value;
+    }
+    const contentSyncIndex = artifactManifest.artifacts.findIndex(
+      (artifact) => artifact.contentSync !== "not-requested",
+    );
+    if (contentSyncIndex >= 0 && !privacy.value.artifactContentSync) {
+      return fail(
+        "semantic_conflict",
+        `$.artifactManifest.artifacts[${contentSyncIndex}].contentSync`,
+        "Requested artifact content sync requires run artifactContentSync consent",
+      );
+    }
+  }
+
+  let failure: ResearchRunFailureV1 | undefined;
+  if (status.value === "failed") {
+    if (!hasOwn(object.value, "failure")) {
+      return fail("missing_field", "$.failure", "failed runs require failure");
+    }
+    const parsedFailure = parseResearchRunFailureV1(object.value.failure, "$.failure");
+    if (!parsedFailure.ok) return parsedFailure;
+    failure = parsedFailure.value;
+  } else if (hasOwn(object.value, "failure")) {
+    return fail("semantic_conflict", "$.failure", "failure is only valid with failed");
+  }
+
+  if (TERMINAL_RUN_STATUSES.has(status.value)) {
+    if (!artifactManifest) {
+      return fail(
+        "missing_field",
+        "$.artifactManifest",
+        "Terminal runs require an embedded final artifactManifest",
+      );
+    }
+    if (artifactManifest.state !== "final") {
+      return fail(
+        "semantic_conflict",
+        "$.artifactManifest.state",
+        "Terminal runs require a final artifactManifest",
+      );
+    }
+  } else if (artifactManifest?.state === "final") {
+    return fail(
+      "semantic_conflict",
+      "$.artifactManifest.state",
+      "Nonterminal runs must not include a final artifactManifest",
+    );
+  }
+
+  return pass({
+    ...object.value,
+    schema: schema.value,
+    id: id.value,
+    ...(typeof tenantOpaqueId === "string" ? { tenantOpaqueId } : {}),
+    ...(context ? { context } : {}),
+    acceptedTopic: acceptedTopic.value,
+    execution: execution.value,
+    privacy: privacy.value,
+    bounds: bounds.value,
+    status: status.value,
+    ...(typeof waitingReason === "string" ? { waitingReason } : {}),
+    ...(typeof waitingForPhase === "string" ? { waitingForPhase } : {}),
+    createdAt: createdAt.value,
+    updatedAt: updatedAt.value,
+    nextEventSequence: nextEventSequence.value,
+    ...(artifactManifest ? { artifactManifest } : {}),
+    ...(failure ? { failure } : {}),
+  });
+}
+
+export function parseRunEventV1(value: unknown): ProtocolParseResult<RunEventV1> {
+  const wireValue = copyProtocolJsonValue(value);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, "$");
+  if (!object.ok) return object;
+
+  const schemaField = parseRequiredField(object.value, "schema", "$");
+  if (!schemaField.ok) return schemaField;
+  const schema = parseSchema(
+    schemaField.value,
+    RUN_EVENT_SCHEMA,
+    RUN_EVENT_SCHEMA_RE,
+    "$.schema",
+    "schema",
+  );
+  if (!schema.ok) return schema;
+
+  const runIdField = parseRequiredField(object.value, "runId", "$");
+  if (!runIdField.ok) return runIdField;
+  const runId = parseOpaqueIdentifier(runIdField.value, "run", "$.runId", "runId");
+  if (!runId.ok) return runId;
+
+  const sequenceField = parseRequiredField(object.value, "sequence", "$");
+  if (!sequenceField.ok) return sequenceField;
+  const sequence = parsePositiveSafeInteger(sequenceField.value, "$.sequence", "sequence");
+  if (!sequence.ok) return sequence;
+
+  const typeField = parseRequiredField(object.value, "type", "$");
+  if (!typeField.ok) return typeField;
+  const type = parseEnumValue(typeField.value, RUN_EVENT_TYPES, "$.type", "type");
+  if (!type.ok) return type;
+
+  const atField = parseRequiredField(object.value, "at", "$");
+  if (!atField.ok) return atField;
+  const at = parseUtc(atField.value, "$.at", "at");
+  if (!at.ok) return at;
+
+  const dataField = parseRequiredField(object.value, "data", "$");
+  if (!dataField.ok) return dataField;
+  const data = parseObject(dataField.value, "$.data");
+  if (!data.ok) return data;
+
+  if (type.value === "content.deleted") {
+    const safeEventKeys = validateSafeDeletionExtensionKeys(
+      object.value,
+      "$",
+      RUN_EVENT_FIELDS,
+    );
+    if (!safeEventKeys.ok) return safeEventKeys;
+
+    const safeKeys = validateSafeDeletionExtensionKeys(
+      data.value,
+      "$.data",
+      CONTENT_DELETED_DATA_FIELDS,
+    );
+    if (!safeKeys.ok) return safeKeys;
+
+    const deletedObjectCountField = parseRequiredField(
+      data.value,
+      "deletedObjectCount",
+      "$.data",
+    );
+    if (!deletedObjectCountField.ok) return deletedObjectCountField;
+    const deletedObjectCount = parseSafeIntegerInRange(
+      deletedObjectCountField.value,
+      "$.data.deletedObjectCount",
+      "deletedObjectCount",
+      0,
+      MAX_SAFE_INTEGER,
+    );
+    if (!deletedObjectCount.ok) return deletedObjectCount;
+
+    const manifestStatusField = parseRequiredField(
+      data.value,
+      "manifestStatus",
+      "$.data",
+    );
+    if (!manifestStatusField.ok) return manifestStatusField;
+    if (manifestStatusField.value !== "deleted") {
+      return fail(
+        "invalid_value",
+        "$.data.manifestStatus",
+        "manifestStatus must equal deleted",
+      );
+    }
+  }
+
+  return pass({
+    ...object.value,
+    schema: schema.value,
+    runId: runId.value,
+    sequence: sequence.value,
+    type: type.value,
+    at: at.value,
+    data: { ...data.value },
+  });
+}
+
+export function validateRunEventSequence(
+  events: readonly RunEventV1[],
+): ProtocolParseResult<readonly RunEventV1[]> {
+  if (events.length === 0) {
+    return fail("semantic_conflict", "$", "At least one event is required");
+  }
+
+  const first = events[0];
+  if (!Number.isSafeInteger(first.sequence) || first.sequence < 1) {
+    return fail("semantic_conflict", "$[0].sequence", "Event sequence must be a safe integer >= 1");
+  }
+  if (first.sequence !== 1) {
+    return fail("semantic_conflict", "$[0].sequence", "First event sequence must equal 1");
+  }
+
+  const runId = first.runId;
+  for (const [index, event] of events.entries()) {
+    const eventPath = indexPath("$", index);
+    if (event.runId !== runId) {
+      return fail("semantic_conflict", childPath(eventPath, "runId"), `Event runId must equal ${runId}`);
+    }
+    if (!Number.isSafeInteger(event.sequence) || event.sequence < 1) {
+      return fail(
+        "semantic_conflict",
+        childPath(eventPath, "sequence"),
+        "Event sequence must be a safe integer >= 1",
+      );
+    }
+    const expectedSequence = index + 1;
+    if (event.sequence !== expectedSequence) {
+      return fail(
+        "semantic_conflict",
+        childPath(eventPath, "sequence"),
+        `Event sequence must equal ${expectedSequence}`,
+      );
+    }
+  }
+
+  return pass(events);
+}
+
+/**
+ * Validates an already-parsed run's deletion receipt against its complete event
+ * stream. Runs without a manifest or completed deletion still validate stream
+ * order and completeness, but do not require a content.deleted event.
+ */
+export function validateRunManifestDeletionEventV1(
+  run: ResearchRunV1,
+  events: readonly RunEventV1[],
+): ProtocolParseResult<ResearchRunV1> {
+  if (events.length > 0) {
+    const orderedEvents = validateRunEventSequence(events);
+    if (!orderedEvents.ok) return orderedEvents;
+    if (events[0].runId !== run.id) {
+      return fail(
+        "semantic_conflict",
+        "$[0].runId",
+        "Event stream runId must match the enclosing run id",
+      );
+    }
+  }
+
+  const expectedEventCount = run.nextEventSequence - 1;
+  if (events.length !== expectedEventCount) {
+    return fail(
+      "semantic_conflict",
+      "$",
+      `Complete event stream must contain exactly ${expectedEventCount} events`,
+    );
+  }
+
+  const manifest = run.artifactManifest;
+  if (!manifest || manifest.deletion.status !== "completed") {
+    return pass(run);
+  }
+  if (manifest.runId !== run.id) {
+    return fail(
+      "semantic_conflict",
+      "$.artifactManifest.runId",
+      "artifactManifest.runId must match the enclosing run id",
+    );
+  }
+  if (manifest.state !== "final") {
+    return fail(
+      "semantic_conflict",
+      "$.artifactManifest.state",
+      "Completed deletion requires a final artifactManifest",
+    );
+  }
+
+  const eventSequence = manifest.deletion.eventSequence;
+  if (eventSequence === undefined || !Number.isSafeInteger(eventSequence) || eventSequence < 1) {
+    return fail(
+      "semantic_conflict",
+      "$.artifactManifest.deletion.eventSequence",
+      "Completed deletion requires a valid eventSequence",
+    );
+  }
+  const eventIndex = eventSequence - 1;
+  const event = events[eventIndex];
+  if (!event || event.sequence !== eventSequence || event.runId !== run.id) {
+    return fail(
+      "semantic_conflict",
+      "$.artifactManifest.deletion.eventSequence",
+      "Deletion eventSequence must identify an event in the complete run stream",
+    );
+  }
+  if (event.type !== "content.deleted") {
+    return fail(
+      "semantic_conflict",
+      `$[${eventIndex}].type`,
+      "Deletion eventSequence must identify content.deleted",
+    );
+  }
+  const requestedAt = manifest.deletion.requestedAt;
+  const completedAt = manifest.deletion.completedAt;
+  if (
+    requestedAt === undefined ||
+    completedAt === undefined ||
+    compareUtcTimestamps(event.at, requestedAt) < 0 ||
+    compareUtcTimestamps(event.at, completedAt) > 0
+  ) {
+    return fail(
+      "semantic_conflict",
+      `$[${eventIndex}].at`,
+      "content.deleted must occur between requestedAt and completedAt",
+    );
+  }
+  if (event.data.deletedObjectCount !== manifest.deletion.deletedObjectCount) {
+    return fail(
+      "semantic_conflict",
+      `$[${eventIndex}].data.deletedObjectCount`,
+      "content.deleted object count must match the deletion receipt",
+    );
+  }
+  if (event.data.manifestStatus !== "deleted") {
+    return fail(
+      "semantic_conflict",
+      `$[${eventIndex}].data.manifestStatus`,
+      "content.deleted manifestStatus must equal deleted",
+    );
+  }
+
+  return pass(run);
+}

--- a/src/lib/research-protocol/run-manifest.test.ts
+++ b/src/lib/research-protocol/run-manifest.test.ts
@@ -1,0 +1,3490 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Value } from "typebox/value";
+
+import runManifestSchema from "../../../schemas/research/v1/run-manifest.schema.json" with { type: "json" };
+import assemblingManifestJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-assembling.json" with { type: "json" };
+import finalLocalManifestJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-final-local.json" with { type: "json" };
+import finalCloudManifestJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-final-cloud.json" with { type: "json" };
+import retentionUpdateJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-retention-update.json" with { type: "json" };
+import invalidPreviousDigestJson from "../../../schemas/research/v1/fixtures/scenarios/objects/run-manifest-previous-digest.json" with { type: "json" };
+import invalidFinalMutationJson from "../../../schemas/research/v1/fixtures/scenarios/objects/run-manifest-final-mutation.json" with { type: "json" };
+import invalidDeletionPairJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-deletion-pair.json" with { type: "json" };
+import invalidPrivateTitleJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-private-title.json" with { type: "json" };
+import invalidDeletionEventJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-deletion-event.json" with { type: "json" };
+import invalidModelRawPromptJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-model-raw-prompt.json" with { type: "json" };
+import invalidDeletedContentPayloadJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-deleted-content-payload.json" with { type: "json" };
+import invalidNestedPrivateExtensionJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-nested-private-extension.json" with { type: "json" };
+import invalidNestedPrivacyStorageKeysJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-nested-privacy-storage-keys.json" with { type: "json" };
+import invalidRootPrivateExcerptsJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-root-private-excerpts.json" with { type: "json" };
+import invalidScheduledNullExpiryJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-scheduled-null-expiry.json" with { type: "json" };
+import invalidSplitObjectStoreKeyJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-split-object-store-key.json" with { type: "json" };
+import invalidSevenDayOverflowJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-retention-7-days-overflow.json" with { type: "json" };
+import invalidRunOnlyOverflowJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-retention-run-only-overflow.json" with { type: "json" };
+import invalidSevenDayLeapOverflowJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-retention-7-days-leap-overflow.json" with { type: "json" };
+import invalidRunOnlyLeapOverflowJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-retention-run-only-leap-overflow.json" with { type: "json" };
+import invalidFinalizedBeforeCreatedJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-finalized-before-created.json" with { type: "json" };
+import invalidSourceBeforeCreatedJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-source-before-created.json" with { type: "json" };
+import invalidSourceAfterFinalizedJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-source-after-finalized.json" with { type: "json" };
+import invalidArtifactBeforeCreatedJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-artifact-before-created.json" with { type: "json" };
+import invalidArtifactAfterFinalizedJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-artifact-after-finalized.json" with { type: "json" };
+import invalidRetentionBeforeCreatedJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-retention-before-created.json" with { type: "json" };
+import invalidRetentionBeforeFinalizedJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-retention-before-finalized.json" with { type: "json" };
+import invalidContentExpiresBeforeCreatedJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-content-expires-before-created.json" with { type: "json" };
+import invalidContentExpiresBeforeFinalizedJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-content-expires-before-finalized.json" with { type: "json" };
+import invalidDeletionHomoglyphArrayJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-deletion-homoglyph-array.json" with { type: "json" };
+import invalidDeletionHomoglyphNestedJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-deletion-homoglyph-nested.json" with { type: "json" };
+import invalidDeletionHomoglyphRootJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-deletion-homoglyph-root.json" with { type: "json" };
+import invalidUnicodeSensitiveExtensionJson from "../../../schemas/research/v1/fixtures/invalid/run-manifest-unicode-sensitive-extension.json" with { type: "json" };
+import validExtensionBoundariesJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-extension-boundaries.json" with { type: "json" };
+import validDeletionAsciiExtensionJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-deletion-ascii-extension.json" with { type: "json" };
+import validNestedBenignExtensionJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-nested-benign-extension.json" with { type: "json" };
+import validUnicodeExtensionJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-unicode-extension.json" with { type: "json" };
+import validChronologyBoundariesJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-chronology-boundaries.json" with { type: "json" };
+import validSevenDayBoundaryJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-retention-7-days-boundary.json" with { type: "json" };
+import validRunOnlyBoundaryJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-retention-run-only-boundary.json" with { type: "json" };
+import validSevenDayLeapBoundaryJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-retention-7-days-leap-boundary.json" with { type: "json" };
+import validRunOnlyLeapBoundaryJson from "../../../schemas/research/v1/fixtures/valid/run-manifest-retention-run-only-leap-boundary.json" with { type: "json" };
+
+import { digestProtocolObject } from "./digest.ts";
+import {
+  aggregateManifestUsage,
+  parseRunManifestV1,
+  SENSITIVE_EXTENSION_COMPOUND_KEY_PATTERN,
+  SENSITIVE_EXTENSION_KEY_PATTERN,
+  SENSITIVE_EXTENSION_VARIANT_KEY_PATTERN,
+  validateManifestRetentionConsent,
+  validateRunManifestRevision,
+  validateRunManifestRevisionV1,
+  type RunManifestModelExecutionV1,
+  type RunManifestV1,
+} from "./run-manifest.ts";
+import type { ResearchModelReceiptV1 } from "./topic-discovery.ts";
+
+function expectOk<T>(result: { ok: true; value: T } | { ok: false; error: { path: string; message: string } }): T {
+  if (!result.ok) {
+    assert.fail(`${result.error.path}: ${result.error.message}`);
+  }
+  return result.value;
+}
+
+function expectError(
+  result: { ok: true; value: unknown } | { ok: false; error: { path: string; code: string; message: string } },
+  path: string,
+  code?: string,
+): { path: string; code: string; message: string } {
+  if (result.ok) {
+    assert.fail("expected parse failure");
+  }
+  assert.equal(result.error.path, path);
+  if (code) {
+    assert.equal(result.error.code, code);
+  }
+  return result.error;
+}
+
+function recalculate<T extends Record<string, unknown>>(value: T): T {
+  const ownJson = (input: unknown): unknown => {
+    if (input === null || typeof input !== "object") return input;
+    if (Array.isArray(input)) return Array.from(input, ownJson);
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(input)) {
+      Object.defineProperty(result, key, {
+        value: ownJson((input as Record<string, unknown>)[key]),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return result;
+  };
+  return { ...value, digest: digestProtocolObject(ownJson(value)) };
+}
+
+function receiptUsage(
+  inputTokens: number | null,
+  outputTokens: number | null,
+  costUsd: number | null,
+): ResearchModelReceiptV1 {
+  return {
+    familiarId: "sage",
+    runtime: "copilot",
+    effectiveModel: "gpt-5.6-sol",
+    modelSource: "session",
+    providerBilling: "user-connected",
+    usage: {
+      inputTokens,
+      outputTokens,
+      costUsd,
+      reportedByRuntime: inputTokens !== null || outputTokens !== null || costUsd !== null,
+    },
+  };
+}
+
+function execution(
+  taskId: string,
+  attempt: number,
+  inputTokens: number | null,
+  outputTokens: number | null,
+  costUsd: number | null,
+): RunManifestModelExecutionV1 {
+  return {
+    taskId,
+    phase: "scope",
+    attempt,
+    inputDigest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    outputDigest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    receipt: receiptUsage(inputTokens, outputTokens, costUsd),
+  };
+}
+
+test("classifies zero model executions as unreported", () => {
+  assert.deepEqual(aggregateManifestUsage([]), {
+    inputTokens: null,
+    outputTokens: null,
+    costUsd: null,
+    completeness: "unreported",
+  });
+});
+
+test("aggregates only reported values and marks gaps partial", () => {
+  assert.deepEqual(
+    aggregateManifestUsage([
+      execution("modeltask_01", 1, 100, null, null),
+      execution("modeltask_02", 1, null, 50, 0.25),
+    ]),
+    {
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.25,
+      completeness: "partial",
+    },
+  );
+});
+
+test("aggregates complete usage with exact sums", () => {
+  assert.deepEqual(
+    aggregateManifestUsage([
+      execution("modeltask_01", 1, 100, 50, 0.25),
+      execution("modeltask_02", 1, 20, 10, 0.75),
+    ]),
+    {
+      inputTokens: 120,
+      outputTokens: 60,
+      costUsd: 1,
+      completeness: "complete",
+    },
+  );
+});
+
+test("aggregates costs from canonical decimal spellings without binary drift", () => {
+  for (const [costs, expected] of [
+    [[0.1, 0.2], 0.3],
+    [[1, 2, 3], 6],
+    [[1.25, 2.5, 0.125], 3.875],
+    [[1e-7, 2e-7], 3e-7],
+    [[1e21, 2e21], 3e21],
+    [[5e-324, 5e-324], 1e-323],
+    [[1e20, 1], 1e20],
+    [[Number.MAX_VALUE, 5e-324], Number.MAX_VALUE],
+  ] as const) {
+    const aggregate = aggregateManifestUsage(
+      costs.map((cost, index) =>
+        execution(`modeltask_decimal_${index}`, 1, 0, 0, cost),
+      ),
+    );
+    assert.equal(aggregate.costUsd, expected, costs.join(" + "));
+  }
+});
+
+test("manifest aggregate cost requires the exact decimal sum", () => {
+  const modelExecutions = [
+    execution("modeltask_decimal_1", 1, 1, 1, 0.1),
+    execution("modeltask_decimal_2", 1, 1, 1, 0.2),
+  ];
+  const exact = recalculate({
+    ...finalCloudManifestJson,
+    modelExecutions,
+    usage: {
+      inputTokens: 2,
+      outputTokens: 2,
+      costUsd: 0.3,
+      completeness: "complete" as const,
+    },
+  });
+  assert.equal(expectOk(parseRunManifestV1(exact)).usage.costUsd, 0.3);
+
+  const drifted = recalculate({
+    ...exact,
+    usage: {
+      ...exact.usage,
+      costUsd: 0.30000000000000004,
+    },
+  });
+  expectError(
+    parseRunManifestV1(drifted),
+    "$.usage.costUsd",
+    "semantic_conflict",
+  );
+});
+
+test("rejects aggregate token and cost overflow", () => {
+  assert.throws(
+    () =>
+      aggregateManifestUsage([
+        execution("modeltask_overflow_1", 1, Number.MAX_SAFE_INTEGER, null, null),
+        execution("modeltask_overflow_2", 1, 1, null, null),
+      ]),
+    RangeError,
+  );
+  assert.throws(
+    () =>
+      aggregateManifestUsage([
+        execution("modeltask_overflow_1", 1, null, null, Number.MAX_VALUE),
+        execution("modeltask_overflow_2", 1, null, null, Number.MAX_VALUE),
+      ]),
+    RangeError,
+  );
+});
+
+test("parser rejects manifests whose aggregate usage overflows", () => {
+  const tokenOverflow = recalculate({
+    ...finalCloudManifestJson,
+    modelExecutions: [
+      execution("modeltask_overflow_1", 1, Number.MAX_SAFE_INTEGER, null, null),
+      execution("modeltask_overflow_2", 1, 1, null, null),
+    ],
+    usage: {
+      inputTokens: 0,
+      outputTokens: null,
+      costUsd: null,
+      completeness: "partial" as const,
+    },
+  });
+  expectError(parseRunManifestV1(tokenOverflow), "$.usage", "invalid_value");
+
+  const costOverflow = recalculate({
+    ...finalCloudManifestJson,
+    modelExecutions: [
+      execution("modeltask_overflow_1", 1, null, null, Number.MAX_VALUE),
+      execution("modeltask_overflow_2", 1, null, null, Number.MAX_VALUE),
+    ],
+    usage: {
+      inputTokens: null,
+      outputTokens: null,
+      costUsd: 0,
+      completeness: "partial" as const,
+    },
+  });
+  expectError(parseRunManifestV1(costOverflow), "$.usage", "invalid_value");
+});
+
+test("valid fixtures satisfy the schema, parse, and recalculate their root digests", () => {
+  for (const fixture of [
+    assemblingManifestJson,
+    finalLocalManifestJson,
+    finalCloudManifestJson,
+    retentionUpdateJson,
+  ]) {
+    assert.equal(Value.Check(runManifestSchema, fixture), true);
+    const parsed = expectOk(parseRunManifestV1(fixture));
+    assert.equal(parsed.digest, digestProtocolObject(fixture));
+    assert.equal((parsed.futureExtension as { preserve: boolean }).preserve, true);
+  }
+
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  assert.equal((local.artifacts[0].futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((local.retention.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((local.deletion.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((local.usage.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((local.sources[0].futureExtension as { preserve: boolean }).preserve, true);
+});
+
+test("manifest chronology accepts exact boundaries and ignores additive timestamp-looking fields", () => {
+  assert.equal(Value.Check(runManifestSchema, validChronologyBoundariesJson), true);
+  assert.equal(
+    validChronologyBoundariesJson.digest,
+    digestProtocolObject(validChronologyBoundariesJson),
+  );
+
+  const parsed = expectOk(parseRunManifestV1(validChronologyBoundariesJson));
+  const evidence = parsed.sources.find((source) => source.kind === "public-evidence");
+  assert.equal(evidence?.fetchedAt, parsed.createdAt);
+  assert.equal(parsed.artifacts[0].createdAt, parsed.finalizedAt);
+  assert.equal(parsed.retention.updatedAt, parsed.finalizedAt);
+  assert.equal(
+    (parsed.extensionMetadata as { recordedAt: string }).recordedAt,
+    "1900-01-01T00:00:00.000Z",
+  );
+  assert.equal(
+    (parsed.modelExecutions[0] as RunManifestModelExecutionV1 & { completedAt: string })
+      .completedAt,
+    "2099-12-31T23:59:59.000Z",
+  );
+});
+
+test("manifest chronology rejects declared inclusion timestamps outside the manifest window", () => {
+  for (const [fixture, path] of [
+    [invalidFinalizedBeforeCreatedJson, "$.finalizedAt"],
+    [invalidSourceBeforeCreatedJson, "$.sources[0].fetchedAt"],
+    [invalidSourceAfterFinalizedJson, "$.sources[0].fetchedAt"],
+    [invalidArtifactBeforeCreatedJson, "$.artifacts[0].createdAt"],
+    [invalidArtifactAfterFinalizedJson, "$.artifacts[0].createdAt"],
+    [invalidRetentionBeforeCreatedJson, "$.retention.updatedAt"],
+    [invalidRetentionBeforeFinalizedJson, "$.retention.updatedAt"],
+  ] as const) {
+    const { expectedSchemaValid, ...manifest } = fixture;
+    assert.equal(expectedSchemaValid, true, path);
+    assert.equal(Value.Check(runManifestSchema, manifest), true, path);
+    assert.equal(manifest.digest, digestProtocolObject(manifest), path);
+    expectError(parseRunManifestV1(manifest), path, "semantic_conflict");
+  }
+});
+
+test("standalone revision-1 finite retention deadlines cannot exceed their policy ceilings", () => {
+  for (const manifest of [validSevenDayBoundaryJson, validRunOnlyBoundaryJson]) {
+    assert.equal(Value.Check(runManifestSchema, manifest), true);
+    assert.equal(manifest.digest, digestProtocolObject(manifest));
+    expectOk(parseRunManifestV1(manifest));
+  }
+
+  for (const fixture of [invalidSevenDayOverflowJson, invalidRunOnlyOverflowJson]) {
+    const { expectedSchemaValid, ...manifest } = fixture;
+    assert.equal(expectedSchemaValid, true);
+    assert.equal(Value.Check(runManifestSchema, manifest), true);
+    assert.equal(manifest.digest, digestProtocolObject(manifest));
+    expectError(
+      parseRunManifestV1(manifest),
+      "$.retention.contentExpiresAt",
+      "semantic_conflict",
+    );
+  }
+});
+
+test("finite retention deadlines inclusively honor the trusted clock lower bound", () => {
+  for (const fixture of [
+    invalidContentExpiresBeforeCreatedJson,
+    invalidContentExpiresBeforeFinalizedJson,
+  ]) {
+    const { expectedSchemaValid, ...manifest } = fixture;
+    assert.equal(expectedSchemaValid, true);
+    assert.equal(Value.Check(runManifestSchema, manifest), true);
+    assert.equal(manifest.digest, digestProtocolObject(manifest));
+    expectError(
+      parseRunManifestV1(manifest),
+      "$.retention.contentExpiresAt",
+      "semantic_conflict",
+    );
+  }
+
+  for (const [base, before, equal, after] of [
+    [
+      assemblingManifestJson,
+      "2026-08-16T19:59:59.999999999Z",
+      "2026-08-16T20:00:00.000Z",
+      "2026-08-16T20:00:00.000000001Z",
+    ],
+    [
+      finalLocalManifestJson,
+      "2026-08-16T20:03:59.999999999Z",
+      "2026-08-16T20:04:00.000Z",
+      "2026-08-16T20:04:00.000000001Z",
+    ],
+  ] as const) {
+    const lowerBound =
+      "finalizedAt" in base ? base.finalizedAt : base.createdAt;
+    for (const [contentExpiresAt, accepted] of [
+      [before, false],
+      [equal, true],
+      [after, true],
+    ] as const) {
+      const candidate = recalculate({
+        ...base,
+        retention: {
+          ...base.retention,
+          status: "deletion_scheduled" as const,
+          contentExpiresAt,
+        },
+        deletion: {
+          status: "scheduled" as const,
+          requestedAt: lowerBound,
+        },
+      });
+      assert.equal(Value.Check(runManifestSchema, candidate), true);
+      if (accepted) {
+        assert.equal(
+          expectOk(parseRunManifestV1(candidate)).retention.contentExpiresAt,
+          contentExpiresAt,
+        );
+      } else {
+        expectError(
+          parseRunManifestV1(candidate),
+          "$.retention.contentExpiresAt",
+          "semantic_conflict",
+        );
+      }
+    }
+
+    const projectCandidate = recalculate({
+      ...base,
+      retention: {
+        ...base.retention,
+        policy: "project" as const,
+        effectivePolicy: "project" as const,
+        status: "deletion_scheduled" as const,
+        contentExpiresAt: before,
+      },
+      deletion: {
+        status: "scheduled" as const,
+        requestedAt: lowerBound,
+      },
+    });
+    assert.equal(Value.Check(runManifestSchema, projectCandidate), true);
+    expectError(
+      parseRunManifestV1(projectCandidate),
+      "$.retention.contentExpiresAt",
+      "semantic_conflict",
+    );
+  }
+});
+
+test("standalone later revisions anchor finite retention deadlines to finalizedAt", () => {
+  const original = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const [policy, contentExpiresAt] of [
+    ["run-only", "2026-08-17T20:04:00.000000001Z"],
+    ["7-days", "2026-08-23T20:04:00.000000001Z"],
+  ] as const) {
+    const unverifiedRevision = recalculate({
+      ...original,
+      revision: 2,
+      previousDigest: original.digest,
+      retention: {
+        ...original.retention,
+        policy,
+        effectivePolicy: policy,
+        status: "deletion_scheduled" as const,
+        contentExpiresAt,
+        updatedAt: "2026-08-16T21:04:00.000Z",
+      },
+      deletion: {
+        status: "scheduled" as const,
+        requestedAt: "2026-08-16T21:04:00.000Z",
+      },
+    });
+    expectError(
+      parseRunManifestV1(unverifiedRevision),
+      "$.retention.contentExpiresAt",
+      "semantic_conflict",
+    );
+  }
+});
+
+test("public standalone parsing rejects later retention authority above the original policy", () => {
+  for (const fixture of [assemblingManifestJson, finalLocalManifestJson]) {
+    for (const contextless of [false, true]) {
+      const policyCandidate: Record<string, unknown> = {
+        ...fixture,
+        revision: 2,
+        previousDigest: fixture.digest,
+        retention: {
+          ...fixture.retention,
+          effectivePolicy: "project",
+        },
+      };
+      if (contextless) {
+        delete policyCandidate.context;
+        policyCandidate.sources = [];
+      }
+
+      expectError(
+        parseRunManifestV1(recalculate(policyCandidate)),
+        "$.retention.effectivePolicy",
+        "semantic_conflict",
+      );
+
+      const deadlineCandidate: Record<string, unknown> = {
+        ...fixture,
+        revision: 2,
+        previousDigest: fixture.digest,
+        retention: {
+          ...fixture.retention,
+          status: "deletion_scheduled",
+          contentExpiresAt: "2026-08-24T20:04:00.000Z",
+          updatedAt: "2026-08-17T20:04:00.000Z",
+        },
+        deletion: {
+          status: "scheduled",
+          requestedAt: "2026-08-17T20:04:00.000Z",
+        },
+      };
+      if (contextless) {
+        delete deadlineCandidate.context;
+        deadlineCandidate.sources = [];
+      }
+      expectError(
+        parseRunManifestV1(recalculate(deadlineCandidate)),
+        "$.retention.contentExpiresAt",
+        "semantic_conflict",
+      );
+    }
+  }
+});
+
+test("the revision validator alone can parse a freshly consented bound extension", () => {
+  const previous = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const candidate = recalculate({
+    ...previous,
+    revision: 2,
+    previousDigest: previous.digest,
+    retention: {
+      ...previous.retention,
+      effectivePolicy: "project" as const,
+      updatedAt: "2026-08-16T20:06:00.000Z",
+    },
+  });
+
+  expectError(
+    validateRunManifestRevisionV1(previous, candidate, {
+      contextConsent: "project",
+    }),
+    "$.retention.effectivePolicy",
+    "semantic_conflict",
+  );
+  assert.deepEqual(
+    expectOk(
+      validateRunManifestRevisionV1(previous, candidate, {
+        freshConsent: true,
+        freshConsentAt: "2026-08-16T20:05:30.000Z",
+        contextConsent: "project",
+      }),
+    ),
+    candidate,
+  );
+});
+
+test("finite retention duration counts the 2016 positive leap second", () => {
+  for (const manifest of [
+    validRunOnlyLeapBoundaryJson,
+    validSevenDayLeapBoundaryJson,
+  ]) {
+    assert.equal(Value.Check(runManifestSchema, manifest), true);
+    assert.equal(manifest.digest, digestProtocolObject(manifest));
+    expectOk(parseRunManifestV1(manifest));
+  }
+
+  for (const fixture of [
+    invalidRunOnlyLeapOverflowJson,
+    invalidSevenDayLeapOverflowJson,
+  ]) {
+    const { expectedSchemaValid, ...manifest } = fixture;
+    assert.equal(expectedSchemaValid, true);
+    assert.equal(Value.Check(runManifestSchema, manifest), true);
+    assert.equal(manifest.digest, digestProtocolObject(manifest));
+    expectError(
+      parseRunManifestV1(manifest),
+      "$.retention.contentExpiresAt",
+      "semantic_conflict",
+    );
+  }
+});
+
+test("Run Manifest rejects non-canonical wire data before invoking accessors", () => {
+  class CustomArray<T> extends Array<T> {}
+  let accessorCalls = 0;
+
+  const accessor = { ...finalLocalManifestJson } as Record<string, unknown>;
+  Object.defineProperty(accessor, "schema", {
+    get() {
+      accessorCalls += 1;
+      return finalLocalManifestJson.schema;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  expectError(parseRunManifestV1(accessor), "$", "invalid_value");
+
+  const hidden = { ...finalLocalManifestJson };
+  Object.defineProperty(hidden, "hidden", {
+    value: "not-json",
+    enumerable: false,
+  });
+  expectError(parseRunManifestV1(hidden), "$", "invalid_value");
+
+  const symbolKeyed = { ...finalLocalManifestJson };
+  Object.defineProperty(symbolKeyed, Symbol("hidden"), {
+    value: "not-json",
+    enumerable: true,
+  });
+  expectError(parseRunManifestV1(symbolKeyed), "$", "invalid_value");
+
+  const hiddenToJson = { ...finalLocalManifestJson };
+  Object.defineProperty(hiddenToJson, "toJSON", {
+    value() {
+      accessorCalls += 1;
+      return finalLocalManifestJson;
+    },
+    enumerable: false,
+  });
+  expectError(parseRunManifestV1(hiddenToJson), "$", "invalid_value");
+
+  const extraProperty = [1, 2];
+  Object.defineProperty(extraProperty, "extra", {
+    value: true,
+    enumerable: true,
+  });
+  for (const values of [[1, , 3], CustomArray.from([1, 2]), extraProperty]) {
+    expectError(
+      parseRunManifestV1({ ...finalLocalManifestJson, wireExtension: { values } }),
+      "$",
+      "invalid_value",
+    );
+  }
+
+  assert.equal(accessorCalls, 0);
+});
+
+test("Run Manifest returns detached additive objects and arrays", () => {
+  const extension = {
+    nested: { state: "original" },
+    items: [{ value: 1 }],
+  };
+  const candidate = recalculate({
+    ...finalLocalManifestJson,
+    wireExtension: extension,
+  });
+
+  const parsed = expectOk(parseRunManifestV1(candidate));
+  const parsedExtension = parsed.wireExtension as typeof extension;
+
+  assert.notStrictEqual(parsedExtension, extension);
+  assert.notStrictEqual(parsedExtension.nested, extension.nested);
+  assert.notStrictEqual(parsedExtension.items, extension.items);
+  assert.notStrictEqual(parsedExtension.items[0], extension.items[0]);
+
+  extension.nested.state = "mutated";
+  extension.items[0].value = 99;
+  extension.items.push({ value: 2 });
+  assert.equal(parsedExtension.nested.state, "original");
+  assert.equal(parsedExtension.items[0].value, 1);
+  assert.equal(parsedExtension.items.length, 1);
+});
+
+test("rejects unknown schema majors and wrong root digests", () => {
+  expectError(
+    parseRunManifestV1({ ...finalLocalManifestJson, schema: "opencoven.run-manifest/v2" }),
+    "$.schema",
+    "unknown_major",
+  );
+  expectError(
+    parseRunManifestV1({
+      ...finalLocalManifestJson,
+      digest: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    }),
+    "$.digest",
+    "digest_mismatch",
+  );
+});
+
+test("revision-only fixtures are digest-valid and fail their labeled pairwise invariants", () => {
+  const previous = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const invalidPreviousDigest = invalidPreviousDigestJson;
+  const invalidFinalMutation = invalidFinalMutationJson;
+
+  for (const fixture of [invalidPreviousDigest, invalidFinalMutation]) {
+    assert.equal(Value.Check(runManifestSchema, fixture), true);
+    assert.equal(fixture.digest, digestProtocolObject(fixture));
+  }
+
+  expectError(
+    validateRunManifestRevision(previous, invalidPreviousDigest),
+    "$.previousDigest",
+    "semantic_conflict",
+  );
+
+  expectError(
+    validateRunManifestRevision(previous, invalidFinalMutation),
+    "$.artifacts",
+    "semantic_conflict",
+  );
+});
+
+test("context and source correspondence plus source and execution uniqueness are enforced", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const withoutContextSource = {
+    ...local,
+    sources: local.sources.filter((source) => source.kind !== "context-pack"),
+  };
+  delete (withoutContextSource as Record<string, unknown>).context;
+  assert.equal(expectOk(parseRunManifestV1(recalculate(withoutContextSource))).context, undefined);
+
+  const duplicatedSource = recalculate({
+    ...local,
+    sources: [...local.sources, { ...local.sources[0] }],
+  });
+  expectError(parseRunManifestV1(duplicatedSource), "$.sources[1].id", "semantic_conflict");
+
+  const duplicatedExecution = recalculate({
+    ...local,
+    modelExecutions: [execution("modeltask_01", 1, null, null, null), execution("modeltask_01", 1, null, null, null)],
+    usage: aggregateManifestUsage([execution("modeltask_01", 1, null, null, null), execution("modeltask_01", 1, null, null, null)]),
+  });
+  expectError(parseRunManifestV1(duplicatedExecution), "$.modelExecutions[1]", "semantic_conflict");
+
+  const mismatchedContext = recalculate({
+    ...local,
+    sources: local.sources.map((source) =>
+      source.kind === "context-pack" ? { ...source, digest: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" } : source,
+    ),
+  });
+  expectError(parseRunManifestV1(mismatchedContext), "$.sources[0]", "semantic_conflict");
+});
+
+test("context absent forbids context-pack sources", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const noContext = { ...local };
+  delete (noContext as Record<string, unknown>).context;
+  const invalid = recalculate(noContext);
+  expectError(parseRunManifestV1(invalid), "$.sources[0]", "semantic_conflict");
+});
+
+test("public evidence canonicalUrl enforces HTTP(S) URL syntax", () => {
+  const cloud = expectOk(parseRunManifestV1(finalCloudManifestJson));
+  const withUrl = (canonicalUrl: string) =>
+    recalculate({
+      ...cloud,
+      sources: cloud.sources.map((source) =>
+        source.kind === "public-evidence"
+          ? { ...source, canonicalUrl }
+          : source,
+      ),
+    });
+
+  for (const canonicalUrl of [
+    "https://www.iana.org/research",
+    "http://www.cloudflare.com:8080/path?query=1",
+  ]) {
+    const candidate = withUrl(canonicalUrl);
+    assert.equal(Value.Check(runManifestSchema, candidate), true, canonicalUrl);
+    const result = parseRunManifestV1(candidate);
+    assert.equal(result.ok, true, canonicalUrl);
+    const parsed = expectOk(result);
+    assert.equal(
+      parsed.sources.find((source) => source.kind === "public-evidence")?.canonicalUrl,
+      canonicalUrl,
+    );
+  }
+
+  for (const [canonicalUrl, expectedSchemaValid] of [
+    ["", false],
+    ["file:///Users/example/report.html", false],
+    ["https://user:password@example.com/research", false],
+    ["https://example.com/research#private", false],
+    ["http://localhost/research", true],
+    ["http://127.0.0.1/research", true],
+    ["http://[::1]/research", true],
+    ["http://[fec0::1]/research", true],
+    ["https://10.0.0.1/research", true],
+    ["https://metadata.service.internal/research", true],
+    ["https://example.test/research", true],
+    ["https://-invalid.example.com/research", true],
+    ["/Users/example/report.html", false],
+  ] as const) {
+    const candidate = withUrl(canonicalUrl);
+    assert.equal(
+      Value.Check(runManifestSchema, candidate),
+      expectedSchemaValid,
+      canonicalUrl,
+    );
+    expectError(
+      parseRunManifestV1(candidate),
+      "$.sources[1].canonicalUrl",
+      "invalid_value",
+    );
+  }
+});
+
+test("public evidence canonicalUrl requires exact canonical WHATWG serialization", () => {
+  const cloud = expectOk(parseRunManifestV1(finalCloudManifestJson));
+  const withUrl = (canonicalUrl: string) =>
+    recalculate({
+      ...cloud,
+      sources: cloud.sources.map((source) =>
+        source.kind === "public-evidence"
+          ? { ...source, canonicalUrl }
+          : source,
+      ),
+    });
+
+  for (const canonicalUrl of [
+    "https://www.iana.org/",
+    "https://www.iana.org/research?phase=1",
+    "http://www.cloudflare.com:8080/path",
+  ]) {
+    const candidate = withUrl(canonicalUrl);
+    assert.equal(Value.Check(runManifestSchema, candidate), true, canonicalUrl);
+    assert.equal(
+      expectOk(parseRunManifestV1(candidate)).sources.find(
+        (source) => source.kind === "public-evidence",
+      )?.canonicalUrl,
+      canonicalUrl,
+    );
+  }
+
+  for (const [canonicalUrl, expectedSchemaValid] of [
+    ["http:////www.iana.org/path", false],
+    ["http:///www.iana.org/path", false],
+    ["http://", false],
+    ["http:\\\\www.iana.org\\path", false],
+    ["https://www.iana.org /path", false],
+    ["HTTPS://www.iana.org/path", false],
+    ["https://WWW.IANA.ORG/path", true],
+    ["http://www.iana.org:80/path", true],
+    ["https://www.iana.org", true],
+    ["https://www.iana.org/a/../research", true],
+  ] as const) {
+    const candidate = withUrl(canonicalUrl);
+    assert.equal(
+      Value.Check(runManifestSchema, candidate),
+      expectedSchemaValid,
+      canonicalUrl,
+    );
+    expectError(
+      parseRunManifestV1(candidate),
+      "$.sources[1].canonicalUrl",
+      "invalid_value",
+    );
+  }
+});
+
+test("public evidence canonicalUrl accepts global DNS and IP hosts", () => {
+  const cloud = expectOk(parseRunManifestV1(finalCloudManifestJson));
+  const withUrl = (canonicalUrl: string) =>
+    recalculate({
+      ...cloud,
+      sources: cloud.sources.map((source) =>
+        source.kind === "public-evidence"
+          ? { ...source, canonicalUrl }
+          : source,
+      ),
+    });
+
+  for (const canonicalUrl of [
+    "https://www.iana.org/research",
+    "http://www.cloudflare.com:8080/path?query=1",
+    "https://www.iana.org./research",
+    "http://1.0.0.0/",
+    "http://9.255.255.255/",
+    "http://11.0.0.0/",
+    "http://100.63.255.255/",
+    "http://100.128.0.0/",
+    "http://126.255.255.255/",
+    "http://128.0.0.0/",
+    "http://169.253.255.255/",
+    "http://169.255.0.0/",
+    "http://172.15.255.255/",
+    "http://172.32.0.0/",
+    "http://192.0.0.9/",
+    "http://192.0.0.10/",
+    "http://192.0.1.255/",
+    "http://192.0.3.0/",
+    "http://192.31.196.1/",
+    "http://192.52.193.1/",
+    "http://192.167.255.255/",
+    "http://192.169.0.0/",
+    "http://192.175.48.1/",
+    "http://198.17.255.255/",
+    "http://198.20.0.0/",
+    "http://198.51.99.255/",
+    "http://198.51.101.0/",
+    "http://203.0.112.255/",
+    "http://203.0.114.0/",
+    "http://223.255.255.255/",
+    "http://[::808:808]/",
+    "http://[::ffff:808:808]/",
+    "http://[64:ff9b::808:808]/",
+    "http://[2000::1]/",
+    "http://[2001:1::1]/",
+    "http://[2001:1::2]/",
+    "http://[2001:1::3]/",
+    "http://[2001:3::1]/",
+    "http://[2001:4:112::1]/",
+    "http://[2001:20::1]/",
+    "http://[2001:30::1]/",
+    "http://[2001:200::1]/",
+    "http://[2001:4860:4860::8888]/",
+    "http://[2002:808:808::1]/",
+    "http://[2606:4700:4700::1111]/",
+  ]) {
+    const candidate = withUrl(canonicalUrl);
+    assert.equal(Value.Check(runManifestSchema, candidate), true, canonicalUrl);
+    const result = parseRunManifestV1(candidate);
+    assert.equal(result.ok, true, canonicalUrl);
+    const parsed = expectOk(result);
+    assert.equal(
+      parsed.sources.find((source) => source.kind === "public-evidence")
+        ?.canonicalUrl,
+      canonicalUrl,
+    );
+  }
+});
+
+test("public evidence canonicalUrl rejects special-use names and non-global IP literals", () => {
+  const cloud = expectOk(parseRunManifestV1(finalCloudManifestJson));
+  const withUrl = (canonicalUrl: string) =>
+    recalculate({
+      ...cloud,
+      sources: cloud.sources.map((source) =>
+        source.kind === "public-evidence"
+          ? { ...source, canonicalUrl }
+          : source,
+      ),
+    });
+
+  for (const canonicalUrl of [
+    "http://localhost/research",
+    "http://localhost./research",
+    "http://service.local/research",
+    "http://service.localdomain/research",
+    "http://service.corp/research",
+    "http://service.mail/research",
+    "http://service.internal/research",
+    "http://service.invalid/research",
+    "http://service.test/research",
+    "http://service.onion/research",
+    "http://service.alt/research",
+    "http://home.arpa/research",
+    "http://router.home.arpa/research",
+    "http://in-addr.arpa/research",
+    "http://service.arpa/research",
+    "http://service.home/research",
+    "http://service.lan/research",
+    "https://example.com/research",
+    "https://sub.example.net/research",
+    "https://example.org/research",
+    "http://0.255.255.255/research",
+    "http://127.0.0.1/research",
+    "https://10.0.0.1/research",
+    "https://100.64.0.0/research",
+    "https://100.127.255.255/research",
+    "https://169.254.0.1/research",
+    "https://172.16.0.1/research",
+    "https://172.31.255.255/research",
+    "https://192.0.0.0/research",
+    "https://192.0.0.8/research",
+    "https://192.0.0.11/research",
+    "https://192.0.0.170/research",
+    "https://192.0.2.1/research",
+    "https://192.88.99.1/research",
+    "https://192.168.1.1/research",
+    "https://198.18.0.1/research",
+    "https://198.19.255.255/research",
+    "https://198.51.100.1/research",
+    "https://203.0.113.1/research",
+    "https://224.0.0.1/research",
+    "https://239.255.255.255/research",
+    "https://240.0.0.1/research",
+    "https://255.255.255.255/research",
+    "http://[::]/research",
+    "http://[::1]/research",
+    "http://[::a00:1]/research",
+    "http://[::c0a8:101]/research",
+    "http://[::ffff:c0a8:101]/research",
+    "http://[64:ff9b::c0a8:101]/research",
+    "http://[64:ff9b:1::1]/research",
+    "http://[100::1]/research",
+    "http://[100:0:0:1::1]/research",
+    "http://[2001::1]/research",
+    "http://[2001:1::4]/research",
+    "http://[2001:2::1]/research",
+    "http://[2001:4:111:ffff::1]/research",
+    "http://[2001:10::1]/research",
+    "http://[2001:40::1]/research",
+    "http://[2001:db8::1]/research",
+    "http://[2002:0a00:0001::1]/research",
+    "http://[2002:c0a8:0101::1]/research",
+    "http://[3ffe::1]/research",
+    "http://[3fff::1]/research",
+    "http://[4000::1]/research",
+    "http://[5f00::1]/research",
+    "http://[fc00::1]/research",
+    "http://[fdff::1]/research",
+    "http://[fe80::1]/research",
+    "http://[fec0::1]/research",
+    "http://[ff02::1]/research",
+    "https://-invalid.iana.org/research",
+  ]) {
+    const candidate = withUrl(canonicalUrl);
+    assert.equal(Value.Check(runManifestSchema, candidate), true, canonicalUrl);
+    const result = parseRunManifestV1(candidate);
+    assert.equal(result.ok, false, canonicalUrl);
+    expectError(
+      result,
+      "$.sources[1].canonicalUrl",
+      "invalid_value",
+    );
+  }
+});
+
+test("cloud content requires requested or completed synchronization", () => {
+  const cloud = expectOk(parseRunManifestV1(finalCloudManifestJson));
+  const invalid = recalculate({
+    ...cloud,
+    artifacts: [{ ...cloud.artifacts[0], contentSync: "not-requested" as const }],
+  });
+  expectError(parseRunManifestV1(invalid), "$.artifacts[0].contentSync", "semantic_conflict");
+});
+
+test("artifact titles reject paths, controls, and known secret prefixes", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const title of ["notes/private.txt", "C:\\private\\notes", "bad\u0001title", "sk-secret"]) {
+    const invalid = recalculate({
+      ...local,
+      artifacts: [{ ...local.artifacts[0], title }],
+    });
+    assert.equal(Value.Check(runManifestSchema, invalid), false, title);
+    expectError(parseRunManifestV1(invalid), "$.artifacts[0].title", "invalid_value");
+  }
+
+  const { expectedSchemaValid, ...invalidPrivateTitle } =
+    invalidPrivateTitleJson;
+  assert.equal(expectedSchemaValid, true);
+  assert.equal(Value.Check(runManifestSchema, invalidPrivateTitle), true);
+  assert.equal(
+    invalidPrivateTitle.digest,
+    digestProtocolObject(invalidPrivateTitle),
+  );
+  expectError(
+    parseRunManifestV1(invalidPrivateTitle),
+    "$.artifacts[0].title",
+    "invalid_value",
+  );
+});
+
+test("artifact title safety uses a Unicode security-normalized copy", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const title of [
+    "file：／／Users／alice／secret.txt",
+    "Users／alice／secret.txt",
+    "C：＼Users＼alice＼secret.txt",
+    "fi\u2060le：／／Users／alice／secret.txt",
+  ]) {
+    const invalid = recalculate({
+      ...local,
+      artifacts: [{ ...local.artifacts[0], title }],
+    });
+    assert.equal(Value.Check(runManifestSchema, invalid), true, title);
+    expectError(
+      parseRunManifestV1(invalid),
+      "$.artifacts[0].title",
+      "invalid_value",
+    );
+  }
+
+  const title = "Résumé — 研究ノート";
+  const benign = recalculate({
+    ...local,
+    artifacts: [{ ...local.artifacts[0], title }],
+  });
+  assert.equal(Value.Check(runManifestSchema, benign), true);
+  assert.equal(expectOk(parseRunManifestV1(benign)).artifacts[0].title, title);
+});
+
+test("artifact titles reject RFC 3986 URI scheme prefixes", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const title of [
+    "https://example.test",
+    "mailto:notes@example.test",
+    "geo:37.7,-122.4",
+    "custom+scheme:value",
+    "CuStOm.ScHeMe-2:value",
+    "data: private",
+    "javascript: alert(1)",
+    "CuStOm+ScHeMe.2-foo: not a URL",
+    "a:value",
+    "a:",
+  ]) {
+    const invalid = recalculate({
+      ...local,
+      artifacts: [{ ...local.artifacts[0], title }],
+    });
+    assert.equal(Value.Check(runManifestSchema, invalid), false, title);
+    expectError(parseRunManifestV1(invalid), "$.artifacts[0].title", "invalid_value");
+  }
+
+  for (const title of [
+    "ｄａｔａ： private",
+    "ｊａｖａｓｃｒｉｐｔ： alert(1)",
+    "CuStOm\u2060+Scheme： invalid payload",
+  ]) {
+    const invalid = recalculate({
+      ...local,
+      artifacts: [{ ...local.artifacts[0], title }],
+    });
+    assert.equal(Value.Check(runManifestSchema, invalid), true, title);
+    expectError(parseRunManifestV1(invalid), "$.artifacts[0].title", "invalid_value");
+  }
+});
+
+test("artifact title URI detection preserves ordinary colon text and RFC 3986 boundaries", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const title of [
+    "Decision 1: summary",
+    "Version 2: summary",
+    "12:30 summary",
+    "1custom:value",
+    "custom_scheme:value",
+    "custom scheme:value",
+  ]) {
+    const candidate = recalculate({
+      ...local,
+      artifacts: [{ ...local.artifacts[0], title }],
+    });
+    assert.equal(Value.Check(runManifestSchema, candidate), true, title);
+    assert.equal(expectOk(parseRunManifestV1(candidate)).artifacts[0].title, title);
+  }
+});
+
+test("sensitive manifest objects reject forbidden extension keys case-insensitively", () => {
+  assert.equal(
+    runManifestSchema.$defs.sensitivePropertyName.not.pattern,
+    SENSITIVE_EXTENSION_KEY_PATTERN,
+  );
+  assert.equal(
+    runManifestSchema.$defs.sensitivePropertyName.allOf[0].not.pattern,
+    SENSITIVE_EXTENSION_VARIANT_KEY_PATTERN,
+  );
+  assert.equal(
+    runManifestSchema.$defs.sensitivePropertyName.allOf[1].not.pattern,
+    SENSITIVE_EXTENSION_COMPOUND_KEY_PATTERN,
+  );
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const key of [
+    "excerpt",
+    "excerpts",
+    "prompt",
+    "prompts",
+    "text",
+    "texts",
+    "content",
+    "contents",
+    "blob",
+    "blobs",
+    "filename",
+    "filenames",
+    "localPath",
+    "localPaths",
+    "filePath",
+    "filePaths",
+    "path",
+    "paths",
+    "credential",
+    "credentials",
+    "secret",
+    "secrets",
+    "objectKey",
+    "objectKeys",
+    "storageKey",
+    "storageKeys",
+    "bucketKey",
+    "bucketKeys",
+    "deletedContent",
+    "deletedContents",
+    "privateExcerpts",
+    "privacyPrompts",
+    "rawPrompt",
+    "rawPrompts",
+    "CoNtEnT",
+    "private_contentValue",
+    "privateCONTENTvalue",
+    "rawTEXTvalue",
+    "private_storageKeyValue",
+    "objectStoreKey",
+  ]) {
+    const invalid = recalculate({
+      ...local,
+      artifacts: [{ ...local.artifacts[0], [key]: "private material" }],
+    });
+    assert.equal(Value.Check(runManifestSchema, invalid), false, key);
+    expectError(parseRunManifestV1(invalid), `$.artifacts[0].${key}`, "semantic_conflict");
+  }
+
+  const contextSource = recalculate({
+    ...local,
+    sources: [{ ...local.sources[0], TeXt: "private material" }],
+  });
+  assert.equal(Value.Check(runManifestSchema, contextSource), false);
+  expectError(parseRunManifestV1(contextSource), "$.sources[0].TeXt", "semantic_conflict");
+
+  const deletion = recalculate({
+    ...local,
+    deletion: { ...local.deletion, DeLeTeDcOnTeNt: "private material" },
+  });
+  assert.equal(Value.Check(runManifestSchema, deletion), false);
+  expectError(
+    parseRunManifestV1(deletion),
+    "$.deletion.DeLeTeDcOnTeNt",
+    "semantic_conflict",
+  );
+
+  const cloudMetadata = recalculate({
+    ...local,
+    artifacts: [
+      {
+        ...local.artifacts[0],
+        placement: "cloud-metadata",
+        filename: "private-report.md",
+      },
+    ],
+  });
+  assert.equal(Value.Check(runManifestSchema, cloudMetadata), false);
+  expectError(
+    parseRunManifestV1(cloudMetadata),
+    "$.artifacts[0].filename",
+    "semantic_conflict",
+  );
+
+  for (const [key, path] of [
+    ["privateExcerpt", "$.artifacts[0].privateExcerpt"],
+    ["PrivateExcerpt", "$.artifacts[0].PrivateExcerpt"],
+    ["local_file_path", "$.artifacts[0].local_file_path"],
+    ["credentialHint", "$.artifacts[0].credentialHint"],
+    ["private-excerpt", '$.artifacts[0]["private-excerpt"]'],
+    ["private.excerpt", '$.artifacts[0]["private.excerpt"]'],
+    ["PrIvAtEeXcErPt", "$.artifacts[0].PrIvAtEeXcErPt"],
+  ] as const) {
+    const invalid = recalculate({
+      ...local,
+      artifacts: [{ ...local.artifacts[0], [key]: "private material" }],
+    });
+    assert.equal(Value.Check(runManifestSchema, invalid), false, key);
+    expectError(parseRunManifestV1(invalid), path, "semantic_conflict");
+  }
+});
+
+test("privacy extension tokenization preserves benign whole-word near misses", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const key of [
+    "context",
+    "contentment",
+    "textile",
+    "pathology",
+    "secretary",
+    "credentialed",
+    "blobfish",
+    "promptly",
+    "privateContextValue",
+    "rawTextureValue",
+    "objectKeyboardLayout",
+  ]) {
+    const candidate = recalculate({
+      ...local,
+      artifacts: [{ ...local.artifacts[0], [key]: "benign audit metadata" }],
+    });
+    assert.equal(Value.Check(runManifestSchema, candidate), true, key);
+    assert.equal(
+      expectOk(parseRunManifestV1(candidate)).artifacts[0][key],
+      "benign audit metadata",
+      key,
+    );
+  }
+});
+
+test("schema and parser reject forbidden keys nested in sensitive extension objects and arrays", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const [candidate, path] of [
+    [
+      recalculate({
+        ...local,
+        sources: [
+          {
+            ...local.sources[0],
+            metadata: { items: [{ privateExcerpt: "private material" }] },
+          },
+        ],
+      }),
+      "$.sources[0].metadata.items[0].privateExcerpt",
+    ],
+    [
+      recalculate({
+        ...local,
+        artifacts: [
+          {
+            ...local.artifacts[0],
+            metadata: { nested: { local_file_path: "/private/report.md" } },
+          },
+        ],
+      }),
+      "$.artifacts[0].metadata.nested.local_file_path",
+    ],
+    [
+      recalculate({
+        ...local,
+        deletion: {
+          ...local.deletion,
+          metadata: [{ credentialHint: "tenant/private/object" }],
+        },
+      }),
+      "$.deletion.metadata[0].credentialHint",
+    ],
+  ] as const) {
+    assert.equal(Value.Check(runManifestSchema, candidate), false);
+    expectError(parseRunManifestV1(candidate), path, "semantic_conflict");
+  }
+
+  assert.equal(
+    invalidNestedPrivateExtensionJson.digest,
+    digestProtocolObject(invalidNestedPrivateExtensionJson),
+  );
+  assert.equal(Value.Check(runManifestSchema, invalidNestedPrivateExtensionJson), false);
+  expectError(
+    parseRunManifestV1(invalidNestedPrivateExtensionJson),
+    "$.sources[0].metadata.items[0].privateExcerpt",
+    "semantic_conflict",
+  );
+});
+
+test("digest-correct fixtures enforce root, model, plural, and nested privacy boundaries", () => {
+  const reviewerBoundaryFixture = invalidNestedPrivateExtensionJson.sources[0]
+    .metadata.items[0] as Record<string, unknown>;
+  for (const key of [
+    "private_contentValue",
+    "privateCONTENTvalue",
+    "rawTEXTvalue",
+    "private_storageKeyValue",
+  ]) {
+    assert.equal(key in reviewerBoundaryFixture, true, `${key} must have a parity fixture`);
+  }
+
+  for (const [fixture, path] of [
+    [invalidRootPrivateExcerptsJson, "$.privateExcerpts"],
+    [invalidModelRawPromptJson, "$.modelExecutions[0].rawPrompt"],
+    [
+      invalidNestedPrivacyStorageKeysJson,
+      "$.retention.extensionMetadata.items[0].privacyStorageKeys",
+    ],
+  ] as const) {
+    assert.equal(fixture.digest, digestProtocolObject(fixture));
+    assert.equal(Value.Check(runManifestSchema, fixture), false);
+    expectError(parseRunManifestV1(fixture), path, "semantic_conflict");
+  }
+
+  assert.equal(
+    validExtensionBoundariesJson.digest,
+    digestProtocolObject(validExtensionBoundariesJson),
+  );
+  assert.equal(Value.Check(runManifestSchema, validExtensionBoundariesJson), true);
+  const benignBoundaryFixture = validExtensionBoundariesJson.extensionMetadata as Record<
+    string,
+    unknown
+  >;
+  for (const key of [
+    "context",
+    "contentment",
+    "textile",
+    "pathology",
+    "secretary",
+    "credentialed",
+  ]) {
+    assert.equal(key in benignBoundaryFixture, true, `${key} must have a parity fixture`);
+  }
+  assert.deepEqual(
+    expectOk(parseRunManifestV1(validExtensionBoundariesJson)),
+    validExtensionBoundariesJson,
+  );
+});
+
+test("privacy fixtures reject lowercase compounds and split identifier paths", () => {
+  assert.equal(
+    invalidDeletedContentPayloadJson.digest,
+    digestProtocolObject(invalidDeletedContentPayloadJson),
+  );
+  assert.equal(Value.Check(runManifestSchema, invalidDeletedContentPayloadJson), false);
+  expectError(
+    parseRunManifestV1(invalidDeletedContentPayloadJson),
+    "$.extensionMetadata.deletedcontentpayload",
+    "semantic_conflict",
+  );
+
+  const { expectedSchemaValid, ...splitPathManifest } = invalidSplitObjectStoreKeyJson;
+  assert.equal(expectedSchemaValid, true);
+  assert.equal(
+    splitPathManifest.digest,
+    digestProtocolObject(splitPathManifest),
+  );
+  assert.equal(Value.Check(runManifestSchema, splitPathManifest), true);
+  expectError(
+    parseRunManifestV1(splitPathManifest),
+    "$.extensionMetadata.audit.object.store.key",
+    "semantic_conflict",
+  );
+});
+
+test("privacy key paths reject dangerous split components but preserve near misses", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const [extension, path] of [
+    [{ audit: { object: { key: "private" } } }, "$.extension.audit.object.key"],
+    [{ audit: { object: { store: { key: "private" } } } }, "$.extension.audit.object.store.key"],
+    [{ audit: { storage: { key: "private" } } }, "$.extension.audit.storage.key"],
+    [{ audit: { bucket: { key: "private" } } }, "$.extension.audit.bucket.key"],
+    [{ audit: [{ store: { key: "private" } }] }, "$.extension.audit[0].store.key"],
+  ] as const) {
+    const invalid = recalculate({ ...local, extension });
+    assert.equal(Value.Check(runManifestSchema, invalid), true, path);
+    expectError(parseRunManifestV1(invalid), path, "semantic_conflict");
+  }
+
+  for (const extension of [
+    { key: "benign standalone key" },
+    { audit: { key: "benign nested key" } },
+    { audit: { object: { label: "benign object metadata" } } },
+  ]) {
+    const candidate = recalculate({ ...local, extension });
+    assert.equal(Value.Check(runManifestSchema, candidate), true);
+    assert.deepEqual(expectOk(parseRunManifestV1(candidate)).extension, extension);
+  }
+
+  assert.equal(Value.Check(runManifestSchema, validNestedBenignExtensionJson), true);
+  const benign = expectOk(parseRunManifestV1(validNestedBenignExtensionJson));
+  const metadata = benign.deletion.metadata as Record<string, unknown>;
+  assert.deepEqual(
+    {
+      objectives: metadata.objectives,
+      storefront: metadata.storefront,
+      storagelike: metadata.storagelike,
+      bucketed: metadata.bucketed,
+      keystone: metadata.keystone,
+      deletedcontentmentpayload: metadata.deletedcontentmentpayload,
+    },
+    {
+      objectives: "met",
+      storefront: "closed",
+      storagelike: "audit-only",
+      bucketed: true,
+      keystone: "retention",
+      deletedcontentmentpayload: "benign",
+    },
+  );
+});
+
+test("privacy keys are NFKC-normalized while benign Unicode extensions remain lossless", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const [key, path] of [
+    ["ｒａｗＰｒｏｍｐｔ", '$.extension["ｒａｗＰｒｏｍｐｔ"]'],
+    ["ｏｂｊｅｃｔＫｅｙ", '$.extension["ｏｂｊｅｃｔＫｅｙ"]'],
+    ["deletedＣｏｎｔｅｎｔPayload", '$.extension["deletedＣｏｎｔｅｎｔPayload"]'],
+    ["caféＰｒｏｍｐｔ", '$.extension["caféＰｒｏｍｐｔ"]'],
+    ["監査prompt", '$.extension["監査prompt"]'],
+  ] as const) {
+    const candidate = recalculate({
+      ...local,
+      extension: { [key]: "private material" },
+    });
+    assert.equal(Value.Check(runManifestSchema, candidate), true, key);
+    expectError(parseRunManifestV1(candidate), path, "semantic_conflict");
+  }
+
+  const unicodeExtension = {
+    "研究メタデータ": {
+      "café": "préservé",
+      "аudit": { "状態": "complete" },
+    },
+  };
+  const candidate = recalculate({ ...local, ...unicodeExtension });
+  assert.equal(Value.Check(runManifestSchema, candidate), true);
+  const parsed = expectOk(parseRunManifestV1(candidate));
+  assert.deepEqual(
+    parsed["研究メタデータ"],
+    unicodeExtension["研究メタデータ"],
+  );
+  assert.equal(
+    Object.keys(parsed).includes("研究メタデータ"),
+    true,
+    "the parser must preserve the original Unicode key rather than its NFKC form",
+  );
+
+  assert.equal(Value.Check(runManifestSchema, validUnicodeExtensionJson), true);
+  assert.deepEqual(
+    expectOk(parseRunManifestV1(validUnicodeExtensionJson)),
+    validUnicodeExtensionJson,
+  );
+
+  const { expectedSchemaValid, ...invalidUnicodeSensitiveExtension } =
+    invalidUnicodeSensitiveExtensionJson;
+  assert.equal(expectedSchemaValid, true);
+  assert.equal(
+    Value.Check(runManifestSchema, invalidUnicodeSensitiveExtension),
+    true,
+  );
+  expectError(
+    parseRunManifestV1(invalidUnicodeSensitiveExtension),
+    '$["ｒａｗＰｒｏｍｐｔ"]',
+    "semantic_conflict",
+  );
+});
+
+test("deletion receipt extensions require raw ASCII keys recursively", () => {
+  for (const [fixture, path] of [
+    [invalidDeletionHomoglyphRootJson, '$.deletion["objectKеy"]'],
+    [invalidDeletionHomoglyphNestedJson, '$.deletion.auditEnvelope["objectKеy"]'],
+    [invalidDeletionHomoglyphArrayJson, '$.deletion.auditEnvelope[0]["objectKеy"]'],
+  ] as const) {
+    assert.equal(fixture.digest, digestProtocolObject(fixture));
+    assert.equal(Value.Check(runManifestSchema, fixture), false, path);
+    expectError(parseRunManifestV1(fixture), path, "semantic_conflict");
+  }
+
+  assert.equal(
+    validDeletionAsciiExtensionJson.digest,
+    digestProtocolObject(validDeletionAsciiExtensionJson),
+  );
+  assert.equal(Value.Check(runManifestSchema, validDeletionAsciiExtensionJson), true);
+  assert.deepEqual(
+    expectOk(parseRunManifestV1(validDeletionAsciiExtensionJson)),
+    validDeletionAsciiExtensionJson,
+  );
+});
+
+test("root and nested deleted-content payload extensions reject while near misses remain valid", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const [candidate, path, expectedSchemaValid] of [
+    [
+      recalculate({ ...local, deletedContentPayload: "private material" }),
+      "$.deletedContentPayload",
+      false,
+    ],
+    [
+      recalculate({
+        ...local,
+        extension: { audit: { deleted: { content: { payload: "private material" } } } },
+      }),
+      "$.extension.audit.deleted.content",
+      false,
+    ],
+    [
+      recalculate({
+        ...local,
+        extension: { audit: { deletedcontentpayload: "private material" } },
+      }),
+      "$.extension.audit.deletedcontentpayload",
+      false,
+    ],
+  ] as const) {
+    assert.equal(Value.Check(runManifestSchema, candidate), expectedSchemaValid, path);
+    expectError(parseRunManifestV1(candidate), path, "semantic_conflict");
+  }
+
+  const nearMiss = recalculate({
+    ...local,
+    extension: {
+      audit: {
+        key: "benign",
+        deletedcontentmentpayload: "benign",
+        object: { storefront: { keystone: "benign" } },
+      },
+    },
+  });
+  assert.equal(Value.Check(runManifestSchema, nearMiss), true);
+  expectOk(parseRunManifestV1(nearMiss));
+});
+
+test("schema and parser enforce privacy keys at every manifest object boundary", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const cloud = expectOk(parseRunManifestV1(finalCloudManifestJson));
+  assert.ok(local.context);
+
+  const cases: Array<{ candidate: Record<string, unknown>; path: string }> = [
+    {
+      candidate: recalculate({ ...local, privateExcerpts: ["private"] }),
+      path: "$.privateExcerpts",
+    },
+    {
+      candidate: recalculate({
+        ...local,
+        context: { ...local.context, privacyPrompts: ["private"] },
+      }),
+      path: "$.context.privacyPrompts",
+    },
+    {
+      candidate: recalculate({
+        ...local,
+        sources: [{ ...local.sources[0], privateExcerpts: ["private"] }],
+      }),
+      path: "$.sources[0].privateExcerpts",
+    },
+    {
+      candidate: recalculate({
+        ...cloud,
+        sources: cloud.sources.map((source) =>
+          source.kind === "public-evidence"
+            ? { ...source, rawPrompt: "private" }
+            : source,
+        ),
+      }),
+      path: "$.sources[1].rawPrompt",
+    },
+    {
+      candidate: recalculate({
+        ...local,
+        artifacts: [{ ...local.artifacts[0], privateExcerpts: ["private"] }],
+      }),
+      path: "$.artifacts[0].privateExcerpts",
+    },
+    {
+      candidate: recalculate({
+        ...cloud,
+        modelExecutions: [
+          { ...cloud.modelExecutions[0], rawPrompt: "private" },
+        ],
+      }),
+      path: "$.modelExecutions[0].rawPrompt",
+    },
+    {
+      candidate: recalculate({
+        ...cloud,
+        modelExecutions: [
+          {
+            ...cloud.modelExecutions[0],
+            receipt: {
+              ...cloud.modelExecutions[0].receipt,
+              privateExcerpts: ["private"],
+            },
+          },
+        ],
+      }),
+      path: "$.modelExecutions[0].receipt.privateExcerpts",
+    },
+    {
+      candidate: recalculate({
+        ...cloud,
+        modelExecutions: [
+          {
+            ...cloud.modelExecutions[0],
+            receipt: {
+              ...cloud.modelExecutions[0].receipt,
+              usage: {
+                ...cloud.modelExecutions[0].receipt.usage,
+                privacyPrompts: ["private"],
+              },
+            },
+          },
+        ],
+      }),
+      path: "$.modelExecutions[0].receipt.usage.privacyPrompts",
+    },
+    {
+      candidate: recalculate({
+        ...local,
+        usage: { ...local.usage, privateExcerpts: ["private"] },
+      }),
+      path: "$.usage.privateExcerpts",
+    },
+    {
+      candidate: recalculate({
+        ...local,
+        retention: { ...local.retention, privacyStorageKeys: ["private"] },
+      }),
+      path: "$.retention.privacyStorageKeys",
+    },
+    {
+      candidate: recalculate({
+        ...local,
+        deletion: { ...local.deletion, deletedContents: ["private"] },
+      }),
+      path: "$.deletion.deletedContents",
+    },
+  ];
+
+  for (const { candidate, path } of cases) {
+    assert.equal(candidate.digest, digestProtocolObject(candidate), path);
+    assert.equal(Value.Check(runManifestSchema, candidate), false, path);
+    expectError(parseRunManifestV1(candidate), path, "semantic_conflict");
+  }
+});
+
+test("privacy key checks do not scan extension values", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const benign = recalculate({
+    ...local,
+    sources: [
+      {
+        ...local.sources[0],
+        displayMetadata: {
+          nested: [{ label: "safe", values: [null, true, 1] }],
+        },
+      },
+    ],
+    artifacts: [
+      {
+        ...local.artifacts[0],
+        displayMetadata: {
+          label: "secret",
+          mediaHint: "text/markdown",
+          examples: ["/Users/example/private.md", "deletedContent"],
+        },
+      },
+    ],
+    deletion: {
+      ...local.deletion,
+      auditMetadata: { note: "objectKey" },
+    },
+  });
+  assert.equal(Value.Check(runManifestSchema, benign), true);
+  const parsedBenign = expectOk(parseRunManifestV1(benign));
+  assert.deepEqual(
+    (parsedBenign.sources[0].displayMetadata as { nested: Array<{ values: unknown[] }> }).nested[0].values,
+    [null, true, 1],
+  );
+  assert.deepEqual(
+    (parsedBenign.artifacts[0].displayMetadata as { examples: string[] }).examples,
+    ["/Users/example/private.md", "deletedContent"],
+  );
+
+  const cloud = expectOk(parseRunManifestV1(finalCloudManifestJson));
+  const publicEvidence = recalculate({
+    ...cloud,
+    sources: cloud.sources.map((source) =>
+      source.kind === "public-evidence"
+        ? {
+            ...source,
+            displayMetadata: {
+              label: "excerpt",
+              examples: ["text", "path"],
+              canonicalUrl: source.canonicalUrl,
+            },
+          }
+        : source,
+    ),
+  });
+  const parsedPublicEvidence = expectOk(parseRunManifestV1(publicEvidence));
+  const evidence = parsedPublicEvidence.sources.find((source) => source.kind === "public-evidence");
+  assert.deepEqual(
+    (evidence?.displayMetadata as { examples: string[] }).examples,
+    ["text", "path"],
+  );
+
+  assert.equal(Value.Check(runManifestSchema, validNestedBenignExtensionJson), true);
+  assert.deepEqual(
+    expectOk(parseRunManifestV1(validNestedBenignExtensionJson)),
+    validNestedBenignExtensionJson,
+  );
+});
+
+test("declared protocol fields remain authoritative inside sensitive objects", () => {
+  for (const fixture of [finalLocalManifestJson, retentionUpdateJson]) {
+    assert.equal(Value.Check(runManifestSchema, fixture), true);
+    expectOk(parseRunManifestV1(fixture));
+  }
+
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const completed = recalculate({
+    ...local,
+    revision: 2,
+    previousDigest: local.digest,
+    retention: {
+      ...local.retention,
+      status: "deleted" as const,
+      contentExpiresAt: "2026-08-17T20:00:00.000Z",
+      updatedAt: "2026-08-17T20:00:00.000Z",
+    },
+    deletion: {
+      ...local.deletion,
+      status: "completed" as const,
+      requestedAt: "2026-08-17T19:00:00.000Z",
+      completedAt: "2026-08-17T20:00:00.000Z",
+      deletedObjectCount: 3,
+      eventSequence: 2,
+    },
+  });
+  assert.equal(Value.Check(runManifestSchema, completed), true);
+  const parsed = expectOk(parseRunManifestV1(completed));
+  assert.equal(parsed.artifacts[0].contentSync, "not-requested");
+  assert.equal(parsed.retention.contentExpiresAt, "2026-08-17T20:00:00.000Z");
+  assert.equal(parsed.deletion.deletedObjectCount, 3);
+});
+
+test("invalid deletion fixtures isolate their named pair and event invariants", () => {
+  assert.notEqual(invalidDeletionPairJson.retention.contentExpiresAt, null);
+  assert.equal(
+    invalidDeletionPairJson.digest,
+    digestProtocolObject(invalidDeletionPairJson),
+  );
+  assert.equal(Value.Check(runManifestSchema, invalidDeletionPairJson), false);
+  expectError(
+    parseRunManifestV1(invalidDeletionPairJson),
+    "$.retention.status",
+    "semantic_conflict",
+  );
+  const repairedPair = recalculate({
+    ...invalidDeletionPairJson,
+    deletion: {
+      ...invalidDeletionPairJson.deletion,
+      status: "scheduled" as const,
+    },
+  });
+  assert.equal(Value.Check(runManifestSchema, repairedPair), true);
+  expectOk(parseRunManifestV1(repairedPair));
+
+  assert.notEqual(invalidDeletionEventJson.retention.contentExpiresAt, null);
+  assert.equal(
+    invalidDeletionEventJson.digest,
+    digestProtocolObject(invalidDeletionEventJson),
+  );
+  assert.equal(Value.Check(runManifestSchema, invalidDeletionEventJson), false);
+  expectError(
+    parseRunManifestV1(invalidDeletionEventJson),
+    "$.deletion.eventSequence",
+    "missing_field",
+  );
+  const repairedEvent = recalculate({
+    ...invalidDeletionEventJson,
+    deletion: {
+      ...invalidDeletionEventJson.deletion,
+      eventSequence: 2,
+    },
+  });
+  assert.equal(Value.Check(runManifestSchema, repairedEvent), true);
+  expectOk(parseRunManifestV1(repairedEvent));
+});
+
+test("retention and deletion status pairs and receipt requirements are enforced", () => {
+  assert.equal(Value.Check(runManifestSchema, invalidDeletionPairJson), false);
+  expectError(parseRunManifestV1(invalidDeletionPairJson), "$.retention.status", "semantic_conflict");
+
+  assert.equal(Value.Check(runManifestSchema, invalidDeletionEventJson), false);
+  expectError(parseRunManifestV1(invalidDeletionEventJson), "$.deletion.eventSequence", "missing_field");
+
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  for (const deletion of [
+    { status: "scheduled" as const },
+    { status: "pending" as const },
+    { status: "partial_failure" as const },
+  ]) {
+    const invalid = recalculate({
+      ...local,
+      retention: { ...local.retention, status: deletion.status === "scheduled" ? "deletion_scheduled" : "deletion_pending" },
+      deletion,
+    });
+    expectError(parseRunManifestV1(invalid), "$.deletion.requestedAt", "missing_field");
+  }
+
+  const activeWithExpiry = recalculate({
+    ...local,
+    retention: { ...local.retention, contentExpiresAt: "2026-08-20T00:00:00.000Z" },
+  });
+  assert.equal(Value.Check(runManifestSchema, activeWithExpiry), false);
+  expectError(parseRunManifestV1(activeWithExpiry), "$.retention.contentExpiresAt", "semantic_conflict");
+
+  assert.equal(Value.Check(runManifestSchema, invalidScheduledNullExpiryJson), false);
+  expectError(
+    parseRunManifestV1(invalidScheduledNullExpiryJson),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+
+  for (const [retentionStatus, deletion] of [
+    [
+      "deletion_pending",
+      {
+        status: "pending",
+        requestedAt: "2026-08-17T19:00:00.000Z",
+      },
+    ],
+    [
+      "deletion_pending",
+      {
+        status: "partial_failure",
+        requestedAt: "2026-08-17T19:00:00.000Z",
+      },
+    ],
+    [
+      "deleted",
+      {
+        status: "completed",
+        requestedAt: "2026-08-17T19:00:00.000Z",
+        completedAt: "2026-08-17T20:00:00.000Z",
+        deletedObjectCount: 3,
+        eventSequence: 2,
+      },
+    ],
+  ] as const) {
+    const invalid = recalculate({
+      ...local,
+      retention: {
+        ...local.retention,
+        status: retentionStatus,
+        contentExpiresAt: null,
+      },
+      deletion,
+    });
+    assert.equal(Value.Check(runManifestSchema, invalid), false);
+    expectError(
+      parseRunManifestV1(invalid),
+      "$.retention.contentExpiresAt",
+      "semantic_conflict",
+    );
+  }
+});
+
+test("completed deletion receipts reject reversed chronology and allow equality", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const completed = (requestedAt: string, completedAt: string) =>
+    recalculate({
+      ...local,
+      revision: 2,
+      previousDigest: local.digest,
+      retention: {
+        ...local.retention,
+        status: "deleted" as const,
+        contentExpiresAt: completedAt,
+        updatedAt: completedAt,
+      },
+      deletion: {
+        status: "completed" as const,
+        requestedAt,
+        completedAt,
+        deletedObjectCount: 1,
+        eventSequence: 2,
+      },
+    });
+
+  const reversed = completed(
+    "2026-08-17T20:00:00.000Z",
+    "2026-08-17T19:59:59.999999999Z",
+  );
+  assert.equal(Value.Check(runManifestSchema, reversed), true);
+  expectError(
+    parseRunManifestV1(reversed),
+    "$.deletion.completedAt",
+    "semantic_conflict",
+  );
+
+  expectOk(
+    parseRunManifestV1(
+      completed("2026-08-17T20:00:00Z", "2026-08-17T20:00:00.000000000Z"),
+    ),
+  );
+});
+
+test("deletion requests cannot predate manifest creation or finalization", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const completed = (
+    base: RunManifestV1,
+    requestedAt: string,
+    completedAt: string,
+  ) =>
+    recalculate({
+      ...base,
+      revision: base.revision + 1,
+      previousDigest: base.digest,
+      retention: {
+        ...base.retention,
+        status: "deleted" as const,
+        contentExpiresAt: completedAt,
+        updatedAt: completedAt,
+      },
+      deletion: {
+        status: "completed" as const,
+        requestedAt,
+        completedAt,
+        deletedObjectCount: 1,
+        eventSequence: 2,
+      },
+    });
+
+  const historicalReceipt = completed(
+    local,
+    "2000-01-01T00:00:00.000Z",
+    "2000-01-01T00:00:00.000Z",
+  );
+  assert.equal(historicalReceipt.digest, digestProtocolObject(historicalReceipt));
+  expectError(
+    parseRunManifestV1(historicalReceipt),
+    "$.deletion.requestedAt",
+    "semantic_conflict",
+  );
+
+  expectOk(
+    parseRunManifestV1(
+      completed(local, local.finalizedAt!, local.finalizedAt!),
+    ),
+  );
+
+  const leapBase = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...local,
+        createdAt: "2016-12-31T23:59:59.000000000Z",
+        finalizedAt: "2016-12-31T23:59:60.500000000Z",
+        artifacts: local.artifacts.map((artifact) => ({
+          ...artifact,
+          createdAt: "2016-12-31T23:59:60.000000000Z",
+        })),
+        retention: {
+          ...local.retention,
+          updatedAt: "2016-12-31T23:59:60.500000000Z",
+        },
+      }),
+    ),
+  );
+  expectError(
+    parseRunManifestV1(
+      completed(
+        leapBase,
+        "2016-12-31T23:59:60.499999999Z",
+        "2016-12-31T23:59:60.500000000Z",
+      ),
+    ),
+    "$.deletion.requestedAt",
+    "semantic_conflict",
+  );
+  expectOk(
+    parseRunManifestV1(
+      completed(
+        leapBase,
+        "2016-12-31T23:59:60.500000000Z",
+        "2016-12-31T23:59:60.500000000Z",
+      ),
+    ),
+  );
+});
+
+test("retention consent uses context consent or the original policy ceiling", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  assert.equal(validateManifestRetentionConsent(local, undefined).ok, false);
+  assert.equal(validateManifestRetentionConsent(local, "7-days").ok, true);
+
+  const contextCeiling = validateManifestRetentionConsent(local, "run-only");
+  expectError(contextCeiling, "$.retention.policy", "semantic_conflict");
+
+  const noContext = { ...local };
+  delete (noContext as Record<string, unknown>).context;
+  noContext.sources = noContext.sources.filter((source) => source.kind !== "context-pack");
+  const noContextParsed = expectOk(parseRunManifestV1(recalculate(noContext)));
+  assert.equal(validateManifestRetentionConsent(noContextParsed, "run-only").ok, true);
+  const tooLong = recalculate({
+    ...noContextParsed,
+    retention: { ...noContextParsed.retention, effectivePolicy: "project" as const },
+  });
+  const tooLongParsed = parseRunManifestV1(tooLong);
+  assert.equal(tooLongParsed.ok, false);
+});
+
+test("single-manifest consent validation cannot trust a later updatedAt clock", () => {
+  const original = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const unverifiedRevision = recalculate({
+    ...original,
+    revision: 2,
+    previousDigest: original.digest,
+    retention: {
+      ...original.retention,
+      status: "deletion_scheduled" as const,
+      contentExpiresAt: "2026-08-24T20:04:00.000Z",
+      updatedAt: "2026-08-17T20:04:00.000Z",
+    },
+    deletion: {
+      status: "scheduled" as const,
+      requestedAt: "2026-08-17T20:04:00.000Z",
+    },
+  });
+
+  expectError(
+    validateManifestRetentionConsent(
+      unverifiedRevision as unknown as RunManifestV1,
+      "7-days",
+    ),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+});
+
+test("revision chains accept assembling-to-final and allowed retention updates", () => {
+  const assembling = expectOk(parseRunManifestV1(assemblingManifestJson));
+  const finalLocalRevision2 = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...finalLocalManifestJson,
+        revision: 2,
+        previousDigest: assembling.digest,
+      }),
+    ),
+  );
+  assert.equal(
+    validateRunManifestRevision(assembling, finalLocalRevision2, { contextConsent: "7-days" }).ok,
+    true,
+  );
+
+  const finalLocal = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const update = expectOk(parseRunManifestV1(retentionUpdateJson));
+  assert.deepEqual(
+    expectOk(validateRunManifestRevision(finalLocal, update, { contextConsent: "7-days" })),
+    update,
+  );
+});
+
+test("revision validation rejects unproven predecessors and replays serialized chains", () => {
+  const root = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const ordinarySecondCandidate = recalculate({
+    ...root,
+    revision: 2,
+    previousDigest: root.digest,
+    retention: {
+      ...root.retention,
+      updatedAt: "2026-08-16T20:06:00.000Z",
+    },
+  });
+  const ordinaryThirdCandidate = recalculate({
+    ...ordinarySecondCandidate,
+    revision: 3,
+    previousDigest: ordinarySecondCandidate.digest,
+    retention: {
+      ...ordinarySecondCandidate.retention,
+      updatedAt: "2026-08-16T20:07:00.000Z",
+    },
+  });
+  const fabricatedSecond = expectOk(parseRunManifestV1(ordinarySecondCandidate));
+  expectError(
+    validateRunManifestRevisionV1(fabricatedSecond, ordinaryThirdCandidate, {
+      contextConsent: "7-days",
+    }),
+    "$.revision",
+    "semantic_conflict",
+  );
+
+  const validatedSecond = expectOk(
+    validateRunManifestRevisionV1(root, ordinarySecondCandidate, {
+      contextConsent: "7-days",
+    }),
+  );
+  expectError(
+    validateRunManifestRevisionV1(
+      ordinarySecondCandidate as unknown as RunManifestV1,
+      ordinaryThirdCandidate,
+      { contextConsent: "7-days" },
+    ),
+    "$.revision",
+    "semantic_conflict",
+  );
+  assert.deepEqual(
+    expectOk(
+      validateRunManifestRevisionV1(validatedSecond, ordinaryThirdCandidate, {
+        contextConsent: "7-days",
+      }),
+    ),
+    ordinaryThirdCandidate,
+  );
+
+  const consentAuthorizedCandidate = recalculate({
+    ...root,
+    revision: 2,
+    previousDigest: root.digest,
+    retention: {
+      ...root.retention,
+      effectivePolicy: "project" as const,
+      updatedAt: "2026-08-16T20:06:00.000Z",
+    },
+  });
+  expectError(
+    parseRunManifestV1(consentAuthorizedCandidate),
+    "$.retention.effectivePolicy",
+    "semantic_conflict",
+  );
+
+  const successor = recalculate({
+    ...consentAuthorizedCandidate,
+    revision: 3,
+    previousDigest: consentAuthorizedCandidate.digest,
+    retention: {
+      ...consentAuthorizedCandidate.retention,
+      updatedAt: "2026-08-16T20:07:00.000Z",
+    },
+  });
+  expectError(
+    validateRunManifestRevisionV1(
+      consentAuthorizedCandidate as unknown as RunManifestV1,
+      successor,
+      { contextConsent: "project" },
+    ),
+    "$.revision",
+    "semantic_conflict",
+  );
+
+  const authorized = expectOk(
+    validateRunManifestRevisionV1(root, consentAuthorizedCandidate, {
+      freshConsent: true,
+      freshConsentAt: "2026-08-16T20:05:30.000Z",
+      contextConsent: "project",
+    }),
+  );
+  assert.deepEqual(
+    expectOk(
+      validateRunManifestRevisionV1(authorized, successor, {
+        contextConsent: "project",
+      }),
+    ),
+    successor,
+  );
+
+  const [serializedRoot, serializedSecond, serializedThird] = JSON.parse(
+    JSON.stringify([root, consentAuthorizedCandidate, successor]),
+  ) as [unknown, unknown, unknown];
+  const replayedRoot = expectOk(parseRunManifestV1(serializedRoot));
+  const replayedSecond = expectOk(
+    validateRunManifestRevisionV1(replayedRoot, serializedSecond, {
+      freshConsent: true,
+      freshConsentAt: "2026-08-16T20:05:30.000Z",
+      contextConsent: "project",
+    }),
+  );
+  assert.deepEqual(
+    expectOk(
+      validateRunManifestRevisionV1(replayedSecond, serializedThird, {
+        contextConsent: "project",
+      }),
+    ),
+    successor,
+  );
+});
+
+test("new deletion requests cannot predate trusted retention authority", () => {
+  const previous = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const scheduled = (requestedAt: string) =>
+    recalculate({
+      ...previous,
+      revision: 2,
+      previousDigest: previous.digest,
+      retention: {
+        ...previous.retention,
+        effectivePolicy: "run-only" as const,
+        status: "deletion_scheduled" as const,
+        contentExpiresAt: "2026-08-16T20:10:00.000Z",
+        updatedAt: "2026-08-16T20:06:00.000Z",
+      },
+      deletion: {
+        ...previous.deletion,
+        status: "scheduled" as const,
+        requestedAt,
+      },
+    });
+
+  expectError(
+    validateRunManifestRevisionV1(
+      previous,
+      scheduled("2026-08-16T20:04:59.999999999Z"),
+      { contextConsent: "7-days" },
+    ),
+    "$.deletion.requestedAt",
+    "semantic_conflict",
+  );
+  assert.equal(
+    validateRunManifestRevisionV1(
+      previous,
+      scheduled(previous.retention.updatedAt),
+      { contextConsent: "7-days" },
+    ).ok,
+    true,
+  );
+});
+
+test("contextless revisions restore retention only within the original policy", () => {
+  const originalValue: Record<string, unknown> = {
+    ...finalLocalManifestJson,
+    sources: [],
+  };
+  delete originalValue.context;
+  const original = expectOk(parseRunManifestV1(recalculate(originalValue)));
+  const previousValue: Record<string, unknown> = {
+    ...original,
+    revision: 2,
+    previousDigest: original.digest,
+    retention: {
+      ...original.retention,
+      effectivePolicy: "run-only",
+      status: "deletion_scheduled",
+      contentExpiresAt: "2026-08-17T20:04:00.000Z",
+      updatedAt: "2026-08-16T20:06:00.000Z",
+    },
+    deletion: {
+      ...original.deletion,
+      status: "scheduled",
+      requestedAt: "2026-08-16T20:06:00.000Z",
+    },
+  };
+  const previous = expectOk(
+    validateRunManifestRevision(original, recalculate(previousValue)),
+  );
+  const restored = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...previous,
+        revision: 3,
+        previousDigest: previous.digest,
+        retention: {
+          ...previous.retention,
+          effectivePolicy: "7-days" as const,
+          contentExpiresAt: "2026-08-23T20:04:00.000Z",
+          updatedAt: "2026-08-16T20:08:00.000Z",
+        },
+      }),
+    ),
+  );
+
+  expectError(
+    validateRunManifestRevision(previous, restored),
+    "$.retention.effectivePolicy",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestRevision(previous, restored, {
+      freshConsent: true,
+      freshConsentAt: previous.retention.updatedAt,
+    }),
+    "$.retention.effectivePolicy",
+    "semantic_conflict",
+  );
+  assert.equal(
+    validateRunManifestRevision(previous, restored, {
+      freshConsent: true,
+      freshConsentAt: "2026-08-16T20:07:00.000Z",
+    }).ok,
+    true,
+  );
+});
+
+test("contextless revisions ignore fictitious Context Pack retention authority", () => {
+  const originalValue: Record<string, unknown> = {
+    ...finalLocalManifestJson,
+    sources: [],
+  };
+  delete originalValue.context;
+  const original = expectOk(parseRunManifestV1(recalculate(originalValue)));
+  const previousValue: Record<string, unknown> = {
+    ...original,
+    revision: 2,
+    previousDigest: original.digest,
+    retention: {
+      ...original.retention,
+      effectivePolicy: "run-only",
+      status: "deletion_scheduled",
+      contentExpiresAt: "2026-08-17T20:04:00.000Z",
+      updatedAt: "2026-08-16T20:06:00.000Z",
+    },
+    deletion: {
+      ...original.deletion,
+      status: "scheduled",
+      requestedAt: "2026-08-16T20:06:00.000Z",
+    },
+  };
+  const previous = expectOk(
+    validateRunManifestRevision(original, recalculate(previousValue)),
+  );
+  const beyondOriginal = recalculate({
+    ...previous,
+    revision: 3,
+    previousDigest: previous.digest,
+    retention: {
+      ...previous.retention,
+      effectivePolicy: "project" as const,
+      status: "active" as const,
+      contentExpiresAt: null,
+      updatedAt: "2026-08-16T20:08:00.000Z",
+    },
+    deletion: {
+      status: "not_scheduled" as const,
+      futureExtension: { preserve: true },
+    },
+  });
+
+  expectError(
+    validateRunManifestRevision(previous, beyondOriginal, {
+      freshConsent: true,
+      freshConsentAt: "2026-08-16T20:07:00.000Z",
+      contextConsent: "project",
+    }),
+    "$.retention.effectivePolicy",
+    "semantic_conflict",
+  );
+});
+
+test("final retention shortening starts a coherent deletion clock", () => {
+  const previous = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const activeShortening = recalculate({
+    ...previous,
+    revision: 2,
+    previousDigest: previous.digest,
+    retention: {
+      ...previous.retention,
+      effectivePolicy: "run-only" as const,
+      status: "active" as const,
+      contentExpiresAt: null,
+      updatedAt: "2026-08-16T20:06:00.000Z",
+    },
+    deletion: {
+      status: "not_scheduled" as const,
+      futureExtension: { preserve: true },
+    },
+  });
+
+  assert.equal(Value.Check(runManifestSchema, activeShortening), false);
+  expectError(
+    parseRunManifestV1(activeShortening),
+    "$.retention.status",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestRevision(
+      previous,
+      activeShortening as unknown as RunManifestV1,
+      { contextConsent: "7-days" },
+    ),
+    "$.retention.status",
+    "semantic_conflict",
+  );
+
+  const scheduledShortening = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...retentionUpdateJson,
+        retention: {
+          ...retentionUpdateJson.retention,
+          effectivePolicy: "run-only" as const,
+          contentExpiresAt: "2026-08-17T20:04:00.000Z",
+        },
+      }),
+    ),
+  );
+  assert.equal(
+    validateRunManifestRevision(previous, scheduledShortening, {
+      contextConsent: "7-days",
+    }).ok,
+    true,
+  );
+});
+
+test("revision retention deadlines are policy-bounded and monotonic", () => {
+  const final = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const scheduledCandidate = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...retentionUpdateJson,
+        retention: {
+          ...retentionUpdateJson.retention,
+          contentExpiresAt: "2026-08-23T20:04:00.000Z",
+        },
+      }),
+    ),
+  );
+  const scheduled = expectOk(
+    validateRunManifestRevision(final, scheduledCandidate, {
+      contextConsent: "7-days",
+    }),
+  );
+
+  const manifestWithDeadline = (
+    effectivePolicy: "run-only" | "7-days",
+    contentExpiresAt: string,
+  ) =>
+    recalculate({
+      ...scheduled,
+      retention: {
+        ...scheduled.retention,
+        effectivePolicy,
+        contentExpiresAt,
+      },
+    });
+  const scheduleWithDeadline = (
+    effectivePolicy: "run-only" | "7-days",
+    contentExpiresAt: string,
+  ) =>
+    manifestWithDeadline(effectivePolicy, contentExpiresAt);
+
+  expectError(
+    parseRunManifestV1(
+      manifestWithDeadline("7-days", "2099-01-01T00:00:00.000Z"),
+    ),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+  assert.equal(
+    validateRunManifestRevision(
+      final,
+      scheduleWithDeadline("run-only", "2026-08-17T20:04:00.000Z"),
+      { contextConsent: "7-days" },
+    ).ok,
+    true,
+  );
+  expectError(
+    validateRunManifestRevision(
+      final,
+      scheduleWithDeadline("run-only", "2026-08-17T20:04:00.000000001Z"),
+      { contextConsent: "7-days" },
+    ),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+
+  const nextScheduled = (
+    contentExpiresAt: string | null,
+    updatedAt = "2026-08-17T20:01:00.000Z",
+  ) =>
+    recalculate({
+      ...scheduled,
+      revision: 3,
+      previousDigest: scheduled.digest,
+      retention: {
+        ...scheduled.retention,
+        contentExpiresAt,
+        updatedAt,
+      },
+    });
+
+  assert.equal(
+    validateRunManifestRevision(
+      scheduled,
+      nextScheduled("2026-08-22T20:04:00.000Z"),
+      { contextConsent: "7-days" },
+    ).ok,
+    true,
+  );
+  expectError(
+    validateRunManifestRevision(
+      scheduled,
+      nextScheduled("2026-08-23T20:04:00.000000001Z"),
+      { contextConsent: "7-days" },
+    ),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestRevision(
+      scheduled,
+      nextScheduled("2026-08-24T20:00:00.000Z"),
+      {
+        contextConsent: "7-days",
+        freshConsent: true,
+        freshConsentAt: "2026-08-16T20:06:00.000Z",
+      },
+    ),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+  assert.equal(
+    validateRunManifestRevision(
+      scheduled,
+      nextScheduled("2026-08-24T20:00:00.000Z"),
+      {
+        contextConsent: "7-days",
+        freshConsent: true,
+        freshConsentAt: "2026-08-17T20:00:00.000Z",
+      },
+    ).ok,
+    true,
+  );
+  expectError(
+    validateRunManifestRevision(
+      scheduled,
+      nextScheduled("2026-08-24T20:00:00.000000001Z"),
+      {
+        contextConsent: "7-days",
+        freshConsent: true,
+        freshConsentAt: "2026-08-17T20:00:00.000Z",
+      },
+    ),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+
+  const cleared = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...scheduled,
+        revision: 3,
+        previousDigest: scheduled.digest,
+        retention: {
+          ...scheduled.retention,
+          status: "active" as const,
+          contentExpiresAt: null,
+          updatedAt: "2026-08-17T20:01:00.000Z",
+        },
+        deletion: {
+          status: "not_scheduled" as const,
+          futureExtension: { preserve: true },
+        },
+      }),
+    ),
+  );
+  expectError(
+    validateRunManifestRevision(scheduled, cleared, { contextConsent: "7-days" }),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+});
+
+test("policy-shortened successors revalidate inherited deadline authority", () => {
+  const original = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const scheduled = expectOk(
+    validateRunManifestRevisionV1(original, retentionUpdateJson, {
+      contextConsent: "7-days",
+    }),
+  );
+  const overRunOnlyCeiling = recalculate({
+    ...scheduled,
+    revision: 3,
+    previousDigest: scheduled.digest,
+    retention: {
+      ...scheduled.retention,
+      effectivePolicy: "run-only" as const,
+      updatedAt: "2026-08-16T20:07:00.000Z",
+    },
+  });
+
+  expectError(
+    validateRunManifestRevisionV1(scheduled, overRunOnlyCeiling, {
+      contextConsent: "7-days",
+    }),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+
+  const compliant = recalculate({
+    ...overRunOnlyCeiling,
+    retention: {
+      ...overRunOnlyCeiling.retention,
+      contentExpiresAt: "2026-08-17T20:04:00.000Z",
+    },
+  });
+  const validated = expectOk(
+    validateRunManifestRevisionV1(scheduled, compliant, {
+      contextConsent: "7-days",
+    }),
+  );
+  assert.deepEqual(validated, compliant);
+  assert.deepEqual(
+    {
+      retentionStatus: validated.retention.status,
+      deletionStatus: validated.deletion.status,
+      requestedAt: validated.deletion.requestedAt,
+    },
+    {
+      retentionStatus: "deletion_scheduled",
+      deletionStatus: "scheduled",
+      requestedAt: "2026-08-16T20:06:00.000Z",
+    },
+  );
+});
+
+test("validated deadline authority carries through scheduled, partial, and completed successors", () => {
+  const original = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const scheduled = expectOk(
+    validateRunManifestRevisionV1(original, retentionUpdateJson, {
+      contextConsent: "7-days",
+    }),
+  );
+  const extendedCandidate = recalculate({
+    ...scheduled,
+    revision: 3,
+    previousDigest: scheduled.digest,
+    retention: {
+      ...scheduled.retention,
+      contentExpiresAt: "2026-08-24T20:00:00.000Z",
+      updatedAt: "2026-08-17T20:01:00.000Z",
+    },
+  });
+  const extended = expectOk(
+    validateRunManifestRevisionV1(scheduled, extendedCandidate, {
+      freshConsent: true,
+      freshConsentAt: "2026-08-17T20:00:00.000Z",
+      contextConsent: "7-days",
+    }),
+  );
+
+  const unchangedScheduledCandidate = recalculate({
+    ...extended,
+    revision: 4,
+    previousDigest: extended.digest,
+    retention: {
+      ...extended.retention,
+      updatedAt: "2026-08-17T20:02:00.000Z",
+    },
+  });
+  const unchangedScheduled = expectOk(
+    validateRunManifestRevisionV1(extended, unchangedScheduledCandidate, {
+      contextConsent: "7-days",
+    }),
+  );
+  assert.deepEqual(unchangedScheduled, unchangedScheduledCandidate);
+
+  const shorterPartial = recalculate({
+    ...extended,
+    revision: 4,
+    previousDigest: extended.digest,
+    retention: {
+      ...extended.retention,
+      status: "deletion_pending" as const,
+      contentExpiresAt: "2026-08-23T23:00:00.000Z",
+      updatedAt: "2026-08-17T20:02:00.000Z",
+    },
+    deletion: {
+      ...extended.deletion,
+      status: "partial_failure" as const,
+    },
+  });
+  const partial = expectOk(
+    validateRunManifestRevisionV1(extended, shorterPartial, {
+      contextConsent: "7-days",
+    }),
+  );
+
+  const completedCandidate = recalculate({
+    ...partial,
+    revision: 5,
+    previousDigest: partial.digest,
+    retention: {
+      ...partial.retention,
+      status: "deleted" as const,
+      updatedAt: "2026-08-18T20:02:00.000Z",
+    },
+    deletion: {
+      ...partial.deletion,
+      status: "completed" as const,
+      completedAt: "2026-08-18T20:02:00.000Z",
+      deletedObjectCount: 1,
+      eventSequence: 2,
+    },
+  });
+  assert.deepEqual(
+    expectOk(
+      validateRunManifestRevisionV1(partial, completedCandidate, {
+        contextConsent: "7-days",
+      }),
+    ),
+    completedCandidate,
+  );
+
+  const newlyExtended = recalculate({
+    ...unchangedScheduled,
+    revision: 5,
+    previousDigest: unchangedScheduled.digest,
+    retention: {
+      ...unchangedScheduled.retention,
+      contentExpiresAt: "2026-08-25T20:00:00.000Z",
+      updatedAt: "2026-08-18T20:01:00.000Z",
+    },
+  });
+  expectError(
+    validateRunManifestRevisionV1(unchangedScheduled, newlyExtended, {
+      contextConsent: "7-days",
+    }),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestRevisionV1(unchangedScheduled, newlyExtended, {
+      freshConsent: true,
+      freshConsentAt: "2026-08-17T20:00:00.000Z",
+      contextConsent: "7-days",
+    }),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+  assert.deepEqual(
+    expectOk(
+      validateRunManifestRevisionV1(unchangedScheduled, newlyExtended, {
+        freshConsent: true,
+        freshConsentAt: "2026-08-18T20:00:00.000Z",
+        contextConsent: "7-days",
+      }),
+    ),
+    newlyExtended,
+  );
+});
+
+test("fresh consent restores scheduled project retention and removes its deadline", () => {
+  const original = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const scheduled = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...original,
+        retention: {
+          ...original.retention,
+          policy: "project" as const,
+          effectivePolicy: "project" as const,
+          status: "deletion_scheduled" as const,
+          contentExpiresAt: "2026-08-20T20:04:00.000Z",
+          updatedAt: "2026-08-16T20:06:00.000Z",
+        },
+        deletion: {
+          status: "scheduled" as const,
+          requestedAt: "2026-08-16T20:06:00.000Z",
+        },
+      }),
+    ),
+  );
+  const restored = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...scheduled,
+        revision: 2,
+        previousDigest: scheduled.digest,
+        retention: {
+          ...scheduled.retention,
+          status: "active" as const,
+          contentExpiresAt: null,
+          updatedAt: "2026-08-16T20:08:00.000Z",
+        },
+        deletion: {
+          status: "not_scheduled" as const,
+        },
+      }),
+    ),
+  );
+
+  expectError(
+    validateRunManifestRevision(scheduled, restored, {
+      contextConsent: "project",
+    }),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestRevision(scheduled, restored, {
+      freshConsent: true,
+      freshConsentAt: scheduled.retention.updatedAt,
+      contextConsent: "project",
+    }),
+    "$.retention.contentExpiresAt",
+    "semantic_conflict",
+  );
+  assert.equal(
+    validateRunManifestRevision(scheduled, restored, {
+      freshConsent: true,
+      freshConsentAt: "2026-08-16T20:07:00.000Z",
+      contextConsent: "project",
+    }).ok,
+    true,
+  );
+});
+
+test("scheduled deletion cancellation consent must postdate the latest request", () => {
+  const restoration = (
+    createdAt: string,
+    finalizedAt: string,
+    retentionUpdatedAt: string,
+    requestedAt: string,
+    restoredUpdatedAt: string,
+  ) => {
+    const original = expectOk(
+      parseRunManifestV1(
+        recalculate({
+          ...finalLocalManifestJson,
+          createdAt,
+          finalizedAt,
+          artifacts: finalLocalManifestJson.artifacts.map((artifact) => ({
+            ...artifact,
+            createdAt: finalizedAt,
+          })),
+          retention: {
+            ...finalLocalManifestJson.retention,
+            policy: "project" as const,
+            effectivePolicy: "project" as const,
+            updatedAt: retentionUpdatedAt,
+          },
+        }),
+      ),
+    );
+    const scheduledCandidate = recalculate({
+      ...original,
+      revision: 2,
+      previousDigest: original.digest,
+      retention: {
+        ...original.retention,
+        status: "deletion_scheduled" as const,
+        contentExpiresAt: restoredUpdatedAt,
+      },
+      deletion: {
+        ...original.deletion,
+        status: "scheduled" as const,
+        requestedAt,
+      },
+    });
+    const scheduled = expectOk(
+      validateRunManifestRevisionV1(original, scheduledCandidate, {
+        contextConsent: "project",
+      }),
+    );
+    const restored = recalculate({
+      ...scheduled,
+      revision: 3,
+      previousDigest: scheduled.digest,
+      retention: {
+        ...scheduled.retention,
+        status: "active" as const,
+        contentExpiresAt: null,
+        updatedAt: restoredUpdatedAt,
+      },
+      deletion: {
+        status: "not_scheduled" as const,
+        futureExtension: scheduled.deletion.futureExtension,
+      },
+    });
+    return { restored, scheduled };
+  };
+
+  const ordinary = restoration(
+    "2026-08-16T20:00:00.000Z",
+    "2026-08-16T20:04:00.000Z",
+    "2026-08-16T20:05:00.000Z",
+    "2026-08-16T20:06:00.000Z",
+    "2026-08-16T20:07:00.000Z",
+  );
+  for (const freshConsentAt of [
+    "2026-08-16T20:05:30.000Z",
+    "2026-08-16T20:06:00.000Z",
+  ]) {
+    expectError(
+      validateRunManifestRevisionV1(ordinary.scheduled, ordinary.restored, {
+        freshConsent: true,
+        freshConsentAt,
+        contextConsent: "project",
+      }),
+      "$.retention.contentExpiresAt",
+      "semantic_conflict",
+    );
+  }
+  assert.equal(
+    validateRunManifestRevisionV1(ordinary.scheduled, ordinary.restored, {
+      freshConsent: true,
+      freshConsentAt: "2026-08-16T20:06:00.000000001Z",
+      contextConsent: "project",
+    }).ok,
+    true,
+  );
+
+  const leap = restoration(
+    "2016-12-31T23:59:58Z",
+    "2016-12-31T23:59:59Z",
+    "2016-12-31T23:59:59.500000000Z",
+    "2016-12-31T23:59:60Z",
+    "2017-01-01T00:00:00Z",
+  );
+  for (const freshConsentAt of [
+    "2016-12-31T23:59:59.999999999Z",
+    "2016-12-31T23:59:60Z",
+  ]) {
+    expectError(
+      validateRunManifestRevisionV1(leap.scheduled, leap.restored, {
+        freshConsent: true,
+        freshConsentAt,
+        contextConsent: "project",
+      }),
+      "$.retention.contentExpiresAt",
+      "semantic_conflict",
+    );
+  }
+  assert.equal(
+    validateRunManifestRevisionV1(leap.scheduled, leap.restored, {
+      freshConsent: true,
+      freshConsentAt: "2016-12-31T23:59:60.000000001Z",
+      contextConsent: "project",
+    }).ok,
+    true,
+  );
+});
+
+test("project retention cannot be restored after scheduled deletion starts", () => {
+  const original = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const scheduled = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...original,
+        retention: {
+          ...original.retention,
+          policy: "project" as const,
+          effectivePolicy: "project" as const,
+          status: "deletion_scheduled" as const,
+          contentExpiresAt: "2026-08-20T20:04:00.000Z",
+          updatedAt: "2026-08-16T20:06:00.000Z",
+        },
+        deletion: {
+          status: "scheduled" as const,
+          requestedAt: "2026-08-16T20:06:00.000Z",
+        },
+      }),
+    ),
+  );
+
+  for (const deletionStatus of ["pending", "partial_failure"] as const) {
+    const inProgress = expectOk(
+      parseRunManifestV1(
+        recalculate({
+          ...scheduled,
+          retention: {
+            ...scheduled.retention,
+            status: "deletion_pending" as const,
+          },
+          deletion: {
+            ...scheduled.deletion,
+            status: deletionStatus,
+          },
+        }),
+      ),
+    );
+    const restored = expectOk(
+      parseRunManifestV1(
+        recalculate({
+          ...inProgress,
+          revision: 2,
+          previousDigest: inProgress.digest,
+          retention: {
+            ...inProgress.retention,
+            status: "active" as const,
+            contentExpiresAt: null,
+            updatedAt: "2026-08-16T20:08:00.000Z",
+          },
+          deletion: {
+            status: "not_scheduled" as const,
+          },
+        }),
+      ),
+    );
+    expectError(
+      validateRunManifestRevision(inProgress, restored, {
+        freshConsent: true,
+        freshConsentAt: "2026-08-16T20:07:00.000Z",
+        contextConsent: "project",
+      }),
+      "$.retention.contentExpiresAt",
+      "semantic_conflict",
+    );
+  }
+
+  const completed = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...scheduled,
+        retention: {
+          ...scheduled.retention,
+          status: "deleted" as const,
+          updatedAt: "2026-08-16T20:07:00.000Z",
+        },
+        deletion: {
+          status: "completed" as const,
+          requestedAt: "2026-08-16T20:06:00.000Z",
+          completedAt: "2026-08-16T20:07:00.000Z",
+          deletedObjectCount: 1,
+          eventSequence: 2,
+        },
+      }),
+    ),
+  );
+  const resurrected = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...completed,
+        revision: 2,
+        previousDigest: completed.digest,
+        retention: {
+          ...completed.retention,
+          status: "active" as const,
+          contentExpiresAt: null,
+          updatedAt: "2026-08-16T20:09:00.000Z",
+        },
+        deletion: {
+          status: "not_scheduled" as const,
+        },
+      }),
+    ),
+  );
+  expectError(
+    validateRunManifestRevision(completed, resurrected, {
+      freshConsent: true,
+      freshConsentAt: "2026-08-16T20:08:00.000Z",
+      contextConsent: "project",
+    }),
+    "$.deletion.status",
+    "semantic_conflict",
+  );
+});
+
+test("revision deletion progress is monotonic while partial failures remain retryable", () => {
+  const final = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const partialFailureCandidate = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...retentionUpdateJson,
+        retention: {
+          ...retentionUpdateJson.retention,
+          status: "deletion_pending" as const,
+          contentExpiresAt: "2026-08-23T20:04:00.000Z",
+        },
+        deletion: {
+          ...retentionUpdateJson.deletion,
+          status: "partial_failure" as const,
+        },
+      }),
+    ),
+  );
+  const partialFailure = expectOk(
+    validateRunManifestRevision(final, partialFailureCandidate, {
+      contextConsent: "7-days",
+    }),
+  );
+
+  const retryCandidate = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...partialFailure,
+        revision: 3,
+        previousDigest: partialFailure.digest,
+        retention: {
+          ...partialFailure.retention,
+          updatedAt: "2026-08-16T20:07:00.000Z",
+        },
+        deletion: {
+          ...partialFailure.deletion,
+          status: "pending" as const,
+        },
+      }),
+    ),
+  );
+  const retry = expectOk(
+    validateRunManifestRevision(partialFailure, retryCandidate, {
+      contextConsent: "7-days",
+    }),
+  );
+
+  const movedBackward = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...retry,
+        retention: {
+          ...retry.retention,
+          status: "deletion_scheduled" as const,
+        },
+        deletion: {
+          ...retry.deletion,
+          status: "scheduled" as const,
+        },
+      }),
+    ),
+  );
+  expectError(
+    validateRunManifestRevision(partialFailure, movedBackward, {
+      contextConsent: "7-days",
+    }),
+    "$.retention.status",
+    "semantic_conflict",
+  );
+
+  const changedRequest = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...retry,
+        deletion: {
+          ...retry.deletion,
+          requestedAt: "2026-08-16T20:07:00.000Z",
+        },
+      }),
+    ),
+  );
+  expectError(
+    validateRunManifestRevision(partialFailure, changedRequest, {
+      contextConsent: "7-days",
+    }),
+    "$.deletion.requestedAt",
+    "semantic_conflict",
+  );
+
+  const staleUpdate = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...retry,
+        retention: {
+          ...retry.retention,
+          updatedAt: "2026-08-16T20:05:00.000Z",
+        },
+      }),
+    ),
+  );
+  expectError(
+    validateRunManifestRevision(partialFailure, staleUpdate, {
+      contextConsent: "7-days",
+    }),
+    "$.retention.updatedAt",
+    "semantic_conflict",
+  );
+});
+
+test("revision chains reject bad links, immutable final mutations, and retention changes", () => {
+  const previous = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const next = expectOk(parseRunManifestV1(retentionUpdateJson));
+
+  expectError(
+    validateRunManifestRevision(
+      previous,
+      recalculate({
+        ...next,
+        previousDigest: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      }),
+    ),
+    "$.previousDigest",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestRevision(
+      previous,
+      recalculate({ ...next, id: "manifest_other" }),
+    ),
+    "$.id",
+    "semantic_conflict",
+  );
+
+  const mutated = recalculate({
+    ...next,
+    revision: previous.revision + 1,
+    previousDigest: previous.digest,
+    artifacts: [{ ...previous.artifacts[0], title: "Changed" }],
+  });
+  expectError(validateRunManifestRevision(previous, mutated), "$.artifacts", "semantic_conflict");
+
+  const shortened = recalculate({
+    ...next,
+    retention: {
+      ...next.retention,
+      effectivePolicy: "run-only" as const,
+      contentExpiresAt: "2026-08-17T20:04:00.000Z",
+    },
+  });
+  expectError(
+    validateRunManifestRevision(previous, shortened),
+    "$.retention.policy",
+    "semantic_conflict",
+  );
+  assert.equal(
+    validateRunManifestRevision(previous, shortened, { contextConsent: "7-days" }).ok,
+    true,
+  );
+
+  const lengthened = recalculate({
+    ...next,
+    retention: { ...next.retention, effectivePolicy: "project" as const },
+  });
+  expectError(
+    validateRunManifestRevision(previous, lengthened, { contextConsent: "project" }),
+    "$.retention.effectivePolicy",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestRevision(previous, lengthened, { freshConsent: true }),
+    "$.retention.policy",
+    "semantic_conflict",
+  );
+  expectError(
+    validateRunManifestRevision(previous, lengthened, {
+      freshConsent: true,
+      contextConsent: "7-days",
+    }),
+    "$.retention.effectivePolicy",
+    "semantic_conflict",
+  );
+  assert.equal(
+    validateRunManifestRevision(previous, lengthened, {
+      freshConsent: true,
+      freshConsentAt: "2026-08-16T20:05:30.000Z",
+      contextConsent: "project",
+    }).ok,
+    true,
+  );
+});
+
+test("completed deletion cannot be resurrected by a later revision", () => {
+  const final = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const deletedCandidate = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...final,
+        revision: 2,
+        previousDigest: final.digest,
+        retention: {
+          ...final.retention,
+          status: "deleted" as const,
+          contentExpiresAt: "2026-08-16T20:06:00.000Z",
+          updatedAt: "2026-08-16T20:06:00.000Z",
+        },
+        deletion: {
+          ...final.deletion,
+          status: "completed" as const,
+          requestedAt: "2026-08-16T20:05:00.000Z",
+          completedAt: "2026-08-16T20:06:00.000Z",
+          deletedObjectCount: 1,
+          eventSequence: 2,
+        },
+      }),
+    ),
+  );
+  const deleted = expectOk(
+    validateRunManifestRevision(final, deletedCandidate, {
+      contextConsent: "7-days",
+    }),
+  );
+  const resurrected = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...deleted,
+        revision: 3,
+        previousDigest: deleted.digest,
+        retention: {
+          ...deleted.retention,
+          status: "active" as const,
+          contentExpiresAt: null,
+          updatedAt: "2026-08-16T20:07:00.000Z",
+        },
+        deletion: {
+          status: "not_scheduled" as const,
+          futureExtension: { preserve: true },
+        },
+      }),
+    ),
+  );
+
+  expectError(
+    validateRunManifestRevision(deleted, resurrected, {
+      contextConsent: "project",
+      freshConsent: true,
+      freshConsentAt: "2026-08-16T20:06:30.000Z",
+    }),
+    "$.deletion.status",
+    "semantic_conflict",
+  );
+});
+
+test("assembling revisions cannot change the original retention policy", () => {
+  const previous = expectOk(parseRunManifestV1(assemblingManifestJson));
+  const changedPolicy = expectOk(
+    parseRunManifestV1(
+      recalculate({
+        ...previous,
+        revision: 2,
+        previousDigest: previous.digest,
+        retention: {
+          ...previous.retention,
+          policy: "project" as const,
+          effectivePolicy: "project" as const,
+        },
+      }),
+    ),
+  );
+  expectError(
+    validateRunManifestRevision(previous, changedPolicy, {
+      freshConsent: true,
+      contextConsent: "project",
+    }),
+    "$.retention.policy",
+    "semantic_conflict",
+  );
+});
+
+test("final revisions preserve finalizedAt and unknown additive immutable fields", () => {
+  const previous = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const next = expectOk(parseRunManifestV1(retentionUpdateJson));
+  expectError(
+    validateRunManifestRevision(
+      previous,
+      recalculate({ ...next, finalizedAt: "2026-08-16T20:03:00.000Z" }),
+    ),
+    "$.finalizedAt",
+    "semantic_conflict",
+  );
+
+  const changedUnknown = recalculate({
+    ...next,
+    futureExtension: { preserve: false },
+  });
+  expectError(validateRunManifestRevision(previous, changedUnknown), "$.futureExtension", "semantic_conflict");
+});
+
+test("custom-prototype artifacts and extensions are rejected rather than stripped of inherited fields", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const inheritedArtifact = Object.create({ inheritedField: "drop-me" });
+  const inheritedExtension = Object.create({ inheritedNestedField: "drop-me" });
+  Object.assign(inheritedExtension, { preserve: true });
+  Object.assign(inheritedArtifact, local.artifacts[0]);
+  inheritedArtifact.futureExtension = inheritedExtension;
+  const candidate = recalculate({
+    ...local,
+    artifacts: [inheritedArtifact],
+  });
+  expectError(parseRunManifestV1(candidate), "$", "invalid_value");
+});
+
+test("custom-prototype arrays in additive fields are rejected while normal arrays are accepted", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+
+  class CustomArray extends Array {}
+  const customPrototypeArray = CustomArray.from([1, 2, 3]);
+  assert.notEqual(Object.getPrototypeOf(customPrototypeArray), Array.prototype);
+  const withCustomArray = recalculate({
+    ...local,
+    futureExtension: { values: customPrototypeArray },
+  });
+  expectError(parseRunManifestV1(withCustomArray), "$", "invalid_value");
+
+  const withNormalArray = recalculate({
+    ...local,
+    futureExtension: { values: [1, 2, 3] },
+  });
+  const parsed = expectOk(parseRunManifestV1(withNormalArray));
+  assert.equal(Object.getPrototypeOf(parsed.futureExtension as object), Object.prototype);
+  assert.deepEqual((parsed.futureExtension as { values: number[] }).values, [1, 2, 3]);
+});
+
+test("canonical copying preserves own __proto__ fields and rejects non-JSON objects", () => {
+  const local = expectOk(parseRunManifestV1(finalLocalManifestJson));
+  const extension = JSON.parse('{"__proto__":{"preserve":true}}') as Record<string, unknown>;
+  const withProtoKey = recalculate({
+    ...local,
+    futureExtension: extension,
+  });
+  const parsed = expectOk(parseRunManifestV1(withProtoKey));
+  assert.equal(Object.hasOwn(parsed.futureExtension as object, "__proto__"), true);
+  const protoValue = (parsed.futureExtension as Record<string, unknown>).__proto__ as Record<string, unknown>;
+  assert.equal(Object.getPrototypeOf(protoValue), Object.prototype);
+  assert.equal(protoValue.preserve, true);
+
+  const withDate = {
+    ...local,
+    futureExtension: { capturedAt: new Date("2026-08-16T20:00:00.000Z") },
+  };
+  expectError(parseRunManifestV1(withDate), "$", "invalid_value");
+});
+
+test("manifest revision validation rejects exotic option shells before provenance checks", () => {
+  const params = new URLSearchParams("freshConsent=true");
+  Object.setPrototypeOf(params, Object.prototype);
+  Object.freeze(params);
+
+  expectError(
+    validateRunManifestRevisionV1(
+      {} as RunManifestV1,
+      {},
+      params as unknown as Parameters<typeof validateRunManifestRevisionV1>[2],
+    ),
+    "$.options",
+    "invalid_value",
+  );
+
+  const options = Object.defineProperty({}, "freshConsent", {
+    enumerable: true,
+    get() {
+      throw new Error("option getter must not execute");
+    },
+  });
+  expectError(
+    validateRunManifestRevisionV1(
+      {} as RunManifestV1,
+      {},
+      options,
+    ),
+    "$.options",
+    "invalid_value",
+  );
+});

--- a/src/lib/research-protocol/run-manifest.ts
+++ b/src/lib/research-protocol/run-manifest.ts
@@ -1,0 +1,2526 @@
+import {
+  compareUtcTimestamps,
+  copyProtocolJsonValue,
+  fail,
+  isOpaqueId,
+  isRecord,
+  isSha256,
+  isUtcTimestamp,
+  parseResearchContextBindingV1,
+  pass,
+  retentionDoesNotExceed,
+  RETENTION_ORDER,
+  utcTimestampToProtocolNanoseconds,
+  type ProtocolParseResult,
+  type ResearchContextBindingV1,
+  type RetentionPolicyV1,
+  type UnknownFields,
+} from "./common.ts";
+import { canonicalJson, digestProtocolObject } from "./digest.ts";
+import {
+  parseResearchModelReceiptV1,
+  type ResearchModelReceiptV1,
+} from "./topic-discovery.ts";
+import {
+  normalizeUnicodeSecurityText,
+  validateSafeDeletionExtensionKeys,
+  validateSafeExtensionKeys as validateSensitiveObjectKeys,
+} from "./privacy-extension.ts";
+import { snapshotProtocolObjectProperties } from "./option-shell.ts";
+
+export {
+  SENSITIVE_EXTENSION_KEY_PATTERN,
+  SENSITIVE_EXTENSION_VARIANT_KEY_PATTERN,
+  SENSITIVE_EXTENSION_COMPONENT_KEY_PATTERN,
+  SENSITIVE_EXTENSION_COMPOUND_KEY_PATTERN,
+} from "./privacy-extension.ts";
+
+const RUN_MANIFEST_SCHEMA = "opencoven.run-manifest/v1";
+const RUN_MANIFEST_SCHEMA_RE = /^opencoven\.run-manifest\/v(\d+)$/;
+const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
+
+const SOURCE_KINDS = ["context-pack", "public-evidence"] as const;
+const CONTEXT_AVAILABILITY = ["device-local"] as const;
+const ARTIFACT_PLACEMENTS = ["device-local", "cloud-metadata", "cloud-content"] as const;
+const CONTENT_SYNCS = ["not-requested", "pending", "synced", "failed"] as const;
+const TASK_PHASES = ["scope", "challenge", "synthesize", "control"] as const;
+const RETENTION_POLICIES = ["run-only", "7-days", "project"] as const;
+const RETENTION_STATUSES = ["active", "deletion_scheduled", "deletion_pending", "deleted"] as const;
+const DELETION_STATUSES = ["not_scheduled", "scheduled", "pending", "completed", "partial_failure"] as const;
+const MANIFEST_STATES = ["assembling", "final"] as const;
+const COMPLETENESS_VALUES = ["complete", "partial", "unreported"] as const;
+
+const ARTIFACT_TITLE_URI_SCHEME_PREFIX_RE = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+const ARTIFACT_TITLE_SECRET_RE = /(?:sk-|ghp_|github_pat_)/;
+const ARTIFACT_TITLE_CONTROL_RE = /[\u0000-\u001f\u007f-\u009f]/;
+const RUN_MANIFEST_FIELDS = new Set([
+  "schema",
+  "id",
+  "runId",
+  "digest",
+  "revision",
+  "previousDigest",
+  "state",
+  "createdAt",
+  "finalizedAt",
+  "context",
+  "sources",
+  "artifacts",
+  "modelExecutions",
+  "usage",
+  "retention",
+  "deletion",
+]);
+const CONTEXT_BINDING_FIELDS = new Set([
+  "contextPackId",
+  "contextPackDigest",
+  "topicProposalId",
+]);
+const CONTEXT_PACK_SOURCE_FIELDS = new Set(["kind", "id", "digest", "availability"]);
+const PUBLIC_EVIDENCE_SOURCE_FIELDS = new Set([
+  "kind",
+  "id",
+  "contentDigest",
+  "snapshotDigest",
+  "canonicalUrl",
+  "fetchedAt",
+]);
+const ARTIFACT_FIELDS = new Set([
+  "id",
+  "kind",
+  "title",
+  "mediaType",
+  "digest",
+  "bytes",
+  "placement",
+  "contentSync",
+  "createdAt",
+]);
+const MODEL_EXECUTION_FIELDS = new Set([
+  "taskId",
+  "phase",
+  "attempt",
+  "inputDigest",
+  "outputDigest",
+  "receipt",
+]);
+const MODEL_RECEIPT_FIELDS = new Set([
+  "familiarId",
+  "runtime",
+  "effectiveModel",
+  "modelSource",
+  "providerBilling",
+  "usage",
+]);
+const MODEL_USAGE_FIELDS = new Set([
+  "inputTokens",
+  "outputTokens",
+  "costUsd",
+  "reportedByRuntime",
+]);
+const MANIFEST_USAGE_FIELDS = new Set([
+  "inputTokens",
+  "outputTokens",
+  "costUsd",
+  "completeness",
+]);
+const RETENTION_FIELDS = new Set([
+  "policy",
+  "effectivePolicy",
+  "status",
+  "contentExpiresAt",
+  "updatedAt",
+]);
+const DELETION_FIELDS = new Set([
+  "status",
+  "requestedAt",
+  "completedAt",
+  "deletedObjectCount",
+  "retainedAuditUntil",
+  "eventSequence",
+]);
+
+export type ArtifactRegistrationV1 = {
+  id: string;
+  kind: string;
+  title: string;
+  mediaType: string;
+  digest: string;
+  bytes: number;
+  placement: "device-local" | "cloud-metadata" | "cloud-content";
+  contentSync: "not-requested" | "pending" | "synced" | "failed";
+  createdAt: string;
+} & UnknownFields;
+
+export type RunManifestSourceV1 =
+  | ({
+      kind: "context-pack";
+      id: string;
+      digest: string;
+      availability: "device-local";
+    } & UnknownFields)
+  | ({
+      kind: "public-evidence";
+      id: string;
+      contentDigest: string;
+      snapshotDigest: string;
+      canonicalUrl: string;
+      fetchedAt: string;
+    } & UnknownFields);
+
+export type RunManifestModelExecutionV1 = {
+  taskId: string;
+  phase: "scope" | "challenge" | "synthesize" | "control";
+  attempt: number;
+  inputDigest: string;
+  outputDigest: string;
+  receipt: ResearchModelReceiptV1;
+} & UnknownFields;
+
+export type RunManifestUsageV1 = {
+  inputTokens: number | null;
+  outputTokens: number | null;
+  costUsd: number | null;
+  completeness: "complete" | "partial" | "unreported";
+} & UnknownFields;
+
+export type RunManifestRetentionV1 = {
+  policy: "run-only" | "7-days" | "project";
+  effectivePolicy: "run-only" | "7-days" | "project";
+  status: "active" | "deletion_scheduled" | "deletion_pending" | "deleted";
+  contentExpiresAt: string | null;
+  updatedAt: string;
+} & UnknownFields;
+
+export type RunManifestDeletionReceiptV1 = {
+  status: "not_scheduled" | "scheduled" | "pending" | "completed" | "partial_failure";
+  requestedAt?: string;
+  completedAt?: string;
+  deletedObjectCount?: number;
+  retainedAuditUntil?: string;
+  eventSequence?: number;
+} & UnknownFields;
+
+export type RunManifestV1 = {
+  schema: "opencoven.run-manifest/v1";
+  id: string;
+  runId: string;
+  digest: string;
+  revision: number;
+  previousDigest?: string;
+  state: "assembling" | "final";
+  createdAt: string;
+  finalizedAt?: string;
+  context?: ResearchContextBindingV1;
+  sources: RunManifestSourceV1[];
+  artifacts: ArtifactRegistrationV1[];
+  modelExecutions: RunManifestModelExecutionV1[];
+  usage: RunManifestUsageV1;
+  retention: RunManifestRetentionV1;
+  deletion: RunManifestDeletionReceiptV1;
+} & UnknownFields;
+
+export type ManifestRevisionOptions = {
+  freshConsent?: boolean;
+  freshConsentAt?: string;
+  contextConsent?: RetentionPolicyV1;
+};
+
+const MANIFEST_REVISION_OPTION_FIELDS = new Set([
+  "freshConsent",
+  "freshConsentAt",
+  "contextConsent",
+]);
+
+function childPath(path: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${path}.${key}`
+    : `${path}[${JSON.stringify(key)}]`;
+}
+
+function indexPath(path: string, index: number): string {
+  return `${path}[${index}]`;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function parseManifestRevisionOptions(
+  value: ManifestRevisionOptions,
+): ProtocolParseResult<ManifestRevisionOptions> {
+  const wireValue = snapshotProtocolObjectProperties(
+    value,
+    "$.options",
+    "Manifest revision options",
+  );
+  if (!wireValue.ok) return wireValue;
+  for (const key of Object.keys(wireValue.value)) {
+    if (!MANIFEST_REVISION_OPTION_FIELDS.has(key)) {
+      return fail(
+        "invalid_value",
+        childPath("$.options", key),
+        `Unknown manifest revision option ${key}`,
+      );
+    }
+  }
+
+  const options: ManifestRevisionOptions = {};
+  if (hasOwn(wireValue.value, "freshConsent")) {
+    if (typeof wireValue.value.freshConsent !== "boolean") {
+      return fail(
+        "invalid_type",
+        "$.options.freshConsent",
+        "freshConsent must be a boolean",
+      );
+    }
+    options.freshConsent = wireValue.value.freshConsent;
+  }
+  if (hasOwn(wireValue.value, "freshConsentAt")) {
+    if (!isUtcTimestamp(wireValue.value.freshConsentAt)) {
+      return fail(
+        "invalid_value",
+        "$.options.freshConsentAt",
+        "freshConsentAt must be a UTC RFC 3339 timestamp",
+      );
+    }
+    options.freshConsentAt = wireValue.value.freshConsentAt;
+  }
+  if (hasOwn(wireValue.value, "contextConsent")) {
+    const contextConsent = wireValue.value.contextConsent;
+    if (
+      typeof contextConsent !== "string" ||
+      !Object.hasOwn(RETENTION_ORDER, contextConsent)
+    ) {
+      return fail(
+        "invalid_value",
+        "$.options.contextConsent",
+        "contextConsent must be run-only, 7-days, or project",
+      );
+    }
+    options.contextConsent = contextConsent as RetentionPolicyV1;
+  }
+  return pass(options);
+}
+
+function validateModelReceiptExtensionKeys(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<void> {
+  const receiptKeys = validateSensitiveObjectKeys(value, path, MODEL_RECEIPT_FIELDS);
+  if (!receiptKeys.ok) return receiptKeys;
+  if (!isRecord(value) || !hasOwn(value, "usage")) return pass(undefined);
+  return validateSensitiveObjectKeys(
+    value.usage,
+    childPath(path, "usage"),
+    MODEL_USAGE_FIELDS,
+  );
+}
+
+function parseObject(value: unknown, path: string): ProtocolParseResult<Record<string, unknown>> {
+  if (!isRecord(value)) {
+    return fail("invalid_type", path, "Expected an object");
+  }
+  return pass(value);
+}
+
+function parseRequiredField(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): ProtocolParseResult<unknown> {
+  if (!hasOwn(record, key)) {
+    return fail("missing_field", childPath(path, key), `Missing required field ${key}`);
+  }
+  return pass(record[key]);
+}
+
+function parseString(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  return pass(value);
+}
+
+function parseEnumValue<const T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  path: string,
+  label: string,
+): ProtocolParseResult<T[number]> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!allowed.includes(value as T[number])) {
+    return fail("invalid_value", path, `${label} must be one of ${allowed.join(", ")}`);
+  }
+  return pass(value as T[number]);
+}
+
+function parseSchema(value: unknown, path: string): ProtocolParseResult<"opencoven.run-manifest/v1"> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, "schema must be a string");
+  }
+  if (value === RUN_MANIFEST_SCHEMA) {
+    return pass(RUN_MANIFEST_SCHEMA);
+  }
+  const match = RUN_MANIFEST_SCHEMA_RE.exec(value);
+  if (match) {
+    return fail("unknown_major", path, `Unsupported schema major v${match[1]}`);
+  }
+  return fail("invalid_value", path, `schema must equal ${RUN_MANIFEST_SCHEMA}`);
+}
+
+function parseSafeIntegerInRange(
+  value: unknown,
+  path: string,
+  label: string,
+  minimum: number,
+  maximum: number,
+): ProtocolParseResult<number> {
+  if (typeof value !== "number") {
+    return fail("invalid_type", path, `${label} must be a number`);
+  }
+  if (!Number.isSafeInteger(value)) {
+    return fail("invalid_value", path, `${label} must be a safe integer`);
+  }
+  if (value < minimum || value > maximum) {
+    return fail("invalid_value", path, `${label} must be between ${minimum} and ${maximum}`);
+  }
+  return pass(value);
+}
+
+function parsePositiveSafeInteger(value: unknown, path: string, label: string): ProtocolParseResult<number> {
+  return parseSafeIntegerInRange(value, path, label, 1, MAX_SAFE_INTEGER);
+}
+
+function parseNullableSafeInteger(
+  value: unknown,
+  path: string,
+  label: string,
+): ProtocolParseResult<number | null> {
+  if (value === null) return pass(null);
+  return parseSafeIntegerInRange(value, path, label, 0, MAX_SAFE_INTEGER);
+}
+
+function parseNonNegativeFiniteNumber(
+  value: unknown,
+  path: string,
+  label: string,
+): ProtocolParseResult<number> {
+  if (typeof value !== "number") {
+    return fail("invalid_type", path, `${label} must be a number`);
+  }
+  if (!Number.isFinite(value) || value < 0) {
+    return fail("invalid_value", path, `${label} must be a finite number >= 0`);
+  }
+  return pass(value);
+}
+
+function parseNullableNonNegativeFiniteNumber(
+  value: unknown,
+  path: string,
+  label: string,
+): ProtocolParseResult<number | null> {
+  if (value === null) return pass(null);
+  return parseNonNegativeFiniteNumber(value, path, label);
+}
+
+function parseOpaqueIdentifier(
+  value: unknown,
+  prefix: string,
+  path: string,
+  label: string,
+): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isOpaqueId(value, prefix)) {
+    return fail("invalid_value", path, `${label} must match ${prefix}_...`);
+  }
+  return pass(value);
+}
+
+function parseSha256(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isSha256(value)) {
+    return fail("invalid_value", path, `${label} must be a lowercase SHA-256 digest`);
+  }
+  return pass(value);
+}
+
+function parseUtc(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isUtcTimestamp(value)) {
+    return fail("invalid_value", path, `${label} must be a UTC RFC 3339 timestamp`);
+  }
+  return pass(value);
+}
+
+const NON_GLOBAL_IPV4_RANGES = [
+  [0x00000000, 8],
+  [0x0a000000, 8],
+  [0x64400000, 10],
+  [0x7f000000, 8],
+  [0xa9fe0000, 16],
+  [0xac100000, 12],
+  [0xc0000000, 24],
+  [0xc0000200, 24],
+  [0xc0586300, 24],
+  [0xc0a80000, 16],
+  [0xc6120000, 15],
+  [0xc6336400, 24],
+  [0xcb007100, 24],
+  [0xe0000000, 4],
+  [0xf0000000, 4],
+] as const;
+const GLOBAL_IPV4_EXCEPTIONS = new Set([0xc0000009, 0xc000000a]);
+
+function parseIpv4Address(hostname: string): number | undefined {
+  const parts = hostname.split(".");
+  if (
+    parts.length !== 4 ||
+    parts.some((part) => !/^\d{1,3}$/.test(part) || Number(part) > 255)
+  ) {
+    return undefined;
+  }
+  return parts.reduce((address, part) => address * 256 + Number(part), 0);
+}
+
+function ipv4AddressIsInRange(
+  address: number,
+  base: number,
+  prefixLength: number,
+): boolean {
+  const size = 2 ** (32 - prefixLength);
+  return address >= base && address < base + size;
+}
+
+function isPublicIpv4Address(address: number): boolean {
+  if (GLOBAL_IPV4_EXCEPTIONS.has(address)) return true;
+  return !NON_GLOBAL_IPV4_RANGES.some(([base, prefixLength]) =>
+    ipv4AddressIsInRange(address, base, prefixLength),
+  );
+}
+
+function isPublicIpv4(hostname: string): boolean {
+  const address = parseIpv4Address(hostname);
+  return address !== undefined && isPublicIpv4Address(address);
+}
+
+function parseIpv6Address(hostname: string): readonly number[] | undefined {
+  let normalized = hostname
+    .toLowerCase()
+    .replace(/^\[/, "")
+    .replace(/\]$/, "");
+  if (normalized.includes(".")) {
+    const finalColon = normalized.lastIndexOf(":");
+    if (finalColon < 0) return undefined;
+    const ipv4 = parseIpv4Address(normalized.slice(finalColon + 1));
+    if (ipv4 === undefined) return undefined;
+    normalized = `${normalized.slice(0, finalColon)}:${(ipv4 >>> 16).toString(16)}:${(ipv4 & 0xffff).toString(16)}`;
+  }
+
+  const halves = normalized.split("::");
+  if (halves.length > 2) return undefined;
+  const parseHalf = (half: string): number[] | undefined => {
+    if (half === "") return [];
+    const groups = half.split(":");
+    if (groups.some((group) => !/^[a-f0-9]{1,4}$/.test(group))) {
+      return undefined;
+    }
+    return groups.map((group) => Number.parseInt(group, 16));
+  };
+  const left = parseHalf(halves[0]!);
+  const right = parseHalf(halves[1] ?? "");
+  if (!left || !right) return undefined;
+
+  if (halves.length === 1) {
+    return left.length === 8 ? left : undefined;
+  }
+  const omittedGroups = 8 - left.length - right.length;
+  if (omittedGroups < 1) return undefined;
+  return [...left, ...Array.from({ length: omittedGroups }, () => 0), ...right];
+}
+
+function ipv6HasPrefix(
+  address: readonly number[],
+  prefix: readonly number[],
+  prefixLength: number,
+): boolean {
+  const completeGroups = Math.floor(prefixLength / 16);
+  for (let index = 0; index < completeGroups; index += 1) {
+    if (address[index] !== (prefix[index] ?? 0)) return false;
+  }
+  const remainingBits = prefixLength % 16;
+  if (remainingBits === 0) return true;
+  const mask = (0xffff << (16 - remainingBits)) & 0xffff;
+  return (
+    (address[completeGroups]! & mask) ===
+    ((prefix[completeGroups] ?? 0) & mask)
+  );
+}
+
+function isPublicIpv6(hostname: string): boolean {
+  const address = parseIpv6Address(hostname);
+  if (!address) return false;
+  const embeddedIpv4 = address[6]! * 0x10000 + address[7]!;
+
+  if (
+    ipv6HasPrefix(address, [0, 0, 0, 0, 0, 0], 96) ||
+    ipv6HasPrefix(address, [0, 0, 0, 0, 0, 0xffff], 96) ||
+    ipv6HasPrefix(address, [0, 0, 0, 0, 0xffff, 0], 96) ||
+    ipv6HasPrefix(address, [0x0064, 0xff9b, 0, 0, 0, 0], 96)
+  ) {
+    return isPublicIpv4Address(embeddedIpv4);
+  }
+  if (ipv6HasPrefix(address, [0x2002], 16)) {
+    const sixToFourIpv4 = address[1]! * 0x10000 + address[2]!;
+    return isPublicIpv4Address(sixToFourIpv4);
+  }
+  if (ipv6HasPrefix(address, [0x2001, 0], 23)) {
+    const protocolAnycast =
+      address[1] === 1 &&
+      address.slice(2, 7).every((group) => group === 0) &&
+      address[7]! >= 1 &&
+      address[7]! <= 3;
+    return (
+      protocolAnycast ||
+      ipv6HasPrefix(address, [0x2001, 0x0003], 32) ||
+      ipv6HasPrefix(address, [0x2001, 0x0004, 0x0112], 48) ||
+      ipv6HasPrefix(address, [0x2001, 0x0020], 28) ||
+      ipv6HasPrefix(address, [0x2001, 0x0030], 28)
+    );
+  }
+  if (
+    ipv6HasPrefix(address, [0x2001, 0x0db8], 32) ||
+    ipv6HasPrefix(address, [0x3ffe], 16) ||
+    ipv6HasPrefix(address, [0x3fff], 20)
+  ) {
+    return false;
+  }
+  return (address[0]! & 0xe000) === 0x2000;
+}
+
+const SPECIAL_USE_HOST_SUFFIXES = [
+  "alt",
+  "arpa",
+  "corp",
+  "example",
+  "home",
+  "internal",
+  "invalid",
+  "lan",
+  "local",
+  "localdomain",
+  "localhost",
+  "mail",
+  "onion",
+  "test",
+] as const;
+const SPECIAL_USE_HOSTNAMES = new Set([
+  "example.com",
+  "example.net",
+  "example.org",
+]);
+
+function isPublicHostname(hostname: string): boolean {
+  const normalized = hostname
+    .toLowerCase()
+    .replace(/^\[/, "")
+    .replace(/\]$/, "")
+    .replace(/\.$/, "");
+  if (/^\d+(?:\.\d+){3}$/.test(normalized)) {
+    return isPublicIpv4(normalized);
+  }
+  if (normalized.includes(":")) {
+    return isPublicIpv6(normalized);
+  }
+
+  if (!normalized.includes(".")) return false;
+  if (
+    normalized.length > 253 ||
+    normalized
+      .split(".")
+      .some(
+        (label) =>
+          label.length === 0 ||
+          label.length > 63 ||
+          !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label),
+      )
+  ) {
+    return false;
+  }
+  if (
+    SPECIAL_USE_HOST_SUFFIXES.some(
+      (suffix) => normalized === suffix || normalized.endsWith(`.${suffix}`),
+    )
+  ) {
+    return false;
+  }
+  return ![...SPECIAL_USE_HOSTNAMES].some(
+    (name) => normalized === name || normalized.endsWith(`.${name}`),
+  );
+}
+
+function parsePublicCanonicalUrl(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<string> {
+  const parsedString = parseString(value, path, "canonicalUrl");
+  if (!parsedString.ok) return parsedString;
+  const candidate = parsedString.value;
+  const syntax = /^(https?):\/\/([^/?#]+)/.exec(candidate);
+  if (
+    candidate.length === 0 ||
+    candidate !== candidate.trim() ||
+    /[\s\\]/u.test(candidate) ||
+    candidate.includes("#") ||
+    syntax === null ||
+    syntax[2] === "" ||
+    syntax[2]!.includes("@")
+  ) {
+    return fail(
+      "invalid_value",
+      path,
+      "canonicalUrl must be an absolute public HTTP(S) URL without userinfo or fragments",
+    );
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return fail("invalid_value", path, "canonicalUrl must be a valid absolute URL");
+  }
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.hostname === "" ||
+    !isPublicHostname(parsed.hostname)
+  ) {
+    return fail(
+      "invalid_value",
+      path,
+      "canonicalUrl must identify a public HTTP(S) host without userinfo",
+    );
+  }
+  if (parsed.href !== candidate) {
+    return fail(
+      "invalid_value",
+      path,
+      "canonicalUrl must exactly equal its canonical WHATWG URL serialization",
+    );
+  }
+  return pass(candidate);
+}
+
+function parseNullableUtc(value: unknown, path: string, label: string): ProtocolParseResult<string | null> {
+  if (value === null) return pass(null);
+  return parseUtc(value, path, label);
+}
+
+function hasArtifactTitleUriScheme(value: string): boolean {
+  return ARTIFACT_TITLE_URI_SCHEME_PREFIX_RE.test(value);
+}
+
+function parseArtifactTitle(value: unknown, path: string): ProtocolParseResult<string> {
+  const title = parseString(value, path, "title");
+  if (!title.ok) return title;
+  const securityTitle = normalizeUnicodeSecurityText(title.value);
+  if (
+    securityTitle.includes("/") ||
+    securityTitle.includes("\\") ||
+    hasArtifactTitleUriScheme(securityTitle) ||
+    ARTIFACT_TITLE_CONTROL_RE.test(securityTitle) ||
+    ARTIFACT_TITLE_SECRET_RE.test(securityTitle)
+  ) {
+    return fail(
+      "invalid_value",
+      path,
+      "title must not contain paths, URI schemes, control characters, or known secret prefixes",
+    );
+  }
+  return title;
+}
+
+function parseSource(value: unknown, path: string): ProtocolParseResult<RunManifestSourceV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const kindField = parseRequiredField(object.value, "kind", path);
+  if (!kindField.ok) return kindField;
+  const kind = parseEnumValue(kindField.value, SOURCE_KINDS, childPath(path, "kind"), "kind");
+  if (!kind.ok) return kind;
+
+  const idField = parseRequiredField(object.value, "id", path);
+  if (!idField.ok) return idField;
+  const id = parseOpaqueIdentifier(
+    idField.value,
+    kind.value === "context-pack" ? "ctx" : "evidence",
+    childPath(path, "id"),
+    "id",
+  );
+  if (!id.ok) return id;
+
+  if (kind.value === "context-pack") {
+    const safeKeys = validateSensitiveObjectKeys(
+      object.value,
+      path,
+      CONTEXT_PACK_SOURCE_FIELDS,
+    );
+    if (!safeKeys.ok) return safeKeys;
+
+    const digestField = parseRequiredField(object.value, "digest", path);
+    if (!digestField.ok) return digestField;
+    const digest = parseSha256(digestField.value, childPath(path, "digest"), "digest");
+    if (!digest.ok) return digest;
+
+    const availabilityField = parseRequiredField(object.value, "availability", path);
+    if (!availabilityField.ok) return availabilityField;
+    const availability = parseEnumValue(
+      availabilityField.value,
+      CONTEXT_AVAILABILITY,
+      childPath(path, "availability"),
+      "availability",
+    );
+    if (!availability.ok) return availability;
+
+    return pass({
+      ...object.value,
+      kind: kind.value,
+      id: id.value,
+      digest: digest.value,
+      availability: availability.value,
+    });
+  }
+
+  const safeKeys = validateSensitiveObjectKeys(
+    object.value,
+    path,
+    PUBLIC_EVIDENCE_SOURCE_FIELDS,
+  );
+  if (!safeKeys.ok) return safeKeys;
+
+  const contentDigestField = parseRequiredField(object.value, "contentDigest", path);
+  if (!contentDigestField.ok) return contentDigestField;
+  const contentDigest = parseSha256(
+    contentDigestField.value,
+    childPath(path, "contentDigest"),
+    "contentDigest",
+  );
+  if (!contentDigest.ok) return contentDigest;
+
+  const snapshotDigestField = parseRequiredField(object.value, "snapshotDigest", path);
+  if (!snapshotDigestField.ok) return snapshotDigestField;
+  const snapshotDigest = parseSha256(
+    snapshotDigestField.value,
+    childPath(path, "snapshotDigest"),
+    "snapshotDigest",
+  );
+  if (!snapshotDigest.ok) return snapshotDigest;
+
+  const canonicalUrlField = parseRequiredField(object.value, "canonicalUrl", path);
+  if (!canonicalUrlField.ok) return canonicalUrlField;
+  const canonicalUrl = parsePublicCanonicalUrl(
+    canonicalUrlField.value,
+    childPath(path, "canonicalUrl"),
+  );
+  if (!canonicalUrl.ok) return canonicalUrl;
+
+  const fetchedAtField = parseRequiredField(object.value, "fetchedAt", path);
+  if (!fetchedAtField.ok) return fetchedAtField;
+  const fetchedAt = parseUtc(fetchedAtField.value, childPath(path, "fetchedAt"), "fetchedAt");
+  if (!fetchedAt.ok) return fetchedAt;
+
+  return pass({
+    ...object.value,
+    kind: kind.value,
+    id: id.value,
+    contentDigest: contentDigest.value,
+    snapshotDigest: snapshotDigest.value,
+    canonicalUrl: canonicalUrl.value,
+    fetchedAt: fetchedAt.value,
+  });
+}
+
+function parseArtifact(value: unknown, path: string): ProtocolParseResult<ArtifactRegistrationV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+  const safeKeys = validateSensitiveObjectKeys(object.value, path, ARTIFACT_FIELDS);
+  if (!safeKeys.ok) return safeKeys;
+
+  const idField = parseRequiredField(object.value, "id", path);
+  if (!idField.ok) return idField;
+  const id = parseOpaqueIdentifier(idField.value, "artifact", childPath(path, "id"), "id");
+  if (!id.ok) return id;
+
+  const kindField = parseRequiredField(object.value, "kind", path);
+  if (!kindField.ok) return kindField;
+  const kind = parseString(kindField.value, childPath(path, "kind"), "kind");
+  if (!kind.ok) return kind;
+
+  const titleField = parseRequiredField(object.value, "title", path);
+  if (!titleField.ok) return titleField;
+  const title = parseArtifactTitle(titleField.value, childPath(path, "title"));
+  if (!title.ok) return title;
+
+  const mediaTypeField = parseRequiredField(object.value, "mediaType", path);
+  if (!mediaTypeField.ok) return mediaTypeField;
+  const mediaType = parseString(mediaTypeField.value, childPath(path, "mediaType"), "mediaType");
+  if (!mediaType.ok) return mediaType;
+
+  const digestField = parseRequiredField(object.value, "digest", path);
+  if (!digestField.ok) return digestField;
+  const digest = parseSha256(digestField.value, childPath(path, "digest"), "digest");
+  if (!digest.ok) return digest;
+
+  const bytesField = parseRequiredField(object.value, "bytes", path);
+  if (!bytesField.ok) return bytesField;
+  const bytes = parseSafeIntegerInRange(
+    bytesField.value,
+    childPath(path, "bytes"),
+    "bytes",
+    0,
+    MAX_SAFE_INTEGER,
+  );
+  if (!bytes.ok) return bytes;
+
+  const placementField = parseRequiredField(object.value, "placement", path);
+  if (!placementField.ok) return placementField;
+  const placement = parseEnumValue(
+    placementField.value,
+    ARTIFACT_PLACEMENTS,
+    childPath(path, "placement"),
+    "placement",
+  );
+  if (!placement.ok) return placement;
+
+  const contentSyncField = parseRequiredField(object.value, "contentSync", path);
+  if (!contentSyncField.ok) return contentSyncField;
+  const contentSync = parseEnumValue(
+    contentSyncField.value,
+    CONTENT_SYNCS,
+    childPath(path, "contentSync"),
+    "contentSync",
+  );
+  if (!contentSync.ok) return contentSync;
+  if (placement.value === "cloud-content" && contentSync.value === "not-requested") {
+    return fail(
+      "semantic_conflict",
+      childPath(path, "contentSync"),
+      "cloud-content artifacts require content synchronization to be requested",
+    );
+  }
+
+  const createdAtField = parseRequiredField(object.value, "createdAt", path);
+  if (!createdAtField.ok) return createdAtField;
+  const createdAt = parseUtc(createdAtField.value, childPath(path, "createdAt"), "createdAt");
+  if (!createdAt.ok) return createdAt;
+
+  return pass({
+    ...object.value,
+    id: id.value,
+    kind: kind.value,
+    title: title.value,
+    mediaType: mediaType.value,
+    digest: digest.value,
+    bytes: bytes.value,
+    placement: placement.value,
+    contentSync: contentSync.value,
+    createdAt: createdAt.value,
+  });
+}
+
+function parseModelExecution(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<RunManifestModelExecutionV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+  const safeKeys = validateSensitiveObjectKeys(
+    object.value,
+    path,
+    MODEL_EXECUTION_FIELDS,
+  );
+  if (!safeKeys.ok) return safeKeys;
+
+  const taskIdField = parseRequiredField(object.value, "taskId", path);
+  if (!taskIdField.ok) return taskIdField;
+  const taskId = parseOpaqueIdentifier(taskIdField.value, "modeltask", childPath(path, "taskId"), "taskId");
+  if (!taskId.ok) return taskId;
+
+  const phaseField = parseRequiredField(object.value, "phase", path);
+  if (!phaseField.ok) return phaseField;
+  const phase = parseEnumValue(phaseField.value, TASK_PHASES, childPath(path, "phase"), "phase");
+  if (!phase.ok) return phase;
+
+  const attemptField = parseRequiredField(object.value, "attempt", path);
+  if (!attemptField.ok) return attemptField;
+  const attempt = parsePositiveSafeInteger(attemptField.value, childPath(path, "attempt"), "attempt");
+  if (!attempt.ok) return attempt;
+
+  const inputDigestField = parseRequiredField(object.value, "inputDigest", path);
+  if (!inputDigestField.ok) return inputDigestField;
+  const inputDigest = parseSha256(
+    inputDigestField.value,
+    childPath(path, "inputDigest"),
+    "inputDigest",
+  );
+  if (!inputDigest.ok) return inputDigest;
+
+  const outputDigestField = parseRequiredField(object.value, "outputDigest", path);
+  if (!outputDigestField.ok) return outputDigestField;
+  const outputDigest = parseSha256(
+    outputDigestField.value,
+    childPath(path, "outputDigest"),
+    "outputDigest",
+  );
+  if (!outputDigest.ok) return outputDigest;
+
+  const receiptField = parseRequiredField(object.value, "receipt", path);
+  if (!receiptField.ok) return receiptField;
+  const safeReceiptKeys = validateModelReceiptExtensionKeys(
+    receiptField.value,
+    childPath(path, "receipt"),
+  );
+  if (!safeReceiptKeys.ok) return safeReceiptKeys;
+  const receipt = parseResearchModelReceiptV1(receiptField.value, childPath(path, "receipt"));
+  if (!receipt.ok) return receipt;
+
+  return pass({
+    ...object.value,
+    taskId: taskId.value,
+    phase: phase.value,
+    attempt: attempt.value,
+    inputDigest: inputDigest.value,
+    outputDigest: outputDigest.value,
+    receipt: receipt.value,
+  });
+}
+
+function parseUsage(value: unknown, path: string): ProtocolParseResult<RunManifestUsageV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+  const safeKeys = validateSensitiveObjectKeys(
+    object.value,
+    path,
+    MANIFEST_USAGE_FIELDS,
+  );
+  if (!safeKeys.ok) return safeKeys;
+
+  const inputTokensField = parseRequiredField(object.value, "inputTokens", path);
+  if (!inputTokensField.ok) return inputTokensField;
+  const inputTokens = parseNullableSafeInteger(
+    inputTokensField.value,
+    childPath(path, "inputTokens"),
+    "inputTokens",
+  );
+  if (!inputTokens.ok) return inputTokens;
+
+  const outputTokensField = parseRequiredField(object.value, "outputTokens", path);
+  if (!outputTokensField.ok) return outputTokensField;
+  const outputTokens = parseNullableSafeInteger(
+    outputTokensField.value,
+    childPath(path, "outputTokens"),
+    "outputTokens",
+  );
+  if (!outputTokens.ok) return outputTokens;
+
+  const costUsdField = parseRequiredField(object.value, "costUsd", path);
+  if (!costUsdField.ok) return costUsdField;
+  const costUsd = parseNullableNonNegativeFiniteNumber(
+    costUsdField.value,
+    childPath(path, "costUsd"),
+    "costUsd",
+  );
+  if (!costUsd.ok) return costUsd;
+
+  const completenessField = parseRequiredField(object.value, "completeness", path);
+  if (!completenessField.ok) return completenessField;
+  const completeness = parseEnumValue(
+    completenessField.value,
+    COMPLETENESS_VALUES,
+    childPath(path, "completeness"),
+    "completeness",
+  );
+  if (!completeness.ok) return completeness;
+
+  return pass({
+    ...object.value,
+    inputTokens: inputTokens.value,
+    outputTokens: outputTokens.value,
+    costUsd: costUsd.value,
+    completeness: completeness.value,
+  });
+}
+
+function parseRetention(value: unknown, path: string): ProtocolParseResult<RunManifestRetentionV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+  const safeKeys = validateSensitiveObjectKeys(object.value, path, RETENTION_FIELDS);
+  if (!safeKeys.ok) return safeKeys;
+
+  const policyField = parseRequiredField(object.value, "policy", path);
+  if (!policyField.ok) return policyField;
+  const policy = parseEnumValue(policyField.value, RETENTION_POLICIES, childPath(path, "policy"), "policy");
+  if (!policy.ok) return policy;
+
+  const effectivePolicyField = parseRequiredField(object.value, "effectivePolicy", path);
+  if (!effectivePolicyField.ok) return effectivePolicyField;
+  const effectivePolicy = parseEnumValue(
+    effectivePolicyField.value,
+    RETENTION_POLICIES,
+    childPath(path, "effectivePolicy"),
+    "effectivePolicy",
+  );
+  if (!effectivePolicy.ok) return effectivePolicy;
+
+  const statusField = parseRequiredField(object.value, "status", path);
+  if (!statusField.ok) return statusField;
+  const status = parseEnumValue(
+    statusField.value,
+    RETENTION_STATUSES,
+    childPath(path, "status"),
+    "status",
+  );
+  if (!status.ok) return status;
+
+  const contentExpiresAtField = parseRequiredField(object.value, "contentExpiresAt", path);
+  if (!contentExpiresAtField.ok) return contentExpiresAtField;
+  const contentExpiresAt = parseNullableUtc(
+    contentExpiresAtField.value,
+    childPath(path, "contentExpiresAt"),
+    "contentExpiresAt",
+  );
+  if (!contentExpiresAt.ok) return contentExpiresAt;
+
+  const updatedAtField = parseRequiredField(object.value, "updatedAt", path);
+  if (!updatedAtField.ok) return updatedAtField;
+  const updatedAt = parseUtc(updatedAtField.value, childPath(path, "updatedAt"), "updatedAt");
+  if (!updatedAt.ok) return updatedAt;
+
+  return pass({
+    ...object.value,
+    policy: policy.value,
+    effectivePolicy: effectivePolicy.value,
+    status: status.value,
+    contentExpiresAt: contentExpiresAt.value,
+    updatedAt: updatedAt.value,
+  });
+}
+
+function parseDeletion(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<RunManifestDeletionReceiptV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+  const safeKeys = validateSafeDeletionExtensionKeys(
+    object.value,
+    path,
+    DELETION_FIELDS,
+  );
+  if (!safeKeys.ok) return safeKeys;
+
+  const statusField = parseRequiredField(object.value, "status", path);
+  if (!statusField.ok) return statusField;
+  const status = parseEnumValue(
+    statusField.value,
+    DELETION_STATUSES,
+    childPath(path, "status"),
+    "status",
+  );
+  if (!status.ok) return status;
+
+  let requestedAt: string | undefined;
+  if (hasOwn(object.value, "requestedAt")) {
+    const parsed = parseUtc(object.value.requestedAt, childPath(path, "requestedAt"), "requestedAt");
+    if (!parsed.ok) return parsed;
+    requestedAt = parsed.value;
+  }
+
+  let completedAt: string | undefined;
+  if (hasOwn(object.value, "completedAt")) {
+    const parsed = parseUtc(object.value.completedAt, childPath(path, "completedAt"), "completedAt");
+    if (!parsed.ok) return parsed;
+    completedAt = parsed.value;
+  }
+
+  let deletedObjectCount: number | undefined;
+  if (hasOwn(object.value, "deletedObjectCount")) {
+    const parsed = parseSafeIntegerInRange(
+      object.value.deletedObjectCount,
+      childPath(path, "deletedObjectCount"),
+      "deletedObjectCount",
+      0,
+      MAX_SAFE_INTEGER,
+    );
+    if (!parsed.ok) return parsed;
+    deletedObjectCount = parsed.value;
+  }
+
+  let retainedAuditUntil: string | undefined;
+  if (hasOwn(object.value, "retainedAuditUntil")) {
+    const parsed = parseUtc(
+      object.value.retainedAuditUntil,
+      childPath(path, "retainedAuditUntil"),
+      "retainedAuditUntil",
+    );
+    if (!parsed.ok) return parsed;
+    retainedAuditUntil = parsed.value;
+  }
+
+  let eventSequence: number | undefined;
+  if (hasOwn(object.value, "eventSequence")) {
+    const parsed = parsePositiveSafeInteger(
+      object.value.eventSequence,
+      childPath(path, "eventSequence"),
+      "eventSequence",
+    );
+    if (!parsed.ok) return parsed;
+    eventSequence = parsed.value;
+  }
+
+  return pass({
+    ...object.value,
+    status: status.value,
+    ...(typeof requestedAt === "string" ? { requestedAt } : {}),
+    ...(typeof completedAt === "string" ? { completedAt } : {}),
+    ...(typeof deletedObjectCount === "number" ? { deletedObjectCount } : {}),
+    ...(typeof retainedAuditUntil === "string" ? { retainedAuditUntil } : {}),
+    ...(typeof eventSequence === "number" ? { eventSequence } : {}),
+  });
+}
+
+function validateRetentionDeletionPair(
+  retention: RunManifestRetentionV1,
+  deletion: RunManifestDeletionReceiptV1,
+): ProtocolParseResult<void> {
+  const valid =
+    (retention.status === "active" && deletion.status === "not_scheduled") ||
+    (retention.status === "deletion_scheduled" && deletion.status === "scheduled") ||
+    (retention.status === "deletion_pending" &&
+      (deletion.status === "pending" || deletion.status === "partial_failure")) ||
+    (retention.status === "deleted" && deletion.status === "completed");
+  if (!valid) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.status",
+      `retention status ${retention.status} is incompatible with deletion status ${deletion.status}`,
+    );
+  }
+  return pass(undefined);
+}
+
+function validateDeletionRequirements(
+  deletion: RunManifestDeletionReceiptV1,
+): ProtocolParseResult<void> {
+  if (
+    (deletion.status === "scheduled" ||
+      deletion.status === "pending" ||
+      deletion.status === "partial_failure") &&
+    !hasOwn(deletion, "requestedAt")
+  ) {
+    return fail("missing_field", "$.deletion.requestedAt", "Deletion status requires requestedAt");
+  }
+  if (deletion.status === "completed") {
+    for (const key of ["requestedAt", "completedAt", "deletedObjectCount", "eventSequence"] as const) {
+      if (!hasOwn(deletion, key)) {
+        return fail("missing_field", `$.deletion.${key}`, `Completed deletion requires ${key}`);
+      }
+    }
+    if (compareUtcTimestamps(deletion.completedAt!, deletion.requestedAt!) < 0) {
+      return fail(
+        "semantic_conflict",
+        "$.deletion.completedAt",
+        "completedAt must not be earlier than requestedAt",
+      );
+    }
+  }
+  return pass(undefined);
+}
+
+function validateDeletionChronology(
+  createdAt: string,
+  finalizedAt: string | undefined,
+  deletion: RunManifestDeletionReceiptV1,
+): ProtocolParseResult<void> {
+  if (deletion.requestedAt === undefined) return pass(undefined);
+  if (compareUtcTimestamps(deletion.requestedAt, createdAt) < 0) {
+    return fail(
+      "semantic_conflict",
+      "$.deletion.requestedAt",
+      "requestedAt must not be earlier than manifest createdAt",
+    );
+  }
+  if (
+    finalizedAt !== undefined &&
+    compareUtcTimestamps(deletion.requestedAt, finalizedAt) < 0
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.deletion.requestedAt",
+      "requestedAt must not be earlier than manifest finalizedAt",
+    );
+  }
+  return pass(undefined);
+}
+
+function validateManifestChronology(
+  createdAt: string,
+  finalizedAt: string | undefined,
+  sources: readonly RunManifestSourceV1[],
+  artifacts: readonly ArtifactRegistrationV1[],
+  retention: RunManifestRetentionV1,
+): ProtocolParseResult<void> {
+  if (
+    finalizedAt !== undefined &&
+    compareUtcTimestamps(finalizedAt, createdAt) < 0
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.finalizedAt",
+      "finalizedAt must not be earlier than manifest createdAt",
+    );
+  }
+
+  for (const [index, source] of sources.entries()) {
+    if (source.kind !== "public-evidence") continue;
+    if (
+      compareUtcTimestamps(source.fetchedAt, createdAt) < 0 ||
+      (finalizedAt !== undefined &&
+        compareUtcTimestamps(source.fetchedAt, finalizedAt) > 0)
+    ) {
+      return fail(
+        "semantic_conflict",
+        `$.sources[${index}].fetchedAt`,
+        "Public evidence fetchedAt must fall within the manifest assembly window",
+      );
+    }
+  }
+
+  for (const [index, artifact] of artifacts.entries()) {
+    if (
+      compareUtcTimestamps(artifact.createdAt, createdAt) < 0 ||
+      (finalizedAt !== undefined &&
+        compareUtcTimestamps(artifact.createdAt, finalizedAt) > 0)
+    ) {
+      return fail(
+        "semantic_conflict",
+        `$.artifacts[${index}].createdAt`,
+        "Artifact createdAt must fall within the manifest assembly window",
+      );
+    }
+  }
+
+  if (compareUtcTimestamps(retention.updatedAt, createdAt) < 0) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.updatedAt",
+      "Retention updatedAt must not be earlier than manifest createdAt",
+    );
+  }
+  if (
+    finalizedAt !== undefined &&
+    compareUtcTimestamps(retention.updatedAt, finalizedAt) < 0
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.updatedAt",
+      "Final manifest retention updatedAt must not be earlier than finalizedAt",
+    );
+  }
+  const retentionClockLowerBound = finalizedAt ?? createdAt;
+  if (
+    retention.contentExpiresAt !== null &&
+    compareUtcTimestamps(
+      retention.contentExpiresAt,
+      retentionClockLowerBound,
+    ) < 0
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.contentExpiresAt",
+      `contentExpiresAt must not be earlier than manifest ${finalizedAt === undefined ? "createdAt" : "finalizedAt"}`,
+    );
+  }
+  return pass(undefined);
+}
+
+function validateRetentionClock(
+  retention: RunManifestRetentionV1,
+): ProtocolParseResult<void> {
+  if (retention.status === "active" && retention.contentExpiresAt !== null) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.contentExpiresAt",
+      "active retention must not have contentExpiresAt",
+    );
+  }
+  if (retention.status !== "active" && retention.contentExpiresAt === null) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.contentExpiresAt",
+      "scheduled or completed deletion requires contentExpiresAt",
+    );
+  }
+  return pass(undefined);
+}
+
+function validateFinalRetentionShortening(
+  state: RunManifestV1["state"],
+  shortened: boolean,
+  retention: RunManifestRetentionV1,
+  deletion: RunManifestDeletionReceiptV1,
+): ProtocolParseResult<void> {
+  if (state !== "final" || !shortened) return pass(undefined);
+  if (retention.status === "active" || deletion.status === "not_scheduled") {
+    return fail(
+      "semantic_conflict",
+      "$.retention.status",
+      "shortened final retention must have scheduled-or-later deletion",
+    );
+  }
+  const pair = validateRetentionDeletionPair(retention, deletion);
+  if (!pair.ok) return pair;
+  if (retention.contentExpiresAt === null) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.contentExpiresAt",
+      "shortened final retention requires contentExpiresAt",
+    );
+  }
+  return pass(undefined);
+}
+
+function manifestDigest(value: unknown): string {
+  return digestProtocolObject(value);
+}
+
+function canonicalField(record: Record<string, unknown>, key: string): string {
+  const descriptor = Object.getOwnPropertyDescriptor(record, key);
+  if (descriptor && (!descriptor.enumerable || !("value" in descriptor))) {
+    return canonicalJson(record);
+  }
+  return canonicalJson({
+    present: Boolean(descriptor),
+    ...(descriptor && "value" in descriptor ? { value: descriptor.value } : {}),
+  });
+}
+
+function sameCanonicalField(
+  previous: Record<string, unknown>,
+  next: Record<string, unknown>,
+  key: string,
+): boolean {
+  return canonicalField(previous, key) === canonicalField(next, key);
+}
+
+function compareImmutableField(
+  previous: Record<string, unknown>,
+  next: Record<string, unknown>,
+  key: string,
+  path: string,
+): ProtocolParseResult<void> {
+  if (!sameCanonicalField(previous, next, key)) {
+    return fail("semantic_conflict", path, `${key} cannot change after finalization`);
+  }
+  return pass(undefined);
+}
+
+const MUTABLE_ROOT_FIELDS = new Set(["digest", "revision", "previousDigest"]);
+const MUTABLE_RETENTION_FIELDS = new Set(["effectivePolicy", "status", "contentExpiresAt", "updatedAt"]);
+const MUTABLE_DELETION_FIELDS = new Set([
+  "status",
+  "requestedAt",
+  "completedAt",
+  "deletedObjectCount",
+  "retainedAuditUntil",
+  "eventSequence",
+]);
+const RETENTION_STATUS_ORDER = {
+  active: 0,
+  deletion_scheduled: 1,
+  deletion_pending: 2,
+  deleted: 3,
+} as const;
+const DELETION_STATUS_ORDER = {
+  not_scheduled: 0,
+  scheduled: 1,
+  pending: 2,
+  partial_failure: 2,
+  completed: 3,
+} as const;
+const RETENTION_DURATION_SECONDS = {
+  "run-only": 24 * 60 * 60,
+  "7-days": 7 * 24 * 60 * 60,
+} as const;
+
+function validateFiniteRetentionDeadline(
+  retention: RunManifestRetentionV1,
+  clockStart: string,
+): ProtocolParseResult<void> {
+  if (
+    retention.contentExpiresAt === null ||
+    retention.effectivePolicy === "project"
+  ) {
+    return pass(undefined);
+  }
+  const deadline = utcTimestampToProtocolNanoseconds(retention.contentExpiresAt);
+  const ceiling =
+    utcTimestampToProtocolNanoseconds(clockStart) +
+    BigInt(RETENTION_DURATION_SECONDS[retention.effectivePolicy]) *
+      BigInt(1_000_000_000);
+  if (deadline > ceiling) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.contentExpiresAt",
+      `${retention.effectivePolicy} content expiration exceeds its policy deadline ceiling`,
+    );
+  }
+  return pass(undefined);
+}
+
+function validateFreshRetentionConsent(
+  previous: RunManifestV1,
+  next: RunManifestV1,
+  options: ManifestRevisionOptions,
+  path: string,
+): ProtocolParseResult<string> {
+  if (
+    options.freshConsent !== true ||
+    options.freshConsentAt === undefined ||
+    !isUtcTimestamp(options.freshConsentAt) ||
+    (next.context !== undefined && options.contextConsent === undefined)
+  ) {
+    return fail(
+      "semantic_conflict",
+      path,
+      next.context === undefined
+        ? "Retention lengthening requires explicit fresh consent"
+        : "Retention lengthening requires explicit fresh Context Pack consent",
+    );
+  }
+  const latestPriorAuthority =
+    previous.deletion.requestedAt !== undefined &&
+    compareUtcTimestamps(
+      previous.deletion.requestedAt,
+      previous.retention.updatedAt,
+    ) > 0
+      ? previous.deletion.requestedAt
+      : previous.retention.updatedAt;
+  if (
+    compareUtcTimestamps(options.freshConsentAt, latestPriorAuthority) <= 0 ||
+    compareUtcTimestamps(options.freshConsentAt, next.retention.updatedAt) > 0
+  ) {
+    return fail(
+      "semantic_conflict",
+      path,
+      "Fresh consent must postdate prior retention and deletion-request authority and be no later than the new revision",
+    );
+  }
+  return pass(options.freshConsentAt);
+}
+
+function validateRetentionLifecycleRevision(
+  previous: RunManifestV1,
+  next: RunManifestV1,
+  options: ManifestRevisionOptions,
+): ProtocolParseResult<void> {
+  const previousDeadline = previous.retention.contentExpiresAt;
+  const nextDeadline = next.retention.contentExpiresAt;
+  if (
+    compareUtcTimestamps(
+      next.retention.updatedAt,
+      previous.retention.updatedAt,
+    ) < 0
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.updatedAt",
+      "Retention updatedAt cannot move backward",
+    );
+  }
+  const policyLengthened =
+    RETENTION_ORDER[next.retention.effectivePolicy] >
+    RETENTION_ORDER[previous.retention.effectivePolicy];
+  const deadlineExtended =
+    previousDeadline !== null &&
+    nextDeadline !== null &&
+    compareUtcTimestamps(nextDeadline, previousDeadline) > 0;
+  const deadlineRemoved = previousDeadline !== null && nextDeadline === null;
+  const restoration =
+    deadlineRemoved &&
+    previous.retention.status === "deletion_scheduled" &&
+    previous.deletion.status === "scheduled" &&
+    next.retention.effectivePolicy === "project" &&
+    next.retention.status === "active" &&
+    next.deletion.status === "not_scheduled";
+  const lengtheningPath = policyLengthened
+    ? "$.retention.effectivePolicy"
+    : "$.retention.contentExpiresAt";
+  const retentionLengthened =
+    policyLengthened || deadlineExtended || deadlineRemoved;
+  const deletionPendingOrLater = [previous, next].some(
+    (manifest) =>
+      manifest.retention.status === "deletion_pending" ||
+      manifest.retention.status === "deleted" ||
+      manifest.deletion.status === "pending" ||
+      manifest.deletion.status === "partial_failure" ||
+      manifest.deletion.status === "completed",
+  );
+  if (retentionLengthened && deletionPendingOrLater) {
+    return fail(
+      "semantic_conflict",
+      lengtheningPath,
+      "Retention cannot be restored after deletion has started",
+    );
+  }
+
+  let freshConsentAt: string | undefined;
+  if (retentionLengthened) {
+    const freshConsent = validateFreshRetentionConsent(
+      previous,
+      next,
+      options,
+      lengtheningPath,
+    );
+    if (!freshConsent.ok) return freshConsent;
+    freshConsentAt = freshConsent.value;
+  }
+
+  if (previousDeadline !== null && nextDeadline === null && !restoration) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.contentExpiresAt",
+      "An established content expiration deadline cannot be cleared",
+    );
+  }
+  if (
+    RETENTION_STATUS_ORDER[next.retention.status] <
+      RETENTION_STATUS_ORDER[previous.retention.status] &&
+    !restoration
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.status",
+      "Retention deletion progress cannot move backward",
+    );
+  }
+  if (
+    DELETION_STATUS_ORDER[next.deletion.status] <
+      DELETION_STATUS_ORDER[previous.deletion.status] &&
+    !restoration
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.deletion.status",
+      "Deletion progress cannot move backward",
+    );
+  }
+  if (
+    previous.deletion.requestedAt !== undefined &&
+    next.deletion.requestedAt !== previous.deletion.requestedAt &&
+    !restoration
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.deletion.requestedAt",
+      "An established deletion request timestamp cannot change",
+    );
+  }
+  if (
+    previous.deletion.requestedAt === undefined &&
+    next.deletion.requestedAt !== undefined &&
+    compareUtcTimestamps(
+      next.deletion.requestedAt,
+      previous.retention.updatedAt,
+    ) < 0
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.deletion.requestedAt",
+      "A new deletion request must not predate prior retention authority",
+    );
+  }
+
+  const inheritsFiniteDeadlineAuthority =
+    previousDeadline !== null &&
+    nextDeadline !== null &&
+    RETENTION_ORDER[next.retention.effectivePolicy] >=
+      RETENTION_ORDER[previous.retention.effectivePolicy] &&
+    compareUtcTimestamps(nextDeadline, previousDeadline) <= 0;
+  if (!inheritsFiniteDeadlineAuthority) {
+    const deadline = validateFiniteRetentionDeadline(
+      next.retention,
+      freshConsentAt ??
+        next.finalizedAt ??
+        previous.finalizedAt ??
+        next.createdAt,
+    );
+    if (!deadline.ok) return deadline;
+  }
+
+  if (previous.deletion.status === "completed") {
+    for (const key of [
+      "requestedAt",
+      "completedAt",
+      "deletedObjectCount",
+      "retainedAuditUntil",
+      "eventSequence",
+    ] as const) {
+      if (canonicalField(previous.deletion, key) !== canonicalField(next.deletion, key)) {
+        return fail(
+          "semantic_conflict",
+          `$.deletion.${key}`,
+          "Completed deletion receipts are terminal",
+        );
+      }
+    }
+  }
+  if (previous.retention.status === "deleted") {
+    for (const key of [
+      "effectivePolicy",
+      "status",
+      "contentExpiresAt",
+      "updatedAt",
+    ] as const) {
+      if (canonicalField(previous.retention, key) !== canonicalField(next.retention, key)) {
+        return fail(
+          "semantic_conflict",
+          `$.retention.${key}`,
+          "Deleted retention state is terminal",
+        );
+      }
+    }
+  }
+  return pass(undefined);
+}
+
+function compareUnknownFields(
+  previous: Record<string, unknown>,
+  next: Record<string, unknown>,
+  excluded: ReadonlySet<string>,
+  path: string,
+): ProtocolParseResult<void> {
+  const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+  for (const key of keys) {
+    if (excluded.has(key)) continue;
+    const result = compareImmutableField(previous, next, key, childPath(path, key));
+    if (!result.ok) return result;
+  }
+  return pass(undefined);
+}
+
+function addTokenTotal(current: number | null, value: unknown, label: string, index: number): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`execution ${index} ${label} must be a non-negative safe integer`);
+  }
+  const total = (current ?? 0) + value;
+  if (!Number.isSafeInteger(total) || total < 0) {
+    throw new RangeError(`${label} aggregate exceeds Number.MAX_SAFE_INTEGER`);
+  }
+  return total;
+}
+
+type ExactDecimal = {
+  coefficient: bigint;
+  exponent: number;
+};
+
+const MAX_EXACT_DECIMAL_SCALE_SPAN = 1_000;
+
+function canonicalNumberDecimal(value: number): ExactDecimal {
+  const spelling = value.toString();
+  const [mantissa, exponentSpelling] = spelling.toLowerCase().split("e");
+  if (mantissa === undefined) {
+    throw new TypeError("costUsd has no canonical decimal spelling");
+  }
+  const pointIndex = mantissa.indexOf(".");
+  const fractionalDigits =
+    pointIndex === -1 ? 0 : mantissa.length - pointIndex - 1;
+  const digits = mantissa.replace(".", "");
+  let coefficient = BigInt(digits);
+  let exponent =
+    (exponentSpelling === undefined ? 0 : Number(exponentSpelling)) -
+    fractionalDigits;
+
+  while (
+    coefficient !== BigInt(0) &&
+    coefficient % BigInt(10) === BigInt(0)
+  ) {
+    coefficient /= BigInt(10);
+    exponent += 1;
+  }
+  return { coefficient, exponent };
+}
+
+function addCostTotal(
+  current: ExactDecimal | null,
+  value: unknown,
+  index: number,
+): ExactDecimal {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new TypeError(`execution ${index} costUsd must be a finite number >= 0`);
+  }
+  const next = canonicalNumberDecimal(value);
+  if (current === null) return next;
+
+  const exponent = Math.min(current.exponent, next.exponent);
+  const currentScale = current.exponent - exponent;
+  const nextScale = next.exponent - exponent;
+  if (
+    currentScale > MAX_EXACT_DECIMAL_SCALE_SPAN ||
+    nextScale > MAX_EXACT_DECIMAL_SCALE_SPAN
+  ) {
+    throw new RangeError("costUsd canonical decimal scale span is too large");
+  }
+  let coefficient =
+    current.coefficient * BigInt(10) ** BigInt(currentScale) +
+    next.coefficient * BigInt(10) ** BigInt(nextScale);
+  let normalizedExponent = exponent;
+  while (
+    coefficient !== BigInt(0) &&
+    coefficient % BigInt(10) === BigInt(0)
+  ) {
+    coefficient /= BigInt(10);
+    normalizedExponent += 1;
+  }
+  return { coefficient, exponent: normalizedExponent };
+}
+
+function exactDecimalToNumber(value: ExactDecimal): number {
+  const result = Number(`${value.coefficient}e${value.exponent}`);
+  if (!Number.isFinite(result) || result < 0) {
+    throw new RangeError("costUsd aggregate is not a finite non-negative number");
+  }
+  return result;
+}
+
+export function aggregateManifestUsage(
+  executions: readonly RunManifestModelExecutionV1[],
+): RunManifestUsageV1 {
+  if (!Array.isArray(executions)) {
+    throw new TypeError("model executions must be an array");
+  }
+
+  let inputTokens: number | null = null;
+  let outputTokens: number | null = null;
+  let costTotal: ExactDecimal | null = null;
+  let anyReported = false;
+  let anyMissing = false;
+
+  for (const [index, execution] of executions.entries()) {
+    const usage = (execution as RunManifestModelExecutionV1 | null | undefined)?.receipt?.usage;
+    if (!isRecord(usage)) {
+      throw new TypeError(`execution ${index} has invalid receipt usage`);
+    }
+    if (usage.inputTokens === null) {
+      anyMissing = true;
+    } else {
+      anyReported = true;
+      inputTokens = addTokenTotal(inputTokens, usage.inputTokens, "inputTokens", index);
+    }
+    if (usage.outputTokens === null) {
+      anyMissing = true;
+    } else {
+      anyReported = true;
+      outputTokens = addTokenTotal(outputTokens, usage.outputTokens, "outputTokens", index);
+    }
+    if (usage.costUsd === null) {
+      anyMissing = true;
+    } else {
+      anyReported = true;
+      costTotal = addCostTotal(costTotal, usage.costUsd, index);
+    }
+  }
+
+  return {
+    inputTokens,
+    outputTokens,
+    costUsd: costTotal === null ? null : exactDecimalToNumber(costTotal),
+    completeness:
+      executions.length > 0 && !anyMissing
+        ? "complete"
+        : anyReported
+          ? "partial"
+          : "unreported",
+  };
+}
+
+type RunManifestParseMode =
+  | "standalone"
+  | "revision-candidate"
+  | "embedded-candidate";
+
+function parseRunManifestValueV1(
+  value: unknown,
+  mode: RunManifestParseMode,
+): ProtocolParseResult<RunManifestV1> {
+  const standalone = mode === "standalone";
+  const validateStandaloneDeadline = mode === "standalone";
+  const wireValue = copyProtocolJsonValue(value);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, "$");
+  if (!object.ok) return object;
+  const safeKeys = validateSensitiveObjectKeys(
+    object.value,
+    "$",
+    RUN_MANIFEST_FIELDS,
+  );
+  if (!safeKeys.ok) return safeKeys;
+
+  const schemaField = parseRequiredField(object.value, "schema", "$");
+  if (!schemaField.ok) return schemaField;
+  const schema = parseSchema(schemaField.value, "$.schema");
+  if (!schema.ok) return schema;
+
+  const idField = parseRequiredField(object.value, "id", "$");
+  if (!idField.ok) return idField;
+  const id = parseOpaqueIdentifier(idField.value, "manifest", "$.id", "id");
+  if (!id.ok) return id;
+
+  const runIdField = parseRequiredField(object.value, "runId", "$");
+  if (!runIdField.ok) return runIdField;
+  const runId = parseOpaqueIdentifier(runIdField.value, "run", "$.runId", "runId");
+  if (!runId.ok) return runId;
+
+  const digestField = parseRequiredField(object.value, "digest", "$");
+  if (!digestField.ok) return digestField;
+  const digest = parseSha256(digestField.value, "$.digest", "digest");
+  if (!digest.ok) return digest;
+
+  const revisionField = parseRequiredField(object.value, "revision", "$");
+  if (!revisionField.ok) return revisionField;
+  const revision = parsePositiveSafeInteger(revisionField.value, "$.revision", "revision");
+  if (!revision.ok) return revision;
+
+  let previousDigest: string | undefined;
+  if (revision.value === 1) {
+    if (hasOwn(object.value, "previousDigest")) {
+      return fail("semantic_conflict", "$.previousDigest", "revision 1 must not include previousDigest");
+    }
+  } else {
+    if (!hasOwn(object.value, "previousDigest")) {
+      return fail("missing_field", "$.previousDigest", "revisions after 1 require previousDigest");
+    }
+    const parsedPreviousDigest = parseSha256(
+      object.value.previousDigest,
+      "$.previousDigest",
+      "previousDigest",
+    );
+    if (!parsedPreviousDigest.ok) return parsedPreviousDigest;
+    previousDigest = parsedPreviousDigest.value;
+  }
+
+  const stateField = parseRequiredField(object.value, "state", "$");
+  if (!stateField.ok) return stateField;
+  const state = parseEnumValue(stateField.value, MANIFEST_STATES, "$.state", "state");
+  if (!state.ok) return state;
+
+  const createdAtField = parseRequiredField(object.value, "createdAt", "$");
+  if (!createdAtField.ok) return createdAtField;
+  const createdAt = parseUtc(createdAtField.value, "$.createdAt", "createdAt");
+  if (!createdAt.ok) return createdAt;
+
+  let finalizedAt: string | undefined;
+  if (state.value === "assembling") {
+    if (hasOwn(object.value, "finalizedAt")) {
+      return fail("semantic_conflict", "$.finalizedAt", "assembling manifests must not include finalizedAt");
+    }
+  } else {
+    const finalizedAtField = parseRequiredField(object.value, "finalizedAt", "$");
+    if (!finalizedAtField.ok) return finalizedAtField;
+    const parsedFinalizedAt = parseUtc(finalizedAtField.value, "$.finalizedAt", "finalizedAt");
+    if (!parsedFinalizedAt.ok) return parsedFinalizedAt;
+    finalizedAt = parsedFinalizedAt.value;
+  }
+
+  let context: ResearchContextBindingV1 | undefined;
+  if (hasOwn(object.value, "context")) {
+    const safeContextKeys = validateSensitiveObjectKeys(
+      object.value.context,
+      "$.context",
+      CONTEXT_BINDING_FIELDS,
+    );
+    if (!safeContextKeys.ok) return safeContextKeys;
+    const parsedContext = parseResearchContextBindingV1(object.value.context, "$.context");
+    if (!parsedContext.ok) return parsedContext;
+    context = parsedContext.value;
+  }
+
+  const sourcesField = parseRequiredField(object.value, "sources", "$");
+  if (!sourcesField.ok) return sourcesField;
+  if (!Array.isArray(sourcesField.value)) {
+    return fail("invalid_type", "$.sources", "sources must be an array");
+  }
+  const sources: RunManifestSourceV1[] = [];
+  const sourceIds = new Set<string>();
+  let contextSourceCount = 0;
+  let contextSourceIndex = -1;
+  for (const [index, sourceValue] of sourcesField.value.entries()) {
+    const sourcePath = indexPath("$.sources", index);
+    const source = parseSource(sourceValue, sourcePath);
+    if (!source.ok) return source;
+    if (sourceIds.has(source.value.id)) {
+      return fail("semantic_conflict", childPath(sourcePath, "id"), "source ids must be unique");
+    }
+    sourceIds.add(source.value.id);
+    if (source.value.kind === "context-pack") {
+      contextSourceCount += 1;
+      contextSourceIndex = index;
+    }
+    sources.push(source.value);
+  }
+
+  const artifactsField = parseRequiredField(object.value, "artifacts", "$");
+  if (!artifactsField.ok) return artifactsField;
+  if (!Array.isArray(artifactsField.value)) {
+    return fail("invalid_type", "$.artifacts", "artifacts must be an array");
+  }
+  const artifacts: ArtifactRegistrationV1[] = [];
+  const artifactIds = new Set<string>();
+  for (const [index, artifactValue] of artifactsField.value.entries()) {
+    const artifactPath = indexPath("$.artifacts", index);
+    const artifact = parseArtifact(artifactValue, artifactPath);
+    if (!artifact.ok) return artifact;
+    if (artifactIds.has(artifact.value.id)) {
+      return fail("semantic_conflict", childPath(artifactPath, "id"), "artifact ids must be unique");
+    }
+    artifactIds.add(artifact.value.id);
+    artifacts.push(artifact.value);
+  }
+
+  const modelExecutionsField = parseRequiredField(object.value, "modelExecutions", "$");
+  if (!modelExecutionsField.ok) return modelExecutionsField;
+  if (!Array.isArray(modelExecutionsField.value)) {
+    return fail("invalid_type", "$.modelExecutions", "modelExecutions must be an array");
+  }
+  const modelExecutions: RunManifestModelExecutionV1[] = [];
+  const executionPairs = new Set<string>();
+  for (const [index, executionValue] of modelExecutionsField.value.entries()) {
+    const executionPath = indexPath("$.modelExecutions", index);
+    const execution = parseModelExecution(executionValue, executionPath);
+    if (!execution.ok) return execution;
+    const pair = `${execution.value.taskId}\u0000${execution.value.attempt}`;
+    if (executionPairs.has(pair)) {
+      return fail("semantic_conflict", executionPath, "taskId and attempt pairs must be unique");
+    }
+    executionPairs.add(pair);
+    modelExecutions.push(execution.value);
+  }
+
+  const usageField = parseRequiredField(object.value, "usage", "$");
+  if (!usageField.ok) return usageField;
+  const usage = parseUsage(usageField.value, "$.usage");
+  if (!usage.ok) return usage;
+
+  const retentionField = parseRequiredField(object.value, "retention", "$");
+  if (!retentionField.ok) return retentionField;
+  const retention = parseRetention(retentionField.value, "$.retention");
+  if (!retention.ok) return retention;
+
+  const deletionField = parseRequiredField(object.value, "deletion", "$");
+  if (!deletionField.ok) return deletionField;
+  const deletion = parseDeletion(deletionField.value, "$.deletion");
+  if (!deletion.ok) return deletion;
+
+  if (context) {
+    if (contextSourceCount !== 1) {
+      return fail(
+        "semantic_conflict",
+        "$.sources",
+        "context requires exactly one context-pack source",
+      );
+    }
+    const contextSource = sources[contextSourceIndex];
+    if (
+      contextSource.kind !== "context-pack" ||
+      contextSource.id !== context.contextPackId ||
+      contextSource.digest !== context.contextPackDigest
+    ) {
+      return fail(
+        "semantic_conflict",
+        indexPath("$.sources", contextSourceIndex),
+        "context-pack source must match context id and digest",
+      );
+    }
+  } else if (contextSourceCount > 0) {
+    return fail(
+      "semantic_conflict",
+      indexPath("$.sources", contextSourceIndex),
+      "context-less manifests must not contain a context-pack source",
+    );
+  }
+
+  let expectedUsage: RunManifestUsageV1;
+  try {
+    expectedUsage = aggregateManifestUsage(modelExecutions);
+  } catch (error) {
+    return fail(
+      "invalid_value",
+      "$.usage",
+      error instanceof Error ? `usage aggregation failed: ${error.message}` : "usage aggregation failed",
+    );
+  }
+  for (const key of ["inputTokens", "outputTokens", "costUsd", "completeness"] as const) {
+    if (usage.value[key] !== expectedUsage[key]) {
+      return fail(
+        "semantic_conflict",
+        childPath("$.usage", key),
+        `usage.${key} must equal the aggregate model execution usage`,
+      );
+    }
+  }
+
+  if (revision.value === 1 && retention.value.effectivePolicy !== retention.value.policy) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.effectivePolicy",
+      "revision 1 effectivePolicy must equal policy",
+    );
+  }
+  if (
+    standalone &&
+    !retentionDoesNotExceed(
+      retention.value.effectivePolicy,
+      retention.value.policy,
+    )
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.effectivePolicy",
+      "effectivePolicy must not exceed policy outside validated revision-chain consent",
+    );
+  }
+
+  const pair = validateRetentionDeletionPair(retention.value, deletion.value);
+  if (!pair.ok) return pair;
+  const deletionRequirements = validateDeletionRequirements(deletion.value);
+  if (!deletionRequirements.ok) return deletionRequirements;
+  const deletionChronology = validateDeletionChronology(
+    createdAt.value,
+    finalizedAt,
+    deletion.value,
+  );
+  if (!deletionChronology.ok) return deletionChronology;
+  const chronology = validateManifestChronology(
+    createdAt.value,
+    finalizedAt,
+    sources,
+    artifacts,
+    retention.value,
+  );
+  if (!chronology.ok) return chronology;
+  const clock = validateRetentionClock(retention.value);
+  if (!clock.ok) return clock;
+  if (validateStandaloneDeadline) {
+    const deadline = validateFiniteRetentionDeadline(
+      retention.value,
+      finalizedAt ?? createdAt.value,
+    );
+    if (!deadline.ok) return deadline;
+  }
+  const shortening = validateFinalRetentionShortening(
+    state.value,
+    RETENTION_ORDER[retention.value.effectivePolicy] <
+      RETENTION_ORDER[retention.value.policy],
+    retention.value,
+    deletion.value,
+  );
+  if (!shortening.ok) return shortening;
+
+  let computedDigest: string;
+  try {
+    computedDigest = manifestDigest(object.value);
+  } catch (error) {
+    return fail(
+      "invalid_value",
+      "$.digest",
+      error instanceof Error ? error.message : "Manifest is not canonical JSON",
+    );
+  }
+  if (computedDigest !== digest.value) {
+    return fail(
+      "digest_mismatch",
+      "$.digest",
+      `digest must equal ${computedDigest}`,
+    );
+  }
+
+  const parsedManifest = {
+    ...object.value,
+    schema: schema.value,
+    id: id.value,
+    runId: runId.value,
+    digest: digest.value,
+    revision: revision.value,
+    ...(typeof previousDigest === "string" ? { previousDigest } : {}),
+    state: state.value,
+    createdAt: createdAt.value,
+    ...(typeof finalizedAt === "string" ? { finalizedAt } : {}),
+    ...(context ? { context } : {}),
+    sources,
+    artifacts,
+    modelExecutions,
+    usage: usage.value,
+    retention: retention.value,
+    deletion: deletion.value,
+  };
+  return pass(parsedManifest as RunManifestV1);
+}
+
+export function parseRunManifestV1(value: unknown): ProtocolParseResult<RunManifestV1> {
+  const parsed = parseRunManifestValueV1(value, "standalone");
+  if (!parsed.ok || parsed.value.revision !== 1) return parsed;
+  const remembered = rememberValidatedRevisionReference(
+    parsed.value,
+    parsed.value,
+  );
+  if (!remembered.ok) return remembered;
+  return parsed;
+}
+
+/**
+ * Parses a manifest that will immediately be checked against its preceding
+ * revision. The candidate's finite deadline is deferred to the chain validator,
+ * where verified fresh consent can supply a later clock.
+ */
+function parseRunManifestRevisionCandidateV1(
+  value: unknown,
+): ProtocolParseResult<RunManifestV1> {
+  return parseRunManifestValueV1(value, "revision-candidate");
+}
+
+/** @internal Embedded manifests remain provisional until run + pack composition. */
+export function parseEmbeddedRunManifestCandidateV1(
+  value: unknown,
+): ProtocolParseResult<RunManifestV1> {
+  return parseRunManifestValueV1(value, "embedded-candidate");
+}
+
+export function validateManifestRetentionConsent(
+  manifest: RunManifestV1,
+  contextConsent: RetentionPolicyV1 | undefined,
+): ProtocolParseResult<RunManifestV1> {
+  const consent = validateManifestRetentionCeiling(manifest, contextConsent);
+  if (!consent.ok) return consent;
+  const deadline = validateFiniteRetentionDeadline(
+    manifest.retention,
+    manifest.finalizedAt ?? manifest.createdAt,
+  );
+  if (!deadline.ok) return deadline;
+  return pass(manifest);
+}
+
+function validateManifestRetentionCeiling(
+  manifest: RunManifestV1,
+  contextConsent: RetentionPolicyV1 | undefined,
+): ProtocolParseResult<RunManifestV1> {
+  if (!manifest.context) {
+    if (
+      !retentionDoesNotExceed(
+        manifest.retention.effectivePolicy,
+        manifest.retention.policy,
+      )
+    ) {
+      return fail(
+        "semantic_conflict",
+        "$.retention.effectivePolicy",
+        "effectivePolicy must not exceed the original policy without a context",
+      );
+    }
+    return pass(manifest);
+  }
+
+  if (contextConsent === undefined) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.policy",
+      "context consent is required when a manifest has a context binding",
+    );
+  }
+  if (!retentionDoesNotExceed(manifest.retention.policy, contextConsent)) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.policy",
+      "retention policy exceeds context consent",
+    );
+  }
+  if (!retentionDoesNotExceed(manifest.retention.effectivePolicy, contextConsent)) {
+    return fail(
+      "semantic_conflict",
+      "$.retention.effectivePolicy",
+      "effective retention policy exceeds context consent",
+    );
+  }
+  return pass(manifest);
+}
+
+function validateParsedRunManifestRevision(
+  previous: RunManifestV1,
+  next: RunManifestV1,
+  options: ManifestRevisionOptions = {},
+): ProtocolParseResult<RunManifestV1> {
+  if (next.revision !== previous.revision + 1) {
+    return fail(
+      "semantic_conflict",
+      "$.revision",
+      `revision must equal ${previous.revision + 1}`,
+    );
+  }
+  if (next.previousDigest !== previous.digest) {
+    return fail(
+      "semantic_conflict",
+      "$.previousDigest",
+      "previousDigest must equal the preceding manifest digest",
+    );
+  }
+  if (next.id !== previous.id) {
+    return fail("semantic_conflict", "$.id", "id cannot change across revisions");
+  }
+  if (next.runId !== previous.runId) {
+    return fail("semantic_conflict", "$.runId", "runId cannot change across revisions");
+  }
+  if (next.createdAt !== previous.createdAt) {
+    return fail("semantic_conflict", "$.createdAt", "createdAt cannot change across revisions");
+  }
+
+  let previousDigest: string;
+  try {
+    previousDigest = manifestDigest(previous);
+  } catch (error) {
+    return fail(
+      "semantic_conflict",
+      "$.digest",
+      error instanceof Error ? error.message : "previous manifest is not canonical JSON",
+    );
+  }
+  if (previousDigest !== previous.digest) {
+    return fail("semantic_conflict", "$.digest", "previous manifest digest is not correct");
+  }
+
+  let nextDigest: string;
+  try {
+    nextDigest = manifestDigest(next);
+  } catch (error) {
+    return fail(
+      "semantic_conflict",
+      "$.digest",
+      error instanceof Error ? error.message : "next manifest is not canonical JSON",
+    );
+  }
+  if (nextDigest !== next.digest) {
+    return fail("semantic_conflict", "$.digest", "next manifest digest is not correct");
+  }
+
+  const previousRetention = previous.retention as unknown as Record<string, unknown>;
+  const nextRetention = next.retention as unknown as Record<string, unknown>;
+  const policy = compareImmutableField(previousRetention, nextRetention, "policy", "$.retention.policy");
+  if (!policy.ok) return policy;
+
+  if (previous.deletion.status === "completed" && next.deletion.status !== "completed") {
+    return fail(
+      "semantic_conflict",
+      "$.deletion.status",
+      "completed deletion is terminal",
+    );
+  }
+  if (previous.retention.status === "deleted" && next.retention.status !== "deleted") {
+    return fail(
+      "semantic_conflict",
+      "$.retention.status",
+      "deleted retention is terminal",
+    );
+  }
+
+  if (previous.state === "final") {
+    if (next.state !== "final") {
+      return fail("semantic_conflict", "$.state", "a final manifest must remain final");
+    }
+    if (next.finalizedAt !== previous.finalizedAt) {
+      return fail(
+        "semantic_conflict",
+        "$.finalizedAt",
+        "finalizedAt cannot change after finalization",
+      );
+    }
+
+    for (const key of ["schema", "id", "runId", "state", "createdAt", "finalizedAt"] as const) {
+      const result = compareImmutableField(previous, next, key, `$.${key}`);
+      if (!result.ok) return result;
+    }
+    for (const key of ["context", "sources", "artifacts", "modelExecutions", "usage"] as const) {
+      const result = compareImmutableField(previous, next, key, `$.${key}`);
+      if (!result.ok) return result;
+    }
+    const retentionUnknowns = compareUnknownFields(
+      previousRetention,
+      nextRetention,
+      MUTABLE_RETENTION_FIELDS,
+      "$.retention",
+    );
+    if (!retentionUnknowns.ok) return retentionUnknowns;
+
+    const previousDeletion = previous.deletion as unknown as Record<string, unknown>;
+    const nextDeletion = next.deletion as unknown as Record<string, unknown>;
+    const deletionUnknowns = compareUnknownFields(
+      previousDeletion,
+      nextDeletion,
+      MUTABLE_DELETION_FIELDS,
+      "$.deletion",
+    );
+    if (!deletionUnknowns.ok) return deletionUnknowns;
+
+    const rootUnknowns = compareUnknownFields(
+      previous as unknown as Record<string, unknown>,
+      next as unknown as Record<string, unknown>,
+      new Set([
+        ...MUTABLE_ROOT_FIELDS,
+        "schema",
+        "id",
+        "runId",
+        "state",
+        "createdAt",
+        "finalizedAt",
+        "context",
+        "sources",
+        "artifacts",
+        "modelExecutions",
+        "usage",
+        "retention",
+        "deletion",
+      ]),
+      "$",
+    );
+    if (!rootUnknowns.ok) return rootUnknowns;
+  }
+
+  const consent = validateManifestRetentionCeiling(
+    next,
+    options.contextConsent,
+  );
+  if (!consent.ok) return consent;
+
+  const lifecycle = validateRetentionLifecycleRevision(previous, next, options);
+  if (!lifecycle.ok) return lifecycle;
+
+  const shortening = validateFinalRetentionShortening(
+    next.state,
+    RETENTION_ORDER[next.retention.effectivePolicy] <
+      RETENTION_ORDER[previous.retention.effectivePolicy],
+    next.retention,
+    next.deletion,
+  );
+  if (!shortening.ok) return shortening;
+
+  return pass(next);
+}
+
+type ValidatedRevisionProvenance = {
+  fingerprint: string;
+  detachedValue: RunManifestV1;
+};
+
+const validatedRevisionProvenance = new WeakMap<
+  object,
+  ValidatedRevisionProvenance
+>();
+
+function rememberValidatedRevisionReference(
+  reference: object,
+  manifest: RunManifestV1,
+): ProtocolParseResult<void> {
+  const detached = copyProtocolJsonValue(manifest);
+  if (!detached.ok) return detached;
+  let fingerprint: string;
+  try {
+    fingerprint = canonicalJson(reference);
+  } catch {
+    return fail(
+      "invalid_value",
+      "$",
+      "Validated manifest must contain only canonical JSON data",
+    );
+  }
+  validatedRevisionProvenance.set(reference, {
+    fingerprint,
+    detachedValue: detached.value,
+  });
+  return pass(undefined);
+}
+
+function resolveTrustedPredecessor(
+  previous: RunManifestV1,
+): ProtocolParseResult<RunManifestV1> {
+  const provenance =
+    previous !== null && typeof previous === "object"
+      ? validatedRevisionProvenance.get(previous)
+      : undefined;
+  if (provenance !== undefined) {
+    try {
+      if (canonicalJson(previous) !== provenance.fingerprint) {
+        return fail(
+          "semantic_conflict",
+          "$.digest",
+          "A validated predecessor cannot be mutated",
+        );
+      }
+    } catch {
+      return fail(
+        "semantic_conflict",
+        "$.digest",
+        "A validated predecessor cannot be mutated",
+      );
+    }
+    return pass(provenance.detachedValue);
+  }
+  return fail(
+    "semantic_conflict",
+    "$.revision",
+    "Previous manifest lacks revision-1-rooted validation provenance",
+  );
+}
+
+/**
+ * Parses and validates one candidate revision atomically. Candidate parsing may
+ * defer standalone retention ceilings only inside this composition boundary;
+ * the linked previous revision and fresh consent checks must then authorize any
+ * extension before the parsed candidate is returned. Only strict revision-1
+ * parsing establishes root provenance; every later predecessor must be the
+ * unmodified result returned by a successful sequential validation.
+ */
+export function validateRunManifestRevisionV1(
+  previous: RunManifestV1,
+  candidate: unknown,
+  options: ManifestRevisionOptions = {},
+): ProtocolParseResult<RunManifestV1> {
+  const parsedOptions = parseManifestRevisionOptions(options);
+  if (!parsedOptions.ok) return parsedOptions;
+  const trustedPrevious = resolveTrustedPredecessor(previous);
+  if (!trustedPrevious.ok) return trustedPrevious;
+  const next = parseRunManifestRevisionCandidateV1(candidate);
+  if (!next.ok) return next;
+  const validated = validateParsedRunManifestRevision(
+    trustedPrevious.value,
+    next.value,
+    parsedOptions.value,
+  );
+  if (!validated.ok) return validated;
+  const rememberedResult = rememberValidatedRevisionReference(
+    validated.value,
+    validated.value,
+  );
+  if (!rememberedResult.ok) return rememberedResult;
+  return validated;
+}
+
+/** @deprecated Use validateRunManifestRevisionV1. */
+export const validateRunManifestRevision = validateRunManifestRevisionV1;

--- a/src/lib/research-protocol/topic-discovery.test.ts
+++ b/src/lib/research-protocol/topic-discovery.test.ts
@@ -1,0 +1,535 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Value } from "typebox/value";
+
+import invalidTopicDiscoveryEight from "../../../schemas/research/v1/fixtures/invalid/topic-discovery-job-eight.json" with { type: "json" };
+import invalidTopicDiscoveryOne from "../../../schemas/research/v1/fixtures/invalid/topic-discovery-job-one.json" with { type: "json" };
+import invalidTopicDiscoveryReceiptFamiliar from "../../../schemas/research/v1/fixtures/invalid/topic-discovery-job-receipt-familiar.json" with { type: "json" };
+import invalidTopicDiscoveryTwo from "../../../schemas/research/v1/fixtures/invalid/topic-discovery-job-two.json" with { type: "json" };
+import invalidTopicProposalScore from "../../../schemas/research/v1/fixtures/invalid/topic-proposal-score.json" with { type: "json" };
+import topicDiscoveryJobSchema from "../../../schemas/research/v1/topic-discovery-job.schema.json" with { type: "json" };
+import topicProposalSchema from "../../../schemas/research/v1/topic-proposal.schema.json" with { type: "json" };
+import sevenProposalTopicDiscoveryJob from "../../../schemas/research/v1/fixtures/valid/topic-discovery-job-seven.json" with { type: "json" };
+import validTopicDiscoveryJob from "../../../schemas/research/v1/fixtures/valid/topic-discovery-job.json" with { type: "json" };
+import validTopicProposal from "../../../schemas/research/v1/fixtures/valid/topic-proposal.json" with { type: "json" };
+
+import {
+  parseResearchModelReceiptV1,
+  parseTopicDiscoveryJobV1,
+  parseTopicProposalV1,
+  topicProposalVisibleTotal,
+} from "./topic-discovery.ts";
+
+function expectOk<T>(result: { ok: true; value: T } | { ok: false; error: { path: string; message: string } }): T {
+  if (!result.ok) {
+    assert.fail(`${result.error.path}: ${result.error.message}`);
+  }
+  return result.value;
+}
+
+function expectError(
+  result: { ok: true; value: unknown } | { ok: false; error: { path: string; code: string; message: string } },
+  path: string,
+  code?: string,
+): { path: string; code: string; message: string } {
+  if (result.ok) {
+    assert.fail("expected parse failure");
+  }
+  assert.equal(result.error.path, path);
+  if (code) {
+    assert.equal(result.error.code, code);
+  }
+  return result.error;
+}
+
+test("valid fixtures satisfy schemas and parse", () => {
+  assert.ok(Value.Check(topicDiscoveryJobSchema, validTopicDiscoveryJob));
+  assert.ok(Value.Check(topicProposalSchema, validTopicProposal));
+
+  const job = expectOk(parseTopicDiscoveryJobV1(validTopicDiscoveryJob));
+  const proposal = expectOk(parseTopicProposalV1(validTopicProposal));
+
+  assert.equal((job.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((job.modelReceipt?.futureExtension as { preserve: boolean }).preserve, true);
+  assert.equal((proposal.futureExtension as { preserve: boolean }).preserve, true);
+});
+
+test("topicProposalVisibleTotal applies the Section 10.3 weights in integer hundredths", () => {
+  const scores = {
+    groundability: 4,
+    decisionValue: 3,
+    unresolvedness: 2,
+    recurrence: 1,
+    novelty: 4,
+    timeliness: 2,
+    familiarFit: 4,
+    feasibility: 3,
+    humanResonance: 4,
+    riskPenalty: 2,
+    visibleTotal: 2.64,
+  };
+
+  assert.equal(topicProposalVisibleTotal(scores), 2.64);
+  assert.equal(expectOk(parseTopicProposalV1({ ...validTopicProposal, scores })).scores.visibleTotal, 2.64);
+});
+
+test("topicProposalVisibleTotal exposes each exact weight and its bounded range", () => {
+  const zeros = {
+    groundability: 0,
+    decisionValue: 0,
+    unresolvedness: 0,
+    recurrence: 0,
+    novelty: 0,
+    timeliness: 0,
+    familiarFit: 0,
+    feasibility: 0,
+    humanResonance: 0,
+    riskPenalty: 0,
+    visibleTotal: 0,
+  };
+  const expectedWeights = {
+    groundability: 0.18,
+    decisionValue: 0.16,
+    unresolvedness: 0.13,
+    recurrence: 0.10,
+    novelty: 0.10,
+    timeliness: 0.08,
+    familiarFit: 0.08,
+    feasibility: 0.08,
+    humanResonance: 0.09,
+  } as const;
+
+  for (const [key, weight] of Object.entries(expectedWeights)) {
+    assert.equal(topicProposalVisibleTotal({ ...zeros, [key]: 1 }), weight, key);
+  }
+  assert.equal(topicProposalVisibleTotal({ ...zeros, riskPenalty: 1 }), -0.20);
+  assert.equal(
+    topicProposalVisibleTotal({
+      ...zeros,
+      groundability: 4,
+      decisionValue: 4,
+      unresolvedness: 4,
+      recurrence: 4,
+      novelty: 4,
+      timeliness: 4,
+      familiarFit: 4,
+      feasibility: 4,
+      humanResonance: 4,
+    }),
+    4,
+  );
+  assert.equal(topicProposalVisibleTotal({ ...zeros, riskPenalty: 4 }), -0.8);
+});
+
+test("proposal visibleTotal schema and parser require hundredth precision in the weighted range", () => {
+  const tooPrecise = {
+    ...validTopicProposal,
+    scores: { ...validTopicProposal.scores, visibleTotal: 2.641 },
+  };
+
+  assert.equal(Value.Check(topicProposalSchema, tooPrecise), false);
+  expectError(parseTopicProposalV1(tooPrecise), "$.scores.visibleTotal", "invalid_value");
+});
+
+test("proposal visibleTotal mismatches reject with semantic_conflict", () => {
+  expectError(
+    parseTopicProposalV1({
+      ...validTopicProposal,
+      scores: { ...validTopicProposal.scores, visibleTotal: 2.63 },
+    }),
+    "$.scores.visibleTotal",
+    "semantic_conflict",
+  );
+});
+
+test("completed jobs require three through seven proposalIds", () => {
+  for (const job of [validTopicDiscoveryJob, sevenProposalTopicDiscoveryJob]) {
+    assert.equal(Value.Check(topicDiscoveryJobSchema, job), true);
+    expectOk(parseTopicDiscoveryJobV1(job));
+  }
+
+  for (const job of [
+    { ...validTopicDiscoveryJob, proposalIds: [] },
+    invalidTopicDiscoveryOne,
+    invalidTopicDiscoveryTwo,
+    invalidTopicDiscoveryEight,
+  ]) {
+    assert.equal(Value.Check(topicDiscoveryJobSchema, job), false);
+    expectError(parseTopicDiscoveryJobV1(job), "$.proposalIds", "semantic_conflict");
+  }
+});
+
+test("proposal cardinality bounds apply only to completed jobs", () => {
+  const { finishedAt: _finishedAt, ...inProgress } = validTopicDiscoveryJob;
+  for (const job of [
+    {
+      ...inProgress,
+      status: "queued" as const,
+      proposalIds: ["proposal_01"],
+    },
+    {
+      ...inProgress,
+      status: "running" as const,
+      proposalIds: Array.from({ length: 8 }, (_, index) => `proposal_${index + 1}`),
+    },
+  ]) {
+    assert.equal(Value.Check(topicDiscoveryJobSchema, job), true);
+    expectOk(parseTopicDiscoveryJobV1(job));
+  }
+});
+
+test("running job without startedAt rejects", () => {
+  const { startedAt: _startedAt, finishedAt: _finishedAt, ...baseJob } = validTopicDiscoveryJob;
+  const runningJob = { ...baseJob, status: "running" as const };
+
+  assert.equal(Value.Check(topicDiscoveryJobSchema, runningJob), false);
+  expectError(parseTopicDiscoveryJobV1(runningJob), "$.startedAt", "missing_field");
+});
+
+test("discovery lifecycle chronology is inclusive and leap-second aware", () => {
+  const boundary = {
+    ...validTopicDiscoveryJob,
+    requestedAt: "2016-12-31T23:59:60Z",
+    startedAt: "2016-12-31T23:59:60Z",
+    finishedAt: "2016-12-31T23:59:60Z",
+  };
+  const parsedBoundary = expectOk(parseTopicDiscoveryJobV1(boundary));
+  assert.equal(parsedBoundary.finishedAt, boundary.finishedAt);
+
+  const leapBoundary = {
+    ...validTopicDiscoveryJob,
+    requestedAt: "2016-12-31T23:59:59.999999999Z",
+    startedAt: "2016-12-31T23:59:60Z",
+    finishedAt: "2017-01-01T00:00:00Z",
+  };
+  expectOk(parseTopicDiscoveryJobV1(leapBoundary));
+
+  for (const [candidate, path] of [
+    [
+      {
+        ...validTopicDiscoveryJob,
+        status: "queued",
+        requestedAt: "2026-08-15T20:00:00Z",
+        startedAt: "2026-08-15T19:59:59.999999999Z",
+        finishedAt: undefined,
+        modelReceipt: undefined,
+      },
+      "$.startedAt",
+    ],
+    [
+      {
+        ...validTopicDiscoveryJob,
+        requestedAt: "2026-08-15T20:00:00Z",
+        startedAt: "2026-08-15T20:01:00Z",
+        finishedAt: "2026-08-15T20:00:59.999999999Z",
+      },
+      "$.finishedAt",
+    ],
+    [
+      {
+        ...validTopicDiscoveryJob,
+        status: "failed",
+        requestedAt: "2026-08-15T20:00:00Z",
+        startedAt: undefined,
+        finishedAt: "2026-08-15T19:59:59.999999999Z",
+        modelReceipt: undefined,
+        failure: {
+          code: "runtime_error",
+          message: "failed",
+          retryable: false,
+        },
+      },
+      "$.finishedAt",
+    ],
+  ] as const) {
+    const normalized = { ...candidate } as Record<string, unknown>;
+    for (const key of ["startedAt", "finishedAt", "modelReceipt"]) {
+      if (normalized[key] === undefined) delete normalized[key];
+    }
+    expectError(
+      parseTopicDiscoveryJobV1(normalized),
+      path,
+      "semantic_conflict",
+    );
+  }
+});
+
+test("running job forbids finishedAt and failure", () => {
+  const runningWithFinishedAt = {
+    ...validTopicDiscoveryJob,
+    status: "running" as const,
+  };
+  assert.equal(Value.Check(topicDiscoveryJobSchema, runningWithFinishedAt), false);
+  expectError(parseTopicDiscoveryJobV1(runningWithFinishedAt), "$.finishedAt", "semantic_conflict");
+
+  const { finishedAt: _finishedAt, ...runningBase } = validTopicDiscoveryJob;
+  const runningWithFailure = {
+    ...runningBase,
+    status: "running" as const,
+    failure: { code: "runtime_error", message: "Retry later", retryable: true },
+  };
+  assert.equal(Value.Check(topicDiscoveryJobSchema, runningWithFailure), false);
+  expectError(parseTopicDiscoveryJobV1(runningWithFailure), "$.failure", "semantic_conflict");
+});
+
+test("queued job accepts startedAt but forbids finishedAt and failure", () => {
+  const runtimeFailure = { code: "runtime_error", message: "Retry later", retryable: true };
+  const { finishedAt: _finishedAt, ...queuedBase } = validTopicDiscoveryJob;
+
+  const queuedWithStartedAt = {
+    ...queuedBase,
+    status: "queued" as const,
+    startedAt: validTopicDiscoveryJob.startedAt,
+  };
+  assert.equal(Value.Check(topicDiscoveryJobSchema, queuedWithStartedAt), true);
+  const parsedQueuedWithStartedAt = expectOk(parseTopicDiscoveryJobV1(queuedWithStartedAt));
+  assert.equal(parsedQueuedWithStartedAt.startedAt, validTopicDiscoveryJob.startedAt);
+
+  const queuedWithFinishedAt = {
+    ...queuedBase,
+    status: "queued" as const,
+    finishedAt: validTopicDiscoveryJob.finishedAt,
+  };
+  assert.equal(Value.Check(topicDiscoveryJobSchema, queuedWithFinishedAt), false);
+  expectError(parseTopicDiscoveryJobV1(queuedWithFinishedAt), "$.finishedAt", "semantic_conflict");
+
+  const queuedWithFailure = {
+    ...queuedBase,
+    status: "queued" as const,
+    failure: runtimeFailure,
+  };
+  assert.equal(Value.Check(topicDiscoveryJobSchema, queuedWithFailure), false);
+  expectError(parseTopicDiscoveryJobV1(queuedWithFailure), "$.failure", "semantic_conflict");
+});
+
+test("completed and failed jobs remain valid", () => {
+  assert.equal(Value.Check(topicDiscoveryJobSchema, validTopicDiscoveryJob), true);
+  expectOk(parseTopicDiscoveryJobV1(validTopicDiscoveryJob));
+
+  const validFailedJob = {
+    ...validTopicDiscoveryJob,
+    status: "failed" as const,
+    failure: { code: "runtime_error", message: "Retry later", retryable: true },
+  };
+  assert.equal(Value.Check(topicDiscoveryJobSchema, validFailedJob), true);
+  expectOk(parseTopicDiscoveryJobV1(validFailedJob));
+});
+
+test("receipt-bearing discovery jobs bind receipt attribution to the job familiar", () => {
+  assert.equal(Value.Check(topicDiscoveryJobSchema, invalidTopicDiscoveryReceiptFamiliar), true);
+  expectError(
+    parseTopicDiscoveryJobV1(invalidTopicDiscoveryReceiptFamiliar),
+    "$.modelReceipt.familiarId",
+    "semantic_conflict",
+  );
+
+  const valid = expectOk(parseTopicDiscoveryJobV1(validTopicDiscoveryJob));
+  assert.equal(valid.modelReceipt?.familiarId, valid.familiarId);
+});
+
+test("completed, failed, and cancelled jobs without finishedAt reject", () => {
+  const cases = [
+    { status: "completed", extra: {} },
+    {
+      status: "failed",
+      extra: { failure: { code: "runtime_error", message: "Retry later", retryable: true } },
+    },
+    { status: "cancelled", extra: {} },
+  ] as const;
+
+  for (const { status, extra } of cases) {
+    const { finishedAt: _finishedAt, ...baseJob } = validTopicDiscoveryJob;
+    const job = { ...baseJob, status, ...extra };
+
+    assert.equal(Value.Check(topicDiscoveryJobSchema, job), false);
+    expectError(parseTopicDiscoveryJobV1(job), "$.finishedAt", "missing_field");
+  }
+});
+
+test("completed job with failure rejects and cancelled job with failure rejects", () => {
+  const completedWithFailure = {
+    ...validTopicDiscoveryJob,
+    failure: { code: "runtime_error", message: "Retry later", retryable: true },
+  };
+  assert.equal(Value.Check(topicDiscoveryJobSchema, completedWithFailure), false);
+  expectError(parseTopicDiscoveryJobV1(completedWithFailure), "$.failure", "semantic_conflict");
+
+  const cancelledWithFailure = {
+    ...validTopicDiscoveryJob,
+    status: "cancelled" as const,
+    failure: { code: "runtime_error", message: "Retry later", retryable: true },
+  };
+  assert.equal(Value.Check(topicDiscoveryJobSchema, cancelledWithFailure), false);
+  expectError(parseTopicDiscoveryJobV1(cancelledWithFailure), "$.failure", "semantic_conflict");
+
+  const failedWithoutFailure = {
+    ...validTopicDiscoveryJob,
+    status: "failed" as const,
+  };
+  assert.equal(Value.Check(topicDiscoveryJobSchema, failedWithoutFailure), false);
+  expectError(parseTopicDiscoveryJobV1(failedWithoutFailure), "$.failure", "missing_field");
+});
+
+test("receipt usage semantics enforce nullability/reporting rules", () => {
+  const validNullUsage = expectOk(
+    parseResearchModelReceiptV1(
+      {
+        ...validTopicDiscoveryJob.modelReceipt,
+        usage: {
+          inputTokens: null,
+          outputTokens: null,
+          costUsd: null,
+          reportedByRuntime: false,
+        },
+      },
+      "$.receipt",
+    ),
+  );
+  assert.equal(validNullUsage.usage.reportedByRuntime, false);
+
+  const validReportedUsage = expectOk(
+    parseResearchModelReceiptV1(
+      {
+        ...validTopicDiscoveryJob.modelReceipt,
+        usage: {
+          inputTokens: 1,
+          outputTokens: null,
+          costUsd: null,
+          reportedByRuntime: true,
+        },
+      },
+      "$.receipt",
+    ),
+  );
+  assert.equal(validReportedUsage.usage.inputTokens, 1);
+
+  expectError(
+    parseResearchModelReceiptV1(
+      {
+        ...validTopicDiscoveryJob.modelReceipt,
+        usage: {
+          inputTokens: 1,
+          outputTokens: null,
+          costUsd: null,
+          reportedByRuntime: false,
+        },
+      },
+      "$.receipt",
+    ),
+    "$.receipt.usage",
+    "semantic_conflict",
+  );
+
+  expectError(
+    parseResearchModelReceiptV1(
+      {
+        ...validTopicDiscoveryJob.modelReceipt,
+        usage: {
+          inputTokens: null,
+          outputTokens: null,
+          costUsd: null,
+          reportedByRuntime: true,
+        },
+      },
+      "$.receipt",
+    ),
+    "$.receipt.usage",
+    "semantic_conflict",
+  );
+});
+
+test("standalone model receipt parser rejects accessors without invoking them", () => {
+  let calls = 0;
+  const receipt = { ...validTopicDiscoveryJob.modelReceipt };
+  Object.defineProperty(receipt, "familiarId", {
+    get() {
+      calls += 1;
+      return validTopicDiscoveryJob.modelReceipt.familiarId;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+
+  expectError(parseResearchModelReceiptV1(receipt, "$.receipt"), "$.receipt", "invalid_value");
+  assert.equal(calls, 0);
+});
+
+test("unknown additive fields survive at top and nested levels", () => {
+  const proposal = expectOk(
+    parseTopicProposalV1({
+      ...validTopicProposal,
+      topMarker: "proposal",
+      evidence: [
+        {
+          ...validTopicProposal.evidence[0],
+          note: "keep",
+          selector: { ...validTopicProposal.evidence[0].selector, marker: true },
+        },
+      ],
+      scores: { ...validTopicProposal.scores, rubricVersion: 2 },
+      suggested: { ...validTopicProposal.suggested, owner: "sage" },
+    }),
+  );
+
+  assert.equal(proposal.topMarker, "proposal");
+  assert.equal(proposal.evidence[0].note, "keep");
+  assert.equal(proposal.evidence[0].selector.marker, true);
+  assert.equal(proposal.scores.rubricVersion, 2);
+  assert.equal(proposal.suggested.owner, "sage");
+
+  const job = expectOk(
+    parseTopicDiscoveryJobV1({
+      ...validTopicDiscoveryJob,
+      topMarker: "job",
+      modelReceipt: {
+        ...validTopicDiscoveryJob.modelReceipt,
+        note: "keep",
+        usage: { ...validTopicDiscoveryJob.modelReceipt.usage, marker: 1 },
+      },
+    }),
+  );
+
+  assert.equal(job.topMarker, "job");
+  assert.equal(job.modelReceipt?.note, "keep");
+  assert.equal(job.modelReceipt?.usage.marker, 1);
+});
+
+test("custom-prototype top-level objects are rejected", () => {
+  const proposal = Object.create({ schema: validTopicProposal.schema });
+  Object.assign(proposal, {
+    id: validTopicProposal.id,
+    discoveryJobId: validTopicProposal.discoveryJobId,
+    contextPackId: validTopicProposal.contextPackId,
+    title: validTopicProposal.title,
+    question: validTopicProposal.question,
+    whyNow: validTopicProposal.whyNow,
+    evidence: validTopicProposal.evidence,
+    counterevidence: validTopicProposal.counterevidence,
+    scores: validTopicProposal.scores,
+    suggested: validTopicProposal.suggested,
+    uncertainty: validTopicProposal.uncertainty,
+    relatedMissionIds: validTopicProposal.relatedMissionIds,
+    createdAt: validTopicProposal.createdAt,
+  });
+  expectError(parseTopicProposalV1(proposal), "$", "invalid_value");
+
+  const job = Object.create({ schema: validTopicDiscoveryJob.schema });
+  Object.assign(job, {
+    id: validTopicDiscoveryJob.id,
+    contextPackId: validTopicDiscoveryJob.contextPackId,
+    contextPackDigest: validTopicDiscoveryJob.contextPackDigest,
+    familiarId: validTopicDiscoveryJob.familiarId,
+    status: validTopicDiscoveryJob.status,
+    requestedAt: validTopicDiscoveryJob.requestedAt,
+    startedAt: validTopicDiscoveryJob.startedAt,
+    finishedAt: validTopicDiscoveryJob.finishedAt,
+    proposalIds: validTopicDiscoveryJob.proposalIds,
+    modelReceipt: validTopicDiscoveryJob.modelReceipt,
+  });
+  expectError(parseTopicDiscoveryJobV1(job), "$", "invalid_value");
+});
+
+test("invalid score fixture rejects", () => {
+  assert.equal(Value.Check(topicProposalSchema, invalidTopicProposalScore), false);
+  expectError(parseTopicProposalV1(invalidTopicProposalScore), "$.scores.groundability", "invalid_value");
+});

--- a/src/lib/research-protocol/topic-discovery.ts
+++ b/src/lib/research-protocol/topic-discovery.ts
@@ -1,0 +1,950 @@
+import {
+  compareUtcTimestamps,
+  copyProtocolJsonValue,
+  fail,
+  isOpaqueId,
+  isRecord,
+  isSha256,
+  isUtcTimestamp,
+  pass,
+  type ProtocolParseResult,
+  type UnknownFields,
+} from "./common.ts";
+import {
+  parseContextSelectorV1,
+  type ContextSelectorV1,
+} from "./context-pack.ts";
+
+const TOPIC_DISCOVERY_JOB_SCHEMA = "opencoven.topic-discovery-job/v1";
+const TOPIC_DISCOVERY_JOB_SCHEMA_RE = /^opencoven\.topic-discovery-job\/v(\d+)$/;
+const TOPIC_PROPOSAL_SCHEMA = "opencoven.topic-proposal/v1";
+const TOPIC_PROPOSAL_SCHEMA_RE = /^opencoven\.topic-proposal\/v(\d+)$/;
+const JOB_STATUSES = ["queued", "running", "completed", "failed", "cancelled"] as const;
+const MODEL_SOURCES = [
+  "next-message",
+  "session",
+  "familiar-default",
+  "runtime-default",
+  "global-default",
+] as const;
+const SUGGESTED_MODES = ["brief", "sweep", "paper", "autoresearch"] as const;
+const SCORE_KEYS = [
+  "groundability",
+  "decisionValue",
+  "unresolvedness",
+  "recurrence",
+  "novelty",
+  "timeliness",
+  "familiarFit",
+  "feasibility",
+  "humanResonance",
+] as const;
+const TOPIC_SCORE_WEIGHT_HUNDREDTHS = {
+  groundability: 18,
+  decisionValue: 16,
+  unresolvedness: 13,
+  recurrence: 10,
+  novelty: 10,
+  timeliness: 8,
+  familiarFit: 8,
+  feasibility: 8,
+  humanResonance: 9,
+  riskPenalty: -20,
+} as const;
+const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
+
+export type TopicEvidenceRefV1 = {
+  resourceId: string;
+  selector: ContextSelectorV1;
+  excerpt: string;
+  excerptDigest: string;
+} & UnknownFields;
+
+export type ResearchModelUsageV1 = {
+  inputTokens: number | null;
+  outputTokens: number | null;
+  costUsd: number | null;
+  reportedByRuntime: boolean;
+} & UnknownFields;
+
+export type ResearchModelReceiptV1 = {
+  familiarId: string;
+  runtime: string;
+  effectiveModel: string | null;
+  modelSource: "next-message" | "session" | "familiar-default" | "runtime-default" | "global-default";
+  providerBilling: "user-connected";
+  usage: ResearchModelUsageV1;
+} & UnknownFields;
+
+export type TopicDiscoveryFailureV1 = {
+  code: string;
+  message: string;
+  retryable: boolean;
+} & UnknownFields;
+
+export type TopicDiscoveryJobV1 = {
+  schema: "opencoven.topic-discovery-job/v1";
+  id: string;
+  contextPackId: string;
+  contextPackDigest: string;
+  familiarId: string;
+  status: "queued" | "running" | "completed" | "failed" | "cancelled";
+  requestedAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  proposalIds: string[];
+  modelReceipt?: ResearchModelReceiptV1;
+  failure?: TopicDiscoveryFailureV1;
+} & UnknownFields;
+
+export type TopicProposalScoresV1 = {
+  groundability: number;
+  decisionValue: number;
+  unresolvedness: number;
+  recurrence: number;
+  novelty: number;
+  timeliness: number;
+  familiarFit: number;
+  feasibility: number;
+  humanResonance: number;
+  riskPenalty: number;
+  visibleTotal: number;
+} & UnknownFields;
+
+export type TopicProposalSuggestedV1 = {
+  mode: "brief" | "sweep" | "paper" | "autoresearch";
+  deliverable: string;
+  sourceTarget: number;
+  wallClockMinutes: number;
+} & UnknownFields;
+
+export type TopicProposalV1 = {
+  schema: "opencoven.topic-proposal/v1";
+  id: string;
+  discoveryJobId: string;
+  contextPackId: string;
+  title: string;
+  question: string;
+  whyNow: string;
+  evidence: TopicEvidenceRefV1[];
+  counterevidence: TopicEvidenceRefV1[];
+  scores: TopicProposalScoresV1;
+  suggested: TopicProposalSuggestedV1;
+  uncertainty: string;
+  relatedMissionIds: string[];
+  createdAt: string;
+} & UnknownFields;
+
+type JobStatusV1 = TopicDiscoveryJobV1["status"];
+type ModelSourceV1 = ResearchModelReceiptV1["modelSource"];
+type SuggestedModeV1 = TopicProposalSuggestedV1["mode"];
+type ScoreKey = (typeof SCORE_KEYS)[number];
+
+function childPath(path: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${path}.${key}`
+    : `${path}[${JSON.stringify(key)}]`;
+}
+
+function indexPath(path: string, index: number): string {
+  return `${path}[${index}]`;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function parseObject(value: unknown, path: string): ProtocolParseResult<Record<string, unknown>> {
+  if (!isRecord(value)) {
+    return fail("invalid_type", path, "Expected an object");
+  }
+  return pass(value);
+}
+
+function parseRequiredField(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): ProtocolParseResult<unknown> {
+  if (!hasOwn(record, key)) {
+    return fail("missing_field", childPath(path, key), `Missing required field ${key}`);
+  }
+  return pass(record[key]);
+}
+
+function parseString(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  return pass(value);
+}
+
+function parseBoolean(value: unknown, path: string, label: string): ProtocolParseResult<boolean> {
+  if (typeof value !== "boolean") {
+    return fail("invalid_type", path, `${label} must be a boolean`);
+  }
+  return pass(value);
+}
+
+function parseEnumValue<const T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  path: string,
+  label: string,
+): ProtocolParseResult<T[number]> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!allowed.includes(value as T[number])) {
+    return fail("invalid_value", path, `${label} must be one of ${allowed.join(", ")}`);
+  }
+  return pass(value as T[number]);
+}
+
+function parseSafeIntegerInRange(
+  value: unknown,
+  path: string,
+  label: string,
+  minimum: number,
+  maximum: number,
+): ProtocolParseResult<number> {
+  if (typeof value !== "number") {
+    return fail("invalid_type", path, `${label} must be a number`);
+  }
+  if (!Number.isSafeInteger(value)) {
+    return fail("invalid_value", path, `${label} must be a safe integer`);
+  }
+  if (value < minimum || value > maximum) {
+    return fail("invalid_value", path, `${label} must be between ${minimum} and ${maximum}`);
+  }
+  return pass(value);
+}
+
+function parsePositiveSafeInteger(value: unknown, path: string, label: string): ProtocolParseResult<number> {
+  return parseSafeIntegerInRange(value, path, label, 1, MAX_SAFE_INTEGER);
+}
+
+function parseNullableSafeInteger(
+  value: unknown,
+  path: string,
+  label: string,
+): ProtocolParseResult<number | null> {
+  if (value === null) {
+    return pass(null);
+  }
+  return parseSafeIntegerInRange(value, path, label, 0, MAX_SAFE_INTEGER);
+}
+
+function parseNullableNonNegativeFiniteNumber(
+  value: unknown,
+  path: string,
+  label: string,
+): ProtocolParseResult<number | null> {
+  if (value === null) {
+    return pass(null);
+  }
+  if (typeof value !== "number") {
+    return fail("invalid_type", path, `${label} must be a number or null`);
+  }
+  if (!Number.isFinite(value) || value < 0) {
+    return fail("invalid_value", path, `${label} must be a finite number >= 0 or null`);
+  }
+  return pass(value);
+}
+
+function parseNullableString(value: unknown, path: string, label: string): ProtocolParseResult<string | null> {
+  if (value === null) {
+    return pass(null);
+  }
+  return parseString(value, path, label);
+}
+
+function parseOpaqueIdentifier(
+  value: unknown,
+  prefix: string,
+  path: string,
+  label: string,
+): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isOpaqueId(value, prefix)) {
+    return fail("invalid_value", path, `${label} must match ${prefix}_...`);
+  }
+  return pass(value);
+}
+
+function parseSha256(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isSha256(value)) {
+    return fail("invalid_value", path, `${label} must be a lowercase SHA-256 digest`);
+  }
+  return pass(value);
+}
+
+function parseUtc(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (!isUtcTimestamp(value)) {
+    return fail("invalid_value", path, `${label} must be a UTC RFC 3339 timestamp`);
+  }
+  return pass(value);
+}
+
+function parseSchema<const T extends string>(
+  value: unknown,
+  exact: T,
+  re: RegExp,
+  path: string,
+  label: string,
+): ProtocolParseResult<T> {
+  if (typeof value !== "string") {
+    return fail("invalid_type", path, `${label} must be a string`);
+  }
+  if (value === exact) {
+    return pass(exact);
+  }
+  const match = re.exec(value);
+  if (match) {
+    return fail("unknown_major", path, `Unsupported ${label} major v${match[1]}`);
+  }
+  return fail("invalid_value", path, `${label} must equal ${exact}`);
+}
+
+function parseTopicEvidenceRefV1(value: unknown, path: string): ProtocolParseResult<TopicEvidenceRefV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const resourceIdField = parseRequiredField(object.value, "resourceId", path);
+  if (!resourceIdField.ok) return resourceIdField;
+  const resourceId = parseOpaqueIdentifier(resourceIdField.value, "resource", childPath(path, "resourceId"), "resourceId");
+  if (!resourceId.ok) return resourceId;
+
+  const selectorField = parseRequiredField(object.value, "selector", path);
+  if (!selectorField.ok) return selectorField;
+  const selector = parseContextSelectorV1(selectorField.value, childPath(path, "selector"));
+  if (!selector.ok) return selector;
+
+  const excerptField = parseRequiredField(object.value, "excerpt", path);
+  if (!excerptField.ok) return excerptField;
+  const excerpt = parseString(excerptField.value, childPath(path, "excerpt"), "excerpt");
+  if (!excerpt.ok) return excerpt;
+
+  const excerptDigestField = parseRequiredField(object.value, "excerptDigest", path);
+  if (!excerptDigestField.ok) return excerptDigestField;
+  const excerptDigest = parseSha256(excerptDigestField.value, childPath(path, "excerptDigest"), "excerptDigest");
+  if (!excerptDigest.ok) return excerptDigest;
+
+  return pass({
+    ...object.value,
+    resourceId: resourceId.value,
+    selector: selector.value,
+    excerpt: excerpt.value,
+    excerptDigest: excerptDigest.value,
+  });
+}
+
+function parseEvidenceArray(
+  value: unknown,
+  path: string,
+  { minimum = 0 }: { minimum?: number } = {},
+): ProtocolParseResult<TopicEvidenceRefV1[]> {
+  if (!Array.isArray(value)) {
+    return fail("invalid_type", path, "Expected an array");
+  }
+  if (value.length < minimum) {
+    return fail("invalid_value", path, `Expected at least ${minimum} item${minimum === 1 ? "" : "s"}`);
+  }
+  const items: TopicEvidenceRefV1[] = [];
+  for (const [index, item] of value.entries()) {
+    const parsed = parseTopicEvidenceRefV1(item, indexPath(path, index));
+    if (!parsed.ok) return parsed;
+    items.push(parsed.value);
+  }
+  return pass(items);
+}
+
+function parseUniqueIdArray(
+  value: unknown,
+  path: string,
+  prefix: string,
+  label: string,
+): ProtocolParseResult<string[]> {
+  if (!Array.isArray(value)) {
+    return fail("invalid_type", path, `${label} must be an array`);
+  }
+  const parsed: string[] = [];
+  const seen = new Set<string>();
+  for (const [index, item] of value.entries()) {
+    const id = parseOpaqueIdentifier(item, prefix, indexPath(path, index), `${label} item`);
+    if (!id.ok) return id;
+    if (seen.has(id.value)) {
+      return fail("semantic_conflict", indexPath(path, index), `Duplicate ${label} item ${id.value}`);
+    }
+    seen.add(id.value);
+    parsed.push(id.value);
+  }
+  return pass(parsed);
+}
+
+export function topicProposalVisibleTotal(scores: TopicProposalV1["scores"]): number {
+  return topicProposalVisibleTotalHundredths(scores) / 100;
+}
+
+function topicProposalVisibleTotalHundredths(scores: TopicProposalV1["scores"]): number {
+  // v1 weights have exactly two decimal places. Keeping the complete
+  // calculation in integer hundredths makes wire comparisons deterministic.
+  let total = 0;
+  for (const key of SCORE_KEYS) {
+    total += scores[key] * TOPIC_SCORE_WEIGHT_HUNDREDTHS[key];
+  }
+  return total + scores.riskPenalty * TOPIC_SCORE_WEIGHT_HUNDREDTHS.riskPenalty;
+}
+
+function parseHundredthNumberInRange(
+  value: unknown,
+  path: string,
+  label: string,
+  minimumHundredths: number,
+  maximumHundredths: number,
+): ProtocolParseResult<{ value: number; hundredths: number }> {
+  if (typeof value !== "number") {
+    return fail("invalid_type", path, `${label} must be a number`);
+  }
+  if (!Number.isFinite(value)) {
+    return fail("invalid_value", path, `${label} must be finite`);
+  }
+
+  const hundredths = Math.round(value * 100);
+  if (hundredths / 100 !== value) {
+    return fail("invalid_value", path, `${label} must have at most two decimal places`);
+  }
+  if (hundredths < minimumHundredths || hundredths > maximumHundredths) {
+    return fail(
+      "invalid_value",
+      path,
+      `${label} must be between ${minimumHundredths / 100} and ${maximumHundredths / 100}`,
+    );
+  }
+  return pass({ value, hundredths });
+}
+
+function parseScores(value: unknown, path: string): ProtocolParseResult<TopicProposalScoresV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const parsedScores = {} as Record<ScoreKey, number>;
+  for (const key of SCORE_KEYS) {
+    const field = parseRequiredField(object.value, key, path);
+    if (!field.ok) return field;
+    const parsed = parseSafeIntegerInRange(field.value, childPath(path, key), key, 0, 4);
+    if (!parsed.ok) return parsed;
+    parsedScores[key] = parsed.value;
+  }
+
+  const riskPenaltyField = parseRequiredField(object.value, "riskPenalty", path);
+  if (!riskPenaltyField.ok) return riskPenaltyField;
+  const riskPenalty = parseSafeIntegerInRange(riskPenaltyField.value, childPath(path, "riskPenalty"), "riskPenalty", 0, 4);
+  if (!riskPenalty.ok) return riskPenalty;
+
+  const visibleTotalField = parseRequiredField(object.value, "visibleTotal", path);
+  if (!visibleTotalField.ok) return visibleTotalField;
+  const visibleTotal = parseHundredthNumberInRange(
+    visibleTotalField.value,
+    childPath(path, "visibleTotal"),
+    "visibleTotal",
+    -80,
+    400,
+  );
+  if (!visibleTotal.ok) return visibleTotal;
+
+  const scores = {
+    ...object.value,
+    ...parsedScores,
+    riskPenalty: riskPenalty.value,
+    visibleTotal: visibleTotal.value.value,
+  } as TopicProposalScoresV1;
+  const expectedVisibleTotalHundredths = topicProposalVisibleTotalHundredths(scores);
+  if (visibleTotal.value.hundredths !== expectedVisibleTotalHundredths) {
+    return fail(
+      "semantic_conflict",
+      childPath(path, "visibleTotal"),
+      `visibleTotal must equal recomputed total ${expectedVisibleTotalHundredths / 100}`,
+    );
+  }
+
+  return pass(scores);
+}
+
+function parseSuggested(value: unknown, path: string): ProtocolParseResult<TopicProposalSuggestedV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const modeField = parseRequiredField(object.value, "mode", path);
+  if (!modeField.ok) return modeField;
+  const mode = parseEnumValue(modeField.value, SUGGESTED_MODES, childPath(path, "mode"), "mode");
+  if (!mode.ok) return mode;
+
+  const deliverableField = parseRequiredField(object.value, "deliverable", path);
+  if (!deliverableField.ok) return deliverableField;
+  const deliverable = parseString(deliverableField.value, childPath(path, "deliverable"), "deliverable");
+  if (!deliverable.ok) return deliverable;
+
+  const sourceTargetField = parseRequiredField(object.value, "sourceTarget", path);
+  if (!sourceTargetField.ok) return sourceTargetField;
+  const sourceTarget = parsePositiveSafeInteger(sourceTargetField.value, childPath(path, "sourceTarget"), "sourceTarget");
+  if (!sourceTarget.ok) return sourceTarget;
+
+  const wallClockMinutesField = parseRequiredField(object.value, "wallClockMinutes", path);
+  if (!wallClockMinutesField.ok) return wallClockMinutesField;
+  const wallClockMinutes = parsePositiveSafeInteger(
+    wallClockMinutesField.value,
+    childPath(path, "wallClockMinutes"),
+    "wallClockMinutes",
+  );
+  if (!wallClockMinutes.ok) return wallClockMinutes;
+
+  return pass({
+    ...object.value,
+    mode: mode.value as SuggestedModeV1,
+    deliverable: deliverable.value,
+    sourceTarget: sourceTarget.value,
+    wallClockMinutes: wallClockMinutes.value,
+  });
+}
+
+function parseTopicDiscoveryFailureV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<TopicDiscoveryFailureV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const codeField = parseRequiredField(object.value, "code", path);
+  if (!codeField.ok) return codeField;
+  const code = parseString(codeField.value, childPath(path, "code"), "code");
+  if (!code.ok) return code;
+
+  const messageField = parseRequiredField(object.value, "message", path);
+  if (!messageField.ok) return messageField;
+  const message = parseString(messageField.value, childPath(path, "message"), "message");
+  if (!message.ok) return message;
+
+  const retryableField = parseRequiredField(object.value, "retryable", path);
+  if (!retryableField.ok) return retryableField;
+  const retryable = parseBoolean(retryableField.value, childPath(path, "retryable"), "retryable");
+  if (!retryable.ok) return retryable;
+
+  return pass({
+    ...object.value,
+    code: code.value,
+    message: message.value,
+    retryable: retryable.value,
+  });
+}
+
+function parseModelUsage(value: unknown, path: string): ProtocolParseResult<ResearchModelUsageV1> {
+  const object = parseObject(value, path);
+  if (!object.ok) return object;
+
+  const inputTokensField = parseRequiredField(object.value, "inputTokens", path);
+  if (!inputTokensField.ok) return inputTokensField;
+  const inputTokens = parseNullableSafeInteger(inputTokensField.value, childPath(path, "inputTokens"), "inputTokens");
+  if (!inputTokens.ok) return inputTokens;
+
+  const outputTokensField = parseRequiredField(object.value, "outputTokens", path);
+  if (!outputTokensField.ok) return outputTokensField;
+  const outputTokens = parseNullableSafeInteger(outputTokensField.value, childPath(path, "outputTokens"), "outputTokens");
+  if (!outputTokens.ok) return outputTokens;
+
+  const costUsdField = parseRequiredField(object.value, "costUsd", path);
+  if (!costUsdField.ok) return costUsdField;
+  const costUsd = parseNullableNonNegativeFiniteNumber(costUsdField.value, childPath(path, "costUsd"), "costUsd");
+  if (!costUsd.ok) return costUsd;
+
+  const reportedByRuntimeField = parseRequiredField(object.value, "reportedByRuntime", path);
+  if (!reportedByRuntimeField.ok) return reportedByRuntimeField;
+  const reportedByRuntime = parseBoolean(
+    reportedByRuntimeField.value,
+    childPath(path, "reportedByRuntime"),
+    "reportedByRuntime",
+  );
+  if (!reportedByRuntime.ok) return reportedByRuntime;
+
+  const anyNonNull = inputTokens.value !== null || outputTokens.value !== null || costUsd.value !== null;
+  if (!reportedByRuntime.value && anyNonNull) {
+    return fail(
+      "semantic_conflict",
+      path,
+      "reportedByRuntime false requires inputTokens, outputTokens, and costUsd to all be null",
+    );
+  }
+  if (reportedByRuntime.value && !anyNonNull) {
+    return fail(
+      "semantic_conflict",
+      path,
+      "reportedByRuntime true requires at least one of inputTokens, outputTokens, or costUsd to be non-null",
+    );
+  }
+
+  return pass({
+    ...object.value,
+    inputTokens: inputTokens.value,
+    outputTokens: outputTokens.value,
+    costUsd: costUsd.value,
+    reportedByRuntime: reportedByRuntime.value,
+  });
+}
+
+export function parseResearchModelReceiptV1(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ResearchModelReceiptV1> {
+  const wireValue = copyProtocolJsonValue(value, path);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, path);
+  if (!object.ok) return object;
+
+  const familiarIdField = parseRequiredField(object.value, "familiarId", path);
+  if (!familiarIdField.ok) return familiarIdField;
+  const familiarId = parseString(familiarIdField.value, childPath(path, "familiarId"), "familiarId");
+  if (!familiarId.ok) return familiarId;
+
+  const runtimeField = parseRequiredField(object.value, "runtime", path);
+  if (!runtimeField.ok) return runtimeField;
+  const runtime = parseString(runtimeField.value, childPath(path, "runtime"), "runtime");
+  if (!runtime.ok) return runtime;
+
+  const effectiveModelField = parseRequiredField(object.value, "effectiveModel", path);
+  if (!effectiveModelField.ok) return effectiveModelField;
+  const effectiveModel = parseNullableString(
+    effectiveModelField.value,
+    childPath(path, "effectiveModel"),
+    "effectiveModel",
+  );
+  if (!effectiveModel.ok) return effectiveModel;
+
+  const modelSourceField = parseRequiredField(object.value, "modelSource", path);
+  if (!modelSourceField.ok) return modelSourceField;
+  const modelSource = parseEnumValue(modelSourceField.value, MODEL_SOURCES, childPath(path, "modelSource"), "modelSource");
+  if (!modelSource.ok) return modelSource;
+
+  const providerBillingField = parseRequiredField(object.value, "providerBilling", path);
+  if (!providerBillingField.ok) return providerBillingField;
+  const providerBilling = parseString(
+    providerBillingField.value,
+    childPath(path, "providerBilling"),
+    "providerBilling",
+  );
+  if (!providerBilling.ok) return providerBilling;
+  if (providerBilling.value !== "user-connected") {
+    return fail("invalid_value", childPath(path, "providerBilling"), "providerBilling must be user-connected");
+  }
+
+  const usageField = parseRequiredField(object.value, "usage", path);
+  if (!usageField.ok) return usageField;
+  const usage = parseModelUsage(usageField.value, childPath(path, "usage"));
+  if (!usage.ok) return usage;
+
+  return pass({
+    ...object.value,
+    familiarId: familiarId.value,
+    runtime: runtime.value,
+    effectiveModel: effectiveModel.value,
+    modelSource: modelSource.value as ModelSourceV1,
+    providerBilling: "user-connected",
+    usage: usage.value,
+  });
+}
+
+export function parseTopicDiscoveryJobV1(value: unknown): ProtocolParseResult<TopicDiscoveryJobV1> {
+  const wireValue = copyProtocolJsonValue(value);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, "$");
+  if (!object.ok) return object;
+
+  const schemaField = parseRequiredField(object.value, "schema", "$");
+  if (!schemaField.ok) return schemaField;
+  const schema = parseSchema(
+    schemaField.value,
+    TOPIC_DISCOVERY_JOB_SCHEMA,
+    TOPIC_DISCOVERY_JOB_SCHEMA_RE,
+    "$.schema",
+    "schema",
+  );
+  if (!schema.ok) return schema;
+
+  const idField = parseRequiredField(object.value, "id", "$");
+  if (!idField.ok) return idField;
+  const id = parseOpaqueIdentifier(idField.value, "topicjob", "$.id", "id");
+  if (!id.ok) return id;
+
+  const contextPackIdField = parseRequiredField(object.value, "contextPackId", "$");
+  if (!contextPackIdField.ok) return contextPackIdField;
+  const contextPackId = parseOpaqueIdentifier(contextPackIdField.value, "ctx", "$.contextPackId", "contextPackId");
+  if (!contextPackId.ok) return contextPackId;
+
+  const contextPackDigestField = parseRequiredField(object.value, "contextPackDigest", "$");
+  if (!contextPackDigestField.ok) return contextPackDigestField;
+  const contextPackDigest = parseSha256(contextPackDigestField.value, "$.contextPackDigest", "contextPackDigest");
+  if (!contextPackDigest.ok) return contextPackDigest;
+
+  const familiarIdField = parseRequiredField(object.value, "familiarId", "$");
+  if (!familiarIdField.ok) return familiarIdField;
+  const familiarId = parseString(familiarIdField.value, "$.familiarId", "familiarId");
+  if (!familiarId.ok) return familiarId;
+
+  const statusField = parseRequiredField(object.value, "status", "$");
+  if (!statusField.ok) return statusField;
+  const status = parseEnumValue(statusField.value, JOB_STATUSES, "$.status", "status");
+  if (!status.ok) return status;
+
+  const requestedAtField = parseRequiredField(object.value, "requestedAt", "$");
+  if (!requestedAtField.ok) return requestedAtField;
+  const requestedAt = parseUtc(requestedAtField.value, "$.requestedAt", "requestedAt");
+  if (!requestedAt.ok) return requestedAt;
+
+  let startedAt: string | undefined;
+  if (hasOwn(object.value, "startedAt")) {
+    const parsedStartedAt = parseUtc(object.value.startedAt, "$.startedAt", "startedAt");
+    if (!parsedStartedAt.ok) return parsedStartedAt;
+    startedAt = parsedStartedAt.value;
+  }
+
+  let finishedAt: string | undefined;
+  if (hasOwn(object.value, "finishedAt")) {
+    const parsedFinishedAt = parseUtc(object.value.finishedAt, "$.finishedAt", "finishedAt");
+    if (!parsedFinishedAt.ok) return parsedFinishedAt;
+    finishedAt = parsedFinishedAt.value;
+  }
+  if (
+    startedAt !== undefined &&
+    compareUtcTimestamps(startedAt, requestedAt.value) < 0
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.startedAt",
+      "startedAt must not be earlier than requestedAt",
+    );
+  }
+  if (
+    finishedAt !== undefined &&
+    (
+      compareUtcTimestamps(finishedAt, requestedAt.value) < 0 ||
+      (
+        startedAt !== undefined &&
+        compareUtcTimestamps(finishedAt, startedAt) < 0
+      )
+    )
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.finishedAt",
+      "finishedAt must not be earlier than requestedAt or startedAt",
+    );
+  }
+
+  const proposalIdsField = parseRequiredField(object.value, "proposalIds", "$");
+  if (!proposalIdsField.ok) return proposalIdsField;
+  const proposalIds = parseUniqueIdArray(proposalIdsField.value, "$.proposalIds", "proposal", "proposalIds");
+  if (!proposalIds.ok) return proposalIds;
+
+  let modelReceipt: ResearchModelReceiptV1 | undefined;
+  if (hasOwn(object.value, "modelReceipt")) {
+    const parsedModelReceipt = parseResearchModelReceiptV1(object.value.modelReceipt, "$.modelReceipt");
+    if (!parsedModelReceipt.ok) return parsedModelReceipt;
+    modelReceipt = parsedModelReceipt.value;
+    if (modelReceipt.familiarId !== familiarId.value) {
+      return fail(
+        "semantic_conflict",
+        "$.modelReceipt.familiarId",
+        "modelReceipt familiarId must equal the Topic Discovery Job familiarId",
+      );
+    }
+  }
+
+  let failure: TopicDiscoveryFailureV1 | undefined;
+  if (hasOwn(object.value, "failure")) {
+    const parsedFailure = parseTopicDiscoveryFailureV1(object.value.failure, "$.failure");
+    if (!parsedFailure.ok) return parsedFailure;
+    failure = parsedFailure.value;
+  }
+
+  const hasStartedAt = typeof startedAt !== "undefined";
+  const hasFinishedAt = typeof finishedAt !== "undefined";
+  const hasFailure = typeof failure !== "undefined";
+
+  if (status.value === "queued") {
+    if (hasFinishedAt) {
+      return fail("semantic_conflict", "$.finishedAt", "queued jobs must not include finishedAt");
+    }
+    if (hasFailure) {
+      return fail("semantic_conflict", "$.failure", "queued jobs must not include failure");
+    }
+  }
+
+  if (status.value === "running" && !hasStartedAt) {
+    return fail("missing_field", "$.startedAt", "running jobs require startedAt");
+  }
+  if (status.value === "running" && hasFinishedAt) {
+    return fail("semantic_conflict", "$.finishedAt", "running jobs must not include finishedAt");
+  }
+  if (status.value === "running" && hasFailure) {
+    return fail("semantic_conflict", "$.failure", "running jobs must not include failure");
+  }
+  if (["completed", "failed", "cancelled"].includes(status.value) && !hasFinishedAt) {
+    return fail("missing_field", "$.finishedAt", `${status.value} jobs require finishedAt`);
+  }
+  if (
+    status.value === "completed" &&
+    (proposalIds.value.length < 3 || proposalIds.value.length > 7)
+  ) {
+    return fail(
+      "semantic_conflict",
+      "$.proposalIds",
+      "completed jobs require between three and seven proposalIds",
+    );
+  }
+  if (status.value === "completed" && hasFailure) {
+    return fail("semantic_conflict", "$.failure", "completed jobs must not include failure");
+  }
+  if (status.value === "failed" && !hasFailure) {
+    return fail("missing_field", "$.failure", "failed jobs require failure");
+  }
+  if (status.value === "cancelled" && hasFailure) {
+    return fail("semantic_conflict", "$.failure", "cancelled jobs must not include failure");
+  }
+
+  return pass({
+    ...object.value,
+    schema: TOPIC_DISCOVERY_JOB_SCHEMA,
+    id: id.value,
+    contextPackId: contextPackId.value,
+    contextPackDigest: contextPackDigest.value,
+    familiarId: familiarId.value,
+    status: status.value as JobStatusV1,
+    requestedAt: requestedAt.value,
+    ...(typeof startedAt === "string" ? { startedAt } : {}),
+    ...(typeof finishedAt === "string" ? { finishedAt } : {}),
+    proposalIds: proposalIds.value,
+    ...(modelReceipt ? { modelReceipt } : {}),
+    ...(failure ? { failure } : {}),
+  });
+}
+
+export function parseTopicProposalV1(value: unknown): ProtocolParseResult<TopicProposalV1> {
+  const wireValue = copyProtocolJsonValue(value);
+  if (!wireValue.ok) return wireValue;
+
+  const object = parseObject(wireValue.value, "$");
+  if (!object.ok) return object;
+
+  const schemaField = parseRequiredField(object.value, "schema", "$");
+  if (!schemaField.ok) return schemaField;
+  const schema = parseSchema(
+    schemaField.value,
+    TOPIC_PROPOSAL_SCHEMA,
+    TOPIC_PROPOSAL_SCHEMA_RE,
+    "$.schema",
+    "schema",
+  );
+  if (!schema.ok) return schema;
+
+  const idField = parseRequiredField(object.value, "id", "$");
+  if (!idField.ok) return idField;
+  const id = parseOpaqueIdentifier(idField.value, "proposal", "$.id", "id");
+  if (!id.ok) return id;
+
+  const discoveryJobIdField = parseRequiredField(object.value, "discoveryJobId", "$");
+  if (!discoveryJobIdField.ok) return discoveryJobIdField;
+  const discoveryJobId = parseOpaqueIdentifier(
+    discoveryJobIdField.value,
+    "topicjob",
+    "$.discoveryJobId",
+    "discoveryJobId",
+  );
+  if (!discoveryJobId.ok) return discoveryJobId;
+
+  const contextPackIdField = parseRequiredField(object.value, "contextPackId", "$");
+  if (!contextPackIdField.ok) return contextPackIdField;
+  const contextPackId = parseOpaqueIdentifier(contextPackIdField.value, "ctx", "$.contextPackId", "contextPackId");
+  if (!contextPackId.ok) return contextPackId;
+
+  const titleField = parseRequiredField(object.value, "title", "$");
+  if (!titleField.ok) return titleField;
+  const title = parseString(titleField.value, "$.title", "title");
+  if (!title.ok) return title;
+
+  const questionField = parseRequiredField(object.value, "question", "$");
+  if (!questionField.ok) return questionField;
+  const question = parseString(questionField.value, "$.question", "question");
+  if (!question.ok) return question;
+
+  const whyNowField = parseRequiredField(object.value, "whyNow", "$");
+  if (!whyNowField.ok) return whyNowField;
+  const whyNow = parseString(whyNowField.value, "$.whyNow", "whyNow");
+  if (!whyNow.ok) return whyNow;
+
+  const evidenceField = parseRequiredField(object.value, "evidence", "$");
+  if (!evidenceField.ok) return evidenceField;
+  const evidence = parseEvidenceArray(evidenceField.value, "$.evidence", { minimum: 1 });
+  if (!evidence.ok) return evidence;
+
+  const counterevidenceField = parseRequiredField(object.value, "counterevidence", "$");
+  if (!counterevidenceField.ok) return counterevidenceField;
+  const counterevidence = parseEvidenceArray(counterevidenceField.value, "$.counterevidence");
+  if (!counterevidence.ok) return counterevidence;
+
+  const scoresField = parseRequiredField(object.value, "scores", "$");
+  if (!scoresField.ok) return scoresField;
+  const scores = parseScores(scoresField.value, "$.scores");
+  if (!scores.ok) return scores;
+
+  const suggestedField = parseRequiredField(object.value, "suggested", "$");
+  if (!suggestedField.ok) return suggestedField;
+  const suggested = parseSuggested(suggestedField.value, "$.suggested");
+  if (!suggested.ok) return suggested;
+
+  const uncertaintyField = parseRequiredField(object.value, "uncertainty", "$");
+  if (!uncertaintyField.ok) return uncertaintyField;
+  const uncertainty = parseString(uncertaintyField.value, "$.uncertainty", "uncertainty");
+  if (!uncertainty.ok) return uncertainty;
+
+  const relatedMissionIdsField = parseRequiredField(object.value, "relatedMissionIds", "$");
+  if (!relatedMissionIdsField.ok) return relatedMissionIdsField;
+  const relatedMissionIds = parseUniqueIdArray(
+    relatedMissionIdsField.value,
+    "$.relatedMissionIds",
+    "mission",
+    "relatedMissionIds",
+  );
+  if (!relatedMissionIds.ok) return relatedMissionIds;
+
+  const createdAtField = parseRequiredField(object.value, "createdAt", "$");
+  if (!createdAtField.ok) return createdAtField;
+  const createdAt = parseUtc(createdAtField.value, "$.createdAt", "createdAt");
+  if (!createdAt.ok) return createdAt;
+
+  return pass({
+    ...object.value,
+    schema: TOPIC_PROPOSAL_SCHEMA,
+    id: id.value,
+    discoveryJobId: discoveryJobId.value,
+    contextPackId: contextPackId.value,
+    title: title.value,
+    question: question.value,
+    whyNow: whyNow.value,
+    evidence: evidence.value,
+    counterevidence: counterevidence.value,
+    scores: scores.value,
+    suggested: suggested.value,
+    uncertainty: uncertainty.value,
+    relatedMissionIds: relatedMissionIds.value,
+    createdAt: createdAt.value,
+  });
+}


### PR DESCRIPTION
## Summary

- implements provider-neutral Research Protocol v1 schemas, fixtures, parsers, canonical validation, and conformance wiring
- consolidates the fuller Unit 0 implementation with the missing second-audit option-shell and replay-consent protections
- keeps the scope to protocol contracts; no UI, local store, executor, or hosted cloud implementation

## Validation

- research protocol: 232/232
- conformance: 14/14 files
- typecheck, lint:source, test wiring (1,731 files), diff check
- branch squashed to one reviewed commit with clean attribution

Beads: `cave-6sles`, `cave-6sles.1`
