### PR TITLE
Persist a group message delete to every session it fans out to (cave-1osn7)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -446,7 +446,15 @@ final class ChatThread: Identifiable, Hashable {
     /// it left from — not appended — and the failure is said out loud as an
     /// inline note. A silent local-only delete is the exact bug being fixed,
     /// so failing quietly here would only move it.
+    ///
+    /// A GROUP message is one bubble over several server sessions, so this can
+    /// be several deletes rather than one — see `serverDeleteTarget` for how
+    /// they are located and `persistDelete` for what happens when only some of
+    /// them land. `familiarNames` is only ever read to write that report: the
+    /// thread knows familiar ids and the sentence is read back to a person, so
+    /// the display names come from the view that has them.
     func deleteMessage(_ messageId: String, client: CaveClient?,
+                       familiarNames: [String: String] = [:],
                        onChange: @escaping () -> Void) {
         guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
         let removed = messages[index]
@@ -480,7 +488,8 @@ final class ChatThread: Identifiable, Hashable {
         pendingServerDelete = Task { [weak self] in
             _ = await previous?.value
             await self?.persistDelete(of: removed, at: index, target: target,
-                                      client: client, onChange: onChange)
+                                      client: client, familiarNames: familiarNames,
+                                      onChange: onChange)
         }
     }
 
@@ -488,53 +497,129 @@ final class ChatThread: Identifiable, Hashable {
     /// it, so it stays out of observation. See `deleteMessage`.
     @ObservationIgnored private var pendingServerDelete: Task<Void, Never>?
 
-    /// Where a message lives on the server, when it lives there at all.
+    /// Where a message lives on the server, when it lives there at all — one
+    /// entry per session that can be holding a copy of it.
     ///
-    /// Deliberately narrow, and the group exclusion is load-bearing rather
-    /// than incidental: a group is N independent server sessions presented as
-    /// one transcript, so `familiarIds.first` names an arbitrary one of them
-    /// and a position in the merged local list answers to no position in any
-    /// of their turn lists. A direct chat is the only shape with one session
-    /// to address. Group messages also mostly carry no server turn id —
-    /// `reload` no-ops for groups and `AppModel.loadHistory` only ever runs
-    /// against a thread it built with a single familiar — but replay CAN
-    /// adopt one, so it is the guard below that holds, not the absence of an
-    /// id.
+    /// A group used to be refused outright here, and the reason was real: a
+    /// group is N independent server sessions presented as one transcript, so
+    /// `familiarIds.first` names an arbitrary one of them and a position in
+    /// the merged local list answers to no position in any of their turn
+    /// lists. What was missing was not a session id but a PROJECTION. Session
+    /// F's turn list is exactly the sub-sequence of this thread's messages
+    /// that F was sent: every user prompt, because `send` fans one prompt out
+    /// to every familiar, plus the replies F itself produced and no other
+    /// familiar's. Take that sub-sequence and the merged list resolves into as
+    /// many honest per-session transcripts as the thread has familiars, each
+    /// of which the existing prefix-agreement matcher can check position by
+    /// position exactly as it does for a direct chat.
+    ///
+    /// So the shape of the answer follows the shape of the message. An
+    /// assistant bubble carries the `familiarId` that produced it, which names
+    /// exactly one session — one delete, and no way to fail halfway. A user
+    /// bubble was fanned out, so it is N server turns with N different ids,
+    /// and deleting it is N deletes; `persistDelete` owns what that means when
+    /// only some of them land. A direct chat is the same code with one entry,
+    /// not a special case beside it.
     ///
     /// A queued send, inline slash output, and a thread with no session yet
-    /// have nothing on the server to remove either, and for those the local
-    /// removal is already the whole truth.
+    /// have nothing on the server to remove, and for those the local removal
+    /// is already the whole truth.
     private func serverDeleteTarget(for message: DisplayMessage,
                                     at index: Int) -> ServerDeleteTarget? {
-        guard !isGroup, !message.isQueued,
+        guard !message.isQueued,
               // Inline slash output is local-only — but a `system` turn the
               // server named on a restore is a real turn there (the server
               // persists chain-less system turns) and deletes like any other.
               // Refusing every system message would leave those undeletable
               // by the silent local splice this whole path exists to end.
-              message.role != .system || message.serverTurnId != nil,
-              let familiarId = familiarIds.first,
-              let sessionId = sessionIds[familiarId], !sessionId.isEmpty else { return nil }
-        // Messages the server never receives do not occupy a turn, so they
-        // must not be counted when locating one. Kept whole rather than
-        // counted: naming a turn by position is only safe if the positions
-        // before it can be checked against the server's own transcript.
-        let preceding = messages[..<index].filter { Self.occupiesServerTurn($0) }
-        return ServerDeleteTarget(sessionId: sessionId, turnId: message.serverTurnId,
-                                  preceding: preceding)
+              message.role != .system || message.serverTurnId != nil
+        else { return nil }
+        let group = isGroup
+        let sessions: [ServerDeleteTarget.Session] = holders(of: message).compactMap { familiarId in
+            guard let sessionId = sessionIds[familiarId], !sessionId.isEmpty else { return nil }
+            guard let projected = Self.sessionTurn(message, in: familiarId, isGroup: group) else {
+                return nil
+            }
+            // Messages this session never received do not occupy a turn in it,
+            // so they must not be counted when locating one. Kept whole rather
+            // than counted: naming a turn by position is only safe if the
+            // positions before it can be checked against that session's own
+            // transcript.
+            let preceding = messages[..<index].compactMap {
+                Self.sessionTurn($0, in: familiarId, isGroup: group)
+            }
+            return ServerDeleteTarget.Session(familiarId: familiarId, sessionId: sessionId,
+                                              message: projected, preceding: preceding)
+        }
+        return sessions.isEmpty ? nil : ServerDeleteTarget(sessions: sessions)
+    }
+
+    /// Which of this thread's familiars could be holding this message.
+    ///
+    /// A reply lives in exactly one session — the one that produced it — so
+    /// deleting it anywhere else would remove a different familiar's turn. A
+    /// user prompt went to all of them, because that is what `send` does.
+    private func holders(of message: DisplayMessage) -> [String] {
+        guard message.role == .assistant else { return familiarIds }
+        if let familiarId = message.familiarId { return [familiarId] }
+        // An unattributed reply can only be a direct chat's, where there is one
+        // session and it is that one. In a group it names no session at all,
+        // and picking one would be the arbitrary `familiarIds.first` this whole
+        // projection exists to replace.
+        return isGroup ? [] : familiarIds
     }
 
     private struct ServerDeleteTarget {
-        let sessionId: String
-        /// Known only for a message the server has already named to us — on a
-        /// restore, or on the replay that adopted a reply the server had.
-        let turnId: String?
-        /// Every local message before this one that occupies a server turn,
-        /// in order. Its COUNT is the ordinal used to name a message composed
-        /// in this session — one that has never been through a restore and so
-        /// carries no `serverTurnId` — and its contents are what proves that
-        /// ordinal actually lines up with the server's transcript.
-        let preceding: [DisplayMessage]
+        /// Every server session that can hold this message: one for a direct
+        /// chat or a group reply, N for a group's user turn.
+        let sessions: [Session]
+
+        struct Session {
+            let familiarId: String
+            let sessionId: String
+            /// The message as THIS session's transcript sees it — see
+            /// `sessionTurn(_:in:isGroup:)`. Its `serverTurnId`, when it has
+            /// one, names a turn in this session and no other.
+            let message: DisplayMessage
+            /// Every local message before it that occupies a turn in THIS
+            /// session, in order. Its COUNT is the ordinal used to name a
+            /// message the server has never named to us, and its contents are
+            /// what proves that ordinal actually lines up with this session's
+            /// transcript.
+            let preceding: [DisplayMessage]
+        }
+    }
+
+    /// This message as one session's transcript sees it, or nil when that
+    /// session never held it.
+    ///
+    /// This is the whole of what makes a group addressable. Dropping another
+    /// familiar's reply is not tidying: counted, each of the N-1 replies the
+    /// fan-out produced for the other familiars would push every later
+    /// position that many turns too far down THIS session's turn list, and the
+    /// ordinal would name a stranger's turn.
+    ///
+    /// The turn id is narrowed for the same reason the position is. A
+    /// `serverTurnId` names a turn in the one session whose transcript handed
+    /// it over. In a direct chat that is the only session there is, so it
+    /// stands. In a group, adoption is the only route that names anything and
+    /// it only ever names a reply, so an id on a fanned-out user turn cannot
+    /// have come from the session being asked — comparing it there would
+    /// report a disagreeing transcript that is nothing but the wrong
+    /// session's id. Stripped, the turn falls back to role-and-text under the
+    /// same prefix agreement as any message the server never named.
+    nonisolated private static func sessionTurn(_ message: DisplayMessage,
+                                                in familiarId: String,
+                                                isGroup: Bool) -> DisplayMessage? {
+        guard occupiesServerTurn(message) else { return nil }
+        if message.role == .assistant {
+            if let owner = message.familiarId { return owner == familiarId ? message : nil }
+            return isGroup ? nil : message
+        }
+        guard isGroup else { return message }
+        var projected = message
+        projected.serverTurnId = nil
+        return projected
     }
 
     /// Does this message hold a position in the server's turn list?
@@ -549,61 +634,151 @@ final class ChatThread: Identifiable, Hashable {
         return message.role != .system && !message.isQueued
     }
 
+    /// Delete this message from every session that holds it — naming all of
+    /// the turns before removing any of them.
+    ///
+    /// The two phases are the point. A group's user turn is N deletes, and
+    /// discovering at the third session that the turn cannot be named would
+    /// leave two sessions deleted and two not, over a message nothing can put
+    /// back. Resolving first turns every "we cannot say where it is" refusal —
+    /// the common one, and the only one this code can provoke — into a refusal
+    /// that has changed nothing at all, so it rolls back cleanly and costs the
+    /// user a swipe.
+    ///
+    /// What survives that is a delete that was named in every session and then
+    /// refused by some of them: a desktop that went away between requests. That
+    /// one cannot be made atomic from here — the route deletes one turn in one
+    /// session and has no undelete — so it is reported rather than hidden.
     private func persistDelete(of message: DisplayMessage, at index: Int,
                                target: ServerDeleteTarget, client: CaveClient,
+                               familiarNames: [String: String],
                                onChange: @escaping () -> Void) async {
-        let turnId: String
-        if let known = target.turnId, !known.isEmpty {
-            turnId = known
-        } else {
-            // A message composed in this session has no server-assigned id
-            // yet, and nothing in the send path hands one back. Reading the
-            // conversation is the only way to name the turn — and the read
-            // has THREE outcomes a `try?` collapses into one:
-            //
-            //  - it THROWS 404: `GET /api/chat/conversation/{id}` answers 404
-            //    when the server holds no transcript for this chat (see that
-            //    route's final `not found`). The desktop was reached and told
-            //    us it has nothing, so the local removal was already the whole
-            //    delete. Blaming the network here would be a lie AND would put
-            //    back a message no server copy will ever resurrect.
-            //  - it THROWS anything else: a real failure, report it.
-            //  - it RETURNS nil: same answer as the 404, reached through the
-            //    narrow `conversation: null` shape the route uses when a board
-            //    card claims the session but no transcript exists yet.
-            let convo: Conversation?
-            do {
-                convo = try await client.conversation(sessionId: target.sessionId)
-            } catch CaveError.badResponse(404) {
-                return
-            } catch {
-                rollBack(message, to: index, reason: error.localizedDescription,
-                         onChange: onChange)
-                return
-            }
-            guard let convo else { return }
-            switch Self.turnMatch(for: message, following: target.preceding, in: convo.turns) {
-            case .named(let id):
-                turnId = id
+        var deletions: [(familiarId: String, sessionId: String, turnId: String)] = []
+        for session in target.sessions {
+            switch await resolveTurn(in: session, client: client) {
+            case .named(let turnId):
+                deletions.append((session.familiarId, session.sessionId, turnId))
             case .absent:
-                return
-            case .ambiguous:
-                // The server HAS a transcript and it does not line up with
-                // ours, so we cannot say whether it holds this message. Saying
-                // nothing would leave the bubble gone here and the turn alive
-                // there — a silent local-only delete, which is the bug this
-                // whole path exists to end, not a success.
-                rollBack(message, to: index,
-                         reason: "the desktop's copy of this chat has changed; refresh and try again",
-                         onChange: onChange)
+                // This session's transcript agreed as far as it goes and ends
+                // before the message — a prompt whose fan-out never reached
+                // this familiar. There is nothing here to delete, and that is
+                // not a reason to refuse the sessions that do hold it.
+                continue
+            case .unresolved(let reason):
+                // Nothing has been deleted yet, so refusing is free.
+                rollBack(message, to: index, reason: reason, onChange: onChange)
                 return
             }
         }
-        do {
-            try await client.deleteConversationTurn(sessionId: target.sessionId, turnId: turnId)
-        } catch {
-            rollBack(message, to: index, reason: error.localizedDescription, onChange: onChange)
+        var failures: [(familiarId: String, reason: String)] = []
+        for deletion in deletions {
+            do {
+                try await client.deleteConversationTurn(sessionId: deletion.sessionId,
+                                                        turnId: deletion.turnId)
+            } catch {
+                // Keep going: every session that still answers is one fewer
+                // surviving copy, and the report below wants the whole list.
+                failures.append((deletion.familiarId, error.localizedDescription))
+            }
         }
+        guard let firstFailure = failures.first else { return }
+        if failures.count == deletions.count {
+            // Nothing landed anywhere. The server is in exactly the state it
+            // was in before the swipe, so put the message back and say why —
+            // the direct chat's behaviour, and the one every "desktop
+            // unreachable" failure takes whatever the thread's shape.
+            rollBack(message, to: index, reason: firstFailure.reason, onChange: onChange)
+            return
+        }
+        reportPartialDelete(failures, familiarNames: familiarNames, onChange: onChange)
+    }
+
+    /// What one session says about where this message is, if anywhere.
+    private enum ServerTurnResolution {
+        case named(String)
+        case absent
+        /// The session could not be asked, or answered with a transcript that
+        /// does not line up. Either way we cannot name a turn, and guessing is
+        /// how a delete removes a stranger's message.
+        case unresolved(String)
+    }
+
+    /// Name this message's turn inside one session, without deleting anything.
+    private func resolveTurn(in session: ServerDeleteTarget.Session,
+                             client: CaveClient) async -> ServerTurnResolution {
+        if let known = session.message.serverTurnId, !known.isEmpty { return .named(known) }
+        // A message composed in this session has no server-assigned id yet,
+        // and nothing in the send path hands one back. Reading the
+        // conversation is the only way to name the turn — and the read has
+        // THREE outcomes a `try?` collapses into one:
+        //
+        //  - it THROWS 404: `GET /api/chat/conversation/{id}` answers 404 when
+        //    the server holds no transcript for this chat (see that route's
+        //    final `not found`). The desktop was reached and told us it has
+        //    nothing, so the local removal was already the whole delete for
+        //    this session. Blaming the network here would be a lie AND would
+        //    put back a message no server copy will ever resurrect.
+        //  - it THROWS anything else: a real failure, report it.
+        //  - it RETURNS nil: same answer as the 404, reached through the
+        //    narrow `conversation: null` shape the route uses when a board
+        //    card claims the session but no transcript exists yet.
+        let convo: Conversation?
+        do {
+            convo = try await client.conversation(sessionId: session.sessionId)
+        } catch CaveError.badResponse(404) {
+            return .absent
+        } catch {
+            return .unresolved(error.localizedDescription)
+        }
+        guard let convo else { return .absent }
+        switch Self.turnMatch(for: session.message, following: session.preceding,
+                              in: convo.turns) {
+        case .named(let id):
+            return .named(id)
+        case .absent:
+            return .absent
+        case .ambiguous:
+            // The server HAS a transcript and it does not line up with ours,
+            // so we cannot say whether it holds this message. Saying nothing
+            // would leave the bubble gone here and the turn alive there — a
+            // silent local-only delete, which is the bug this whole path
+            // exists to end, not a success.
+            return .unresolved("the desktop's copy of this chat has changed; refresh and try again")
+        }
+    }
+
+    /// Say out loud that a delete landed in some of a group's sessions and not
+    /// others, and deliberately leave the message removed.
+    ///
+    /// Rolling back is the wrong instrument here, and it is worth being exact
+    /// about why, because everywhere else on this path rolling back is the
+    /// honest move. It is honest there because nothing happened. Here
+    /// something did: the turn is really gone from at least one session and
+    /// the route has no undelete, so re-inserting the bubble would assert
+    /// copies the server has already destroyed. Worse, it would assert them
+    /// unrecoverably — those sessions' transcripts have moved, so the next
+    /// swipe's prefix walk finds them disagreeing, refuses as `ambiguous`, and
+    /// the copies that DID survive can never be deleted at all. Keeping the
+    /// removal is the description that is true of most sessions and leaves the
+    /// user somewhere to go.
+    ///
+    /// The one thing never done here is nothing. An unreported partial delete
+    /// is the silent local-only delete this whole path exists to end, just with
+    /// fewer sessions holding the evidence.
+    private func reportPartialDelete(_ failures: [(familiarId: String, reason: String)],
+                                     familiarNames: [String: String],
+                                     onChange: @escaping () -> Void) {
+        let names = failures.map { familiarNames[$0.familiarId] ?? $0.familiarId }
+        let reason = failures[0].reason
+        // Most `localizedDescription`s already end in a full stop, and
+        // "… status 404.." is a shabby thing to read back to someone.
+        let detail = reason.hasSuffix(".") ? String(reason.dropLast()) : reason
+        appendSystem(
+            "That message was deleted, but it is still in this chat with "
+                + "\(names.joined(separator: ", ")) — \(detail).",
+            isError: true)
+        updatedAt = Date()
+        onChange()
     }
 
     /// What the server's transcript says about a message it never named.
@@ -652,6 +827,15 @@ final class ChatThread: Identifiable, Hashable {
     /// it never received — while a disagreement inside the transcript says
     /// nothing at all about where this message is. Only the first of those is
     /// evidence that the local removal was the whole delete.
+    ///
+    /// Reused unchanged for a group, one session at a time. `preceding` is by
+    /// then the session's own projection rather than the whole merged list
+    /// (see `sessionTurn(_:in:isGroup:)`), so what arrives here is the same
+    /// question it has always answered: does one local transcript line up with
+    /// one server transcript, position by position. It also happens to be the
+    /// only guard that catches a fan-out that reached some familiars and not
+    /// others — that session's turns are shifted, the walk disagrees, and the
+    /// delete is refused rather than aimed at whatever sits at the ordinal.
     nonisolated private static func turnMatch(for message: DisplayMessage,
                                               following preceding: [DisplayMessage],
                                               in turns: [ChatTurn]) -> ServerTurnMatch {

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -743,7 +743,18 @@ final class ChatThread: Identifiable, Hashable {
             // would leave the bubble gone here and the turn alive there — a
             // silent local-only delete, which is the bug this whole path
             // exists to end, not a success.
-            return .unresolved("the desktop's copy of this chat has changed; refresh and try again")
+            //
+            // "Refresh and try again" is real advice in a DIRECT chat and only
+            // there: pull-to-refresh calls `reload`, the transcript comes back
+            // from the server with a `serverTurnId` on every message, and the
+            // next swipe deletes by name without the matcher at all. `reload`
+            // opens with `guard !isGroup`, so a group has no such route — the
+            // gesture is a no-op and the sentence would be sending someone to
+            // pull at a list that cannot change. Say what is true instead.
+            return .unresolved(
+                isGroup
+                    ? "the desktop's copy of this chat has changed and a group chat can't be refreshed to catch up"
+                    : "the desktop's copy of this chat has changed; refresh and try again")
         }
     }
 
@@ -836,6 +847,16 @@ final class ChatThread: Identifiable, Hashable {
     /// only guard that catches a fan-out that reached some familiars and not
     /// others — that session's turns are shifted, the walk disagrees, and the
     /// delete is refused rather than aimed at whatever sits at the ordinal.
+    ///
+    /// One sentence above does NOT survive the move, and it is the one about
+    /// the price of refusing. A direct chat pays a swipe: refreshing reloads
+    /// the transcript, every message comes back named, and the retry needs no
+    /// matching. `reload` refuses groups, so a group has no way to re-acquire
+    /// those ids — a session whose turns are shifted stays shifted, and every
+    /// later delete in the thread is refused for as long as the thread lives.
+    /// That is still the right side to err on (the alternative is deleting a
+    /// stranger's turn) but it is a standing cost, not a swipe, and the
+    /// refusal says so rather than promising a refresh that does nothing.
     nonisolated private static func turnMatch(for message: DisplayMessage,
                                               following preceding: [DisplayMessage],
                                               in turns: [ChatTurn]) -> ServerTurnMatch {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -2092,7 +2092,20 @@ struct ChatView: View {
         // removal, on the refusal, and again on a rollback that lands after the
         // request. Touching again here only re-wrote the threads file a second
         // time for the same change.
-        thread.deleteMessage(message.id, client: app.client) { app.touch(thread) }
+        // The names are only read if a group delete lands in some of its
+        // familiars' sessions and not others: that report names the chats the
+        // message survived in, and it is read by a person, so it says "Nyx"
+        // rather than the familiar id the thread stores.
+        // `uniquingKeysWith:` rather than `uniqueKeysWithValues:` — the latter
+        // traps on a repeated key, and a duplicated familiar id in a thread
+        // must not turn a swipe into a crash.
+        let familiarNames = Dictionary(
+            thread.familiarIds.compactMap { id in
+                app.familiar(id).map { (id, $0.displayName) }
+            },
+            uniquingKeysWith: { first, _ in first })
+        thread.deleteMessage(message.id, client: app.client,
+                             familiarNames: familiarNames) { app.touch(thread) }
     }
 
     private func openReader(text: String, familiar: Familiar?) {

--- a/scripts/ios-message-delete-persistence.test.mjs
+++ b/scripts/ios-message-delete-persistence.test.mjs
@@ -7,7 +7,16 @@
 // The sibling ios-thread-server-persistence.test.mjs covers whole-thread
 // archive/pin/delete. This covers the per-message delete only.
 //
-// iOS Swift is NOT compiled by CI, so this source-text contract is the only
+// Round two covers GROUP threads, which the first round refused outright. A
+// group is N independent server sessions behind one presented transcript, so
+// one local user bubble is N server turns with N different ids. The refusal
+// (`guard !isGroup`) was the remaining half of the same bug: a group message
+// was removed locally and nowhere else. The assertions below are therefore in
+// two families — that the merged local list is projected into one honest
+// transcript per session before any position is trusted, and that a delete
+// which lands in some sessions and not others is neither hidden nor undone.
+//
+// iOS Swift is NOT compiled by most of CI, so this source-text contract is the
 // gate. Each assertion is checked to FAIL against its regression, not merely
 // to pass.
 import assert from "node:assert/strict";
@@ -158,38 +167,117 @@ assert.match(
   /let previous = pendingServerDelete\s*\n\s*pendingServerDelete = Task \{/,
   "the serialization must be a chain the NEXT delete can await, not a fire-and-forget task",
 );
+// A group's partial-failure report names the chats the message survived in, and
+// it is read by a person. The thread stores familiar ids; only the view knows
+// the display names, so they have to be carried across.
+assert.match(
+  body,
+  /await self\?\.persistDelete\(of: removed, at: index, target: target,\s*\n\s*client: client, familiarNames: familiarNames,/,
+  "the display names must reach the partial-failure report",
+);
 
 const target = blockAfter(thread, "private func serverDeleteTarget(for message: DisplayMessage,");
 assert.ok(target, "serverDeleteTarget must exist");
+// The `!isGroup` refusal that used to open this guard WAS the remaining half of
+// the bug: a group message was spliced out locally and the server never heard.
+// It is gone, and it must not come back — a group is addressable one session at
+// a time (see `sessionTurn` below), not un-addressable.
+assert.doesNotMatch(
+  target,
+  /guard !isGroup/,
+  "a group message must no longer be refused outright — that refusal IS the remaining bug",
+);
 assert.match(
   target,
-  /guard !isGroup, !message\.isQueued,/,
-  "a group turn and a queued send have no server turn to remove",
+  /guard !message\.isQueued,/,
+  "a queued send has no server turn to remove",
 );
 // Inline slash output is local-only, but the server persists chain-less
 // `system` turns of its own and hands them back on a restore. Refusing every
 // system message leaves those deletable only by the local splice being fixed.
 assert.match(
   target,
-  /message\.role != \.system \|\| message\.serverTurnId != nil,/,
+  /message\.role != \.system \|\| message\.serverTurnId != nil/,
   "a system turn the SERVER named is a real turn and must delete like one; only " +
     "inline slash output (never named) stays local",
 );
 assert.match(
   target,
-  /let sessionId = sessionIds\[familiarId\], !sessionId\.isEmpty else \{ return nil \}/,
-  "a thread with no server session must not attempt a server call",
+  /holders\(of: message\)\.compactMap \{ familiarId in/,
+  "every session that can hold the message needs its own entry — a group's user turn is N " +
+    "server turns with N different ids, and deleting one of them leaves the rest",
 );
 assert.match(
   target,
-  /let preceding = messages\[\.\.<index\]\.filter \{ Self\.occupiesServerTurn\(\$0\) \}/,
-  "the ordinal must skip messages the server never receives, or it names the wrong turn",
+  /let sessionId = sessionIds\[familiarId\], !sessionId\.isEmpty else \{ return nil \}/,
+  "a familiar with no server session must not attempt a server call",
+);
+assert.match(
+  target,
+  /let preceding = messages\[\.\.<index\]\.compactMap \{\s*\n\s*Self\.sessionTurn\(\$0, in: familiarId, isGroup: group\)\s*\n\s*\}/,
+  "the ordinal must be counted in THIS session's projection — a flat filter over the merged " +
+    "list counts every other familiar's reply and names a turn N-1 positions too far down",
 );
 assert.match(
   target,
   /preceding: preceding\)/,
   "the preceding messages must be carried, not just counted — the count alone cannot be " +
     "checked against the server's transcript",
+);
+assert.match(
+  target,
+  /return sessions\.isEmpty \? nil : ServerDeleteTarget\(sessions: sessions\)/,
+  "no addressable session means the server holds nothing to remove, and the local removal " +
+    "is already the whole delete",
+);
+
+// -- Which sessions hold a message, and how each one sees it ----------------
+const holders = blockAfter(thread, "private func holders(of message: DisplayMessage) -> [String] {");
+assert.ok(holders, "holders(of:) must exist");
+assert.match(
+  holders,
+  /guard message\.role == \.assistant else \{ return familiarIds \}/,
+  "`send` fans one prompt out to every familiar, so a user bubble is one turn in EVERY " +
+    "session — deleting it in one of them leaves the copies the other familiars hold",
+);
+assert.match(
+  holders,
+  /if let familiarId = message\.familiarId \{ return \[familiarId\] \}/,
+  "a reply lives only in the session that produced it; deleting it anywhere else removes a " +
+    "different familiar's turn",
+);
+assert.match(
+  holders,
+  /return isGroup \? \[\] : familiarIds/,
+  "an unattributed reply names no session in a group — picking one is exactly the arbitrary " +
+    "`familiarIds.first` this projection replaces",
+);
+
+const sessionTurn = blockAfter(
+  thread,
+  "nonisolated private static func sessionTurn(_ message: DisplayMessage,",
+);
+assert.ok(sessionTurn, "sessionTurn(_:in:isGroup:) must exist");
+assert.match(
+  sessionTurn,
+  /guard occupiesServerTurn\(message\) else \{ return nil \}/,
+  "a message the server never receives holds no position in any session's turn list",
+);
+assert.match(
+  sessionTurn,
+  /if let owner = message\.familiarId \{ return owner == familiarId \? message : nil \}/,
+  "another familiar's reply is not in this session's transcript — counted, each of the N-1 " +
+    "replies one fan-out produces pushes every later position that many turns too far",
+);
+// The id is narrowed for the same reason the position is. In a direct chat the
+// only session there is named the turn, so the id stands and the comparison
+// stays the one that cannot coincide.
+assert.match(
+  sessionTurn,
+  /guard isGroup else \{ return message \}\s*\n\s*var projected = message\s*\n\s*projected\.serverTurnId = nil/,
+  "in a group, a fanned-out turn's id was handed over by ONE session — comparing it against " +
+    "another session's transcript reports a disagreement that is only the wrong session's id, " +
+    "while a direct chat must keep comparing by id",
 );
 
 const occupies = blockAfter(
@@ -204,66 +292,162 @@ assert.match(
     "sits in conversation.turns, and skipping it shifts every later ordinal one turn early",
 );
 
+// -- Resolve every session, THEN delete -------------------------------------
 const persist = blockAfter(thread, "private func persistDelete(of message: DisplayMessage, at index: Int,");
 assert.ok(persist, "persistDelete must exist");
+assert.match(
+  persist,
+  /for session in target\.sessions \{\s*\n\s*switch await resolveTurn\(in: session, client: client\)/,
+  "every session that can hold the message must be asked, not just the first one",
+);
+// The two phases are the whole defence against a half-done group delete. A
+// group user turn is N deletes, and finding at the third session that the turn
+// cannot be named would leave two sessions deleted and two not, over a message
+// nothing can put back.
+const resolveLoop = blockAfter(persist, "for session in target.sessions {");
+assert.ok(resolveLoop, "the resolve loop must exist");
+assert.doesNotMatch(
+  resolveLoop,
+  /deleteConversationTurn/,
+  "no turn may be deleted from inside the resolve loop — a refusal at the third session would " +
+    "leave the first two deleted with nothing able to put them back",
+);
+assert.ok(
+  persist.indexOf("resolveTurn(in: session") < persist.indexOf("deleteConversationTurn"),
+  "every turn must be named before any turn is deleted",
+);
+assert.match(
+  persist,
+  /case \.absent:[\s\S]*?continue/,
+  "a session whose transcript agrees and ends before this message never received it — that is " +
+    "not a reason to refuse the sessions that DO hold it",
+);
+assert.match(
+  persist,
+  /case \.unresolved\(let reason\):[\s\S]*?rollBack\(message, to: index, reason: reason, onChange: onChange\)\s*\n\s*return/,
+  "a session whose turn cannot be named refuses the WHOLE delete, while nothing has been " +
+    "deleted yet and refusing is free",
+);
+assert.match(
+  persist,
+  /try await client\.deleteConversationTurn\(sessionId: deletion\.sessionId,\s*\n\s*turnId: deletion\.turnId\)/,
+  "the named turns must actually be deleted on the server — the whole point of the bead",
+);
+
+const deleteLoop = blockAfter(persist, "for deletion in deletions {");
+assert.ok(deleteLoop, "the delete loop must exist");
+assert.doesNotMatch(
+  deleteLoop,
+  /\breturn\b|\bbreak\b/,
+  "one session refusing must not abandon the others — every session that still answers is one " +
+    "fewer surviving copy, and the report wants the whole list",
+);
+assert.match(
+  deleteLoop,
+  /failures\.append\(\(deletion\.familiarId, error\.localizedDescription\)\)/,
+  "a refusal must be recorded against the familiar whose chat still holds the message",
+);
+
+// Total failure and partial failure are different states and must stay so.
+assert.match(
+  persist,
+  /if failures\.count == deletions\.count \{[\s\S]*?rollBack\(message, to: index, reason: firstFailure\.reason, onChange: onChange\)/,
+  "nothing landed anywhere: the server is exactly as it was before the swipe, so the message " +
+    "goes back and says why — the direct chat's behaviour, whatever the thread's shape",
+);
+assert.match(
+  persist,
+  /reportPartialDelete\(failures, familiarNames: familiarNames, onChange: onChange\)/,
+  "a delete that landed in some sessions and not others must be reported, not swallowed",
+);
+assert.ok(
+  persist.indexOf("if failures.count == deletions.count") < persist.indexOf("reportPartialDelete"),
+  "the all-failed rollback must be decided first — a PARTIAL failure must not roll back, " +
+    "because the turn really is gone from at least one session and nothing can undo that",
+);
+
+const resolve = blockAfter(thread, "private func resolveTurn(in session: ServerDeleteTarget.Session,");
+assert.ok(resolve, "resolveTurn must exist");
+assert.match(
+  resolve,
+  /if let known = session\.message\.serverTurnId, !known\.isEmpty \{ return \.named\(known\) \}/,
+  "a turn this session already named needs no matching at all",
+);
 // `try?` collapses three different answers into one. The read THROWING is a
 // real failure — except for the 404 that `GET /api/chat/conversation/{id}`
 // returns when it holds no transcript at all, which is the server saying the
 // message is not there. Returning no conversation says the same thing through
 // the route's narrow `conversation: null` shape.
 assert.match(
-  persist,
-  /\} catch CaveError\.badResponse\(404\) \{\s*\n\s*return\s*\n\s*\} catch \{\s*\n\s*rollBack\(/,
+  resolve,
+  /\} catch CaveError\.badResponse\(404\) \{\s*\n\s*return \.absent\s*\n\s*\} catch \{\s*\n\s*return \.unresolved\(/,
   "a 404 from the conversation read means the server holds no transcript for this chat — " +
     "reporting it as 'the desktop could not be reached' is a lie AND resurrects a message " +
     "no server copy will ever bring back",
 );
 assert.match(
-  persist,
-  /do \{\s*\n\s*convo = try await client\.conversation\(sessionId: target\.sessionId\)/,
-  "a FAILED read is a real failure and must roll back",
+  resolve,
+  /do \{\s*\n\s*convo = try await client\.conversation\(sessionId: session\.sessionId\)/,
+  "a FAILED read is a real failure and must refuse",
 );
 assert.doesNotMatch(
-  persist,
+  resolve,
   /try\? await client\.conversation/,
   "`try?` collapses a failed read into 'the server does not have it'",
 );
 assert.match(
-  persist,
-  /guard let convo else \{ return \}/,
+  resolve,
+  /guard let convo else \{ return \.absent \}/,
   "a read that succeeds with no conversation means the server does not have the message — " +
     "that must NOT be reported as a failure",
 );
 assert.match(
-  persist,
-  /switch Self\.turnMatch\(for: message, following: target\.preceding, in: convo\.turns\)/,
-  "the turn must be named from the server's own transcript, with the preceding messages " +
-    "available to check the position against",
+  resolve,
+  /switch Self\.turnMatch\(for: session\.message, following: session\.preceding,\s*\n\s*in: convo\.turns\)/,
+  "the turn must be named from THIS session's own transcript, checked against THIS session's " +
+    "projection of the local list",
 );
 // The three outcomes have to stay three. Collapsing `ambiguous` into `absent`
 // is the silent local-only delete this whole bead exists to end: the bubble is
 // gone here, the turn is alive there, and nobody is told.
 assert.match(
-  persist,
-  /case \.absent:\s*\n\s*return/,
-  "a transcript that agrees and simply ends before this message proves the server never " +
-    "received it — the local removal was already the whole delete",
+  resolve,
+  /case \.absent:\s*\n\s*return \.absent/,
+  "a transcript that agrees and simply ends before this message proves that session never " +
+    "received it — the local removal was already the whole delete there",
 );
 assert.match(
-  persist,
-  /case \.ambiguous:[\s\S]*?rollBack\(message, to: index,\s*\n\s*reason: "[^"]+",/,
+  resolve,
+  /case \.ambiguous:[\s\S]*?return \.unresolved\("[^"]+"\)/,
   "a transcript that DISAGREES says nothing about where this message is — keeping the " +
     "removal there is a silent local-only delete, which is the bug being fixed",
 );
-assert.match(
-  persist,
-  /try await client\.deleteConversationTurn\(sessionId: target\.sessionId, turnId: turnId\)/,
-  "the named turn must actually be deleted on the server — the whole point of the bead",
+
+// -- A partial group delete is stated, never undone and never hidden --------
+const partial = blockAfter(
+  thread,
+  "private func reportPartialDelete(_ failures: [(familiarId: String, reason: String)],",
+);
+assert.ok(partial, "reportPartialDelete must exist");
+assert.doesNotMatch(
+  partial,
+  /messages\.insert/,
+  "a partial delete must NOT put the message back. The turn really is gone from at least one " +
+    "session and the route has no undelete, so re-inserting asserts copies the server has " +
+    "already destroyed — and those sessions' transcripts have moved, so the next swipe is " +
+    "refused as `ambiguous` and the copies that DID survive become undeletable for good",
 );
 assert.match(
-  persist,
-  /catch \{\s*\n\s*rollBack\(message, to: index, reason: error\.localizedDescription, onChange: onChange\)/,
-  "a refused delete must roll back AND say why",
+  partial,
+  /appendSystem\([\s\S]*?isError: true\)/,
+  "an unreported partial delete is the silent local-only delete this bead exists to end, " +
+    "just with fewer sessions holding the evidence",
+);
+assert.match(
+  partial,
+  /familiarNames\[\$0\.familiarId\] \?\? \$0\.familiarId/,
+  "the report must name the chats the message survived in, by display name where the view " +
+    "knows one and by familiar id when it does not",
 );
 
 const matcher = blockAfter(thread, "nonisolated private static func turnMatch(for message: DisplayMessage,");
@@ -330,11 +514,17 @@ assert.match(
   "a failed delete must be visible; a silent local-only delete is the bug being fixed",
 );
 
-// -- The view hands the client through --------------------------------------
+// -- The view hands the client (and the familiar names) through --------------
 assert.match(
   view,
-  /thread\.deleteMessage\(message\.id, client: app\.client\) \{ app\.touch\(thread\) \}/,
+  /thread\.deleteMessage\(message\.id, client: app\.client,\s*\n\s*familiarNames: familiarNames\) \{ app\.touch\(thread\) \}/,
   "the swipe action must go through the server-backed path, not the old local splice",
+);
+assert.match(
+  view,
+  /uniquingKeysWith: \{ first, _ in first \}\)/,
+  "`uniqueKeysWithValues:` traps on a repeated key — a duplicated familiar id in a thread must " +
+    "not turn a swipe into a crash",
 );
 
 console.log("ios-message-delete-persistence: ok");

--- a/scripts/ios-message-delete-persistence.test.mjs
+++ b/scripts/ios-message-delete-persistence.test.mjs
@@ -212,6 +212,17 @@ assert.match(
   /let sessionId = sessionIds\[familiarId\], !sessionId\.isEmpty else \{ return nil \}/,
   "a familiar with no server session must not attempt a server call",
 );
+// The message and the messages before it must be projected into the SAME
+// session. Projecting the message into one familiar's session while counting
+// the ordinal in another's names a turn in a transcript nobody checked — and
+// for a reply, whose holder is a single familiar, it silently drops the only
+// session that had it and the delete never reaches the server at all.
+assert.match(
+  target,
+  /guard let projected = Self\.sessionTurn\(message, in: familiarId, isGroup: group\) else \{/,
+  "the message must be projected into the session whose ordinal is about to be counted, " +
+    "not into some other familiar's",
+);
 assert.match(
   target,
   /let preceding = messages\[\.\.<index\]\.compactMap \{\s*\n\s*Self\.sessionTurn\(\$0, in: familiarId, isGroup: group\)\s*\n\s*\}/,
@@ -418,9 +429,26 @@ assert.match(
 );
 assert.match(
   resolve,
-  /case \.ambiguous:[\s\S]*?return \.unresolved\("[^"]+"\)/,
+  /case \.ambiguous:[\s\S]*?return \.unresolved\(\s*\n?\s*isGroup/,
   "a transcript that DISAGREES says nothing about where this message is — keeping the " +
     "removal there is a silent local-only delete, which is the bug being fixed",
+);
+// "Refresh and try again" is only advice a DIRECT chat can act on. `reload`
+// opens with `guard !isGroup`, so pull-to-refresh is a no-op for a group and
+// the transcript can never re-acquire the server turn ids that would let the
+// retry skip the matcher. Telling a group's user to refresh is sending them to
+// pull at a list that cannot change.
+assert.match(
+  resolve,
+  /\?\s*"the desktop's copy of this chat has changed and a group chat can't be refreshed to catch up"\s*\n\s*:\s*"the desktop's copy of this chat has changed; refresh and try again"\)/,
+  "only a direct chat may be told to refresh — `reload` refuses groups, so that advice " +
+    "cannot work there and the refusal must say something true instead",
+);
+assert.match(
+  thread,
+  /func reload\(client: CaveClient\) async throws \{\s*\n\s*guard !isGroup/,
+  "the assertion above is only worth anything while `reload` really does refuse groups — " +
+    "if that changes, the refusal copy should change with it",
 );
 
 // -- A partial group delete is stated, never undone and never hidden --------
@@ -448,6 +476,12 @@ assert.match(
   /familiarNames\[\$0\.familiarId\] \?\? \$0\.familiarId/,
   "the report must name the chats the message survived in, by display name where the view " +
     "knows one and by familiar id when it does not",
+);
+assert.match(
+  partial,
+  /onChange\(\)/,
+  "the note is the ONLY record a partial delete leaves — unpersisted it is gone at the next " +
+    "launch, which is the silent local-only delete again with an extra step",
 );
 
 const matcher = blockAfter(thread, "nonisolated private static func turnMatch(for message: DisplayMessage,");


### PR DESCRIPTION
The group half of **#4819**. Bead: `cave-1osn7` (child of `cave-ioswipe.6`).

#4827 landed durable single-message delete for direct chats and refused groups outright — `serverDeleteTarget` opened with `guard !isGroup`, so a group message was spliced out of the local array and the server never heard. That refusal is not a scoping note, it is the remaining half of the same bug: the message comes back on reinstall and never disappears on any other client.

## The projection is what was missing

A group is N independent server sessions behind one presented transcript, so `familiarIds.first` names an arbitrary one of them and a position in the merged local list answers to no position in any single session's turn list. That was the stated reason for the refusal, and it is true — but what was missing was not a session id. It was a **projection**.

Session F's turn list is exactly the sub-sequence of this thread's messages that F was sent: every user prompt, because `send` fans one prompt out to every familiar, plus the replies F itself produced and no other familiar's. `sessionTurn(_:in:isGroup:)` takes that sub-sequence, and the merged list resolves into as many honest per-session transcripts as the thread has familiars.

Dropping another familiar's reply is the load-bearing part, not tidying: counted, each of the N-1 replies one fan-out produces would push every later position that many turns too far down *this* session's turn list, and the ordinal would name a stranger's turn.

The turn id is narrowed for the same reason the position is. A `serverTurnId` names a turn in the one session whose transcript handed it over. In a direct chat that is the only session there is, so it stands and the comparison stays the one that cannot coincide. In a group, adoption is the only route that names anything and it only ever names a reply, so an id on a fanned-out user turn cannot have come from the session being asked — comparing it there would report a disagreeing transcript that is nothing but the wrong session's id. Stripped, that turn falls back to role-and-text under the same prefix agreement as any unnamed message.

## Reused, deliberately: the prefix-agreement matcher

`turnMatch(for:following:in:)` and `turn(_:is:)` are **unchanged**. What arrives at them is now the session's own projection rather than the whole merged list, so the question they answer is the one they have always answered: does one local transcript line up with one server transcript, position by position.

Reusing it rather than writing a group matcher is the point. Every argument in #4827 for refusing a drifted ordinal applies here unchanged, and a group has *more* ways to drift, not fewer — a fan-out that reaches three familiars and fails for the fourth leaves that session's turns shifted by one. Nothing else in this change would catch that. The prefix walk does: it disagrees, and the delete is refused rather than aimed at whatever sits at the ordinal.

## The group user turn, and what a partial failure means

An assistant bubble names one session, so it is one delete and cannot fail halfway. A user bubble was fanned out, so it is N deletes with N different ids — and "some sessions deleted, some not" is a real state.

**Two phases.** Every session's turn is named before any turn is deleted. This is not tidiness: finding at the third session that the turn cannot be named would otherwise leave two sessions deleted and two not, over a message nothing can put back. Resolving first turns every refusal this code can actually provoke — a transcript that does not line up, a desktop that cannot be reached — into a refusal that has changed nothing, so it rolls back cleanly and costs the user a swipe. A session whose transcript agrees and simply ends before the message never received it; that is skipped, not treated as a reason to refuse the sessions that do hold it.

What survives the two phases is a delete named everywhere and then refused by some sessions — a desktop that went away between requests. That cannot be made atomic from here: the route deletes one turn in one session and has no undelete.

- **Every session refused.** Nothing landed, the server is exactly as it was before the swipe, so the message goes back at the index it left from with an inline note — identical to a direct chat's behaviour, and the path every "desktop unreachable" failure takes whatever the thread's shape.
- **Some landed, some did not.** The removal **stands**, and an inline error note names the chats the message survived in, with the reason.

That asymmetry is the one decision worth arguing, so here is the argument. Rolling back is honest everywhere else on this path *because nothing happened*. Here something did: the turn really is gone from at least one session. Re-inserting the bubble would assert copies the server has already destroyed — and it would assert them **unrecoverably**, because those sessions' transcripts have now moved, so the next swipe's prefix walk finds them disagreeing, refuses as `ambiguous`, and the copies that *did* survive become undeletable for good. Keeping the removal is the description that is true of most sessions and the only one that does not trap the user. The one thing never done here is nothing: an unreported partial delete is the silent local-only delete this bead exists to end, just with fewer sessions holding the evidence.

`ChatView` passes the familiars' display names, because the thread stores ids and that sentence is read by a person.

## Verification

**The contract test.** `scripts/ios-message-delete-persistence.test.mjs` grows a group family of assertions. **37 mutations, all caught, all reverted** — every one checked to *fail* against its regression, not merely to pass: the group refusal restored; sessions taken from `familiarIds` instead of `holders(of:)`; `preceding` reverted to the flat merged-list filter or dropped entirely; a user turn fanned to one session only; a reply deleted in every session rather than its own; an unattributed group reply guessing a session; another familiar's reply counted in this session's projection; a group user turn keeping another session's turn id; only the first session resolved; a delete issued from inside the resolve loop; one absent session refusing the rest; an unnameable turn no longer refusing the whole delete; the delete loop abandoning the remaining sessions on first failure; total failure reported as partial instead of rolled back; a partial delete going unreported, or putting the message back, or not naming the surviving chats, or not marked as an error; the partial report ordered before the total-failure test; plus the round-one rules re-checked in their new home (`try?` restored, the 404 read as transport failure, `ambiguous` collapsed into `absent`, the matcher fed the merged list, the DELETE call dropped, the view reverted to the two-argument call).

Two assertions from round one were **replaced rather than kept**, and both were assertions of the bug: `guard !isGroup, !message.isQueued,` is now `guard !message.isQueued,` plus a `doesNotMatch(/guard !isGroup/)` that stops the refusal coming back, and the flat `preceding` filter is now the per-session projection. Several others moved verbatim in intent into `resolveTurn`, which is where the conversation read now lives. No assertion was weakened or deleted.

**It compiles.** `xcodebuild -scheme CovenCave build` does not compile `CovenCaveTests`, so the test target's `thread.deleteMessage(firstId, client: nil, onChange: {})` is checked here instead, via the defaulted parameter. Type-checked with swiftc 6.3.3 `-typecheck` over the real `Models/`, `State/` and `Networking/` sources plus a probe replicating every out-of-module call site (`ChatView`'s new call, the test target's call, and `DisplayMessage`'s initializers): **zero diagnostics in `-swift-version 5`, which is the project's `SWIFT_VERSION`, and zero in `6`**. Two negative controls confirm the probe is actually reached — swiftc suppresses diagnostics for later files once any error exists, so an "identical to baseline" claim over a source set with pre-existing platform errors would have been worthless.

| Command | Result |
| --- | --- |
| `node --require ./scripts/css-source-contract-hook.cjs scripts/ios-message-delete-persistence.test.mjs` | ok |
| `ios-thread-server-persistence` / `ios-swipe-ux` / `ios-offline-compose` / `ios-claude-design-fidelity` | ok |
| all 68 `scripts/ios-*.test.mjs` | ok |
| `pnpm check:tests-wired` | 1804 files wired |
| `pnpm typecheck` | ok |
| `pnpm lint` | ok |

## What is still open on #4819

Not `Closes`. Message delete is now durable for direct **and** group threads; the issue's other half — **thread archive/pin persisting to the server** — is untouched here and remains work on `cave-ioswipe.6`.
