### PR TITLE
Keep reply composer visible after tool results

### DIFF
--- a/src/components/chat-inline-composer.test.ts
+++ b/src/components/chat-inline-composer.test.ts
@@ -37,15 +37,18 @@ test("one composer element, rendered in exactly one of two positions", () => {
 });
 
 test("pre-session tool results move the composer into the reply dock", () => {
+  const zeroTurnBranch = chatView.indexOf("{turns.length === 0 ? (");
+  const sessionlessBranch = chatView.indexOf(") : sessionId === null ? (", zeroTurnBranch);
+  const dashboardStart = chatView.indexOf("<ChatNewDashboard", sessionlessBranch);
+  const dashboardEnd = chatView.indexOf("/>", dashboardStart);
+
+  assert.ok(zeroTurnBranch >= 0, "the transcript has an explicit zero-turn branch");
+  assert.ok(sessionlessBranch > zeroTurnBranch, "the new-chat dashboard is restricted to sessionless zero-turn chats");
+  assert.ok(dashboardStart > sessionlessBranch, "the sessionless branch renders the new-chat dashboard");
   assert.match(
-    chatView,
-    /const inlineComposer = sessionId === null && turns\.length === 0;/,
-    "image, auto-mode, and other tool-only turns must make the composer dock even before a session id exists",
-  );
-  assert.match(
-    chatView,
-    /turns\.length === 0 \? \([\s\S]*?sessionId === null \? \([\s\S]*?<ChatNewDashboard[\s\S]*?composer=\{composerNode\}/,
-    "the inline composer belongs exclusively to the zero-turn new-chat dashboard",
+    chatView.slice(dashboardStart, dashboardEnd),
+    /composer=\{composerNode\}/,
+    "the zero-turn new-chat dashboard receives the shared composer",
   );
 });
 

--- a/src/components/chat-inline-composer.test.ts
+++ b/src/components/chat-inline-composer.test.ts
@@ -17,7 +17,11 @@ const css = readFileSync(new URL("../styles/home-dashboard.css", import.meta.url
 
 test("one composer element, rendered in exactly one of two positions", () => {
   assert.match(chatView, /const composerNode = \(/, "the dock is extracted to a variable, not duplicated");
-  assert.match(chatView, /const inlineComposer = sessionId === null;/, "inline only on a brand-new chat");
+  assert.match(
+    chatView,
+    /const inlineComposer = sessionId === null && turns\.length === 0;/,
+    "the composer stays inline only while the brand-new chat dashboard is visible",
+  );
   assert.match(
     chatView,
     /\{inlineComposer \? null : composerNode\}/,
@@ -29,6 +33,19 @@ test("one composer element, rendered in exactly one of two positions", () => {
     (chatView.match(/className="cave-composer-dock"/g) ?? []).length,
     1,
     "a second dock element would mean two composers",
+  );
+});
+
+test("pre-session tool results move the composer into the reply dock", () => {
+  assert.match(
+    chatView,
+    /const inlineComposer = sessionId === null && turns\.length === 0;/,
+    "image, auto-mode, and other tool-only turns must make the composer dock even before a session id exists",
+  );
+  assert.match(
+    chatView,
+    /turns\.length === 0 \? \([\s\S]*?sessionId === null \? \([\s\S]*?<ChatNewDashboard[\s\S]*?composer=\{composerNode\}/,
+    "the inline composer belongs exclusively to the zero-turn new-chat dashboard",
   );
 });
 

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -7038,7 +7038,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // chatContextControls and placed adaptively — footer cluster for new chats
   // (inlineComposer) and session header for active chats (!inlineComposer)
   // so picker state is never duplicated.
-  const inlineComposer = sessionId === null;
+  // Tool-only commands such as /image and /auto can produce transcript turns
+  // before the daemon assigns a session id. The new-chat dashboard disappears
+  // as soon as that happens, so move the same composer into the reply dock.
+  const inlineComposer = sessionId === null && turns.length === 0;
   const composerPopoverPlacement = inlineComposer ? "bottom-start" : undefined;
   const composerAutocompletePosition = inlineComposer ? "top-full mt-2" : "bottom-full mb-2";
   const chatContextControls = (


### PR DESCRIPTION
## Summary
- dock the existing composer when tool-only turns arrive before a daemon session ID
- preserve exactly one composer while the zero-turn dashboard owns the inline placement
- add regression coverage for pre-session image, auto-mode, and tool-only results

## Verification
- `node --experimental-strip-types src/components/chat-inline-composer.test.ts` (6 passed)
- `pnpm typecheck`
- `pnpm lint`
- `NPM_CONFIG_LOGLEVEL=error pnpm test:app` (1258 files passed)
- `pnpm test:api` (385 files passed)
- `pnpm check:tests-wired` (1721 files wired)
- `git diff --check`

Bead: `cave-tzy63`