### PR TITLE
test: restore main to green — three guards left stale by 2026-08-20 merges

### DIFF
--- a/scripts/dev-app-teardown.test.mjs
+++ b/scripts/dev-app-teardown.test.mjs
@@ -83,8 +83,19 @@ echo "server_token $COVEN_CAVE_AUTH_TOKEN" >>"${pidFile}"
 node -e '
   const http = require("http");
   const fs = require("fs");
+  // Mirror src/proxy.ts: only an authenticated readiness probe earns the proof
+  // header. Stamping it unconditionally would keep this fixture passing even if
+  // the launcher stopped minting and exporting COVEN_CAVE_DEV_PROBE_TOKEN for
+  // the dev server it owns, which is the contract this test relies on.
+  const expected = (process.env.COVEN_CAVE_DEV_PROBE_TOKEN || "").trim();
   const server = http.createServer((request, response) => {
-    response.writeHead(204);
+    const url = new URL(request.url, "http://127.0.0.1");
+    const ready = expected.length > 0
+      && request.method === "GET"
+      && url.pathname === "/"
+      && url.searchParams.get("__devShellProbe") === "1"
+      && request.headers["x-coven-cave-readiness-token"] === expected;
+    response.writeHead(204, ready ? { "x-coven-cave-readiness": "1" } : {});
     response.end();
   });
   server.listen(${port}, "127.0.0.1", () => {

--- a/scripts/dev-app-teardown.test.mjs
+++ b/scripts/dev-app-teardown.test.mjs
@@ -83,19 +83,19 @@ echo "server_token $COVEN_CAVE_AUTH_TOKEN" >>"${pidFile}"
 node -e '
   const http = require("http");
   const fs = require("fs");
-  // Mirror src/proxy.ts: only an authenticated readiness probe earns the proof
-  // header. Stamping it unconditionally would keep this fixture passing even if
-  // the launcher stopped minting and exporting COVEN_CAVE_DEV_PROBE_TOKEN for
-  // the dev server it owns, which is the contract this test relies on.
-  const expected = (process.env.COVEN_CAVE_DEV_PROBE_TOKEN || "").trim();
   const server = http.createServer((request, response) => {
+    // Mirror the readiness contract in src/proxy.ts: only an authenticated
+    // dev-shell probe earns the proof header. Answering it unconditionally
+    // would let this test pass against a launcher that never sends a token.
     const url = new URL(request.url, "http://127.0.0.1");
-    const ready = expected.length > 0
-      && request.method === "GET"
+    const expected = process.env.COVEN_CAVE_DEV_PROBE_TOKEN || "";
+    const supplied = request.headers["x-coven-cave-readiness-token"] || "";
+    const ready = request.method === "GET"
       && url.pathname === "/"
       && url.searchParams.get("__devShellProbe") === "1"
-      && request.headers["x-coven-cave-readiness-token"] === expected;
-    response.writeHead(204, ready ? { "x-coven-cave-readiness": "1" } : {});
+      && expected.length > 0
+      && supplied === expected;
+    response.writeHead(204, { "x-coven-cave-readiness": ready ? "1" : "0" });
     response.end();
   });
   server.listen(${port}, "127.0.0.1", () => {

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -246,11 +246,11 @@ assert.doesNotMatch(
   "Workspace should not render a floating Salem perch",
 );
 
-// The open (not-done) board cards are polled from /api/board, kept with their
-// familiar so the Tasks badge can scope the count.
+// The open (not-done) board cards come from the shared "board:cards" surface
+// resource, kept with their familiar so the Tasks badge can scope the count.
 assert.match(
   workspace,
-  /fetch\("\/api\/board"[\s\S]*\.filter\(\s*\(c\) => c\.status !== "done",?\s*\)[\s\S]*\.map\(\s*\(c\) => \(\{ familiarId: c\.familiarId \?\? null \}\)\s*\)/,
+  /readSurfaceResource<[\s\S]*?>\("board:cards"\)[\s\S]*\.filter\(\s*\(c\) => c\.status !== "done",?\s*\)[\s\S]*\.map\(\s*\(c\) => \(\{ familiarId: c\.familiarId \?\? null \}\)\s*\)/,
   "open (not-done) board cards are collected with their familiarId",
 );
 

--- a/src/components/role-surfaces/navigator-surface.test.ts
+++ b/src/components/role-surfaces/navigator-surface.test.ts
@@ -52,15 +52,17 @@ test("moves, renames, reassignments, answers, adds and removals are real writes"
 });
 
 test("the dependency chart is the room's own overlay, never a board field", () => {
-  // The board has no dependency column; writing one client-side would show
-  // every other surface a link it cannot honour.
+  // Dependencies are canonical on the card (`Card.dependencies`), so the board
+  // write carries that field and nothing else. The overlay survives only as a
+  // legacy read-side store, which the room may cut but never publishes as a
+  // client-invented `dependsOn` the rest of the Cave could not honour.
   assert.match(surface, /overlay: ChartOverlay/);
   assert.match(surface, /normalizeOverlay\(state\.overlay, liveIds\)/);
-  assert.match(surface, /setDependency\(overlay, stepId, needs\)/);
+  assert.match(surface, /setDependency\(overlay, stepId, null\)/);
   assert.doesNotMatch(surface, /body: JSON\.stringify\(\{[^}]*\bdependsOn\b/);
   assert.match(
     surface,
-    /Discard this session's links — the board's own cards are untouched/,
+    /Discard the legacy overlay's surviving links — canonical dependencies on the cards are untouched/,
     "the reset control says what it does and does not touch",
   );
 });
@@ -126,7 +128,7 @@ test("the drawer's own panels degrade separately from the canvas", () => {
 test("mutations announce, and visible failures announce assertively", () => {
   assert.match(surface, /import \{ useAnnouncer \} from "@\/components\/ui\/live-region"/);
   assert.match(surface, /const \{ announce \} = useAnnouncer\(\)/);
-  assert.match(surface, /announce\(failure, "assertive"\)/);
+  assert.match(surface, /announce\(`\$\{failure\}\$\{detail\}`, "assertive"\)/);
   assert.match(surface, /announce\(message, "assertive"\)/);
   assert.match(surface, /const \[writeError, setWriteError\] = useState<string \| null>\(null\)/);
   assert.doesNotMatch(surface, /<p role="alert"/, "the announcer is the live region, not a second one");

--- a/src/components/role-surfaces/navigator-surface.test.ts
+++ b/src/components/role-surfaces/navigator-surface.test.ts
@@ -51,14 +51,18 @@ test("moves, renames, reassignments, answers, adds and removals are real writes"
   assert.match(surface, /publishBoardChanged\(\)/);
 });
 
-test("the dependency chart is the room's own overlay, never a board field", () => {
+test("dependency edits write canonical card fields while the legacy overlay is import-and-prune only", () => {
   // Dependencies are canonical on the card (`Card.dependencies`), so the board
   // write carries that field and nothing else. The overlay survives only as a
-  // legacy read-side store, which the room may cut but never publishes as a
+  // legacy read-side store the room may import from or cut, never as a
   // client-invented `dependsOn` the rest of the Cave could not honour.
   assert.match(surface, /overlay: ChartOverlay/);
   assert.match(surface, /normalizeOverlay\(state\.overlay, liveIds\)/);
+  assert.match(surface, /overlayImportPlan\(cards, overlay\)/);
+  assert.match(surface, /\{ dependencies: \[\.\.\.existing, addition\] \}/);
+  assert.match(surface, /const body: Record<string, unknown> = \{ dependencies: kept \}/);
   assert.match(surface, /setDependency\(overlay, stepId, null\)/);
+  assert.doesNotMatch(surface, /setDependency\(overlay, stepId, parentId\)/);
   assert.doesNotMatch(surface, /body: JSON\.stringify\(\{[^}]*\bdependsOn\b/);
   assert.match(
     surface,
@@ -128,6 +132,7 @@ test("the drawer's own panels degrade separately from the canvas", () => {
 test("mutations announce, and visible failures announce assertively", () => {
   assert.match(surface, /import \{ useAnnouncer \} from "@\/components\/ui\/live-region"/);
   assert.match(surface, /const \{ announce \} = useAnnouncer\(\)/);
+  assert.match(surface, /setWriteError\(`\$\{failure\}\$\{detail\}`\)/);
   assert.match(surface, /announce\(`\$\{failure\}\$\{detail\}`, "assertive"\)/);
   assert.match(surface, /announce\(message, "assertive"\)/);
   assert.match(surface, /const \[writeError, setWriteError\] = useState<string \| null>\(null\)/);


### PR DESCRIPTION
## What

`main` is red. Three independent test breaks landed on 2026-08-20, each one a
stale guard left behind by a merge that changed the code it pins. None of them
is a product regression — every underlying behaviour is intact — but together
they fail `pnpm test:app` and `pnpm test:api`, which reddens `PR checks` on
every open PR and masks real failures behind them.

## The three breaks

**1. `src/components/role-surfaces/navigator-surface.test.ts`** — stale since
#4757 (`5a09173153`), which rewrote `navigator-surface.tsx`:

- `announce(failure, "assertive")` is now ``announce(`${failure}${detail}`, "assertive")``
- `setDependency(overlay, stepId, needs)` is now `setDependency(overlay, stepId, null)` —
  dependencies became canonical on `Card.dependencies`, so the legacy overlay is
  only ever *cut*, never written
- the reset copy was rewritten

The test's leading comment also claimed "the board has no dependency column",
which #4757 made false (the source writes `{ dependencies: kept }`). Corrected
rather than left as a lie next to a passing assertion.

**2. `scripts/dev-app-teardown.test.mjs`** — stale since #4759 (`ae27407a91`),
which made readiness an *authenticated* probe: `dev-app-origin-health.mjs` now
sends `x-coven-cave-readiness-token` and accepts only a response carrying
`x-coven-cave-readiness: 1`, which `src/proxy.ts` stamps for a matching probe.
#4759 updated `dev-app.test.mjs` and `dev-app-origin-health.test.mjs` but not
this fixture, whose stub dev server still answered a bare `204`. Readiness could
therefore never be satisfied and the launcher timed out.

The stub now mirrors the `src/proxy.ts` contract instead of stamping the header
unconditionally, so the fixture still fails if the launcher ever stops minting
and exporting `COVEN_CAVE_DEV_PROBE_TOKEN` for the dev server it owns.

**3. `src/components/familiar-menu-bar.test.ts`** — stale since `387e9b1b5b`
("Reuse board resource and fix split pane sizing"), which moved the open-task
card read in `workspace.tsx` from `fetch("/api/board")` to
`readSurfaceResource("board:cards")`. The behavioural contract the guard exists
to protect is byte-identical — the same `.filter((c) => c.status !== "done")`
and `.map((c) => ({ familiarId: c.familiarId ?? null }))` still feed the Tasks
badge — only the transport moved. Re-anchored on the surface-resource read.

## Verification

- `navigator-surface.test.ts` — 23 pass / 0 fail
- `dev-app-teardown.test.mjs` — ok (and non-vacuously: it only goes green
  because the launcher really exports the token and the probe really sends it)
- `familiar-menu-bar.test.ts` — ok
- Full `pnpm test:app` / `pnpm test:api` on this branch, plus CI

## Scope

Test-side only. No product code is touched; every change re-points a guard at
what its own source now does, or corrects a comment that had become false.

Bead: `cave-2s8b2`

## Relationship to #4768

Another session opened #4768 against breaks 1 and 2 while this branch was in
flight. Its versions of both files were stronger than the ones here, so they
have been adopted verbatim (`a1fa67070d`) and this PR is now a strict superset.

Neither PR can go green on its own: the required `Frontend build` check
aggregates the whole validation matrix (`FRONTEND_VALIDATION_RESULT`), so app
tests must pass to merge. #4768 does not carry break 3, and this branch did not
carry its improvements — hence the consolidation rather than two PRs racing.
