### PR TITLE
Stop pre-authorizing client-v1 paths with no handler (cave-4841)

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -441,6 +441,137 @@ function effectiveRouteSource(file: string, source: string): string {
   return parts.join("\n");
 }
 
+// --- source text vs. source code ---------------------------------------------
+//
+// assert.match reads a route file as text, so any check spelled as "the source
+// mentions X" is satisfied by a comment, a string, or a doc block that merely
+// names X. For the credential assertions below that is not a nit: the whole
+// point of those checks is to catch an author who MEANT to call the guard, and
+// "meant to" is exactly what a `// TODO: … requireScope(…)` line looks like.
+// Strip comments and literal text first so only code can satisfy them.
+//
+// A character scanner rather than a regex pair, because the naive
+// `replace(/\/\/.*/g, "")` corrupts as much as it removes: a `//` inside a
+// string literal, or a quote inside a regex character class such as /["']/,
+// flips the state and eats real code up to the next delimiter. Anything the
+// scanner cannot classify is dropped rather than kept, so the failure mode is a
+// noisy assertion, not a silent pass.
+function skipQuoted(source: string, start: number, quote: string): number {
+  let i = start + 1;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === "\\") {
+      i += 2;
+      continue;
+    }
+    if (ch === quote || ch === "\n") return i + 1;
+    i += 1;
+  }
+  return i;
+}
+
+function skipTemplate(source: string, start: number): number {
+  let i = start + 1;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === "\\") {
+      i += 2;
+      continue;
+    }
+    if (ch === "`") return i + 1;
+    // A ${…} substitution is dropped with the literal around it: real code has
+    // no reason to call a credential guard from inside an interpolation, and
+    // dropping it keeps the scanner from mistaking the closing brace for the
+    // end of the template.
+    if (ch === "$" && source[i + 1] === "{") {
+      i += 2;
+      let depth = 1;
+      while (i < source.length && depth > 0) {
+        const inner = source[i];
+        if (inner === "\\") {
+          i += 2;
+          continue;
+        }
+        if (inner === "`") {
+          i = skipTemplate(source, i);
+          continue;
+        }
+        if (inner === '"' || inner === "'") {
+          i = skipQuoted(source, i, inner);
+          continue;
+        }
+        if (inner === "{") depth += 1;
+        else if (inner === "}") depth -= 1;
+        i += 1;
+      }
+      continue;
+    }
+    i += 1;
+  }
+  return i;
+}
+
+function skipRegexLiteral(source: string, start: number): number {
+  let i = start + 1;
+  let inClass = false;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === "\\") {
+      i += 2;
+      continue;
+    }
+    if (ch === "\n") return i; // unterminated: it was division after all
+    if (ch === "[") inClass = true;
+    else if (ch === "]") inClass = false;
+    else if (ch === "/" && !inClass) return i + 1;
+    i += 1;
+  }
+  return i;
+}
+
+// A `/` opens a regex literal only where a value may begin. Reading the last
+// meaningful character already emitted is the standard way to tell that from
+// division without a full parser.
+const REGEX_MAY_FOLLOW = /(?:[(,=:[!&|?{};+\-*%~^<>]|\b(?:return|typeof|instanceof|in|of|new|delete|void|do|else|case|yield|await))$/;
+
+function executableSource(source: string): string {
+  let out = "";
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (ch === "/" && next === "/") {
+      while (i < source.length && source[i] !== "\n") i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) i += 1;
+      i += 2;
+      out += " ";
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipQuoted(source, i, ch);
+      out += `${ch}${ch}`;
+      continue;
+    }
+    if (ch === "`") {
+      i = skipTemplate(source, i);
+      out += "``";
+      continue;
+    }
+    if (ch === "/" && REGEX_MAY_FOLLOW.test(out.trimEnd())) {
+      i = skipRegexLiteral(source, i);
+      out += " ";
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
 const routeFiles = walkRoutes(apiRoot);
 const actualRoutes = routeFiles.map(routeFromFile).sort();
 const contractRoutes = contracts.map((contract) => contract.route).sort();
@@ -479,22 +610,57 @@ assert.deepEqual(actualRoutes, contractRoutes, "every src/app/api route must hav
 // that bargain, checked against what is actually on disk rather than against a
 // list someone has to remember to prune.
 //
-// A concrete probe path per route, because the ingress classifier takes a
-// request pathname and the App Router directory speaks in [param] segments.
-// Any bracketed segment (including a [...catchAll]) stands in as one literal
-// segment, which is exactly what the single-segment [^/]+ patterns match.
-function clientV1ProbePath(route: string): string {
-  const segments = route
-    .slice(1)
-    .split("/")
-    .map((segment) => (segment.startsWith("[") ? "probe-segment" : segment));
-  return `/api/${segments.join("/")}`;
+// Concrete probe paths per route, because the ingress classifier takes a
+// request pathname and the App Router directory speaks in [param] segments. A
+// single [param] stands in as one literal segment, which is exactly what the
+// single-segment [^/]+ patterns match.
+//
+// A [...catchAll] does NOT reduce to one segment, and treating it as if it did
+// is how a route impersonates a reviewed public path:
+// pairing/requests/[...rest] would probe as /api/client/v1/pairing/requests/
+// probe-segment, match the single-segment public pattern, and be excused from
+// the requireScope assertion below — while actually serving an unbounded tail
+// that no one reviewed. So a catch-all is probed at every width it serves: the
+// one-segment case it shares with [param], a two-segment case standing in for
+// the whole tail, and — for the optional [[...catchAll]] — the parent path with
+// the segment absent. The classification below then only excuses the route if
+// EVERY one of those shapes is in the reviewed public set.
+const PROBE_SEGMENT = "probe-segment";
+
+function isDynamicSegment(segment: string): boolean {
+  return segment.startsWith("[");
+}
+
+function isCatchAllSegment(segment: string): boolean {
+  return segment.startsWith("[...") || segment.startsWith("[[...");
+}
+
+function isOptionalCatchAllSegment(segment: string): boolean {
+  return segment.startsWith("[[...");
+}
+
+function clientV1ProbePaths(route: string): string[] {
+  const segments = route.slice(1).split("/");
+  let paths: string[][] = [[]];
+  for (const segment of segments) {
+    const widths = !isDynamicSegment(segment)
+      ? [[segment]]
+      : isCatchAllSegment(segment)
+        ? [
+            ...(isOptionalCatchAllSegment(segment) ? [[] as string[]] : []),
+            [PROBE_SEGMENT],
+            [PROBE_SEGMENT, PROBE_SEGMENT],
+          ]
+        : [[PROBE_SEGMENT]];
+    paths = paths.flatMap((prefix) => widths.map((width) => [...prefix, ...width]));
+  }
+  return paths.map((parts) => `/api/${parts.join("/")}`);
 }
 
 const clientV1Routes = routeFiles
   .map((file) => ({ file, route: routeFromFile(file) }))
   .filter(({ route }) => route.startsWith("/client/v1"));
-const clientV1ProbePaths = clientV1Routes.map(({ route }) => clientV1ProbePath(route));
+const clientV1ProbeSurface = clientV1Routes.flatMap(({ route }) => clientV1ProbePaths(route));
 
 // Half one: the list may not pre-authorize a path that nothing serves. Before
 // cave-4841 it named thirteen Phase 2 paths and none of them had a route.ts, so
@@ -504,7 +670,7 @@ const clientV1ProbePaths = clientV1Routes.map(({ route }) => clientV1ProbePath(r
 // entry is now part of adding the handler.
 for (const pattern of CLIENT_V1_AUTHENTICATED_PATHS) {
   assert.ok(
-    clientV1ProbePaths.some((probe) => pattern.test(probe)),
+    clientV1ProbeSurface.some((probe) => pattern.test(probe)),
     `${pattern} pre-authorizes client-v1 ingress but no src/app/api/client/v1 route.ts matches it`,
   );
 }
@@ -519,7 +685,12 @@ for (const pattern of CLIENT_V1_AUTHENTICATED_PATHS) {
 // CLIENT_V1_PUBLIC_PATHS only matches a path the allow-list assertion above
 // already admits by name.
 for (const { file, route } of clientV1Routes) {
-  const source = effectiveRouteSource(file, readFileSync(file, "utf8"));
+  // executableSource, not the raw text: both assertions below are satisfied by
+  // a call the route really makes, never by the NAME appearing in a comment or
+  // a string. `// TODO(next): route this through requireScope(...)` on a route
+  // with no credential check at all is exactly the accident this pair exists to
+  // catch, and it read as a pass until cave-4841's review.
+  const source = executableSource(effectiveRouteSource(file, readFileSync(file, "utf8")));
   if (route === "/client/v1/admin" || route.startsWith("/client/v1/admin/")) {
     // Admin routes never reach the client-v1 ingress branch at all
     // (clientV1IngressKind returns null for them), so they keep the ordinary
@@ -532,7 +703,14 @@ for (const { file, route } of clientV1Routes) {
     );
     continue;
   }
-  if (clientV1IngressKind(clientV1ProbePath(route)) === CLIENT_V1_PUBLIC_INGRESS) {
+  // EVERY shape the route serves has to be in the reviewed public set, not just
+  // the narrowest one — a catch-all that happens to cover a reviewed
+  // single-segment path still serves the rest of its tail credential-free.
+  if (
+    clientV1ProbePaths(route).every(
+      (probe) => clientV1IngressKind(probe) === CLIENT_V1_PUBLIC_INGRESS,
+    )
+  ) {
     continue;
   }
   assert.match(

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -15,6 +15,11 @@ import {
   projectConversationExecutionAttempts,
 } from "../../lib/server/familiar-execution-analytics-projection.ts";
 import { serializeExecutionAttemptLedgerRecord } from "../../lib/server/familiar-execution-analytics-store.ts";
+import {
+  CLIENT_V1_AUTHENTICATED_PATHS,
+  CLIENT_V1_PUBLIC_INGRESS,
+  clientV1IngressKind,
+} from "../../proxy-helpers.ts";
 
 const root = process.cwd();
 const apiRoot = path.join(root, "src", "app", "api");
@@ -464,6 +469,78 @@ assert.deepEqual(
   "Phase 1 must expose exactly the reviewed client-v1 bootstrap and admin routes",
 );
 assert.deepEqual(actualRoutes, contractRoutes, "every src/app/api route must have an API contract entry");
+
+// --- client-v1 proxy pre-authorization (cave-4841) -------------------------
+//
+// clientV1IngressKind classifies a request BEFORE proxy() reaches the
+// sidecar-token block, and a match makes proxy() return early: the mobile
+// access gate is skipped and no bearer is checked. Everything after that point
+// is the route's own responsibility. The two assertions below are the halves of
+// that bargain, checked against what is actually on disk rather than against a
+// list someone has to remember to prune.
+//
+// A concrete probe path per route, because the ingress classifier takes a
+// request pathname and the App Router directory speaks in [param] segments.
+// Any bracketed segment (including a [...catchAll]) stands in as one literal
+// segment, which is exactly what the single-segment [^/]+ patterns match.
+function clientV1ProbePath(route: string): string {
+  const segments = route
+    .slice(1)
+    .split("/")
+    .map((segment) => (segment.startsWith("[") ? "probe-segment" : segment));
+  return `/api/${segments.join("/")}`;
+}
+
+const clientV1Routes = routeFiles
+  .map((file) => ({ file, route: routeFromFile(file) }))
+  .filter(({ route }) => route.startsWith("/client/v1"));
+const clientV1ProbePaths = clientV1Routes.map(({ route }) => clientV1ProbePath(route));
+
+// Half one: the list may not pre-authorize a path that nothing serves. Before
+// cave-4841 it named thirteen Phase 2 paths and none of them had a route.ts, so
+// the first Phase 2 handler to land would have been exempted from the sidecar
+// token on the day it appeared — with its own requireScope call as the sole
+// remaining layer, and no test anywhere insisting that call exist. Adding the
+// entry is now part of adding the handler.
+for (const pattern of CLIENT_V1_AUTHENTICATED_PATHS) {
+  assert.ok(
+    clientV1ProbePaths.some((probe) => pattern.test(probe)),
+    `${pattern} pre-authorizes client-v1 ingress but no src/app/api/client/v1 route.ts matches it`,
+  );
+}
+
+// Half two: every client-v1 route that is not deliberately credential-free has
+// to enforce a credential in its own source. That holds whether or not the path
+// is pre-authorized above — the pre-authorization removes the sidecar token,
+// and this check is what makes removing it survivable. Classification is read
+// from the repo, not hardcoded: the admin family from the directory it lives
+// in, the credential-free bootstrap surface from clientV1IngressKind itself.
+// Growing the public set to dodge this check is not a quiet edit —
+// CLIENT_V1_PUBLIC_PATHS only matches a path the allow-list assertion above
+// already admits by name.
+for (const { file, route } of clientV1Routes) {
+  const source = effectiveRouteSource(file, readFileSync(file, "utf8"));
+  if (route === "/client/v1/admin" || route.startsWith("/client/v1/admin/")) {
+    // Admin routes never reach the client-v1 ingress branch at all
+    // (clientV1IngressKind returns null for them), so they keep the ordinary
+    // sidecar-token path and layer requireClientV1Admin on top. Different
+    // credential, same obligation to name one.
+    assert.match(
+      source,
+      /requireClientV1Admin\s*\(/,
+      `${route} must call requireClientV1Admin`,
+    );
+    continue;
+  }
+  if (clientV1IngressKind(clientV1ProbePath(route)) === CLIENT_V1_PUBLIC_INGRESS) {
+    continue;
+  }
+  assert.match(
+    source,
+    /requireScope\s*\(/,
+    `${route} is neither the admin family nor the reviewed credential-free bootstrap surface, so it must call requireScope`,
+  );
+}
 
 for (const contract of contracts) {
   const file = path.join(apiRoot, ...contract.route.slice(1).split("/"), "route.ts");

--- a/src/lib/server/client-v1/auth.test.ts
+++ b/src/lib/server/client-v1/auth.test.ts
@@ -157,19 +157,37 @@ test("valid scope returns only the active credential record", async () => {
   assert.equal(JSON.stringify(result).includes("valid-bearer"), false);
 });
 
-test("client-v1 ingress allowlists only the reviewed public and authenticated routes", () => {
+test("client-v1 ingress allowlists only the reviewed public routes", () => {
   const publicRoutes = [
     "/api/client/v1/health",
     "/api/client/v1/pairing/requests",
     "/api/client/v1/pairing/requests/request-1",
     "/api/client/v1/pairing/requests/request-1/exchange",
   ];
-  const authenticatedRoutes = [
+  for (const route of publicRoutes) {
+    assert.equal(clientV1IngressKind(route), CLIENT_V1_PUBLIC_INGRESS, route);
+  }
+  // Nothing is pre-authorized (cave-4841). A client-v1 ingress match makes
+  // proxy() skip the mobile access gate and return before the sidecar-token
+  // block, so it is only ever safe for a path whose own handler authenticates —
+  // and the Phase 2 paths below have no handler at all. Listing them ahead of
+  // time meant the first one to land would arrive already exempt. They classify
+  // null until their route.ts exists, which keeps them on the ordinary
+  // sidecar-token gate in the meantime.
+  for (const route of [
+    "/api/client/v1",
+    "/api/client/v1/admin",
+    "/api/client/v1/admin/credentials",
+    "/api/client/v1/admin/pairing-requests",
+    "/api/client/v1/private",
+    "/api/client/v10/health",
+    "/api/chat/conversation",
     "/api/client/v1/familiars",
     "/api/client/v1/projects",
     "/api/client/v1/conversations",
     "/api/client/v1/conversations/search",
     "/api/client/v1/conversations/conversation-1",
+    "/api/client/v1/conversations/conversation-1/messages",
     "/api/client/v1/messages/send",
     "/api/client/v1/attachments",
     "/api/client/v1/attachments/attachment-1",
@@ -180,22 +198,6 @@ test("client-v1 ingress allowlists only the reviewed public and authenticated ro
     "/api/client/v1/runs/run-1/retry",
     "/api/client/v1/attention/attention-1/respond",
     "/api/client/v1/github/actions",
-  ];
-  for (const route of publicRoutes) {
-    assert.equal(clientV1IngressKind(route), CLIENT_V1_PUBLIC_INGRESS, route);
-  }
-  for (const route of authenticatedRoutes) {
-    assert.equal(clientV1IngressKind(route), "authenticated", route);
-  }
-  for (const route of [
-    "/api/client/v1",
-    "/api/client/v1/admin",
-    "/api/client/v1/admin/credentials",
-    "/api/client/v1/admin/pairing-requests",
-    "/api/client/v1/private",
-    "/api/client/v1/conversations/conversation-1/messages",
-    "/api/client/v10/health",
-    "/api/chat/conversation",
   ]) {
     assert.equal(clientV1IngressKind(route), null, route);
   }
@@ -273,15 +275,19 @@ test("reviewed client-v1 routes use loopback ingress without exposing private ro
 
     for (const route of [
       "/api/client/v1/pairing/requests",
-      "/api/client/v1/conversations",
+      "/api/client/v1/pairing/requests/request-1/exchange",
     ]) {
       const response = await proxy(proxyRequest(route, { headers }));
       assert.equal(passedThrough(response), true, `${route} returned ${response.status}`);
     }
 
+    // /api/client/v1/conversations sits with the private routes rather than the
+    // loopback-ingress ones: it has no handler, so it is not pre-authorized and
+    // a bare loopback caller gets the ordinary 401 (cave-4841).
     for (const route of [
       "/api/client/v1/admin/credentials",
       "/api/client/v1/private",
+      "/api/client/v1/conversations",
       "/api/chat/conversation",
     ]) {
       const response = await proxy(proxyRequest(route, { headers }));
@@ -413,11 +419,15 @@ test("client-v1 body-bearing ingress requires a known Content-Length", async () 
     }));
     await assertProxyError(chunked, 400, "invalid content-length");
 
-    const authenticatedMissing = await proxy(proxyRequest("/api/client/v1/conversations", {
-      method: "POST",
-      headers: baseHeaders,
-    }));
-    await assertProxyError(authenticatedMissing, 411, "content-length required");
+    // The rule is a property of client-v1 ingress, not of one route, so check a
+    // second ingress path. It has to be a path that classifies — since
+    // cave-4841 that is the reviewed public set, because nothing is
+    // pre-authorized ahead of its handler.
+    const exchangeMissing = await proxy(proxyRequest(
+      "/api/client/v1/pairing/requests/request-1/exchange",
+      { method: "POST", headers: baseHeaders },
+    ));
+    await assertProxyError(exchangeMissing, 411, "content-length required");
   } finally {
     restoreProxyEnv();
   }
@@ -519,7 +529,7 @@ test("client-v1 loopback bypass preserves host, origin, and content-type gates",
       COVEN_CAVE_LOCAL_PEER_SECRET: "loopback-secret",
     });
 
-    const badHost = await proxy(proxyRequest("/api/client/v1/conversations", {
+    const badHost = await proxy(proxyRequest("/api/client/v1/pairing/requests", {
       headers: {
         [LOCAL_PEER_HEADER]: "loopback-secret",
         host: "evil.example",
@@ -527,7 +537,7 @@ test("client-v1 loopback bypass preserves host, origin, and content-type gates",
     }));
     assert.equal(badHost.status, 403);
 
-    const badOrigin = await proxy(proxyRequest("/api/client/v1/conversations", {
+    const badOrigin = await proxy(proxyRequest("/api/client/v1/pairing/requests", {
       headers: {
         [LOCAL_PEER_HEADER]: "loopback-secret",
         origin: "https://evil.example",
@@ -535,7 +545,7 @@ test("client-v1 loopback bypass preserves host, origin, and content-type gates",
     }));
     assert.equal(badOrigin.status, 403);
 
-    const badContentType = await proxy(proxyRequest("/api/client/v1/conversations", {
+    const badContentType = await proxy(proxyRequest("/api/client/v1/pairing/requests", {
       method: "POST",
       headers: {
         [LOCAL_PEER_HEADER]: "loopback-secret",

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -181,6 +181,16 @@ const CLIENT_V1_PUBLIC_PATHS = [
  * because a handler landing later inherits the exemption without ever opting
  * into it.
  *
+ * The converse is not free either, so absence is a decision rather than a safe
+ * default. Both of the client-v1-only protections in proxy() are gated on the
+ * ingress classification this list feeds: the hard `403 forbidden peer: client
+ * v1 requires direct loopback` that rejects anything but a direct loopback
+ * peer, and clientV1RequestBodyError's 411/413 content-length gate with its
+ * 64 KB cap. Neither applies to a path that classifies null. So a future
+ * authenticated route that lands un-listed does not merely keep the sidecar
+ * gate: it gains a bearer requirement and loses loopback-only ingress and the
+ * body cap. Listing it once it checks its own credential restores both.
+ *
  * So the invariant is: a pattern belongs here only once a route.ts on disk
  * matches it AND that route calls requireScope. Both halves are asserted in
  * src/app/api/api-contracts.test.ts. Phase 2 adds its entry in the same change

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -170,21 +170,29 @@ const CLIENT_V1_PUBLIC_PATHS = [
   /^\/api\/client\/v1\/pairing\/requests\/[^/]+\/exchange$/,
 ];
 
-const CLIENT_V1_AUTHENTICATED_PATHS = [
-  /^\/api\/client\/v1\/familiars$/,
-  /^\/api\/client\/v1\/projects$/,
-  /^\/api\/client\/v1\/conversations$/,
-  /^\/api\/client\/v1\/conversations\/search$/,
-  /^\/api\/client\/v1\/conversations\/[^/]+$/,
-  /^\/api\/client\/v1\/messages\/send$/,
-  /^\/api\/client\/v1\/attachments$/,
-  /^\/api\/client\/v1\/attachments\/[^/]+$/,
-  /^\/api\/client\/v1\/commands$/,
-  /^\/api\/client\/v1\/tasks\/handoff$/,
-  /^\/api\/client\/v1\/runs\/[^/]+\/(?:stream|stop|retry)$/,
-  /^\/api\/client\/v1\/attention\/[^/]+\/respond$/,
-  /^\/api\/client\/v1\/github\/actions$/,
-];
+/**
+ * Client-v1 paths whose OWN handler authenticates the bearer credential.
+ *
+ * Matching here is a DEMOTION, not a promotion: proxy() skips mobileAccessGate
+ * for a client-v1 ingress and returns before the sidecar-token block, so the
+ * only credential check left is the one the route performs for itself
+ * (requireScope, src/lib/server/client-v1/auth.ts). That trade is sound for a
+ * path that really does check — and a hole for a path that does not exist yet,
+ * because a handler landing later inherits the exemption without ever opting
+ * into it.
+ *
+ * So the invariant is: a pattern belongs here only once a route.ts on disk
+ * matches it AND that route calls requireScope. Both halves are asserted in
+ * src/app/api/api-contracts.test.ts. Phase 2 adds its entry in the same change
+ * that adds its handler; until then this list is empty and every unhandled
+ * client-v1 path falls through to the ordinary sidecar-token gate, which is
+ * where an unauthenticated loopback caller should land.
+ *
+ * It was NOT empty before cave-4841: thirteen Phase 2 paths were listed against
+ * zero handlers, so the first Phase 2 route to land would have been reachable
+ * from any loopback process with no sidecar token at all.
+ */
+export const CLIENT_V1_AUTHENTICATED_PATHS: RegExp[] = [];
 
 export function clientV1IngressKind(pathname: string): ClientV1IngressKind | null {
   if (pathname.includes("%") || pathname.includes("\\")) return null;


### PR DESCRIPTION
Closes #4841.

## The defect

`CLIENT_V1_AUTHENTICATED_PATHS` in `src/proxy-helpers.ts` listed thirteen Phase 2
paths — `familiars`, `projects`, `conversations`, `conversations/search`,
`messages/send`, `attachments`, `commands`, `tasks/handoff`,
`runs/:id/{stream,stop,retry}`, `attention/:id/respond`, `github/actions` — and
re-enumerating `src/app/api/client/v1/**/route.ts` at `origin/main` (`e58f755af`,
after #4840 landed) confirms **none of them has a handler**. The eight that exist
are health, three pairing routes, and four admin routes.

A match in that list is a **demotion, not a promotion**. `src/proxy.ts` computes
`clientV1Ingress` before the mobile access gate, skips `mobileAccessGate`
entirely for a match, and returns `nextWithMobileAccessMarker(req, false)`
*before* the sidecar-token block. That is a sound trade for a path whose own
handler authenticates the bearer. For a path that does not exist yet it is a hole
with a fuse on it: the day a Phase 2 handler lands at
`src/app/api/client/v1/conversations/route.ts` (#4834, the next piece of work),
it is reachable from any loopback process with **no sidecar token**, having
inherited an exemption it never opted into.

Its own `requireScope` call would be the only layer left — and `requireScope`,
`consumeAuthenticated` and `consumeInvalidBearer` all have **zero non-test call
sites** today, so nothing establishes that habit.

## What changed

**1. The list is now empty.** Every unhandled client-v1 path falls through to the
ordinary sidecar-token gate, which is where an unauthenticated loopback caller
belongs. The entry gets added when the handler lands, not before.

No behaviour change for the eight existing routes: health and the three pairing
routes still classify `public`, and the four admin routes still classify `null`
and keep `requireClientV1Admin` layered on the ordinary sidecar path.

**2 & 3. Two static assertions in `src/app/api/api-contracts.test.ts`,** following
that file's existing route-walking / source-inspecting pattern rather than
inventing a new mechanism. Both read the repository instead of a list someone has
to remember to prune:

- **Every pattern in `CLIENT_V1_AUTHENTICATED_PATHS` must match a `route.ts` that
  actually exists.** Adding the entry becomes part of adding the handler.
- **Every client-v1 route that is neither the admin family nor the
  credential-free bootstrap surface must call `requireScope`.** The admin family
  is classified by the directory it lives in (and is separately asserted to call
  `requireClientV1Admin`); the credential-free set is classified by
  `clientV1IngressKind` itself, not a hardcoded list. Widening the public set to
  dodge this is not a quiet edit — `CLIENT_V1_PUBLIC_PATHS` only matches a path
  the existing Phase 1 allow-list assertion already admits by name.

This second one is the assertion that will actually meet #4834.

Both were verified to fail before they pass: reinstating the `conversations`
pattern trips the first, and a synthetic `conversations/route.ts` without
`requireScope` trips the second — whether or not it is pre-authorized, since the
obligation does not depend on the ingress entry.

`src/lib/server/client-v1/auth.test.ts` moves its thirteen authenticated-route
expectations into the `null` group (the direct expression of the fix) and repoints
the proxy tests that used `/api/client/v1/conversations` as a stand-in ingress path
onto real public client-v1 routes, so the host / origin / content-type / body-size
coverage survives intact. `/api/client/v1/conversations` now appears alongside
`/api/client/v1/private` in the 401 group.

## Assessment: moving the bearer check into the proxy (item 4) — recommend NOT here

Looked at, deliberately not done; filing separately is the right call.

`src/proxy.ts` cannot reach the credential store at that point in the request
lifecycle without an architectural change:

- **Runtime.** `proxy.ts` exports no `runtime`, and `next.config.ts` sets no
  `nodeMiddleware`, so it runs on the Edge runtime. Every module it reaches is
  Web-Crypto-only by deliberate discipline: `proxy-helpers.ts` hand-rolls
  `timingSafeEqualString` over `TextEncoder` rather than using
  `node:crypto.timingSafeEqual`, and `mobile-access-token.ts` /
  `passkey-presence.ts` / `research-media-ticket.ts` use `crypto.subtle` and
  `btoa` with **zero** `node:` imports between them.
  `credential-store.ts` opens with `node:crypto`, `node:fs/promises` and
  `node:path`, and resolves `caveHome()`. Importing it into the proxy means
  moving the proxy to the Node runtime.
- **Instance identity.** `getClientV1Runtime()` memoizes on
  `globalThis.__covenCaveClientV1Runtime`. The proxy and the route handlers are
  separate bundles, so the proxy would get a *second*, independent store —
  duplicate credential-file reads per request, separate rate-limit buckets, and
  divergent `lastUsedAt` writes against the same file.
- **Cost and scope.** The matcher is
  `/((?!_next/static|_next/image|favicon.ico|pdf\.worker\.min\.mjs$).*)`, so this
  sits on every page and asset request, and the store is async filesystem I/O with
  locking. And the proxy cannot know which `ClientV1Scope` a path requires, so
  `requireScope` stays in the route regardless — the proxy could only add a
  bearer-*existence* pre-filter.

Item 3 is the cheap durable win and it is in this PR. If defence in depth is still
wanted, the tractable shape is a Node-runtime client-v1 credential pre-filter with
an explicitly shared store instance — a separate change with its own review.

## Validation

- `pnpm typecheck` — clean
- `pnpm lint` — clean (design codemod check + `eslint --max-warnings=0`)
- `node scripts/check-tests-wired.mjs` — `all 1792 test files wired into CI`
- `src/app/api/api-contracts.test.ts` — 296 route contracts passed
- `src/lib/server/client-v1/auth.test.ts` — 17/17 pass
- `src/proxy-behavior.test.ts`, `src/middleware.test.ts`,
  `src/passkey-proxy-gate.test.ts` — pass
- `src/lib/server/client-v1/{runtime,rate-limit,discovery,contract}.test.ts` — pass
  (one discovery case skips on Windows: file symlinks unsupported, EPERM)

Test files were run through the runner's own argv
(`nodeArgsFor(...)`), not a hand-built `--test` command. No new test file was
added, so `SUITES` / `ALIAS_LOADER` needed no change — confirmed by
`check-tests-wired.mjs`.

## Worktree note

The checkout is at roughly 38 registered worktrees against a budget of 28 and
there is no bead for this issue in the local Beads DB, so
`pnpm beads:worktrees:create` would refuse. This branch was created with the
documented last-resort fallback:

```
git worktree add -b fix/cave-4841-proxy-preauth .worktrees/cave-4841-proxy-preauth origin/main
```

so the unit carries **no `metadata.coven.worktree` lifecycle record**. It will
report `uncertain` to `pnpm beads:worktrees` permanently and
`pnpm beads:worktrees:apply` can never retire it — it needs hand-retirement via
the archive-tag route after merge. Per `CLAUDE.md`, the missing metadata is
deliberately **not** hand-written onto a bead to make the patrol pass.
