### PR TITLE
Meter the pairing poll route against the exchange brute-force budget (cave-11w87)

### DIFF
--- a/src/app/api/client/v1/pairing/requests/[id]/exchange/route.ts
+++ b/src/app/api/client/v1/pairing/requests/[id]/exchange/route.ts
@@ -50,14 +50,11 @@ export function createPairingExchangePostHandler(runtime: ClientV1Runtime) {
     // blocking another's exchange. Read the budget before comparing secrets,
     // or a limit charged after the fact would bound nothing.
     //
-    // Known gap, deliberately not closed here: the bound is per-route, not
-    // system-wide. GET /api/client/v1/pairing/requests/[id] calls
-    // pairingStore.lookup(id, secret), which runs the byte-identical
-    // hashesEqual against the same secretHash and distinguishes
-    // `secret_mismatch` (401) from `found`/`consumed` — while referencing no
-    // rate limiter at all. An attacker holding a pairing id can therefore
-    // guess the secret unmetered through GET and spend a single exchange call
-    // once it has one. Metering that oracle is tracked separately.
+    // The bound is system-wide, not per-route: GET
+    // /api/client/v1/pairing/requests/[id] compares the same secretHash
+    // through pairingStore.lookup and charges THIS bucket for its own
+    // mismatches. Keep it that way — a second bucket for that route would
+    // meter it while leaving the pair of them unbounded.
     const limit = runtime.rateLimiter.peekPairingExchangeFailure(id);
     if (!limit.allowed) return clientV1RateLimitResponse(limit);
 

--- a/src/app/api/client/v1/pairing/requests/[id]/route.test.ts
+++ b/src/app/api/client/v1/pairing/requests/[id]/route.test.ts
@@ -274,6 +274,37 @@ test("polling with the correct secret is never rate limited", async () => {
       runtime.rateLimiter.peekPairingExchangeFailure(unknownId).remaining,
       CLIENT_V1_PAIRING_EXCHANGE_FAILURE_LIMIT,
     );
+
+    // The already-exchanged branch presents a CORRECT secret too, so it has to
+    // be as free as the 200 above. A client that polls once more after its
+    // exchange succeeds — a retry loop that raced its own success, or one
+    // confirming the outcome — still holds the right secret, and charging it
+    // here would spend the shared budget on the legitimate holder and lock the
+    // pairing's own exchange out for the rest of the window. Asserted directly
+    // because every other guard in this file exercises `found` or `not_found`:
+    // without this, charging the 409 path breaks no test.
+    const exchange = createPairingExchangePostHandler(runtime);
+    const spent = runtime.pairingStore.create({
+      ...pairingInput,
+      installationId: "chat-install-spent",
+    });
+    assert.equal(runtime.pairingStore.decide(spent.id, "approved", now), true);
+    const exchanged = await exchange(
+      exchangeRequest(spent.id, spent.secret),
+      context(spent.id),
+    );
+    assert.equal(exchanged.status, 200);
+
+    const replayed = await poll(request(spent.id, spent.secret), context(spent.id));
+    assert.equal(replayed.status, 409);
+    assert.equal(
+      ((await replayed.json()) as { error: { code: string } }).error.code,
+      "conflict",
+    );
+    assert.equal(
+      runtime.rateLimiter.peekPairingExchangeFailure(spent.id).remaining,
+      CLIENT_V1_PAIRING_EXCHANGE_FAILURE_LIMIT,
+    );
   } finally {
     assert.equal(resolve(root).startsWith(scratchPrefix), true);
     await rm(root, { recursive: true, force: true });

--- a/src/app/api/client/v1/pairing/requests/[id]/route.test.ts
+++ b/src/app/api/client/v1/pairing/requests/[id]/route.test.ts
@@ -4,8 +4,11 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 import { PAIRING_TTL_MS } from "@/lib/server/client-v1/pairing-store.ts";
+import { CLIENT_V1_PAIRING_EXCHANGE_FAILURE_LIMIT } from "@/lib/server/client-v1/rate-limit.ts";
 import { createClientV1Runtime } from "@/lib/server/client-v1/runtime.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
 
+import { createPairingExchangePostHandler } from "./exchange/route.ts";
 import { createPairingRequestGetHandler } from "./route.ts";
 
 const scratchPrefix = resolve(process.cwd(), ".scratch-client-v1-poll-");
@@ -26,6 +29,23 @@ function request(id: string, secret?: string, querySecret?: string): Request {
   return new Request(url, {
     headers: secret ? { [secretHeader]: secret } : undefined,
   });
+}
+
+function exchangeRequest(id: string, secret: string): Request {
+  return new Request(
+    `http://127.0.0.1:3020/api/client/v1/pairing/requests/${id}/exchange`,
+    {
+      method: "POST",
+      headers: { [LOCAL_PEER_HEADER]: "loopback-secret", [secretHeader]: secret },
+    },
+  );
+}
+
+// A well-formed guess, not a malformed one: a secret failing the contract
+// shape is refused before the store ever compares it, so only this kind of
+// attempt reaches the comparison the budget exists to bound.
+function nearMiss(secret: string): string {
+  return `${secret.slice(0, -1)}${secret.endsWith("A") ? "B" : "A"}`;
 }
 
 test("poll exposes only id, status, and expiry across the complete lifecycle", async () => {
@@ -97,6 +117,163 @@ test("poll accepts pairing secrets only from the reviewed header", async () => {
       assert.equal(body.error.code, "unauthorized");
       assert.equal(JSON.stringify(body).includes(issued.secret), false);
     }
+  } finally {
+    assert.equal(resolve(root).startsWith(scratchPrefix), true);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("poll meters wrong pairing secrets against the exchange's own budget", async () => {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const now = 17_000;
+    const runtime = createClientV1Runtime({
+      credentialRoot: root,
+      loopbackSecret: "loopback-secret",
+      now: () => now,
+    });
+    const poll = createPairingRequestGetHandler(runtime);
+    const exchange = createPairingExchangePostHandler(runtime);
+    const attacked = runtime.pairingStore.create(pairingInput);
+    const bystander = runtime.pairingStore.create({
+      ...pairingInput,
+      installationId: "chat-install-bystander",
+    });
+    assert.equal(runtime.pairingStore.decide(attacked.id, "approved", now), true);
+    assert.equal(runtime.pairingStore.decide(bystander.id, "approved", now), true);
+
+    // 401 versus 200 is a complete oracle for the secret, so this route has to
+    // be bounded exactly as tightly as the exchange it feeds.
+    const guess = nearMiss(attacked.secret);
+    assert.notEqual(guess, attacked.secret);
+    for (
+      let attempt = 0;
+      attempt < CLIENT_V1_PAIRING_EXCHANGE_FAILURE_LIMIT;
+      attempt += 1
+    ) {
+      const rejected = await poll(request(attacked.id, guess), context(attacked.id));
+      assert.equal(rejected.status, 401, `guess ${attempt} must be refused, not limited`);
+    }
+
+    const limited = await poll(request(attacked.id, guess), context(attacked.id));
+    assert.equal(limited.status, 429);
+    assert.equal(
+      ((await limited.json()) as { error: { code: string } }).error.code,
+      "rate_limited",
+    );
+
+    // The whole point of sharing one bucket: guessing through the poll route
+    // must not leave a full exchange budget in reserve for the moment the
+    // oracle gives up the secret.
+    const exchanged = await exchange(
+      exchangeRequest(attacked.id, attacked.secret),
+      context(attacked.id),
+    );
+    assert.equal(exchanged.status, 429);
+
+    // And the lockout is confined to the pairing under attack.
+    const untouched = await poll(
+      request(bystander.id, bystander.secret),
+      context(bystander.id),
+    );
+    assert.equal(untouched.status, 200);
+  } finally {
+    assert.equal(resolve(root).startsWith(scratchPrefix), true);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("poll refuses once exchange failures alone have spent the shared budget", async () => {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const now = 19_000;
+    const runtime = createClientV1Runtime({
+      credentialRoot: root,
+      loopbackSecret: "loopback-secret",
+      now: () => now,
+    });
+    const poll = createPairingRequestGetHandler(runtime);
+    const exchange = createPairingExchangePostHandler(runtime);
+    const attacked = runtime.pairingStore.create(pairingInput);
+    assert.equal(runtime.pairingStore.decide(attacked.id, "approved", now), true);
+
+    const guess = nearMiss(attacked.secret);
+    for (
+      let attempt = 0;
+      attempt < CLIENT_V1_PAIRING_EXCHANGE_FAILURE_LIMIT;
+      attempt += 1
+    ) {
+      const rejected = await exchange(
+        exchangeRequest(attacked.id, guess),
+        context(attacked.id),
+      );
+      assert.equal(rejected.status, 401, `guess ${attempt} must be refused, not limited`);
+    }
+
+    // The budget gates the comparison itself, so while it is spent the poll
+    // refuses the correct secret too — a deliberate per-pairing lockout for the
+    // rest of the 60 s window, matching what the exchange already does, rather
+    // than a quieter 401 that would keep answering the attacker's question.
+    const holder = await poll(
+      request(attacked.id, attacked.secret),
+      context(attacked.id),
+    );
+    assert.equal(holder.status, 429);
+    const body = await holder.json() as { error: { code: string } };
+    assert.equal(body.error.code, "rate_limited");
+    assert.equal(holder.headers.get("retry-after"), "60");
+    assert.equal(JSON.stringify(body).includes(attacked.secret), false);
+  } finally {
+    assert.equal(resolve(root).startsWith(scratchPrefix), true);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("polling with the correct secret is never rate limited", async () => {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const now = 21_000;
+    const runtime = createClientV1Runtime({
+      credentialRoot: root,
+      loopbackSecret: "loopback-secret",
+      now: () => now,
+    });
+    const poll = createPairingRequestGetHandler(runtime);
+    const issued = runtime.pairingStore.create(pairingInput);
+
+    // A client polls this route until an administrator decides. 150 polls is a
+    // 2 s interval across the full 5-minute pairing TTL, well past the failure
+    // limit: presenting the correct secret must cost the holder nothing, or the
+    // fix would lock out the one caller it exists to protect.
+    const polls = 150;
+    assert.ok(polls > CLIENT_V1_PAIRING_EXCHANGE_FAILURE_LIMIT);
+    for (let attempt = 0; attempt < polls; attempt += 1) {
+      const pending = await poll(request(issued.id, issued.secret), context(issued.id));
+      assert.equal(pending.status, 200, `poll ${attempt} must answer, not rate limit`);
+      assert.equal(
+        ((await pending.json()) as { data: { status: string } }).data.status,
+        "pending",
+      );
+    }
+
+    // Not merely unthrottled — never charged, so the budget is still whole for
+    // an attacker who shows up after the holder has been polling for minutes.
+    assert.equal(
+      runtime.rateLimiter.peekPairingExchangeFailure(issued.id).remaining,
+      CLIENT_V1_PAIRING_EXCHANGE_FAILURE_LIMIT,
+    );
+
+    // A `not_found` is not charged either: no record carries that id, so there
+    // is no secret to guess and charging would mint a bucket per guessed id —
+    // exactly the map churn `peek` refuses to cause.
+    const unknownId = `${issued.id.slice(0, -1)}${issued.id.endsWith("a") ? "b" : "a"}`;
+    assert.notEqual(unknownId, issued.id);
+    const notFound = await poll(request(unknownId, issued.secret), context(unknownId));
+    assert.equal(notFound.status, 404);
+    assert.equal(
+      runtime.rateLimiter.peekPairingExchangeFailure(unknownId).remaining,
+      CLIENT_V1_PAIRING_EXCHANGE_FAILURE_LIMIT,
+    );
   } finally {
     assert.equal(resolve(root).startsWith(scratchPrefix), true);
     await rm(root, { recursive: true, force: true });

--- a/src/app/api/client/v1/pairing/requests/[id]/route.ts
+++ b/src/app/api/client/v1/pairing/requests/[id]/route.ts
@@ -5,6 +5,7 @@ import {
 } from "@/lib/server/client-v1/contract.ts";
 import {
   clientV1ErrorResponse,
+  clientV1RateLimitResponse,
   clientV1SuccessResponse,
 } from "@/lib/server/client-v1/responses.ts";
 import {
@@ -32,11 +33,29 @@ export function createPairingRequestGetHandler(runtime: ClientV1Runtime) {
       return clientV1ErrorResponse("unauthorized", "Unauthorized.");
     }
 
+    // `lookup` runs the byte-identical hashesEqual against the same secretHash
+    // the exchange compares, so a 401 here answers a guess exactly as well as a
+    // 401 there. This therefore charges the exchange route's per-pairing budget
+    // rather than keeping one of its own: two buckets would meter each route
+    // and bound neither, handing an attacker ten free guesses per route and a
+    // full exchange budget still in reserve once the poll oracle had given up
+    // the secret. Read the budget before comparing, or a limit charged after
+    // the fact would bound nothing.
+    const limit = runtime.rateLimiter.peekPairingExchangeFailure(id);
+    if (!limit.allowed) return clientV1RateLimitResponse(limit);
+
     const result = runtime.pairingStore.lookup(id, secret);
     if (result.kind === "secret_mismatch") {
+      // Only a wrong secret is charged. This route is polled while the client
+      // waits on an administrator decision, so charging the correct secret
+      // would rate limit the legitimate holder for waiting.
+      runtime.rateLimiter.consumePairingExchangeFailure(id);
       return clientV1ErrorResponse("unauthorized", "Unauthorized.");
     }
     if (result.kind === "not_found") {
+      // Not charged, for the reason the exchange route gives: `not_found`
+      // means no record and no terminal record carries this id, so there is no
+      // secret to guess and charging would mint one bucket per guessed id.
       return clientV1ErrorResponse("not_found", "Pairing request not found.");
     }
     if (result.kind === "consumed") {

--- a/src/lib/server/client-v1/rate-limit.ts
+++ b/src/lib/server/client-v1/rate-limit.ts
@@ -25,15 +25,21 @@ export interface ClientV1RateLimiter {
    * any other pairing. Only a *wrong* secret is ever charged: a correct secret
    * — including the repeated polls a client makes while its request is still
    * pending — costs nothing, so legitimate polling is never rate limited.
+   *
+   * One bucket covers *every* route that compares a pairing secret, which
+   * today is the exchange POST and the pairing-request GET. The name records
+   * where the budget was introduced, not who may spend it: a second bucket per
+   * comparison site would meter each route while bounding neither, since the
+   * cheapest attack is simply to exhaust one oracle and then use the other.
    */
   consumePairingExchangeFailure(pairingRequestId: string): ClientV1RateLimitResult;
   /**
    * Read the failure budget for one pairing request without charging it.
    *
-   * The exchange route has to know whether the budget is already exhausted
-   * *before* it compares secrets, or the limit would bound nothing. Reading
-   * never creates an entry, so probing unknown ids cannot evict the entries
-   * that are bounding a real brute-force attempt.
+   * A route has to know whether the budget is already exhausted *before* it
+   * compares secrets, or the limit would bound nothing. Reading never creates
+   * an entry, so probing unknown ids cannot evict the entries that are
+   * bounding a real brute-force attempt.
    */
   peekPairingExchangeFailure(pairingRequestId: string): ClientV1RateLimitResult;
 }


### PR DESCRIPTION
Closes #4846.

`GET /api/client/v1/pairing/requests/[id]` calls `pairingStore.lookup(id, secret)`, which runs the **byte-identical** `hashesEqual` against the same `secretHash` that `consumeForExchange` compares, and answers 401 on a mismatch versus 200/409 on a hit. That handler referenced no rate limiter.

So the per-pairing brute-force budget #4840 added on the exchange route covered one of the two comparison sites, and therefore bounded neither: a guess could be tested unmetered through this route and the exchange spent once, with `peekPairingExchangeFailure` still seeing an empty bucket.

**Severity is low, as the issue says.** The secret is 43 base64url characters (256 bits), ingress is loopback-only, and the TTL is five minutes — guessing is infeasible regardless. This is also not a regression: the GET route was untouched by #4840 and was never covered. It is fixed because #4840 introduces a budget whose stated purpose is bounding brute force, and that purpose was met on only one of the two routes that compare the secret. This closes a gap in a claim, not a live exploit.

## What changed

The poll handler now peeks the same per-id bucket before comparing and charges it only on `secret_mismatch`, mirroring the exchange route exactly.

**One shared bucket, not one per route.** This is the load-bearing choice. Two buckets would meter each route and bound neither — an attacker gets ten guesses per route, and a full exchange budget still in reserve for the moment the poll oracle gives up the secret. `M5` in the matrix below is exactly that mutation, and two tests catch it.

**Peek before the comparison, charge after.** A limit charged after the fact would bound nothing; `M2` (peek removed, mismatch still charged) is caught.

**Only a wrong secret is charged.** A legitimate client polls this route while it waits on an administrator decision, so charging a correct secret would rate limit the one caller the route exists for. `M4` (charge every lookup) is caught by the 150-poll test, which asserts not merely that the holder is unthrottled but that the bucket is left completely unspent.

**`not_found` is not charged**, for the reason the exchange route already gives: the store answers `not_found` only when no record and no terminal record carries the id, so there is no secret to guess and charging would mint one bucket per guessed id — the map churn `peek` deliberately refuses to cause. `M7` is caught.

**An exhausted budget answers 429 `rate_limited` with `retry-after`**, the same response the exchange route gives, rather than a quieter 401 that would keep answering the attacker's question. `M6` is caught. While the budget is spent the correct secret is refused here too — the same deliberate per-pairing lockout the exchange route already documents, and it cannot be triggered by the holder's own polling.

**Other call sites:** `pairingStore.lookup` has exactly one non-test call site, this one, so nothing else needs the same treatment. `poll` and `inspect` also touch secret material but have no route behind them.

Two comment-only edits ride along: the exchange route's "Known gap, deliberately not closed here" paragraph is now false and says the opposite, and the rate limiter's JSDoc now records that one bucket covers every route comparing a pairing secret.

## Failing test first

Written before the fix and confirmed against the unfixed handler (`M1` in the matrix — the whole fix reverted, i.e. the state of `main`):

```
✔ poll exposes only id, status, and expiry across the complete lifecycle
✔ poll accepts pairing secrets only from the reviewed header
✖ poll meters wrong pairing secrets against the exchange's own budget
✖ poll refuses once exchange failures alone have spent the shared budget
✔ polling with the correct secret is never rate limited
ℹ pass 3   ℹ fail 2
```

The third test passes unfixed by design — it is the guard that the fix does not over-charge, and it is killed by `M4`/`M7` instead.

## Mutation matrix

Every assertion added was mutation-checked. The fix was committed first, each mutation applied to the committed file, and the file restored with `git checkout HEAD --` after each run (`git status --porcelain` empty afterwards).

| mutation | result | killed by |
| --- | --- | --- |
| M1 whole fix removed (state of `main`) | KILLED | meters-wrong-secrets; refuses-after-exchange-failures |
| M2 peek removed, mismatch still charged | KILLED | meters-wrong-secrets; refuses-after-exchange-failures |
| M3 mismatch no longer charged, peek kept | KILLED | meters-wrong-secrets |
| M4 charge every lookup, not only a mismatch | KILLED | correct-secret-never-rate-limited |
| M5 private bucket (`poll:${id}`) instead of the shared one | KILLED | meters-wrong-secrets; refuses-after-exchange-failures |
| M6 exhausted budget answers 401 instead of 429 | KILLED | meters-wrong-secrets; refuses-after-exchange-failures |
| M7 `not_found` charged too | KILLED | correct-secret-never-rate-limited |

No surviving mutants; every new test kills at least one. No existing assertion was weakened or deleted.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` (`✓ all 1792 test files wired into CI`), and `pnpm build` all pass. Test files were run with the exact argv `scripts/run-tests.mjs` reports via `nodeArgsFor`. Green: the pairing GET route (5/5), the exchange route (5/5), `rate-limit.test.ts` (10/10), `pairing-store.test.ts` (8/8), and the pairing-create route (3/3).

## Deliberately left undone

The limiter methods are still named `consumePairingExchangeFailure` / `peekPairingExchangeFailure` and the constant `CLIENT_V1_PAIRING_EXCHANGE_FAILURE_LIMIT`, although the budget now covers both routes. Renaming would be more honest but would rewrite ~50 lines across `rate-limit.ts` and three test files, and #4841 is in flight over the same module — the issue names it as a blocker for the first authenticated client-v1 route. The JSDoc says plainly that the name records where the budget was introduced, not who may spend it. Worth a follow-up once #4841 lands.
