### PR TITLE
fix(release): let the iOS archive resolve provisioning headlessly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -735,12 +735,31 @@ jobs:
         working-directory: apps/ios/CovenCave
         shell: bash
         env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
           ARCHIVE_PATH="$RUNNER_TEMP/CovenCave.xcarchive"
           EXPORT_PATH="$RUNNER_TEMP/CovenCave-TestFlight"
           EXPORT_OPTIONS_PATH="$RUNNER_TEMP/CovenCave-ExportOptions.plist"
+          # `apps/ios/CovenCave/project.yml` sets CODE_SIGN_STYLE: Automatic, but
+          # xcodebuild treats automatic signing as DISABLED unless it is given
+          # `-allowProvisioningUpdates`. Without these flags the archive fails
+          # with "No profiles for 'ai.opencoven.cave' were found ... Automatic
+          # signing is disabled", even though the previous step installed and
+          # validated App Store profiles for both targets. Authenticate with the
+          # App Store Connect key staged above so the resolution is headless.
+          [ -n "${APPLE_API_KEY_PATH:-}" ] || {
+            echo "::error::APPLE_API_KEY_PATH is required; the key staging step must run first"
+            exit 1
+          }
+          PROVISIONING_ARGS=(
+            -allowProvisioningUpdates
+            -authenticationKeyPath "$APPLE_API_KEY_PATH"
+            -authenticationKeyID "$APPLE_API_KEY"
+            -authenticationKeyIssuerID "$APPLE_API_ISSUER"
+          )
           cat > "$EXPORT_OPTIONS_PATH" <<PLIST
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -763,11 +782,13 @@ jobs:
             -configuration Release \
             -destination 'generic/platform=iOS' \
             -archivePath "$ARCHIVE_PATH" \
+            "${PROVISIONING_ARGS[@]}" \
             archive
           xcodebuild -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
             -exportOptionsPlist "$EXPORT_OPTIONS_PATH" \
-            -exportPath "$EXPORT_PATH"
+            -exportPath "$EXPORT_PATH" \
+            "${PROVISIONING_ARGS[@]}"
           IPA_COUNT="$(find "$EXPORT_PATH" -maxdepth 1 -type f -name '*.ipa' | wc -l | tr -d ' ')"
           [ "$IPA_COUNT" -eq 1 ] || {
             echo "::error::Expected exactly one exported IPA, found $IPA_COUNT"

--- a/scripts/ios-build-ci.test.mjs
+++ b/scripts/ios-build-ci.test.mjs
@@ -137,4 +137,29 @@ assert.doesNotMatch(
   "TestFlight publication failures must not block unrelated desktop artifacts",
 );
 
+// ── The archive can actually resolve signing ────────────────────────────────
+// `project.yml` sets CODE_SIGN_STYLE: Automatic, and xcodebuild treats that as
+// DISABLED unless `-allowProvisioningUpdates` is passed. Release run
+// 32496765932 failed the archive with "No profiles for 'ai.opencoven.cave' were
+// found ... Automatic signing is disabled" despite the preceding step having
+// installed and validated App Store profiles for both targets. This went
+// unnoticed because every recent release resolved `resume-confirmed` and
+// skipped the archive entirely — the job reported success without ever
+// building. Pin the flags so the reachable path stays signable.
+assert.match(
+  iosJob,
+  /-allowProvisioningUpdates/,
+  "the iOS archive must pass -allowProvisioningUpdates; automatic signing is otherwise disabled under xcodebuild",
+);
+for (const flag of [
+  "-authenticationKeyPath",
+  "-authenticationKeyID",
+  "-authenticationKeyIssuerID",
+]) {
+  assert.ok(
+    iosJob.includes(flag),
+    `the iOS archive must authenticate provisioning with ${flag} so profile resolution is headless`,
+  );
+}
+
 console.log("ios-build-ci.test.mjs: ok");


### PR DESCRIPTION
## Problem

`v0.3.9`'s release run
[32496765932](https://github.com/OpenCoven/coven-cave/actions/runs/32496765932)
reached `Archive and export the iOS app` — and failed there:

```
error: No profiles for 'ai.opencoven.cave' were found: Xcode couldn't find any
iOS App Development provisioning profiles matching 'ai.opencoven.cave'.
Automatic signing is disabled and unable to generate a profile. To enable
automatic signing, pass -allowProvisioningUpdates to xcodebuild.
** ARCHIVE FAILED **
```

`apps/ios/CovenCave/project.yml` sets `CODE_SIGN_STYLE: Automatic`, and
`xcodebuild` treats automatic signing as **disabled** unless it is passed
`-allowProvisioningUpdates`. The step immediately before had installed *and
validated* App Store profiles for both targets (`Install iOS signing assets`
succeeded, exporting `IOS_PROFILE_PATH_APP` / `IOS_PROFILE_PATH_WIDGET`) — the
archive simply could not reach them.

### Why a green iOS leg did not catch this

The recent runs that reported the iOS job as `success` never archived. In run
32244036383 the step conclusions are:

```
success  Resolve iOS release metadata
skipped  Install iOS signing assets
skipped  Archive and export the iOS app
skipped  Validate, upload, and confirm TestFlight processing
```

They resolved `resume-confirmed` — that build version already existed on App
Store Connect — so the job was a no-op that reported green. A passing iOS leg
was not evidence the iOS leg worked.

## Change

- `.github/workflows/release.yml` — pass `-allowProvisioningUpdates` plus
  `-authenticationKeyPath` / `-authenticationKeyID` / `-authenticationKeyIssuerID`
  to **both** `xcodebuild archive` and `xcodebuild -exportArchive`, reusing the
  App Store Connect key that `Stage App Store Connect API key` already writes to
  `APPLE_API_KEY_PATH`. Resolution stays headless — no interactive account. The
  step fails fast with a clear message if that key is absent.
- `scripts/ios-build-ci.test.mjs` — guard all four flags inside the iOS job
  slice.

## Verification

- `python3 -c "yaml.safe_load(...)"` parses the workflow; the archive step's
  `run` body extracted from the parsed YAML passes `bash -n`.
- `node scripts/ios-build-ci.test.mjs` — passes.
- Negative control: renaming `-allowProvisioningUpdates` in the workflow fails
  the guard with `the iOS archive must pass -allowProvisioningUpdates`;
  restoring it passes.

Tracked by `cave-ofbij`. Follows #4812, which fixed the macOS sidecar OOM that
was blocking this job from running at all.
