### PR TITLE
Pin the release-notes guard-disclosure env expressions (cave-9dg)

### DIFF
--- a/scripts/release-promotion-workflow.test.mjs
+++ b/scripts/release-promotion-workflow.test.mjs
@@ -594,6 +594,93 @@ test("no release gate can be switched off by a step-level or job-level if:", asy
   );
 });
 
+// The same family of off switch as the X gate's env above, one step further
+// out. `release-notes.test.mjs` pins the CONSUMER thoroughly — only the literal
+// "true" turns the banner on, "1" and "false" do not — and nothing pinned the
+// PRODUCER. Replacing either expression with a constant `false`, or dropping
+// the env entry, silences the banner for a cut that really did ship with the
+// baseline parsers, while every check stays green and every naming regex still
+// matches. That is cave-yp21x exactly: v0.2.0 shipped with both guards skipped
+// and nobody noticed for four days, because the only evidence was a grey
+// "skipped" line in a workflow run.
+test("the release-notes guard disclosure is on exactly when its own hatch was pulled", async () => {
+  const release = await workflow("release.yml");
+  // Located by what it runs rather than by what it is called, so a rename
+  // cannot take this pin quiet with it. Collected rather than `find`-ed
+  // because a second invoker would otherwise shadow the real one and this
+  // whole test would pass against a step that publishes nothing — the
+  // neighbouring recovery step, which rewrites the renderer from an audited
+  // blob, mentions the same script and does not run it.
+  const renderers = Object.values(release.jobs)
+    .flatMap((job) => job.steps ?? [])
+    .filter((candidate) => /(?:^|\s)bash scripts\/release-notes\.sh\b/m.test(candidate.run ?? ""));
+  assert.equal(renderers.length, 1, "exactly one step renders and publishes the release body");
+  const [step] = renderers;
+
+  // Each disclosure belongs to exactly one hatch. Pairing them here is what
+  // makes the cross-checks below possible: a disclosure wired to the wrong
+  // input reads as fine in isolation.
+  const disclosures = {
+    COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "allow_unconfigured_registries",
+    COVEN_RELEASE_X_GUARD_SKIPPED: "allow_unconfigured_x_app",
+  };
+
+  // A dispatch carries every declared default, so "nothing pulled" is the
+  // workflow's own definition of it rather than this file's guess — and a
+  // default flipped to true fails here instead of quietly disclosing on every
+  // recovery run.
+  const declared = release.on.workflow_dispatch.inputs;
+  const defaults = Object.fromEntries(
+    Object.entries(declared).map(([name, spec]) => [name, spec.default]),
+  );
+  for (const hatch of Object.values(disclosures)) {
+    assert.equal(declared[hatch].type, "boolean", `${hatch} is no longer a boolean hatch`);
+    assert.equal(declared[hatch].default, false, `${hatch} defaults to pulled`);
+  }
+
+  const tagPush = releaseRun();
+  const plainDispatch = releaseRun({ event: "workflow_dispatch", inputs: defaults });
+
+  for (const [name, hatch] of Object.entries(disclosures)) {
+    const expression = step.env?.[name];
+    // Dropping the entry is the quietest way to lose the banner: the renderer
+    // reads an unset variable as "not skipped" and says nothing.
+    assert.ok(expression !== undefined, `${name} is no longer passed to the release-notes renderer`);
+
+    assert.equal(
+      interpolate(expression, tagPush),
+      "false",
+      `${name} discloses a skipped guard on a tag push, which cannot skip one`,
+    );
+    assert.equal(
+      interpolate(expression, plainDispatch),
+      "false",
+      `${name} discloses a skipped guard on an ordinary recovery dispatch`,
+    );
+
+    // Pulling the hatch is the only thing that turns it on, and it turns on
+    // only its own disclosure — an X-app recovery must not report the schema
+    // registries as skipped, or the banner stops meaning anything.
+    const pulled = releaseRun({
+      event: "workflow_dispatch",
+      inputs: { ...defaults, [hatch]: true },
+    });
+    assert.equal(
+      interpolate(expression, pulled),
+      "true",
+      `${name} stays silent on a dispatch that pulled ${hatch}`,
+    );
+    for (const [other, otherHatch] of Object.entries(disclosures)) {
+      if (other === name) continue;
+      assert.equal(
+        interpolate(step.env[other], pulled),
+        "false",
+        `${other} is disclosed by ${hatch}, which is ${otherHatch}'s hatch`,
+      );
+    }
+  }
+});
+
 test("checksums publishes SHA256SUMS only for a wholly successful build", async () => {
   const release = await workflow("release.yml");
   const condition = release.jobs.checksums.if;

--- a/scripts/release-promotion-workflow.test.mjs
+++ b/scripts/release-promotion-workflow.test.mjs
@@ -611,11 +611,23 @@ test("the release-notes guard disclosure is on exactly when its own hatch was pu
   // whole test would pass against a step that publishes nothing — the
   // neighbouring recovery step, which rewrites the renderer from an audited
   // blob, mentions the same script and does not run it.
-  const renderers = Object.values(release.jobs)
-    .flatMap((job) => job.steps ?? [])
-    .filter((candidate) => /(?:^|\s)bash scripts\/release-notes\.sh\b/m.test(candidate.run ?? ""));
+  const renderers = Object.entries(release.jobs).flatMap(([jobName, job]) =>
+    (job.steps ?? [])
+      .filter((candidate) => /(?:^|\s)bash scripts\/release-notes\.sh\b/m.test(candidate.run ?? ""))
+      .map((step) => ({ jobName, job, step })),
+  );
   assert.equal(renderers.length, 1, "exactly one step renders and publishes the release body");
-  const [step] = renderers;
+  const [{ jobName, job, step }] = renderers;
+
+  // Rendering is only half the job, and the half that leaves no trace if it is
+  // dropped. A step that writes the body to a temp file and never sends it
+  // publishes nothing, while both env expressions below still read perfectly
+  // and every assertion in this test still passes.
+  assert.match(
+    step.run,
+    /gh release edit\b[^\n]*--notes-file/,
+    `${jobName} renders the release body but no longer publishes it`,
+  );
 
   // Each disclosure belongs to exactly one hatch. Pairing them here is what
   // makes the cross-checks below possible: a disclosure wired to the wrong
@@ -630,8 +642,14 @@ test("the release-notes guard disclosure is on exactly when its own hatch was pu
   // default flipped to true fails here instead of quietly disclosing on every
   // recovery run.
   const declared = release.on.workflow_dispatch.inputs;
+  // Declared defaults only. An input with no `default` key — `tag`,
+  // `ios_delivery_id` — would otherwise enter the run context as `undefined`
+  // and overwrite the value `releaseRun` supplies, quietly unsetting the tag
+  // of every dispatch scenario below.
   const defaults = Object.fromEntries(
-    Object.entries(declared).map(([name, spec]) => [name, spec.default]),
+    Object.entries(declared)
+      .filter(([, spec]) => spec?.default !== undefined)
+      .map(([name, spec]) => [name, spec.default]),
   );
   for (const hatch of Object.values(disclosures)) {
     assert.equal(declared[hatch].type, "boolean", `${hatch} is no longer a boolean hatch`);
@@ -640,9 +658,43 @@ test("the release-notes guard disclosure is on exactly when its own hatch was pu
 
   const tagPush = releaseRun();
   const plainDispatch = releaseRun({ event: "workflow_dispatch", inputs: defaults });
+  const pulls = Object.fromEntries(
+    Object.values(disclosures).map((hatch) => [
+      hatch,
+      releaseRun({ event: "workflow_dispatch", inputs: { ...defaults, [hatch]: true } }),
+    ]),
+  );
+
+  // A correct value on a step that does not run discloses nothing. Nothing
+  // else in this file covers these two conditions — the gate sweep above only
+  // walks steps named "Require …", and this step is not one — so an `if:` on
+  // the step or on its host job that goes quiet exactly when a hatch is pulled
+  // silences the banner with every assertion below still green. Same failure
+  // as cave-yp21x, one spelling further out. `windows_diagnostics_only` is
+  // deliberately absent: that hatch legitimately skips this job, and every
+  // scenario here leaves it at its declared default.
+  for (const [occasion, context] of [
+    ["a tag push", tagPush],
+    ["an ordinary recovery dispatch", plainDispatch],
+    ...Object.entries(pulls).map(([hatch, context]) => [`a dispatch that pulled ${hatch}`, context]),
+  ]) {
+    assert.equal(
+      evaluateCondition(job.if, context),
+      true,
+      `${jobName} does not run on ${occasion} — the release body, and its disclosure, go unpublished`,
+    );
+    assert.equal(
+      evaluateCondition(step.if, context),
+      true,
+      `the release body is not published on ${occasion} — the disclosure goes with it`,
+    );
+  }
 
   for (const [name, hatch] of Object.entries(disclosures)) {
-    const expression = step.env?.[name];
+    // Job-level `env` reaches every step in the job, so either placement
+    // genuinely passes the disclosure to the renderer; only absence from both
+    // loses the banner.
+    const expression = step.env?.[name] ?? job.env?.[name];
     // Dropping the entry is the quietest way to lose the banner: the renderer
     // reads an unset variable as "not skipped" and says nothing.
     assert.ok(expression !== undefined, `${name} is no longer passed to the release-notes renderer`);
@@ -661,10 +713,7 @@ test("the release-notes guard disclosure is on exactly when its own hatch was pu
     // Pulling the hatch is the only thing that turns it on, and it turns on
     // only its own disclosure — an X-app recovery must not report the schema
     // registries as skipped, or the banner stops meaning anything.
-    const pulled = releaseRun({
-      event: "workflow_dispatch",
-      inputs: { ...defaults, [hatch]: true },
-    });
+    const pulled = pulls[hatch];
     assert.equal(
       interpolate(expression, pulled),
       "true",
@@ -673,7 +722,7 @@ test("the release-notes guard disclosure is on exactly when its own hatch was pu
     for (const [other, otherHatch] of Object.entries(disclosures)) {
       if (other === name) continue;
       assert.equal(
-        interpolate(step.env[other], pulled),
+        interpolate(step.env?.[other] ?? job.env?.[other], pulled),
         "false",
         `${other} is disclosed by ${hatch}, which is ${otherHatch}'s hatch`,
       );

--- a/scripts/release-promotion-workflow.test.mjs
+++ b/scripts/release-promotion-workflow.test.mjs
@@ -611,9 +611,15 @@ test("the release-notes guard disclosure is on exactly when its own hatch was pu
   // whole test would pass against a step that publishes nothing — the
   // neighbouring recovery step, which rewrites the renderer from an audited
   // blob, mentions the same script and does not run it.
+  // Anchored to the start of a line, because a substring is not an invocation:
+  // `# bash scripts/release-notes.sh …` leaves every character an unanchored
+  // regex looks for while running nothing at all. That is the same
+  // naming-not-consulting failure this section opens by describing, and it
+  // applies to the publish match below just as much.
+  const invokesRenderer = /^[ \t]*bash (?:\.\/)?scripts\/release-notes\.sh\b/m;
   const renderers = Object.entries(release.jobs).flatMap(([jobName, job]) =>
     (job.steps ?? [])
-      .filter((candidate) => /(?:^|\s)bash scripts\/release-notes\.sh\b/m.test(candidate.run ?? ""))
+      .filter((candidate) => invokesRenderer.test(candidate.run ?? ""))
       .map((step) => ({ jobName, job, step })),
   );
   assert.equal(renderers.length, 1, "exactly one step renders and publishes the release body");
@@ -623,9 +629,19 @@ test("the release-notes guard disclosure is on exactly when its own hatch was pu
   // dropped. A step that writes the body to a temp file and never sends it
   // publishes nothing, while both env expressions below still read perfectly
   // and every assertion in this test still passes.
+  //
+  // The publish is matched against the file the render actually wrote, not
+  // against `--notes-file` in the abstract, so pointing the upload at some
+  // other path — or at a body composed by hand — fails here rather than
+  // reading as a publish that happens to send the wrong bytes.
+  const rendered = /^[ \t]*bash (?:\.\/)?scripts\/release-notes\.sh\b[^\n]*?>\s*(\S+)/m.exec(
+    step.run,
+  );
+  assert.ok(rendered, `${jobName} no longer renders the release body to a file`);
+  const renderedBody = rendered[1].replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
   assert.match(
     step.run,
-    /gh release edit\b[^\n]*--notes-file/,
+    new RegExp(String.raw`^[ \t]*gh release edit\b[^\n]*--notes-file\s+${renderedBody}(?:\s|$)`, "m"),
     `${jobName} renders the release body but no longer publishes it`,
   );
 
@@ -690,11 +706,16 @@ test("the release-notes guard disclosure is on exactly when its own hatch was pu
     );
   }
 
+  // Actions resolves `env` step → job → workflow, and the renderer sees the
+  // value from whichever of the three declares it, so all three placements are
+  // a real disclosure and only absence from every one of them loses the banner.
+  // Resolving in that order also keeps a step-level entry authoritative, which
+  // is what Actions does: a step that shadows a correct job-level expression
+  // with a constant must still fail here.
+  const disclosureEnv = (name) => step.env?.[name] ?? job.env?.[name] ?? release.env?.[name];
+
   for (const [name, hatch] of Object.entries(disclosures)) {
-    // Job-level `env` reaches every step in the job, so either placement
-    // genuinely passes the disclosure to the renderer; only absence from both
-    // loses the banner.
-    const expression = step.env?.[name] ?? job.env?.[name];
+    const expression = disclosureEnv(name);
     // Dropping the entry is the quietest way to lose the banner: the renderer
     // reads an unset variable as "not skipped" and says nothing.
     assert.ok(expression !== undefined, `${name} is no longer passed to the release-notes renderer`);
@@ -722,7 +743,7 @@ test("the release-notes guard disclosure is on exactly when its own hatch was pu
     for (const [other, otherHatch] of Object.entries(disclosures)) {
       if (other === name) continue;
       assert.equal(
-        interpolate(step.env?.[other] ?? job.env?.[other], pulled),
+        interpolate(disclosureEnv(other), pulled),
         "false",
         `${other} is disclosed by ${hatch}, which is ${otherHatch}'s hatch`,
       );


### PR DESCRIPTION
Advances **#4820** ([Chat v1 P7] Packaging, compatibility, publishing, and rollout). Bead: `cave-9dg`, discovered from `cave-25t`.

## The gap

`cave-25t` pinned release.yml's gate *conditions* by shape. One adjacent off switch of the same family was still unpinned, and it is the exact surface `cave-yp21x` was filed about.

The `checksums` job passes the skipped-guard disclosure into `scripts/release-notes.sh`:

```yaml
COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_registries }}
COVEN_RELEASE_X_GUARD_SKIPPED:         ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_x_app }}
```

`scripts/release-notes.test.mjs` pins the **consumer** thoroughly — only the literal `"true"` turns the banner on, `"1"` and `"false"` do not. Nothing pinned the **producer**. Replacing either expression with a constant `false`, or dropping the env entry, silences the banner for a cut that really did ship with the baseline parsers, while every check stays green and every naming regex still matches.

That is `cave-yp21x` exactly: v0.2.0 shipped with both guards skipped and nobody noticed for four days, because the only evidence was a grey *skipped* line in a workflow run.

## The pin

One test, using the Actions expression evaluator `cave-25t` added to this file. It covers three dimensions, because proving only the first leaves two ways to lose the banner with every assertion still green:

1. **The value.** Each disclosure interpolates to `"false"` on a tag push and on a plain recovery dispatch, and to `"true"` exactly when *its own* hatch is pulled — including the cross case, since an X-app recovery reporting the schema registries as skipped makes the banner stop meaning anything.
2. **The step runs.** Both the renderer step's own `if:` and its host job's are evaluated under every one of those scenarios. A correct value on a step that does not run discloses nothing, and the gate sweep earlier in the file cannot see this step: it walks only steps named `Require …`.
3. **The step publishes.** The rendered body has to reach the release. A step that writes it to a temp file and sends nothing leaves both expressions byte-identical and every other assertion passing.

Details that are deliberate:

- **The step is located by the command it runs, not its name**, so a rename cannot take the pin quiet with it. It collects matches and asserts exactly one rather than taking the first — the neighbouring recovery step rewrites the renderer from an audited blob and mentions the same script without running it, and a `find` here silently latched onto that step instead.
- **Both source matches are anchored to the start of a line**, because a substring is not an invocation: `# gh release edit … --notes-file` leaves every character an unanchored regex looks for while publishing nothing. Same for the step-locating match.
- **The publish is matched against the file the render actually wrote**, not against `--notes-file` in the abstract, so pointing the upload at a path the renderer never produced fails here.
- **"Nothing pulled" comes from the workflow's own declared input defaults**, not this file's guess, so a default flipped to `true` fails here instead of quietly disclosing on every recovery run. Only *declared* defaults are carried; an input with no `default` key (`tag`, `ios_delivery_id`) would otherwise enter the run context as `undefined` and unset the tag of every dispatch scenario.
- **`windows_diagnostics_only` is deliberately left at its default.** That hatch's whole contract is to build and measure an MSI "without uploading artifacts or editing release metadata", so it legitimately skips this job — there is no body for it to disclose in.
- **Presence of each env entry is asserted separately**, because deleting it is the quietest way to lose the banner: the renderer reads an unset variable as "not skipped" and says nothing. Resolution follows Actions' full `step` → `job` → `workflow` `env` chain, so a benign relocation is not a failure while a step-level constant shadowing a correct job-level expression still is.

## Verification

Mutation-tested against `release.yml` across two independently designed passes, 34 mutations total. All applied to the real file and reverted; `release.yml` is byte-identical to `main` and `git status` is clean.

Caught (30), by dimension:

| Dimension | Mutations caught |
| --- | --- |
| value | constant `false`; constant `true`; `&& false` tail; the `workflow_dispatch` guard dropped; cross-wired to the other hatch; rewired to a job output; either env entry deleted; an env key lowercased |
| declaration | either hatch's `default` flipped to `true`; a hatch retyped from `boolean` to `string`; `windows_diagnostics_only` defaulted to `true` |
| runs | step `if:` quiet when a hatch is pulled; step `if:` quiet on a tag push; job `if:` gaining a hatch clause; the job made dispatch-only; the job relaxed to `always()`; the job renamed; the step relocated into the advisory `homebrew` job; `continue-on-error` on the step or the job |
| publishes | the whole step deleted; the publish line deleted; the publish line commented out; both the render and publish lines commented out; `--notes-file` swapped for an inline `--notes`; `--notes-file` pointed at a file the renderer never wrote; a second step in this or another job invoking the renderer |

Correctly tolerated (3): the `env` pair moved to job level, the same pair moved to workflow level, and `github.event.inputs.*` in place of `inputs.*`. All three still reach the renderer.

Out of scope (1): `checksums` dropping `needs: build` survives. It reorders the release rather than touching the disclosure, and no test in the repository pins that edge — filed as `cave-meuwb` rather than widened into this PR.

| Command | Result |
| --- | --- |
| `node --require ./scripts/css-source-contract-hook.cjs scripts/release-promotion-workflow.test.mjs` | 10/10 pass |
| `pnpm check:tests-wired` | 1777 files wired |
| `pnpm typecheck` | clean |
| `pnpm lint` | clean |

Test-only; `release.yml` is unchanged.

## Not in scope

`check-x-app-release.test.mjs`, `check-opencode-registry-release.test.mjs` and `check-grok-registry-release.test.mjs` still pin their workflow steps with `[\s\S]*?` spanning regexes over the raw YAML — naming, not consulting. `cave-25t` closed the `if:`/`continue-on-error` dimension over those steps generically; this closes the env dimension for the disclosure pair. The remaining env/argument dimension over those three is tracked on `cave-9dg`'s Related note.
