### PR TITLE
Persist a single-message delete from iOS (cave-ioswipe.6)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -387,9 +387,12 @@ struct CaveClient {
         return try await familiarAvatarMutation(for: req)
     }
 
-    private static func encodedPathSegment(_ value: String) throws -> String {
+    private static func encodedPathSegment(
+        _ value: String,
+        describing subject: String = "familiar identifier"
+    ) throws -> String {
         guard let encoded = value.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed) else {
-            throw CaveError.transport("Could not encode the familiar identifier.")
+            throw CaveError.transport("Could not encode the \(subject).")
         }
         return encoded
     }
@@ -768,6 +771,30 @@ struct CaveClient {
         let decoded = try JSONDecoder().decode(BoardPatchResponse.self, from: data)
         if let card = decoded.card { return card }
         throw CaveError.transport(decoded.error ?? "Task update did not return a card.")
+    }
+
+    /// `DELETE /api/chat/conversation/{sessionId}/turns/{turnId}` — remove one
+    /// message from a chat, durably.
+    ///
+    /// A per-turn route rather than a re-PUT of the transcript: a client that
+    /// deletes by writing back the list it happens to be holding erases any
+    /// reply that streamed in while the user was deciding. Naming the single
+    /// turn is what lets two clients delete without losing each other's turns.
+    ///
+    /// Idempotent, so it retries like the other DELETEs here: a turn that is
+    /// already gone answers 200 with `deleted: false`, and a conversation the
+    /// server does not have answers 404 — neither is a failure to report, both
+    /// mean the message is not there any more. Returns whether this call was
+    /// the one that removed it.
+    @discardableResult
+    func deleteConversationTurn(sessionId: String, turnId: String) async throws -> Bool {
+        let session = try Self.encodedPathSegment(sessionId, describing: "chat identifier")
+        let turn = try Self.encodedPathSegment(turnId, describing: "message identifier")
+        let req = try request("api/chat/conversation/\(session)/turns/\(turn)", method: "DELETE")
+        let (data, resp) = try await data(for: req, retryingIdempotentMutation: true)
+        try Self.checkDelete(resp)
+        struct TurnDeleteResponse: Decodable { var deleted: Bool? }
+        return (try? JSONDecoder().decode(TurnDeleteResponse.self, from: data))?.deleted ?? false
     }
 
     func conversation(sessionId: String) async throws -> Conversation? {

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -785,7 +785,8 @@ struct CaveClient {
     /// already gone answers 200 with `deleted: false`, and a conversation the
     /// server does not have answers 404 — neither is a failure to report, both
     /// mean the message is not there any more. Returns whether this call was
-    /// the one that removed it.
+    /// the one that removed it (a retry of a call that already landed answers
+    /// `deleted: false`, so a false return is not evidence of failure).
     @discardableResult
     func deleteConversationTurn(sessionId: String, turnId: String) async throws -> Bool {
         let session = try Self.encodedPathSegment(sessionId, describing: "chat identifier")
@@ -793,8 +794,18 @@ struct CaveClient {
         let req = try request("api/chat/conversation/\(session)/turns/\(turn)", method: "DELETE")
         let (data, resp) = try await data(for: req, retryingIdempotentMutation: true)
         try Self.checkDelete(resp)
-        struct TurnDeleteResponse: Decodable { var deleted: Bool? }
-        return (try? JSONDecoder().decode(TurnDeleteResponse.self, from: data))?.deleted ?? false
+        struct TurnDeleteResponse: Decodable { var ok: Bool?; var deleted: Bool? }
+        let decoded = try? JSONDecoder().decode(TurnDeleteResponse.self, from: data)
+        // A 404 from THIS route means the chat is not there, so neither is the
+        // message. A 404 from no route at all — a desktop too old to have
+        // shipped it — means the delete never happened, and swallowing that
+        // one would hand back the silent local-only delete this route exists
+        // to end. The route always answers in an `ok` envelope; an unrouted
+        // 404 answers with a page.
+        if (resp as? HTTPURLResponse)?.statusCode == 404, decoded?.ok == nil {
+            throw CaveError.badResponse(404)
+        }
+        return decoded?.deleted ?? false
     }
 
     func conversation(sessionId: String) async throws -> Conversation? {

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -801,9 +801,10 @@ struct CaveClient {
         // shipped it — means the delete never happened, and swallowing that
         // one would hand back the silent local-only delete this route exists
         // to end. The route always answers in an `ok` envelope; an unrouted
-        // 404 answers with a page.
+        // 404 answers with a page. Said in words rather than as a status code,
+        // because this one is read back to the user in a chat bubble.
         if (resp as? HTTPURLResponse)?.statusCode == 404, decoded?.ok == nil {
-            throw CaveError.badResponse(404)
+            throw CaveError.transport("This Cave is too old to delete a single message.")
         }
         return decoded?.deleted ?? false
     }

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -469,11 +469,24 @@ final class ChatThread: Identifiable, Hashable {
         onChange()
 
         guard let client, let target else { return }
-        Task { [weak self] in
+        // One at a time, per thread. A second swipe lands well inside the
+        // first request, and a message with no server id is named by reading
+        // the conversation — a read that would still be showing the turn the
+        // first delete is in the middle of removing. Its transcript then
+        // disagrees with ours, which is a refusal, so the second delete of a
+        // two-swipe cleanup would fail for no reason but timing. Chaining
+        // costs nothing visible: the bubble is already gone by here.
+        let previous = pendingServerDelete
+        pendingServerDelete = Task { [weak self] in
+            _ = await previous?.value
             await self?.persistDelete(of: removed, at: index, target: target,
                                       client: client, onChange: onChange)
         }
     }
+
+    /// The tail of this thread's serialized server deletes. Nothing renders
+    /// it, so it stays out of observation. See `deleteMessage`.
+    @ObservationIgnored private var pendingServerDelete: Task<Void, Never>?
 
     /// Where a message lives on the server, when it lives there at all.
     ///
@@ -513,7 +526,8 @@ final class ChatThread: Identifiable, Hashable {
 
     private struct ServerDeleteTarget {
         let sessionId: String
-        /// Known only for a message the server named to us on a restore.
+        /// Known only for a message the server has already named to us — on a
+        /// restore, or on the replay that adopted a reply the server had.
         let turnId: String?
         /// Every local message before this one that occupies a server turn,
         /// in order. Its COUNT is the ordinal used to name a message composed
@@ -538,36 +552,72 @@ final class ChatThread: Identifiable, Hashable {
     private func persistDelete(of message: DisplayMessage, at index: Int,
                                target: ServerDeleteTarget, client: CaveClient,
                                onChange: @escaping () -> Void) async {
-        let turnId: String?
-        if let known = target.turnId {
+        let turnId: String
+        if let known = target.turnId, !known.isEmpty {
             turnId = known
         } else {
             // A message composed in this session has no server-assigned id
             // yet, and nothing in the send path hands one back. Reading the
             // conversation is the only way to name the turn — and the read
-            // has to separate two outcomes a `try?` collapses into one: the
-            // read THROWING is a real failure to report, while it returning
-            // no conversation is the server saying it holds no transcript for
-            // this chat, in which case the local removal was already the
-            // whole delete and there is nothing to roll back.
+            // has THREE outcomes a `try?` collapses into one:
+            //
+            //  - it THROWS 404: `GET /api/chat/conversation/{id}` answers 404
+            //    when the server holds no transcript for this chat (see that
+            //    route's final `not found`). The desktop was reached and told
+            //    us it has nothing, so the local removal was already the whole
+            //    delete. Blaming the network here would be a lie AND would put
+            //    back a message no server copy will ever resurrect.
+            //  - it THROWS anything else: a real failure, report it.
+            //  - it RETURNS nil: same answer as the 404, reached through the
+            //    narrow `conversation: null` shape the route uses when a board
+            //    card claims the session but no transcript exists yet.
             let convo: Conversation?
             do {
                 convo = try await client.conversation(sessionId: target.sessionId)
+            } catch CaveError.badResponse(404) {
+                return
             } catch {
-                rollBack(message, to: index, reason: "the desktop could not be reached",
+                rollBack(message, to: index, reason: error.localizedDescription,
                          onChange: onChange)
                 return
             }
             guard let convo else { return }
-            turnId = Self.turnId(matching: message, following: target.preceding,
-                                 in: convo.turns)
+            switch Self.turnMatch(for: message, following: target.preceding, in: convo.turns) {
+            case .named(let id):
+                turnId = id
+            case .absent:
+                return
+            case .ambiguous:
+                // The server HAS a transcript and it does not line up with
+                // ours, so we cannot say whether it holds this message. Saying
+                // nothing would leave the bubble gone here and the turn alive
+                // there — a silent local-only delete, which is the bug this
+                // whole path exists to end, not a success.
+                rollBack(message, to: index,
+                         reason: "the desktop's copy of this chat has changed; refresh and try again",
+                         onChange: onChange)
+                return
+            }
         }
-        guard let turnId, !turnId.isEmpty else { return }
         do {
             try await client.deleteConversationTurn(sessionId: target.sessionId, turnId: turnId)
         } catch {
             rollBack(message, to: index, reason: error.localizedDescription, onChange: onChange)
         }
+    }
+
+    /// What the server's transcript says about a message it never named.
+    private enum ServerTurnMatch {
+        /// The transcript lines up and this turn is the message.
+        case named(String)
+        /// The transcript lines up as far as it goes and simply ends before
+        /// this message: the server never received it, so the local removal
+        /// was already the whole delete.
+        case absent
+        /// The transcript disagrees. Whether the server holds this message is
+        /// unknowable from here, so neither deleting nor claiming success is
+        /// honest.
+        case ambiguous
     }
 
     /// Name a turn from the server's own transcript, and refuse unless the
@@ -591,27 +641,46 @@ final class ChatThread: Identifiable, Hashable {
     /// it would also delete an older identical turn for a message the server
     /// never received at all, which is the failure that cannot be undone.
     ///
-    /// Refusing costs the message reappearing on the next refresh — after
-    /// which it carries a `serverTurnId` and deletes by name, no matching
-    /// involved. Deleting the wrong turn costs someone else's message,
-    /// permanently. The cheap mistake is the one to make.
-    nonisolated private static func turnId(matching message: DisplayMessage,
-                                           following preceding: [DisplayMessage],
-                                           in turns: [ChatTurn]) -> String? {
-        let ordinal = preceding.count
-        guard ordinal < turns.count, Self.turn(turns[ordinal], is: message) else { return nil }
-        for position in preceding.indices where !Self.turn(turns[position], is: preceding[position]) {
-            return nil
+    /// Refusing costs the user a swipe: the message stays, with a note saying
+    /// so, and one refresh later it carries a `serverTurnId` and deletes by
+    /// name with no matching involved. Deleting the wrong turn costs someone
+    /// else's message, permanently. The cheap mistake is the one to make.
+    ///
+    /// The prefix is walked BEFORE the ordinal so a refusal can say which kind
+    /// it is. Running off the end of a transcript that has agreed the whole
+    /// way is the server being behind us — every message from there on is one
+    /// it never received — while a disagreement inside the transcript says
+    /// nothing at all about where this message is. Only the first of those is
+    /// evidence that the local removal was the whole delete.
+    nonisolated private static func turnMatch(for message: DisplayMessage,
+                                              following preceding: [DisplayMessage],
+                                              in turns: [ChatTurn]) -> ServerTurnMatch {
+        for position in preceding.indices {
+            guard position < turns.count else { return .absent }
+            guard Self.turn(turns[position], is: preceding[position]) else { return .ambiguous }
         }
-        return turns[ordinal].id
+        let ordinal = preceding.count
+        guard ordinal < turns.count else { return .absent }
+        guard Self.turn(turns[ordinal], is: message) else { return .ambiguous }
+        return .named(turns[ordinal].id)
     }
 
     /// Is this server turn this local message? By id whenever the server has
     /// named the message to us — the only comparison that cannot coincide —
     /// and by role and text for a message it never named.
+    ///
+    /// Text is compared with the edges trimmed because the two sides store the
+    /// same reply differently: `chat/send` persists the assistant turn as
+    /// `text.trim()`, while the stream that filled the local bubble appended
+    /// every chunk exactly as it arrived. A reply that ends in a newline would
+    /// otherwise read as a disagreeing transcript and refuse every later
+    /// delete in the session. The guard's strength is the whole prefix
+    /// agreeing, not one turn matching byte for byte.
     nonisolated private static func turn(_ turn: ChatTurn, is message: DisplayMessage) -> Bool {
         if let serverTurnId = message.serverTurnId { return turn.id == serverTurnId }
-        return turn.role == message.role.rawValue && turn.text == message.text
+        guard turn.role == message.role.rawValue else { return false }
+        return turn.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            == message.text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// Put a rolled-back message back where it left from and say why it is

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -478,35 +478,54 @@ final class ChatThread: Identifiable, Hashable {
     /// Where a message lives on the server, when it lives there at all.
     ///
     /// Deliberately narrow. Only a direct chat is ever restored from a server
-    /// transcript — `reload` no-ops for groups, which are N sessions behind
-    /// one presented thread — so only a direct chat's messages can be named
-    /// back to a turn. A queued send, inline slash output, and a thread with
-    /// no session yet have nothing on the server to remove, and for those the
-    /// local removal is already the whole truth.
+    /// transcript — `reload` no-ops for groups, and `AppModel.loadHistory`
+    /// only ever runs against a thread it built with a single familiar — so
+    /// only a direct chat's messages can be named back to a turn. A queued
+    /// send, inline slash output, and a thread with no session yet have
+    /// nothing on the server to remove, and for those the local removal is
+    /// already the whole truth.
     private func serverDeleteTarget(for message: DisplayMessage,
                                     at index: Int) -> ServerDeleteTarget? {
-        guard !isGroup, !message.isQueued, message.role != .system,
+        guard !isGroup, !message.isQueued,
+              // Inline slash output is local-only — but a `system` turn the
+              // server named on a restore is a real turn there (the server
+              // persists chain-less system turns) and deletes like any other.
+              // Refusing every system message would leave those undeletable
+              // by the silent local splice this whole path exists to end.
+              message.role != .system || message.serverTurnId != nil,
               let familiarId = familiarIds.first,
               let sessionId = sessionIds[familiarId], !sessionId.isEmpty else { return nil }
         // Messages the server never receives do not occupy a turn, so they
-        // must not be counted when locating one.
-        let ordinal = messages[..<index].filter { Self.occupiesServerTurn($0) }.count
+        // must not be counted when locating one. Kept whole rather than
+        // counted: naming a turn by position is only safe if the positions
+        // before it can be checked against the server's own transcript.
+        let preceding = messages[..<index].filter { Self.occupiesServerTurn($0) }
         return ServerDeleteTarget(sessionId: sessionId, turnId: message.serverTurnId,
-                                  ordinal: ordinal)
+                                  preceding: preceding)
     }
 
     private struct ServerDeleteTarget {
         let sessionId: String
         /// Known only for a message the server named to us on a restore.
         let turnId: String?
-        /// Position among the turns the server can see, used to name a message
-        /// composed in this session — one that has never been through a
-        /// restore and so carries no `serverTurnId`.
-        let ordinal: Int
+        /// Every local message before this one that occupies a server turn,
+        /// in order. Its COUNT is the ordinal used to name a message composed
+        /// in this session — one that has never been through a restore and so
+        /// carries no `serverTurnId` — and its contents are what proves that
+        /// ordinal actually lines up with the server's transcript.
+        let preceding: [DisplayMessage]
     }
 
+    /// Does this message hold a position in the server's turn list?
+    ///
+    /// A message the server named on a restore does, whatever its role: a
+    /// restored `system` turn sits in `conversation.turns` like any other, and
+    /// skipping it here would shift every later ordinal one turn early. A
+    /// message the server never named counts only if it is the kind that gets
+    /// sent — inline slash output and a queued send never become turns.
     nonisolated private static func occupiesServerTurn(_ message: DisplayMessage) -> Bool {
-        message.role != .system && !message.isQueued
+        if message.serverTurnId != nil { return true }
+        return message.role != .system && !message.isQueued
     }
 
     private func persistDelete(of message: DisplayMessage, at index: Int,
@@ -518,19 +537,25 @@ final class ChatThread: Identifiable, Hashable {
         } else {
             // A message composed in this session has no server-assigned id
             // yet, and nothing in the send path hands one back. Reading the
-            // conversation is the only way to name the turn — and it also
-            // separates the two cases a nil id otherwise conflates: the read
-            // FAILING is a real failure to report, while the read succeeding
-            // and matching nothing means the server genuinely does not have
-            // this message and the local removal was the whole delete.
-            guard let convo = try? await client.conversation(sessionId: target.sessionId) else {
+            // conversation is the only way to name the turn — and the read
+            // has to separate two outcomes a `try?` collapses into one: the
+            // read THROWING is a real failure to report, while it returning
+            // no conversation is the server saying it holds no transcript for
+            // this chat, in which case the local removal was already the
+            // whole delete and there is nothing to roll back.
+            let convo: Conversation?
+            do {
+                convo = try await client.conversation(sessionId: target.sessionId)
+            } catch {
                 rollBack(message, to: index, reason: "the desktop could not be reached",
                          onChange: onChange)
                 return
             }
-            turnId = Self.turnId(matching: message, at: target.ordinal, in: convo.turns)
+            guard let convo else { return }
+            turnId = Self.turnId(matching: message, following: target.preceding,
+                                 in: convo.turns)
         }
-        guard let turnId else { return }
+        guard let turnId, !turnId.isEmpty else { return }
         do {
             try await client.deleteConversationTurn(sessionId: target.sessionId, turnId: turnId)
         } catch {
@@ -538,16 +563,48 @@ final class ChatThread: Identifiable, Hashable {
         }
     }
 
-    /// Name a turn by position, then refuse unless it is the same message.
-    /// Position alone would delete a stranger's turn whenever the transcripts
-    /// have drifted; role and text agreeing as well is what makes a match a
-    /// match rather than a guess.
-    nonisolated private static func turnId(matching message: DisplayMessage, at ordinal: Int,
+    /// Name a turn from the server's own transcript, and refuse unless the
+    /// transcript names it beyond doubt.
+    ///
+    /// Position alone deletes a stranger's turn as soon as the two transcripts
+    /// drift, and they drift routinely: a reply that failed ambiguously (or
+    /// was cancelled) leaves a local bubble with no server turn behind it, and
+    /// every ordinal after it is then one too high. Role and text agreeing at
+    /// the drifted position is not enough on its own either — a chat is full
+    /// of repeated short turns ("ok", "continue", "y"), and an off-by-two in
+    /// an alternating transcript lands on the same role every single time.
+    ///
+    /// So the ordinal has to be backed by a transcript that lines up, not by
+    /// arithmetic alone: EVERY position before it must agree too — by turn id
+    /// for the messages the server already named, by role and text for the
+    /// rest — and only then is the turn sitting at the ordinal this message.
+    ///
+    /// A unique role+text match elsewhere in the transcript is deliberately
+    /// NOT accepted as a second route. It would rescue a drifted ordinal, but
+    /// it would also delete an older identical turn for a message the server
+    /// never received at all, which is the failure that cannot be undone.
+    ///
+    /// Refusing costs the message reappearing on the next refresh — after
+    /// which it carries a `serverTurnId` and deletes by name, no matching
+    /// involved. Deleting the wrong turn costs someone else's message,
+    /// permanently. The cheap mistake is the one to make.
+    nonisolated private static func turnId(matching message: DisplayMessage,
+                                           following preceding: [DisplayMessage],
                                            in turns: [ChatTurn]) -> String? {
-        guard ordinal >= 0, ordinal < turns.count else { return nil }
-        let turn = turns[ordinal]
-        guard turn.role == message.role.rawValue, turn.text == message.text else { return nil }
-        return turn.id
+        let ordinal = preceding.count
+        guard ordinal < turns.count, Self.turn(turns[ordinal], is: message) else { return nil }
+        for position in preceding.indices where !Self.turn(turns[position], is: preceding[position]) {
+            return nil
+        }
+        return turns[ordinal].id
+    }
+
+    /// Is this server turn this local message? By id whenever the server has
+    /// named the message to us — the only comparison that cannot coincide —
+    /// and by role and text for a message it never named.
+    nonisolated private static func turn(_ turn: ChatTurn, is message: DisplayMessage) -> Bool {
+        if let serverTurnId = message.serverTurnId { return turn.id == serverTurnId }
+        return turn.role == message.role.rawValue && turn.text == message.text
     }
 
     /// Put a rolled-back message back where it left from and say why it is
@@ -1081,7 +1138,11 @@ final class ChatThread: Identifiable, Hashable {
               convo.turns[lastUser].text == prompt else { return false }
         if let reply = convo.turns[(lastUser + 1)...].last(where: { $0.role == "assistant" }) {
             let insertAt = messages.firstIndex(where: { $0.isQueued }) ?? messages.endIndex
-            messages.insert(DisplayMessage(role: .assistant, familiarId: familiarId,
+            // The server named this turn to us, so carry its id: an adopted
+            // reply is server-owned, and without the id a later delete has to
+            // guess at it by position instead of naming it.
+            messages.insert(DisplayMessage(serverTurnId: reply.id,
+                                           role: .assistant, familiarId: familiarId,
                                            text: reply.text, isError: reply.isError ?? false,
                                            activity: ActivityFold.steps(fromTools: reply.tools)),
                             at: insertAt)

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -8,6 +8,15 @@ struct DisplayMessage: Identifiable, Codable, Hashable {
     /// results) — rendered as a centred note, never sent to a familiar.
     enum Role: String, Codable { case user, assistant, system }
     var id: String = UUID().uuidString
+    /// The server's id for this turn, when the transcript it came from was a
+    /// server transcript. `id` above cannot be used for this: it is minted
+    /// locally on compose and stays stable across the persisted snapshot, so
+    /// overwriting it on restore would rewrite the identity every open. nil
+    /// means the server has never named this message to us — a message
+    /// composed in this session, a queued send, or inline slash output — and a
+    /// delete of one of those has nothing to remove on the server.
+    /// Optional so snapshots written before durable message delete decode.
+    var serverTurnId: String?
     var role: Role
     var familiarId: String?
     var text: String
@@ -91,6 +100,7 @@ extension DisplayMessage {
         // appliedControls is declared before requestedControls, and the
         // memberwise initializer requires that order.
         return DisplayMessage(
+            serverTurnId: turn.id,
             role: role,
             familiarId: role == .assistant ? familiarId : nil,
             text: turn.text,
@@ -423,9 +433,135 @@ final class ChatThread: Identifiable, Hashable {
         }
     }
 
-    func deleteMessage(_ messageId: String) {
-        messages.removeAll { $0.id == messageId }
+    /// Remove one message — durably, wherever the server has a copy of it.
+    ///
+    /// This used to be an array splice and nothing else: iOS dropped the
+    /// message from its in-memory thread, rewrote its own snapshot file, and
+    /// told nobody. The message came back on reinstall and never disappeared
+    /// on any other client. `DELETE /api/chat/conversation/{id}/turns/{turnId}`
+    /// is the server half; this is the client half.
+    ///
+    /// Optimistic, because a delete that waits on the tailnet reads as a
+    /// broken swipe. If the server refuses, the message goes back at the index
+    /// it left from — not appended — and the failure is said out loud as an
+    /// inline note. A silent local-only delete is the exact bug being fixed,
+    /// so failing quietly here would only move it.
+    func deleteMessage(_ messageId: String, client: CaveClient?,
+                       onChange: @escaping () -> Void) {
+        guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
+        let removed = messages[index]
+        // Resolved BEFORE the removal: the ordinal is this message's position
+        // among the turns the server can see, and removing it first would
+        // shift every later message onto the wrong turn.
+        let target = serverDeleteTarget(for: removed, at: index)
+        // No client and a message the server owns: refuse rather than remove.
+        // Removing here would be a local-only delete with nothing left to
+        // report it later — the original bug, reached by a different door.
+        guard client != nil || target == nil else {
+            appendSystem("That message can't be deleted while the desktop is unreachable.",
+                         isError: true)
+            updatedAt = Date()
+            onChange()
+            return
+        }
+        messages.remove(at: index)
         updatedAt = Date()
+        onChange()
+
+        guard let client, let target else { return }
+        Task { [weak self] in
+            await self?.persistDelete(of: removed, at: index, target: target,
+                                      client: client, onChange: onChange)
+        }
+    }
+
+    /// Where a message lives on the server, when it lives there at all.
+    ///
+    /// Deliberately narrow. Only a direct chat is ever restored from a server
+    /// transcript — `reload` no-ops for groups, which are N sessions behind
+    /// one presented thread — so only a direct chat's messages can be named
+    /// back to a turn. A queued send, inline slash output, and a thread with
+    /// no session yet have nothing on the server to remove, and for those the
+    /// local removal is already the whole truth.
+    private func serverDeleteTarget(for message: DisplayMessage,
+                                    at index: Int) -> ServerDeleteTarget? {
+        guard !isGroup, !message.isQueued, message.role != .system,
+              let familiarId = familiarIds.first,
+              let sessionId = sessionIds[familiarId], !sessionId.isEmpty else { return nil }
+        // Messages the server never receives do not occupy a turn, so they
+        // must not be counted when locating one.
+        let ordinal = messages[..<index].filter { Self.occupiesServerTurn($0) }.count
+        return ServerDeleteTarget(sessionId: sessionId, turnId: message.serverTurnId,
+                                  ordinal: ordinal)
+    }
+
+    private struct ServerDeleteTarget {
+        let sessionId: String
+        /// Known only for a message the server named to us on a restore.
+        let turnId: String?
+        /// Position among the turns the server can see, used to name a message
+        /// composed in this session — one that has never been through a
+        /// restore and so carries no `serverTurnId`.
+        let ordinal: Int
+    }
+
+    nonisolated private static func occupiesServerTurn(_ message: DisplayMessage) -> Bool {
+        message.role != .system && !message.isQueued
+    }
+
+    private func persistDelete(of message: DisplayMessage, at index: Int,
+                               target: ServerDeleteTarget, client: CaveClient,
+                               onChange: @escaping () -> Void) async {
+        let turnId: String?
+        if let known = target.turnId {
+            turnId = known
+        } else {
+            // A message composed in this session has no server-assigned id
+            // yet, and nothing in the send path hands one back. Reading the
+            // conversation is the only way to name the turn — and it also
+            // separates the two cases a nil id otherwise conflates: the read
+            // FAILING is a real failure to report, while the read succeeding
+            // and matching nothing means the server genuinely does not have
+            // this message and the local removal was the whole delete.
+            guard let convo = try? await client.conversation(sessionId: target.sessionId) else {
+                rollBack(message, to: index, reason: "the desktop could not be reached",
+                         onChange: onChange)
+                return
+            }
+            turnId = Self.turnId(matching: message, at: target.ordinal, in: convo.turns)
+        }
+        guard let turnId else { return }
+        do {
+            try await client.deleteConversationTurn(sessionId: target.sessionId, turnId: turnId)
+        } catch {
+            rollBack(message, to: index, reason: error.localizedDescription, onChange: onChange)
+        }
+    }
+
+    /// Name a turn by position, then refuse unless it is the same message.
+    /// Position alone would delete a stranger's turn whenever the transcripts
+    /// have drifted; role and text agreeing as well is what makes a match a
+    /// match rather than a guess.
+    nonisolated private static func turnId(matching message: DisplayMessage, at ordinal: Int,
+                                           in turns: [ChatTurn]) -> String? {
+        guard ordinal >= 0, ordinal < turns.count else { return nil }
+        let turn = turns[ordinal]
+        guard turn.role == message.role.rawValue, turn.text == message.text else { return nil }
+        return turn.id
+    }
+
+    /// Put a rolled-back message back where it left from and say why it is
+    /// still there. The index can have moved while the request was in flight
+    /// (a reply streamed in, another delete landed), so it is clamped rather
+    /// than trusted.
+    private func rollBack(_ message: DisplayMessage, to index: Int, reason: String,
+                          onChange: @escaping () -> Void) {
+        if !messages.contains(where: { $0.id == message.id }) {
+            messages.insert(message, at: min(max(index, 0), messages.count))
+        }
+        appendSystem("That message was not deleted — \(reason).", isError: true)
+        updatedAt = Date()
+        onChange()
     }
 
     /// Re-run a failed (or the latest) assistant reply in place: reset its bubble

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -706,6 +706,15 @@ final class ChatThread: Identifiable, Hashable {
     /// familiar's failure in a group is retried without re-firing the others, and
     /// a 1:1 retry doesn't duplicate the user prompt. No-ops if the bubble has no
     /// familiar or no preceding user prompt to replay.
+    ///
+    /// It also drops the bubble's `serverTurnId`. A retry is an ordinary send —
+    /// `SendBody` carries no branch or replace field — so the server appends a
+    /// NEW turn pair and keeps the old assistant turn where it was. Holding on
+    /// to that id would point this bubble at a turn whose text it no longer
+    /// shows, and a delete would then remove the superseded turn while the
+    /// reply on screen stayed. Nil is the honest state: the server has never
+    /// named THIS reply to us, so a delete goes through the transcript matcher
+    /// like any other unnamed message.
     func retry(_ messageId: String, client: CaveClient, onChange: @escaping () -> Void) {
         guard let idx = messages.firstIndex(where: { $0.id == messageId }),
               messages[idx].role == .assistant,
@@ -719,14 +728,6 @@ final class ChatThread: Identifiable, Hashable {
         )
         guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         guard requireSendProvenance(to: [familiarId]) else { return }
-        // Drop the server turn id along with the text it named. A retry is an
-        // ordinary send (`SendBody` carries no branch or replace field), so the
-        // server appends a NEW turn pair and keeps the old assistant turn where
-        // it was. Holding on to that id would point this bubble at a turn whose
-        // text it no longer shows — and a delete would then remove the
-        // superseded turn while the reply on screen stayed. Nil is the honest
-        // state: the server has never named THIS reply to us, so a delete goes
-        // through the transcript matcher like any other unnamed message.
         mutate(messageId) {
             $0.serverTurnId = nil
             $0.text = ""; $0.isError = false; $0.streaming = true; $0.activity = nil

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -477,13 +477,20 @@ final class ChatThread: Identifiable, Hashable {
 
     /// Where a message lives on the server, when it lives there at all.
     ///
-    /// Deliberately narrow. Only a direct chat is ever restored from a server
-    /// transcript — `reload` no-ops for groups, and `AppModel.loadHistory`
-    /// only ever runs against a thread it built with a single familiar — so
-    /// only a direct chat's messages can be named back to a turn. A queued
-    /// send, inline slash output, and a thread with no session yet have
-    /// nothing on the server to remove, and for those the local removal is
-    /// already the whole truth.
+    /// Deliberately narrow, and the group exclusion is load-bearing rather
+    /// than incidental: a group is N independent server sessions presented as
+    /// one transcript, so `familiarIds.first` names an arbitrary one of them
+    /// and a position in the merged local list answers to no position in any
+    /// of their turn lists. A direct chat is the only shape with one session
+    /// to address. Group messages also mostly carry no server turn id —
+    /// `reload` no-ops for groups and `AppModel.loadHistory` only ever runs
+    /// against a thread it built with a single familiar — but replay CAN
+    /// adopt one, so it is the guard below that holds, not the absence of an
+    /// id.
+    ///
+    /// A queued send, inline slash output, and a thread with no session yet
+    /// have nothing on the server to remove either, and for those the local
+    /// removal is already the whole truth.
     private func serverDeleteTarget(for message: DisplayMessage,
                                     at index: Int) -> ServerDeleteTarget? {
         guard !isGroup, !message.isQueued,
@@ -616,7 +623,10 @@ final class ChatThread: Identifiable, Hashable {
         if !messages.contains(where: { $0.id == message.id }) {
             messages.insert(message, at: min(max(index, 0), messages.count))
         }
-        appendSystem("That message was not deleted — \(reason).", isError: true)
+        // Most `localizedDescription`s already end in a full stop, and
+        // "… status 404.." is a shabby thing to read back to someone.
+        let detail = reason.hasSuffix(".") ? String(reason.dropLast()) : reason
+        appendSystem("That message was not deleted — \(detail).", isError: true)
         updatedAt = Date()
         onChange()
     }

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -719,7 +719,18 @@ final class ChatThread: Identifiable, Hashable {
         )
         guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         guard requireSendProvenance(to: [familiarId]) else { return }
-        mutate(messageId) { $0.text = ""; $0.isError = false; $0.streaming = true; $0.activity = nil }
+        // Drop the server turn id along with the text it named. A retry is an
+        // ordinary send (`SendBody` carries no branch or replace field), so the
+        // server appends a NEW turn pair and keeps the old assistant turn where
+        // it was. Holding on to that id would point this bubble at a turn whose
+        // text it no longer shows — and a delete would then remove the
+        // superseded turn while the reply on screen stayed. Nil is the honest
+        // state: the server has never named THIS reply to us, so a delete goes
+        // through the transcript matcher like any other unnamed message.
+        mutate(messageId) {
+            $0.serverTurnId = nil
+            $0.text = ""; $0.isError = false; $0.streaming = true; $0.activity = nil
+        }
         updatedAt = Date()
         onChange()
         Task { await self.stream(familiarId: familiarId, prompt: prompt,

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -2085,7 +2085,10 @@ struct ChatView: View {
     }
 
     private func deleteMessage(_ message: DisplayMessage) {
-        thread.deleteMessage(message.id)
+        // `app.client` may be nil (not connected yet). The thread refuses the
+        // delete in that case if the message has a server copy, rather than
+        // removing it here and telling nobody.
+        thread.deleteMessage(message.id, client: app.client) { app.touch(thread) }
         app.touch(thread)
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -2088,8 +2088,11 @@ struct ChatView: View {
         // `app.client` may be nil (not connected yet). The thread refuses the
         // delete in that case if the message has a server copy, rather than
         // removing it here and telling nobody.
+        // The closure IS the persist: `deleteMessage` calls it on the optimistic
+        // removal, on the refusal, and again on a rollback that lands after the
+        // request. Touching again here only re-wrote the threads file a second
+        // time for the same change.
         thread.deleteMessage(message.id, client: app.client) { app.touch(thread) }
-        app.touch(thread)
     }
 
     private func openReader(text: String, familiar: Familiar?) {

--- a/apps/ios/CovenCave/CovenCaveTests/TranscriptRowsTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/TranscriptRowsTests.swift
@@ -153,7 +153,9 @@ final class TranscriptRowsTests: XCTestCase {
         let secondId = thread.appendSystem("two")
         XCTAssertEqual(thread.transcriptRows.count, 3, "same-day append adds one row")
 
-        thread.deleteMessage(firstId)
+        // System notes are inline slash output the server never sees, so this
+        // stays a local removal even with a client attached.
+        thread.deleteMessage(firstId, client: nil, onChange: {})
         XCTAssertEqual(thread.transcriptRows.map(\.id), ["day-\(secondId)", secondId])
 
         thread.clearMessages()

--- a/scripts/ios-message-delete-persistence.test.mjs
+++ b/scripts/ios-message-delete-persistence.test.mjs
@@ -112,6 +112,19 @@ assert.match(
   "an adopted reply must carry the server's turn id — the server just named it",
 );
 
+// A retry re-streams into the SAME local bubble, but it is an ordinary send —
+// `SendBody` has no branch or replace field — so the server appends a new turn
+// pair and leaves the old assistant turn alone. Keeping the id would aim a
+// later delete at a turn whose text this bubble no longer shows: the superseded
+// turn would go and the reply on screen would stay.
+const retry = blockAfter(thread, "func retry(_ messageId: String, client: CaveClient, onChange: @escaping () -> Void) {");
+assert.ok(retry, "retry must exist");
+assert.match(
+  retry,
+  /mutate\(messageId\) \{\s*\n\s*\$0\.serverTurnId = nil/,
+  "a retried bubble must drop the server turn id along with the text it named",
+);
+
 // -- Delete ---------------------------------------------------------------
 const body = blockAfter(thread, "func deleteMessage(_ messageId: String, client: CaveClient?,");
 assert.ok(body, "deleteMessage must take a client");

--- a/scripts/ios-message-delete-persistence.test.mjs
+++ b/scripts/ios-message-delete-persistence.test.mjs
@@ -1,0 +1,189 @@
+// cave-ioswipe.6 (iOS half): deleting ONE message must reach the server, not
+// only the in-memory thread and its snapshot file. The server half landed as
+// DELETE /api/chat/conversation/{id}/turns/{turnId}; until this, iOS still
+// spliced its own array and told nobody, so a deleted message came back on
+// reinstall and never disappeared on any other client.
+//
+// The sibling ios-thread-server-persistence.test.mjs covers whole-thread
+// archive/pin/delete. This covers the per-message delete only.
+//
+// iOS Swift is NOT compiled by CI, so this source-text contract is the only
+// gate. Each assertion is checked to FAIL against its regression, not merely
+// to pass.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const thread = await read("apps/ios/CovenCave/CovenCave/State/ChatThread.swift");
+const client = await read("apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift");
+const view = await read("apps/ios/CovenCave/CovenCave/Views/ChatView.swift");
+
+/** Extract a brace-balanced block starting at `marker` (which ends at its `{`). */
+function blockAfter(src, marker) {
+  const start = src.indexOf(marker);
+  if (start < 0) return null;
+  let depth = 0;
+  for (let i = start + marker.length - 1; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    else if (src[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+// -- Client ---------------------------------------------------------------
+const del = blockAfter(client, "func deleteConversationTurn(sessionId: String, turnId: String) async throws -> Bool {");
+assert.ok(del, "deleteConversationTurn must exist");
+assert.match(
+  del,
+  /request\("api\/chat\/conversation\/\\\(session\)\/turns\/\\\(turn\)", method: "DELETE"\)/,
+  "the per-turn route must be addressed, not a PUT of the whole transcript — " +
+    "re-PUTing the list erases any reply that streamed in while the user was deciding",
+);
+assert.match(
+  del,
+  /retryingIdempotentMutation: true/,
+  "the delete is idempotent server-side and must retry, or a dropped response reads as failure",
+);
+assert.match(
+  del,
+  /Self\.checkDelete\(resp\)/,
+  "a 404 means the message is already not there — that is not a failure to report",
+);
+for (const [value, subject] of [
+  ["sessionId", "chat identifier"],
+  ["turnId", "message identifier"],
+]) {
+  assert.match(
+    del,
+    new RegExp(`Self\\.encodedPathSegment\\(${value}, describing: "${subject}"\\)`),
+    `${value} must be percent-encoded before it becomes a path segment`,
+  );
+}
+
+// -- The message carries the server's id ----------------------------------
+// Without this the client has nothing to name in the route, and every delete
+// silently degrades to the local splice this bead exists to remove.
+assert.match(
+  thread,
+  /\/\/\/ Optional so snapshots written before durable message delete decode\.\n\s*var serverTurnId: String\?/,
+  "DisplayMessage must carry the server turn id, optional so old snapshots decode",
+);
+const restored = blockAfter(thread, "static func restored(from turn: ChatTurn, familiarId: String?) -> DisplayMessage {");
+assert.ok(restored, "DisplayMessage.restored must exist");
+assert.match(
+  restored,
+  /DisplayMessage\(\s*\n\s*serverTurnId: turn\.id,/,
+  "a restored message must adopt the server's turn id",
+);
+// `id` is minted on compose and persisted; overwriting it on restore would
+// rewrite message identity on every open.
+assert.doesNotMatch(
+  restored,
+  /\bid: turn\.id\b/,
+  "the local message id must not be replaced by the server's — it is the persisted identity",
+);
+const duplicate = blockAfter(thread, "static func duplicate(of message: DisplayMessage) -> DisplayMessage {");
+assert.ok(duplicate, "DisplayMessage.duplicate must exist");
+assert.doesNotMatch(
+  duplicate,
+  /serverTurnId/,
+  "a duplicated message is a NEW turn — carrying the source's server id would delete the original",
+);
+
+// -- Delete ---------------------------------------------------------------
+const body = blockAfter(thread, "func deleteMessage(_ messageId: String, client: CaveClient?,");
+assert.ok(body, "deleteMessage must take a client");
+assert.match(
+  body,
+  /let target = serverDeleteTarget\(for: removed, at: index\)[\s\S]*?messages\.remove\(at: index\)/,
+  "the server target must be resolved BEFORE the removal — removing first shifts every " +
+    "later message onto the wrong turn",
+);
+assert.match(
+  body,
+  /guard client != nil \|\| target == nil else \{[\s\S]*?appendSystem\([\s\S]*?isError: true\)[\s\S]*?return\n\s*\}/,
+  "with no client and a message the server owns, the delete must be refused out loud — " +
+    "removing it here is the original bug reached by a different door",
+);
+assert.match(
+  body,
+  /messages\.remove\(at: index\)\n\s*updatedAt = Date\(\)\n\s*onChange\(\)/,
+  "the removal must be optimistic — a delete that waits on the tailnet reads as a broken swipe",
+);
+assert.match(
+  body,
+  /Task \{ \[weak self\] in\s*\n\s*await self\?\.persistDelete\(of: removed, at: index, target: target,/,
+  "the removal must be followed by a durable delete",
+);
+
+const target = blockAfter(thread, "private func serverDeleteTarget(for message: DisplayMessage,");
+assert.ok(target, "serverDeleteTarget must exist");
+assert.match(
+  target,
+  /guard !isGroup, !message\.isQueued, message\.role != \.system,/,
+  "a group turn, a queued send and inline slash output have no server turn to remove",
+);
+assert.match(
+  target,
+  /let sessionId = sessionIds\[familiarId\], !sessionId\.isEmpty else \{ return nil \}/,
+  "a thread with no server session must not attempt a server call",
+);
+assert.match(
+  target,
+  /messages\[\.\.<index\]\.filter \{ Self\.occupiesServerTurn\(\$0\) \}\.count/,
+  "the ordinal must skip messages the server never receives, or it names the wrong turn",
+);
+
+const persist = blockAfter(thread, "private func persistDelete(of message: DisplayMessage, at index: Int,");
+assert.ok(persist, "persistDelete must exist");
+assert.match(
+  persist,
+  /guard let convo = try\? await client\.conversation\(sessionId: target\.sessionId\) else \{\s*\n\s*rollBack\(/,
+  "a message composed this session has no server id yet; a FAILED read is a real failure " +
+    "and must roll back rather than pass as 'the server does not have it'",
+);
+assert.match(
+  persist,
+  /turnId = Self\.turnId\(matching: message, at: target\.ordinal, in: convo\.turns\)/,
+  "the turn must be named from the server's own transcript",
+);
+assert.match(
+  persist,
+  /catch \{\s*\n\s*rollBack\(message, to: index, reason: error\.localizedDescription, onChange: onChange\)/,
+  "a refused delete must roll back AND say why",
+);
+
+const matcher = blockAfter(thread, "nonisolated private static func turnId(matching message: DisplayMessage, at ordinal: Int,");
+assert.ok(matcher, "turnId(matching:at:in:) must exist");
+assert.match(
+  matcher,
+  /guard turn\.role == message\.role\.rawValue, turn\.text == message\.text else \{ return nil \}/,
+  "position alone would delete a stranger's turn once the transcripts drift — " +
+    "role and text must agree too",
+);
+
+const rollBack = blockAfter(thread, "private func rollBack(_ message: DisplayMessage, to index: Int, reason: String,");
+assert.ok(rollBack, "rollBack must exist");
+assert.match(
+  rollBack,
+  /messages\.insert\(message, at: min\(max\(index, 0\), messages\.count\)\)/,
+  "a rolled-back message must return to where it left from, clamped — the transcript can " +
+    "have moved while the request was in flight",
+);
+assert.match(
+  rollBack,
+  /appendSystem\([\s\S]*?isError: true\)/,
+  "a failed delete must be visible; a silent local-only delete is the bug being fixed",
+);
+
+// -- The view hands the client through --------------------------------------
+assert.match(
+  view,
+  /thread\.deleteMessage\(message\.id, client: app\.client\) \{ app\.touch\(thread\) \}/,
+  "the swipe action must go through the server-backed path, not the old local splice",
+);
+
+console.log("ios-message-delete-persistence: ok");

--- a/scripts/ios-message-delete-persistence.test.mjs
+++ b/scripts/ios-message-delete-persistence.test.mjs
@@ -57,7 +57,7 @@ assert.match(
 // local-only delete the route exists to end.
 assert.match(
   del,
-  /statusCode == 404, decoded\?\.ok == nil \{[\s\S]*?throw CaveError\.badResponse\(404\)/,
+  /statusCode == 404, decoded\?\.ok == nil \{[\s\S]*?throw CaveError\.transport\(/,
   "a 404 that is not this route's own JSON envelope must be reported, not swallowed — " +
     "otherwise an older desktop reads as 'already deleted'",
 );

--- a/scripts/ios-message-delete-persistence.test.mjs
+++ b/scripts/ios-message-delete-persistence.test.mjs
@@ -52,6 +52,15 @@ assert.match(
   /Self\.checkDelete\(resp\)/,
   "a 404 means the message is already not there — that is not a failure to report",
 );
+// ...but ONLY when the 404 came from this route. A desktop too old to have
+// shipped it 404s the same way, and swallowing that hands back the silent
+// local-only delete the route exists to end.
+assert.match(
+  del,
+  /statusCode == 404, decoded\?\.ok == nil \{[\s\S]*?throw CaveError\.badResponse\(404\)/,
+  "a 404 that is not this route's own JSON envelope must be reported, not swallowed — " +
+    "otherwise an older desktop reads as 'already deleted'",
+);
 for (const [value, subject] of [
   ["sessionId", "chat identifier"],
   ["turnId", "message identifier"],
@@ -92,6 +101,16 @@ assert.doesNotMatch(
   /serverTurnId/,
   "a duplicated message is a NEW turn — carrying the source's server id would delete the original",
 );
+// The other place the server hands a turn id to a message: replay adopts a
+// reply that landed while the transport was down. Without the id that reply is
+// server-owned but unnamed, and a later delete has to guess at it by position.
+const adopt = blockAfter(thread, "private func adoptServerTurnIfPresent(prompt: String, familiarId: String,");
+assert.ok(adopt, "adoptServerTurnIfPresent must exist");
+assert.match(
+  adopt,
+  /DisplayMessage\(serverTurnId: reply\.id,/,
+  "an adopted reply must carry the server's turn id — the server just named it",
+);
 
 // -- Delete ---------------------------------------------------------------
 const body = blockAfter(thread, "func deleteMessage(_ messageId: String, client: CaveClient?,");
@@ -123,8 +142,17 @@ const target = blockAfter(thread, "private func serverDeleteTarget(for message: 
 assert.ok(target, "serverDeleteTarget must exist");
 assert.match(
   target,
-  /guard !isGroup, !message\.isQueued, message\.role != \.system,/,
-  "a group turn, a queued send and inline slash output have no server turn to remove",
+  /guard !isGroup, !message\.isQueued,/,
+  "a group turn and a queued send have no server turn to remove",
+);
+// Inline slash output is local-only, but the server persists chain-less
+// `system` turns of its own and hands them back on a restore. Refusing every
+// system message leaves those deletable only by the local splice being fixed.
+assert.match(
+  target,
+  /message\.role != \.system \|\| message\.serverTurnId != nil,/,
+  "a system turn the SERVER named is a real turn and must delete like one; only " +
+    "inline slash output (never named) stays local",
 );
 assert.match(
   target,
@@ -133,22 +161,55 @@ assert.match(
 );
 assert.match(
   target,
-  /messages\[\.\.<index\]\.filter \{ Self\.occupiesServerTurn\(\$0\) \}\.count/,
+  /let preceding = messages\[\.\.<index\]\.filter \{ Self\.occupiesServerTurn\(\$0\) \}/,
   "the ordinal must skip messages the server never receives, or it names the wrong turn",
+);
+assert.match(
+  target,
+  /preceding: preceding\)/,
+  "the preceding messages must be carried, not just counted — the count alone cannot be " +
+    "checked against the server's transcript",
+);
+
+const occupies = blockAfter(
+  thread,
+  "nonisolated private static func occupiesServerTurn(_ message: DisplayMessage) -> Bool {",
+);
+assert.ok(occupies, "occupiesServerTurn must exist");
+assert.match(
+  occupies,
+  /if message\.serverTurnId != nil \{ return true \}/,
+  "a message the server NAMED holds a position whatever its role — a restored system turn " +
+    "sits in conversation.turns, and skipping it shifts every later ordinal one turn early",
 );
 
 const persist = blockAfter(thread, "private func persistDelete(of message: DisplayMessage, at index: Int,");
 assert.ok(persist, "persistDelete must exist");
+// `try?` collapses two different answers into one: the read THROWING is a real
+// failure, while it returning no conversation is the server saying it holds no
+// transcript — in which case the local removal was already the whole delete
+// and rolling back would resurrect a message for no reason.
 assert.match(
   persist,
-  /guard let convo = try\? await client\.conversation\(sessionId: target\.sessionId\) else \{\s*\n\s*rollBack\(/,
-  "a message composed this session has no server id yet; a FAILED read is a real failure " +
-    "and must roll back rather than pass as 'the server does not have it'",
+  /do \{\s*\n\s*convo = try await client\.conversation\(sessionId: target\.sessionId\)\s*\n\s*\} catch \{\s*\n\s*rollBack\(/,
+  "a FAILED read is a real failure and must roll back",
 );
 assert.match(
   persist,
-  /turnId = Self\.turnId\(matching: message, at: target\.ordinal, in: convo\.turns\)/,
-  "the turn must be named from the server's own transcript",
+  /guard let convo else \{ return \}/,
+  "a read that succeeds with no conversation means the server does not have the message — " +
+    "that must NOT be reported as a failure",
+);
+assert.match(
+  persist,
+  /turnId = Self\.turnId\(matching: message, following: target\.preceding,\s*\n\s*in: convo\.turns\)/,
+  "the turn must be named from the server's own transcript, with the preceding messages " +
+    "available to check the position against",
+);
+assert.match(
+  persist,
+  /try await client\.deleteConversationTurn\(sessionId: target\.sessionId, turnId: turnId\)/,
+  "the named turn must actually be deleted on the server — the whole point of the bead",
 );
 assert.match(
   persist,
@@ -156,13 +217,34 @@ assert.match(
   "a refused delete must roll back AND say why",
 );
 
-const matcher = blockAfter(thread, "nonisolated private static func turnId(matching message: DisplayMessage, at ordinal: Int,");
-assert.ok(matcher, "turnId(matching:at:in:) must exist");
+const matcher = blockAfter(thread, "nonisolated private static func turnId(matching message: DisplayMessage,");
+assert.ok(matcher, "turnId(matching:following:in:) must exist");
+// Position plus role-and-text AT that position is not enough. A reply that
+// failed ambiguously leaves a local bubble with no server turn behind it, so
+// the ordinal drifts — and a chat is full of repeated short turns, so the
+// drifted position agrees on role and text often enough to delete a stranger's
+// message. Every earlier position has to line up too.
 assert.match(
   matcher,
-  /guard turn\.role == message\.role\.rawValue, turn\.text == message\.text else \{ return nil \}/,
-  "position alone would delete a stranger's turn once the transcripts drift — " +
-    "role and text must agree too",
+  /guard ordinal < turns\.count, Self\.turn\(turns\[ordinal\], is: message\) else \{ return nil \}/,
+  "the ordinal must land on a turn that IS this message",
+);
+assert.match(
+  matcher,
+  /for position in preceding\.indices where !Self\.turn\(turns\[position\], is: preceding\[position\]\) \{\s*\n\s*return nil\s*\n\s*\}/,
+  "every position before the ordinal must agree with the server's transcript, or the " +
+    "ordinal is arithmetic rather than evidence and deletes the wrong turn",
+);
+
+const sameTurn = blockAfter(
+  thread,
+  "nonisolated private static func turn(_ turn: ChatTurn, is message: DisplayMessage) -> Bool {",
+);
+assert.ok(sameTurn, "turn(_:is:) must exist");
+assert.match(
+  sameTurn,
+  /if let serverTurnId = message\.serverTurnId \{ return turn\.id == serverTurnId \}/,
+  "a message the server named is compared by id — the only comparison that cannot coincide",
 );
 
 const rollBack = blockAfter(thread, "private func rollBack(_ message: DisplayMessage, to index: Int, reason: String,");

--- a/scripts/ios-message-delete-persistence.test.mjs
+++ b/scripts/ios-message-delete-persistence.test.mjs
@@ -134,8 +134,16 @@ assert.match(
 );
 assert.match(
   body,
-  /Task \{ \[weak self\] in\s*\n\s*await self\?\.persistDelete\(of: removed, at: index, target: target,/,
-  "the removal must be followed by a durable delete",
+  /Task \{ \[weak self\] in\s*\n\s*_ = await previous\?\.value\s*\n\s*await self\?\.persistDelete\(of: removed, at: index, target: target,/,
+  "the removal must be followed by a durable delete, and one delete must wait for the " +
+    "one before it — a second swipe lands inside the first request, and the conversation " +
+    "read that names an unnamed message would still see the turn being removed, refuse, " +
+    "and fail the second delete of a two-swipe cleanup for nothing but timing",
+);
+assert.match(
+  body,
+  /let previous = pendingServerDelete\s*\n\s*pendingServerDelete = Task \{/,
+  "the serialization must be a chain the NEXT delete can await, not a fire-and-forget task",
 );
 
 const target = blockAfter(thread, "private func serverDeleteTarget(for message: DisplayMessage,");
@@ -185,14 +193,27 @@ assert.match(
 
 const persist = blockAfter(thread, "private func persistDelete(of message: DisplayMessage, at index: Int,");
 assert.ok(persist, "persistDelete must exist");
-// `try?` collapses two different answers into one: the read THROWING is a real
-// failure, while it returning no conversation is the server saying it holds no
-// transcript — in which case the local removal was already the whole delete
-// and rolling back would resurrect a message for no reason.
+// `try?` collapses three different answers into one. The read THROWING is a
+// real failure — except for the 404 that `GET /api/chat/conversation/{id}`
+// returns when it holds no transcript at all, which is the server saying the
+// message is not there. Returning no conversation says the same thing through
+// the route's narrow `conversation: null` shape.
 assert.match(
   persist,
-  /do \{\s*\n\s*convo = try await client\.conversation\(sessionId: target\.sessionId\)\s*\n\s*\} catch \{\s*\n\s*rollBack\(/,
+  /\} catch CaveError\.badResponse\(404\) \{\s*\n\s*return\s*\n\s*\} catch \{\s*\n\s*rollBack\(/,
+  "a 404 from the conversation read means the server holds no transcript for this chat — " +
+    "reporting it as 'the desktop could not be reached' is a lie AND resurrects a message " +
+    "no server copy will ever bring back",
+);
+assert.match(
+  persist,
+  /do \{\s*\n\s*convo = try await client\.conversation\(sessionId: target\.sessionId\)/,
   "a FAILED read is a real failure and must roll back",
+);
+assert.doesNotMatch(
+  persist,
+  /try\? await client\.conversation/,
+  "`try?` collapses a failed read into 'the server does not have it'",
 );
 assert.match(
   persist,
@@ -202,9 +223,24 @@ assert.match(
 );
 assert.match(
   persist,
-  /turnId = Self\.turnId\(matching: message, following: target\.preceding,\s*\n\s*in: convo\.turns\)/,
+  /switch Self\.turnMatch\(for: message, following: target\.preceding, in: convo\.turns\)/,
   "the turn must be named from the server's own transcript, with the preceding messages " +
     "available to check the position against",
+);
+// The three outcomes have to stay three. Collapsing `ambiguous` into `absent`
+// is the silent local-only delete this whole bead exists to end: the bubble is
+// gone here, the turn is alive there, and nobody is told.
+assert.match(
+  persist,
+  /case \.absent:\s*\n\s*return/,
+  "a transcript that agrees and simply ends before this message proves the server never " +
+    "received it — the local removal was already the whole delete",
+);
+assert.match(
+  persist,
+  /case \.ambiguous:[\s\S]*?rollBack\(message, to: index,\s*\n\s*reason: "[^"]+",/,
+  "a transcript that DISAGREES says nothing about where this message is — keeping the " +
+    "removal there is a silent local-only delete, which is the bug being fixed",
 );
 assert.match(
   persist,
@@ -217,8 +253,8 @@ assert.match(
   "a refused delete must roll back AND say why",
 );
 
-const matcher = blockAfter(thread, "nonisolated private static func turnId(matching message: DisplayMessage,");
-assert.ok(matcher, "turnId(matching:following:in:) must exist");
+const matcher = blockAfter(thread, "nonisolated private static func turnMatch(for message: DisplayMessage,");
+assert.ok(matcher, "turnMatch(for:following:in:) must exist");
 // Position plus role-and-text AT that position is not enough. A reply that
 // failed ambiguously leaves a local bubble with no server turn behind it, so
 // the ordinal drifts — and a chat is full of repeated short turns, so the
@@ -226,14 +262,24 @@ assert.ok(matcher, "turnId(matching:following:in:) must exist");
 // message. Every earlier position has to line up too.
 assert.match(
   matcher,
-  /guard ordinal < turns\.count, Self\.turn\(turns\[ordinal\], is: message\) else \{ return nil \}/,
-  "the ordinal must land on a turn that IS this message",
+  /guard ordinal < turns\.count else \{ return \.absent \}\s*\n\s*guard Self\.turn\(turns\[ordinal\], is: message\) else \{ return \.ambiguous \}/,
+  "the ordinal must land on a turn that IS this message; a turn that is not this message " +
+    "is a disagreement, not proof the message is missing",
 );
 assert.match(
   matcher,
-  /for position in preceding\.indices where !Self\.turn\(turns\[position\], is: preceding\[position\]\) \{\s*\n\s*return nil\s*\n\s*\}/,
+  /for position in preceding\.indices \{\s*\n\s*guard position < turns\.count else \{ return \.absent \}\s*\n\s*guard Self\.turn\(turns\[position\], is: preceding\[position\]\) else \{ return \.ambiguous \}/,
   "every position before the ordinal must agree with the server's transcript, or the " +
     "ordinal is arithmetic rather than evidence and deletes the wrong turn",
+);
+// The prefix walk has to come FIRST. Running off the end of a transcript that
+// has agreed the whole way is the server being behind us; running off the end
+// of one that never agreed proves nothing, and calling that `absent` is how a
+// refusal turns back into a silent local-only delete.
+assert.ok(
+  matcher.indexOf("for position in preceding.indices") < matcher.indexOf("let ordinal = preceding.count"),
+  "the prefix must be checked before the ordinal, so `absent` is only ever reached through " +
+    "a transcript that agreed as far as it goes",
 );
 
 const sameTurn = blockAfter(
@@ -245,6 +291,16 @@ assert.match(
   sameTurn,
   /if let serverTurnId = message\.serverTurnId \{ return turn\.id == serverTurnId \}/,
   "a message the server named is compared by id — the only comparison that cannot coincide",
+);
+// `chat/send` persists the assistant turn as `text.trim()`; the stream that
+// filled the local bubble appended every chunk as it arrived. Comparing raw
+// makes a reply ending in a newline read as a disagreeing transcript, which
+// refuses every later delete in the session.
+assert.match(
+  sameTurn,
+  /turn\.text\.trimmingCharacters\(in: \.whitespacesAndNewlines\)\s*\n?\s*== message\.text\.trimmingCharacters\(in: \.whitespacesAndNewlines\)/,
+  "text must be compared with the edges trimmed — the server trims what it persists and " +
+    "the stream does not",
 );
 
 const rollBack = blockAfter(thread, "private func rollBack(_ message: DisplayMessage, to index: Int, reason: String,");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1752,6 +1752,7 @@ export const SUITES = {
     "scripts/ios-bulk-reminders.test.mjs",
     "scripts/ios-session-refetch.test.mjs",
     "scripts/ios-thread-server-persistence.test.mjs",
+    "scripts/ios-message-delete-persistence.test.mjs",
     "scripts/ios-swipe-ux.test.mjs",
     "scripts/ios-reconnect-pill.test.mjs",
     "scripts/ios-port-discovery.test.mjs",


### PR DESCRIPTION
Closes the client half of **#4819**. Bead: `cave-ioswipe.6`.

The server half landed as `DELETE /api/chat/conversation/{id}/turns/{turnId}` in #4824. iOS never called it: `ChatThread.deleteMessage` removed the message from its in-memory array, rewrote its own snapshot file, and told nobody. The message came back on reinstall and never disappeared on any other client — which is the whole of what the bead is about.

## Four pieces

- **`DisplayMessage.serverTurnId`**, adopted on restore from the server transcript, and on the replay that adopts a reply the server already had. The local `id` cannot serve: it is minted on compose and persisted, so overwriting it on restore would rewrite message identity on every open. `duplicate(of:)` deliberately does not copy it — a duplicated message is a NEW turn, and carrying the source's id would make deleting the copy delete the original. `retry` clears it, for the mirror-image reason: a retry is an ordinary send, so the server appends a new turn pair and keeps the old assistant turn, and a bubble still naming the old one would delete a turn whose text it no longer shows.
- **`CaveClient.deleteConversationTurn`** issues the per-turn DELETE with the same idempotent-retry treatment as the other DELETEs here. A 404 *from this route* (the conversation is gone) and `deleted: false` (the turn already went) are both *not there any more*, not failures to report. A 404 that is **not** this route's own `ok` envelope is a desktop too old to have shipped the route, and is reported in a sentence — swallowing it would hand back the silent local-only delete the route exists to end.
- **`ChatThread.deleteMessage`** removes optimistically, then persists. A delete that waits on the tailnet reads as a broken swipe, so the bubble goes first — but if the server refuses, or if we cannot name the turn beyond doubt, the message is re-inserted at the index it left from (clamped: the transcript can move while the request is in flight) and an inline error note says why it is still there. Deletes are serialized per thread so the second swipe of a cleanup is not refused for nothing but timing.
- **`ChatView`** hands the client through, and `deleteMessage`'s `onChange` closure IS the persist — the old second `app.touch(thread)` only rewrote the threads file twice for one change.

## Three decisions worth naming

**A message composed in this session has no server id yet**, and nothing in the send path hands one back. Rather than degrade those to a local-only delete, `persistDelete` reads the conversation and names the turn by position — but position, even backed by role and text *at* that position, is not evidence. A reply that failed ambiguously leaves a local bubble with no server turn behind it, every later ordinal is then one too high, and a chat is full of repeated short turns, so an off-by-two in an alternating transcript lands on the same role and often the same text. The server also persists chain-less `system` turns of its own and hands them back on a restore, which is a second way to run the ordinal early. So the ordinal has to be backed by a transcript that lines up: **every earlier position must agree too** — by turn id where the server named the message, by role and text otherwise (edges trimmed, because `chat/send` persists an assistant turn as `text.trim()` while the stream appended each chunk raw). A unique role+text match elsewhere in the transcript is deliberately not accepted as a rescue: it would delete an older identical turn for a message the server never received.

**A refusal is not a success.** The matcher answers `named` / `absent` / `ambiguous`, and only `absent` — a transcript that agreed the whole way and simply ends before this message — keeps the local removal. `ambiguous` rolls back and says so, because keeping the removal there leaves the bubble gone here and the turn alive on the server, which is #4819 through a different door. Refusing costs the user a swipe; after one refresh the message carries a `serverTurnId` and deletes by name with no matching involved.

**With no client at all, a message the server owns is refused rather than removed.** Removing it there would be a local-only delete with nothing left to report it later — the original bug again.

## Scope

Direct chats. A group thread is N server sessions behind one presented transcript, so `familiarIds.first` names an arbitrary one of them and a position in the merged local list answers to no position in any of their turn lists; those stay local, as before. The bead keeps that as remaining work rather than this PR pretending to cover it.

## Verification

iOS Swift is not compiled by PR CI's frontend jobs, so `scripts/ios-message-delete-persistence.test.mjs` is the source-text gate, in the same shape as its sibling `ios-thread-server-persistence.test.mjs` and wired into the mobile suite (`pnpm test:mobile`). The `iOS build` job (`xcodebuild`, macOS runner) is what actually compiles it, and runs on this PR.

Every assertion was checked to **fail** against its regression, not merely to pass. Twenty-nine mutations, all caught, all reverted — including: `serverTurnId` dropped from `restored`; `duplicate()` copying it; the adopted reply dropping it; `retry` keeping the stale one; `checkDelete` → `check`; the unrouted-404 report removed; `retryingIdempotentMutation` dropped; the turn id left unencoded; `occupiesServerTurn` ignoring server-named turns; the prefix-agreement walk dropped, reordered after the ordinal, or reporting `absent` instead of `ambiguous`; the target resolved after the removal; `preceding` reduced to a count; the conversation read reverted to `try?`; the 404 read rolled back as a transport failure; `ambiguous` collapsed into `absent`; `absent` rolled back; text compared untrimmed; the DELETE call dropped; the no-client refusal dropped; rollback's inline note dropped; rollback appending instead of restoring position; deletes de-serialized; the view reverted to the local splice.

Also type-checked locally with `swiftc -typecheck` (Swift 6.3.3, `-swift-version 5` and `6`) over the real `Models/`, `State/` and `Networking/` sources plus a probe replicating every out-of-module `DisplayMessage(...)` and `deleteMessage(...)` call site: `ChatThread.swift`, `CaveClient.swift`'s new method and the probe are clean, and the source set's pre-existing diagnostics are identical to `origin/main`'s.

| Command | Result |
| --- | --- |
| `node scripts/ios-message-delete-persistence.test.mjs` | ok |
| `ios-thread-server-persistence` / `ios-swipe-ux` / `ios-offline-compose` | ok (unchanged) |
| `pnpm check:tests-wired` | 1778 files wired |
| `pnpm typecheck` / `pnpm lint` | ok |
