### PR TITLE
Serve the client-v1 canonical read projections (cave-jfa9y)

### DIFF
--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -7,14 +7,17 @@ without that client being part of the Cave build and without it being handed
 the desktop shell's own per-launch secret.
 
 **Read the scope line before you read anything else.** As of this commit the
-surface is eight routes: a health handshake, three pairing routes that walk a
-client from "no credential" to "holding a bearer", and four administrator
-routes that let the Cave's own settings UI see and decide those requests. There
-is **no authenticated resource route yet**. A bearer this API issues is real,
-persisted, and revocable, and it currently opens nothing — every route that
-would consume it is unbuilt. If you are writing a client, you can implement and
-test the whole pairing handshake today, and you will have nothing to call with
-the result.
+surface is thirteen routes: a health handshake, three pairing routes that walk a
+client from "no credential" to "holding a bearer", four administrator routes
+that let the Cave's own settings UI see and decide those requests, and **five
+canonical reads** a bearer actually opens — familiars, projects, conversations,
+one conversation, and that conversation's messages.
+
+Every read is a `GET`, requires the `chat:read` scope, and is paged with an
+opaque cursor. **Everything else is still unbuilt**: there is no write route, no
+streaming route, no attachment route, and the other five scopes
+(`chat:write`, `conversations:write`, `attachments:write`, `tasks:write`,
+`github:write`) are recorded on a credential and read by nothing.
 
 ## Where the contract actually lives
 
@@ -26,7 +29,7 @@ disagree, the code is right and this file is stale.
 | Versions, scopes, capabilities, error codes, limits, public-route list | [`src/lib/server/client-v1/contract.ts`](../../src/lib/server/client-v1/contract.ts) |
 | Byte-pinned export of all of the above, plus example envelopes | [`contract-fixture.json`](../../src/lib/server/client-v1/contract-fixture.json) and its `.sha256` |
 | Who may reach which route, and from where | [`src/proxy.ts`](../../src/proxy.ts) and [`src/proxy-helpers.ts`](../../src/proxy-helpers.ts) |
-| Per-route request and response shapes | the eight `route.ts` files under `src/app/api/client/v1/` |
+| Per-route request and response shapes | the thirteen `route.ts` files under `src/app/api/client/v1/` |
 | Storage, lifetimes, hashing | `pairing-store.ts`, `credential-store.ts`, `instance-id.ts` |
 | The discovery record a client reads to find the endpoint | [`server.ts`](../../server.ts) — **not** `client-v1/discovery.ts`, which nothing in production calls |
 
@@ -38,7 +41,7 @@ constants should vendor the fixture, not re-type the tables below.
 
 `scripts/client-v1-doc-contract.test.mjs` pins *this document* to both — every
 route file on disk and every entry in the contract's `publicRoutes`, every
-scope, and every error code must appear here, so a ninth route cannot land
+scope, and every error code must appear here, so a fourteenth route cannot land
 undocumented.
 
 ## The envelope
@@ -79,17 +82,21 @@ type level as well as in practice:
   client older than the minimum should stop and tell its user to update rather
   than pair.
 - **`capabilities`** is the full list above on every response. It is what the
-  surface *declares*; several entries (`familiars`, `projects`,
-  `conversations`, `conversation-messages`, `streaming`, `cursors`,
-  `revisions`) name route families that do not exist yet. Treat it as the
-  roadmap the Cave commits to, not as an inventory of live endpoints.
+  surface *declares*, and it is now partly an inventory: `familiars`,
+  `projects`, `conversations`, `conversation-messages` and `cursors` name live
+  routes (see *Canonical read routes*). `streaming` and `revisions` still name
+  route families that do not exist. Treat the list as the roadmap the Cave
+  commits to rather than as proof any one endpoint is there.
 - **`error.retryable`** defaults to `false` and is set true only where the
   route means it. Today that is exactly `pairing_pending`, `rate_limited`, and
   the `internal_error` a failed credential issue returns.
-- `requestId`, `identity`, `revision`, and `cursor` are defined on the envelope
-  and **no current route sets any of them**. They are the forward surface for
-  the paginated, revisioned resource routes; do not write a client that depends
-  on them being present.
+- **`cursor` is set by the canonical read routes** and by nothing else — see
+  *Paging* below for its exact shape and for when it is omitted. `requestId`,
+  `identity` and `revision` remain defined on the envelope and set by **no**
+  route; do not write a client that depends on them being present. `revision`
+  in particular is deliberately still unemitted: it implies a reconcile
+  protocol (a conditional read or write keyed on the token) that nothing
+  implements, and a token nothing consumes is worse than an absent field.
 
 `apiVersion`, `minimumClientVersion`, and `capabilities` deliberately ride the
 envelope and are *not* repeated inside `data` — including on `/health`, where
@@ -101,22 +108,22 @@ different answers to the same question.
 The mapping is total and canonical (`httpStatusForClientV1ErrorCode` in
 `responses.ts`); a route cannot serve `not_found` with a 200 or a 410. All
 thirteen codes are part of the contract, but only the ones marked *in use*
-are reachable on the eight routes that exist.
+are reachable on the thirteen routes that exist.
 
 | Code | HTTP | In use | What a client should do |
 |---|---|---|---|
-| `invalid_request` | 400 | yes | Fix the request. Never retry unchanged — the body or a field failed validation. |
-| `unauthorized` | 401 | yes | On pairing routes: the pairing secret is missing, malformed, or wrong, or the loopback stamp is absent. On admin routes: the sidecar token is wrong. Do not retry with the same credential. |
-| `scope_denied` | 403 | yes | Returned by admin mutations whose `Origin`/`Referer` is not same-origin. Also the intended answer for a credential lacking a required scope, once scoped routes exist. |
-| `not_found` | 404 | yes | The id does not exist. For pairing this includes "expired long enough ago to have been evicted". |
+| `invalid_request` | 400 | yes | Fix the request. Never retry unchanged — the body or a field failed validation. On the canonical reads it also covers an unsupported or repeated query parameter, an out-of-range `limit`, and a cursor this Cave did not mint. |
+| `unauthorized` | 401 | yes | On pairing routes: the pairing secret is missing, malformed, or wrong, or the loopback stamp is absent. On the canonical reads: the bearer is missing, malformed, unknown, or revoked — or the loopback stamp is absent. On admin routes: the sidecar token is wrong. Do not retry with the same credential. |
+| `scope_denied` | 403 | yes | A credential that exists but was not granted the scope the route requires — `chat:read` on every canonical read. Also returned by admin mutations whose `Origin`/`Referer` is not same-origin. Re-pair with the scope; retrying is pointless. |
+| `not_found` | 404 | yes | The id does not exist. For pairing this includes "expired long enough ago to have been evicted"; for a conversation it also covers an id that could never name one. |
 | `conflict` | 409 | yes | The resource is in a state that refuses this operation — a pairing already exchanged (`details.reason: "pairing_replayed"`) or already decided (`"pairing_already_decided"`). |
 | `pairing_pending` | 409 | yes | Retryable. Nobody has approved or denied yet. Poll. |
 | `pairing_denied` | 403 | yes | Terminal. The user said no; do not re-request without a fresh user action. |
 | `pairing_expired` | 410 | yes | Terminal for this request. Start a new pairing request. |
 | `rate_limited` | 429 | yes | Retryable. Honour `Retry-After`; `details.limit` and `details.resetAt` (epoch ms) carry the budget. |
 | `internal_error` | 500 | yes | Retryable where the route says so — see the exchange route, where a failed credential write restores the pairing precisely so a retry works. |
-| `service_unavailable` | 503 | yes | The Cave is not configured for this operation. On admin routes it means `COVEN_CAVE_AUTH_TOKEN` is unset. Not fixable by retrying. |
-| `reconcile_required` | 409 | no | Reserved for the resource routes' revision protocol. |
+| `service_unavailable` | 503 | yes | The Cave cannot answer right now. On admin routes it means `COVEN_CAVE_AUTH_TOKEN` is unset and is not fixable by retrying; on `GET /familiars` it means the daemon roster could not be read and **is** retryable. |
+| `reconcile_required` | 409 | yes | The client's position is no longer valid against canonical state. Today that is exactly one case: a messages cursor naming a turn that has left the conversation's active branch (`details.reason: "resume_from_canonical_state"`). Not retryable — restart the read. |
 | `incompatible_version` | 426 | no | Reserved. Version incompatibility is currently discovered by reading `minimumClientVersion` off `/health`, not by being told. |
 
 ## Reaching the API at all
@@ -154,10 +161,16 @@ the check fails closed: every route that depends on it answers 401 or 403.
 That branch also *skips* the mobile-access gate, which is why a phone reaching
 in over Tailscale Serve gets the 403 above rather than a mobile-auth prompt.
 
-Two of the four public routes re-check the stamp in the route itself
-(`POST /pairing/requests` and `POST .../exchange`, via
-`runtime.authenticator.isTrustedLoopback`) and answer `unauthorized` in the
-envelope when it fails. `GET /pairing/requests/:id` does not: it takes its
+`clientV1IngressKind` also classifies the five canonical read paths, as
+`authenticated` rather than public. That classification is a **demotion**, not a
+promotion: `proxy()` skips the mobile-access gate and returns *before* the
+sidecar-token block, so on those paths the route's own bearer check is the only
+credential check in the request. See *When the authenticated routes land*.
+
+Seven of the thirteen routes re-check the stamp in the route itself, via
+`runtime.authenticator.isTrustedLoopback`, and answer `unauthorized` in the
+envelope when it fails: `POST /pairing/requests`, `POST .../exchange`, and all
+five canonical reads. `GET /pairing/requests/:id` does not: it takes its
 locality entirely from the proxy branch, and its own 401s are about the pairing
 secret. `GET /health` performs no check of its own either — it is local because
 the proxy branch above says so, and for no other reason.
@@ -417,6 +430,321 @@ pairing under attack; other pairings are unaffected. **The bucket is shared with
 `GET /pairing/requests/:id`**, so guesses against either route spend the same
 ten and lock out both.
 
+## Canonical read routes
+
+The four resources the capability list has always advertised —
+`"familiars"`, `"projects"`, `"conversations"`, `"conversation-messages"` —
+served as paged reads over `"cursors"`. Every one of them is a `GET`, requires
+the `chat:read` scope, and projects a store the Cave itself reads, so a paired
+client and the desktop never disagree about what exists.
+
+### Authentication, and how it fails
+
+Each route performs two checks of its own, in this order, **before** it reads
+anything:
+
+1. **The loopback stamp** (`x-coven-cave-local-peer`), through
+   `runtime.authenticator.isTrustedLoopback` — the same check the two pairing
+   `POST`s make. A missing or wrong stamp is `unauthorized`. This is deliberate
+   redundancy: the proxy's direct-loopback branch already covers these paths,
+   but a percent-encoded dynamic segment escapes that branch entirely (see
+   *Reaching the API at all*), and two of these five paths are
+   dynamic-segmented.
+2. **The bearer**, through `requireScope({ bearer, scope: "chat:read" })`. The
+   credential is read **only** from an `Authorization: Bearer …` header —
+   never a query parameter, never a cookie. A missing, malformed, unknown, or
+   revoked bearer is `unauthorized`; a credential that exists but was not
+   granted `chat:read` is `scope_denied`.
+
+Both failures are metered, against different buckets — see *Rate limits*.
+
+Only then is the store read. That ordering is part of the contract, not an
+implementation detail: it means an unauthenticated caller cannot use these
+routes to drive a daemon request, scan the transcript directory, or learn
+whether a conversation id exists.
+
+### Paging: `limit` and `cursor`
+
+The list routes accept exactly two query parameters. **Any other parameter, and
+any repeated parameter, is `invalid_request`** — a `?limt=5` answered with the
+default page is how a client comes to believe it asked for five.
+
+| Parameter | Default | Rules |
+|---|---|---|
+| `limit` | `50` (`defaultPageSize`) | A plain positive integer, 1 to `100` (`maxPageSize`). No leading zeros, no sign, no exponent, no surrounding space. Out of range is refused, **not** clamped. |
+| `cursor` | — | An opaque token this Cave minted. Never construct or edit one. |
+
+`GET /api/client/v1/conversations/:id` serves a single record and therefore
+accepts **no** query parameters at all, including `limit` and `cursor`.
+
+The cursor rides the shared envelope:
+
+```json
+{
+  "cursor": { "current": "eyJ2Ijox…", "next": "eyJ2Ijox…", "hasMore": true }
+}
+```
+
+- **`next` is present only when `hasMore` is true.** Follow it until it is
+  absent; that is the whole termination rule.
+- **`current` is the token you sent**, absent on a first page.
+- **The `cursor` field is omitted entirely** when there is no token to publish —
+  a first page that holds the whole set, or an empty first page. Do not treat a
+  missing `cursor` as an error.
+- **Re-sending a cursor returns the same page.** Paging is a function of (store,
+  cursor, limit); replaying never advances and never loops.
+- **A deleted record does not strand you.** The token records a position in the
+  ordering, not an index, so the next page resumes at the next surviving record.
+- `previous` is never emitted. These reads are forward-only.
+
+Orderings are total — a sort key plus the id as tiebreak — because a page
+boundary landing between two records with equal sort keys would otherwise repeat
+both or skip both:
+
+| Route | Order |
+|---|---|
+| `/familiars` | `id` ascending. A roster entry has no timestamp at all, so the identity is the sort key. |
+| `/projects` | `createdAt` descending, then `id` descending. `createdAt` is immutable; `updatedAt` moves under an open cursor. |
+| `/conversations` | `updatedAt` descending, then `id` descending. `createdAt` is optional on a conversation summary, so it cannot key the page. |
+| `/conversations/:id/messages` | Transcript order, oldest first. **Not** a keyset — see that route. |
+
+**One consequence worth planning for:** `/conversations` keys on a *mutable*
+field, so a conversation that receives a turn while you are paging moves to the
+front of the ordering and can appear in two pages. The repeat is visible (the
+same `id` twice) and recoverable; the alternative — keying on a field half the
+corpus lacks — is neither.
+
+### `GET /api/client/v1/familiars`
+
+This Cave's visible familiar roster: the daemon roster merged with
+`familiars.toml` and the local removal tombstones, which is exactly what the
+Cave's own roster UI shows.
+
+**Request:** `Authorization: Bearer …`, the loopback stamp, optional `limit` and
+`cursor`.
+
+**200:**
+
+```json
+{
+  "data": {
+    "familiars": [
+      {
+        "id": "scribe",
+        "displayName": "Scribe",
+        "role": "Archivist",
+        "description": "Keeps the ledger.",
+        "pronouns": "they/them",
+        "status": "idle",
+        "lastSeenAt": "2026-08-20T10:00:00.000Z",
+        "activeSessions": 2
+      }
+    ]
+  },
+  "cursor": { "next": "eyJ2Ijox…", "hasMore": true }
+}
+```
+
+Only `id`, `displayName` and `role` are guaranteed; every other field is omitted
+when the roster does not carry it. `lastSeenAt` is the daemon's `last_seen`
+passed through verbatim — Cave neither writes nor parses it, so treat its format
+as unspecified rather than as an ISO instant.
+
+**503 `service_unavailable`, retryable:** the roster could not be read. This is
+returned for **every** roster failure, *including the daemon answering 401 or
+403*. That failure is about the Cave's own access token, not your bearer;
+discarding a working credential and re-pairing cannot fix a daemon outage.
+
+An empty roster is a `200` with `"familiars": []`, never a `404`.
+
+### `GET /api/client/v1/projects`
+
+The Cave project registry (`<cave home>/projects.json`), deduplicated by
+normalized root.
+
+**Request:** `Authorization: Bearer …`, the loopback stamp, optional `limit` and
+`cursor`.
+
+**200:**
+
+```json
+{
+  "data": {
+    "projects": [
+      {
+        "id": "p1",
+        "name": "Cave",
+        "root": "/Users/me/code/cave",
+        "color": "#123456",
+        "repoUrl": "https://github.com/OpenCoven/coven-cave",
+        "createdAt": "2026-08-01T00:00:00.000Z",
+        "updatedAt": "2026-08-09T00:00:00.000Z"
+      }
+    ]
+  }
+}
+```
+
+`color` and `repoUrl` are omitted when unset. `root` is an absolute path and is
+published deliberately: it is the registry's real identity, and a paired
+credential belongs to an application running as this user on this machine, which
+can already read the directory it names.
+
+Two fields of the stored record are **not** served. `legacyRoot` is
+response-only scaffolding that lets the Cave's own web client re-key browser
+stores after a root normalization; it is stripped before every write and is not
+part of what a project is. `access` is a familiar-scoped permission answer, and
+a Client v1 credential is not a familiar — this route serves the operator
+registry view, so there is no familiar whose access could be applied.
+
+### `GET /api/client/v1/conversations`
+
+The conversation ledger — the same rows, in the same order, that the Cave's own
+sessions list is built from.
+
+**Request:** `Authorization: Bearer …`, the loopback stamp, optional `limit` and
+`cursor`.
+
+**200:**
+
+```json
+{
+  "data": {
+    "conversations": [
+      {
+        "id": "conversation-1",
+        "familiarId": "scribe",
+        "harness": "claude",
+        "model": "opus",
+        "runtime": "native",
+        "title": "Ledger cleanup",
+        "origin": "chat",
+        "status": "completed",
+        "exitCode": 0,
+        "pending": false,
+        "createdAt": "2026-08-01T00:00:00.000Z",
+        "updatedAt": "2026-08-09T00:00:00.000Z"
+      }
+    ]
+  },
+  "cursor": { "next": "eyJ2Ijox…", "hasMore": true }
+}
+```
+
+Only `id`, `familiarId` and `updatedAt` are guaranteed. `exitCode` may be
+`null`, which means the run has no exit code yet — distinct from the field being
+absent, which means none was ever recorded.
+
+**No turns are included.** The transcript is served by the messages route below,
+which pages it. Inlining even the latest turn here would make the cost of a page
+depend on how much was said rather than on how many conversations you asked for.
+
+Three stored fields are deliberately withheld: `harnessSessionId` (it rotates on
+every resume and is never the conversation's identity), and `branch` / `prUrl`
+(working-tree attribution for the Cave's own PR badges, which describe the work
+rather than the conversation).
+
+### `GET /api/client/v1/conversations/:id`
+
+One conversation's record — the same projection, over the same source, that the
+list route serves for the same id. Use it to refresh one conversation without
+paging the whole ledger.
+
+**Request:** `Authorization: Bearer …` and the loopback stamp. **No query
+parameters**, including `limit` and `cursor`.
+
+**200:**
+
+```json
+{
+  "data": {
+    "conversation": {
+      "id": "conversation-1",
+      "familiarId": "scribe",
+      "updatedAt": "2026-08-09T00:00:00.000Z"
+    }
+  }
+}
+```
+
+**404 `not_found`:** no conversation carries that id. This is the answer for a
+malformed id too — an empty segment, a traversal attempt, an over-long string —
+because a client can act on neither differently, and one answer means the route
+cannot be used to map which id shapes the store recognises.
+
+Note this route reads the ledger rather than the transcript file, which costs a
+directory scan. That is on purpose: `status` and `exitCode` are *derived* while
+the ledger is built and do not exist in the stored file, so serving this from
+the file would answer the same question two different ways depending on which
+route you asked.
+
+### `GET /api/client/v1/conversations/:id/messages`
+
+One conversation's transcript, oldest first, paged.
+
+**Request:** `Authorization: Bearer …`, the loopback stamp, optional `limit` and
+`cursor`.
+
+**200:**
+
+```json
+{
+  "data": {
+    "messages": [
+      {
+        "id": "t3",
+        "conversationId": "conversation-1",
+        "parentId": "t1",
+        "role": "assistant",
+        "text": "Done.",
+        "createdAt": "2026-08-01T00:01:00.000Z",
+        "attachmentCount": 1,
+        "toolCount": 2,
+        "isError": false,
+        "cancelled": false
+      }
+    ]
+  },
+  "cursor": { "next": "eyJ2Ijox…", "hasMore": true }
+}
+```
+
+`role` is `"user"`, `"assistant"` or `"system"`. `parentId` is `null` for the
+root turn. `isError` and `cancelled` are omitted unless the store recorded them.
+
+**Two things about this route are not the obvious default**, and both come from
+how a conversation is stored:
+
+- **The messages are the *active branch*, not the stored array.** A conversation
+  file holds every turn of every branch in one append-ordered array; what you
+  get is the chain from the active leaf back to the root — the same path the
+  desktop renders. Turns on abandoned branches are not served.
+- **Paging resumes by position, not by comparing keys.** A user turn and the
+  assistant reply answering it are persisted with the *same* `createdAt`, and a
+  turn id is unique only inside one transcript, so any `(createdAt, id)` keyset
+  would put some replies in front of the prompts they answer.
+
+That second point makes one failure possible here that the list routes do not
+have:
+
+**409 `reconcile_required`, not retryable**, with
+`details.reason: "resume_from_canonical_state"`. The cursor names a turn that is
+no longer on the active branch — someone switched branches in the desktop while
+you were paging. Restart the read from the beginning. The route refuses to
+guess: restarting silently at the top would replay the conversation as if
+nothing had happened, and resuming at position zero would serve a different
+branch under the same token.
+
+**404 `not_found`:** the conversation does not exist, its file could not be
+read, or the id could never name one.
+
+**What is withheld, and why it matters.** A turn's `reasoning` is the harness's
+private scratchpad, and a tool call carries whatever the tool was pointed at — a
+path, a command, the contents of a file it read. Neither is served. `toolCount`
+and `attachmentCount` tell you the turn did work without handing over the work.
+`usage` and `costUsd` are also withheld. `chat:read` is a grant to read the
+conversation, not everything the conversation touched.
+
 ## Administrator routes
 
 These four are the Cave's own consent surface: the settings UI that lists
@@ -573,8 +901,8 @@ entries per category with least-recently-seen eviction.
 |---|---|---|---|
 | Pairing creation | 10 / 60 s | the loopback stamp — one process-wide constant, so this is a single shared bucket | every accepted `POST /pairing/requests` |
 | Pairing secret failure | 10 / 60 s | the pairing request id | only a **wrong** secret, on `POST .../exchange` **or** `GET /pairing/requests/:id` — one shared bucket |
-| Authenticated requests | 120 / 60 s | credential id | *nothing yet* — no route calls it |
-| Invalid bearer | 120 / 60 s | source identity | *nothing yet* — no route calls it |
+| Authenticated requests | 120 / 60 s | credential id | every accepted canonical read, **and** every `scope_denied` on one — a real credential asking for a grant it does not hold is an authenticated request |
+| Invalid bearer | 120 / 60 s | the loopback stamp — one process-wide constant, so this is a single shared bucket | every `unauthorized` on a canonical read: a missing, malformed, unknown, or revoked bearer |
 
 Creation is bounded process-wide on purpose: each accepted request occupies a
 slot in a fixed-size store, so the quantity worth bounding is the total rate of
@@ -723,16 +1051,21 @@ Client-side rules that fall out of the above:
 Stated because a client author will otherwise discover them by writing code
 against something that is not there.
 
-- **No authenticated route exists.** `requireScope`, `consumeAuthenticated`, and
-  `consumeInvalidBearer` have zero non-test call sites, so a bearer is currently
-  issued, persisted, listed, and revocable — and never verified. Nothing
-  pre-authorizes the routes that will consume it, either:
-  `CLIENT_V1_AUTHENTICATED_PATHS` (`src/proxy-helpers.ts`) is now **empty**, so
-  every client-v1 path with no handler classifies `null` and falls through to
-  the ordinary sidecar-token gate. See *When the authenticated routes land*.
-- **Scopes are recorded, not enforced.** They are validated on request, stored
-  on the credential, and shown to the approving user. Nothing reads them at
-  request time yet, because nothing consumes a credential.
+- **Reads only.** The five canonical reads are the whole authenticated surface.
+  There is no way to send a message, create a conversation, upload an
+  attachment, or act on a task through this API, and the five write scopes are
+  recorded on a credential and read by nothing.
+- **`streaming` and `revisions` are advertised and unbuilt.** Both are in the
+  capability list; neither has a route. To follow a running conversation today
+  you re-read `GET /conversations/:id/messages` and diff — there is no
+  server-push channel, and no revision token to make a conditional read cheap.
+- **`/conversations` pages on a mutable key.** A conversation whose transcript
+  grows while you are paging moves to the front of the ordering, so it can
+  appear in two pages. Deduplicate by `id`. See *Paging* for why the immutable
+  alternative is unavailable here.
+- **A conversation's whole turn text is served inline.** There is no per-message
+  size cap and no truncation, so a page of 100 long turns is a large response.
+  Ask for a smaller `limit` on a constrained client.
 - **The reviewed discovery module has no production caller** — but the record
   itself is written; see *Finding the endpoint* above. `server.ts` cannot import
   from `src/`, so it carries its own copy of the publish/remove logic and
@@ -742,24 +1075,31 @@ against something that is not there.
   the reviewed side.
 - **Admin routes are not bound to direct loopback** —
   [#4843](https://github.com/OpenCoven/coven-cave/issues/4843), described above.
-- **A percent-encoded pairing id escapes the client-v1 ingress branch** —
-  `cave-f1xki`, described above. Reproduced, not yet fixed.
-- **`requestId` is never emitted**, so there is no server-assigned correlation
-  id to quote in a bug report. The envelope field exists; no route sets it.
+- **A percent-encoded dynamic segment escapes the client-v1 ingress branch** —
+  `cave-f1xki` / [#4854](https://github.com/OpenCoven/coven-cave/issues/4854),
+  described above. Reproduced, not yet fixed. It now reaches two canonical reads
+  as well as the pairing lookup, which is why both re-check the loopback stamp
+  in the route rather than relying on the branch.
+- **`requestId` and `identity` are never emitted**, so there is no
+  server-assigned correlation id to quote in a bug report and no envelope-level
+  statement of which resource a response describes. Both envelope fields exist;
+  no route sets either.
 
 ## When the authenticated routes land
 
-Nothing here is callable yet, but the wiring a Phase 2 route inherits is already
-decided, and it is not the obvious default. Read this before adding one.
+The first five landed (cave-jfa9y). The wiring they inherited is not the obvious
+default, and it is the same wiring the next one will inherit — read this before
+adding a route here.
 
-`CLIENT_V1_AUTHENTICATED_PATHS` is empty on purpose. **Matching it is a
-demotion, not a promotion**: `proxy()` computes the ingress kind before the
-mobile-access gate, skips that gate for any client-v1 match, and returns before
-the sidecar-token block ever runs — so for a listed path the *only* credential
-check left is the one the route performs on itself. That is a sound trade for a
-route that really calls `requireScope`, and a hole for a path that does not
-exist yet: a handler landing later would inherit an exemption it never opted
-into. The list previously named thirteen Phase 2 paths against zero handlers.
+`CLIENT_V1_AUTHENTICATED_PATHS` now holds exactly those five paths. **Matching
+it is a demotion, not a promotion**: `proxy()` computes the ingress kind before
+the mobile-access gate, skips that gate for any client-v1 match, and returns
+before the sidecar-token block ever runs — so for a listed path the *only*
+credential check left is the one the route performs on itself. That is a sound
+trade for a route that really calls `requireScope`, and a hole for a path that
+does not exist yet: a handler landing later would inherit an exemption it never
+opted into. The list previously named thirteen Phase 2 paths against zero
+handlers, which is why it was emptied before any of them existed.
 
 **But absence is a decision too, and it costs something.** Both of the
 client-v1-only protections described under *Reaching the API at all* are gated
@@ -783,3 +1123,22 @@ rather than a list somebody must remember to prune:
    `requireClientV1Admin`. Both are matched against a comment-, string- and
    regex-stripped view of the source, so a `// TODO: … requireScope(…)` on a
    route with no credential check does not satisfy them.
+3. the same route must also call `consumeAuthenticated`. A pre-authorized path
+   has already given up the sidecar-token gate, so an unmetered one lets a
+   single valid bearer drive the credential store, the daemon, and the
+   transcript directory without bound — and nothing else in the suite would
+   notice, because an unmetered route passes every functional test it has.
+
+Two consequences of that first assertion are worth stating outright, because
+both look like bugs from outside:
+
+- **The route must not depend on the ingress branch it is listed for.** The
+  percent-encoding hole above means the branch can be skipped entirely, so each
+  of the five re-checks the loopback stamp itself. Being on the list is not a
+  guarantee that `proxy()` classified the request.
+- **A path can be listed without being a distinct route.**
+  `/api/client/v1/conversations/search` classifies `authenticated` because there
+  is no static `search` route under `conversations` — the App Router serves that
+  path from the `[id]` handler with the id `"search"`, which answers
+  `not_found`. Classifying it any other way would describe a route that does not
+  exist.

--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -642,7 +642,7 @@ sessions list is built from.
         "familiarId": "scribe",
         "harness": "claude",
         "model": "opus",
-        "runtime": "native",
+        "runtime": "local:/Users/me/code/app",
         "title": "Ledger cleanup",
         "origin": "chat",
         "status": "completed",
@@ -660,6 +660,15 @@ sessions list is built from.
 Only `id`, `familiarId` and `updatedAt` are guaranteed. `exitCode` may be
 `null`, which means the run has no exit code yet — distinct from the field being
 absent, which means none was ever recorded.
+
+**`runtime` is not an enum, and for a local run it is a path.**
+`POST /api/chat/send` writes the field as
+`local:<the run's working directory>`, so the value you actually receive on most
+conversations looks like `"local:/Users/me/code/app"` — an absolute path, often
+under the operator's home directory, and not necessarily a registered project
+root. It is served on the same grounds as a project's `root`: a paired
+credential belongs to an application running as this user on this machine. Treat
+it as an opaque string, and think before you log or display it.
 
 **No turns are included.** The transcript is served by the messages route below,
 which pages it. Inlining even the latest turn here would make the cost of a page

--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -121,7 +121,7 @@ are reachable on the thirteen routes that exist.
 | `pairing_denied` | 403 | yes | Terminal. The user said no; do not re-request without a fresh user action. |
 | `pairing_expired` | 410 | yes | Terminal for this request. Start a new pairing request. |
 | `rate_limited` | 429 | yes | Retryable. Honour `Retry-After`; `details.limit` and `details.resetAt` (epoch ms) carry the budget. |
-| `internal_error` | 500 | yes | Retryable where the route says so — see the exchange route, where a failed credential write restores the pairing precisely so a retry works. |
+| `internal_error` | 500 | yes | Retryable where the route says so — see the exchange route, where a failed credential write restores the pairing precisely so a retry works. On the canonical reads it is **not** retryable: it means a stored record could not be projected, and the store answers the same way next second. |
 | `service_unavailable` | 503 | yes | The Cave cannot answer right now. On admin routes it means `COVEN_CAVE_AUTH_TOKEN` is unset and is not fixable by retrying; on `GET /familiars` it means the daemon roster could not be read and **is** retryable. |
 | `reconcile_required` | 409 | yes | The client's position is no longer valid against canonical state. Today that is exactly one case: a messages cursor naming a turn that has left the conversation's active branch (`details.reason: "resume_from_canonical_state"`). Not retryable — restart the read. |
 | `incompatible_version` | 426 | no | Reserved. Version incompatibility is currently discovered by reading `minimumClientVersion` off `/health`, not by being told. |
@@ -463,6 +463,29 @@ implementation detail: it means an unauthenticated caller cannot use these
 routes to drive a daemon request, scan the transcript directory, or learn
 whether a conversation id exists.
 
+### When a stored record cannot be projected
+
+**500 `internal_error`, not retryable.** None of the stores behind these routes
+validates the JSON it returns, so a required field can arrive absent or wrongly
+typed — a hand-edited `projects.json` row with no `createdAt`, a conversation
+file written by an older Cave, a daemon that renamed a roster field. The
+projection refuses such a record rather than serving a shape that contradicts
+the types above, and the route answers this.
+
+Three things follow, and a client should plan for all three:
+
+- **It is envelope-shaped**, like every other answer here. It replaced an
+  uncaught throw, which Next answered with a body that is not a Client v1
+  envelope at all.
+- **It is not retryable and carries no `details`.** The record reads the same
+  next second, and naming the field would describe the contents of the
+  operator's disk to a caller who cannot repair it. Surface it and stop.
+- **It is per *page*, not per record.** One unprojectable row fails every page
+  that contains it, so a paging walk stops there rather than skipping the row —
+  quietly dropping a record from a *canonical* read would tell a client the
+  conversation does not exist. Rows before it in the ordering are served
+  normally.
+
 ### Paging: `limit` and `cursor`
 
 The list routes accept exactly two query parameters. **Any other parameter, and
@@ -487,7 +510,10 @@ The cursor rides the shared envelope:
 
 - **`next` is present only when `hasMore` is true.** Follow it until it is
   absent; that is the whole termination rule.
-- **`current` is the token you sent**, absent on a first page.
+- **`current` is the token you sent**, absent on a first page. Strictly it is a
+  re-mint of the position that token named, which is the same bytes for every
+  token this Cave issued and need not be for one you wrote yourself — another
+  reason not to.
 - **The `cursor` field is omitted entirely** when there is no token to publish —
   a first page that holds the whole set, or an empty first page. Do not treat a
   missing `cursor` as an error.
@@ -709,8 +735,17 @@ One conversation's transcript, oldest first, paged.
 }
 ```
 
-`role` is `"user"`, `"assistant"` or `"system"`. `parentId` is `null` for the
-root turn. `isError` and `cancelled` are omitted unless the store recorded them.
+`role` is `"user"`, `"assistant"` or `"system"` — a turn carrying anything else
+is refused rather than served. `parentId` is `null` for the root turn. `isError`
+and `cancelled` are omitted unless the store recorded them.
+
+**`conversationId` is the transcript's own id, not the one you spelled in the
+URL.** A conversation resolves to a file, and the filesystems this ships on are
+case-insensitive, so `/conversations/CONVERSATION-1/messages` answers with the
+messages of `conversation-1`. The id you get back is therefore always one
+`GET /conversations/:id` will also answer to — the requested spelling need not
+be, because that route matches the ledger exactly and answers `not_found` for a
+case that does not match.
 
 **Two things about this route are not the obvious default**, and both come from
 how a conversation is stored:

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1395,6 +1395,14 @@ export const SUITES = {
     "src/app/api/client/v1/admin/credentials/route.test.ts",
     "src/app/api/client/v1/admin/credentials/[id]/route.test.ts",
     "src/app/api/client/v1/admin/security.e2e.test.ts",
+    "src/lib/server/client-v1/pagination.test.ts",
+    "src/lib/server/client-v1/reads.test.ts",
+    "src/lib/server/client-v1/read-guard.test.ts",
+    "src/app/api/client/v1/familiars/route.test.ts",
+    "src/app/api/client/v1/projects/route.test.ts",
+    "src/app/api/client/v1/conversations/route.test.ts",
+    "src/app/api/client/v1/conversations/[id]/route.test.ts",
+    "src/app/api/client/v1/conversations/[id]/messages/route.test.ts",
     "src/app/api/x/account-routes.test.ts",
     "src/app/api/x/research-routes.test.ts",
     "src/app/api/research/recommendations/route.test.ts",
@@ -1866,6 +1874,14 @@ const ALIAS_LOADER = new Set([
   "src/app/api/client/v1/admin/credentials/route.test.ts",
   "src/app/api/client/v1/admin/credentials/[id]/route.test.ts",
   "src/app/api/client/v1/admin/security.e2e.test.ts",
+  // The Phase 2 canonical reads: the route modules resolve "@/lib/server/..."
+  // and "@/proxy-helpers" as runtime values, and their suites import the same
+  // aliases for the loopback header and the runtime factory.
+  "src/app/api/client/v1/familiars/route.test.ts",
+  "src/app/api/client/v1/projects/route.test.ts",
+  "src/app/api/client/v1/conversations/route.test.ts",
+  "src/app/api/client/v1/conversations/[id]/route.test.ts",
+  "src/app/api/client/v1/conversations/[id]/messages/route.test.ts",
   // onboarding diagnostics and core tools resolve shared server/API aliases.
   "src/lib/server/onboarding-diagnostics.test.ts",
   "src/lib/server/onboarding-core-tools.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -110,10 +110,24 @@ const contracts: RouteContract[] = [
   { route: "/client/v1/admin/credentials/[id]", methods: ["DELETE"], kind: "json", readsJson: true },
   { route: "/client/v1/admin/pairing-requests", methods: ["GET"], kind: "json" },
   { route: "/client/v1/admin/pairing-requests/[id]/decision", methods: ["POST"], kind: "json", readsJson: true },
+  // The Phase 2 canonical reads (cave-jfa9y). Every one is a GET with no body,
+  // and every one authenticates its own bearer through requireScope — which is
+  // load-bearing rather than routine, because these five paths are the first
+  // entries in CLIENT_V1_AUTHENTICATED_PATHS and a listed path returns from
+  // proxy() before the sidecar-token block ever runs. They also re-check the
+  // loopback stamp for themselves, the way the two pairing POSTs do, because a
+  // percent-encoded dynamic segment escapes the client-v1 ingress branch that
+  // would otherwise guarantee it (#4854) — and two of these five are
+  // dynamic-segmented.
+  { route: "/client/v1/conversations", methods: ["GET"], kind: "json" },
+  { route: "/client/v1/conversations/[id]", methods: ["GET"], kind: "json" },
+  { route: "/client/v1/conversations/[id]/messages", methods: ["GET"], kind: "json" },
+  { route: "/client/v1/familiars", methods: ["GET"], kind: "json" },
   { route: "/client/v1/health", methods: ["GET"], kind: "json" },
   { route: "/client/v1/pairing/requests", methods: ["POST"], kind: "json", readsJson: true },
   { route: "/client/v1/pairing/requests/[id]", methods: ["GET"], kind: "json" },
   { route: "/client/v1/pairing/requests/[id]/exchange", methods: ["POST"], kind: "json" },
+  { route: "/client/v1/projects", methods: ["GET"], kind: "json" },
   { route: "/codex-automations/[id]", methods: ["GET", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/codex-automations/[id]/run", methods: ["POST"], kind: "json", localOriginGuard: true },
   { route: "/codex-automations/[id]/runs", methods: ["GET"], kind: "json" },
@@ -577,14 +591,15 @@ const actualRoutes = routeFiles.map(routeFromFile).sort();
 const contractRoutes = contracts.map((contract) => contract.route).sort();
 
 // Phase 0 forbade every /api/client/v1 route while the public contract was
-// still an unserved module. Phase 1 ends that for the reviewed bootstrap and
+// still an unserved module. Phase 1 ended that for the reviewed bootstrap and
 // admin surface: health (a client cannot discover it is too old without an
 // endpoint to ask), the pairing exchange, and the admin routes that approve
-// and revoke credentials. The gate is narrowed rather than dropped, because
-// what it was really protecting against is client-v1 surface appearing faster
-// than it is reviewed — so each new route has to be added here deliberately,
-// not just by existing on disk. This is the single allow-list: health and the
-// pairing authority narrow it once, together, to the routes that exist.
+// and revoke credentials. Phase 2 adds the canonical reads the contract's
+// capability list has been advertising since Phase 0 — familiars, projects,
+// conversations, and a conversation's messages (cave-jfa9y). The gate is
+// narrowed rather than dropped, because what it was really protecting against
+// is client-v1 surface appearing faster than it is reviewed — so each new route
+// has to be added here deliberately, not just by existing on disk.
 assert.deepEqual(
   actualRoutes.filter((route) => route.startsWith("/client/v1")),
   [
@@ -592,12 +607,17 @@ assert.deepEqual(
     "/client/v1/admin/credentials/[id]",
     "/client/v1/admin/pairing-requests",
     "/client/v1/admin/pairing-requests/[id]/decision",
+    "/client/v1/conversations",
+    "/client/v1/conversations/[id]",
+    "/client/v1/conversations/[id]/messages",
+    "/client/v1/familiars",
     "/client/v1/health",
     "/client/v1/pairing/requests",
     "/client/v1/pairing/requests/[id]",
     "/client/v1/pairing/requests/[id]/exchange",
+    "/client/v1/projects",
   ],
-  "Phase 1 must expose exactly the reviewed client-v1 bootstrap and admin routes",
+  "client-v1 must expose exactly the reviewed bootstrap, admin, and canonical-read routes",
 );
 assert.deepEqual(actualRoutes, contractRoutes, "every src/app/api route must have an API contract entry");
 
@@ -717,6 +737,23 @@ for (const { file, route } of clientV1Routes) {
     source,
     /requireScope\s*\(/,
     `${route} is neither the admin family nor the reviewed credential-free bootstrap surface, so it must call requireScope`,
+  );
+  // Half three (cave-jfa9y): the same route must also meter the credential it
+  // just accepted. Added with the first routes that actually call requireScope,
+  // because until then consumeAuthenticated had no caller and the obligation
+  // had nothing to attach to. A pre-authorized path has already given up the
+  // sidecar-token gate, so an unmetered one lets a single valid bearer drive
+  // the store, the daemon, and the transcript directory without bound — and
+  // nothing else in the suite would notice, since an unmetered route passes
+  // every functional test it has.
+  //
+  // Matched on the success-path charge specifically. A future route that needs
+  // a different budget should widen this alternation deliberately, in review,
+  // rather than inherit an exemption by being written differently.
+  assert.match(
+    source,
+    /consumeAuthenticated\s*\(/,
+    `${route} calls requireScope but never charges the authenticated rate-limit budget`,
   );
 }
 

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -747,9 +747,10 @@ for (const { file, route } of clientV1Routes) {
   // nothing else in the suite would notice, since an unmetered route passes
   // every functional test it has.
   //
-  // Matched on the success-path charge specifically. A future route that needs
-  // a different budget should widen this alternation deliberately, in review,
-  // rather than inherit an exemption by being written differently.
+  // Matched on the success-path charge specifically, and on that name ALONE —
+  // there is no alternation here, deliberately. A future route that meters
+  // against a different budget fails this assertion and has to widen it in
+  // review rather than inherit an exemption by being written differently.
   assert.match(
     source,
     /consumeAuthenticated\s*\(/,

--- a/src/app/api/client/v1/conversations/[id]/messages/route.test.ts
+++ b/src/app/api/client/v1/conversations/[id]/messages/route.test.ts
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import type { ChatTurn, ConversationFile } from "@/lib/cave-conversations.ts";
+import { encodeClientV1Cursor } from "@/lib/server/client-v1/pagination.ts";
+import type { ClientV1ReadSources } from "@/lib/server/client-v1/read-sources.ts";
+import { createClientV1Runtime, type ClientV1Runtime } from "@/lib/server/client-v1/runtime.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
+
+import { createClientV1ConversationMessagesGetHandler } from "./route.ts";
+
+const scratchPrefix = resolve(process.cwd(), ".scratch-client-v1-messages-");
+const STAMP = "loopback-secret";
+
+function turn(
+  id: string,
+  parentId: string | null,
+  at: string,
+  role: ChatTurn["role"] = "user",
+): ChatTurn {
+  return { id, parentId, role, text: `text-${id}`, createdAt: at };
+}
+
+/**
+ * A branched transcript. t2 is an abandoned reply to t1; the live branch is
+ * t1 → t3 → t4, and both replies were persisted with their prompt's stamp.
+ */
+const BRANCHED: ConversationFile = {
+  sessionId: "conversation-1",
+  familiarId: "scribe",
+  harness: "claude",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-01T00:02:00.000Z",
+  activeLeafId: "t4",
+  turns: [
+    turn("t1", null, "2026-08-01T00:00:00.000Z"),
+    turn("t2", "t1", "2026-08-01T00:00:00.000Z", "assistant"),
+    turn("t3", "t1", "2026-08-01T00:00:00.000Z", "assistant"),
+    turn("t4", "t3", "2026-08-01T00:02:00.000Z"),
+  ],
+};
+
+function sources(overrides: Partial<ClientV1ReadSources> = {}): ClientV1ReadSources {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unsupported read source for this route");
+  };
+  return {
+    listFamiliars: unsupported,
+    listProjects: unsupported,
+    listConversations: unsupported,
+    loadConversation: async (id) => (id === "conversation-1" ? BRANCHED : null),
+    ...overrides,
+  };
+}
+
+function request(id: string, headers: Record<string, string> = {}, query = ""): Request {
+  return new Request(
+    `http://127.0.0.1:3020/api/client/v1/conversations/${encodeURIComponent(id)}/messages${query}`,
+    { headers: { [LOCAL_PEER_HEADER]: STAMP, ...headers } },
+  );
+}
+
+function context(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function withRuntime<T>(
+  scopes: ("chat:read" | "chat:write")[],
+  body: (runtime: ClientV1Runtime, bearer: string) => Promise<T>,
+): Promise<T> {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const runtime = createClientV1Runtime({ credentialRoot: root, loopbackSecret: STAMP });
+    const issued = await runtime.credentialStore.issue({
+      appName: "OpenCoven Chat",
+      installationId: "chat-install-1",
+      scopes,
+    });
+    return await body(runtime, issued.bearer);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+test("messages are the live branch in chronological order, not the stored array", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationMessagesGetHandler(runtime, sources());
+    const response = await handler(
+      request("conversation-1", { authorization: `Bearer ${bearer}` }),
+      context("conversation-1"),
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      capabilities: string[];
+      data: { messages: Record<string, unknown>[] };
+    };
+    // t2 is on the branch the user walked away from; serving the raw turns
+    // array would interleave it into the transcript.
+    assert.deepEqual(body.data.messages.map((message) => message.id), ["t1", "t3", "t4"]);
+    assert.deepEqual(body.data.messages[1], {
+      id: "t3",
+      conversationId: "conversation-1",
+      parentId: "t1",
+      role: "assistant",
+      text: "text-t3",
+      createdAt: "2026-08-01T00:00:00.000Z",
+      attachmentCount: 0,
+      toolCount: 0,
+    });
+    assert.ok(body.capabilities.includes("conversation-messages"));
+  });
+});
+
+test("paging a transcript resumes by position, so a shared stamp cannot reorder it", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationMessagesGetHandler(runtime, sources());
+    const authorization = `Bearer ${bearer}`;
+    // t1 and t3 carry the SAME createdAt. A keyset over (createdAt, id) would
+    // have to break the tie on the id, which puts the reply before the prompt
+    // it answers.
+    const first = await handler(
+      request("conversation-1", { authorization }, "?limit=2"),
+      context("conversation-1"),
+    );
+    const firstBody = await first.json() as {
+      cursor: { next: string; hasMore: boolean };
+      data: { messages: { id: string }[] };
+    };
+    assert.deepEqual(firstBody.data.messages.map((message) => message.id), ["t1", "t3"]);
+    assert.equal(firstBody.cursor.hasMore, true);
+
+    const second = await handler(
+      request(
+        "conversation-1",
+        { authorization },
+        `?limit=2&cursor=${encodeURIComponent(firstBody.cursor.next)}`,
+      ),
+      context("conversation-1"),
+    );
+    const secondBody = await second.json() as {
+      cursor: { current: string; next?: string; hasMore: boolean };
+      data: { messages: { id: string }[] };
+    };
+    assert.deepEqual(secondBody.data.messages.map((message) => message.id), ["t4"]);
+    assert.equal(secondBody.cursor.hasMore, false);
+    assert.equal(secondBody.cursor.next, undefined);
+
+    // Replaying the same cursor returns the same page rather than advancing.
+    const replay = await handler(
+      request(
+        "conversation-1",
+        { authorization },
+        `?limit=2&cursor=${encodeURIComponent(firstBody.cursor.next)}`,
+      ),
+      context("conversation-1"),
+    );
+    assert.deepEqual(await replay.json(), secondBody);
+  });
+});
+
+test("a cursor whose turn left the active branch is reconcile_required", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationMessagesGetHandler(runtime, sources());
+    // t2 is a real turn in the file and is NOT on the branch being served, so
+    // this is precisely the state a client reaches by paging while someone
+    // switches branches in the desktop. Restarting at the top would silently
+    // replay the conversation; resuming at position zero would serve a
+    // different branch under the same token.
+    const stale = encodeClientV1Cursor({ sort: "2026-08-01T00:00:00.000Z", id: "t2" });
+    const response = await handler(
+      request("conversation-1", { authorization: `Bearer ${bearer}` }, `?cursor=${encodeURIComponent(stale)}`),
+      context("conversation-1"),
+    );
+    assert.equal(response.status, 409);
+    const body = await response.json() as {
+      error: { code: string; retryable: boolean; details: { reason: string } };
+    };
+    assert.equal(body.error.code, "reconcile_required");
+    assert.equal(body.error.details.reason, "resume_from_canonical_state");
+    // Not retryable: the same cursor will be refused the same way until the
+    // client restarts the read.
+    assert.equal(body.error.retryable, false);
+  });
+});
+
+test("an empty transcript is an empty page with no cursor", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationMessagesGetHandler(
+      runtime,
+      sources({
+        loadConversation: async () => ({ ...BRANCHED, activeLeafId: undefined, turns: [] }),
+      }),
+    );
+    const response = await handler(
+      request("conversation-1", { authorization: `Bearer ${bearer}` }),
+      context("conversation-1"),
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json() as { cursor?: unknown; data: { messages: unknown[] } };
+    assert.deepEqual(body.data.messages, []);
+    assert.equal("cursor" in body, false);
+  });
+});
+
+test("an unreadable or absent transcript is not_found, never a 500", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationMessagesGetHandler(runtime, sources());
+    const authorization = `Bearer ${bearer}`;
+    // loadConversation resolves the id through a traversal guard and returns
+    // null for anything it refuses, so a `..` segment that survived URL
+    // decoding (#4854) reads as absent rather than reaching the filesystem.
+    for (const id of ["conversation-9", "../../../etc/passwd", ".."]) {
+      const response = await handler(request(id, { authorization }), context(id));
+      assert.equal(response.status, 404, id);
+      assert.equal(
+        (await response.json() as { error: { code: string } }).error.code,
+        "not_found",
+        id,
+      );
+    }
+  });
+});
+
+test("the transcript's harness internals never reach the wire", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationMessagesGetHandler(
+      runtime,
+      sources({
+        loadConversation: async () => ({
+          ...BRANCHED,
+          activeLeafId: "t1",
+          turns: [
+            {
+              ...turn("t1", null, "2026-08-01T00:00:00.000Z", "assistant"),
+              reasoning: "private-scratchpad",
+              tools: [{
+                id: "tool-1",
+                name: "bash",
+                input: "cat ~/.ssh/id_rsa",
+                output: "PRIVATE-KEY-MATERIAL",
+                status: "ok",
+              }],
+              costUsd: 0.02,
+            },
+          ],
+        }),
+      }),
+    );
+    const response = await handler(
+      request("conversation-1", { authorization: `Bearer ${bearer}` }),
+      context("conversation-1"),
+    );
+    const raw = await response.text();
+    for (const leaked of ["private-scratchpad", "PRIVATE-KEY-MATERIAL", "id_rsa", "costUsd"]) {
+      assert.equal(raw.includes(leaked), false, leaked);
+    }
+    const body = JSON.parse(raw) as { data: { messages: { toolCount: number }[] } };
+    // The fact that the turn ran a tool is still reported; what the tool
+    // touched is not.
+    assert.equal(body.data.messages[0].toolCount, 1);
+  });
+});
+
+test("the route refuses every request that does not carry a scoped bearer", async () => {
+  await withRuntime(["chat:write"], async (runtime, writeOnlyBearer) => {
+    const handler = createClientV1ConversationMessagesGetHandler(runtime, sources());
+    assert.equal(
+      (await handler(request("conversation-1"), context("conversation-1"))).status,
+      401,
+    );
+    assert.equal(
+      (await handler(
+        request("conversation-1", { authorization: "Bearer not-a-real-bearer" }),
+        context("conversation-1"),
+      )).status,
+      401,
+    );
+    assert.equal(
+      (await handler(
+        request("conversation-1", { authorization: `Bearer ${writeOnlyBearer}` }),
+        context("conversation-1"),
+      )).status,
+      403,
+    );
+    const unstamped = new Request(
+      "http://127.0.0.1:3020/api/client/v1/conversations/conversation-1/messages",
+      { headers: { authorization: `Bearer ${writeOnlyBearer}` } },
+    );
+    assert.equal((await handler(unstamped, context("conversation-1"))).status, 401);
+  });
+});
+
+test("no transcript is opened before the credential is checked", async () => {
+  let reads = 0;
+  await withRuntime(["chat:write"], async (runtime, writeOnlyBearer) => {
+    const handler = createClientV1ConversationMessagesGetHandler(
+      runtime,
+      sources({
+        loadConversation: async () => {
+          reads += 1;
+          return BRANCHED;
+        },
+      }),
+    );
+    await handler(request("conversation-1"), context("conversation-1"));
+    await handler(
+      request("conversation-1", { authorization: `Bearer ${writeOnlyBearer}` }),
+      context("conversation-1"),
+    );
+    assert.equal(reads, 0);
+  });
+});

--- a/src/app/api/client/v1/conversations/[id]/messages/route.test.ts
+++ b/src/app/api/client/v1/conversations/[id]/messages/route.test.ts
@@ -312,3 +312,65 @@ test("no transcript is opened before the credential is checked", async () => {
     assert.equal(reads, 0);
   });
 });
+
+test("conversationId is the transcript's own id, never the spelling in the URL", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    // A conversation resolves to a FILE, and both filesystems this ships on are
+    // case-insensitive, so `/conversations/CONVERSATION-1/messages` reads
+    // conversation-1.json and answers 200. Echoing the requested spelling
+    // handed the client a `conversationId` that `GET /conversations/<that>`
+    // then answers `not_found` for, because the ledger route matches sessionId
+    // exactly — two canonical reads disagreeing about one conversation's id.
+    //
+    // The fixture is the seam, not the filesystem: loadConversation is the
+    // thing that resolves loosely, so the source below stands in for it.
+    const handler = createClientV1ConversationMessagesGetHandler(
+      runtime,
+      sources({
+        loadConversation: async (id) =>
+          (id.toLowerCase() === "conversation-1" ? BRANCHED : null),
+      }),
+    );
+    const response = await handler(
+      request("CONVERSATION-1", { authorization: `Bearer ${bearer}` }),
+      context("CONVERSATION-1"),
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json() as { data: { messages: { conversationId: string }[] } };
+    assert.ok(body.data.messages.length > 0);
+    for (const message of body.data.messages) {
+      assert.equal(message.conversationId, "conversation-1");
+    }
+  });
+});
+
+test("an unprojectable turn answers an envelope, not a Next error page", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    // loadConversation validates nothing beyond "this parsed", so a transcript
+    // whose turn carries no text reached the envelope builder as `undefined`
+    // and threw out of the handler. Next answered with its own body, which no
+    // Client v1 client can parse.
+    const handler = createClientV1ConversationMessagesGetHandler(
+      runtime,
+      sources({
+        loadConversation: async () => ({
+          ...BRANCHED,
+          activeLeafId: "t9",
+          turns: [{ id: "t9", parentId: null, role: "user" } as ChatTurn],
+        }),
+      }),
+    );
+    const response = await handler(
+      request("conversation-1", { authorization: `Bearer ${bearer}` }),
+      context("conversation-1"),
+    );
+    assert.equal(response.status, 500);
+    const body = await response.json() as {
+      apiVersion: string;
+      error: { code: string; retryable: boolean };
+    };
+    assert.equal(body.error.code, "internal_error");
+    assert.equal(body.error.retryable, false);
+    assert.equal(body.apiVersion, "1.0");
+  });
+});

--- a/src/app/api/client/v1/conversations/[id]/messages/route.ts
+++ b/src/app/api/client/v1/conversations/[id]/messages/route.ts
@@ -1,0 +1,123 @@
+/**
+ * GET /api/client/v1/conversations/:id/messages
+ *
+ * One conversation's transcript, oldest first, one page at a time.
+ *
+ * Two things about this read are not the obvious default, and both come from
+ * how Cave actually stores a conversation:
+ *
+ *   - `ConversationFile.turns` holds every turn of every branch in one
+ *     append-ordered array. What a client should see is the chain from
+ *     `activeLeafId` back to the root — the same path the desktop renders — so
+ *     the route resolves that path rather than serving the array.
+ *   - a user turn and the assistant reply answering it are persisted with the
+ *     *same* `createdAt`, and a turn id is unique only inside one transcript.
+ *     So the page cannot be a keyset over `(createdAt, id)`: any tiebreak would
+ *     put some replies before the prompts they answer. It is a keyset over
+ *     *position in the resolved branch* instead, and the cursor names the last
+ *     turn served.
+ *
+ * That makes one failure possible which the list routes do not have: the branch
+ * can move under an open cursor, leaving the named turn off the path. The route
+ * answers `reconcile_required` — the code the contract reserves for exactly
+ * this — rather than restarting silently at the top or resuming at position
+ * zero on a different branch.
+ *
+ * The credential check is written out here rather than delegated; see the note
+ * in the familiars route for why the shape of that check is load-bearing.
+ */
+
+import { paginateClientV1Sequence } from "@/lib/server/client-v1/pagination.ts";
+import {
+  CLIENT_V1_READ_SCOPE,
+  chargeClientV1AuthFailure,
+  clientV1BearerFrom,
+  clientV1InvalidReadRequest,
+  parseClientV1ReadPage,
+} from "@/lib/server/client-v1/read-guard.ts";
+import {
+  clientV1ReadSources,
+  type ClientV1ReadSources,
+} from "@/lib/server/client-v1/read-sources.ts";
+import {
+  clientV1ConversationSequence,
+  clientV1MessagePageKey,
+  projectClientV1Message,
+} from "@/lib/server/client-v1/reads.ts";
+import {
+  clientV1ErrorResponse,
+  clientV1RateLimitResponse,
+  clientV1SuccessResponse,
+} from "@/lib/server/client-v1/responses.ts";
+import {
+  getClientV1Runtime,
+  type ClientV1Runtime,
+} from "@/lib/server/client-v1/runtime.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
+
+export const dynamic = "force-dynamic";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export function createClientV1ConversationMessagesGetHandler(
+  clientV1: ClientV1Runtime,
+  sources: ClientV1ReadSources,
+) {
+  return async function clientV1ConversationMessagesGet(
+    request: Request,
+    { params }: RouteContext,
+  ): Promise<Response> {
+    const stamp = request.headers.get(LOCAL_PEER_HEADER);
+    if (!clientV1.authenticator.isTrustedLoopback(stamp)) {
+      return clientV1ErrorResponse("unauthorized", "Unauthorized.");
+    }
+    const auth = await clientV1.authenticator.requireScope({
+      bearer: clientV1BearerFrom(request),
+      scope: CLIENT_V1_READ_SCOPE,
+    });
+    if (!auth.ok) return chargeClientV1AuthFailure(clientV1, auth, stamp!);
+    const budget = clientV1.rateLimiter.consumeAuthenticated(auth.credential.id);
+    if (!budget.allowed) return clientV1RateLimitResponse(budget);
+
+    let page;
+    try {
+      page = parseClientV1ReadPage(new URL(request.url));
+    } catch (cause) {
+      return clientV1InvalidReadRequest(cause);
+    }
+
+    const id = (await params).id;
+    const conversation = await sources.loadConversation(id);
+    if (!conversation) {
+      // Absent covers "no such conversation", "unreadable file", and "that id
+      // could never name one" — loadConversation resolves the id through a
+      // traversal guard and answers null for all three.
+      return clientV1ErrorResponse("not_found", "Conversation not found.");
+    }
+
+    const result = paginateClientV1Sequence(clientV1ConversationSequence(conversation), {
+      limit: page.limit,
+      after: page.after,
+      keyOf: clientV1MessagePageKey,
+    });
+    if (!result) {
+      return clientV1ErrorResponse(
+        "reconcile_required",
+        "The cursor names a message that is no longer on this conversation's active branch.",
+        { details: { reason: "resume_from_canonical_state" } },
+      );
+    }
+
+    return clientV1SuccessResponse(
+      { messages: result.items.map((turn) => projectClientV1Message(id, turn)) },
+      result.cursor ? { cursor: result.cursor } : {},
+    );
+  };
+}
+
+export async function GET(request: Request, context: RouteContext): Promise<Response> {
+  return createClientV1ConversationMessagesGetHandler(
+    getClientV1Runtime(),
+    clientV1ReadSources(),
+  )(request, context);
+}

--- a/src/app/api/client/v1/conversations/[id]/messages/route.ts
+++ b/src/app/api/client/v1/conversations/[id]/messages/route.ts
@@ -33,6 +33,7 @@ import {
   chargeClientV1AuthFailure,
   clientV1BearerFrom,
   clientV1InvalidReadRequest,
+  clientV1ReadFailure,
   parseClientV1ReadPage,
 } from "@/lib/server/client-v1/read-guard.ts";
 import {
@@ -87,31 +88,43 @@ export function createClientV1ConversationMessagesGetHandler(
     }
 
     const id = (await params).id;
-    const conversation = await sources.loadConversation(id);
-    if (!conversation) {
-      // Absent covers "no such conversation", "unreadable file", and "that id
-      // could never name one" — loadConversation resolves the id through a
-      // traversal guard and answers null for all three.
-      return clientV1ErrorResponse("not_found", "Conversation not found.");
-    }
+    try {
+      const conversation = await sources.loadConversation(id);
+      if (!conversation) {
+        // Absent covers "no such conversation", "unreadable file", and "that id
+        // could never name one" — loadConversation resolves the id through a
+        // traversal guard and answers null for all three.
+        return clientV1ErrorResponse("not_found", "Conversation not found.");
+      }
 
-    const result = paginateClientV1Sequence(clientV1ConversationSequence(conversation), {
-      limit: page.limit,
-      after: page.after,
-      keyOf: clientV1MessagePageKey,
-    });
-    if (!result) {
-      return clientV1ErrorResponse(
-        "reconcile_required",
-        "The cursor names a message that is no longer on this conversation's active branch.",
-        { details: { reason: "resume_from_canonical_state" } },
+      const result = paginateClientV1Sequence(clientV1ConversationSequence(conversation), {
+        limit: page.limit,
+        after: page.after,
+        keyOf: clientV1MessagePageKey,
+      });
+      if (!result) {
+        return clientV1ErrorResponse(
+          "reconcile_required",
+          "The cursor names a message that is no longer on this conversation's active branch.",
+          { details: { reason: "resume_from_canonical_state" } },
+        );
+      }
+
+      // `conversation.sessionId`, never the `id` off the URL. Conversations
+      // resolve to a FILE, and the two common filesystems here are
+      // case-insensitive, so `/conversations/CHAT/messages` serves `chat.json`
+      // — and echoing the requested spelling handed the client a
+      // `conversationId` that `/conversations/CHAT` then answers `not_found`
+      // for, because that route matches `sessionId` exactly. One canonical
+      // read must not mint an id another canonical read denies.
+      const conversationId = conversation.sessionId;
+      return clientV1SuccessResponse(
+        { messages: result.items.map((turn) => projectClientV1Message(conversationId, turn)) },
+        result.cursor ? { cursor: result.cursor } : {},
       );
+    } catch {
+      return clientV1ReadFailure();
     }
-
-    return clientV1SuccessResponse(
-      { messages: result.items.map((turn) => projectClientV1Message(id, turn)) },
-      result.cursor ? { cursor: result.cursor } : {},
-    );
   };
 }
 

--- a/src/app/api/client/v1/conversations/[id]/route.test.ts
+++ b/src/app/api/client/v1/conversations/[id]/route.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import type { ConversationSummary } from "@/lib/cave-conversations.ts";
+import type { ClientV1ReadSources } from "@/lib/server/client-v1/read-sources.ts";
+import { createClientV1Runtime, type ClientV1Runtime } from "@/lib/server/client-v1/runtime.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
+
+import { createClientV1ConversationGetHandler } from "./route.ts";
+
+const scratchPrefix = resolve(process.cwd(), ".scratch-client-v1-conversation-");
+const STAMP = "loopback-secret";
+
+const LEDGER: ConversationSummary[] = [
+  {
+    sessionId: "conversation-1",
+    familiarId: "scribe",
+    harness: "claude",
+    title: "Ledger cleanup",
+    status: "completed",
+    exitCode: 0,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-05T00:00:00.000Z",
+  },
+  {
+    sessionId: "conversation-2",
+    familiarId: "mote",
+    updatedAt: "2026-08-06T00:00:00.000Z",
+  },
+];
+
+function sources(overrides: Partial<ClientV1ReadSources> = {}): ClientV1ReadSources {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unsupported read source for this route");
+  };
+  return {
+    listFamiliars: unsupported,
+    listProjects: unsupported,
+    listConversations: async () => LEDGER,
+    loadConversation: unsupported,
+    ...overrides,
+  };
+}
+
+function request(id: string, headers: Record<string, string> = {}, query = ""): Request {
+  return new Request(
+    `http://127.0.0.1:3020/api/client/v1/conversations/${encodeURIComponent(id)}${query}`,
+    { headers: { [LOCAL_PEER_HEADER]: STAMP, ...headers } },
+  );
+}
+
+function context(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function withRuntime<T>(
+  scopes: ("chat:read" | "chat:write")[],
+  body: (runtime: ClientV1Runtime, bearer: string) => Promise<T>,
+): Promise<T> {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const runtime = createClientV1Runtime({ credentialRoot: root, loopbackSecret: STAMP });
+    const issued = await runtime.credentialStore.issue({
+      appName: "OpenCoven Chat",
+      installationId: "chat-install-1",
+      scopes,
+    });
+    return await body(runtime, issued.bearer);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+test("one conversation reads exactly as its row in the ledger", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationGetHandler(runtime, sources());
+    const response = await handler(
+      request("conversation-1", { authorization: `Bearer ${bearer}` }),
+      context("conversation-1"),
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json() as { data: { conversation: Record<string, unknown> } };
+    // Byte-identical to what the list route serves for the same id. The detail
+    // read is deliberately the same projection over the same source: deriving
+    // it from loadConversation instead would have dropped `status` and
+    // `exitCode`, which the ledger computes and a raw transcript file does not
+    // carry — so the same conversation would have reported two different
+    // shapes depending on which route a client asked.
+    assert.deepEqual(body.data.conversation, {
+      id: "conversation-1",
+      familiarId: "scribe",
+      harness: "claude",
+      title: "Ledger cleanup",
+      status: "completed",
+      exitCode: 0,
+      createdAt: "2026-08-01T00:00:00.000Z",
+      updatedAt: "2026-08-05T00:00:00.000Z",
+    });
+  });
+});
+
+test("an id no conversation carries is not_found, whatever shape it has", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationGetHandler(runtime, sources());
+    const authorization = `Bearer ${bearer}`;
+    for (const id of [
+      "conversation-9",
+      // A traversal attempt that survived URL decoding, which is reachable
+      // because a percent-encoded segment escapes the client-v1 ingress
+      // classification entirely (#4854).
+      "../../../etc/passwd",
+      "..",
+      "",
+      "conversation-1/messages",
+      // Prefix and suffix near-misses: the id is matched whole, never by
+      // startsWith, so neither can reach a real conversation.
+      "conversation-",
+      "conversation-10",
+    ]) {
+      const response = await handler(
+        request(id, { authorization }),
+        context(id),
+      );
+      assert.equal(response.status, 404, id);
+      const body = await response.json() as { error: { code: string; retryable: boolean } };
+      assert.equal(body.error.code, "not_found", id);
+      assert.equal(body.error.retryable, false, id);
+    }
+  });
+});
+
+test("the detail route serves no page parameters at all", async () => {
+  // A single record has nothing to page, so `limit` and `cursor` are as
+  // meaningless here as `offset` — and answering a request that carries one as
+  // though it did not is how a client learns to send them everywhere.
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationGetHandler(runtime, sources());
+    const authorization = `Bearer ${bearer}`;
+    for (const query of ["?limit=5", "?cursor=abc", "?offset=1"]) {
+      const response = await handler(
+        request("conversation-1", { authorization }, query),
+        context("conversation-1"),
+      );
+      assert.equal(response.status, 400, query);
+      assert.equal(
+        (await response.json() as { error: { code: string } }).error.code,
+        "invalid_request",
+        query,
+      );
+    }
+  });
+});
+
+test("the route refuses every request that does not carry a scoped bearer", async () => {
+  await withRuntime(["chat:write"], async (runtime, writeOnlyBearer) => {
+    const handler = createClientV1ConversationGetHandler(runtime, sources());
+    assert.equal(
+      (await handler(request("conversation-1"), context("conversation-1"))).status,
+      401,
+    );
+    assert.equal(
+      (await handler(
+        request("conversation-1", { authorization: "Bearer not-a-real-bearer" }),
+        context("conversation-1"),
+      )).status,
+      401,
+    );
+    assert.equal(
+      (await handler(
+        request("conversation-1", { authorization: `Bearer ${writeOnlyBearer}` }),
+        context("conversation-1"),
+      )).status,
+      403,
+    );
+    const unstamped = new Request(
+      "http://127.0.0.1:3020/api/client/v1/conversations/conversation-1",
+      { headers: { authorization: `Bearer ${writeOnlyBearer}` } },
+    );
+    assert.equal((await handler(unstamped, context("conversation-1"))).status, 401);
+  });
+});
+
+test("an unauthenticated probe cannot learn whether a conversation exists", async () => {
+  // The ledger is not read at all until the credential is settled, so a
+  // refused caller sees the same answer for a real id and an invented one —
+  // and cannot use the route to enumerate conversation ids.
+  let reads = 0;
+  await withRuntime(["chat:write"], async (runtime, writeOnlyBearer) => {
+    const handler = createClientV1ConversationGetHandler(
+      runtime,
+      sources({
+        listConversations: async () => {
+          reads += 1;
+          return LEDGER;
+        },
+      }),
+    );
+    const real = await handler(request("conversation-1"), context("conversation-1"));
+    const invented = await handler(request("conversation-9"), context("conversation-9"));
+    assert.equal(real.status, invented.status);
+    assert.deepEqual(await real.json(), await invented.json());
+    await handler(
+      request("conversation-1", { authorization: `Bearer ${writeOnlyBearer}` }),
+      context("conversation-1"),
+    );
+    assert.equal(reads, 0);
+  });
+});

--- a/src/app/api/client/v1/conversations/[id]/route.ts
+++ b/src/app/api/client/v1/conversations/[id]/route.ts
@@ -23,6 +23,7 @@ import {
   chargeClientV1AuthFailure,
   clientV1BearerFrom,
   clientV1InvalidReadRequest,
+  clientV1ReadFailure,
 } from "@/lib/server/client-v1/read-guard.ts";
 import {
   clientV1ReadSources,
@@ -71,16 +72,23 @@ export function createClientV1ConversationGetHandler(
     }
 
     const id = (await params).id;
-    const summary = (await sources.listConversations())
-      .find((candidate) => candidate.sessionId === id);
-    if (!summary) {
-      // One answer for "no such conversation" and for an id that could never
-      // name one — a traversal attempt, an empty segment, an over-long string.
-      // A client can act on neither differently, and one answer means this
-      // route cannot be used to map which id shapes the store recognises.
-      return clientV1ErrorResponse("not_found", "Conversation not found.");
+    try {
+      const summary = (await sources.listConversations())
+        .find((candidate) => candidate.sessionId === id);
+      if (!summary) {
+        // One answer for "no such conversation" and for an id that could never
+        // name one — a traversal attempt, an empty segment, an over-long string.
+        // A client can act on neither differently, and one answer means this
+        // route cannot be used to map which id shapes the store recognises.
+        return clientV1ErrorResponse("not_found", "Conversation not found.");
+      }
+      // Guarded because the ledger row is unvalidated JSON: a transcript that
+      // parsed but carries no `updatedAt` is refused by the projection, and
+      // uncaught that refusal left this handler as a non-envelope 500.
+      return clientV1SuccessResponse({ conversation: projectClientV1Conversation(summary) });
+    } catch {
+      return clientV1ReadFailure();
     }
-    return clientV1SuccessResponse({ conversation: projectClientV1Conversation(summary) });
   };
 }
 

--- a/src/app/api/client/v1/conversations/[id]/route.ts
+++ b/src/app/api/client/v1/conversations/[id]/route.ts
@@ -1,0 +1,92 @@
+/**
+ * GET /api/client/v1/conversations/:id
+ *
+ * One conversation's canonical record — the same projection, over the same
+ * source, that `/api/client/v1/conversations` serves for the same id. A client
+ * refreshing one conversation should not have to page the whole ledger.
+ *
+ * It reads the ledger rather than the transcript file on purpose, and that
+ * choice costs a directory scan. `status` and `exitCode` are *derived* while
+ * the ledger is built (deriveConversationSignals, cave-conversations.ts) and do
+ * not exist in the stored file, so serving this route from `loadConversation`
+ * would answer the same question two different ways depending on which route a
+ * client asked. The scan is the cost Cave's own sessions list already pays on
+ * every poll, and it shares the same stat-keyed summary cache.
+ *
+ * The credential check is written out here rather than delegated; see the note
+ * in the familiars route for why the shape of that check is load-bearing.
+ */
+
+import {
+  CLIENT_V1_READ_SCOPE,
+  assertClientV1NoReadQuery,
+  chargeClientV1AuthFailure,
+  clientV1BearerFrom,
+  clientV1InvalidReadRequest,
+} from "@/lib/server/client-v1/read-guard.ts";
+import {
+  clientV1ReadSources,
+  type ClientV1ReadSources,
+} from "@/lib/server/client-v1/read-sources.ts";
+import { projectClientV1Conversation } from "@/lib/server/client-v1/reads.ts";
+import {
+  clientV1ErrorResponse,
+  clientV1RateLimitResponse,
+  clientV1SuccessResponse,
+} from "@/lib/server/client-v1/responses.ts";
+import {
+  getClientV1Runtime,
+  type ClientV1Runtime,
+} from "@/lib/server/client-v1/runtime.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
+
+export const dynamic = "force-dynamic";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export function createClientV1ConversationGetHandler(
+  clientV1: ClientV1Runtime,
+  sources: ClientV1ReadSources,
+) {
+  return async function clientV1ConversationGet(
+    request: Request,
+    { params }: RouteContext,
+  ): Promise<Response> {
+    const stamp = request.headers.get(LOCAL_PEER_HEADER);
+    if (!clientV1.authenticator.isTrustedLoopback(stamp)) {
+      return clientV1ErrorResponse("unauthorized", "Unauthorized.");
+    }
+    const auth = await clientV1.authenticator.requireScope({
+      bearer: clientV1BearerFrom(request),
+      scope: CLIENT_V1_READ_SCOPE,
+    });
+    if (!auth.ok) return chargeClientV1AuthFailure(clientV1, auth, stamp!);
+    const budget = clientV1.rateLimiter.consumeAuthenticated(auth.credential.id);
+    if (!budget.allowed) return clientV1RateLimitResponse(budget);
+
+    try {
+      assertClientV1NoReadQuery(new URL(request.url));
+    } catch (cause) {
+      return clientV1InvalidReadRequest(cause);
+    }
+
+    const id = (await params).id;
+    const summary = (await sources.listConversations())
+      .find((candidate) => candidate.sessionId === id);
+    if (!summary) {
+      // One answer for "no such conversation" and for an id that could never
+      // name one — a traversal attempt, an empty segment, an over-long string.
+      // A client can act on neither differently, and one answer means this
+      // route cannot be used to map which id shapes the store recognises.
+      return clientV1ErrorResponse("not_found", "Conversation not found.");
+    }
+    return clientV1SuccessResponse({ conversation: projectClientV1Conversation(summary) });
+  };
+}
+
+export async function GET(request: Request, context: RouteContext): Promise<Response> {
+  return createClientV1ConversationGetHandler(
+    getClientV1Runtime(),
+    clientV1ReadSources(),
+  )(request, context);
+}

--- a/src/app/api/client/v1/conversations/route.test.ts
+++ b/src/app/api/client/v1/conversations/route.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import type { ConversationSummary } from "@/lib/cave-conversations.ts";
+import { CLIENT_V1_LIMITS } from "@/lib/server/client-v1/contract.ts";
+import { decodeClientV1Cursor } from "@/lib/server/client-v1/pagination.ts";
+import type { ClientV1ReadSources } from "@/lib/server/client-v1/read-sources.ts";
+import { createClientV1Runtime, type ClientV1Runtime } from "@/lib/server/client-v1/runtime.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
+
+import { createClientV1ConversationsGetHandler } from "./route.ts";
+
+const scratchPrefix = resolve(process.cwd(), ".scratch-client-v1-conversations-");
+const STAMP = "loopback-secret";
+
+function summary(sessionId: string, updatedAt: string): ConversationSummary {
+  return { sessionId, familiarId: "scribe", harness: "claude", updatedAt };
+}
+
+const LEDGER: ConversationSummary[] = [
+  summary("conversation-a", "2026-08-01T00:00:00.000Z"),
+  summary("conversation-b", "2026-08-05T00:00:00.000Z"),
+  summary("conversation-c", "2026-08-05T00:00:00.000Z"),
+];
+
+function sources(overrides: Partial<ClientV1ReadSources> = {}): ClientV1ReadSources {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unsupported read source for this route");
+  };
+  return {
+    listFamiliars: unsupported,
+    listProjects: unsupported,
+    listConversations: async () => LEDGER,
+    loadConversation: unsupported,
+    ...overrides,
+  };
+}
+
+function request(query = "", headers: Record<string, string> = {}): Request {
+  return new Request(`http://127.0.0.1:3020/api/client/v1/conversations${query}`, {
+    headers: { [LOCAL_PEER_HEADER]: STAMP, ...headers },
+  });
+}
+
+async function withRuntime<T>(
+  scopes: ("chat:read" | "chat:write")[],
+  body: (runtime: ClientV1Runtime, bearer: string) => Promise<T>,
+): Promise<T> {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const runtime = createClientV1Runtime({ credentialRoot: root, loopbackSecret: STAMP });
+    const issued = await runtime.credentialStore.issue({
+      appName: "OpenCoven Chat",
+      installationId: "chat-install-1",
+      scopes,
+    });
+    return await body(runtime, issued.bearer);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+test("conversations are served most-recently-updated first, id breaking the tie", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationsGetHandler(runtime, sources());
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      capabilities: string[];
+      data: { conversations: Record<string, unknown>[] };
+    };
+    assert.deepEqual(
+      body.data.conversations.map((row) => row.id),
+      ["conversation-c", "conversation-b", "conversation-a"],
+    );
+    assert.deepEqual(body.data.conversations[0], {
+      id: "conversation-c",
+      familiarId: "scribe",
+      harness: "claude",
+      updatedAt: "2026-08-05T00:00:00.000Z",
+    });
+    assert.ok(body.capabilities.includes("conversations"));
+    assert.ok(body.capabilities.includes("cursors"));
+  });
+});
+
+test("the ledger pages through a cursor without repeating a tied conversation", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationsGetHandler(runtime, sources());
+    const authorization = `Bearer ${bearer}`;
+    const first = await handler(request("?limit=2", { authorization }));
+    const firstBody = await first.json() as {
+      cursor: { next: string; hasMore: boolean };
+      data: { conversations: { id: string }[] };
+    };
+    assert.deepEqual(
+      firstBody.data.conversations.map((row) => row.id),
+      ["conversation-c", "conversation-b"],
+    );
+    // conversation-b and conversation-c share an updatedAt, so the cursor must
+    // carry the id as well or the second page starts at conversation-c again.
+    assert.deepEqual(decodeClientV1Cursor(firstBody.cursor.next), {
+      sort: "2026-08-05T00:00:00.000Z",
+      id: "conversation-b",
+    });
+
+    const second = await handler(
+      request(`?limit=2&cursor=${encodeURIComponent(firstBody.cursor.next)}`, { authorization }),
+    );
+    const secondBody = await second.json() as {
+      cursor: { hasMore: boolean; next?: string };
+      data: { conversations: { id: string }[] };
+    };
+    assert.deepEqual(secondBody.data.conversations.map((row) => row.id), ["conversation-a"]);
+    assert.equal(secondBody.cursor.hasMore, false);
+    assert.equal(secondBody.cursor.next, undefined);
+  });
+});
+
+test("the page ceiling is the contract's, not the caller's", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const many = Array.from({ length: CLIENT_V1_LIMITS.maxPageSize + 10 }, (_, index) =>
+      summary(`conversation-${String(index).padStart(4, "0")}`, "2026-08-05T00:00:00.000Z"));
+    const handler = createClientV1ConversationsGetHandler(
+      runtime,
+      sources({ listConversations: async () => many }),
+    );
+    const authorization = `Bearer ${bearer}`;
+    const capped = await handler(
+      request(`?limit=${CLIENT_V1_LIMITS.maxPageSize}`, { authorization }),
+    );
+    const cappedBody = await capped.json() as {
+      cursor: { hasMore: boolean };
+      data: { conversations: unknown[] };
+    };
+    assert.equal(cappedBody.data.conversations.length, CLIENT_V1_LIMITS.maxPageSize);
+    assert.equal(cappedBody.cursor.hasMore, true);
+
+    // One over the ceiling is refused rather than quietly clamped: a client
+    // that asked for 101 and received 100 cannot tell whether it reached the
+    // ceiling or the end of the ledger.
+    const refused = await handler(
+      request(`?limit=${CLIENT_V1_LIMITS.maxPageSize + 1}`, { authorization }),
+    );
+    assert.equal(refused.status, 400);
+  });
+});
+
+test("an empty ledger is an empty page with no cursor", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationsGetHandler(
+      runtime,
+      sources({ listConversations: async () => [] }),
+    );
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 200);
+    const body = await response.json() as { cursor?: unknown; data: { conversations: unknown[] } };
+    assert.deepEqual(body.data.conversations, []);
+    assert.equal("cursor" in body, false);
+  });
+});
+
+test("the route refuses every request that does not carry a scoped bearer", async () => {
+  await withRuntime(["chat:write"], async (runtime, writeOnlyBearer) => {
+    const handler = createClientV1ConversationsGetHandler(runtime, sources());
+    assert.equal((await handler(request())).status, 401);
+    assert.equal(
+      (await handler(request("", { authorization: "Bearer not-a-real-bearer" }))).status,
+      401,
+    );
+    assert.equal(
+      (await handler(request("", { authorization: `Bearer ${writeOnlyBearer}` }))).status,
+      403,
+    );
+    const unstamped = new Request("http://127.0.0.1:3020/api/client/v1/conversations", {
+      headers: { authorization: `Bearer ${writeOnlyBearer}` },
+    });
+    assert.equal((await handler(unstamped)).status, 401);
+  });
+});
+
+test("no transcript is read before the credential is checked", async () => {
+  let reads = 0;
+  await withRuntime(["chat:write"], async (runtime, writeOnlyBearer) => {
+    const handler = createClientV1ConversationsGetHandler(
+      runtime,
+      sources({
+        listConversations: async () => {
+          reads += 1;
+          return [];
+        },
+      }),
+    );
+    await handler(request());
+    await handler(request("", { authorization: `Bearer ${writeOnlyBearer}` }));
+    assert.equal(reads, 0);
+  });
+});

--- a/src/app/api/client/v1/conversations/route.test.ts
+++ b/src/app/api/client/v1/conversations/route.test.ts
@@ -198,3 +198,62 @@ test("no transcript is read before the credential is checked", async () => {
     assert.equal(reads, 0);
   });
 });
+
+test("an unprojectable ledger row answers an envelope, not a Next error page", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    // A conversation file that PARSES but carries no `updatedAt` does not take
+    // listConversations' fallback row — that substitution is keyed on a parse
+    // failure — so the field reaches the projection as `undefined`. It used to
+    // throw out of the handler, and Next answered with its own error body:
+    // not a Client v1 envelope, on a surface whose whole contract is that every
+    // response is one. One bad row took down every page containing it.
+    const handler = createClientV1ConversationsGetHandler(
+      runtime,
+      sources({
+        listConversations: async () => [
+          ...LEDGER,
+          { sessionId: "conversation-broken", familiarId: "scribe" } as ConversationSummary,
+        ],
+      }),
+    );
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 500);
+    const body = await response.json() as {
+      apiVersion: string;
+      error: { code: string; message: string; retryable: boolean; details?: unknown };
+    };
+    assert.equal(body.error.code, "internal_error");
+    // Not retryable: the store answers the same way next second, so a retry
+    // spends the caller's budget to be told the same thing.
+    assert.equal(body.error.retryable, false);
+    // The envelope is intact — a client that only knows how to parse this shape
+    // can still read its own failure.
+    assert.equal(body.apiVersion, "1.0");
+    // And the refusal names no field of a stored record: details on an error
+    // the caller cannot fix is a description of the server's disk.
+    assert.equal(body.error.details, undefined);
+    assert.equal(body.error.message.includes("updatedAt"), false);
+  });
+});
+
+test("a store that throws answers an envelope too", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    // listConversations swallows a readdir failure, but ensureDir above it does
+    // not, and neither does loadConfig on the roster route. The guard covers
+    // the read as well as the projection over it.
+    const handler = createClientV1ConversationsGetHandler(
+      runtime,
+      sources({
+        listConversations: async () => {
+          throw new Error("EACCES: permission denied, scandir '/home/me/.coven/cave/conversations'");
+        },
+      }),
+    );
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 500);
+    const body = await response.json() as { error: { code: string; message: string } };
+    assert.equal(body.error.code, "internal_error");
+    // The path the store named must not reach the wire.
+    assert.equal(body.error.message.includes("/home/me"), false);
+  });
+});

--- a/src/app/api/client/v1/conversations/route.ts
+++ b/src/app/api/client/v1/conversations/route.ts
@@ -25,6 +25,7 @@ import {
   chargeClientV1AuthFailure,
   clientV1BearerFrom,
   clientV1InvalidReadRequest,
+  clientV1ReadFailure,
   parseClientV1ReadPage,
 } from "@/lib/server/client-v1/read-guard.ts";
 import {
@@ -75,17 +76,25 @@ export function createClientV1ConversationsGetHandler(
 
     // Reading the ledger touches every transcript file on disk, so it happens
     // only once the credential and its budget are settled.
-    const summaries = await sources.listConversations();
-    const { cursor, items } = paginateClientV1Keyset(sortClientV1Conversations(summaries), {
-      limit: page.limit,
-      after: page.after,
-      keyOf: clientV1ConversationPageKey,
-      compare: compareClientV1RecencyKeys,
-    });
-    return clientV1SuccessResponse(
-      { conversations: items.map(projectClientV1Conversation) },
-      cursor ? { cursor } : {},
-    );
+    //
+    // Guarded from here down: readConversationSummary copies conv.updatedAt out
+    // of a file that merely parsed, so one transcript missing it is refused by
+    // projectClientV1Conversation instead of escaping as a non-envelope 500.
+    try {
+      const summaries = await sources.listConversations();
+      const { cursor, items } = paginateClientV1Keyset(sortClientV1Conversations(summaries), {
+        limit: page.limit,
+        after: page.after,
+        keyOf: clientV1ConversationPageKey,
+        compare: compareClientV1RecencyKeys,
+      });
+      return clientV1SuccessResponse(
+        { conversations: items.map(projectClientV1Conversation) },
+        cursor ? { cursor } : {},
+      );
+    } catch {
+      return clientV1ReadFailure();
+    }
   };
 }
 

--- a/src/app/api/client/v1/conversations/route.ts
+++ b/src/app/api/client/v1/conversations/route.ts
@@ -1,0 +1,97 @@
+/**
+ * GET /api/client/v1/conversations
+ *
+ * The canonical read of this Cave's conversation ledger, one page at a time.
+ * Projected from `listConversations`, which reads
+ * `<caveHome>/conversations/*.json` — the same source the Cave's own sessions
+ * list is built from, and in the same `updatedAt`-descending order, so a paired
+ * client and the desktop never present two different orderings of one ledger.
+ *
+ * Transcripts are not included: a conversation's turns are served by
+ * `/api/client/v1/conversations/:id/messages`, which pages them. Inlining even
+ * the most recent turn here would make the cost of a page depend on how much
+ * was said rather than on how many conversations were asked for.
+ *
+ * The credential check is written out here rather than delegated; see the note
+ * in the familiars route for why the shape of that check is load-bearing.
+ */
+
+import {
+  compareClientV1RecencyKeys,
+  paginateClientV1Keyset,
+} from "@/lib/server/client-v1/pagination.ts";
+import {
+  CLIENT_V1_READ_SCOPE,
+  chargeClientV1AuthFailure,
+  clientV1BearerFrom,
+  clientV1InvalidReadRequest,
+  parseClientV1ReadPage,
+} from "@/lib/server/client-v1/read-guard.ts";
+import {
+  clientV1ReadSources,
+  type ClientV1ReadSources,
+} from "@/lib/server/client-v1/read-sources.ts";
+import {
+  clientV1ConversationPageKey,
+  projectClientV1Conversation,
+  sortClientV1Conversations,
+} from "@/lib/server/client-v1/reads.ts";
+import {
+  clientV1ErrorResponse,
+  clientV1RateLimitResponse,
+  clientV1SuccessResponse,
+} from "@/lib/server/client-v1/responses.ts";
+import {
+  getClientV1Runtime,
+  type ClientV1Runtime,
+} from "@/lib/server/client-v1/runtime.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
+
+export const dynamic = "force-dynamic";
+
+export function createClientV1ConversationsGetHandler(
+  clientV1: ClientV1Runtime,
+  sources: ClientV1ReadSources,
+) {
+  return async function clientV1ConversationsGet(request: Request): Promise<Response> {
+    const stamp = request.headers.get(LOCAL_PEER_HEADER);
+    if (!clientV1.authenticator.isTrustedLoopback(stamp)) {
+      return clientV1ErrorResponse("unauthorized", "Unauthorized.");
+    }
+    const auth = await clientV1.authenticator.requireScope({
+      bearer: clientV1BearerFrom(request),
+      scope: CLIENT_V1_READ_SCOPE,
+    });
+    if (!auth.ok) return chargeClientV1AuthFailure(clientV1, auth, stamp!);
+    const budget = clientV1.rateLimiter.consumeAuthenticated(auth.credential.id);
+    if (!budget.allowed) return clientV1RateLimitResponse(budget);
+
+    let page;
+    try {
+      page = parseClientV1ReadPage(new URL(request.url));
+    } catch (cause) {
+      return clientV1InvalidReadRequest(cause);
+    }
+
+    // Reading the ledger touches every transcript file on disk, so it happens
+    // only once the credential and its budget are settled.
+    const summaries = await sources.listConversations();
+    const { cursor, items } = paginateClientV1Keyset(sortClientV1Conversations(summaries), {
+      limit: page.limit,
+      after: page.after,
+      keyOf: clientV1ConversationPageKey,
+      compare: compareClientV1RecencyKeys,
+    });
+    return clientV1SuccessResponse(
+      { conversations: items.map(projectClientV1Conversation) },
+      cursor ? { cursor } : {},
+    );
+  };
+}
+
+export async function GET(request: Request): Promise<Response> {
+  return createClientV1ConversationsGetHandler(
+    getClientV1Runtime(),
+    clientV1ReadSources(),
+  )(request);
+}

--- a/src/app/api/client/v1/familiars/route.test.ts
+++ b/src/app/api/client/v1/familiars/route.test.ts
@@ -1,0 +1,267 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import { CLIENT_V1_LIMITS } from "@/lib/server/client-v1/contract.ts";
+import { decodeClientV1Cursor, encodeClientV1Cursor } from "@/lib/server/client-v1/pagination.ts";
+import { CLIENT_V1_AUTHENTICATED_LIMIT } from "@/lib/server/client-v1/rate-limit.ts";
+import type { ClientV1ReadSources } from "@/lib/server/client-v1/read-sources.ts";
+import { createClientV1Runtime, type ClientV1Runtime } from "@/lib/server/client-v1/runtime.ts";
+import type { VisibleFamiliarRosterEntry } from "@/lib/server/familiar-roster.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
+
+import { createClientV1FamiliarsGetHandler } from "./route.ts";
+
+const scratchPrefix = resolve(process.cwd(), ".scratch-client-v1-familiars-");
+const STAMP = "loopback-secret";
+
+function roster(...ids: string[]): VisibleFamiliarRosterEntry[] {
+  return ids.map((id) => ({ id, display_name: id.toUpperCase(), role: "Familiar" }));
+}
+
+function sources(overrides: Partial<ClientV1ReadSources> = {}): ClientV1ReadSources {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unsupported read source for this route");
+  };
+  return {
+    listFamiliars: async () => ({
+      ok: true,
+      config: {} as never,
+      target: {} as never,
+      roster: roster("adept", "mote", "warden"),
+    }),
+    listProjects: unsupported,
+    listConversations: unsupported,
+    loadConversation: unsupported,
+    ...overrides,
+  };
+}
+
+function request(query = "", headers: Record<string, string> = {}): Request {
+  return new Request(`http://127.0.0.1:3020/api/client/v1/familiars${query}`, {
+    headers: { [LOCAL_PEER_HEADER]: STAMP, ...headers },
+  });
+}
+
+async function withRuntime<T>(
+  scopes: ("chat:read" | "chat:write")[],
+  body: (runtime: ClientV1Runtime, bearer: string) => Promise<T>,
+): Promise<T> {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const runtime = createClientV1Runtime({ credentialRoot: root, loopbackSecret: STAMP });
+    const issued = await runtime.credentialStore.issue({
+      appName: "OpenCoven Chat",
+      installationId: "chat-install-1",
+      scopes,
+    });
+    return await body(runtime, issued.bearer);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+test("a paired credential reads the roster in a total id order", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1FamiliarsGetHandler(runtime, sources());
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      capabilities: string[];
+      cursor?: unknown;
+      data: { familiars: { id: string; displayName: string; role: string }[] };
+    };
+    assert.deepEqual(body.data.familiars.map((entry) => entry.id), ["adept", "mote", "warden"]);
+    assert.deepEqual(body.data.familiars[0], {
+      id: "adept",
+      displayName: "ADEPT",
+      role: "Familiar",
+    });
+    // The whole roster fits one page, so there is no cursor token to publish.
+    assert.equal("cursor" in body, false);
+    assert.ok(body.capabilities.includes("familiars"));
+  });
+});
+
+test("the roster pages through a cursor and stops without repeating a familiar", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1FamiliarsGetHandler(runtime, sources());
+    const authorization = `Bearer ${bearer}`;
+    const first = await handler(request("?limit=2", { authorization }));
+    const firstBody = await first.json() as {
+      cursor: { next: string; hasMore: boolean };
+      data: { familiars: { id: string }[] };
+    };
+    assert.deepEqual(firstBody.data.familiars.map((entry) => entry.id), ["adept", "mote"]);
+    assert.equal(firstBody.cursor.hasMore, true);
+
+    const second = await handler(
+      request(`?limit=2&cursor=${encodeURIComponent(firstBody.cursor.next)}`, { authorization }),
+    );
+    const secondBody = await second.json() as {
+      cursor: { current: string; next?: string; hasMore: boolean };
+      data: { familiars: { id: string }[] };
+    };
+    assert.deepEqual(secondBody.data.familiars.map((entry) => entry.id), ["warden"]);
+    assert.equal(secondBody.cursor.hasMore, false);
+    assert.equal(secondBody.cursor.next, undefined);
+    assert.equal(secondBody.cursor.current, firstBody.cursor.next);
+    assert.deepEqual(decodeClientV1Cursor(firstBody.cursor.next), { sort: "mote", id: "mote" });
+  });
+});
+
+test("an unreadable roster is service_unavailable, never a credential problem", async () => {
+  // The daemon rejecting Cave's own access token says nothing about the
+  // client's bearer. Answering 401 here would tell a correctly paired client to
+  // throw its credential away and re-pair, which cannot fix a daemon outage.
+  for (const status of [401, 403, 503]) {
+    await withRuntime(["chat:read"], async (runtime, bearer) => {
+      const handler = createClientV1FamiliarsGetHandler(
+        runtime,
+        sources({
+          listFamiliars: async () => ({
+            ok: false,
+            config: {} as never,
+            target: {} as never,
+            status,
+            error: `daemon http ${status}`,
+          }),
+        }),
+      );
+      const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+      assert.equal(response.status, 503, `daemon ${status}`);
+      const body = await response.json() as { error: { code: string; retryable: boolean } };
+      assert.equal(body.error.code, "service_unavailable");
+      assert.equal(body.error.retryable, true);
+    });
+  }
+});
+
+test("an empty roster is an empty page with no cursor rather than a 404", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1FamiliarsGetHandler(
+      runtime,
+      sources({
+        listFamiliars: async () => ({
+          ok: true,
+          config: {} as never,
+          target: {} as never,
+          roster: [],
+        }),
+      }),
+    );
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 200);
+    const body = await response.json() as { cursor?: unknown; data: { familiars: unknown[] } };
+    assert.deepEqual(body.data.familiars, []);
+    assert.equal("cursor" in body, false);
+  });
+});
+
+test("the route refuses every request that does not carry a scoped bearer", async () => {
+  await withRuntime(["chat:write"], async (runtime, writeOnlyBearer) => {
+    const handler = createClientV1FamiliarsGetHandler(runtime, sources());
+
+    // No bearer at all.
+    assert.equal((await handler(request())).status, 401);
+    // A bearer nothing issued.
+    assert.equal(
+      (await handler(request("", { authorization: "Bearer not-a-real-bearer" }))).status,
+      401,
+    );
+    // A credential that exists but was not granted chat:read.
+    const denied = await handler(
+      request("", { authorization: `Bearer ${writeOnlyBearer}` }),
+    );
+    assert.equal(denied.status, 403);
+    assert.equal(
+      (await denied.json() as { error: { code: string } }).error.code,
+      "scope_denied",
+    );
+    // A credential presented without the listener's loopback stamp. The proxy
+    // classifies this path as client-v1 ingress and would normally refuse a
+    // non-loopback peer before the route runs — but a percent-encoded path
+    // segment escapes that classification entirely (#4854), so the route must
+    // not be the layer that assumes it ran.
+    const unstamped = new Request("http://127.0.0.1:3020/api/client/v1/familiars", {
+      headers: { authorization: `Bearer ${writeOnlyBearer}` },
+    });
+    assert.equal((await handler(unstamped)).status, 401);
+  });
+});
+
+test("a revoked credential stops reading immediately", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1FamiliarsGetHandler(runtime, sources());
+    const authorization = `Bearer ${bearer}`;
+    assert.equal((await handler(request("", { authorization }))).status, 200);
+    const records = await runtime.credentialStore.reload();
+    const [id] = [...records.keys()];
+    await runtime.credentialStore.revoke(id, "test");
+    assert.equal((await handler(request("", { authorization }))).status, 401);
+  });
+});
+
+test("the route refuses a query it does not serve instead of guessing a page", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1FamiliarsGetHandler(runtime, sources());
+    const authorization = `Bearer ${bearer}`;
+    for (const query of [
+      `?limit=${CLIENT_V1_LIMITS.maxPageSize + 1}`,
+      "?limit=0",
+      "?cursor=not%2Ba%2Bcursor",
+      "?offset=10",
+    ]) {
+      const response = await handler(request(query, { authorization }));
+      assert.equal(response.status, 400, query);
+      const body = await response.json() as { error: { code: string; details?: unknown } };
+      assert.equal(body.error.code, "invalid_request", query);
+      assert.notEqual(body.error.details, undefined, query);
+    }
+    // A cursor this Cave really minted, for a familiar that has since been
+    // removed, resumes at the next surviving row rather than failing.
+    const removed = encodeClientV1Cursor({ sort: "adept", id: "adept" });
+    const response = await handler(
+      request(`?cursor=${encodeURIComponent(removed)}`, { authorization }),
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json() as { data: { familiars: { id: string }[] } };
+    assert.deepEqual(body.data.familiars.map((entry) => entry.id), ["mote", "warden"]);
+  });
+});
+
+test("a paired credential's reads are bounded by its own authenticated budget", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1FamiliarsGetHandler(runtime, sources());
+    const authorization = `Bearer ${bearer}`;
+    for (let attempt = 0; attempt < CLIENT_V1_AUTHENTICATED_LIMIT; attempt += 1) {
+      assert.equal((await handler(request("", { authorization }))).status, 200, `attempt ${attempt}`);
+    }
+    const throttled = await handler(request("", { authorization }));
+    assert.equal(throttled.status, 429);
+    assert.equal(throttled.headers.get("retry-after"), "60");
+  });
+});
+
+test("the roster is never read before the credential is checked", async () => {
+  // A read that runs first is a read an unauthenticated caller can trigger: on
+  // this route that is a live daemon request, which is both a side effect and a
+  // timing signal.
+  let reads = 0;
+  await withRuntime(["chat:write"], async (runtime, writeOnlyBearer) => {
+    const handler = createClientV1FamiliarsGetHandler(
+      runtime,
+      sources({
+        listFamiliars: async () => {
+          reads += 1;
+          return { ok: true, config: {} as never, target: {} as never, roster: [] };
+        },
+      }),
+    );
+    await handler(request());
+    await handler(request("", { authorization: "Bearer not-a-real-bearer" }));
+    await handler(request("", { authorization: `Bearer ${writeOnlyBearer}` }));
+    assert.equal(reads, 0);
+  });
+});

--- a/src/app/api/client/v1/familiars/route.ts
+++ b/src/app/api/client/v1/familiars/route.ts
@@ -1,0 +1,107 @@
+/**
+ * GET /api/client/v1/familiars
+ *
+ * The canonical read of this Cave's visible familiar roster, one page at a
+ * time. Projected from `loadVisibleFamiliarRoster` — the daemon roster merged
+ * with familiars.toml and the removal tombstones — which is the same source the
+ * Cave's own roster UI reads, so a paired client and the desktop never disagree
+ * about who exists.
+ *
+ * The credential check below is written out here rather than delegated: this
+ * path is listed in CLIENT_V1_AUTHENTICATED_PATHS, and a listed path is
+ * *demoted* by proxy() — the mobile-access gate is skipped and the request
+ * returns before the sidecar-token block, leaving this call to requireScope as
+ * the only credential check in the whole request. The loopback stamp is checked
+ * first for defence in depth, because the proxy branch that would otherwise
+ * guarantee it is escapable through a percent-encoded path segment (#4854).
+ */
+
+import {
+  compareClientV1AscendingKeys,
+  paginateClientV1Keyset,
+} from "@/lib/server/client-v1/pagination.ts";
+import {
+  CLIENT_V1_READ_SCOPE,
+  chargeClientV1AuthFailure,
+  clientV1BearerFrom,
+  clientV1InvalidReadRequest,
+  parseClientV1ReadPage,
+} from "@/lib/server/client-v1/read-guard.ts";
+import {
+  clientV1ReadSources,
+  type ClientV1ReadSources,
+} from "@/lib/server/client-v1/read-sources.ts";
+import {
+  clientV1FamiliarPageKey,
+  projectClientV1Familiar,
+  sortClientV1Familiars,
+} from "@/lib/server/client-v1/reads.ts";
+import {
+  clientV1ErrorResponse,
+  clientV1RateLimitResponse,
+  clientV1SuccessResponse,
+} from "@/lib/server/client-v1/responses.ts";
+import {
+  getClientV1Runtime,
+  type ClientV1Runtime,
+} from "@/lib/server/client-v1/runtime.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
+
+export const dynamic = "force-dynamic";
+
+export function createClientV1FamiliarsGetHandler(
+  clientV1: ClientV1Runtime,
+  sources: ClientV1ReadSources,
+) {
+  return async function clientV1FamiliarsGet(request: Request): Promise<Response> {
+    const stamp = request.headers.get(LOCAL_PEER_HEADER);
+    if (!clientV1.authenticator.isTrustedLoopback(stamp)) {
+      return clientV1ErrorResponse("unauthorized", "Unauthorized.");
+    }
+    const auth = await clientV1.authenticator.requireScope({
+      bearer: clientV1BearerFrom(request),
+      scope: CLIENT_V1_READ_SCOPE,
+    });
+    if (!auth.ok) return chargeClientV1AuthFailure(clientV1, auth, stamp!);
+    const budget = clientV1.rateLimiter.consumeAuthenticated(auth.credential.id);
+    if (!budget.allowed) return clientV1RateLimitResponse(budget);
+
+    let page;
+    try {
+      page = parseClientV1ReadPage(new URL(request.url));
+    } catch (cause) {
+      return clientV1InvalidReadRequest(cause);
+    }
+
+    // Read the roster only after the credential is settled: this is a live
+    // request to the daemon, so running it first would let an unauthenticated
+    // caller drive traffic off the machine and time the answer.
+    const result = await sources.listFamiliars();
+    if (!result.ok) {
+      // Reported as unavailable whatever the daemon said — including its own
+      // 401/403. That failure is about Cave's access token, not the client's
+      // bearer, and answering `unauthorized` would tell a correctly paired
+      // client to discard a credential that is working perfectly.
+      return clientV1ErrorResponse(
+        "service_unavailable",
+        "The familiar roster is unavailable.",
+        { retryable: true },
+      );
+    }
+
+    const { cursor, items } = paginateClientV1Keyset(sortClientV1Familiars(result.roster), {
+      limit: page.limit,
+      after: page.after,
+      keyOf: clientV1FamiliarPageKey,
+      compare: compareClientV1AscendingKeys,
+    });
+    return clientV1SuccessResponse(
+      { familiars: items.map(projectClientV1Familiar) },
+      cursor ? { cursor } : {},
+    );
+  };
+}
+
+export async function GET(request: Request): Promise<Response> {
+  return createClientV1FamiliarsGetHandler(getClientV1Runtime(), clientV1ReadSources())(request);
+}

--- a/src/app/api/client/v1/familiars/route.ts
+++ b/src/app/api/client/v1/familiars/route.ts
@@ -25,6 +25,7 @@ import {
   chargeClientV1AuthFailure,
   clientV1BearerFrom,
   clientV1InvalidReadRequest,
+  clientV1ReadFailure,
   parseClientV1ReadPage,
 } from "@/lib/server/client-v1/read-guard.ts";
 import {
@@ -76,29 +77,38 @@ export function createClientV1FamiliarsGetHandler(
     // Read the roster only after the credential is settled: this is a live
     // request to the daemon, so running it first would let an unauthenticated
     // caller drive traffic off the machine and time the answer.
-    const result = await sources.listFamiliars();
-    if (!result.ok) {
-      // Reported as unavailable whatever the daemon said — including its own
-      // 401/403. That failure is about Cave's access token, not the client's
-      // bearer, and answering `unauthorized` would tell a correctly paired
-      // client to discard a credential that is working perfectly.
-      return clientV1ErrorResponse(
-        "service_unavailable",
-        "The familiar roster is unavailable.",
-        { retryable: true },
-      );
-    }
+    //
+    // Everything from here down is inside the guard: the roster is a daemon
+    // HTTP response with no schema in front of it, so a renamed or retyped
+    // field reaches projectClientV1Familiar, which refuses it. Uncaught, that
+    // refusal left the handler as a non-envelope 500.
+    try {
+      const result = await sources.listFamiliars();
+      if (!result.ok) {
+        // Reported as unavailable whatever the daemon said — including its own
+        // 401/403. That failure is about Cave's access token, not the client's
+        // bearer, and answering `unauthorized` would tell a correctly paired
+        // client to discard a credential that is working perfectly.
+        return clientV1ErrorResponse(
+          "service_unavailable",
+          "The familiar roster is unavailable.",
+          { retryable: true },
+        );
+      }
 
-    const { cursor, items } = paginateClientV1Keyset(sortClientV1Familiars(result.roster), {
-      limit: page.limit,
-      after: page.after,
-      keyOf: clientV1FamiliarPageKey,
-      compare: compareClientV1AscendingKeys,
-    });
-    return clientV1SuccessResponse(
-      { familiars: items.map(projectClientV1Familiar) },
-      cursor ? { cursor } : {},
-    );
+      const { cursor, items } = paginateClientV1Keyset(sortClientV1Familiars(result.roster), {
+        limit: page.limit,
+        after: page.after,
+        keyOf: clientV1FamiliarPageKey,
+        compare: compareClientV1AscendingKeys,
+      });
+      return clientV1SuccessResponse(
+        { familiars: items.map(projectClientV1Familiar) },
+        cursor ? { cursor } : {},
+      );
+    } catch {
+      return clientV1ReadFailure();
+    }
   };
 }
 

--- a/src/app/api/client/v1/projects/route.test.ts
+++ b/src/app/api/client/v1/projects/route.test.ts
@@ -24,6 +24,8 @@ function project(id: string, createdAt: string): CaveProject {
   };
 }
 
+// createdAt ascending alpha < bravo = delta, and every updatedAt identical, so
+// the two orderings agree until something is touched.
 const REGISTRY: CaveProject[] = [
   project("alpha", "2026-08-01T00:00:00.000Z"),
   project("bravo", "2026-08-03T00:00:00.000Z"),
@@ -106,10 +108,12 @@ test("the registry's response-only migration marker never reaches a client", asy
   });
 });
 
-test("a project created between two pages cannot displace one already served", async () => {
-  // This is why the page key is createdAt and not updatedAt. Touching alpha
-  // moves it to the top of an updatedAt ordering, and a cursor holding a
-  // *later* timestamp would then skip it entirely.
+test("a project touched mid-pagination is still served on the next page", async () => {
+  // This is why the page key is createdAt and not updatedAt. alpha is the one
+  // record still owed to the client after page one. Touching it moves it to
+  // the FRONT of an updatedAt ordering — ahead of the cursor rather than
+  // behind it — so an updatedAt keyset would skip it and the client would
+  // never learn the project exists.
   await withRuntime(["chat:read"], async (runtime, bearer) => {
     const authorization = `Bearer ${bearer}`;
     let registry = [...REGISTRY];
@@ -125,7 +129,7 @@ test("a project created between two pages cannot displace one already served", a
     assert.deepEqual(firstBody.data.projects.map((row) => row.id), ["delta", "bravo"]);
 
     registry = registry.map((row) =>
-      row.id === "delta" ? { ...row, updatedAt: "2026-08-30T00:00:00.000Z" } : row);
+      row.id === "alpha" ? { ...row, updatedAt: "2026-08-30T00:00:00.000Z" } : row);
 
     const second = await handler(
       request(`?limit=2&cursor=${encodeURIComponent(firstBody.cursor.next)}`, { authorization }),

--- a/src/app/api/client/v1/projects/route.test.ts
+++ b/src/app/api/client/v1/projects/route.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import type { CaveProject } from "@/lib/cave-projects-types.ts";
+import { encodeClientV1Cursor } from "@/lib/server/client-v1/pagination.ts";
+import type { ClientV1ReadSources } from "@/lib/server/client-v1/read-sources.ts";
+import { createClientV1Runtime, type ClientV1Runtime } from "@/lib/server/client-v1/runtime.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
+
+import { createClientV1ProjectsGetHandler } from "./route.ts";
+
+const scratchPrefix = resolve(process.cwd(), ".scratch-client-v1-projects-");
+const STAMP = "loopback-secret";
+
+function project(id: string, createdAt: string): CaveProject {
+  return {
+    id,
+    name: `Project ${id}`,
+    root: `/Users/me/code/${id}`,
+    createdAt,
+    updatedAt: "2026-08-20T00:00:00.000Z",
+  };
+}
+
+const REGISTRY: CaveProject[] = [
+  project("alpha", "2026-08-01T00:00:00.000Z"),
+  project("bravo", "2026-08-03T00:00:00.000Z"),
+  project("delta", "2026-08-03T00:00:00.000Z"),
+];
+
+function sources(overrides: Partial<ClientV1ReadSources> = {}): ClientV1ReadSources {
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unsupported read source for this route");
+  };
+  return {
+    listFamiliars: unsupported,
+    listProjects: async () => REGISTRY,
+    listConversations: unsupported,
+    loadConversation: unsupported,
+    ...overrides,
+  };
+}
+
+function request(query = "", headers: Record<string, string> = {}): Request {
+  return new Request(`http://127.0.0.1:3020/api/client/v1/projects${query}`, {
+    headers: { [LOCAL_PEER_HEADER]: STAMP, ...headers },
+  });
+}
+
+async function withRuntime<T>(
+  scopes: ("chat:read" | "chat:write")[],
+  body: (runtime: ClientV1Runtime, bearer: string) => Promise<T>,
+): Promise<T> {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const runtime = createClientV1Runtime({ credentialRoot: root, loopbackSecret: STAMP });
+    const issued = await runtime.credentialStore.issue({
+      appName: "OpenCoven Chat",
+      installationId: "chat-install-1",
+      scopes,
+    });
+    return await body(runtime, issued.bearer);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+}
+
+test("projects are served newest-created first with the id breaking a tie", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ProjectsGetHandler(runtime, sources());
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      capabilities: string[];
+      data: { projects: Record<string, unknown>[] };
+    };
+    // bravo and delta share a createdAt; the id tiebreak is descending, so
+    // delta precedes bravo and the ordering is total.
+    assert.deepEqual(body.data.projects.map((row) => row.id), ["delta", "bravo", "alpha"]);
+    assert.deepEqual(body.data.projects[2], {
+      id: "alpha",
+      name: "Project alpha",
+      root: "/Users/me/code/alpha",
+      createdAt: "2026-08-01T00:00:00.000Z",
+      updatedAt: "2026-08-20T00:00:00.000Z",
+    });
+    assert.ok(body.capabilities.includes("projects"));
+  });
+});
+
+test("the registry's response-only migration marker never reaches a client", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ProjectsGetHandler(
+      runtime,
+      sources({
+        listProjects: async () => [
+          { ...project("alpha", "2026-08-01T00:00:00.000Z"), legacyRoot: "~/code/alpha" },
+        ],
+      }),
+    );
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    const body = await response.json() as { data: { projects: Record<string, unknown>[] } };
+    assert.equal("legacyRoot" in body.data.projects[0], false);
+  });
+});
+
+test("a project created between two pages cannot displace one already served", async () => {
+  // This is why the page key is createdAt and not updatedAt. Touching alpha
+  // moves it to the top of an updatedAt ordering, and a cursor holding a
+  // *later* timestamp would then skip it entirely.
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const authorization = `Bearer ${bearer}`;
+    let registry = [...REGISTRY];
+    const handler = createClientV1ProjectsGetHandler(
+      runtime,
+      sources({ listProjects: async () => registry }),
+    );
+    const first = await handler(request("?limit=2", { authorization }));
+    const firstBody = await first.json() as {
+      cursor: { next: string };
+      data: { projects: { id: string }[] };
+    };
+    assert.deepEqual(firstBody.data.projects.map((row) => row.id), ["delta", "bravo"]);
+
+    registry = registry.map((row) =>
+      row.id === "delta" ? { ...row, updatedAt: "2026-08-30T00:00:00.000Z" } : row);
+
+    const second = await handler(
+      request(`?limit=2&cursor=${encodeURIComponent(firstBody.cursor.next)}`, { authorization }),
+    );
+    const secondBody = await second.json() as { data: { projects: { id: string }[] } };
+    assert.deepEqual(secondBody.data.projects.map((row) => row.id), ["alpha"]);
+  });
+});
+
+test("an empty registry is an empty page, not a 404", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ProjectsGetHandler(
+      runtime,
+      sources({ listProjects: async () => [] }),
+    );
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 200);
+    const body = await response.json() as { cursor?: unknown; data: { projects: unknown[] } };
+    assert.deepEqual(body.data.projects, []);
+    assert.equal("cursor" in body, false);
+  });
+});
+
+test("an empty continuation page still echoes the cursor the client sent", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ProjectsGetHandler(runtime, sources());
+    const exhausted = encodeClientV1Cursor({ sort: "1970-01-01T00:00:00.000Z", id: "zzzz" });
+    const response = await handler(
+      request(`?cursor=${encodeURIComponent(exhausted)}`, {
+        authorization: `Bearer ${bearer}`,
+      }),
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      cursor: { current: string; next?: string; hasMore: boolean };
+      data: { projects: unknown[] };
+    };
+    assert.deepEqual(body.data.projects, []);
+    assert.equal(body.cursor.hasMore, false);
+    assert.equal(body.cursor.next, undefined);
+    assert.equal(body.cursor.current, exhausted);
+  });
+});
+
+test("the route refuses every request that does not carry a scoped bearer", async () => {
+  await withRuntime(["chat:write"], async (runtime, writeOnlyBearer) => {
+    const handler = createClientV1ProjectsGetHandler(runtime, sources());
+    assert.equal((await handler(request())).status, 401);
+    assert.equal(
+      (await handler(request("", { authorization: "Bearer not-a-real-bearer" }))).status,
+      401,
+    );
+    assert.equal(
+      (await handler(request("", { authorization: `Bearer ${writeOnlyBearer}` }))).status,
+      403,
+    );
+    const unstamped = new Request("http://127.0.0.1:3020/api/client/v1/projects", {
+      headers: { authorization: `Bearer ${writeOnlyBearer}` },
+    });
+    assert.equal((await handler(unstamped)).status, 401);
+  });
+});
+
+test("the registry is never read before the credential is checked", async () => {
+  let reads = 0;
+  await withRuntime(["chat:write"], async (runtime, writeOnlyBearer) => {
+    const handler = createClientV1ProjectsGetHandler(
+      runtime,
+      sources({
+        listProjects: async () => {
+          reads += 1;
+          return [];
+        },
+      }),
+    );
+    await handler(request());
+    await handler(request("", { authorization: `Bearer ${writeOnlyBearer}` }));
+    assert.equal(reads, 0);
+  });
+});

--- a/src/app/api/client/v1/projects/route.ts
+++ b/src/app/api/client/v1/projects/route.ts
@@ -1,0 +1,89 @@
+/**
+ * GET /api/client/v1/projects
+ *
+ * The canonical read of the Cave project registry
+ * (`<caveHome>/projects.json`), one page at a time. This is the operator view
+ * `loadProjects` returns — every registered project, deduplicated by normalized
+ * root — and deliberately not the familiar-scoped view `/api/projects?familiarId=`
+ * serves: a Client v1 credential is not a familiar, so there is no familiar
+ * whose access could be applied, and inventing one would answer a permission
+ * question this route never asked.
+ *
+ * The credential check is written out here rather than delegated; see the note
+ * in the familiars route for why the shape of that check is load-bearing.
+ */
+
+import {
+  compareClientV1RecencyKeys,
+  paginateClientV1Keyset,
+} from "@/lib/server/client-v1/pagination.ts";
+import {
+  CLIENT_V1_READ_SCOPE,
+  chargeClientV1AuthFailure,
+  clientV1BearerFrom,
+  clientV1InvalidReadRequest,
+  parseClientV1ReadPage,
+} from "@/lib/server/client-v1/read-guard.ts";
+import {
+  clientV1ReadSources,
+  type ClientV1ReadSources,
+} from "@/lib/server/client-v1/read-sources.ts";
+import {
+  clientV1ProjectPageKey,
+  projectClientV1Project,
+  sortClientV1Projects,
+} from "@/lib/server/client-v1/reads.ts";
+import {
+  clientV1ErrorResponse,
+  clientV1RateLimitResponse,
+  clientV1SuccessResponse,
+} from "@/lib/server/client-v1/responses.ts";
+import {
+  getClientV1Runtime,
+  type ClientV1Runtime,
+} from "@/lib/server/client-v1/runtime.ts";
+import { LOCAL_PEER_HEADER } from "@/proxy-helpers.ts";
+
+export const dynamic = "force-dynamic";
+
+export function createClientV1ProjectsGetHandler(
+  clientV1: ClientV1Runtime,
+  sources: ClientV1ReadSources,
+) {
+  return async function clientV1ProjectsGet(request: Request): Promise<Response> {
+    const stamp = request.headers.get(LOCAL_PEER_HEADER);
+    if (!clientV1.authenticator.isTrustedLoopback(stamp)) {
+      return clientV1ErrorResponse("unauthorized", "Unauthorized.");
+    }
+    const auth = await clientV1.authenticator.requireScope({
+      bearer: clientV1BearerFrom(request),
+      scope: CLIENT_V1_READ_SCOPE,
+    });
+    if (!auth.ok) return chargeClientV1AuthFailure(clientV1, auth, stamp!);
+    const budget = clientV1.rateLimiter.consumeAuthenticated(auth.credential.id);
+    if (!budget.allowed) return clientV1RateLimitResponse(budget);
+
+    let page;
+    try {
+      page = parseClientV1ReadPage(new URL(request.url));
+    } catch (cause) {
+      return clientV1InvalidReadRequest(cause);
+    }
+
+    const projects = await sources.listProjects();
+    const { cursor, items } = paginateClientV1Keyset(sortClientV1Projects(projects), {
+      limit: page.limit,
+      after: page.after,
+      keyOf: clientV1ProjectPageKey,
+      compare: compareClientV1RecencyKeys,
+    });
+    return clientV1SuccessResponse(
+      { projects: items.map(projectClientV1Project) },
+      cursor ? { cursor } : {},
+    );
+  };
+}
+
+export async function GET(request: Request): Promise<Response> {
+  return createClientV1ProjectsGetHandler(getClientV1Runtime(), clientV1ReadSources())(request);
+}

--- a/src/app/api/client/v1/projects/route.ts
+++ b/src/app/api/client/v1/projects/route.ts
@@ -22,6 +22,7 @@ import {
   chargeClientV1AuthFailure,
   clientV1BearerFrom,
   clientV1InvalidReadRequest,
+  clientV1ReadFailure,
   parseClientV1ReadPage,
 } from "@/lib/server/client-v1/read-guard.ts";
 import {
@@ -70,17 +71,24 @@ export function createClientV1ProjectsGetHandler(
       return clientV1InvalidReadRequest(cause);
     }
 
-    const projects = await sources.listProjects();
-    const { cursor, items } = paginateClientV1Keyset(sortClientV1Projects(projects), {
-      limit: page.limit,
-      after: page.after,
-      keyOf: clientV1ProjectPageKey,
-      compare: compareClientV1RecencyKeys,
-    });
-    return clientV1SuccessResponse(
-      { projects: items.map(projectClientV1Project) },
-      cursor ? { cursor } : {},
-    );
+    // Guarded from the read down: loadProjects returns whatever projects.json
+    // parsed to, so a hand-edited row missing createdAt is refused by
+    // projectClientV1Project rather than escaping as a non-envelope 500.
+    try {
+      const projects = await sources.listProjects();
+      const { cursor, items } = paginateClientV1Keyset(sortClientV1Projects(projects), {
+        limit: page.limit,
+        after: page.after,
+        keyOf: clientV1ProjectPageKey,
+        compare: compareClientV1RecencyKeys,
+      });
+      return clientV1SuccessResponse(
+        { projects: items.map(projectClientV1Project) },
+        cursor ? { cursor } : {},
+      );
+    } catch {
+      return clientV1ReadFailure();
+    }
   };
 }
 

--- a/src/lib/server/client-v1/auth.test.ts
+++ b/src/lib/server/client-v1/auth.test.ts
@@ -17,6 +17,7 @@ import { proxy } from "../../../proxy.ts";
 import {
   ACCESS_TOKEN_COOKIE,
   ACCESS_TOKEN_QUERY_PARAM,
+  CLIENT_V1_AUTHENTICATED_PATHS,
   CLIENT_V1_PUBLIC_INGRESS,
   LOCAL_PEER_HEADER,
   TAILNET_PEER_HEADER,
@@ -158,6 +159,61 @@ test("valid scope returns only the active credential record", async () => {
   assert.equal(JSON.stringify(result).includes("valid-bearer"), false);
 });
 
+test("an authentication failure names the budget its caller can be charged against", async () => {
+  // requireScope normalizes both failures into a ready-made Response, which is
+  // right for what the client sees and useless to the route: the two failures
+  // are charged against *different* rate-limit buckets, and a Response cannot
+  // be asked which one it is. Reading `response.status` back would work by
+  // coincidence — it couples the metering decision to an HTTP status the
+  // contract is free to remap. The discriminant states it directly.
+  const unknownBearer = createClientV1Authenticator({
+    credentialStore: storeWithLookup(async () => null),
+    loopbackSecret: "loopback-secret",
+  });
+  const unknown = await unknownBearer.requireScope({
+    bearer: "unknown-bearer",
+    scope: "chat:read",
+  });
+  assert.equal(unknown.ok, false);
+  if (!unknown.ok) {
+    assert.equal(unknown.reason, "unauthorized");
+    // No credential was found, so there is no authenticated identity to meter;
+    // the route has to fall back to its invalid-bearer bucket.
+    assert.equal(unknown.credential, undefined);
+  }
+
+  const missing = await unknownBearer.requireScope({ bearer: null, scope: "chat:read" });
+  assert.equal(missing.ok, false);
+  if (!missing.ok) {
+    assert.equal(missing.reason, "unauthorized");
+    assert.equal(missing.credential, undefined);
+  }
+
+  const underScoped = createClientV1Authenticator({
+    credentialStore: storeWithLookup(async () => ({
+      ...ACTIVE_CREDENTIAL,
+      scopes: ["chat:read"],
+    })),
+    loopbackSecret: "loopback-secret",
+  });
+  const denied = await underScoped.requireScope({
+    bearer: "valid-bearer",
+    scope: "chat:write",
+  });
+  assert.equal(denied.ok, false);
+  if (!denied.ok) {
+    assert.equal(denied.reason, "scope_denied");
+    // The credential rides along because this failure IS an authenticated
+    // request — a real credential asking for something it was not granted. The
+    // only other meterable key would be the bearer itself, and a rate-limit
+    // bucket keyed by a secret is a secret written into a Map.
+    assert.equal(denied.credential?.id, ACTIVE_CREDENTIAL.id);
+    // Same discipline as the success branch below: the bearer is an input, and
+    // it must not survive into anything a caller might log.
+    assert.equal(JSON.stringify(denied.credential).includes("valid-bearer"), false);
+  }
+});
+
 /**
  * The contract's public routes as request pathnames: `:id` templates filled in,
  * and the GET/POST pair on one path collapsed, because ingress classification
@@ -184,13 +240,30 @@ test("client-v1 ingress allowlists only the reviewed public routes", () => {
   for (const route of publicRoutes) {
     assert.equal(clientV1IngressKind(route), CLIENT_V1_PUBLIC_INGRESS, route);
   }
-  // Nothing is pre-authorized (cave-4841). A client-v1 ingress match makes
-  // proxy() skip the mobile access gate and return before the sidecar-token
-  // block, so it is only ever safe for a path whose own handler authenticates —
-  // and the Phase 2 paths below have no handler at all. Listing them ahead of
-  // time meant the first one to land would arrive already exempt. They classify
-  // null until their route.ts exists, which keeps them on the ordinary
-  // sidecar-token gate in the meantime.
+  // The canonical reads are pre-authorized, and only because their handlers
+  // exist (cave-jfa9y). A client-v1 ingress match makes proxy() skip the mobile
+  // access gate and return before the sidecar-token block, so it is only ever
+  // safe for a path whose own handler authenticates — which is why cave-4841
+  // emptied this list after it named thirteen Phase 2 paths against zero
+  // handlers. Each entry below has a route.ts that calls requireScope, asserted
+  // against the disk in src/app/api/api-contracts.test.ts.
+  for (const route of [
+    "/api/client/v1/familiars",
+    "/api/client/v1/projects",
+    "/api/client/v1/conversations",
+    "/api/client/v1/conversations/conversation-1",
+    "/api/client/v1/conversations/conversation-1/messages",
+    // Not a real conversation, and deliberately still "authenticated": there is
+    // no static `search` route under conversations, so the App Router serves
+    // this path from the [id] handler with the id "search". Classifying it any
+    // other way would describe a route that does not exist.
+    "/api/client/v1/conversations/search",
+  ]) {
+    assert.equal(clientV1IngressKind(route), "authenticated", route);
+  }
+  // Everything else still classifies null. The Phase 2 paths below have no
+  // handler at all, so listing them ahead of time would mean the first one to
+  // land arrives already exempt from the sidecar-token gate.
   for (const route of [
     "/api/client/v1",
     "/api/client/v1/admin",
@@ -199,12 +272,6 @@ test("client-v1 ingress allowlists only the reviewed public routes", () => {
     "/api/client/v1/private",
     "/api/client/v10/health",
     "/api/chat/conversation",
-    "/api/client/v1/familiars",
-    "/api/client/v1/projects",
-    "/api/client/v1/conversations",
-    "/api/client/v1/conversations/search",
-    "/api/client/v1/conversations/conversation-1",
-    "/api/client/v1/conversations/conversation-1/messages",
     "/api/client/v1/messages/send",
     "/api/client/v1/attachments",
     "/api/client/v1/attachments/attachment-1",
@@ -228,8 +295,51 @@ test("client-v1 ingress allowlists only the reviewed public routes", () => {
     "/api/client/v1/pairing/requests/",
     "/api/client/v1/pairing/requests/request-1/messages",
     "/api/client/v1/pairing/requests/request-1/exchange/extra",
+    // The same near-miss family for the newly authenticated set. These matter
+    // more than the public ones do: an authenticated match ALSO returns before
+    // the sidecar-token block, so an unanchored or over-wide pattern here hands
+    // credential-free ingress to a path with no client-v1 handler behind it.
+    "/decoy/api/client/v1/projects",
+    "/api/client/v1/projectsz",
+    "/api/client/v1/familiars/familiar-1",
+    "/api/client/v1/conversations/",
+    "/api/client/v1/conversations/conversation-1/messages/message-1",
+    "/api/client/v1/conversations/conversation-1/turns",
   ]) {
     assert.equal(clientV1IngressKind(route), null, route);
+  }
+});
+
+test("every pre-authorized path is one the proxy hands to a client-v1 handler", () => {
+  // Matching CLIENT_V1_AUTHENTICATED_PATHS is a DEMOTION: proxy() skips the
+  // mobile-access gate and returns before the sidecar-token block, so the
+  // route's own requireScope is the only credential check left in the request.
+  // The list therefore has to stay inside the client-v1 surface and out of the
+  // admin family, which keeps the ordinary sidecar-token path on purpose.
+  for (const pattern of CLIENT_V1_AUTHENTICATED_PATHS) {
+    // RegExp#source escapes every forward slash, so this is the anchored
+    // client-v1 prefix as the engine spells it.
+    const source = pattern.source;
+    assert.ok(source.startsWith("^\\/api\\/client\\/v1\\/"), source);
+    assert.ok(source.endsWith("$"), source);
+    assert.equal(source.includes("admin"), false, source);
+    // Single-segment parameters only. `.+` or `[\s\S]` would let one entry
+    // pre-authorize an unbounded tail of paths nobody reviewed.
+    assert.equal(source.includes(".+"), false, source);
+    assert.equal(source.includes(".*"), false, source);
+  }
+  // Public and authenticated are disjoint. An overlap would be ambiguous
+  // rather than harmless: the public branch is consulted first, so a public
+  // pattern that widened over an authenticated path would silently reclassify
+  // an authenticated route as credential-free bootstrap.
+  for (const path of [
+    "/api/client/v1/familiars",
+    "/api/client/v1/projects",
+    "/api/client/v1/conversations",
+    "/api/client/v1/conversations/conversation-1",
+    "/api/client/v1/conversations/conversation-1/messages",
+  ]) {
+    assert.notEqual(clientV1IngressKind(path), CLIENT_V1_PUBLIC_INGRESS, path);
   }
 });
 
@@ -327,18 +437,27 @@ test("reviewed client-v1 routes use loopback ingress without exposing private ro
     for (const route of [
       "/api/client/v1/pairing/requests",
       "/api/client/v1/pairing/requests/request-1/exchange",
+      // The canonical reads pass the proxy with no sidecar token, which is
+      // exactly the demotion CLIENT_V1_AUTHENTICATED_PATHS buys and the reason
+      // each of these routes calls requireScope for itself (cave-jfa9y). What
+      // reaches the handler here is an unauthenticated request; the route
+      // tests assert it is refused there.
+      "/api/client/v1/familiars",
+      "/api/client/v1/projects",
+      "/api/client/v1/conversations",
+      "/api/client/v1/conversations/conversation-1",
+      "/api/client/v1/conversations/conversation-1/messages",
     ]) {
       const response = await proxy(proxyRequest(route, { headers }));
       assert.equal(passedThrough(response), true, `${route} returned ${response.status}`);
     }
 
-    // /api/client/v1/conversations sits with the private routes rather than the
-    // loopback-ingress ones: it has no handler, so it is not pre-authorized and
-    // a bare loopback caller gets the ordinary 401 (cave-4841).
+    // Admin and unhandled client-v1 paths stay on the ordinary sidecar-token
+    // gate, so a bare loopback caller gets the ordinary 401 (cave-4841).
     for (const route of [
       "/api/client/v1/admin/credentials",
       "/api/client/v1/private",
-      "/api/client/v1/conversations",
+      "/api/client/v1/messages/send",
       "/api/chat/conversation",
     ]) {
       const response = await proxy(proxyRequest(route, { headers }));

--- a/src/lib/server/client-v1/auth.ts
+++ b/src/lib/server/client-v1/auth.ts
@@ -6,9 +6,37 @@ import type {
 } from "./credential-store.ts";
 import { clientV1ErrorResponse } from "./responses.ts";
 
+/**
+ * The outcome of one scope check.
+ *
+ * The failure branch carries a `reason` — and, when the caller really did
+ * present a working credential, that credential — because the two failures are
+ * metered against different rate-limit buckets and the caller cannot tell them
+ * apart from the Response alone. `unauthorized` means no credential was
+ * established, so only `consumeInvalidBearer` has a key to charge;
+ * `scope_denied` means an authenticated client asked for something it was not
+ * granted, which belongs to that credential's `consumeAuthenticated` budget.
+ *
+ * The alternative was for a route to branch on `response.status`, which works
+ * only for as long as the canonical status map in responses.ts happens to keep
+ * 401 and 403 distinct — a metering decision quietly coupled to an HTTP code.
+ * The response itself is unchanged: the client still sees two normalized
+ * envelopes and learns nothing extra about which bearers exist.
+ */
 export type ClientV1AuthResult =
   | { ok: true; credential: ClientV1CredentialRecord }
-  | { ok: false; response: Response };
+  | {
+    ok: false;
+    reason: "unauthorized";
+    credential?: undefined;
+    response: Response;
+  }
+  | {
+    ok: false;
+    reason: "scope_denied";
+    credential: ClientV1CredentialRecord;
+    response: Response;
+  };
 
 export interface ClientV1Authenticator {
   isTrustedLoopback(headerValue: string | null): boolean;
@@ -26,6 +54,7 @@ export interface ClientV1AuthenticatorOptions {
 function unauthorized(): ClientV1AuthResult {
   return {
     ok: false,
+    reason: "unauthorized",
     response: clientV1ErrorResponse("unauthorized", "Unauthorized."),
   };
 }
@@ -50,6 +79,8 @@ export function createClientV1Authenticator({
       if (!credential.scopes.includes(scope)) {
         return {
           ok: false,
+          reason: "scope_denied",
+          credential,
           response: clientV1ErrorResponse(
             "scope_denied",
             "The credential does not grant the required scope.",

--- a/src/lib/server/client-v1/pagination.test.ts
+++ b/src/lib/server/client-v1/pagination.test.ts
@@ -299,3 +299,65 @@ test("sequence pagination on an empty transcript publishes no cursor", () => {
   assert.deepEqual(empty!.items, []);
   assert.equal(empty!.cursor, undefined);
 });
+
+test("the encoder never mints a token this module's own decoder refuses", () => {
+  // encode and decode are a pair, and nothing asserted they agreed. Page keys
+  // are read straight out of stores that do not validate their own JSON, so a
+  // non-string sort key is reachable — and JSON.stringify carries a number
+  // through happily while dropping an `undefined` key entirely. The token then
+  // came back as `invalid_request` ("its sort key is not a string") for a
+  // cursor THIS SERVER wrote, which a client following `next` reads as its own
+  // bug and cannot page past.
+  assert.throws(
+    () => encodeClientV1Cursor({ sort: 1767225600000 as unknown as string, id: "c1" }),
+    /page key must be two strings/,
+  );
+  assert.throws(
+    () => encodeClientV1Cursor({ sort: undefined as unknown as string, id: "c1" }),
+    /page key must be two strings/,
+  );
+  assert.throws(
+    () => encodeClientV1Cursor({ sort: "s", id: "" }),
+    /page key must be two strings/,
+  );
+  // The property the pair owes each other, stated once: anything minted decodes
+  // back to the key it was minted from.
+  for (const key of [
+    { sort: "", id: "i" },
+    { sort: "2026-08-01T00:00:00.000Z", id: "conversation-1" },
+    { sort: "💀", id: "💀" },
+    { sort: "a".repeat(120), id: "b".repeat(120) },
+  ]) {
+    assert.deepEqual(decodeClientV1Cursor(encodeClientV1Cursor(key)), key);
+  }
+});
+
+test("the key comparator stays a strict weak order when a sort key is not a string", () => {
+  // `undefined < "a"` and `undefined > "a"` are BOTH false, so an unguarded
+  // comparison collapses to a tie against every string — and the id tiebreak
+  // then makes the order CYCLIC rather than merely arbitrary. These three keys
+  // are the measured witness: before the coercion each compared greater than
+  // the next, and Array#sort returned three different orders for the three
+  // input permutations. A keyset over a cyclic order skips rows.
+  const bad = { sort: undefined as unknown as string, id: "m" };
+  const low = { sort: "a", id: "z" };
+  const high = { sort: "b", id: "a" };
+  const cycle = compareClientV1RecencyKeys(bad, low) > 0
+    && compareClientV1RecencyKeys(low, high) > 0
+    && compareClientV1RecencyKeys(high, bad) > 0;
+  assert.equal(cycle, false);
+  const orders = new Set(
+    [[0, 1, 2], [0, 2, 1], [1, 0, 2], [1, 2, 0], [2, 0, 1], [2, 1, 0]].map((permutation) =>
+      permutation
+        .map((index) => [bad, low, high][index])
+        .sort(compareClientV1RecencyKeys)
+        .map((key) => key.id)
+        .join(",")),
+  );
+  assert.equal(orders.size, 1, `sort order depended on input order: ${[...orders].join(" | ")}`);
+  // Antisymmetry, in both comparators, for the same reason.
+  assert.equal(
+    Math.sign(compareClientV1AscendingKeys(bad, low)),
+    -Math.sign(compareClientV1AscendingKeys(low, bad)),
+  );
+});

--- a/src/lib/server/client-v1/pagination.test.ts
+++ b/src/lib/server/client-v1/pagination.test.ts
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CLIENT_V1_LIMITS, parseClientV1Cursor } from "./contract.ts";
+import {
+  CLIENT_V1_CURSOR_VERSION,
+  compareClientV1AscendingKeys,
+  compareClientV1RecencyKeys,
+  decodeClientV1Cursor,
+  encodeClientV1Cursor,
+  paginateClientV1Keyset,
+  paginateClientV1Sequence,
+  parseClientV1PageLimit,
+  type ClientV1PageKey,
+} from "./pagination.ts";
+
+type Row = { id: string; at: string };
+
+const ROWS: Row[] = [
+  { id: "e", at: "2026-08-05T00:00:00.000Z" },
+  { id: "d", at: "2026-08-04T00:00:00.000Z" },
+  // A deliberate tie on the sort field: the id tiebreak is the only thing
+  // making this order total, and a non-total order is a cursor that can skip
+  // or repeat a row for reasons no client can see.
+  { id: "c", at: "2026-08-03T00:00:00.000Z" },
+  { id: "b", at: "2026-08-03T00:00:00.000Z" },
+  { id: "a", at: "2026-08-01T00:00:00.000Z" },
+];
+
+const keyOf = (row: Row): ClientV1PageKey => ({ sort: row.at, id: row.id });
+
+function page(limit: number, after: ClientV1PageKey | null) {
+  return paginateClientV1Keyset(ROWS, {
+    limit,
+    after,
+    keyOf,
+    compare: compareClientV1RecencyKeys,
+  });
+}
+
+test("cursor tokens round-trip and stay inside the contract's cursor budget", () => {
+  const key: ClientV1PageKey = { sort: "2026-08-03T00:00:00.000Z", id: "conversation-1" };
+  const encoded = encodeClientV1Cursor(key);
+  assert.match(encoded, /^[A-Za-z0-9_-]+$/, "cursor must be unpadded base64url");
+  assert.ok(
+    encoded.length <= CLIENT_V1_LIMITS.cursorCharacters,
+    `cursor is ${encoded.length} characters, over the contract's ${CLIENT_V1_LIMITS.cursorCharacters}`,
+  );
+  assert.deepEqual(decodeClientV1Cursor(encoded), key);
+  // Opaque means opaque: the sort key and id must not be readable without
+  // decoding, or a client will start composing cursors by hand.
+  assert.equal(encoded.includes("conversation-1"), false);
+});
+
+test("cursor decoding refuses everything that is not a cursor this Cave minted", () => {
+  const valid = encodeClientV1Cursor({ sort: "s", id: "i" });
+  const rejected: [string, unknown][] = [
+    ["empty", ""],
+    ["not a string", 7],
+    ["null", null],
+    ["outside the base64url alphabet", "not+valid/base64="],
+    // Buffer.from(…, "base64url") silently drops trailing junk, so a
+    // non-canonical encoding decodes to a *valid* payload unless the
+    // round-trip is checked. Without that check this string is accepted.
+    ["non-canonical padding", `${valid}=`],
+    ["not JSON", Buffer.from("not json at all", "utf8").toString("base64url")],
+    ["a JSON array", Buffer.from("[1,2,3]", "utf8").toString("base64url")],
+    [
+      "a future cursor version",
+      Buffer.from(JSON.stringify({ v: 2, s: "s", i: "i" }), "utf8").toString("base64url"),
+    ],
+    [
+      "a missing id",
+      Buffer.from(JSON.stringify({ v: CLIENT_V1_CURSOR_VERSION, s: "s" }), "utf8").toString("base64url"),
+    ],
+    [
+      "an empty id",
+      Buffer.from(JSON.stringify({ v: CLIENT_V1_CURSOR_VERSION, s: "s", i: "" }), "utf8").toString("base64url"),
+    ],
+    [
+      "a non-string sort key",
+      Buffer.from(JSON.stringify({ v: CLIENT_V1_CURSOR_VERSION, s: 1, i: "i" }), "utf8").toString("base64url"),
+    ],
+    [
+      "an unexpected field",
+      Buffer.from(
+        JSON.stringify({ v: CLIENT_V1_CURSOR_VERSION, s: "s", i: "i", extra: "x" }),
+        "utf8",
+      ).toString("base64url"),
+    ],
+    ["over the cursor budget", "A".repeat(CLIENT_V1_LIMITS.cursorCharacters + 1)],
+  ];
+  for (const [label, candidate] of rejected) {
+    assert.throws(() => decodeClientV1Cursor(candidate), /cursor/i, label);
+  }
+  // The budget boundary itself is admissible, not merely one below it.
+  assert.doesNotThrow(() => {
+    const key = { sort: "s".repeat(120), id: "i" };
+    const encoded = encodeClientV1Cursor(key);
+    assert.ok(encoded.length <= CLIENT_V1_LIMITS.cursorCharacters);
+    decodeClientV1Cursor(encoded);
+  });
+});
+
+test("page limit defaults to the contract page size and is bounded by its ceiling", () => {
+  assert.equal(parseClientV1PageLimit(null), CLIENT_V1_LIMITS.defaultPageSize);
+  assert.equal(parseClientV1PageLimit("1"), 1);
+  assert.equal(
+    parseClientV1PageLimit(String(CLIENT_V1_LIMITS.maxPageSize)),
+    CLIENT_V1_LIMITS.maxPageSize,
+  );
+  for (const candidate of [
+    "0",
+    "-1",
+    "1.5",
+    "1e2",
+    " 10",
+    "10 ",
+    "",
+    "010",
+    "abc",
+    "+5",
+    String(CLIENT_V1_LIMITS.maxPageSize + 1),
+  ]) {
+    assert.throws(() => parseClientV1PageLimit(candidate), /limit/i, candidate);
+  }
+});
+
+test("the first page over-fetches to decide hasMore and never leaks the probe row", () => {
+  const first = page(2, null);
+  assert.deepEqual(first.items.map((row) => row.id), ["e", "d"]);
+  // No `current`: nothing was resumed, so publishing one would hand back a
+  // token the client never sent.
+  assert.deepEqual(first.cursor, {
+    next: encodeClientV1Cursor(keyOf(ROWS[1])),
+    hasMore: true,
+  });
+  assert.doesNotThrow(() => parseClientV1Cursor(first.cursor!));
+});
+
+test("following next walks the whole set exactly once and then stops", () => {
+  const seen: string[] = [];
+  let after: ClientV1PageKey | null = null;
+  for (let guard = 0; guard < 10; guard += 1) {
+    const result = page(2, after);
+    seen.push(...result.items.map((row) => row.id));
+    const next = result.cursor?.next;
+    if (!next) break;
+    after = decodeClientV1Cursor(next);
+  }
+  assert.deepEqual(seen, ["e", "d", "c", "b", "a"]);
+});
+
+test("a tied sort key is separated by the id tiebreak rather than repeated", () => {
+  // "c" and "b" share a timestamp. A cursor comparing the sort key alone would
+  // either serve both again or skip both.
+  const boundary = page(3, null);
+  assert.deepEqual(boundary.items.map((row) => row.id), ["e", "d", "c"]);
+  const next = page(3, decodeClientV1Cursor(boundary.cursor!.next!));
+  assert.deepEqual(next.items.map((row) => row.id), ["b", "a"]);
+  assert.equal(next.cursor?.hasMore, false);
+  assert.equal(next.cursor?.next, undefined);
+});
+
+test("replaying the same cursor is idempotent rather than advancing or looping", () => {
+  const first = page(2, null);
+  const after = decodeClientV1Cursor(first.cursor!.next!);
+  const once = page(2, after);
+  const twice = page(2, after);
+  assert.deepEqual(once.items, twice.items);
+  assert.deepEqual(once.cursor, twice.cursor);
+});
+
+test("a first page holding the whole set publishes no cursor at all", () => {
+  const last = page(5, null);
+  assert.deepEqual(last.items.map((row) => row.id), ["e", "d", "c", "b", "a"]);
+  // `{ hasMore: false }` on its own is not a cursor the contract accepts, and
+  // asserting that here is the point: the paginator must not hand the envelope
+  // builder a value parseClientV1Cursor throws on.
+  assert.equal(last.cursor, undefined);
+  assert.throws(() => parseClientV1Cursor({ hasMore: false }), /at least one/);
+});
+
+test("an empty first page publishes no cursor at all", () => {
+  const empty = paginateClientV1Keyset([] as Row[], {
+    limit: 10,
+    after: null,
+    keyOf,
+    compare: compareClientV1RecencyKeys,
+  });
+  assert.deepEqual(empty.items, []);
+  // parseClientV1Cursor refuses a cursor carrying no token, so emitting
+  // `{ hasMore: false }` with nothing else on a *first* page would make the
+  // envelope builder throw. Omitting the field entirely is the only shape the
+  // contract accepts here.
+  assert.equal(empty.cursor, undefined);
+});
+
+test("an empty continuation page keeps the cursor the client sent", () => {
+  const after: ClientV1PageKey = { sort: "1970-01-01T00:00:00.000Z", id: "zzzz" };
+  const empty = page(10, after);
+  assert.deepEqual(empty.items, []);
+  assert.deepEqual(empty.cursor, {
+    current: encodeClientV1Cursor(after),
+    hasMore: false,
+  });
+  assert.doesNotThrow(() => parseClientV1Cursor(empty.cursor!));
+});
+
+test("a cursor whose row has been deleted resumes at the next surviving row", () => {
+  // Keyset paging is defined by the ordering, not by a row still existing, so
+  // deleting the row a client is holding must not strand it.
+  const after: ClientV1PageKey = { sort: "2026-08-04T00:00:00.000Z", id: "d" };
+  const survived = paginateClientV1Keyset(
+    ROWS.filter((row) => row.id !== "d"),
+    { limit: 2, after, keyOf, compare: compareClientV1RecencyKeys },
+  );
+  assert.deepEqual(survived.items.map((row) => row.id), ["c", "b"]);
+});
+
+test("ascending pagination walks the same set from the other end", () => {
+  const ascending = [...ROWS].sort((a, b) => compareClientV1AscendingKeys(keyOf(a), keyOf(b)));
+  assert.deepEqual(ascending.map((row) => row.id), ["a", "b", "c", "d", "e"]);
+  const first = paginateClientV1Keyset(ascending, {
+    limit: 2,
+    after: null,
+    keyOf,
+    compare: compareClientV1AscendingKeys,
+  });
+  assert.deepEqual(first.items.map((row) => row.id), ["a", "b"]);
+});
+
+test("sequence pagination resumes by position, not by comparing keys", () => {
+  // Chat turns are a chain, not a sorted set: a user turn and its assistant
+  // reply share a createdAt stamp, so ordering them by (createdAt, id) would
+  // swap the reply in front of the message it answers. Position is the only
+  // correct resume key here.
+  const turns = [
+    { id: "t1", at: "2026-08-01T00:00:00.000Z" },
+    { id: "t2", at: "2026-08-01T00:00:00.000Z" },
+    { id: "t3", at: "2026-08-02T00:00:00.000Z" },
+  ];
+  const first = paginateClientV1Sequence(turns, { limit: 2, after: null, keyOf });
+  assert.notEqual(first, null);
+  assert.deepEqual(first!.items.map((turn) => turn.id), ["t1", "t2"]);
+  assert.equal(first!.cursor?.hasMore, true);
+  const second = paginateClientV1Sequence(turns, {
+    limit: 2,
+    after: decodeClientV1Cursor(first!.cursor!.next!),
+    keyOf,
+  });
+  assert.deepEqual(second!.items.map((turn) => turn.id), ["t3"]);
+  assert.equal(second!.cursor?.hasMore, false);
+});
+
+test("sequence pagination reports an unresolvable cursor rather than guessing", () => {
+  const turns = [{ id: "t1", at: "2026-08-01T00:00:00.000Z" }];
+  // The active branch moved under the client. Restarting silently at the top
+  // would replay the transcript as if nothing happened; resuming at position 0
+  // would serve a different branch under the same cursor.
+  assert.equal(
+    paginateClientV1Sequence(turns, {
+      limit: 2,
+      after: { sort: "2026-08-01T00:00:00.000Z", id: "gone" },
+      keyOf,
+    }),
+    null,
+  );
+});
+
+test("sequence pagination on an empty transcript publishes no cursor", () => {
+  const empty = paginateClientV1Sequence([] as Row[], { limit: 2, after: null, keyOf });
+  assert.deepEqual(empty!.items, []);
+  assert.equal(empty!.cursor, undefined);
+});

--- a/src/lib/server/client-v1/pagination.test.ts
+++ b/src/lib/server/client-v1/pagination.test.ts
@@ -52,6 +52,29 @@ test("cursor tokens round-trip and stay inside the contract's cursor budget", ()
   assert.equal(encoded.includes("conversation-1"), false);
 });
 
+const BASE64URL_ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+/**
+ * A different string that decodes to the same bytes as `token`.
+ *
+ * Unpadded base64url leaves unused low bits in the final character whenever the
+ * payload length is not a multiple of three, so several spellings decode
+ * identically. Only one of them is the spelling this Cave emits.
+ *
+ * Built by search rather than by arithmetic, and it throws when no twin exists,
+ * so a payload length that happened to leave no spare bits fails the test
+ * loudly instead of passing it vacuously.
+ */
+function nonCanonicalTwin(token: string): string {
+  const bytes = Buffer.from(token, "base64url");
+  for (const candidate of BASE64URL_ALPHABET) {
+    const twin = `${token.slice(0, -1)}${candidate}`;
+    if (twin !== token && Buffer.from(twin, "base64url").equals(bytes)) return twin;
+  }
+  throw new Error("this token has no non-canonical twin to test with");
+}
+
 test("cursor decoding refuses everything that is not a cursor this Cave minted", () => {
   const valid = encodeClientV1Cursor({ sort: "s", id: "i" });
   const rejected: [string, unknown][] = [
@@ -59,10 +82,13 @@ test("cursor decoding refuses everything that is not a cursor this Cave minted",
     ["not a string", 7],
     ["null", null],
     ["outside the base64url alphabet", "not+valid/base64="],
-    // Buffer.from(…, "base64url") silently drops trailing junk, so a
-    // non-canonical encoding decodes to a *valid* payload unless the
-    // round-trip is checked. Without that check this string is accepted.
-    ["non-canonical padding", `${valid}=`],
+    ["padded", `${valid}=`],
+    // The case the alphabet check above CANNOT reach: a different spelling,
+    // entirely inside the alphabet, that Buffer.from decodes to exactly the
+    // same bytes because unpadded base64url leaves spare low bits in the last
+    // character. Only the round-trip check rejects this one — without it the
+    // decode succeeds and a cursor nobody minted is accepted as canonical.
+    ["a non-canonical spelling of a real cursor", nonCanonicalTwin(valid)],
     ["not JSON", Buffer.from("not json at all", "utf8").toString("base64url")],
     ["a JSON array", Buffer.from("[1,2,3]", "utf8").toString("base64url")],
     [

--- a/src/lib/server/client-v1/pagination.ts
+++ b/src/lib/server/client-v1/pagination.ts
@@ -1,0 +1,255 @@
+/**
+ * Keyset pagination for the Client v1 canonical reads.
+ *
+ * `cursors` is one of the capabilities the contract advertises, and the shared
+ * envelope already carries a `ClientV1Cursor`. This module is the half that was
+ * missing: minting and reading the opaque token that rides in it.
+ *
+ * The shape follows the daemon's session pager (OpenCoven/coven#783) rather
+ * than inventing a second dialect for the same problem — keyset ordering over a
+ * total `(sortKey, id)` comparator, an over-fetch of one row to derive
+ * `hasMore`, and an opaque URL-safe base64 cursor. Two deliberate differences:
+ *
+ *   - the page ceiling is `CLIENT_V1_LIMITS.maxPageSize` (100), not the
+ *     daemon's 1000. The number that governs a Client v1 route is the one the
+ *     contract publishes to clients; a route serving 1000 would be serving a
+ *     size its own fixture says is impossible.
+ *   - an out-of-range `limit` is refused rather than clamped. Clamping answers
+ *     a request nobody made, and the client cannot tell the difference between
+ *     "your ceiling is lower than you thought" and "that is the whole set".
+ *
+ * Offsets are deliberately absent. Every store behind these routes is mutated
+ * by the running Cave while a client pages through it, and an offset silently
+ * skips or repeats rows whenever anything is inserted or deleted above the
+ * window. A keyset resumes from a position in the *ordering*, so a deleted row
+ * costs the client nothing.
+ */
+
+import { CLIENT_V1_LIMITS, type ClientV1Cursor } from "./contract.ts";
+
+/**
+ * Version tag inside the encoded cursor.
+ *
+ * Present so a future change to the payload can be refused outright instead of
+ * being misread: an unversioned token that gains a field decodes as a valid
+ * token with a missing one, and the page it resumes is silently wrong.
+ */
+export const CLIENT_V1_CURSOR_VERSION = 1;
+
+/**
+ * The position a cursor resumes from.
+ *
+ * `sort` is whatever the resource orders by (an ISO timestamp for the recency
+ * lists, an id for the alphabetical ones). `id` is the tiebreak that makes the
+ * ordering total — without it two records sharing a sort key are unordered
+ * relative to each other, and a page boundary that lands between them either
+ * repeats both or skips both.
+ */
+export type ClientV1PageKey = {
+  sort: string;
+  id: string;
+};
+
+export type ClientV1PageResult<T> = {
+  items: T[];
+  /**
+   * Absent — not `{ hasMore: false }` — when there is no token to publish.
+   *
+   * `parseClientV1Cursor` refuses a cursor carrying neither `current`, `next`
+   * nor `previous`, so an empty first page has no representable cursor and the
+   * envelope must omit the field rather than carry an unparseable one.
+   */
+  cursor?: ClientV1Cursor;
+};
+
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+const POSITIVE_INTEGER_RE = /^[1-9][0-9]*$/;
+
+function cursorError(detail: string): Error {
+  return new Error(`Client v1 cursor is not readable: ${detail}.`);
+}
+
+export function encodeClientV1Cursor(key: ClientV1PageKey): string {
+  return Buffer.from(
+    JSON.stringify({ v: CLIENT_V1_CURSOR_VERSION, s: key.sort, i: key.id }),
+    "utf8",
+  ).toString("base64url");
+}
+
+export function decodeClientV1Cursor(raw: unknown): ClientV1PageKey {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw cursorError("it is not a non-empty string");
+  }
+  if (raw.length > CLIENT_V1_LIMITS.cursorCharacters) {
+    throw cursorError(`it exceeds ${CLIENT_V1_LIMITS.cursorCharacters} characters`);
+  }
+  if (!BASE64URL_RE.test(raw)) {
+    throw cursorError("it is outside the unpadded base64url alphabet");
+  }
+  const decoded = Buffer.from(raw, "base64url");
+  // Buffer.from is lenient: it drops characters it cannot place rather than
+  // failing, so a token with trailing junk decodes to a perfectly valid
+  // payload. Re-encoding is what makes the token canonical, and canonical is
+  // what makes "this is a cursor we minted" checkable at all.
+  if (decoded.toString("base64url") !== raw) {
+    throw cursorError("it is not a canonical encoding");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded.toString("utf8"));
+  } catch {
+    throw cursorError("its payload is not JSON");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw cursorError("its payload is not an object");
+  }
+  const payload = parsed as Record<string, unknown>;
+  const keys = Object.keys(payload).sort();
+  if (keys.length !== 3 || keys[0] !== "i" || keys[1] !== "s" || keys[2] !== "v") {
+    throw cursorError("its payload carries unexpected fields");
+  }
+  if (payload.v !== CLIENT_V1_CURSOR_VERSION) {
+    throw cursorError(`its version is not ${CLIENT_V1_CURSOR_VERSION}`);
+  }
+  if (typeof payload.s !== "string") throw cursorError("its sort key is not a string");
+  if (typeof payload.i !== "string" || payload.i.length === 0) {
+    throw cursorError("its id is missing");
+  }
+  return { sort: payload.s, id: payload.i };
+}
+
+/**
+ * The page size for one request, from the raw `limit` query parameter.
+ *
+ * Absent means the contract's `defaultPageSize`. Anything else has to be a
+ * plain positive integer inside `maxPageSize`: no leading zeros, no sign, no
+ * exponent, no surrounding space. `Number("1e2")` is 100 and `Number(" 10")` is
+ * 10, so parsing with `Number` alone would accept spellings the contract never
+ * published and quietly serve a page the client did not ask for.
+ */
+export function parseClientV1PageLimit(raw: string | null | undefined): number {
+  if (raw === null || raw === undefined) return CLIENT_V1_LIMITS.defaultPageSize;
+  if (!POSITIVE_INTEGER_RE.test(raw)) {
+    throw new Error(
+      `Client v1 limit must be a whole number between 1 and ${CLIENT_V1_LIMITS.maxPageSize}.`,
+    );
+  }
+  const limit = Number(raw);
+  if (limit > CLIENT_V1_LIMITS.maxPageSize) {
+    throw new Error(
+      `Client v1 limit must be a whole number between 1 and ${CLIENT_V1_LIMITS.maxPageSize}.`,
+    );
+  }
+  return limit;
+}
+
+function compareStrings(left: string, right: string): number {
+  // Codepoint order, never localeCompare: the comparator has to agree with
+  // itself across processes and locales or a cursor minted by one request
+  // resumes somewhere else on the next.
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+/** Newest first, id descending on a tie. */
+export function compareClientV1RecencyKeys(left: ClientV1PageKey, right: ClientV1PageKey): number {
+  const bySort = compareStrings(right.sort, left.sort);
+  if (bySort !== 0) return bySort;
+  return compareStrings(right.id, left.id);
+}
+
+/** Lowest first, id ascending on a tie. */
+export function compareClientV1AscendingKeys(left: ClientV1PageKey, right: ClientV1PageKey): number {
+  const bySort = compareStrings(left.sort, right.sort);
+  if (bySort !== 0) return bySort;
+  return compareStrings(left.id, right.id);
+}
+
+function pageCursor(
+  after: ClientV1PageKey | null,
+  next: ClientV1PageKey | null,
+): ClientV1Cursor | undefined {
+  if (!after && !next) return undefined;
+  return {
+    ...(after ? { current: encodeClientV1Cursor(after) } : {}),
+    ...(next ? { next: encodeClientV1Cursor(next) } : {}),
+    hasMore: next !== null,
+  };
+}
+
+/**
+ * One page of an ordered set, resumed by comparing keys.
+ *
+ * `sorted` must already be ordered by `compare`. The window starts at the first
+ * entry strictly after `after` in that ordering, which is what makes a cursor
+ * survive the deletion of the row it names: the token records a position in the
+ * order, not an index into an array.
+ *
+ * Re-sending the same cursor therefore returns the same page rather than
+ * advancing — pagination is a function of (set, cursor, limit) and nothing
+ * else. A client that follows `next` terminates because `next` is published
+ * only when a further row exists.
+ */
+export function paginateClientV1Keyset<T>(
+  sorted: readonly T[],
+  options: {
+    limit: number;
+    after: ClientV1PageKey | null;
+    keyOf: (item: T) => ClientV1PageKey;
+    compare: (left: ClientV1PageKey, right: ClientV1PageKey) => number;
+  },
+): ClientV1PageResult<T> {
+  const { after, compare, keyOf, limit } = options;
+  const start = after === null
+    ? 0
+    : sorted.findIndex((item) => compare(keyOf(item), after) > 0);
+  const window = start < 0 ? [] : sorted.slice(start, start + limit + 1);
+  const items = window.slice(0, limit);
+  // The over-fetched row is the evidence for `hasMore` and is never served: a
+  // page of `limit + 1` would break the ceiling the contract publishes.
+  const next = window.length > limit && items.length > 0
+    ? keyOf(items[items.length - 1])
+    : null;
+  return { items, cursor: pageCursor(after, next) };
+}
+
+/**
+ * One page of an ordered *sequence*, resumed by position.
+ *
+ * Chat turns are a chain rather than a sorted set. A user turn and the
+ * assistant reply that answers it are persisted with the same `createdAt`
+ * stamp, so ordering by `(createdAt, id)` would reorder a conversation into
+ * nonsense; and turn ids are unique only inside one transcript. The sequence
+ * itself is the order, so the cursor names the last item served and the next
+ * page starts after it.
+ *
+ * Returns `null` when the cursor names an item the sequence no longer
+ * contains, which for a transcript means the active branch moved underneath the
+ * client. That is a state the client has to reconcile rather than an error the
+ * server can paper over: restarting at the top silently replays the
+ * conversation, and resuming at position zero serves a different branch under
+ * the same token.
+ */
+export function paginateClientV1Sequence<T>(
+  sequence: readonly T[],
+  options: {
+    limit: number;
+    after: ClientV1PageKey | null;
+    keyOf: (item: T) => ClientV1PageKey;
+  },
+): ClientV1PageResult<T> | null {
+  const { after, keyOf, limit } = options;
+  let start = 0;
+  if (after !== null) {
+    const index = sequence.findIndex((item) => keyOf(item).id === after.id);
+    if (index < 0) return null;
+    start = index + 1;
+  }
+  const window = sequence.slice(start, start + limit + 1);
+  const items = window.slice(0, limit);
+  const next = window.length > limit && items.length > 0
+    ? keyOf(items[items.length - 1])
+    : null;
+  return { items, cursor: pageCursor(after, next) };
+}

--- a/src/lib/server/client-v1/pagination.ts
+++ b/src/lib/server/client-v1/pagination.ts
@@ -69,7 +69,31 @@ function cursorError(detail: string): Error {
   return new Error(`Client v1 cursor is not readable: ${detail}.`);
 }
 
+/**
+ * Refuse to mint a token this module's own decoder would reject.
+ *
+ * Every page key is read out of a store that does not validate its own JSON —
+ * a hand-edited `projects.json` row, a conversation file written by an older
+ * Cave, a daemon roster field that changed type — so `sort` and `id` are only
+ * strings by convention. `JSON.stringify` carries a number through happily and
+ * drops an `undefined` key entirely, and `decodeClientV1Cursor` then answers
+ * `invalid_request` ("its sort key is not a string") for a token *this server
+ * wrote*. A client following `next` cannot advance and is told its own cursor
+ * is malformed. Throwing here turns that into the route's `internal_error`,
+ * which is at least true.
+ */
+function assertMintableKey(key: ClientV1PageKey): void {
+  const sort: unknown = key.sort;
+  const id: unknown = key.id;
+  if (typeof sort !== "string" || typeof id !== "string" || id.length === 0) {
+    throw new Error(
+      "Client v1 cursor cannot be minted: a page key must be two strings with a non-empty id.",
+    );
+  }
+}
+
 export function encodeClientV1Cursor(key: ClientV1PageKey): string {
+  assertMintableKey(key);
   return Buffer.from(
     JSON.stringify({ v: CLIENT_V1_CURSOR_VERSION, s: key.sort, i: key.id }),
     "utf8",
@@ -89,8 +113,15 @@ export function decodeClientV1Cursor(raw: unknown): ClientV1PageKey {
   const decoded = Buffer.from(raw, "base64url");
   // Buffer.from is lenient: it drops characters it cannot place rather than
   // failing, so a token with trailing junk decodes to a perfectly valid
-  // payload. Re-encoding is what makes the token canonical, and canonical is
-  // what makes "this is a cursor we minted" checkable at all.
+  // payload. Re-encoding is what pins the token to one spelling, so two
+  // tokens that mean the same position cannot be spelled differently.
+  //
+  // It does NOT make "this is a cursor we minted" checkable, and nothing here
+  // does: the payload is unauthenticated, so anyone can produce a token that
+  // decodes. That is deliberate rather than an omission — a cursor names a
+  // position in an ordering the caller is already authorized to read, so
+  // forging one buys a different page of the same data and no more. Do not let
+  // a later change hang an authorization decision off a decoded cursor.
   if (decoded.toString("base64url") !== raw) {
     throw cursorError("it is not a canonical encoding");
   }
@@ -147,8 +178,21 @@ function compareStrings(left: string, right: string): number {
   // Codepoint order, never localeCompare: the comparator has to agree with
   // itself across processes and locales or a cursor minted by one request
   // resumes somewhere else on the next.
-  if (left < right) return -1;
-  if (left > right) return 1;
+  //
+  // Coerced first, because "total" is a claim about the values that actually
+  // arrive and no store behind these routes validates its own JSON. Both `<`
+  // and `>` are FALSE against `undefined`, so an unvalidated key collapses to a
+  // tie against every string — and the id tiebreak then makes the order
+  // *cyclic* rather than merely arbitrary. Measured on
+  // `{sort: undefined, id: "m"}`, `{sort: "a", id: "z"}`, `{sort: "b", id:
+  // "a"}`: each compares greater than the next, and Array#sort returned three
+  // different orders for the three input permutations. A keyset over a cyclic
+  // order skips rows. Coercion keeps trichotomy; the record is refused later,
+  // by the projection, where refusing is meaningful.
+  const l = typeof left === "string" ? left : "";
+  const r = typeof right === "string" ? right : "";
+  if (l < r) return -1;
+  if (l > r) return 1;
   return 0;
 }
 

--- a/src/lib/server/client-v1/read-guard.test.ts
+++ b/src/lib/server/client-v1/read-guard.test.ts
@@ -48,6 +48,52 @@ test("the bearer is read only from a well-formed Authorization header", () => {
   }
 });
 
+test("the bearer is read from the header and from NOTHING else", () => {
+  // The module doc states this as a rule and the published reference repeats it
+  // — "never a query parameter, never a cookie" — and until this test nothing
+  // enforced it: adding a `?access_token=` fallback to clientV1BearerFrom left
+  // every suite green, including the route suites, because the credential is
+  // read before the query is parsed and so never reaches the unsupported-
+  // parameter refusal.
+  //
+  // The rule is not stylistic. A credential in a URL survives in shell history,
+  // in `Referer`, and in every access log between here and the process; a
+  // credential a browser attaches on its own (a cookie) is one an attacker can
+  // spend cross-origin, which is exactly what the loopback stamp cannot stop
+  // because a browser on this machine IS a local peer.
+  const withUrl = (url: string, headers: Record<string, string> = {}) =>
+    clientV1BearerFrom(new Request(url, { headers }));
+
+  for (const url of [
+    "http://127.0.0.1:3020/api/client/v1/projects?access_token=token-1",
+    "http://127.0.0.1:3020/api/client/v1/projects?bearer=token-1",
+    "http://127.0.0.1:3020/api/client/v1/projects?authorization=Bearer%20token-1",
+    "http://127.0.0.1:3020/api/client/v1/projects?token=token-1",
+  ]) {
+    assert.equal(withUrl(url), null, url);
+  }
+  // A cookie is not a credential here either, however it is spelled.
+  for (const cookie of [
+    "authorization=Bearer token-1",
+    "client_v1_bearer=token-1",
+    "access_token=token-1",
+  ]) {
+    assert.equal(
+      withUrl("http://127.0.0.1:3020/api/client/v1/projects", { cookie }),
+      null,
+      cookie,
+    );
+  }
+  // And a query parameter cannot override a header that IS present, which is
+  // the shape a "fallback" usually lands in.
+  assert.equal(
+    withUrl("http://127.0.0.1:3020/api/client/v1/projects?access_token=other", {
+      authorization: "Bearer token-1",
+    }),
+    "token-1",
+  );
+});
+
 test("read query parameters default, bound, and refuse what they do not serve", () => {
   const at = (query: string) =>
     parseClientV1ReadPage(new URL(`http://127.0.0.1:3020/api/client/v1/projects${query}`));

--- a/src/lib/server/client-v1/read-guard.test.ts
+++ b/src/lib/server/client-v1/read-guard.test.ts
@@ -16,6 +16,7 @@ import {
   chargeClientV1AuthFailure,
   clientV1BearerFrom,
   clientV1InvalidReadRequest,
+  clientV1ReadFailure,
   parseClientV1ReadPage,
 } from "./read-guard.ts";
 import { createClientV1Runtime } from "./runtime.ts";
@@ -184,5 +185,31 @@ test("the loopback stamp header the routes require is the server-stamped one", a
     assert.equal(LOCAL_PEER_HEADER, "x-coven-cave-local-peer");
   } finally {
     await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("the read failure is an envelope that describes nothing about the record", async () => {
+  // It exists because the throw used to escape the handler, and Next answered
+  // with its own body — not a Client v1 envelope, on a surface whose contract
+  // is that every response is one. A client that only knows this shape has to
+  // be able to read its own failure.
+  const response = clientV1ReadFailure();
+  assert.equal(response.status, 500);
+  assert.equal(response.headers.get("content-type"), "application/json");
+  const body = await response.json() as {
+    apiVersion: string;
+    error: { code: string; message: string; retryable: boolean; details?: unknown };
+  };
+  assert.equal(body.error.code, "internal_error");
+  assert.equal(body.apiVersion, "1.0");
+  // Not retryable: the record reads the same next second, so retrying spends
+  // the caller's budget to be told the same thing.
+  assert.equal(body.error.retryable, false);
+  // And carries no details. Every message on this path names a field of a
+  // stored record, and some would carry its value — a description of the
+  // operator's disk, handed to a caller who cannot repair it.
+  assert.equal(body.error.details, undefined);
+  for (const disclosure of ["projects.json", "conversations", "updatedAt", "createdAt", "/", "\\"]) {
+    assert.equal(body.error.message.includes(disclosure), false, disclosure);
   }
 });

--- a/src/lib/server/client-v1/read-guard.test.ts
+++ b/src/lib/server/client-v1/read-guard.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import { LOCAL_PEER_HEADER } from "../../../proxy-helpers.ts";
+import { CLIENT_V1_LIMITS } from "./contract.ts";
+import { encodeClientV1Cursor } from "./pagination.ts";
+import {
+  CLIENT_V1_INVALID_BEARER_LIMIT,
+  CLIENT_V1_AUTHENTICATED_LIMIT,
+} from "./rate-limit.ts";
+import {
+  CLIENT_V1_READ_SCOPE,
+  assertClientV1NoReadQuery,
+  chargeClientV1AuthFailure,
+  clientV1BearerFrom,
+  clientV1InvalidReadRequest,
+  parseClientV1ReadPage,
+} from "./read-guard.ts";
+import { createClientV1Runtime } from "./runtime.ts";
+
+const scratchPrefix = resolve(process.cwd(), ".scratch-client-v1-read-guard-");
+
+function request(headers: Record<string, string> = {}): Request {
+  return new Request("http://127.0.0.1:3020/api/client/v1/projects", { headers });
+}
+
+test("the bearer is read only from a well-formed Authorization header", () => {
+  assert.equal(clientV1BearerFrom(request()), null);
+  assert.equal(clientV1BearerFrom(request({ authorization: "Bearer token-1" })), "token-1");
+  // Scheme matching is case-insensitive per RFC 7235, and any run of spaces or
+  // tabs separates it from the credential.
+  assert.equal(clientV1BearerFrom(request({ authorization: "bearer token-1" })), "token-1");
+  assert.equal(clientV1BearerFrom(request({ authorization: "BEARER \t token-1" })), "token-1");
+  for (const malformed of [
+    "",
+    "token-1",
+    "Basic token-1",
+    "Bearer",
+    "Bearer ",
+    "Bearer token-1 token-2",
+    "Bearerish token-1",
+    `Bearer ${"x".repeat(513)}`,
+  ]) {
+    assert.equal(clientV1BearerFrom(request({ authorization: malformed })), null, malformed);
+  }
+});
+
+test("read query parameters default, bound, and refuse what they do not serve", () => {
+  const at = (query: string) =>
+    parseClientV1ReadPage(new URL(`http://127.0.0.1:3020/api/client/v1/projects${query}`));
+
+  assert.deepEqual(at(""), { limit: CLIENT_V1_LIMITS.defaultPageSize, after: null });
+  assert.deepEqual(at("?limit=7"), { limit: 7, after: null });
+
+  const cursor = encodeClientV1Cursor({ sort: "2026-08-01T00:00:00.000Z", id: "p1" });
+  assert.deepEqual(at(`?cursor=${cursor}`), {
+    limit: CLIENT_V1_LIMITS.defaultPageSize,
+    after: { sort: "2026-08-01T00:00:00.000Z", id: "p1" },
+  });
+
+  assert.throws(() => at(`?limit=${CLIENT_V1_LIMITS.maxPageSize + 1}`), /limit/i);
+  assert.throws(() => at("?cursor=not%2Ba%2Bcursor"), /cursor/i);
+  // A parameter the route does not serve is a client bug, and answering it
+  // with the default page is how `?limt=5` silently becomes fifty rows.
+  assert.throws(() => at("?limt=5"), /do not support the "limt" parameter/);
+  // Repeating a supported parameter is equally ambiguous: URLSearchParams.get
+  // would quietly pick the first and discard the second.
+  assert.throws(() => at("?limit=5&limit=9"), /once/i);
+});
+
+test("a single-record read serves no query parameters at all", () => {
+  const at = (query: string) =>
+    assertClientV1NoReadQuery(
+      new URL(`http://127.0.0.1:3020/api/client/v1/conversations/conversation-1${query}`),
+    );
+  assert.doesNotThrow(() => at(""));
+  // Including the two the list routes DO serve: there is nothing here to page.
+  for (const query of ["?limit=5", "?cursor=abc", "?offset=1", "?limit="]) {
+    assert.throws(() => at(query), /do not support/, query);
+  }
+});
+
+test("a refused query becomes a 400 that names the parameter at fault", async () => {
+  const response = clientV1InvalidReadRequest(
+    new Error("Client v1 read requests do not support the \"limt\" parameter."),
+  );
+  assert.equal(response.status, 400);
+  const body = await response.json() as {
+    error: { code: string; retryable: boolean; details: { reason: string } };
+  };
+  assert.equal(body.error.code, "invalid_request");
+  // Never retryable: the same request will be refused the same way forever.
+  assert.equal(body.error.retryable, false);
+  assert.match(body.error.details.reason, /"limt"/);
+
+  // The detail budget is 256 characters and the error builder throws above it,
+  // so an over-long message must be truncated rather than turned into a 500.
+  const truncated = clientV1InvalidReadRequest(new Error("x".repeat(4_000)));
+  assert.equal(truncated.status, 400);
+  const truncatedBody = await truncated.json() as { error: { details: { reason: string } } };
+  assert.equal(
+    truncatedBody.error.details.reason.length,
+    CLIENT_V1_LIMITS.errorDetailValueCharacters,
+  );
+
+  // A non-Error rejection must still produce an envelope, not throw a second
+  // time on `cause.message`.
+  assert.equal(clientV1InvalidReadRequest("nope").status, 400);
+});
+
+test("an unauthorized failure is charged to the invalid-bearer budget", async () => {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const runtime = createClientV1Runtime({ credentialRoot: root, loopbackSecret: "stamp" });
+    const failure = await runtime.authenticator.requireScope({
+      bearer: null,
+      scope: CLIENT_V1_READ_SCOPE,
+    });
+    assert.equal(failure.ok, false);
+    if (failure.ok) return;
+
+    let response: Response | null = null;
+    for (let attempt = 0; attempt < CLIENT_V1_INVALID_BEARER_LIMIT; attempt += 1) {
+      response = chargeClientV1AuthFailure(runtime, failure, "stamp");
+      assert.equal(response.status, 401, `attempt ${attempt}`);
+    }
+    // The budget is spent by wrong credentials, so the next one is refused
+    // before it can be a guess at all.
+    response = chargeClientV1AuthFailure(runtime, failure, "stamp");
+    assert.equal(response!.status, 429);
+    const body = await response!.json() as { error: { code: string; details: { limit: string } } };
+    assert.equal(body.error.code, "rate_limited");
+    assert.equal(body.error.details.limit, String(CLIENT_V1_INVALID_BEARER_LIMIT));
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("a scope denial is charged to the credential's own authenticated budget", async () => {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const runtime = createClientV1Runtime({ credentialRoot: root, loopbackSecret: "stamp" });
+    const issued = await runtime.credentialStore.issue({
+      appName: "OpenCoven Chat",
+      installationId: "chat-install-1",
+      scopes: ["chat:write"],
+    });
+    const failure = await runtime.authenticator.requireScope({
+      bearer: issued.bearer,
+      scope: CLIENT_V1_READ_SCOPE,
+    });
+    assert.equal(failure.ok, false);
+    if (failure.ok) return;
+    assert.equal(failure.reason, "scope_denied");
+
+    for (let attempt = 0; attempt < CLIENT_V1_AUTHENTICATED_LIMIT; attempt += 1) {
+      assert.equal(chargeClientV1AuthFailure(runtime, failure, "stamp").status, 403);
+    }
+    assert.equal(chargeClientV1AuthFailure(runtime, failure, "stamp").status, 429);
+    // Charging the wrong bucket would have been invisible: both refusals look
+    // the same from outside. The invalid-bearer budget must be untouched.
+    assert.equal(runtime.rateLimiter.consumeInvalidBearer("stamp").allowed, true);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("the read scope is the only read grant the contract publishes", () => {
+  // Every canonical read here is gated on one scope. Stated as an assertion
+  // because the routes name the constant, not the string, and a silent change
+  // to it would widen or narrow four routes at once.
+  assert.equal(CLIENT_V1_READ_SCOPE, "chat:read");
+});
+
+test("the loopback stamp header the routes require is the server-stamped one", async () => {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const runtime = createClientV1Runtime({ credentialRoot: root, loopbackSecret: "stamp" });
+    assert.equal(runtime.authenticator.isTrustedLoopback("stamp"), true);
+    assert.equal(runtime.authenticator.isTrustedLoopback("not-the-stamp"), false);
+    assert.equal(runtime.authenticator.isTrustedLoopback(null), false);
+    assert.equal(LOCAL_PEER_HEADER, "x-coven-cave-local-peer");
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});

--- a/src/lib/server/client-v1/read-guard.ts
+++ b/src/lib/server/client-v1/read-guard.ts
@@ -162,5 +162,33 @@ export function clientV1InvalidReadRequest(cause: unknown): Response {
   });
 }
 
+/**
+ * The 500 a route answers when the store, or the projection over it, refused.
+ *
+ * Without it the throw escaped the handler and Next answered with its own
+ * error page — a body that is not a Client v1 envelope, on a surface whose
+ * whole contract is that every response is one. A client parsing the envelope
+ * fails to read its own failure, which is the exact trap the *Reaching the API
+ * at all* section warns about for the proxy's rejections.
+ *
+ * It is reachable from ordinary data, not just from a bug: no store behind
+ * these routes validates the JSON it returns, and `projectClientV1*` refuses a
+ * record whose required field is absent or wrongly typed (see reads.ts). One
+ * hand-edited `projects.json` row, one conversation file written by an older
+ * Cave, or one daemon that renamed a roster field reaches this path.
+ *
+ * `retryable` is deliberately false. The store answers the same way next
+ * second, so a client that retries is spending its budget to be told the same
+ * thing; the operator has to repair the record.
+ *
+ * The cause is deliberately NOT forwarded to the client. Every message on this
+ * path names a field of a stored record, and some of them would carry the
+ * value — details on an error a caller cannot fix is a description of the
+ * server's disk.
+ */
+export function clientV1ReadFailure(): Response {
+  return clientV1ErrorResponse("internal_error", "The read could not be served.");
+}
+
 /** The contract's page-size ceiling, re-exported so routes can name it once. */
 export const CLIENT_V1_MAX_PAGE_SIZE = CLIENT_V1_LIMITS.maxPageSize;

--- a/src/lib/server/client-v1/read-guard.ts
+++ b/src/lib/server/client-v1/read-guard.ts
@@ -1,0 +1,166 @@
+/**
+ * The shared policy the Client v1 canonical read routes apply before serving.
+ *
+ * What is NOT here, deliberately: the `requireScope` call itself, and the
+ * `consumeAuthenticated` charge on the success path. Both stay written out in
+ * every route module, because that is the form
+ * `src/app/api/api-contracts.test.ts` reads — it asserts, against a comment-,
+ * string- and regex-stripped view of each route's own source, that the route
+ * enforces a credential. A route that delegated the whole check to a helper
+ * would satisfy the letter of that assertion only if the assertion were taught
+ * to follow the import, which is exactly the loosening the assertion exists to
+ * prevent. The pieces below are the parts that carry no credential decision:
+ * parsing the header, parsing the query, and choosing which rate-limit bucket
+ * an already-decided failure is charged against.
+ */
+
+import {
+  CLIENT_V1_LIMITS,
+  type ClientV1Scope,
+} from "./contract.ts";
+import type { ClientV1AuthResult } from "./auth.ts";
+import {
+  decodeClientV1Cursor,
+  parseClientV1PageLimit,
+  type ClientV1PageKey,
+} from "./pagination.ts";
+import { clientV1ErrorResponse, clientV1RateLimitResponse } from "./responses.ts";
+import type { ClientV1Runtime } from "./runtime.ts";
+
+/**
+ * The single grant every canonical read requires.
+ *
+ * `chat:read` is the only read scope the contract publishes; the other five are
+ * writes. Familiars, projects, conversations and their messages are all the
+ * same read, so they are gated on the same grant rather than on five scopes
+ * that do not exist.
+ */
+export const CLIENT_V1_READ_SCOPE: ClientV1Scope = "chat:read";
+
+/** Query parameters the read routes serve. Anything else is a client bug. */
+const SUPPORTED_READ_PARAMETERS = new Set(["cursor", "limit"]);
+
+/**
+ * A bearer is at most this many characters before it is refused unread.
+ *
+ * An issued bearer is 43 base64url characters. The cap is far above that and is
+ * only here so an unbounded header cannot be pushed through `createHash` on
+ * every request; it is not a format assertion, because the store compares
+ * hashes and has no opinion about the alphabet.
+ */
+const MAX_BEARER_CHARACTERS = 512;
+
+const BEARER_RE = /^Bearer[ \t]+([^\s]+)$/i;
+
+/**
+ * The credential from an `Authorization: Bearer …` header, or null.
+ *
+ * Header only. Not a query parameter, not a cookie: a credential in a URL
+ * survives in shell history, referer headers and server logs, and a credential
+ * a browser attaches on its own is a credential an attacker can spend
+ * cross-origin.
+ *
+ * Returning null rather than throwing is what keeps a malformed header off the
+ * credential store — requireScope answers `unauthorized` for a null bearer
+ * without a lookup.
+ */
+export function clientV1BearerFrom(request: Request): string | null {
+  const header = request.headers.get("authorization");
+  if (!header || header.length > MAX_BEARER_CHARACTERS + "Bearer ".length) return null;
+  const match = BEARER_RE.exec(header.trim());
+  if (!match) return null;
+  const bearer = match[1];
+  return bearer.length <= MAX_BEARER_CHARACTERS ? bearer : null;
+}
+
+/**
+ * The page window one read request asks for.
+ *
+ * Throws on anything it cannot serve so the route answers `invalid_request`
+ * rather than quietly serving a different page than the one requested. That
+ * includes an unsupported parameter (`?limt=5` must not silently return fifty
+ * rows) and a repeated supported one (`URLSearchParams.get` would pick the
+ * first and discard the second without telling anybody).
+ */
+export function parseClientV1ReadPage(url: URL): {
+  limit: number;
+  after: ClientV1PageKey | null;
+} {
+  const seen = new Set<string>();
+  for (const name of url.searchParams.keys()) {
+    if (!SUPPORTED_READ_PARAMETERS.has(name)) {
+      throw new Error(`Client v1 read requests do not support the "${name}" parameter.`);
+    }
+    if (seen.has(name)) {
+      throw new Error(`Client v1 read requests accept "${name}" at most once.`);
+    }
+    seen.add(name);
+  }
+  const limit = parseClientV1PageLimit(url.searchParams.get("limit"));
+  const rawCursor = url.searchParams.get("cursor");
+  return {
+    limit,
+    after: rawCursor === null ? null : decodeClientV1Cursor(rawCursor),
+  };
+}
+
+/**
+ * Refuse any query parameter on a route that serves a single record.
+ *
+ * A one-record read has nothing to page, so `limit` and `cursor` are as
+ * meaningless on it as `offset`. Ignoring them would be the friendlier
+ * behaviour and the worse one: a client that sends `?limit=5` and is answered
+ * normally learns that the parameter is accepted everywhere, and carries that
+ * belief to a route where it changes the answer.
+ */
+export function assertClientV1NoReadQuery(url: URL): void {
+  for (const name of url.searchParams.keys()) {
+    throw new Error(`Client v1 read requests do not support the "${name}" parameter.`);
+  }
+}
+
+/**
+ * Charge one authentication failure against the bucket it belongs to.
+ *
+ * The two failures are metered separately because they bound different things.
+ * `unauthorized` means no credential was established, so the only key available
+ * is the caller's loopback stamp — one process-wide constant, which makes this
+ * a single shared bucket exactly like pairing creation, and for the same
+ * reason: every finer key would be attacker-chosen. `scope_denied` means a real
+ * credential asked for a grant it does not hold, so it is charged to that
+ * credential's own authenticated budget, where it cannot starve anyone else.
+ *
+ * A caller that has exhausted its bucket is answered 429 instead of the
+ * original refusal. That is deliberate: the refusal itself is the signal an
+ * attacker is reading, so once the budget is gone it stops being served.
+ */
+export function chargeClientV1AuthFailure(
+  runtime: ClientV1Runtime,
+  failure: Extract<ClientV1AuthResult, { ok: false }>,
+  sourceIdentity: string,
+): Response {
+  const budget = failure.reason === "scope_denied"
+    ? runtime.rateLimiter.consumeAuthenticated(failure.credential.id)
+    : runtime.rateLimiter.consumeInvalidBearer(sourceIdentity);
+  return budget.allowed ? failure.response : clientV1RateLimitResponse(budget);
+}
+
+/**
+ * The 400 a route answers when parseClientV1ReadPage refused the query.
+ *
+ * The thrown message is forwarded in `details.reason` because it is the only
+ * thing that tells a client author *which* parameter was wrong, and every one
+ * of those messages is authored in this module — none of them carries a value
+ * the caller supplied except the parameter name it already knows. Truncated to
+ * the contract's detail budget so a long parameter name cannot make the error
+ * builder throw while building an error.
+ */
+export function clientV1InvalidReadRequest(cause: unknown): Response {
+  const reason = cause instanceof Error ? cause.message : "The read request is not valid.";
+  return clientV1ErrorResponse("invalid_request", "The read request is not valid.", {
+    details: { reason: reason.slice(0, CLIENT_V1_LIMITS.errorDetailValueCharacters) },
+  });
+}
+
+/** The contract's page-size ceiling, re-exported so routes can name it once. */
+export const CLIENT_V1_MAX_PAGE_SIZE = CLIENT_V1_LIMITS.maxPageSize;

--- a/src/lib/server/client-v1/read-sources.ts
+++ b/src/lib/server/client-v1/read-sources.ts
@@ -1,0 +1,59 @@
+/**
+ * The stores the Client v1 canonical reads project, behind one injectable seam.
+ *
+ * Every module here resolves its on-disk location at import time — CONV_DIR is
+ * `path.join(caveHome(), "conversations")` evaluated when cave-conversations.ts
+ * is first loaded — so a test that wants a different Cave home has to set the
+ * environment before the import graph is built. That makes suite behaviour
+ * depend on module load order, which is exactly the kind of coupling that turns
+ * a green run on one machine into a red run on another.
+ *
+ * So the routes take their sources as an argument, the same way they already
+ * take their ClientV1Runtime. `clientV1ReadSources()` is the production
+ * binding; a test hands the handler a plain object and never touches the
+ * filesystem or the daemon at all.
+ */
+
+import {
+  listConversations,
+  loadConversation,
+  type ConversationFile,
+  type ConversationSummary,
+} from "../../cave-conversations.ts";
+import { loadProjects } from "../../cave-projects.ts";
+import type { CaveProject } from "../../cave-projects-types.ts";
+import {
+  loadVisibleFamiliarRoster,
+  type VisibleFamiliarRosterResult,
+} from "../familiar-roster.ts";
+
+export interface ClientV1ReadSources {
+  /**
+   * The visible familiar roster, or the failure that stopped it being read.
+   *
+   * Returns the result rather than throwing because a daemon that is down is
+   * an ordinary, reportable state of this Cave — not an exception — and the
+   * route has to distinguish it from an empty roster.
+   */
+  listFamiliars(): Promise<VisibleFamiliarRosterResult>;
+  listProjects(): Promise<CaveProject[]>;
+  listConversations(): Promise<ConversationSummary[]>;
+  /**
+   * One transcript, or null.
+   *
+   * Null covers "no such conversation" and "that id cannot name one" alike:
+   * loadConversation resolves the path through a traversal guard and returns
+   * null on any failure, so a `..` segment that survived URL decoding is
+   * absent rather than an error, and the route answers `not_found` for both.
+   */
+  loadConversation(id: string): Promise<ConversationFile | null>;
+}
+
+export function clientV1ReadSources(): ClientV1ReadSources {
+  return Object.freeze({
+    listFamiliars: loadVisibleFamiliarRoster,
+    listProjects: loadProjects,
+    listConversations,
+    loadConversation,
+  });
+}

--- a/src/lib/server/client-v1/reads.test.ts
+++ b/src/lib/server/client-v1/reads.test.ts
@@ -1,0 +1,346 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ChatTurn, ConversationFile, ConversationSummary } from "../../cave-conversations.ts";
+import type { CaveProject } from "../../cave-projects-types.ts";
+import type { VisibleFamiliarRosterEntry } from "../familiar-roster.ts";
+import { parseClientV1JsonObject } from "./contract.ts";
+import { compareClientV1AscendingKeys, compareClientV1RecencyKeys } from "./pagination.ts";
+import {
+  clientV1ConversationPageKey,
+  clientV1ConversationSequence,
+  clientV1FamiliarPageKey,
+  clientV1MessagePageKey,
+  clientV1ProjectPageKey,
+  projectClientV1Conversation,
+  projectClientV1Familiar,
+  projectClientV1Message,
+  projectClientV1Project,
+  sortClientV1Conversations,
+  sortClientV1Familiars,
+  sortClientV1Projects,
+} from "./reads.ts";
+
+test("the familiar projection carries the roster's stated fields and omits the rest", () => {
+  const entry: VisibleFamiliarRosterEntry = {
+    id: "scribe",
+    display_name: "Scribe",
+    role: "Archivist",
+    description: "Keeps the ledger.",
+    pronouns: "they/them",
+    status: "idle",
+    last_seen: "2026-08-20T10:00:00.000Z",
+    active_sessions: 2,
+    memory_freshness: "fresh",
+    emoji: "🖋",
+    icon: "quill",
+  };
+  assert.deepEqual(projectClientV1Familiar(entry), {
+    id: "scribe",
+    displayName: "Scribe",
+    role: "Archivist",
+    description: "Keeps the ledger.",
+    pronouns: "they/them",
+    status: "idle",
+    lastSeenAt: "2026-08-20T10:00:00.000Z",
+    activeSessions: 2,
+  });
+});
+
+test("the familiar projection drops optional fields instead of writing undefined", () => {
+  // parseClientV1JsonValue refuses a key whose value is undefined, so a
+  // projection that spreads `description: entry.description` throws inside the
+  // envelope builder the first time a familiar has no description. Absence has
+  // to be absence.
+  const projected = projectClientV1Familiar({
+    id: "mote",
+    display_name: "Mote",
+    role: "Familiar",
+  });
+  assert.deepEqual(Object.keys(projected).sort(), ["displayName", "id", "role"]);
+  assert.doesNotThrow(() => parseClientV1JsonObject(projected));
+});
+
+test("the familiar projection refuses a non-integer session count and a blank last seen", () => {
+  const projected = projectClientV1Familiar({
+    id: "mote",
+    display_name: "Mote",
+    role: "Familiar",
+    last_seen: "   ",
+    active_sessions: 1.5,
+  });
+  assert.equal("lastSeenAt" in projected, false);
+  assert.equal("activeSessions" in projected, false);
+});
+
+test("familiars sort by id because a familiar record carries no timestamp", () => {
+  // The roster is a daemon read merged with familiars.toml; nothing in it has a
+  // createdAt or an updatedAt. Ordering by anything else would be ordering by a
+  // field that does not exist, so the identity is also the sort key — which is
+  // total by construction.
+  const roster: VisibleFamiliarRosterEntry[] = [
+    { id: "warden", display_name: "Warden", role: "Guard" },
+    { id: "adept", display_name: "Adept", role: "Scholar" },
+    { id: "mote", display_name: "Mote", role: "Familiar" },
+  ];
+  assert.deepEqual(
+    sortClientV1Familiars(roster).map((entry) => entry.id),
+    ["adept", "mote", "warden"],
+  );
+  assert.deepEqual(clientV1FamiliarPageKey(roster[0]), { sort: "warden", id: "warden" });
+  assert.equal(
+    compareClientV1AscendingKeys(
+      clientV1FamiliarPageKey(roster[1]),
+      clientV1FamiliarPageKey(roster[0]),
+    ) < 0,
+    true,
+  );
+});
+
+const PROJECT: CaveProject = {
+  id: "p1",
+  name: "Cave",
+  root: "/Users/me/code/cave",
+  color: "#123456",
+  repoUrl: "https://github.com/OpenCoven/coven-cave",
+  legacyRoot: "~/code/cave",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-09T00:00:00.000Z",
+};
+
+test("the project projection publishes the registry record and not its migration marker", () => {
+  assert.deepEqual(projectClientV1Project(PROJECT), {
+    id: "p1",
+    name: "Cave",
+    root: "/Users/me/code/cave",
+    color: "#123456",
+    repoUrl: "https://github.com/OpenCoven/coven-cave",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-09T00:00:00.000Z",
+  });
+  // legacyRoot exists to let the Cave's own web client re-key browser stores
+  // after a root normalization. It is response-only scaffolding for that one
+  // consumer, not part of what a project *is*, and publishing it would invite
+  // an external client to key on a value the server strips before every write.
+  assert.equal("legacyRoot" in projectClientV1Project(PROJECT), false);
+  // `access` is a familiar-scoped view, absent on the operator registry read
+  // this route performs. Publishing the field would state a permission answer
+  // this route never computed.
+  assert.equal("access" in projectClientV1Project({ ...PROJECT, access: "read" }), false);
+});
+
+test("projects page by createdAt because updatedAt moves under an open cursor", () => {
+  // Both timestamps are required on a CaveProject, so either could key the
+  // page. createdAt is the immutable one: a project patched between two page
+  // requests changes its updatedAt, moves in the ordering, and is then either
+  // served twice or skipped. createdAt cannot move.
+  assert.deepEqual(clientV1ProjectPageKey(PROJECT), {
+    sort: "2026-08-01T00:00:00.000Z",
+    id: "p1",
+  });
+  const older: CaveProject = { ...PROJECT, id: "p0", createdAt: "2026-07-01T00:00:00.000Z" };
+  const tied: CaveProject = { ...PROJECT, id: "p2" };
+  assert.deepEqual(
+    sortClientV1Projects([older, PROJECT, tied]).map((project) => project.id),
+    ["p2", "p1", "p0"],
+  );
+  assert.equal(
+    compareClientV1RecencyKeys(clientV1ProjectPageKey(tied), clientV1ProjectPageKey(PROJECT)) < 0,
+    true,
+    "a createdAt tie must break on the id, descending",
+  );
+});
+
+const SUMMARY: ConversationSummary = {
+  sessionId: "conversation-1",
+  harnessSessionId: "harness-9",
+  familiarId: "scribe",
+  harness: "claude",
+  model: "opus",
+  runtime: "native",
+  title: "Ledger cleanup",
+  origin: "chat",
+  branch: "feat/x",
+  prUrl: "https://github.com/OpenCoven/coven-cave/pull/1",
+  status: "completed",
+  exitCode: 0,
+  pending: false,
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-09T00:00:00.000Z",
+};
+
+test("the conversation projection reports the summary the sessions list is built from", () => {
+  assert.deepEqual(projectClientV1Conversation(SUMMARY), {
+    id: "conversation-1",
+    familiarId: "scribe",
+    harness: "claude",
+    model: "opus",
+    runtime: "native",
+    title: "Ledger cleanup",
+    origin: "chat",
+    status: "completed",
+    exitCode: 0,
+    pending: false,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-09T00:00:00.000Z",
+  });
+  // harnessSessionId rotates on every resume and is never the conversation's
+  // identity; branch and prUrl are working-tree attribution for the Cave's own
+  // PR badges. None of the three describe the conversation to a chat client.
+  const projected = projectClientV1Conversation(SUMMARY);
+  for (const leaked of ["harnessSessionId", "branch", "prUrl"]) {
+    assert.equal(leaked in projected, false, leaked);
+  }
+});
+
+test("the conversation projection tolerates the fields the store leaves optional", () => {
+  const minimal = projectClientV1Conversation({
+    sessionId: "conversation-2",
+    familiarId: "mote",
+    updatedAt: "2026-08-09T00:00:00.000Z",
+  });
+  assert.deepEqual(minimal, {
+    id: "conversation-2",
+    familiarId: "mote",
+    updatedAt: "2026-08-09T00:00:00.000Z",
+  });
+  assert.doesNotThrow(() => parseClientV1JsonObject(minimal));
+  // exitCode is `number | null` in the store — null means "no exit code yet",
+  // which is a fact worth serving, unlike an absent field.
+  assert.equal(
+    projectClientV1Conversation({ ...SUMMARY, exitCode: null }).exitCode,
+    null,
+  );
+});
+
+test("conversations page by updatedAt, the one timestamp the summary always has", () => {
+  // createdAt is optional on a ConversationSummary — a transcript written
+  // before the field existed, or a corrupt-file fallback row, has none — so it
+  // cannot be the sort key. updatedAt is required and is also the order
+  // listConversations already serves, so a client sees one ordering from Cave.
+  assert.deepEqual(clientV1ConversationPageKey(SUMMARY), {
+    sort: "2026-08-09T00:00:00.000Z",
+    id: "conversation-1",
+  });
+  const older: ConversationSummary = {
+    sessionId: "conversation-0",
+    familiarId: "mote",
+    updatedAt: "2026-08-02T00:00:00.000Z",
+  };
+  const tied: ConversationSummary = { ...SUMMARY, sessionId: "conversation-3" };
+  assert.deepEqual(
+    sortClientV1Conversations([older, SUMMARY, tied]).map((row) => row.sessionId),
+    ["conversation-3", "conversation-1", "conversation-0"],
+  );
+});
+
+function turn(id: string, parentId: string | null, at: string, role: ChatTurn["role"] = "user"): ChatTurn {
+  return { id, parentId, role, text: `text-${id}`, createdAt: at };
+}
+
+test("the message sequence follows the active branch, not the stored array order", () => {
+  // turns is a tree flattened into one append-ordered array across every
+  // branch. Serving that array is serving turns from branches the user
+  // abandoned, interleaved with the live one.
+  const conversation = {
+    sessionId: "conversation-1",
+    familiarId: "scribe",
+    harness: "claude",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:03:00.000Z",
+    activeLeafId: "t4",
+    turns: [
+      turn("t1", null, "2026-08-01T00:00:00.000Z"),
+      turn("t2", "t1", "2026-08-01T00:01:00.000Z", "assistant"),
+      turn("t3", "t1", "2026-08-01T00:02:00.000Z", "assistant"),
+      turn("t4", "t3", "2026-08-01T00:03:00.000Z"),
+    ],
+  } satisfies ConversationFile;
+  assert.deepEqual(
+    clientV1ConversationSequence(conversation).map((entry) => entry.id),
+    ["t1", "t3", "t4"],
+  );
+});
+
+test("a conversation with no active leaf serves its stored order rather than nothing", () => {
+  const conversation = {
+    sessionId: "conversation-1",
+    familiarId: "scribe",
+    harness: "claude",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:01:00.000Z",
+    turns: [
+      turn("t1", null, "2026-08-01T00:00:00.000Z"),
+      turn("t2", "t1", "2026-08-01T00:01:00.000Z", "assistant"),
+    ],
+  } satisfies ConversationFile;
+  assert.deepEqual(
+    clientV1ConversationSequence(conversation).map((entry) => entry.id),
+    ["t1", "t2"],
+  );
+  // A transcript file whose turns array is missing or corrupt must read as an
+  // empty transcript, never throw on the way to a 500.
+  assert.deepEqual(
+    clientV1ConversationSequence({ ...conversation, turns: undefined as unknown as ChatTurn[] }),
+    [],
+  );
+});
+
+test("the message projection keeps the transcript and drops the harness internals", () => {
+  const source: ChatTurn = {
+    id: "t2",
+    parentId: "t1",
+    role: "assistant",
+    text: "Done.",
+    createdAt: "2026-08-01T00:01:00.000Z",
+    reasoning: "internal chain of thought",
+    attachments: [{ id: "a1" } as never],
+    tools: [
+      { id: "tool-1", name: "bash", input: "ls ~/.ssh", output: "id_rsa", status: "ok" },
+    ],
+    usage: { input: 1 } as never,
+    costUsd: 0.02,
+    isError: false,
+    cancelled: true,
+  };
+  const projected = projectClientV1Message("conversation-1", source);
+  assert.deepEqual(projected, {
+    id: "t2",
+    conversationId: "conversation-1",
+    parentId: "t1",
+    role: "assistant",
+    text: "Done.",
+    createdAt: "2026-08-01T00:01:00.000Z",
+    attachmentCount: 1,
+    toolCount: 1,
+    isError: false,
+    cancelled: true,
+  });
+  // reasoning is the harness's private scratchpad and tool input/output carry
+  // whatever the tool touched — the example above holds a private key path and
+  // its contents. Counting them tells a client the turn did work without
+  // handing over the work.
+  const serialized = JSON.stringify(projected);
+  for (const leaked of ["internal chain of thought", "id_rsa", "~/.ssh", "costUsd", "usage"]) {
+    assert.equal(serialized.includes(leaked), false, leaked);
+  }
+});
+
+test("the message projection normalizes a root turn's parent to null", () => {
+  // parentId is `undefined` on a legacy turn and `null` on an authored root.
+  // Both mean root, and `undefined` is not a value the envelope can carry.
+  const legacy = projectClientV1Message("conversation-1", {
+    id: "t1",
+    role: "user",
+    text: "hello",
+    createdAt: "2026-08-01T00:00:00.000Z",
+  });
+  assert.equal(legacy.parentId, null);
+  assert.doesNotThrow(() => parseClientV1JsonObject(legacy));
+  assert.deepEqual(clientV1MessagePageKey({
+    id: "t1",
+    role: "user",
+    text: "hello",
+    createdAt: "2026-08-01T00:00:00.000Z",
+  }), { sort: "2026-08-01T00:00:00.000Z", id: "t1" });
+});

--- a/src/lib/server/client-v1/reads.test.ts
+++ b/src/lib/server/client-v1/reads.test.ts
@@ -344,3 +344,80 @@ test("the message projection normalizes a root turn's parent to null", () => {
     createdAt: "2026-08-01T00:00:00.000Z",
   }), { sort: "2026-08-01T00:00:00.000Z", id: "t1" });
 });
+
+test("a projection refuses a record whose required field the store did not supply", () => {
+  // None of the four stores validates its own JSON. `loadProjects` returns
+  // whatever projects.json parsed to, `readConversationSummary` copies
+  // `conv.updatedAt` out of a file that merely parsed (a *parse* failure takes
+  // the fallback row; a file that parses without the field does not), and the
+  // roster is a daemon HTTP response with no schema in front of it. Before this
+  // refusal, `undefined` reached parseClientV1JsonObject and threw from inside
+  // the envelope builder, which nothing caught — so one bad row answered a
+  // non-envelope 500 and took down every page that contained it.
+  assert.throws(
+    () => projectClientV1Conversation({ sessionId: "c1", familiarId: "f" } as ConversationSummary),
+    /conversation updatedAt is not a string/,
+  );
+  assert.throws(
+    () => projectClientV1Project({ id: "p1", name: "n", root: "/r", updatedAt: "u" } as CaveProject),
+    /project createdAt is not a string/,
+  );
+  assert.throws(
+    () => projectClientV1Familiar({ id: "a", role: "r" } as VisibleFamiliarRosterEntry),
+    /familiar display_name is not a string/,
+  );
+  assert.throws(
+    () => projectClientV1Message("c1", { id: "t1", role: "user", createdAt: "x" } as ChatTurn),
+    /message text is not a string/,
+  );
+  assert.throws(
+    () => projectClientV1Message("c1", {
+      id: "t1",
+      role: "narrator" as ChatTurn["role"],
+      text: "hi",
+      createdAt: "x",
+    }),
+    /role is not "user", "assistant" or "system"/,
+  );
+});
+
+test("a projection refuses a required field that is present but wrongly typed", () => {
+  // The harder half, and the one nothing else would catch: a numeric
+  // `updatedAt` is JSON-safe, so the envelope builder accepts it. Served, it
+  // contradicts the published string type — and it also mints a cursor whose
+  // sort key is a number, which decodeClientV1Cursor refuses. Measured before
+  // the fix: the client received row 1 with a `next` token and following that
+  // token answered `invalid_request`, so the walk could not advance past the
+  // row. Refusing at the projection is what keeps that unreachable.
+  assert.throws(
+    () => projectClientV1Conversation({
+      sessionId: "c1",
+      familiarId: "f",
+      updatedAt: 1767225600000 as unknown as string,
+    }),
+    /conversation updatedAt is not a string/,
+  );
+  // An empty id is refused for a different reason than an empty familiarId is
+  // tolerated: decodeClientV1Cursor rejects a token carrying no id, so an empty
+  // one here would mint a cursor this Cave cannot read back.
+  assert.throws(
+    () => projectClientV1Conversation({ sessionId: "", familiarId: "f", updatedAt: "u" }),
+    /sessionId is not a non-empty string/,
+  );
+});
+
+test("the conversation projection still serves the corrupt-file fallback row", () => {
+  // fallbackConversationSummary (cave-conversations.ts) is what listConversations
+  // substitutes for a file it could not read or parse, and it sets
+  // `familiarId: ""`. That row is a real conversation with an unreadable body,
+  // so it has to reach the client — an emptiness check on familiarId would have
+  // turned every corrupt transcript into a 500 for the whole page.
+  assert.deepEqual(
+    projectClientV1Conversation({
+      sessionId: "c1",
+      familiarId: "",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    }),
+    { id: "c1", familiarId: "", updatedAt: "2026-08-01T00:00:00.000Z" },
+  );
+});

--- a/src/lib/server/client-v1/reads.test.ts
+++ b/src/lib/server/client-v1/reads.test.ts
@@ -421,3 +421,28 @@ test("the conversation projection still serves the corrupt-file fallback row", (
     { id: "c1", familiarId: "", updatedAt: "2026-08-01T00:00:00.000Z" },
   );
 });
+
+test("a conversation's runtime is served as the path it really is", () => {
+  // Found against a production build reading this machine's real ledger, not
+  // against a fixture: POST /api/chat/send writes `runtime` as
+  // `local:${cwd}` (src/app/api/chat/send/route.ts), so the field a client
+  // receives is an absolute path under the operator's home directory — while
+  // the doc's example showed `"native"` and read like an enum.
+  //
+  // It is served deliberately, on the same grounds as a project's `root`, and
+  // pinned here so the next person to read this projection sees that `runtime`
+  // is in the path-bearing class alongside `root` rather than in the opaque
+  // -label class alongside `harness` and `model`.
+  const projected = projectClientV1Conversation({
+    sessionId: "conversation-1",
+    familiarId: "scribe",
+    runtime: "local:/Users/me/.coven/workspaces/familiars/scribe",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  });
+  assert.equal(projected.runtime, "local:/Users/me/.coven/workspaces/familiars/scribe");
+  // The rest of the record stays free of it: nothing else on a conversation
+  // carries a path, so a client that chooses not to render `runtime` renders no
+  // filesystem layout at all.
+  const withoutRuntime = { ...projected, runtime: undefined };
+  assert.equal(JSON.stringify(withoutRuntime).includes("/Users/me"), false);
+});

--- a/src/lib/server/client-v1/reads.ts
+++ b/src/lib/server/client-v1/reads.ts
@@ -77,6 +77,25 @@ export type ClientV1ConversationRecord = {
   familiarId: string;
   harness?: string;
   model?: string;
+  /**
+   * How the run was hosted — and, for a local run, WHERE.
+   *
+   * Not an enum, despite reading like one. `POST /api/chat/send` writes it as
+   * `` `local:${cwd}` `` (route.ts), so on a real Cave the value is
+   * `local:C:/Users/<name>/…` — an absolute path carrying the operator's home
+   * directory. Measured against a production build on a real conversation
+   * ledger, not inferred from the type.
+   *
+   * Served anyway, on the same grounds as {@link ClientV1ProjectRecord.root}: a
+   * paired credential belongs to an application running as this user on this
+   * machine, which can already read that directory. It is called out here, and
+   * in the published reference, because it is the one field on this record a
+   * client author would not expect to be a path — and a client that logs or
+   * renders it is surfacing the operator's filesystem layout.
+   *
+   * Note the conversation cwd is NOT necessarily a registered project root: it
+   * can be a worktree or any directory a familiar was pointed at.
+   */
   runtime?: string;
   title?: string;
   origin?: string;

--- a/src/lib/server/client-v1/reads.ts
+++ b/src/lib/server/client-v1/reads.ts
@@ -1,0 +1,291 @@
+/**
+ * Canonical read projections for the Client v1 resource routes.
+ *
+ * Every shape here is derived from a store Cave already keeps, never invented:
+ *
+ *   - familiars      `VisibleFamiliarRosterEntry` (server/familiar-roster.ts),
+ *                    the daemon roster merged with familiars.toml and the
+ *                    removal tombstones.
+ *   - projects       `CaveProject` (cave-projects-types.ts), the
+ *                    `<caveHome>/projects.json` registry.
+ *   - conversations  `ConversationSummary` (cave-conversations.ts), what
+ *                    listConversations reads out of
+ *                    `<caveHome>/conversations/*.json`.
+ *   - messages       `ChatTurn` from the same transcript file.
+ *
+ * A projection is narrower than its record on purpose. Two rules decide what
+ * survives: a field has to describe the resource to a *client* (so the Cave's
+ * own migration scaffolding and PR-badge attribution do not), and it must not
+ * hand over content the client did not ask for by holding `chat:read` (so a
+ * turn's reasoning and its tool arguments do not — see projectClientV1Message).
+ *
+ * Optional fields are omitted rather than set to `undefined`. The envelope
+ * builder runs every payload through parseClientV1JsonObject, which rejects a
+ * key whose value is `undefined`, so `{ title: summary.title }` on a
+ * conversation with no title throws on the way out rather than serving a null.
+ */
+
+import type { ChatTurn, ConversationFile, ConversationSummary } from "../../cave-conversations.ts";
+import type { CaveProject } from "../../cave-projects-types.ts";
+import { resolveActivePath } from "../../conversation-tree.ts";
+import type { VisibleFamiliarRosterEntry } from "../familiar-roster.ts";
+import {
+  compareClientV1AscendingKeys,
+  compareClientV1RecencyKeys,
+  type ClientV1PageKey,
+} from "./pagination.ts";
+
+export type ClientV1FamiliarRecord = {
+  id: string;
+  displayName: string;
+  role: string;
+  description?: string;
+  pronouns?: string;
+  status?: string;
+  /**
+   * The daemon's `last_seen`, passed through verbatim.
+   *
+   * Deliberately not validated as an ISO instant and not renamed to something
+   * that promises one: the value originates in the daemon, Cave neither writes
+   * nor parses it, and re-stamping it here would state a precision Cave cannot
+   * vouch for.
+   */
+  lastSeenAt?: string;
+  activeSessions?: number;
+};
+
+export type ClientV1ProjectRecord = {
+  id: string;
+  name: string;
+  /**
+   * The project's absolute root.
+   *
+   * A path, and published on purpose: it is the registry's real identity (the
+   * loader dedupes by normalized root, not by id), and a paired Client v1
+   * credential belongs to an application running as this same user on this
+   * same machine, which can already read the directory it names.
+   */
+  root: string;
+  color?: string;
+  repoUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ClientV1ConversationRecord = {
+  id: string;
+  familiarId: string;
+  harness?: string;
+  model?: string;
+  runtime?: string;
+  title?: string;
+  origin?: string;
+  status?: string;
+  exitCode?: number | null;
+  pending?: boolean;
+  createdAt?: string;
+  updatedAt: string;
+};
+
+export type ClientV1MessageRecord = {
+  id: string;
+  conversationId: string;
+  parentId: string | null;
+  role: ChatTurn["role"];
+  text: string;
+  createdAt: string;
+  attachmentCount: number;
+  toolCount: number;
+  isError?: boolean;
+  cancelled?: boolean;
+};
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function optionalCount(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+function countOf(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+export function projectClientV1Familiar(
+  entry: VisibleFamiliarRosterEntry,
+): ClientV1FamiliarRecord {
+  const description = optionalText(entry.description);
+  const pronouns = optionalText(entry.pronouns);
+  const status = optionalText(entry.status);
+  const lastSeenAt = optionalText(entry.last_seen);
+  const activeSessions = optionalCount(entry.active_sessions);
+  return {
+    id: entry.id,
+    displayName: entry.display_name,
+    role: entry.role,
+    ...(description ? { description } : {}),
+    ...(pronouns ? { pronouns } : {}),
+    ...(status ? { status } : {}),
+    ...(lastSeenAt ? { lastSeenAt } : {}),
+    ...(activeSessions === undefined ? {} : { activeSessions }),
+  };
+}
+
+export function projectClientV1Project(project: CaveProject): ClientV1ProjectRecord {
+  const color = optionalText(project.color);
+  const repoUrl = optionalText(project.repoUrl);
+  return {
+    id: project.id,
+    name: project.name,
+    root: project.root,
+    ...(color ? { color } : {}),
+    ...(repoUrl ? { repoUrl } : {}),
+    createdAt: project.createdAt,
+    updatedAt: project.updatedAt,
+  };
+}
+
+export function projectClientV1Conversation(
+  summary: ConversationSummary,
+): ClientV1ConversationRecord {
+  const harness = optionalText(summary.harness);
+  const model = optionalText(summary.model);
+  const runtime = optionalText(summary.runtime);
+  const title = optionalText(summary.title);
+  const origin = optionalText(summary.origin);
+  const status = optionalText(summary.status);
+  const createdAt = optionalText(summary.createdAt);
+  return {
+    id: summary.sessionId,
+    familiarId: summary.familiarId,
+    ...(harness ? { harness } : {}),
+    ...(model ? { model } : {}),
+    ...(runtime ? { runtime } : {}),
+    ...(title ? { title } : {}),
+    ...(origin ? { origin } : {}),
+    ...(status ? { status } : {}),
+    // `null` is a fact — the run has no exit code yet — so it is served, while
+    // `undefined` (the store never recorded one) is omitted.
+    ...(summary.exitCode === undefined ? {} : { exitCode: summary.exitCode }),
+    ...(summary.pending === undefined ? {} : { pending: summary.pending }),
+    ...(createdAt ? { createdAt } : {}),
+    updatedAt: summary.updatedAt,
+  };
+}
+
+export function projectClientV1Message(
+  conversationId: string,
+  turn: ChatTurn,
+): ClientV1MessageRecord {
+  return {
+    id: turn.id,
+    conversationId,
+    // `undefined` on a legacy turn, `null` on an authored root. Both mean root,
+    // and only one of them is a value the envelope can carry.
+    parentId: turn.parentId ?? null,
+    role: turn.role,
+    text: turn.text,
+    createdAt: turn.createdAt,
+    // Counts, not contents. `reasoning` is the harness's private scratchpad and
+    // a tool call carries whatever the tool was pointed at — a path, a command,
+    // a file it read. `chat:read` is a grant to read the conversation, not to
+    // read everything the conversation touched.
+    attachmentCount: countOf(turn.attachments),
+    toolCount: countOf(turn.tools),
+    ...(turn.isError === undefined ? {} : { isError: turn.isError }),
+    ...(turn.cancelled === undefined ? {} : { cancelled: turn.cancelled }),
+  };
+}
+
+/**
+ * The turns a client should see, in the order Cave renders them.
+ *
+ * `ConversationFile.turns` is every turn of every branch in one append-ordered
+ * array; the rendered conversation is the chain from `activeLeafId` to the
+ * root. Serving the raw array would interleave abandoned branches into the
+ * transcript. With no active leaf the file is either pre-branching or one Cave
+ * declined to linearize, and the stored order is then the only order there is.
+ */
+export function clientV1ConversationSequence(conversation: ConversationFile): ChatTurn[] {
+  const turns = Array.isArray(conversation.turns) ? conversation.turns : [];
+  if (!conversation.activeLeafId) return turns;
+  return resolveActivePath(turns, conversation.activeLeafId);
+}
+
+/**
+ * A familiar's page key is its id.
+ *
+ * Nothing on a roster entry is a timestamp — the record has no createdAt and no
+ * updatedAt, and `last_seen` is an opaque daemon string that may be absent. The
+ * id is the only field guaranteed present and unique, so it is both the sort
+ * key and the tiebreak, which makes the ordering total by construction.
+ */
+export function clientV1FamiliarPageKey(entry: VisibleFamiliarRosterEntry): ClientV1PageKey {
+  return { sort: entry.id, id: entry.id };
+}
+
+/**
+ * A project's page key is its creation time.
+ *
+ * `updatedAt` is the more natural "recent projects" order, and it is the wrong
+ * key: it moves whenever the project is patched, so a project edited between
+ * two page requests jumps in the ordering and is then either served twice or
+ * skipped. `createdAt` is required and immutable. This matches the daemon's
+ * session pager (OpenCoven/coven#783), which keys on `created_at, id` for the
+ * same reason.
+ */
+export function clientV1ProjectPageKey(project: CaveProject): ClientV1PageKey {
+  return { sort: project.createdAt, id: project.id };
+}
+
+/**
+ * A conversation's page key is its last write.
+ *
+ * Unlike a project, `createdAt` is *optional* on a ConversationSummary — a
+ * transcript written before the field existed has none, and neither does the
+ * fallback row a corrupt file produces — so it cannot key the page. `updatedAt`
+ * is required, and it is also the order listConversations already sorts by, so
+ * a client sees one ordering out of Cave rather than two.
+ *
+ * The cost is the mutable-key cost above: a conversation that receives a turn
+ * mid-pagination moves to the front and can be seen twice. That is visible to
+ * the client (the same id in two pages) and recoverable, where the alternative
+ * — keying on a field half the corpus lacks — is neither.
+ */
+export function clientV1ConversationPageKey(summary: ConversationSummary): ClientV1PageKey {
+  return { sort: summary.updatedAt, id: summary.sessionId };
+}
+
+/**
+ * A message's page key.
+ *
+ * The `sort` half is informational only: messages are paginated by position in
+ * the resolved branch, not by comparing keys, because a user turn and the
+ * assistant reply answering it are persisted with the *same* createdAt stamp.
+ */
+export function clientV1MessagePageKey(turn: ChatTurn): ClientV1PageKey {
+  return { sort: turn.createdAt, id: turn.id };
+}
+
+export function sortClientV1Familiars(
+  roster: readonly VisibleFamiliarRosterEntry[],
+): VisibleFamiliarRosterEntry[] {
+  return [...roster].sort((left, right) =>
+    compareClientV1AscendingKeys(clientV1FamiliarPageKey(left), clientV1FamiliarPageKey(right)));
+}
+
+export function sortClientV1Projects(projects: readonly CaveProject[]): CaveProject[] {
+  return [...projects].sort((left, right) =>
+    compareClientV1RecencyKeys(clientV1ProjectPageKey(left), clientV1ProjectPageKey(right)));
+}
+
+export function sortClientV1Conversations(
+  summaries: readonly ConversationSummary[],
+): ConversationSummary[] {
+  return [...summaries].sort((left, right) =>
+    compareClientV1RecencyKeys(
+      clientV1ConversationPageKey(left),
+      clientV1ConversationPageKey(right),
+    ));
+}

--- a/src/lib/server/client-v1/reads.ts
+++ b/src/lib/server/client-v1/reads.ts
@@ -100,6 +100,74 @@ export type ClientV1MessageRecord = {
   cancelled?: boolean;
 };
 
+/**
+ * A field the projection promises to serve, refused when the store cannot
+ * supply it.
+ *
+ * None of the four stores validates the JSON it hands back. `loadProjects`
+ * returns whatever `projects.json` parsed to, `readConversationSummary` copies
+ * `conv.updatedAt` straight out of a file that merely parsed, and the familiar
+ * roster is a daemon HTTP response with no schema in front of it. So a required
+ * field arriving absent or wrongly typed is a reachable state, not a type-system
+ * impossibility — and without this check it failed two different silent ways:
+ *
+ *   - `undefined` reached parseClientV1JsonObject, which throws. Nothing caught
+ *     it, so the route answered a non-envelope 500 and one bad row took down
+ *     every page that contained it.
+ *   - a wrongly *typed* value (a numeric `updatedAt`, say) is JSON-safe, so it
+ *     was served as-is — contradicting the published type — and then minted a
+ *     cursor whose sort key was a number, which this Cave's own decoder refuses.
+ *     Measured: the client got row 1 and a `next` token, and following it
+ *     answered `invalid_request`. The walk could not advance past the row.
+ *
+ * Refusing is loud and honest: the route turns it into `internal_error`. It is
+ * deliberately not a skip — quietly dropping a record from a "canonical read"
+ * would tell a client the conversation does not exist.
+ */
+function requiredText(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`Client v1 cannot project a record whose ${field} is not a string.`);
+  }
+  return value;
+}
+
+/**
+ * The same check for a field that is also a page key or an addressable id.
+ *
+ * Empty is tolerated by requiredText because the stores really do produce it —
+ * `fallbackConversationSummary` sets `familiarId: ""` for a file it could not
+ * read, and serving that row is better than losing it. An *id* is different:
+ * decodeClientV1Cursor refuses a token with an empty id, so an empty one here
+ * would mint exactly the undecodable cursor assertMintableKey exists to stop.
+ */
+function requiredId(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `Client v1 cannot project a record whose ${field} is not a non-empty string.`,
+    );
+  }
+  return value;
+}
+
+/**
+ * A turn's role, checked for membership rather than for type.
+ *
+ * The doc tells a client to branch on exactly these three. A transcript
+ * carrying a fourth would make that instruction wrong with nothing failing,
+ * and a transcript carrying none at all reached the envelope builder as
+ * `undefined` and threw there instead.
+ */
+const MESSAGE_ROLES = new Set<ChatTurn["role"]>(["user", "assistant", "system"]);
+
+function requiredRole(value: unknown): ChatTurn["role"] {
+  if (!MESSAGE_ROLES.has(value as ChatTurn["role"])) {
+    throw new Error(
+      'Client v1 cannot project a message whose role is not "user", "assistant" or "system".',
+    );
+  }
+  return value as ChatTurn["role"];
+}
+
 function optionalText(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
@@ -121,9 +189,9 @@ export function projectClientV1Familiar(
   const lastSeenAt = optionalText(entry.last_seen);
   const activeSessions = optionalCount(entry.active_sessions);
   return {
-    id: entry.id,
-    displayName: entry.display_name,
-    role: entry.role,
+    id: requiredId(entry.id, "familiar id"),
+    displayName: requiredText(entry.display_name, "familiar display_name"),
+    role: requiredText(entry.role, "familiar role"),
     ...(description ? { description } : {}),
     ...(pronouns ? { pronouns } : {}),
     ...(status ? { status } : {}),
@@ -136,13 +204,13 @@ export function projectClientV1Project(project: CaveProject): ClientV1ProjectRec
   const color = optionalText(project.color);
   const repoUrl = optionalText(project.repoUrl);
   return {
-    id: project.id,
-    name: project.name,
-    root: project.root,
+    id: requiredId(project.id, "project id"),
+    name: requiredText(project.name, "project name"),
+    root: requiredText(project.root, "project root"),
     ...(color ? { color } : {}),
     ...(repoUrl ? { repoUrl } : {}),
-    createdAt: project.createdAt,
-    updatedAt: project.updatedAt,
+    createdAt: requiredText(project.createdAt, "project createdAt"),
+    updatedAt: requiredText(project.updatedAt, "project updatedAt"),
   };
 }
 
@@ -157,8 +225,8 @@ export function projectClientV1Conversation(
   const status = optionalText(summary.status);
   const createdAt = optionalText(summary.createdAt);
   return {
-    id: summary.sessionId,
-    familiarId: summary.familiarId,
+    id: requiredId(summary.sessionId, "conversation sessionId"),
+    familiarId: requiredText(summary.familiarId, "conversation familiarId"),
     ...(harness ? { harness } : {}),
     ...(model ? { model } : {}),
     ...(runtime ? { runtime } : {}),
@@ -170,7 +238,7 @@ export function projectClientV1Conversation(
     ...(summary.exitCode === undefined ? {} : { exitCode: summary.exitCode }),
     ...(summary.pending === undefined ? {} : { pending: summary.pending }),
     ...(createdAt ? { createdAt } : {}),
-    updatedAt: summary.updatedAt,
+    updatedAt: requiredText(summary.updatedAt, "conversation updatedAt"),
   };
 }
 
@@ -179,14 +247,14 @@ export function projectClientV1Message(
   turn: ChatTurn,
 ): ClientV1MessageRecord {
   return {
-    id: turn.id,
-    conversationId,
+    id: requiredId(turn.id, "message id"),
+    conversationId: requiredId(conversationId, "message conversationId"),
     // `undefined` on a legacy turn, `null` on an authored root. Both mean root,
     // and only one of them is a value the envelope can carry.
     parentId: turn.parentId ?? null,
-    role: turn.role,
-    text: turn.text,
-    createdAt: turn.createdAt,
+    role: requiredRole(turn.role),
+    text: requiredText(turn.text, "message text"),
+    createdAt: requiredText(turn.createdAt, "message createdAt"),
     // Counts, not contents. `reasoning` is the harness's private scratchpad and
     // a tool call carries whatever the tool was pointed at — a path, a command,
     // a file it read. `chat:read` is a grant to read the conversation, not to

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -216,15 +216,36 @@ const CLIENT_V1_PUBLIC_PATHS = CLIENT_V1_PUBLIC_ROUTES.map((route) =>
  * So the invariant is: a pattern belongs here only once a route.ts on disk
  * matches it AND that route calls requireScope. Both halves are asserted in
  * src/app/api/api-contracts.test.ts. Phase 2 adds its entry in the same change
- * that adds its handler; until then this list is empty and every unhandled
- * client-v1 path falls through to the ordinary sidecar-token gate, which is
- * where an unauthenticated loopback caller should land.
+ * that adds its handler; an unhandled client-v1 path stays off this list and
+ * falls through to the ordinary sidecar-token gate, which is where an
+ * unauthenticated loopback caller should land.
  *
- * It was NOT empty before cave-4841: thirteen Phase 2 paths were listed against
- * zero handlers, so the first Phase 2 route to land would have been reachable
- * from any loopback process with no sidecar token at all.
+ * It was NOT empty before cave-4841, and then it was: thirteen Phase 2 paths
+ * were listed against zero handlers, so the first Phase 2 route to land would
+ * have been reachable from any loopback process with no sidecar token at all.
+ * cave-4841 emptied it; the five entries below are the first to earn their
+ * place, and each arrives in the same change as the handler that serves it.
+ *
+ * All five are canonical reads (cave-jfa9y), and each calls requireScope for
+ * `chat:read` AND re-checks the loopback stamp for itself, the way the two
+ * pairing POSTs do. That second check is not redundant belt-and-braces: the
+ * ingress classification below returns null for any pathname containing a
+ * percent sign, so a percent-encoded dynamic segment on the two conversation
+ * routes escapes the direct-loopback branch entirely (#4854). The route cannot
+ * assume the branch it is listed for actually ran.
+ *
+ * Written through clientV1PathPattern rather than as hand-rolled regexes so
+ * these share the public set's anchoring and its one-segment `:id` scoping. A
+ * hand-written pattern that forgot a `^` would silently pre-authorize
+ * `/decoy/api/client/v1/projects`.
  */
-export const CLIENT_V1_AUTHENTICATED_PATHS: RegExp[] = [];
+export const CLIENT_V1_AUTHENTICATED_PATHS: RegExp[] = [
+  "/api/client/v1/familiars",
+  "/api/client/v1/projects",
+  "/api/client/v1/conversations",
+  "/api/client/v1/conversations/:id",
+  "/api/client/v1/conversations/:id/messages",
+].map(clientV1PathPattern);
 
 export function clientV1IngressKind(pathname: string): ClientV1IngressKind | null {
   if (pathname.includes("%") || pathname.includes("\\")) return null;


### PR DESCRIPTION
`CLIENT_V1_CAPABILITIES` has advertised `"familiars"`, `"projects"`,
`"conversations"`, `"conversation-messages"` and `"cursors"` since Phase 0, with
no route behind any of them. This makes the advertisement true for all four
resources, as **five paged `GET`s** under `/api/client/v1`.

Closes the read half of #4834 (bead `cave-jfa9y`). Nothing here writes, streams,
or reads an attachment; `streaming` and `revisions` are still advertised and
unbuilt, and the five write scopes are still recorded on a credential and read
by nothing.

## The routes

| Route | Serves | Order |
|---|---|---|
| `GET /familiars` | `loadVisibleFamiliarRoster()` — the daemon roster merged with `familiars.toml` and the removal tombstones | `id` ascending |
| `GET /projects` | `loadProjects()` — `<caveHome>/projects.json` | `createdAt` desc, `id` desc |
| `GET /conversations` | `listConversations()` — `<caveHome>/conversations/*.json` | `updatedAt` desc, `id` desc |
| `GET /conversations/:id` | the same ledger row, selected by id | — |
| `GET /conversations/:id/messages` | the turns of one transcript, resolved to its active branch | transcript order, oldest first |

Every projection comes from a store Cave already keeps. Where a projection is
narrower than its record, that is a decision with a reason, and the reason is in
the code and the doc:

- **`legacyRoot`** is not served. It is response-only scaffolding that lets the
  Cave's *own* web client re-key browser stores after a root normalization; it
  is stripped before every write. **`access`** is not served either — it is a
  familiar-scoped permission answer, and a Client v1 credential is not a
  familiar.
- **`harnessSessionId`**, **`branch`** and **`prUrl`** are not served on a
  conversation. The first rotates on every resume and is never the
  conversation's identity; the other two are working-tree attribution for the
  Cave's own PR badges.
- **A turn's `reasoning`, its tool `input`/`output`, `usage` and `costUsd`** are
  not served. `toolCount` and `attachmentCount` report that the turn did work
  without handing over what it touched. `chat:read` is a grant to read the
  conversation, not everything the conversation touched. There is a test whose
  fixture puts a private-key path in a tool call and asserts the bytes never
  reach the wire.

**`GET /conversations/:id` reads the ledger, not the transcript file**, and that
costs a directory scan. On purpose: `status` and `exitCode` are *derived* while
the ledger is built (`deriveConversationSignals`) and do not exist in the stored
file, so serving the detail read from the file would answer the same question
two different ways depending on which route a client asked. Cave's own sessions
list already pays that scan on every poll and shares the same stat-keyed cache.

## Pagination

Follows the daemon's session pager (OpenCoven/coven#783) rather than inventing a
second dialect: keyset ordering over a **total** `(sortKey, id)` comparator, an
over-fetch of one row to derive `hasMore`, an opaque unpadded base64url cursor.
Two deliberate differences, both stated in `pagination.ts`:

- the ceiling is the **contract's** `maxPageSize` (100), not the daemon's 1000.
  A Client v1 route serving 1000 would be serving a size its own published
  fixture says is impossible.
- an out-of-range `limit` is **refused, not clamped**. A client that asked for
  101 and received 100 cannot distinguish a ceiling from an ending.

Boundaries, each with a test:

| Boundary | Behaviour |
|---|---|
| Empty first page | **No `cursor` field at all.** `parseClientV1Cursor` refuses a cursor carrying no token, so `{ hasMore: false }` alone would make the envelope builder throw. |
| First page holding the whole set | Same — no cursor. |
| Empty continuation page | `{ current, hasMore: false }`, echoing the token sent. |
| Cursor replayed | Same page. Paging is a function of (store, cursor, limit); it never advances and never loops. |
| Cursor whose record was deleted | Resumes at the next surviving record — the token names a position in the *ordering*, not an index. |
| Tied sort key | Separated by the `id` tiebreak. A non-total order repeats or skips both. |
| Malformed / non-canonical cursor | `invalid_request`. |
| Unsupported or repeated query parameter | `invalid_request`. `?limt=5` answered with the default page is how a client comes to believe it asked for five. |

**Projects key on `createdAt`, conversations on `updatedAt`** — and the
asymmetry is forced. `createdAt` is immutable, so it is the right keyset field;
but `createdAt` is *optional* on a `ConversationSummary` (a pre-field transcript,
or the fallback row a corrupt file produces, has none), so conversations cannot
use it. The cost is documented: a conversation that receives a turn
mid-pagination moves to the front and can appear in two pages. That repeat is
visible to the client and recoverable; keying on a field half the corpus lacks
is neither.

**Messages page by position, not by comparing keys.** A user turn and the
assistant reply answering it are persisted with the *same* `createdAt`, and turn
ids are unique only inside one transcript — so any `(createdAt, id)` keyset would
put replies in front of the prompts they answer. The messages are also the
**active branch**, not the stored `turns` array, which holds every branch in
append order. Those two facts produce one failure the list routes cannot have: a
cursor naming a turn that has left the branch answers **`reconcile_required`**
(`details.reason: "resume_from_canonical_state"`) rather than restarting
silently at the top or resuming at position zero on a different branch. That is
the first use of a code the contract had reserved and never served.

## The `CLIENT_V1_AUTHENTICATED_PATHS` bargain

Each of the five paths is added to that list **in this same change as its
handler**, which is what the assertions from #4847 require. Listing is a
**demotion**: `proxy()` skips the mobile-access gate and returns before the
sidecar-token block, so each route's own `requireScope` is the only credential
check left in the request.

So each route writes that check out in its own source rather than delegating it.
That is not stylistic — `api-contracts.test.ts` matches `requireScope\s*\(`
against a comment-, string- and regex-stripped view of **the route file**, and a
route that delegated the whole check would satisfy that assertion only if the
assertion were taught to follow the import, which is precisely the loosening it
exists to prevent. `read-guard.ts` holds only the pieces that carry no
credential decision (header parsing, query parsing, bucket selection), and its
module doc says why.

**Each route also re-checks the loopback stamp itself**, the way the two pairing
`POST`s do. `clientV1IngressKind` returns `null` for any pathname containing a
percent sign, so a percent-encoded dynamic segment escapes the direct-loopback
branch entirely (**#4854**, open, fix in flight elsewhere — not touched here).
Two of these five paths are dynamic-segmented, so the route cannot assume the
branch it is listed for actually ran.

One listed path deserves calling out: **`/api/client/v1/conversations/search`
classifies `authenticated`**, and is meant to. There is no static `search` route
under `conversations`, so the App Router serves that path from the `[id]`
handler with the id `"search"`, which answers `not_found`. `auth.test.ts` moves
it from the null list with that reasoning written down rather than leaving a
pattern that lies about which routes exist.

## Two changes outside the routes

**`ClientV1AuthResult`'s failure branch now carries a `reason`**, plus the
credential on `scope_denied`. `requireScope`, `consumeAuthenticated` and
`consumeInvalidBearer` had zero non-test call sites; as the first real consumer,
this found the shape short. Both failures normalize to a ready-made `Response`,
but they are metered against *different* buckets — an unknown bearer against
`consumeInvalidBearer`, an under-scoped real credential against that
credential's `consumeAuthenticated` — and a `Response` cannot be asked which one
it is. Branching on `response.status` would have worked by coincidence: it
couples a metering decision to an HTTP code the contract is free to remap. The
success branch is untouched (`auth.test.ts` deep-equals it), and the client sees
exactly the same two envelopes as before.

**A third static assertion beside #4847's two**: a client-v1 route that calls
`requireScope` must also call `consumeAuthenticated`. A pre-authorized path has
already given up the sidecar-token gate, so an unmetered one lets a single valid
bearer drive the credential store, the daemon and the transcript directory
without bound — and nothing else in the suite would notice, because an unmetered
route passes every functional test it has. Matched on the success-path charge
specifically, so a future route needing a different budget widens the
alternation in review rather than inheriting an exemption by being written
differently.

## Scope left undone, deliberately

- **No `GET /familiars/:id` and no `GET /projects/:id`.** Neither store has a
  by-id read; both would be a filter over the list this PR already serves, and
  the roster one would spend a daemon round-trip per call. Not worth the surface
  until a client asks.
- **`revision` is still unemitted.** The `revisions` capability implies a
  reconcile protocol (a conditional read or write keyed on the token) that
  nothing implements, and a token nothing consumes is the #4194 defect. Stated
  as a gap in the doc instead.
- **No per-message size cap.** A turn's whole text is served; a page of 100 long
  turns is a large response. Documented under *Known gaps*; the existing
  `/api/chat/conversation/[id]` serves the entire transcript in one payload, so
  this is strictly better rather than a regression.
- **#4854 is not fixed here** — a fix is in flight in another worktree. The
  routes are built so their safety does not depend on that gate.

## Validation

Failing-test-first per module and per route; every new test file was run and
seen to fail with `ERR_MODULE_NOT_FOUND` (or a red assertion, for the two
additions to existing suites) before the implementation existed.

**Mutation matrix: 23 mutants, 23 caught, 0 survivors.** The first pass had one
survivor and one assertion that passed for the wrong reason; both are fixed in
`94d0283c9` rather than reported as acceptable:

- the cursor decoder's canonical re-encode check had **no test that could reach
  it** — the only non-canonical case asserted was a padded token, already
  refused by the alphabet check. Removing the round-trip check left every
  assertion green. Unpadded base64url leaves spare low bits in the final
  character, so several spellings decode to identical bytes; the suite now
  searches for such a twin and asserts it is refused, and throws rather than
  passing vacuously if none exists.
- the projects paging test *claimed* to demonstrate why the key is `createdAt`
  and did not: it touched a record already served, which both orderings skip
  alike. Keying on `updatedAt` survived it. It now touches the one record still
  owed to the client, which an `updatedAt` ordering moves in front of the cursor
  and therefore skips entirely.

Gates, all green locally on `94d0283c9`: `pnpm typecheck`, `pnpm lint`,
`pnpm check:tests-wired` (1804 files), `pnpm build`, plus every suite named in
the issue — `api-contracts.test.ts` (301 route contracts), `client-v1/auth.test.ts`
(21), `export-client-v1-contract.test.mjs` (7), `client-v1-doc-contract.test.mjs`
(7), `proxy-behavior.test.ts` — and the adjacent client-v1 suites for
regressions (health, all three pairing routes, `admin/security.e2e`,
`contract.test.ts`, `rate-limit.test.ts`).

`docs/api/client-v1.md` gains a *Canonical read routes* section with a
`### \`METHOD /path\`` block per route, and its stale claims are corrected
throughout: the eight-route scope line, the "no authenticated route exists" gap,
the capability list's "route families that do not exist yet", the two
never-charged rate-limit buckets, the `scope_denied` and `reconcile_required`
rows in the error table, and the *When the authenticated routes land* section
that was written for exactly this moment.

Closes #4834



Closes #4834
