### PR TITLE
fix(scripts): repair the direct-run guard that made two CLIs inert on Windows (cave-zya, cave-wxq)

### DIFF
--- a/scripts/check-beads-jsonl-duplicates.mjs
+++ b/scripts/check-beads-jsonl-duplicates.mjs
@@ -20,9 +20,10 @@
 // arrives via a PR, and the wired test calls this. The pre-commit hook is fast
 // local feedback, not the guarantee.
 
-import { readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+
+import { isDirectRun as isDirectRunOf } from "./direct-run.mjs";
 
 /**
  * Scan JSONL text for repeated `id` values and unparseable lines.
@@ -158,26 +159,11 @@ function main(argv) {
   return 0;
 }
 
-// "Am I being run directly?" — compared as REAL paths, not as URL strings.
-//
-// Two ways the naive `import.meta.url === \`file://${process.argv[1]}\`` goes
-// wrong, and both make main() silently never run, which is the worst failure
-// mode for a checker:
-//   1. no percent-encoding — a checkout under a path containing a space gives
-//      `file:///tmp/a b/x.mjs` where import.meta.url is `file:///tmp/a%20b/x.mjs`;
-//   2. symlinks — on macOS `/var` is a symlink to `/private/var`, so argv[1]
-//      can be `/var/folders/...` while import.meta.url resolves to
-//      `/private/var/folders/...`. pathToFileURL alone does NOT fix this.
-// realpathSync on both sides collapses both cases. Verified by an executable
-// test that runs this file from a temp directory whose name contains a space.
+// "Am I being run directly?" — see scripts/direct-run.mjs for the three ways
+// the naive URL-string comparison goes wrong. Verified by an executable test
+// that runs this file from a temp directory whose name contains a space.
 function isDirectRun() {
-  const entry = process.argv[1];
-  if (!entry) return false;
-  try {
-    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
-  } catch {
-    return false;
-  }
+  return isDirectRunOf(import.meta.url);
 }
 
 if (isDirectRun()) {

--- a/scripts/check-beads-jsonl-duplicates.test.mjs
+++ b/scripts/check-beads-jsonl-duplicates.test.mjs
@@ -143,6 +143,9 @@ test("a checkout path containing a space still runs the CLI", () => {
   const dir = mkdtempSync(join(tmpdir(), "beads dup guard "));
   const script = join(dir, "check.mjs");
   copyFileSync(join(repoRoot, "scripts/check-beads-jsonl-duplicates.mjs"), script);
+  // The direct-run guard is a sibling module, so the copy needs it alongside
+  // under the name the script imports.
+  copyFileSync(join(repoRoot, "scripts/direct-run.mjs"), join(dir, "direct-run.mjs"));
   const dirty = join(dir, "dirty.jsonl");
   writeFileSync(dirty, [rec("a"), rec("a")].join("\n") + "\n");
 
@@ -152,6 +155,20 @@ test("a checkout path containing a space still runs the CLI", () => {
     1,
     `CLI must still run from a path with a space (got ${res.status}); ` +
       "a naive file:// concatenation silently no-ops here",
+  );
+  // Status alone is too weak to prove the CLI ran: a module that fails to load
+  // also exits 1, so this assertion passed for the wrong reason the moment the
+  // guard moved into a sibling module. Pin the output that only real work
+  // produces.
+  assert.doesNotMatch(
+    res.stderr,
+    /ERR_MODULE_NOT_FOUND|Cannot find module/,
+    "the copied CLI must load its imports, not exit 1 because one is missing",
+  );
+  assert.match(
+    `${res.stdout}${res.stderr}`,
+    /duplicate/i,
+    "and must exit 1 because it found the duplicate, not for any other reason",
   );
   rmSync(dir, { recursive: true, force: true });
 });

--- a/scripts/check-conflict-markers.mjs
+++ b/scripts/check-conflict-markers.mjs
@@ -13,6 +13,8 @@
 
 import { execFileSync } from "node:child_process";
 
+import { isDirectRun } from "./direct-run.mjs";
+
 /**
  * Only `<<<<<<<` and `>>>>>>>` trigger a failure, never a bare `=======`.
  *
@@ -98,4 +100,4 @@ function main() {
   process.exit(1);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+if (isDirectRun(import.meta.url)) main();

--- a/scripts/dev-port-owner.mjs
+++ b/scripts/dev-port-owner.mjs
@@ -1,5 +1,4 @@
-import { realpathSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { isDirectRun as isDirectRunOf } from "./direct-run.mjs";
 
 /**
  * Who owns the dedicated dev port?
@@ -73,14 +72,10 @@ export async function classifyPortOwner({
   }
 }
 
+// See scripts/direct-run.mjs for the three ways a naive URL/argv comparison
+// breaks.
 function isDirectRun() {
-  const entry = process.argv[1];
-  if (!entry) return false;
-  try {
-    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
-  } catch {
-    return false;
-  }
+  return isDirectRunOf(import.meta.url);
 }
 
 if (isDirectRun()) {

--- a/scripts/dev-port-owner.test.mjs
+++ b/scripts/dev-port-owner.test.mjs
@@ -91,6 +91,11 @@ assert.equal(args.get("timeout-ms"), "500");
   try {
     const fixtureScript = path.join(fixtureDir, "dev-port-owner.mjs");
     copyFileSync(new URL("./dev-port-owner.mjs", import.meta.url), fixtureScript);
+    // The direct-run guard is a sibling module, so the copy needs it alongside.
+    copyFileSync(
+      new URL("./direct-run.mjs", import.meta.url),
+      path.join(fixtureDir, "direct-run.mjs"),
+    );
     const result = spawnSync(process.execPath, [fixtureScript, "--port", "0"], {
       encoding: "utf8",
     });

--- a/scripts/direct-run.mjs
+++ b/scripts/direct-run.mjs
@@ -1,0 +1,44 @@
+// "Am I being run directly, rather than imported?" — compared as REAL paths,
+// never as URL strings.
+//
+// The naive spelling is `import.meta.url === `file://${process.argv[1]}``, and
+// it fails three separate ways. Every one of them makes the module's `main()`
+// silently never run, which is the worst possible failure mode for a guard: the
+// gate reports success because it did nothing at all.
+//
+//   1. **no percent-encoding** — a checkout under a path containing a space
+//      gives `file:///tmp/a b/x.mjs` where `import.meta.url` is
+//      `file:///tmp/a%20b/x.mjs`;
+//   2. **symlinks** — on macOS `/var` is a symlink to `/private/var`, so
+//      `argv[1]` can be `/var/folders/…` while `import.meta.url` resolves to
+//      `/private/var/folders/…`. `pathToFileURL` alone does NOT fix this;
+//   3. **Windows separators and the third slash** — `argv[1]` is a backslashed
+//      drive path (`C:\Users\…`) while `import.meta.url` is
+//      `file:///C:/Users/…`. The naive form yields `file://C:\Users\…`, which
+//      matches nothing, so on Windows these CLIs were unconditionally inert.
+//
+// `realpathSync` on both sides collapses all three. This lives in its own
+// module because the helper was previously copy-pasted into each script that
+// needed it, and that duplication is precisely what drifted: two scripts were
+// repaired while `check-conflict-markers.mjs` and `generate-icon-subset.mjs`
+// kept the broken spelling and went unnoticed on Windows for months
+// (cave-zya). One definition, four callers — the same discipline
+// `budget-headroom.mjs` exists to enforce.
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * @param {string} importMetaUrl the calling module's `import.meta.url`
+ * @returns {boolean} true when that module is the process entry point
+ */
+export function isDirectRun(importMetaUrl) {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(importMetaUrl));
+  } catch {
+    // A missing or unreadable entry path is not a direct run. Failing closed
+    // here keeps an importing test from accidentally executing a CLI body.
+    return false;
+  }
+}

--- a/scripts/direct-run.test.mjs
+++ b/scripts/direct-run.test.mjs
@@ -1,0 +1,149 @@
+// Proves the shared direct-run guard by EXECUTING scripts, never by matching
+// their source text.
+//
+// A source-text pin cannot tell a working CLI entry from a broken one — that is
+// exactly how cave-zya survived: `check-conflict-markers.mjs` and
+// `generate-icon-subset.mjs` both carried a spelling that reads correctly and
+// was unconditionally inert on Windows, so a repo-wide gate exited 0 on a tree
+// full of conflict markers and the icon subset was never regenerated during a
+// Windows build. Only running them catches that.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { isDirectRun } from "./direct-run.mjs";
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+
+function tempDir(prefix) {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+test("an imported module is not a direct run", () => {
+  // direct-run.mjs is imported by this file, never the process entry point, so
+  // the helper must say no for it. Deliberately NOT asserted against
+  // `import.meta.url`: under `node --test` this file IS argv[1], so that would
+  // pin the runner's invocation shape rather than the helper's semantics.
+  const imported = new URL("./direct-run.mjs", import.meta.url).href;
+  assert.equal(isDirectRun(imported), false);
+});
+
+test("a module that does not exist on disk is not a direct run", () => {
+  // realpathSync throws for a missing path; the helper must fail closed rather
+  // than propagate, so an importing test can never execute a CLI body.
+  const missing = new URL("./direct-run.does-not-exist.mjs", import.meta.url).href;
+  assert.equal(isDirectRun(missing), false);
+});
+
+test("a missing argv[1] is not a direct run", () => {
+  const original = process.argv[1];
+  try {
+    // Node can be invoked with no script path (`node --eval`), and the helper
+    // must fail closed rather than throw.
+    process.argv[1] = undefined;
+    assert.equal(isDirectRun(import.meta.url), false);
+  } finally {
+    process.argv[1] = original;
+  }
+});
+
+test("a script run directly reports a direct run, even from a path with a space", () => {
+  const dir = tempDir("direct run guard ");
+  try {
+    const script = join(dir, "entry.mjs");
+    // Import the helper by absolute file URL so the fixture needs no
+    // node_modules resolution of its own.
+    const helper = JSON.stringify(new URL("./direct-run.mjs", import.meta.url).href);
+    writeFileSync(
+      script,
+      `import { isDirectRun } from ${helper};\n` +
+        `process.stdout.write(isDirectRun(import.meta.url) ? "DIRECT" : "IMPORTED");\n`,
+      "utf8",
+    );
+
+    const run = spawnSync(process.execPath, [script], { encoding: "utf8" });
+    assert.equal(run.status, 0, run.stderr);
+    assert.equal(run.stdout, "DIRECT", "a directly executed script must report DIRECT");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("check-conflict-markers actually runs as a CLI and fails a dirty tree", () => {
+  // The cave-zya regression itself. Before the fix this exited 0 and printed
+  // nothing on Windows, because main() never ran.
+  const script = join(scriptsDir, "check-conflict-markers.mjs");
+
+  const makeRepo = (contents) => {
+    const dir = tempDir("conflict markers ");
+    const git = (...args) => spawnSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+    git("init", "-q");
+    git("config", "user.email", "test@example.invalid");
+    git("config", "user.name", "Test");
+    writeFileSync(join(dir, "a.ts"), contents, "utf8");
+    git("add", "-A");
+    git("commit", "-qm", "fixture");
+    return dir;
+  };
+
+  const clean = makeRepo("const a = 1;\n");
+  const dirty = makeRepo("<<<<<<< HEAD\n");
+  try {
+    const ok = spawnSync(process.execPath, [script], { cwd: clean, encoding: "utf8" });
+    assert.equal(ok.status, 0, `a clean tree must exit 0\n${ok.stderr}`);
+    assert.match(ok.stdout, /no committed conflict markers/, "and say so on stdout");
+
+    const bad = spawnSync(process.execPath, [script], { cwd: dirty, encoding: "utf8" });
+    assert.equal(bad.status, 1, "a gate that cannot fail is not a gate");
+    assert.match(bad.stderr, /merge-conflict markers/i);
+  } finally {
+    rmSync(clean, { recursive: true, force: true });
+    rmSync(dirty, { recursive: true, force: true });
+  }
+});
+
+test("generate-icon-subset actually runs as a CLI and regenerates identical output", async () => {
+  // The second instance of the same defect, and the one with teeth: this script
+  // runs in `prebuild`, so a dead guard means a Windows build silently ships
+  // whatever subset happened to be committed.
+  //
+  // Its outputs resolve against `import.meta.url`, not the cwd, so a copy of the
+  // script would still write into this checkout. Snapshot the three committed
+  // files, run it for real, then restore them no matter what. Regeneration is
+  // idempotent by construction (every build does it), so asserting the bytes are
+  // unchanged both proves main() ran and pins that invariant.
+  const { SUBSET_URL, GLYPH_URL, FAMILIAR_CORE_URL } = await import("./generate-icon-subset.mjs");
+  const outputs = [SUBSET_URL, GLYPH_URL, FAMILIAR_CORE_URL].map((url) => fileURLToPath(url));
+  const before = outputs.map((file) => readFileSync(file));
+
+  try {
+    const run = spawnSync(
+      process.execPath,
+      [join(scriptsDir, "generate-icon-subset.mjs")],
+      { encoding: "utf8" },
+    );
+
+    // A guard that never fires produces no output on either stream and exits 0 —
+    // indistinguishable from success unless you look for the output itself.
+    assert.notEqual(
+      `${run.stdout}${run.stderr}`.trim(),
+      "",
+      "the CLI produced no output at all, which is exactly what a dead direct-run guard looks like",
+    );
+    assert.equal(run.status, 0, `generate-icon-subset should succeed\n${run.stderr}`);
+
+    outputs.forEach((file, index) => {
+      assert.ok(
+        readFileSync(file).equals(before[index]),
+        `${file} changed — the committed icon subset is stale, rerun pnpm prebuild`,
+      );
+    });
+  } finally {
+    outputs.forEach((file, index) => writeFileSync(file, before[index]));
+  }
+});

--- a/scripts/generate-icon-subset.mjs
+++ b/scripts/generate-icon-subset.mjs
@@ -14,6 +14,8 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 
+import { isDirectRun } from "./direct-run.mjs";
+
 const require = createRequire(import.meta.url);
 
 export const ICON_TSX_URL = new URL("../src/lib/icon.tsx", import.meta.url);
@@ -148,7 +150,7 @@ export function generate() {
 }
 
 // CLI entry — write all generated collections (and hard-fail on unknown names).
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectRun(import.meta.url)) {
   const {
     subset,
     missing,

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -82,6 +82,7 @@ export const SUITES = {
     "scripts/eslint/react-hooks-gate.test.mjs",
     "scripts/check-beads-jsonl-duplicates.test.mjs",
     "scripts/check-conflict-markers.test.mjs",
+    "scripts/direct-run.test.mjs",
     "scripts/pdf-worker-asset.test.mjs",
     "scripts/onboarding-feedback-report.test.mjs",
     "scripts/beads-jsonl-merge-driver.test.mjs",

--- a/scripts/worktree-autolock.mjs
+++ b/scripts/worktree-autolock.mjs
@@ -30,9 +30,10 @@
 // Advisory only: this never blocks a tool call and always exits 0.
 
 import { execFileSync } from "node:child_process";
-import { appendFileSync, mkdirSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+
+import { isDirectRun as isDirectRunOf } from "./direct-run.mjs";
 
 const THROTTLE_MS = 60_000;
 const REASON_PREFIX = "auto-locked";
@@ -287,24 +288,12 @@ function main() {
   }
 }
 
-// "Am I being run directly?" — compared as REAL paths, not as URL strings, the
-// same way `check-beads-jsonl-duplicates.mjs` does it. The naive
-// `import.meta.url === \`file://${process.argv[1]}\`` fails two ways here, and
-// both make the hook silently never run — the worst outcome for a guard, since
-// worktrees would look protected while nothing locked them:
-//   1. no percent-encoding — a checkout under a path with a space gives
-//      `file:///tmp/a b/x.mjs` while import.meta.url is `file:///tmp/a%20b/x.mjs`;
-//   2. symlinks — on macOS `/tmp` is a symlink to `/private/tmp`, so argv[1]
-//      can be `/tmp/...` while import.meta.url resolves to `/private/tmp/...`.
-// realpathSync on both sides collapses both cases.
+// "Am I being run directly?" — see scripts/direct-run.mjs for the three ways
+// the naive URL-string comparison goes wrong. Getting this wrong here makes the
+// hook silently never run, which is the worst outcome for a guard: worktrees
+// would look protected while nothing locked them.
 function isDirectRun() {
-  const entry = process.argv[1];
-  if (!entry) return false;
-  try {
-    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
-  } catch {
-    return false;
-  }
+  return isDirectRunOf(import.meta.url);
 }
 
 // Importable for tests; only acts when run as the hook itself. The hook's JSON

--- a/scripts/worktree-autolock.test.mjs
+++ b/scripts/worktree-autolock.test.mjs
@@ -168,6 +168,14 @@ try {
     mkdirSync(spaced);
     const script = path.join(spaced, "worktree-autolock.mjs");
     copyFileSync(fileURLToPath(new URL("./worktree-autolock.mjs", import.meta.url)), script);
+    // The direct-run guard now lives in a sibling module, so the copy needs it
+    // too — otherwise the script dies on ERR_MODULE_NOT_FOUND before reaching
+    // the behaviour under test, which reads as the same silence this case
+    // exists to catch.
+    copyFileSync(
+      fileURLToPath(new URL("./direct-run.mjs", import.meta.url)),
+      path.join(spaced, "direct-run.mjs"),
+    );
 
     // Reach the script through a symlink so argv[1] and import.meta.url differ.
     const linked = path.join(box, "link");

--- a/scripts/worktree-retention-push.mjs
+++ b/scripts/worktree-retention-push.mjs
@@ -21,9 +21,10 @@
 // Advisory only: this never blocks a tool call and always exits 0.
 
 import { execFileSync } from "node:child_process";
-import { appendFileSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+
+import { isDirectRun as isDirectRunOf } from "./direct-run.mjs";
 
 const THROTTLE_MS = 60_000;
 // Bounds worst-case latency added to one tool call. Pushed worktrees drop out
@@ -478,17 +479,11 @@ function main() {
   }
 }
 
-// Real-path comparison, matching worktree-autolock.mjs: a naive URL/argv
-// comparison breaks on paths with spaces and on macOS symlinked /tmp, and a
-// guard that silently never runs is the worst outcome.
+// Real-path comparison — see scripts/direct-run.mjs for the three ways a naive
+// URL/argv comparison breaks. A guard that silently never runs is the worst
+// outcome here: worktrees would look retained while nothing pushed them.
 function isDirectRun() {
-  const entry = process.argv[1];
-  if (!entry) return false;
-  try {
-    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
-  } catch {
-    return false;
-  }
+  return isDirectRunOf(import.meta.url);
 }
 
 if (isDirectRun()) {

--- a/src/lib/performance-budgets.ts
+++ b/src/lib/performance-budgets.ts
@@ -250,6 +250,7 @@ const LIST_FIXTURE = "fixtures/phase-6/performance-fixtures.json#phase-6-list-10
  * | windows, 3 benchmarks concurrently  | 1,809.08 |    4,718.10 | 38.34% |
  * | linux (wsl2), idle                  | 1,759.80 |    2,787.94 | 63.12% |
  * | linux (wsl2), 3 concurrently        | 1,639.41 |    3,117.21 | 52.59% |
+ * | **ubuntu-24.04 runner (real CI)**   |   790.20 |    1,485.00 | 53.22% |
  * | windows, read pool collapsed to 1   | 4,397.85 |    3,926.19 | 112.01% |
  * | linux (wsl2), read pool collapsed   | 3,460.77 |    2,718.62 | 127.30% |
  *
@@ -265,8 +266,15 @@ const LIST_FIXTURE = "fixtures/phase-6/performance-fixtures.json#phase-6-list-10
  * worst healthy and 22 points under the nearest collapse. That is a thinner
  * multiple than the 1.9x the cold ms ceiling uses, and deliberately so: the 1.9x
  * exists to absorb scheduling noise, and here the worst case is the QUIET run.
- * Re-seed from the first real `ubuntu-24.04` nightly; WSL2 is Linux syscalls
- * over a VM disk, which is the right family but not the right machine.
+ *
+ * **Confirmed against a real runner (cave-wxq, 2026-08-21, run 32524317599).**
+ * The seed was built entirely from the review machine, with WSL2 standing in for
+ * the nightly's platform — Linux syscalls over a VM disk, the right family but
+ * not the right machine. The first `ubuntu-24.04` nightly measured **53.22%**,
+ * inside the WSL2 pair that bracketed it and 37 points clear of the ceiling, so
+ * no number moves. WSL2 turned out to be the pessimistic stand-in: real CI is
+ * faster in absolute terms (790 ms cold) yet lands mid-band on the ratio, which
+ * is the property a relative budget is chosen for.
  *
  * A ratio budget's job here is to catch the collapse an absolute ceiling
  * structurally cannot. Erosion remains the baseline comparison's job.


### PR DESCRIPTION
Closes `cave-zya`. Closes `cave-wxq`. Both were filed during the review of #4788 and left open there as "real, but not this PR's".

## cave-zya — a repo-wide gate that has been passing everything on Windows

`import.meta.url === ``file://${process.argv[1]}``` never matches on Windows. `argv[1]` is a backslashed drive path (`C:\Users\…`) while `import.meta.url` is `file:///C:/Users/…`, so the naive form builds `file://C:\Users\…` and compares equal to nothing. Every CLI guarded that way ran its imports and then exited 0 having done nothing.

Two scripts were affected, and neither failure is cosmetic:

- **`scripts/check-conflict-markers.mjs`** exists because unresolved conflict blocks reached `main`, stopped a file parsing, and 500'd every route including `/api/app/build-info`. On Windows it has been passing a tree full of markers since #4434, printing not one line of output.
- **`scripts/generate-icon-subset.mjs`** runs in `prebuild`, so a Windows build silently shipped whatever icon subset happened to be committed rather than regenerating it.

## The duplication is why it drifted

Two *other* scripts — `check-beads-jsonl-duplicates.mjs` and `worktree-autolock.mjs` — had already hit this and fixed it, each with its own private copy of the helper and its own comment. That is exactly what let the other two stay broken: a reader of the naive form had no way to know a repaired form existed one directory away.

So this extracts one definition, `scripts/direct-run.mjs`, and converts all four callers — the same "one definition, N callers" discipline `scripts/budget-headroom.mjs` was extracted to enforce. The shared comment documents all **three** failure modes; the two prior copies each knew only the first two:

1. no percent-encoding (a checkout path containing a space);
2. symlinks (`/var` → `/private/var` on macOS — `pathToFileURL` alone does **not** fix this);
3. Windows separators and the third slash — the one that bit here.

## Verification is by execution, not by source text

A source-text pin cannot tell a working entry from an inert one, which is precisely how this survived review. `scripts/direct-run.test.mjs` runs the CLIs:

- `check-conflict-markers` must exit 0 and *say so* on a clean fixture repo, and exit 1 on one containing `<<<<<<< HEAD`.
- `generate-icon-subset` must produce output and regenerate byte-identical files. Its outputs resolve against `import.meta.url` rather than the cwd, so the test snapshots the three committed JSON files and restores them in a `finally` — asserting the bytes are unchanged both proves `main()` ran and pins idempotency.
- The helper itself is checked for an imported module, a missing `argv[1]`, a nonexistent path, and a script executed from a directory whose name contains a space.

**Mutation-tested both ways.** Restoring the broken spelling in `check-conflict-markers.mjs` fails its test; restoring it in `generate-icon-subset.mjs` fails its test. A guard nothing can break is not a guard.

## cave-wxq — the ratio ceiling, confirmed on a real runner

`conversation-list.cold-scan.share-of-full-parse-pct` shipped at 90% in #4788, seeded entirely from the review machine with WSL2 standing in for the nightly's platform. I dispatched the nightly (run `32524317599`) and it measured **53.22%** — inside the WSL2 pair that bracketed it, 37 points clear of the ceiling. **No number moves**; the datapoint is recorded in the seed table, because a limit justified only on a platform CI never runs is an unchecked limit.

Every enforced budget on that real `ubuntu-24.04` run:

| budget | measured | limit | headroom |
| --- | ---: | ---: | ---: |
| cold-scan p50 | 790.20 ms | 5,000 ms | 84.2% |
| warm-cache p50 | 145.21 ms | 750 ms | 80.6% |
| cold-scan share of full parse | 53.22% | 90% | 40.9% |
| cold-scan bytes | 41.59 MiB | 64 MiB | 35.0% |
| warm-cache bytes | 0 B | 8 MiB | 100.0% |
| cache hit rate | 100% | ≥ 95% | 5.3% |

Worth noting for the next re-seed: WSL2 was the *pessimistic* stand-in. Real CI is faster in absolute terms (790 ms cold against WSL2's 1,760 ms) yet lands mid-band on the ratio — which is exactly the property a relative budget is chosen for.

## Gates

`pnpm typecheck` clean · `pnpm lint` clean · `pnpm check:tests-wired` 1,771/1,771 · new suite 6/6 · the four converted scripts' own suites pass.

One local-only failure, confirmed pre-existing by stashing this branch and re-running on pristine `main`: `scripts/worktree-autolock.test.mjs` dies at `symlinkSync` with `EPERM`, because creating a symlink on Windows needs elevation. It passes on Linux CI and is unrelated to this change.
