### PR TITLE
fix: restore frontend validation and conversation contracts

### DIFF
--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -176,7 +176,13 @@ const MAX_CHUNK_BYTES = (Number(process.env.BUNDLE_MAX_CHUNK_KB) || 2400) * 1024
 // documented convention above, 615 is the smallest ceiling that clears the 2%
 // THIN threshold here (13.2 KiB / 2.1% headroom) for this one-time addition;
 // this is a ceiling for this feature's CSS, not a licence for the next one.
-const MAX_ROOT_CSS_BYTES = (Number(process.env.BUNDLE_MAX_ROOT_CSS_KB) || 615) * 1024;
+// RAISED root 615→630 (2026-08-21, cave-x4kt4): #4791 added the globally
+// mounted desktop terminal focus carousel and refreshed shell context controls;
+// d272ed0 added the chat/sidebar PR-state badge variants. After coalescing the
+// duplicate draft/unknown selectors, the measured root payload is 630,447 B,
+// 687 B above the old ceiling. 630 KiB is the smallest rounded ceiling that
+// restores the documented 2% headroom (14.7 KiB / 2.3%).
+const MAX_ROOT_CSS_BYTES = (Number(process.env.BUNDLE_MAX_ROOT_CSS_KB) || 630) * 1024;
 const MAX_HOME_CSS_BYTES = (Number(process.env.BUNDLE_MAX_HOME_CSS_KB) || 940) * 1024;
 
 if (!existsSync(chunksDir)) {

--- a/src/components/bottom-terminal-health.test.ts
+++ b/src/components/bottom-terminal-health.test.ts
@@ -22,8 +22,13 @@ assert.match(
 );
 assert.match(
   terminal,
-  /setInterval\([\s\S]*?bridge\.invoke<string\[]>\("pty_list"\)[\s\S]*?DESKTOP_HEALTH_INTERVAL_MS/,
-  "a visible desktop terminal continuously verifies that its PTY remains registered",
+  /usePausablePoll\([\s\S]*?desktopHealthProbeRef\.current\?\.\(\)[\s\S]*?DESKTOP_HEALTH_INTERVAL_MS[\s\S]*?enabled: platform === "desktop" && ready && visible/,
+  "a visible desktop terminal verifies its PTY through the shared visibility-aware poll",
+);
+assert.doesNotMatch(
+  terminal,
+  /setInterval\(/,
+  "terminal health must not poll while the app is hidden",
 );
 assert.match(
   terminal,

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -7,6 +7,7 @@ import type React from "react";
 import { useTauriPlatform } from "@/lib/tauri-platform";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
 import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { TerminalKeyBar } from "@/components/terminal-key-bar";
 import { PtyWsBridge } from "@/lib/pty-ws-bridge";
 import { Icon } from "@/lib/icon";
@@ -406,6 +407,12 @@ export function BottomTerminal({
   // a visible-but-unfocused split pane must keep announcing output.
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
+  const desktopHealthProbeRef = useRef<(() => Promise<void>) | null>(null);
+  usePausablePoll(
+    () => desktopHealthProbeRef.current?.(),
+    DESKTOP_HEALTH_INTERVAL_MS,
+    { enabled: platform === "desktop" && ready && visible },
+  );
 
   const flushMirror = useCallback(() => {
     flushTimerRef.current = null;
@@ -519,7 +526,6 @@ export function BottomTerminal({
 
     let disposed = false;
     let cleanup: (() => void) | null = null;
-    let healthTimer: ReturnType<typeof setInterval> | null = null;
 
     void (async () => {
      try {
@@ -654,15 +660,9 @@ export function BottomTerminal({
       } else {
         log("pty_start: skipped, already in pty_list");
       }
-      if (!disposed) {
-        setReady(true);
-        setHealth("healthy");
-      }
-      term.focus();
-
-      healthTimer = setInterval(() => {
+      const healthProbe = async () => {
         if (disposed || stopped || !visibleRef.current) return;
-        void bridge.invoke<string[]>("pty_list").then((sessions) => {
+        await bridge.invoke<string[]>("pty_list").then((sessions) => {
           if (disposed || stopped || sessions.includes(threadId)) return;
           sendToPtyRef.current = null;
           setReady(false);
@@ -670,7 +670,13 @@ export function BottomTerminal({
           setStartError("The shell process stopped responding. Retry to start a fresh attachment.");
           srAnnounce("Terminal shell stopped responding", "assertive");
         }).catch((error) => log("pty health check FAILED", error));
-      }, DESKTOP_HEALTH_INTERVAL_MS);
+      };
+      desktopHealthProbeRef.current = healthProbe;
+      if (!disposed) {
+        setReady(true);
+        setHealth("healthy");
+      }
+      term.focus();
 
       const resizer = makeResizer(term, fit, () => visibleRef.current, (cols, rows) => {
         void bridge.invoke("pty_resize", {
@@ -705,9 +711,8 @@ export function BottomTerminal({
         pendingMirrorRef.current = "";
         termRef.current = null;
         term.dispose();
-        if (healthTimer) {
-          clearInterval(healthTimer);
-          healthTimer = null;
+        if (desktopHealthProbeRef.current === healthProbe) {
+          desktopHealthProbeRef.current = null;
         }
         // Deliberately NO pty_stop here. Unmount is usually a tab switch
         // (keepalive reparenting), and the fire-and-forget stop raced the

--- a/src/components/chat-list-filter-defaults.test.ts
+++ b/src/components/chat-list-filter-defaults.test.ts
@@ -15,7 +15,7 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /const clearSessionFilters = useCallback\(\(\) => \{\s*setSearch\(""\);\s*setStatusFilter\("all"\);\s*onSelectionChange\("all"\);\s*setShowArchived\(false\);\s*\}, \[onSelectionChange\]\);/,
+  /const clearSessionFilters = useCallback\(\(\) => \{\s*setSearch\(""\);\s*setStatusFilter\("all"\);\s*setKindFilter\("all"\);\s*onSelectionChange\("all"\);\s*setShowArchived\(false\);\s*\}, \[onSelectionChange\]\);/,
   "One reset should clear every non-familiar Sessions filter",
 );
 assert.match(
@@ -25,8 +25,8 @@ assert.match(
 );
 assert.match(
   source,
-  /const hasAppliedFilters =\s*search\.trim\(\)\.length > 0 \|\|\s*statusFilter !== "all" \|\|\s*effectiveSelection !== "all" \|\|\s*showArchived;/,
-  "The clear action should track search, status, project, and archive filters without treating familiar scope as a filter",
+  /const hasAppliedFilters =\s*search\.trim\(\)\.length > 0 \|\|\s*statusFilter !== "all" \|\|\s*kindFilter !== "all" \|\|\s*effectiveSelection !== "all" \|\|\s*showArchived;/,
+  "The clear action should track search, status, kind, project, and archive filters without treating familiar scope as a filter",
 );
 assert.match(
   source,

--- a/src/components/chat-list-pr-badge.test.ts
+++ b/src/components/chat-list-pr-badge.test.ts
@@ -69,7 +69,7 @@ assert.match(
 );
 
 // ── Badge styling: GitHub's state colors ─────────────────────────────────────
-for (const state of ["merged", "closed", "draft"]) {
+for (const state of ["merged", "closed", "draft", "unknown"]) {
   assert.match(
     css,
     new RegExp(`\\.chat-list-pr-badge\\[data-pr-state="${state}"\\]`),

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -864,7 +864,9 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
           <label
             className={[
               "chat-list-search-control flex h-8 min-w-0 items-center gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/60 px-2.5 transition-colors focus-within:border-[var(--accent-presence)]/50 focus-within:bg-[var(--bg-raised)]",
-              compact ? "max-w-[520px] flex-1" : "w-full max-w-[250px] min-[900px]:w-[250px]",
+              compact
+                ? "max-w-[520px] flex-1"
+                : "w-full max-w-[190px] min-[1440px]:w-[250px] min-[1440px]:max-w-[250px]",
             ].join(" ")}
           >
             <Icon name="ph:magnifying-glass" width={13} className="shrink-0 text-[var(--text-muted)]" />
@@ -931,32 +933,6 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
                       <span aria-hidden className="chat-status-chip__dot" />
                       {presentation.label}
                       <span className="chat-status-chip__count">{statusCounts[key]}</span>
-                    </button>
-                  );
-                })}
-              </span>
-              {/* Work-kind chips: exclusive toggles — "Tasks only" narrows to
-                  Board-task chats, "GitHub only" to chats wearing the PR
-                  badge. Pressing the active chip clears it back to all. */}
-              <span aria-hidden className="h-3.5 w-px shrink-0 bg-[var(--border-hairline)]" />
-              <span role="group" aria-label="Filter sessions by work kind" className="flex flex-wrap items-center gap-0.5">
-                {CHAT_SESSION_KIND_ORDER.map((key) => {
-                  const presentation = CHAT_SESSION_KIND[key];
-                  const active = kindFilter === key;
-                  return (
-                    <button
-                      key={key}
-                      type="button"
-                      aria-pressed={active}
-                      disabled={chatStatusChipDisabled(kindCounts[key], active)}
-                      onClick={() => setKindFilter(active ? "all" : key)}
-                      title={presentation.description}
-                      className="chat-status-chip focus-ring"
-                      data-kind={key}
-                    >
-                      <Icon name={presentation.icon} width={11} aria-hidden />
-                      {presentation.label}
-                      <span className="chat-status-chip__count">{kindCounts[key]}</span>
                     </button>
                   );
                 })}
@@ -1034,6 +1010,31 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
                 {CHAT_SESSION_SORT_LABEL[sessionSort]}
                 <Icon name="ph:caret-up-down" width={10} className="text-[var(--text-muted)]" aria-hidden />
               </button>
+              {/* Work-kind chips follow the core search/status/sort controls so
+                  they wrap together as a secondary filter row on laptop widths. */}
+              <span aria-hidden className="h-3.5 w-px shrink-0 bg-[var(--border-hairline)]" />
+              <span role="group" aria-label="Filter sessions by work kind" className="flex flex-wrap items-center gap-0.5">
+                {CHAT_SESSION_KIND_ORDER.map((key) => {
+                  const presentation = CHAT_SESSION_KIND[key];
+                  const active = kindFilter === key;
+                  return (
+                    <button
+                      key={key}
+                      type="button"
+                      aria-pressed={active}
+                      disabled={chatStatusChipDisabled(kindCounts[key], active)}
+                      onClick={() => setKindFilter(active ? "all" : key)}
+                      title={presentation.description}
+                      className="chat-status-chip focus-ring"
+                      data-kind={key}
+                    >
+                      <Icon name={presentation.icon} width={11} aria-hidden />
+                      {presentation.label}
+                      <span className="chat-status-chip__count">{kindCounts[key]}</span>
+                    </button>
+                  );
+                })}
+              </span>
               <Popover
                 open={sortOpen}
                 onOpenChange={setSortOpen}

--- a/src/components/familiar-tab-analytics.test.ts
+++ b/src/components/familiar-tab-analytics.test.ts
@@ -103,7 +103,7 @@ test("charts derive from real model fields with honest empty state", () => {
   );
   assert.match(
     src,
-    /heatmapFromSessions\(recentSessions, Date\.parse\(updatedAt \?\? ""\)\)/,
+    /const parsed = Date\.parse\(updatedAt \?\? ""\);[\s\S]{0,120}?const now = Number\.isFinite\(parsed\) \? parsed : Date\.now\(\);[\s\S]{0,100}?heatmapFromSessions\(recentSessions, now\)/,
     "heatmap buckets real created_at timestamps against the current refresh",
   );
   assert.match(

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -55,7 +55,11 @@ assert.match(css, /\.menu-bar__search \{[\s\S]*?border:\s*1px solid var\(--borde
 assert.match(css, /\.shell-top-history \{/, "history Back/Forward pair has its grouping styles");
 assert.match(css, /\.menu-bar__task-label \{\s*\n\s*display:\s*none/, "task labels are CSS-demoted — the bar shows icons only");
 assert.match(css, /\.menu-bar__task-label--live \{\s*\n\s*display:\s*inline/, "…except live enrich progress, which is information, not chrome");
-assert.match(css, /:root\[data-tauri-titlebar\] \.shell-window-titlebar \{[\s\S]{0,300}?flex: 0 0 30px/, "native macOS renders a dedicated 30px window title strip");
+assert.match(
+  css,
+  /:root\[data-tauri-titlebar\] \.shell-window-titlebar \{[\s\S]{0,300}?flex: 0 0 var\(--shell-native-titlebar-height\)/,
+  "native macOS renders the shared-height window title strip",
+);
 assert.match(css, /:root\[data-tauri-titlebar\] \.shell-top \{[\s\S]{0,300}?min-height: 34px/, "the functional toolbar keeps its compact 34px row below the title strip");
 assert.match(
   css,

--- a/src/components/shell-chrome-revamp.test.ts
+++ b/src/components/shell-chrome-revamp.test.ts
@@ -125,8 +125,8 @@ assert.match(
 );
 assert.match(
   desktopChrome,
-  /:root\[data-tauri-titlebar\] \.shell-window-titlebar \{[\s\S]{0,500}?border-bottom: 1px solid color-mix/,
-  "native macOS separates the centered identity strip from the functional toolbar with a quiet hairline",
+  /:root\[data-tauri-titlebar\] \.shell-window-titlebar__rail \{[\s\S]{0,700}?border-right: 1px solid var\(--border-hairline\)/,
+  "native macOS separates the connected identity rail from the functional toolbar with a quiet hairline",
 );
 
 // ── 3. Bottom status bar ─────────────────────────────────────────────────────

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -75,8 +75,8 @@ assert.equal(
 );
 assert.match(
   shell,
-  /<div className="shell-window-titlebar__controls">[\s\S]*?\{navToggle\}[\s\S]*?\{historyNav\}[\s\S]*?<\/div>/,
-  "the native title strip groups its interactive boundary controls",
+  /<div className="shell-titlebar-drag-lane" data-tauri-drag-region="deep" aria-hidden="true" \/>\s*\{navToggle\}[\s\S]*?\{historyNav\}/,
+  "the workspace toolbar keeps a dedicated drag lane before its boundary controls",
 );
 assert.match(
   shell,

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -17,6 +17,7 @@ import { UpdateBannerTrigger } from "@/components/update-available";
 import { OpenCovenToolsBannerTrigger } from "@/components/open-coven-tools-update";
 import { CaveHomeMigrationBannerTrigger } from "@/components/cave-home-migration-banner";
 import { DesktopHistoryNav } from "@/components/desktop-history-nav";
+import { useMacTrafficLightsForNavState } from "@/lib/use-mac-traffic-lights";
 import { useIsMobile } from "@/lib/use-viewport";
 import { MobileDrawer, type MobileDrawerSlot } from "@/components/mobile-drawer";
 import { DetailSplitHost, type DetailSplitTile } from "@/components/detail-split-host";
@@ -619,6 +620,8 @@ function ShellInner({
   // match the Cave's minimized default. The mounted layout effects restore a
   // remembered open panel before the first post-hydration paint.
   const [navOpen, setNavOpen] = useState(chatContextual);
+  const trafficLightsVisible = isMobile || navOpen;
+  useMacTrafficLightsForNavState(trafficLightsVisible);
   const [navChromeWidth, setNavChromeWidth] = useState(
     chatContextual ? NAV_OPEN_PX : NAV_RAIL_PX,
   );
@@ -1388,9 +1391,10 @@ function ShellInner({
         onClick={toggleRightChat}
       >
         <Icon
-          name={rightChatOpen ? "ph:chat-circle-dots-fill" : "ph:chat-circle-dots"}
+          name={rightChatOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"}
           width={CAVE_ICON_SIZE.shellToggle}
           height={CAVE_ICON_SIZE.shellToggle}
+          className="shell-top-toggle__icon--mirrored"
         />
       </button>
     ) : null

--- a/src/components/workspace-context-switcher.test.ts
+++ b/src/components/workspace-context-switcher.test.ts
@@ -41,11 +41,11 @@ assert.ok(projectIndex < familiarIndex, "project picker renders before familiar 
 // ── No raw 10px gaps — spacing must use tokens ──────────────────────────────
 assert.doesNotMatch(css, /\bgap:\s*10px\b/, "CSS gap uses spacing tokens, not raw 10px");
 
-// ── Crew border is exactly the plan recipe ───────────────────────────────────
+// ── Crew border uses the quiet rail chrome introduced by #4791 ───────────────
 assert.match(
   css,
-  /border: 1px solid color-mix\(in oklch, var\(--accent-presence\) 38%, var\(--border-hairline\)\)/,
-  "crew trigger border uses exact 1px color-mix recipe",
+  /border: 1px solid var\(--border-hairline\)/,
+  "crew trigger uses the standard hairline border",
 );
 
 // ── Collapsed caret selector targets the stable class, not a generated icon class ──

--- a/src/styles/globals/calendar-agenda.css
+++ b/src/styles/globals/calendar-agenda.css
@@ -58,9 +58,7 @@
 .chat-list-pr-badge[data-pr-state="closed"] {
   color: var(--color-danger);
 }
-.chat-list-pr-badge[data-pr-state="draft"] {
-  color: var(--text-muted);
-}
+.chat-list-pr-badge[data-pr-state="draft"],
 .chat-list-pr-badge[data-pr-state="unknown"] {
   color: var(--text-muted);
 }

--- a/src/styles/globals/shell-navigation.css
+++ b/src/styles/globals/shell-navigation.css
@@ -906,9 +906,7 @@
 .cnav__pr-badge[data-pr-state="closed"] {
   color: var(--color-danger);
 }
-.cnav__pr-badge[data-pr-state="draft"] {
-  color: var(--text-muted);
-}
+.cnav__pr-badge[data-pr-state="draft"],
 .cnav__pr-badge[data-pr-state="unknown"] {
   color: var(--text-muted);
 }

--- a/src/styles/globals/surface-code-room.css
+++ b/src/styles/globals/surface-code-room.css
@@ -228,7 +228,7 @@
   bottom: 0;
   right: 0;
   min-width: var(--space-3);
-  padding: 0 1px;
+  padding: 0;
   border-radius: var(--radius-pill);
   background: var(--bg-panel);
   color: var(--text-secondary);


### PR DESCRIPTION
## Summary
- restore the frontend design-token and bundle-budget gates regressed by #4791
- consolidate truthful conversation PR badge contracts, including neutral unknown status and kind-filter reset behavior
- align shell contracts and implementation for the connected native title rail, mirrored right-sidebar toggle, and macOS traffic-light visibility
- replace terminal PTY health polling with the shared visibility-aware polling hook
- align the analytics heatmap contract with its valid timestamp fallback

## Verification
- all 1,286 `pnpm test:app` files pass
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- root CSS: 616 KiB / 630 KiB (14.3 KiB, 2.3% headroom)
- standalone budget passes

Bead: `cave-x4kt4`
Supersedes #4796 by consolidating its conversation-filter contract fixes.
