### PR TITLE
fix(release): sign the iOS archive manually against the installed profiles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -724,6 +724,9 @@ jobs:
             local output_name
             output_name="$(printf '%s' "$label" | tr '[:lower:]' '[:upper:]')"
             echo "IOS_PROFILE_PATH_${output_name}=$PROFILE_DIR/${uuid}.mobileprovision" >> "$GITHUB_ENV"
+            # The archive signs manually against this exact profile, addressed
+            # by UUID so a profile rename cannot silently repoint the build.
+            echo "IOS_PROFILE_UUID_${output_name}=$uuid" >> "$GITHUB_ENV"
           }
           install_profile "$IOS_APP_PROVISIONING_PROFILE_BASE64" app ai.opencoven.cave
           install_profile "$IOS_WIDGET_PROVISIONING_PROFILE_BASE64" widget ai.opencoven.cave.widgets
@@ -743,22 +746,33 @@ jobs:
           ARCHIVE_PATH="$RUNNER_TEMP/CovenCave.xcarchive"
           EXPORT_PATH="$RUNNER_TEMP/CovenCave-TestFlight"
           EXPORT_OPTIONS_PATH="$RUNNER_TEMP/CovenCave-ExportOptions.plist"
-          # `apps/ios/CovenCave/project.yml` sets CODE_SIGN_STYLE: Automatic, but
-          # xcodebuild treats automatic signing as DISABLED unless it is given
-          # `-allowProvisioningUpdates`. Without these flags the archive fails
-          # with "No profiles for 'ai.opencoven.cave' were found ... Automatic
-          # signing is disabled", even though the previous step installed and
-          # validated App Store profiles for both targets. Authenticate with the
-          # App Store Connect key staged above so the resolution is headless.
-          [ -n "${APPLE_API_KEY_PATH:-}" ] || {
-            echo "::error::APPLE_API_KEY_PATH is required; the key staging step must run first"
-            exit 1
-          }
-          PROVISIONING_ARGS=(
-            -allowProvisioningUpdates
-            -authenticationKeyPath "$APPLE_API_KEY_PATH"
-            -authenticationKeyID "$APPLE_API_KEY"
-            -authenticationKeyIssuerID "$APPLE_API_ISSUER"
+          # Sign manually against the App Store profiles the previous step
+          # installed and validated. Automatic signing is not available here:
+          # xcodebuild treats it as disabled unless it is told to update
+          # provisioning, and when it is told to, Apple answers the handshake
+          # with
+          #   Communication with Apple failed: ... (401) for URL
+          #   https://appstoreconnect.apple.com/xcbuild/.../listTeams.action
+          # because the App Store Connect key is user-scoped
+          # (vars.APPLE_API_KEY_SUBJECT=user) and cannot perform team
+          # operations. Manual signing needs no Apple round-trip at all.
+          #
+          # CODE_SIGN_STYLE and the identity are the same for both targets, so
+          # they pass as ordinary build settings. The profile is NOT — the app
+          # and the widget need different ones — so each target reads its own
+          # user-defined setting, declared in apps/ios/CovenCave/project.yml.
+          for required in IOS_PROFILE_UUID_APP IOS_PROFILE_UUID_WIDGET; do
+            [ -n "${!required:-}" ] || {
+              echo "::error::$required is required; the signing-asset step must run first"
+              exit 1
+            }
+          done
+          SIGNING_ARGS=(
+            CODE_SIGN_STYLE=Manual
+            CODE_SIGN_IDENTITY="Apple Distribution"
+            DEVELOPMENT_TEAM="$APPLE_TEAM_ID"
+            CAVE_IOS_APP_PROFILE="$IOS_PROFILE_UUID_APP"
+            CAVE_IOS_WIDGET_PROFILE="$IOS_PROFILE_UUID_WIDGET"
           )
           cat > "$EXPORT_OPTIONS_PATH" <<PLIST
           <?xml version="1.0" encoding="UTF-8"?>
@@ -770,9 +784,18 @@ jobs:
             <key>method</key>
             <string>app-store-connect</string>
             <key>signingStyle</key>
-            <string>automatic</string>
+            <string>manual</string>
             <key>teamID</key>
             <string>$APPLE_TEAM_ID</string>
+            <key>signingCertificate</key>
+            <string>Apple Distribution</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>ai.opencoven.cave</key>
+              <string>$IOS_PROFILE_UUID_APP</string>
+              <key>ai.opencoven.cave.widgets</key>
+              <string>$IOS_PROFILE_UUID_WIDGET</string>
+            </dict>
           </dict>
           </plist>
           PLIST
@@ -782,13 +805,12 @@ jobs:
             -configuration Release \
             -destination 'generic/platform=iOS' \
             -archivePath "$ARCHIVE_PATH" \
-            "${PROVISIONING_ARGS[@]}" \
+            "${SIGNING_ARGS[@]}" \
             archive
           xcodebuild -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
             -exportOptionsPlist "$EXPORT_OPTIONS_PATH" \
-            -exportPath "$EXPORT_PATH" \
-            "${PROVISIONING_ARGS[@]}"
+            -exportPath "$EXPORT_PATH"
           IPA_COUNT="$(find "$EXPORT_PATH" -maxdepth 1 -type f -name '*.ipa' | wc -l | tr -d ' ')"
           [ "$IPA_COUNT" -eq 1 ] || {
             echo "::error::Expected exactly one exported IPA, found $IPA_COUNT"

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -62,6 +62,15 @@ targets:
         SWIFT_EMIT_LOC_STRINGS: YES
         IPHONEOS_DEPLOYMENT_TARGET: "18.0"
         CODE_SIGN_ENTITLEMENTS: CovenCave/CovenCave.entitlements
+        # Release CI signs manually against the App Store profile it installs
+        # and validates, because the App Store Connect key available to the
+        # workflow is user-scoped (vars.APPLE_API_KEY_SUBJECT=user) and Apple
+        # answers xcodebuild's automatic-signing handshake with HTTP 401 on
+        # listTeams. The workflow supplies the profile UUID per target through
+        # this user-defined setting; a build that does not set it resolves to
+        # empty, which CODE_SIGN_STYLE: Automatic above ignores — so local and
+        # Debug builds are unaffected.
+        PROVISIONING_PROFILE_SPECIFIER: $(CAVE_IOS_APP_PROFILE)
     dependencies:
       - package: WebRTC
         product: WebRTC
@@ -123,6 +132,9 @@ targets:
         IPHONEOS_DEPLOYMENT_TARGET: "18.0"
         SKIP_INSTALL: YES
         CODE_SIGN_ENTITLEMENTS: CovenCaveWidgets/CovenCaveWidgets.entitlements
+        # See the note on the app target: the release workflow passes this
+        # target's own App Store profile UUID, and it is empty everywhere else.
+        PROVISIONING_PROFILE_SPECIFIER: $(CAVE_IOS_WIDGET_PROFILE)
 
 schemes:
   CovenCave:

--- a/scripts/ios-build-ci.test.mjs
+++ b/scripts/ios-build-ci.test.mjs
@@ -15,6 +15,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const workflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+const project = readFileSync(
+  new URL("../apps/ios/CovenCave/project.yml", import.meta.url),
+  "utf8",
+);
 const iosJobStart = workflow.indexOf("  release-ios-build:");
 const iosJobEnd = workflow.indexOf("\n  build:", iosJobStart);
 assert.notEqual(iosJobStart, -1, "release.yml defines the iOS build job delimiter");
@@ -138,27 +142,59 @@ assert.doesNotMatch(
 );
 
 // ── The archive can actually resolve signing ────────────────────────────────
-// `project.yml` sets CODE_SIGN_STYLE: Automatic, and xcodebuild treats that as
-// DISABLED unless `-allowProvisioningUpdates` is passed. Release run
-// 32496765932 failed the archive with "No profiles for 'ai.opencoven.cave' were
-// found ... Automatic signing is disabled" despite the preceding step having
-// installed and validated App Store profiles for both targets. This went
-// unnoticed because every recent release resolved `resume-confirmed` and
-// skipped the archive entirely — the job reported success without ever
-// building. Pin the flags so the reachable path stays signable.
+// Release run 32496765932 failed the archive with "No profiles for
+// 'ai.opencoven.cave' were found ... Automatic signing is disabled", and run
+// 32501746425 — after adding -allowProvisioningUpdates — failed with
+// "Communication with Apple failed: ... (401) ... listTeams.action". The App
+// Store Connect key here is user-scoped (vars.APPLE_API_KEY_SUBJECT=user) and
+// cannot perform team operations, so automatic signing is unavailable no matter
+// how it is invoked. The archive must therefore sign manually against the
+// profiles the preceding step installs and validates.
+//
+// None of this was caught earlier because every recent release resolved
+// `resume-confirmed` and skipped the archive, the export and the upload
+// outright — the job reported success without ever building.
 assert.match(
   iosJob,
-  /-allowProvisioningUpdates/,
-  "the iOS archive must pass -allowProvisioningUpdates; automatic signing is otherwise disabled under xcodebuild",
+  /CODE_SIGN_STYLE=Manual/,
+  "the iOS archive must sign manually; the user-scoped App Store Connect key cannot drive automatic signing",
 );
-for (const flag of [
-  "-authenticationKeyPath",
-  "-authenticationKeyID",
-  "-authenticationKeyIssuerID",
+assert.doesNotMatch(
+  iosJob,
+  /-allowProvisioningUpdates/,
+  "automatic provisioning is unavailable with a user-scoped key and must not be reintroduced",
+);
+// The app and the widget need DIFFERENT profiles, and a build setting passed on
+// the xcodebuild command line applies to every target. Each target therefore
+// reads its own user-defined setting, declared in project.yml.
+for (const [variable, envVar] of [
+  ["CAVE_IOS_APP_PROFILE", "IOS_PROFILE_UUID_APP"],
+  ["CAVE_IOS_WIDGET_PROFILE", "IOS_PROFILE_UUID_WIDGET"],
 ]) {
   assert.ok(
-    iosJob.includes(flag),
-    `the iOS archive must authenticate provisioning with ${flag} so profile resolution is headless`,
+    iosJob.includes(`${variable}="$${envVar}"`),
+    `the iOS archive must pass ${variable} from ${envVar} so each target signs with its own profile`,
+  );
+  assert.match(
+    project,
+    new RegExp(`PROVISIONING_PROFILE_SPECIFIER: \\$\\(${variable}\\)`),
+    `project.yml must route a target's provisioning profile through ${variable}`,
+  );
+  assert.match(
+    iosJob,
+    new RegExp(`${envVar}=\\$uuid|${envVar}_?`),
+    `the signing-asset step must export ${envVar}`,
+  );
+}
+assert.match(
+  iosJob,
+  /<string>manual<\/string>/,
+  "the export options must use manual signing to match the archive",
+);
+for (const bundleId of ["ai.opencoven.cave", "ai.opencoven.cave.widgets"]) {
+  assert.ok(
+    iosJob.includes(`<key>${bundleId}</key>`),
+    `the export options must map ${bundleId} to its provisioning profile`,
   );
 }
 


### PR DESCRIPTION
## Problem

Automatic signing cannot work in this workflow, and #4813 proved it the hard
way.

| Run | Change in effect | Failure |
| --- | --- | --- |
| [32496765932](https://github.com/OpenCoven/coven-cave/actions/runs/32496765932) | original | `No profiles for 'ai.opencoven.cave' were found ... Automatic signing is disabled` |
| [32501746425](https://github.com/OpenCoven/coven-cave/actions/runs/32501746425) | #4813 added the provisioning-update flag | `Communication with Apple failed: A non-HTTP 200 response was received (401) for URL .../xcbuild/QH65B2/listTeams.action` |

The 401 is the root cause: `vars.APPLE_API_KEY_SUBJECT` is **`user`**, so the App
Store Connect key this repository holds is user-scoped and cannot perform team
operations such as listing teams. No invocation of automatic signing can
succeed with these credentials.

## Change

Sign manually against the App Store profiles the preceding step *already*
installs and validates (correct bundle id, `get-task-allow` false, no
provisioned devices). That path makes no Apple round-trip at all, which also
removes a network dependency from the release.

- `.github/workflows/release.yml`
  - export `IOS_PROFILE_UUID_APP` / `IOS_PROFILE_UUID_WIDGET` from the
    signing-asset step, addressing each profile by UUID so a rename cannot
    silently repoint the build;
  - archive with `CODE_SIGN_STYLE=Manual`, `CODE_SIGN_IDENTITY="Apple Distribution"`
    and the team, plus each target's profile;
  - export with `signingStyle: manual` and an explicit `provisioningProfiles`
    map for both bundle ids.
- `apps/ios/CovenCave/project.yml` — the app and widget need **different**
  profiles, and a build setting given to `xcodebuild` applies to every target.
  So each target reads its own user-defined setting
  (`$(CAVE_IOS_APP_PROFILE)` / `$(CAVE_IOS_WIDGET_PROFILE)`).
- `scripts/ios-build-ci.test.mjs` — pin manual signing, pin the per-target
  routing across both files, and assert the provisioning-update flag is not
  reintroduced.

### Local and Debug builds are unaffected

The user-defined settings resolve to empty when nothing supplies them, and
`CODE_SIGN_STYLE` stays `Automatic` from the project base.

## Verification

Generated the project with `xcodegen` and read the resolved settings back with
`xcodebuild -showBuildSettings`:

```
# with values supplied
ai.opencoven.cave          PROVISIONING_PROFILE_SPECIFIER = UUID-APP-TEST
ai.opencoven.cave.widgets  PROVISIONING_PROFILE_SPECIFIER = UUID-WIDGET-TEST
                           CODE_SIGN_STYLE = Manual

# with nothing supplied (local default)
ai.opencoven.cave          CODE_SIGN_STYLE = Automatic   (no specifier set)
```

- `release.yml` and `project.yml` both parse; the archive step's `run` body
  extracted from the parsed YAML passes `bash -n`.
- All 68 `scripts/ios-*.test.mjs` guards pass.
- Negative controls: flipping `CODE_SIGN_STYLE=Manual` to `Automatic` fails with
  `the iOS archive must sign manually`; renaming the widget variable in
  `project.yml` fails with `project.yml must route a target's provisioning
  profile through CAVE_IOS_WIDGET_PROFILE`. Both pass again once restored.

Tracked by `cave-ofbij`.

### Why no guard caught this earlier

Every recent release resolved `resume-confirmed` and skipped the archive, the
export and the upload outright — e.g. run 32244036383:

```
skipped  Install iOS signing assets
skipped  Archive and export the iOS app
skipped  Validate, upload, and confirm TestFlight processing
```

A green iOS leg was not evidence the iOS leg worked.
