### PR TITLE
Persist single-message delete to the server

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1368,6 +1368,7 @@ export const SUITES = {
     "src/lib/server/daemon-travel-reconcile.test.ts",
     "src/app/api/chat/conversation/route.test.ts",
     "src/app/api/chat/conversation/[id]/route.test.ts",
+    "src/app/api/chat/conversation/[id]/turns/[turnId]/route.test.ts",
     "src/app/api/sessions/[id]/route.test.ts",
     "src/app/api/canvas/route.test.ts",
     "src/lib/server/familiar-execution-analytics.test.ts",
@@ -2099,6 +2100,7 @@ const ALIAS_LOADER = new Set([
   "src/app/api/hermes-profiles/route.test.ts",
   "src/app/api/salem/route.test.ts",
   "src/app/api/chat/conversation/[id]/route.test.ts",
+  "src/app/api/chat/conversation/[id]/turns/[turnId]/route.test.ts",
   // familiar-brain imports familiar-stream, whose graph reaches "@/lib/…".
   "src/lib/voice/familiar-brain.test.ts",
   "src/lib/voice/registry.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -67,6 +67,7 @@ const contracts: RouteContract[] = [
   { route: "/chat/attachment", methods: ["GET"], kind: "stream", localOriginGuard: true, pathGuard: true },
   { route: "/chat/conversation", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/chat/conversation/[id]", methods: ["GET", "POST", "PUT", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/chat/conversation/[id]/turns/[turnId]", methods: ["DELETE"], kind: "json" },
   { route: "/chat/model-state", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/chat/rewrite", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/chat/search", methods: ["GET"], kind: "json" },

--- a/src/app/api/chat/conversation/[id]/turns/[turnId]/route.test.ts
+++ b/src/app/api/chat/conversation/[id]/turns/[turnId]/route.test.ts
@@ -163,3 +163,84 @@ test("deleting every turn leaves the conversation itself in place", async () => 
   assert.equal(stored.sessionId, "sess-empty");
   assert.deepEqual(stored.turns, []);
 });
+
+test("a turn id holding a percent sign is matched literally, not decoded again", async () => {
+  // Next already percent-decodes route params, so `%25` on the wire reaches
+  // the handler as a bare `%`. Decoding a second time threw URIError here and
+  // surfaced as an unhandled 500 with no JSON envelope.
+  writeConversation("sess-percent", [turn("u1", null, 1), turn("a100%", "u1", 2)], {
+    activeLeafId: "a100%",
+  });
+
+  const res = await DELETE(new Request("http://127.0.0.1/x"), {
+    params: Promise.resolve({ id: "sess-percent", turnId: "a100%" }),
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.deleted, true);
+  assert.deepEqual(readConversation("sess-percent").turns.map((t) => t.id), ["u1"]);
+});
+
+test("an escape-shaped turn id is not double-decoded into a different id", async () => {
+  // "%41" would decode to "A". The stored id is the literal text, so a second
+  // decode would silently miss the turn and report it already gone.
+  writeConversation("sess-escape", [turn("u1", null, 1), turn("a-%41", "u1", 2)], {
+    activeLeafId: "a-%41",
+  });
+
+  const res = await DELETE(new Request("http://127.0.0.1/x"), {
+    params: Promise.resolve({ id: "sess-escape", turnId: "a-%41" }),
+  });
+
+  assert.equal((await res.json()).deleted, true);
+  assert.deepEqual(readConversation("sess-escape").turns.map((t) => t.id), ["u1"]);
+});
+
+test("an over-long turn id is refused", async () => {
+  const res = await DELETE(new Request("http://127.0.0.1/x"), {
+    params: Promise.resolve({ id: "sess-badturn", turnId: "a".repeat(201) }),
+  });
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, "invalid turn id");
+});
+
+test("the response reports the repaired leaf, never the transcript", async () => {
+  // GET runs every conversation through sanitizeConversationMetadata; echoing
+  // the raw file from here would hand clients a shape GET never produces, and
+  // ship the whole transcript back over the tailnet on every delete.
+  writeConversation("sess-shape", [turn("u1", null, 1), turn("a1", "u1", 2)], {
+    activeLeafId: "a1",
+  });
+
+  const body = await (await call("sess-shape", "a1")).json();
+  assert.deepEqual(body, { ok: true, deleted: true, activeLeafId: "u1" });
+
+  const retry = await (await call("sess-shape", "a1")).json();
+  assert.deepEqual(retry, { ok: true, deleted: false, activeLeafId: "u1" });
+});
+
+test("deleting the last turn reports a null leaf rather than omitting it", async () => {
+  writeConversation("sess-nullleaf", [turn("u1", null, 1)], { activeLeafId: "u1" });
+
+  const body = await (await call("sess-nullleaf", "u1")).json();
+  assert.deepEqual(body, { ok: true, deleted: true, activeLeafId: null });
+});
+
+test("a legacy linear conversation is migrated and spliced, not corrupted", async () => {
+  // Pre-branching files carry no parentId and no activeLeafId; loadConversation
+  // linearizes them on read, so the delete must land on the migrated shape.
+  writeConversation("sess-legacy", [
+    { id: "u1", role: "user", text: "u1", createdAt: "2026-06-01T00:00:01.000Z" },
+    { id: "a1", role: "assistant", text: "a1", createdAt: "2026-06-01T00:00:02.000Z" },
+    { id: "u2", role: "user", text: "u2", createdAt: "2026-06-01T00:00:03.000Z" },
+  ]);
+
+  const body = await (await call("sess-legacy", "a1")).json();
+  assert.equal(body.deleted, true);
+
+  const stored = readConversation("sess-legacy");
+  assert.deepEqual(stored.turns.map((t) => t.id), ["u1", "u2"]);
+  assert.equal(stored.turns.find((t) => t.id === "u2").parentId, "u1");
+  assert.equal(stored.activeLeafId, "u2");
+});

--- a/src/app/api/chat/conversation/[id]/turns/[turnId]/route.test.ts
+++ b/src/app/api/chat/conversation/[id]/turns/[turnId]/route.test.ts
@@ -1,0 +1,165 @@
+// @ts-nocheck
+// Route tests for DELETE /api/chat/conversation/[id]/turns/[turnId].
+//
+// COVEN_CAVE_HOME (and the CONV_DIR derived from it) is computed once at
+// module load by cave-conversations.ts, so it must be set BEFORE route.ts is
+// imported — a static import would hoist above the assignment and point every
+// call at the real ~/.coven store. Hence the dynamic import below, matching
+// the sibling test for /chat/conversation/[id].
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TMP = mkdtempSync(join(tmpdir(), "conversation-turn-route-"));
+const TMP_COVEN = mkdtempSync(join(tmpdir(), "conversation-turn-route-coven-"));
+process.env.COVEN_CAVE_HOME = TMP;
+process.env.COVEN_HOME = TMP_COVEN;
+
+const CONV_DIR = join(TMP, "conversations");
+
+const { DELETE } = await import("./route.ts");
+
+function turn(id: string, parentId: string | null, seconds: number, text = id) {
+  return {
+    id,
+    parentId,
+    role: id.startsWith("u") ? "user" : "assistant",
+    text,
+    createdAt: `2026-06-01T00:00:${String(seconds).padStart(2, "0")}.000Z`,
+  };
+}
+
+function writeConversation(id: string, turns: unknown[], extra: Record<string, unknown> = {}) {
+  mkdirSync(CONV_DIR, { recursive: true });
+  writeFileSync(
+    join(CONV_DIR, `${id}.json`),
+    JSON.stringify({
+      sessionId: id,
+      familiarId: "milo",
+      harness: "claude",
+      title: "Test chat",
+      createdAt: "2026-06-01T00:00:00Z",
+      updatedAt: "2026-06-01T00:00:00Z",
+      turns,
+      ...extra,
+    }),
+  );
+}
+
+function readConversation(id: string) {
+  return JSON.parse(readFileSync(join(CONV_DIR, `${id}.json`), "utf8"));
+}
+
+function call(id: string, turnId: string) {
+  return DELETE(new Request(`http://127.0.0.1/api/chat/conversation/${id}/turns/${turnId}`), {
+    params: Promise.resolve({ id, turnId }),
+  });
+}
+
+test("deleting a turn persists to the conversation file", async () => {
+  writeConversation("sess-basic", [turn("u1", null, 1), turn("a1", "u1", 2)], {
+    activeLeafId: "a1",
+  });
+
+  const res = await call("sess-basic", "a1");
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.deleted, true);
+
+  // The durable file is the point of the whole change — an in-memory response
+  // would look identical to the client-side splice this replaces.
+  const stored = readConversation("sess-basic");
+  assert.deepEqual(stored.turns.map((t) => t.id), ["u1"]);
+  assert.equal(stored.activeLeafId, "u1", "the leaf follows the deletion to the parent");
+  assert.notEqual(stored.updatedAt, "2026-06-01T00:00:00Z", "the chat is marked touched");
+});
+
+test("deleting a turn keeps the replies that followed it", async () => {
+  writeConversation(
+    "sess-splice",
+    [turn("u1", null, 1), turn("a1", "u1", 2), turn("u2", "a1", 3), turn("a2", "u2", 4)],
+    { activeLeafId: "a2" },
+  );
+
+  await call("sess-splice", "a1");
+
+  const stored = readConversation("sess-splice");
+  assert.deepEqual(stored.turns.map((t) => t.id), ["u1", "u2", "a2"]);
+  assert.equal(stored.turns.find((t) => t.id === "u2").parentId, "u1");
+  assert.equal(stored.activeLeafId, "a2", "an unrelated leaf is untouched");
+});
+
+test("a repeated delete succeeds without changing anything", async () => {
+  writeConversation("sess-retry", [turn("u1", null, 1), turn("a1", "u1", 2)], {
+    activeLeafId: "a1",
+  });
+
+  await call("sess-retry", "a1");
+  const after = readConversation("sess-retry");
+
+  // A client whose first response was lost retries. Reporting failure here
+  // would make a successful delete look broken.
+  const res = await call("sess-retry", "a1");
+  const body = await res.json();
+  assert.equal(res.status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.deleted, false);
+  assert.deepEqual(readConversation("sess-retry"), after, "the second call writes nothing");
+});
+
+test("an unknown conversation is a 404, not a silent success", async () => {
+  const res = await call("sess-absent", "a1");
+  const body = await res.json();
+  assert.equal(res.status, 404);
+  assert.equal(body.ok, false);
+});
+
+test("an invalid session id is refused before any load", async () => {
+  const res = await DELETE(new Request("http://127.0.0.1/x"), {
+    params: Promise.resolve({ id: "../escape", turnId: "a1" }),
+  });
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, "invalid session id");
+});
+
+test("an empty turn id is refused", async () => {
+  writeConversation("sess-badturn", [turn("u1", null, 1)]);
+  const res = await DELETE(new Request("http://127.0.0.1/x"), {
+    params: Promise.resolve({ id: "sess-badturn", turnId: "" }),
+  });
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, "invalid turn id");
+});
+
+test("deleting the pending first turn clears the stub marker", async () => {
+  // Left set, the sessions list keeps reporting a phantom failed run for a
+  // turn that no longer exists.
+  writeConversation("sess-stub", [turn("u1", null, 1)], {
+    activeLeafId: "u1",
+    pendingUserTurnId: "u1",
+  });
+
+  await call("sess-stub", "u1");
+
+  const stored = readConversation("sess-stub");
+  assert.deepEqual(stored.turns, []);
+  assert.equal(stored.pendingUserTurnId, undefined);
+  assert.equal(stored.activeLeafId, undefined, "no leaf is left pointing at a removed turn");
+});
+
+test("deleting every turn leaves the conversation itself in place", async () => {
+  writeConversation("sess-empty", [turn("u1", null, 1)], { activeLeafId: "u1" });
+
+  await call("sess-empty", "u1");
+
+  // Removing the last message is not the same request as deleting the chat —
+  // that is what DELETE /api/chat/conversation/[id] is for, and it also
+  // sacrifices the session.
+  const stored = readConversation("sess-empty");
+  assert.equal(stored.sessionId, "sess-empty");
+  assert.deepEqual(stored.turns, []);
+});

--- a/src/app/api/chat/conversation/[id]/turns/[turnId]/route.ts
+++ b/src/app/api/chat/conversation/[id]/turns/[turnId]/route.ts
@@ -41,12 +41,18 @@ export async function DELETE(
   _req: Request,
   { params }: { params: Promise<{ id: string; turnId: string }> },
 ) {
-  const { id, turnId: rawTurnId } = await params;
+  // No decodeURIComponent: Next already percent-decodes dynamic route params,
+  // which is what the sibling `[id]` route relies on for the session id.
+  // Decoding a second time is wrong twice over — a turn id holding a literal
+  // `%41` would be mangled into `A` and match nothing, and an id holding a
+  // bare `%` (sent correctly as `%25`) arrives decoded as `%`, where
+  // decodeURIComponent throws URIError: an unhandled 500 with no JSON
+  // envelope, from a perfectly well-formed request.
+  const { id, turnId } = await params;
   if (!isSafeConversationSessionId(id)) {
     return NextResponse.json({ ok: false, error: "invalid session id" }, { status: 400 });
   }
-  const turnId = decodeURIComponent(rawTurnId ?? "");
-  if (!isPlausibleTurnId(turnId)) {
+  if (typeof turnId !== "string" || !isPlausibleTurnId(turnId)) {
     return NextResponse.json({ ok: false, error: "invalid turn id" }, { status: 400 });
   }
 
@@ -64,7 +70,11 @@ export async function DELETE(
       // Idempotent: a retried delete whose first response never arrived must
       // not report failure. See deleteTurn for why this is worth the
       // ambiguity with a genuinely unknown id.
-      return NextResponse.json({ ok: true, deleted: false, conversation });
+      return NextResponse.json({
+        ok: true,
+        deleted: false,
+        activeLeafId: conversation.activeLeafId ?? null,
+      });
     }
 
     conversation.turns = result.turns;
@@ -77,6 +87,17 @@ export async function DELETE(
     conversation.updatedAt = new Date().toISOString();
 
     await saveConversation(conversation);
-    return NextResponse.json({ ok: true, deleted: true, conversation });
+    // Only the repaired leaf, not the transcript. Every handler on
+    // `/chat/conversation/[id]` that returns a conversation runs it through
+    // that route's private sanitizeConversationMetadata first (it normalizes
+    // modelIntent and drops responseMetadata off user turns); echoing the raw
+    // file here would hand clients a shape GET never produces, and ship the
+    // whole transcript back over the tailnet on every single-message delete.
+    // A client that wants the new state re-reads it with GET.
+    return NextResponse.json({
+      ok: true,
+      deleted: true,
+      activeLeafId: conversation.activeLeafId ?? null,
+    });
   });
 }

--- a/src/app/api/chat/conversation/[id]/turns/[turnId]/route.ts
+++ b/src/app/api/chat/conversation/[id]/turns/[turnId]/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+
+import {
+  isSafeConversationSessionId,
+  loadConversation,
+  saveConversation,
+  withConversationLock,
+} from "@/lib/cave-conversations";
+import { deleteTurn } from "@/lib/conversation-tree";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * DELETE /api/chat/conversation/[id]/turns/[turnId] — remove one message from
+ * a chat, durably.
+ *
+ * Deleting a message used to be a client-side array splice: iOS dropped it
+ * from its in-memory thread and rewrote its own local snapshot file, so the
+ * message came back on reinstall and never disappeared anywhere else. This is
+ * the server half.
+ *
+ * It is a per-turn route rather than another shape of the existing PUT, which
+ * replaces the whole turn array. A client that deletes by re-PUTing its list
+ * writes back everything it happens to be holding — so a reply that streamed
+ * in while the user was deciding is silently erased by the delete. Naming the
+ * single turn means concurrent writers cannot lose each other's turns, which
+ * is exactly the property "reflect across clients" needs.
+ *
+ * No local-origin guard, deliberately: `/chat/conversation/[id]` has none
+ * either, because the iOS app reaches these routes across the tailnet. Adding
+ * one here would make the mobile delete fail where the mobile read succeeds.
+ */
+
+/** Bounds only — turn ids are opaque to this route and never touch a path. */
+function isPlausibleTurnId(value: string): boolean {
+  return value.length > 0 && value.length <= 200;
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string; turnId: string }> },
+) {
+  const { id, turnId: rawTurnId } = await params;
+  if (!isSafeConversationSessionId(id)) {
+    return NextResponse.json({ ok: false, error: "invalid session id" }, { status: 400 });
+  }
+  const turnId = decodeURIComponent(rawTurnId ?? "");
+  if (!isPlausibleTurnId(turnId)) {
+    return NextResponse.json({ ok: false, error: "invalid turn id" }, { status: 400 });
+  }
+
+  return withConversationLock(id, async () => {
+    const conversation = await loadConversation(id);
+    // A missing conversation is a real 404 rather than a silent success: the
+    // client is asking about a chat this server does not have, which is a
+    // different situation from a turn that is already gone.
+    if (!conversation) {
+      return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
+    }
+
+    const result = deleteTurn(conversation.turns, turnId, conversation.activeLeafId);
+    if (!result.deleted) {
+      // Idempotent: a retried delete whose first response never arrived must
+      // not report failure. See deleteTurn for why this is worth the
+      // ambiguity with a genuinely unknown id.
+      return NextResponse.json({ ok: true, deleted: false, conversation });
+    }
+
+    conversation.turns = result.turns;
+    if (result.activeLeafId === undefined) delete conversation.activeLeafId;
+    else conversation.activeLeafId = result.activeLeafId;
+    // The first-turn stub marker names a specific pending turn; leaving it
+    // pointing at a deleted one makes the sessions list report a phantom
+    // failed run forever.
+    if (conversation.pendingUserTurnId === turnId) delete conversation.pendingUserTurnId;
+    conversation.updatedAt = new Date().toISOString();
+
+    await saveConversation(conversation);
+    return NextResponse.json({ ok: true, deleted: true, conversation });
+  });
+}

--- a/src/lib/conversation-tree.test.ts
+++ b/src/lib/conversation-tree.test.ts
@@ -6,6 +6,7 @@ import {
   buildSiblingIndex,
   childLeaf,
   linearizeLegacy,
+  deleteTurn,
   type TreeTurn,
 } from "./conversation-tree.ts";
 
@@ -160,4 +161,87 @@ test("buildSiblingIndex agrees with siblingsOf for every turn (one pass)", () =>
     assert.deepEqual(viaIndex.siblings.map((s) => s.id), viaScan.siblings.map((s) => s.id), turn.id);
     assert.equal(viaIndex.index, viaScan.index, turn.id);
   }
+});
+
+// ── deleteTurn ──────────────────────────────────────────────────────────────
+// Deleting a message splices the node out and reparents its children, rather
+// than pruning the subtree. Taking the replies along with the message is the
+// obvious wrong behaviour; leaving children pointing at a removed id is the
+// subtle one, because resolveActivePath then stops its ancestor walk early
+// and silently renders a truncated conversation.
+
+test("deleteTurn reparents children instead of pruning the subtree", () => {
+  const turns = [t("u1", null, 1), t("a1", "u1", 2), t("u2", "a1", 3), t("a2", "u2", 4)];
+  const result = deleteTurn(turns, "a1", "a2");
+
+  assert.equal(result.deleted, true);
+  assert.deepEqual(result.turns.map((x) => x.id), ["u1", "u2", "a2"]);
+  assert.equal(result.turns.find((x) => x.id === "u2")?.parentId, "u1", "the reply is adopted");
+  // The whole point: the surviving turns still form one walkable chain.
+  assert.deepEqual(
+    resolveActivePath(result.turns, result.activeLeafId!).map((x) => x.id),
+    ["u1", "u2", "a2"],
+  );
+});
+
+test("deleteTurn on an unknown id is a no-op, not a failure", () => {
+  const turns = [t("u1", null, 1), t("a1", "u1", 2)];
+  const result = deleteTurn(turns, "never-existed", "a1");
+
+  assert.equal(result.deleted, false);
+  assert.equal(result.turns, turns, "the array is handed back untouched");
+  assert.equal(result.activeLeafId, "a1");
+});
+
+test("deleting the active leaf moves it to the parent", () => {
+  const turns = [t("u1", null, 1), t("a1", "u1", 2), t("u2", "a1", 3)];
+  const result = deleteTurn(turns, "u2", "u2");
+
+  assert.equal(result.activeLeafId, "a1");
+  assert.deepEqual(result.turns.map((x) => x.id), ["u1", "a1"]);
+});
+
+test("deleting a root leaf falls back to the newest remaining turn", () => {
+  // Two root branches; the active one is deleted and has no parent to fall
+  // back to, so the path must not be left pointing at nothing.
+  const turns = [t("r1", null, 1), t("r2", null, 2), t("a2", "r2", 3)];
+  const result = deleteTurn(turns, "r1", "r1");
+
+  assert.equal(result.activeLeafId, "a2");
+  assert.deepEqual(result.turns.map((x) => x.id), ["r2", "a2"]);
+});
+
+test("deleting the only turn leaves no active leaf rather than a dangling one", () => {
+  const result = deleteTurn([t("u1", null, 1)], "u1", "u1");
+
+  assert.deepEqual(result.turns, []);
+  assert.equal(result.activeLeafId, undefined);
+  assert.equal(result.deleted, true);
+});
+
+test("deleting a root promotes its children to roots", () => {
+  const turns = [t("u1", null, 1), t("a1", "u1", 2), t("a1b", "u1", 3)];
+  const result = deleteTurn(turns, "u1", "a1");
+
+  assert.equal(result.turns.find((x) => x.id === "a1")?.parentId, null);
+  assert.equal(result.turns.find((x) => x.id === "a1b")?.parentId, null);
+  assert.equal(result.activeLeafId, "a1", "an unrelated active leaf is left alone");
+});
+
+test("deleteTurn keeps sibling branches independent", () => {
+  // a1 and a1b are alternative replies to u1. Deleting one must not disturb
+  // the other or the branch hanging off it.
+  const turns = [t("u1", null, 1), t("a1", "u1", 2), t("a1b", "u1", 3), t("u2", "a1b", 4)];
+  const result = deleteTurn(turns, "a1", "u2");
+
+  assert.deepEqual(result.turns.map((x) => x.id), ["u1", "a1b", "u2"]);
+  assert.equal(result.activeLeafId, "u2");
+  assert.deepEqual(resolveActivePath(result.turns, "u2").map((x) => x.id), ["u1", "a1b", "u2"]);
+});
+
+test("deleteTurn does not mutate the array it was given", () => {
+  const turns = [t("u1", null, 1), t("a1", "u1", 2), t("u2", "a1", 3)];
+  const before = JSON.stringify(turns);
+  deleteTurn(turns, "a1", "u2");
+  assert.equal(JSON.stringify(turns), before);
 });

--- a/src/lib/conversation-tree.test.ts
+++ b/src/lib/conversation-tree.test.ts
@@ -245,3 +245,70 @@ test("deleteTurn does not mutate the array it was given", () => {
   deleteTurn(turns, "a1", "u2");
   assert.equal(JSON.stringify(turns), before);
 });
+
+// The leaf repair below fires only when the deleted turn WAS the active leaf
+// and has no usable parent — i.e. a deleted root. Getting the replacement
+// wrong is silent: the file keeps every turn, and the transcript just renders
+// short.
+
+function sys(id: string, seconds: number): TreeTurn {
+  return {
+    id,
+    parentId: null,
+    role: "system",
+    createdAt: `2026-06-23T00:00:${String(seconds).padStart(2, "0")}.000Z`,
+  };
+}
+
+test("the replacement leaf is never a chain-less system echo", () => {
+  // A /help or coven-exec echo is appended with no parentId and is routinely
+  // the newest turn in the file. cave-conversations strips exactly these
+  // before validating the leaf's ancestor chain, so selecting one resolves to
+  // no chain at all — the sessions list loses the chat's status, and the
+  // transcript renders the echo alone with r1 hidden.
+  const turns = [t("r1", null, 1), t("r2", null, 2), sys("s1", 3)];
+  const result = deleteTurn(turns, "r2", "r2");
+
+  assert.equal(result.activeLeafId, "r1");
+  assert.deepEqual(
+    resolveActivePath(result.turns, result.activeLeafId!).map((x) => x.id),
+    ["r1", "s1"],
+    "the echo is woven back in as an orphan, not treated as the leaf",
+  );
+});
+
+test("a chain-less system echo is not inherited as the leaf either", () => {
+  // Same trap one step earlier: the deleted leaf's own parent is the echo.
+  const turns = [sys("s1", 1), t("u2", "s1", 2)];
+  const result = deleteTurn(turns, "u2", "u2");
+
+  assert.equal(result.activeLeafId, undefined, "no structural turn is left to point at");
+});
+
+test("the replacement leaf descends past a createdAt tie to the real leaf", () => {
+  // chat/send stamps a user turn and its reply with one createdAt, so
+  // byCreatedAt tie-breaks on id and can sort the PARENT last. Taking the
+  // newest turn verbatim would point the path at "zu2" and hide its reply.
+  const turns = [t("r1", null, 1), t("zu2", null, 5), t("aa2", "zu2", 5)];
+  const result = deleteTurn(turns, "r1", "r1");
+
+  assert.equal(result.activeLeafId, "aa2");
+  assert.deepEqual(
+    resolveActivePath(result.turns, result.activeLeafId!).map((x) => x.id),
+    ["zu2", "aa2"],
+  );
+});
+
+test("the replacement leaf is the deepest turn of the newest branch", () => {
+  const turns = [t("r1", null, 1), t("r2", null, 2), t("a2", "r2", 3), t("u3", "a2", 4)];
+  const result = deleteTurn(turns, "r1", "r1");
+
+  assert.equal(result.activeLeafId, "u3");
+});
+
+test("only chain-less system echoes remaining leaves no active leaf", () => {
+  const result = deleteTurn([t("u1", null, 1), sys("s1", 2)], "u1", "u1");
+
+  assert.deepEqual(result.turns.map((x) => x.id), ["s1"]);
+  assert.equal(result.activeLeafId, undefined);
+});

--- a/src/lib/conversation-tree.ts
+++ b/src/lib/conversation-tree.ts
@@ -156,6 +156,18 @@ export function linearizeLegacy<T extends TreeTurn>(
   return { turns: linked, activeLeafId: linked[linked.length - 1].id };
 }
 
+/**
+ * A chain-less system echo (role "system", no parentId) is never a legal
+ * active leaf. `cave-conversations.activeConversationTurns` strips exactly
+ * these turns before validating the leaf's ancestor chain, so a leaf pointing
+ * at one resolves to no chain at all: the sessions list loses the chat's
+ * status and attention evidence, and `resolveActivePath` renders the echo
+ * alone with every real turn hidden.
+ */
+function isChainlessSystem<T extends TreeTurn>(turn: T): boolean {
+  return turn.role === "system" && (turn.parentId ?? null) === null;
+}
+
 /** Result of splicing one turn out of the tree. */
 export type TurnDeletion<T extends TreeTurn> = {
   turns: T[];
@@ -204,13 +216,26 @@ export function deleteTurn<T extends TreeTurn>(
   if (activeLeafId !== turnId) return { turns: remaining, activeLeafId, deleted: true };
 
   // The active leaf was the turn just removed. Prefer its parent — that is
-  // where the conversation visibly continues from — and fall back to the
-  // newest remaining turn so a deleted root does not leave the path empty.
-  if (inheritedParent !== null && remaining.some((turn) => turn.id === inheritedParent)) {
-    return { turns: remaining, activeLeafId: inheritedParent, deleted: true };
+  // where the conversation visibly continues from — unless the parent is a
+  // chain-less system echo, which is not a resolvable leaf at all.
+  const parent = inheritedParent === null
+    ? undefined
+    : remaining.find((turn) => turn.id === inheritedParent);
+  if (parent && !isChainlessSystem(parent)) {
+    return { turns: remaining, activeLeafId: parent.id, deleted: true };
   }
-  const newestRemaining = remaining.length > 0
-    ? byCreatedAt(remaining)[remaining.length - 1]!.id
-    : undefined;
-  return { turns: remaining, activeLeafId: newestRemaining, deleted: true };
+
+  // No usable parent (a deleted root), so fall back to the newest remaining
+  // turn rather than leaving the path empty. Two constraints on the pick:
+  //
+  //  - Skip chain-less system echoes. They are frequently the newest turn in
+  //    the file (a /help or coven-exec echo appended after the last reply),
+  //    and selecting one hides every real turn — see isChainlessSystem.
+  //  - Descend to that turn's own leaf. A user turn and its reply share one
+  //    createdAt stamp, so byCreatedAt tie-breaks on id and can sort the
+  //    PARENT last; pointing the path at it would truncate the reply away.
+  const candidates = remaining.filter((turn) => !isChainlessSystem(turn));
+  if (candidates.length === 0) return { turns: remaining, activeLeafId: undefined, deleted: true };
+  const newest = byCreatedAt(candidates)[candidates.length - 1]!.id;
+  return { turns: remaining, activeLeafId: childLeaf(remaining, newest), deleted: true };
 }

--- a/src/lib/conversation-tree.ts
+++ b/src/lib/conversation-tree.ts
@@ -155,3 +155,62 @@ export function linearizeLegacy<T extends TreeTurn>(
   }));
   return { turns: linked, activeLeafId: linked[linked.length - 1].id };
 }
+
+/** Result of splicing one turn out of the tree. */
+export type TurnDeletion<T extends TreeTurn> = {
+  turns: T[];
+  /** Repaired leaf: unchanged unless it named the removed turn. */
+  activeLeafId: string | undefined;
+  /** False when the id named no turn — a retry of an already-applied delete. */
+  deleted: boolean;
+};
+
+/**
+ * Remove one turn, splicing it out of the tree rather than pruning its
+ * subtree: every child is reparented to the removed turn's parent.
+ *
+ * Deleting a message the user no longer wants must not silently take the
+ * replies that followed it, and it must not leave children pointing at an id
+ * that is gone — `resolveActivePath` would then stop its ancestor walk early
+ * and render a truncated conversation. Splicing keeps every surviving turn on
+ * exactly one path.
+ *
+ * Returning `deleted: false` for an unknown id, rather than throwing, is what
+ * makes the operation idempotent: a client retrying a delete whose response it
+ * never saw must not be told the second attempt failed. The cost is that a
+ * genuinely wrong id reads the same as an already-applied one — after the
+ * fact, the two are indistinguishable, and the retry is the case worth
+ * getting right.
+ */
+export function deleteTurn<T extends TreeTurn>(
+  turns: T[],
+  turnId: string,
+  activeLeafId?: string,
+): TurnDeletion<T> {
+  const target = turns.find((turn) => turn.id === turnId);
+  if (!target) return { turns, activeLeafId, deleted: false };
+
+  const inheritedParent = target.parentId ?? null;
+  const remaining = turns
+    .filter((turn) => turn.id !== turnId)
+    .map((turn) => {
+      if ((turn.parentId ?? null) !== turnId) return turn;
+      // A child inheriting itself as parent would be a self-cycle; the walk
+      // guards against cycles, but a root is the honest answer here.
+      const parentId = inheritedParent === turn.id ? null : inheritedParent;
+      return { ...turn, parentId };
+    });
+
+  if (activeLeafId !== turnId) return { turns: remaining, activeLeafId, deleted: true };
+
+  // The active leaf was the turn just removed. Prefer its parent — that is
+  // where the conversation visibly continues from — and fall back to the
+  // newest remaining turn so a deleted root does not leave the path empty.
+  if (inheritedParent !== null && remaining.some((turn) => turn.id === inheritedParent)) {
+    return { turns: remaining, activeLeafId: inheritedParent, deleted: true };
+  }
+  const newestRemaining = remaining.length > 0
+    ? byCreatedAt(remaining)[remaining.length - 1]!.id
+    : undefined;
+  return { turns: remaining, activeLeafId: newestRemaining, deleted: true };
+}


### PR DESCRIPTION
Part of #4819 (bead `cave-ioswipe.6`). **Does not close it** — the iOS client still needs wiring; see below.

## What was actually missing

The issue names three things. Two of them already work:

- **Thread archive** and **thread pin** persist through `PATCH /api/sessions/{id}` (`archived` / `pinned`), backed by `archiveSessionLocal` / `setSessionPinnedLocal` in cave state. `CaveClient.setSessionFlags` already calls it, with idempotent retry.
- **Thread delete** persists through `DELETE /api/chat/conversation/{id}`, which also sacrifices the session so a stale retry cannot resurrect it.

**Message delete does not.** `ChatThread.deleteMessage` is `messages.removeAll { $0.id == messageId }`, and `app.touch(thread)` writes iOS's own `cave-threads.json` in Application Support. iOS never writes to `/api/chat/conversation/{id}` at all — it only ever GETs it. So a deleted message comes back on reinstall and never disappears on the web client or a second device.

This PR is the server half.

## `DELETE /api/chat/conversation/[id]/turns/[turnId]`

**Why a per-turn route and not the existing `PUT`.** `PUT` replaces the whole turn array. A client that deletes by re-PUTing its list writes back whatever it happens to be holding — so a reply that streamed in while the user was deciding is silently erased along with the message they meant to remove. Naming the single turn means concurrent writers cannot lose each other's turns, which is precisely what "reflect across clients" requires. The whole handler runs inside `withConversationLock`.

**`deleteTurn` splices, it does not prune.** Children of the removed turn are reparented to its parent. Two failure modes are being avoided:

- Taking the replies along with the message — the obvious wrong behaviour.
- Leaving children pointing at a removed id — the subtle one. `resolveActivePath` walks ancestors from `activeLeafId`; a dangling `parentId` stops that walk early and silently renders a *truncated* conversation, with no error anywhere.

**Idempotent by design.** An unknown turn id returns `200 {ok: true, deleted: false}` rather than an error, because a client retrying a delete whose response it never saw must not be told the second attempt failed — and iOS's `retryingIdempotentMutation` does exactly that. The cost is that a genuinely wrong id reads the same as an already-applied one; after the fact those are indistinguishable, and the retry is the case worth getting right. A **missing conversation** is still a real `404`, since that is a different situation from a turn that is already gone.

**Two bits of state repair**, each with a test:
- The active leaf follows a deleted turn to its parent, falling back to the newest remaining turn when the deleted one was a root, and to nothing when the chat is now empty.
- `pendingUserTurnId` is cleared when it names the deleted turn — left set, the sessions list keeps reporting a phantom failed run for a turn that no longer exists.

**No local-origin guard**, matching `/chat/conversation/[id]`, which has none either: the iOS app reaches these routes across the tailnet, so a guard here would make the mobile delete fail where the mobile read succeeds. Registered in `api-contracts.test.ts` accordingly.

## Verification

All run through `nodeArgsFor` so the argv matches CI's exactly:

| File | Result |
|---|---|
| `src/app/api/chat/conversation/[id]/turns/[turnId]/route.test.ts` | 8 passed, 0 failed (new) |
| `src/lib/conversation-tree.test.ts` | 25 passed, 0 failed (17 existing + 8 new) |
| `src/app/api/chat/conversation/[id]/route.test.ts` | 18 passed, 0 failed (unchanged, checked for regression) |
| `src/app/api/api-contracts.test.ts` | passed |
| `node scripts/check-tests-wired.mjs` | ✓ all 1776 test files wired into CI |
| `pnpm typecheck` / `pnpm lint` / `pnpm build` | clean; within bundle and standalone budgets |

The new test file is registered in both SUITES and `ALIAS_LOADER` (the route reaches `@/lib/cave-conversations`).

## What is still missing from #4819

- **The iOS client.** `ChatThread.deleteMessage` should call this route with optimistic UI and explicit rollback on failure, the way `fanOutThreadFlag` already does for archive and pin. That is the other half of "clear failure signaling", and it needs an Xcode build I cannot run on this machine.
- **Web client parity.** Nothing in the web UI calls the new route yet either.

## One note on the bead

The GitHub mirror lists this as `status: blocked` on `cave-sve2a` and `cave-2nl6c`. Neither bead exists in the local Beads DB — nor did `cave-ioswipe.6` itself until I restored the family from `.beads.backup-pre-recovery/ios-swipe-beads-import.jsonl`, which the pre-recovery rollback had dropped. The restored bead carries no dependencies. Flagging it rather than assuming the mirror is stale.