### PR TITLE
Polish Research prompt recommendations

### DIFF
--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -672,7 +672,7 @@ export function ResearchMissionComposer({
                     key={field.key}
                     className="research-brief__row"
                     data-set={Boolean(value)}
-                    title={value || "not set"}
+                    title={value || undefined}
                   >
                     <span className="research-brief__mark" aria-hidden>{value ? "✓" : "·"}</span>
                     <span className="research-brief__cell">

--- a/src/components/role-surfaces/research-tab-prompt.test.ts
+++ b/src/components/role-surfaces/research-tab-prompt.test.ts
@@ -356,3 +356,13 @@ test("prompt tab styles are token-driven and container-responsive", () => {
   assert.match(css, /\.research-topic-recommendations__card \.agentic-recommendation-card__actions \{/);
   assert.match(css, /@container research-desk \(max-width: 560px\) \{[\s\S]*\.research-topic-recommendations/);
 });
+
+test("the autosized mission prompt owns scrolling without native resize collisions", () => {
+  assert.match(css, /\.research-intake__prompt > textarea \{[^}]*resize: none/);
+  assert.match(css, /\.research-intake__prompt > textarea \{[^}]*scrollbar-gutter: stable/);
+  assert.match(css, /\.research-intake__prompt > textarea \{[^}]*padding-right: calc\(var\(--space-3\) \+ var\(--space-3\)\)/);
+  assert.match(css, /\.research-intent-count \{[^}]*right: calc\(var\(--space-3\) \+ var\(--space-2\)\)/);
+  assert.match(css, /\.research-builder__field textarea \{[^}]*resize: vertical/);
+  assert.doesNotMatch(composer, /title=\{value \|\| "not set"\}/);
+  assert.match(composer, /title=\{value \|\| undefined\}/);
+});

--- a/src/lib/research-prompt-brief.test.ts
+++ b/src/lib/research-prompt-brief.test.ts
@@ -145,6 +145,38 @@ test("promptRecommendations derives one card per real signal, each explaining it
   }
 });
 
+test("promptRecommendations recover full questions from generated truncated titles", () => {
+  const intent = [
+    "Research and compare: Visual planning for agentic guided coding sessions.",
+    "Primary questions: identify the strongest interaction patterns and tradeoffs.",
+  ].join(" ");
+  const generatedTitle = `${intent.slice(0, 77)}…`;
+  const [rec] = promptRecommendations([
+    mission({
+      id: "m-generated",
+      title: generatedTitle,
+      intent,
+      status: "completed",
+    }),
+  ]);
+  assert.equal(rec.title, "Visual planning for agentic guided coding sessions");
+  assert.equal(rec.brief.question, rec.title);
+  assert.doesNotMatch(assembleBrief(rec.brief), /Primary questions|…/);
+});
+
+test("promptRecommendations preserve explicit mission titles", () => {
+  const [rec] = promptRecommendations([
+    mission({
+      id: "m-named",
+      title: "Planning systems landscape",
+      intent: "Research and compare: Visual planning for guided coding.",
+      status: "completed",
+    }),
+  ]);
+  assert.equal(rec.title, "Planning systems landscape");
+  assert.equal(rec.brief.question, rec.title);
+});
+
 test("promptRecommendations flags a run short of its source target", () => {
   const thin = mission({
     id: "m4",

--- a/src/lib/research-prompt-brief.test.ts
+++ b/src/lib/research-prompt-brief.test.ts
@@ -145,7 +145,7 @@ test("promptRecommendations derives one card per real signal, each explaining it
   }
 });
 
-test("promptRecommendations recover full questions from generated truncated titles", () => {
+test("promptRecommendations recovers full questions from generated truncated titles", () => {
   const intent = [
     "Research and compare: Visual planning for agentic guided coding sessions.",
     "Primary questions: identify the strongest interaction patterns and tradeoffs.",
@@ -164,16 +164,16 @@ test("promptRecommendations recover full questions from generated truncated titl
   assert.doesNotMatch(assembleBrief(rec.brief), /Primary questions|…/);
 });
 
-test("promptRecommendations preserve explicit mission titles", () => {
+test("promptRecommendations preserves explicit mission titles", () => {
   const [rec] = promptRecommendations([
     mission({
       id: "m-named",
-      title: "Planning systems landscape",
+      title: "Research brief: Planning systems landscape. Focus on team workflows",
       intent: "Research and compare: Visual planning for guided coding.",
       status: "completed",
     }),
   ]);
-  assert.equal(rec.title, "Planning systems landscape");
+  assert.equal(rec.title, "Research brief: Planning systems landscape. Focus on team workflows");
   assert.equal(rec.brief.question, rec.title);
 });
 

--- a/src/lib/research-prompt-brief.ts
+++ b/src/lib/research-prompt-brief.ts
@@ -251,9 +251,30 @@ export type ResearchPromptRecommendation = {
   brief: ResearchBrief;
 };
 
-/** Trim a mission title down to something that reads as a prompt subject. */
+/**
+ * Recover the reusable question behind a mission title.
+ *
+ * Generated mission titles are capped at 80 characters, but the mission still
+ * carries the full intent. Prefer that intent when the title matches the
+ * generated form, then remove research-wrapper copy so a recommendation does
+ * not load a truncated title or nest prompt instructions into the composer.
+ * Explicitly named missions keep their title.
+ */
 function subject(mission: ResearchMission): string {
-  return mission.title.replace(/\s+/g, " ").trim();
+  const intent = mission.intent.replace(/\s+/g, " ").trim();
+  const generatedTitle = intent.length <= 80 ? intent : `${intent.slice(0, 77)}…`;
+  let value = mission.title.replace(/\s+/g, " ").trim() === generatedTitle
+    ? intent
+    : mission.title.replace(/\s+/g, " ").trim();
+  value = value.replace(
+    /^research(?:\s+(?:and\s+compare|prompt|brief|mission|task))?\s*[:\-–—]\s*/i,
+    "",
+  );
+  const instructionTail = value.search(
+    /[.!?]\s+(?:primary\s+questions?|questions?|task|recommend|compare|focus)\b/i,
+  );
+  if (instructionTail !== -1) value = value.slice(0, instructionTail);
+  return value.replace(/[\s.…:;,–—-]+$/u, "");
 }
 
 /**

--- a/src/lib/research-prompt-brief.ts
+++ b/src/lib/research-prompt-brief.ts
@@ -263,9 +263,10 @@ export type ResearchPromptRecommendation = {
 function subject(mission: ResearchMission): string {
   const intent = mission.intent.replace(/\s+/g, " ").trim();
   const generatedTitle = intent.length <= 80 ? intent : `${intent.slice(0, 77)}…`;
-  let value = mission.title.replace(/\s+/g, " ").trim() === generatedTitle
-    ? intent
-    : mission.title.replace(/\s+/g, " ").trim();
+  const title = mission.title.replace(/\s+/g, " ").trim();
+  if (title !== generatedTitle) return title;
+
+  let value = intent;
   value = value.replace(
     /^research(?:\s+(?:and\s+compare|prompt|brief|mission|task))?\s*[:\-–—]\s*/i,
     "",

--- a/src/styles/globals/surface-research-prompt.css
+++ b/src/styles/globals/surface-research-prompt.css
@@ -90,13 +90,32 @@
   /* Room for the counter so a long brief never runs under it. */
   padding-bottom: calc(var(--space-3) + 14px);
 }
+.research-intake__prompt > textarea {
+  resize: none;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklch, var(--research-accent) 24%, transparent) transparent;
+  padding-right: calc(var(--space-3) + var(--space-3));
+  padding-bottom: calc(var(--space-3) + var(--space-4));
+}
+.research-intake__prompt > textarea::-webkit-scrollbar {
+  width: var(--space-1);
+}
+.research-intake__prompt > textarea::-webkit-scrollbar-track {
+  background: transparent;
+}
+.research-intake__prompt > textarea::-webkit-scrollbar-thumb {
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--research-accent) 24%, transparent);
+}
 
 /* Character count, anchored inside the prompt box (its container is already
    position: relative for the slash-command palette). */
 .research-intent-count {
   position: absolute;
-  right: 12px;
-  bottom: 8px;
+  right: calc(var(--space-3) + var(--space-2));
+  bottom: var(--space-2);
   font-size: var(--text-xs);
   font-variant-numeric: tabular-nums;
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- recover full reusable questions when generated mission titles were truncated
- preserve explicit mission titles while stripping Research wrapper instructions
- remove unset native tooltips and prevent prompt scrollbar/counter collisions

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm check:tests-wired`
- targeted Research prompt suites passed
- `pnpm test:api` reached two unrelated platform-sensitive credential-store failures on macOS; current `main` CI is green and the PR required check will validate the exact head

Bead: `cave-d1p8s`