### PR TITLE
Bind the client-v1 ingress gate to every path it claims (cave-uuxga)

### DIFF
--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -121,9 +121,10 @@ are reachable on the eight routes that exist.
 
 ## Reaching the API at all
 
-Four checks sit in front of every route here, none of them in the route file: a
-loopback `Host` gate, a cross-origin gate, control-plane body rules, and a
-direct-loopback peer gate. Every one of them answers in a **different shape from
+Five checks sit in front of every route here, none of them in the route file: a
+request-target refusal for escaped paths, a loopback `Host` gate, a
+cross-origin gate, control-plane body rules, and a direct-loopback peer gate.
+Every one of them answers in a **different shape from
 the envelope above**: the proxy returns `{"ok": false, "error": "<reason>"}`. A
 client that assumes every response parses as a Client v1 envelope will fail to
 read its own rejection. Branch on the HTTP status first.
@@ -154,28 +155,47 @@ the check fails closed: every route that depends on it answers 401 or 403.
 That branch also *skips* the mobile-access gate, which is why a phone reaching
 in over Tailscale Serve gets the 403 above rather than a mobile-auth prompt.
 
-Two of the four public routes re-check the stamp in the route itself
-(`POST /pairing/requests` and `POST .../exchange`, via
-`runtime.authenticator.isTrustedLoopback`) and answer `unauthorized` in the
-envelope when it fails. `GET /pairing/requests/:id` does not: it takes its
-locality entirely from the proxy branch, and its own 401s are about the pairing
-secret. `GET /health` performs no check of its own either — it is local because
-the proxy branch above says so, and for no other reason.
+Three of the four public routes re-check the stamp in the route itself
+(`POST /pairing/requests`, `GET /pairing/requests/:id`, and `POST .../exchange`,
+via `runtime.authenticator.isTrustedLoopback`) and answer `unauthorized` in the
+envelope when it fails. `GET /health` performs no check of its own — it is local
+because the proxy branch above says so, and for no other reason. It returns no
+user data and no paths.
 
-**That difference is load-bearing, because the proxy branch has a hole
-(`cave-f1xki`).** `clientV1IngressKind` returns `null` for any pathname
-containing `%` or `\`, while Next still percent-decodes a dynamic segment before
-matching it — so a pairing id written with one percent-escaped character
-classifies as *not* client-v1 ingress and reaches the handler anyway, skipping
-both the direct-loopback branch above and the body rules below. It is not an
-open door: such a request now has to satisfy the ordinary API gate instead, so
-an unauthenticated caller is refused where the plain path would have been
-served. But a caller that already holds the sidecar token or the mobile access
-credential can use it to reach `GET /pairing/requests/:id` from **off the
-machine**, which the 403 above otherwise forbids. `POST .../exchange` is
-unaffected — its own stamp check answers 401 — and `GET /health` and
-`POST /pairing/requests` have no dynamic segment, so a percent in their paths
-simply 404s. Reproduced against a production build; the fix is still open.
+**The poll route did not always re-check, and that gap is what made
+`cave-f1xki` (#4854) exploitable.** `clientV1IngressKind` returns `null` for any
+pathname containing `%` or `\`, while Next still percent-decodes a *dynamic*
+segment before matching it — so a pairing id written with one percent-escaped
+character classified as *not* client-v1 ingress and reached the handler anyway,
+skipping both the direct-loopback branch above and the body rules below. A
+caller already holding the sidecar token or the mobile access credential could
+use that to read `GET /pairing/requests/:id` from **off the machine**, which the
+403 above otherwise forbids. Measured against a production build: the plain path
+answered `403 forbidden peer` and the percent-written one answered `200` with
+the pairing record.
+
+**Fixed by refusing such a target outright.** `proxy.ts` answers any request
+whose pathname is inside `/api/client/v1` and contains a `%` or a `\` with
+
+```
+400 {"ok":false,"error":"invalid client v1 path"}
+```
+
+before anything is classified. Nothing a correct client sends is affected: every
+segment of this surface is a fixed literal or a UUID, and the pairing secret
+travels in a header — so no legitimate path needs an escape. Percent-encoding in
+the **query string** is untouched.
+
+The refusal is scoped by path prefix rather than by the ingress lists, so it
+covers the admin family and any dynamic-segmented route added later, including
+one nobody remembers to add to a list. Refusal was chosen over normalizing the
+pathname before classifying it because Next decodes a dynamic segment exactly
+once and does *not* treat a decoded `%2F` as a separator (both measured), so a
+normalizing fix would have to reproduce those rules exactly and keep reproducing
+them across Next versions — while decoding twice would open the `%252e` class
+instead. The poll route's own stamp check, added in the same change, is the
+second layer: the surface no longer has a route that takes its locality solely
+from the proxy branch.
 
 ### Body and content-type rules on the public routes
 
@@ -320,12 +340,16 @@ Reads the status of a pairing request you hold the secret for. This is the
 route a client polls while the user is deciding, if it does not want to poll by
 attempting the exchange.
 
-**Requires:** the pairing secret in the `x-coven-pairing-secret` header. That
-header is the only accepted carrier — a `?secret=` query parameter is refused
-with 401, so the secret never lands in a URL, a log, or a `Referer`.
+**Requires:** the loopback stamp, and the pairing secret in the
+`x-coven-pairing-secret` header. That header is the only accepted carrier — a
+`?secret=` query parameter is refused with 401, so the secret never lands in a
+URL, a log, or a `Referer`.
 
-Note that this route does **not** re-check the loopback stamp itself; the proxy
-branch is what makes it local.
+The stamp is re-checked here, as it is on both pairing POSTs, and it is checked
+before the rate-limit budget is read. It used to be left entirely to the proxy
+branch — which is what made `cave-f1xki` (#4854) reachable on this route and no
+other. A client that can call the exchange can call this, since that route has
+always required the same stamp.
 
 **200:**
 
@@ -342,7 +366,7 @@ what they need to drive the next step.
 
 | Status | Code | Cause |
 |---|---|---|
-| 401 | `unauthorized` | The id is not a UUID, the secret header is absent or not 43 base64url characters, **or** the secret is wrong for a request that exists. |
+| 401 | `unauthorized` | The loopback stamp is absent or does not match, the id is not a UUID, the secret header is absent or not 43 base64url characters, **or** the secret is wrong for a request that exists. |
 | 429 | `rate_limited` | The per-pairing wrong-secret budget is spent — **including by the exchange route**, which shares it. Checked before the secret is compared, so a correct secret gets this too. |
 | 404 | `not_found` | No request or terminal record carries this id. |
 | 409 | `conflict` | Already exchanged. `details.reason` is `"pairing_replayed"`. |
@@ -449,21 +473,32 @@ All four call `requireClientV1Admin`, which:
    case is what stops a non-browser caller skipping the check by sending no
    source header at all.
 
-`requireClientV1Admin` deliberately does **not** consult the loopback stamp. Its
-own comment gives the reason: transport locality is not proof of the
+`requireClientV1Admin` still does **not** consult the loopback stamp itself, for
+the reason its own comment gives: transport locality is not proof of the
 administrator, and the per-launch sidecar credential is.
 
-**Current gap ([#4843](https://github.com/OpenCoven/coven-cave/issues/4843)).**
-Because `/api/client/v1/admin/*` appears in neither the public nor the
-authenticated path list, `clientV1IngressKind` returns `null` for it and the
-family never enters the direct-loopback branch in `proxy.ts`. It is reachable by
-anything that holds the sidecar token, including a non-browser caller arriving
-over Tailscale Serve with no `Origin`/`Referer` — which can therefore *read* the
-credential list and the pending-request list. Mutations still fail, because a
-`ts.net` origin does not satisfy the same-origin check. Severity is low (the
-token is per-launch and never leaves the machine) and binding the family to
-direct loopback is a design decision under review, not a patch to apply
-blindly. Documented here because it is the behaviour today.
+**Locality is required as well, one layer up
+([#4843](https://github.com/OpenCoven/coven-cave/issues/4843)).** `proxy.ts`
+answers any `/api/client/v1/admin/*` request that is not a direct loopback peer
+with
+
+```
+403 {"ok":false,"error":"forbidden peer: client v1 admin requires direct loopback"}
+```
+
+The two checks answer different questions — the proxy asks *from where*,
+`requireClientV1Admin` asks *who* — and the gate binds the family without
+excusing it: the admin paths still do **not** appear in either ingress list, so
+they never take the client-v1 branch's pass-through and the sidecar token is
+still required afterwards by the ordinary gate.
+
+Before that gate existed, a non-browser caller arriving over Tailscale Serve
+with the sidecar token and no `Origin`/`Referer` could *read* the credential list
+and the pending-request list from off the machine (mutations already failed,
+because a `ts.net` origin does not satisfy the same-origin check). Severity was
+low — the token is per-launch and never leaves the machine — but the
+pairing-approval queue is the human-consent surface for the entire authority, so
+it now requires the same direct-loopback stamp the pairing routes require.
 
 ### `GET /api/client/v1/admin/pairing-requests`
 
@@ -740,10 +775,6 @@ against something that is not there.
   `src/lib/server/client-v1/discovery.ts` is reached only by its own tests. Two
   implementations of one on-disk contract can drift, and the `src/lib` one is
   the reviewed side.
-- **Admin routes are not bound to direct loopback** —
-  [#4843](https://github.com/OpenCoven/coven-cave/issues/4843), described above.
-- **A percent-encoded pairing id escapes the client-v1 ingress branch** —
-  `cave-f1xki`, described above. Reproduced, not yet fixed.
 - **`requestId` is never emitted**, so there is no server-assigned correlation
   id to quote in a bug report. The envelope field exists; no route sets it.
 
@@ -768,6 +799,15 @@ direct loopback`, and the 411/413 body rules with their 64 KiB cap. Neither
 applies to a path that classifies `null`. So an authenticated route that lands
 un-listed does not merely keep the sidecar-token gate: it *gains* a bearer
 requirement and *loses* loopback-only ingress and the body cap.
+
+The admin family shows the other way to buy locality back. It classifies `null`
+by design — its protection is the sidecar token, and listing it would return
+before the block that checks one — so `proxy.ts` binds it to a direct loopback
+peer with a check of its own (#4843) and then lets it fall through to the
+ordinary gate. A Phase 2 route that needs locality without the demotion should
+follow that shape rather than being added to the list. Nothing has to be
+remembered for the escaped-target refusal, though: that one is scoped by path
+prefix, so a new route is covered the day it lands.
 
 The invariant, asserted in `src/app/api/api-contracts.test.ts` against the repo
 rather than a list somebody must remember to prune:

--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -194,8 +194,9 @@ once and does *not* treat a decoded `%2F` as a separator (both measured), so a
 normalizing fix would have to reproduce those rules exactly and keep reproducing
 them across Next versions — while decoding twice would open the `%252e` class
 instead. The poll route's own stamp check, added in the same change, is the
-second layer: the surface no longer has a route that takes its locality solely
-from the proxy branch.
+second layer: no route that serves *user data* takes its locality from the proxy
+branch alone any more. `GET /health` still does, and deliberately — it answers
+the same compatibility envelope to everyone and carries nothing to leak.
 
 ### Body and content-type rules on the public routes
 

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -89,23 +89,28 @@ const contracts: RouteContract[] = [
   // before it holds a credential, which is the whole reason they exist. They
   // are the paths clientV1IngressKind (src/proxy-helpers.ts) classifies as
   // public, so proxy.ts applies the client-v1 ingress rules to them instead of
-  // the ordinary gate. Health returns no user data and no paths. The three
-  // pairing routes do not guard themselves uniformly, so read them one at a
-  // time: both POSTs re-check the loopback stamp through
-  // runtime.authenticator.isTrustedLoopback (client-v1/auth.ts), while
-  // GET /client/v1/pairing/requests/[id] never calls it and takes its locality
-  // solely from the clientV1Ingress branch in proxy.ts. Both id-bearing routes
-  // do require the per-request pairing secret; the creating POST mints that
-  // secret rather than checking one, and is bounded by the pairing-create rate
-  // limit instead.
+  // the ordinary gate. Health returns no user data and no paths, and is the one
+  // route on this surface whose locality comes from that proxy branch alone.
+  // All three pairing routes re-check the loopback stamp for themselves through
+  // runtime.authenticator.isTrustedLoopback (client-v1/auth.ts) — the two POSTs
+  // always did, and GET /client/v1/pairing/requests/[id] joined them in #4854,
+  // because being the one dynamic-segmented route with no check of its own is
+  // what made the escaped-path ingress hole answer there and nowhere else. Both
+  // id-bearing routes also require the per-request pairing secret; the creating
+  // POST mints that secret rather than checking one, and is bounded by the
+  // pairing-create rate limit instead.
   //
   // The admin routes are NOT exempted. clientV1IngressKind returns null for
-  // them, so they never leave the ordinary sidecar-token path in proxy.ts, and
-  // that is where their locality comes from. requireClientV1Admin
+  // them, so they never take the client-v1 ingress branch's pass-through and
+  // stay on the ordinary sidecar-token path in proxy.ts. Their locality is not
+  // a by-product of that path: proxy.ts binds the family to a direct loopback
+  // peer with a check of its own (#4843), refusing a forwarded caller with
+  // `403 forbidden peer: client v1 admin requires direct loopback` before
+  // falling through to that gate. requireClientV1Admin
   // (client-v1/admin-auth.ts) then adds the per-launch COVEN_CAVE_AUTH_TOKEN,
   // plus a same-origin Origin/Referer on mutations; it reads no loopback stamp
   // of its own, deliberately, because transport locality is not proof of the
-  // administrator.
+  // administrator — the proxy check asks FROM WHERE, this one asks WHO.
   { route: "/client/v1/admin/credentials", methods: ["GET"], kind: "json" },
   { route: "/client/v1/admin/credentials/[id]", methods: ["DELETE"], kind: "json", readsJson: true },
   { route: "/client/v1/admin/pairing-requests", methods: ["GET"], kind: "json" },

--- a/src/app/api/client/v1/pairing/requests/[id]/route.test.ts
+++ b/src/app/api/client/v1/pairing/requests/[id]/route.test.ts
@@ -23,11 +23,18 @@ function context(id: string) {
   return { params: Promise.resolve({ id }) };
 }
 
+// Carries the listener's direct-loopback stamp, because the poll route now
+// re-checks it for itself (cave-f1xki). Every request these tests describe is a
+// client on the machine, which is the only shape that stamp is minted for; the
+// unstamped shapes get their own test below.
 function request(id: string, secret?: string, querySecret?: string): Request {
   const url = new URL(`http://127.0.0.1:3020/api/client/v1/pairing/requests/${id}`);
   if (querySecret) url.searchParams.set("secret", querySecret);
   return new Request(url, {
-    headers: secret ? { [secretHeader]: secret } : undefined,
+    headers: {
+      [LOCAL_PEER_HEADER]: "loopback-secret",
+      ...(secret ? { [secretHeader]: secret } : {}),
+    },
   });
 }
 
@@ -89,6 +96,50 @@ test("poll exposes only id, status, and expiry across the complete lifecycle", a
       status: "expired",
       expiresAt: expiring.expiresAt,
     });
+  } finally {
+    assert.equal(resolve(root).startsWith(scratchPrefix), true);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("poll refuses a caller without the listener's direct-loopback stamp", async () => {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const runtime = createClientV1Runtime({
+      credentialRoot: root,
+      loopbackSecret: "loopback-secret",
+      now: () => 1_000,
+    });
+    const handler = createPairingRequestGetHandler(runtime);
+    const issued = runtime.pairingStore.create(pairingInput);
+
+    // The correct secret, so nothing but the missing/forged stamp can account
+    // for the refusal. This is the defence in depth cave-f1xki (#4854) is
+    // about: the proxy's ingress classification was slipped with a percent
+    // escape, and this route — alone among the public routes with a dynamic
+    // segment — had no locality check of its own to fall back on.
+    for (const stamp of [undefined, "", "wrong-loopback-secret"]) {
+      const headers = new Headers({ [secretHeader]: issued.secret });
+      if (stamp !== undefined) headers.set(LOCAL_PEER_HEADER, stamp);
+      const response = await handler(
+        new Request(
+          `http://127.0.0.1:3020/api/client/v1/pairing/requests/${issued.id}`,
+          { headers },
+        ),
+        context(issued.id),
+      );
+      const body = await response.json() as { error: { code: string }; data?: unknown };
+      assert.equal(response.status, 401, `stamp ${JSON.stringify(stamp)}`);
+      assert.equal(body.error.code, "unauthorized");
+      assert.equal(body.data, undefined);
+      assert.equal(JSON.stringify(body).includes(issued.secret), false);
+      assert.equal(JSON.stringify(body).includes("loopback-secret"), false);
+    }
+
+    // And the refusal is not a lockout of the legitimate holder: the stamped
+    // request with the same secret still answers.
+    const stamped = await handler(request(issued.id, issued.secret), context(issued.id));
+    assert.equal(stamped.status, 200);
   } finally {
     assert.equal(resolve(root).startsWith(scratchPrefix), true);
     await rm(root, { recursive: true, force: true });

--- a/src/app/api/client/v1/pairing/requests/[id]/route.test.ts
+++ b/src/app/api/client/v1/pairing/requests/[id]/route.test.ts
@@ -280,6 +280,58 @@ test("poll refuses once exchange failures alone have spent the shared budget", a
   }
 });
 
+test("poll checks the loopback stamp before it reads the rate-limit budget", async () => {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const now = 19_000;
+    const runtime = createClientV1Runtime({
+      credentialRoot: root,
+      loopbackSecret: "loopback-secret",
+      now: () => now,
+    });
+    const poll = createPairingRequestGetHandler(runtime);
+    const exchange = createPairingExchangePostHandler(runtime);
+    const attacked = runtime.pairingStore.create(pairingInput);
+    assert.equal(runtime.pairingStore.decide(attacked.id, "approved", now), true);
+
+    const guess = nearMiss(attacked.secret);
+    for (
+      let attempt = 0;
+      attempt < CLIENT_V1_PAIRING_EXCHANGE_FAILURE_LIMIT;
+      attempt += 1
+    ) {
+      const rejected = await exchange(
+        exchangeRequest(attacked.id, guess),
+        context(attacked.id),
+      );
+      assert.equal(rejected.status, 401, `guess ${attempt} must be refused, not limited`);
+    }
+
+    // The ORDER of the two checks is the assertion, not either check alone: the
+    // test above shows a stamped holder gets 429 in this exact state, so an
+    // unstamped caller getting 401 can only mean the stamp was read first. Move
+    // the stamp check below the budget peek and this flips to 429 — which would
+    // hand a caller who never proved locality a live read on whether some
+    // pairing id is currently under attack, and is the shape docs/api/client-v1.md
+    // states ("checked before the rate-limit budget is read").
+    const unstamped = await poll(
+      new Request(
+        `http://127.0.0.1:3020/api/client/v1/pairing/requests/${attacked.id}`,
+        { headers: { [secretHeader]: attacked.secret } },
+      ),
+      context(attacked.id),
+    );
+    assert.equal(unstamped.status, 401);
+    const body = await unstamped.json() as { error: { code: string } };
+    assert.equal(body.error.code, "unauthorized");
+    assert.equal(unstamped.headers.get("retry-after"), null);
+    assert.equal(JSON.stringify(body).includes(attacked.secret), false);
+  } finally {
+    assert.equal(resolve(root).startsWith(scratchPrefix), true);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("polling with the correct secret is never rate limited", async () => {
   const root = await mkdtemp(scratchPrefix);
   try {

--- a/src/app/api/client/v1/pairing/requests/[id]/route.ts
+++ b/src/app/api/client/v1/pairing/requests/[id]/route.ts
@@ -12,6 +12,7 @@ import {
   getClientV1Runtime,
   type ClientV1Runtime,
 } from "@/lib/server/client-v1/runtime.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
 
 export const dynamic = "force-dynamic";
 
@@ -22,6 +23,18 @@ export function createPairingRequestGetHandler(runtime: ClientV1Runtime) {
     request: Request,
     { params: rawParams }: RouteContext,
   ): Promise<Response> {
+    // Defence in depth, and the direct lesson of cave-f1xki (#4854): this was
+    // the ONLY public route that was both dynamic-segmented and free of a
+    // locality check of its own, so when the proxy's ingress classification
+    // could be slipped with a percent-escape, this was the route that answered.
+    // POST /pairing/requests and POST .../exchange already re-check the same
+    // stamp and answered 401 to the identical request. A legitimate poller is
+    // on the machine — it is about to call the exchange, which has always
+    // required this — so the check costs a real client nothing.
+    if (!runtime.authenticator.isTrustedLoopback(request.headers.get(LOCAL_PEER_HEADER))) {
+      return clientV1ErrorResponse("unauthorized", "Unauthorized.");
+    }
+
     let id: string;
     let secret: string;
     try {

--- a/src/lib/server/client-v1/admin-auth.ts
+++ b/src/lib/server/client-v1/admin-auth.ts
@@ -55,7 +55,19 @@ export function requireClientV1Admin(
 ): Response | null {
   // The listener's loopback stamp proves transport locality, not the Cave
   // administrator. Only the configured per-launch sidecar credential grants
-  // this route family.
+  // this route family, so that is what this function checks — and it still
+  // reads no stamp of its own.
+  //
+  // Locality is now required as well, one layer up: proxy() answers
+  // `403 forbidden peer: client v1 admin requires direct loopback` for
+  // /api/client/v1/admin/* that is not a direct loopback peer (#4843). That is
+  // the layer that can see it — the stamp is meaningful only next to
+  // `remoteIngress`, which is assembled from the mobile and sidecar gates and
+  // is not visible from here. The two checks answer different questions: this
+  // one asks WHO, the proxy asks FROM WHERE. Before the proxy gate existed, a
+  // forwarded caller holding the sidecar token and sending no Origin/Referer
+  // could read the credential list and the pending-pairing queue from off the
+  // machine.
   const secret = process.env.COVEN_CAVE_AUTH_TOKEN?.trim();
   if (!secret) return adminAuthorizationUnavailable();
 

--- a/src/lib/server/client-v1/auth.test.ts
+++ b/src/lib/server/client-v1/auth.test.ts
@@ -20,7 +20,11 @@ import {
   CLIENT_V1_PUBLIC_INGRESS,
   LOCAL_PEER_HEADER,
   TAILNET_PEER_HEADER,
+  TOKEN_HEADER,
   clientV1IngressKind,
+  isClientV1AdminPath,
+  isClientV1Path,
+  isRefusedClientV1Path,
 } from "../../../proxy-helpers.ts";
 
 const ACTIVE_CREDENTIAL: ClientV1CredentialRecord = {
@@ -254,6 +258,129 @@ test("proxy public ingress follows the contract's public routes", () => {
   }
 });
 
+/**
+ * Client v1 request-targets carrying a percent-escape or a backslash
+ * (cave-f1xki, #4854).
+ *
+ * The list this file shipped without: every `clientV1IngressKind` case here was
+ * a clean path, which is precisely why the escaped-path hole reached a
+ * production build unnoticed. Both segment positions are represented, because
+ * they behave differently and only one of them was ever exploitable: Next
+ * matches a STATIC segment against raw bytes (so `healt%68` is a 404), while a
+ * DYNAMIC segment is percent-decoded for `[id]` matching before the route sees
+ * it — so a `%` there routed while middleware still read the raw `%` and
+ * classified the request as not-client-v1.
+ */
+const ESCAPED_CLIENT_V1_PATHS = [
+  // The measured exploit shape: `%31` decodes to the id's own trailing `1`.
+  "/api/client/v1/pairing/requests/018f4f1a-77c2-7a31-8a15-55a25aaba00%31",
+  // Double-encoded. Next decodes exactly ONCE (measured: the route received a
+  // literal `%31`), so this is the shape a decode-twice "normalization" fix
+  // would have mishandled — the `%252e` class the refusal avoids entirely.
+  "/api/client/v1/pairing/requests/018f4f1a-77c2-7a31-8a15-55a25aaba0%2531",
+  // Encoded separator, both cases. Measured: Next routes this as ONE `[id]`
+  // segment, so a fix that decoded the whole pathname would split it into two,
+  // fail the single-segment public pattern, and go on returning null — the
+  // same hole with more code.
+  "/api/client/v1/pairing/requests/aaa%2Fbbb",
+  "/api/client/v1/pairing/requests/aaa%2fbbb",
+  // Encoded dot-dot, both cases. Note the WHATWG URL parser resolves these
+  // itself, so proxy() never sees one; the classifier must still refuse the
+  // string, because that resolution is a property of the caller's parser and
+  // not of this function.
+  "/api/client/v1/pairing/requests/%2e%2e/exchange",
+  "/api/client/v1/pairing/requests/%2E%2E/exchange",
+  // Encoded backslash — NOT folded to `/` by the URL parser, unlike a literal
+  // one, so this really can arrive here.
+  "/api/client/v1/pairing/requests/aaa%5Cbbb",
+  "/api/client/v1/pairing/requests/aaa%5cbbb",
+  // Not even well-formed escapes. Nothing may decode these to decide.
+  "/api/client/v1/pairing/requests/aaa%zz",
+  "/api/client/v1/pairing/requests/aaa%",
+  // Static segments: a 404 at the router, but the classifier is not the thing
+  // that says so and must not be relied on to.
+  "/api/client/v1/healt%68",
+  "/api/client/v1/health%20",
+  "/api/client/v1/pairing/request%73",
+  // Literal backslashes. The URL parser folds these to `/` for a special
+  // scheme, so proxy() sees the slash form — which is exactly why the check
+  // cannot assume someone else already folded them.
+  "/api/client/v1/pairing/requests/aaa\\bbb",
+  "/api\\client\\v1\\health",
+  "/api/client/v1\\health",
+  // The admin family is inside the refusal too, because the refusal is scoped
+  // by prefix rather than by the two ingress lists — admin classifies null by
+  // design and would otherwise have kept the hole after the classifier was
+  // fixed.
+  "/api/client/v1/admin/credential%73",
+  "/api/client/v1/admin/credentials/aaa%2Fbbb",
+  "/api/client/v1/admin/pairing-requests/aaa%34bbb/decision",
+  "/api/client/v1/admin\\credentials",
+];
+
+test("client-v1 request-targets carrying an escape are refused, not classified", () => {
+  for (const pathname of ESCAPED_CLIENT_V1_PATHS) {
+    assert.equal(isClientV1Path(pathname), true, pathname);
+    assert.equal(isRefusedClientV1Path(pathname), true, pathname);
+    // Second layer, and it must stay the SAFE direction: an escaped id already
+    // matches the `[^/]+` id pattern by raw bytes, so a classifier that stopped
+    // bailing would promote these into the credential-free public set.
+    assert.equal(clientV1IngressKind(pathname), null, pathname);
+  }
+});
+
+test("the client-v1 escape refusal is scoped to the client-v1 path prefix", () => {
+  // An escape outside this surface is none of the refusal's business — every
+  // other API family accepts encoded path segments, and widening the refusal to
+  // /api/ would break them.
+  for (const pathname of [
+    "/api/chat/conversation/aaa%2Fbbb",
+    "/api/client/v10/health%20",
+    "/decoy/api/client/v1/pairing/requests/aaa%34bbb",
+    "/client/v1/pairing/requests/aaa%34bbb",
+  ]) {
+    assert.equal(isClientV1Path(pathname), false, pathname);
+    assert.equal(isRefusedClientV1Path(pathname), false, pathname);
+  }
+
+  // And a clean client-v1 path is inside the surface without being refused —
+  // otherwise the refusal would take the whole family down with it.
+  for (const pathname of [
+    "/api/client/v1",
+    "/api/client/v1/health",
+    "/api/client/v1/pairing/requests/018f4f1a-77c2-7a31-8a15-55a25aaba001",
+    "/api/client/v1/admin/credentials",
+  ]) {
+    assert.equal(isClientV1Path(pathname), true, pathname);
+    assert.equal(isRefusedClientV1Path(pathname), false, pathname);
+  }
+});
+
+test("the client-v1 admin family is recognized as its own locality-bound set", () => {
+  for (const pathname of [
+    "/api/client/v1/admin",
+    "/api/client/v1/admin/credentials",
+    "/api/client/v1/admin/credentials/018f4f1a-77c2-7a31-8a15-55a25aaba002",
+    "/api/client/v1/admin/pairing-requests",
+    "/api/client/v1/admin/pairing-requests/018f4f1a-77c2-7a31-8a15-55a25aaba001/decision",
+    "/api/client/v1/admin\\credentials",
+  ]) {
+    assert.equal(isClientV1AdminPath(pathname), true, pathname);
+    // Bound, never excused: the admin family must not also become a client-v1
+    // INGRESS, because matching there skips the mobile-access gate and returns
+    // before the sidecar-token block that is admin's actual protection.
+    assert.equal(clientV1IngressKind(pathname), null, pathname);
+  }
+  for (const pathname of [
+    "/api/client/v1/health",
+    "/api/client/v1/administrivia",
+    "/api/client/v1/pairing/requests/admin",
+    "/api/admin/credentials",
+  ]) {
+    assert.equal(isClientV1AdminPath(pathname), false, pathname);
+  }
+});
+
 const ENV_KEYS = [
   "COVEN_CAVE_ACCESS_TOKEN",
   "COVEN_CAVE_AUTH_TOKEN",
@@ -424,6 +551,234 @@ test("client-v1 admin stays on the private authenticated boundary", async () => 
       },
     ));
     assert.equal(passedThrough(authenticated), true);
+  } finally {
+    restoreProxyEnv();
+  }
+});
+
+test("a percent-escaped client-v1 target is refused before it can slip the ingress rules", async () => {
+  try {
+    setProxyEnv({
+      COVEN_CAVE_ACCESS_TOKEN: "configured-mobile-secret",
+      COVEN_CAVE_AUTH_TOKEN: "configured-sidecar-secret",
+      COVEN_CAVE_LOCAL_PEER_SECRET: "loopback-secret",
+    });
+    const id = "018f4f1a-77c2-7a31-8a15-55a25aaba001";
+    const escapedId = "018f4f1a-77c2-7a31-8a15-55a25aaba00%31";
+    // Remote ingress as Tailscale Serve produces it: no direct-loopback stamp,
+    // and a credential that satisfies the ordinary gate. This is the caller the
+    // 403 exists to refuse, and the exact caller that reached the handler
+    // before this fix (measured against a production build: the plain path
+    // answered 403, the escaped one answered 200 with the pairing record).
+    const remote = { [TOKEN_HEADER]: "configured-sidecar-secret" };
+    const local = { [LOCAL_PEER_HEADER]: "loopback-secret" };
+
+    const plainRemote = await proxy(proxyRequest(
+      `/api/client/v1/pairing/requests/${id}`,
+      { headers: remote },
+    ));
+    await assertProxyError(
+      plainRemote,
+      403,
+      "forbidden peer: client v1 requires direct loopback",
+    );
+
+    const escapedRemote = await proxy(proxyRequest(
+      `/api/client/v1/pairing/requests/${escapedId}`,
+      { headers: remote },
+    ));
+    await assertProxyError(escapedRemote, 400, "invalid client v1 path");
+
+    // Refused for the local caller too. The point is not "remote callers are
+    // refused" — it is that no request on an escaped client-v1 target is ever
+    // handed to a route, so no future route can inherit the hole.
+    const escapedLocal = await proxy(proxyRequest(
+      `/api/client/v1/pairing/requests/${escapedId}`,
+      { headers: { ...local, origin: ORIGIN, referer: `${ORIGIN}/` } },
+    ));
+    await assertProxyError(escapedLocal, 400, "invalid client v1 path");
+
+    // Every escaped target the URL parser leaves intact, across both segment
+    // positions, the admin family, and malformed escapes.
+    for (const pathname of ESCAPED_CLIENT_V1_PATHS) {
+      const request = proxyRequest(pathname, {
+        headers: { ...local, origin: ORIGIN, referer: `${ORIGIN}/` },
+      });
+      // The parser folds a literal `\` to `/` and resolves `%2e%2e`, so those
+      // entries arrive here as clean paths. Only assert about the ones that
+      // still carry an escape by the time proxy() reads them.
+      if (!isRefusedClientV1Path(request.nextUrl.pathname)) continue;
+      const response = await proxy(request);
+      assert.equal(passedThrough(response), false, pathname);
+      await assertProxyError(response, 400, "invalid client v1 path");
+    }
+  } finally {
+    restoreProxyEnv();
+  }
+});
+
+test("the client-v1 body rules cannot be shed by escaping the path", async () => {
+  try {
+    setProxyEnv({
+      COVEN_CAVE_LOCAL_PEER_SECRET: "loopback-secret",
+    });
+    const baseHeaders = {
+      [LOCAL_PEER_HEADER]: "loopback-secret",
+      "content-type": "application/json",
+      origin: ORIGIN,
+      referer: `${ORIGIN}/`,
+    };
+    const id = "018f4f1a-77c2-7a31-8a15-55a25aaba001";
+    const escapedId = "018f4f1a-77c2-7a31-8a15-55a25aaba00%31";
+
+    // The loopback gate was not the only control lost when an escaped path
+    // classified null: clientV1RequestBodyError hangs off the same
+    // classification, so the 411/413 rules and the 64 KiB cap went with it.
+    // Measured against a production build before the fix, with the sidecar
+    // token: chunked was 400 on the plain path and reached the route on the
+    // escaped one; a 70 KB body was 413 on the plain path and reached the route
+    // on the escaped one.
+    const shapes: {
+      label: string;
+      headers: Record<string, string>;
+      status: number;
+      error: string;
+    }[] = [
+      { label: "no content-length", headers: {}, status: 411, error: "content-length required" },
+      {
+        label: "chunked",
+        headers: { "content-length": "1", "transfer-encoding": "chunked" },
+        status: 400,
+        error: "invalid content-length",
+      },
+      {
+        label: "over the 64 KiB cap",
+        headers: { "content-length": String(64 * 1024 + 1) },
+        status: 413,
+        error: "request body too large",
+      },
+    ];
+
+    for (const shape of shapes) {
+      const plain = await proxy(proxyRequest(
+        `/api/client/v1/pairing/requests/${id}/exchange`,
+        { method: "POST", headers: { ...baseHeaders, ...shape.headers } },
+      ));
+      await assertProxyError(plain, shape.status, shape.error);
+
+      const escaped = await proxy(proxyRequest(
+        `/api/client/v1/pairing/requests/${escapedId}/exchange`,
+        { method: "POST", headers: { ...baseHeaders, ...shape.headers } },
+      ));
+      assert.equal(passedThrough(escaped), false, shape.label);
+      // Refused earlier than the body rule rather than by it: the target is
+      // rejected outright, so the body never becomes a question. What must
+      // never happen again is the third answer — passing through.
+      await assertProxyError(escaped, 400, "invalid client v1 path");
+    }
+
+    // A well-formed body on the escaped path is refused too, so the refusal is
+    // about the target and not about the body being wrong.
+    const wellFormed = await proxy(proxyRequest(
+      `/api/client/v1/pairing/requests/${escapedId}/exchange`,
+      { method: "POST", headers: { ...baseHeaders, "content-length": "0" } },
+    ));
+    await assertProxyError(wellFormed, 400, "invalid client v1 path");
+  } finally {
+    restoreProxyEnv();
+  }
+});
+
+test("client-v1 percent-encoding stays legal in the query string", async () => {
+  try {
+    setProxyEnv({
+      COVEN_CAVE_LOCAL_PEER_SECRET: "loopback-secret",
+    });
+
+    // The refusal reads nextUrl.pathname, and it has to stay there: query
+    // values are percent-encoded by every correct client, and refusing on the
+    // whole URL would break the surface it is meant to protect.
+    const response = await proxy(proxyRequest(
+      "/api/client/v1/health?probe=a%20b%2Fc",
+      {
+        headers: {
+          [LOCAL_PEER_HEADER]: "loopback-secret",
+          origin: ORIGIN,
+          referer: `${ORIGIN}/`,
+        },
+      },
+    ));
+
+    assert.equal(passedThrough(response), true);
+  } finally {
+    restoreProxyEnv();
+  }
+});
+
+test("client-v1 admin requires the listener's direct-loopback peer", async () => {
+  try {
+    // No COVEN_CAVE_ACCESS_TOKEN: with mobile access armed, its gate answers
+    // an unauthenticated admin request first (401) and the peer gate under test
+    // is never reached. The sibling test above covers that arrangement.
+    setProxyEnv({
+      COVEN_CAVE_AUTH_TOKEN: "configured-sidecar-secret",
+      COVEN_CAVE_LOCAL_PEER_SECRET: "loopback-secret",
+    });
+
+    // #4843: a forwarded caller holding the sidecar token and sending no
+    // Origin/Referer — a native client rather than a browser — could read the
+    // credential list and the pending-pairing queue from off the machine. The
+    // mutation CSRF check never applied to it, because reads do not take one.
+    for (const pathname of [
+      "/api/client/v1/admin/credentials",
+      "/api/client/v1/admin/pairing-requests",
+      "/api/client/v1/admin/credentials/018f4f1a-77c2-7a31-8a15-55a25aaba002",
+      "/api/client/v1/admin/pairing-requests/018f4f1a-77c2-7a31-8a15-55a25aaba001/decision",
+    ]) {
+      const remote = await proxy(proxyRequest(pathname, {
+        headers: { [TOKEN_HEADER]: "configured-sidecar-secret" },
+      }));
+      assert.equal(passedThrough(remote), false, pathname);
+      await assertProxyError(
+        remote,
+        403,
+        "forbidden peer: client v1 admin requires direct loopback",
+      );
+    }
+
+    // A caller with no stamp and no credential is refused by the same gate, so
+    // the peer requirement does not depend on which credential is presented.
+    const unstamped = await proxy(proxyRequest("/api/client/v1/admin/credentials"));
+    await assertProxyError(
+      unstamped,
+      403,
+      "forbidden peer: client v1 admin requires direct loopback",
+    );
+
+    // Bound, not excused. The stamped caller reaches the ORDINARY gate — it is
+    // still refused without a credential, because admin must never take the
+    // client-v1 ingress branch's pass-through.
+    const stampedTokenless = await proxy(proxyRequest("/api/client/v1/admin/credentials", {
+      headers: {
+        [LOCAL_PEER_HEADER]: "loopback-secret",
+        origin: ORIGIN,
+        referer: `${ORIGIN}/`,
+      },
+    }));
+    assert.equal(passedThrough(stampedTokenless), false);
+    assert.equal(stampedTokenless.status, 401);
+
+    // And the real administrator — on the machine, holding the credential —
+    // still gets through to requireClientV1Admin.
+    const stampedAuthenticated = await proxy(proxyRequest("/api/client/v1/admin/credentials", {
+      headers: {
+        [LOCAL_PEER_HEADER]: "loopback-secret",
+        [TOKEN_HEADER]: "configured-sidecar-secret",
+        origin: ORIGIN,
+        referer: `${ORIGIN}/`,
+      },
+    }));
+    assert.equal(passedThrough(stampedAuthenticated), true);
   } finally {
     restoreProxyEnv();
   }

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -167,6 +167,83 @@ export type ClientV1IngressKind =
   | typeof CLIENT_V1_PUBLIC_INGRESS
   | "authenticated";
 
+/** Root of the whole Client v1 surface: public, admin, and every path under it
+ *  that no route serves yet. */
+export const CLIENT_V1_PATH_PREFIX = "/api/client/v1";
+
+/**
+ * True for any pathname inside the Client v1 surface.
+ *
+ * Backslashes are folded to `/` for the prefix test only. Next answers a
+ * request-target such as `/api\client\v1\health` with a 308 to the slash form,
+ * so a `\` never reaches a handler — but the fold means the refusal below
+ * cannot be dodged by writing the prefix with the separator Next is about to
+ * rewrite. A `%` needs no equivalent treatment: Next matches STATIC segments
+ * against the raw bytes (`/api/client/v1/healt%68` is a 404, measured), so no
+ * escape can manufacture the literal prefix.
+ */
+export function isClientV1Path(pathname: string) {
+  const separatorNormalized = pathname.replace(/\\/g, "/");
+  return (
+    separatorNormalized === CLIENT_V1_PATH_PREFIX
+    || separatorNormalized.startsWith(`${CLIENT_V1_PATH_PREFIX}/`)
+  );
+}
+
+/**
+ * True for a Client v1 request-target proxy() must refuse outright (cave-f1xki,
+ * #4854).
+ *
+ * The defect: Next does not route a `%` in a static segment, but it DOES route
+ * one in a dynamic segment — it percent-decodes the segment for `[id]` matching
+ * while middleware still reads the raw `%` in `nextUrl.pathname`. So
+ * `GET /api/client/v1/pairing/requests/<uuid with %34>` reached the handler
+ * while classifying as *not* client-v1 ingress, which skipped the direct-
+ * loopback gate AND the 411/413/64 KiB body rules, both of which hang off that
+ * classification. Measured against a production build: the plain path answered
+ * `403 forbidden peer` to a forwarded caller holding the sidecar token, and the
+ * percent-written one answered `200` with the pairing record.
+ *
+ * Refusal rather than normalization, deliberately:
+ *
+ *   - Decoding is the thing that would have to be exactly right. Next decodes a
+ *     segment ONCE (`%2534` arrives at the route as `%34`, measured) and does
+ *     NOT treat a decoded `%2F` as a separator (`aaa%2Fbbb` routes as ONE `[id]`
+ *     segment, measured). A classifier that decoded the whole pathname would
+ *     split that into two segments and go on returning null — the same hole —
+ *     and a classifier that decoded twice would open the `%252e` class instead.
+ *     Refusing decodes nothing, so it stays correct without tracking Next's
+ *     decoding rules across versions.
+ *   - No legitimate client needs it. Every Client v1 path segment is either a
+ *     fixed literal or a UUID (`parseClientV1PairingRequestId`), and the pairing
+ *     secret travels in a header, so nothing a real client sends contains a `%`
+ *     or a `\`.
+ *   - It generalises. The check is scoped by PREFIX, not by the two ingress
+ *     lists, so it covers admin and any future dynamic-segmented route the day
+ *     that route lands — including one nobody remembers to add to a list. Fixing
+ *     only the classifier would have left `/api/client/v1/admin/*` (which
+ *     classifies null by design) and every unlisted path exactly as they were.
+ *   - `\` earns the same treatment for the same reason: never legitimate, and
+ *     leaving it to classify null was the other half of the same silent bail.
+ */
+export function isRefusedClientV1Path(pathname: string) {
+  return isClientV1Path(pathname)
+    && (pathname.includes("%") || pathname.includes("\\"));
+}
+
+/**
+ * True for the Client v1 administrative family — the credential list, the
+ * pairing-approval queue, and the decisions taken on it.
+ */
+export function isClientV1AdminPath(pathname: string) {
+  const separatorNormalized = pathname.replace(/\\/g, "/");
+  const adminPrefix = `${CLIENT_V1_PATH_PREFIX}/admin`;
+  return (
+    separatorNormalized === adminPrefix
+    || separatorNormalized.startsWith(`${adminPrefix}/`)
+  );
+}
+
 const CLIENT_V1_PATH_PARAMETER = /^:[A-Za-z0-9_]+$/;
 
 /** One contract route path (`/…/pairing/requests/:id`) as an exact matcher. */
@@ -227,6 +304,13 @@ const CLIENT_V1_PUBLIC_PATHS = CLIENT_V1_PUBLIC_ROUTES.map((route) =>
 export const CLIENT_V1_AUTHENTICATED_PATHS: RegExp[] = [];
 
 export function clientV1IngressKind(pathname: string): ClientV1IngressKind | null {
+  // Kept, and no longer load-bearing. proxy() refuses such a target through
+  // isRefusedClientV1Path before it ever asks for a classification, so this
+  // line is now the second of two layers rather than the only one. It stays
+  // because dropping it would make a classifier that someone calls from a new
+  // site silently PROMOTE an escaped path into the public set — `%2534` in an
+  // id already matches the `[^/]+` id pattern by raw bytes — which is the one
+  // direction a bail-out to null must never take.
   if (pathname.includes("%") || pathname.includes("\\")) return null;
   if (CLIENT_V1_PUBLIC_PATHS.some((pattern) => pattern.test(pathname))) {
     return CLIENT_V1_PUBLIC_INGRESS;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -28,6 +28,8 @@ import {
   verifiedTailnetNode,
   requiresPasskeyPresence,
   clientV1IngressKind,
+  isClientV1AdminPath,
+  isRefusedClientV1Path,
 } from "./proxy-helpers";
 import { isValidMobileAccessCredential } from "./lib/mobile-access-token.ts";
 import { PRESENCE_COOKIE, verifyPresenceToken } from "./lib/passkey-presence.ts";
@@ -312,6 +314,17 @@ export async function proxy(req: NextRequest) {
     process.env.COVEN_CAVE_TAILNET_PEER_SECRET,
   );
   const tailnetPeerVerified = tailnetNodeId !== null;
+  // A Client v1 request-target carrying a percent-escape or a backslash is
+  // refused before anything is classified (cave-f1xki, #4854). It cannot be a
+  // real client — every segment of this surface is a fixed literal or a UUID —
+  // and leaving it to the classifier is exactly how it slipped the gate: the
+  // classifier answered null, so the direct-loopback branch and the
+  // 411/413/64 KiB body rules below, which both hang off a non-null answer,
+  // never ran. See isRefusedClientV1Path for why this refuses rather than
+  // normalizes.
+  if (isRefusedClientV1Path(req.nextUrl.pathname)) {
+    return jsonError(400, "invalid client v1 path");
+  }
   const clientV1Ingress = clientV1IngressKind(req.nextUrl.pathname);
   const mobileRes = clientV1Ingress
     ? null
@@ -461,6 +474,27 @@ export async function proxy(req: NextRequest) {
   const clientV1BodyError = clientV1RequestBodyError(req, clientV1Ingress);
   if (clientV1BodyError) {
     return jsonError(clientV1BodyError.status, clientV1BodyError.error);
+  }
+
+  // The Client v1 administrative family is bound to the same direct-loopback
+  // peer the public family requires (#4843) — but only bound, never excused.
+  // It deliberately does NOT join the clientV1Ingress branch below: matching
+  // there is a demotion (mobileAccessGate skipped, the sidecar-token block
+  // returned before), and admin's whole protection is that sidecar token. So
+  // this refuses, then falls through to the ordinary gate.
+  //
+  // requireClientV1Admin's own comment — that transport locality is not proof
+  // of the administrator, and the per-launch credential is — argues for
+  // requiring the token, not against also requiring locality. The two answer
+  // different questions (who, and from where), and the route family this
+  // protects is the human-consent surface for the entire authority: the
+  // pairing-approval queue and the credential list. A bearer token alone let a
+  // forwarded caller off the machine READ both, which is measurably what
+  // happened before this line existed.
+  if (isClientV1AdminPath(req.nextUrl.pathname)) {
+    if (!trustedLocalPeer || remoteIngress) {
+      return jsonError(403, "forbidden peer: client v1 admin requires direct loopback");
+    }
   }
 
   if (clientV1Ingress) {


### PR DESCRIPTION
Closes #4854. Closes #4843. One PR because they are the same surface: *which*
client-v1 paths get the direct-loopback gate, and whether that classification
can be evaded.

## #4854 — reproduced, then fixed

Reproduced first against a real production build (`pnpm build`; `node server.mjs`),
with a raw-socket client so the request-target bytes are never re-normalised
before they leave.

`clientV1IngressKind` returned `null` for any pathname containing `%` or `\`.
Next does not route a `%` in a **static** segment, but it does route one in a
**dynamic** segment — it percent-decodes the segment for `[id]` matching while
middleware still reads the raw `%` in `nextUrl.pathname`. So the classification
returned `null` and the direct-loopback gate never ran.

Remote ingress (`x-forwarded-for`, which suppresses `server.ts`'s local-peer
stamp) plus the sidecar token, against the pre-fix build:

| request | before | after |
|---|---|---|
| `GET /pairing/requests/<uuid>` | 403 `forbidden peer` | 403 `forbidden peer` |
| `GET /pairing/requests/<uuid with %34>` | **200 + the pairing record** | **400 `invalid client v1 path`** |
| same, no pairing secret | 401 client-v1 envelope (route reached) | 400 `invalid client v1 path` |
| `GET /admin/credentials`, no Origin/Referer | **200 + credential list** | **403 `… admin requires direct loopback`** |
| `GET /admin/pairing-requests`, no Origin/Referer | **200 + pending queue** | **403 `… admin requires direct loopback`** |

The **body rules** were lost under the same `null`, measured on the exchange
route with the sidecar token:

| shape | plain path | escaped path (before) | escaped path (after) |
|---|---|---|---|
| `Transfer-Encoding: chunked` | 400 `invalid content-length` | route reached | 400 `invalid client v1 path` |
| no `Content-Length` | 411 `content-length required` | route reached | 400 `invalid client v1 path` |
| 70 KB body | 413 `request body too large` | route reached | 400 `invalid client v1 path` |

### The design call: refuse, not normalize

The issue named three candidate shapes. They are not equivalent.

**Chosen: refuse a percent-escaped or backslash-bearing client-v1 target
outright**, at the proxy, before anything is classified — `400 invalid client v1
path`.

- **Over-decoding is a real hazard, and refusal has none of it.** Two measured
  facts make normalization hard to get right: Next decodes a dynamic segment
  **exactly once** (`%2531` arrives at the route as a literal `%31`), and it does
  **not** treat a decoded `%2F` as a separator (`aaa%2Fbbb` routes as ONE `[id]`
  segment). A fix that decoded the whole pathname would split that into two
  segments, fail the single-segment public pattern, and go on returning `null` —
  the same hole with more code. A fix that decoded twice would open the `%252e`
  class. Refusing decodes nothing, so it cannot drift out of step with Next.
- **No legitimate client is affected.** Every client-v1 path segment is a fixed
  literal or a UUID (`parseClientV1PairingRequestId`), and the pairing secret
  travels in a header. Percent-encoding in the **query string** is untouched, and
  there is a test pinning that.
- **It generalises.** The refusal is scoped by path **prefix**, not by the two
  ingress lists, so it covers the admin family and any dynamic-segmented route
  added later — including one nobody remembers to add to a list. Fixing only the
  classifier would have left `/api/client/v1/admin/*` (which classifies `null` by
  design) exactly as it was.
- **`\` gets the same treatment**, for the same reason. It is never legitimate,
  and it was the other half of the same silent bail. Note the WHATWG URL parser
  folds a literal `\` to `/` for a special scheme — the real server answers 308 —
  so the check deliberately does not assume someone else already folded it, and
  `%5C` is not folded at all.

Rejected: *re-check the stamp in the poll route only* fixes exactly one route and
restores neither the body rules nor anything for a future route. It is included
anyway as **defence in depth**: `GET /pairing/requests/:id` now re-checks
`isTrustedLoopback` as both pairing POSTs already did. It was the only public
route that was both dynamic-segmented and self-check-free, which is why it was
the one that answered. A client that can call the exchange can call this — the
exchange has always required the same stamp.

`clientV1IngressKind`'s own `%`/`\` bail is **kept**, now as the second of two
layers. Removing it would let a caller from some new call site *promote* an
escaped path into the credential-free public set, since an escaped id already
matches the `[^/]+` pattern by raw bytes.

## #4843 — the design decision, revisited and changed

`requireClientV1Admin` deliberately does not consult the loopback stamp; its
comment says transport locality is not proof of the administrator, and the
per-launch sidecar credential is.

**That reasoning holds, and it is not an objection to this change.** It is an
argument for *requiring the token* — it says nothing against *also* requiring
locality. The two answer different questions: the token asks **who**, the stamp
asks **from where**. Requiring both is strictly stronger and contradicts nothing
the comment claims.

So `proxy.ts` now answers any `/api/client/v1/admin/*` request that is not a
direct loopback peer with `403 forbidden peer: client v1 admin requires direct
loopback`. Rationale: the admin family is the human-consent surface for the
entire authority — the pairing-approval queue and the credential list — and a
bearer token alone let a forwarded caller off the machine read both (measured
above). The real administrator is the Tauri webview on the machine, a direct
loopback peer, so the gate costs it nothing; no in-repo caller of these
endpoints exists at all.

**Bound, not excused.** Admin still does **not** appear in either ingress list:
matching there is a *demotion* (the mobile-access gate is skipped and `proxy()`
returns before the sidecar-token block), and that token is admin's whole
protection. The new gate refuses and then falls through to the ordinary gate, so
a stamped-but-tokenless admin request is still 401. A test asserts exactly that,
and the mutation that turns the gate into a pass-through is caught by it.

`requireClientV1Admin` still reads no stamp of its own — the stamp is only
meaningful next to `remoteIngress`, which is assembled from the mobile and
sidecar gates and is not visible from a route handler. Duplicating a weaker
version of the check there would invite the two to drift.

## Tests

`auth.test.ts`'s `clientV1IngressKind` cases contained **no percent or backslash
input at all**, which is why this shipped. Added, in both static and dynamic
segment positions: percent, double-percent, literal backslash, encoded
backslash, encoded slash, encoded dot-dot, malformed escapes (`%zz`, a trailing
bare `%`), and mixed case on every escape that has one. Plus proxy-level tests
for the refusal, for the body-rule loss, for the admin peer gate, and a guard
that query-string percent-encoding stays legal.

### Mutation matrix

Every added assertion was mutation-checked: the fix was reverted piecewise, the
failure confirmed, and the file restored from `HEAD` (`git status --porcelain`
clean after each).

| # | Mutation | Result |
|---|---|---|
| M1 | proxy refusal disabled | ✗ *escaped target is refused…*, *body rules cannot be shed…* |
| M2 | admin loopback gate disabled | ✗ *client-v1 admin requires the listener's direct-loopback peer* |
| M3 | poll route's stamp check disabled | ✗ *poll refuses a caller without the listener's direct-loopback stamp* |
| M4 | refusal drops the backslash half | ✗ *escaped targets are refused, not classified* |
| M5 | `isClientV1Path` stops folding backslashes | ✗ *escaped targets are refused, not classified* |
| M6 | refusal widened to all of `/api/` | ✗ *escape refusal is scoped to the client-v1 path prefix*, + the escape test |
| M7 | refusal reads the query string too | ✗ *percent-encoding stays legal in the query string* |
| M8 | admin joins the ingress branch (pass-through) | ✗ *client-v1 admin requires the listener's direct-loopback peer* |
| M9 | `clientV1IngressKind` stops bailing on an escape | ✗ *escaped targets are refused, not classified* |
| M12 | `isClientV1AdminPath` matches only the exact `/admin` | ✗ *admin family is recognized…*, *admin requires the direct-loopback peer* |

No mutation survived.

## Assertions from #4847 / #4851 / #4849

None weakened, none deleted. The only pre-existing test line touched is the
`request()` helper in `pairing/requests/[id]/route.test.ts`, which now sends the
loopback stamp because the route under test re-checks it — an added header, not
a relaxed assertion. Every assertion in that file is unchanged and still passes.

## Docs

`docs/api/client-v1.md` documented the current behaviour of both issues; both
sections are rewritten, the two "known gap" bullets removed, and the poll route's
own section updated to state the stamp requirement and its 401 cause.
`scripts/client-v1-doc-contract.test.mjs` passes.

Closes #4843
