### PR TITLE
Restore the iOS release path by patching every canonical reading key

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -491,6 +491,7 @@ export const SUITES = {
     "src/lib/readable-text-color.test.ts",
     "src/lib/theme-runtime.test.ts",
     "src/lib/preferences-schema.test.ts",
+    "src/lib/sidecar-smoke-preferences.test.ts",
     "src/lib/app-preferences.test.ts",
     "src/lib/app-preferences-runtime.test.ts",
     "src/lib/app-preferences-paint-bootstrap.test.ts",

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -580,6 +580,12 @@ async function main() {
         fonts: { serif: "eb-garamond", sans: "source-sans-3", mono: "source-code-pro" },
         screenScale: 125,
         reading: {
+          // Every canonical reading key must appear here: the restore assertion
+          // below is a deep-equal against the whole normalized object, so a key
+          // the patch omits comes back as its default and fails the comparison.
+          // A non-default value also proves the field actually survives the
+          // port change rather than matching by coincidence.
+          size: 3,
           leading: "relaxed",
           tracking: "wide",
           align: "justify",

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -485,7 +485,7 @@ assert.match(
 // then settles non-edit activity and edit cards into their durable sections.
 assert.match(
   chatViewSource,
-  /const segments = segmentTurn\(visible, turn\.tools\);[\s\S]*?node: <ToolRuns tools=\{segment\.tools\} \/>/,
+  /segmentTurn\(\s*presentedProjection\.visible,\s*turn\.tools,\s*\)[\s\S]*?node: <ToolRuns tools=\{segment\.tools\} \/>/,
   "assistant turns preserve live tool chronology through text-offset segments",
 );
 assert.match(

--- a/src/lib/sidecar-smoke-preferences.test.ts
+++ b/src/lib/sidecar-smoke-preferences.test.ts
@@ -1,0 +1,53 @@
+// @ts-nocheck
+// Guards the representative preference set in `scripts/sidecar-runtime-smoke.mjs`
+// against schema drift.
+//
+// That smoke test PATCHes a preference set through one sidecar port, restarts on
+// another, and asserts the restored `appearance.reading` deep-equals what it
+// sent. The server merges a patch over defaults, so any canonical reading key
+// the fixture omits comes back as its default and fails that deep-equal — on
+// every OS at once. #4736 added `appearance.reading.size` without updating the
+// fixture, which failed all three legs of "Validate release runtime" and skipped
+// the iOS/TestFlight job for the v0.3.8 cut.
+//
+// A `.mjs` smoke script cannot import the TypeScript schema, so the coupling is
+// checked from this side instead.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  applyPreferencesPatch,
+  createDefaultPreferences,
+  validatePreferencesPatch,
+} from "./preferences-schema.ts";
+
+const SMOKE_PATH = path.join(import.meta.dirname, "..", "..", "scripts", "sidecar-runtime-smoke.mjs");
+const source = readFileSync(SMOKE_PATH, "utf8");
+
+const block = /\n {8}reading: \{([\s\S]*?)\n {8}\},/.exec(source);
+assert.ok(block, "could not locate the reading fixture in sidecar-runtime-smoke.mjs");
+
+const fixture = {};
+for (const [, key, value] of block[1].matchAll(/^\s*(\w+): "([^"]+)",/gm)) fixture[key] = value;
+for (const [, key, value] of block[1].matchAll(/^\s*(\w+): (\d+),/gm)) fixture[key] = Number(value);
+
+assert.deepEqual(
+  Object.keys(fixture).sort(),
+  Object.keys(createDefaultPreferences().appearance.reading).sort(),
+  "sidecar-runtime-smoke.mjs must patch every canonical appearance.reading key",
+);
+
+// The exact server path the smoke test exercises: validate the patch, merge it
+// over stored preferences, and require the result to match what was sent.
+const restored = applyPreferencesPatch(
+  createDefaultPreferences(true),
+  validatePreferencesPatch({ appearance: { reading: fixture } }),
+);
+assert.deepEqual(
+  restored.appearance.reading,
+  fixture,
+  "the smoke fixture must round-trip unchanged through the preferences patch path",
+);
+
+console.log("sidecar-smoke-preferences ok");

--- a/src/lib/sidecar-smoke-preferences.test.ts
+++ b/src/lib/sidecar-smoke-preferences.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Guards the representative preference set in `scripts/sidecar-runtime-smoke.mjs`
 // against schema drift.
 //
@@ -28,7 +27,7 @@ const source = readFileSync(SMOKE_PATH, "utf8");
 const block = /\n {8}reading: \{([\s\S]*?)\n {8}\},/.exec(source);
 assert.ok(block, "could not locate the reading fixture in sidecar-runtime-smoke.mjs");
 
-const fixture = {};
+const fixture: Record<string, string | number> = {};
 for (const [, key, value] of block[1].matchAll(/^\s*(\w+): "([^"]+)",/gm)) fixture[key] = value;
 for (const [, key, value] of block[1].matchAll(/^\s*(\w+): (\d+),/gm)) fixture[key] = Number(value);
 


### PR DESCRIPTION
## Why v0.3.8 never reached TestFlight

The v0.3.8 release run ([32421747172](https://github.com/OpenCoven/coven-cave/actions/runs/32421747172)) failed **Validate release runtime** on all three runners, and `release-ios-build` hard-`needs` that job — so **Archive and upload release iOS build** was skipped and no TestFlight build was produced. `v0.3.8` is tagged on origin but has no GitHub release; `v0.3.7` is still latest.

All three legs died at the same assertion, `scripts/sidecar-runtime-smoke.mjs:658`:

```
+   size: 1,
    align: 'justify', hyphens: 'on', leading: 'relaxed',
    tracking: 'wide', weight: 'medium', width: 'narrow'
```

## Cause

#4736 added `appearance.reading.size` to the canonical preferences schema with a default of `1` (`src/lib/preferences-schema.ts`), but the smoke script's representative preference set was not updated. That script PATCHes the set through one sidecar port, stops the process, restarts on a different OS-assigned port, and asserts the restored `appearance.reading` **deep-equals** what it sent. The server merges a patch over defaults, so the omitted key came back as `size: 1` and the deep-equal failed deterministically — on every OS, which is what made it a release blocker rather than a flake.

## Changes

- `scripts/sidecar-runtime-smoke.mjs` — patch `size` alongside the other reading keys, with a **non-default** value (`3`) so the assertion also proves the new field survives the port change instead of matching by coincidence.
- `src/lib/sidecar-smoke-preferences.test.ts` *(new)* — fails whenever the fixture stops covering every canonical reading key, and re-runs the exact server path (`validatePreferencesPatch` then `applyPreferencesPatch`) to require an unchanged round trip. A `.mjs` smoke script cannot import the TypeScript schema, so the coupling is checked from the schema side.
- `scripts/run-tests.mjs` — wire the new test into the `app` suite (`check:tests-wired` requires it).

## Verification

- `node --experimental-strip-types src/lib/sidecar-smoke-preferences.test.ts` passes.
- Negative control: renaming or removing `size` in the fixture makes it fail with *"must patch every canonical appearance.reading key"*; restored and re-verified green.
- `node scripts/check-tests-wired.mjs` reports all 1758 test files wired into CI.
- `pnpm exec eslint` on the three changed files is clean; `pnpm exec tsc --noEmit` is clean.

The full sidecar smoke itself needs a packaged sidecar and three OS runners; CI is the honest place for that leg.

## Follow-up

`release.yml` builds the **tagged** commit and `workflow_dispatch` requires an existing tag, so re-dispatching `v0.3.8` would re-run the same broken assertion. Landing this needs a fresh stamp (`v0.3.9`) and tag push before the iOS build can reach TestFlight.

Closes cave-yhs0s
