### PR TITLE
fix(release): pin V8 heap ceiling for the sidecar bundle build

### DIFF
--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -472,6 +472,17 @@ bundle_piper_runtime
 bundle_kokoro_runtime
 
 echo "==> next build"
+# Raise the V8 heap for the release build. Node sizes its default old-space from
+# available RAM, so this build passes on the 16 GB ubuntu and Windows runners and
+# on developer machines, but OOMs on macos-15 — which caps the default near
+# 2 GB and dies in Next's TypeScript phase, after "Compiled successfully".
+# That failure skips the packaged-sidecar smoke and therefore the iOS TestFlight
+# upload downstream, so pin the ceiling here (where every caller inherits it)
+# rather than per-workflow. Respect an inherited NODE_OPTIONS if the caller
+# already set one.
+if [ -z "${NODE_OPTIONS:-}" ]; then
+  export NODE_OPTIONS="--max-old-space-size=4096"
+fi
 (cd "$ROOT" && pnpm build) >&2
 
 STANDALONE="$ROOT/.next/standalone"

--- a/scripts/sidecar-bundle.test.mjs
+++ b/scripts/sidecar-bundle.test.mjs
@@ -40,4 +40,20 @@ assert.doesNotMatch(
   "sidecar-bundle.sh must not use bare npm install",
 );
 
+// Release-availability regression: the macos-15 runner sizes V8's default
+// old-space near 2 GB, and the Next build's TypeScript phase exceeds it. That
+// OOM failed `Build packaged sidecar bundle` on release candidate run
+// 32491280461, skipping the packaged smoke and blocking the iOS TestFlight
+// upload downstream. The heap ceiling must stay pinned in the script so every
+// caller (release.yml and full-validation.yml) inherits it.
+const heapCeiling = script.match(/--max-old-space-size=(\d+)/);
+assert.ok(
+  heapCeiling,
+  "sidecar-bundle.sh must pin NODE_OPTIONS --max-old-space-size for the next build (macos runners OOM at the ~2 GB default)",
+);
+assert.ok(
+  Number(heapCeiling[1]) >= 4096,
+  `sidecar-bundle.sh heap ceiling must be at least 4096 MB, got ${heapCeiling[1]}`,
+);
+
 console.log("sidecar-bundle security test: ok");


### PR DESCRIPTION
## Problem

`v0.3.9` cannot reach TestFlight. Release candidate run
[32491280461](https://github.com/OpenCoven/coven-cave/actions/runs/32491280461)
failed `Validate candidate runtime (macos-15)` at **Build packaged sidecar bundle**:

```
✓ Compiled successfully in 81s
  Running TypeScript ...
[6835] 79946 ms: Mark-Compact 2033.0 (2051.6) -> 2031.0 (2048.6) MB ...
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

Node sizes V8's default old-space from available RAM, so the macos-15 runner
caps near 2 GB while the 16 GB ubuntu/Windows runners and developer machines do
not. `bash scripts/sidecar-bundle.sh` exits 0 locally on macOS; it only fails on
the runner. The failure skipped `pnpm test:sidecar-runtime` and
`pnpm test:daemon-faults`, and without a green candidate run
`scripts/release-promotion.mjs` refuses to authorize the final tag — so
`release-ios-build` never runs.

## Change

- `scripts/sidecar-bundle.sh` — export `NODE_OPTIONS=--max-old-space-size=4096`
  before `pnpm build` when the caller has not already set one. Pinned in the
  script so both `release.yml` and `full-validation.yml` inherit it rather than
  drifting apart per workflow. 4096 doubles the failing ceiling and stays well
  under the runner's RAM.
- `scripts/sidecar-bundle.test.mjs` — guard the pin so a later edit cannot drop
  it silently.

## Verification

- `bash -n scripts/sidecar-bundle.sh` — syntax ok.
- `node scripts/sidecar-bundle.test.mjs` — passes.
- Negative control: temporarily lowering the pin to 2048 fails the guard with
  `heap ceiling must be at least 4096 MB, got 2048`; restoring it passes.

Tracked by `cave-khusy`.
