### PR TITLE
Repair red main: seven failures behind the desktop chrome refresh

### DIFF
--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -176,7 +176,40 @@ const MAX_CHUNK_BYTES = (Number(process.env.BUNDLE_MAX_CHUNK_KB) || 2400) * 1024
 // documented convention above, 615 is the smallest ceiling that clears the 2%
 // THIN threshold here (13.2 KiB / 2.1% headroom) for this one-time addition;
 // this is a ceiling for this feature's CSS, not a licence for the next one.
-const MAX_ROOT_CSS_BYTES = (Number(process.env.BUNDLE_MAX_ROOT_CSS_KB) || 615) * 1024;
+// RAISED root 615→640 (2026-08-21, repairing red `main`), after first
+// reclaiming what was NOT genuine root cost. The gate failed at 630,421 B
+// (615.65 KiB) — 661 bytes over — on the desktop chrome refresh (#4791).
+// Attribution, measured as facade source bytes per commit:
+//   dd93af6b1 (the 600→615 raise) 449,195 → 8aaaf2f21 465,310 = +16.1 KiB source
+//   of which #4758 (recovered product work) +11.7 KiB and #4791 +3.2 KiB;
+//   built root CSS moved 601.8 → 615.65 KiB over the same span.
+// All of it is always-loaded shell chrome, so none of it is a #3264
+// mis-scoping: #4791 added the Dia-style connected-rail titlebar to
+// desktop-chrome.css (`:root[data-tauri-titlebar]`, globally mounted), #4758
+// added .split-host__* focus-mode and carousel rules to
+// surface-chat-overlays.css and moved the rail's scope controls into
+// workspace-context-switcher.css. Every declaration is tokenized;
+// codemod:design:check is a no-op over them.
+// The one thing that WAS accidental is now gone: dev-shell-recovery.css
+// (1,864 B) reached the root layout through a static import in a component
+// that compiles away in production, so every production page load paid for a
+// dev-only overlay's styles. Loading the overlay through next/dynamic drops it
+// out of the root set — measured 630,421 → 628,557 B (613.83 KiB).
+// That reclaim alone would clear the gate by 1,203 bytes (0.19%), which is the
+// cave-iktbc stopgap exactly: green today, and the next CSS PR of any size
+// fails. So the ceiling moves as well, derived from the rate rather than from
+// the 2% THIN line (cave-yizcb):
+//   2026-08-05 589 KiB → 2026-08-21 615.65 KiB = 1.67 KiB/day over 16 days
+//   2026-08-16 601.8 KiB → 2026-08-21 615.65 KiB = 2.8 KiB/day over the last 5
+// The rate has roughly doubled. 640 leaves 26.2 KiB (4.1%) — about 15 days at
+// the 16-day average, about 9 at the recent one. Reclaiming rather than raising
+// (#3264) is still the better answer for root: the remaining candidates in the
+// facade are settings-familiars.css, calendar-agenda.css,
+// surface-compact-calendar.css and surface-role-workspaces.css, and none was
+// attempted here because this branch exists to un-red `main`, not to re-order
+// the cascade under several concurrent sessions. This is a ceiling for the
+// shell chrome that already landed, not a licence for the next surface.
+const MAX_ROOT_CSS_BYTES = (Number(process.env.BUNDLE_MAX_ROOT_CSS_KB) || 640) * 1024;
 const MAX_HOME_CSS_BYTES = (Number(process.env.BUNDLE_MAX_HOME_CSS_KB) || 940) * 1024;
 
 if (!existsSync(chunksDir)) {

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -661,7 +661,12 @@ export function BottomTerminal({
       term.focus();
 
       healthTimer = setInterval(() => {
-        if (disposed || stopped || !visibleRef.current) return;
+        // visibleRef covers the terminal pane; document.hidden covers the whole
+        // window. A backgrounded window has nobody to tell that the shell died,
+        // and the next tick after it returns re-probes anyway, so probing
+        // through it only spends IPC. This is the polling discipline
+        // src/lib/pausable-poll-discipline.test.ts exists to keep structural.
+        if (disposed || stopped || !visibleRef.current || document.hidden) return;
         void bridge.invoke<string[]>("pty_list").then((sessions) => {
           if (disposed || stopped || sessions.includes(threadId)) return;
           sendToPtyRef.current = null;

--- a/src/components/chat-list-filter-defaults.test.ts
+++ b/src/components/chat-list-filter-defaults.test.ts
@@ -15,7 +15,7 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /const clearSessionFilters = useCallback\(\(\) => \{\s*setSearch\(""\);\s*setStatusFilter\("all"\);\s*onSelectionChange\("all"\);\s*setShowArchived\(false\);\s*\}, \[onSelectionChange\]\);/,
+  /const clearSessionFilters = useCallback\(\(\) => \{\s*setSearch\(""\);\s*setStatusFilter\("all"\);\s*setKindFilter\("all"\);\s*onSelectionChange\("all"\);\s*setShowArchived\(false\);\s*\}, \[onSelectionChange\]\);/,
   "One reset should clear every non-familiar Sessions filter",
 );
 assert.match(
@@ -25,8 +25,8 @@ assert.match(
 );
 assert.match(
   source,
-  /const hasAppliedFilters =\s*search\.trim\(\)\.length > 0 \|\|\s*statusFilter !== "all" \|\|\s*effectiveSelection !== "all" \|\|\s*showArchived;/,
-  "The clear action should track search, status, project, and archive filters without treating familiar scope as a filter",
+  /const hasAppliedFilters =\s*search\.trim\(\)\.length > 0 \|\|\s*statusFilter !== "all" \|\|\s*kindFilter !== "all" \|\|\s*effectiveSelection !== "all" \|\|\s*showArchived;/,
+  "The clear action should track search, status, kind, project, and archive filters without treating familiar scope as a filter",
 );
 assert.match(
   source,

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -202,7 +202,7 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
   // the old All/Active segmented control: "Active" was one of five states the
   // daemon actually reports, so it could never answer "what failed?".
   const [statusFilter, setStatusFilter] = useState<ChatSessionStatusFilter>("all");
-  // Work-kind filter — exclusive toggle chips beside the status chips: narrow
+  // Work-kind filter — exclusive options in the toolbar overflow menu: narrow
   // the list to Board-task chats or to chats whose work reached GitHub.
   const [kindFilter, setKindFilter] = useState<ChatSessionKindFilter>("all");
   // Reading order for the list. "recent" additionally groups into activity
@@ -856,15 +856,16 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
         </div>
         )}
 
-        {/* Compact session toolbar — the handoff keeps search, counted status
-            filters, and the named sort on one line. Secondary view controls
-            stay available through one overflow menu instead of widening the
-            primary reading path. */}
+        {/* Compact session toolbar — search, counted status filters, and sort
+            stay on one line. Work-kind and view controls live in the overflow
+            menu so adding a filter cannot wrap the primary reading path. */}
         <div className="chat-sessions-toolbar mt-3 flex flex-wrap items-center gap-2 px-4 pb-3">
           <label
             className={[
               "chat-list-search-control flex h-8 min-w-0 items-center gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/60 px-2.5 transition-colors focus-within:border-[var(--accent-presence)]/50 focus-within:bg-[var(--bg-raised)]",
-              compact ? "max-w-[520px] flex-1" : "w-full max-w-[250px] min-[900px]:w-[250px]",
+              compact
+                ? "max-w-[520px] flex-1"
+                : "min-w-[160px] max-w-[250px] flex-1",
             ].join(" ")}
           >
             <Icon name="ph:magnifying-glass" width={13} className="shrink-0 text-[var(--text-muted)]" />
@@ -935,32 +936,6 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
                   );
                 })}
               </span>
-              {/* Work-kind chips: exclusive toggles — "Tasks only" narrows to
-                  Board-task chats, "GitHub only" to chats wearing the PR
-                  badge. Pressing the active chip clears it back to all. */}
-              <span aria-hidden className="h-3.5 w-px shrink-0 bg-[var(--border-hairline)]" />
-              <span role="group" aria-label="Filter sessions by work kind" className="flex flex-wrap items-center gap-0.5">
-                {CHAT_SESSION_KIND_ORDER.map((key) => {
-                  const presentation = CHAT_SESSION_KIND[key];
-                  const active = kindFilter === key;
-                  return (
-                    <button
-                      key={key}
-                      type="button"
-                      aria-pressed={active}
-                      disabled={chatStatusChipDisabled(kindCounts[key], active)}
-                      onClick={() => setKindFilter(active ? "all" : key)}
-                      title={presentation.description}
-                      className="chat-status-chip focus-ring"
-                      data-kind={key}
-                    >
-                      <Icon name={presentation.icon} width={11} aria-hidden />
-                      {presentation.label}
-                      <span className="chat-status-chip__count">{kindCounts[key]}</span>
-                    </button>
-                  );
-                })}
-              </span>
               {hasAppliedFilters && !(visibleRows === 0 && !showContentSection) && (
                 <Button
                   variant="ghost"
@@ -983,6 +958,21 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
                 className="h-7 w-7 shrink-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] text-[var(--text-muted)]"
                 minWidth={216}
               >
+                {CHAT_SESSION_KIND_ORDER.map((key) => {
+                  const presentation = CHAT_SESSION_KIND[key];
+                  return (
+                    <PopoverItem
+                      key={key}
+                      icon={presentation.icon}
+                      checked={kindFilter === key}
+                      disabled={chatStatusChipDisabled(kindCounts[key], kindFilter === key)}
+                      onSelect={() => setKindFilter(kindFilter === key ? "all" : key)}
+                    >
+                      {presentation.label} ({kindCounts[key]})
+                    </PopoverItem>
+                  );
+                })}
+                <PopoverSeparator />
                 <PopoverItem
                   checked={groupBy === "none"}
                   onSelect={() => setGroupBy(normalizeChatGroupBy("none"))}

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -864,7 +864,7 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
           <label
             className={[
               "chat-list-search-control flex h-8 min-w-0 items-center gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/60 px-2.5 transition-colors focus-within:border-[var(--accent-presence)]/50 focus-within:bg-[var(--bg-raised)]",
-              compact ? "max-w-[520px] flex-1" : "w-full max-w-[250px] min-[900px]:w-[250px]",
+              compact ? "max-w-[520px] flex-1" : "w-full max-w-[250px] min-[900px]:w-[190px]",
             ].join(" ")}
           >
             <Icon name="ph:magnifying-glass" width={13} className="shrink-0 text-[var(--text-muted)]" />

--- a/src/components/dev-shell-recovery-overlay.tsx
+++ b/src/components/dev-shell-recovery-overlay.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  type DevShellRecoveryState,
+  createDevShellRecovery,
+} from "@/lib/dev-shell-recovery";
+
+import "@/styles/dev-shell-recovery.css";
+
+// This module holds the overlay *and* its stylesheet so both stay out of the
+// production graph. `dev-shell-recovery.tsx` reaches it through next/dynamic;
+// see the comment there for why a static import was not good enough.
+
+const HEARTBEAT_INTERVAL_MS = 5_000;
+const RELOAD_MARKER_KEY = "coven-cave:dev-shell-recovery:reloaded-at";
+
+export async function probeOrigin(): Promise<boolean> {
+  try {
+    // Any answer at all proves the dev server is back; the status does not
+    // matter, only that the loopback origin is no longer refusing connections.
+    await fetch(`${window.location.origin}/?__devShellProbe=${Date.now()}`, {
+      method: "HEAD",
+      cache: "no-store",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function DevShellRecoveryOverlay() {
+  const [state, setState] = useState<DevShellRecoveryState>("healthy");
+  const [reloadBlocked, setReloadBlocked] = useState(false);
+  const controllerRef = useRef<ReturnType<typeof createDevShellRecovery> | null>(null);
+
+  useEffect(() => {
+    const controller = createDevShellRecovery({
+      probe: probeOrigin,
+      reload: () => window.location.reload(),
+      onStateChange: (next) => {
+        setState(next);
+        setReloadBlocked(controllerRef.current?.reloadBlocked ?? false);
+      },
+      readLastReloadAt: () => {
+        const raw = window.sessionStorage.getItem(RELOAD_MARKER_KEY);
+        const parsed = raw === null ? Number.NaN : Number(raw);
+        return Number.isFinite(parsed) ? parsed : null;
+      },
+      writeLastReloadAt: (at) => {
+        window.sessionStorage.setItem(RELOAD_MARKER_KEY, String(at));
+      },
+    });
+    controllerRef.current = controller;
+
+    const onError = (event: ErrorEvent) => controller.report(event.error ?? event.message);
+    const onRejection = (event: PromiseRejectionEvent) => controller.report(event.reason);
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onRejection);
+
+    // The passive listeners above only fire when the app happens to reach for
+    // the server, so poll as well: a window left idle must still notice.
+    const heartbeat = window.setInterval(() => {
+      if (document.hidden) return;
+      void probeOrigin().then((reachable) => {
+        if (!reachable) controller.observeOriginLost();
+      });
+    }, HEARTBEAT_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(heartbeat);
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onRejection);
+      controller.stop();
+      controllerRef.current = null;
+    };
+  }, []);
+
+  const retry = useCallback(() => {
+    controllerRef.current?.retry();
+    setReloadBlocked(false);
+  }, []);
+
+  if (state === "healthy") return null;
+  const reloading = state === "reloading";
+  const body = reloading
+    ? "The dev server answered. Reloading to pick up the new build."
+    : reloadBlocked
+      ? "Reloading did not clear the failure, so Cave stopped retrying. Restart the dev server, then reconnect."
+      : "The dev server stopped answering. Cave will reconnect on its own as soon as it comes back.";
+
+  return (
+    <div className="dev-shell-recovery" role="alert" aria-live="assertive">
+      <div className="dev-shell-recovery__card">
+        <h2 className="dev-shell-recovery__title">Dev server unreachable</h2>
+        <p className="dev-shell-recovery__body">{body}</p>
+        <p className="dev-shell-recovery__origin">{typeof window === "undefined" ? "" : window.location.origin}</p>
+        {!reloading ? (
+          <div className="dev-shell-recovery__actions">
+            <button type="button" className="dev-shell-recovery__button focus-ring" onClick={retry}>
+              Reconnect
+            </button>
+          </div>
+        ) : null}
+        <p className="dev-shell-recovery__status">
+          <span className="dev-shell-recovery__pulse" aria-hidden="true" />
+          {state === "checking" ? "Checking the dev server…" : null}
+          {state === "unreachable" && !reloadBlocked ? "Waiting for the dev server…" : null}
+          {state === "unreachable" && reloadBlocked ? "Paused after a failed reload." : null}
+          {reloading ? "Reloading…" : null}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dev-shell-recovery.tsx
+++ b/src/components/dev-shell-recovery.tsx
@@ -1,30 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 
-import {
-  type DevShellRecoveryState,
-  createDevShellRecovery,
-} from "@/lib/dev-shell-recovery";
-
-import "@/styles/dev-shell-recovery.css";
-
-const HEARTBEAT_INTERVAL_MS = 5_000;
-const RELOAD_MARKER_KEY = "coven-cave:dev-shell-recovery:reloaded-at";
-
-async function probeOrigin(): Promise<boolean> {
-  try {
-    // Any answer at all proves the dev server is back; the status does not
-    // matter, only that the loopback origin is no longer refusing connections.
-    await fetch(`${window.location.origin}/?__devShellProbe=${Date.now()}`, {
-      method: "HEAD",
-      cache: "no-store",
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
+// The overlay lives in its own module, reached through next/dynamic, purely so
+// that `@/styles/dev-shell-recovery.css` stays out of the production graph.
+// The component below already compiles away under NODE_ENV !== "development",
+// but a *static* import of that stylesheet does not: Turbopack attributes it to
+// the root layout's stylesheet set, so every production page load downloaded
+// ~2 KB of dev-only overlay CSS. It also counted against the root-layout CSS
+// budget in scripts/bundle-budget.mjs, which is what surfaced it.
+const DevShellRecoveryOverlay = dynamic(
+  () => import("./dev-shell-recovery-overlay").then((module) => module.DevShellRecoveryOverlay),
+  { ssr: false },
+);
 
 /**
  * Keeps the desktop dev window from sitting silently on a dead loopback origin.
@@ -33,92 +21,8 @@ async function probeOrigin(): Promise<boolean> {
  * no way back short of hunting the process tree by hand.
  */
 export function DevShellRecovery() {
-  // A build-time constant, so production drops the overlay and its heartbeat.
+  // A build-time constant, so production drops the overlay, its heartbeat, and
+  // — because the import above is lazy — its stylesheet.
   if (process.env.NODE_ENV !== "development") return null;
   return <DevShellRecoveryOverlay />;
-}
-
-function DevShellRecoveryOverlay() {
-  const [state, setState] = useState<DevShellRecoveryState>("healthy");
-  const [reloadBlocked, setReloadBlocked] = useState(false);
-  const controllerRef = useRef<ReturnType<typeof createDevShellRecovery> | null>(null);
-
-  useEffect(() => {
-    const controller = createDevShellRecovery({
-      probe: probeOrigin,
-      reload: () => window.location.reload(),
-      onStateChange: (next) => {
-        setState(next);
-        setReloadBlocked(controllerRef.current?.reloadBlocked ?? false);
-      },
-      readLastReloadAt: () => {
-        const raw = window.sessionStorage.getItem(RELOAD_MARKER_KEY);
-        const parsed = raw === null ? Number.NaN : Number(raw);
-        return Number.isFinite(parsed) ? parsed : null;
-      },
-      writeLastReloadAt: (at) => {
-        window.sessionStorage.setItem(RELOAD_MARKER_KEY, String(at));
-      },
-    });
-    controllerRef.current = controller;
-
-    const onError = (event: ErrorEvent) => controller.report(event.error ?? event.message);
-    const onRejection = (event: PromiseRejectionEvent) => controller.report(event.reason);
-    window.addEventListener("error", onError);
-    window.addEventListener("unhandledrejection", onRejection);
-
-    // The passive listeners above only fire when the app happens to reach for
-    // the server, so poll as well: a window left idle must still notice.
-    const heartbeat = window.setInterval(() => {
-      if (document.hidden) return;
-      void probeOrigin().then((reachable) => {
-        if (!reachable) controller.observeOriginLost();
-      });
-    }, HEARTBEAT_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(heartbeat);
-      window.removeEventListener("error", onError);
-      window.removeEventListener("unhandledrejection", onRejection);
-      controller.stop();
-      controllerRef.current = null;
-    };
-  }, []);
-
-  const retry = useCallback(() => {
-    controllerRef.current?.retry();
-    setReloadBlocked(false);
-  }, []);
-
-  if (state === "healthy") return null;
-  const reloading = state === "reloading";
-  const body = reloading
-    ? "The dev server answered. Reloading to pick up the new build."
-    : reloadBlocked
-      ? "Reloading did not clear the failure, so Cave stopped retrying. Restart the dev server, then reconnect."
-      : "The dev server stopped answering. Cave will reconnect on its own as soon as it comes back.";
-
-  return (
-    <div className="dev-shell-recovery" role="alert" aria-live="assertive">
-      <div className="dev-shell-recovery__card">
-        <h2 className="dev-shell-recovery__title">Dev server unreachable</h2>
-        <p className="dev-shell-recovery__body">{body}</p>
-        <p className="dev-shell-recovery__origin">{typeof window === "undefined" ? "" : window.location.origin}</p>
-        {!reloading ? (
-          <div className="dev-shell-recovery__actions">
-            <button type="button" className="dev-shell-recovery__button focus-ring" onClick={retry}>
-              Reconnect
-            </button>
-          </div>
-        ) : null}
-        <p className="dev-shell-recovery__status">
-          <span className="dev-shell-recovery__pulse" aria-hidden="true" />
-          {state === "checking" ? "Checking the dev server…" : null}
-          {state === "unreachable" && !reloadBlocked ? "Waiting for the dev server…" : null}
-          {state === "unreachable" && reloadBlocked ? "Paused after a failed reload." : null}
-          {reloading ? "Reloading…" : null}
-        </p>
-      </div>
-    </div>
-  );
 }

--- a/src/components/familiar-tab-analytics.test.ts
+++ b/src/components/familiar-tab-analytics.test.ts
@@ -101,10 +101,33 @@ test("charts derive from real model fields with honest empty state", () => {
     /activityHeatmapWindowDays\([\s\S]{0,160}?session\.created_at/,
     "heatmap range matures from the familiar's first real session",
   );
+  // This used to pin the exact one-line call
+  // `heatmapFromSessions(recentSessions, Date.parse(updatedAt ?? ""))`, which
+  // is the argument-list shape docs/source-text-pins.md calls out as not fair
+  // game — and it duly broke on a fix rather than a regression. #4791 kept the
+  // same contract and closed a real hole in it: `Date.parse("")` is NaN, so a
+  // familiar with no updatedAt bucketed its whole history against NaN. The
+  // derivation now falls back to the wall clock. Pin the contract instead: the
+  // window is anchored on the model's refresh instant, the buckets come from
+  // the real session rows, and no familiar is ever measured against NaN.
+  const heatStart = src.indexOf("const heat = useMemo(");
+  const heatEnd = src.indexOf("const bars = useMemo(");
+  assert.ok(heatStart >= 0 && heatEnd > heatStart, "the heatmap is derived in AnalyticsBody");
+  const heatDerivation = src.slice(heatStart, heatEnd);
   assert.match(
-    src,
-    /heatmapFromSessions\(recentSessions, Date\.parse\(updatedAt \?\? ""\)\)/,
-    "heatmap buckets real created_at timestamps against the current refresh",
+    heatDerivation,
+    /heatmapFromSessions\(recentSessions,/,
+    "heatmap buckets real created_at timestamps from the live session rows",
+  );
+  assert.match(
+    heatDerivation,
+    /Date\.parse\(updatedAt \?\? ""\)/,
+    "…anchored on the model's own refresh instant",
+  );
+  assert.match(
+    heatDerivation,
+    /Date\.now\(\)/,
+    "…falling back to the wall clock, so an absent updatedAt never buckets against NaN",
   );
   assert.match(
     src,

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -55,7 +55,32 @@ assert.match(css, /\.menu-bar__search \{[\s\S]*?border:\s*1px solid var\(--borde
 assert.match(css, /\.shell-top-history \{/, "history Back/Forward pair has its grouping styles");
 assert.match(css, /\.menu-bar__task-label \{\s*\n\s*display:\s*none/, "task labels are CSS-demoted — the bar shows icons only");
 assert.match(css, /\.menu-bar__task-label--live \{\s*\n\s*display:\s*inline/, "…except live enrich progress, which is information, not chrome");
-assert.match(css, /:root\[data-tauri-titlebar\] \.shell-window-titlebar \{[\s\S]{0,300}?flex: 0 0 30px/, "native macOS renders a dedicated 30px window title strip");
+// The strip was a hard-coded 30px until the desktop chrome refresh (#4791)
+// grew it to 34px so it lines up with the functional toolbar it now shares a
+// row with, and moved the number into --shell-native-titlebar-height so the
+// rail offsets, panel padding and .shell-top height all derive from one value
+// instead of repeating a literal. Pinning "30px" pinned the literal, not the
+// promise; the promise is that native macOS still reserves a dedicated strip of
+// fixed height, sized from that token.
+const nativeTitleStripRule = css.match(
+  /^:root\[data-tauri-titlebar\] \.shell-window-titlebar \{[^}]*\}/m,
+)?.[0];
+assert.ok(nativeTitleStripRule, "native macOS has a dedicated window title strip rule");
+assert.match(
+  nativeTitleStripRule,
+  /flex: 0 0 var\(--shell-native-titlebar-height\);/,
+  "the native window title strip is a fixed band sized from --shell-native-titlebar-height",
+);
+assert.match(
+  nativeTitleStripRule,
+  /min-height: var\(--shell-native-titlebar-height\);/,
+  "…and cannot be squeezed below that height",
+);
+assert.match(
+  css,
+  /^:root\[data-tauri-titlebar\] \{[^}]*--shell-native-titlebar-height:\s*\d+px;/m,
+  "--shell-native-titlebar-height resolves to a concrete height under the native titlebar",
+);
 assert.match(css, /:root\[data-tauri-titlebar\] \.shell-top \{[\s\S]{0,300}?min-height: 34px/, "the functional toolbar keeps its compact 34px row below the title strip");
 assert.match(
   css,

--- a/src/components/shell-chrome-revamp.test.ts
+++ b/src/components/shell-chrome-revamp.test.ts
@@ -123,10 +123,32 @@ assert.match(
   /\.shell-top:has\(\.notification-bell__popover\) \{[^}]*z-index: 140;/,
   "an open notification dropdown lifts its title-bar stacking context above shell content",
 );
+// The identity strip used to sit ABOVE the functional toolbar, separated from
+// it by a horizontal hairline. The desktop chrome refresh (#4791) made them one
+// row: the resizable rail owns the window's top-left corner, including the
+// native traffic-light area, and workspace chrome begins at the rail's live
+// edge. So the boundary turned vertical and both `border-bottom` declarations
+// went to 0 — the strip has nothing below it to divide from any more.
+// The guarantee is unchanged and re-pointed at where it now lives: native
+// chrome does not run into workspace chrome, it is divided by a quiet hairline
+// built from the design tokens.
+const nativeTitleRailRule = desktopChrome.match(
+  /:root\[data-tauri-titlebar\] \.shell-window-titlebar__rail \{[^}]*\}/,
+)?.[0];
+assert.ok(nativeTitleRailRule, "the native title strip has a rail region");
 assert.match(
-  desktopChrome,
-  /:root\[data-tauri-titlebar\] \.shell-window-titlebar \{[\s\S]{0,500}?border-bottom: 1px solid color-mix/,
-  "native macOS separates the centered identity strip from the functional toolbar with a quiet hairline",
+  nativeTitleRailRule,
+  /border-right: 1px solid var\(--border-hairline\);/,
+  "native macOS divides the title-strip rail from the workspace chrome beside it with a quiet hairline",
+);
+const nativeNavPanelRule = desktopChrome.match(
+  /:root\[data-tauri-titlebar\] \.shell-nav-panel \{[^}]*\}/,
+)?.[0];
+assert.ok(nativeNavPanelRule, "the native layout styles the nav panel below the strip");
+assert.match(
+  nativeNavPanelRule,
+  /box-shadow: inset -1px 0 0 var\(--border-hairline\);/,
+  "that same hairline continues down the nav panel, so the divide is one unbroken line",
 );
 
 // ── 3. Bottom status bar ─────────────────────────────────────────────────────

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -73,9 +73,23 @@ assert.equal(
   1,
   "the hydration-stable top-bar wrapper should remain draggable when its empty chrome is clicked",
 );
+// #4791 replaced the drag-lane pin below with one asserting a
+// `.shell-window-titlebar__controls` group holding `{navToggle}` and
+// `{historyNav}` — shell.tsx's own vocabulary — but shell.tsx was not touched
+// by that commit, or by anything since, so the assertion described markup that
+// has never existed in this file. The grouping is real; it lives on the
+// standalone destination shells, where the connected rail puts its boundary
+// controls inside the native strip. Both guarantees are kept below, each
+// against the file that actually makes the promise, so neither the drag lane
+// nor the grouping loses its cover.
 assert.match(
   shell,
-  /<div className="shell-window-titlebar__controls">[\s\S]*?\{navToggle\}[\s\S]*?\{historyNav\}[\s\S]*?<\/div>/,
+  /<div className="shell-titlebar-drag-lane" data-tauri-drag-region="deep" aria-hidden="true" \/>\s*\{navToggle\}/,
+  "the desktop top bar exposes a dedicated non-interactive drag lane before its controls",
+);
+assert.match(
+  analyticsShell,
+  /<div className="shell-window-titlebar__controls">[\s\S]*?onClick=\{handleToggleNav\}[\s\S]*?<DesktopHistoryNav \/>[\s\S]*?<\/div>/,
   "the native title strip groups its interactive boundary controls",
 );
 assert.match(

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -18,6 +18,7 @@ import { OpenCovenToolsBannerTrigger } from "@/components/open-coven-tools-updat
 import { CaveHomeMigrationBannerTrigger } from "@/components/cave-home-migration-banner";
 import { DesktopHistoryNav } from "@/components/desktop-history-nav";
 import { useIsMobile } from "@/lib/use-viewport";
+import { useMacTrafficLightsForNavState } from "@/lib/use-mac-traffic-lights";
 import { MobileDrawer, type MobileDrawerSlot } from "@/components/mobile-drawer";
 import { DetailSplitHost, type DetailSplitTile } from "@/components/detail-split-host";
 import {
@@ -627,6 +628,17 @@ function ShellInner({
   // change, not on every sidebar toggle).
   const navOpenRef = useRef(navOpen);
   navOpenRef.current = navOpen;
+  // The native macOS traffic lights float inside the connected rail's title
+  // strip, so they follow the rail rather than the window: visible while the
+  // navigation is expanded, and on mobile where the rail IS the navigation;
+  // hidden once it collapses to the 56px icon rail, which is narrower than the
+  // 78px inset they need. desktop-chrome.css reads the resulting
+  // [data-traffic-lights] state to drop that inset and hide the centered title.
+  // The hook is inert off the macOS desktop shell. The destination shells
+  // (analytics-page-shell) already do this; the workspace shell is the surface
+  // the connected rail was built for.
+  const trafficLightsVisible = isMobile || navOpen;
+  useMacTrafficLightsForNavState(trafficLightsVisible);
   const defaultNavSize =
     chatContextual || mounted ? `${NAV_OPEN_PX}px` : `${NAV_RAIL_PX}px`;
 
@@ -1387,8 +1399,13 @@ function ShellInner({
         title={`${rightChatOpen ? "Close" : "Open"} Chat panel (${rightPanelShortcutLabel})`}
         onClick={toggleRightChat}
       >
+        {/* The two panel toggles are the same control on opposite edges, so
+            they read as a pair: the same sidebar glyph, mirrored, rather than a
+            second chat bubble that says nothing about what the button does.
+            .shell-top-toggle__icon--mirrored is the flip. */}
         <Icon
-          name={rightChatOpen ? "ph:chat-circle-dots-fill" : "ph:chat-circle-dots"}
+          name={rightChatOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"}
+          className="shell-top-toggle__icon--mirrored"
           width={CAVE_ICON_SIZE.shellToggle}
           height={CAVE_ICON_SIZE.shellToggle}
         />

--- a/src/components/workspace-context-switcher.test.ts
+++ b/src/components/workspace-context-switcher.test.ts
@@ -41,11 +41,37 @@ assert.ok(projectIndex < familiarIndex, "project picker renders before familiar 
 // ── No raw 10px gaps — spacing must use tokens ──────────────────────────────
 assert.doesNotMatch(css, /\bgap:\s*10px\b/, "CSS gap uses spacing tokens, not raw 10px");
 
-// ── Crew border is exactly the plan recipe ───────────────────────────────────
+// ── Crew trigger: quiet 1px hairline at rest, presence accent on hover ───────
+// The recipe moved in the desktop chrome refresh (#4791): the resting border is
+// now the plain --border-hairline token over --bg-subtle, and --accent-presence
+// marks the control on hover instead of tinting it permanently. That direction
+// is the design language's ("the accent is presence first... never for
+// secondary buttons, links, or decorative colour"), so the contract — not the
+// old color-mix spelling — is what this pin guards: a 1px border whose colour
+// comes from the hairline token, and the presence accent still identifying the
+// familiar control on interaction. Scoped to the crew rule so a hairline border
+// elsewhere in the sheet cannot satisfy it.
+const crewTriggerRule = css.match(
+  /^\.workspace-context-switcher__crew \.familiar-switcher__trigger--labeled \{[\s\S]*?\n\}/m,
+)?.[0];
+assert.ok(crewTriggerRule, "crew trigger rule is present");
+const crewBorder = crewTriggerRule.match(/\n\s*border:\s*([^;]+);/)?.[1];
+assert.ok(crewBorder, "crew trigger declares a border");
+assert.match(crewBorder, /^1px solid\b/, "crew trigger border is exactly 1px solid");
 assert.match(
-  css,
-  /border: 1px solid color-mix\(in oklch, var\(--accent-presence\) 38%, var\(--border-hairline\)\)/,
-  "crew trigger border uses exact 1px color-mix recipe",
+  crewBorder,
+  /var\(--border-hairline\)/,
+  "crew trigger border colour comes from the --border-hairline token",
+);
+
+const crewHoverRule = css.match(
+  /^\.workspace-context-switcher__crew \.familiar-switcher__trigger--labeled:hover \{[\s\S]*?\n\}/m,
+)?.[0];
+assert.ok(crewHoverRule, "crew trigger hover rule is present");
+assert.match(
+  crewHoverRule,
+  /var\(--accent-presence\)/,
+  "the presence accent marks the crew trigger on hover",
 );
 
 // ── Collapsed caret selector targets the stable class, not a generated icon class ──

--- a/src/lib/design-token-drift.test.ts
+++ b/src/lib/design-token-drift.test.ts
@@ -75,7 +75,19 @@ const BASELINES = {
 };
 
 // Product recovery banks the consolidated rail, analytics, profile, memory, and chat spacing cleanup.
-BASELINES.offScaleSpacingPx = 1607;
+// +1: the desktop chrome refresh (#4791) — `padding: 0 1px` on
+// .code-terminal-carousel__index in surface-code-room.css. The index is a
+// --text-2xs mono digit in a pill pinned to the bottom-right corner of a
+// terminal carousel tile, --space-3 wide and --space-3 tall; --space-1 (4px)
+// of inline padding would more than double it and turn a corner marker into a
+// lozenge sitting over the tile's content. Same 1/2px micro-mark family the
+// Chart Room, Weaves, Review Deck, GitHub-composer and live-transcript
+// handoffs banked above. It is the ONLY off-scale spacing value that whole
+// commit added — measured file by file against dec4f93f9^, everything else it
+// wrote to desktop-chrome.css, surface-code-room.css and
+// workspace-context-switcher.css is on --space-1..-6 or a named token — and
+// tokenize-css.mjs is a no-op over all three, so tier 1 stays clean.
+BASELINES.offScaleSpacingPx = 1608;
 BASELINES.inlineTsxStyles = 280;
 
 // ── unit sanity for the codemod transform ───────────────────────────────────

--- a/src/styles/chat-list.css
+++ b/src/styles/chat-list.css
@@ -123,7 +123,7 @@
   align-items: center;
   gap: var(--space-1);
   height: 26px;
-  padding: 0 var(--space-1);
+  padding: 0 var(--space-2);
   border: 1px solid transparent;
   border-radius: var(--radius-control);
   background: transparent;

--- a/src/styles/chat-list.css
+++ b/src/styles/chat-list.css
@@ -123,7 +123,7 @@
   align-items: center;
   gap: var(--space-1);
   height: 26px;
-  padding: 0 var(--space-2);
+  padding: 0 var(--space-1);
   border: 1px solid transparent;
   border-radius: var(--radius-control);
   background: transparent;

--- a/tests/chat-sessions-surface.spec.ts
+++ b/tests/chat-sessions-surface.spec.ts
@@ -137,7 +137,11 @@ test.describe("sessions list", () => {
     expect(searchBox!.width).toBeLessThanOrEqual(260);
     expect(Math.abs(searchBox!.y - allBox!.y)).toBeLessThanOrEqual(4);
     expect(Math.abs(searchBox!.y - sortBox!.y)).toBeLessThanOrEqual(4);
-    await expect(page.getByRole("button", { name: "Session view options" })).toBeVisible();
+    const viewOptions = page.getByRole("button", { name: "Session view options" });
+    await expect(viewOptions).toBeVisible();
+    await viewOptions.click();
+    await expect(page.getByRole("menuitemradio", { name: /^Tasks \(\d+\)$/ })).toBeVisible();
+    await expect(page.getByRole("menuitemradio", { name: /^GitHub \(\d+\)$/ })).toBeVisible();
   });
 
   test("clear filters appears for any applied filter and restores familiar scope", async ({ page }) => {


### PR DESCRIPTION
`main` has been red since `dec4f93f9` (#4791, "Refresh desktop chrome and activity UX"), and every open PR inherits it through the `pull_request` merge ref.

**There were seven failures, not two.** The app runner stops at the first failing file, so each one hid the next — the cascade `docs/source-text-pins.md` documents ("a brittle pin does not just fail, it hides every real failure behind it"). They surfaced one at a time, over five CI rounds. One commit per theme.

Five are stale pins where the production change was correct. One is production code #4791 never landed. One is a real layout regression from `d272ed0b1`.

## 1. Crew trigger border — `workspace-context-switcher.test.ts`

The refresh quieted the crew trigger: the resting border moved from `color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline))` to the plain `--border-hairline` token over `--bg-subtle`, leaving `--accent-presence` to mark it on hover.

Intent, not drift — and the proof is inside the same commit: it **already re-pointed the twin pin** in `sidebar-rail-header.test.ts`, retitling it "quiet rail chrome" and asserting the selector uses a quiet hairline *"instead of a heavy accent outline"*. It simply missed this duplicate. `docs/coven-design-language.md` agrees: the accent is presence first, "never for secondary buttons, links, or decorative colour".

Re-pointed at the contract rather than deleted — 1px solid, colour resolving through `--border-hairline`, presence accent still identifying the control on hover — and scoped to the crew rule so a hairline border elsewhere in the sheet cannot satisfy it vacuously.

## 2. `bundle-budget: root-layout CSS 616 KB exceeds budget 615 KB`

661 bytes over. Bumping the number is only half right.

**What was accidental, and is now fixed.** `dev-shell-recovery.css` shipped to every production page load. `DevShellRecovery` returns `null` under `NODE_ENV !== "development"` so the component compiles away — but a *static* CSS import is attributed to the root layout's stylesheet set regardless of what the component does at runtime. Production users downloaded 1,864 bytes of an overlay that can never render. The overlay now loads through `next/dynamic`, so the stylesheet follows it into a lazy chunk the production branch never requests. Measured: **630,421 → 628,557 B**.

**What was genuine growth.** The rest is always-loaded shell chrome, not a #3264 mis-scoping. Facade source bytes went 449,195 (`dd93af6b1`, where 615 was set) → 465,310 (`8aaaf2f21`): +11.7 KiB from #4758's `.split-host__*` focus-mode and carousel rules plus the rail scope controls moving into their own sheet, +3.2 KiB from #4791's connected-rail titlebar. All globally mounted, all already tokenized, `codemod:design:check` a no-op over it.

**Why the ceiling still moves.** The reclaim alone clears the gate by 1,203 bytes — 0.19% headroom, green today and failing for whoever pushes the next stylesheet. That is the `cave-iktbc` stopgap exactly, and the tool itself prints `⚠ THIN` at that number. 640 KiB is derived from measured growth rather than the 2% line (per `cave-yizcb`): **1.67 KiB/day** over the last 16 days, **2.8 KiB/day** over the last 5. It leaves 26.2 KiB (4.1%) — about 15 days at the slower rate, 9 at the faster. The measurements and the remaining #3264 reclaim candidates are recorded above the constant, with the previous raises.

## 3. Sessions filter pins — `chat-list-filter-defaults.test.ts`

`d272ed0b1` added a conversation-kind filter and wired it correctly on both sides of the contract these pins describe — `clearSessionFilters` resets it, `hasAppliedFilters` counts it. The pins were not updated with it. Production is right; the pins were stale by omission.

The same repair is open as #4796 by @BunsDev; the regexes here are byte-identical to that PR's, so whichever lands second merges without a conflict. #4796 cannot go green on its own — it does not carry the bundle-budget fix.

## 4. Four more pins the refresh left behind

- **shell-chrome-revamp** — the identity strip used to sit *above* the toolbar, divided by a horizontal hairline. #4791 made them one row: the rail owns the window's top-left corner and workspace chrome begins at its live edge, so both `border-bottom` declarations went to 0 and the divide turned vertical. The pin follows it to the rail's `border-right` and the nav panel's inset shadow, so "native chrome does not run into workspace chrome" is still asserted, where it is now true.
- **menu-bar-icon-size** — the strip was a hard-coded 30px; #4791 grew it to 34px to line up with the toolbar it shares a row with and moved the number into `--shell-native-titlebar-height`, so rail offsets, panel padding and `.shell-top` height all derive from one value. Pinning "30px" pinned the literal; the promise — a dedicated strip of fixed height sized from that token — is what is pinned now.
- **design-token-drift** — the +1 is real and sanctioned: `padding: 0 1px` on `.code-terminal-carousel__index`, a `--text-2xs` mono digit in a `--space-3` pill in a tile corner, where `--space-1` would more than double it. Measured file by file against `dec4f93f9^`, it is the **only** off-scale spacing value that whole commit added. Baseline 1607 → 1608 with that reason recorded beside the others.
- **familiar-tab-analytics** — the pin held an exact argument list, which the doc names as not fair game, and it broke on a *fix*: `Date.parse("")` is NaN, so a familiar with no `updatedAt` bucketed its entire history against NaN, and #4791 added a wall-clock fallback. The contract is pinned instead — real session rows, anchored on the model's refresh instant, never measured against NaN — which now covers the hole as well as the original claim.

## 5. The workspace half #4791 never landed — `shell-edge-rails.test.ts`

`shell.tsx` was not touched by that commit, or by anything since. So three assertions described markup and wiring that has never existed here, the `.shell-top-toggle__icon--mirrored` rule it added styled nothing, and `useMacTrafficLightsForNavState` had exactly one caller — the destination shells — while the workspace shell the rail was built for had none.

Two of the three are completed rather than un-asserted, because the CSS, the Rust command and the hook are already on `main` and state the intent unambiguously:

- The right panel toggle now mirrors the left sidebar control instead of showing a second chat bubble. The two toggles are the same control on opposite edges and should read as a pair; `--mirrored` is the flip the refresh already added and left dead. Only the glyph changes — the accessible name the e2e specs drive is untouched.
- The workspace shell adopts the traffic-light nav-state hook. The native lights float inside the rail's title strip, so they follow the rail: visible while navigation is expanded and on mobile, hidden once it collapses to the 56px icon rail, which is narrower than the 78px inset they need. `desktop-chrome.css` already reads the resulting `[data-traffic-lights]` state to drop that inset and hide the centered title, and `analytics-page-shell` already does this. The hook is inert off the macOS desktop shell.

The third was a copy-paste slip, not missing work: the pin for a `.shell-window-titlebar__controls` group holding `{navToggle}` and `{historyNav}` was written against `shell.tsx`, but that grouping belongs to `analytics-page-shell`, and the assertion it *replaced* — a dedicated non-interactive drag lane before the controls — still describes `shell.tsx` correctly today. Both guarantees are asserted now, each against the file that makes the promise.

Separately, the same commit added an unguarded health-probe interval to `bottom-terminal.tsx`, which `pausable-poll-discipline.test.ts` fails on. It already skipped while the pane was hidden; it now also skips while the window is. A backgrounded window has nobody to tell that the shell died, and the next tick after it returns re-probes anyway. Guarding it is the honest fix; adding the file to the allowlist was the other one.

## 6. The sessions toolbar wraps — `tests/chat-sessions-surface.spec.ts`

`d272ed0b1` again: a divider plus the Tasks and GitHub work-kind chips joined a toolbar whose own comment promises "search, counted status filters, and the named sort on one line", and the sort control wrapped to a second row. It failed on the initial run and the retry, so it is a regression rather than a flake.

Measured at the desktop preset (1280x720): the toolbar's inner width is 990px and the row wanted 1104 — search 250, status chips 466, divider 1, kind chips 160, overflow 24, sort 155, plus 48 of gaps. `flex-wrap` decides line breaks from each item's *hypothetical* size, so flex-shrink and `min-width` cannot influence it; 114px had to actually go.

My first attempt bought that back by shrinking the row (search 190px, chips on `--space-1`). It fit locally with 10px to spare and **still wrapped on CI**, because 10px was never a margin — it was a coincidence of the renderer the measurement was taken on.

@BunsDev landed the better answer directly onto this branch (`2b542c97b`, `594c11108`): the work-kind filters move into the toolbar's overflow menu, and the search becomes `flex-1` with a 160–250px band. That is what the toolbar's own comment already prescribed — *"secondary view controls stay available through one overflow menu instead of widening the primary reading path"* — and it removes the pressure at the source instead of budgeting against it. Both of my size reductions were reverted as unnecessary, and the e2e spec was *strengthened* rather than relaxed: it now opens the menu and asserts both kind options are reachable with their counts.

Verified locally on the merged head: `chat-sessions-surface` and `mobile/command-center-pages`, 12 passed.

## Verification

Every repaired pin was **mutation-checked** per `docs/source-text-pins.md` — the guarantee was broken in the source, the pin had to fail with its own message, then restored and pass. For the crew border that is five separate mutations, each firing a distinct assertion.

Local: `tsc --noEmit` clean, `pnpm lint` clean (`tokenize-tsx-design --check`: 0 files with drift), `pnpm build` clean, `node scripts/bundle-budget.mjs` green with 4.1% root headroom, `node --test scripts/bundle-budget.test.mjs` green, `check:tests-wired` green, and `playwright test tests/chat-sessions-surface.spec.ts tests/mobile/command-center-pages.spec.ts` — 12 passed.

## Overlap with other open PRs, stated plainly

#4798 was opened after this one and repairs failures 1 and 2 differently — a looser re-point of the crew pin, a 615→630 raise without the `dev-shell-recovery.css` reclaim, and some CSS selector coalescing this branch does not touch. Those hunks genuinely conflict with these. Choosing between them is the owner's call; #4798 has not been touched.

## Unrelated observation, not touched here

`scripts/check-conflict-markers.mjs` guards its entry point by comparing `import.meta.url` against `"file://" + process.argv[1]`, which never matches on Windows (`file:///C:/...` vs `C:\...`), so the CLI silently exits 0 there and its test fails locally on Windows only. The file is byte-identical to `origin/main` and unaffected by this branch; Linux CI is unaffected.
