### PR TITLE
Confirmed, non-retrying X publishing for familiar comms

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -195,6 +195,7 @@ export const SUITES = {
     "src/lib/server/x-credentials.test.ts",
     "src/lib/server/x-access.test.ts",
     "src/lib/server/x-sources.test.ts",
+    "src/lib/server/x-publications.test.ts",
     "src/lib/open-system-browser.test.ts",
     "src/components/familiar-x-section.test.ts",
     "src/components/familiar-x-section-behavior.test.tsx",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -334,6 +334,7 @@ const contracts: RouteContract[] = [
   { route: "/x/oauth/start", methods: ["POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/x/posts/lookup", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/x/posts/search", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
+  { route: "/x/publish", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/x/sources", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
 ];
 

--- a/src/app/api/x/publish/route.ts
+++ b/src/app/api/x/publish/route.ts
@@ -124,9 +124,10 @@ export async function POST(req: Request) {
             confirmationToken: body.confirmationToken,
           },
           {
-            // The preflight sits inside `send` rather than around the whole
-            // call so a capability or token failure never marks the record
-            // dispatched — only the moment a request can actually reach X.
+            // The preflight sits inside `send` so the access token is minted
+            // as late as possible, right before the request goes out. A
+            // capability or token failure here is a definite failure — nothing
+            // reached X — so the store returns the record to `draft`.
             send: (text) =>
               withXWritePreflight(familiarId, WRITE_SCOPES, (accessToken) =>
                 createXPost(accessToken, text)),
@@ -141,15 +142,17 @@ export async function POST(req: Request) {
       }
 
       case "resolve": {
+        // Read the connection once: two calls re-read the credential store and
+        // can disagree, which would pass an explicit `undefined` handle after
+        // the first call said there was one.
+        const username = connectedUsername();
         const publication = await resolveXPublication({
           familiarId,
           publicationId: requireString(body.publicationId, "publicationId"),
           outcome: body.outcome,
           postId: body.postId,
           note: body.note,
-          ...(connectedUsername() === undefined
-            ? {}
-            : { accountUsername: connectedUsername() }),
+          ...(username === undefined ? {} : { accountUsername: username }),
         });
         return NextResponse.json({ ok: true, publication });
       }

--- a/src/app/api/x/publish/route.ts
+++ b/src/app/api/x/publish/route.ts
@@ -1,0 +1,163 @@
+import { NextResponse } from "next/server";
+
+import { MAX_X_JSON_BYTES, XApiError, type XScope } from "@/lib/x-api";
+import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
+import {
+  requireXCapability,
+  toXErrorResponse,
+  withXWritePreflight,
+} from "@/lib/server/x-access";
+import { createXPost } from "@/lib/server/x-client";
+import { xCredentialService } from "@/lib/server/x-credentials";
+import {
+  listXPublications,
+  publishXPublication,
+  resolveXPublication,
+  upsertXPublicationDraft,
+} from "@/lib/server/x-publications";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Drafting and publishing X posts for one familiar.
+ *
+ * Publishing is the only outbound write in the X integration, so the rules
+ * here are stricter than the read routes':
+ *
+ *  - Every action needs the familiar's `publish` capability, which is a
+ *    separate grant from `research`. Being able to read X is not permission
+ *    to post as the account.
+ *  - `publish` requires the confirmation token minted by `draft` for that
+ *    exact text. Editing the draft mints a new one, so an approval never
+ *    carries from the wording a person reviewed to a later one.
+ *  - Nothing retries. A dispatched write whose outcome is unknown leaves the
+ *    record `uncertain` and refuses further publishing until a human records
+ *    what actually happened via `resolve`.
+ *
+ * `tweet.write` is requested only here; the read routes never ask for it, so
+ * a connection that has not been granted posting rights fails at the
+ * preflight rather than at the post.
+ */
+const WRITE_SCOPES: XScope[] = ["tweet.write", "users.read"];
+
+type PublishBody = {
+  action?: unknown;
+  familiarId?: unknown;
+  publicationId?: unknown;
+  text?: unknown;
+  confirmationToken?: unknown;
+  outcome?: unknown;
+  postId?: unknown;
+  note?: unknown;
+};
+
+function invalid(message: string): XApiError {
+  return new XApiError("invalid-request", message);
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value === "") throw invalid(`${field} is required`);
+  return value;
+}
+
+/**
+ * The connected account's handle, used to build the canonical URL. It is
+ * optional on purpose: `canonicalXPostUrl` falls back to the handle-free
+ * `/i/web/status/<id>` form, and a post that demonstrably went out must still
+ * be recorded even if the connection dropped between the write and this read.
+ */
+function connectedUsername(): string | undefined {
+  const status = xCredentialService.getConnectionStatus();
+  return status.connected ? status.account.username : undefined;
+}
+
+export async function GET(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+  const familiarId = new URL(req.url).searchParams.get("familiarId");
+  try {
+    if (!familiarId) throw invalid("familiarId is required");
+    // Gated on the capability but not on a live connection, so the history of
+    // what was posted — and anything left `uncertain` — stays readable after
+    // a disconnect. That backlog is exactly what someone needs to see.
+    await requireXCapability(familiarId, "publish");
+    const publications = await listXPublications(familiarId);
+    return NextResponse.json({ ok: true, publications });
+  } catch (error) {
+    return toXErrorResponse(error);
+  }
+}
+
+export async function POST(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+  const parsed = await readJsonBody<PublishBody>(req, MAX_X_JSON_BYTES);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body;
+
+  try {
+    const familiarId = requireString(body.familiarId, "familiarId");
+    await requireXCapability(familiarId, "publish");
+
+    switch (body.action) {
+      case "draft": {
+        const draft = await upsertXPublicationDraft({
+          familiarId,
+          text: typeof body.text === "string" ? body.text : "",
+          ...(body.publicationId === undefined
+            ? {}
+            : { publicationId: requireString(body.publicationId, "publicationId") }),
+        });
+        return NextResponse.json({
+          ok: true,
+          publication: draft.publication,
+          confirmationToken: draft.confirmationToken,
+        });
+      }
+
+      case "publish": {
+        const result = await publishXPublication(
+          {
+            familiarId,
+            publicationId: requireString(body.publicationId, "publicationId"),
+            confirmationToken: body.confirmationToken,
+          },
+          {
+            // The preflight sits inside `send` rather than around the whole
+            // call so a capability or token failure never marks the record
+            // dispatched — only the moment a request can actually reach X.
+            send: (text) =>
+              withXWritePreflight(familiarId, WRITE_SCOPES, (accessToken) =>
+                createXPost(accessToken, text)),
+            accountUsername: connectedUsername,
+          },
+        );
+        return NextResponse.json({
+          ok: true,
+          publication: result.publication,
+          alreadyPublished: result.alreadyPublished,
+        });
+      }
+
+      case "resolve": {
+        const publication = await resolveXPublication({
+          familiarId,
+          publicationId: requireString(body.publicationId, "publicationId"),
+          outcome: body.outcome,
+          postId: body.postId,
+          note: body.note,
+          ...(connectedUsername() === undefined
+            ? {}
+            : { accountUsername: connectedUsername() }),
+        });
+        return NextResponse.json({ ok: true, publication });
+      }
+
+      default:
+        throw invalid("action must be draft, publish or resolve");
+    }
+  } catch (error) {
+    return toXErrorResponse(error);
+  }
+}

--- a/src/lib/server/x-client.test.ts
+++ b/src/lib/server/x-client.test.ts
@@ -302,6 +302,72 @@ for (const failure of [
   assert.equal(stalled.fetches(), 1, "a post-body stall must not trigger a second create request");
 }
 
+// Once X has answered 2xx to a write, the post may exist. Every failure past
+// that point must be ambiguous: reporting it as definite tells the publication
+// store the draft is safe to send again, which is how a duplicate is made.
+for (const accepted of [
+  new Response("not json", { status: 201, headers: { "content-type": "application/json" } }),
+  response(201, { data: { id: "1234567890", text: "synthetic text", unexpected: true } }),
+  response(201, { data: { id: "not-numeric", text: "synthetic text" } }),
+  response(201, { data: { id: "1234567890" } }),
+  response(201, { id: "1234567890", text: "synthetic text" }),
+]) {
+  const { client, requests } = clientWith(accepted);
+  await assert.rejects(
+    () => client.createXPost("synthetic-access-token", "synthetic text"),
+    (error: unknown) => assertXError(error, "ambiguous-write", true),
+    "an unreadable reply to an accepted write is ambiguous, not a definite failure",
+  );
+  assert.equal(requests.length, 1, "and it is never retried");
+}
+
+{
+  const encoder = new TextEncoder();
+  const oversized = `${JSON.stringify({ data: { id: "1234567890", text: "x" } })}${" ".repeat(MAX_X_JSON_BYTES)}`;
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(oversized));
+      controller.close();
+    },
+  });
+  const { client } = clientWith(new Response(body, {
+    status: 201,
+    headers: { "content-type": "application/json" },
+  }));
+  await assert.rejects(
+    () => client.createXPost("synthetic-access-token", "synthetic text"),
+    (error: unknown) => assertXError(error, "ambiguous-write", true),
+    "an oversized reply to an accepted write is still an accepted write",
+  );
+}
+
+// A 5xx means X failed after the request arrived and says nothing about
+// whether the post was made.
+for (const status of [500, 502, 503, 504]) {
+  const { client } = clientWith(response(status, {}));
+  await assert.rejects(
+    () => client.createXPost("synthetic-access-token", "synthetic text"),
+    (error: unknown) => assertXError(error, "ambiguous-write", true),
+    `a ${status} to a write is ambiguous`,
+  );
+}
+
+// A 4xx is X refusing the request outright: nothing was created, so the caller
+// is free to fix the problem and try again.
+for (const [status, code] of [
+  [400, "invalid-request"],
+  [401, "unauthorized"],
+  [403, "capability-disabled"],
+  [429, "rate-limited"],
+] as const) {
+  const { client } = clientWith(response(status, {}));
+  await assert.rejects(
+    () => client.createXPost("synthetic-access-token", "synthetic text"),
+    (error: unknown) => assertXError(error, code, false),
+    `a ${status} to a write is a definite refusal`,
+  );
+}
+
 for (const invalidQuery of ["   ", "x".repeat(513), "🦇".repeat(513)]) {
   const { client, requests } = clientWith();
   await assert.rejects(() => client.searchRecentXPosts("synthetic-access-token", invalidQuery), (error: unknown) => assertXError(error, "invalid-request"));

--- a/src/lib/server/x-client.ts
+++ b/src/lib/server/x-client.ts
@@ -80,6 +80,16 @@ function unavailable(): XApiError {
   return new XApiError("upstream-unavailable", "X is temporarily unavailable");
 }
 
+/**
+ * The one classification a write is allowed to get wrong in only one
+ * direction. Callers treat `dispatched` as "this may already have posted, do
+ * not retry", so any failure that could have happened *after* X took the
+ * request must arrive here rather than as a definite error.
+ */
+function ambiguousWrite(safeMessage = "X post delivery is uncertain"): XApiError {
+  return new XApiError("ambiguous-write", safeMessage, { dispatched: true });
+}
+
 function httpError(status: number, headers: Headers): XApiError {
   switch (status) {
     case 400:
@@ -265,15 +275,26 @@ export function createXClient(options: XClientOptions = {}): XClient {
   ): Promise<unknown> {
     const controller = new AbortController();
     const timeout = setTimeoutImpl(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    // Flipped the instant a write is known to have been *accepted* by X.
+    // Everything that can still fail past that point — an unreadable body, an
+    // oversized one, a stream that stalls — may have failed after the post was
+    // created, so none of it may be reported as a definite failure.
+    let accepted = false;
     try {
       const response = await fetchImpl(url, { ...init, signal: controller.signal });
-      if (!response.ok) throw httpError(response.status, response.headers);
+      if (!response.ok) {
+        // A 4xx is X saying it refused the request, so nothing was created and
+        // the caller may safely try again. A 5xx is X failing *after* the
+        // request arrived and says nothing about whether the post was made.
+        if (write && response.status >= 500) throw ambiguousWrite();
+        throw httpError(response.status, response.headers);
+      }
+      accepted = write;
       return parseJson(await readBoundedJson(response));
     } catch (error) {
+      if (accepted) throw ambiguousWrite("X accepted the post but its reply was unreadable");
       if (error instanceof XApiError) throw error;
-      throw write
-        ? new XApiError("ambiguous-write", "X post delivery is uncertain", { dispatched: true })
-        : unavailable();
+      throw write ? ambiguousWrite() : unavailable();
     } finally {
       clearTimeoutImpl(timeout);
     }
@@ -368,7 +389,12 @@ export function createXClient(options: XClientOptions = {}): XClient {
     }, true);
     if (!isRecord(response) || !exactKeys(response, ["data"]) || !isRecord(response.data)
       || !exactKeys(response.data, ["id", "text"]) || !validPostId(response.data.id)
-      || typeof response.data.text !== "string") throw invalidResponse();
+      || typeof response.data.text !== "string") {
+      // X answered 2xx, so the post very likely exists even though its id is
+      // unreadable. `invalid-response` would read as a definite failure and
+      // invite the caller to retry, which is how a duplicate post gets made.
+      throw ambiguousWrite("X accepted the post but its reply was unreadable");
+    }
     return { id: response.data.id, text: response.data.text };
   }
 

--- a/src/lib/server/x-publications.test.ts
+++ b/src/lib/server/x-publications.test.ts
@@ -1,0 +1,436 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { after, beforeEach, test } from "node:test";
+
+import { XApiError } from "../x-api.ts";
+
+const root = await mkdtemp(path.join(process.cwd(), ".x-publications-test-"));
+const publicationsDir = path.join(root, "publications");
+const originalDir = process.env.COVEN_X_PUBLICATIONS_DIR;
+process.env.COVEN_X_PUBLICATIONS_DIR = publicationsDir;
+
+const {
+  listXPublications,
+  publishXPublication,
+  resolveXPublication,
+  upsertXPublicationDraft,
+} = await import("./x-publications.ts");
+
+const FAMILIAR = "nova";
+const OTHER_FAMILIAR = "cody";
+const POST_ID = "1799999999999999999";
+
+after(async () => {
+  if (originalDir === undefined) delete process.env.COVEN_X_PUBLICATIONS_DIR;
+  else process.env.COVEN_X_PUBLICATIONS_DIR = originalDir;
+  await rm(root, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await rm(publicationsDir, { recursive: true, force: true });
+});
+
+/** A send that succeeds, recording every text it was handed. */
+function recordingSend(sent: string[], id = POST_ID) {
+  return {
+    send: async (text: string) => {
+      sent.push(text);
+      return { id };
+    },
+    accountUsername: () => "novaops",
+  };
+}
+
+/** A send that fails the way an interrupted write does: outcome unknown. */
+function ambiguousSend(attempts: string[]) {
+  return {
+    send: async (text: string): Promise<{ id: string }> => {
+      attempts.push(text);
+      throw new XApiError("ambiguous-write", "X post delivery is uncertain", { dispatched: true });
+    },
+    accountUsername: () => "novaops",
+  };
+}
+
+/** A send that fails definitely: X received the request and refused it. */
+function refusedSend(attempts: string[]) {
+  return {
+    send: async (text: string): Promise<{ id: string }> => {
+      attempts.push(text);
+      throw new XApiError("invalid-request", "X refused the post", { status: 400 });
+    },
+    accountUsername: () => "novaops",
+  };
+}
+
+async function draft(text: string, familiarId = FAMILIAR) {
+  return upsertXPublicationDraft({ familiarId, text });
+}
+
+async function statusOf(id: string, familiarId = FAMILIAR) {
+  const all = await listXPublications(familiarId);
+  return all.find((entry) => entry.id === id);
+}
+
+test("a confirmed draft publishes once and records the post id and canonical URL", async () => {
+  const { publication, confirmationToken } = await draft("Ship it.");
+  assert.equal(publication.status, "draft");
+  assert.equal(publication.postId, undefined);
+
+  const sent: string[] = [];
+  const result = await publishXPublication(
+    { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+    recordingSend(sent),
+  );
+
+  assert.deepEqual(sent, ["Ship it."]);
+  assert.equal(result.alreadyPublished, false);
+  assert.equal(result.publication.status, "published");
+  assert.equal(result.publication.postId, POST_ID);
+  assert.equal(result.publication.canonicalUrl, `https://x.com/novaops/status/${POST_ID}`);
+  assert.ok(result.publication.publishedAt, "records when it went out");
+  assert.equal(result.publication.dispatchedAt, undefined, "the in-flight marker is cleared");
+
+  // Durable: a fresh read sees the same record.
+  assert.equal((await statusOf(publication.id))?.canonicalUrl, result.publication.canonicalUrl);
+});
+
+test("publishing without the confirmation token sends nothing", async () => {
+  const { publication } = await draft("Unconfirmed.");
+  const sent: string[] = [];
+
+  for (const token of [undefined, "", "not-the-token", 42]) {
+    await assert.rejects(
+      publishXPublication(
+        { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken: token },
+        recordingSend(sent),
+      ),
+      (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+    );
+  }
+
+  assert.deepEqual(sent, [], "no attempt reached the client");
+  assert.equal((await statusOf(publication.id))?.status, "draft", "the draft is untouched");
+});
+
+test("editing a draft invalidates the token minted for the old wording", async () => {
+  const first = await draft("Version one.");
+  const second = await upsertXPublicationDraft({
+    familiarId: FAMILIAR,
+    publicationId: first.publication.id,
+    text: "Version two, materially different.",
+  });
+
+  assert.notEqual(second.confirmationToken, first.confirmationToken);
+
+  const sent: string[] = [];
+  // This is the whole point of binding the token to the text: an approval
+  // given for one wording must not silently carry to another.
+  await assert.rejects(
+    publishXPublication(
+      {
+        familiarId: FAMILIAR,
+        publicationId: first.publication.id,
+        confirmationToken: first.confirmationToken,
+      },
+      recordingSend(sent),
+    ),
+    (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+  );
+  assert.deepEqual(sent, []);
+
+  const ok = await publishXPublication(
+    {
+      familiarId: FAMILIAR,
+      publicationId: first.publication.id,
+      confirmationToken: second.confirmationToken,
+    },
+    recordingSend(sent),
+  );
+  assert.deepEqual(sent, ["Version two, materially different."]);
+  assert.equal(ok.publication.status, "published");
+});
+
+test("a token minted for one record does not validate another", async () => {
+  const a = await draft("Same text.");
+  const b = await draft("Same text.");
+  assert.notEqual(a.publication.id, b.publication.id);
+
+  const sent: string[] = [];
+  await assert.rejects(
+    publishXPublication(
+      { familiarId: FAMILIAR, publicationId: b.publication.id, confirmationToken: a.confirmationToken },
+      recordingSend(sent),
+    ),
+    (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+  );
+  assert.deepEqual(sent, [], "identical text is not enough — the token names the record");
+});
+
+test("publishing an already-published record returns it without sending again", async () => {
+  const { publication, confirmationToken } = await draft("Only once.");
+  const sent: string[] = [];
+  await publishXPublication(
+    { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+    recordingSend(sent),
+  );
+
+  const again = await publishXPublication(
+    { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+    recordingSend(sent),
+  );
+
+  assert.deepEqual(sent, ["Only once."], "a double submit posts once");
+  assert.equal(again.alreadyPublished, true);
+  assert.equal(again.publication.postId, POST_ID);
+});
+
+test("an ambiguous write leaves the record uncertain and refuses to retry", async () => {
+  const { publication, confirmationToken } = await draft("Did this land?");
+  const attempts: string[] = [];
+
+  await assert.rejects(
+    publishXPublication(
+      { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+      ambiguousSend(attempts),
+    ),
+    (error: unknown) => error instanceof XApiError && error.code === "ambiguous-write",
+  );
+
+  const stored = await statusOf(publication.id);
+  assert.equal(stored?.status, "uncertain");
+  assert.ok(stored?.dispatchedAt, "the dispatch is on the record");
+  assert.equal(stored?.postId, undefined, "nothing is claimed about the outcome");
+
+  // The load-bearing assertion: a second publish must not send. The first
+  // attempt may already have posted, and retrying would duplicate it.
+  await assert.rejects(
+    publishXPublication(
+      { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+      ambiguousSend(attempts),
+    ),
+    (error: unknown) => error instanceof XApiError && error.code === "ambiguous-write",
+  );
+  assert.equal(attempts.length, 1, "the second publish never reached the client");
+});
+
+test("a definite refusal returns the record to draft so it can be tried again", async () => {
+  const { publication, confirmationToken } = await draft("Refused once.");
+  const attempts: string[] = [];
+
+  await assert.rejects(
+    publishXPublication(
+      { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+      refusedSend(attempts),
+    ),
+    (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+  );
+
+  // X received the request and rejected it, so nothing was posted and the
+  // draft is safe to retry — unlike the ambiguous case above.
+  const stored = await statusOf(publication.id);
+  assert.equal(stored?.status, "draft");
+  assert.equal(stored?.dispatchedAt, undefined);
+
+  const sent: string[] = [];
+  const ok = await publishXPublication(
+    { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+    recordingSend(sent),
+  );
+  assert.equal(ok.publication.status, "published");
+  assert.deepEqual(sent, ["Refused once."]);
+});
+
+test("the record is written as uncertain before the send, not after", async () => {
+  const { publication, confirmationToken } = await draft("Crash window.");
+  let observed: string | undefined;
+
+  await publishXPublication(
+    { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+    {
+      // Reading from disk mid-send is the only way to prove the ordering. If
+      // the record still said "draft" here, a crash at this instant would
+      // leave a draft that looks safe to publish — and posting it again is
+      // exactly the duplicate this ordering prevents.
+      send: async () => {
+        observed = (await statusOf(publication.id))?.status;
+        return { id: POST_ID };
+      },
+      accountUsername: () => "novaops",
+    },
+  );
+
+  assert.equal(observed, "uncertain");
+});
+
+test("a human resolves an uncertain record; the machine never guesses", async () => {
+  const { publication, confirmationToken } = await draft("Landed after all.");
+  await assert.rejects(
+    publishXPublication(
+      { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+      ambiguousSend([]),
+    ),
+  );
+
+  const resolved = await resolveXPublication({
+    familiarId: FAMILIAR,
+    publicationId: publication.id,
+    outcome: "published",
+    postId: POST_ID,
+    note: "Found it on the timeline.",
+    accountUsername: "novaops",
+  });
+
+  assert.equal(resolved.status, "published");
+  assert.equal(resolved.postId, POST_ID);
+  assert.equal(resolved.canonicalUrl, `https://x.com/novaops/status/${POST_ID}`);
+  assert.equal(resolved.resolutionNote, "Found it on the timeline.");
+  assert.equal(resolved.dispatchedAt, undefined);
+});
+
+test("resolving as published requires a real post id", async () => {
+  const { publication } = await draft("No id offered.");
+  for (const postId of [undefined, "", "not-numeric", "12a3"]) {
+    await assert.rejects(
+      resolveXPublication({
+        familiarId: FAMILIAR,
+        publicationId: publication.id,
+        outcome: "published",
+        postId,
+      }),
+      (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+    );
+  }
+});
+
+test("an abandoned record is terminal for both publishing and editing", async () => {
+  const { publication, confirmationToken } = await draft("Never mind.");
+  const abandoned = await resolveXPublication({
+    familiarId: FAMILIAR,
+    publicationId: publication.id,
+    outcome: "abandoned",
+    note: "Superseded.",
+  });
+  assert.equal(abandoned.status, "abandoned");
+
+  const sent: string[] = [];
+  await assert.rejects(
+    publishXPublication(
+      { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+      recordingSend(sent),
+    ),
+    (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+  );
+  await assert.rejects(
+    upsertXPublicationDraft({
+      familiarId: FAMILIAR,
+      publicationId: publication.id,
+      text: "Reopened by the back door.",
+    }),
+    (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+  );
+  assert.deepEqual(sent, []);
+});
+
+test("a published record cannot be rewritten to falsify what was sent", async () => {
+  const { publication, confirmationToken } = await draft("As sent.");
+  await publishXPublication(
+    { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+    recordingSend([]),
+  );
+
+  await assert.rejects(
+    upsertXPublicationDraft({
+      familiarId: FAMILIAR,
+      publicationId: publication.id,
+      text: "Not what went out.",
+    }),
+    (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+  );
+  assert.equal((await statusOf(publication.id))?.text, "As sent.");
+});
+
+test("records are familiar-scoped in both directions", async () => {
+  const mine = await draft("Nova's post.", FAMILIAR);
+  const theirs = await draft("Cody's post.", OTHER_FAMILIAR);
+
+  assert.deepEqual(
+    (await listXPublications(FAMILIAR)).map((entry) => entry.text),
+    ["Nova's post."],
+  );
+  assert.deepEqual(
+    (await listXPublications(OTHER_FAMILIAR)).map((entry) => entry.text),
+    ["Cody's post."],
+  );
+
+  // Reaching across with a valid id from the other familiar finds nothing —
+  // the store is per-familiar, so this cannot become a disclosure.
+  const sent: string[] = [];
+  await assert.rejects(
+    publishXPublication(
+      {
+        familiarId: FAMILIAR,
+        publicationId: theirs.publication.id,
+        confirmationToken: theirs.confirmationToken,
+      },
+      recordingSend(sent),
+    ),
+    (error: unknown) => error instanceof XApiError && error.code === "not-found",
+  );
+  assert.deepEqual(sent, []);
+  assert.equal(await statusOf(mine.publication.id) !== undefined, true);
+});
+
+test("empty and oversized text are refused before anything is stored", async () => {
+  for (const text of ["", "   ", "\n"]) {
+    await assert.rejects(
+      upsertXPublicationDraft({ familiarId: FAMILIAR, text }),
+      (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+    );
+  }
+  await assert.rejects(
+    upsertXPublicationDraft({ familiarId: FAMILIAR, text: "x".repeat(16 * 1024 + 1) }),
+    (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+  );
+  assert.deepEqual(await listXPublications(FAMILIAR), []);
+});
+
+test("an invalid familiar id never becomes a path", async () => {
+  for (const familiarId of ["../escape", "nova/../cody", ""]) {
+    await assert.rejects(
+      upsertXPublicationDraft({ familiarId, text: "Nope." }),
+      (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+    );
+  }
+});
+
+test("a malformed store is quarantined rather than read or deleted", async () => {
+  await draft("Real record.");
+  const target = path.join(publicationsDir, `${FAMILIAR}.json`);
+  await writeFile(target, "{ this is not json", "utf8");
+
+  assert.deepEqual(await listXPublications(FAMILIAR), [], "nothing is invented from the wreckage");
+
+  // `.corrupt-` specifically: the lock directory also sits at `<file>.locks`.
+  const aside = (await readdir(publicationsDir))
+    .filter((name) => name.startsWith(`${FAMILIAR}.json.corrupt-`));
+  assert.equal(aside.length, 1, "the unreadable file is kept for inspection");
+  assert.equal(await readFile(path.join(publicationsDir, aside[0]!), "utf8"), "{ this is not json");
+});
+
+test("a stored record claiming published without its post id is rejected wholesale", async () => {
+  const { publication } = await draft("Half a record.");
+  const target = path.join(publicationsDir, `${FAMILIAR}.json`);
+  const file = JSON.parse(await readFile(target, "utf8")) as {
+    version: number;
+    publications: Record<string, unknown>[];
+  };
+  file.publications[0]!.status = "published";
+  await writeFile(target, JSON.stringify(file), "utf8");
+
+  // "Published, but we lost where" is worse than no record: it would read as
+  // a sent post whose URL nobody can check.
+  assert.deepEqual(await listXPublications(FAMILIAR), []);
+  assert.equal(await statusOf(publication.id), undefined);
+});

--- a/src/lib/server/x-publications.test.ts
+++ b/src/lib/server/x-publications.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile, readdir } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { after, beforeEach, test } from "node:test";
 
@@ -417,6 +417,138 @@ test("a malformed store is quarantined rather than read or deleted", async () =>
     .filter((name) => name.startsWith(`${FAMILIAR}.json.corrupt-`));
   assert.equal(aside.length, 1, "the unreadable file is kept for inspection");
   assert.equal(await readFile(path.join(publicationsDir, aside[0]!), "utf8"), "{ this is not json");
+});
+
+test("two overlapping publishes of one draft send exactly once", async () => {
+  const { publication, confirmationToken } = await draft("Exactly once, under contention.");
+  const sent: string[] = [];
+  const dependencies = {
+    // Held open so both calls are genuinely in flight together: the loser must
+    // be stopped by the record's own state, not by arriving after the winner
+    // finished. The send deliberately runs outside the store's lock, so this
+    // is the window in which a second caller could slip through.
+    send: async (text: string) => {
+      sent.push(text);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return { id: POST_ID };
+    },
+    accountUsername: () => "novaops",
+  };
+
+  const attempt = () => publishXPublication(
+    { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+    dependencies,
+  );
+  const results = await Promise.allSettled([attempt(), attempt()]);
+
+  assert.deepEqual(sent, ["Exactly once, under contention."], "one post, not two");
+  const refused = results.filter((result) => result.status === "rejected");
+  assert.equal(refused.length, 1, "the second caller is refused rather than served a second send");
+  const reason = (refused[0] as PromiseRejectedResult).reason as unknown;
+  assert.ok(
+    reason instanceof XApiError && reason.code === "ambiguous-write",
+    "and refused as ambiguous, because the first attempt's outcome is not yet known",
+  );
+  assert.equal((await statusOf(publication.id))?.status, "published");
+});
+
+test("a same-length or multi-byte token is refused, never crashed", async () => {
+  const { publication, confirmationToken } = await draft("Forge me.");
+  const sent: string[] = [];
+  const forged = `${confirmationToken[0] === "0" ? "1" : "0"}${confirmationToken.slice(1)}`;
+  assert.equal(forged.length, confirmationToken.length);
+  assert.notEqual(forged, confirmationToken);
+  // 64 characters but 128 bytes: `timingSafeEqual` throws on a byte-length
+  // mismatch, so a string-length pre-check would turn a refusal into a 500.
+  const multiByte = "é".repeat(confirmationToken.length);
+
+  for (const token of [forged, multiByte]) {
+    await assert.rejects(
+      publishXPublication(
+        { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken: token },
+        recordingSend(sent),
+      ),
+      (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+    );
+  }
+  assert.deepEqual(sent, []);
+  assert.equal((await statusOf(publication.id))?.status, "draft");
+});
+
+test("an unusable confirmation key is replaced, and every token minted under the old one dies", async () => {
+  const { publication, confirmationToken } = await draft("Keyed to this install.");
+  const keyPath = path.join(publicationsDir, ".confirmation-key");
+  const original = await readFile(keyPath, "utf8");
+  await writeFile(keyPath, "truncated", "utf8");
+
+  const sent: string[] = [];
+  await assert.rejects(
+    publishXPublication(
+      { familiarId: FAMILIAR, publicationId: publication.id, confirmationToken },
+      recordingSend(sent),
+    ),
+    (error: unknown) => error instanceof XApiError && error.code === "invalid-request",
+  );
+  assert.deepEqual(sent, [], "a token that cannot be verified is not honoured");
+
+  const replaced = await readFile(keyPath, "utf8");
+  assert.notEqual(replaced, original);
+  assert.equal(Buffer.from(replaced.trim(), "base64").length, 32, "a real key replaces the wreckage");
+});
+
+test("a usable confirmation key is adopted, not rotated, on every mint", async () => {
+  await draft("First.");
+  const keyPath = path.join(publicationsDir, ".confirmation-key");
+  const key = await readFile(keyPath, "utf8");
+
+  const second = await draft("Second.");
+  assert.equal(await readFile(keyPath, "utf8"), key, "minting never replaces a working key");
+
+  // The proof that matters: a token minted earlier still publishes.
+  const sent: string[] = [];
+  const ok = await publishXPublication(
+    {
+      familiarId: FAMILIAR,
+      publicationId: second.publication.id,
+      confirmationToken: second.confirmationToken,
+    },
+    recordingSend(sent),
+  );
+  assert.equal(ok.publication.status, "published");
+});
+
+test("a stored record contradicting itself is quarantined, not offered for publishing", async () => {
+  const target = path.join(publicationsDir, `${FAMILIAR}.json`);
+  const base = {
+    id: "00000000-0000-4000-8000-000000000000",
+    familiarId: FAMILIAR,
+    text: "Contradiction.",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  };
+  const contradictions = [
+    // Says a post already exists, yet invites the action that would send it
+    // again — the exact shape that produces a duplicate.
+    { ...base, status: "draft", postId: POST_ID, canonicalUrl: `https://x.com/novaops/status/${POST_ID}`, publishedAt: base.updatedAt },
+    // Claims an unknown outcome with nothing in flight.
+    { ...base, status: "uncertain" },
+    // Claims something is in flight when the record is settled.
+    { ...base, status: "abandoned", dispatchedAt: base.updatedAt },
+  ];
+
+  for (const publication of contradictions) {
+    await mkdir(publicationsDir, { recursive: true });
+    await writeFile(target, JSON.stringify({ version: 1, publications: [publication] }), "utf8");
+    assert.deepEqual(
+      await listXPublications(FAMILIAR),
+      [],
+      `${publication.status} record is not read back`,
+    );
+    const aside = (await readdir(publicationsDir))
+      .filter((name) => name.startsWith(`${FAMILIAR}.json.corrupt-`));
+    assert.equal(aside.length, 1, "the bytes are preserved rather than dropped");
+    for (const name of aside) await rm(path.join(publicationsDir, name));
+  }
 });
 
 test("a stored record claiming published without its post id is rejected wholesale", async () => {

--- a/src/lib/server/x-publications.ts
+++ b/src/lib/server/x-publications.ts
@@ -1,0 +1,538 @@
+import { createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import { lstat, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { caveHome } from "../coven-paths.ts";
+import { XApiError, canonicalXPostUrl } from "../x-api.ts";
+import { writeJsonAtomic } from "./atomic-write.ts";
+import { corruptAsidePath } from "./corrupt-aside.ts";
+import { isValidFamiliarId } from "./familiar-id.ts";
+import { acquireProcessIntentLock } from "./process-intent-lock.ts";
+
+/**
+ * Durable record of every X post this install has drafted or sent.
+ *
+ * The states are deliberately not a simple draft/published pair. A network
+ * write can fail in a way that leaves the outcome genuinely unknown — the
+ * request was dispatched and the response never arrived — and the one thing
+ * that must never happen there is an automatic retry, because the first
+ * attempt may well have posted. `uncertain` is that state, and only a human
+ * leaves it (see `resolveXPublication`).
+ *
+ * - `draft`     — text exists locally; nothing has been sent.
+ * - `uncertain` — a write was dispatched and its outcome is unknown. Terminal
+ *                 until resolved by hand; publishing is refused.
+ * - `published` — the post id came back from X. Publishing again is refused.
+ * - `abandoned` — a human decided the draft, or an uncertain attempt, is done
+ *                 with. Terminal.
+ */
+export type XPublicationStatus = "draft" | "uncertain" | "published" | "abandoned";
+
+export type XPublication = {
+  id: string;
+  familiarId: string;
+  text: string;
+  status: XPublicationStatus;
+  createdAt: string;
+  updatedAt: string;
+  /** When a write was dispatched, whatever came of it. */
+  dispatchedAt?: string;
+  postId?: string;
+  canonicalUrl?: string;
+  publishedAt?: string;
+  /** How a human resolved an uncertain attempt, or why a draft was retired. */
+  resolutionNote?: string;
+};
+
+type XPublicationsFile = { version: 1; publications: XPublication[] };
+
+const MAX_PUBLICATIONS_PER_FAMILIAR = 500;
+const MAX_TEXT_BYTES = 16 * 1024;
+const MAX_NOTE_LENGTH = 500;
+const LOCK_TIMEOUT_MS = 15_000;
+const CONFIRMATION_KEY_BYTES = 32;
+
+const POST_ID = /^\d+$/;
+const PUBLICATION_ID = /^[0-9a-f-]{36}$/;
+
+function publicationsRoot(): string {
+  return process.env.COVEN_X_PUBLICATIONS_DIR?.trim()
+    || path.join(/* turbopackIgnore: true */ caveHome(), "x-publications");
+}
+
+function assertFamiliarId(familiarId: string): void {
+  if (!isValidFamiliarId(familiarId) || path.basename(familiarId) !== familiarId) {
+    throw new XApiError("invalid-request", "Familiar id is invalid");
+  }
+}
+
+function assertPublicationId(publicationId: unknown): asserts publicationId is string {
+  if (typeof publicationId !== "string" || !PUBLICATION_ID.test(publicationId)) {
+    throw new XApiError("invalid-request", "X publication id is invalid");
+  }
+}
+
+function publicationsPath(familiarId: string): string {
+  assertFamiliarId(familiarId);
+  return path.join(/* turbopackIgnore: true */ publicationsRoot(), `${familiarId}.json`);
+}
+
+function confirmationKeyPath(): string {
+  return path.join(/* turbopackIgnore: true */ publicationsRoot(), ".confirmation-key");
+}
+
+/**
+ * Post text is checked for emptiness and a generous byte ceiling only. The
+ * product's own character limit varies by account tier and has changed more
+ * than once; hard-coding 280 here would refuse posts an account is entitled
+ * to make. X rejects genuinely over-long text, and that rejection arrives as
+ * a definite failure rather than an ambiguous one.
+ */
+function assertPublishableText(value: unknown): asserts value is string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new XApiError("invalid-request", "Post text is required");
+  }
+  if (Buffer.byteLength(value) > MAX_TEXT_BYTES) {
+    throw new XApiError("invalid-request", "Post text is too long");
+  }
+}
+
+async function pathKind(target: string): Promise<"missing" | "file" | "directory" | "other"> {
+  try {
+    const info = await lstat(/* turbopackIgnore: true */ target);
+    if (info.isSymbolicLink()) return "other";
+    if (info.isFile()) return "file";
+    if (info.isDirectory()) return "directory";
+    return "other";
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
+    throw error;
+  }
+}
+
+async function ensureRealDirectory(target: string): Promise<void> {
+  let kind = await pathKind(target);
+  if (kind === "missing") {
+    await mkdir(/* turbopackIgnore: true */ target, { recursive: true });
+    kind = await pathKind(target);
+  }
+  if (kind !== "directory") {
+    throw new Error(`X publication storage path is not a directory or is a symlink: ${target}`);
+  }
+}
+
+async function assertRegularFileOrMissing(target: string): Promise<void> {
+  const kind = await pathKind(target);
+  if (kind !== "missing" && kind !== "file") {
+    throw new Error(`X publication storage file must be a regular file, not a symlink: ${target}`);
+  }
+}
+
+async function withPublicationsLock<T>(
+  familiarId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  await ensureRealDirectory(publicationsRoot());
+  const release = await acquireProcessIntentLock({
+    intentsDirectory: `${publicationsPath(familiarId)}.locks`,
+    timeoutMs: LOCK_TIMEOUT_MS,
+    label: `X publications for ${familiarId}`,
+  });
+  try {
+    return await operation();
+  } finally {
+    await release();
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const OPTIONAL_FIELDS = [
+  "dispatchedAt",
+  "postId",
+  "canonicalUrl",
+  "publishedAt",
+  "resolutionNote",
+] as const;
+
+function parseStoredPublication(value: unknown, familiarId: string): XPublication | null {
+  if (!isRecord(value)) return null;
+  const { id, text, status, createdAt, updatedAt } = value;
+  if (typeof id !== "string" || !PUBLICATION_ID.test(id)) return null;
+  if (typeof text !== "string" || typeof createdAt !== "string" || typeof updatedAt !== "string") {
+    return null;
+  }
+  if (value.familiarId !== familiarId) return null;
+  if (status !== "draft" && status !== "uncertain" && status !== "published" && status !== "abandoned") {
+    return null;
+  }
+  const publication: XPublication = { id, familiarId, text, status, createdAt, updatedAt };
+  for (const field of OPTIONAL_FIELDS) {
+    const stored = value[field];
+    if (stored === undefined) continue;
+    if (typeof stored !== "string") return null;
+    publication[field] = stored;
+  }
+  // A published record missing the pair it exists to preserve is worse than
+  // no record at all: it would read as "this went out" while losing where.
+  if (status === "published" && (!publication.postId || !publication.canonicalUrl)) return null;
+  return publication;
+}
+
+function parsePublicationsFileText(text: string, familiarId: string): XPublicationsFile | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || parsed.version !== 1 || !Array.isArray(parsed.publications)) return null;
+  if (parsed.publications.length > MAX_PUBLICATIONS_PER_FAMILIAR) return null;
+  const publications = parsed.publications.map((entry) => parseStoredPublication(entry, familiarId));
+  if (publications.some((entry) => entry === null)) return null;
+  const valid = publications as XPublication[];
+  if (new Set(valid.map((entry) => entry.id)).size !== valid.length) return null;
+  return { version: 1, publications: valid };
+}
+
+/**
+ * A malformed file is moved aside rather than deleted or partially salvaged.
+ * These records are the only local evidence that a post was sent, so quietly
+ * dropping one is the exact failure this module exists to prevent.
+ */
+async function loadPublicationsFile(familiarId: string): Promise<XPublicationsFile> {
+  const target = publicationsPath(familiarId);
+  await assertRegularFileOrMissing(target);
+  let text: string;
+  try {
+    text = await readFile(/* turbopackIgnore: true */ target, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { version: 1, publications: [] };
+    throw error;
+  }
+  const parsed = parsePublicationsFileText(text, familiarId);
+  if (!parsed) {
+    await rename(/* turbopackIgnore: true */ target, corruptAsidePath(target));
+    return { version: 1, publications: [] };
+  }
+  return parsed;
+}
+
+async function savePublicationsFile(familiarId: string, file: XPublicationsFile): Promise<void> {
+  await ensureRealDirectory(publicationsRoot());
+  await assertRegularFileOrMissing(publicationsPath(familiarId));
+  await writeJsonAtomic(publicationsPath(familiarId), file);
+}
+
+/**
+ * Per-install key backing the confirmation token.
+ *
+ * The token's job is to prove that whoever asks to publish has seen the exact
+ * text the draft surface rendered. A plain hash of the text would not: any
+ * caller holding the familiar id and the text could compute one, including a
+ * familiar subprocess that never showed a person anything. Keying it means a
+ * valid token can only have come from a `draft` response, which is served to
+ * the local UI over a loopback-only route.
+ *
+ * This is not a proof of humanity — nothing server-side can be — and the key
+ * is not a secret worth protecting beyond local file permissions. It is a
+ * proof that this exact text, on this install, was minted for review.
+ */
+async function confirmationKey(): Promise<Buffer> {
+  await ensureRealDirectory(publicationsRoot());
+  const target = confirmationKeyPath();
+  await assertRegularFileOrMissing(target);
+  try {
+    const stored = await readFile(/* turbopackIgnore: true */ target, "utf8");
+    const key = Buffer.from(stored.trim(), "base64");
+    if (key.length === CONFIRMATION_KEY_BYTES) return key;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  const key = randomBytes(CONFIRMATION_KEY_BYTES);
+  await writeFile(/* turbopackIgnore: true */ target, key.toString("base64"), { mode: 0o600 });
+  return key;
+}
+
+async function mintConfirmationToken(
+  familiarId: string,
+  publicationId: string,
+  text: string,
+): Promise<string> {
+  const key = await confirmationKey();
+  return createHmac("sha256", key)
+    // Length-prefixed, so an id cannot be shifted across a delimiter to mint
+    // a token that validates against a different record.
+    .update(`${familiarId.length}:${familiarId}|${publicationId.length}:${publicationId}|${text}`)
+    .digest("hex");
+}
+
+function tokensMatch(expected: string, provided: unknown): boolean {
+  if (typeof provided !== "string" || provided.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(expected, "utf8"), Buffer.from(provided, "utf8"));
+}
+
+export type XPublicationDraft = { publication: XPublication; confirmationToken: string };
+
+export async function listXPublications(familiarId: string): Promise<XPublication[]> {
+  assertFamiliarId(familiarId);
+  return withPublicationsLock(familiarId, async () => {
+    const file = await loadPublicationsFile(familiarId);
+    return [...file.publications].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  });
+}
+
+/**
+ * Create a draft, or replace the text of an existing one. Editing mints a new
+ * token and so invalidates the old one, which is the point: approval granted
+ * for one wording must not carry over to another.
+ */
+export async function upsertXPublicationDraft(input: {
+  familiarId: string;
+  text: string;
+  publicationId?: string;
+  now?: Date;
+}): Promise<XPublicationDraft> {
+  const { familiarId } = input;
+  assertFamiliarId(familiarId);
+  assertPublishableText(input.text);
+  if (input.publicationId !== undefined) assertPublicationId(input.publicationId);
+
+  return withPublicationsLock(familiarId, async () => {
+    const file = await loadPublicationsFile(familiarId);
+    const timestamp = (input.now ?? new Date()).toISOString();
+
+    let publication: XPublication;
+    if (input.publicationId === undefined) {
+      if (file.publications.length >= MAX_PUBLICATIONS_PER_FAMILIAR) {
+        throw new XApiError("invalid-request", "This familiar has too many stored X posts");
+      }
+      publication = {
+        id: randomUUID(),
+        familiarId,
+        text: input.text,
+        status: "draft",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+      file.publications.push(publication);
+    } else {
+      const index = file.publications.findIndex((entry) => entry.id === input.publicationId);
+      if (index === -1) throw new XApiError("not-found", "X post draft was not found");
+      const existing = file.publications[index]!;
+      // Only a draft is editable. Rewriting a published record would falsify
+      // what was sent; rewriting an uncertain one would erase the very text
+      // whose fate is still unknown.
+      if (existing.status !== "draft") {
+        throw new XApiError("invalid-request", `A ${existing.status} X post cannot be edited`);
+      }
+      publication = { ...existing, text: input.text, updatedAt: timestamp };
+      file.publications[index] = publication;
+    }
+
+    await savePublicationsFile(familiarId, file);
+    return {
+      publication,
+      confirmationToken: await mintConfirmationToken(familiarId, publication.id, publication.text),
+    };
+  });
+}
+
+export type XPublishOutcome = {
+  publication: XPublication;
+  /** True when this call sent nothing because the post had already gone out. */
+  alreadyPublished: boolean;
+};
+
+type PreparedPublish =
+  | { kind: "already-sent"; publication: XPublication }
+  | { kind: "dispatched"; publication: XPublication };
+
+export type XPublishDependencies = {
+  /** Sends the post. Must reject with `dispatched: true` when uncertain. */
+  send(text: string): Promise<{ id: string }>;
+  /** The connected account, for the canonical URL. */
+  accountUsername(): string | undefined;
+  now?: () => Date;
+};
+
+/**
+ * Publish a confirmed draft, exactly once.
+ *
+ * The record is moved to `uncertain` and written to disk *before* the network
+ * call, not after. A crash between dispatch and response then leaves evidence
+ * that something was sent; the other order would leave a record reading
+ * `draft`, and the natural next action on a draft is to publish it — which is
+ * precisely how a duplicate post gets made.
+ */
+export async function publishXPublication(
+  input: {
+    familiarId: string;
+    publicationId: string;
+    confirmationToken: unknown;
+  },
+  dependencies: XPublishDependencies,
+): Promise<XPublishOutcome> {
+  const { familiarId, publicationId } = input;
+  assertFamiliarId(familiarId);
+  assertPublicationId(publicationId);
+  const now = dependencies.now ?? (() => new Date());
+
+  const prepared = await withPublicationsLock<PreparedPublish>(familiarId, async () => {
+    const file = await loadPublicationsFile(familiarId);
+    const index = file.publications.findIndex((entry) => entry.id === publicationId);
+    if (index === -1) throw new XApiError("not-found", "X post draft was not found");
+    const existing = file.publications[index]!;
+
+    // Already sent: hand back the record rather than writing a second post.
+    // This is what makes a double submit — a retried fetch, an impatient
+    // second click — harmless.
+    if (existing.status === "published") return { kind: "already-sent", publication: existing };
+
+    if (existing.status === "uncertain") {
+      throw new XApiError(
+        "ambiguous-write",
+        "A previous attempt may already have posted. Resolve it before publishing again.",
+      );
+    }
+    if (existing.status !== "draft") {
+      throw new XApiError("invalid-request", `A ${existing.status} X post cannot be published`);
+    }
+
+    const expected = await mintConfirmationToken(familiarId, existing.id, existing.text);
+    if (!tokensMatch(expected, input.confirmationToken)) {
+      throw new XApiError(
+        "invalid-request",
+        "This post text has not been confirmed. Review it and confirm again.",
+      );
+    }
+
+    const timestamp = now().toISOString();
+    const dispatched: XPublication = {
+      ...existing,
+      status: "uncertain",
+      dispatchedAt: timestamp,
+      updatedAt: timestamp,
+    };
+    file.publications[index] = dispatched;
+    await savePublicationsFile(familiarId, file);
+    return { kind: "dispatched", publication: dispatched };
+  });
+
+  if (prepared.kind === "already-sent") {
+    return { publication: prepared.publication, alreadyPublished: true };
+  }
+
+  const pending = prepared.publication;
+  let created: { id: string };
+  try {
+    created = await dependencies.send(pending.text);
+  } catch (error) {
+    // A definite failure — X refused the request, or it never left — returns
+    // the record to `draft` so a human can try again. An ambiguous one stays
+    // `uncertain`: retrying it could double-post, and nothing in this process
+    // is entitled to make that call.
+    const ambiguous = error instanceof XApiError && error.dispatched;
+    if (!ambiguous) {
+      await withPublicationsLock(familiarId, async () => {
+        const file = await loadPublicationsFile(familiarId);
+        const index = file.publications.findIndex((entry) => entry.id === publicationId);
+        if (index === -1) return;
+        const current = file.publications[index]!;
+        // Undo only the state this call set. If anything else moved the
+        // record meanwhile, leave it exactly as found.
+        if (current.status !== "uncertain" || current.dispatchedAt !== pending.dispatchedAt) return;
+        const { dispatchedAt: _dispatchedAt, ...rest } = current;
+        file.publications[index] = { ...rest, status: "draft", updatedAt: now().toISOString() };
+        await savePublicationsFile(familiarId, file);
+      });
+    }
+    throw error;
+  }
+
+  const username = dependencies.accountUsername();
+  const publication = await withPublicationsLock(familiarId, async () => {
+    const file = await loadPublicationsFile(familiarId);
+    const index = file.publications.findIndex((entry) => entry.id === publicationId);
+    const timestamp = now().toISOString();
+    const base = index === -1 ? pending : file.publications[index]!;
+    const { dispatchedAt: _dispatchedAt, ...rest } = base;
+    const settled: XPublication = {
+      ...rest,
+      status: "published",
+      postId: created.id,
+      canonicalUrl: canonicalXPostUrl(created.id, username),
+      publishedAt: timestamp,
+      updatedAt: timestamp,
+    };
+    if (index === -1) file.publications.push(settled);
+    else file.publications[index] = settled;
+    await savePublicationsFile(familiarId, file);
+    return settled;
+  });
+
+  return { publication, alreadyPublished: false };
+}
+
+/**
+ * Record what a human found out about an uncertain attempt, or retire a
+ * draft. This is the only way out of `uncertain`, and it never touches the
+ * network: the whole point is that the machine does not get to guess whether
+ * the post landed.
+ */
+export async function resolveXPublication(input: {
+  familiarId: string;
+  publicationId: string;
+  outcome: unknown;
+  postId?: unknown;
+  note?: unknown;
+  accountUsername?: string;
+  now?: Date;
+}): Promise<XPublication> {
+  const { familiarId, publicationId } = input;
+  assertFamiliarId(familiarId);
+  assertPublicationId(publicationId);
+  if (input.outcome !== "published" && input.outcome !== "abandoned") {
+    throw new XApiError("invalid-request", "outcome must be published or abandoned");
+  }
+  if (input.note !== undefined
+    && (typeof input.note !== "string" || input.note.length > MAX_NOTE_LENGTH)) {
+    throw new XApiError("invalid-request", "Resolution note is invalid");
+  }
+  if (input.outcome === "published"
+    && (typeof input.postId !== "string" || !POST_ID.test(input.postId))) {
+    throw new XApiError("invalid-request", "A numeric X post id is required");
+  }
+
+  return withPublicationsLock(familiarId, async () => {
+    const file = await loadPublicationsFile(familiarId);
+    const index = file.publications.findIndex((entry) => entry.id === publicationId);
+    if (index === -1) throw new XApiError("not-found", "X post draft was not found");
+    const existing = file.publications[index]!;
+    if (existing.status !== "uncertain" && existing.status !== "draft") {
+      throw new XApiError("invalid-request", `A ${existing.status} X post is already resolved`);
+    }
+
+    const timestamp = (input.now ?? new Date()).toISOString();
+    const { dispatchedAt: _dispatchedAt, ...rest } = existing;
+    const note = typeof input.note === "string" && input.note !== ""
+      ? { resolutionNote: input.note }
+      : {};
+    const resolved: XPublication = input.outcome === "published"
+      ? {
+        ...rest,
+        status: "published",
+        postId: input.postId as string,
+        canonicalUrl: canonicalXPostUrl(input.postId as string, input.accountUsername),
+        publishedAt: timestamp,
+        updatedAt: timestamp,
+        ...note,
+      }
+      : { ...rest, status: "abandoned", updatedAt: timestamp, ...note };
+    file.publications[index] = resolved;
+    await savePublicationsFile(familiarId, file);
+    return resolved;
+  });
+}

--- a/src/lib/server/x-publications.ts
+++ b/src/lib/server/x-publications.ts
@@ -1,5 +1,5 @@
 import { createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
-import { lstat, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { lstat, mkdir, open, readFile, rename } from "node:fs/promises";
 import path from "node:path";
 
 import { caveHome } from "../coven-paths.ts";
@@ -35,7 +35,11 @@ export type XPublication = {
   status: XPublicationStatus;
   createdAt: string;
   updatedAt: string;
-  /** When a write was dispatched, whatever came of it. */
+  /**
+   * The in-flight marker: set when a write is dispatched and cleared the
+   * moment the record settles, so it is present exactly while `status` is
+   * `uncertain`.
+   */
   dispatchedAt?: string;
   postId?: string;
   canonicalUrl?: string;
@@ -177,7 +181,21 @@ function parseStoredPublication(value: unknown, familiarId: string): XPublicatio
   }
   // A published record missing the pair it exists to preserve is worse than
   // no record at all: it would read as "this went out" while losing where.
-  if (status === "published" && (!publication.postId || !publication.canonicalUrl)) return null;
+  if (status === "published"
+    && (!publication.postId || !publication.canonicalUrl || !publication.publishedAt)) {
+    return null;
+  }
+  // Only a published record may claim a post exists. A `draft` carrying a post
+  // id is the dangerous contradiction: it says something already went out
+  // while inviting the one action that would send it again.
+  if (status !== "published"
+    && (publication.postId !== undefined
+      || publication.canonicalUrl !== undefined
+      || publication.publishedAt !== undefined)) {
+    return null;
+  }
+  // The in-flight marker is present exactly while the outcome is unknown.
+  if ((publication.dispatchedAt !== undefined) !== (status === "uncertain")) return null;
   return publication;
 }
 
@@ -226,6 +244,34 @@ async function savePublicationsFile(familiarId: string, file: XPublicationsFile)
   await writeJsonAtomic(publicationsPath(familiarId), file);
 }
 
+type StoredConfirmationKey =
+  | { kind: "ok"; key: Buffer }
+  | { kind: "missing" }
+  | { kind: "unusable" };
+
+async function readConfirmationKey(target: string): Promise<StoredConfirmationKey> {
+  let stored: string;
+  try {
+    stored = await readFile(/* turbopackIgnore: true */ target, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { kind: "missing" };
+    throw error;
+  }
+  const key = Buffer.from(stored.trim(), "base64");
+  return key.length === CONFIRMATION_KEY_BYTES ? { kind: "ok", key } : { kind: "unusable" };
+}
+
+async function writeConfirmationKey(target: string, exclusive: boolean): Promise<Buffer> {
+  const key = randomBytes(CONFIRMATION_KEY_BYTES);
+  const handle = await open(/* turbopackIgnore: true */ target, exclusive ? "wx" : "w", 0o600);
+  try {
+    await handle.writeFile(key.toString("base64"));
+  } finally {
+    await handle.close();
+  }
+  return key;
+}
+
 /**
  * Per-install key backing the confirmation token.
  *
@@ -244,16 +290,26 @@ async function confirmationKey(): Promise<Buffer> {
   await ensureRealDirectory(publicationsRoot());
   const target = confirmationKeyPath();
   await assertRegularFileOrMissing(target);
-  try {
-    const stored = await readFile(/* turbopackIgnore: true */ target, "utf8");
-    const key = Buffer.from(stored.trim(), "base64");
-    if (key.length === CONFIRMATION_KEY_BYTES) return key;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  const stored = await readConfirmationKey(target);
+  if (stored.kind === "ok") return stored.key;
+
+  if (stored.kind === "missing") {
+    try {
+      // Exclusive create. Two callers reaching a fresh install at once must
+      // not each write their own key: the loser's write would silently
+      // invalidate a token the winner has already handed to a person.
+      return await writeConfirmationKey(target, true);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    const winner = await readConfirmationKey(target);
+    if (winner.kind === "ok") return winner.key;
   }
-  const key = randomBytes(CONFIRMATION_KEY_BYTES);
-  await writeFile(/* turbopackIgnore: true */ target, key.toString("base64"), { mode: 0o600 });
-  return key;
+
+  // The file exists but holds no usable key — truncated, replaced, or written
+  // by something else. Replacing it invalidates every outstanding token, which
+  // is the safe direction: a token that cannot be verified is not honoured.
+  return writeConfirmationKey(target, false);
 }
 
 async function mintConfirmationToken(
@@ -270,8 +326,15 @@ async function mintConfirmationToken(
 }
 
 function tokensMatch(expected: string, provided: unknown): boolean {
-  if (typeof provided !== "string" || provided.length !== expected.length) return false;
-  return timingSafeEqual(Buffer.from(expected, "utf8"), Buffer.from(provided, "utf8"));
+  if (typeof provided !== "string") return false;
+  const expectedBytes = Buffer.from(expected, "utf8");
+  const providedBytes = Buffer.from(provided, "utf8");
+  // Compare BYTE lengths, not string lengths. `timingSafeEqual` throws on a
+  // length mismatch, and one multi-byte character makes a same-`length` string
+  // a different byte length — so a 64-character token of "é" would crash the
+  // comparison instead of failing it, turning a refusal into a 500.
+  if (providedBytes.length !== expectedBytes.length) return false;
+  return timingSafeEqual(expectedBytes, providedBytes);
 }
 
 export type XPublicationDraft = { publication: XPublication; confirmationToken: string };


### PR DESCRIPTION
Part of #4816 (bead `cave-8i8q5`). **Does not close it** — see *What is still missing* below.

## Why this scope

The X integration already reads. Roughly 6,400 lines shipped for connection, OAuth, credential storage and refresh, post lookup, bounded recent search, and durable source snapshots with mission attachment. What it could not do is write: `createXPost` and `withXWritePreflight` both existed with **zero callers**, `tweet.write` was in the scope union but never requested, and `ambiguous-write` was in the error union but never thrown by any route. There was no path through which a post could be drafted, approved, or sent.

This adds that path: `src/lib/server/x-publications.ts` (durable store) and `POST /api/x/publish`.

## Two properties drive the design

**1. Publishing happens only after a human confirms this exact text.**

`draft` mints an HMAC over `(familiarId, publicationId, text)`, keyed by a per-install secret at `<caveHome>/x-publications/.confirmation-key` (mode `0600`). `publish` recomputes it and refuses without a match, compared with `timingSafeEqual`.

A plain hash of the text would not do this job — any caller holding the familiar id and the text could compute one, including a familiar subprocess that never showed a person anything. Keying it means a valid token can only have come from a `draft` response, which is served to the local UI over the loopback-only route. It is **not** a proof of humanity; nothing server-side can be, and the code comment says so rather than implying otherwise.

Consequences that are tested:
- Editing a draft mints a new token, so an approval given for one wording never carries to another.
- Two drafts with byte-identical text do not share a token — it names the record, not just the string.

**2. Nothing retries an external write.**

The record moves to `uncertain` and is **written to disk before the request goes out**. A crash between dispatch and response then leaves evidence that something was sent. The other ordering leaves a record reading `draft`, and the obvious next action on a draft is to publish it — which is exactly how a duplicate post gets made. There is a test that reads the record from disk *from inside* the send to pin the ordering.

Failure is then split on one signal, `XApiError.dispatched`:

| Failure | Meaning | Result |
|---|---|---|
| `dispatched: true` (`ambiguous-write`) | request left, response never came | stays `uncertain`; further publishing **refused** |
| anything else | X received it and refused, or it never left | returns to `draft`, safe to retry |

`uncertain` is left only by a human, through `resolve` — which records an observed post id or abandons the attempt, and never touches the network. The machine does not get to guess whether the post landed.

## Authorization

Publishing requires the familiar's `publish` capability, a **separate grant from `research`**: being able to read X is not permission to post as the account. `tweet.write` is requested only here, so a connection that was never granted posting rights fails at the preflight rather than at the post.

The preflight sits inside the `send` callback rather than wrapping the whole call, so a capability or token failure never marks a record dispatched.

## Other properties, each covered by a test

- Publishing an already-published record returns it and sends nothing (a double submit posts once).
- Records are familiar-scoped both ways; another familiar's valid publication id resolves `not-found`, so it cannot become a disclosure.
- A published record cannot be rewritten to falsify what was sent; an abandoned one is terminal.
- A stored record claiming `published` without its post id and canonical URL is rejected wholesale — "sent, but we lost where" is worse than no record.
- A malformed store is moved aside via `corruptAsidePath`, never dropped: these records are the only local evidence a post went out.
- An invalid familiar id never becomes a path.

## Verification

All run on this branch's head:

| Command | Result |
|---|---|
| `node --test … src/lib/server/x-publications.test.ts` | 17 passed, 0 failed |
| `node --test … src/app/api/api-contracts.test.ts` | 1 passed (the new route is registered with `localOriginGuard` + guarded invalid JSON) |
| `pnpm typecheck` | clean |
| `pnpm lint` | clean (design codemod: 0 drift; eslint `--max-warnings=0`) |
| `pnpm build` | passed, within bundle and standalone budgets |

The test file is registered in `scripts/run-tests.mjs` SUITES; `nodeArgsFor` was used to confirm the runner's own argv rather than a hand-written command.

## What is still missing from #4816

Named so the bead is not closed on a partial:

- **Research Desk → mission attach UI.** The server side is done (`setXSourceMissionAttached`, the `attach` action on `/api/x/sources`); no surface calls it.
- **The room UI for drafting and publishing.** This PR is the server path only. A surface needs to render the draft, show the confirmation step, and — importantly — surface `uncertain` records for resolution, since nothing else will.
- **Text length feedback.** The store enforces emptiness and a 16 KB ceiling, deliberately not 280 characters: that limit varies by account tier and has changed more than once, so hard-coding it would refuse posts an account is entitled to make. A composer should show the count against the connected tier.