### PR TITLE
test: cover conversation kind filter contracts

### DIFF
--- a/src/components/chat-list-filter-defaults.test.ts
+++ b/src/components/chat-list-filter-defaults.test.ts
@@ -15,7 +15,7 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /const clearSessionFilters = useCallback\(\(\) => \{\s*setSearch\(""\);\s*setStatusFilter\("all"\);\s*onSelectionChange\("all"\);\s*setShowArchived\(false\);\s*\}, \[onSelectionChange\]\);/,
+  /const clearSessionFilters = useCallback\(\(\) => \{\s*setSearch\(""\);\s*setStatusFilter\("all"\);\s*setKindFilter\("all"\);\s*onSelectionChange\("all"\);\s*setShowArchived\(false\);\s*\}, \[onSelectionChange\]\);/,
   "One reset should clear every non-familiar Sessions filter",
 );
 assert.match(
@@ -25,8 +25,8 @@ assert.match(
 );
 assert.match(
   source,
-  /const hasAppliedFilters =\s*search\.trim\(\)\.length > 0 \|\|\s*statusFilter !== "all" \|\|\s*effectiveSelection !== "all" \|\|\s*showArchived;/,
-  "The clear action should track search, status, project, and archive filters without treating familiar scope as a filter",
+  /const hasAppliedFilters =\s*search\.trim\(\)\.length > 0 \|\|\s*statusFilter !== "all" \|\|\s*kindFilter !== "all" \|\|\s*effectiveSelection !== "all" \|\|\s*showArchived;/,
+  "The clear action should track search, status, kind, project, and archive filters without treating familiar scope as a filter",
 );
 assert.match(
   source,

--- a/src/components/chat-list-pr-badge.test.ts
+++ b/src/components/chat-list-pr-badge.test.ts
@@ -69,7 +69,7 @@ assert.match(
 );
 
 // ── Badge styling: GitHub's state colors ─────────────────────────────────────
-for (const state of ["merged", "closed", "draft"]) {
+for (const state of ["merged", "closed", "draft", "unknown"]) {
   assert.match(
     css,
     new RegExp(`\\.chat-list-pr-badge\\[data-pr-state="${state}"\\]`),


### PR DESCRIPTION
## Summary
- update the Sessions reset contract to include the new task/GitHub kind filter
- include kind filtering in applied-filter detection coverage
- pin neutral styling for unknown PR states

## Verification
- focused PR status, PR normalization, kind filter, badge, and reset tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`

Bead: `cave-nego0`