### PR TITLE
Attach Research resources before the first pass

### DIFF
--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -591,15 +591,17 @@ export function ResearchMissionComposer({
         </div>
 
         {attachedLinks.length > 0 ? (
-          <div className="research-intake__attached" role="group" aria-label="Related context">
-            <span className="research-intake__attached-label">Related context ({attachedLinks.length}):</span>
+          <div className="research-intake__attached" role="group" aria-label="Resources ready for first pass">
+            <span className="research-intake__attached-label">
+              Resources ready for first pass ({attachedLinks.length}):
+            </span>
             {attachedLinks.map((link) => (
               <span key={link.id} className="research-intake__attached-chip">
                 {link.title}
                 <button
                   type="button"
                   className="research-intake__attached-remove"
-                  aria-label={`Remove ${link.title} from related context`}
+                  aria-label={`Remove ${link.title} from the first research pass`}
                   onClick={() => onRemoveAttached?.(link.id)}
                 >
                   ✕

--- a/src/components/role-surfaces/research-quick-saves.test.ts
+++ b/src/components/role-surfaces/research-quick-saves.test.ts
@@ -137,3 +137,15 @@ test("bulk selection drops saves that no longer exist in the current library", (
     allLinks,
   );
 });
+
+test("empty search results preserve selection while restoring canonical order", () => {
+  const links = [
+    link({ id: "a", title: "Alpha" }),
+    link({ id: "b", title: "Beta" }),
+  ];
+  const deleted = link({ id: "deleted", title: "Deleted" });
+  assert.deepEqual(
+    updateVisibleQuickSaveSelection(links, [links[1], deleted, links[0]], []),
+    links,
+  );
+});

--- a/src/components/role-surfaces/research-quick-saves.test.ts
+++ b/src/components/role-surfaces/research-quick-saves.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { draftTokens, matchReason, matchSavedLinks } from "./research-quick-saves";
+import {
+  draftTokens,
+  matchReason,
+  matchSavedLinks,
+  updateVisibleQuickSaveSelection,
+} from "./research-quick-saves";
 import type { SavedLink } from "@/lib/link-organizer";
 
 function link(patch: Partial<SavedLink> & Pick<SavedLink, "id" | "title">): SavedLink {
@@ -92,4 +97,43 @@ test("counts across groups always sum to the input", () => {
 
 test("no links means no groups at all", () => {
   assert.deepEqual(matchSavedLinks([], "rollback"), []);
+});
+
+test("selecting visible quick saves preserves hidden selections and canonical order", () => {
+  const links = [
+    link({ id: "a", title: "Alpha" }),
+    link({ id: "b", title: "Beta" }),
+    link({ id: "c", title: "Gamma" }),
+  ];
+  assert.deepEqual(
+    updateVisibleQuickSaveSelection(links, [links[2]], [links[0], links[1]]),
+    links,
+  );
+});
+
+test("clearing fully selected search results removes only visible saves", () => {
+  const links = [
+    link({ id: "a", title: "Alpha" }),
+    link({ id: "b", title: "Beta" }),
+    link({ id: "c", title: "Gamma" }),
+  ];
+  assert.deepEqual(
+    updateVisibleQuickSaveSelection(links, links, [links[0], links[1]]),
+    [links[2]],
+  );
+});
+
+test("bulk selection drops saves that no longer exist in the current library", () => {
+  const current = [
+    link({ id: "a", title: "Alpha" }),
+    link({ id: "deleted", title: "Deleted" }),
+  ];
+  const allLinks = [
+    link({ id: "a", title: "Alpha" }),
+    link({ id: "b", title: "Beta" }),
+  ];
+  assert.deepEqual(
+    updateVisibleQuickSaveSelection(allLinks, current, [allLinks[1]]),
+    allLinks,
+  );
 });

--- a/src/components/role-surfaces/research-quick-saves.ts
+++ b/src/components/role-surfaces/research-quick-saves.ts
@@ -145,7 +145,6 @@ export function updateVisibleQuickSaveSelection<TLink extends QuickSaveLink>(
   selected: readonly TLink[],
   visible: readonly TLink[],
 ): TLink[] {
-  if (visible.length === 0) return [...selected];
   const visibleIds = new Set(visible.map((link) => link.id));
   const selectedIds = new Set(selected.map((link) => link.id));
   const clearVisible = visible.every((link) => selectedIds.has(link.id));

--- a/src/components/role-surfaces/research-quick-saves.ts
+++ b/src/components/role-surfaces/research-quick-saves.ts
@@ -135,3 +135,24 @@ export function matchSavedLinks<TLink extends QuickSaveLink>(
 
   return groups;
 }
+
+/**
+ * Toggle every currently visible save while preserving selections hidden by
+ * the search. The returned array follows the canonical saved-link order.
+ */
+export function updateVisibleQuickSaveSelection<TLink extends QuickSaveLink>(
+  allLinks: readonly TLink[],
+  selected: readonly TLink[],
+  visible: readonly TLink[],
+): TLink[] {
+  if (visible.length === 0) return [...selected];
+  const visibleIds = new Set(visible.map((link) => link.id));
+  const selectedIds = new Set(selected.map((link) => link.id));
+  const clearVisible = visible.every((link) => selectedIds.has(link.id));
+  if (clearVisible) {
+    for (const id of visibleIds) selectedIds.delete(id);
+  } else {
+    for (const id of visibleIds) selectedIds.add(id);
+  }
+  return allLinks.filter((link) => selectedIds.has(link.id));
+}

--- a/src/components/role-surfaces/research-tab-prompt.test.ts
+++ b/src/components/role-surfaces/research-tab-prompt.test.ts
@@ -155,29 +155,18 @@ test("the enhance route contract matches what Improve sends", () => {
   assert.equal(bad.ok, false);
 });
 
-// ── Quick saves: attach state → candidate sources on the new mission ─────────
+// ── Quick saves: selected resources are part of the launch contract ──────────
 
-test("quick saves materialize saved Articles and attach ordinary sources via the ledger", () => {
+test("quick saves are included in mission creation before the run starts", () => {
   // Rows are real toggles; chips render with a remove affordance.
   assert.match(promptTab, /aria-pressed=\{isAttached\}/);
   assert.match(promptTab, /useResearchLinks\(\)/);
-  assert.match(composer, /Related context \(\{attachedLinks\.length\}\):/);
+  assert.match(composer, /Resources ready for first pass \(\{attachedLinks\.length\}\):/);
   assert.match(composer, /onRemoveAttached\?\.\(link\.id\)/);
-  // After start, Article quick saves materialize from their saved-link record;
-  // ordinary links retain the evidence ledger's attach-source action.
-  assert.match(
-    promptTab,
-    /if \(link\.xArticle\) \{\s*const attach = await research\.act\(result\.mission\.id, \{\s*action: "attach-saved-link",\s*savedLinkId: link\.id,\s*familiarId: result\.mission\.familiarId,/,
-  );
-  assert.match(
-    promptTab,
-    /const attach = await research\.act\(result\.mission\.id, \{\s*action: "attach-source"/,
-  );
-  assert.match(promptTab, /sourceType: "web"/);
-  assert.match(promptTab, /status: "candidate"/);
-  // Attach happens before the desk hand-off, and the hand-off follows the
-  // mission (the pre-redesign contract).
-  const attachIndex = promptTab.indexOf('action: "attach-source"');
+  assert.match(promptTab, /research\.start\(\{\s*\.\.\.input,\s*savedLinkIds: attached\.map\(\(link\) => link\.id\),\s*\}\)/);
+  assert.doesNotMatch(promptTab, /action: "attach-saved-link"/);
+  assert.doesNotMatch(promptTab, /action: "attach-source"/);
+  const attachIndex = promptTab.indexOf("savedLinkIds: attached.map");
   const navigateIndex = promptTab.indexOf(
     'onNavigate("desk", { missionId: result.mission.id })',
     attachIndex,
@@ -187,27 +176,12 @@ test("quick saves materialize saved Articles and attach ordinary sources via the
   assert.match(promptTab, /All in Resources →/);
 });
 
-test("a failed attach never abandons a started mission", () => {
-  // Once start() succeeds the spend is committed — the desk hand-off ALWAYS
-  // happens. Attach failures are collected without aborting the loop and
-  // surface as a partial-failure announcement, never as a generic "could not
-  // start" that invites a duplicate-spend retry.
-  assert.match(promptTab, /let failedAttaches = 0/);
-  assert.match(promptTab, /\.catch\(\(\) => \(\{ ok: false as const \}\)\)/);
-  assert.match(promptTab, /if \(!attach\.ok\) failedAttaches \+= 1/);
-  assert.match(promptTab, /useAnnouncer/);
-  assert.match(
-    promptTab,
-    /Mission started — \$\{failedAttaches\} link\$\{failedAttaches === 1 \? "" : "s"\} failed to attach\./,
-  );
-  // The announcement happens before the hand-off, and the hand-off is inside
-  // the success branch but outside any per-link condition.
-  const announceIndex = promptTab.indexOf("failed to attach.");
-  const navigateIndex = promptTab.indexOf(
-    'onNavigate("desk", { missionId: result.mission.id })',
-    announceIndex,
-  );
-  assert.ok(announceIndex !== -1 && navigateIndex !== -1 && announceIndex < navigateIndex);
+test("quick saves support search-scoped bulk selection without losing hidden picks", () => {
+  assert.match(promptTab, /updateVisibleQuickSaveSelection\(links\.links, current, visibleLinks\)/);
+  assert.match(promptTab, /`Clear \$\{visibleLinks\.length\} results`/);
+  assert.match(promptTab, /`Select all \$\{visibleLinks\.length\} results`/);
+  assert.match(promptTab, /Selected resources are included before the first research pass starts\./);
+  assert.match(promptTab, /announce\(`\$\{action\} \$\{visibleLinks\.length\} search result/);
 });
 
 // ── Contextual next topics: bounded GET, explicit actions, no draft refresh ─

--- a/src/components/role-surfaces/research-tab-prompt.test.ts
+++ b/src/components/role-surfaces/research-tab-prompt.test.ts
@@ -178,10 +178,11 @@ test("quick saves are included in mission creation before the run starts", () =>
 
 test("quick saves support search-scoped bulk selection without losing hidden picks", () => {
   assert.match(promptTab, /updateVisibleQuickSaveSelection\(links\.links, current, visibleLinks\)/);
-  assert.match(promptTab, /`Clear \$\{visibleLinks\.length\} results`/);
-  assert.match(promptTab, /`Select all \$\{visibleLinks\.length\} results`/);
+  assert.match(promptTab, /visibleResultLabel = `\$\{visibleLinks\.length\} \$\{visibleLinks\.length === 1 \? "result" : "results"\}`/);
+  assert.match(promptTab, /`Clear \$\{visibleResultLabel\}`/);
+  assert.match(promptTab, /`Select all \$\{visibleResultLabel\}`/);
   assert.match(promptTab, /Selected resources are included before the first research pass starts\./);
-  assert.match(promptTab, /announce\(`\$\{action\} \$\{visibleLinks\.length\} search result/);
+  assert.match(promptTab, /announce\(`\$\{action\} \$\{visibleResultLabel\}\.`\)/);
 });
 
 // ── Contextual next topics: bounded GET, explicit actions, no draft refresh ─

--- a/src/components/role-surfaces/research-tab-prompt.tsx
+++ b/src/components/role-surfaces/research-tab-prompt.tsx
@@ -50,7 +50,11 @@ import type {
 } from "@/lib/research-topic-recommendations";
 import { relativeTime } from "@/lib/relative-time";
 import { useAgenticRecommendations } from "@/lib/use-agentic-recommendations";
-import { matchSavedLinks, type QuickSaveGroup } from "./research-quick-saves";
+import {
+  matchSavedLinks,
+  updateVisibleQuickSaveSelection,
+  type QuickSaveGroup,
+} from "./research-quick-saves";
 import {
   createRecommendedResearchMissionInput,
   ResearchMissionComposer,
@@ -215,6 +219,13 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
     () => matchSavedLinks(visibleLinks, draft),
     [visibleLinks, draft],
   );
+  const allVisibleAttached = visibleLinks.length > 0
+    && visibleLinks.every((link) => attached.some((entry) => entry.id === link.id));
+  const toggleVisibleLinks = () => {
+    const action = allVisibleAttached ? "Cleared" : "Selected";
+    setAttached((current) => updateVisibleQuickSaveSelection(links.links, current, visibleLinks));
+    announce(`${action} ${visibleLinks.length} search result${visibleLinks.length === 1 ? "" : "s"}.`);
+  };
 
   const onDraftChange = useCallback((next: string) => setDraft(next), []);
 
@@ -451,40 +462,12 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
             onDraftChange={onDraftChange}
             onOpenResources={() => onNavigate("resources")}
             onStart={async (input) => {
-              const result = await research.start(input);
+              const result = await research.start({
+                ...input,
+                savedLinkIds: attached.map((link) => link.id),
+              });
               if (result.ok) {
-                // Saved Articles must materialize their persisted body; ordinary
-                // links retain the evidence ledger's candidate-source action.
-                // A failed attach is non-fatal: the mission exists (and its spend
-                // is committed), so failures never abort the desk hand-off.
-                let failedAttaches = 0;
-                for (const link of attached) {
-                  if (link.xArticle) {
-                    const attach = await research.act(result.mission.id, {
-                      action: "attach-saved-link",
-                      savedLinkId: link.id,
-                      familiarId: result.mission.familiarId,
-                    }).catch(() => ({ ok: false as const }));
-                    if (!attach.ok) failedAttaches += 1;
-                    continue;
-                  }
-                  const attach = await research.act(result.mission.id, {
-                    action: "attach-source",
-                    source: {
-                      id: `link-${link.id}`,
-                      title: link.title,
-                      url: link.url,
-                      sourceType: "web",
-                      status: "candidate",
-                    },
-                  }).catch(() => ({ ok: false as const }));
-                  if (!attach.ok) failedAttaches += 1;
-                }
                 setAttached([]);
-                if (failedAttaches > 0) {
-                  announce(`Mission started — ${failedAttaches} link${failedAttaches === 1 ? "" : "s"} failed to attach.`);
-                }
-                // A freshly started mission lives on the Desk — follow it there.
                 onNavigate("desk", { missionId: result.mission.id });
               }
               return result;
@@ -582,8 +565,20 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
           <div className="research-quick-saves__head">
             <strong>Quick saves</strong>
             <span className="research-quick-saves__count">
-              tap to attach as context for this investigation
+              Selected resources are included before the first research pass starts.
             </span>
+            {visibleLinks.length > 0 ? (
+              <button
+                type="button"
+                className="research-quick-saves__select-visible focus-ring"
+                aria-pressed={allVisibleAttached}
+                onClick={toggleVisibleLinks}
+              >
+                {allVisibleAttached
+                  ? `Clear ${visibleLinks.length} results`
+                  : `Select all ${visibleLinks.length} results`}
+              </button>
+            ) : null}
             <input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
@@ -679,7 +674,7 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
         </button>
         {attached.length > 0 ? (
           <span className="research-quick-saves__attached">
-            {attached.length} attached to this run
+            {attached.length} ready for the first pass
           </span>
         ) : null}
         <span className="research-quick-saves__origin">

--- a/src/components/role-surfaces/research-tab-prompt.tsx
+++ b/src/components/role-surfaces/research-tab-prompt.tsx
@@ -11,9 +11,9 @@
  * the frame's shape, and the reason the intake itself no longer has to compete
  * with a permanently-open list. Rows toggle an attach state that renders as
  * "Related context" chips inside the composer card. On Start research the
- * mission is created first, then ordinary links become `candidate` sources
- * while saved Articles materialize through their immutable saved-link action,
- * and the desk opens on the new mission.
+ * selected IDs cross the creation boundary, so ordinary links and saved
+ * Articles are persisted before the first run begins and the desk opens on
+ * the new mission.
  *
  * Grouping is REAL data only: a "✦ Suggested for this prompt" group matched
  * against the live draft, then one group per saved-link category, then the
@@ -221,10 +221,11 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
   );
   const allVisibleAttached = visibleLinks.length > 0
     && visibleLinks.every((link) => attached.some((entry) => entry.id === link.id));
+  const visibleResultLabel = `${visibleLinks.length} ${visibleLinks.length === 1 ? "result" : "results"}`;
   const toggleVisibleLinks = () => {
     const action = allVisibleAttached ? "Cleared" : "Selected";
     setAttached((current) => updateVisibleQuickSaveSelection(links.links, current, visibleLinks));
-    announce(`${action} ${visibleLinks.length} search result${visibleLinks.length === 1 ? "" : "s"}.`);
+    announce(`${action} ${visibleResultLabel}.`);
   };
 
   const onDraftChange = useCallback((next: string) => setDraft(next), []);
@@ -570,13 +571,13 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
             {visibleLinks.length > 0 ? (
               <button
                 type="button"
-                className="research-quick-saves__select-visible focus-ring"
+                className="research-quick-saves__all focus-ring"
                 aria-pressed={allVisibleAttached}
                 onClick={toggleVisibleLinks}
               >
                 {allVisibleAttached
-                  ? `Clear ${visibleLinks.length} results`
-                  : `Select all ${visibleLinks.length} results`}
+                  ? `Clear ${visibleResultLabel}`
+                  : `Select all ${visibleResultLabel}`}
               </button>
             ) : null}
             <input

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -147,10 +147,9 @@ test("prompt tab composes the composer + quick saves and follows starts to the d
   assert.match(promptTab, /ResearchMissionComposer/);
   // Quick saves read the same links store as the Resources tab via the shared hook.
   assert.match(promptTab, /useResearchLinks/);
-  // Attached saves land on the new mission as candidate sources through the
-  // ledger's exact attach-source action.
-  assert.match(promptTab, /action: "attach-source"/);
-  assert.match(promptTab, /status: "candidate"/);
+  // Attached saves travel with mission creation so the first pass sees them.
+  assert.match(promptTab, /savedLinkIds: attached\.map\(\(link\) => link\.id\)/);
+  assert.doesNotMatch(promptTab, /action: "attach-source"/);
   assert.match(promptTab, /daemonRunning=\{context\.runtimeState\.daemonRunning\}/);
   assert.match(promptTab, /onNavigate\("desk", \{ missionId: result\.mission\.id \}\)/);
 });

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -404,48 +404,49 @@ test("mission input rejects lossful and NUL-bearing prompt fields", () => {
     constraints: ["c".repeat(RESEARCH_CONSTRAINT_MAX_LENGTH)],
   });
 
-  test("mission creation validates, deduplicates, and bounds initial saved links", () => {
-    const valid = {
-      familiarId: "sage",
-      intent: "Compare two databases",
-      mode: "brief",
-      modeSource: "auto",
-      deliverable: "brief",
-      constraints: [],
-      bounds: {
-        wallClockMinutes: 20,
-        maxIterations: 1,
-        sourceTarget: 6,
-        checkpointEvery: 1,
-        stopWhenCostUnavailable: false,
-      },
-    };
-    const accepted = validateCreateResearchMissionInput({
-      ...valid,
-      savedLinkIds: ["link-a", " link-b ", "link-a"],
-    });
-    assert.equal(accepted.ok, true);
-    if (accepted.ok) {
-      assert.deepEqual(accepted.value.savedLinkIds, ["link-a", "link-b"]);
-    }
-
-    for (const savedLinkIds of [
-      "link-a",
-      ["ok", 42],
-      [""],
-      ["x".repeat(129)],
-      Array.from({ length: RESEARCH_INITIAL_SAVED_LINK_MAX_COUNT + 1 }, (_, index) => `link-${index}`),
-    ]) {
-      assert.equal(
-        validateCreateResearchMissionInput({ ...valid, savedLinkIds }).ok,
-        false,
-      );
-    }
-  });
   assert.equal(boundary.ok, true);
   if (boundary.ok) {
     assert.equal(boundary.value.title?.length, RESEARCH_TITLE_MAX_LENGTH);
     assert.equal(boundary.value.constraints?.[0]?.length, RESEARCH_CONSTRAINT_MAX_LENGTH);
+  }
+});
+
+test("mission creation validates, deduplicates, and bounds initial saved links", () => {
+  const valid = {
+    familiarId: "sage",
+    intent: "Compare two databases",
+    mode: "brief",
+    modeSource: "auto",
+    deliverable: "brief",
+    constraints: [],
+    bounds: {
+      wallClockMinutes: 20,
+      maxIterations: 1,
+      sourceTarget: 6,
+      checkpointEvery: 1,
+      stopWhenCostUnavailable: false,
+    },
+  };
+  const accepted = validateCreateResearchMissionInput({
+    ...valid,
+    savedLinkIds: ["link-a", " link-b ", "link-a"],
+  });
+  assert.equal(accepted.ok, true);
+  if (accepted.ok) {
+    assert.deepEqual(accepted.value.savedLinkIds, ["link-a", "link-b"]);
+  }
+
+  for (const savedLinkIds of [
+    "link-a",
+    ["ok", 42],
+    [""],
+    ["x".repeat(129)],
+    Array.from({ length: RESEARCH_INITIAL_SAVED_LINK_MAX_COUNT + 1 }, (_, index) => `link-${index}`),
+  ]) {
+    assert.equal(
+      validateCreateResearchMissionInput({ ...valid, savedLinkIds }).ok,
+      false,
+    );
   }
 });
 

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -20,6 +20,7 @@ import {
   RESEARCH_INTENT_MIN_LENGTH,
   RESEARCH_PROJECT_ROOT_MAX_LENGTH,
   RESEARCH_HARNESS_IDS,
+  RESEARCH_INITIAL_SAVED_LINK_MAX_COUNT,
   RESEARCH_MODEL_MAX_LENGTH,
   RESEARCH_RUNTIME_DEFAULT_HARNESS,
   RESEARCH_TITLE_MAX_LENGTH,
@@ -401,6 +402,45 @@ test("mission input rejects lossful and NUL-bearing prompt fields", () => {
     deliverable: "d".repeat(RESEARCH_DELIVERABLE_MAX_LENGTH),
     audience: "a".repeat(RESEARCH_AUDIENCE_MAX_LENGTH),
     constraints: ["c".repeat(RESEARCH_CONSTRAINT_MAX_LENGTH)],
+  });
+
+  test("mission creation validates, deduplicates, and bounds initial saved links", () => {
+    const valid = {
+      familiarId: "sage",
+      intent: "Compare two databases",
+      mode: "brief",
+      modeSource: "auto",
+      deliverable: "brief",
+      constraints: [],
+      bounds: {
+        wallClockMinutes: 20,
+        maxIterations: 1,
+        sourceTarget: 6,
+        checkpointEvery: 1,
+        stopWhenCostUnavailable: false,
+      },
+    };
+    const accepted = validateCreateResearchMissionInput({
+      ...valid,
+      savedLinkIds: ["link-a", " link-b ", "link-a"],
+    });
+    assert.equal(accepted.ok, true);
+    if (accepted.ok) {
+      assert.deepEqual(accepted.value.savedLinkIds, ["link-a", "link-b"]);
+    }
+
+    for (const savedLinkIds of [
+      "link-a",
+      ["ok", 42],
+      [""],
+      ["x".repeat(129)],
+      Array.from({ length: RESEARCH_INITIAL_SAVED_LINK_MAX_COUNT + 1 }, (_, index) => `link-${index}`),
+    ]) {
+      assert.equal(
+        validateCreateResearchMissionInput({ ...valid, savedLinkIds }).ok,
+        false,
+      );
+    }
   });
   assert.equal(boundary.ok, true);
   if (boundary.ok) {

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -354,6 +354,8 @@ export type CreateResearchMissionInput = {
   harness?: string;
   /** Harness-specific model id, passed through verbatim when supported. */
   model?: string;
+  /** Saved Research resources made available before iteration one launches. */
+  savedLinkIds?: string[];
 };
 
 export type ResearchMissionActionInput =
@@ -748,6 +750,8 @@ export const RESEARCH_PROJECT_ROOT_MAX_LENGTH = 2_000;
 export const RESEARCH_DIRECTION_MAX_LENGTH = 10_000;
 export const RESEARCH_CONSTRAINT_MAX_COUNT = 20;
 export const RESEARCH_CONSTRAINT_MAX_LENGTH = 500;
+export const RESEARCH_INITIAL_SAVED_LINK_MAX_COUNT = 500;
+export const RESEARCH_SAVED_LINK_ID_MAX_LENGTH = 128;
 
 export function validateCreateResearchMissionInput(
   input: unknown,
@@ -830,6 +834,39 @@ export function validateCreateResearchMissionInput(
     }
     if (constraint) constraints.push(constraint);
   }
+  if (value.savedLinkIds !== undefined && !Array.isArray(value.savedLinkIds)) {
+    return { ok: false, error: "savedLinkIds must be an array of strings" };
+  }
+  const rawSavedLinkIds = value.savedLinkIds ?? [];
+  if (rawSavedLinkIds.length > RESEARCH_INITIAL_SAVED_LINK_MAX_COUNT) {
+    return {
+      ok: false,
+      error: `savedLinkIds must contain at most ${RESEARCH_INITIAL_SAVED_LINK_MAX_COUNT} items`,
+    };
+  }
+  if (rawSavedLinkIds.some((item) => typeof item !== "string")) {
+    return { ok: false, error: "savedLinkIds must be an array of strings" };
+  }
+  const savedLinkIds: string[] = [];
+  const seenSavedLinkIds = new Set<string>();
+  for (const rawSavedLinkId of rawSavedLinkIds as string[]) {
+    const savedLinkId = rawSavedLinkId.trim();
+    if (
+      !savedLinkId
+      || savedLinkId.length > RESEARCH_SAVED_LINK_ID_MAX_LENGTH
+      || savedLinkId.includes("\0")
+      || hasUnpairedUtf16Surrogate(rawSavedLinkId)
+    ) {
+      return {
+        ok: false,
+        error: `each saved link id must be valid Unicode text without NUL and at most ${RESEARCH_SAVED_LINK_ID_MAX_LENGTH} characters`,
+      };
+    }
+    if (!seenSavedLinkIds.has(savedLinkId)) {
+      seenSavedLinkIds.add(savedLinkId);
+      savedLinkIds.push(savedLinkId);
+    }
+  }
   const optionalText = (field: "title" | "audience" | "projectRoot", max: number) => {
     const raw = value[field];
     if (raw === undefined || raw === null || raw === "") return undefined;
@@ -909,6 +946,7 @@ export function validateCreateResearchMissionInput(
       bounds: bounds.value,
       ...(harness ? { harness } : {}),
       ...(model ? { model } : {}),
+      ...(savedLinkIds.length > 0 ? { savedLinkIds } : {}),
     },
   };
 }

--- a/src/lib/server/research-link-materialization.test.ts
+++ b/src/lib/server/research-link-materialization.test.ts
@@ -166,18 +166,24 @@ test("saved Article author display-name falls back to the X username", async () 
   );
 });
 
-test("missing and non-Article saved links are rejected safely", async () => {
+test("ordinary saved links become candidate web sources without source files", async () => {
   const workspace = await createResearchMissionWorkspace(mission("missing-article"));
   const nonArticle = await saveResearchLinks(["https://example.com/reference"], "desk");
 
   await assert.rejects(
     () => materializeSavedLinkForMission(workspace, "missing-link"),
-    { message: "saved X Article not found" },
+    { message: "saved link not found" },
   );
-  await assert.rejects(
-    () => materializeSavedLinkForMission(workspace, nonArticle.added[0]!.id),
-    { message: "saved X Article not found" },
-  );
+  const materialized = await materializeSavedLinkForMission(workspace, nonArticle.added[0]!.id);
+  assert.deepEqual(materialized.source, {
+    id: materialized.source.id,
+    title: nonArticle.added[0]!.title,
+    url: "https://example.com/reference",
+    sourceType: "web",
+    status: "candidate",
+  });
+  assert.match(materialized.source.id, /^saved-[a-f0-9]{24}$/);
+  await materialized.rollback();
 });
 
 test("rollback restores exact overwritten contents and only removes the newly-created source file", async () => {

--- a/src/lib/server/research-link-materialization.ts
+++ b/src/lib/server/research-link-materialization.ts
@@ -11,9 +11,16 @@ export type MaterializedSavedLink = {
   rollback(): Promise<void>;
 };
 
-function savedLinkDigest(savedLinkId: string, contentSha256: string): string {
+function savedXArticleDigest(savedLinkId: string, contentSha256: string): string {
   return createHash("sha256")
     .update(`saved-x-article:${savedLinkId}\n${contentSha256}`)
+    .digest("hex")
+    .slice(0, 24);
+}
+
+function savedLinkReferenceDigest(savedLinkId: string, url: string): string {
+  return createHash("sha256")
+    .update(`saved-link:${savedLinkId}\n${url}`)
     .digest("hex")
     .slice(0, 24);
 }
@@ -54,9 +61,24 @@ export async function materializeSavedLinkForMission(
   savedLinkId: string,
 ): Promise<MaterializedSavedLink> {
   const savedLink = await getSavedLinkById(savedLinkId);
-  if (!savedLink?.xArticle) throw new Error("saved X Article not found");
+  if (!savedLink) throw new Error("saved link not found");
 
-  const digest = savedLinkDigest(savedLink.id, savedLink.xArticle.contentSha256);
+  if (!savedLink.xArticle) {
+    const digest = savedLinkReferenceDigest(savedLink.id, savedLink.url);
+    return {
+      source: {
+        id: `saved-${digest}`,
+        title: savedLink.title,
+        url: savedLink.url,
+        sourceType: savedLink.paper ? "paper" : "web",
+        ...(savedLink.paper?.publishedAt ? { publishedAt: savedLink.paper.publishedAt } : {}),
+        status: "candidate",
+      },
+      rollback: async () => {},
+    };
+  }
+
+  const digest = savedXArticleDigest(savedLink.id, savedLink.xArticle.contentSha256);
   const fileName = `x-article-${digest}.md`;
   const labels = authorLabel(savedLink.xArticle.author);
   const written = await writeResearchMissionSourceFile(

--- a/src/lib/server/research-mission-runner-automation-scheduling.test.ts
+++ b/src/lib/server/research-mission-runner-automation-scheduling.test.ts
@@ -24,6 +24,7 @@ function deps(overrides: Partial<ResearchMissionRunnerDeps> = {}): ResearchMissi
   let sessionOwner: Awaited<ReturnType<ResearchMissionRunnerDeps["loadSessionOwner"]>> = null;
   return {
     createWorkspace: async (mission) => mission,
+    removeWorkspace: async () => {},
     loadMission: async () => null,
     saveMission: async () => {},
     loadSessionOwner: async () => sessionOwner ? structuredClone(sessionOwner) : null,

--- a/src/lib/server/research-mission-runner-concurrency-terminal.test.ts
+++ b/src/lib/server/research-mission-runner-concurrency-terminal.test.ts
@@ -43,6 +43,7 @@ function deps(overrides: Partial<ResearchMissionRunnerDeps> = {}): ResearchMissi
   let sessionOwner: Awaited<ReturnType<ResearchMissionRunnerDeps["loadSessionOwner"]>> = null;
   return {
     createWorkspace: async (mission) => mission,
+    removeWorkspace: async () => {},
     loadMission: async () => null,
     saveMission: async () => {},
     loadSessionOwner: async () => sessionOwner ? structuredClone(sessionOwner) : null,

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -281,6 +281,90 @@ test("create/start persists before launch and records the real session", async (
   assert.equal(result.status, "running");
 });
 
+test("create/start materializes selected saved links before the first launch", async () => {
+  const calls: string[] = [];
+  const savedMissionSources: string[][] = [];
+  const runner = makeResearchMissionRunner(deps({
+    createWorkspace: async (mission) => {
+      calls.push("create");
+      return mission;
+    },
+    materializeSavedLink: async (_mission, savedLinkId) => {
+      calls.push(`materialize:${savedLinkId}`);
+      return {
+        source: {
+          id: `saved-${savedLinkId}`,
+          title: `Saved ${savedLinkId}`,
+          url: `https://example.com/${savedLinkId}`,
+          sourceType: "web",
+          status: "candidate",
+        },
+        rollback: async () => {},
+      };
+    },
+    saveMission: async (mission) => {
+      calls.push("save");
+      savedMissionSources.push(mission.sources.map((source) => source.id));
+    },
+    startFlow: async () => {
+      calls.push("start");
+      assert.deepEqual(savedMissionSources.at(-1), ["saved-link-a", "saved-link-b"]);
+      return { ok: true, run: RUN, sessionId: "session-1", executor: "session" };
+    },
+  }));
+
+  const result = await runner.createAndStart({
+    ...INPUT,
+    savedLinkIds: ["link-a", "link-b"],
+  });
+
+  assert.deepEqual(calls, [
+    "create",
+    "materialize:link-a",
+    "materialize:link-b",
+    "save",
+    "start",
+    "save",
+  ]);
+  assert.deepEqual(result.sources.map((source) => source.id), [
+    "saved-link-a",
+    "saved-link-b",
+  ]);
+});
+
+test("create/start rolls back initial resource files when pre-launch persistence fails", async () => {
+  let rollbackCalls = 0;
+  let startCalls = 0;
+  const runner = makeResearchMissionRunner(deps({
+    materializeSavedLink: async () => ({
+      source: {
+        id: "saved-link-a",
+        title: "Saved link",
+        url: "https://example.com/link-a",
+        sourceType: "web",
+        status: "candidate",
+      },
+      rollback: async () => {
+        rollbackCalls += 1;
+      },
+    }),
+    saveMission: async () => {
+      throw new Error("disk full");
+    },
+    startFlow: async () => {
+      startCalls += 1;
+      return { ok: true, run: RUN, sessionId: "session-1", executor: "session" };
+    },
+  }));
+
+  await assert.rejects(
+    runner.createAndStart({ ...INPUT, savedLinkIds: ["link-a"] }),
+    /disk full/,
+  );
+  assert.equal(rollbackCalls, 1);
+  assert.equal(startCalls, 0);
+});
+
 test("create/start records exact daemon authority outside public mission state", async () => {
   const sessionAuthority = {
     kind: "owner-local-daemon" as const,

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -166,6 +166,7 @@ function deps(overrides: Partial<ResearchMissionRunnerDeps> = {}): ResearchMissi
   let sessionOwner: Awaited<ReturnType<ResearchMissionRunnerDeps["loadSessionOwner"]>> = null;
   return {
     createWorkspace: async (mission) => mission,
+    removeWorkspace: async () => {},
     loadMission: async () => null,
     saveMission: async () => {},
     loadSessionOwner: async () => sessionOwner ? structuredClone(sessionOwner) : null,
@@ -333,9 +334,12 @@ test("create/start materializes selected saved links before the first launch", a
 });
 
 test("create/start rolls back initial resource files when pre-launch persistence fails", async () => {
-  let rollbackCalls = 0;
+  const rollbackCalls: string[] = [];
   let startCalls = 0;
   const runner = makeResearchMissionRunner(deps({
+    removeWorkspace: async (id) => {
+      rollbackCalls.push(`workspace:${id}`);
+    },
     materializeSavedLink: async () => ({
       source: {
         id: "saved-link-a",
@@ -345,7 +349,7 @@ test("create/start rolls back initial resource files when pre-launch persistence
         status: "candidate",
       },
       rollback: async () => {
-        rollbackCalls += 1;
+          rollbackCalls.push("resource");
       },
     }),
     saveMission: async () => {
@@ -361,8 +365,27 @@ test("create/start rolls back initial resource files when pre-launch persistence
     runner.createAndStart({ ...INPUT, savedLinkIds: ["link-a"] }),
     /disk full/,
   );
-  assert.equal(rollbackCalls, 1);
+  assert.deepEqual(rollbackCalls, ["resource", "workspace:mission-1"]);
   assert.equal(startCalls, 0);
+});
+
+test("create/start removes the new workspace when initial resource materialization fails", async () => {
+  const calls: string[] = [];
+  const runner = makeResearchMissionRunner(deps({
+    removeWorkspace: async (id) => {
+      calls.push(`remove:${id}`);
+    },
+    materializeSavedLink: async () => {
+      calls.push("materialize");
+      throw new Error("saved link unavailable");
+    },
+  }));
+
+  await assert.rejects(
+    runner.createAndStart({ ...INPUT, savedLinkIds: ["link-a"] }),
+    /saved link unavailable/,
+  );
+  assert.deepEqual(calls, ["materialize", "remove:mission-1"]);
 });
 
 test("create/start records exact daemon authority outside public mission state", async () => {

--- a/src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
+++ b/src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
@@ -26,6 +26,7 @@ function deps(overrides: Partial<ResearchMissionRunnerDeps> = {}): ResearchMissi
   let sessionOwner: Awaited<ReturnType<ResearchMissionRunnerDeps["loadSessionOwner"]>> = null;
   return {
     createWorkspace: async (mission) => mission,
+    removeWorkspace: async () => {},
     loadMission: async () => null,
     saveMission: async () => {},
     loadSessionOwner: async () => sessionOwner ? structuredClone(sessionOwner) : null,

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -1808,7 +1808,37 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       if (!validated.ok) throw new Error(validated.error);
       let mission = createMissionRecord(validated.value, deps.randomId(), deps.now());
       mission = await deps.createWorkspace(mission);
-      await saveMission(mission);
+      const initialResourceRollbacks: Array<() => Promise<void>> = [];
+      const rollbackInitialResources = async (error: unknown): Promise<never> => {
+        const rollbackErrors: unknown[] = [];
+        for (const rollback of initialResourceRollbacks.reverse()) {
+          try {
+            await rollback();
+          } catch (rollbackError) {
+            rollbackErrors.push(rollbackError);
+          }
+        }
+        if (rollbackErrors.length > 0) {
+          throw new AggregateError(
+            [error, ...rollbackErrors],
+            "Initial research resources could not be prepared or rolled back",
+          );
+        }
+        throw error;
+      };
+      try {
+        for (const savedLinkId of validated.value.savedLinkIds ?? []) {
+          const materialized = await deps.materializeSavedLink(mission, savedLinkId);
+          initialResourceRollbacks.push(materialized.rollback);
+          mission = {
+            ...mission,
+            sources: [...mission.sources, materialized.source],
+          };
+        }
+        await saveMission(mission);
+      } catch (error) {
+        return rollbackInitialResources(error);
+      }
       // The start sequence shares the per-mission action lock: without it, a
       // concurrent locked act('cancel') landing between the pre-launch save
       // and the launch-result save was silently overwritten back to running.

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -46,6 +46,7 @@ import {
   loadResearchMissionSessionOwner,
   readValidatedMissionFile,
   recordResearchMissionSessionOwner,
+  removeResearchMissionWorkspace,
   researchMissionWorkspacePath,
   saveResearchMission,
   type ResearchMissionSessionOwner,
@@ -135,6 +136,7 @@ type ResearchAutomationCreateInput = {
 
 export type ResearchMissionRunnerDeps = {
   createWorkspace(mission: ResearchMission): Promise<ResearchMission>;
+  removeWorkspace(id: string): Promise<void>;
   loadMission(id: string): Promise<ResearchMission | null>;
   saveMission(mission: ResearchMission): Promise<void>;
   loadSessionOwner(missionId: string): Promise<ResearchMissionSessionOwner | null>;
@@ -1818,10 +1820,15 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
             rollbackErrors.push(rollbackError);
           }
         }
+        try {
+          await deps.removeWorkspace(mission.id);
+        } catch (rollbackError) {
+          rollbackErrors.push(rollbackError);
+        }
         if (rollbackErrors.length > 0) {
           throw new AggregateError(
             [error, ...rollbackErrors],
-            "Initial research resources could not be prepared or rolled back",
+            "Initial research mission could not be prepared or rolled back",
           );
         }
         throw error;
@@ -2098,6 +2105,7 @@ export async function researchDaemonSessionState(
 export function makeProductionResearchMissionRunner() {
   const deps: ResearchMissionRunnerDeps = {
     createWorkspace: createResearchMissionWorkspace,
+    removeWorkspace: removeResearchMissionWorkspace,
     loadMission: loadResearchMission,
     saveMission: saveResearchMission,
     loadSessionOwner: loadResearchMissionSessionOwner,

--- a/src/lib/server/research-mission-store.ts
+++ b/src/lib/server/research-mission-store.ts
@@ -556,6 +556,14 @@ export async function createResearchMissionWorkspace(
   });
 }
 
+export async function removeResearchMissionWorkspace(id: string): Promise<void> {
+  assertMissionId(id);
+  await withResearchMissionLock(id, async () => {
+    const directory = await assertRealMissionDirectory(id);
+    await rm(/* turbopackIgnore: true */ directory, { recursive: true, force: false });
+  });
+}
+
 export async function saveResearchMission(mission: ResearchMission): Promise<void> {
   assertMissionId(mission.id);
   await withResearchMissionLock(mission.id, async () => {

--- a/src/styles/globals/surface-research-prompt.css
+++ b/src/styles/globals/surface-research-prompt.css
@@ -897,6 +897,20 @@
   white-space: nowrap;
   font-size: var(--text-2xs);
 }
+.research-quick-saves__select-visible {
+  flex: none;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid color-mix(in oklch, var(--research-accent) 38%, var(--border));
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--research-accent) 9%, transparent);
+  color: var(--research-accent);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+.research-quick-saves__select-visible[aria-pressed="true"] {
+  background: color-mix(in oklch, var(--research-accent) 15%, transparent);
+}
 .research-quick-saves__search {
   margin-left: auto;
   max-width: 220px;

--- a/src/styles/globals/surface-research-prompt.css
+++ b/src/styles/globals/surface-research-prompt.css
@@ -897,20 +897,6 @@
   white-space: nowrap;
   font-size: var(--text-2xs);
 }
-.research-quick-saves__select-visible {
-  flex: none;
-  padding: var(--space-1) var(--space-2);
-  border: 1px solid color-mix(in oklch, var(--research-accent) 38%, var(--border));
-  border-radius: var(--radius-pill);
-  background: color-mix(in oklch, var(--research-accent) 9%, transparent);
-  color: var(--research-accent);
-  font-size: var(--text-2xs);
-  font-weight: 600;
-  cursor: pointer;
-}
-.research-quick-saves__select-visible[aria-pressed="true"] {
-  background: color-mix(in oklch, var(--research-accent) 15%, transparent);
-}
 .research-quick-saves__search {
   margin-left: auto;
   max-width: 220px;

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -1266,9 +1266,14 @@ test.describe("research desk tabs", () => {
     await expect(saves.getByRole("button", { name: new RegExp(X_ARTICLE_LINK.title) })).toBeVisible();
     await expect(saves.getByRole("button", { name: new RegExp(ORDINARY_RESOURCE_LINK.title) })).toBeVisible();
 
-    await saves.getByRole("button", { name: new RegExp(X_ARTICLE_LINK.title) }).click();
-    await saves.getByRole("button", { name: new RegExp(ORDINARY_RESOURCE_LINK.title) }).click();
-    await expect(prompt.getByText("2 attached to this run")).toBeVisible();
+    const search = saves.getByRole("textbox", { name: "Search saves" });
+    await search.fill("Ordinary research sibling");
+    await saves.getByRole("button", { name: "Select all 1 results" }).click();
+    await expect(prompt.getByText("1 ready for the first pass")).toBeVisible();
+
+    await search.fill(X_ARTICLE_LINK.title);
+    await saves.getByRole("button", { name: "Select all 1 results" }).click();
+    await expect(prompt.getByText("2 ready for the first pass")).toBeVisible();
     await prompt.getByRole("button", { name: /^Quick saves/ }).click();
     await expect(prompt.getByRole("region", { name: "Quick saves" })).toHaveCount(0);
 
@@ -1277,37 +1282,16 @@ test.describe("research desk tabs", () => {
     await prompt.getByRole("button", { name: "Start research" }).click();
 
     await expect.poll(() => handles.createdMissionBodies.length).toBe(1);
-    await expect.poll(() => handles.missionActionBodies.length).toBe(2);
-    await expect.poll(() => handles.missionRequests.length).toBe(3);
+    await expect.poll(() => handles.missionRequests.length).toBe(1);
 
     const createdBody = handles.createdMissionBodies[0] as Record<string, unknown>;
     expect(createdBody.familiarId).toBe(FAMILIAR_ID);
     expect(createdBody.intent).toBe(missionPrompt);
-
-    const expectedXAction = {
-      action: "attach-saved-link",
-      savedLinkId: "x-article-1",
-      familiarId: "researcher",
-    };
-    const expectedOrdinaryAction = {
-      action: "attach-source",
-      source: {
-        id: "link-ordinary-sibling-1",
-        title: "Ordinary research sibling",
-        url: ORDINARY_RESOURCE_URL,
-        sourceType: "web",
-        status: "candidate",
-      },
-    };
-    expect(handles.missionActionBodies).toContainEqual(expectedXAction);
-    expect(handles.missionActionBodies).toContainEqual(expectedOrdinaryAction);
+    expect(createdBody.savedLinkIds).toEqual(["x-article-1", "ordinary-sibling-1"]);
+    expect(handles.missionActionBodies).toEqual([]);
 
     expect(handles.missionRequests[0]?.kind).toBe("create");
     expect(handles.missionRequests[0]?.missionId).toBe(PROMPT_CREATED_MISSION.id);
-    for (const request of handles.missionRequests.slice(1)) {
-      expect(request.kind).toBe("action");
-      expect(request.missionId).toBe(PROMPT_CREATED_MISSION.id);
-    }
 
     await expect(deskTab(page, /^Desk/)).toHaveAttribute("aria-selected", "true");
     await expect(
@@ -1369,7 +1353,7 @@ test.describe("research desk tabs", () => {
 
     // Attaching one reports back on the collapsed bar.
     await saves.getByRole("button", { name: /Qdrant guide/ }).click();
-    await expect(intake.getByText("1 attached to this run")).toBeVisible();
+    await expect(intake.getByText("1 ready for the first pass")).toBeVisible();
   });
 
   test("keeps Research recommendations hidden and idle when the capability is disabled", async ({ page }) => {

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -1268,11 +1268,11 @@ test.describe("research desk tabs", () => {
 
     const search = saves.getByRole("textbox", { name: "Search saves" });
     await search.fill("Ordinary research sibling");
-    await saves.getByRole("button", { name: "Select all 1 results" }).click();
+    await saves.getByRole("button", { name: "Select all 1 result" }).click();
     await expect(prompt.getByText("1 ready for the first pass")).toBeVisible();
 
     await search.fill(X_ARTICLE_LINK.title);
-    await saves.getByRole("button", { name: "Select all 1 results" }).click();
+    await saves.getByRole("button", { name: "Select all 1 result" }).click();
     await expect(prompt.getByText("2 ready for the first pass")).toBeVisible();
     await prompt.getByRole("button", { name: /^Quick saves/ }).click();
     await expect(prompt.getByRole("region", { name: "Quick saves" })).toHaveCount(0);


### PR DESCRIPTION
## Summary
- attach selected Quick Saves atomically while creating a Research mission, before its first run begins
- support search-scoped bulk selection while preserving hidden selections and canonical library ordering
- materialize saved X Articles and ordinary links before launch, with full resource and workspace rollback on preparation failure
- make first-pass resource readiness explicit in the Research composer and E2E contract

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` — 1,286 files passed
- `pnpm test:api`
- `pnpm check:tests-wired`
- `pnpm build`
- `git diff --check`
- focused Research runner/materialization tests
- focused desktop Playwright: atomic selected-resource creation and Sessions toolbar alignment

Rebased onto release `0.3.9` and the canonical red-main frontend repair.

Bead: `cave-3noim`
