### PR TITLE
Enforce client-v1 filesystem ownership on Windows (cave-adcmu)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1381,6 +1381,7 @@ export const SUITES = {
     "src/lib/server/client-v1/auth.test.ts",
     "src/lib/server/client-v1/rate-limit.test.ts",
     "src/lib/server/client-v1/discovery.test.ts",
+    "src/lib/server/client-v1/path-ownership.test.ts",
     "src/lib/server/client-v1/runtime.test.ts",
     "src/app/api/client/v1/health/route.test.ts",
     "src/app/api/client/v1/pairing/requests/route.test.ts",

--- a/server.mjs
+++ b/server.mjs
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { createHmac, randomUUID } from "node:crypto";
 import {
   chmodSync,
@@ -81,10 +81,139 @@ function standaloneCaveHome() {
 function clientV1DiscoveryFile() {
   return join(standaloneCaveHome(), CLIENT_V1_DISCOVERY_FILE);
 }
-function requireStandaloneOwner(metadata, label) {
-  if (typeof process.getuid === "function" && metadata.uid !== process.getuid()) {
-    throw new Error(`Client v1 discovery ${label} must be owned by the current user.`);
+const WINDOWS_SYSTEM_SID = "S-1-5-18";
+const WINDOWS_ADMINISTRATORS_SID = "S-1-5-32-544";
+const WINDOWS_ACL_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+$item = Get-Item -LiteralPath $env:COVEN_CAVE_CLIENT_V1_ACL_PATH -Force
+$me = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+$system = New-Object System.Security.Principal.SecurityIdentifier('${WINDOWS_SYSTEM_SID}')
+$admins = New-Object System.Security.Principal.SecurityIdentifier('${WINDOWS_ADMINISTRATORS_SID}')
+$trusted = @($me.Value, $system.Value, $admins.Value)
+
+function Read-State {
+  param($target)
+  $acl = $target.GetAccessControl('Access,Owner')
+  $aces = @($acl.Access | ForEach-Object {
+    [pscustomobject]@{
+      sid = $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value
+      type = [string]$_.AccessControlType
+    }
+  })
+  [pscustomobject]@{
+    owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value
+    protected = [bool]$acl.AreAccessRulesProtected
+    aces = $aces
   }
+}
+
+function Test-Exclusive {
+  param($state)
+  if (-not $state.protected) { return $false }
+  if ($state.owner -ne $me.Value) { return $false }
+  foreach ($ace in $state.aces) {
+    if ($ace.type -ne 'Allow') { return $false }
+    if ($trusted -notcontains $ace.sid) { return $false }
+  }
+  return $true
+}
+
+$state = Read-State $item
+$repaired = $false
+$removed = @()
+if (-not (Test-Exclusive $state)) {
+  $removed = @($state.aces | Where-Object { $trusted -notcontains $_.sid } |
+    ForEach-Object { $_.sid } | Select-Object -Unique)
+  $acl = $item.GetAccessControl('Access')
+  $acl.SetAccessRuleProtection($true, $false)
+  foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRule($rule) }
+  $inheritance = if ($item.PSIsContainer) { 'ContainerInherit, ObjectInherit' } else { 'None' }
+  foreach ($sid in @($me, $system, $admins)) {
+    $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+      $sid, 'FullControl', $inheritance, 'None', 'Allow')))
+  }
+  $item.SetAccessControl($acl)
+  $repaired = $true
+  $state = Read-State $item
+}
+
+[pscustomobject]@{
+  self = $me.Value
+  owner = $state.owner
+  protected = $state.protected
+  repaired = $repaired
+  removed = @($removed)
+  aces = $state.aces
+} | ConvertTo-Json -Compress -Depth 4
+`;
+const standaloneVerifiedWindowsPaths = /* @__PURE__ */ new Set();
+function assertStandaloneWindowsExclusive(path, label) {
+  if (standaloneVerifiedWindowsPaths.has(path)) return;
+  const systemRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
+  let report;
+  try {
+    report = JSON.parse(execFileSync(
+      join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-NoLogo",
+        "-InputFormat",
+        "None",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        WINDOWS_ACL_SCRIPT
+      ],
+      {
+        env: { ...process.env, COVEN_CAVE_CLIENT_V1_ACL_PATH: path },
+        encoding: "utf8",
+        windowsHide: true,
+        timeout: 15e3,
+        maxBuffer: 1024 * 1024
+      }
+    ));
+  } catch (cause) {
+    throw new Error(
+      `Client v1 discovery ${label} ownership could not be verified on Windows: ${cause.message}. Refusing ${path}; inspect it with: icacls "${path}"`,
+      { cause }
+    );
+  }
+  const trusted = /* @__PURE__ */ new Set([report.self, WINDOWS_SYSTEM_SID, WINDOWS_ADMINISTRATORS_SID]);
+  const findings = [];
+  if (report.owner !== report.self) {
+    findings.push(`owned by ${report.owner}, not ${report.self}`);
+  }
+  if (!report.protected) findings.push("its DACL still inherits from the parent");
+  const foreign = report.aces.filter((ace) => ace.type !== "Allow" || !trusted.has(ace.sid)).map((ace) => `${ace.type}:${ace.sid}`);
+  if (foreign.length > 0) {
+    findings.push(`access granted to ${[...new Set(foreign)].join(", ")}`);
+  }
+  if (findings.length > 0) {
+    throw new Error(
+      `Client v1 discovery ${label} is not exclusive to the current user: ${findings.join("; ")}. Refusing ${path}; inspect it with: icacls "${path}"`
+    );
+  }
+  if (report.repaired) {
+    console.warn(
+      `Client v1 discovery ${label} had no enforced access control on Windows; restricted ${path} to the current user and revoked ${report.removed.length > 0 ? report.removed.join(", ") : "inherited entries"}.`
+    );
+  }
+  standaloneVerifiedWindowsPaths.add(path);
+}
+function requireStandaloneOwner(path, metadata, label) {
+  if (typeof process.getuid === "function") {
+    if (metadata.uid !== process.getuid()) {
+      throw new Error(`Client v1 discovery ${label} must be owned by the current user.`);
+    }
+    return;
+  }
+  if (process.platform !== "win32") {
+    throw new Error(
+      `Client v1 discovery ${label} ownership cannot be verified on ${process.platform}: this platform exposes neither a uid nor a Windows ACL, so ${path} is refused.`
+    );
+  }
+  assertStandaloneWindowsExclusive(path, label);
 }
 function assertStandaloneDiscoveryTarget(path) {
   try {
@@ -92,7 +221,7 @@ function assertStandaloneDiscoveryTarget(path) {
     if (!metadata.isFile() || metadata.isSymbolicLink()) {
       throw new Error(`Client v1 discovery target must be a regular file: ${path}.`);
     }
-    requireStandaloneOwner(metadata, "target");
+    requireStandaloneOwner(path, metadata, "target");
   } catch (error) {
     if (error.code === "ENOENT") return;
     throw error;
@@ -105,7 +234,7 @@ function publishStandaloneClientV1DiscoveryRecord(endpoint) {
   if (rootMetadata.isSymbolicLink() || !rootMetadata.isDirectory()) {
     throw new Error("Client v1 discovery root must be a real directory.");
   }
-  requireStandaloneOwner(rootMetadata, "root");
+  requireStandaloneOwner(root, rootMetadata, "root");
   const physicalRoot = realpathSync(root);
   if (physicalRoot !== root) {
     throw new Error("Client v1 discovery root must not resolve through a symlink.");
@@ -153,7 +282,7 @@ function removeStandaloneClientV1DiscoveryRecord(nonce) {
   try {
     before = lstatSync(path);
     if (!before.isFile() || before.isSymbolicLink()) return false;
-    requireStandaloneOwner(before, "target");
+    requireStandaloneOwner(path, before, "target");
     parsed = JSON.parse(readFileSync(path, "utf8"));
   } catch (error) {
     if (error.code === "ENOENT") return false;

--- a/server.mjs
+++ b/server.mjs
@@ -184,6 +184,9 @@ function assertStandaloneWindowsExclusive(path, label) {
         maxBuffer: 1024 * 1024
       }
     ));
+    if (!report || typeof report !== "object" || typeof report.self !== "string" || !report.self || typeof report.owner !== "string" || !report.owner || typeof report.protected !== "boolean" || typeof report.repaired !== "boolean" || !Array.isArray(report.aces) || !Array.isArray(report.removed)) {
+      throw new Error("the ACL probe returned a malformed report");
+    }
   } catch (cause) {
     throw new Error(
       `Client v1 discovery ${label} ownership could not be verified on Windows: ${cause.message}. Refusing ${path}; inspect it with: icacls "${path}"`,

--- a/server.mjs
+++ b/server.mjs
@@ -316,7 +316,11 @@ function removeStandaloneClientV1DiscoveryRecord(nonce) {
 }
 function cleanupStandaloneClientV1Discovery() {
   if (!clientV1DiscoveryPublished) return;
-  removeStandaloneClientV1DiscoveryRecord(CLIENT_V1_DISCOVERY_NONCE);
+  try {
+    removeStandaloneClientV1DiscoveryRecord(CLIENT_V1_DISCOVERY_NONCE);
+  } catch (error) {
+    console.error("[cave] failed to remove client-v1 discovery record", error);
+  }
 }
 const LOCAL_PEER_HEADER = "x-coven-cave-local-peer";
 const LOCAL_PEER_SECRET = randomUUID();

--- a/server.mjs
+++ b/server.mjs
@@ -150,6 +150,17 @@ const standaloneVerifiedWindowsPaths = /* @__PURE__ */ new Set();
 function assertStandaloneWindowsExclusive(path, label) {
   if (standaloneVerifiedWindowsPaths.has(path)) return;
   const systemRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
+  const probeEnv = {
+    COVEN_CAVE_CLIENT_V1_ACL_PATH: path,
+    // Next augments ProcessEnv to require this. It carries no secret.
+    NODE_ENV: process.env.NODE_ENV,
+    SystemRoot: systemRoot,
+    windir: systemRoot,
+    PATH: join(systemRoot, "System32"),
+    PATHEXT: process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD",
+    TEMP: process.env.TEMP || process.env.TMP || join(systemRoot, "Temp"),
+    TMP: process.env.TMP || process.env.TEMP || join(systemRoot, "Temp")
+  };
   let report;
   try {
     report = JSON.parse(execFileSync(
@@ -166,7 +177,7 @@ function assertStandaloneWindowsExclusive(path, label) {
         WINDOWS_ACL_SCRIPT
       ],
       {
-        env: { ...process.env, COVEN_CAVE_CLIENT_V1_ACL_PATH: path },
+        env: probeEnv,
         encoding: "utf8",
         windowsHide: true,
         timeout: 15e3,

--- a/server.ts
+++ b/server.ts
@@ -454,7 +454,19 @@ function removeStandaloneClientV1DiscoveryRecord(nonce: string): boolean {
 
 function cleanupStandaloneClientV1Discovery(): void {
   if (!clientV1DiscoveryPublished) return;
-  removeStandaloneClientV1DiscoveryRecord(CLIENT_V1_DISCOVERY_NONCE);
+  // This runs first inside the SIGINT/SIGTERM handler, so a throw here escapes
+  // the signal handler and kills the process before `terminatePtySessions()`
+  // and `server.close()` — stranding PTY children and leaving behind the very
+  // record this function exists to remove. The owner guard could not throw on
+  // win32 before it learned to read a DACL; now it can, and it does so by
+  // spawning a subprocess at the exact moment the OS is tearing the session
+  // down. Refusing to unlink a record we cannot verify is still correct — but
+  // it is a reason to skip the unlink, never a reason to abort the shutdown.
+  try {
+    removeStandaloneClientV1DiscoveryRecord(CLIENT_V1_DISCOVERY_NONCE);
+  } catch (error) {
+    console.error("[cave] failed to remove client-v1 discovery record", error);
+  }
 }
 
 // Local-peer stamp (cave-vn2r): only this file sees the raw TCP socket, so

--- a/server.ts
+++ b/server.ts
@@ -263,6 +263,24 @@ function assertStandaloneWindowsExclusive(path: string, label: string): void {
         maxBuffer: 1024 * 1024,
       },
     ));
+    // `aces` carries the whole access decision, so a shape this cannot read has
+    // to be an error rather than a default: an absent or non-array `aces` reads
+    // downstream as "no principal has access" and would therefore admit the
+    // path. Same contract as parseClientV1WindowsAclReport in the module.
+    if (
+      !report
+      || typeof report !== "object"
+      || typeof report.self !== "string"
+      || !report.self
+      || typeof report.owner !== "string"
+      || !report.owner
+      || typeof report.protected !== "boolean"
+      || typeof report.repaired !== "boolean"
+      || !Array.isArray(report.aces)
+      || !Array.isArray(report.removed)
+    ) {
+      throw new Error("the ACL probe returned a malformed report");
+    }
   } catch (cause) {
     throw new Error(
       `Client v1 discovery ${label} ownership could not be verified on Windows: `

--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { createHmac, randomUUID } from "node:crypto";
 import {
   chmodSync,
@@ -139,13 +139,171 @@ function clientV1DiscoveryFile(): string {
   return join(standaloneCaveHome(), CLIENT_V1_DISCOVERY_FILE);
 }
 
+// Windows ownership, inlined for the same reason as everything else in this
+// block: `build:server` runs esbuild with `--bundle=false`, so server.mjs
+// cannot import src/lib/server/client-v1/path-ownership.ts. That module is the
+// authority; the PowerShell below is a verbatim copy of its script and
+// discovery.test.ts fails if the two ever drift.
+const WINDOWS_SYSTEM_SID = "S-1-5-18";
+const WINDOWS_ADMINISTRATORS_SID = "S-1-5-32-544";
+
+const WINDOWS_ACL_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+$item = Get-Item -LiteralPath $env:COVEN_CAVE_CLIENT_V1_ACL_PATH -Force
+$me = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+$system = New-Object System.Security.Principal.SecurityIdentifier('${WINDOWS_SYSTEM_SID}')
+$admins = New-Object System.Security.Principal.SecurityIdentifier('${WINDOWS_ADMINISTRATORS_SID}')
+$trusted = @($me.Value, $system.Value, $admins.Value)
+
+function Read-State {
+  param($target)
+  $acl = $target.GetAccessControl('Access,Owner')
+  $aces = @($acl.Access | ForEach-Object {
+    [pscustomobject]@{
+      sid = $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value
+      type = [string]$_.AccessControlType
+    }
+  })
+  [pscustomobject]@{
+    owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value
+    protected = [bool]$acl.AreAccessRulesProtected
+    aces = $aces
+  }
+}
+
+function Test-Exclusive {
+  param($state)
+  if (-not $state.protected) { return $false }
+  if ($state.owner -ne $me.Value) { return $false }
+  foreach ($ace in $state.aces) {
+    if ($ace.type -ne 'Allow') { return $false }
+    if ($trusted -notcontains $ace.sid) { return $false }
+  }
+  return $true
+}
+
+$state = Read-State $item
+$repaired = $false
+$removed = @()
+if (-not (Test-Exclusive $state)) {
+  $removed = @($state.aces | Where-Object { $trusted -notcontains $_.sid } |
+    ForEach-Object { $_.sid } | Select-Object -Unique)
+  $acl = $item.GetAccessControl('Access')
+  $acl.SetAccessRuleProtection($true, $false)
+  foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRule($rule) }
+  $inheritance = if ($item.PSIsContainer) { 'ContainerInherit, ObjectInherit' } else { 'None' }
+  foreach ($sid in @($me, $system, $admins)) {
+    $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+      $sid, 'FullControl', $inheritance, 'None', 'Allow')))
+  }
+  $item.SetAccessControl($acl)
+  $repaired = $true
+  $state = Read-State $item
+}
+
+[pscustomobject]@{
+  self = $me.Value
+  owner = $state.owner
+  protected = $state.protected
+  repaired = $repaired
+  removed = @($removed)
+  aces = $state.aces
+} | ConvertTo-Json -Compress -Depth 4
+`;
+
+const standaloneVerifiedWindowsPaths = new Set<string>();
+
+function assertStandaloneWindowsExclusive(path: string, label: string): void {
+  if (standaloneVerifiedWindowsPaths.has(path)) return;
+  const systemRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
+  let report: {
+    self: string;
+    owner: string;
+    protected: boolean;
+    repaired: boolean;
+    removed: string[];
+    aces: { sid: string; type: string }[];
+  };
+  try {
+    report = JSON.parse(execFileSync(
+      join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-NoLogo",
+        "-InputFormat",
+        "None",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        WINDOWS_ACL_SCRIPT,
+      ],
+      {
+        env: { ...process.env, COVEN_CAVE_CLIENT_V1_ACL_PATH: path },
+        encoding: "utf8",
+        windowsHide: true,
+        timeout: 15_000,
+        maxBuffer: 1024 * 1024,
+      },
+    ));
+  } catch (cause) {
+    throw new Error(
+      `Client v1 discovery ${label} ownership could not be verified on Windows: `
+      + `${(cause as Error).message}. Refusing ${path}; inspect it with: icacls "${path}"`,
+      { cause },
+    );
+  }
+
+  const trusted = new Set([report.self, WINDOWS_SYSTEM_SID, WINDOWS_ADMINISTRATORS_SID]);
+  const findings: string[] = [];
+  if (report.owner !== report.self) {
+    findings.push(`owned by ${report.owner}, not ${report.self}`);
+  }
+  if (!report.protected) findings.push("its DACL still inherits from the parent");
+  const foreign = report.aces
+    .filter((ace) => ace.type !== "Allow" || !trusted.has(ace.sid))
+    .map((ace) => `${ace.type}:${ace.sid}`);
+  if (foreign.length > 0) {
+    findings.push(`access granted to ${[...new Set(foreign)].join(", ")}`);
+  }
+  if (findings.length > 0) {
+    throw new Error(
+      `Client v1 discovery ${label} is not exclusive to the current user: `
+      + `${findings.join("; ")}. Refusing ${path}; inspect it with: icacls "${path}"`,
+    );
+  }
+  if (report.repaired) {
+    console.warn(
+      `Client v1 discovery ${label} had no enforced access control on Windows; `
+      + `restricted ${path} to the current user and revoked `
+      + `${report.removed.length > 0 ? report.removed.join(", ") : "inherited entries"}.`,
+    );
+  }
+  standaloneVerifiedWindowsPaths.add(path);
+}
+
 function requireStandaloneOwner(
+  path: string,
   metadata: NonNullable<ReturnType<typeof lstatSync>>,
   label: string,
 ): void {
-  if (typeof process.getuid === "function" && metadata.uid !== process.getuid()) {
-    throw new Error(`Client v1 discovery ${label} must be owned by the current user.`);
+  // The uid comparison alone was inert on win32 — `process.getuid` is undefined
+  // there and `lstat` reports uid 0 for every path — so the discovery record
+  // that points a client at this server had no enforced owner at all. Anything
+  // that can answer neither question is refused rather than waved through.
+  if (typeof process.getuid === "function") {
+    if (metadata.uid !== process.getuid()) {
+      throw new Error(`Client v1 discovery ${label} must be owned by the current user.`);
+    }
+    return;
   }
+  if (process.platform !== "win32") {
+    throw new Error(
+      `Client v1 discovery ${label} ownership cannot be verified on ${process.platform}: `
+      + `this platform exposes neither a uid nor a Windows ACL, so ${path} is refused.`,
+    );
+  }
+  assertStandaloneWindowsExclusive(path, label);
 }
 
 function assertStandaloneDiscoveryTarget(path: string): void {
@@ -154,7 +312,7 @@ function assertStandaloneDiscoveryTarget(path: string): void {
     if (!metadata.isFile() || metadata.isSymbolicLink()) {
       throw new Error(`Client v1 discovery target must be a regular file: ${path}.`);
     }
-    requireStandaloneOwner(metadata, "target");
+    requireStandaloneOwner(path, metadata, "target");
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
     throw error;
@@ -168,7 +326,7 @@ function publishStandaloneClientV1DiscoveryRecord(endpoint: string): void {
   if (rootMetadata.isSymbolicLink() || !rootMetadata.isDirectory()) {
     throw new Error("Client v1 discovery root must be a real directory.");
   }
-  requireStandaloneOwner(rootMetadata, "root");
+  requireStandaloneOwner(root, rootMetadata, "root");
   const physicalRoot = realpathSync(root);
   if (physicalRoot !== root) {
     throw new Error("Client v1 discovery root must not resolve through a symlink.");
@@ -230,7 +388,7 @@ function removeStandaloneClientV1DiscoveryRecord(nonce: string): boolean {
   try {
     before = lstatSync(path);
     if (!before.isFile() || before.isSymbolicLink()) return false;
-    requireStandaloneOwner(before, "target");
+    requireStandaloneOwner(path, before, "target");
     parsed = JSON.parse(readFileSync(path, "utf8"));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;

--- a/server.ts
+++ b/server.ts
@@ -216,6 +216,23 @@ const standaloneVerifiedWindowsPaths = new Set<string>();
 function assertStandaloneWindowsExclusive(path: string, label: string): void {
   if (standaloneVerifiedWindowsPaths.has(path)) return;
   const systemRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
+  // The smallest environment PowerShell needs, never this server's own: it
+  // holds COVEN_CAVE_ACCESS_TOKEN and COVEN_CAVE_AUTH_TOKEN, and a subprocess
+  // that only has to read a DACL has no business receiving them. Same rule
+  // sanitizedEnv() enforces for PTY shells. The path under test travels here
+  // too, so no quoting rule stands between a path containing a quote and the
+  // identity being checked.
+  const probeEnv: NodeJS.ProcessEnv = {
+    COVEN_CAVE_CLIENT_V1_ACL_PATH: path,
+    // Next augments ProcessEnv to require this. It carries no secret.
+    NODE_ENV: process.env.NODE_ENV,
+    SystemRoot: systemRoot,
+    windir: systemRoot,
+    PATH: join(systemRoot, "System32"),
+    PATHEXT: process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD",
+    TEMP: process.env.TEMP || process.env.TMP || join(systemRoot, "Temp"),
+    TMP: process.env.TMP || process.env.TEMP || join(systemRoot, "Temp"),
+  };
   let report: {
     self: string;
     owner: string;
@@ -239,7 +256,7 @@ function assertStandaloneWindowsExclusive(path: string, label: string): void {
         WINDOWS_ACL_SCRIPT,
       ],
       {
-        env: { ...process.env, COVEN_CAVE_CLIENT_V1_ACL_PATH: path },
+        env: probeEnv,
         encoding: "utf8",
         windowsHide: true,
         timeout: 15_000,

--- a/src/lib/server/client-v1/credential-store.test.ts
+++ b/src/lib/server/client-v1/credential-store.test.ts
@@ -535,3 +535,65 @@ test("refuses a credential store a foreign Windows principal can write", async (
     );
   });
 });
+
+test("refuses a planted credential file a foreign Windows principal can write", async () => {
+  // The root can be exclusive while the file is not — a record planted before
+  // the directory was ever restricted keeps its own inherited DACL. This is the
+  // attack in its most direct form: a valid-looking record whose bearerHash the
+  // attacker chose, sitting where the store will read it.
+  const exclusive = {
+    self: "S-1-5-21-11-22-33-1001",
+    owner: "S-1-5-21-11-22-33-1001",
+    protected: true,
+    repaired: false,
+    removed: [],
+    aces: [{ sid: "S-1-5-21-11-22-33-1001", type: "Allow" }],
+  };
+
+  await withCredentialRoot(async (root) => {
+    const path = join(root, CLIENT_V1_CREDENTIAL_STORE_FILE);
+    await writeFile(
+      path,
+      JSON.stringify({
+        version: 1,
+        credentials: [{
+          id: "planted",
+          appName: "Attacker",
+          installationId: "planted-installation",
+          scopes: ["chat:read"],
+          bearerHash: "a".repeat(64),
+          createdAt: 1,
+          lastUsedAt: null,
+          revokedAt: null,
+          revocationReason: null,
+        }],
+      }),
+    );
+
+    const store = createCredentialStore({
+      root,
+      ownership: {
+        platform: "win32" as const,
+        getuid: null,
+        warn: () => {},
+        // Only the file is shared; the root passes, so nothing but the file
+        // check can produce this refusal.
+        probeWindowsAcl: async (probed: string) => ({
+          ...exclusive,
+          aces: probed === path
+            ? [...exclusive.aces, { sid: "S-1-5-32-545", type: "Allow" }]
+            : exclusive.aces,
+        }),
+      },
+    });
+
+    await assert.rejects(
+      store.reload(),
+      /Client v1 credential store file is not exclusive to the current user/,
+    );
+    await assert.rejects(
+      store.findByBearer("anything"),
+      /Client v1 credential store file is not exclusive to the current user/,
+    );
+  });
+});

--- a/src/lib/server/client-v1/credential-store.test.ts
+++ b/src/lib/server/client-v1/credential-store.test.ts
@@ -484,3 +484,54 @@ test("lastUsedAt persistence is coalesced to at most once per minute per credent
     assert.equal((await store.reload()).get(issued.credential.id)?.lastUsedAt, 71_000);
   });
 });
+
+test("refuses a credential store a foreign Windows principal can write", async () => {
+  // The severe half of the defect: an attacker who can write this file injects
+  // a record with a bearerHash of their choosing and any scopes, which mints
+  // full authority with no pairing and no admin approval. On win32 nothing
+  // stopped that — `process.getuid` is undefined, `lstat` reports uid 0, and
+  // `chmod(0o600)` only toggles the read-only bit. Injecting the platform keeps
+  // the branch under test on the POSIX runners, where it is otherwise dead.
+  const exclusive = {
+    self: "S-1-5-21-11-22-33-1001",
+    owner: "S-1-5-21-11-22-33-1001",
+    protected: true,
+    repaired: false,
+    removed: [],
+    aces: [{ sid: "S-1-5-21-11-22-33-1001", type: "Allow" }],
+  };
+  const windows = (aces: { sid: string; type: string }[]) => ({
+    platform: "win32" as const,
+    getuid: null,
+    warn: () => {},
+    probeWindowsAcl: async () => ({ ...exclusive, aces }),
+  });
+  const shared = [
+    { sid: "S-1-5-21-11-22-33-1001", type: "Allow" },
+    { sid: "S-1-5-32-545", type: "Allow" },
+  ];
+
+  await withCredentialRoot(async (root) => {
+    const store = createCredentialStore({ root, ownership: windows(shared) });
+    await assert.rejects(
+      store.issue(credentialInput),
+      /Client v1 credential store root is not exclusive to the current user/,
+    );
+    await assert.rejects(store.reload(), /is not exclusive to the current user/);
+    await assert.rejects(
+      readFile(join(root, CLIENT_V1_CREDENTIAL_STORE_FILE), "utf8"),
+      { code: "ENOENT" },
+      "a refused store must not have been written",
+    );
+  });
+
+  await withCredentialRoot(async (root) => {
+    const store = createCredentialStore({ root, ownership: windows(exclusive.aces) });
+    const issued = await store.issue(credentialInput);
+    assert.equal(
+      await store.verify(issued.credential.id, issued.bearer),
+      true,
+      "an exclusive Windows path must still issue and verify",
+    );
+  });
+});

--- a/src/lib/server/client-v1/credential-store.ts
+++ b/src/lib/server/client-v1/credential-store.ts
@@ -21,6 +21,10 @@ import {
   parseClientV1PairingScopes,
   type ClientV1Scope,
 } from "./contract.ts";
+import {
+  assertClientV1PathOwnership,
+  type ClientV1PathOwnershipOptions,
+} from "./path-ownership.ts";
 import type { ClientV1PairingApproved } from "./pairing-store.ts";
 
 export const CLIENT_V1_CREDENTIAL_STORE_FILE = "client-v1-credentials.json";
@@ -72,6 +76,7 @@ export interface CredentialStoreOptions {
    */
   chmodCommittedFile?: (path: string, mode: number) => Promise<void>;
   now?: () => number;
+  ownership?: ClientV1PathOwnershipOptions;
   readFile?: (path: string, encoding: "utf8") => Promise<string>;
   root?: string;
   temporaryRandomBytes?: (size: number) => Buffer;
@@ -156,7 +161,10 @@ function cloneMap(
   return new Map(Array.from(records, ([id, record]) => [id, cloneRecord(record)]));
 }
 
-async function assertRegularCredentialFileOrMissing(path: string): Promise<void> {
+async function assertRegularCredentialFileOrMissing(
+  path: string,
+  ownership: ClientV1PathOwnershipOptions | undefined,
+): Promise<void> {
   try {
     const metadata = await lstat(path);
     if (!metadata.isFile() || metadata.isSymbolicLink()) {
@@ -164,6 +172,7 @@ async function assertRegularCredentialFileOrMissing(path: string): Promise<void>
         `Client v1 credential store file must be a regular file, not a symlink: ${path}.`,
       );
     }
+    await assertClientV1PathOwnership(path, metadata, "credential store file", ownership);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
     throw error;
@@ -172,6 +181,7 @@ async function assertRegularCredentialFileOrMissing(path: string): Promise<void>
 
 async function initializeCredentialStoreLocation(
   configuredRoot: string,
+  ownership: ClientV1PathOwnershipOptions | undefined,
 ): Promise<CredentialStoreLocation> {
   const resolvedRoot = resolve(configuredRoot);
   try {
@@ -188,10 +198,18 @@ async function initializeCredentialStoreLocation(
       `Client v1 credential store root must resolve to a real directory: ${resolvedRoot}.`,
     );
   }
+  // Ownership first: on Windows the assertion is also what restricts the
+  // directory, and the chmod below is the no-op it has always been there.
+  await assertClientV1PathOwnership(
+    physicalRoot,
+    metadata,
+    "credential store root",
+    ownership,
+  );
   await chmod(physicalRoot, 0o700);
 
   const path = join(physicalRoot, CLIENT_V1_CREDENTIAL_STORE_FILE);
-  await assertRegularCredentialFileOrMissing(path);
+  await assertRegularCredentialFileOrMissing(path, ownership);
   return {
     path,
     queueKey: path,
@@ -201,6 +219,7 @@ async function initializeCredentialStoreLocation(
 
 async function assertCredentialStoreLocation(
   location: CredentialStoreLocation,
+  ownership: ClientV1PathOwnershipOptions | undefined,
 ): Promise<void> {
   const metadata = await lstat(location.root);
   if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
@@ -213,7 +232,13 @@ async function assertCredentialStoreLocation(
       `Client v1 credential store root was replaced by a symlink: ${location.root}.`,
     );
   }
-  await assertRegularCredentialFileOrMissing(location.path);
+  await assertClientV1PathOwnership(
+    location.root,
+    metadata,
+    "credential store root",
+    ownership,
+  );
+  await assertRegularCredentialFileOrMissing(location.path, ownership);
 }
 
 function parseRecord(value: unknown): ClientV1CredentialRecord | null {
@@ -358,6 +383,7 @@ export function clientV1CredentialStorePath(root = caveHome()): string {
 
 export class FileCredentialStore implements CredentialStore {
   readonly #configuredRoot: string;
+  readonly #ownership: ClientV1PathOwnershipOptions | undefined;
   readonly #now: () => number;
   readonly #readFile: (path: string, encoding: "utf8") => Promise<string>;
   readonly #temporaryRandomBytes: (size: number) => Buffer;
@@ -367,6 +393,7 @@ export class FileCredentialStore implements CredentialStore {
 
   constructor(options: CredentialStoreOptions = {}) {
     this.#configuredRoot = options.root ?? caveHome();
+    this.#ownership = options.ownership;
     this.#now = options.now ?? Date.now;
     this.#readFile = options.readFile ?? readFile;
     this.#temporaryRandomBytes = options.temporaryRandomBytes ?? randomBytes;
@@ -376,7 +403,10 @@ export class FileCredentialStore implements CredentialStore {
   #location(): Promise<CredentialStoreLocation> {
     if (this.#locationPromise) return this.#locationPromise;
     let pending!: Promise<CredentialStoreLocation>;
-    pending = initializeCredentialStoreLocation(this.#configuredRoot).catch((error) => {
+    pending = initializeCredentialStoreLocation(
+      this.#configuredRoot,
+      this.#ownership,
+    ).catch((error) => {
       if (this.#locationPromise === pending) this.#locationPromise = null;
       throw error;
     });
@@ -389,7 +419,7 @@ export class FileCredentialStore implements CredentialStore {
   ): Promise<T> {
     const location = await this.#location();
     return runExclusive(location.queueKey, async () => {
-      await assertCredentialStoreLocation(location);
+      await assertCredentialStoreLocation(location, this.#ownership);
       return operation(location);
     });
   }
@@ -412,7 +442,7 @@ export class FileCredentialStore implements CredentialStore {
   }
 
   async #persist(location: CredentialStoreLocation): Promise<void> {
-    await assertCredentialStoreLocation(location);
+    await assertCredentialStoreLocation(location, this.#ownership);
     await writeStoreAtomic(
       location.path,
       this.#records,

--- a/src/lib/server/client-v1/discovery.test.ts
+++ b/src/lib/server/client-v1/discovery.test.ts
@@ -226,6 +226,67 @@ test("removes only a matching current nonce and preserves replaced records", asy
   });
 });
 
+test("refuses to publish or remove a discovery record a foreign Windows principal can write", async () => {
+  // `process.getuid` is undefined on win32 and `lstat` reports uid 0 there, so
+  // the ownership guard used to pass unconditionally on the platform this
+  // repository develops on. Injecting the platform keeps that branch under test
+  // on the POSIX runners, where it is otherwise unreachable.
+  const exclusive = {
+    self: "S-1-5-21-11-22-33-1001",
+    owner: "S-1-5-21-11-22-33-1001",
+    protected: true,
+    repaired: false,
+    removed: [],
+    aces: [{ sid: "S-1-5-21-11-22-33-1001", type: "Allow" }],
+  };
+  const windows = (aces: { sid: string; type: string }[]) => ({
+    platform: "win32" as const,
+    getuid: null,
+    warn: () => {},
+    probeWindowsAcl: async () => ({ ...exclusive, aces }),
+  });
+  const shared = [{ sid: "S-1-5-21-11-22-33-1001", type: "Allow" }, {
+    sid: "S-1-5-32-545",
+    type: "Allow",
+  }];
+
+  await withOwnedRoot(async (root) => {
+    await assert.rejects(
+      publishClientV1DiscoveryRecord(record(), { root, ownership: windows(shared) }),
+      /Client v1 discovery root is not exclusive to the current user/,
+    );
+    await assert.rejects(readFile(clientV1DiscoveryPath(root)), { code: "ENOENT" });
+  });
+
+  await withOwnedRoot(async (root) => {
+    await publishClientV1DiscoveryRecord(record(), {
+      root,
+      ownership: windows(exclusive.aces),
+    });
+    assert.deepEqual(
+      JSON.parse(await readFile(clientV1DiscoveryPath(root), "utf8")),
+      record(),
+      "an exclusive Windows path must still publish",
+    );
+
+    // The root is already a verified path by now, so removal trips on the
+    // target instead — the module caches only successes, and only per path.
+    await assert.rejects(
+      removeClientV1DiscoveryRecord({
+        nonce: "discovery-nonce-1",
+        root,
+        ownership: windows(shared),
+      }),
+      /Client v1 discovery target is not exclusive to the current user/,
+    );
+    assert.deepEqual(
+      JSON.parse(await readFile(clientV1DiscoveryPath(root), "utf8")),
+      record(),
+      "a refused removal must leave the record in place",
+    );
+  });
+});
+
 test("server lifecycle publishes only from listener readiness and performs nonce-safe shutdown cleanup", async () => {
   const source = await readFile(resolve(process.cwd(), "server.ts"), "utf8");
   const listen = source.indexOf("server.listen(port, hostname");
@@ -248,4 +309,40 @@ test("server lifecycle publishes only from listener readiness and performs nonce
   );
   assert.match(source, /process\.once\("SIGINT"/);
   assert.match(source, /process\.once\("SIGTERM"/);
+});
+
+test("the standalone server enforces ownership on Windows with this module's script", async () => {
+  const source = await readFile(resolve(process.cwd(), "server.ts"), "utf8");
+
+  // `--bundle=false` keeps server.mjs from importing path-ownership.ts, so the
+  // guard is inlined; these assertions are what stops the copy rotting back
+  // into the version that passed unconditionally on win32.
+  assert.doesNotMatch(
+    source,
+    /typeof process\.getuid === "function" && metadata\.uid !== process\.getuid\(\)/,
+    "the standalone owner guard must not short-circuit on a platform without getuid",
+  );
+  assert.match(
+    source,
+    /if \(process\.platform !== "win32"\) \{[\s\S]{0,240}?ownership cannot be verified on/,
+    "a platform with neither a uid nor a Windows ACL must be refused, not admitted",
+  );
+  assert.match(source, /assertStandaloneWindowsExclusive\(path, label\)/);
+
+  const script = (text: string, what: string): string => {
+    const match = /const WINDOWS_ACL_SCRIPT = `([\s\S]*?)`;/.exec(text);
+    assert.ok(match, `${what} must define WINDOWS_ACL_SCRIPT`);
+    return match![1]!;
+  };
+  assert.equal(
+    script(source, "server.ts"),
+    script(
+      await readFile(
+        resolve(process.cwd(), "src/lib/server/client-v1/path-ownership.ts"),
+        "utf8",
+      ),
+      "path-ownership.ts",
+    ),
+    "the inlined ACL script must stay identical to the module it copies",
+  );
 });

--- a/src/lib/server/client-v1/discovery.test.ts
+++ b/src/lib/server/client-v1/discovery.test.ts
@@ -309,6 +309,27 @@ test("server lifecycle publishes only from listener readiness and performs nonce
   );
   assert.match(source, /process\.once\("SIGINT"/);
   assert.match(source, /process\.once\("SIGTERM"/);
+
+  // The cleanup runs first inside the signal handler, so an ownership refusal
+  // there would escape it and kill the process before PTY children are
+  // terminated and the listener is closed — leaving behind the record this is
+  // supposed to remove. The guard could not throw on win32 until it learned to
+  // read a DACL; the cleanup must absorb it.
+  const cleanup =
+    /function cleanupStandaloneClientV1Discovery\(\): void \{[\s\S]*?\n\}/.exec(source);
+  assert.ok(cleanup, "server.ts must define cleanupStandaloneClientV1Discovery");
+  assert.match(
+    cleanup![0],
+    /try \{\s*removeStandaloneClientV1DiscoveryRecord\(CLIENT_V1_DISCOVERY_NONCE\);\s*\} catch/,
+    "an ownership refusal must skip the unlink, never abort shutdown",
+  );
+  const shutdown = /function shutdownHttpServer\(\): void \{[\s\S]*?\n\}/.exec(source);
+  assert.ok(shutdown, "server.ts must define shutdownHttpServer");
+  assert.ok(
+    shutdown![0].indexOf("cleanupStandaloneClientV1Discovery()")
+      < shutdown![0].indexOf("terminatePtySessions()"),
+    "cleanup runs before PTY teardown, which is why it must not be able to throw",
+  );
 });
 
 test("the standalone server enforces ownership on Windows with this module's script", async () => {

--- a/src/lib/server/client-v1/discovery.test.ts
+++ b/src/lib/server/client-v1/discovery.test.ts
@@ -329,20 +329,42 @@ test("the standalone server enforces ownership on Windows with this module's scr
   );
   assert.match(source, /assertStandaloneWindowsExclusive\(path, label\)/);
 
-  const script = (text: string, what: string): string => {
-    const match = /const WINDOWS_ACL_SCRIPT = `([\s\S]*?)`;/.exec(text);
-    assert.ok(match, `${what} must define WINDOWS_ACL_SCRIPT`);
-    return match![1]!;
+  const moduleSource = await readFile(
+    resolve(process.cwd(), "src/lib/server/client-v1/path-ownership.ts"),
+    "utf8",
+  );
+
+  // Compare every part of the copy that can drift, not just the PowerShell.
+  // The script text alone leaves three holes, each of which silently disarms
+  // the standalone server while this test stays green: the trusted-SID
+  // constants (the script names them by IDENTIFIER, so changing a value in one
+  // file only is invisible to a text compare), the JS-side verification that
+  // turns the report into a refusal, and the ACE filter inside it.
+  const region = (text: string, what: string, pattern: RegExp): string => {
+    const match = pattern.exec(text);
+    assert.ok(match, `${what} must define ${pattern.source.slice(0, 40)}…`);
+    return (match![1] ?? match![0])!;
   };
-  assert.equal(
-    script(source, "server.ts"),
-    script(
-      await readFile(
-        resolve(process.cwd(), "src/lib/server/client-v1/path-ownership.ts"),
-        "utf8",
-      ),
-      "path-ownership.ts",
-    ),
-    "the inlined ACL script must stay identical to the module it copies",
+  const parts: [string, RegExp][] = [
+    ["the inlined ACL script", /const WINDOWS_ACL_SCRIPT = `([\s\S]*?)`;/],
+    ["the trusted SYSTEM SID", /const WINDOWS_SYSTEM_SID = "([^"]+)";/],
+    ["the trusted Administrators SID", /const WINDOWS_ADMINISTRATORS_SID = "([^"]+)";/],
+    ["the trusted-principal set", /const trusted = new Set\(\[[^\]]*\]\);/],
+    [
+      "the exclusivity findings",
+      /if \(report\.owner !== report\.self\) \{[\s\S]*?if \(foreign\.length > 0\) \{[\s\S]*?\n {2}\}/,
+    ],
+  ];
+  for (const [what, pattern] of parts) {
+    assert.equal(
+      region(source, "server.ts", pattern),
+      region(moduleSource, "path-ownership.ts", pattern),
+      `${what} must stay identical to the module server.mjs cannot import`,
+    );
+  }
+  assert.match(
+    source,
+    /if \(findings\.length > 0\) \{\s*throw new Error\(/,
+    "the standalone server must refuse on any finding, not merely collect them",
   );
 });

--- a/src/lib/server/client-v1/discovery.ts
+++ b/src/lib/server/client-v1/discovery.ts
@@ -13,6 +13,10 @@ import { join, resolve } from "node:path";
 
 import { caveHome } from "../../coven-paths.ts";
 import { CLIENT_V1_DISCOVERY_CONTRACT } from "./contract.ts";
+import {
+  assertClientV1PathOwnership,
+  type ClientV1PathOwnershipOptions,
+} from "./path-ownership.ts";
 
 export const CLIENT_V1_DISCOVERY_FILE = CLIENT_V1_DISCOVERY_CONTRACT.fileName;
 
@@ -26,6 +30,7 @@ export interface ClientV1DiscoveryRecord {
 
 export interface ClientV1DiscoveryOptions {
   isProcessAlive?: (pid: number) => boolean;
+  ownership?: ClientV1PathOwnershipOptions;
   root?: string;
   temporaryRandomBytes?: (size: number) => Buffer;
 }
@@ -62,10 +67,13 @@ function processIsAlive(pid: number): boolean {
   }
 }
 
-function requireOwned(metadata: Awaited<ReturnType<typeof lstat>>, label: string): void {
-  if (typeof process.getuid === "function" && metadata.uid !== process.getuid()) {
-    throw new Error(`Client v1 discovery ${label} must be owned by the current user.`);
-  }
+function requireOwned(
+  path: string,
+  metadata: Awaited<ReturnType<typeof lstat>>,
+  label: string,
+  ownership: ClientV1PathOwnershipOptions | undefined,
+): Promise<void> {
+  return assertClientV1PathOwnership(path, metadata, `discovery ${label}`, ownership);
 }
 
 function requireEndpoint(value: unknown): string {
@@ -157,7 +165,10 @@ export function validateClientV1DiscoveryRecord(
   };
 }
 
-async function assertRegularTargetOrMissing(path: string): Promise<void> {
+async function assertRegularTargetOrMissing(
+  path: string,
+  ownership: ClientV1PathOwnershipOptions | undefined,
+): Promise<void> {
   try {
     const metadata = await lstat(path);
     if (!metadata.isFile() || metadata.isSymbolicLink()) {
@@ -165,14 +176,17 @@ async function assertRegularTargetOrMissing(path: string): Promise<void> {
         `Client v1 discovery target must be a regular file, not a symlink: ${path}.`,
       );
     }
-    requireOwned(metadata, "target");
+    await requireOwned(path, metadata, "target", ownership);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
     throw error;
   }
 }
 
-async function initializeLocation(configuredRoot: string): Promise<DiscoveryLocation> {
+async function initializeLocation(
+  configuredRoot: string,
+  ownership: ClientV1PathOwnershipOptions | undefined,
+): Promise<DiscoveryLocation> {
   const resolvedRoot = resolve(configuredRoot);
   try {
     const configuredMetadata = await lstat(resolvedRoot);
@@ -189,14 +203,19 @@ async function initializeLocation(configuredRoot: string): Promise<DiscoveryLoca
   if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
     throw new Error("Client v1 discovery root must be a real directory.");
   }
-  requireOwned(metadata, "root");
+  // Ownership first: on Windows the assertion is also what restricts the
+  // directory, and the chmod below is the no-op it has always been there.
+  await requireOwned(physicalRoot, metadata, "root", ownership);
   await chmod(physicalRoot, 0o700);
   const path = join(physicalRoot, CLIENT_V1_DISCOVERY_FILE);
-  await assertRegularTargetOrMissing(path);
+  await assertRegularTargetOrMissing(path, ownership);
   return { path, root: physicalRoot };
 }
 
-async function existingLocation(configuredRoot: string): Promise<DiscoveryLocation | null> {
+async function existingLocation(
+  configuredRoot: string,
+  ownership: ClientV1PathOwnershipOptions | undefined,
+): Promise<DiscoveryLocation | null> {
   const resolvedRoot = resolve(configuredRoot);
   try {
     const configuredMetadata = await lstat(resolvedRoot);
@@ -212,14 +231,17 @@ async function existingLocation(configuredRoot: string): Promise<DiscoveryLocati
   if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
     throw new Error("Client v1 discovery root must be a real directory.");
   }
-  requireOwned(metadata, "root");
+  await requireOwned(physicalRoot, metadata, "root", ownership);
   return {
     path: join(physicalRoot, CLIENT_V1_DISCOVERY_FILE),
     root: physicalRoot,
   };
 }
 
-async function assertLocation(location: DiscoveryLocation): Promise<void> {
+async function assertLocation(
+  location: DiscoveryLocation,
+  ownership: ClientV1PathOwnershipOptions | undefined,
+): Promise<void> {
   const metadata = await lstat(location.root);
   if (
     !metadata.isDirectory()
@@ -228,8 +250,8 @@ async function assertLocation(location: DiscoveryLocation): Promise<void> {
   ) {
     throw new Error("Client v1 discovery root was replaced.");
   }
-  requireOwned(metadata, "root");
-  await assertRegularTargetOrMissing(location.path);
+  await requireOwned(location.root, metadata, "root", ownership);
+  await assertRegularTargetOrMissing(location.path, ownership);
 }
 
 export function clientV1DiscoveryPath(root = caveHome()): string {
@@ -241,11 +263,11 @@ export async function publishClientV1DiscoveryRecord(
   options: ClientV1DiscoveryOptions = {},
 ): Promise<ClientV1DiscoveryRecord> {
   const record = validateClientV1DiscoveryRecord(value, options);
-  const location = await initializeLocation(options.root ?? caveHome());
+  const location = await initializeLocation(options.root ?? caveHome(), options.ownership);
   const random = options.temporaryRandomBytes ?? randomBytes;
 
   return runExclusive(location.path, async () => {
-    await assertLocation(location);
+    await assertLocation(location, options.ownership);
     const temporaryPath =
       `${location.path}.${process.pid}.${random(6).toString("hex")}.tmp`;
     let handle: Awaited<ReturnType<typeof open>> | null = null;
@@ -258,7 +280,7 @@ export async function publishClientV1DiscoveryRecord(
       await handle.sync();
       await handle.close();
       handle = null;
-      await assertLocation(location);
+      await assertLocation(location, options.ownership);
       await rename(temporaryPath, location.path);
       ownsTemporaryPath = false;
       await chmod(location.path, 0o600);
@@ -275,17 +297,19 @@ export async function publishClientV1DiscoveryRecord(
 
 export async function removeClientV1DiscoveryRecord({
   nonce,
+  ownership,
   root = caveHome(),
 }: {
   nonce: string;
+  ownership?: ClientV1PathOwnershipOptions;
   root?: string;
 }): Promise<boolean> {
   if (!nonce) return false;
-  const location = await existingLocation(root);
+  const location = await existingLocation(root, ownership);
   if (!location) return false;
 
   return runExclusive(location.path, async () => {
-    await assertLocation(location);
+    await assertLocation(location, ownership);
     let before: Awaited<ReturnType<typeof lstat>>;
     let raw: string;
     try {
@@ -298,7 +322,7 @@ export async function removeClientV1DiscoveryRecord({
     if (!before.isFile() || before.isSymbolicLink()) {
       throw new Error("Client v1 discovery target must be a regular file.");
     }
-    requireOwned(before, "target");
+    await requireOwned(location.path, before, "target", ownership);
 
     let parsed: unknown;
     try {

--- a/src/lib/server/client-v1/path-ownership.test.ts
+++ b/src/lib/server/client-v1/path-ownership.test.ts
@@ -7,6 +7,7 @@ import test, { type TestContext } from "node:test";
 
 import {
   assertClientV1PathOwnership,
+  parseClientV1WindowsAclReport,
   probeWindowsAcl,
   resetClientV1PathOwnershipCache,
   type ClientV1PathOwnershipOptions,
@@ -288,6 +289,60 @@ test("the real probe restricts and verifies a real path on Windows", async (t: T
   }
 });
 
+test("a malformed probe report is refused rather than read as an empty DACL", () => {
+  const exclusive = {
+    self: SELF_SID,
+    owner: SELF_SID,
+    protected: true,
+    repaired: false,
+    removed: [] as unknown[],
+    aces: [{ sid: SELF_SID, type: "Allow" }] as unknown[],
+  };
+  assert.deepEqual(
+    parseClientV1WindowsAclReport(JSON.stringify(exclusive)),
+    { ...exclusive, removed: [], aces: [{ sid: SELF_SID, type: "Allow" }] },
+  );
+
+  // `aces` carries the whole access decision. Coercing an unreadable one to `[]`
+  // reads as "no principal has access" and therefore ADMITS the path, so every
+  // shape that is not a list has to be an error. The only test that drives the
+  // real subprocess is win32-only, so this is where a POSIX runner sees it.
+  for (
+    const [what, raw] of [
+      ["aces absent", JSON.stringify({ ...exclusive, aces: undefined })],
+      ["aces a bare object", JSON.stringify({ ...exclusive, aces: { sid: USERS_SID, type: "Allow" } })],
+      ["aces a string", JSON.stringify({ ...exclusive, aces: "Allow" })],
+      ["removed absent", JSON.stringify({ ...exclusive, removed: undefined })],
+      ["self absent", JSON.stringify({ ...exclusive, self: undefined })],
+      ["self empty", JSON.stringify({ ...exclusive, self: "" })],
+      ["owner absent", JSON.stringify({ ...exclusive, owner: undefined })],
+      ["protected a string", JSON.stringify({ ...exclusive, protected: "true" })],
+      ["repaired absent", JSON.stringify({ ...exclusive, repaired: undefined })],
+      ["a bare array", "[]"],
+      ["a bare string", "\"nope\""],
+      ["null", "null"],
+    ] as const
+  ) {
+    assert.throws(
+      () => parseClientV1WindowsAclReport(raw),
+      /malformed report/,
+      `${what} must be refused, not defaulted`,
+    );
+  }
+
+  assert.throws(() => parseClientV1WindowsAclReport("not json at all"), SyntaxError);
+
+  // An entry the probe could not name is untrusted, never trusted-by-omission.
+  const nameless = parseClientV1WindowsAclReport(
+    JSON.stringify({ ...exclusive, aces: [{}, null, { sid: USERS_SID }] }),
+  );
+  assert.deepEqual(nameless.aces, [
+    { sid: "", type: "" },
+    { sid: "", type: "" },
+    { sid: USERS_SID, type: "" },
+  ]);
+});
+
 test("the ACL probe is spawned without this process's environment", async () => {
   // Both copies of the probe run inside the Cave server, which holds
   // COVEN_CAVE_ACCESS_TOKEN and COVEN_CAVE_AUTH_TOKEN. A subprocess that only
@@ -296,24 +351,51 @@ test("the ACL probe is spawned without this process's environment", async () => 
   // spread outright in server.ts.
   const { readFile } = await import("node:fs/promises");
   const { resolve } = await import("node:path");
-  for (const file of ["src/lib/server/client-v1/path-ownership.ts", "server.ts"]) {
+
+  // Assert the PROPERTY, not one spelling of the mistake. A ban on the literal
+  // `env: { ...process.env` is satisfied by `...process.env` one line lower, by
+  // `Object.assign({}, process.env, …)`, and by naming a secret outright — so
+  // instead: read the object each copy actually builds, and require that every
+  // `process.env` it reaches for is on this list. Both copies, because the
+  // regression CI caught existed in both and only one was ever checked here.
+  const ALLOWED = new Set(["NODE_ENV", "SystemRoot", "windir", "PATHEXT", "TEMP", "TMP"]);
+  const blocks: [string, RegExp][] = [
+    ["src/lib/server/client-v1/path-ownership.ts", /function windowsProbeEnv\([\s\S]*?\n}/],
+    ["server.ts", /const probeEnv: NodeJS\.ProcessEnv = \{[\s\S]*?\n {2}\};/],
+  ];
+  for (const [file, pattern] of blocks) {
     const source = await readFile(resolve(process.cwd(), file), "utf8");
     assert.doesNotMatch(
       source,
       /env: \{\s*\.\.\.process\.env/,
       `${file} must not hand the server's environment to the ACL probe`,
     );
-  }
 
-  const source = await readFile(
-    resolve(process.cwd(), "src/lib/server/client-v1/path-ownership.ts"),
-    "utf8",
-  );
-  const probeEnv = /function windowsProbeEnv\([\s\S]*?\n}/.exec(source);
-  assert.ok(probeEnv, "the probe environment must be built explicitly");
-  assert.doesNotMatch(
-    probeEnv![0],
-    /COVEN_CAVE_(?!CLIENT_V1_ACL_PATH)/,
-    "only the path under test may cross into the probe from the COVEN_CAVE namespace",
-  );
+    const block = pattern.exec(source);
+    assert.ok(block, `${file} must build the probe environment as an explicit literal`);
+    assert.doesNotMatch(
+      block![0],
+      /\.\.\./,
+      `${file} must not spread anything into the probe environment`,
+    );
+    assert.doesNotMatch(
+      block![0],
+      /Object\.assign|structuredClone/,
+      `${file} must not copy an environment into the probe wholesale`,
+    );
+    const reached = [...block![0].matchAll(/process\.env(?:\.(\w+)|\[\s*["'`](\w+)["'`]\s*\])/g)]
+      .map((match) => match[1] ?? match[2]!);
+    assert.ok(reached.length > 0, `${file} probe environment did not parse`);
+    for (const name of reached) {
+      assert.ok(
+        ALLOWED.has(name),
+        `${file} hands process.env.${name} to the ACL probe; only ${[...ALLOWED].join(", ")} may cross`,
+      );
+    }
+    assert.doesNotMatch(
+      block![0],
+      /COVEN_CAVE_(?!CLIENT_V1_ACL_PATH)/,
+      `${file}: only the path under test may cross into the probe from the COVEN_CAVE namespace`,
+    );
+  }
 });

--- a/src/lib/server/client-v1/path-ownership.test.ts
+++ b/src/lib/server/client-v1/path-ownership.test.ts
@@ -1,0 +1,289 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { type TestContext } from "node:test";
+
+import {
+  assertClientV1PathOwnership,
+  probeWindowsAcl,
+  resetClientV1PathOwnershipCache,
+  type ClientV1PathOwnershipOptions,
+  type ClientV1WindowsAclReport,
+} from "./path-ownership.ts";
+
+const SELF_SID = "S-1-5-21-11-22-33-1001";
+const SYSTEM_SID = "S-1-5-18";
+const ADMINISTRATORS_SID = "S-1-5-32-544";
+/** BUILTIN\Users — the shape of ACE a machine-wide profile policy inherits. */
+const USERS_SID = "S-1-5-32-545";
+
+function report(
+  overrides: Partial<ClientV1WindowsAclReport> = {},
+): ClientV1WindowsAclReport {
+  return {
+    self: SELF_SID,
+    owner: SELF_SID,
+    protected: true,
+    repaired: false,
+    removed: [],
+    aces: [
+      { sid: SELF_SID, type: "Allow" },
+      { sid: SYSTEM_SID, type: "Allow" },
+      { sid: ADMINISTRATORS_SID, type: "Allow" },
+    ],
+    ...overrides,
+  };
+}
+
+/**
+ * A Windows host as the module sees one: no `getuid`, `platform` win32.
+ *
+ * Every Windows assertion below runs on the Linux CI runners too, because the
+ * branch under test is unreachable on any machine CI owns — which is exactly
+ * how it stayed inert long enough to become an issue. The one test that needs
+ * a real DACL says so and skips with a diagnostic elsewhere.
+ */
+function windows(
+  overrides: Partial<ClientV1PathOwnershipOptions> = {},
+): ClientV1PathOwnershipOptions {
+  return {
+    platform: "win32",
+    getuid: null,
+    warn: () => {},
+    probeWindowsAcl: async () => report(),
+    ...overrides,
+  };
+}
+
+/** A path unique to one test, so the module-level success cache cannot leak. */
+let pathCounter = 0;
+function uniquePath(): string {
+  pathCounter += 1;
+  return `C:\\Users\\test\\.coven\\cave\\probe-${pathCounter}.json`;
+}
+
+test("compares uid where the platform has one", async () => {
+  await assertClientV1PathOwnership(uniquePath(), { uid: 1000 }, "credential store root", {
+    getuid: () => 1000,
+  });
+
+  await assert.rejects(
+    assertClientV1PathOwnership(uniquePath(), { uid: 1001 }, "credential store root", {
+      getuid: () => 1000,
+    }),
+    /Client v1 credential store root must be owned by the current user\./,
+  );
+});
+
+test("refuses a Windows path a foreign principal can write", async () => {
+  await assert.rejects(
+    assertClientV1PathOwnership(
+      uniquePath(),
+      { uid: 0 },
+      "credential store root",
+      windows({
+        probeWindowsAcl: async () =>
+          report({
+            aces: [
+              { sid: SELF_SID, type: "Allow" },
+              { sid: USERS_SID, type: "Allow" },
+            ],
+          }),
+      }),
+    ),
+    (error: Error) => {
+      assert.match(error.message, /is not exclusive to the current user/);
+      assert.match(error.message, new RegExp(`Allow:${USERS_SID}`));
+      assert.match(error.message, /inspect it with: icacls/);
+      return true;
+    },
+  );
+});
+
+test("refuses a Windows path owned by another principal", async () => {
+  await assert.rejects(
+    assertClientV1PathOwnership(
+      uniquePath(),
+      { uid: 0 },
+      "discovery target",
+      windows({ probeWindowsAcl: async () => report({ owner: "S-1-5-21-11-22-33-1002" }) }),
+    ),
+    /Client v1 discovery target is not exclusive to the current user: owned by S-1-5-21-11-22-33-1002, not S-1-5-21-11-22-33-1001/,
+  );
+});
+
+test("refuses a Windows path whose DACL still inherits", async () => {
+  await assert.rejects(
+    assertClientV1PathOwnership(
+      uniquePath(),
+      { uid: 0 },
+      "discovery root",
+      windows({ probeWindowsAcl: async () => report({ protected: false }) }),
+    ),
+    /its DACL still inherits from the parent/,
+  );
+});
+
+test("refuses a Windows path carrying a Deny entry for an untrusted principal", async () => {
+  await assert.rejects(
+    assertClientV1PathOwnership(
+      uniquePath(),
+      { uid: 0 },
+      "discovery root",
+      windows({
+        probeWindowsAcl: async () =>
+          report({ aces: [{ sid: SELF_SID, type: "Allow" }, { sid: USERS_SID, type: "Deny" }] }),
+      }),
+    ),
+    new RegExp(`Deny:${USERS_SID}`),
+  );
+});
+
+test("refuses when the Windows probe cannot answer, naming the cause", async () => {
+  const cause = new Error("spawn powershell.exe ENOENT");
+  await assert.rejects(
+    assertClientV1PathOwnership(
+      uniquePath(),
+      { uid: 0 },
+      "credential store file",
+      windows({
+        probeWindowsAcl: async () => {
+          throw cause;
+        },
+      }),
+    ),
+    (error: Error) => {
+      assert.match(
+        error.message,
+        /Client v1 credential store file ownership could not be verified on Windows: spawn powershell\.exe ENOENT/,
+      );
+      assert.equal((error as { cause?: unknown }).cause, cause);
+      return true;
+    },
+  );
+});
+
+test("refuses a platform that exposes neither a uid nor a Windows ACL", async () => {
+  const path = uniquePath();
+  await assert.rejects(
+    assertClientV1PathOwnership(path, { uid: 0 }, "credential store root", {
+      platform: "sunos",
+      getuid: null,
+    }),
+    new RegExp(
+      "Client v1 credential store root ownership cannot be verified on sunos: "
+      + "this platform exposes neither a uid nor a Windows ACL",
+    ),
+  );
+});
+
+test("admits a repaired Windows path but says so, naming what it revoked", async () => {
+  const warnings: string[] = [];
+  await assertClientV1PathOwnership(
+    uniquePath(),
+    { uid: 0 },
+    "credential store root",
+    windows({
+      warn: (message) => warnings.push(message),
+      probeWindowsAcl: async () => report({ repaired: true, removed: [USERS_SID] }),
+    }),
+  );
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0]!, /had no enforced access control on Windows/);
+  assert.match(warnings[0]!, new RegExp(`revoked ${USERS_SID}\\.`));
+});
+
+test("probes a verified Windows path once and a refused one every time", async () => {
+  const verified = uniquePath();
+  let verifiedProbes = 0;
+  const options = windows({
+    probeWindowsAcl: async () => {
+      verifiedProbes += 1;
+      return report();
+    },
+  });
+  await assertClientV1PathOwnership(verified, { uid: 0 }, "discovery root", options);
+  await assertClientV1PathOwnership(verified, { uid: 0 }, "discovery root", options);
+  assert.equal(verifiedProbes, 1, "a verified path must not re-spawn the probe per request");
+
+  // A refusal is never cached: repairing the DACL out of band has to take
+  // effect without restarting the server.
+  const refused = uniquePath();
+  let refusedProbes = 0;
+  const refusedOptions = windows({
+    probeWindowsAcl: async () => {
+      refusedProbes += 1;
+      return report({ protected: false });
+    },
+  });
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await assert.rejects(
+      assertClientV1PathOwnership(refused, { uid: 0 }, "discovery root", refusedOptions),
+    );
+  }
+  assert.equal(refusedProbes, 2);
+
+  resetClientV1PathOwnershipCache();
+  await assertClientV1PathOwnership(verified, { uid: 0 }, "discovery root", options);
+  assert.equal(verifiedProbes, 2, "resetting the cache must re-drive the probe");
+});
+
+test("the real probe restricts and verifies a real path on Windows", async (t: TestContext) => {
+  if (process.platform !== "win32") {
+    t.skip(
+      "the ACL probe is win32-only; the injected-probe tests above cover the same "
+      + "branch on every platform",
+    );
+    return;
+  }
+
+  const root = await mkdtemp(join(tmpdir(), "cave-client-v1-acl-"));
+  try {
+    const planted = join(root, "planted.json");
+    await writeFile(planted, "{}");
+
+    const first = await probeWindowsAcl(root);
+    assert.equal(first.self, first.owner, "the probe must run as the owner of a path it created");
+    assert.equal(first.protected, true, "the directory DACL must end up protected");
+    assert.deepEqual(
+      [...new Set(first.aces.map((ace) => ace.type))],
+      ["Allow"],
+      "no Deny entry may survive the repair",
+    );
+    for (const ace of first.aces) {
+      assert.ok(
+        [first.self, "S-1-5-18", "S-1-5-32-544"].includes(ace.sid),
+        `unexpected principal on the repaired DACL: ${ace.sid}`,
+      );
+    }
+
+    // Whatever the machine's profile policy inherits, this is what the guard
+    // exists to catch: hand an untrusted principal write access and the next
+    // probe must both see it and take it away.
+    execFileSync("icacls.exe", [planted, "/grant", `*${USERS_SID}:(M)`], {
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    const repaired = await probeWindowsAcl(planted);
+    assert.equal(repaired.repaired, true, "a foreign grant must be detected");
+    assert.ok(
+      repaired.removed.includes(USERS_SID),
+      `the repair must revoke ${USERS_SID}, revoked: ${repaired.removed.join(", ") || "nothing"}`,
+    );
+    assert.equal(
+      repaired.aces.some((ace) => ace.sid === USERS_SID),
+      false,
+      "the foreign grant must be gone from the DACL",
+    );
+
+    // And the whole assertion, end to end, through the exported guard.
+    await assertClientV1PathOwnership(planted, { uid: 0 }, "credential store file", {
+      warn: () => {},
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/src/lib/server/client-v1/path-ownership.test.ts
+++ b/src/lib/server/client-v1/path-ownership.test.ts
@@ -287,3 +287,33 @@ test("the real probe restricts and verifies a real path on Windows", async (t: T
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("the ACL probe is spawned without this process's environment", async () => {
+  // Both copies of the probe run inside the Cave server, which holds
+  // COVEN_CAVE_ACCESS_TOKEN and COVEN_CAVE_AUTH_TOKEN. A subprocess that only
+  // has to read a DACL must not receive them — the same rule sanitizedEnv()
+  // enforces for PTY shells, and the reason `server-pty-ws.test.ts` bans the
+  // spread outright in server.ts.
+  const { readFile } = await import("node:fs/promises");
+  const { resolve } = await import("node:path");
+  for (const file of ["src/lib/server/client-v1/path-ownership.ts", "server.ts"]) {
+    const source = await readFile(resolve(process.cwd(), file), "utf8");
+    assert.doesNotMatch(
+      source,
+      /env: \{\s*\.\.\.process\.env/,
+      `${file} must not hand the server's environment to the ACL probe`,
+    );
+  }
+
+  const source = await readFile(
+    resolve(process.cwd(), "src/lib/server/client-v1/path-ownership.ts"),
+    "utf8",
+  );
+  const probeEnv = /function windowsProbeEnv\([\s\S]*?\n}/.exec(source);
+  assert.ok(probeEnv, "the probe environment must be built explicitly");
+  assert.doesNotMatch(
+    probeEnv![0],
+    /COVEN_CAVE_(?!CLIENT_V1_ACL_PATH)/,
+    "only the path under test may cross into the probe from the COVEN_CAVE namespace",
+  );
+});

--- a/src/lib/server/client-v1/path-ownership.ts
+++ b/src/lib/server/client-v1/path-ownership.ts
@@ -125,12 +125,42 @@ if (-not (Test-Exclusive $state)) {
 } | ConvertTo-Json -Compress -Depth 4
 `;
 
+function windowsSystemRoot(): string {
+  return process.env.SystemRoot || process.env.windir || "C:\\Windows";
+}
+
 function windowsPowerShellPath(): string {
   // Absolute, never PATH: an attacker who can prepend a directory to PATH could
   // otherwise answer the ownership question with their own `powershell.exe`,
   // which is the one spoof a guard like this must not accept.
-  const systemRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
-  return join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+  return join(windowsSystemRoot(), "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
+
+/**
+ * The smallest environment PowerShell needs, never the server's own.
+ *
+ * This process holds `COVEN_CAVE_ACCESS_TOKEN` and `COVEN_CAVE_AUTH_TOKEN`;
+ * a subprocess that only has to read a DACL has no business receiving them.
+ * `SystemRoot`/`windir` locate the runtime, `PATHEXT` and a System32-only
+ * `PATH` keep command resolution inside the system directory, and `TEMP`/`TMP`
+ * give the host somewhere to write. The path under test travels here too, so
+ * no quoting rule stands between a path containing a quote or a `$` and the
+ * identity being checked.
+ */
+function windowsProbeEnv(path: string): NodeJS.ProcessEnv {
+  const systemRoot = windowsSystemRoot();
+  const system32 = join(systemRoot, "System32");
+  return {
+    COVEN_CAVE_CLIENT_V1_ACL_PATH: path,
+    // Next augments ProcessEnv to require this. It carries no secret.
+    NODE_ENV: process.env.NODE_ENV,
+    SystemRoot: systemRoot,
+    windir: systemRoot,
+    PATH: system32,
+    PATHEXT: process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD",
+    TEMP: process.env.TEMP || process.env.TMP || join(systemRoot, "Temp"),
+    TMP: process.env.TMP || process.env.TEMP || join(systemRoot, "Temp"),
+  };
 }
 
 function parseAclReport(raw: string): ClientV1WindowsAclReport {
@@ -175,9 +205,7 @@ export const probeWindowsAcl: ClientV1WindowsAclProbe = async (path) => {
       WINDOWS_ACL_SCRIPT,
     ],
     {
-      // The path travels in the environment so no quoting rule stands between a
-      // path containing a quote or a `$` and the identity being checked.
-      env: { ...process.env, COVEN_CAVE_CLIENT_V1_ACL_PATH: path },
+      env: windowsProbeEnv(path),
       encoding: "utf8",
       windowsHide: true,
       timeout: 15_000,

--- a/src/lib/server/client-v1/path-ownership.ts
+++ b/src/lib/server/client-v1/path-ownership.ts
@@ -1,0 +1,303 @@
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * SIDs whose access to a client v1 path is not a finding.
+ *
+ * SYSTEM and the local Administrators group can already take ownership of any
+ * file and rewrite its DACL, so denying them buys no confidentiality and only
+ * breaks backup and anti-malware agents. Everything else — including the
+ * `Users` and `Authenticated Users` groups that a machine-wide profile policy
+ * may inherit onto `%USERPROFILE%` — is a principal that could mint a bearer,
+ * so it is stripped and then refused if it survives.
+ */
+const WINDOWS_SYSTEM_SID = "S-1-5-18";
+const WINDOWS_ADMINISTRATORS_SID = "S-1-5-32-544";
+
+/** Result of one `windows-acl` probe: the state of the path after any repair. */
+export interface ClientV1WindowsAclReport {
+  /** SID of the identity this process runs as. */
+  self: string;
+  /** SID that owns the path. */
+  owner: string;
+  /** Whether the DACL is protected from inheritance. */
+  protected: boolean;
+  /** Whether the probe had to rewrite the DACL to reach the exclusive state. */
+  repaired: boolean;
+  /** SIDs the repair stripped, empty when nothing had to change. */
+  removed: string[];
+  /** The DACL as it stands now. */
+  aces: { sid: string; type: string }[];
+}
+
+export type ClientV1WindowsAclProbe = (path: string) => Promise<ClientV1WindowsAclReport>;
+
+export interface ClientV1PathOwnershipOptions {
+  /**
+   * Seams for tests. `platform`/`getuid` select the branch and
+   * `probeWindowsAcl` stands in for the PowerShell subprocess, so the Windows
+   * branch is exercised on the Linux runners too — the branch is otherwise
+   * dead on every machine CI owns, which is how it stayed inert.
+   */
+  platform?: NodeJS.Platform;
+  getuid?: (() => number) | null;
+  probeWindowsAcl?: ClientV1WindowsAclProbe;
+  warn?: (message: string) => void;
+}
+
+/**
+ * Windows PowerShell reads and repairs the DACL; `stat` cannot.
+ *
+ * Node reports `uid: 0` for every path on win32 and `chmod` there sets nothing
+ * but the read-only bit, so neither half of the POSIX contract this module
+ * enforces has a native equivalent. `GetAccessControl("Access")` writes only
+ * the DACL section — `Set-Acl`, which also carries owner and audit sections,
+ * fails with `PrivilegeNotHeldException` (SeSecurityPrivilege) against an
+ * already-protected path.
+ *
+ * Ownership is verified, never taken: a path owned by somebody else is a
+ * finding to report, not a race to win.
+ */
+const WINDOWS_ACL_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+$item = Get-Item -LiteralPath $env:COVEN_CAVE_CLIENT_V1_ACL_PATH -Force
+$me = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+$system = New-Object System.Security.Principal.SecurityIdentifier('${WINDOWS_SYSTEM_SID}')
+$admins = New-Object System.Security.Principal.SecurityIdentifier('${WINDOWS_ADMINISTRATORS_SID}')
+$trusted = @($me.Value, $system.Value, $admins.Value)
+
+function Read-State {
+  param($target)
+  $acl = $target.GetAccessControl('Access,Owner')
+  $aces = @($acl.Access | ForEach-Object {
+    [pscustomobject]@{
+      sid = $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value
+      type = [string]$_.AccessControlType
+    }
+  })
+  [pscustomobject]@{
+    owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier]).Value
+    protected = [bool]$acl.AreAccessRulesProtected
+    aces = $aces
+  }
+}
+
+function Test-Exclusive {
+  param($state)
+  if (-not $state.protected) { return $false }
+  if ($state.owner -ne $me.Value) { return $false }
+  foreach ($ace in $state.aces) {
+    if ($ace.type -ne 'Allow') { return $false }
+    if ($trusted -notcontains $ace.sid) { return $false }
+  }
+  return $true
+}
+
+$state = Read-State $item
+$repaired = $false
+$removed = @()
+if (-not (Test-Exclusive $state)) {
+  $removed = @($state.aces | Where-Object { $trusted -notcontains $_.sid } |
+    ForEach-Object { $_.sid } | Select-Object -Unique)
+  $acl = $item.GetAccessControl('Access')
+  $acl.SetAccessRuleProtection($true, $false)
+  foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRule($rule) }
+  $inheritance = if ($item.PSIsContainer) { 'ContainerInherit, ObjectInherit' } else { 'None' }
+  foreach ($sid in @($me, $system, $admins)) {
+    $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+      $sid, 'FullControl', $inheritance, 'None', 'Allow')))
+  }
+  $item.SetAccessControl($acl)
+  $repaired = $true
+  $state = Read-State $item
+}
+
+[pscustomobject]@{
+  self = $me.Value
+  owner = $state.owner
+  protected = $state.protected
+  repaired = $repaired
+  removed = @($removed)
+  aces = $state.aces
+} | ConvertTo-Json -Compress -Depth 4
+`;
+
+function windowsPowerShellPath(): string {
+  // Absolute, never PATH: an attacker who can prepend a directory to PATH could
+  // otherwise answer the ownership question with their own `powershell.exe`,
+  // which is the one spoof a guard like this must not accept.
+  const systemRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
+  return join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
+
+function parseAclReport(raw: string): ClientV1WindowsAclReport {
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  const aces = Array.isArray(parsed.aces) ? parsed.aces : [];
+  const removed = Array.isArray(parsed.removed) ? parsed.removed : [];
+  if (
+    typeof parsed.self !== "string"
+    || !parsed.self
+    || typeof parsed.owner !== "string"
+    || !parsed.owner
+    || typeof parsed.protected !== "boolean"
+    || typeof parsed.repaired !== "boolean"
+  ) {
+    throw new Error("the ACL probe returned a malformed report");
+  }
+  return {
+    self: parsed.self,
+    owner: parsed.owner,
+    protected: parsed.protected,
+    repaired: parsed.repaired,
+    removed: removed.map((sid) => String(sid)),
+    aces: aces.map((ace) => {
+      const entry = (ace ?? {}) as Record<string, unknown>;
+      return { sid: String(entry.sid ?? ""), type: String(entry.type ?? "") };
+    }),
+  };
+}
+
+export const probeWindowsAcl: ClientV1WindowsAclProbe = async (path) => {
+  const { stdout } = await execFileAsync(
+    windowsPowerShellPath(),
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-NoLogo",
+      "-InputFormat",
+      "None",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      WINDOWS_ACL_SCRIPT,
+    ],
+    {
+      // The path travels in the environment so no quoting rule stands between a
+      // path containing a quote or a `$` and the identity being checked.
+      env: { ...process.env, COVEN_CAVE_CLIENT_V1_ACL_PATH: path },
+      encoding: "utf8",
+      windowsHide: true,
+      timeout: 15_000,
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  return parseAclReport(stdout);
+};
+
+/**
+ * Findings that make a path unusable, or an empty list when it is exclusive.
+ */
+function exclusivityFindings(report: ClientV1WindowsAclReport): string[] {
+  const findings: string[] = [];
+  const trusted = new Set([report.self, WINDOWS_SYSTEM_SID, WINDOWS_ADMINISTRATORS_SID]);
+  if (report.owner !== report.self) {
+    findings.push(`owned by ${report.owner}, not ${report.self}`);
+  }
+  if (!report.protected) findings.push("its DACL still inherits from the parent");
+  const foreign = report.aces
+    .filter((ace) => ace.type !== "Allow" || !trusted.has(ace.sid))
+    .map((ace) => `${ace.type}:${ace.sid}`);
+  if (foreign.length > 0) {
+    findings.push(`access granted to ${[...new Set(foreign)].join(", ")}`);
+  }
+  return findings;
+}
+
+/**
+ * Successful verifications, keyed by path.
+ *
+ * A probe costs ~290 ms, and `verify`/`findByBearer` run it once per
+ * authenticated request, so caching is what keeps the Windows branch off the
+ * hot path. Only successes are cached: a path that fails is re-probed, so
+ * repairing the ACL out of band does not require a restart. Cached success is
+ * per process, so unlike the POSIX branch this does not re-detect a DACL
+ * loosened mid-run — the symlink and realpath guards at the same call sites
+ * still do run every time.
+ */
+const verifiedWindowsPaths = new Map<string, ClientV1WindowsAclReport>();
+
+/** Test seam: drop cached verifications so a suite can re-drive the probe. */
+export function resetClientV1PathOwnershipCache(): void {
+  verifiedWindowsPaths.clear();
+}
+
+/**
+ * Refuse a client v1 path that another principal could write.
+ *
+ * Writing `client-v1-credentials.json` mints authority — the parser validates
+ * shape and nothing else — and writing `client-v1-discovery.json` points a
+ * client at an attacker's port, so "some other principal can write here" is
+ * the whole of the threat and the only question worth asking of the path.
+ *
+ * The POSIX branch is the uid comparison this has always made. The Windows
+ * branch replaces a `typeof process.getuid === "function"` guard that was
+ * false on win32 and therefore passed unconditionally. Anything else — a
+ * platform with neither `getuid` nor a Windows ACL — is refused rather than
+ * waved through, because being unable to answer the question is not an answer.
+ */
+export async function assertClientV1PathOwnership(
+  path: string,
+  // `lstat` widens to `Stats | BigIntStats`, so accept both rather than make
+  // every call site narrow a union it never actually produces.
+  metadata: { uid: number | bigint },
+  label: string,
+  options: ClientV1PathOwnershipOptions = {},
+): Promise<void> {
+  const platform = options.platform ?? process.platform;
+  const getuid = options.getuid === undefined ? process.getuid : options.getuid;
+
+  if (typeof getuid === "function") {
+    if (metadata.uid !== getuid()) {
+      throw new Error(`Client v1 ${label} must be owned by the current user.`);
+    }
+    return;
+  }
+
+  if (platform !== "win32") {
+    throw new Error(
+      `Client v1 ${label} ownership cannot be verified on ${platform}: `
+      + `this platform exposes neither a uid nor a Windows ACL, so ${path} is refused.`,
+    );
+  }
+
+  if (verifiedWindowsPaths.has(path)) return;
+
+  const probe = options.probeWindowsAcl ?? probeWindowsAcl;
+  let report: ClientV1WindowsAclReport;
+  try {
+    report = await probe(path);
+  } catch (cause) {
+    throw new Error(
+      `Client v1 ${label} ownership could not be verified on Windows: `
+      + `${(cause as Error).message}. Refusing ${path}; inspect it with: icacls "${path}"`,
+      { cause },
+    );
+  }
+
+  const findings = exclusivityFindings(report);
+  if (findings.length > 0) {
+    throw new Error(
+      `Client v1 ${label} is not exclusive to the current user: ${findings.join("; ")}. `
+      + `Refusing ${path}; inspect it with: icacls "${path}"`,
+    );
+  }
+
+  if (report.repaired) {
+    // Expected on first run for every existing install — `%USERPROFILE%`
+    // inherits group ACEs by default and `chmod(0o700)` never stripped them —
+    // so this is a notice, not an incident. It still has to be said: until this
+    // repair the store carried no enforced access control at all.
+    const removed = report.removed.length > 0
+      ? report.removed.join(", ")
+      : "inherited entries";
+    (options.warn ?? console.warn)(
+      `Client v1 ${label} had no enforced access control on Windows; `
+      + `restricted ${path} to the current user and revoked ${removed}.`,
+    );
+  }
+
+  verifiedWindowsPaths.set(path, report);
+}

--- a/src/lib/server/client-v1/path-ownership.ts
+++ b/src/lib/server/client-v1/path-ownership.ts
@@ -163,10 +163,25 @@ function windowsProbeEnv(path: string): NodeJS.ProcessEnv {
   };
 }
 
-function parseAclReport(raw: string): ClientV1WindowsAclReport {
+/**
+ * Parse one probe's stdout, refusing anything that is not the whole report.
+ *
+ * `aces` carries the entire access decision, so a shape this cannot read has to
+ * be an error rather than a default. Coercing a malformed `aces` to `[]` — which
+ * is what an earlier revision did — reads as "no principal has access" and
+ * therefore *admits* the path: the one field worth being strict about was the
+ * one field being forgiven. Nothing exercises that on a POSIX runner either,
+ * because the only test that drives the real subprocess is win32-only.
+ *
+ * Exported for the parser tests, which are the platform-independent coverage
+ * the subprocess itself cannot have.
+ */
+export function parseClientV1WindowsAclReport(raw: string): ClientV1WindowsAclReport {
   const parsed = JSON.parse(raw) as Record<string, unknown>;
-  const aces = Array.isArray(parsed.aces) ? parsed.aces : [];
-  const removed = Array.isArray(parsed.removed) ? parsed.removed : [];
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("the ACL probe returned a malformed report");
+  }
+  const { aces, removed } = parsed;
   if (
     typeof parsed.self !== "string"
     || !parsed.self
@@ -174,6 +189,8 @@ function parseAclReport(raw: string): ClientV1WindowsAclReport {
     || !parsed.owner
     || typeof parsed.protected !== "boolean"
     || typeof parsed.repaired !== "boolean"
+    || !Array.isArray(aces)
+    || !Array.isArray(removed)
   ) {
     throw new Error("the ACL probe returned a malformed report");
   }
@@ -212,7 +229,7 @@ export const probeWindowsAcl: ClientV1WindowsAclProbe = async (path) => {
       maxBuffer: 1024 * 1024,
     },
   );
-  return parseAclReport(stdout);
+  return parseClientV1WindowsAclReport(stdout);
 };
 
 /**


### PR DESCRIPTION
Closes #4842.

## The defect, measured rather than assumed

Every filesystem ownership guard in the client-v1 authority was
`typeof process.getuid === "function" && metadata.uid !== process.getuid()`.
On win32 the first operand is false, so the conjunction is false and the guard
passes unconditionally. Measured on this Windows 11 host:

| probe | result |
| --- | --- |
| `typeof process.getuid` | `undefined` |
| `os.userInfo().uid` | `-1` |
| `lstat(dir).uid` / `lstat(file).uid` | `0` / `0` |
| `chmod(file, 0o600)` then `stat().mode & 0o777` | `0o666` — unchanged |
| DACL of a **new** file in `%USERPROFILE%` | `Allow Modify` to `…-1002` **and** `S-1-5-21-2425639158-…-2471593247`, both inherited |

So the uid comparison was inert, and had it run it would have compared `0` to
`0`. `chmod` did not even set the read-only bit at `0o600`. The credential
store and the discovery record had **no enforced access control on Windows**,
and nothing said so.

The last row is why this is not theoretical: a file this code creates in the
cave home is writable by two principals that are not the user. Writing
`client-v1-credentials.json` mints authority — the parser validates shape and
nothing else — and writing `client-v1-discovery.json` points a client at an
attacker-controlled loopback port.

## The design decision

The issue offered a real ACL check or a fail-closed diagnostic. Three
measurements drove the choice:

1. **An owner-SID check would have been theatre.** The measured DACL has the
   *right owner* and the *wrong access*. Comparing owner SIDs would have
   returned "fine" on a file two other principals could write. The security
   property is write access, so the check is on the DACL.
2. **Verify-only would have bricked this machine, not protected it.** Those
   inherited Modify ACEs come from the profile policy, so a verify-only guard
   refuses on first run and stays refusing, with no action the user can take
   from inside the app. The issue names the mode half of the defect
   explicitly — `chmod(0o700)` is what `initializeLocation` already calls and
   what Windows silently ignores — so **performing that restriction is finishing
   the existing contract, not new policy.** On POSIX the directory is already
   user-only; Windows now matches.
3. **Shelling out per read is not acceptable, and does not have to happen.**
   One PowerShell launch measured 270–360 ms, and `verify`/`findByBearer` run
   the location assertion once per authenticated request. Successes are
   therefore cached per path, so the probe runs once per path per process.
   Failures are **not** cached, so repairing a DACL out of band takes effect
   without a restart.

So: read the DACL, restrict the path to the current user (plus SYSTEM and
Administrators, which can take ownership regardless — denying them buys no
confidentiality and breaks backup and AV agents), verify the result, and refuse
with the exact `icacls` command when it cannot be reached. Ownership is
**verified, never taken**: a path owned by somebody else is a finding to
report, not a race to win.

Two spoofing notes. `powershell.exe` is resolved from `%SystemRoot%`, never
PATH — an attacker who can prepend a PATH entry must not get to answer the
ownership question. The path travels in the environment, not the command line,
so no quoting rule stands between a path containing a quote and the check.

Anything that can answer neither question — no `getuid`, not win32 — is now
**refused** rather than waved through.

### Two implementation details worth knowing

- `Set-Acl` fails with `PrivilegeNotHeldException` (SeSecurityPrivilege)
  against an already-protected path, because it carries owner and audit
  sections. `GetAccessControl("Access")` + `SetAccessControl` writes the DACL
  only and is idempotent. Measured: first call repairs, second call reports
  `repaired: false` and performs no write at all.
- Restricting the directory propagates to children by inheritance, including
  ones that already exist, so the temp file `writeStoreAtomic` creates is
  exclusive before it is renamed into place.

## What changed

- **`src/lib/server/client-v1/path-ownership.ts`** (new) — the platform-aware
  guard. POSIX keeps the uid comparison unchanged; win32 gets the DACL probe;
  anything else is refused.
- **`discovery.ts`** — `requireOwned` now delegates; `ownership` threads through
  `publishClientV1DiscoveryRecord` and `removeClientV1DiscoveryRecord`.
- **`credential-store.ts`** — gained an ownership check it **never had on any
  platform**, at the root and at the store file.
- **`server.ts`** — `build:server` runs esbuild with `--bundle=false`, so the
  standalone server cannot import from `src/`; the guard is inlined, and
  `discovery.test.ts` fails if the inlined ACL script drifts from the module's.

## Failing test first

Reverting the three production files to `e58f755af` and deleting the new module,
then running the new tests unchanged:

```
discovery.test.ts        tests 8   pass 5   fail 2
  ✖ refuses to publish or remove a discovery record a foreign Windows principal can write
      AssertionError: Missing expected rejection.
  ✖ the standalone server enforces ownership on Windows with this module's script
      AssertionError: the standalone owner guard must not short-circuit on a platform without getuid
credential-store.test.ts tests 19  pass 17  fail 1
  ✖ refuses a credential store a foreign Windows principal can write
      AssertionError: Missing expected rejection.
path-ownership.test.ts   ERR_MODULE_NOT_FOUND
```

"Missing expected rejection" is the bug stated precisely: pre-fix, publishing a
discovery record and issuing a credential on a root a foreign Windows principal
can write both **succeed**.

## Cross-platform, and not vacuous

The Windows branch is unreachable on every machine CI owns, which is how it
stayed inert long enough to become an issue. So `platform`, `getuid` and the ACL
probe are injectable, and **every Windows assertion runs on the Linux runners
too** — they are ordinary assertions there, not skips. Exactly one test needs a
real DACL; it says so and `t.skip`s elsewhere with a reason, and it is additive
rather than load-bearing. On Windows it runs for real: it grants `S-1-5-32-545`
Modify with `icacls` and asserts the next probe both detects and revokes it.

## Mutation matrix

15 mutations, 15 killed. Each was applied, the test run, then reverted; the tree
was verified clean after every batch.

| # | mutation | result |
| --- | --- | --- |
| M1 | owner-SID check disabled | KILLED — *owned by another principal* |
| M2 | `protected` check disabled | KILLED — *DACL still inherits* (+1) |
| M3 | foreign-ACE filter disabled | KILLED — *foreign principal can write*, *Deny entry* |
| M4 | cache failures as well as successes | KILLED — *probes a verified path once…* |
| M5 | unsupported platform admitted | KILLED — *neither a uid nor a Windows ACL* |
| M6 | `repaired` warning dropped | KILLED — *admits a repaired path but says so* |
| M7 | probe-error diagnostic dropped | KILLED — *probe cannot answer, naming the cause* |
| M8 | PowerShell `Test-Exclusive` always true | KILLED — *the real probe…* (Windows) |
| M9 | POSIX uid comparison disabled | KILLED — *compares uid where the platform has one* |
| M10 | inlined ACL script altered | KILLED — parity assertion |
| M11 | inert `getuid` guard restored in server.ts | KILLED — parity assertion |
| M12 | discovery root check removed at **one** site | **SURVIVED** → M14 |
| M13 | credential root check removed at **one** site | **SURVIVED** → M15 |
| M14 | discovery root check removed at **both** sites | KILLED |
| M15 | credential root check removed at **both** sites | KILLED |
| M16 | credential **file** check removed | **SURVIVED** → test added → KILLED |

M12/M13 survived because each site has a redundant sibling (init-time and
per-operation), which M14/M15 confirm: the invariant is covered, just not
attributable to a single line. That redundancy is the pre-existing structure and
is kept deliberately.

**M16 was a real gap and is the reason mutation testing earned its keep.** The
root can be exclusive while the file is not — a record planted before the
directory was ever restricted keeps its own inherited DACL — and no test covered
it. `refuses a planted credential file a foreign Windows principal can write`
now drives a path-aware probe so only the file check can produce the refusal.

No existing assertion was weakened or deleted.

## Gates

```
pnpm typecheck          EXIT=0
pnpm lint               EXIT=0  (0 file(s) with drift; eslint --max-warnings=0)
pnpm check:tests-wired  EXIT=0  ✓ all 1793 test files wired into CI
pnpm build              EXIT=0  ✓ bundle-budget / standalone-budget within budget
```

Every touched test, run under the exact argv `scripts/run-tests.mjs`
`nodeArgsFor` produces:

```
path-ownership.test.ts   tests 10  pass 10  fail 0  skipped 0
discovery.test.ts        tests 8   pass 7   fail 0  skipped 1
credential-store.test.ts tests 20  pass 19  fail 0  skipped 1
auth.test.ts             tests 17  pass 17  fail 0  skipped 0
runtime.test.ts          tests 1   pass 1   fail 0  skipped 0
```

The skips are the pre-existing Windows symlink-privilege skips, unchanged.

## Operator-visible change

First run on Windows restricts `~/.coven/cave` and the two client-v1 files to
the current user and logs one line naming what it revoked. That is expected for
every existing install — `%USERPROFILE%` inherits group ACEs by default and
`chmod(0o700)` never stripped them — so it is a notice, not an incident. It
still has to be said: until that repair the store carried no enforced access
control at all.

---

## Follow-up: the first CI run caught a real defect

`Frontend validation (API tests)` failed at `src/server-pty-ws.test.ts`, on an
assertion that predates this PR:

```
assert.doesNotMatch(src, /env: \{\s*\.\.\.process\.env/,
  "spawnPty must not spread raw process.env — pnpm leaks npm_config_* into it");
```

It is written file-wide over `server.ts`, and the first version of the inlined
probe spread `process.env` into PowerShell. That process holds
`COVEN_CAVE_ACCESS_TOKEN` and `COVEN_CAVE_AUTH_TOKEN`, so a subprocess whose
entire job is to read a DACL was being handed the server's bearer secrets. The
rule was written for PTY shells and is just as right here.

**Not weakened — fixed.** Both copies now build a minimal environment:
`SystemRoot`/`windir` to locate the runtime, a System32-only `PATH` with
`PATHEXT` so command resolution stays inside the system directory, `TEMP`/`TMP`,
and the path under test. Verified against real PowerShell on Windows: the probe
still reads and repairs a DACL with nothing else inherited (`tests 11 pass 11`).

Nothing covered this for `path-ownership.ts`, which spawns the same subprocess
from the same process, so a guard was added there and mutation-checked:

| # | mutation | result |
| --- | --- | --- |
| M18 | `path-ownership.ts` reintroduces the spread | KILLED |
| M19 | `server.ts` reintroduces the spread | KILLED |
| M20 | a `COVEN_CAVE_` secret added to the probe env | KILLED |

Running total: **18 mutations, 18 killed.**

`NODE_ENV` is passed through because Next augments `ProcessEnv` to require it;
it carries no secret.

### Gates re-run on `19599f1`

```
pnpm typecheck          EXIT=0
pnpm lint               EXIT=0
pnpm check:tests-wired  EXIT=0  ✓ all 1793 test files wired into CI
pnpm build              EXIT=0
src/server-pty-ws.test.ts  EXIT=0   (the test that caught it)
path-ownership.test.ts   tests 11  pass 11  fail 0
discovery.test.ts        tests 8   pass 7   fail 0  skipped 1
credential-store.test.ts tests 20  pass 19  fail 0  skipped 1
```

`server.mjs` is regenerated and committed — `server-pty-ws.test.ts` also asserts
the artifact matches `server.ts`.
