### PR TITLE
Bound Beads Dolt sync credential hangs

### DIFF
--- a/.beads/README.md
+++ b/.beads/README.md
@@ -26,8 +26,8 @@ bd show <issue-id>
 bd update <issue-id> --claim
 bd update <issue-id> --status done
 
-# Sync with Dolt remote
-bd dolt push
+# Sync with the Dolt remote through the repository watchdog
+pnpm beads:sync
 ```
 
 ### Working with Issues
@@ -51,7 +51,7 @@ Issues in Beads are:
 - Fast, lightweight, and stays out of your way
 
 🔧 **Git Integration**
-- Dolt-native sync via bd dolt push / bd dolt pull
+- Bounded Dolt-native sync via `pnpm beads:sync`
 - Branch-aware issue tracking
 - Dolt-native three-way merge resolution
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,7 +308,7 @@ This protocol applies when ending a Beads implementation workflow. It is subordi
 
    # Team-maintainer opt-in only, unless current instructions forbid it:
    git pull --rebase
-   bd dolt push
+   pnpm beads:sync
    git push
    git status
    ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -888,7 +888,7 @@ This protocol applies when ending a Beads implementation workflow. It is subordi
 
    # Team-maintainer opt-in only, unless current instructions forbid it:
    git pull --rebase
-   bd dolt push
+   pnpm beads:sync
    git push
    git status
    ```

--- a/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
+++ b/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
@@ -427,6 +427,15 @@ function retryGuidance(write: (value: string) => void): void {
   );
 }
 
+function cleanupUnprovenGuidance(write: (value: string) => void): void {
+  write(
+    "[beads:sync] Verify and stop the surviving process tree before retrying; it may still hold the Dolt lock or be pushing.\n",
+  );
+  write(
+    "[beads:sync] Inspect `git ls-remote origin refs/dolt/data` before deciding whether a push retry is needed.\n",
+  );
+}
+
 async function runPhase(
   phase: SyncPhase,
   options: Required<
@@ -566,7 +575,7 @@ export async function runBeadsSync(options: BeadsSyncOptions = {}): Promise<numb
       writeStderr(
         `[beads:sync] ${phase} timed out after ${timeoutMs}ms and could not prove process-tree cleanup.\n`,
       );
-      if (phase === "push") retryGuidance(writeStderr);
+      cleanupUnprovenGuidance(writeStderr);
       return 1;
     }
     if (result.status !== 0) {
@@ -935,9 +944,12 @@ terminates the complete owned process tree if Git or a credential helper stops
 making progress. Do not use the raw commands for routine sync in this
 repository.
 
-If push fails or times out, retry `pnpm beads:sync` once. Do not edit Git
-configuration or credential helpers after one transient 403; the known
-intermittent identity failure can succeed without any configuration change.
+If push fails or times out and the wrapper confirms the owned process tree was
+terminated, retry `pnpm beads:sync` once. If cleanup could not be proven, verify
+and stop the surviving process tree before retrying; it may still hold the Dolt
+lock or be pushing. Do not edit Git configuration or credential helpers after
+one transient 403; the known intermittent identity failure can succeed without
+any configuration change.
 For pending Beads changes, verify the remote ref actually advanced:
 
 ```bash
@@ -947,8 +959,9 @@ git ls-remote origin refs/dolt/data
 ```
 
 Compare the before and after OIDs. An expected advancement proves the remote
-accepted pending changes. No advancement is required when there were no local
-Dolt changes to publish.
+changed, but concurrent syncs mean it does not identify which actor advanced
+the ref. No advancement is required when there were no local Dolt changes to
+publish.
 ````
 
 - [ ] **Step 5: Update both session-completion command sequences**

--- a/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
+++ b/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
@@ -677,7 +677,7 @@ After the existing Dolt workflow assertion, add:
 ```js
 assert.match(
   workflow,
-  /Retry `pnpm beads:sync` once[\s\S]*Do not edit Git configuration or credential helpers[\s\S]*refs\/dolt\/data/,
+  /Retry `pnpm beads:sync` once[\s\S]*Do not edit Git\s+configuration or credential helpers[\s\S]*refs\/dolt\/data/,
   "workflow docs should explain bounded retry and remote-ref verification",
 );
 ```

--- a/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
+++ b/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
@@ -1,0 +1,1038 @@
+# Beads Dolt Sync Watchdog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Cave's unbounded `bd dolt pull && bd dolt push` shell chain with a cross-platform watchdog that bounds both phases, terminates the complete owned process tree, and documents an honest retry and remote-ref verification procedure.
+
+**Architecture:** Add one TypeScript CLI orchestrator under `scripts/` that launches `bd` through the existing Windows-safe resolver and reuses Cave's bounded-output and process-tree termination helpers. Exercise it through a fake `bd` executable, including a POSIX descendant that ignores `SIGTERM`, then route the stable `pnpm beads:sync` entrypoint and repository guidance through the wrapper.
+
+**Tech Stack:** Node.js 24, TypeScript strip-types execution, `node:test`, Node child processes, pnpm, Cave `withBdLaunch`, Cave `BoundedProcessOutput`, Cave `terminateProcessTree`.
+
+---
+
+## File structure
+
+- Create `scripts/beads-sync.ts`
+  - Own sequential pull/push orchestration, credential-prompt suppression,
+    bounded diagnostics, timeout classification, and exact process-tree cleanup.
+- Create `scripts/beads-sync.test.mjs`
+  - Exercise healthy ordering, pull short-circuiting, push failure, timeout
+    cleanup, and cleanup-proof failure.
+- Modify `src/lib/bd-bin.test.ts`
+  - Add the new script to the source guard that requires shell-free
+    `withBdLaunch` routing.
+- Modify `scripts/run-tests.mjs`
+  - Wire the new script test into the app test suite.
+- Modify `package.json`
+  - Keep the public command name `beads:sync`, but route it through the new
+    TypeScript entrypoint.
+- Modify `scripts/beads-familiar-workflow.test.mjs`
+  - Pin the new package command and safe operator guidance.
+- Modify `docs/workflows/beads-familiars.md`
+  - Make `pnpm beads:sync` canonical and document one retry plus
+    `refs/dolt/data` verification.
+- Modify `AGENTS.md`
+  - Replace the raw session-completion push with the bounded entrypoint.
+- Modify `CLAUDE.md`
+  - Replace the raw session-completion push with the bounded entrypoint.
+
+### Task 1: Add failing sync orchestration contracts
+
+**Files:**
+- Create: `scripts/beads-sync.test.mjs`
+- Modify: `scripts/run-tests.mjs:80-100`
+- Modify: `src/lib/bd-bin.test.ts:202-215`
+
+- [ ] **Step 1: Create the fake-CLI test harness and healthy ordering test**
+
+Create `scripts/beads-sync.test.mjs` with:
+
+```js
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+
+import { runBeadsSync } from "./beads-sync.ts";
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "beads-sync-"));
+  const bin = join(root, "bin");
+  const log = join(root, "bd-log.jsonl");
+  const descendantPid = join(root, "descendant.pid");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(
+    join(bin, "bd"),
+    `#!/usr/bin/env node
+import { appendFileSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+
+const args = process.argv.slice(2);
+const phase = args[1];
+appendFileSync(
+  process.env.BD_FAKE_LOG,
+  JSON.stringify({
+    args,
+    gitTerminalPrompt: process.env.GIT_TERMINAL_PROMPT,
+    gcmInteractive: process.env.GCM_INTERACTIVE,
+  }) + "\\n",
+);
+
+if (phase === "pull") {
+  process.stdout.write("pull ok\\n");
+  process.stderr.write("pull note\\n");
+  process.exit(Number(process.env.BD_FAKE_PULL_EXIT ?? "0"));
+}
+
+if (process.env.BD_FAKE_PUSH_HANG === "1") {
+  const descendant = spawn(
+    process.execPath,
+    ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"],
+    { stdio: "ignore" },
+  );
+  writeFileSync(process.env.BD_FAKE_DESCENDANT_PID, String(descendant.pid));
+  process.on("SIGTERM", () => {});
+  setInterval(() => {}, 1000);
+}
+
+process.stdout.write("push ok\\n");
+process.stderr.write("push note\\n");
+process.exit(Number(process.env.BD_FAKE_PUSH_EXIT ?? "0"));
+`,
+    "utf8",
+  );
+  chmodSync(join(bin, "bd"), 0o755);
+  return {
+    root,
+    log,
+    descendantPid,
+    env: {
+      ...process.env,
+      PATH: `${bin}${process.env.PATH ? `${delimiter}${process.env.PATH}` : ""}`,
+      BD_FAKE_LOG: log,
+      BD_FAKE_DESCENDANT_PID: descendantPid,
+    },
+  };
+}
+
+function readLog(path) {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function outputSink() {
+  let value = "";
+  return {
+    write(chunk) {
+      value += chunk;
+    },
+    text() {
+      return value;
+    },
+  };
+}
+
+test("sync runs pull before push with noninteractive credential settings", async () => {
+  const current = fixture();
+  const stdout = outputSink();
+  const stderr = outputSink();
+  try {
+    const status = await runBeadsSync({
+      env: current.env,
+      writeStdout: (value) => stdout.write(value),
+      writeStderr: (value) => stderr.write(value),
+    });
+
+    assert.equal(status, 0, stderr.text());
+    assert.deepEqual(
+      readLog(current.log),
+      [
+        {
+          args: ["dolt", "pull"],
+          gitTerminalPrompt: "0",
+          gcmInteractive: "Never",
+        },
+        {
+          args: ["dolt", "push"],
+          gitTerminalPrompt: "0",
+          gcmInteractive: "Never",
+        },
+      ],
+    );
+    assert.match(stdout.text(), /\[beads:sync\] pull/);
+    assert.match(stdout.text(), /pull ok/);
+    assert.match(stdout.text(), /\[beads:sync\] push/);
+    assert.match(stdout.text(), /push ok/);
+    assert.match(stderr.text(), /pull note/);
+    assert.match(stderr.text(), /push note/);
+  } finally {
+    rmSync(current.root, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2: Add pull and push failure contracts**
+
+Append to `scripts/beads-sync.test.mjs`:
+
+```js
+test("pull failure preserves its status and never starts push", async () => {
+  const current = fixture();
+  const stderr = outputSink();
+  try {
+    const status = await runBeadsSync({
+      env: { ...current.env, BD_FAKE_PULL_EXIT: "7" },
+      writeStdout: () => {},
+      writeStderr: (value) => stderr.write(value),
+    });
+
+    assert.equal(status, 7);
+    assert.deepEqual(
+      readLog(current.log).map((entry) => entry.args),
+      [["dolt", "pull"]],
+    );
+    assert.match(stderr.text(), /pull exited with status 7/);
+  } finally {
+    rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("push failure preserves its status and prints safe retry guidance", async () => {
+  const current = fixture();
+  const stderr = outputSink();
+  try {
+    const status = await runBeadsSync({
+      env: { ...current.env, BD_FAKE_PUSH_EXIT: "9" },
+      writeStdout: () => {},
+      writeStderr: (value) => stderr.write(value),
+    });
+
+    assert.equal(status, 9);
+    assert.deepEqual(
+      readLog(current.log).map((entry) => entry.args),
+      [["dolt", "pull"], ["dolt", "push"]],
+    );
+    assert.match(stderr.text(), /push exited with status 9/);
+    assert.match(stderr.text(), /Retry `pnpm beads:sync` once/);
+    assert.match(stderr.text(), /refs\/dolt\/data/);
+    assert.match(stderr.text(), /Do not edit Git configuration or credential helpers/);
+  } finally {
+    rmSync(current.root, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 3: Add timeout and cleanup-proof contracts**
+
+Append to `scripts/beads-sync.test.mjs`:
+
+```js
+async function waitForMissingProcess(pid, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if (error?.code === "ESRCH") return true;
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return false;
+}
+
+test("push timeout kills a descendant that ignores SIGTERM", {
+  skip: process.platform === "win32",
+}, async () => {
+  const current = fixture();
+  const stderr = outputSink();
+  try {
+    const status = await runBeadsSync({
+      env: { ...current.env, BD_FAKE_PUSH_HANG: "1" },
+      timeoutMs: 200,
+      terminationGraceMs: 200,
+      writeStdout: () => {},
+      writeStderr: (value) => stderr.write(value),
+    });
+
+    assert.equal(status, 124, stderr.text());
+    const pid = Number(readFileSync(current.descendantPid, "utf8"));
+    assert.equal(await waitForMissingProcess(pid), true, `descendant ${pid} survived timeout`);
+    assert.match(stderr.text(), /push timed out after 200ms/);
+    assert.match(stderr.text(), /owned process tree terminated/);
+    assert.match(stderr.text(), /Retry `pnpm beads:sync` once/);
+  } finally {
+    rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("unproven tree cleanup is a hard error, not an ordinary timeout", async () => {
+  const stderr = outputSink();
+  const fakeChild = new EventEmitter();
+  fakeChild.pid = 424242;
+  fakeChild.exitCode = null;
+  fakeChild.signalCode = null;
+  fakeChild.stdout = new PassThrough();
+  fakeChild.stderr = new PassThrough();
+
+  const status = await runBeadsSync({
+    timeoutMs: 1,
+    spawnProcess: () => fakeChild,
+    terminateTree: async () => false,
+    writeStdout: () => {},
+    writeStderr: (value) => stderr.write(value),
+  });
+
+  assert.equal(status, 1);
+  assert.match(stderr.text(), /could not prove process-tree cleanup/);
+  assert.doesNotMatch(stderr.text(), /owned process tree terminated/);
+});
+```
+
+- [ ] **Step 4: Wire the test into the app suite**
+
+Add `"scripts/beads-sync.test.mjs",` immediately after
+`"scripts/beads-create.test.mjs",` in the first `SUITES.app.files` group in
+`scripts/run-tests.mjs`.
+
+Update `src/lib/bd-bin.test.ts`:
+
+```ts
+const ROUTED_SCRIPTS = [
+  "scripts/beads-create.ts",
+  "scripts/beads-pr-shared.ts",
+  "scripts/beads-surface-audit.ts",
+  "scripts/beads-sync.ts",
+  "scripts/worktree-lifecycle-create.ts",
+  "scripts/worktree-lifecycle-inventory.ts",
+  "scripts/worktree-lifecycle-metadata-repair.ts",
+];
+```
+
+- [ ] **Step 5: Run the new test and verify the expected failure**
+
+Run:
+
+```bash
+node scripts/beads-sync.test.mjs
+```
+
+Expected: FAIL with `ERR_MODULE_NOT_FOUND` for `scripts/beads-sync.ts`.
+
+- [ ] **Step 6: Commit the failing contracts**
+
+```bash
+git add scripts/beads-sync.test.mjs scripts/run-tests.mjs src/lib/bd-bin.test.ts
+git commit -m "test: define bounded Beads sync contract"
+```
+
+### Task 2: Implement bounded pull and push orchestration
+
+**Files:**
+- Create: `scripts/beads-sync.ts`
+- Test: `scripts/beads-sync.test.mjs`
+- Test: `src/lib/bd-bin.test.ts`
+
+- [ ] **Step 1: Implement the complete sync entrypoint**
+
+Create `scripts/beads-sync.ts`:
+
+```ts
+#!/usr/bin/env node
+
+import {
+  spawn,
+  type ChildProcess,
+  type SpawnOptions,
+} from "node:child_process";
+
+import { withBdLaunch } from "../src/lib/bd-bin.ts";
+import {
+  BoundedProcessOutput,
+  safeProcessErrorMessage,
+  terminateProcessTree,
+} from "../src/lib/process-execution.ts";
+import { isDirectRun } from "./direct-run.mjs";
+
+const DEFAULT_PHASE_TIMEOUT_MS = 90_000;
+const OUTPUT_BYTES = 64 * 1024;
+
+type SyncPhase = "pull" | "push";
+
+type SpawnProcess = (
+  command: string,
+  args: string[],
+  options: SpawnOptions,
+) => ChildProcess;
+
+type TerminateTree = (
+  child: ChildProcess,
+  options?: { platform?: NodeJS.Platform; graceMs?: number },
+) => Promise<boolean>;
+
+export type BeadsSyncOptions = {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  timeoutMs?: number;
+  terminationGraceMs?: number;
+  spawnProcess?: SpawnProcess;
+  terminateTree?: TerminateTree;
+  writeStdout?: (value: string) => void;
+  writeStderr?: (value: string) => void;
+};
+
+type PhaseResult = {
+  status: number;
+  stdout: string;
+  stderr: string;
+  kind: "completed" | "timed-out" | "cleanup-unproven" | "spawn-failed";
+  error?: string;
+};
+
+function positiveFiniteTimeout(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new TypeError("Beads sync timeout must be a positive finite number");
+  }
+  return Math.ceil(value);
+}
+
+function writeRetained(write: (value: string) => void, value: string): void {
+  if (!value) return;
+  write(value.endsWith("\n") ? value : `${value}\n`);
+}
+
+function retryGuidance(write: (value: string) => void): void {
+  write("[beads:sync] Retry `pnpm beads:sync` once.\n");
+  write(
+    "[beads:sync] Do not edit Git configuration or credential helpers after one transient 403.\n",
+  );
+  write(
+    "[beads:sync] For pending Beads changes, compare `git ls-remote origin refs/dolt/data` before and after the retry.\n",
+  );
+}
+
+async function runPhase(
+  phase: SyncPhase,
+  options: Required<
+    Pick<
+      BeadsSyncOptions,
+      | "env"
+      | "platform"
+      | "timeoutMs"
+      | "spawnProcess"
+      | "terminateTree"
+      | "writeStdout"
+      | "writeStderr"
+    >
+  > & Pick<BeadsSyncOptions, "terminationGraceMs">,
+): Promise<PhaseResult> {
+  const launch = withBdLaunch("bd", ["dolt", phase]);
+  const stdout = new BoundedProcessOutput(OUTPUT_BYTES);
+  const stderr = new BoundedProcessOutput(OUTPUT_BYTES);
+  let child: ChildProcess;
+
+  try {
+    child = options.spawnProcess(launch.command, launch.args, {
+      env: {
+        ...options.env,
+        GIT_TERMINAL_PROMPT: "0",
+        GCM_INTERACTIVE: "Never",
+      },
+      windowsHide: true,
+      shell: false,
+      detached: options.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    return {
+      status: 1,
+      stdout: "",
+      stderr: "",
+      kind: "spawn-failed",
+      error: safeProcessErrorMessage(error, "Beads CLI"),
+    };
+  }
+
+  child.stdout?.on("data", (chunk) => stdout.append(chunk));
+  child.stderr?.on("data", (chunk) => stderr.append(chunk));
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let timedOut = false;
+    const finish = (result: PhaseResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const retained = () => ({
+      stdout: stdout.text(),
+      stderr: stderr.text(),
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      void options
+        .terminateTree(child, {
+          platform: options.platform,
+          graceMs: options.terminationGraceMs,
+        })
+        .then((cleanupProven) => {
+          finish({
+            status: cleanupProven ? 124 : 1,
+            ...retained(),
+            kind: cleanupProven ? "timed-out" : "cleanup-unproven",
+          });
+        })
+        .catch(() => {
+          finish({
+            status: 1,
+            ...retained(),
+            kind: "cleanup-unproven",
+          });
+        });
+    }, options.timeoutMs);
+
+    child.once("error", (error) => {
+      finish({
+        status: 1,
+        ...retained(),
+        kind: "spawn-failed",
+        error: safeProcessErrorMessage(error, "Beads CLI"),
+      });
+    });
+    child.once("close", (code) => {
+      if (timedOut) return;
+      finish({
+        status: code ?? 1,
+        ...retained(),
+        kind: "completed",
+      });
+    });
+  });
+}
+
+export async function runBeadsSync(options: BeadsSyncOptions = {}): Promise<number> {
+  const timeoutMs = positiveFiniteTimeout(
+    options.timeoutMs ?? DEFAULT_PHASE_TIMEOUT_MS,
+  );
+  const writeStdout = options.writeStdout ?? ((value) => process.stdout.write(value));
+  const writeStderr = options.writeStderr ?? ((value) => process.stderr.write(value));
+  const resolved = {
+    env: options.env ?? process.env,
+    platform: options.platform ?? process.platform,
+    timeoutMs,
+    terminationGraceMs: options.terminationGraceMs,
+    spawnProcess: options.spawnProcess ?? spawn,
+    terminateTree: options.terminateTree ?? terminateProcessTree,
+    writeStdout,
+    writeStderr,
+  };
+
+  for (const phase of ["pull", "push"] as const) {
+    writeStdout(`[beads:sync] ${phase}\n`);
+    const result = await runPhase(phase, resolved);
+    writeRetained(writeStdout, result.stdout);
+    writeRetained(writeStderr, result.stderr);
+
+    if (result.kind === "spawn-failed") {
+      writeStderr(`[beads:sync] ${phase} failed: ${result.error}\n`);
+      if (phase === "push") retryGuidance(writeStderr);
+      return 1;
+    }
+    if (result.kind === "timed-out") {
+      writeStderr(
+        `[beads:sync] ${phase} timed out after ${timeoutMs}ms; owned process tree terminated.\n`,
+      );
+      if (phase === "push") retryGuidance(writeStderr);
+      return 124;
+    }
+    if (result.kind === "cleanup-unproven") {
+      writeStderr(
+        `[beads:sync] ${phase} timed out after ${timeoutMs}ms and could not prove process-tree cleanup.\n`,
+      );
+      if (phase === "push") retryGuidance(writeStderr);
+      return 1;
+    }
+    if (result.status !== 0) {
+      writeStderr(
+        `[beads:sync] ${phase} exited with status ${result.status}.\n`,
+      );
+      if (phase === "push") retryGuidance(writeStderr);
+      return result.status;
+    }
+  }
+
+  return 0;
+}
+
+async function main(): Promise<void> {
+  process.exitCode = await runBeadsSync();
+}
+
+if (isDirectRun(import.meta.url)) {
+  void main().catch((error) => {
+    process.stderr.write(
+      `[beads:sync] ${safeProcessErrorMessage(error, "Beads sync")}\n`,
+    );
+    process.exitCode = 1;
+  });
+}
+```
+
+- [ ] **Step 2: Run the focused tests**
+
+Run:
+
+```bash
+node scripts/beads-sync.test.mjs
+node --experimental-strip-types src/lib/bd-bin.test.ts
+```
+
+Expected:
+
+```text
+... all five beads-sync subtests pass ...
+bd-bin.test.ts ok
+```
+
+- [ ] **Step 3: Run typecheck and lint on the implementation**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm lint
+```
+
+Expected: both commands exit `0`.
+
+- [ ] **Step 4: Commit the watchdog implementation**
+
+```bash
+git add scripts/beads-sync.ts
+git commit -m "fix: bound Beads Dolt sync processes"
+```
+
+### Task 3: Route the stable command and operator guidance
+
+**Files:**
+- Modify: `package.json:101`
+- Modify: `scripts/beads-familiar-workflow.test.mjs:10-85`
+- Modify: `docs/workflows/beads-familiars.md:65-95`
+- Modify: `AGENTS.md` in the managed Beads session-completion block
+- Modify: `CLAUDE.md` in the managed Beads session-completion block
+
+- [ ] **Step 1: Change the workflow contract test first**
+
+In `scripts/beads-familiar-workflow.test.mjs`, replace:
+
+```js
+sync: "bd dolt pull && bd dolt push",
+```
+
+with:
+
+```js
+sync: "node --experimental-strip-types scripts/beads-sync.ts",
+```
+
+Replace:
+
+```js
+assert.match(claude, /bd dolt push[\s\S]*git push/, "Claude session close guidance should include Beads Dolt sync before git push");
+```
+
+with:
+
+```js
+assert.match(
+  claude,
+  /pnpm beads:sync[\s\S]*git push/,
+  "Claude session close guidance should use bounded Beads sync before git push",
+);
+assert.match(
+  agents,
+  /pnpm beads:sync[\s\S]*git push/,
+  "agent session close guidance should use bounded Beads sync before git push",
+);
+```
+
+After the existing Dolt workflow assertion, add:
+
+```js
+assert.match(
+  workflow,
+  /Retry `pnpm beads:sync` once[\s\S]*Do not edit Git configuration or credential helpers[\s\S]*refs\/dolt\/data/,
+  "workflow docs should explain bounded retry and remote-ref verification",
+);
+```
+
+- [ ] **Step 2: Run the workflow contract and verify it fails**
+
+Run:
+
+```bash
+node scripts/beads-familiar-workflow.test.mjs
+```
+
+Expected: FAIL because `package.json`, `AGENTS.md`, `CLAUDE.md`, and the workflow
+doc still contain the raw Dolt push contract.
+
+- [ ] **Step 3: Route `pnpm beads:sync` through the watchdog**
+
+In `package.json`, replace:
+
+```json
+"beads:sync": "bd dolt pull && bd dolt push",
+```
+
+with:
+
+```json
+"beads:sync": "node --experimental-strip-types scripts/beads-sync.ts",
+```
+
+- [ ] **Step 4: Document the bounded command and retry procedure**
+
+Replace the raw sync block in `docs/workflows/beads-familiars.md`:
+
+```markdown
+Use Dolt sync when a bead graph needs to move between machines:
+
+```bash
+bd dolt pull
+bd dolt push
+```
+```
+
+with:
+
+````markdown
+Use the bounded repository entrypoint when a bead graph needs to move between
+machines:
+
+```bash
+pnpm beads:sync
+```
+
+It runs `bd dolt pull` and then `bd dolt push`, but bounds each phase and
+terminates the complete owned process tree if Git or a credential helper stops
+making progress. Do not use the raw commands for routine sync in this
+repository.
+
+If push fails or times out, Retry `pnpm beads:sync` once. Do not edit Git
+configuration or credential helpers after one transient 403; the known
+intermittent identity failure can succeed without any configuration change.
+For pending Beads changes, verify the remote ref actually advanced:
+
+```bash
+git ls-remote origin refs/dolt/data
+pnpm beads:sync
+git ls-remote origin refs/dolt/data
+```
+
+Compare the before and after OIDs. An expected advancement proves the remote
+accepted pending changes. No advancement is required when there were no local
+Dolt changes to publish.
+````
+
+- [ ] **Step 5: Update both session-completion command sequences**
+
+In `AGENTS.md` and `CLAUDE.md`, replace the managed Beads block sequence:
+
+```bash
+git pull --rebase
+bd dolt push
+git push
+git status
+```
+
+with:
+
+```bash
+git pull --rebase
+pnpm beads:sync
+git push
+git status
+```
+
+Do not change the generated block markers, profile metadata, or unrelated
+Beads guidance.
+
+- [ ] **Step 6: Run the focused workflow contracts**
+
+Run:
+
+```bash
+node scripts/beads-familiar-workflow.test.mjs
+node scripts/beads-sync.test.mjs
+node --experimental-strip-types src/lib/bd-bin.test.ts
+```
+
+Expected: all three commands exit `0`.
+
+- [ ] **Step 7: Commit the package and operator migration**
+
+```bash
+git add package.json scripts/beads-familiar-workflow.test.mjs docs/workflows/beads-familiars.md AGENTS.md CLAUDE.md
+git commit -m "docs: route Beads sync through watchdog"
+```
+
+### Task 4: Validate the complete change
+
+**Files:**
+- Verify all files changed in Tasks 1-3
+
+- [ ] **Step 1: Run the exact regression tests**
+
+Run:
+
+```bash
+node scripts/beads-sync.test.mjs
+node scripts/beads-familiar-workflow.test.mjs
+node --experimental-strip-types src/lib/bd-bin.test.ts
+```
+
+Expected: all commands exit `0`; the timeout fixture reports no surviving
+descendant.
+
+- [ ] **Step 2: Run the repository test wiring guard**
+
+Run:
+
+```bash
+pnpm check:tests-wired
+```
+
+Expected: exit `0`; `scripts/beads-sync.test.mjs` is recognized as wired.
+
+- [ ] **Step 3: Run static validation**
+
+Run:
+
+```bash
+pnpm lint
+pnpm typecheck
+```
+
+Expected: both commands exit `0`.
+
+- [ ] **Step 4: Run the app suite containing the new tests**
+
+Run:
+
+```bash
+pnpm test:app
+```
+
+Expected: exit `0`.
+
+- [ ] **Step 5: Inspect the final scoped diff**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git status --short --branch
+git diff --stat origin/main...HEAD
+git log --oneline origin/main..HEAD
+```
+
+Expected:
+
+- no whitespace errors;
+- only the design, plan, watchdog, tests, package entrypoint, and directly
+  related Beads guidance are changed;
+- the branch contains the design commit plus the implementation commits;
+- the worktree is clean after committing the plan and any final corrections.
+
+- [ ] **Step 6: Commit any final test-only correction**
+
+If validation required a correction, stage only the files in this plan and
+commit when the index is nonempty:
+
+```bash
+git add \
+  scripts/beads-sync.ts \
+  scripts/beads-sync.test.mjs \
+  scripts/run-tests.mjs \
+  src/lib/bd-bin.test.ts \
+  package.json \
+  scripts/beads-familiar-workflow.test.mjs \
+  docs/workflows/beads-familiars.md \
+  AGENTS.md \
+  CLAUDE.md
+git diff --cached --quiet || git commit -m "test: harden Beads sync watchdog coverage"
+```
+
+If no correction was needed, do not create an empty commit.
+
+### Task 5: Open, verify, and merge the PR
+
+**Files:**
+- No additional source changes expected
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin fix/cave-hg7qb-dolt-push-watchdog
+```
+
+Expected: the exact local head is retained on `origin`.
+
+- [ ] **Step 2: Open the pull request**
+
+```bash
+pr_url=$(gh pr create \
+  --repo OpenCoven/coven-cave \
+  --base main \
+  --head fix/cave-hg7qb-dolt-push-watchdog \
+  --title "Bound Beads Dolt sync credential hangs" \
+  --body "$(cat <<'EOF'
+## Summary
+- route `pnpm beads:sync` through a shell-free Node watchdog
+- bound pull and push, terminate the complete owned process tree, and preserve redacted diagnostics
+- document one safe retry and `refs/dolt/data` verification
+
+## Validation
+- `node scripts/beads-sync.test.mjs`
+- `node scripts/beads-familiar-workflow.test.mjs`
+- `node --experimental-strip-types src/lib/bd-bin.test.ts`
+- `pnpm check:tests-wired`
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test:app`
+
+Bead: `cave-hg7qb`
+EOF
+)")
+printf '%s\n' "$pr_url"
+```
+
+Expected: a PR URL with no AI attribution footer.
+
+- [ ] **Step 3: Record the PR on the Bead**
+
+```bash
+pr_url=$(gh pr view fix/cave-hg7qb-dolt-push-watchdog \
+  --repo OpenCoven/coven-cave \
+  --json url \
+  --jq .url)
+bd update cave-hg7qb --external-ref "$pr_url"
+bd comments add cave-hg7qb \
+  "Implemented bounded pull/push orchestration with verified process-tree cleanup; PR: $pr_url."
+```
+
+Expected: `bd show cave-hg7qb --json` reports the PR URL and implementation
+evidence.
+
+- [ ] **Step 4: Read every review thread and required check**
+
+```bash
+pr_number=$(gh pr view fix/cave-hg7qb-dolt-push-watchdog \
+  --repo OpenCoven/coven-cave \
+  --json number \
+  --jq .number)
+gh pr view "$pr_number" \
+  --repo OpenCoven/coven-cave \
+  --json headRefOid,mergeable,mergeStateStatus,statusCheckRollup
+gh api graphql --paginate --slurp \
+  -F pr="$pr_number" \
+  -f query='
+    query($pr: Int!, $endCursor: String) {
+      repository(owner: "OpenCoven", name: "coven-cave") {
+        pullRequest(number: $pr) {
+          reviewThreads(first: 100, after: $endCursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              isResolved
+              path
+              comments(first: 100) {
+                pageInfo { hasNextPage endCursor }
+                nodes { author { login } body url }
+              }
+            }
+          }
+        }
+      }
+    }
+  '
+gh pr checks "$pr_number" --repo OpenCoven/coven-cave --required
+```
+
+Expected:
+
+- `headRefOid` equals the pushed local head;
+- all review threads and their returned comments have been read and any real
+  defect is fixed;
+- required `Frontend build` reports success on that exact head.
+
+The paginated query must report `hasNextPage: false` for every review-thread
+page. If any thread's nested `comments.pageInfo.hasNextPage` is true, query that
+thread node by its returned `id` with the same `--paginate` pattern before
+merging.
+
+- [ ] **Step 5: Verify the exact head and squash-merge**
+
+```bash
+set -euo pipefail
+pr_number=$(gh pr view fix/cave-hg7qb-dolt-push-watchdog \
+  --repo OpenCoven/coven-cave \
+  --json number \
+  --jq .number)
+expected_head=$(git rev-parse HEAD)
+actual_head=$(gh pr view "$pr_number" --repo OpenCoven/coven-cave --json headRefOid --jq .headRefOid)
+test "$actual_head" = "$expected_head"
+gh pr checks "$pr_number" --repo OpenCoven/coven-cave --required
+gh pr merge "$pr_number" \
+  --repo OpenCoven/coven-cave \
+  --squash \
+  --match-head-commit "$expected_head"
+```
+
+Expected: merge succeeds without `--admin` and without direct push to `main`.
+
+- [ ] **Step 6: Verify `origin/main` and close the Bead**
+
+```bash
+pr_number=$(gh pr view fix/cave-hg7qb-dolt-push-watchdog \
+  --repo OpenCoven/coven-cave \
+  --json number \
+  --jq .number)
+git fetch origin main
+gh pr view "$pr_number" --repo OpenCoven/coven-cave --json state,mergedAt,mergeCommit
+git show origin/main:scripts/beads-sync.ts >/dev/null
+git show origin/main:package.json | grep 'scripts/beads-sync.ts'
+bd close cave-hg7qb --reason "Merged in PR #$pr_number. pnpm beads:sync now bounds pull and push, verifies owned process-tree cleanup on timeout, and documents safe retry plus refs/dolt/data verification."
+```
+
+Expected: PR state `MERGED`, merged files present on `origin/main`, and Bead
+status `closed`.
+
+- [ ] **Step 7: Record worktree disposition**
+
+```bash
+pnpm beads:worktrees
+```
+
+Expected: the merged `cave-hg7qb` unit has a visible post-merge disposition.
+If it is not cleanup-ready, preserve it and record the owner/reason on the
+Bead. If it is cleanup-ready, prove the exact head is retained by a remote
+branch or pushed archive tag before using the repository's sanctioned
+retirement path.

--- a/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
+++ b/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
@@ -103,7 +103,7 @@ if (process.env.BD_FAKE_PUSH_HANG === "1") {
   );
   writeFileSync(process.env.BD_FAKE_DESCENDANT_PID, String(descendant.pid));
   process.on("SIGTERM", () => {});
-  setInterval(() => {}, 1000);
+  await new Promise(() => {});
 }
 
 process.stdout.write("push ok\\n");

--- a/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
+++ b/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
@@ -264,7 +264,7 @@ test("push timeout kills a descendant that ignores SIGTERM", {
   try {
     const status = await runBeadsSync({
       env: { ...current.env, BD_FAKE_PUSH_HANG: "1" },
-      timeoutMs: 200,
+      timeoutMs: 1_000,
       terminationGraceMs: 200,
       writeStdout: () => {},
       writeStderr: (value) => stderr.write(value),
@@ -273,7 +273,7 @@ test("push timeout kills a descendant that ignores SIGTERM", {
     assert.equal(status, 124, stderr.text());
     const pid = Number(readFileSync(current.descendantPid, "utf8"));
     assert.equal(await waitForMissingProcess(pid), true, `descendant ${pid} survived timeout`);
-    assert.match(stderr.text(), /push timed out after 200ms/);
+    assert.match(stderr.text(), /push timed out after 1000ms/);
     assert.match(stderr.text(), /owned process tree terminated/);
     assert.match(stderr.text(), /Retry `pnpm beads:sync` once/);
   } finally {

--- a/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
+++ b/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
@@ -362,7 +362,7 @@ import {
   type SpawnOptions,
 } from "node:child_process";
 
-import { withBdLaunch } from "../src/lib/bd-bin.ts";
+import { resolveBdLaunchCommand, withBdLaunch } from "../src/lib/bd-bin.ts";
 import {
   BoundedProcessOutput,
   safeProcessErrorMessage,
@@ -451,7 +451,14 @@ async function runPhase(
     >
   > & Pick<BeadsSyncOptions, "terminationGraceMs">,
 ): Promise<PhaseResult> {
-  const launch = withBdLaunch("bd", ["dolt", phase]);
+  const launch = withBdLaunch(
+    "bd",
+    ["dolt", phase],
+    resolveBdLaunchCommand({
+      env: options.env,
+      platform: options.platform,
+    }),
+  );
   const stdout = new BoundedProcessOutput(OUTPUT_BYTES);
   const stderr = new BoundedProcessOutput(OUTPUT_BYTES);
   let child: ChildProcess;
@@ -481,6 +488,12 @@ async function runPhase(
   child.stdout?.on("data", (chunk) => stdout.append(chunk));
   child.stderr?.on("data", (chunk) => stderr.append(chunk));
 
+  const releaseUnprovenChildHandles = () => {
+    child.stdout?.destroy();
+    child.stderr?.destroy();
+    child.unref();
+  };
+
   return new Promise((resolve) => {
     let settled = false;
     let timedOut = false;
@@ -502,6 +515,7 @@ async function runPhase(
           graceMs: options.terminationGraceMs,
         })
         .then((cleanupProven) => {
+          if (!cleanupProven) releaseUnprovenChildHandles();
           finish({
             status: cleanupProven ? 124 : 1,
             ...retained(),
@@ -509,6 +523,7 @@ async function runPhase(
           });
         })
         .catch(() => {
+          releaseUnprovenChildHandles();
           finish({
             status: 1,
             ...retained(),
@@ -518,6 +533,7 @@ async function runPhase(
     }, options.timeoutMs);
 
     child.once("error", (error) => {
+      if (timedOut) return;
       finish({
         status: 1,
         ...retained(),
@@ -688,6 +704,7 @@ const terminate = (
       graceMs: options.terminationGraceMs,
     })
     .then((cleanupProven) => {
+      if (!cleanupProven) releaseUnprovenChildHandles();
       finish({
         status: cleanupProven ? successStatus : 1,
         ...retained(),
@@ -695,6 +712,7 @@ const terminate = (
       });
     })
     .catch(() => {
+      releaseUnprovenChildHandles();
       finish({
         status: 1,
         ...retained(),
@@ -718,9 +736,20 @@ if (options.signal.aborted) onAbort();
 ```
 
 Remove the abort listener inside `finish`, ignore `close` while `terminating`,
-and report cancellation separately:
+ignore delayed child `error` events while `terminating`, and report cancellation
+separately:
 
 ```ts
+child.once("error", (error) => {
+  if (terminating) return;
+  finish({
+    status: 1,
+    ...retained(),
+    kind: "spawn-failed",
+    error: safeProcessErrorMessage(error, "Beads CLI"),
+  });
+});
+
 if (result.kind === "cancelled") {
   writeStderr(
     `[beads:sync] ${phase} cancelled; owned process tree terminated.\n`,

--- a/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
+++ b/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
@@ -877,7 +877,7 @@ After the existing Dolt workflow assertion, add:
 ```js
 assert.match(
   workflow,
-  /Retry `pnpm beads:sync` once[\s\S]*Do not edit Git\s+configuration or credential helpers[\s\S]*refs\/dolt\/data/,
+  /retry `pnpm beads:sync` once[\s\S]*Do not edit Git\s+configuration or credential helpers[\s\S]*refs\/dolt\/data/i,
   "workflow docs should explain bounded retry and remote-ref verification",
 );
 ```
@@ -935,7 +935,7 @@ terminates the complete owned process tree if Git or a credential helper stops
 making progress. Do not use the raw commands for routine sync in this
 repository.
 
-If push fails or times out, Retry `pnpm beads:sync` once. Do not edit Git
+If push fails or times out, retry `pnpm beads:sync` once. Do not edit Git
 configuration or credential helpers after one transient 403; the known
 intermittent identity failure can succeed without any configuration change.
 For pending Beads changes, verify the remote ref actually advanced:

--- a/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
+++ b/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
@@ -14,7 +14,8 @@
 
 - Create `scripts/beads-sync.ts`
   - Own sequential pull/push orchestration, credential-prompt suppression,
-    bounded diagnostics, timeout classification, and exact process-tree cleanup.
+    bounded diagnostics, timeout/cancellation classification, and exact
+    process-tree cleanup.
 - Create `scripts/beads-sync.test.mjs`
   - Exercise healthy ordering, pull short-circuiting, push failure, timeout
     cleanup, and cleanup-proof failure.
@@ -264,7 +265,7 @@ test("push timeout kills a descendant that ignores SIGTERM", {
   try {
     const status = await runBeadsSync({
       env: { ...current.env, BD_FAKE_PUSH_HANG: "1" },
-      timeoutMs: 1_000,
+      timeoutMs: 3_000,
       terminationGraceMs: 200,
       writeStdout: () => {},
       writeStderr: (value) => stderr.write(value),
@@ -273,7 +274,7 @@ test("push timeout kills a descendant that ignores SIGTERM", {
     assert.equal(status, 124, stderr.text());
     const pid = Number(readFileSync(current.descendantPid, "utf8"));
     assert.equal(await waitForMissingProcess(pid), true, `descendant ${pid} survived timeout`);
-    assert.match(stderr.text(), /push timed out after 1000ms/);
+    assert.match(stderr.text(), /push timed out after 3000ms/);
     assert.match(stderr.text(), /owned process tree terminated/);
     assert.match(stderr.text(), /Retry `pnpm beads:sync` once/);
   } finally {
@@ -606,7 +607,7 @@ node --experimental-strip-types src/lib/bd-bin.test.ts
 Expected:
 
 ```text
-... all five beads-sync subtests pass ...
+... all six beads-sync subtests pass ...
 bd-bin.test.ts ok
 ```
 
@@ -626,6 +627,205 @@ Expected: both commands exit `0`.
 ```bash
 git add scripts/beads-sync.ts
 git commit -m "fix: bound Beads Dolt sync processes"
+```
+
+### Task 2A: Preserve exact-tree cleanup on wrapper cancellation
+
+**Files:**
+- Modify: `scripts/beads-sync.ts`
+- Modify: `scripts/beads-sync.test.mjs`
+- Modify: `docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md`
+
+- [ ] **Step 1: Add an abort signal to the phase runner**
+
+Add `signal?: AbortSignal` to `BeadsSyncOptions`, resolve a default un-aborted
+signal in `runBeadsSync`, and pass it into `runPhase`. Add conventional signal
+statuses:
+
+```ts
+const SIGNAL_EXIT_CODES = {
+  SIGINT: 130,
+  SIGTERM: 143,
+} as const;
+
+type SupportedSignal = keyof typeof SIGNAL_EXIT_CODES;
+
+function cancellationStatus(signal: AbortSignal): number {
+  const reason = signal.reason;
+  return typeof reason === "string" && reason in SIGNAL_EXIT_CODES
+    ? SIGNAL_EXIT_CODES[reason as SupportedSignal]
+    : 130;
+}
+```
+
+- [ ] **Step 2: Share exact-tree termination between timeout and cancellation**
+
+In `runPhase`, replace the timeout-only boolean with one `terminating` guard and
+one helper that calls `terminateTree`:
+
+```ts
+const terminate = (
+  successKind: "timed-out" | "cancelled",
+  successStatus: number,
+  failureKind:
+    | "timeout-cleanup-unproven"
+    | "cancellation-cleanup-unproven",
+) => {
+  if (settled || terminating) return;
+  terminating = true;
+  void options
+    .terminateTree(child, {
+      platform: options.platform,
+      graceMs: options.terminationGraceMs,
+    })
+    .then((cleanupProven) => {
+      finish({
+        status: cleanupProven ? successStatus : 1,
+        ...retained(),
+        kind: cleanupProven ? successKind : failureKind,
+      });
+    })
+    .catch(() => {
+      finish({
+        status: 1,
+        ...retained(),
+        kind: failureKind,
+      });
+    });
+};
+
+const timer = setTimeout(() => {
+  terminate("timed-out", 124, "timeout-cleanup-unproven");
+}, options.timeoutMs);
+const onAbort = () => {
+  terminate(
+    "cancelled",
+    cancellationStatus(options.signal),
+    "cancellation-cleanup-unproven",
+  );
+};
+options.signal.addEventListener("abort", onAbort, { once: true });
+if (options.signal.aborted) onAbort();
+```
+
+Remove the abort listener inside `finish`, ignore `close` while `terminating`,
+and report cancellation separately:
+
+```ts
+if (result.kind === "cancelled") {
+  writeStderr(
+    `[beads:sync] ${phase} cancelled; owned process tree terminated.\n`,
+  );
+  return result.status;
+}
+if (result.kind === "cancellation-cleanup-unproven") {
+  writeStderr(
+    `[beads:sync] ${phase} was cancelled and could not prove process-tree cleanup.\n`,
+  );
+  return 1;
+}
+```
+
+- [ ] **Step 3: Install direct CLI signal handlers**
+
+Replace `main` with:
+
+```ts
+async function main(): Promise<void> {
+  const controller = new AbortController();
+  const onSignal = (signal: SupportedSignal) => {
+    if (!controller.signal.aborted) controller.abort(signal);
+  };
+  const onSigint = () => onSignal("SIGINT");
+  const onSigterm = () => onSignal("SIGTERM");
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+  try {
+    process.exitCode = await runBeadsSync({ signal: controller.signal });
+  } finally {
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+  }
+}
+```
+
+- [ ] **Step 4: Prove the direct CLI cannot orphan its child**
+
+Add a POSIX-only test that starts the real TypeScript entrypoint, waits for the
+fake descendant PID, sends `SIGTERM` only to the wrapper, and verifies status
+`143` plus descendant removal:
+
+```js
+import { spawn } from "node:child_process";
+import { EventEmitter, once } from "node:events";
+import { delimiter, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "beads-sync.ts");
+
+async function waitForFile(path, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return existsSync(path);
+}
+
+test("direct CLI SIGTERM cleans its detached bd process tree", {
+  skip: process.platform === "win32",
+}, async () => {
+  const current = fixture();
+  let stderr = "";
+  const wrapper = spawn(
+    process.execPath,
+    ["--experimental-strip-types", SCRIPT],
+    {
+      env: { ...current.env, BD_FAKE_PUSH_HANG: "1" },
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+  wrapper.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  try {
+    assert.equal(await waitForFile(current.descendantPid), true);
+    wrapper.kill("SIGTERM");
+    const [code, signal] = await once(wrapper, "close");
+    assert.equal(signal, null);
+    assert.equal(code, 143, stderr);
+    const pid = Number(readFileSync(current.descendantPid, "utf8"));
+    assert.equal(await waitForMissingProcess(pid), true);
+    assert.match(stderr, /push cancelled; owned process tree terminated/);
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) {
+      wrapper.kill("SIGKILL");
+    }
+    rmSync(current.root, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 5: Run the focused signal and timeout tests**
+
+Run:
+
+```bash
+node scripts/beads-sync.test.mjs
+pnpm typecheck
+pnpm lint
+```
+
+Expected: six sync subtests pass; typecheck and lint exit `0`.
+
+- [ ] **Step 6: Commit the cancellation correction**
+
+```bash
+git add scripts/beads-sync.ts scripts/beads-sync.test.mjs \
+  docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md \
+  docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
+git commit -m "fix: clean Beads sync trees on signals"
 ```
 
 ### Task 3: Route the stable command and operator guidance

--- a/docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md
+++ b/docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md
@@ -149,7 +149,10 @@ again.
 
 Documentation instructs the operator to:
 
-1. Retry `pnpm beads:sync` once.
+1. Retry `pnpm beads:sync` once only after the wrapper confirms the owned
+   process tree terminated. If cleanup is unproven, verify and stop the
+   surviving process tree before retrying because it may still hold the Dolt
+   lock or be pushing.
 2. Do not edit Git configuration or credential helpers after one transient 403;
    the known intermittent identity failure can succeed on the immediate retry.
 3. When verifying a push that should contain pending Beads changes, compare the

--- a/docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md
+++ b/docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md
@@ -109,7 +109,7 @@ On POSIX, `detached: true` gives the spawned `bd` process a new process group.
 `SIGKILL`, and confirms the group no longer exists. On Windows, the same helper
 uses `taskkill.exe /PID <pid> /T /F`.
 
-The direct CLI installs one-shot `SIGINT` and `SIGTERM` handlers that abort the
+The direct CLI installs idempotent `SIGINT` and `SIGTERM` handlers that abort the
 active phase and wait for this cleanup before allowing the wrapper to exit.
 Without those handlers, the detached process group required for correct timeout
 cleanup could survive an interrupted wrapper.

--- a/docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md
+++ b/docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md
@@ -23,6 +23,9 @@ helpers can be child processes of `bd`.
   shared store lock.
 - Terminate the complete owned process tree on timeout and wait for proof that
   cleanup completed before the wrapper exits.
+- Apply the same exact-tree cleanup when the direct wrapper receives `SIGINT`
+  or `SIGTERM`, so detaching the child for safe timeout cleanup never creates an
+  orphan on user cancellation.
 - Keep `bd` launch shell-free and cross-platform by reusing Cave's existing
   Windows-safe Beads binary resolver.
 - Disable terminal credential prompts while preserving configured credential
@@ -79,6 +82,9 @@ The wrapper runs pull and push sequentially.
    complete, and then exit `124`.
 8. If tree termination cannot be proven, report that cleanup is unproven and
    exit `1`; do not shape that result as an ordinary timeout.
+9. If the direct wrapper receives `SIGINT` or `SIGTERM`, abort the active phase,
+   terminate the same owned process tree, and exit with conventional status
+   `130` or `143`.
 
 The direct command uses one timeout for each phase rather than one aggregate
 deadline. A healthy pull does not consume the push's opportunity to finish, and
@@ -103,6 +109,11 @@ On POSIX, `detached: true` gives the spawned `bd` process a new process group.
 `SIGKILL`, and confirms the group no longer exists. On Windows, the same helper
 uses `taskkill.exe /PID <pid> /T /F`.
 
+The direct CLI installs one-shot `SIGINT` and `SIGTERM` handlers that abort the
+active phase and wait for this cleanup before allowing the wrapper to exit.
+Without those handlers, the detached process group required for correct timeout
+cleanup could survive an interrupted wrapper.
+
 Only the process tree created by this wrapper is eligible for termination. The
 wrapper never calls broad process-name cleanup such as `pkill`, `killall`, or
 `bd dolt killall`.
@@ -120,6 +131,8 @@ Stable outcomes are:
 - `0`: pull and push both completed successfully.
 - Child exit code: a phase completed with a nonzero status.
 - `124`: a phase timed out and its complete owned process tree was terminated.
+- `130` or `143`: `SIGINT` or `SIGTERM` cancelled the wrapper and its complete
+  owned process tree was terminated.
 - `1`: spawn failure, invalid internal configuration, or unproven process-tree
   cleanup.
 
@@ -193,6 +206,11 @@ runs with a short injected timeout. The test asserts exit `124` and verifies
 that neither the fake `bd` process group nor the recorded descendant remains.
 This proves the sync entrypoint actually establishes the process ownership that
 `terminateProcessTree` requires.
+
+Another POSIX integration test runs the direct TypeScript CLI, waits for the
+same resistant descendant, sends `SIGTERM` only to the wrapper, and asserts
+status `143` plus descendant removal. This pins the cancellation path that a
+function-level timeout test cannot cover.
 
 Source-contract assertions additionally prevent regression to:
 

--- a/docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md
+++ b/docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md
@@ -161,9 +161,10 @@ Documentation instructs the operator to:
    git ls-remote origin refs/dolt/data
    ```
 
-4. Treat an expected ref advancement as the remote success signal. If the ref
-   does not advance after the retry, report the failure instead of changing
-   credentials speculatively.
+4. Treat an expected ref advancement as evidence that the remote changed. It
+   does not prove which concurrent actor advanced the ref. If the ref does not
+   advance after the retry, report the failure instead of changing credentials
+   speculatively.
 
 No advancement is required when there were no local Dolt changes to publish.
 

--- a/docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md
+++ b/docs/superpowers/specs/2026-08-22-beads-dolt-sync-watchdog-design.md
@@ -1,0 +1,213 @@
+# Beads Dolt Sync Watchdog Design
+
+## Problem
+
+`pnpm beads:sync` currently expands to:
+
+```bash
+bd dolt pull && bd dolt push
+```
+
+That gives the Beads process an unbounded lifetime. A Git-over-HTTPS credential
+wait can therefore leave `bd dolt push` alive without useful network activity
+while it retains the shared Dolt store lock. Every other familiar using the
+shared store then blocks behind a command that may never finish.
+
+The raw shell chain also has no reliable way to terminate descendants. Node's
+single-process timeout support is insufficient because Git and credential
+helpers can be child processes of `bd`.
+
+## Goals
+
+- Bound both Dolt pull and push so neither phase can indefinitely retain the
+  shared store lock.
+- Terminate the complete owned process tree on timeout and wait for proof that
+  cleanup completed before the wrapper exits.
+- Keep `bd` launch shell-free and cross-platform by reusing Cave's existing
+  Windows-safe Beads binary resolver.
+- Disable terminal credential prompts while preserving configured credential
+  helpers.
+- Preserve useful diagnostics without retaining unbounded output or printing
+  common credential material.
+- Keep push failure honest: never report success and never automatically retry
+  an operation whose remote outcome may be ambiguous.
+- Give operators a safe one-retry procedure and a concrete
+  `refs/dolt/data` verification check.
+
+## Non-goals
+
+- Replacing or patching Beads, Dolt, Git, or the user's credential helper.
+- Editing global or repository Git configuration.
+- Automatically retrying failed or timed-out pushes.
+- Automatically killing unrelated Dolt or Git processes.
+- Proving which actor advanced `refs/dolt/data` during concurrent pushes.
+
+## Chosen architecture
+
+Replace the package-level shell chain with a dedicated TypeScript orchestrator:
+
+```text
+pnpm beads:sync
+  -> scripts/beads-sync.ts
+     -> bd dolt pull
+     -> bd dolt push
+```
+
+Each phase launches through `withBdLaunch`, which preserves argv boundaries and
+resolves Windows npm shims without `shell: true`. The child receives ignored
+stdin, piped stdout/stderr, `GIT_TERMINAL_PROMPT=0`, and
+`GCM_INTERACTIVE=Never`. On POSIX the child is detached into its own process
+group; on Windows it remains a normal child suitable for the existing
+`taskkill.exe /T /F` cleanup path.
+
+The orchestrator reuses `BoundedProcessOutput` and `terminateProcessTree` from
+`src/lib/process-execution.ts`. This avoids a second, subtly different process
+termination implementation.
+
+## Command lifecycle
+
+The wrapper runs pull and push sequentially.
+
+1. Print the phase being started.
+2. Spawn the resolved `bd` command with a 90-second phase timeout.
+3. Capture stdout and stderr into separate redacted 64 KiB tails.
+4. If the child exits successfully, print its retained output and continue.
+5. If pull fails, print the retained diagnostics and exit without starting
+   push.
+6. If push fails, print the retained diagnostics and exit nonzero.
+7. If either phase times out, call `terminateProcessTree`, wait for it to
+   complete, and then exit `124`.
+8. If tree termination cannot be proven, report that cleanup is unproven and
+   exit `1`; do not shape that result as an ordinary timeout.
+
+The direct command uses one timeout for each phase rather than one aggregate
+deadline. A healthy pull does not consume the push's opportunity to finish, and
+each individual lock-holding operation remains bounded.
+
+## Timeout and process ownership
+
+The production defaults are:
+
+- Phase timeout: 90 seconds.
+- Retained stdout tail: 64 KiB.
+- Retained stderr tail: 64 KiB.
+- Process-tree termination grace: the shared helper's existing default.
+
+The implementation exports dependency-injected execution functions so tests can
+use shorter deadlines without adding user-facing timeout flags. Runtime
+configuration remains deliberately small: this is a safety boundary, not a
+general command runner.
+
+On POSIX, `detached: true` gives the spawned `bd` process a new process group.
+`terminateProcessTree` sends `SIGTERM` to that group, waits, escalates to
+`SIGKILL`, and confirms the group no longer exists. On Windows, the same helper
+uses `taskkill.exe /PID <pid> /T /F`.
+
+Only the process tree created by this wrapper is eligible for termination. The
+wrapper never calls broad process-name cleanup such as `pkill`, `killall`, or
+`bd dolt killall`.
+
+## Output and error handling
+
+Child output is captured rather than inherited so it can be bounded and passed
+through the repository's existing ANSI stripping and credential redaction.
+Retained output is emitted when a phase settles, preserving normal command
+diagnostics without allowing a noisy or stuck process to grow memory
+indefinitely.
+
+Stable outcomes are:
+
+- `0`: pull and push both completed successfully.
+- Child exit code: a phase completed with a nonzero status.
+- `124`: a phase timed out and its complete owned process tree was terminated.
+- `1`: spawn failure, invalid internal configuration, or unproven process-tree
+  cleanup.
+
+The wrapper names the failed phase in every error. A spawn error uses
+`safeProcessErrorMessage` so executable paths and raw platform errors are not
+exposed unnecessarily.
+
+## Retry and remote verification
+
+The wrapper never retries automatically. A push can update the remote just
+before its local process is killed, so an automatic retry would hide an
+ambiguous result and can repeat the same credential hang while holding the lock
+again.
+
+Documentation instructs the operator to:
+
+1. Retry `pnpm beads:sync` once.
+2. Do not edit Git configuration or credential helpers after one transient 403;
+   the known intermittent identity failure can succeed on the immediate retry.
+3. When verifying a push that should contain pending Beads changes, compare the
+   remote ref before and after:
+
+   ```bash
+   git ls-remote origin refs/dolt/data
+   pnpm beads:sync
+   git ls-remote origin refs/dolt/data
+   ```
+
+4. Treat an expected ref advancement as the remote success signal. If the ref
+   does not advance after the retry, report the failure instead of changing
+   credentials speculatively.
+
+No advancement is required when there were no local Dolt changes to publish.
+
+## Files and responsibilities
+
+- `scripts/beads-sync.ts`
+  - Owns sequential pull/push orchestration, timeout classification, bounded
+    diagnostics, and process-tree cleanup.
+- `scripts/beads-sync.test.mjs`
+  - Covers success ordering, pull short-circuiting, nonzero push failures,
+    timeout classification, and a POSIX integration fixture whose descendant
+    ignores `SIGTERM`.
+- `package.json`
+  - Routes `beads:sync` through the new orchestrator.
+- `scripts/run-tests.mjs`
+  - Wires the new regression test into the app test suite.
+- `scripts/beads-familiar-workflow.test.mjs`
+  - Pins the stable package entrypoint and operator documentation contract.
+- `docs/workflows/beads-familiars.md`
+  - Makes the bounded package command canonical and documents safe retry and
+    `refs/dolt/data` verification.
+- `AGENTS.md` and `CLAUDE.md`
+  - Replace the routine raw push in session-completion guidance with the
+    bounded repository entrypoint.
+
+## Test strategy
+
+Unit-level orchestration tests inject a fake phase runner and assert:
+
+- pull always precedes push;
+- push is never called after pull failure;
+- a push failure preserves its exit status and phase diagnostics;
+- timeout with proven cleanup returns `124`;
+- timeout with unproven cleanup returns `1`.
+
+A POSIX-only integration test places a fake `bd` executable first on `PATH`.
+For `dolt pull` it exits successfully. For `dolt push` it starts a descendant
+that ignores `SIGTERM`, records the descendant PID, and then blocks. The wrapper
+runs with a short injected timeout. The test asserts exit `124` and verifies
+that neither the fake `bd` process group nor the recorded descendant remains.
+This proves the sync entrypoint actually establishes the process ownership that
+`terminateProcessTree` requires.
+
+Source-contract assertions additionally prevent regression to:
+
+- `bd dolt pull && bd dolt push`;
+- `shell: true`;
+- direct bare `spawn("bd", ...)` without `withBdLaunch`;
+- broad name-based process termination.
+
+## Rollout and compatibility
+
+The command name remains `pnpm beads:sync`, so operator and automation entry
+points do not change. Healthy sync behavior remains pull-then-push. The only
+intentional behavior changes are bounded lifetime, noninteractive terminal
+credentials, redacted bounded output, and explicit nonzero timeout semantics.
+
+Direct manual `bd dolt pull` and `bd dolt push` commands still exist upstream,
+but Cave's repository guidance uses the bounded package entrypoint for routine
+work.

--- a/docs/workflows/beads-familiars.md
+++ b/docs/workflows/beads-familiars.md
@@ -79,7 +79,7 @@ terminates the complete owned process tree if Git or a credential helper stops
 making progress. Do not use the raw commands for routine sync in this
 repository.
 
-If push fails or times out, Retry `pnpm beads:sync` once. Do not edit Git
+If push fails or times out, retry `pnpm beads:sync` once. Do not edit Git
 configuration or credential helpers after one transient 403; the known
 intermittent identity failure can succeed without any configuration change.
 For pending Beads changes, verify the remote ref actually advanced:

--- a/docs/workflows/beads-familiars.md
+++ b/docs/workflows/beads-familiars.md
@@ -67,12 +67,32 @@ Beads state lives in Dolt. `.beads/issues.jsonl is an export, not the sync proto
 
 The committed `.beads/issues.jsonl` snapshot is only for review and CI guards. Keep it public-scrubbed before committing: no local git emails, no personal machine paths, no secrets, and no private agent transcript text. Use live `bd` output or Dolt sync for canonical state.
 
-Use Dolt sync when a bead graph needs to move between machines:
+Use the bounded repository entrypoint when a bead graph needs to move between
+machines:
 
 ```bash
-bd dolt pull
-bd dolt push
+pnpm beads:sync
 ```
+
+It runs `bd dolt pull` and then `bd dolt push`, but bounds each phase and
+terminates the complete owned process tree if Git or a credential helper stops
+making progress. Do not use the raw commands for routine sync in this
+repository.
+
+If push fails or times out, Retry `pnpm beads:sync` once. Do not edit Git
+configuration or credential helpers after one transient 403; the known
+intermittent identity failure can succeed without any configuration change.
+For pending Beads changes, verify the remote ref actually advanced:
+
+```bash
+git ls-remote origin refs/dolt/data
+pnpm beads:sync
+git ls-remote origin refs/dolt/data
+```
+
+Compare the before and after OIDs. An expected advancement proves the remote
+accepted pending changes. No advancement is required when there were no local
+Dolt changes to publish.
 
 The package shortcuts are the stable entrypoints for familiars:
 

--- a/docs/workflows/beads-familiars.md
+++ b/docs/workflows/beads-familiars.md
@@ -79,9 +79,12 @@ terminates the complete owned process tree if Git or a credential helper stops
 making progress. Do not use the raw commands for routine sync in this
 repository.
 
-If push fails or times out, retry `pnpm beads:sync` once. Do not edit Git
-configuration or credential helpers after one transient 403; the known
-intermittent identity failure can succeed without any configuration change.
+If push fails or times out **and the wrapper confirms the owned process tree was
+terminated**, retry `pnpm beads:sync` once. If cleanup could not be proven,
+verify and stop the surviving process tree before retrying; it may still hold
+the Dolt lock or be pushing. Do not edit Git configuration or credential
+helpers after one transient 403; the known intermittent identity failure can
+succeed without any configuration change.
 For pending Beads changes, verify the remote ref actually advanced:
 
 ```bash

--- a/docs/workflows/beads-familiars.md
+++ b/docs/workflows/beads-familiars.md
@@ -91,8 +91,9 @@ git ls-remote origin refs/dolt/data
 ```
 
 Compare the before and after OIDs. An expected advancement proves the remote
-accepted pending changes. No advancement is required when there were no local
-Dolt changes to publish.
+changed, but concurrent syncs mean it does not identify which actor advanced
+the ref. No advancement is required when there were no local Dolt changes to
+publish.
 
 The package shortcuts are the stable entrypoints for familiars:
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "beads:patrol": "pnpm beads:prs:patrol && pnpm beads:worktrees",
     "beads:patrol:apply": "pnpm beads:prs:patrol:apply && pnpm beads:worktrees",
     "hfr:export": "node --experimental-strip-types scripts/coven-hfr-export.ts",
-    "beads:sync": "bd dolt pull && bd dolt push",
+    "beads:sync": "node --experimental-strip-types scripts/beads-sync.ts",
     "sync:runtimes": "node scripts/sync-runtimes.mjs",
     "beads:doctor": "bd doctor && bd lint",
     "test:sidecar-runtime": "node scripts/sidecar-runtime-smoke.mjs",

--- a/scripts/beads-familiar-workflow.test.mjs
+++ b/scripts/beads-familiar-workflow.test.mjs
@@ -108,6 +108,21 @@ assert.match(
   /confirms the owned process tree was[\s\S]*stop the surviving process tree before retrying[\s\S]*concurrent syncs/i,
   "the executable plan must preserve conditional retry and concurrent-ref guidance",
 );
+assert.match(
+  watchdogPlan,
+  /resolveBdLaunchCommand\(\{[\s\S]*env: options\.env,[\s\S]*platform: options\.platform,/,
+  "the executable plan must resolve the Beads launcher from the injected environment and platform",
+);
+assert.match(
+  watchdogPlan,
+  /releaseUnprovenChildHandles[\s\S]*if \(!cleanupProven\) releaseUnprovenChildHandles\(\)[\s\S]*\.catch\(\(\) => \{[\s\S]*releaseUnprovenChildHandles\(\)/,
+  "the executable plan must release child pipes and references when cleanup is unproven",
+);
+assert.match(
+  watchdogPlan,
+  /child\.once\("error", \(error\) => \{[\s\S]*if \(terminating\) return;/,
+  "the executable plan must ignore delayed child errors after termination begins",
+);
 assert.match(workflow, /## Pull Request Management/, "workflow doc should include PR management guidance");
 assert.match(workflow, /pnpm beads:prs[\s\S]*pnpm beads:prs:apply/, "workflow doc should document PR bridge commands");
 assert.match(

--- a/scripts/beads-familiar-workflow.test.mjs
+++ b/scripts/beads-familiar-workflow.test.mjs
@@ -84,7 +84,7 @@ assert.match(workflow, /public-scrubbed before committing/, "workflow doc should
 assert.match(workflow, /bd dolt pull[\s\S]*bd dolt push/, "workflow doc should name Dolt sync commands");
 assert.match(
   workflow,
-  /Retry `pnpm beads:sync` once[\s\S]*Do not edit Git\s+configuration or credential helpers[\s\S]*refs\/dolt\/data/,
+  /retry `pnpm beads:sync` once[\s\S]*Do not edit Git\s+configuration or credential helpers[\s\S]*refs\/dolt\/data/i,
   "workflow docs should explain bounded retry and remote-ref verification",
 );
 assert.match(workflow, /## Pull Request Management/, "workflow doc should include PR management guidance");

--- a/scripts/beads-familiar-workflow.test.mjs
+++ b/scripts/beads-familiar-workflow.test.mjs
@@ -84,8 +84,18 @@ assert.match(workflow, /public-scrubbed before committing/, "workflow doc should
 assert.match(workflow, /bd dolt pull[\s\S]*bd dolt push/, "workflow doc should name Dolt sync commands");
 assert.match(
   workflow,
-  /retry `pnpm beads:sync` once[\s\S]*Do not edit Git\s+configuration or credential helpers[\s\S]*refs\/dolt\/data/i,
+  /confirms the owned process tree was\s+terminated[\s\S]*retry `pnpm beads:sync` once/i,
   "workflow docs should explain bounded retry and remote-ref verification",
+);
+assert.match(
+  workflow,
+  /cleanup could not be proven[\s\S]*stop the surviving process tree before retrying[\s\S]*refs\/dolt\/data/i,
+  "workflow docs should block retry while cleanup remains unproven",
+);
+assert.match(
+  workflow,
+  /Do not edit Git\s+configuration or credential\s+helpers/i,
+  "workflow docs should preserve transient credential guidance",
 );
 assert.match(workflow, /## Pull Request Management/, "workflow doc should include PR management guidance");
 assert.match(workflow, /pnpm beads:prs[\s\S]*pnpm beads:prs:apply/, "workflow doc should document PR bridge commands");

--- a/scripts/beads-familiar-workflow.test.mjs
+++ b/scripts/beads-familiar-workflow.test.mjs
@@ -40,7 +40,7 @@ assert.deepEqual(
     worktreesJson: "node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OpenCoven/coven-cave --json",
     patrol: "pnpm beads:prs:patrol && pnpm beads:worktrees",
     patrolApply: "pnpm beads:prs:patrol:apply && pnpm beads:worktrees",
-    sync: "bd dolt pull && bd dolt push",
+    sync: "node --experimental-strip-types scripts/beads-sync.ts",
     doctor: "bd doctor && bd lint",
   },
   "package scripts should give familiars stable Beads and PR entrypoints",
@@ -50,7 +50,16 @@ assert.match(agents, /Beads Issue Tracker/, "AGENTS.md should install Beads issu
 assert.match(agents, /Coven Familiar Beads Protocol/, "AGENTS.md should add Coven-specific familiar workflow guidance");
 assert.match(agents, /bd prime[\s\S]*bd ready --json[\s\S]*bd update <id> --claim[\s\S]*bd close <id>/, "agents should learn the claim-and-close loop");
 assert.doesNotMatch(agents, /Do NOT use external issue trackers/, "Cave must bridge GitHub and Linear instead of banning them");
-assert.match(claude, /bd dolt push[\s\S]*git push/, "Claude session close guidance should include Beads Dolt sync before git push");
+assert.match(
+  claude,
+  /pnpm beads:sync[\s\S]*git push/,
+  "Claude session close guidance should use bounded Beads sync before git push",
+);
+assert.match(
+  agents,
+  /pnpm beads:sync[\s\S]*git push/,
+  "agent session close guidance should use bounded Beads sync before git push",
+);
 
 assert.equal(beadsMetadata.dolt_database, "cave", "Cave Beads IDs should use the short cave- prefix");
 assert.match(beadsConfig, /sync\.remote:\s+"git\+https:\/\/github\.com\/OpenCoven\/coven-cave\.git"/, "Beads should be configured for Dolt sync through origin");
@@ -73,6 +82,11 @@ assert.match(workflow, /No secrets in bead text/, "workflow doc should include t
 assert.match(workflow, /\.beads\/issues\.jsonl is an export, not the sync protocol/, "workflow doc should prevent JSONL sync misuse");
 assert.match(workflow, /public-scrubbed before committing/, "workflow doc should require public-safe JSONL review exports");
 assert.match(workflow, /bd dolt pull[\s\S]*bd dolt push/, "workflow doc should name Dolt sync commands");
+assert.match(
+  workflow,
+  /Retry `pnpm beads:sync` once[\s\S]*Do not edit Git\s+configuration or credential helpers[\s\S]*refs\/dolt\/data/,
+  "workflow docs should explain bounded retry and remote-ref verification",
+);
 assert.match(workflow, /## Pull Request Management/, "workflow doc should include PR management guidance");
 assert.match(workflow, /pnpm beads:prs[\s\S]*pnpm beads:prs:apply/, "workflow doc should document PR bridge commands");
 assert.match(

--- a/scripts/beads-familiar-workflow.test.mjs
+++ b/scripts/beads-familiar-workflow.test.mjs
@@ -9,6 +9,7 @@ const packageJson = JSON.parse(read("package.json"));
 const agents = read("AGENTS.md");
 const claude = read("CLAUDE.md");
 const workflow = read("docs/workflows/beads-familiars.md");
+const watchdogPlan = read("docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md");
 const beadsConfig = read(".beads/config.yaml");
 const beadsMetadata = JSON.parse(read(".beads/metadata.json"));
 const beadsExport = read(".beads/issues.jsonl").trim().split("\n").map((line) => JSON.parse(line));
@@ -96,6 +97,16 @@ assert.match(
   workflow,
   /Do not edit Git\s+configuration or credential\s+helpers/i,
   "workflow docs should preserve transient credential guidance",
+);
+assert.match(
+  watchdogPlan,
+  /cleanup-unproven[\s\S]*cleanupUnprovenGuidance/,
+  "the executable plan must not recommend an ordinary retry after unproven cleanup",
+);
+assert.match(
+  watchdogPlan,
+  /confirms the owned process tree was[\s\S]*stop the surviving process tree before retrying[\s\S]*concurrent syncs/i,
+  "the executable plan must preserve conditional retry and concurrent-ref guidance",
 );
 assert.match(workflow, /## Pull Request Management/, "workflow doc should include PR management guidance");
 assert.match(workflow, /pnpm beads:prs[\s\S]*pnpm beads:prs:apply/, "workflow doc should document PR bridge commands");

--- a/scripts/beads-sync.test.mjs
+++ b/scripts/beads-sync.test.mjs
@@ -261,11 +261,15 @@ test("push timeout kills a descendant that ignores SIGTERM", {
 test("unproven tree cleanup is a hard error, not an ordinary timeout", async () => {
   const stderr = outputSink();
   const fakeChild = new EventEmitter();
+  let unrefCalled = false;
   fakeChild.pid = 424242;
   fakeChild.exitCode = null;
   fakeChild.signalCode = null;
   fakeChild.stdout = new PassThrough();
   fakeChild.stderr = new PassThrough();
+  fakeChild.unref = () => {
+    unrefCalled = true;
+  };
 
   const status = await runBeadsSync({
     timeoutMs: 1,
@@ -276,7 +280,12 @@ test("unproven tree cleanup is a hard error, not an ordinary timeout", async () 
   });
 
   assert.equal(status, 1);
+  assert.equal(unrefCalled, true, "unproven child must not retain the wrapper event loop");
+  assert.equal(fakeChild.stdout.destroyed, true);
+  assert.equal(fakeChild.stderr.destroyed, true);
   assert.match(stderr.text(), /could not prove process-tree cleanup/);
+  assert.match(stderr.text(), /verify and stop the surviving process tree before retrying/i);
+  assert.doesNotMatch(stderr.text(), /Retry `pnpm beads:sync` once/);
   assert.doesNotMatch(stderr.text(), /owned process tree terminated/);
 });
 

--- a/scripts/beads-sync.test.mjs
+++ b/scripts/beads-sync.test.mjs
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+
+import { runBeadsSync } from "./beads-sync.ts";
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "beads-sync-"));
+  const bin = join(root, "bin");
+  const log = join(root, "bd-log.jsonl");
+  const descendantPid = join(root, "descendant.pid");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(
+    join(bin, "bd"),
+    `#!/usr/bin/env node
+import { appendFileSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+
+const args = process.argv.slice(2);
+const phase = args[1];
+appendFileSync(
+  process.env.BD_FAKE_LOG,
+  JSON.stringify({
+    args,
+    gitTerminalPrompt: process.env.GIT_TERMINAL_PROMPT,
+    gcmInteractive: process.env.GCM_INTERACTIVE,
+  }) + "\\n",
+);
+
+if (phase === "pull") {
+  process.stdout.write("pull ok\\n");
+  process.stderr.write("pull note\\n");
+  process.exit(Number(process.env.BD_FAKE_PULL_EXIT ?? "0"));
+}
+
+if (process.env.BD_FAKE_PUSH_HANG === "1") {
+  const descendant = spawn(
+    process.execPath,
+    ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"],
+    { stdio: "ignore" },
+  );
+  writeFileSync(process.env.BD_FAKE_DESCENDANT_PID, String(descendant.pid));
+  process.on("SIGTERM", () => {});
+  await new Promise(() => {});
+}
+
+process.stdout.write("push ok\\n");
+process.stderr.write("push note\\n");
+process.exit(Number(process.env.BD_FAKE_PUSH_EXIT ?? "0"));
+`,
+    "utf8",
+  );
+  chmodSync(join(bin, "bd"), 0o755);
+  return {
+    root,
+    log,
+    descendantPid,
+    env: {
+      ...process.env,
+      PATH: `${bin}${process.env.PATH ? `${delimiter}${process.env.PATH}` : ""}`,
+      BD_FAKE_LOG: log,
+      BD_FAKE_DESCENDANT_PID: descendantPid,
+    },
+  };
+}
+
+function readLog(path) {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function outputSink() {
+  let value = "";
+  return {
+    write(chunk) {
+      value += chunk;
+    },
+    text() {
+      return value;
+    },
+  };
+}
+
+test("sync runs pull before push with noninteractive credential settings", async () => {
+  const current = fixture();
+  const stdout = outputSink();
+  const stderr = outputSink();
+  try {
+    const status = await runBeadsSync({
+      env: current.env,
+      writeStdout: (value) => stdout.write(value),
+      writeStderr: (value) => stderr.write(value),
+    });
+
+    assert.equal(status, 0, stderr.text());
+    assert.deepEqual(
+      readLog(current.log),
+      [
+        {
+          args: ["dolt", "pull"],
+          gitTerminalPrompt: "0",
+          gcmInteractive: "Never",
+        },
+        {
+          args: ["dolt", "push"],
+          gitTerminalPrompt: "0",
+          gcmInteractive: "Never",
+        },
+      ],
+    );
+    assert.match(stdout.text(), /\[beads:sync\] pull/);
+    assert.match(stdout.text(), /pull ok/);
+    assert.match(stdout.text(), /\[beads:sync\] push/);
+    assert.match(stdout.text(), /push ok/);
+    assert.match(stderr.text(), /pull note/);
+    assert.match(stderr.text(), /push note/);
+  } finally {
+    rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("pull failure preserves its status and never starts push", async () => {
+  const current = fixture();
+  const stderr = outputSink();
+  try {
+    const status = await runBeadsSync({
+      env: { ...current.env, BD_FAKE_PULL_EXIT: "7" },
+      writeStdout: () => {},
+      writeStderr: (value) => stderr.write(value),
+    });
+
+    assert.equal(status, 7);
+    assert.deepEqual(
+      readLog(current.log).map((entry) => entry.args),
+      [["dolt", "pull"]],
+    );
+    assert.match(stderr.text(), /pull exited with status 7/);
+  } finally {
+    rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("push failure preserves its status and prints safe retry guidance", async () => {
+  const current = fixture();
+  const stderr = outputSink();
+  try {
+    const status = await runBeadsSync({
+      env: { ...current.env, BD_FAKE_PUSH_EXIT: "9" },
+      writeStdout: () => {},
+      writeStderr: (value) => stderr.write(value),
+    });
+
+    assert.equal(status, 9);
+    assert.deepEqual(
+      readLog(current.log).map((entry) => entry.args),
+      [["dolt", "pull"], ["dolt", "push"]],
+    );
+    assert.match(stderr.text(), /push exited with status 9/);
+    assert.match(stderr.text(), /Retry `pnpm beads:sync` once/);
+    assert.match(stderr.text(), /refs\/dolt\/data/);
+    assert.match(stderr.text(), /Do not edit Git configuration or credential helpers/);
+  } finally {
+    rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+async function waitForMissingProcess(pid, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if (error?.code === "ESRCH") return true;
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return false;
+}
+
+test("push timeout kills a descendant that ignores SIGTERM", {
+  skip: process.platform === "win32",
+}, async () => {
+  const current = fixture();
+  const stderr = outputSink();
+  try {
+    const status = await runBeadsSync({
+      env: { ...current.env, BD_FAKE_PUSH_HANG: "1" },
+      timeoutMs: 200,
+      terminationGraceMs: 200,
+      writeStdout: () => {},
+      writeStderr: (value) => stderr.write(value),
+    });
+
+    assert.equal(status, 124, stderr.text());
+    const pid = Number(readFileSync(current.descendantPid, "utf8"));
+    assert.equal(await waitForMissingProcess(pid), true, `descendant ${pid} survived timeout`);
+    assert.match(stderr.text(), /push timed out after 200ms/);
+    assert.match(stderr.text(), /owned process tree terminated/);
+    assert.match(stderr.text(), /Retry `pnpm beads:sync` once/);
+  } finally {
+    rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("unproven tree cleanup is a hard error, not an ordinary timeout", async () => {
+  const stderr = outputSink();
+  const fakeChild = new EventEmitter();
+  fakeChild.pid = 424242;
+  fakeChild.exitCode = null;
+  fakeChild.signalCode = null;
+  fakeChild.stdout = new PassThrough();
+  fakeChild.stderr = new PassThrough();
+
+  const status = await runBeadsSync({
+    timeoutMs: 1,
+    spawnProcess: () => fakeChild,
+    terminateTree: async () => false,
+    writeStdout: () => {},
+    writeStderr: (value) => stderr.write(value),
+  });
+
+  assert.equal(status, 1);
+  assert.match(stderr.text(), /could not prove process-tree cleanup/);
+  assert.doesNotMatch(stderr.text(), /owned process tree terminated/);
+});

--- a/scripts/beads-sync.test.mjs
+++ b/scripts/beads-sync.test.mjs
@@ -202,7 +202,7 @@ test("push timeout kills a descendant that ignores SIGTERM", {
   try {
     const status = await runBeadsSync({
       env: { ...current.env, BD_FAKE_PUSH_HANG: "1" },
-      timeoutMs: 200,
+      timeoutMs: 1_000,
       terminationGraceMs: 200,
       writeStdout: () => {},
       writeStderr: (value) => stderr.write(value),
@@ -211,7 +211,7 @@ test("push timeout kills a descendant that ignores SIGTERM", {
     assert.equal(status, 124, stderr.text());
     const pid = Number(readFileSync(current.descendantPid, "utf8"));
     assert.equal(await waitForMissingProcess(pid), true, `descendant ${pid} survived timeout`);
-    assert.match(stderr.text(), /push timed out after 200ms/);
+    assert.match(stderr.text(), /push timed out after 1000ms/);
     assert.match(stderr.text(), /owned process tree terminated/);
     assert.match(stderr.text(), /Retry `pnpm beads:sync` once/);
   } finally {

--- a/scripts/beads-sync.test.mjs
+++ b/scripts/beads-sync.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { EventEmitter } from "node:events";
+import { spawn } from "node:child_process";
+import { EventEmitter, once } from "node:events";
 import {
   chmodSync,
   existsSync,
@@ -10,11 +11,14 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import { PassThrough } from "node:stream";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { runBeadsSync } from "./beads-sync.ts";
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "beads-sync.ts");
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), "beads-sync-"));
@@ -194,6 +198,15 @@ async function waitForMissingProcess(pid, timeoutMs = 2_000) {
   return false;
 }
 
+async function waitForFile(path, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return existsSync(path);
+}
+
 test("push timeout kills a descendant that ignores SIGTERM", {
   skip: process.platform === "win32",
 }, async () => {
@@ -202,7 +215,7 @@ test("push timeout kills a descendant that ignores SIGTERM", {
   try {
     const status = await runBeadsSync({
       env: { ...current.env, BD_FAKE_PUSH_HANG: "1" },
-      timeoutMs: 1_000,
+      timeoutMs: 3_000,
       terminationGraceMs: 200,
       writeStdout: () => {},
       writeStderr: (value) => stderr.write(value),
@@ -211,7 +224,7 @@ test("push timeout kills a descendant that ignores SIGTERM", {
     assert.equal(status, 124, stderr.text());
     const pid = Number(readFileSync(current.descendantPid, "utf8"));
     assert.equal(await waitForMissingProcess(pid), true, `descendant ${pid} survived timeout`);
-    assert.match(stderr.text(), /push timed out after 1000ms/);
+    assert.match(stderr.text(), /push timed out after 3000ms/);
     assert.match(stderr.text(), /owned process tree terminated/);
     assert.match(stderr.text(), /Retry `pnpm beads:sync` once/);
   } finally {
@@ -239,4 +252,47 @@ test("unproven tree cleanup is a hard error, not an ordinary timeout", async () 
   assert.equal(status, 1);
   assert.match(stderr.text(), /could not prove process-tree cleanup/);
   assert.doesNotMatch(stderr.text(), /owned process tree terminated/);
+});
+
+test("direct CLI SIGTERM cleans its detached bd process tree", {
+  skip: process.platform === "win32",
+}, async () => {
+  const current = fixture();
+  let stderr = "";
+  const wrapper = spawn(
+    process.execPath,
+    ["--experimental-strip-types", SCRIPT],
+    {
+      env: { ...current.env, BD_FAKE_PUSH_HANG: "1" },
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+  wrapper.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  try {
+    assert.equal(
+      await waitForFile(current.descendantPid),
+      true,
+      "fake bd did not create its descendant",
+    );
+    wrapper.kill("SIGTERM");
+    const [code, signal] = await Promise.race([
+      once(wrapper, "close"),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("wrapper did not exit after SIGTERM")), 3_000),
+      ),
+    ]);
+    assert.equal(signal, null);
+    assert.equal(code, 143, stderr);
+    const pid = Number(readFileSync(current.descendantPid, "utf8"));
+    assert.equal(await waitForMissingProcess(pid), true, `descendant ${pid} survived SIGTERM`);
+    assert.match(stderr, /push cancelled; owned process tree terminated/);
+  } finally {
+    if (wrapper.exitCode === null && wrapper.signalCode === null) {
+      wrapper.kill("SIGKILL");
+    }
+    rmSync(current.root, { recursive: true, force: true });
+  }
 });

--- a/scripts/beads-sync.test.mjs
+++ b/scripts/beads-sync.test.mjs
@@ -23,11 +23,12 @@ const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "beads-sync.ts");
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), "beads-sync-"));
   const bin = join(root, "bin");
+  const script = join(bin, "bd.js");
   const log = join(root, "bd-log.jsonl");
   const descendantPid = join(root, "descendant.pid");
   mkdirSync(bin, { recursive: true });
   writeFileSync(
-    join(bin, "bd"),
+    script,
     `#!/usr/bin/env node
 import { appendFileSync, writeFileSync } from "node:fs";
 import { spawn } from "node:child_process";
@@ -66,6 +67,8 @@ process.exit(Number(process.env.BD_FAKE_PUSH_EXIT ?? "0"));
 `,
     "utf8",
   );
+  writeFileSync(join(bin, "bd"), `#!/bin/sh\nexec "${process.execPath}" "${script}" "$@"\n`, "utf8");
+  writeFileSync(join(bin, "bd.cmd"), `@"%~dp0\\bd.js" %*\r\n`, "utf8");
   chmodSync(join(bin, "bd"), 0o755);
   return {
     root,
@@ -134,6 +137,29 @@ test("sync runs pull before push with noninteractive credential settings", async
     assert.match(stdout.text(), /push ok/);
     assert.match(stderr.text(), /pull note/);
     assert.match(stderr.text(), /push note/);
+  } finally {
+    rmSync(current.root, { recursive: true, force: true });
+  }
+});
+
+test("sync resolves the Beads launcher from the injected Windows environment", {
+  skip: process.platform !== "win32",
+}, async () => {
+  const current = fixture();
+  const stderr = outputSink();
+  try {
+    const status = await runBeadsSync({
+      env: current.env,
+      platform: "win32",
+      writeStdout: () => {},
+      writeStderr: (value) => stderr.write(value),
+    });
+
+    assert.equal(status, 0, stderr.text());
+    assert.deepEqual(
+      readLog(current.log).map((entry) => entry.args),
+      [["dolt", "pull"], ["dolt", "push"]],
+    );
   } finally {
     rmSync(current.root, { recursive: true, force: true });
   }
@@ -252,6 +278,41 @@ test("unproven tree cleanup is a hard error, not an ordinary timeout", async () 
   assert.equal(status, 1);
   assert.match(stderr.text(), /could not prove process-tree cleanup/);
   assert.doesNotMatch(stderr.text(), /owned process tree terminated/);
+});
+
+test("child errors during termination do not bypass cleanup proof", async () => {
+  const stderr = outputSink();
+  const fakeChild = new EventEmitter();
+  fakeChild.pid = 424242;
+  fakeChild.exitCode = null;
+  fakeChild.signalCode = null;
+  fakeChild.stdout = new PassThrough();
+  fakeChild.stderr = new PassThrough();
+  let releaseCleanup;
+  const cleanup = new Promise((resolve) => {
+    releaseCleanup = resolve;
+  });
+
+  const statusPromise = runBeadsSync({
+    timeoutMs: 1,
+    spawnProcess: () => fakeChild,
+    terminateTree: async () => cleanup,
+    writeStdout: () => {},
+    writeStderr: (value) => stderr.write(value),
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  fakeChild.emit("error", new Error("late child error"));
+  let settled = false;
+  void statusPromise.then(() => {
+    settled = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(settled, false, "termination must wait for process-tree cleanup proof");
+
+  releaseCleanup(true);
+  assert.equal(await statusPromise, 124);
+  assert.match(stderr.text(), /owned process tree terminated/);
 });
 
 test("direct CLI SIGTERM cleans its detached bd process tree", {

--- a/scripts/beads-sync.ts
+++ b/scripts/beads-sync.ts
@@ -6,7 +6,7 @@ import {
   type SpawnOptions,
 } from "node:child_process";
 
-import { withBdLaunch } from "../src/lib/bd-bin.ts";
+import { resolveBdLaunchCommand, withBdLaunch } from "../src/lib/bd-bin.ts";
 import {
   BoundedProcessOutput,
   safeProcessErrorMessage,
@@ -106,7 +106,14 @@ async function runPhase(
     >
   > & Pick<BeadsSyncOptions, "terminationGraceMs">,
 ): Promise<PhaseResult> {
-  const launch = withBdLaunch("bd", ["dolt", phase]);
+  const launch = withBdLaunch(
+    "bd",
+    ["dolt", phase],
+    resolveBdLaunchCommand({
+      env: options.env,
+      platform: options.platform,
+    }),
+  );
   const stdout = new BoundedProcessOutput(OUTPUT_BYTES);
   const stderr = new BoundedProcessOutput(OUTPUT_BYTES);
   if (options.signal.aborted) {
@@ -202,6 +209,7 @@ async function runPhase(
     if (options.signal.aborted) onAbort();
 
     child.once("error", (error) => {
+      if (terminating) return;
       finish({
         status: 1,
         ...retained(),

--- a/scripts/beads-sync.ts
+++ b/scripts/beads-sync.ts
@@ -83,6 +83,15 @@ function retryGuidance(write: (value: string) => void): void {
   );
 }
 
+function cleanupUnprovenGuidance(write: (value: string) => void): void {
+  write(
+    "[beads:sync] Verify and stop the surviving process tree before retrying; it may still hold the Dolt lock or be pushing.\n",
+  );
+  write(
+    "[beads:sync] Inspect `git ls-remote origin refs/dolt/data` before deciding whether a push retry is needed.\n",
+  );
+}
+
 function cancellationStatus(signal: AbortSignal): number {
   const reason = signal.reason;
   return typeof reason === "string" && reason in SIGNAL_EXIT_CODES
@@ -151,6 +160,12 @@ async function runPhase(
   child.stdout?.on("data", (chunk) => stdout.append(chunk));
   child.stderr?.on("data", (chunk) => stderr.append(chunk));
 
+  const releaseUnprovenChildHandles = () => {
+    child.stdout?.destroy();
+    child.stderr?.destroy();
+    child.unref();
+  };
+
   return new Promise((resolve) => {
     let settled = false;
     let terminating = false;
@@ -181,6 +196,7 @@ async function runPhase(
           graceMs: options.terminationGraceMs,
         })
         .then((cleanupProven) => {
+          if (!cleanupProven) releaseUnprovenChildHandles();
           finish({
             status: cleanupProven ? successStatus : 1,
             ...retained(),
@@ -188,6 +204,7 @@ async function runPhase(
           });
         })
         .catch(() => {
+          releaseUnprovenChildHandles();
           finish({
             status: 1,
             ...retained(),
@@ -275,13 +292,14 @@ export async function runBeadsSync(options: BeadsSyncOptions = {}): Promise<numb
       writeStderr(
         `[beads:sync] ${phase} timed out after ${timeoutMs}ms and could not prove process-tree cleanup.\n`,
       );
-      if (phase === "push") retryGuidance(writeStderr);
+      cleanupUnprovenGuidance(writeStderr);
       return 1;
     }
     if (result.kind === "cancellation-cleanup-unproven") {
       writeStderr(
         `[beads:sync] ${phase} was cancelled and could not prove process-tree cleanup.\n`,
       );
+      cleanupUnprovenGuidance(writeStderr);
       return 1;
     }
     if (result.status !== 0) {

--- a/scripts/beads-sync.ts
+++ b/scripts/beads-sync.ts
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+import {
+  spawn,
+  type ChildProcess,
+  type SpawnOptions,
+} from "node:child_process";
+
+import { withBdLaunch } from "../src/lib/bd-bin.ts";
+import {
+  BoundedProcessOutput,
+  safeProcessErrorMessage,
+  terminateProcessTree,
+} from "../src/lib/process-execution.ts";
+import { isDirectRun } from "./direct-run.mjs";
+
+const DEFAULT_PHASE_TIMEOUT_MS = 90_000;
+const OUTPUT_BYTES = 64 * 1024;
+
+type SyncPhase = "pull" | "push";
+
+type SpawnProcess = (
+  command: string,
+  args: string[],
+  options: SpawnOptions,
+) => ChildProcess;
+
+type TerminateTree = (
+  child: ChildProcess,
+  options?: { platform?: NodeJS.Platform; graceMs?: number },
+) => Promise<boolean>;
+
+export type BeadsSyncOptions = {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  timeoutMs?: number;
+  terminationGraceMs?: number;
+  spawnProcess?: SpawnProcess;
+  terminateTree?: TerminateTree;
+  writeStdout?: (value: string) => void;
+  writeStderr?: (value: string) => void;
+};
+
+type PhaseResult = {
+  status: number;
+  stdout: string;
+  stderr: string;
+  kind: "completed" | "timed-out" | "cleanup-unproven" | "spawn-failed";
+  error?: string;
+};
+
+function positiveFiniteTimeout(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new TypeError("Beads sync timeout must be a positive finite number");
+  }
+  return Math.ceil(value);
+}
+
+function writeRetained(write: (value: string) => void, value: string): void {
+  if (!value) return;
+  write(value.endsWith("\n") ? value : `${value}\n`);
+}
+
+function retryGuidance(write: (value: string) => void): void {
+  write("[beads:sync] Retry `pnpm beads:sync` once.\n");
+  write(
+    "[beads:sync] Do not edit Git configuration or credential helpers after one transient 403.\n",
+  );
+  write(
+    "[beads:sync] For pending Beads changes, compare `git ls-remote origin refs/dolt/data` before and after the retry.\n",
+  );
+}
+
+async function runPhase(
+  phase: SyncPhase,
+  options: Required<
+    Pick<
+      BeadsSyncOptions,
+      | "env"
+      | "platform"
+      | "timeoutMs"
+      | "spawnProcess"
+      | "terminateTree"
+      | "writeStdout"
+      | "writeStderr"
+    >
+  > & Pick<BeadsSyncOptions, "terminationGraceMs">,
+): Promise<PhaseResult> {
+  const launch = withBdLaunch("bd", ["dolt", phase]);
+  const stdout = new BoundedProcessOutput(OUTPUT_BYTES);
+  const stderr = new BoundedProcessOutput(OUTPUT_BYTES);
+  let child: ChildProcess;
+
+  try {
+    child = options.spawnProcess(launch.command, launch.args, {
+      env: {
+        ...options.env,
+        GIT_TERMINAL_PROMPT: "0",
+        GCM_INTERACTIVE: "Never",
+      },
+      windowsHide: true,
+      shell: false,
+      detached: options.platform !== "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    return {
+      status: 1,
+      stdout: "",
+      stderr: "",
+      kind: "spawn-failed",
+      error: safeProcessErrorMessage(error, "Beads CLI"),
+    };
+  }
+
+  child.stdout?.on("data", (chunk) => stdout.append(chunk));
+  child.stderr?.on("data", (chunk) => stderr.append(chunk));
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let timedOut = false;
+    const finish = (result: PhaseResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const retained = () => ({
+      stdout: stdout.text(),
+      stderr: stderr.text(),
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      void options
+        .terminateTree(child, {
+          platform: options.platform,
+          graceMs: options.terminationGraceMs,
+        })
+        .then((cleanupProven) => {
+          finish({
+            status: cleanupProven ? 124 : 1,
+            ...retained(),
+            kind: cleanupProven ? "timed-out" : "cleanup-unproven",
+          });
+        })
+        .catch(() => {
+          finish({
+            status: 1,
+            ...retained(),
+            kind: "cleanup-unproven",
+          });
+        });
+    }, options.timeoutMs);
+
+    child.once("error", (error) => {
+      finish({
+        status: 1,
+        ...retained(),
+        kind: "spawn-failed",
+        error: safeProcessErrorMessage(error, "Beads CLI"),
+      });
+    });
+    child.once("close", (code) => {
+      if (timedOut) return;
+      finish({
+        status: code ?? 1,
+        ...retained(),
+        kind: "completed",
+      });
+    });
+  });
+}
+
+export async function runBeadsSync(options: BeadsSyncOptions = {}): Promise<number> {
+  const timeoutMs = positiveFiniteTimeout(
+    options.timeoutMs ?? DEFAULT_PHASE_TIMEOUT_MS,
+  );
+  const writeStdout = options.writeStdout ?? ((value) => process.stdout.write(value));
+  const writeStderr = options.writeStderr ?? ((value) => process.stderr.write(value));
+  const resolved = {
+    env: options.env ?? process.env,
+    platform: options.platform ?? process.platform,
+    timeoutMs,
+    terminationGraceMs: options.terminationGraceMs,
+    spawnProcess: options.spawnProcess ?? spawn,
+    terminateTree: options.terminateTree ?? terminateProcessTree,
+    writeStdout,
+    writeStderr,
+  };
+
+  for (const phase of ["pull", "push"] as const) {
+    writeStdout(`[beads:sync] ${phase}\n`);
+    const result = await runPhase(phase, resolved);
+    writeRetained(writeStdout, result.stdout);
+    writeRetained(writeStderr, result.stderr);
+
+    if (result.kind === "spawn-failed") {
+      writeStderr(`[beads:sync] ${phase} failed: ${result.error}\n`);
+      if (phase === "push") retryGuidance(writeStderr);
+      return 1;
+    }
+    if (result.kind === "timed-out") {
+      writeStderr(
+        `[beads:sync] ${phase} timed out after ${timeoutMs}ms; owned process tree terminated.\n`,
+      );
+      if (phase === "push") retryGuidance(writeStderr);
+      return 124;
+    }
+    if (result.kind === "cleanup-unproven") {
+      writeStderr(
+        `[beads:sync] ${phase} timed out after ${timeoutMs}ms and could not prove process-tree cleanup.\n`,
+      );
+      if (phase === "push") retryGuidance(writeStderr);
+      return 1;
+    }
+    if (result.status !== 0) {
+      writeStderr(
+        `[beads:sync] ${phase} exited with status ${result.status}.\n`,
+      );
+      if (phase === "push") retryGuidance(writeStderr);
+      return result.status;
+    }
+  }
+
+  return 0;
+}
+
+async function main(): Promise<void> {
+  process.exitCode = await runBeadsSync();
+}
+
+if (isDirectRun(import.meta.url)) {
+  void main().catch((error) => {
+    process.stderr.write(
+      `[beads:sync] ${safeProcessErrorMessage(error, "Beads sync")}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/scripts/beads-sync.ts
+++ b/scripts/beads-sync.ts
@@ -16,8 +16,13 @@ import { isDirectRun } from "./direct-run.mjs";
 
 const DEFAULT_PHASE_TIMEOUT_MS = 90_000;
 const OUTPUT_BYTES = 64 * 1024;
+const SIGNAL_EXIT_CODES = {
+  SIGINT: 130,
+  SIGTERM: 143,
+} as const;
 
 type SyncPhase = "pull" | "push";
+type SupportedSignal = keyof typeof SIGNAL_EXIT_CODES;
 
 type SpawnProcess = (
   command: string,
@@ -33,6 +38,7 @@ type TerminateTree = (
 export type BeadsSyncOptions = {
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
+  signal?: AbortSignal;
   timeoutMs?: number;
   terminationGraceMs?: number;
   spawnProcess?: SpawnProcess;
@@ -45,7 +51,13 @@ type PhaseResult = {
   status: number;
   stdout: string;
   stderr: string;
-  kind: "completed" | "timed-out" | "cleanup-unproven" | "spawn-failed";
+  kind:
+    | "completed"
+    | "timed-out"
+    | "cancelled"
+    | "timeout-cleanup-unproven"
+    | "cancellation-cleanup-unproven"
+    | "spawn-failed";
   error?: string;
 };
 
@@ -71,6 +83,13 @@ function retryGuidance(write: (value: string) => void): void {
   );
 }
 
+function cancellationStatus(signal: AbortSignal): number {
+  const reason = signal.reason;
+  return typeof reason === "string" && reason in SIGNAL_EXIT_CODES
+    ? SIGNAL_EXIT_CODES[reason as SupportedSignal]
+    : 130;
+}
+
 async function runPhase(
   phase: SyncPhase,
   options: Required<
@@ -78,6 +97,7 @@ async function runPhase(
       BeadsSyncOptions,
       | "env"
       | "platform"
+      | "signal"
       | "timeoutMs"
       | "spawnProcess"
       | "terminateTree"
@@ -89,6 +109,14 @@ async function runPhase(
   const launch = withBdLaunch("bd", ["dolt", phase]);
   const stdout = new BoundedProcessOutput(OUTPUT_BYTES);
   const stderr = new BoundedProcessOutput(OUTPUT_BYTES);
+  if (options.signal.aborted) {
+    return {
+      status: cancellationStatus(options.signal),
+      stdout: "",
+      stderr: "",
+      kind: "cancelled",
+    };
+  }
   let child: ChildProcess;
 
   try {
@@ -118,19 +146,28 @@ async function runPhase(
 
   return new Promise((resolve) => {
     let settled = false;
-    let timedOut = false;
+    let terminating = false;
     const finish = (result: PhaseResult) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      options.signal.removeEventListener("abort", onAbort);
       resolve(result);
     };
     const retained = () => ({
       stdout: stdout.text(),
       stderr: stderr.text(),
     });
-    const timer = setTimeout(() => {
-      timedOut = true;
+    const terminate = (
+      successKind: Extract<PhaseResult["kind"], "timed-out" | "cancelled">,
+      successStatus: number,
+      failureKind: Extract<
+        PhaseResult["kind"],
+        "timeout-cleanup-unproven" | "cancellation-cleanup-unproven"
+      >,
+    ) => {
+      if (settled || terminating) return;
+      terminating = true;
       void options
         .terminateTree(child, {
           platform: options.platform,
@@ -138,19 +175,31 @@ async function runPhase(
         })
         .then((cleanupProven) => {
           finish({
-            status: cleanupProven ? 124 : 1,
+            status: cleanupProven ? successStatus : 1,
             ...retained(),
-            kind: cleanupProven ? "timed-out" : "cleanup-unproven",
+            kind: cleanupProven ? successKind : failureKind,
           });
         })
         .catch(() => {
           finish({
             status: 1,
             ...retained(),
-            kind: "cleanup-unproven",
+            kind: failureKind,
           });
         });
+    };
+    const timer = setTimeout(() => {
+      terminate("timed-out", 124, "timeout-cleanup-unproven");
     }, options.timeoutMs);
+    const onAbort = () => {
+      terminate(
+        "cancelled",
+        cancellationStatus(options.signal),
+        "cancellation-cleanup-unproven",
+      );
+    };
+    options.signal.addEventListener("abort", onAbort, { once: true });
+    if (options.signal.aborted) onAbort();
 
     child.once("error", (error) => {
       finish({
@@ -161,7 +210,7 @@ async function runPhase(
       });
     });
     child.once("close", (code) => {
-      if (timedOut) return;
+      if (terminating) return;
       finish({
         status: code ?? 1,
         ...retained(),
@@ -177,9 +226,11 @@ export async function runBeadsSync(options: BeadsSyncOptions = {}): Promise<numb
   );
   const writeStdout = options.writeStdout ?? ((value) => process.stdout.write(value));
   const writeStderr = options.writeStderr ?? ((value) => process.stderr.write(value));
+  const signal = options.signal ?? new AbortController().signal;
   const resolved = {
     env: options.env ?? process.env,
     platform: options.platform ?? process.platform,
+    signal,
     timeoutMs,
     terminationGraceMs: options.terminationGraceMs,
     spawnProcess: options.spawnProcess ?? spawn,
@@ -206,11 +257,23 @@ export async function runBeadsSync(options: BeadsSyncOptions = {}): Promise<numb
       if (phase === "push") retryGuidance(writeStderr);
       return 124;
     }
-    if (result.kind === "cleanup-unproven") {
+    if (result.kind === "cancelled") {
+      writeStderr(
+        `[beads:sync] ${phase} cancelled; owned process tree terminated.\n`,
+      );
+      return result.status;
+    }
+    if (result.kind === "timeout-cleanup-unproven") {
       writeStderr(
         `[beads:sync] ${phase} timed out after ${timeoutMs}ms and could not prove process-tree cleanup.\n`,
       );
       if (phase === "push") retryGuidance(writeStderr);
+      return 1;
+    }
+    if (result.kind === "cancellation-cleanup-unproven") {
+      writeStderr(
+        `[beads:sync] ${phase} was cancelled and could not prove process-tree cleanup.\n`,
+      );
       return 1;
     }
     if (result.status !== 0) {
@@ -226,7 +289,20 @@ export async function runBeadsSync(options: BeadsSyncOptions = {}): Promise<numb
 }
 
 async function main(): Promise<void> {
-  process.exitCode = await runBeadsSync();
+  const controller = new AbortController();
+  const onSignal = (signal: SupportedSignal) => {
+    if (!controller.signal.aborted) controller.abort(signal);
+  };
+  const onSigint = () => onSignal("SIGINT");
+  const onSigterm = () => onSignal("SIGTERM");
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+  try {
+    process.exitCode = await runBeadsSync({ signal: controller.signal });
+  } finally {
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+  }
 }
 
 if (isDirectRun(import.meta.url)) {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -87,6 +87,7 @@ export const SUITES = {
     "scripts/onboarding-feedback-report.test.mjs",
     "scripts/beads-jsonl-merge-driver.test.mjs",
     "scripts/beads-create.test.mjs",
+    "scripts/beads-sync.test.mjs",
     "scripts/beads-surface-audit.test.mjs",
     "scripts/install-git-hooks.test.mjs",
     "scripts/worktree-lifecycle-retirement.test.mjs",

--- a/src/lib/bd-bin.test.ts
+++ b/src/lib/bd-bin.test.ts
@@ -221,7 +221,7 @@ for (const script of ROUTED_SCRIPTS) {
   const source = await readFile(new URL(script, ROOT), "utf8");
   assert.match(
     source,
-    /import \{ withBdLaunch \} from "\.\.\/src\/lib\/bd-bin\.ts";/,
+    /import \{[^}]*\bwithBdLaunch\b[^}]*\} from "\.\.\/src\/lib\/bd-bin\.ts";/,
     `${script} must route bd through the resolver`,
   );
   assert.doesNotMatch(

--- a/src/lib/bd-bin.test.ts
+++ b/src/lib/bd-bin.test.ts
@@ -206,6 +206,7 @@ const ROUTED_SCRIPTS = [
   "scripts/beads-create.ts",
   "scripts/beads-pr-shared.ts",
   "scripts/beads-surface-audit.ts",
+  "scripts/beads-sync.ts",
   "scripts/worktree-lifecycle-create.ts",
   "scripts/worktree-lifecycle-inventory.ts",
   "scripts/worktree-lifecycle-metadata-repair.ts",


### PR DESCRIPTION
## Summary
- route `pnpm beads:sync` through a shell-free Node watchdog
- bound pull and push, terminate the complete owned process tree on timeout or interruption, and preserve redacted diagnostics
- document one safe retry and `refs/dolt/data` verification

## Validation
- `node scripts/beads-sync.test.mjs`
- `node scripts/beads-familiar-workflow.test.mjs`
- `node --experimental-strip-types src/lib/bd-bin.test.ts`
- `pnpm check:tests-wired`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:app`

Bead: `cave-hg7qb`