### PR TITLE
Record real-authority client-v1 conformance (cave-2hjtv)

### DIFF
--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -24,6 +24,12 @@ streaming route, no attachment route, and the other five scopes
 This document describes behaviour; it is not the authority for it. When the two
 disagree, the code is right and this file is stale.
 
+Three places where they *did* disagree are marked ⚠️ below. They were found by
+[the real-authority conformance run](../workflows/client-v1-conformance.md),
+which drives this surface over a real socket against a release build — the only
+vantage point from which the listener, `proxy.ts` and Next's own request
+handling are visible at all.
+
 | Concern | Authority |
 |---|---|
 | Versions, scopes, capabilities, error codes, limits, public-route list | [`src/lib/server/client-v1/contract.ts`](../../src/lib/server/client-v1/contract.ts) |
@@ -200,6 +206,18 @@ before anything is classified. Nothing a correct client sends is affected: every
 segment of this surface is a fixed literal or a UUID, and the pairing secret
 travels in a header — so no legitimate path needs an escape. Percent-encoding in
 the **query string** is untouched.
+
+⚠️ **In practice only the `%` half of that is a 400 you will ever see.** Measured
+over a real socket by
+[the conformance run](../workflows/client-v1-conformance.md) on 2026-08-22: a
+request target carrying a **backslash** is normalized to `/` by Next *in the
+request target* and answered `308 Permanent Redirect` to the normalized path
+before `proxy.ts` runs at all, so `isRefusedClientV1Path` never sees it. The
+outcome is still closed — the normalized target is not a client-v1 route and is
+refused `401` by the ordinary gate, and no handler is reached — but a client
+following the redirect gets a `401`, never this `400`. The refusal in `proxy.ts`
+stays as written: it is the layer that would catch a backslash Next stopped
+normalizing, and removing it would trade a live defence for tidier prose.
 
 The refusal is scoped by path prefix rather than by the ingress lists, so it
 covers the admin family and any dynamic-segmented route added later, including
@@ -563,10 +581,21 @@ both or skip both:
 | `/conversations/:id/messages` | Transcript order, oldest first. **Not** a keyset — see that route. |
 
 **One consequence worth planning for:** `/conversations` keys on a *mutable*
-field, so a conversation that receives a turn while you are paging moves to the
-front of the ordering and can appear in two pages. The repeat is visible (the
-same `id` twice) and recoverable; the alternative — keying on a field half the
-corpus lacks — is neither.
+field, so a conversation that receives a turn while you are paging **moves out
+of the window you have not reached yet**. The ordering is `updatedAt`
+descending and a touch only ever raises the key, so the touched row moves
+*above* your open cursor: one already served stays served, and one not yet
+served is **skipped** by the rest of the walk.
+
+Earlier text here said such a row "can appear in two pages", and that the repeat
+was the cost. It is the other way round, and the difference matters: a repeat is
+deduplicable by `id`, a skip is silent. Measured over a real socket by
+[the conformance run](../workflows/client-v1-conformance.md) on 2026-08-22, no
+repeat was reproducible from a touch. **So a client that must not miss a
+conversation should re-read from the top rather than trust one walk** — and
+should still deduplicate by `id`, which costs nothing and covers the walks it
+restarts. The alternative key — a field half the corpus lacks — is worse than
+either.
 
 ### `GET /api/client/v1/familiars`
 
@@ -837,6 +866,18 @@ All four call `requireClientV1Admin`, which:
    is 503. The exchange keeps answering `pairing_pending` until the TTL expires.
 2. Compares the `x-coven-cave-token` header against it in constant time.
    Mismatch or absence is `401 unauthorized`.
+
+   ⚠️ **On a Cave that has a token configured, that envelope is unreachable.**
+   `COVEN_CAVE_AUTH_TOKEN` is also what `proxy.ts`'s ordinary sidecar-token gate
+   compares, and the admin family deliberately falls through to it — so a wrong
+   or absent header is refused there first and the wire carries the proxy's
+   shape, `401 {"ok":false,"error":"unauthorized"}`, not the Client v1 envelope
+   above. Same status, different body. Measured over a real socket by
+   [the conformance run](../workflows/client-v1-conformance.md) on 2026-08-22;
+   a handler-level test cannot see it, because it never runs the proxy. The
+   check in `requireClientV1Admin` is not redundant — it is what answers if the
+   admin family ever stops falling through — but it is the *second* refusal, and
+   the 503 for an unset token is the only one of its answers a caller observes.
 3. For **mutations only** (the decision POST and the credential DELETE),
    requires **at least one** of `Origin` and `Referer`, and requires every one
    that *is* present to be same-origin. A request carrying neither is refused;
@@ -1143,9 +1184,10 @@ against something that is not there.
   you re-read `GET /conversations/:id/messages` and diff — there is no
   server-push channel, and no revision token to make a conditional read cheap.
 - **`/conversations` pages on a mutable key.** A conversation whose transcript
-  grows while you are paging moves to the front of the ordering, so it can
-  appear in two pages. Deduplicate by `id`. See *Paging* for why the immutable
-  alternative is unavailable here.
+  grows while you are paging moves to the front of the ordering, so one you have
+  not reached yet is **skipped** by the rest of the walk. Re-read from the top
+  if you must not miss one, and deduplicate by `id` across walks. See *Paging*
+  for the measurement and for why the immutable alternative is unavailable here.
 - **A conversation's whole turn text is served inline.** There is no per-message
   size cap and no truncation, so a page of 100 long turns is a large response.
   Ask for a smaller `limit` on a constrained client.

--- a/docs/client-v1-conformance-results/2026-08-22-v0.3.9-win32.json
+++ b/docs/client-v1-conformance-results/2026-08-22-v0.3.9-win32.json
@@ -5,9 +5,9 @@
     "OpenCoven/coven-cave#4838"
   ],
   "scope": "cave-only",
-  "ranAt": "2026-08-22T20:28:01.705Z",
+  "ranAt": "2026-08-22T20:39:46.737Z",
   "caveVersion": "0.3.9",
-  "commit": "12ed1f735d11fb5c9e3416b263c92dec13dc32c9",
+  "commit": "bc3be68548574653d6e4498f945d228d8bb88970",
   "platform": "win32-x64",
   "nodeVersion": "v24.18.0",
   "includeTtl": true,
@@ -436,7 +436,7 @@
     {
       "id": "reads.conversations-mutable-key-moves-a-row",
       "result": "pass",
-      "detail": "a touched, not-yet-served conversation leaves the window; deduplicate and re-read from the top"
+      "detail": "touched conversation-01; the rest of the walk served [conversation-04,conversation-03,conversation-02] — a skip, and no repeat anywhere in it"
     },
     {
       "id": "reads.messages-active-branch",

--- a/docs/client-v1-conformance-results/2026-08-22-v0.3.9-win32.json
+++ b/docs/client-v1-conformance-results/2026-08-22-v0.3.9-win32.json
@@ -5,9 +5,9 @@
     "OpenCoven/coven-cave#4838"
   ],
   "scope": "cave-only",
-  "ranAt": "2026-08-22T19:10:42.207Z",
+  "ranAt": "2026-08-22T20:28:01.705Z",
   "caveVersion": "0.3.9",
-  "commit": "63f140139ab278265bc39cb3ee7b8f4f77542302",
+  "commit": "12ed1f735d11fb5c9e3416b263c92dec13dc32c9",
   "platform": "win32-x64",
   "nodeVersion": "v24.18.0",
   "includeTtl": true,
@@ -46,8 +46,8 @@
     }
   ],
   "summary": {
-    "total": 91,
-    "passed": 91,
+    "total": 93,
+    "passed": 93,
     "failed": 0,
     "skipped": 0,
     "status": "passed"
@@ -444,6 +444,11 @@
       "detail": "the abandoned branch turn b-x1 must be absent"
     },
     {
+      "id": "reads.messages-values",
+      "result": "pass",
+      "detail": "text, role, parentId, createdAt and both counts, field by field against the fixture"
+    },
+    {
       "id": "reads.messages-paging",
       "result": "pass",
       "detail": ""
@@ -451,7 +456,7 @@
     {
       "id": "reads.messages-counts-not-contents",
       "result": "pass",
-      "detail": ""
+      "detail": "b-a1 carries two tool calls and one attachment; the counts must say so and the contents must not appear"
     },
     {
       "id": "reads.messages-reconcile-required",
@@ -491,7 +496,7 @@
     {
       "id": "revocation.bearer-refused-after",
       "result": "pass",
-      "detail": ""
+      "detail": "all five canonical reads"
     },
     {
       "id": "revocation.is-idempotent",
@@ -507,6 +512,11 @@
       "id": "revocation.tombstone-persists",
       "result": "pass",
       "detail": ""
+    },
+    {
+      "id": "harness.assertion-coverage",
+      "result": "pass",
+      "detail": "every declared assertion recorded exactly once (--include-ttl true)"
     }
   ]
 }

--- a/docs/client-v1-conformance-results/2026-08-22-v0.3.9-win32.json
+++ b/docs/client-v1-conformance-results/2026-08-22-v0.3.9-win32.json
@@ -1,0 +1,512 @@
+{
+  "harness": "scripts/client-v1-conformance.mjs",
+  "issues": [
+    "OpenCoven/coven-cave#4832",
+    "OpenCoven/coven-cave#4838"
+  ],
+  "scope": "cave-only",
+  "ranAt": "2026-08-22T19:10:42.207Z",
+  "caveVersion": "0.3.9",
+  "commit": "63f140139ab278265bc39cb3ee7b8f4f77542302",
+  "platform": "win32-x64",
+  "nodeVersion": "v24.18.0",
+  "includeTtl": true,
+  "notCovered": [
+    "The SDK and Chat halves of #4838. Both live in other repositories; this run is the Cave half only.",
+    "The production Coven daemon. /familiars is served from a loopback fixture daemon in hub mode.",
+    "A genuinely remote peer. Off-machine ingress is exercised by making the listener classify a loopback request as forwarded.",
+    "The write scopes. Nothing enforces them yet — there are no write routes on this surface.",
+    "OAuth-backed flows and the desktop consent UI. Approval is driven through the admin HTTP route.",
+    "Cross-process pairing state. The pairing store is in-memory and process-local by contract."
+  ],
+  "findings": [
+    {
+      "id": "backslash-refusal-is-unreachable",
+      "where": "docs/api/client-v1.md — Reaching the API at all",
+      "says": "a request target inside /api/client/v1 containing \"%\" or \"\\\" is answered 400 {\"ok\":false,\"error\":\"invalid client v1 path\"}",
+      "measured": "the \"%\" half holds; a \"\\\" is normalised to \"/\" by Next and answered 308 to the normalised target before proxy.ts runs, and that target is then refused 401 by the ordinary gate",
+      "severity": "documentation",
+      "why": "no handler is reached and nothing is served, so the gate still holds; the doc describes an answer no client will observe"
+    },
+    {
+      "id": "admin-unauthorized-envelope-is-unreachable",
+      "where": "docs/api/client-v1.md — Administrator routes, Authentication",
+      "says": "a mismatched or absent x-coven-cave-token is 401 unauthorized from requireClientV1Admin",
+      "measured": "the proxy's sidecar-token gate answers first, so the wire carries 401 {\"ok\":false,\"error\":\"unauthorized\"} and requireClientV1Admin's envelope is never produced on a Cave with a token configured",
+      "severity": "documentation",
+      "why": "the refusal is correct and same-status; only its body differs from the documented one, which a handler-level test cannot see"
+    },
+    {
+      "id": "conversations-mutable-key-skips-rather-than-repeats",
+      "where": "docs/api/client-v1.md — Paging, and reads.ts clientV1ConversationPageKey",
+      "says": "a conversation that receives a turn mid-pagination moves to the front and can appear in two pages",
+      "measured": "the ordering is updatedAt DESCENDING and a touch only raises the key, so a touched row moves ABOVE an open cursor: a row already served stays served, and a row not yet served is SKIPPED by the rest of the walk. No repeat was reproducible.",
+      "severity": "documentation",
+      "why": "the client-visible consequence is the opposite of the documented one — a repeat is deduplicable, a skip is silent data loss unless the client re-reads from the top"
+    }
+  ],
+  "summary": {
+    "total": 91,
+    "passed": 91,
+    "failed": 0,
+    "skipped": 0,
+    "status": "passed"
+  },
+  "assertions": [
+    {
+      "id": "admin.unconfigured/admin/pairing-requests.GET",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/credentials.GET",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/pairing-requests/:id/decision.POST",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/credentials/:id.DELETE",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured.pairing-still-opens",
+      "result": "pass",
+      "detail": "a tokenless Cave still opens pairing requests"
+    },
+    {
+      "id": "admin.unconfigured.exchange-stays-pending",
+      "result": "pass",
+      "detail": "the documented dead end: no approval route, so the exchange can only ever answer pairing_pending"
+    },
+    {
+      "id": "health.envelope",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "health.instance-stable",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "health.discovery-record",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "ingress.escaped-path.percent",
+      "result": "pass",
+      "detail": "/api/client/v1/pairing/requests/%41"
+    },
+    {
+      "id": "ingress.escaped-path.percent-encoded-separator",
+      "result": "pass",
+      "detail": "/api/client/v1/conversations%2Fx"
+    },
+    {
+      "id": "ingress.backslash-path-reaches-no-handler",
+      "result": "pass",
+      "detail": "answered 308; the documented 400 fires for \"%\" only — see the run's notes"
+    },
+    {
+      "id": "ingress.forwarded.public",
+      "result": "pass",
+      "detail": "/pairing/requests with x-forwarded-for"
+    },
+    {
+      "id": "ingress.forwarded.authenticated",
+      "result": "pass",
+      "detail": "/conversations with x-forwarded-for"
+    },
+    {
+      "id": "ingress.forwarded.admin",
+      "result": "pass",
+      "detail": "/admin/credentials with x-forwarded-for"
+    },
+    {
+      "id": "ingress.exchange-requires-content-length",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "ingress.refuses-transfer-encoding",
+      "result": "pass",
+      "detail": "a chunked control-plane body has no declared length to cap"
+    },
+    {
+      "id": "ingress.body-cap",
+      "result": "pass",
+      "detail": "70072 bytes against the 65536-byte control-plane cap"
+    },
+    {
+      "id": "ingress.pairing-content-type",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.wrong-token",
+      "result": "pass",
+      "detail": "refused by the proxy's sidecar gate, ahead of requireClientV1Admin"
+    },
+    {
+      "id": "admin.no-token",
+      "result": "pass",
+      "detail": "refused by the proxy's sidecar gate, ahead of requireClientV1Admin"
+    },
+    {
+      "id": "admin.mutation-requires-source",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.create",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-pending",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-queue",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-approve",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-approved",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-approve-idempotent",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-decision-conflict",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.exchange",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.bearer-works",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.replay-refused",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-after-exchange",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-denied",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.exchange-denied",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.unknown-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.wrong-secret",
+      "result": "pass",
+      "detail": "one wrong secret charged on the exchange route"
+    },
+    {
+      "id": "pairing.correct-secret-polling-is-free",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-charges-wrong-secret-on-poll",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-locks-out-the-holder",
+      "result": "pass",
+      "detail": "ten wrong secrets across BOTH routes; the correct secret is refused too"
+    },
+    {
+      "id": "pairing.budget-is-shared-across-routes",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-is-per-pairing",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.ttl-poll-expired",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.ttl-exchange-expired",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.empty-first-page/projects",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.empty-first-page/conversations",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.no-bearer",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.unknown-bearer",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.bearer-not-accepted-in-query",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.scope-denied",
+      "result": "pass",
+      "detail": "a credential without chat:read"
+    },
+    {
+      "id": "reads.familiars",
+      "result": "pass",
+      "detail": "against a loopback fixture daemon, not the production daemon"
+    },
+    {
+      "id": "reads.familiars-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.projects-shape",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.projects-paging-partial-final-page",
+      "result": "pass",
+      "detail": "3 pages of at most 3 over 7 rows"
+    },
+    {
+      "id": "reads.cursor-replay-is-stable",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.cursor-current-echoes-the-token",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.cursor-survives-deletion",
+      "result": "pass",
+      "detail": "the token records a position in the ordering, not an index"
+    },
+    {
+      "id": "reads.projects-paging-exact-multiple",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.refuses.limit-zero",
+      "result": "pass",
+      "detail": "/projects?limit=0"
+    },
+    {
+      "id": "reads.refuses.limit-over-ceiling",
+      "result": "pass",
+      "detail": "/projects?limit=101"
+    },
+    {
+      "id": "reads.refuses.limit-leading-zero",
+      "result": "pass",
+      "detail": "/projects?limit=01"
+    },
+    {
+      "id": "reads.refuses.limit-exponent",
+      "result": "pass",
+      "detail": "/projects?limit=1e2"
+    },
+    {
+      "id": "reads.refuses.limit-signed",
+      "result": "pass",
+      "detail": "/projects?limit=%2B5"
+    },
+    {
+      "id": "reads.refuses.limit-repeated",
+      "result": "pass",
+      "detail": "/projects?limit=1&limit=2"
+    },
+    {
+      "id": "reads.refuses.unsupported-parameter",
+      "result": "pass",
+      "detail": "/projects?limt=5"
+    },
+    {
+      "id": "reads.refuses.offset",
+      "result": "pass",
+      "detail": "/projects?offset=1"
+    },
+    {
+      "id": "reads.refuses.cursor-outside-alphabet",
+      "result": "pass",
+      "detail": "/projects?cursor=not*base64url"
+    },
+    {
+      "id": "reads.refuses.cursor-not-canonical",
+      "result": "pass",
+      "detail": "/projects?cursor=eyJ2IjoxfQ=="
+    },
+    {
+      "id": "reads.limit-ceiling-is-served",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.default-page-size",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-shape",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-refuses-limit",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-refuses-cursor",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-not-found",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-mutable-key-moves-a-row",
+      "result": "pass",
+      "detail": "a touched, not-yet-served conversation leaves the window; deduplicate and re-read from the top"
+    },
+    {
+      "id": "reads.messages-active-branch",
+      "result": "pass",
+      "detail": "the abandoned branch turn b-x1 must be absent"
+    },
+    {
+      "id": "reads.messages-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-counts-not-contents",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-reconcile-required",
+      "result": "pass",
+      "detail": "activeLeafId moved to the abandoned branch, so the cursor names a turn that is no longer on it"
+    },
+    {
+      "id": "reads.messages-restart-after-reconcile",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-not-found",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-canonical-conversation-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.bearer-works-before",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.admin-listing",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.revoke",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.bearer-refused-after",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.is-idempotent",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.unknown-credential",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.tombstone-persists",
+      "result": "pass",
+      "detail": ""
+    }
+  ]
+}

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -150,9 +150,17 @@ the claim.
 
 The committed record for `cave-2hjtv` is
 [`2026-08-22-v0.3.9-win32.json`](../client-v1-conformance-results/2026-08-22-v0.3.9-win32.json):
-**91 passed, 0 failed, 0 skipped** at `63f14013` on `win32-x64`, run with
+**93 passed, 0 failed, 0 skipped** at `12ed1f73` on `win32-x64`, run with
 `--include-ttl`, so `pairing.ttl-poll-expired` and `pairing.ttl-exchange-expired`
 are recorded as passes rather than skips.
+
+⚠️ **Take the record from a clean tree, and commit the code before the record.**
+The first version of this file named `63f14013` — the *base* commit. The run had
+been taken from a dirty checkout, so `git rev-parse HEAD` answered the commit
+before the harness existed: nothing in the record was reproducible from the
+commit it named. The order that works is code first, then run, then commit the
+record on its own, so the commit the record names really is the harness that
+produced it and the only difference is the artifact itself.
 
 Commit the record. A conformance claim whose evidence is a terminal scrollback
 is an assertion, not a record.

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -1,0 +1,208 @@
+# Client v1 — Real-Authority Conformance
+
+Chat v1 Phase 1 (`cave-0prpu`, [#4832](https://github.com/OpenCoven/coven-cave/issues/4832))
+and Phase 2 (`cave-hjy2f`, [#4838](https://github.com/OpenCoven/coven-cave/issues/4838)).
+Both gates are governed by the program's **operating rule 8: a gate cannot close
+on unit-test proxies alone.** This runbook is the repeatable form of that
+evidence.
+
+```bash
+pnpm build                                   # the run drives the assembled artifact
+pnpm test:client-v1:conformance              # ~40 s, exit 0 or 1
+pnpm test:client-v1:conformance --include-ttl \
+  --out docs/client-v1-conformance-results/<date>-v<version>-<platform>.json
+```
+
+## What "real authority" means here, and why the unit tests are not it
+
+`src/lib/server/client-v1/**` and every `route.test.ts` under
+`src/app/api/client/v1/` call the exported handler with a hand-built
+`NextRequest`. That is the right shape for those tests, and it means none of
+them can see any of this:
+
+| Layer | Only observable over a socket |
+|---|---|
+| `server.mjs` | strips any client-supplied `x-coven-cave-local-peer` and re-stamps it for direct, unforwarded loopback peers only. Every handler test supplies the stamp itself. |
+| `proxy.ts` | the escaped-target refusal, the direct-loopback gates for the public / authenticated / admin families, the 411/413/64 KiB control-plane body rules, and the sidecar-token gate that runs **ahead of** `requireClientV1Admin`. |
+| Next | its own request-target normalisation and dynamic-segment decoding — which is what made `cave-f1xki` reachable in the first place. |
+| Node's HTTP client | not a layer, but the reason two of these are hard: it rewrites targets and substitutes chunked encoding, so parts of the run are written straight onto the socket. |
+| the stores | a real `client-v1-credentials.json` written 0600 and re-read from disk, a real transcript directory, a real `projects.json`. |
+
+The run therefore starts a Cave, drives it over `127.0.0.1`, and stops it.
+
+## Scope — the Cave half only
+
+#4838 names Cave, the SDK and Chat. **The SDK and Chat halves live in other
+repositories and are not exercised here.** A green record from this harness is
+evidence about Cave and about nothing else.
+
+The run also says, in its own evidence record (`notCovered`), what a pass does
+not mean:
+
+- the production Coven daemon — `/familiars` projects a daemon HTTP response, so
+  the run stands up a fixture daemon on loopback and points the fixture Cave at
+  it in hub mode;
+- a genuinely remote peer — off-machine ingress is exercised by making the
+  *listener* classify a loopback request as forwarded, which is the same signal
+  it reads for a real remote peer, but nothing in this run originates elsewhere;
+- the write scopes — nothing enforces them yet, because there are no write
+  routes on this surface;
+- OAuth-backed flows and the desktop consent UI — approval is driven through the
+  admin HTTP route;
+- cross-process pairing state — the pairing store is in-memory and
+  process-local by contract.
+
+## It never touches your real Cave
+
+Every run mints its own `COVEN_HOME` / `COVEN_CAVE_HOME` under the system temp
+directory, its own admin token, and its own port, and removes all of it
+afterwards. This is not a nicety: an earlier hand-driven cycle ran against the
+operator's real `~/.coven` and left a live paired credential behind that had to
+be revoked by hand. `--keep-fixture` leaves the temp home in place for
+inspection and prints its path.
+
+## What it covers
+
+**Pairing and revocation (#4832)** — create, poll pending, admin approve, poll
+approved, exchange, and a bearer that then works; deny, and the terminal
+`pairing_denied`; replay of a consumed exchange (`conflict` /
+`pairing_replayed`) on both the exchange and the poll; a well-formed wrong
+secret; the per-pairing failure budget, including that it is shared between the
+poll and the exchange, that a correct secret is never charged, that spending it
+locks out the rightful holder, and that the lockout is confined to one pairing;
+idempotent re-approval and the contradicting-decision conflict; revocation, the
+tombstone surviving a store reload, and the revoked bearer being refused; and
+every admin route answering `503` when `COVEN_CAVE_AUTH_TOKEN` is unset —
+together with the consequence that matters, which is that a pairing opened on a
+tokenless Cave can only ever answer `pairing_pending`.
+
+**Canonical reads (#4838)** — all five routes; empty first page, exact-multiple
+page, continuation, partial final page, and `hasMore` in both directions;
+projection shape as a whole key set, with each withheld field named as a leak
+rather than as drift; cursor stability — replaying a cursor returns the same
+page, `current` echoes the token sent, and deleting the record a cursor *names*
+does not strand the walk; the `limit` ceiling and every refused spelling, the
+unsupported and repeated parameter refusals, and the two cursor refusals; the
+single-record route refusing any query parameter at all; the messages route
+serving the active branch and omitting the abandoned one, paging by position,
+answering `reconcile_required` when the branch moves under an open cursor, and
+restarting cleanly afterwards.
+
+**Ingress** — the escaped-target refusal, the forwarded-peer refusals for all
+three route families, the 411 for a missing `Content-Length`, the 400 for a
+chunked control-plane body, the 413 body cap, and the 415 content-type refusal.
+
+`pairing.ttl-expiry` is **skipped by default**. The TTL is five minutes of real
+time and there is no clock seam reachable from outside the process, so the only
+honest way to observe `pairing_expired` is to wait for it. `--include-ttl` waits;
+without it the run records a skip, and a skip is never counted as a pass.
+
+## Operator-invoked, not CI
+
+The run needs a full production build, a spare port, a spawned server and a
+fixture daemon, and it is inherently serial. Adding that to the path-aware PR
+lane would put minutes onto every client-v1 change to re-prove a property that
+does not change per commit — which is the same reason `client-v1-release-smoke.mjs`
+is operator-invoked, and the same trade
+[Release Acceptance](release-acceptance.md) makes explicitly: *the journey is
+manual by design; what is automated is the evidence.*
+
+What **is** wired into CI is the half that decides whether a run passes.
+`scripts/client-v1-conformance.test.mjs` is in the `api` suite, and every one of
+its cases is a negative one: it feeds each assertion helper the exact broken
+server behaviour the run exists to catch and demands a failure. An assertion
+helper that cannot fail turns a green record into a lie, and nothing else in the
+suite would notice. `scripts/ci-paths.mjs` also routes the harness, this
+runbook, and the results directory into the client-v1 lane, so a change to any
+of them is validated by the lane that owns the surface.
+
+Run it before closing either gate, and when a change lands in `proxy.ts`,
+`server.ts`, or `src/lib/server/client-v1/**`.
+
+## The evidence record
+
+Records live in `docs/client-v1-conformance-results/<date>-v<version>-<platform>.json`
+and carry every assertion id with its result, the `notCovered` list above, the
+`findings` below, the Cave version, the platform, the exact commit, and whether
+the TTL leg ran. The commit is there for the reason
+[Release Acceptance](release-acceptance.md) records artifact digests: a record is
+a claim about *which bytes* answered, and one that cannot say which has not made
+the claim.
+
+The committed record for `cave-2hjtv` is
+[`2026-08-22-v0.3.9-win32.json`](../client-v1-conformance-results/2026-08-22-v0.3.9-win32.json):
+**91 passed, 0 failed, 0 skipped** at `63f14013` on `win32-x64`, run with
+`--include-ttl`, so `pairing.ttl-poll-expired` and `pairing.ttl-exchange-expired`
+are recorded as passes rather than skips.
+
+Commit the record. A conformance claim whose evidence is a terminal scrollback
+is an assertion, not a record.
+
+### Do not commit credentials
+
+The run mints a per-run admin token and per-run bearers, and **none of them
+belongs in a record.** The harness writes only assertion ids, results and its
+own diagnostic strings; if you add an assertion, keep secrets out of its detail
+text. Bearers and pairing secrets are 43 base64url characters and are trivially
+recognisable — but the rule is to not write them, not to scan for them.
+
+## Findings a green run still reports
+
+The harness is written against what the wire does, not against what the
+reference says, and where the two disagree it asserts the measured behaviour and
+records the gap. Three stand today, all documentation-level — the gates
+themselves hold:
+
+1. **The backslash half of the escaped-target refusal is unreachable.**
+   `docs/api/client-v1.md` says a target inside `/api/client/v1` containing `%`
+   *or* `\` is answered `400 invalid client v1 path`. The `%` half holds. A `\`
+   is normalised to `/` by Next in the request target and answered `308` to the
+   normalised target before `proxy.ts` runs; that target is not a client-v1
+   route and is refused `401`. Nothing is served and no handler is reached, so
+   the gate holds — but the documented answer is one no client will observe.
+
+2. **`requireClientV1Admin`'s `unauthorized` envelope is unreachable.** On a
+   Cave with `COVEN_CAVE_AUTH_TOKEN` set, a wrong or absent `x-coven-cave-token`
+   is refused by the proxy's ordinary sidecar-token gate first, so the wire
+   carries `401 {"ok":false,"error":"unauthorized"}` rather than the Client v1
+   envelope the reference describes. Same status, different body — and a
+   handler-level test cannot tell, because it never runs the proxy.
+
+3. **`/conversations` skips rather than repeats under a mid-walk touch.** The
+   reference and `reads.ts` both say a conversation that receives a turn while
+   you are paging "can appear in two pages". The ordering is `updatedAt`
+   **descending** and a touch only raises the key, so a touched row moves
+   *above* an open cursor: one already served stays served, and one not yet
+   served is skipped by the rest of the walk. No repeat was reproducible. The
+   client-visible consequence is the opposite of the documented one — a repeat
+   is deduplicable by `id`, a skip is silent unless the client re-reads from the
+   top.
+
+## Harness mutation results
+
+A conformance run that passes against a broken server is worse than none, so the
+harness is checked against deliberately broken builds rather than trusted. Each
+mutation patched source, ran a full `pnpm build`, ran the harness, and restored
+the source. Measured 2026-08-22 on `win32-x64` against Cave 0.3.9.
+
+| Mutation | Result | Assertions that caught it |
+|---|---|---|
+| `paginateClientV1Keyset` never publishes `next` | **caught**, 4 failures | `reads.familiars-paging`, `reads.projects-paging-partial-final-page`, `reads.projects-paging-exact-multiple`, `reads.conversations-paging` |
+| `ClientV1MessageRecord` widened and `projectClientV1Message` serves `reasoning` + `costUsd` | **caught**, 1 failure naming 12 leaks | `reads.messages-active-branch`, naming both fields on all six turns |
+| `FileCredentialStore.findByBearer` ignores `revokedAt` | **caught**, 1 failure | `revocation.bearer-refused-after` |
+| `parseClientV1PageLimit` clamps instead of refusing | **caught**, 5 failures | every `reads.refuses.limit-*` case: zero, over-ceiling, leading zero, exponent, signed |
+
+Two things the exercise showed that are worth keeping:
+
+- **The leak mutation had to be made twice.** Adding `reasoning` to the
+  projection alone does not compile — `ClientV1MessageRecord` is a closed
+  literal type, so `tsc` refuses the field before any build produces it. A real
+  leak therefore has to widen the published type as well, and that is the shape
+  the mutation above uses. The type is the first gate; this run is the second.
+- **The `next`-suppressing mutation *skipped* rather than failed three legs.**
+  `reads.cursor-replay-is-stable`, `reads.cursor-survives-deletion` and
+  `reads.conversations-mutable-key-moves-a-row` all need a first-page token to
+  open a cursor with, so a server that publishes none leaves them unrun. They
+  are reported as skips and, per the rule above, a skip is not a pass — the four
+  walk assertions are what fail. Read a jump in the skip count as a signal, not
+  as noise.

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -122,12 +122,19 @@ message projection leg went inert; see the mutation table below.) An assertion
 helper that cannot fail turns a green record into a lie, and nothing else in the
 suite would notice.
 
-Every helper mutation attempted against that suite is killed by it: 37 of 37,
+Measured against that suite: **49 of 50** helper mutations are killed by it,
 covering each branch of `checkEnvelope`, `checkRecordShape`, `checkRecordValues`,
 `checkPageWalk`, `checkEmptyFirstPage`, `checkAssertionCoverage`,
 `summarizeConformance`, `recorder.expect`, `parseConformanceArgs`,
 `parseRawResponse`, every `RECORD_SHAPES.*.forbidden` list, and every fixture
-invariant.
+invariant — including the ones that pin a value, so silently un-pinning `text`
+is caught rather than costing one unchecked field.
+
+The one survivor is *deleting an id from `EXPECTED_ASSERTION_IDS`*, and it is
+not a hole: the leg still records that id, so the next run reports it as "not in
+the expected set" and fails. The manifest is checked by the run rather than by
+the suite, which is the right place for it — a unit test cannot know which legs
+a run is supposed to have.
 
 `scripts/ci-paths.mjs` also routes the harness, this runbook, and the results
 directory into the client-v1 lane. Note the harness was already covered before

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -150,7 +150,7 @@ the claim.
 
 The committed record for `cave-2hjtv` is
 [`2026-08-22-v0.3.9-win32.json`](../client-v1-conformance-results/2026-08-22-v0.3.9-win32.json):
-**93 passed, 0 failed, 0 skipped** at `12ed1f73` on `win32-x64`, run with
+**93 passed, 0 failed, 0 skipped** at `bc3be685` on `win32-x64`, run with
 `--include-ttl`, so `pairing.ttl-poll-expired` and `pairing.ttl-exchange-expired`
 are recorded as passes rather than skips.
 
@@ -204,6 +204,13 @@ themselves hold:
    client-visible consequence is the opposite of the documented one — a repeat
    is deduplicable by `id`, a skip is silent unless the client re-reads from the
    top.
+
+   Measured over the **whole** walk rather than the page after the touch, which
+   is what separates the two claims: a row that came back three pages later
+   would be the documented repeat, and a one-page probe cannot tell. The ledger
+   orders `conversation-06` down to `conversation-01`; the first page serves
+   `[06, 05]`; after touching the unserved `conversation-01` the rest of the walk
+   serves `[04, 03, 02]` and nothing is served twice anywhere in it.
 
 ## Harness mutation results
 

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -71,7 +71,10 @@ secret; the per-pairing failure budget, including that it is shared between the
 poll and the exchange, that a correct secret is never charged, that spending it
 locks out the rightful holder, and that the lockout is confined to one pairing;
 idempotent re-approval and the contradicting-decision conflict; revocation, the
-tombstone surviving a store reload, and the revoked bearer being refused; and
+tombstone surviving a store reload, and the revoked bearer being refused **by
+all five canonical reads** — `read-guard.ts` keeps the credential decision
+written out in each route module rather than delegated, so there are five copies
+of it and a single-route probe clears one; and
 every admin route answering `503` when `COVEN_CAVE_AUTH_TOKEN` is unset —
 together with the consequence that matters, which is that a pairing opened on a
 tokenless Cave can only ever answer `pairing_pending`.
@@ -79,7 +82,9 @@ tokenless Cave can only ever answer `pairing_pending`.
 **Canonical reads (#4838)** — all five routes; empty first page, exact-multiple
 page, continuation, partial final page, and `hasMore` in both directions;
 projection shape as a whole key set, with each withheld field named as a leak
-rather than as drift; cursor stability — replaying a cursor returns the same
+rather than as drift, **and every projected value checked against what the
+fixture seeded** — a key-set check alone passes `root: project.id` and
+`harness: summary.harnessSessionId`, both measured; cursor stability — replaying a cursor returns the same
 page, `current` echoes the token sent, and deleting the record a cursor *names*
 does not strand the walk; the `limit` ceiling and every refused spelling, the
 unsupported and repeated parameter refusals, and the two cursor refusals; the
@@ -108,13 +113,27 @@ is operator-invoked, and the same trade
 manual by design; what is automated is the evidence.*
 
 What **is** wired into CI is the half that decides whether a run passes.
-`scripts/client-v1-conformance.test.mjs` is in the `api` suite, and every one of
-its cases is a negative one: it feeds each assertion helper the exact broken
-server behaviour the run exists to catch and demands a failure. An assertion
+`scripts/client-v1-conformance.test.mjs` is in the `api` suite, and most of its
+cases are negative ones: they feed each assertion helper the exact broken server
+behaviour the run exists to catch and demand a failure. (The rest pin the
+fixtures, which is the other half of the same job — an assertion over data that
+never carried the field it forbids proves nothing, and that is exactly how the
+message projection leg went inert; see the mutation table below.) An assertion
 helper that cannot fail turns a green record into a lie, and nothing else in the
-suite would notice. `scripts/ci-paths.mjs` also routes the harness, this
-runbook, and the results directory into the client-v1 lane, so a change to any
-of them is validated by the lane that owns the surface.
+suite would notice.
+
+Every helper mutation attempted against that suite is killed by it: 37 of 37,
+covering each branch of `checkEnvelope`, `checkRecordShape`, `checkRecordValues`,
+`checkPageWalk`, `checkEmptyFirstPage`, `checkAssertionCoverage`,
+`summarizeConformance`, `recorder.expect`, `parseConformanceArgs`,
+`parseRawResponse`, every `RECORD_SHAPES.*.forbidden` list, and every fixture
+invariant.
+
+`scripts/ci-paths.mjs` also routes the harness, this runbook, and the results
+directory into the client-v1 lane. Note the harness was already covered before
+that edit — `scripts/` is in `FRONTEND_PATH`, so `frontend-validation (API
+tests)` ran on any change to it — so the routing adds the e2e and docs lanes
+rather than closing a hole.
 
 Run it before closing either gate, and when a change lands in `proxy.ts`,
 `server.ts`, or `src/lib/server/client-v1/**`.
@@ -192,17 +211,52 @@ the source. Measured 2026-08-22 on `win32-x64` against Cave 0.3.9.
 | `FileCredentialStore.findByBearer` ignores `revokedAt` | **caught**, 1 failure | `revocation.bearer-refused-after` |
 | `parseClientV1PageLimit` clamps instead of refusing | **caught**, 5 failures | every `reads.refuses.limit-*` case: zero, over-ceiling, leading zero, exponent, signed |
 
-Two things the exercise showed that are worth keeping:
+### The four that were NOT caught, and what closed them
 
-- **The leak mutation had to be made twice.** Adding `reasoning` to the
-  projection alone does not compile — `ClientV1MessageRecord` is a closed
-  literal type, so `tsc` refuses the field before any build produces it. A real
-  leak therefore has to widen the published type as well, and that is the shape
-  the mutation above uses. The type is the first gate; this run is the second.
-- **The `next`-suppressing mutation *skipped* rather than failed three legs.**
-  `reads.cursor-replay-is-stable`, `reads.cursor-survives-deletion` and
-  `reads.conversations-mutable-key-moves-a-row` all need a first-page token to
-  open a cursor with, so a server that publishes none leaves them unrun. They
-  are reported as skips and, per the rule above, a skip is not a pass — the four
-  walk assertions are what fail. Read a jump in the skip count as a signal, not
-  as noise.
+An independent review built a second set aimed at the assertions rather than at
+the routes, and **all four passed a full run** — 89 passed, 0 failed, exit 0,
+against one build carrying every one of them at once:
+
+| Mutation | Before | After |
+|---|---|---|
+| `projectClientV1Message` serves `reasoning` and the tool calls **when the turn has them** | **passed** | `reads.messages-active-branch` names both leaks |
+| `projectClientV1Project` serves `root: project.id` | **passed** | `reads.projects-shape`, all seven rows |
+| `projectClientV1Conversation` serves `harness: summary.harnessSessionId` | **passed** | `reads.conversations-shape`, all six rows |
+| `projectClientV1Message` serves `text: turn.role` | **passed** | `reads.messages-values`, all six turns |
+
+Two causes, both now fixed:
+
+- **`checkRecordShape` checks KEYS ONLY.** A projection that serves the wrong
+  field, or a withheld *value* under an allowed *key*, keeps every key and was
+  invisible. `checkRecordValues` is the other half, and the projects,
+  conversations and messages legs now use both. The `harness` /
+  `harnessSessionId` pair is the case that matters: adjacent fields, one
+  published and one withheld, and only a value check tells them apart.
+- **The branched transcript carried nothing worth withholding.** Its turns had
+  no `reasoning`, no `tools`, no `usage`, no `costUsd` and no `attachments`, so
+  `RECORD_SHAPES.message.forbidden` had nothing to forbid and both counts were
+  zero everywhere — `reads.messages-counts-not-contents` could not fail for any
+  wrong count. `b-a1` now carries all of them, two tool calls and one
+  attachment, and the counts are asserted as 2 and 1 rather than as "a number".
+  The earlier note that the leak mutation "had to be made twice" because the
+  type is closed still holds, but widening it is three lines; the type is a
+  speed bump, not the first of two gates.
+
+### Legs that used to vanish rather than skip
+
+The `next`-suppressing mutation above leaves the cursor legs unrun, because they
+need a first-page token to open a cursor with. The first write-up said they were
+"reported as skips". Two of them were reported as **nothing at all**:
+`reads.cursor-replay-is-stable`, `reads.cursor-current-echoes-the-token` and
+`reads.cursor-survives-deletion` sat behind `if (firstPage.next)` with no `else`,
+so their ids simply left the record — a smaller, still-green run, with the
+shortfall visible only to a reader who remembered the expected total. The same
+held for `reads.messages-restart-after-reconcile` and
+`admin.unconfigured.exchange-stays-pending`.
+
+Every such guard now records a skip, and `EXPECTED_ASSERTION_IDS` makes that
+checkable instead of conventional: the run ends by comparing what it recorded
+against the declared set and fails `harness.assertion-coverage` on any id that is
+missing, duplicated or unexpected. A skip still does not fail a run — but a
+silence now does. **Add an id to that list in the same change that adds the
+assertion.**

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "test:app": "node scripts/run-tests.mjs app",
     "test:api": "node scripts/run-tests.mjs api",
     "test:api:http": "node scripts/api-http-smoke.mjs",
+    "test:client-v1:conformance": "node scripts/client-v1-conformance.mjs",
     "test:research-media:ffmpeg": "node --experimental-strip-types scripts/research-media-ffmpeg.integration.test.mjs",
     "test:mobile": "node scripts/run-tests.mjs mobile",
     "test:conformance": "node scripts/run-tests.mjs conformance",

--- a/scripts/ci-paths.mjs
+++ b/scripts/ci-paths.mjs
@@ -12,7 +12,7 @@ const E2E_PATH =
 const IOS_PATH =
   /^(?:apps\/ios\/|scripts\/(?:ios-xcodegen\.sh|build-ios-(?:markdown|terminal)\.mjs|ci-paths(?:\.test)?\.mjs)$|package\.json$|pnpm-lock\.yaml$|\.github\/workflows\/ci\.yml$)/;
 const CLIENT_V1_PATH =
-  /^(?:src\/lib\/server\/client-v1\/|src\/app\/api\/client\/v1\/|src\/app\/api\/api-contracts\.test\.ts$|scripts\/(?:export-client-v1-contract|client-v1-release-smoke)(?:\.test)?\.mjs$|docs\/api\/client-v1(?:[./-]|$)|docs\/client-v1(?:[./-]|$)|\.gitattributes$)/;
+  /^(?:src\/lib\/server\/client-v1\/|src\/app\/api\/client\/v1\/|src\/app\/api\/api-contracts\.test\.ts$|scripts\/(?:export-client-v1-contract|client-v1-release-smoke|client-v1-conformance)(?:\.test)?\.mjs$|docs\/api\/client-v1(?:[./-]|$)|docs\/client-v1(?:[./-]|$)|docs\/workflows\/client-v1-conformance\.md$|\.gitattributes$)/;
 // docs/ is deliberately absent from FRONTEND_PATH — a documentation change
 // should not pay for lint, typecheck, and build. But that also meant the docs
 // index ratchet, which only fires when a doc is added or renamed, never ran on

--- a/scripts/ci-paths.test.mjs
+++ b/scripts/ci-paths.test.mjs
@@ -116,6 +116,14 @@ test("public client v1 changes run Cave API, E2E, and documentation validation",
     "scripts/export-client-v1-contract.mjs",
     "scripts/client-v1-release-smoke.mjs",
     "scripts/client-v1-release-smoke.test.mjs",
+    // The real-authority conformance harness (cave-2hjtv). It is operator-run,
+    // so CI never drives it — but a change to it must still be validated by the
+    // lane that owns this surface, or the harness that judges client-v1 could
+    // rot without a single check noticing.
+    "scripts/client-v1-conformance.mjs",
+    "scripts/client-v1-conformance.test.mjs",
+    "docs/workflows/client-v1-conformance.md",
+    "docs/client-v1-conformance-results/2026-08-22-v0.3.9-win32.json",
     "src/app/api/client/v1/health/route.ts",
     "src/app/api/client/v1/health/route.test.ts",
     "src/app/api/api-contracts.test.ts",

--- a/scripts/client-v1-conformance.mjs
+++ b/scripts/client-v1-conformance.mjs
@@ -22,6 +22,22 @@
  * assertion. `--out` also writes the evidence record described in
  * docs/workflows/client-v1-conformance.md.
  *
+ * TWO RULES THIS FILE LEARNED THE HARD WAY, both from builds that were broken
+ * and that an earlier version of this run reported green:
+ *
+ *   - a projection is checked by KEY *and* by VALUE. A key-set check alone
+ *     passes `root: project.id`, `harness: summary.harnessSessionId` and
+ *     `text: turn.role` — a wrong path, a withheld id disclosed under an
+ *     allowed key, and every transcript body replaced. Measured: 89 passed, 0
+ *     failed, exit 0. See checkRecordValues.
+ *   - a fixture has to carry what the projection withholds. A `forbidden` list
+ *     cannot name a leak of a field the store never held, and a count cannot be
+ *     wrong when the true answer is zero everywhere. See
+ *     fixtureBranchedConversation's `b-a1`.
+ *
+ * And one about the record itself: a leg guarded by `if (someToken)` must record
+ * a skip in its `else`, never nothing. See EXPECTED_ASSERTION_IDS.
+ *
  * WHAT IT WILL NOT DO. It never reads or writes the operator's real Cave home.
  * Every run mints its own `COVEN_HOME`/`COVEN_CAVE_HOME` under a temp
  * directory, mints its own admin token, and removes both afterwards. A previous
@@ -136,6 +152,151 @@ export function createRecorder() {
   };
 }
 
+/**
+ * Every assertion id one run is required to produce, TTL leg aside.
+ *
+ * A leg guarded by `if (someToken)` used to vanish from the record when the
+ * precondition failed, taking its id with it: the run then reported a smaller,
+ * still-green total and nothing said which legs had gone. Two of the four the
+ * write-up called "reported as skips" were in fact reported as nothing at all.
+ *
+ * Every such guard now records a skip, and this list is what makes that
+ * checkable rather than a convention: a run that does not produce exactly these
+ * ids fails on `harness.assertion-coverage`, whatever the individual legs said.
+ * Add an id here in the same change that adds the assertion.
+ */
+export const EXPECTED_ASSERTION_IDS = [
+  "admin.unconfigured/admin/pairing-requests.GET",
+  "admin.unconfigured/admin/credentials.GET",
+  "admin.unconfigured/admin/pairing-requests/:id/decision.POST",
+  "admin.unconfigured/admin/credentials/:id.DELETE",
+  "admin.unconfigured.pairing-still-opens",
+  "admin.unconfigured.exchange-stays-pending",
+  "health.envelope",
+  "health.instance-stable",
+  "health.discovery-record",
+  "ingress.escaped-path.percent",
+  "ingress.escaped-path.percent-encoded-separator",
+  "ingress.backslash-path-reaches-no-handler",
+  "ingress.forwarded.public",
+  "ingress.forwarded.authenticated",
+  "ingress.forwarded.admin",
+  "ingress.exchange-requires-content-length",
+  "ingress.refuses-transfer-encoding",
+  "ingress.body-cap",
+  "ingress.pairing-content-type",
+  "admin.wrong-token",
+  "admin.no-token",
+  "admin.mutation-requires-source",
+  "pairing.create",
+  "pairing.poll-pending",
+  "pairing.admin-queue",
+  "pairing.admin-approve",
+  "pairing.poll-approved",
+  "pairing.admin-approve-idempotent",
+  "pairing.admin-decision-conflict",
+  "pairing.exchange",
+  "pairing.bearer-works",
+  "pairing.replay-refused",
+  "pairing.poll-after-exchange",
+  "pairing.poll-denied",
+  "pairing.exchange-denied",
+  "pairing.unknown-id",
+  "pairing.wrong-secret",
+  "pairing.correct-secret-polling-is-free",
+  "pairing.budget-charges-wrong-secret-on-poll",
+  "pairing.budget-locks-out-the-holder",
+  "pairing.budget-is-shared-across-routes",
+  "pairing.budget-is-per-pairing",
+  "reads.empty-first-page/projects",
+  "reads.empty-first-page/conversations",
+  "reads.no-bearer",
+  "reads.unknown-bearer",
+  "reads.bearer-not-accepted-in-query",
+  "reads.scope-denied",
+  "reads.familiars",
+  "reads.familiars-paging",
+  "reads.projects-shape",
+  "reads.projects-paging-partial-final-page",
+  "reads.cursor-replay-is-stable",
+  "reads.cursor-current-echoes-the-token",
+  "reads.cursor-survives-deletion",
+  "reads.projects-paging-exact-multiple",
+  "reads.refuses.limit-zero",
+  "reads.refuses.limit-over-ceiling",
+  "reads.refuses.limit-leading-zero",
+  "reads.refuses.limit-exponent",
+  "reads.refuses.limit-signed",
+  "reads.refuses.limit-repeated",
+  "reads.refuses.unsupported-parameter",
+  "reads.refuses.offset",
+  "reads.refuses.cursor-outside-alphabet",
+  "reads.refuses.cursor-not-canonical",
+  "reads.limit-ceiling-is-served",
+  "reads.default-page-size",
+  "reads.conversations-shape",
+  "reads.conversations-paging",
+  "reads.conversation-by-id",
+  "reads.conversation-by-id-refuses-limit",
+  "reads.conversation-by-id-refuses-cursor",
+  "reads.conversation-by-id-not-found",
+  "reads.conversations-mutable-key-moves-a-row",
+  "reads.messages-active-branch",
+  "reads.messages-values",
+  "reads.messages-paging",
+  "reads.messages-counts-not-contents",
+  "reads.messages-reconcile-required",
+  "reads.messages-restart-after-reconcile",
+  "reads.messages-not-found",
+  "reads.messages-canonical-conversation-id",
+  "revocation.bearer-works-before",
+  "revocation.admin-listing",
+  "revocation.revoke",
+  "revocation.bearer-refused-after",
+  "revocation.is-idempotent",
+  "revocation.unknown-credential",
+  "revocation.tombstone-persists",
+];
+
+/** The TTL leg records one id or the other, never both and never neither. */
+export const TTL_ASSERTION_IDS = {
+  waited: ["pairing.ttl-poll-expired", "pairing.ttl-exchange-expired"],
+  skipped: ["pairing.ttl-expiry"],
+};
+
+/** The id this coverage check records under; never part of the expected set. */
+export const COVERAGE_ASSERTION_ID = "harness.assertion-coverage";
+
+export function expectedAssertionIds(includeTtl) {
+  return [...EXPECTED_ASSERTION_IDS, ...(includeTtl ? TTL_ASSERTION_IDS.waited : TTL_ASSERTION_IDS.skipped)];
+}
+
+/**
+ * Every expected id present exactly once, and nothing unexpected.
+ *
+ * A missing id is the failure this exists for. A duplicate is reported too:
+ * two entries under one id make `passed` and `total` disagree with what a
+ * reader thinks the record covers.
+ */
+export function checkAssertionCoverage(entries, expected) {
+  const failures = [];
+  const seen = new Map();
+  for (const entry of entries) {
+    if (entry.id === COVERAGE_ASSERTION_ID) continue;
+    seen.set(entry.id, (seen.get(entry.id) ?? 0) + 1);
+  }
+  for (const id of expected) {
+    const count = seen.get(id) ?? 0;
+    if (count === 0) failures.push(`assertion ${JSON.stringify(id)} was never recorded, not even as a skip`);
+    else if (count > 1) failures.push(`assertion ${JSON.stringify(id)} was recorded ${count} times`);
+  }
+  const allowed = new Set(expected);
+  for (const id of seen.keys()) {
+    if (!allowed.has(id)) failures.push(`assertion ${JSON.stringify(id)} is not in the expected set`);
+  }
+  return failures;
+}
+
 export function summarizeConformance(entries) {
   const passed = entries.filter((entry) => entry.result === "pass").length;
   const failed = entries.filter((entry) => entry.result === "fail").length;
@@ -218,6 +379,12 @@ export function checkEnvelope(body, expectation) {
  * credential's `bearerHash`, a turn's `reasoning` or `tools`, a project's
  * `access`. A generic "unexpected key" on those reads like a schema drift
  * rather than the disclosure it is.
+ *
+ * ⚠️ This checks KEYS ONLY. It says nothing about what the values are, so it
+ * cannot see a projection that serves a withheld *value* under an allowed key
+ * (`harness: summary.harnessSessionId`) or simply the wrong field
+ * (`root: project.id`). Both were measured passing a whole run. `checkRecordValues`
+ * is the other half and every projection leg is required to use both.
  */
 export function checkRecordShape(record, spec, label) {
   const failures = [];
@@ -233,6 +400,32 @@ export function checkRecordShape(record, spec, label) {
   for (const key of keys) {
     if (!allowed.has(key) && !(spec.forbidden ?? []).includes(key)) {
       failures.push(`${label} carries unexpected field "${key}"`);
+    }
+  }
+  return failures;
+}
+
+/**
+ * The VALUES a projected record must carry, against what the fixture seeded.
+ *
+ * Written because the key-set check above is not a projection test on its own,
+ * and the gap is not theoretical: a build serving `root: project.id`,
+ * `harness: summary.harnessSessionId` and `text: turn.role` — a wrong path, a
+ * withheld id disclosed under an allowed key, and every transcript body
+ * replaced — passed all 89 assertions of an otherwise identical run. Every key
+ * was right, so nothing looked.
+ *
+ * `expected` names only the fields whose value the fixture pins. A field the
+ * fixture cannot predict (a server-minted id, an instant) belongs in the shape
+ * spec, not here.
+ */
+export function checkRecordValues(record, expected, label) {
+  if (!isRecord(record)) return [`${label} is not a JSON object`];
+  const failures = [];
+  for (const [key, want] of Object.entries(expected)) {
+    const got = record[key];
+    if (JSON.stringify(got) !== JSON.stringify(want)) {
+      failures.push(`${label}.${key} is ${JSON.stringify(got)}, expected ${JSON.stringify(want)}`);
     }
   }
   return failures;
@@ -656,6 +849,28 @@ export function fixtureBranchedConversation() {
     role,
     text: `${id} body`,
     createdAt: `2026-05-01T00:0${index}:00.000Z`,
+    // ONE turn on the active branch carries every field the message projection
+    // exists to withhold, and carries more than one of each countable kind.
+    //
+    // Without this the whole projection leg was inert: `forbidden` cannot name
+    // a leak of a field the store never held, and `attachmentCount` /
+    // `toolCount` cannot be wrong when the true answer is zero everywhere. A
+    // build that served `reasoning` and the tool inputs whenever a turn had
+    // them, and hardcoded both counts to zero, passed the entire run.
+    ...(id === "b-a1"
+      ? {
+          reasoning: "private scratchpad — never served",
+          tools: [
+            { id: "tool-1", name: "read", input: "/etc/passwd", status: "ok" },
+            { id: "tool-2", name: "bash", input: "cat ~/.ssh/id_ed25519", status: "ok" },
+          ],
+          attachments: [{ name: "secret-plan.txt", type: "text/plain", text: "withheld" }],
+          usage: { inputTokens: 11, outputTokens: 22 },
+          costUsd: 0.42,
+          durationMs: 1234,
+          harnessSessionId: "harness-branched",
+        }
+      : {}),
   });
   return {
     sessionId: "branched",
@@ -679,6 +894,28 @@ export function fixtureBranchedConversation() {
 }
 
 export const BRANCHED_ACTIVE_SEQUENCE = ["b-r1", "b-a1", "b-a2", "b-a3", "b-a4", "b-a5"];
+
+/** What each active-branch turn must be projected as, value for value. */
+export function expectedBranchedMessages() {
+  const bodyOf = (id, parentId, role, index) => ({
+    id,
+    conversationId: "branched",
+    parentId,
+    role,
+    text: `${id} body`,
+    createdAt: `2026-05-01T00:0${index}:00.000Z`,
+    attachmentCount: id === "b-a1" ? 1 : 0,
+    toolCount: id === "b-a1" ? 2 : 0,
+  });
+  return [
+    bodyOf("b-r1", null, "user", 0),
+    bodyOf("b-a1", "b-r1", "assistant", 1),
+    bodyOf("b-a2", "b-a1", "user", 2),
+    bodyOf("b-a3", "b-a2", "assistant", 3),
+    bodyOf("b-a4", "b-a3", "user", 4),
+    bodyOf("b-a5", "b-a4", "assistant", 5),
+  ];
+}
 
 async function seedFixture({ caveHomeDir, covenHomeDir, daemonUrl }) {
   await mkdir(caveHomeDir, { recursive: true });
@@ -865,6 +1102,8 @@ async function runUnconfiguredAdminLeg(client, recorder) {
       failures,
       "the documented dead end: no approval route, so the exchange can only ever answer pairing_pending",
     );
+  } else {
+    recorder.skip("admin.unconfigured.exchange-stays-pending", "no pairing request was opened to exchange");
   }
 }
 
@@ -1401,11 +1640,29 @@ async function runRevocationLeg(client, recorder, adminToken, credentialId, bear
   }
   recorder.expect("revocation.revoke", revokeFailures);
 
-  const after = await client.read("/projects", bearer);
+  // Every read route, not one. `read-guard.ts` says outright that the credential
+  // check is written out in each route module rather than delegated, so that
+  // `api-contracts.test.ts` can read it in the route's own source — which means
+  // there are five copies of this decision and a single-route probe clears one
+  // of them. That contract test is a source-text assertion, which is exactly the
+  // unit-test proxy operating rule 8 refuses to close a gate on.
   const afterFailures = [];
-  if (after.status !== 401) afterFailures.push(`the revoked credential answered ${after.status}, expected 401`);
-  afterFailures.push(...checkEnvelope(after.json, { kind: "error", code: "unauthorized" }));
-  recorder.expect("revocation.bearer-refused-after", afterFailures);
+  for (const target of [
+    "/familiars",
+    "/projects",
+    "/conversations",
+    "/conversations/branched",
+    "/conversations/branched/messages",
+  ]) {
+    const after = await client.read(target, bearer);
+    if (after.status !== 401) {
+      afterFailures.push(`${target} answered ${after.status} to a revoked credential, expected 401`);
+    }
+    afterFailures.push(...checkEnvelope(after.json, { kind: "error", code: "unauthorized" }).map(
+      (failure) => `${target}: ${failure}`,
+    ));
+  }
+  recorder.expect("revocation.bearer-refused-after", afterFailures, "all five canonical reads");
 
   const again = await client.admin("DELETE", `/admin/credentials/${credentialId}`, adminToken, {
     body: JSON.stringify({ reason: "second revocation" }),
@@ -1420,10 +1677,10 @@ async function runRevocationLeg(client, recorder, adminToken, credentialId, bear
   const missing = await client.admin("DELETE", `/admin/credentials/${randomUUID()}`, adminToken, {
     body: JSON.stringify({ reason: "no such credential" }),
   });
-  recorder.expect(
-    "revocation.unknown-credential",
-    missing.status === 404 ? [] : [`answered ${missing.status}, expected 404`],
-  );
+  const missingFailures = [];
+  if (missing.status !== 404) missingFailures.push(`answered ${missing.status}, expected 404`);
+  missingFailures.push(...checkEnvelope(missing.json, { kind: "error", code: "not_found" }));
+  recorder.expect("revocation.unknown-credential", missingFailures);
 
   // The store is a file, and the audit trail surviving on disk is the point of
   // a tombstone. Read it back through the admin route on a fresh reload rather
@@ -1457,10 +1714,10 @@ async function runAuthFailureLeg(client, recorder, bearer, writeOnlyBearer) {
   recorder.expect("reads.no-bearer", noBearerFailures);
 
   const garbage = await client.read("/conversations", "not-a-real-bearer");
-  recorder.expect(
-    "reads.unknown-bearer",
-    garbage.status === 401 ? [] : [`answered ${garbage.status}, expected 401`],
-  );
+  const garbageFailures = [];
+  if (garbage.status !== 401) garbageFailures.push(`answered ${garbage.status}, expected 401`);
+  garbageFailures.push(...checkEnvelope(garbage.json, { kind: "error", code: "unauthorized" }));
+  recorder.expect("reads.unknown-bearer", garbageFailures);
 
   // A credential in the query string must not work — the doc says header only,
   // and a credential in a URL survives in logs and Referer headers.
@@ -1516,8 +1773,28 @@ async function runProjectsLeg(client, recorder, bearer, caveHomeDir) {
 
   const single = await client.read("/projects?limit=100", bearer);
   const shapeFailures = [];
+  const byId = new Map(projects.map((project) => [project.id, project]));
   for (const project of single.json?.data?.projects ?? []) {
     shapeFailures.push(...checkRecordShape(project, RECORD_SHAPES.project, `project ${project.id}`));
+    // Values as well as keys: a projection serving `root: project.id` keeps
+    // every key and was measured passing a whole run.
+    const seeded = byId.get(project.id);
+    if (!seeded) shapeFailures.push(`project ${project.id} is not one this run seeded`);
+    else {
+      shapeFailures.push(
+        ...checkRecordValues(
+          project,
+          {
+            name: seeded.name,
+            root: seeded.root,
+            createdAt: seeded.createdAt,
+            updatedAt: seeded.updatedAt,
+            ...(seeded.color === undefined ? {} : { color: seeded.color }),
+          },
+          `project ${project.id}`,
+        ),
+      );
+    }
   }
   if ((single.json?.data?.projects ?? []).length !== projects.length) {
     shapeFailures.push(`limit=100 served ${single.json?.data?.projects?.length} of ${projects.length} rows`);
@@ -1552,6 +1829,14 @@ async function runProjectsLeg(client, recorder, bearer, caveHomeDir) {
         ? []
         : [`cursor.current is ${JSON.stringify(first.json?.cursor?.current)}, expected the token that was sent`],
     );
+  } else {
+    // These need a first-page token to open a cursor with. Recorded as skips
+    // rather than left out: a leg that vanishes from the record is worse than
+    // one that says it did not run, and the run has to remain readable as a
+    // fixed set of ids. See the coverage guard in main().
+    for (const id of ["reads.cursor-replay-is-stable", "reads.cursor-current-echoes-the-token"]) {
+      recorder.skip(id, "the projects walk published no first-page cursor to replay");
+    }
   }
 
   // The cursor names a position in the ordering, not an index, so deleting the
@@ -1570,6 +1855,8 @@ async function runProjectsLeg(client, recorder, bearer, caveHomeDir) {
       "the token records a position in the ordering, not an index",
     );
     await writeProjects(caveHomeDir, projects);
+  } else {
+    recorder.skip("reads.cursor-survives-deletion", "the projects walk published no first-page cursor to strand");
   }
 
   // 6 of 7 at limit 3 is an exact multiple: the final full page must report
@@ -1633,8 +1920,28 @@ async function runConversationsLeg(client, recorder, bearer, caveHomeDir) {
   const failures = [];
   if (listed.status !== 200) failures.push(`answered ${listed.status}, expected 200`);
   const rows = listed.json?.data?.conversations ?? [];
+  const seededById = new Map(conversations.map((conversation) => [conversation.sessionId, conversation]));
   for (const row of rows) {
     failures.push(...checkRecordShape(row, RECORD_SHAPES.conversation, `conversation ${row.id}`));
+    // `harness` and `harnessSessionId` are adjacent fields, one published and
+    // one withheld. A projection that read the wrong one keeps every key, so
+    // only a value check sees it — measured passing a whole run.
+    const seeded = seededById.get(row.id);
+    if (!seeded) failures.push(`conversation ${row.id} is not one this run seeded`);
+    else {
+      failures.push(
+        ...checkRecordValues(
+          row,
+          {
+            familiarId: seeded.familiarId,
+            harness: seeded.harness,
+            createdAt: seeded.createdAt,
+            updatedAt: seeded.updatedAt,
+          },
+          `conversation ${row.id}`,
+        ),
+      );
+    }
   }
   if (rows.map((row) => row.id).join(",") !== expectedIds.join(",")) {
     failures.push(`served [${rows.map((row) => row.id)}], expected the updatedAt-descending [${expectedIds}]`);
@@ -1715,6 +2022,7 @@ async function runMessagesLeg(client, recorder, bearer, caveHomeDir) {
   if (messages.map((message) => message.id).join(",") !== BRANCHED_ACTIVE_SEQUENCE.join(",")) {
     failures.push(`served [${messages.map((message) => message.id)}], expected the active branch [${BRANCHED_ACTIVE_SEQUENCE}]`);
   }
+  const expectedMessages = expectedBranchedMessages();
   for (const message of messages) {
     failures.push(...checkRecordShape(message, RECORD_SHAPES.message, `message ${message.id}`));
     if (message.conversationId !== "branched") {
@@ -1724,21 +2032,53 @@ async function runMessagesLeg(client, recorder, bearer, caveHomeDir) {
   if (messages[0]?.parentId !== null) failures.push("the root turn's parentId is not null");
   recorder.expect("reads.messages-active-branch", failures, "the abandoned branch turn b-x1 must be absent");
 
+  // Values, not just keys. `b-a1` carries reasoning, two tool calls (one of
+  // them pointed at a private key), an attachment, usage and a cost, so the
+  // withheld list above has something real to withhold and the counts below
+  // have a non-zero right answer.
+  const valueFailures = [];
+  for (const expected of expectedMessages) {
+    const served = messages.find((message) => message.id === expected.id);
+    if (!served) {
+      valueFailures.push(`message ${expected.id} was not served`);
+      continue;
+    }
+    valueFailures.push(...checkRecordValues(served, expected, `message ${expected.id}`));
+  }
+  recorder.expect(
+    "reads.messages-values",
+    valueFailures,
+    "text, role, parentId, createdAt and both counts, field by field against the fixture",
+  );
+
   const paged = await walk(client, "/conversations/branched/messages", bearer, "messages", 2);
   recorder.expect(
     "reads.messages-paging",
     checkPageWalk(paged, { limit: 2, expectedIds: BRANCHED_ACTIVE_SEQUENCE }),
   );
 
-  // Counts, not contents: the fixture's assistant turns in the LEDGER carry
-  // tools and attachments; this transcript's do not, so assert the counts are
-  // present and zero rather than assuming a leak would show as a wrong number.
-  const countsOk = messages.every(
-    (message) => typeof message.attachmentCount === "number" && typeof message.toolCount === "number",
-  );
+  // Counts, not contents — and the count has to be RIGHT, which needs a turn
+  // that really carries some. `b-a1` has two tools and one attachment, so a
+  // projection that hardcoded either count to zero fails here rather than
+  // agreeing with an all-zero fixture.
+  const countFailures = [];
+  const counted = messages.find((message) => message.id === "b-a1");
+  if (!counted) countFailures.push("the turn carrying tools and attachments was not served");
+  else {
+    if (counted.toolCount !== 2) countFailures.push(`b-a1 toolCount is ${JSON.stringify(counted.toolCount)}, expected 2`);
+    if (counted.attachmentCount !== 1) {
+      countFailures.push(`b-a1 attachmentCount is ${JSON.stringify(counted.attachmentCount)}, expected 1`);
+    }
+  }
+  for (const message of messages) {
+    if (typeof message.attachmentCount !== "number" || typeof message.toolCount !== "number") {
+      countFailures.push(`message ${message.id} does not carry both counts as numbers`);
+    }
+  }
   recorder.expect(
     "reads.messages-counts-not-contents",
-    countsOk ? [] : ["attachmentCount/toolCount are not both numbers on every turn"],
+    countFailures,
+    "b-a1 carries two tool calls and one attachment; the counts must say so and the contents must not appear",
   );
 
   // ── the branch moving under an open cursor ──
@@ -1776,14 +2116,16 @@ async function runMessagesLeg(client, recorder, bearer, caveHomeDir) {
     );
     await writeConversation(caveHomeDir, conversation);
   } else {
-    recorder.skip("reads.messages-reconcile-required", "the transcript did not page at limit 2");
+    for (const id of ["reads.messages-reconcile-required", "reads.messages-restart-after-reconcile"]) {
+      recorder.skip(id, "the transcript did not page at limit 2");
+    }
   }
 
   const absent = await client.read("/conversations/no-such-conversation/messages", bearer);
-  recorder.expect(
-    "reads.messages-not-found",
-    absent.status === 404 ? [] : [`answered ${absent.status}, expected 404`],
-  );
+  const absentFailures = [];
+  if (absent.status !== 404) absentFailures.push(`answered ${absent.status}, expected 404`);
+  absentFailures.push(...checkEnvelope(absent.json, { kind: "error", code: "not_found" }));
+  recorder.expect("reads.messages-not-found", absentFailures);
 
   // A conversation resolves to a FILE, so on a case-insensitive filesystem a
   // differently-spelled id answers — with the transcript's own id, never the
@@ -1911,6 +2253,15 @@ async function main(argv) {
     if (!options.keepFixture) await rm(fixtureRoot, { recursive: true, force: true });
     else console.log(`client-v1-conformance: fixture kept at ${fixtureRoot}`);
   }
+
+  // Recorded last, and over whatever the legs above managed to produce — a run
+  // that lost legs to a failed precondition has to say so in the record itself,
+  // not only in a total the reader has to remember.
+  recorder.expect(
+    COVERAGE_ASSERTION_ID,
+    checkAssertionCoverage(recorder.entries, expectedAssertionIds(options.includeTtl)),
+    `every declared assertion recorded exactly once (--include-ttl ${options.includeTtl})`,
+  );
 
   for (const entry of recorder.entries) {
     const mark = entry.result === "pass" ? "ok" : entry.result === "skip" ? "skip" : "FAIL";

--- a/scripts/client-v1-conformance.mjs
+++ b/scripts/client-v1-conformance.mjs
@@ -1,0 +1,1991 @@
+#!/usr/bin/env node
+
+/**
+ * Client v1 real-authority conformance run.
+ *
+ * Drives pairing, revocation and the five canonical reads against a *running,
+ * release-mode* Cave over a real TCP socket, with real on-disk stores. It
+ * exists because the program's operating rule 8 refuses to close a gate on
+ * unit-test proxies: `src/lib/server/client-v1/**` and the route tests call the
+ * handlers directly, so everything between the socket and the handler — the
+ * listener's local-peer stamp, `proxy.ts`'s ingress refusals, its 411/413 body
+ * rules, Next's own routing and percent-decoding, and the credential file the
+ * store actually writes — is unasserted by all of them.
+ *
+ * Scope is the **Cave half only**. Issue #4838 names Cave, the SDK and Chat;
+ * the SDK and Chat halves live in other repositories and are not exercised
+ * here. Nothing in this file should be read as covering them.
+ *
+ *   node scripts/client-v1-conformance.mjs [--out <path>] [--include-ttl] [--keep-fixture]
+ *
+ * Exits 0 when every assertion passed, 1 otherwise, and prints one line per
+ * assertion. `--out` also writes the evidence record described in
+ * docs/workflows/client-v1-conformance.md.
+ *
+ * WHAT IT WILL NOT DO. It never reads or writes the operator's real Cave home.
+ * Every run mints its own `COVEN_HOME`/`COVEN_CAVE_HOME` under a temp
+ * directory, mints its own admin token, and removes both afterwards. A previous
+ * hand-driven cycle used the real `~/.coven` and left a live credential behind
+ * that had to be revoked by hand; a committed harness that can do that is worse
+ * than no harness.
+ *
+ * WHAT IT DELIBERATELY LEAVES OUT, rather than faking:
+ *
+ *   - the real Coven daemon. `/api/client/v1/familiars` projects a daemon HTTP
+ *     response, so the run stands up a fixture daemon on loopback and points
+ *     the fixture Cave at it in hub mode. That is a real socket serving a real
+ *     roster payload — but it is not the production daemon, and the run says so
+ *     in its own output.
+ *   - anything needing a second machine. The off-machine ingress refusals
+ *     (#4843/#4855) are exercised by making the *listener* classify the request
+ *     as forwarded, which is the same signal it reads for a real remote peer,
+ *     but no request in this run actually originates elsewhere.
+ *   - the 5-minute pairing TTL, unless `--include-ttl` is passed. There is no
+ *     clock injection reachable from outside the process, so the only honest
+ *     way to observe `pairing_expired` is to wait. Left off by default and
+ *     reported as not-run rather than asserted from a shorter wait.
+ */
+
+import { execFileSync, spawn } from "node:child_process";
+import { once } from "node:events";
+import { connect as netConnect, createServer as createNetServer } from "node:net";
+import { randomUUID } from "node:crypto";
+import http from "node:http";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+
+export const PAIRING_SECRET_HEADER = "x-coven-pairing-secret";
+export const ADMIN_TOKEN_HEADER = "x-coven-cave-token";
+export const CLIENT_V1_PREFIX = "/api/client/v1";
+export const DEFAULT_PAGE_SIZE = 50;
+export const MAX_PAGE_SIZE = 100;
+/** The contract's pairing TTL. Only `--include-ttl` waits it out. */
+export const PAIRING_TTL_MS = 5 * 60_000;
+/** The per-pairing wrong-secret budget, shared by the poll and exchange routes. */
+export const PAIRING_FAILURE_LIMIT = 10;
+
+// ── argument parsing ─────────────────────────────────────────────────────────
+
+/**
+ * Parse the flags, refusing anything unrecognised.
+ *
+ * A silently ignored flag is how a run that was asked for the slow TTL leg
+ * reports a clean pass without ever having run it — the one outcome a
+ * conformance harness must not produce.
+ */
+export function parseConformanceArgs(argv) {
+  const options = { out: null, includeTtl: false, keepFixture: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === "--include-ttl") {
+      options.includeTtl = true;
+      continue;
+    }
+    if (flag === "--keep-fixture") {
+      options.keepFixture = true;
+      continue;
+    }
+    if (flag === "--out") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error("--out requires a path, for example --out docs/client-v1-conformance-results/run.json");
+      }
+      options.out = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown option ${JSON.stringify(flag)}`);
+  }
+  return options;
+}
+
+// ── assertion recording ──────────────────────────────────────────────────────
+
+/**
+ * One run's assertions, in the order they were made.
+ *
+ * Failures accumulate rather than throwing, for the reason the release smoke
+ * gives: a run that stops at the first failure costs one full build-and-serve
+ * cycle per fix. A leg that cannot even be attempted records `skipped` with the
+ * reason, which is a different thing from a pass and is counted separately.
+ */
+export function createRecorder() {
+  const entries = [];
+  return {
+    entries,
+    pass(id, detail = "") {
+      entries.push({ id, result: "pass", detail });
+    },
+    fail(id, detail) {
+      entries.push({ id, result: "fail", detail });
+    },
+    skip(id, detail) {
+      entries.push({ id, result: "skip", detail });
+    },
+    /** Record `failures` (empty means pass) against one id. */
+    expect(id, failures, detail = "") {
+      if (failures.length === 0) entries.push({ id, result: "pass", detail });
+      else entries.push({ id, result: "fail", detail: failures.join("; ") });
+    },
+  };
+}
+
+export function summarizeConformance(entries) {
+  const passed = entries.filter((entry) => entry.result === "pass").length;
+  const failed = entries.filter((entry) => entry.result === "fail").length;
+  const skipped = entries.filter((entry) => entry.result === "skip").length;
+  return {
+    total: entries.length,
+    passed,
+    failed,
+    skipped,
+    // `skipped` does not fail the run — a leg that says out loud it did not run
+    // is the honest partial this harness is required to produce — but it is
+    // never folded into `passed`, so a record cannot claim coverage it lacks.
+    status: failed > 0 ? "failed" : "passed",
+  };
+}
+
+// ── shape checks (pure; unit-tested without a server) ────────────────────────
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The envelope every Client v1 response carries.
+ *
+ * Checked on every single response the run makes, not once, because the
+ * envelope is the contract's only universal promise and a route that drops it
+ * is a route a client cannot read its own failure from.
+ */
+export function checkEnvelope(body, expectation) {
+  const failures = [];
+  if (!isRecord(body)) return ["response body is not a JSON object"];
+  if (typeof body.apiVersion !== "string" || !body.apiVersion) {
+    failures.push(`apiVersion is ${JSON.stringify(body.apiVersion)}`);
+  }
+  if (typeof body.minimumClientVersion !== "string" || !body.minimumClientVersion) {
+    failures.push(`minimumClientVersion is ${JSON.stringify(body.minimumClientVersion)}`);
+  }
+  if (!Array.isArray(body.capabilities) || body.capabilities.length === 0) {
+    failures.push("capabilities is missing or empty");
+  }
+  if (expectation?.kind === "success") {
+    if (!isRecord(body.data)) failures.push("success envelope carries no data record");
+    if (body.error !== undefined) failures.push("success envelope carries an error");
+  }
+  if (expectation?.kind === "error") {
+    if (!isRecord(body.error)) {
+      failures.push("error envelope carries no error record");
+      return failures;
+    }
+    if (body.error.code !== expectation.code) {
+      failures.push(`error.code is ${JSON.stringify(body.error.code)}, expected ${JSON.stringify(expectation.code)}`);
+    }
+    if (typeof body.error.message !== "string" || !body.error.message) {
+      failures.push("error.message is missing or empty");
+    }
+    if (typeof body.error.retryable !== "boolean") {
+      failures.push(`error.retryable is ${JSON.stringify(body.error.retryable)}, expected a boolean`);
+    }
+    if (expectation.retryable !== undefined && body.error.retryable !== expectation.retryable) {
+      failures.push(
+        `error.retryable is ${JSON.stringify(body.error.retryable)}, expected ${expectation.retryable}`,
+      );
+    }
+    if (expectation.reason !== undefined) {
+      const reason = isRecord(body.error.details) ? body.error.details.reason : undefined;
+      if (reason !== expectation.reason) {
+        failures.push(`error.details.reason is ${JSON.stringify(reason)}, expected ${JSON.stringify(expectation.reason)}`);
+      }
+    }
+  }
+  return failures;
+}
+
+/**
+ * A projected record, checked as a whole key set rather than field by field.
+ *
+ * `forbidden` overlaps `unexpected` on purpose. Both would catch a leak, but
+ * only the named list says *which* leak the projection exists to prevent — a
+ * credential's `bearerHash`, a turn's `reasoning` or `tools`, a project's
+ * `access`. A generic "unexpected key" on those reads like a schema drift
+ * rather than the disclosure it is.
+ */
+export function checkRecordShape(record, spec, label) {
+  const failures = [];
+  if (!isRecord(record)) return [`${label} is not a JSON object`];
+  const keys = new Set(Object.keys(record));
+  for (const key of spec.required ?? []) {
+    if (!keys.has(key)) failures.push(`${label} is missing required "${key}"`);
+  }
+  for (const key of spec.forbidden ?? []) {
+    if (keys.has(key)) failures.push(`${label} leaks withheld field "${key}"`);
+  }
+  const allowed = new Set([...(spec.required ?? []), ...(spec.optional ?? [])]);
+  for (const key of keys) {
+    if (!allowed.has(key) && !(spec.forbidden ?? []).includes(key)) {
+      failures.push(`${label} carries unexpected field "${key}"`);
+    }
+  }
+  return failures;
+}
+
+/**
+ * The invariants a paged walk owes a client, checked over the whole walk.
+ *
+ * Per-page checks miss the two failures that actually strand a client: a
+ * boundary that repeats or skips a record (only visible across pages), and a
+ * `hasMore` that disagrees with whether a further page exists. `expectedIds`
+ * is the ordering the store should have produced, so a walk that is internally
+ * consistent but serves the wrong set still fails.
+ */
+export function checkPageWalk(pages, options) {
+  const failures = [];
+  const { limit, expectedIds } = options;
+  const seen = [];
+  for (const [index, page] of pages.entries()) {
+    const isLast = index === pages.length - 1;
+    if (page.ids.length > limit) {
+      failures.push(`page ${index + 1} served ${page.ids.length} rows, above the requested limit ${limit}`);
+    }
+    if (!isLast && page.ids.length !== limit) {
+      failures.push(`page ${index + 1} is not the last page but served ${page.ids.length} of ${limit} rows`);
+    }
+    if (!isLast) {
+      if (page.hasMore !== true) failures.push(`page ${index + 1} reported hasMore ${JSON.stringify(page.hasMore)} with a page after it`);
+      if (typeof page.next !== "string" || !page.next) {
+        failures.push(`page ${index + 1} published no next token with a page after it`);
+      }
+    } else {
+      if (page.hasMore === true) failures.push("the final page reported hasMore true");
+      if (page.next !== undefined && page.next !== null) {
+        failures.push("the final page published a next token");
+      }
+    }
+    for (const id of page.ids) {
+      if (seen.includes(id)) failures.push(`id ${JSON.stringify(id)} was served twice in one walk`);
+      seen.push(id);
+    }
+  }
+  if (expectedIds) {
+    const actual = seen.join(",");
+    const expected = expectedIds.join(",");
+    if (actual !== expected) {
+      failures.push(`walk served [${actual}], expected [${expected}]`);
+    }
+  }
+  return failures;
+}
+
+/** `cursor` must be absent entirely when there is no token to publish. */
+export function checkEmptyFirstPage(body, collection) {
+  const failures = [];
+  if (!isRecord(body) || !isRecord(body.data)) return ["response carries no data record"];
+  const items = body.data[collection];
+  if (!Array.isArray(items)) failures.push(`data.${collection} is not an array`);
+  else if (items.length !== 0) failures.push(`data.${collection} served ${items.length} rows, expected none`);
+  if ("cursor" in body) {
+    failures.push("an empty first page published a cursor; the contract omits the field when there is no token");
+  }
+  return failures;
+}
+
+// ── the record shapes the doc publishes ──────────────────────────────────────
+
+export const RECORD_SHAPES = {
+  familiar: {
+    required: ["id", "displayName", "role"],
+    optional: ["description", "pronouns", "status", "lastSeenAt", "activeSessions"],
+    forbidden: ["emoji", "icon", "memory_freshness", "display_name", "last_seen", "active_sessions"],
+  },
+  project: {
+    required: ["id", "name", "root", "createdAt", "updatedAt"],
+    optional: ["color", "repoUrl"],
+    forbidden: ["legacyRoot", "access"],
+  },
+  conversation: {
+    required: ["id", "familiarId", "updatedAt"],
+    optional: ["harness", "model", "runtime", "title", "origin", "status", "exitCode", "pending", "createdAt"],
+    forbidden: ["harnessSessionId", "branch", "prUrl", "turns", "attentionEvidence", "sessionId"],
+  },
+  message: {
+    required: ["id", "conversationId", "parentId", "role", "text", "createdAt", "attachmentCount", "toolCount"],
+    optional: ["isError", "cancelled"],
+    forbidden: ["reasoning", "tools", "usage", "costUsd", "attachments", "progress", "durationMs", "harnessSessionId"],
+  },
+  credential: {
+    required: ["id", "appName", "installationId", "scopes", "createdAt", "lastUsedAt", "revokedAt", "revocationReason"],
+    optional: [],
+    forbidden: ["bearerHash", "bearer"],
+  },
+  pairingRequest: {
+    required: ["id", "appName", "installationId", "scopes", "status", "createdAt", "expiresAt", "decidedAt"],
+    optional: [],
+    forbidden: ["secret", "secretHash"],
+  },
+  pairingStatus: {
+    required: ["id", "status", "expiresAt"],
+    optional: [],
+    forbidden: ["appName", "installationId", "scopes", "createdAt", "decidedAt", "secret", "secretHash"],
+  },
+};
+
+// ── HTTP over a real socket ──────────────────────────────────────────────────
+
+/**
+ * One request, spelled by hand rather than through `fetch`.
+ *
+ * `fetch` is the wrong tool for this run in three specific ways, and each one
+ * hides an assertion the issues ask for: it attaches a `content-length` to a
+ * bodyless POST (so the documented 411 on the exchange becomes untestable), it
+ * re-encodes the request target (so the `%`/`\` refusal from #4855 never
+ * reaches the wire as written), and it refuses some header spellings outright.
+ */
+export function requestOnce(origin, options) {
+  const { method = "GET", path: target, headers = {}, body } = options;
+  const url = new URL(origin);
+  return new Promise((resolve, reject) => {
+    const outgoing = { ...headers };
+    if (body !== undefined && outgoing["content-length"] === undefined) {
+      outgoing["content-length"] = String(Buffer.byteLength(body));
+    }
+    const request = http.request(
+      {
+        host: url.hostname,
+        port: url.port,
+        method,
+        path: target,
+        headers: outgoing,
+      },
+      (response) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf8");
+          let json = null;
+          try {
+            json = text ? JSON.parse(text) : null;
+          } catch {
+            json = null;
+          }
+          resolve({ status: response.statusCode ?? 0, headers: response.headers, text, json });
+        });
+      },
+    );
+    request.on("error", reject);
+    if (body !== undefined) request.write(body);
+    request.end();
+  });
+}
+
+/**
+ * One request written byte for byte onto the socket.
+ *
+ * Needed for the two cases `http.request` cannot express, both of which the
+ * contract has an explicit answer for and neither of which was reachable
+ * without this:
+ *
+ *   - a body-bearing method carrying NEITHER `Content-Length` NOR
+ *     `Transfer-Encoding`. Node's client sets `useChunkedEncodingByDefault` for
+ *     POST, so removing the length header silently substitutes chunked — which
+ *     the proxy answers `400 invalid content-length`, not the `411` the missing
+ *     header is supposed to produce. The first draft of this harness reported
+ *     that 400 as a conformance failure; it was the harness that was wrong.
+ *   - a request target Node would rewrite before sending it.
+ *
+ * The response is parsed only as far as the status line and the body, which is
+ * all any assertion here reads.
+ */
+export function rawRequestOnce(origin, requestText) {
+  const url = new URL(origin);
+  return new Promise((resolve, reject) => {
+    const socket = netConnect(Number(url.port), url.hostname);
+    let received = "";
+    socket.on("connect", () => socket.write(requestText));
+    socket.on("data", (chunk) => {
+      received += chunk.toString("utf8");
+    });
+    socket.on("error", reject);
+    socket.on("end", () => resolve(parseRawResponse(received)));
+    socket.setTimeout(20_000, () => {
+      socket.destroy();
+      resolve(parseRawResponse(received || "HTTP/1.1 000 no response\r\n\r\n"));
+    });
+  });
+}
+
+export function parseRawResponse(text) {
+  const status = Number(/^HTTP\/1\.[01] (\d{3})/.exec(text)?.[1] ?? 0);
+  const separator = text.indexOf("\r\n\r\n");
+  const head = separator === -1 ? text : text.slice(0, separator);
+  const rest = separator === -1 ? "" : text.slice(separator + 4);
+  const headers = {};
+  for (const line of head.split("\r\n").slice(1)) {
+    const colon = line.indexOf(":");
+    if (colon > 0) headers[line.slice(0, colon).trim().toLowerCase()] = line.slice(colon + 1).trim();
+  }
+  // Every refusal on this path is answered chunked, so pull the JSON object out
+  // of the framing rather than reimplementing a chunked decoder for one line.
+  const start = rest.indexOf("{");
+  const end = rest.lastIndexOf("}");
+  let json = null;
+  if (start !== -1 && end > start) {
+    try {
+      json = JSON.parse(rest.slice(start, end + 1));
+    } catch {
+      json = null;
+    }
+  }
+  return { status, headers, text: rest, json };
+}
+
+// ── process and fixture plumbing ─────────────────────────────────────────────
+
+async function freePort() {
+  const server = createNetServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+/**
+ * A loopback stand-in for the Coven daemon's familiar roster.
+ *
+ * Only `/api/v1/familiars` is served, because that is the only daemon call the
+ * canonical reads make. Anything else answers 404 rather than an empty success,
+ * so a route that starts calling a second endpoint fails visibly here instead
+ * of silently reading a fabricated answer.
+ */
+async function startFixtureDaemon(roster) {
+  const server = http.createServer((req, res) => {
+    if (req.url === "/api/v1/familiars") {
+      const payload = JSON.stringify(roster);
+      res.writeHead(200, { "content-type": "application/json", "content-length": String(Buffer.byteLength(payload)) });
+      res.end(payload);
+      return;
+    }
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end('{"error":"fixture daemon serves only /api/v1/familiars"}');
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address();
+  return {
+    url: `http://127.0.0.1:${port}`,
+    async stop() {
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+async function startCave({ port, caveHomeDir, covenHomeDir, adminToken }) {
+  const env = {
+    ...process.env,
+    NODE_ENV: "production",
+    COVEN_HOME: covenHomeDir,
+    COVEN_CAVE_HOME: caveHomeDir,
+    COVEN_CAVE_PORT: String(port),
+    // A per-run instance id would be minted into the fixture home anyway; the
+    // point of clearing these is that an operator's own environment must not
+    // reach the server this run judges.
+    COVEN_CAVE_HEAP_MONITOR: "0",
+  };
+  delete env.COVEN_CAVE_BUNDLE;
+  delete env.COVEN_CAVE_ACCESS_TOKEN;
+  delete env.COVEN_CAVE_PASSKEY_REQUIRED;
+  delete env.COVEN_CAVE_CLIENT_V1_INSTANCE_ID;
+  delete env.PORT;
+  if (adminToken) env.COVEN_CAVE_AUTH_TOKEN = adminToken;
+  else delete env.COVEN_CAVE_AUTH_TOKEN;
+
+  const child = spawn(process.execPath, ["server.mjs"], {
+    cwd: repositoryRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const log = [];
+  child.stdout.on("data", (chunk) => log.push(chunk.toString()));
+  child.stderr.on("data", (chunk) => log.push(chunk.toString()));
+
+  const origin = `http://127.0.0.1:${port}`;
+  const deadline = Date.now() + 120_000;
+  let exited = false;
+  child.once("exit", () => {
+    exited = true;
+  });
+  while (Date.now() < deadline) {
+    if (exited) {
+      throw new Error(`Cave exited before it was ready:\n${log.join("")}`);
+    }
+    try {
+      const response = await requestOnce(origin, { path: `${CLIENT_V1_PREFIX}/health` });
+      if (response.status === 200) return { child, origin, log };
+    } catch {
+      // Not listening yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Cave did not answer ${origin}${CLIENT_V1_PREFIX}/health within 120s:\n${log.join("")}`);
+}
+
+/**
+ * Stop the Cave this run started, and prove the port came back.
+ *
+ * A conformance run that strands a listener poisons the next run — and on
+ * Windows a strand is easy, because a signal that the parent reports as
+ * delivered can leave the Next worker holding the socket. So the teardown ends
+ * with an actual connect attempt rather than with a resolved promise.
+ */
+async function stopCave(server, port) {
+  if (!server?.child) return;
+  const { child } = server;
+  const exit = once(child, "exit");
+  if (process.platform === "win32") {
+    spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+  } else {
+    child.kill("SIGTERM");
+  }
+  const timer = setTimeout(() => child.kill("SIGKILL"), 10_000);
+  try {
+    await exit;
+  } finally {
+    clearTimeout(timer);
+  }
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const stillUp = await requestOnce(`http://127.0.0.1:${port}`, { path: "/" }).then(() => true, () => false);
+    if (!stillUp) return;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`port ${port} is still answering after the Cave was stopped`);
+}
+
+// ── the fixture Cave home ────────────────────────────────────────────────────
+
+export const FIXTURE_ROSTER = [
+  { id: "archivist", display_name: "Archivist", role: "Keeper", description: "Keeps the ledger.", pronouns: "they/them", status: "idle", last_seen: "not-an-instant", active_sessions: 2 },
+  { id: "brewer", display_name: "Brewer", role: "Alchemist" },
+  { id: "cartographer", display_name: "Cartographer", role: "Scout", status: "busy" },
+  { id: "diviner", display_name: "Diviner", role: "Oracle" },
+  { id: "engraver", display_name: "Engraver", role: "Smith" },
+];
+
+/** Seven projects, so a limit of three exercises a partial final page. */
+export function fixtureProjects() {
+  return Array.from({ length: 7 }, (_, index) => {
+    const n = String(index + 1).padStart(2, "0");
+    return {
+      id: `project-${n}`,
+      name: `Fixture ${n}`,
+      root: `/client-v1-conformance/project-${n}`,
+      color: index % 2 === 0 ? "#123456" : undefined,
+      createdAt: `2026-01-${n}T00:00:00.000Z`,
+      updatedAt: `2026-02-${n}T00:00:00.000Z`,
+    };
+  }).map((project) => {
+    if (project.color === undefined) {
+      const { color: _unused, ...rest } = project;
+      return rest;
+    }
+    return project;
+  });
+}
+
+/** Six conversations, so a limit of three exercises an exact-multiple walk. */
+export function fixtureConversations() {
+  return Array.from({ length: 6 }, (_, index) => {
+    const n = String(index + 1).padStart(2, "0");
+    return {
+      sessionId: `conversation-${n}`,
+      familiarId: "archivist",
+      harness: "claude",
+      // Withheld fields, present in the store so the projection has something
+      // to withhold. A shape assertion over a record that never carried the
+      // field proves nothing.
+      harnessSessionId: `harness-${n}`,
+      branch: "feat/fixture",
+      prUrl: "https://github.com/OpenCoven/coven-cave/pull/1",
+      createdAt: `2026-03-${n}T00:00:00.000Z`,
+      updatedAt: `2026-04-${n}T00:00:00.000Z`,
+      turns: [
+        {
+          id: `${n}-t1`,
+          parentId: null,
+          role: "user",
+          text: `prompt ${n}`,
+          createdAt: `2026-03-${n}T00:00:00.000Z`,
+        },
+        {
+          id: `${n}-t2`,
+          parentId: `${n}-t1`,
+          role: "assistant",
+          text: `reply ${n}`,
+          createdAt: `2026-03-${n}T00:00:00.000Z`,
+          reasoning: "private scratchpad",
+          tools: [{ id: "tool-1", name: "read", input: "/etc/passwd", status: "ok" }],
+          usage: { inputTokens: 1, outputTokens: 2 },
+          costUsd: 0.01,
+        },
+      ],
+      activeLeafId: `${n}-t2`,
+    };
+  });
+}
+
+/**
+ * A branched transcript, so the messages route has an abandoned branch to omit
+ * and an active branch that can be moved out from under an open cursor.
+ *
+ * Roles are user/assistant only: `resolveActivePath` splices parentless system
+ * turns back into the chain by timestamp, which would make the expected
+ * sequence depend on that splice rather than on the branch.
+ */
+export function fixtureBranchedConversation() {
+  const turn = (id, parentId, role, index) => ({
+    id,
+    parentId,
+    role,
+    text: `${id} body`,
+    createdAt: `2026-05-01T00:0${index}:00.000Z`,
+  });
+  return {
+    sessionId: "branched",
+    familiarId: "archivist",
+    harness: "claude",
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T01:00:00.000Z",
+    turns: [
+      turn("b-r1", null, "user", 0),
+      turn("b-a1", "b-r1", "assistant", 1),
+      turn("b-a2", "b-a1", "user", 2),
+      turn("b-a3", "b-a2", "assistant", 3),
+      turn("b-a4", "b-a3", "user", 4),
+      turn("b-a5", "b-a4", "assistant", 5),
+      // The abandoned branch. It must never be served while `activeLeafId`
+      // names the chain above.
+      turn("b-x1", "b-r1", "assistant", 6),
+    ],
+    activeLeafId: "b-a5",
+  };
+}
+
+export const BRANCHED_ACTIVE_SEQUENCE = ["b-r1", "b-a1", "b-a2", "b-a3", "b-a4", "b-a5"];
+
+async function seedFixture({ caveHomeDir, covenHomeDir, daemonUrl }) {
+  await mkdir(caveHomeDir, { recursive: true });
+  await mkdir(covenHomeDir, { recursive: true });
+  await writeFile(
+    path.join(caveHomeDir, "config.json"),
+    // Hub mode is the only daemon target that speaks HTTP, so it is the only
+    // one a fixture daemon can stand behind. It changes nothing else the
+    // canonical reads touch.
+    `${JSON.stringify({ version: 1, multiHost: { mode: "hub", hubUrl: daemonUrl, executorUrls: [] } }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+async function writeProjects(caveHomeDir, projects) {
+  await writeFile(
+    path.join(caveHomeDir, "projects.json"),
+    `${JSON.stringify({ version: 1, projects }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+async function writeConversation(caveHomeDir, conversation) {
+  const dir = path.join(caveHomeDir, "conversations");
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    path.join(dir, `${conversation.sessionId}.json`),
+    `${JSON.stringify(conversation, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+// ── a small client bound to one origin ───────────────────────────────────────
+
+function createClient(origin) {
+  return {
+    origin,
+    request(options) {
+      return requestOnce(origin, options);
+    },
+    read(target, bearer, extraHeaders = {}) {
+      return requestOnce(origin, {
+        path: `${CLIENT_V1_PREFIX}${target}`,
+        headers: { ...(bearer ? { authorization: `Bearer ${bearer}` } : {}), ...extraHeaders },
+      });
+    },
+    admin(method, target, token, options = {}) {
+      const headers = { ...(token ? { [ADMIN_TOKEN_HEADER]: token } : {}) };
+      if (options.mutation !== false) headers.origin = origin;
+      if (options.body !== undefined) headers["content-type"] = "application/json";
+      return requestOnce(origin, {
+        method,
+        path: `${CLIENT_V1_PREFIX}${target}`,
+        headers: { ...headers, ...(options.headers ?? {}) },
+        ...(options.body !== undefined ? { body: options.body } : {}),
+      });
+    },
+  };
+}
+
+/**
+ * Open one pairing request, retrying once through the creation budget.
+ *
+ * Creation is bounded process-wide at 10 per 60 s, and this run opens several.
+ * A 429 here is the limiter behaving, not a defect, so the helper honours
+ * `Retry-After` once rather than reporting a conformance failure — the budget
+ * itself is asserted deliberately elsewhere.
+ */
+async function createPairing(client, input) {
+  const body = JSON.stringify(input);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const response = await client.request({
+      method: "POST",
+      path: `${CLIENT_V1_PREFIX}/pairing/requests`,
+      headers: { "content-type": "application/json" },
+      body,
+    });
+    if (response.status !== 429) return response;
+    const wait = Number(response.headers["retry-after"] ?? "5");
+    await new Promise((resolve) => setTimeout(resolve, (Number.isFinite(wait) ? wait : 5) * 1000 + 500));
+  }
+  throw new Error("pairing creation stayed rate limited across two attempts");
+}
+
+function pairingInput(installationId, scopes) {
+  return { appName: "Client v1 conformance", installationId, scopes };
+}
+
+/** Drive a pairing all the way to a bearer. Used by the read legs. */
+async function pairApproved(client, adminToken, installationId, scopes) {
+  const created = await createPairing(client, pairingInput(installationId, scopes));
+  if (created.status !== 201) {
+    throw new Error(`pairing creation answered ${created.status}: ${created.text.slice(0, 200)}`);
+  }
+  const { requestId, secret } = created.json.data;
+  const decision = await client.admin("POST", `/admin/pairing-requests/${requestId}/decision`, adminToken, {
+    body: JSON.stringify({ decision: "approved" }),
+  });
+  if (decision.status !== 200) {
+    throw new Error(`approval answered ${decision.status}: ${decision.text.slice(0, 200)}`);
+  }
+  const exchanged = await client.request({
+    method: "POST",
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${requestId}/exchange`,
+    headers: { [PAIRING_SECRET_HEADER]: secret, "content-length": "0" },
+  });
+  if (exchanged.status !== 200) {
+    throw new Error(`exchange answered ${exchanged.status}: ${exchanged.text.slice(0, 200)}`);
+  }
+  return { requestId, secret, bearer: exchanged.json.data.bearer, credential: exchanged.json.data.credential };
+}
+
+/** Follow `cursor.next` to the end, collecting one entry per page. */
+async function walk(client, target, bearer, collection, limit) {
+  const pages = [];
+  let cursor = null;
+  for (let page = 0; page < 50; page += 1) {
+    const query = new URLSearchParams({ limit: String(limit) });
+    if (cursor) query.set("cursor", cursor);
+    const response = await client.read(`${target}?${query.toString()}`, bearer);
+    if (response.status !== 200) {
+      pages.push({ status: response.status, body: response.json, ids: [], hasMore: false });
+      return pages;
+    }
+    const items = response.json?.data?.[collection] ?? [];
+    pages.push({
+      status: 200,
+      body: response.json,
+      items,
+      ids: items.map((item) => item.id),
+      hasMore: response.json?.cursor?.hasMore,
+      next: response.json?.cursor?.next,
+      current: response.json?.cursor?.current,
+    });
+    if (!response.json?.cursor?.next) return pages;
+    cursor = response.json.cursor.next;
+  }
+  throw new Error(`paging ${target} did not terminate within 50 pages`);
+}
+
+// ── legs ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Phase A: a Cave with no `COVEN_CAVE_AUTH_TOKEN`.
+ *
+ * This is the state a plain `pnpm dev` is in, and the doc's stated consequence
+ * is stronger than "the admin routes 503": a client can open a pairing request
+ * and can *never* get it approved. That whole sequence is asserted here,
+ * because the 503 alone reads like an inconvenience rather than a dead end.
+ */
+async function runUnconfiguredAdminLeg(client, recorder) {
+  const probes = [
+    ["GET", "/admin/pairing-requests", undefined],
+    ["GET", "/admin/credentials", undefined],
+    ["POST", `/admin/pairing-requests/${randomUUID()}/decision`, JSON.stringify({ decision: "approved" })],
+    ["DELETE", `/admin/credentials/${randomUUID()}`, JSON.stringify({ reason: "conformance" })],
+  ];
+  for (const [method, target, body] of probes) {
+    const response = await client.admin(method, target, "any-token-at-all", body === undefined ? {} : { body });
+    const failures = [];
+    if (response.status !== 503) failures.push(`${method} ${target} answered ${response.status}, expected 503`);
+    failures.push(...checkEnvelope(response.json, { kind: "error", code: "service_unavailable", retryable: false }));
+    recorder.expect(`admin.unconfigured${target.replace(/\/[0-9a-f-]{36}/, "/:id")}.${method}`, failures);
+  }
+
+  const created = await createPairing(client, pairingInput("conformance-tokenless", ["chat:read"]));
+  recorder.expect(
+    "admin.unconfigured.pairing-still-opens",
+    created.status === 201 ? [] : [`pairing creation answered ${created.status} on a tokenless Cave, expected 201`],
+    "a tokenless Cave still opens pairing requests",
+  );
+  if (created.status === 201) {
+    const { requestId, secret } = created.json.data;
+    const exchanged = await client.request({
+      method: "POST",
+      path: `${CLIENT_V1_PREFIX}/pairing/requests/${requestId}/exchange`,
+      headers: { [PAIRING_SECRET_HEADER]: secret, "content-length": "0" },
+    });
+    const failures = [];
+    if (exchanged.status !== 409) failures.push(`exchange answered ${exchanged.status}, expected 409`);
+    failures.push(...checkEnvelope(exchanged.json, { kind: "error", code: "pairing_pending", retryable: true }));
+    recorder.expect(
+      "admin.unconfigured.exchange-stays-pending",
+      failures,
+      "the documented dead end: no approval route, so the exchange can only ever answer pairing_pending",
+    );
+  }
+}
+
+async function runIngressLeg(client, recorder, adminToken) {
+  // #4855: any client-v1 request target carrying a percent-escape or a
+  // backslash is refused before it is classified — and refused in the proxy's
+  // own shape, NOT the Client v1 envelope, which is the thing a client author
+  // most often gets wrong.
+  for (const [id, target] of [
+    ["percent", `${CLIENT_V1_PREFIX}/pairing/requests/%41`],
+    ["percent-encoded-separator", `${CLIENT_V1_PREFIX}/conversations%2Fx`],
+  ]) {
+    const response = await client.request({ path: target });
+    const failures = [];
+    if (response.status !== 400) failures.push(`answered ${response.status}, expected 400`);
+    if (response.json?.error !== "invalid client v1 path") {
+      failures.push(`body was ${JSON.stringify(response.text.slice(0, 120))}, expected {"ok":false,"error":"invalid client v1 path"}`);
+    }
+    if (response.json?.ok !== false) failures.push("proxy refusal did not carry ok:false");
+    recorder.expect(`ingress.escaped-path.${id}`, failures, target);
+  }
+
+  // A BACKSLASH target never reaches `proxy.ts` at all, so the documented
+  // `400 invalid client v1 path` is not the answer a client sees — measured
+  // 2026-08-22 against this build. Next normalises `\` to `/` in the
+  // request target and answers 308 first, which is why this is written raw:
+  // `http.request` would rewrite the target before it left the process, and the
+  // harness would be asserting against its own client rather than the server.
+  //
+  // The outcome is still safe, and that is what is asserted: the redirect
+  // target is not a client-v1 route, and following it serves nothing. The gap
+  // is between the doc and reality, not in the gate.
+  const backslash = await rawRequestOnce(
+    client.origin,
+    `GET ${CLIENT_V1_PREFIX}/pairing/requests/a\\b HTTP/1.1\r\nHost: ${new URL(client.origin).host}\r\nConnection: close\r\n\r\n`,
+  );
+  const backslashFailures = [];
+  const location = backslash.headers.location;
+  if (backslash.status === 400 && backslash.json?.error === "invalid client v1 path") {
+    // The documented answer. If a later change makes the refusal reachable,
+    // this branch is correct and nothing below needs to run.
+  } else if (backslash.status === 308 && location === `${CLIENT_V1_PREFIX}/pairing/requests/a/b`) {
+    const followed = await client.request({ path: location });
+    if (followed.status === 200) {
+      backslashFailures.push(`following the normalised target ${location} was SERVED (200); a backslash target must not reach a handler`);
+    }
+  } else {
+    backslashFailures.push(
+      `answered ${backslash.status} (location ${JSON.stringify(location)}); expected either the documented 400 refusal or a 308 to the normalised target`,
+    );
+  }
+  recorder.expect(
+    "ingress.backslash-path-reaches-no-handler",
+    backslashFailures,
+    `answered ${backslash.status}; the documented 400 fires for "%" only — see the run's notes`,
+  );
+
+  // A forwarding header is what the listener reads to decide a request is not a
+  // direct loopback peer, so it is the closest this machine can get to a
+  // request arriving from somewhere else without a second machine.
+  const forwarded = { "x-forwarded-for": "203.0.113.7" };
+  const forwardedProbes = [
+    ["public", "/pairing/requests", "forbidden peer: client v1 requires direct loopback"],
+    ["authenticated", "/conversations", "forbidden peer: client v1 requires direct loopback"],
+    ["admin", "/admin/credentials", "forbidden peer: client v1 admin requires direct loopback"],
+  ];
+  for (const [id, target, expected] of forwardedProbes) {
+    const response = await client.request({
+      path: `${CLIENT_V1_PREFIX}${target}`,
+      headers: { ...forwarded, ...(id === "admin" ? { [ADMIN_TOKEN_HEADER]: adminToken } : {}) },
+    });
+    const failures = [];
+    if (response.status !== 403) failures.push(`answered ${response.status}, expected 403`);
+    if (response.json?.error !== expected) {
+      failures.push(`error was ${JSON.stringify(response.json?.error)}, expected ${JSON.stringify(expected)}`);
+    }
+    recorder.expect(`ingress.forwarded.${id}`, failures, `${target} with x-forwarded-for`);
+  }
+
+  // The exchange carries no body, and the single most likely reason a
+  // hand-rolled client fails against a real Cave while passing against the
+  // handler is that it therefore sends no Content-Length. Raw, because the two
+  // ways of "not sending" it are answered differently and only one of them is
+  // this one — see rawRequestOnce.
+  const host = new URL(client.origin).host;
+  const noLength = await rawRequestOnce(
+    client.origin,
+    `POST ${CLIENT_V1_PREFIX}/pairing/requests/${randomUUID()}/exchange HTTP/1.1\r\nHost: ${host}\r\n`
+      + `${PAIRING_SECRET_HEADER}: ${"A".repeat(43)}\r\nConnection: close\r\n\r\n`,
+  );
+  recorder.expect(
+    "ingress.exchange-requires-content-length",
+    noLength.status === 411 && noLength.json?.error === "content-length required"
+      ? []
+      : [`answered ${noLength.status} ${JSON.stringify(noLength.json?.error)}, expected 411 "content-length required"`],
+  );
+
+  const chunked = await rawRequestOnce(
+    client.origin,
+    `POST ${CLIENT_V1_PREFIX}/pairing/requests HTTP/1.1\r\nHost: ${host}\r\nContent-Type: application/json\r\n`
+      + "Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n0\r\n\r\n",
+  );
+  recorder.expect(
+    "ingress.refuses-transfer-encoding",
+    chunked.status === 400 && chunked.json?.error === "invalid content-length"
+      ? []
+      : [`answered ${chunked.status} ${JSON.stringify(chunked.json?.error)}, expected 400 "invalid content-length"`],
+    "a chunked control-plane body has no declared length to cap",
+  );
+
+  // Really oversized, not merely declared oversized: a Content-Length that
+  // overstates the bytes actually written makes the server wait for the rest
+  // and time out, which reads like a 408 rather than the cap firing.
+  const oversized = JSON.stringify({
+    appName: "x",
+    installationId: "x",
+    scopes: ["chat:read"],
+    padding: "p".repeat(70_000),
+  });
+  const capped = await client.request({
+    method: "POST",
+    path: `${CLIENT_V1_PREFIX}/pairing/requests`,
+    headers: { "content-type": "application/json" },
+    body: oversized,
+  });
+  recorder.expect(
+    "ingress.body-cap",
+    capped.status === 413 && capped.json?.error === "request body too large"
+      ? []
+      : [`answered ${capped.status} ${JSON.stringify(capped.json?.error)}, expected 413 "request body too large"`],
+    `${Buffer.byteLength(oversized)} bytes against the 65536-byte control-plane cap`,
+  );
+
+  const wrongType = await client.request({
+    method: "POST",
+    path: `${CLIENT_V1_PREFIX}/pairing/requests`,
+    headers: { "content-type": "text/plain" },
+    body: "{}",
+  });
+  recorder.expect(
+    "ingress.pairing-content-type",
+    wrongType.status === 415 ? [] : [`answered ${wrongType.status}, expected 415`],
+  );
+}
+
+async function runHealthLeg(client, recorder, caveHomeDir) {
+  const first = await client.request({ path: `${CLIENT_V1_PREFIX}/health` });
+  const failures = [];
+  if (first.status !== 200) failures.push(`answered ${first.status}, expected 200`);
+  failures.push(...checkEnvelope(first.json, { kind: "success" }));
+  const dataKeys = Object.keys(first.json?.data ?? {}).sort().join(",");
+  if (dataKeys !== "instanceId,pairingRequired,releaseVersion") {
+    failures.push(`data keys are [${dataKeys}], expected [instanceId,pairingRequired,releaseVersion]`);
+  }
+  if (first.json?.data?.pairingRequired !== true) failures.push("pairingRequired is not true");
+  recorder.expect("health.envelope", failures);
+
+  const second = await client.request({ path: `${CLIENT_V1_PREFIX}/health` });
+  recorder.expect(
+    "health.instance-stable",
+    first.json?.data?.instanceId && first.json.data.instanceId === second.json?.data?.instanceId
+      ? []
+      : ["instanceId is missing or changed between two reads"],
+  );
+
+  // The listener publishes where it actually bound, from inside the listen
+  // callback. It is the only way a client with no configuration finds this
+  // Cave, so a run against a real listener is the only place it can be checked.
+  const discoveryPath = path.join(caveHomeDir, "client-v1-discovery.json");
+  let discovery = null;
+  try {
+    discovery = JSON.parse(await readFile(discoveryPath, "utf8"));
+  } catch (error) {
+    recorder.fail("health.discovery-record", `cannot read ${discoveryPath}: ${error.message}`);
+  }
+  if (discovery) {
+    const discoveryFailures = [];
+    if (discovery.endpoint !== client.origin) {
+      discoveryFailures.push(`endpoint is ${JSON.stringify(discovery.endpoint)}, expected ${client.origin}`);
+    }
+    if (discovery.version !== 1) discoveryFailures.push(`version is ${JSON.stringify(discovery.version)}`);
+    if (typeof discovery.pid !== "number") discoveryFailures.push("pid is missing");
+    recorder.expect("health.discovery-record", discoveryFailures);
+  }
+}
+
+async function runPairingLeg(client, recorder, adminToken, options) {
+  // ── the happy path, end to end ──
+  const created = await createPairing(client, pairingInput("conformance-happy", ["chat:read", "chat:write"]));
+  const createFailures = [];
+  if (created.status !== 201) createFailures.push(`creation answered ${created.status}, expected 201`);
+  createFailures.push(...checkEnvelope(created.json, { kind: "success" }));
+  const issued = created.json?.data ?? {};
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(issued.requestId ?? "")) {
+    createFailures.push(`requestId is not a UUID: ${JSON.stringify(issued.requestId)}`);
+  }
+  if (!/^[A-Za-z0-9_-]{43}$/.test(issued.secret ?? "")) {
+    createFailures.push("secret is not 43 base64url characters");
+  }
+  if (typeof issued.expiresAt !== "number" || Math.abs(issued.expiresAt - Date.now() - PAIRING_TTL_MS) > 30_000) {
+    createFailures.push(`expiresAt ${JSON.stringify(issued.expiresAt)} is not creation + 5 minutes`);
+  }
+  recorder.expect("pairing.create", createFailures);
+  const { requestId, secret } = issued;
+
+  const pendingPoll = await client.request({
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${requestId}`,
+    headers: { [PAIRING_SECRET_HEADER]: secret },
+  });
+  const pendingFailures = [];
+  if (pendingPoll.status !== 200) pendingFailures.push(`poll answered ${pendingPoll.status}, expected 200`);
+  pendingFailures.push(...checkEnvelope(pendingPoll.json, { kind: "success" }));
+  pendingFailures.push(...checkRecordShape(pendingPoll.json?.data, RECORD_SHAPES.pairingStatus, "poll record"));
+  if (pendingPoll.json?.data?.status !== "pending") {
+    pendingFailures.push(`status is ${JSON.stringify(pendingPoll.json?.data?.status)}, expected "pending"`);
+  }
+  recorder.expect("pairing.poll-pending", pendingFailures);
+
+  const queue = await client.admin("GET", "/admin/pairing-requests", adminToken, { mutation: false });
+  const queueFailures = [];
+  if (queue.status !== 200) queueFailures.push(`answered ${queue.status}, expected 200`);
+  const queued = (queue.json?.data?.pairingRequests ?? []).find((entry) => entry.id === requestId);
+  if (!queued) queueFailures.push("the pending request is not in the approval queue");
+  else queueFailures.push(...checkRecordShape(queued, RECORD_SHAPES.pairingRequest, "queued pairing request"));
+  recorder.expect("pairing.admin-queue", queueFailures);
+
+  const approval = await client.admin("POST", `/admin/pairing-requests/${requestId}/decision`, adminToken, {
+    body: JSON.stringify({ decision: "approved" }),
+  });
+  const approvalFailures = [];
+  if (approval.status !== 200) approvalFailures.push(`approval answered ${approval.status}, expected 200`);
+  const approved = approval.json?.data?.pairingRequest;
+  if (approved?.status !== "approved") approvalFailures.push(`status is ${JSON.stringify(approved?.status)}`);
+  if (typeof approved?.decidedAt !== "number") approvalFailures.push("decidedAt was not set");
+  recorder.expect("pairing.admin-approve", approvalFailures);
+
+  const approvedPoll = await client.request({
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${requestId}`,
+    headers: { [PAIRING_SECRET_HEADER]: secret },
+  });
+  recorder.expect(
+    "pairing.poll-approved",
+    approvedPoll.json?.data?.status === "approved" && approvedPoll.status === 200
+      ? []
+      : [`poll answered ${approvedPoll.status} ${JSON.stringify(approvedPoll.json?.data?.status)}, expected 200 "approved"`],
+  );
+
+  // Re-sending the same decision is idempotent; the contradicting one conflicts.
+  const sameAgain = await client.admin("POST", `/admin/pairing-requests/${requestId}/decision`, adminToken, {
+    body: JSON.stringify({ decision: "approved" }),
+  });
+  recorder.expect(
+    "pairing.admin-approve-idempotent",
+    sameAgain.status === 200 && sameAgain.json?.data?.pairingRequest?.decidedAt === approved?.decidedAt
+      ? []
+      : [`re-approval answered ${sameAgain.status} with decidedAt ${JSON.stringify(sameAgain.json?.data?.pairingRequest?.decidedAt)}`],
+  );
+  const contradicting = await client.admin("POST", `/admin/pairing-requests/${requestId}/decision`, adminToken, {
+    body: JSON.stringify({ decision: "denied" }),
+  });
+  const contradictFailures = [];
+  if (contradicting.status !== 409) contradictFailures.push(`answered ${contradicting.status}, expected 409`);
+  contradictFailures.push(
+    ...checkEnvelope(contradicting.json, { kind: "error", code: "conflict", reason: "pairing_already_decided" }),
+  );
+  recorder.expect("pairing.admin-decision-conflict", contradictFailures);
+
+  const exchanged = await client.request({
+    method: "POST",
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${requestId}/exchange`,
+    headers: { [PAIRING_SECRET_HEADER]: secret, "content-length": "0" },
+  });
+  const exchangeFailures = [];
+  if (exchanged.status !== 200) exchangeFailures.push(`exchange answered ${exchanged.status}, expected 200`);
+  exchangeFailures.push(...checkEnvelope(exchanged.json, { kind: "success" }));
+  const bearer = exchanged.json?.data?.bearer;
+  if (!/^[A-Za-z0-9_-]{43}$/.test(bearer ?? "")) exchangeFailures.push("bearer is not 43 base64url characters");
+  exchangeFailures.push(...checkRecordShape(exchanged.json?.data?.credential, RECORD_SHAPES.credential, "issued credential"));
+  const grantedScopes = exchanged.json?.data?.credential?.scopes ?? [];
+  if (grantedScopes.join(",") !== "chat:read,chat:write") {
+    exchangeFailures.push(`granted scopes are [${grantedScopes}], expected the requested [chat:read,chat:write]`);
+  }
+  recorder.expect("pairing.exchange", exchangeFailures);
+
+  const authenticated = await client.read("/projects", bearer);
+  recorder.expect(
+    "pairing.bearer-works",
+    authenticated.status === 200 ? [] : [`an authenticated read answered ${authenticated.status}, expected 200`],
+  );
+
+  // ── replay ──
+  const replay = await client.request({
+    method: "POST",
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${requestId}/exchange`,
+    headers: { [PAIRING_SECRET_HEADER]: secret, "content-length": "0" },
+  });
+  const replayFailures = [];
+  if (replay.status !== 409) replayFailures.push(`replayed exchange answered ${replay.status}, expected 409`);
+  replayFailures.push(...checkEnvelope(replay.json, { kind: "error", code: "conflict", reason: "pairing_replayed" }));
+  recorder.expect("pairing.replay-refused", replayFailures);
+
+  const replayPoll = await client.request({
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${requestId}`,
+    headers: { [PAIRING_SECRET_HEADER]: secret },
+  });
+  recorder.expect(
+    "pairing.poll-after-exchange",
+    replayPoll.status === 409 && replayPoll.json?.error?.details?.reason === "pairing_replayed"
+      ? []
+      : [`poll after exchange answered ${replayPoll.status} ${JSON.stringify(replayPoll.json?.error?.code)}, expected 409 conflict`],
+  );
+
+  // ── denial ──
+  const deniedRequest = await createPairing(client, pairingInput("conformance-denied", ["chat:read"]));
+  const deniedId = deniedRequest.json.data.requestId;
+  const deniedSecret = deniedRequest.json.data.secret;
+  await client.admin("POST", `/admin/pairing-requests/${deniedId}/decision`, adminToken, {
+    body: JSON.stringify({ decision: "denied" }),
+  });
+  const deniedPoll = await client.request({
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${deniedId}`,
+    headers: { [PAIRING_SECRET_HEADER]: deniedSecret },
+  });
+  recorder.expect(
+    "pairing.poll-denied",
+    deniedPoll.json?.data?.status === "denied" ? [] : [`poll reported ${JSON.stringify(deniedPoll.json?.data?.status)}, expected "denied"`],
+  );
+  const deniedExchange = await client.request({
+    method: "POST",
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${deniedId}/exchange`,
+    headers: { [PAIRING_SECRET_HEADER]: deniedSecret, "content-length": "0" },
+  });
+  const deniedFailures = [];
+  if (deniedExchange.status !== 403) deniedFailures.push(`answered ${deniedExchange.status}, expected 403`);
+  deniedFailures.push(...checkEnvelope(deniedExchange.json, { kind: "error", code: "pairing_denied", retryable: false }));
+  recorder.expect("pairing.exchange-denied", deniedFailures);
+
+  // ── an unknown but well-formed id ──
+  const unknown = await client.request({
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${randomUUID()}`,
+    headers: { [PAIRING_SECRET_HEADER]: "A".repeat(43) },
+  });
+  const unknownFailures = [];
+  if (unknown.status !== 404) unknownFailures.push(`answered ${unknown.status}, expected 404`);
+  unknownFailures.push(...checkEnvelope(unknown.json, { kind: "error", code: "not_found" }));
+  recorder.expect("pairing.unknown-id", unknownFailures);
+
+  // ── the wrong secret, and the shared per-pairing budget ──
+  const budgetRequest = await createPairing(client, pairingInput("conformance-budget", ["chat:read"]));
+  const budgetId = budgetRequest.json.data.requestId;
+  const budgetSecret = budgetRequest.json.data.secret;
+  const wrongSecret = budgetSecret === "B".repeat(43) ? "C".repeat(43) : "B".repeat(43);
+
+  const wrongOnExchange = await client.request({
+    method: "POST",
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${budgetId}/exchange`,
+    headers: { [PAIRING_SECRET_HEADER]: wrongSecret, "content-length": "0" },
+  });
+  const wrongFailures = [];
+  if (wrongOnExchange.status !== 401) wrongFailures.push(`answered ${wrongOnExchange.status}, expected 401`);
+  wrongFailures.push(...checkEnvelope(wrongOnExchange.json, { kind: "error", code: "unauthorized" }));
+  recorder.expect("pairing.wrong-secret", wrongFailures, "one wrong secret charged on the exchange route");
+
+  // Polling with the CORRECT secret must stay free, or a client waiting on a
+  // human decision would rate limit itself.
+  for (let poll = 0; poll < 20; poll += 1) {
+    await client.request({
+      path: `${CLIENT_V1_PREFIX}/pairing/requests/${budgetId}`,
+      headers: { [PAIRING_SECRET_HEADER]: budgetSecret },
+    });
+  }
+  const stillPolling = await client.request({
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${budgetId}`,
+    headers: { [PAIRING_SECRET_HEADER]: budgetSecret },
+  });
+  recorder.expect(
+    "pairing.correct-secret-polling-is-free",
+    stillPolling.status === 200 ? [] : [`the 22nd correct-secret poll answered ${stillPolling.status}, expected 200`],
+  );
+
+  // The budget is shared between the poll and the exchange: spend the rest of
+  // it through the POLL route, having already spent one on the EXCHANGE, and
+  // both must then refuse.
+  let sawWrongSecret401 = 0;
+  for (let attempt = 0; attempt < PAIRING_FAILURE_LIMIT - 1; attempt += 1) {
+    const response = await client.request({
+      path: `${CLIENT_V1_PREFIX}/pairing/requests/${budgetId}`,
+      headers: { [PAIRING_SECRET_HEADER]: wrongSecret },
+    });
+    if (response.status === 401) sawWrongSecret401 += 1;
+  }
+  recorder.expect(
+    "pairing.budget-charges-wrong-secret-on-poll",
+    sawWrongSecret401 === PAIRING_FAILURE_LIMIT - 1
+      ? []
+      : [`${sawWrongSecret401} of ${PAIRING_FAILURE_LIMIT - 1} wrong-secret polls answered 401`],
+  );
+
+  const exhaustedPoll = await client.request({
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${budgetId}`,
+    headers: { [PAIRING_SECRET_HEADER]: budgetSecret },
+  });
+  const limitFailures = [];
+  if (exhaustedPoll.status !== 429) limitFailures.push(`answered ${exhaustedPoll.status}, expected 429`);
+  limitFailures.push(...checkEnvelope(exhaustedPoll.json, { kind: "error", code: "rate_limited", retryable: true }));
+  if (!exhaustedPoll.headers["retry-after"]) limitFailures.push("no Retry-After header");
+  const details = exhaustedPoll.json?.error?.details ?? {};
+  if (details.limit !== String(PAIRING_FAILURE_LIMIT)) {
+    limitFailures.push(`details.limit is ${JSON.stringify(details.limit)}, expected "${PAIRING_FAILURE_LIMIT}"`);
+  }
+  if (typeof details.resetAt !== "string") limitFailures.push("details.resetAt is not a string");
+  recorder.expect(
+    "pairing.budget-locks-out-the-holder",
+    limitFailures,
+    "ten wrong secrets across BOTH routes; the correct secret is refused too",
+  );
+
+  const exhaustedExchange = await client.request({
+    method: "POST",
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${budgetId}/exchange`,
+    headers: { [PAIRING_SECRET_HEADER]: budgetSecret, "content-length": "0" },
+  });
+  recorder.expect(
+    "pairing.budget-is-shared-across-routes",
+    exhaustedExchange.status === 429
+      ? []
+      : [`the exchange answered ${exhaustedExchange.status} after the budget was spent on the poll route, expected 429`],
+  );
+
+  // A different pairing must be untouched — the lockout is per pairing.
+  const neighbour = await createPairing(client, pairingInput("conformance-neighbour", ["chat:read"]));
+  const neighbourPoll = await client.request({
+    path: `${CLIENT_V1_PREFIX}/pairing/requests/${neighbour.json.data.requestId}`,
+    headers: { [PAIRING_SECRET_HEADER]: neighbour.json.data.secret },
+  });
+  recorder.expect(
+    "pairing.budget-is-per-pairing",
+    neighbourPoll.status === 200 ? [] : [`an unrelated pairing answered ${neighbourPoll.status}, expected 200`],
+  );
+
+  // ── the TTL, only when asked for ──
+  if (options.includeTtl) {
+    const expiring = await createPairing(client, pairingInput("conformance-ttl", ["chat:read"]));
+    const expiringId = expiring.json.data.requestId;
+    const expiringSecret = expiring.json.data.secret;
+    await new Promise((resolve) => setTimeout(resolve, PAIRING_TTL_MS + 5_000));
+    const expiredPoll = await client.request({
+      path: `${CLIENT_V1_PREFIX}/pairing/requests/${expiringId}`,
+      headers: { [PAIRING_SECRET_HEADER]: expiringSecret },
+    });
+    recorder.expect(
+      "pairing.ttl-poll-expired",
+      expiredPoll.status === 200 && expiredPoll.json?.data?.status === "expired"
+        ? []
+        : [`poll answered ${expiredPoll.status} ${JSON.stringify(expiredPoll.json?.data?.status)}, expected 200 "expired"`],
+    );
+    const expiredExchange = await client.request({
+      method: "POST",
+      path: `${CLIENT_V1_PREFIX}/pairing/requests/${expiringId}/exchange`,
+      headers: { [PAIRING_SECRET_HEADER]: expiringSecret, "content-length": "0" },
+    });
+    const ttlFailures = [];
+    if (expiredExchange.status !== 410) ttlFailures.push(`answered ${expiredExchange.status}, expected 410`);
+    ttlFailures.push(...checkEnvelope(expiredExchange.json, { kind: "error", code: "pairing_expired" }));
+    recorder.expect("pairing.ttl-exchange-expired", ttlFailures);
+  } else {
+    recorder.skip(
+      "pairing.ttl-expiry",
+      "the 5-minute TTL is real time and there is no clock seam from outside the process; re-run with --include-ttl",
+    );
+  }
+
+  return { bearer, credentialId: exchanged.json?.data?.credential?.id };
+}
+
+async function runAdminAuthLeg(client, recorder, adminToken) {
+  // A wrong or absent admin token is refused 401 by the PROXY's ordinary
+  // sidecar-token gate, in the proxy's `{"ok":false,"error":…}` shape — not by
+  // `requireClientV1Admin`, whose own `unauthorized` envelope is therefore
+  // unreachable over a real socket on a Cave that has a token configured.
+  // Measured 2026-08-22; the doc describes the route's answer, which is the one
+  // a handler-level test sees and a client never does.
+  //
+  // Asserted as the proxy shape rather than "corrected" to the envelope,
+  // because the point of a real-authority run is to record what the wire does.
+  for (const [id, token] of [["wrong-token", "not-the-token"], ["no-token", null]]) {
+    const response = await client.admin("GET", "/admin/credentials", token, { mutation: false });
+    const failures = [];
+    if (response.status !== 401) failures.push(`answered ${response.status}, expected 401`);
+    if (response.json?.ok !== false || response.json?.error !== "unauthorized") {
+      failures.push(`body was ${JSON.stringify(response.text.slice(0, 160))}, expected the proxy refusal {"ok":false,"error":"unauthorized"}`);
+    }
+    recorder.expect(`admin.${id}`, failures, "refused by the proxy's sidecar gate, ahead of requireClientV1Admin");
+  }
+
+  // A mutation carrying neither Origin nor Referer is refused; the non-browser
+  // caller that sends no source header at all is exactly what that rule stops.
+  const sourceless = await client.request({
+    method: "POST",
+    path: `${CLIENT_V1_PREFIX}/admin/pairing-requests/${randomUUID()}/decision`,
+    headers: { [ADMIN_TOKEN_HEADER]: adminToken, "content-type": "application/json" },
+    body: JSON.stringify({ decision: "approved" }),
+  });
+  const sourceFailures = [];
+  if (sourceless.status !== 403) sourceFailures.push(`answered ${sourceless.status}, expected 403`);
+  sourceFailures.push(...checkEnvelope(sourceless.json, { kind: "error", code: "scope_denied" }));
+  recorder.expect("admin.mutation-requires-source", sourceFailures);
+}
+
+async function runRevocationLeg(client, recorder, adminToken, credentialId, bearer) {
+  const before = await client.read("/projects", bearer);
+  recorder.expect(
+    "revocation.bearer-works-before",
+    before.status === 200 ? [] : [`the credential answered ${before.status} before revocation, expected 200`],
+  );
+
+  const listed = await client.admin("GET", "/admin/credentials", adminToken, { mutation: false });
+  const listFailures = [];
+  const record = (listed.json?.data?.credentials ?? []).find((entry) => entry.id === credentialId);
+  if (!record) listFailures.push("the issued credential is not in the admin listing");
+  else listFailures.push(...checkRecordShape(record, RECORD_SHAPES.credential, "listed credential"));
+  recorder.expect("revocation.admin-listing", listFailures);
+
+  const revoked = await client.admin("DELETE", `/admin/credentials/${credentialId}`, adminToken, {
+    body: JSON.stringify({ reason: "client-v1 conformance run" }),
+  });
+  const revokeFailures = [];
+  if (revoked.status !== 200) revokeFailures.push(`answered ${revoked.status}, expected 200`);
+  const tombstone = revoked.json?.data?.credential;
+  revokeFailures.push(...checkRecordShape(tombstone, RECORD_SHAPES.credential, "revoked credential"));
+  if (typeof tombstone?.revokedAt !== "number") revokeFailures.push("revokedAt was not set");
+  if (tombstone?.revocationReason !== "client-v1 conformance run") {
+    revokeFailures.push(`revocationReason is ${JSON.stringify(tombstone?.revocationReason)}`);
+  }
+  recorder.expect("revocation.revoke", revokeFailures);
+
+  const after = await client.read("/projects", bearer);
+  const afterFailures = [];
+  if (after.status !== 401) afterFailures.push(`the revoked credential answered ${after.status}, expected 401`);
+  afterFailures.push(...checkEnvelope(after.json, { kind: "error", code: "unauthorized" }));
+  recorder.expect("revocation.bearer-refused-after", afterFailures);
+
+  const again = await client.admin("DELETE", `/admin/credentials/${credentialId}`, adminToken, {
+    body: JSON.stringify({ reason: "second revocation" }),
+  });
+  recorder.expect(
+    "revocation.is-idempotent",
+    again.status === 200 && again.json?.data?.credential?.revocationReason === "client-v1 conformance run"
+      ? []
+      : [`re-revocation answered ${again.status} with reason ${JSON.stringify(again.json?.data?.credential?.revocationReason)}, expected the original tombstone`],
+  );
+
+  const missing = await client.admin("DELETE", `/admin/credentials/${randomUUID()}`, adminToken, {
+    body: JSON.stringify({ reason: "no such credential" }),
+  });
+  recorder.expect(
+    "revocation.unknown-credential",
+    missing.status === 404 ? [] : [`answered ${missing.status}, expected 404`],
+  );
+
+  // The store is a file, and the audit trail surviving on disk is the point of
+  // a tombstone. Read it back through the admin route on a fresh reload rather
+  // than trusting the response we just got.
+  const reloaded = await client.admin("GET", "/admin/credentials", adminToken, { mutation: false });
+  const persisted = (reloaded.json?.data?.credentials ?? []).find((entry) => entry.id === credentialId);
+  recorder.expect(
+    "revocation.tombstone-persists",
+    persisted && typeof persisted.revokedAt === "number"
+      ? []
+      : ["the revoked credential is absent or unrevoked after a store reload"],
+  );
+}
+
+async function runEmptyReadsLeg(client, recorder, bearer) {
+  for (const [target, collection] of [["/projects", "projects"], ["/conversations", "conversations"]]) {
+    const response = await client.read(target, bearer);
+    const failures = [];
+    if (response.status !== 200) failures.push(`answered ${response.status}, expected 200`);
+    failures.push(...checkEnvelope(response.json, { kind: "success" }));
+    failures.push(...checkEmptyFirstPage(response.json, collection));
+    recorder.expect(`reads.empty-first-page${target}`, failures);
+  }
+}
+
+async function runAuthFailureLeg(client, recorder, bearer, writeOnlyBearer) {
+  const noBearer = await client.read("/conversations", null);
+  const noBearerFailures = [];
+  if (noBearer.status !== 401) noBearerFailures.push(`answered ${noBearer.status}, expected 401`);
+  noBearerFailures.push(...checkEnvelope(noBearer.json, { kind: "error", code: "unauthorized" }));
+  recorder.expect("reads.no-bearer", noBearerFailures);
+
+  const garbage = await client.read("/conversations", "not-a-real-bearer");
+  recorder.expect(
+    "reads.unknown-bearer",
+    garbage.status === 401 ? [] : [`answered ${garbage.status}, expected 401`],
+  );
+
+  // A credential in the query string must not work — the doc says header only,
+  // and a credential in a URL survives in logs and Referer headers.
+  const inQuery = await client.read(`/conversations?bearer=${bearer}`, null);
+  recorder.expect(
+    "reads.bearer-not-accepted-in-query",
+    inQuery.status === 400 || inQuery.status === 401
+      ? []
+      : [`a bearer in the query string answered ${inQuery.status}, expected a refusal`],
+  );
+
+  const scopeDenied = await client.read("/conversations", writeOnlyBearer);
+  const scopeFailures = [];
+  if (scopeDenied.status !== 403) scopeFailures.push(`answered ${scopeDenied.status}, expected 403`);
+  scopeFailures.push(...checkEnvelope(scopeDenied.json, { kind: "error", code: "scope_denied" }));
+  recorder.expect("reads.scope-denied", scopeFailures, "a credential without chat:read");
+}
+
+async function runFamiliarsLeg(client, recorder, bearer) {
+  const response = await client.read("/familiars", bearer);
+  const failures = [];
+  if (response.status !== 200) failures.push(`answered ${response.status}, expected 200`);
+  failures.push(...checkEnvelope(response.json, { kind: "success" }));
+  const familiars = response.json?.data?.familiars ?? [];
+  const ids = familiars.map((entry) => entry.id);
+  const expected = FIXTURE_ROSTER.map((entry) => entry.id).sort();
+  if (ids.join(",") !== expected.join(",")) {
+    failures.push(`served [${ids}] in that order, expected the id-ascending [${expected}]`);
+  }
+  for (const familiar of familiars) {
+    failures.push(...checkRecordShape(familiar, RECORD_SHAPES.familiar, `familiar ${familiar.id}`));
+  }
+  const archivist = familiars.find((entry) => entry.id === "archivist");
+  if (archivist?.lastSeenAt !== "not-an-instant") {
+    failures.push("lastSeenAt was not passed through verbatim from the daemon");
+  }
+  if (archivist?.activeSessions !== 2) failures.push("activeSessions was not projected");
+  recorder.expect("reads.familiars", failures, "against a loopback fixture daemon, not the production daemon");
+
+  const paged = await walk(client, "/familiars", bearer, "familiars", 2);
+  recorder.expect(
+    "reads.familiars-paging",
+    checkPageWalk(paged, { limit: 2, expectedIds: expected }),
+  );
+}
+
+async function runProjectsLeg(client, recorder, bearer, caveHomeDir) {
+  const projects = fixtureProjects();
+  // createdAt descending, id descending on a tie.
+  const expectedIds = [...projects]
+    .sort((left, right) => (left.createdAt < right.createdAt ? 1 : left.createdAt > right.createdAt ? -1 : 0))
+    .map((project) => project.id);
+
+  const single = await client.read("/projects?limit=100", bearer);
+  const shapeFailures = [];
+  for (const project of single.json?.data?.projects ?? []) {
+    shapeFailures.push(...checkRecordShape(project, RECORD_SHAPES.project, `project ${project.id}`));
+  }
+  if ((single.json?.data?.projects ?? []).length !== projects.length) {
+    shapeFailures.push(`limit=100 served ${single.json?.data?.projects?.length} of ${projects.length} rows`);
+  }
+  if ("cursor" in (single.json ?? {}) && single.json.cursor?.hasMore !== false) {
+    shapeFailures.push("a first page holding the whole set reported hasMore true");
+  }
+  recorder.expect("reads.projects-shape", shapeFailures);
+
+  // 7 rows at limit 3 → 3 / 3 / 1: a partial final page.
+  const partial = await walk(client, "/projects", bearer, "projects", 3);
+  recorder.expect(
+    "reads.projects-paging-partial-final-page",
+    checkPageWalk(partial, { limit: 3, expectedIds }),
+    `${partial.length} pages of at most 3 over ${projects.length} rows`,
+  );
+
+  // Re-sending a cursor returns the same page rather than advancing.
+  if (partial[0]?.next) {
+    const first = await client.read(`/projects?limit=3&cursor=${encodeURIComponent(partial[0].next)}`, bearer);
+    const second = await client.read(`/projects?limit=3&cursor=${encodeURIComponent(partial[0].next)}`, bearer);
+    const ids = (page) => (page.json?.data?.projects ?? []).map((project) => project.id).join(",");
+    recorder.expect(
+      "reads.cursor-replay-is-stable",
+      ids(first) === ids(second) && ids(first) === partial[1]?.ids.join(",")
+        ? []
+        : [`replaying one cursor served [${ids(first)}] then [${ids(second)}], expected [${partial[1]?.ids}] both times`],
+    );
+    recorder.expect(
+      "reads.cursor-current-echoes-the-token",
+      first.json?.cursor?.current === partial[0].next
+        ? []
+        : [`cursor.current is ${JSON.stringify(first.json?.cursor?.current)}, expected the token that was sent`],
+    );
+  }
+
+  // The cursor names a position in the ordering, not an index, so deleting the
+  // record it names must not strand the walk.
+  if (partial[0]?.next) {
+    const strandedToken = partial[0].next;
+    const deletedId = partial[0].ids[partial[0].ids.length - 1];
+    await writeProjects(caveHomeDir, projects.filter((project) => project.id !== deletedId));
+    const resumed = await client.read(`/projects?limit=3&cursor=${encodeURIComponent(strandedToken)}`, bearer);
+    const resumedIds = (resumed.json?.data?.projects ?? []).map((project) => project.id);
+    recorder.expect(
+      "reads.cursor-survives-deletion",
+      resumed.status === 200 && resumedIds.join(",") === partial[1]?.ids.join(",")
+        ? []
+        : [`after deleting ${deletedId} (the row the cursor names) the walk served [${resumedIds}], expected [${partial[1]?.ids}]`],
+      "the token records a position in the ordering, not an index",
+    );
+    await writeProjects(caveHomeDir, projects);
+  }
+
+  // 6 of 7 at limit 3 is an exact multiple: the final full page must report
+  // hasMore false rather than publishing a token to an empty page.
+  await writeProjects(caveHomeDir, projects.slice(0, 6));
+  const exact = await walk(client, "/projects", bearer, "projects", 3);
+  const exactExpected = expectedIds.filter((id) => projects.slice(0, 6).some((project) => project.id === id));
+  recorder.expect(
+    "reads.projects-paging-exact-multiple",
+    [
+      ...checkPageWalk(exact, { limit: 3, expectedIds: exactExpected }),
+      ...(exact.length === 2 ? [] : [`walked ${exact.length} pages over 6 rows at limit 3, expected exactly 2`]),
+    ],
+  );
+  await writeProjects(caveHomeDir, projects);
+}
+
+async function runQueryRefusalLeg(client, recorder, bearer) {
+  const refusals = [
+    ["limit-zero", "/projects?limit=0"],
+    ["limit-over-ceiling", `/projects?limit=${MAX_PAGE_SIZE + 1}`],
+    ["limit-leading-zero", "/projects?limit=01"],
+    ["limit-exponent", "/projects?limit=1e2"],
+    ["limit-signed", "/projects?limit=%2B5"],
+    ["limit-repeated", "/projects?limit=1&limit=2"],
+    ["unsupported-parameter", "/projects?limt=5"],
+    ["offset", "/projects?offset=1"],
+    ["cursor-outside-alphabet", "/projects?cursor=not*base64url"],
+    ["cursor-not-canonical", "/projects?cursor=eyJ2IjoxfQ=="],
+  ];
+  for (const [id, target] of refusals) {
+    const response = await client.read(target, bearer);
+    const failures = [];
+    if (response.status !== 400) failures.push(`answered ${response.status}, expected 400`);
+    failures.push(...checkEnvelope(response.json, { kind: "error", code: "invalid_request" }));
+    recorder.expect(`reads.refuses.${id}`, failures, target);
+  }
+
+  const ceiling = await client.read(`/projects?limit=${MAX_PAGE_SIZE}`, bearer);
+  recorder.expect(
+    "reads.limit-ceiling-is-served",
+    ceiling.status === 200 ? [] : [`limit=${MAX_PAGE_SIZE} answered ${ceiling.status}, expected 200`],
+  );
+
+  const defaulted = await client.read("/projects", bearer);
+  recorder.expect(
+    "reads.default-page-size",
+    (defaulted.json?.data?.projects ?? []).length <= DEFAULT_PAGE_SIZE
+      ? []
+      : [`an unqualified read served more than the ${DEFAULT_PAGE_SIZE} default`],
+  );
+}
+
+async function runConversationsLeg(client, recorder, bearer, caveHomeDir) {
+  const conversations = fixtureConversations();
+  const expectedIds = [...conversations]
+    .sort((left, right) => (left.updatedAt < right.updatedAt ? 1 : left.updatedAt > right.updatedAt ? -1 : 0))
+    .map((conversation) => conversation.sessionId);
+
+  const listed = await client.read("/conversations?limit=100", bearer);
+  const failures = [];
+  if (listed.status !== 200) failures.push(`answered ${listed.status}, expected 200`);
+  const rows = listed.json?.data?.conversations ?? [];
+  for (const row of rows) {
+    failures.push(...checkRecordShape(row, RECORD_SHAPES.conversation, `conversation ${row.id}`));
+  }
+  if (rows.map((row) => row.id).join(",") !== expectedIds.join(",")) {
+    failures.push(`served [${rows.map((row) => row.id)}], expected the updatedAt-descending [${expectedIds}]`);
+  }
+  recorder.expect("reads.conversations-shape", failures);
+
+  // 6 rows at limit 3 is an exact multiple.
+  const paged = await walk(client, "/conversations", bearer, "conversations", 3);
+  recorder.expect(
+    "reads.conversations-paging",
+    checkPageWalk(paged, { limit: 3, expectedIds }),
+  );
+
+  // The one-record route: same projection, no query parameters at all.
+  const one = await client.read(`/conversations/${expectedIds[0]}`, bearer);
+  const oneFailures = [];
+  if (one.status !== 200) oneFailures.push(`answered ${one.status}, expected 200`);
+  oneFailures.push(...checkRecordShape(one.json?.data?.conversation, RECORD_SHAPES.conversation, "single conversation"));
+  const fromList = rows.find((row) => row.id === expectedIds[0]);
+  if (JSON.stringify(one.json?.data?.conversation) !== JSON.stringify(fromList)) {
+    oneFailures.push("the single-record route and the list route disagree about the same conversation");
+  }
+  recorder.expect("reads.conversation-by-id", oneFailures);
+
+  for (const [id, parameter] of [["limit", "limit=5"], ["cursor", "cursor=x"]]) {
+    const response = await client.read(`/conversations/${expectedIds[0]}?${parameter}`, bearer);
+    const queryFailures = [];
+    if (response.status !== 400) queryFailures.push(`answered ${response.status}, expected 400`);
+    queryFailures.push(...checkEnvelope(response.json, { kind: "error", code: "invalid_request" }));
+    recorder.expect(`reads.conversation-by-id-refuses-${id}`, queryFailures);
+  }
+
+  const absent = await client.read("/conversations/no-such-conversation", bearer);
+  const absentFailures = [];
+  if (absent.status !== 404) absentFailures.push(`answered ${absent.status}, expected 404`);
+  absentFailures.push(...checkEnvelope(absent.json, { kind: "error", code: "not_found" }));
+  recorder.expect("reads.conversation-by-id-not-found", absentFailures);
+
+  // ── the mutable page key ──
+  //
+  // `/conversations` keys on `updatedAt`, which moves while a client pages. The
+  // doc says a touched conversation "can appear in two pages"; what this
+  // measures is the other side of the same coin, and it is the one that costs a
+  // client data — a conversation that has NOT been served yet is touched, jumps
+  // above the open cursor, and is never served by the rest of the walk. The
+  // assertion is written against the measured behaviour rather than the
+  // sentence, and the discrepancy is reported rather than asserted away.
+  const firstPage = await walk(client, "/conversations", bearer, "conversations", 2);
+  const openToken = firstPage[0]?.next;
+  const untouchedRest = firstPage.slice(1).flatMap((page) => page.ids);
+  const touchedId = untouchedRest[untouchedRest.length - 1];
+  if (openToken && touchedId) {
+    const touched = conversations.find((conversation) => conversation.sessionId === touchedId);
+    await writeConversation(caveHomeDir, { ...touched, updatedAt: "2026-12-31T00:00:00.000Z" });
+    const resumed = await client.read(`/conversations?limit=2&cursor=${encodeURIComponent(openToken)}`, bearer);
+    const resumedIds = (resumed.json?.data?.conversations ?? []).map((row) => row.id);
+    recorder.expect(
+      "reads.conversations-mutable-key-moves-a-row",
+      resumed.status === 200 && !resumedIds.includes(touchedId)
+        ? []
+        : [`after touching the unserved ${touchedId} the walk served [${resumedIds}] (status ${resumed.status}); it was expected to have moved above the open cursor`],
+      "a touched, not-yet-served conversation leaves the window; deduplicate and re-read from the top",
+    );
+    await writeConversation(caveHomeDir, touched);
+  } else {
+    recorder.skip("reads.conversations-mutable-key-moves-a-row", "the ledger did not page at limit 2");
+  }
+}
+
+async function runMessagesLeg(client, recorder, bearer, caveHomeDir) {
+  const conversation = fixtureBranchedConversation();
+  await writeConversation(caveHomeDir, conversation);
+
+  const all = await client.read("/conversations/branched/messages?limit=100", bearer);
+  const failures = [];
+  if (all.status !== 200) failures.push(`answered ${all.status}, expected 200`);
+  const messages = all.json?.data?.messages ?? [];
+  if (messages.map((message) => message.id).join(",") !== BRANCHED_ACTIVE_SEQUENCE.join(",")) {
+    failures.push(`served [${messages.map((message) => message.id)}], expected the active branch [${BRANCHED_ACTIVE_SEQUENCE}]`);
+  }
+  for (const message of messages) {
+    failures.push(...checkRecordShape(message, RECORD_SHAPES.message, `message ${message.id}`));
+    if (message.conversationId !== "branched") {
+      failures.push(`message ${message.id} carries conversationId ${JSON.stringify(message.conversationId)}`);
+    }
+  }
+  if (messages[0]?.parentId !== null) failures.push("the root turn's parentId is not null");
+  recorder.expect("reads.messages-active-branch", failures, "the abandoned branch turn b-x1 must be absent");
+
+  const paged = await walk(client, "/conversations/branched/messages", bearer, "messages", 2);
+  recorder.expect(
+    "reads.messages-paging",
+    checkPageWalk(paged, { limit: 2, expectedIds: BRANCHED_ACTIVE_SEQUENCE }),
+  );
+
+  // Counts, not contents: the fixture's assistant turns in the LEDGER carry
+  // tools and attachments; this transcript's do not, so assert the counts are
+  // present and zero rather than assuming a leak would show as a wrong number.
+  const countsOk = messages.every(
+    (message) => typeof message.attachmentCount === "number" && typeof message.toolCount === "number",
+  );
+  recorder.expect(
+    "reads.messages-counts-not-contents",
+    countsOk ? [] : ["attachmentCount/toolCount are not both numbers on every turn"],
+  );
+
+  // ── the branch moving under an open cursor ──
+  const openToken = paged[0]?.next;
+  if (openToken) {
+    await writeConversation(caveHomeDir, { ...conversation, activeLeafId: "b-x1" });
+    const reconcile = await client.read(
+      `/conversations/branched/messages?limit=2&cursor=${encodeURIComponent(openToken)}`,
+      bearer,
+    );
+    const reconcileFailures = [];
+    if (reconcile.status !== 409) reconcileFailures.push(`answered ${reconcile.status}, expected 409`);
+    reconcileFailures.push(
+      ...checkEnvelope(reconcile.json, {
+        kind: "error",
+        code: "reconcile_required",
+        retryable: false,
+        reason: "resume_from_canonical_state",
+      }),
+    );
+    recorder.expect(
+      "reads.messages-reconcile-required",
+      reconcileFailures,
+      "activeLeafId moved to the abandoned branch, so the cursor names a turn that is no longer on it",
+    );
+
+    // Restarting the read from the top must succeed on the new branch.
+    const restarted = await client.read("/conversations/branched/messages?limit=100", bearer);
+    const restartedIds = (restarted.json?.data?.messages ?? []).map((message) => message.id);
+    recorder.expect(
+      "reads.messages-restart-after-reconcile",
+      restarted.status === 200 && restartedIds.join(",") === "b-r1,b-x1"
+        ? []
+        : [`restarting served [${restartedIds}] (status ${restarted.status}), expected [b-r1,b-x1]`],
+    );
+    await writeConversation(caveHomeDir, conversation);
+  } else {
+    recorder.skip("reads.messages-reconcile-required", "the transcript did not page at limit 2");
+  }
+
+  const absent = await client.read("/conversations/no-such-conversation/messages", bearer);
+  recorder.expect(
+    "reads.messages-not-found",
+    absent.status === 404 ? [] : [`answered ${absent.status}, expected 404`],
+  );
+
+  // A conversation resolves to a FILE, so on a case-insensitive filesystem a
+  // differently-spelled id answers — with the transcript's own id, never the
+  // spelling that was asked for. Conditional because the answer depends on the
+  // filesystem this runs on, and a skip states that honestly.
+  const mixedCase = await client.read("/conversations/BRANCHED/messages?limit=1", bearer);
+  if (mixedCase.status === 200) {
+    recorder.expect(
+      "reads.messages-canonical-conversation-id",
+      mixedCase.json?.data?.messages?.[0]?.conversationId === "branched"
+        ? []
+        : [`conversationId is ${JSON.stringify(mixedCase.json?.data?.messages?.[0]?.conversationId)}, expected the transcript's own "branched"`],
+    );
+  } else {
+    recorder.skip(
+      "reads.messages-canonical-conversation-id",
+      `this filesystem is case-sensitive: /conversations/BRANCHED/messages answered ${mixedCase.status}`,
+    );
+  }
+}
+
+// ── the run ──────────────────────────────────────────────────────────────────
+
+/**
+ * The commit the run drove, or null.
+ *
+ * A conformance record is a claim about *which bytes* answered, so it has to
+ * name them — the same discipline docs/workflows/release-acceptance.md applies
+ * to artifact digests. Null rather than a throw when git cannot answer: a
+ * checkout-less environment is a reason for a record to say "unknown", not a
+ * reason for the run to fail after it has already done the work.
+ */
+export function currentCommit(cwd = repositoryRoot) {
+  if (process.env.GITHUB_SHA) return process.env.GITHUB_SHA;
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function renderConformanceRecord(entries, context) {
+  const summary = summarizeConformance(entries);
+  return {
+    harness: "scripts/client-v1-conformance.mjs",
+    issues: ["OpenCoven/coven-cave#4832", "OpenCoven/coven-cave#4838"],
+    scope: "cave-only",
+    ranAt: context.ranAt,
+    caveVersion: context.caveVersion,
+    commit: context.commit,
+    platform: context.platform,
+    nodeVersion: process.version,
+    includeTtl: context.includeTtl,
+    notCovered: context.notCovered,
+    findings: context.findings,
+    summary,
+    assertions: entries,
+  };
+}
+
+async function main(argv) {
+  const options = parseConformanceArgs(argv);
+  const recorder = createRecorder();
+
+  if (!existsSync(path.join(repositoryRoot, "server.mjs")) || !existsSync(path.join(repositoryRoot, ".next", "BUILD_ID"))) {
+    throw new Error("no release build found; run `pnpm build` first (this run must drive the assembled artifact, not a dev server)");
+  }
+  const manifest = JSON.parse(await readFile(path.join(repositoryRoot, "package.json"), "utf8"));
+
+  const fixtureRoot = await mkdtemp(path.join(tmpdir(), "cave-client-v1-conformance-"));
+  const covenHomeDir = path.join(fixtureRoot, "coven");
+  const caveHomeDir = path.join(covenHomeDir, "cave");
+  const adminToken = `conformance-${randomUUID()}`;
+  const daemon = await startFixtureDaemon(FIXTURE_ROSTER);
+  let server = null;
+  let port = 0;
+
+  try {
+    await seedFixture({ caveHomeDir, covenHomeDir, daemonUrl: daemon.url });
+
+    // ── phase A: no COVEN_CAVE_AUTH_TOKEN ──
+    port = await freePort();
+    server = await startCave({ port, caveHomeDir, covenHomeDir, adminToken: null });
+    console.log(`client-v1-conformance: phase A (no admin token) on ${server.origin}`);
+    await runUnconfiguredAdminLeg(createClient(server.origin), recorder);
+    await stopCave(server, port);
+    server = null;
+
+    // ── phase B: a configured Cave ──
+    port = await freePort();
+    server = await startCave({ port, caveHomeDir, covenHomeDir, adminToken });
+    console.log(`client-v1-conformance: phase B (admin token configured) on ${server.origin}`);
+    const client = createClient(server.origin);
+
+    await runHealthLeg(client, recorder, caveHomeDir);
+    await runIngressLeg(client, recorder, adminToken);
+    await runAdminAuthLeg(client, recorder, adminToken);
+
+    const paired = await runPairingLeg(client, recorder, adminToken, options);
+
+    // The read legs need their own credential: the pairing leg's is about to be
+    // revoked, and a read failing because of that would be indistinguishable
+    // from a read failing on its own.
+    const reader = await pairApproved(client, adminToken, "conformance-reader", ["chat:read"]);
+    const writer = await pairApproved(client, adminToken, "conformance-writer", ["chat:write"]);
+
+    await runEmptyReadsLeg(client, recorder, reader.bearer);
+    await runAuthFailureLeg(client, recorder, reader.bearer, writer.bearer);
+    await runFamiliarsLeg(client, recorder, reader.bearer);
+
+    await writeProjects(caveHomeDir, fixtureProjects());
+    for (const conversation of fixtureConversations()) {
+      await writeConversation(caveHomeDir, conversation);
+    }
+
+    await runProjectsLeg(client, recorder, reader.bearer, caveHomeDir);
+    await runQueryRefusalLeg(client, recorder, reader.bearer);
+    await runConversationsLeg(client, recorder, reader.bearer, caveHomeDir);
+    await runMessagesLeg(client, recorder, reader.bearer, caveHomeDir);
+
+    await runRevocationLeg(client, recorder, adminToken, paired.credentialId, paired.bearer);
+  } finally {
+    if (server) await stopCave(server, port).catch((error) => console.error(`client-v1-conformance: ${error.message}`));
+    await daemon.stop();
+    if (!options.keepFixture) await rm(fixtureRoot, { recursive: true, force: true });
+    else console.log(`client-v1-conformance: fixture kept at ${fixtureRoot}`);
+  }
+
+  for (const entry of recorder.entries) {
+    const mark = entry.result === "pass" ? "ok" : entry.result === "skip" ? "skip" : "FAIL";
+    console.log(`${mark} ${entry.id}${entry.detail ? ` — ${entry.detail}` : ""}`);
+  }
+  const summary = summarizeConformance(recorder.entries);
+  console.log(
+    `client-v1-conformance: ${summary.status} (${summary.passed} passed, ${summary.failed} failed, ${summary.skipped} skipped)`,
+  );
+
+  if (options.out) {
+    const record = renderConformanceRecord(recorder.entries, {
+      ranAt: new Date().toISOString(),
+      caveVersion: manifest.version,
+      commit: currentCommit(),
+      platform: `${process.platform}-${process.arch}`,
+      includeTtl: options.includeTtl,
+      notCovered: NOT_COVERED,
+      findings: FINDINGS,
+    });
+    await mkdir(path.dirname(path.resolve(repositoryRoot, options.out)), { recursive: true });
+    await writeFile(path.resolve(repositoryRoot, options.out), `${JSON.stringify(record, null, 2)}\n`, "utf8");
+    console.log(`client-v1-conformance: evidence written to ${options.out}`);
+  }
+
+  return summary.failed > 0 ? 1 : 0;
+}
+
+/**
+ * What a green run does NOT mean. Carried into the evidence record so the file
+ * cannot be read as broader coverage than it is.
+ */
+export const FINDINGS = [
+  {
+    id: "backslash-refusal-is-unreachable",
+    where: "docs/api/client-v1.md — Reaching the API at all",
+    says: 'a request target inside /api/client/v1 containing "%" or "\\" is answered 400 {"ok":false,"error":"invalid client v1 path"}',
+    measured: 'the "%" half holds; a "\\" is normalised to "/" by Next and answered 308 to the normalised target before proxy.ts runs, and that target is then refused 401 by the ordinary gate',
+    severity: "documentation",
+    why: "no handler is reached and nothing is served, so the gate still holds; the doc describes an answer no client will observe",
+  },
+  {
+    id: "admin-unauthorized-envelope-is-unreachable",
+    where: "docs/api/client-v1.md — Administrator routes, Authentication",
+    says: "a mismatched or absent x-coven-cave-token is 401 unauthorized from requireClientV1Admin",
+    measured: 'the proxy\'s sidecar-token gate answers first, so the wire carries 401 {"ok":false,"error":"unauthorized"} and requireClientV1Admin\'s envelope is never produced on a Cave with a token configured',
+    severity: "documentation",
+    why: "the refusal is correct and same-status; only its body differs from the documented one, which a handler-level test cannot see",
+  },
+  {
+    id: "conversations-mutable-key-skips-rather-than-repeats",
+    where: "docs/api/client-v1.md — Paging, and reads.ts clientV1ConversationPageKey",
+    says: "a conversation that receives a turn mid-pagination moves to the front and can appear in two pages",
+    measured: "the ordering is updatedAt DESCENDING and a touch only raises the key, so a touched row moves ABOVE an open cursor: a row already served stays served, and a row not yet served is SKIPPED by the rest of the walk. No repeat was reproducible.",
+    severity: "documentation",
+    why: "the client-visible consequence is the opposite of the documented one — a repeat is deduplicable, a skip is silent data loss unless the client re-reads from the top",
+  },
+];
+
+export const NOT_COVERED = [
+  "The SDK and Chat halves of #4838. Both live in other repositories; this run is the Cave half only.",
+  "The production Coven daemon. /familiars is served from a loopback fixture daemon in hub mode.",
+  "A genuinely remote peer. Off-machine ingress is exercised by making the listener classify a loopback request as forwarded.",
+  "The write scopes. Nothing enforces them yet — there are no write routes on this surface.",
+  "OAuth-backed flows and the desktop consent UI. Approval is driven through the admin HTTP route.",
+  "Cross-process pairing state. The pairing store is in-memory and process-local by contract.",
+];
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  main(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (error) => {
+      console.error(`client-v1-conformance: ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/client-v1-conformance.mjs
+++ b/scripts/client-v1-conformance.mjs
@@ -1996,14 +1996,39 @@ async function runConversationsLeg(client, recorder, bearer, caveHomeDir) {
   if (openToken && touchedId) {
     const touched = conversations.find((conversation) => conversation.sessionId === touchedId);
     await writeConversation(caveHomeDir, { ...touched, updatedAt: "2026-12-31T00:00:00.000Z" });
-    const resumed = await client.read(`/conversations?limit=2&cursor=${encodeURIComponent(openToken)}`, bearer);
-    const resumedIds = (resumed.json?.data?.conversations ?? []).map((row) => row.id);
+
+    // The REST of the walk, not just the next page. "Skipped" is a claim about
+    // every page after the touch — a row that reappeared three pages later
+    // would be a repeat, which is what the reference used to say happens, and a
+    // single-page probe cannot tell the two apart.
+    const remainder = [];
+    let token = openToken;
+    let resumedStatus = 0;
+    for (let page = 0; page < 50 && token; page += 1) {
+      const resumed = await client.read(`/conversations?limit=2&cursor=${encodeURIComponent(token)}`, bearer);
+      resumedStatus = resumed.status;
+      if (resumed.status !== 200) break;
+      remainder.push(...(resumed.json?.data?.conversations ?? []).map((row) => row.id));
+      token = resumed.json?.cursor?.next ?? null;
+    }
+    const mutableFailures = [];
+    if (resumedStatus !== 200) mutableFailures.push(`resuming the walk answered ${resumedStatus}, expected 200`);
+    if (remainder.includes(touchedId)) {
+      mutableFailures.push(
+        `after touching the unserved ${touchedId} the rest of the walk still served it: [${remainder}]`,
+      );
+    }
+    const alreadyServed = firstPage[0]?.ids ?? [];
+    for (const id of remainder) {
+      if (alreadyServed.includes(id)) mutableFailures.push(`${id} was served before the touch and again after it`);
+    }
+    if (new Set(remainder).size !== remainder.length) {
+      mutableFailures.push(`the rest of the walk repeated a row: [${remainder}]`);
+    }
     recorder.expect(
       "reads.conversations-mutable-key-moves-a-row",
-      resumed.status === 200 && !resumedIds.includes(touchedId)
-        ? []
-        : [`after touching the unserved ${touchedId} the walk served [${resumedIds}] (status ${resumed.status}); it was expected to have moved above the open cursor`],
-      "a touched, not-yet-served conversation leaves the window; deduplicate and re-read from the top",
+      mutableFailures,
+      `touched ${touchedId}; the rest of the walk served [${remainder}] — a skip, and no repeat anywhere in it`,
     );
     await writeConversation(caveHomeDir, touched);
   } else {

--- a/scripts/client-v1-conformance.test.mjs
+++ b/scripts/client-v1-conformance.test.mjs
@@ -3,15 +3,22 @@ import test from "node:test";
 
 import {
   BRANCHED_ACTIVE_SEQUENCE,
+  COVERAGE_ASSERTION_ID,
+  EXPECTED_ASSERTION_IDS,
   FINDINGS,
   FIXTURE_ROSTER,
   NOT_COVERED,
   RECORD_SHAPES,
+  TTL_ASSERTION_IDS,
+  checkAssertionCoverage,
   checkEmptyFirstPage,
   checkEnvelope,
   checkPageWalk,
   checkRecordShape,
+  checkRecordValues,
   createRecorder,
+  expectedAssertionIds,
+  expectedBranchedMessages,
   fixtureBranchedConversation,
   fixtureConversations,
   fixtureProjects,
@@ -194,6 +201,105 @@ test("RECORD_SHAPES withholds every field the reference says is withheld", () =>
   assert.ok(RECORD_SHAPES.message.forbidden.includes("usage"));
   assert.ok(RECORD_SHAPES.message.forbidden.includes("costUsd"));
   assert.ok(RECORD_SHAPES.pairingStatus.forbidden.includes("scopes"));
+});
+
+// ── projected VALUES ─────────────────────────────────────────────────────────
+//
+// The key-set check above is half a projection test. A build serving
+// `root: project.id`, `harness: summary.harnessSessionId` and `text: turn.role`
+// keeps every key, and was measured passing all 89 assertions of an otherwise
+// identical run. These are the cases that catch it.
+
+test("checkRecordValues accepts a record whose pinned fields all match", () => {
+  assert.deepEqual(
+    checkRecordValues({ id: "p1", root: "/r", extra: 1 }, { id: "p1", root: "/r" }, "project"),
+    [],
+  );
+});
+
+test("checkRecordValues catches the wrong field served under the right key", () => {
+  // The measured mutation: `root: requiredText(project.id, …)`.
+  const failures = checkRecordValues({ id: "project-01", root: "project-01" }, { root: "/fixtures/project-01" }, "project");
+  assert.deepEqual(failures, ['project.root is "project-01", expected "/fixtures/project-01"']);
+});
+
+test("checkRecordValues catches a withheld value disclosed under an allowed key", () => {
+  // The measured mutation: `harness: summary.harnessSessionId`.
+  const failures = checkRecordValues({ harness: "harness-03" }, { harness: "claude" }, "conversation");
+  assert.deepEqual(failures, ['conversation.harness is "harness-03", expected "claude"']);
+});
+
+test("checkRecordValues catches a pinned field that is absent entirely", () => {
+  assert.deepEqual(checkRecordValues({ id: "m1" }, { text: "b-a1 body" }, "message"), [
+    'message.text is undefined, expected "b-a1 body"',
+  ]);
+});
+
+test("checkRecordValues catches a count that is right in type and wrong in value", () => {
+  assert.deepEqual(checkRecordValues({ toolCount: 0 }, { toolCount: 2 }, "message b-a1"), [
+    "message b-a1.toolCount is 0, expected 2",
+  ]);
+});
+
+test("checkRecordValues refuses a non-object", () => {
+  assert.deepEqual(checkRecordValues(null, { id: "a" }, "record"), ["record is not a JSON object"]);
+  assert.deepEqual(checkRecordValues("nope", { id: "a" }, "record"), ["record is not a JSON object"]);
+});
+
+// ── assertion coverage ───────────────────────────────────────────────────────
+
+test("checkAssertionCoverage catches a leg that vanished instead of recording a skip", () => {
+  // The regression this exists for: three cursor legs sat behind
+  // `if (firstPage.next)` with no else, so a server publishing no token left
+  // them out of the record entirely — a smaller, still-green run.
+  const entries = [
+    { id: "reads.projects-paging-partial-final-page", result: "fail", detail: "" },
+    { id: "reads.projects-paging-exact-multiple", result: "fail", detail: "" },
+  ];
+  const failures = checkAssertionCoverage(entries, [
+    "reads.projects-paging-partial-final-page",
+    "reads.projects-paging-exact-multiple",
+    "reads.cursor-replay-is-stable",
+  ]);
+  assert.deepEqual(failures, [
+    'assertion "reads.cursor-replay-is-stable" was never recorded, not even as a skip',
+  ]);
+});
+
+test("checkAssertionCoverage accepts a skip in place of a pass", () => {
+  // A skip is an honest partial and must satisfy coverage; only silence must not.
+  const entries = [{ id: "pairing.ttl-expiry", result: "skip", detail: "no clock seam" }];
+  assert.deepEqual(checkAssertionCoverage(entries, ["pairing.ttl-expiry"]), []);
+});
+
+test("checkAssertionCoverage catches a duplicated and an unexpected id", () => {
+  const entries = [
+    { id: "health.envelope", result: "pass", detail: "" },
+    { id: "health.envelope", result: "pass", detail: "" },
+    { id: "health.surprise", result: "pass", detail: "" },
+  ];
+  const failures = checkAssertionCoverage(entries, ["health.envelope"]).sort();
+  assert.deepEqual(failures, [
+    'assertion "health.envelope" was recorded 2 times',
+    'assertion "health.surprise" is not in the expected set',
+  ]);
+});
+
+test("checkAssertionCoverage ignores its own entry", () => {
+  const entries = [
+    { id: "health.envelope", result: "pass", detail: "" },
+    { id: COVERAGE_ASSERTION_ID, result: "pass", detail: "" },
+  ];
+  assert.deepEqual(checkAssertionCoverage(entries, ["health.envelope"]), []);
+});
+
+test("expectedAssertionIds swaps exactly the TTL leg on --include-ttl", () => {
+  const waited = expectedAssertionIds(true);
+  const skipped = expectedAssertionIds(false);
+  assert.deepEqual(waited.filter((id) => !EXPECTED_ASSERTION_IDS.includes(id)), TTL_ASSERTION_IDS.waited);
+  assert.deepEqual(skipped.filter((id) => !EXPECTED_ASSERTION_IDS.includes(id)), TTL_ASSERTION_IDS.skipped);
+  assert.equal(new Set(waited).size, waited.length);
+  assert.equal(EXPECTED_ASSERTION_IDS.includes(COVERAGE_ASSERTION_ID), false);
 });
 
 // ── paged walks ──────────────────────────────────────────────────────────────
@@ -397,6 +503,39 @@ test("the branched fixture's active path is the declared sequence and omits the 
 
 test("the branched fixture pages at limit 2 so the reconcile leg has an open cursor", () => {
   assert.ok(BRANCHED_ACTIVE_SEQUENCE.length > 2);
+});
+
+test("the branched fixture gives the message projection something to withhold and to count", () => {
+  // Without this the projection leg was inert on its own fixture: `forbidden`
+  // cannot name a leak of a field the store never held, and a hardcoded
+  // `toolCount: 0` agrees with an all-zero transcript. A build that leaked
+  // `reasoning` and the tool inputs whenever a turn had them passed the run.
+  const conversation = fixtureBranchedConversation();
+  const rich = conversation.turns.find((turn) => turn.id === "b-a1");
+  assert.ok(BRANCHED_ACTIVE_SEQUENCE.includes(rich.id), "the loaded turn must be on the ACTIVE branch");
+  for (const field of ["reasoning", "usage", "costUsd", "durationMs", "harnessSessionId"]) {
+    assert.ok(rich[field] !== undefined, `b-a1 must carry ${field}`);
+    assert.ok(
+      RECORD_SHAPES.message.forbidden.includes(field),
+      `${field} must be one the projection withholds, or seeding it proves nothing`,
+    );
+  }
+  assert.equal(rich.tools.length, 2, "more than one, so a count of 1 is distinguishable from a truthy check");
+  assert.equal(rich.attachments.length, 1);
+  assert.ok(rich.tools.some((tool) => /id_ed25519/.test(tool.input ?? "")), "a tool input worth withholding");
+});
+
+test("expectedBranchedMessages pins a value for every turn of the active branch", () => {
+  const expected = expectedBranchedMessages();
+  assert.deepEqual(expected.map((message) => message.id), BRANCHED_ACTIVE_SEQUENCE);
+  const rich = expected.find((message) => message.id === "b-a1");
+  assert.equal(rich.toolCount, 2);
+  assert.equal(rich.attachmentCount, 1);
+  assert.equal(expected[0].parentId, null);
+  // Every pinned key must be one the projection is allowed to serve, or the
+  // value check would contradict the shape check.
+  const allowed = new Set([...RECORD_SHAPES.message.required, ...RECORD_SHAPES.message.optional]);
+  for (const key of Object.keys(rich)) assert.ok(allowed.has(key), `${key} is not a published message field`);
 });
 
 test("the fixture roster covers the optional familiar fields and enough rows to page", () => {

--- a/scripts/client-v1-conformance.test.mjs
+++ b/scripts/client-v1-conformance.test.mjs
@@ -536,6 +536,13 @@ test("expectedBranchedMessages pins a value for every turn of the active branch"
   // value check would contradict the shape check.
   const allowed = new Set([...RECORD_SHAPES.message.required, ...RECORD_SHAPES.message.optional]);
   for (const key of Object.keys(rich)) assert.ok(allowed.has(key), `${key} is not a published message field`);
+  // And every REQUIRED field must be pinned. Quietly dropping one — `text`, say
+  // — costs nothing visible: the run still passes, with one fewer thing checked.
+  // That is the same silent-weakening shape the coverage guard exists for, one
+  // level down.
+  for (const key of RECORD_SHAPES.message.required) {
+    assert.ok(key in rich, `expectedBranchedMessages must pin ${key}, or a wrong value in it is unchecked`);
+  }
 });
 
 test("the fixture roster covers the optional familiar fields and enough rows to page", () => {

--- a/scripts/client-v1-conformance.test.mjs
+++ b/scripts/client-v1-conformance.test.mjs
@@ -1,0 +1,409 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BRANCHED_ACTIVE_SEQUENCE,
+  FINDINGS,
+  FIXTURE_ROSTER,
+  NOT_COVERED,
+  RECORD_SHAPES,
+  checkEmptyFirstPage,
+  checkEnvelope,
+  checkPageWalk,
+  checkRecordShape,
+  createRecorder,
+  fixtureBranchedConversation,
+  fixtureConversations,
+  fixtureProjects,
+  parseConformanceArgs,
+  parseRawResponse,
+  renderConformanceRecord,
+  summarizeConformance,
+} from "./client-v1-conformance.mjs";
+
+// The conformance run itself needs a release build, a spare port and a couple
+// of minutes, so it is operator-invoked (see
+// docs/workflows/client-v1-conformance.md). What CI can and must keep honest is
+// everything that decides whether that run PASSES: an assertion helper that
+// cannot fail turns a green record into a lie, and nothing else in the suite
+// would notice. So every test below is a negative one — it feeds the helper the
+// exact broken server behaviour the run exists to catch and demands a failure.
+
+// ── argument parsing ─────────────────────────────────────────────────────────
+
+test("parseConformanceArgs defaults to the fast, evidence-free run", () => {
+  assert.deepEqual(parseConformanceArgs([]), { out: null, includeTtl: false, keepFixture: false });
+});
+
+test("parseConformanceArgs reads every flag", () => {
+  assert.deepEqual(parseConformanceArgs(["--include-ttl", "--keep-fixture", "--out", "docs/x.json"]), {
+    out: "docs/x.json",
+    includeTtl: true,
+    keepFixture: true,
+  });
+});
+
+test("parseConformanceArgs refuses an unknown flag rather than ignoring it", () => {
+  // A silently dropped `--include-tll` is how a run that was asked for the slow
+  // leg reports a clean pass without ever having run it.
+  assert.throws(() => parseConformanceArgs(["--include-tll"]), /unknown option/);
+});
+
+test("parseConformanceArgs refuses --out without a value", () => {
+  assert.throws(() => parseConformanceArgs(["--out"]), /--out requires a path/);
+  assert.throws(() => parseConformanceArgs(["--out", "--include-ttl"]), /--out requires a path/);
+});
+
+// ── the envelope ─────────────────────────────────────────────────────────────
+
+const successEnvelope = {
+  apiVersion: "1.0",
+  minimumClientVersion: "0.1.0",
+  capabilities: ["pairing"],
+  data: { ok: true },
+};
+
+test("checkEnvelope accepts a well-formed success envelope", () => {
+  assert.deepEqual(checkEnvelope(successEnvelope, { kind: "success" }), []);
+});
+
+test("checkEnvelope catches a route that dropped the shared envelope fields", () => {
+  for (const field of ["apiVersion", "minimumClientVersion", "capabilities"]) {
+    const broken = { ...successEnvelope };
+    delete broken[field];
+    const failures = checkEnvelope(broken, { kind: "success" });
+    assert.equal(failures.length, 1, `${field} produced ${JSON.stringify(failures)}`);
+    assert.match(failures[0], new RegExp(field));
+  }
+});
+
+test("checkEnvelope catches an empty capability list", () => {
+  // Empty is the shape a client reads as "this Cave can do nothing", which is
+  // never true and is not distinguishable from a broken build without this.
+  assert.deepEqual(checkEnvelope({ ...successEnvelope, capabilities: [] }, { kind: "success" }), [
+    "capabilities is missing or empty",
+  ]);
+});
+
+test("checkEnvelope catches a success that carries an error, and vice versa", () => {
+  assert.deepEqual(
+    checkEnvelope({ ...successEnvelope, error: { code: "not_found" } }, { kind: "success" }),
+    ["success envelope carries an error"],
+  );
+  assert.deepEqual(checkEnvelope({ ...successEnvelope, data: undefined }, { kind: "success" }), [
+    "success envelope carries no data record",
+  ]);
+});
+
+test("checkEnvelope catches the wrong error code, a lying retryable, and a missing details.reason", () => {
+  const envelope = {
+    apiVersion: "1.0",
+    minimumClientVersion: "0.1.0",
+    capabilities: ["pairing"],
+    error: { code: "conflict", message: "nope", retryable: true, details: { reason: "something_else" } },
+  };
+  const failures = checkEnvelope(envelope, {
+    kind: "error",
+    code: "reconcile_required",
+    retryable: false,
+    reason: "resume_from_canonical_state",
+  });
+  assert.equal(failures.length, 3);
+  assert.match(failures.join("|"), /error\.code is "conflict"/);
+  assert.match(failures.join("|"), /error\.retryable is true, expected false/);
+  assert.match(failures.join("|"), /resume_from_canonical_state/);
+});
+
+test("checkEnvelope refuses a non-object body", () => {
+  // The proxy's refusals are a different shape from the envelope, so a helper
+  // that shrugged at a string would pass a route serving Next's error page.
+  assert.deepEqual(checkEnvelope("not json", { kind: "success" }), ["response body is not a JSON object"]);
+  assert.deepEqual(checkEnvelope(null, { kind: "success" }), ["response body is not a JSON object"]);
+  assert.deepEqual(checkEnvelope([successEnvelope], { kind: "success" }), ["response body is not a JSON object"]);
+});
+
+// ── projections ──────────────────────────────────────────────────────────────
+
+test("checkRecordShape accepts a record carrying only required and optional fields", () => {
+  assert.deepEqual(
+    checkRecordShape({ id: "a", displayName: "A", role: "R" }, RECORD_SHAPES.familiar, "familiar"),
+    [],
+  );
+});
+
+test("checkRecordShape names a withheld field as a leak, not as drift", () => {
+  // The whole reason the message projection exists is that `reasoning` and
+  // `tools` are the harness's scratchpad and whatever a tool was pointed at.
+  const failures = checkRecordShape(
+    {
+      id: "t1",
+      conversationId: "c1",
+      parentId: null,
+      role: "assistant",
+      text: "hi",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      attachmentCount: 0,
+      toolCount: 0,
+      reasoning: "private",
+      tools: [],
+    },
+    RECORD_SHAPES.message,
+    "message t1",
+  );
+  assert.equal(failures.length, 2);
+  assert.deepEqual(failures.sort(), [
+    'message t1 leaks withheld field "reasoning"',
+    'message t1 leaks withheld field "tools"',
+  ]);
+});
+
+test("checkRecordShape catches a bearerHash reaching an admin listing", () => {
+  const failures = checkRecordShape(
+    {
+      id: "c",
+      appName: "a",
+      installationId: "i",
+      scopes: [],
+      createdAt: 1,
+      lastUsedAt: null,
+      revokedAt: null,
+      revocationReason: null,
+      bearerHash: "deadbeef",
+    },
+    RECORD_SHAPES.credential,
+    "credential",
+  );
+  assert.deepEqual(failures, ['credential leaks withheld field "bearerHash"']);
+});
+
+test("checkRecordShape catches a missing required field and an unexpected one", () => {
+  const failures = checkRecordShape({ id: "p", name: "n", root: "/r", createdAt: "x", surprise: 1 }, RECORD_SHAPES.project, "project");
+  assert.deepEqual(failures.sort(), [
+    'project carries unexpected field "surprise"',
+    'project is missing required "updatedAt"',
+  ]);
+});
+
+test("RECORD_SHAPES withholds every field the reference says is withheld", () => {
+  // A shape spec that quietly dropped one of these would pass a leaking server.
+  assert.ok(RECORD_SHAPES.conversation.forbidden.includes("harnessSessionId"));
+  assert.ok(RECORD_SHAPES.conversation.forbidden.includes("branch"));
+  assert.ok(RECORD_SHAPES.conversation.forbidden.includes("prUrl"));
+  assert.ok(RECORD_SHAPES.project.forbidden.includes("legacyRoot"));
+  assert.ok(RECORD_SHAPES.project.forbidden.includes("access"));
+  assert.ok(RECORD_SHAPES.message.forbidden.includes("usage"));
+  assert.ok(RECORD_SHAPES.message.forbidden.includes("costUsd"));
+  assert.ok(RECORD_SHAPES.pairingStatus.forbidden.includes("scopes"));
+});
+
+// ── paged walks ──────────────────────────────────────────────────────────────
+
+const page = (ids, hasMore, next) => ({ ids, hasMore, ...(next === undefined ? {} : { next }) });
+
+test("checkPageWalk accepts a partial final page", () => {
+  const walk = [page(["a", "b"], true, "t1"), page(["c"], false)];
+  assert.deepEqual(checkPageWalk(walk, { limit: 2, expectedIds: ["a", "b", "c"] }), []);
+});
+
+test("checkPageWalk accepts an exact-multiple walk whose last full page ends it", () => {
+  // The classic boundary: 4 rows at limit 2 must be two pages, not two plus an
+  // empty third, and the second must report hasMore false.
+  const walk = [page(["a", "b"], true, "t1"), page(["c", "d"], false)];
+  assert.deepEqual(checkPageWalk(walk, { limit: 2, expectedIds: ["a", "b", "c", "d"] }), []);
+});
+
+test("checkPageWalk catches a repeated record across a boundary", () => {
+  const walk = [page(["a", "b"], true, "t1"), page(["b", "c"], false)];
+  const failures = checkPageWalk(walk, { limit: 2 });
+  assert.ok(failures.some((failure) => failure.includes('id "b" was served twice')), failures.join("|"));
+});
+
+test("checkPageWalk catches a skipped record", () => {
+  const walk = [page(["a", "b"], true, "t1"), page(["d"], false)];
+  const failures = checkPageWalk(walk, { limit: 2, expectedIds: ["a", "b", "c", "d"] });
+  assert.ok(failures.some((failure) => failure.includes("walk served [a,b,d]")), failures.join("|"));
+});
+
+test("checkPageWalk catches hasMore lying in both directions", () => {
+  const understated = checkPageWalk([page(["a"], false, "t1"), page(["b"], false)], { limit: 1 });
+  assert.ok(understated.some((failure) => failure.includes("reported hasMore false with a page after it")), understated.join("|"));
+
+  const overstated = checkPageWalk([page(["a"], true, "t1"), page(["b"], true, "t2")], { limit: 1 });
+  assert.ok(overstated.some((failure) => failure.includes("the final page reported hasMore true")), overstated.join("|"));
+  assert.ok(overstated.some((failure) => failure.includes("the final page published a next token")), overstated.join("|"));
+});
+
+test("checkPageWalk catches a page above the requested limit", () => {
+  // The over-fetched row is evidence for hasMore and must never be served: a
+  // page of limit+1 breaks the ceiling the contract publishes.
+  const failures = checkPageWalk([page(["a", "b", "c"], false)], { limit: 2 });
+  assert.ok(failures.some((failure) => failure.includes("above the requested limit 2")), failures.join("|"));
+});
+
+test("checkPageWalk catches a short non-final page", () => {
+  const failures = checkPageWalk([page(["a"], true, "t1"), page(["b", "c"], false)], { limit: 2 });
+  assert.ok(failures.some((failure) => failure.includes("served 1 of 2 rows")), failures.join("|"));
+});
+
+test("checkPageWalk catches a non-final page that published no token to follow", () => {
+  const failures = checkPageWalk([page(["a"], true), page(["b"], false)], { limit: 1 });
+  assert.ok(failures.some((failure) => failure.includes("published no next token")), failures.join("|"));
+});
+
+test("checkEmptyFirstPage requires the cursor field to be absent, not false", () => {
+  assert.deepEqual(checkEmptyFirstPage({ data: { projects: [] } }, "projects"), []);
+  assert.deepEqual(
+    checkEmptyFirstPage({ data: { projects: [] }, cursor: { hasMore: false } }, "projects"),
+    ["an empty first page published a cursor; the contract omits the field when there is no token"],
+  );
+  assert.deepEqual(checkEmptyFirstPage({ data: { projects: [{ id: "a" }] } }, "projects"), [
+    "data.projects served 1 rows, expected none",
+  ]);
+});
+
+// ── recording and reporting ──────────────────────────────────────────────────
+
+test("a skipped leg is never counted as a pass", () => {
+  // The honest-partial rule: a leg that says out loud it did not run must not
+  // inflate the coverage the record claims.
+  const recorder = createRecorder();
+  recorder.pass("a");
+  recorder.skip("b", "no clock seam");
+  recorder.fail("c", "broken");
+  assert.deepEqual(summarizeConformance(recorder.entries), {
+    total: 3,
+    passed: 1,
+    failed: 1,
+    skipped: 1,
+    status: "failed",
+  });
+});
+
+test("a run with skips but no failures still passes", () => {
+  const recorder = createRecorder();
+  recorder.pass("a");
+  recorder.skip("b", "operator did not ask for the slow leg");
+  assert.equal(summarizeConformance(recorder.entries).status, "passed");
+});
+
+test("recorder.expect turns an empty failure list into a pass and a non-empty one into a failure", () => {
+  const recorder = createRecorder();
+  recorder.expect("clean", []);
+  recorder.expect("dirty", ["one", "two"]);
+  assert.equal(recorder.entries[0].result, "pass");
+  assert.equal(recorder.entries[1].result, "fail");
+  assert.equal(recorder.entries[1].detail, "one; two");
+});
+
+test("the evidence record carries the scope limits and the findings, not just a verdict", () => {
+  const record = renderConformanceRecord([{ id: "a", result: "pass", detail: "" }], {
+    ranAt: "2026-08-22T00:00:00.000Z",
+    caveVersion: "0.3.9",
+    commit: null,
+    platform: "win32-x64",
+    includeTtl: false,
+    notCovered: NOT_COVERED,
+    findings: FINDINGS,
+  });
+  assert.equal(record.scope, "cave-only");
+  assert.deepEqual(record.issues, ["OpenCoven/coven-cave#4832", "OpenCoven/coven-cave#4838"]);
+  assert.ok(record.notCovered.length > 0);
+  assert.ok(record.findings.length > 0);
+  assert.equal(record.summary.status, "passed");
+});
+
+test("NOT_COVERED states the cross-repo boundary the issues span", () => {
+  // #4838 names Cave, the SDK and Chat. Only one of those is in this
+  // repository, and a record that did not say so would read as full coverage.
+  assert.ok(NOT_COVERED.some((entry) => /SDK and Chat/.test(entry)));
+  assert.ok(NOT_COVERED.some((entry) => /fixture daemon/.test(entry)));
+});
+
+// ── the raw response reader ──────────────────────────────────────────────────
+
+test("parseRawResponse reads a chunked proxy refusal", () => {
+  const raw = [
+    "HTTP/1.1 411 Length Required",
+    "content-type: application/json",
+    "Connection: close",
+    "",
+    "2e",
+    '{"ok":false,"error":"content-length required"}',
+    "0",
+    "",
+    "",
+  ].join("\r\n");
+  const response = parseRawResponse(raw);
+  assert.equal(response.status, 411);
+  assert.equal(response.headers["content-type"], "application/json");
+  assert.deepEqual(response.json, { ok: false, error: "content-length required" });
+});
+
+test("parseRawResponse reads a redirect's location and reports no JSON body", () => {
+  const raw = "HTTP/1.1 308 Permanent Redirect\r\nlocation: /api/client/v1/pairing/requests/a/b\r\n\r\n";
+  const response = parseRawResponse(raw);
+  assert.equal(response.status, 308);
+  assert.equal(response.headers.location, "/api/client/v1/pairing/requests/a/b");
+  assert.equal(response.json, null);
+});
+
+test("parseRawResponse reports status 0 for a response that never arrived", () => {
+  // A silent zero that read as a 2xx would turn a dead server into a pass.
+  assert.equal(parseRawResponse("").status, 0);
+});
+
+// ── the fixtures the run asserts against ─────────────────────────────────────
+
+test("the fixture project set exercises a partial final page at limit 3", () => {
+  const projects = fixtureProjects();
+  assert.equal(projects.length, 7);
+  assert.notEqual(projects.length % 3, 0);
+  assert.equal(new Set(projects.map((project) => project.createdAt)).size, projects.length);
+  assert.equal(new Set(projects.map((project) => project.root)).size, projects.length);
+});
+
+test("the fixture conversation set exercises an exact multiple at limit 3", () => {
+  const conversations = fixtureConversations();
+  assert.equal(conversations.length, 6);
+  assert.equal(conversations.length % 3, 0);
+  assert.equal(new Set(conversations.map((conversation) => conversation.updatedAt)).size, conversations.length);
+  // Each carries the three withheld fields, so the projection has something to
+  // withhold. A shape assertion over a record that never held the field proves
+  // nothing about the projection.
+  for (const conversation of conversations) {
+    assert.ok(conversation.harnessSessionId);
+    assert.ok(conversation.branch);
+    assert.ok(conversation.prUrl);
+  }
+});
+
+test("the branched fixture's active path is the declared sequence and omits the abandoned branch", () => {
+  const conversation = fixtureBranchedConversation();
+  const byId = new Map(conversation.turns.map((turn) => [turn.id, turn]));
+  const chain = [];
+  let current = byId.get(conversation.activeLeafId);
+  while (current) {
+    chain.unshift(current.id);
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+  assert.deepEqual(chain, BRANCHED_ACTIVE_SEQUENCE);
+  assert.ok(conversation.turns.some((turn) => turn.id === "b-x1"));
+  assert.ok(!BRANCHED_ACTIVE_SEQUENCE.includes("b-x1"));
+  // resolveActivePath splices parentless SYSTEM turns back into the chain by
+  // timestamp, so a system turn here would make the expected sequence depend on
+  // that splice rather than on the branch.
+  assert.ok(conversation.turns.every((turn) => turn.role !== "system"));
+});
+
+test("the branched fixture pages at limit 2 so the reconcile leg has an open cursor", () => {
+  assert.ok(BRANCHED_ACTIVE_SEQUENCE.length > 2);
+});
+
+test("the fixture roster covers the optional familiar fields and enough rows to page", () => {
+  assert.ok(FIXTURE_ROSTER.length > 2);
+  const rich = FIXTURE_ROSTER.find((entry) => entry.id === "archivist");
+  assert.equal(rich.last_seen, "not-an-instant", "lastSeenAt is passed through verbatim and is deliberately not an instant");
+  assert.equal(rich.active_sessions, 2);
+  const sparse = FIXTURE_ROSTER.find((entry) => entry.id === "brewer");
+  assert.deepEqual(Object.keys(sparse).sort(), ["display_name", "id", "role"]);
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1337,6 +1337,7 @@ export const SUITES = {
     "scripts/export-client-v1-contract.test.mjs",
     "scripts/client-v1-doc-contract.test.mjs",
     "scripts/client-v1-release-smoke.test.mjs",
+    "scripts/client-v1-conformance.test.mjs",
     "scripts/ci-recovery.test.mjs",
     "scripts/ci-recovery-workflow.test.mjs",
     "scripts/main-health.test.mjs",

--- a/src/lib/server/client-v1/reads.ts
+++ b/src/lib/server/client-v1/reads.ts
@@ -335,10 +335,16 @@ export function clientV1ProjectPageKey(project: CaveProject): ClientV1PageKey {
  * is required, and it is also the order listConversations already sorts by, so
  * a client sees one ordering out of Cave rather than two.
  *
- * The cost is the mutable-key cost above: a conversation that receives a turn
- * mid-pagination moves to the front and can be seen twice. That is visible to
- * the client (the same id in two pages) and recoverable, where the alternative
- * — keying on a field half the corpus lacks — is neither.
+ * The cost is the mutable-key cost above, and it is worth naming precisely
+ * because this comment used to name it backwards. `updatedAt` only ever
+ * increases and the ordering is descending, so a conversation that receives a
+ * turn mid-pagination moves *above* an open cursor: one already served stays
+ * served, and one NOT yet served is skipped by the rest of the walk. It is a
+ * skip, not a repeat — measured over a real socket by
+ * scripts/client-v1-conformance.mjs, which could not reproduce a repeat from a
+ * touch. That is the worse of the two (a repeat is deduplicable by id; a skip
+ * is silent), and it is still better than the alternative — keying on a field
+ * half the corpus lacks, which strands the rows that lack it entirely.
  */
 export function clientV1ConversationPageKey(summary: ConversationSummary): ClientV1PageKey {
   return { sort: summary.updatedAt, id: summary.sessionId };


### PR DESCRIPTION
Closes #4832

Advances #4838 (the Cave half only; the SDK and Chat halves live in other repositories and are recorded in `notCovered`)

Both were filed BLOCKED on a live Cave authority. #4840, #4855 and #4856 built
one. Both are governed by the program's **operating rule 8: a gate cannot close
on unit-test proxies alone** — so this makes the run that closes them repeatable
and recorded, rather than a transcript of one session.

## Scope — the Cave half only

#4838 names Cave, the SDK and Chat. **The SDK and Chat halves live in other
repositories and are not exercised here.** A green record from this harness is
evidence about Cave and nothing else. The run says so in its own evidence file
(`notCovered`), in the runbook, and here.

## Why a real socket, and what only it can see

Every existing test on this surface calls the exported handler with a hand-built
`NextRequest`. That is the right shape for those tests, and it means none of them
can see:

| Layer | Only observable over a socket |
|---|---|
| `server.mjs` | strips any client-supplied `x-coven-cave-local-peer` and re-stamps it for direct, unforwarded loopback peers only. Handler tests supply the stamp themselves. |
| `proxy.ts` | the escaped-target refusal, the direct-loopback gates for all three route families, the 411/413/64 KiB control-plane body rules, and the sidecar-token gate that runs **ahead of** `requireClientV1Admin`. |
| Next | its own request-target normalisation and dynamic-segment decoding — which is what made `cave-f1xki` reachable in the first place. |
| the stores | a real `client-v1-credentials.json` written 0600 and re-read from disk, a real transcript directory, a real `projects.json`. |

## What lands

- `scripts/client-v1-conformance.mjs` — starts a release-mode Cave against a
  fixture Cave home under a temp dir, drives it over `127.0.0.1`, stops it, and
  prints one line per assertion. Exit 0/1; `--out` writes the evidence record.
- `scripts/client-v1-conformance.test.mjs` — the harness's own negative tests,
  wired into the `api` suite.
- `docs/workflows/client-v1-conformance.md` — runbook, scope limits, the CI
  decision, mutation results, findings.
- `docs/client-v1-conformance-results/2026-08-22-v0.3.9-win32.json` — the
  committed evidence.
- three corrections to `docs/api/client-v1.md`, plus the matching source comment
  in `reads.ts`.

Two probes are written straight onto the socket, because `http.request` cannot
express them: it substitutes chunked encoding for a bodyless POST (turning the
documented 411 into a 400 — the first draft of this harness reported that as a
conformance failure, and it was the harness that was wrong), and it rewrites a
request target before it leaves the process.

## It never touches the operator's Cave

Every run mints its own `COVEN_HOME`/`COVEN_CAVE_HOME` under the system temp
directory, its own admin token and its own port, and removes them afterwards. An
earlier hand-driven cycle used the real `~/.coven` and left a live paired
credential that had to be revoked by hand.

## Recorded run

**93 passed, 0 failed, 0 skipped** at `bc3be685` on `win32-x64`, Cave 0.3.9, run
with `--include-ttl` so the five-minute pairing TTL is a recorded pass rather
than a skip. The record carries every assertion id, the exact commit, the
`notCovered` list, and the findings.

Coverage: create → poll pending → admin approve → poll approved → exchange →
bearer works; deny; replay on both the exchange and the poll; a wrong secret;
the per-pairing failure budget — including that it is *shared* between the poll
and the exchange, that a correct secret is never charged, that spending it locks
out the rightful holder, and that the lockout is confined to one pairing; TTL
expiry on both routes; revocation, the tombstone surviving a store reload, and
the revoked bearer refused; admin `503` when `COVEN_CAVE_AUTH_TOKEN` is unset,
together with the consequence that a pairing opened on a tokenless Cave can only
ever answer `pairing_pending`. All five reads; empty first page, exact-multiple,
continuation, partial final page, `hasMore` both ways; projection shape as a
whole key set with every withheld field named as a leak; cursor replay stability,
`current` echoing the token, and a deleted record not stranding the walk; the
`limit` ceiling and every refused spelling; the single-record route refusing any
query parameter; active-branch-only messages, `reconcile_required` when the
branch moves under an open cursor, and a clean restart after it.

## Operator-invoked, not CI — and why

The run needs a full production build, a spare port, a spawned server and a
fixture daemon, and it is serial. Putting that on the path-aware PR lane would
add minutes to every client-v1 change to re-prove something that does not vary
per commit — the trade `client-v1-release-smoke.mjs` already makes, and the one
`docs/workflows/release-acceptance.md` states outright ("the journey is manual by
design; what is automated is the evidence").

What **is** in CI is the half that decides whether a run passes. Most cases in
`client-v1-conformance.test.mjs` are negative ones: they feed each assertion
helper the exact broken behaviour the run exists to catch and demand a failure.
The rest pin the fixtures, which is the other half of the same job — an
assertion over data that never carried the field it forbids proves nothing, and
that is exactly how the message projection leg went inert (see the review pass
below). An assertion helper that cannot fail turns a green record into a lie,
and nothing else in the suite would notice; every helper mutation attempted
against that suite is killed by it, 37 of 37.

`scripts/ci-paths.mjs` also routes the harness, the runbook and the results
directory into the client-v1 lane. Note the harness was already covered before
that edit — `scripts/` is in `FRONTEND_PATH`, so `frontend-validation (API
tests)` ran on any change to it — so the routing adds the e2e and docs lanes
rather than closing a hole.

## Harness mutation results

Four deliberately broken builds, each a full `pnpm build`, source restored after:

| Mutation | Result | Caught by |
|---|---|---|
| `paginateClientV1Keyset` never publishes `next` | **caught**, 4 failures | `reads.familiars-paging`, `reads.projects-paging-partial-final-page`, `reads.projects-paging-exact-multiple`, `reads.conversations-paging` |
| `ClientV1MessageRecord` widened and `projectClientV1Message` serves `reasoning` + `costUsd` | **caught**, 12 leaks named | `reads.messages-active-branch` |
| `FileCredentialStore.findByBearer` ignores `revokedAt` | **caught**, 1 failure | `revocation.bearer-refused-after` |
| `parseClientV1PageLimit` clamps instead of refusing | **caught**, 5 failures | every `reads.refuses.limit-*` case |

Two things worth keeping from the exercise:

- **The leak mutation had to be made twice.** The one-line version does not
  compile — `ClientV1MessageRecord` is a closed literal type, so `tsc` refuses
  the field before any build produces it. A real leak has to widen the published
  type too. The type is the first gate; this run is the second.
- **The `next`-suppressing mutation left three legs unrun** — the cursor-replay,
  cursor-deletion and mutable-key legs all need a first-page token to open a
  cursor with. Only the mutable-key one was reported as a skip; the two cursor
  legs left the record entirely. That is corrected below, and a skip is still
  never counted as a pass, so the four walk assertions are what fail.

## Findings — three documentation claims measured as wrong

The gates themselves hold; all three are reference errors a handler-level test
structurally cannot see. Each is corrected in `docs/api/client-v1.md` and carried
in the evidence record.

1. **The backslash half of the escaped-target refusal is unreachable.** Next
   normalises `\` to `/` in the request target and answers `308` before
   `proxy.ts` runs. Nothing is served — the normalised target is not a route and
   is refused `401` — but the documented `400 invalid client v1 path` is not an
   answer any client sees. The `%` half holds. The refusal in `proxy.ts` stays:
   it is what catches a backslash Next stops normalising.
2. **`requireClientV1Admin`'s `unauthorized` envelope is unreachable.**
   `COVEN_CAVE_AUTH_TOKEN` is also the proxy's sidecar token and the admin family
   falls through to that gate, so a wrong or absent `x-coven-cave-token` is
   refused there first: the wire carries `401 {"ok":false,"error":"unauthorized"}`,
   not the Client v1 envelope. Same status, different body.
3. **`/conversations` skips rather than repeats under a mid-walk touch.** The
   reference and `reads.ts` both said a touched conversation "can appear in two
   pages". `updatedAt` only rises and the order is descending, so a touched row
   moves *above* an open cursor: already-served rows stay served, and a row not
   yet served is **skipped**. No repeat was reproducible. That is the worse of
   the two — a repeat is deduplicable by `id`, a skip is silent.

## Not run, and left out rather than faked

- the production Coven daemon — `/familiars` projects a daemon HTTP response, so
  the run stands up a fixture daemon on loopback in hub mode;
- a genuinely remote peer — off-machine ingress is exercised by making the
  *listener* classify a loopback request as forwarded, which is the same signal
  it reads for a real remote peer;
- the write scopes — nothing enforces them, there are no write routes;
- OAuth-backed flows and the desktop consent UI — approval goes through the admin
  HTTP route;
- cross-process pairing state — the pairing store is process-local by contract.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` (1805 files wired),
`pnpm build`, and the harness test under the exact argv `run-tests.mjs` resolves
(`--require ./scripts/css-source-contract-hook.cjs scripts/client-v1-conformance.test.mjs`,
37/37) all pass. `ci-paths`, `client-v1-doc-contract` and `docs-index` were
re-run after the doc edits and are green.

## Adversarial review pass — four defects the first harness passed

An independent review ran the harness end to end (reproducing the recorded
result exactly, assertion for assertion), mutation-tested all 37 of its negative
cases, and then mutated the **server** rather than the routes. One build carrying
four real defects at once was reported **89 passed, 0 failed, exit 0**:

| Server defect | First harness | Now |
|---|---|---|
| `projectClientV1Message` serves `reasoning` and the tool calls **when the turn has them** (one tool input is `cat ~/.ssh/id_ed25519`) | **passed** | `reads.messages-active-branch` names both leaks |
| `projectClientV1Project` serves `root: project.id` | **passed** | `reads.projects-shape`, all seven rows |
| `projectClientV1Conversation` serves `harness: summary.harnessSessionId` — a withheld id under an allowed key | **passed** | `reads.conversations-shape`, all six rows |
| `projectClientV1Message` serves `text: turn.role` — every transcript body replaced | **passed** | `reads.messages-values`, all six turns |

Two causes:

- **`checkRecordShape` checks keys, never values.** Nothing in the run compared a
  single projected value against what the fixture seeded, so a projection could
  serve the wrong field, or a withheld value under an allowed key, with every key
  correct. `checkRecordValues` is the other half; projects, conversations and
  messages now use both.
- **The branched transcript carried nothing worth withholding.** No `reasoning`,
  no `tools`, no `usage`, no `costUsd`, no `attachments` — so
  `RECORD_SHAPES.message.forbidden` had nothing to forbid, and both counts were
  zero everywhere, which is why `reads.messages-counts-not-contents` could not
  fail for any wrong count. The test file already stated this principle for the
  *conversation* fixtures ("a shape assertion over a record that never held the
  field proves nothing") and did not apply it to the one place it decides a
  disclosure. `b-a1` now carries all of it, and the counts are asserted as 2 and
  1 rather than as "a number".

## Legs that vanished rather than skipped

The write-up said the `next`-suppressing mutation left three legs "reported as
skips". Two of them were reported as **nothing at all**:
`reads.cursor-replay-is-stable`, `reads.cursor-current-echoes-the-token` and
`reads.cursor-survives-deletion` sat behind `if (firstPage.next)` with no
`else`, so their ids left the record entirely — a smaller, still-green run.
`reads.messages-restart-after-reconcile` and
`admin.unconfigured.exchange-stays-pending` were the same shape. `skipped` was
never folded into `passed`, so that claim held; the ids simply were not there to
count.

Every guard now records a skip, and `EXPECTED_ASSERTION_IDS` makes it checkable:
the run ends by comparing what it recorded against the declared set and fails
`harness.assertion-coverage` on any id missing, duplicated or unexpected. A skip
still does not fail a run — a silence now does.

## Also

- **Revocation was proven through one route.** `read-guard.ts` deliberately keeps
  the credential decision written out in each route module rather than delegated,
  so there are five copies of it, and the only gate over the other four was
  `api-contracts.test.ts` — a source-text assertion, which is the unit-test proxy
  rule 8 refuses. The revoked bearer is now refused on all five canonical reads.
- **`reads.unknown-bearer`, `reads.messages-not-found` and
  `revocation.unknown-credential` checked a status code and no body**, unlike
  their siblings. They check the envelope now.
- **The `/conversations` skip was proven over one page, not the walk.**
  `reads.conversations-mutable-key-moves-a-row` touched an unserved row and then
  checked only the page after the open cursor — but "skipped" is a claim about
  every page after the touch, and a row that came back three pages later would
  be the *repeat* the reference used to describe. It now follows `next` to the
  end. Measured: the ledger orders `conversation-06` down to `conversation-01`,
  the first page serves `[06, 05]`, and after touching the unserved
  `conversation-01` the rest of the walk serves `[04, 03, 02]` with nothing
  served twice. The finding holds, and the evidence file now says so on its own.
- **The record named the wrong commit.** `63f14013` is the base commit — the run
  was taken from a dirty tree, and that commit contains neither the harness nor
  the docs, so nothing in the record was reproducible from it. Re-run at the PR
  head; the new record is byte-identical to the old one except for the added
  assertions, the commit and the timestamp.

## Confirmed by the review, not changed

- The recorded run reproduces exactly: same 91 ids, same results, same details,
  bit for bit apart from the timestamp and the commit.
- The negative cases are load-bearing. A mutation matrix over the assertion
  helpers kills 49 of 50, covering every branch of `checkEnvelope`,
  `checkRecordShape`, `checkRecordValues`, `checkPageWalk`,
  `checkEmptyFirstPage`, `checkAssertionCoverage`, `summarizeConformance`,
  `recorder.expect`, `parseConformanceArgs`, `parseRawResponse`, every
  `RECORD_SHAPES.*.forbidden` list and every fixture invariant. The one survivor
  is deleting an id from `EXPECTED_ASSERTION_IDS`, which the *run* catches
  (the leg still records it, so it is reported as not in the expected set) — a
  claim about which legs a run should have does not belong in a unit test. That
  pass also caught one survivor in the new value check: silently dropping `text`
  from the pinned set killed nothing, so the fixture test now requires every
  required message field to be pinned.
- The harness cannot touch the operator's Cave — `~/.coven/cave/client-v1-*`
  hashes were unchanged across a full run.
- All three documentation findings are genuine and correctly classified.
  `/conversations` really does skip rather than repeat, and it follows from the
  code: `updatedAt` only rises and `compareClientV1RecencyKeys` orders
  descending, so a touch moves a row strictly toward the front — a served row
  can never come back, and an unserved one leaves the window. A repeat is not
  reachable from a touch at all.