### PR TITLE
Page canonical conversations by an immutable key (cave-fhjlu)

### DIFF
--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -577,25 +577,47 @@ both or skip both:
 |---|---|
 | `/familiars` | `id` ascending. A roster entry has no timestamp at all, so the identity is the sort key. |
 | `/projects` | `createdAt` descending, then `id` descending. `createdAt` is immutable; `updatedAt` moves under an open cursor. |
-| `/conversations` | `updatedAt` descending, then `id` descending. `createdAt` is optional on a conversation summary, so it cannot key the page. |
+| `/conversations` | `createdAt` descending, then `id` descending. A conversation with no `createdAt` sorts **last**, ordered among its peers by `id` descending. |
 | `/conversations/:id/messages` | Transcript order, oldest first. **Not** a keyset — see that route. |
 
-**One consequence worth planning for:** `/conversations` keys on a *mutable*
-field, so a conversation that receives a turn while you are paging **moves out
-of the window you have not reached yet**. The ordering is `updatedAt`
-descending and a touch only ever raises the key, so the touched row moves
-*above* your open cursor: one already served stays served, and one not yet
-served is **skipped** by the rest of the walk.
+**Every sort key here is immutable.** Nothing rewrites a project's or a
+conversation's `createdAt`, and a familiar's id is its identity, so the position
+a cursor names is a position the ordering still has when you resume. A walk that
+starts now serves exactly the rows that existed when it started, in the order it
+started with, however much the Cave is written to underneath it. Two things are
+worth planning for anyway:
 
-Earlier text here said such a row "can appear in two pages", and that the repeat
-was the cost. It is the other way round, and the difference matters: a repeat is
-deduplicable by `id`, a skip is silent. Measured over a real socket by
-[the conformance run](../workflows/client-v1-conformance.md) on 2026-08-22, no
-repeat was reproducible from a touch. **So a client that must not miss a
-conversation should re-read from the top rather than trust one walk** — and
-should still deduplicate by `id`, which costs nothing and covers the walks it
-restarts. The alternative key — a field half the corpus lacks — is worse than
-either.
+- **A conversation created while you are paging is not served by that walk.**
+  Its `createdAt` is *now*, which sorts above every cursor you already hold.
+  Nothing is lost — no row that existed when the walk began is affected — but a
+  client that wants the newest conversations re-reads from the top rather than
+  waiting for a walk in progress to surface them.
+- **A conversation deleted while you are paging simply stops appearing.** The
+  cursor names a position in the ordering rather than an index, so the walk
+  continues at the next surviving record.
+
+⚠️ **The ordering of `/conversations` changed.** It was `updatedAt` descending —
+the order the Cave's own sessions list shows — until 2026-08-22. `updatedAt`
+only ever rises and the ordering is descending, so a conversation that received a
+turn mid-walk moved *above* an open cursor: one already served stayed served, and
+one **not yet served was silently skipped** by the rest of the walk. Measured
+over a real socket by [the conformance run](../workflows/client-v1-conformance.md),
+which could not reproduce a repeat from a touch at all. A repeat would have been
+deduplicable by `id`; a skip is silent data loss from a read this document calls
+canonical, so the key moved to the immutable field.
+
+**What that costs you:** this route no longer matches the desktop sessions list
+row for row. `updatedAt` is still served on every conversation record, so sort a
+page by it if you want recency — what you cannot have is recency as a *resumable*
+ordering, because a keyset cursor cannot name a position in an order that moves.
+Deduplicating by `id` still costs nothing and is still worth doing across walks
+you restart.
+
+`createdAt` is optional on a conversation record — a transcript written before
+the field existed has none, and neither does the row Cave substitutes for a file
+it cannot read. Those rows are **served at the end of the walk**, not stranded
+and not skipped: they sort as if their key were empty, which is below every
+timestamp.
 
 ### `GET /api/client/v1/familiars`
 
@@ -682,8 +704,10 @@ registry view, so there is no familiar whose access could be applied.
 
 ### `GET /api/client/v1/conversations`
 
-The conversation ledger — the same rows, in the same order, that the Cave's own
-sessions list is built from.
+The conversation ledger — the same rows the Cave's own sessions list is built
+from, **in a different order**: newest-created first, not most-recently-touched
+first. See *Paging* above for why the recency ordering could not be paged
+safely, and sort a page by `updatedAt` if that is the order you want.
 
 **Request:** `Authorization: Bearer …`, the loopback stamp, optional `limit` and
 `cursor`.
@@ -716,7 +740,9 @@ sessions list is built from.
 
 Only `id`, `familiarId` and `updatedAt` are guaranteed. `exitCode` may be
 `null`, which means the run has no exit code yet — distinct from the field being
-absent, which means none was ever recorded.
+absent, which means none was ever recorded. `createdAt` is the field this route
+pages by, and it is *not* guaranteed: a record without one is served at the end
+of the walk rather than dropped.
 
 **`runtime` is not an enum, and for a local run it is a path.**
 `POST /api/chat/send` writes the field as

--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -567,6 +567,19 @@ The cursor rides the shared envelope:
   cursor, limit); replaying never advances and never loops.
 - **A deleted record does not strand you.** The token records a position in the
   ordering, not an index, so the next page resumes at the next surviving record.
+- **Do not carry a cursor across a Cave upgrade.** A token names a position in
+  *an* ordering, and the ordering a route uses can change between versions —
+  `/conversations` changed on 2026-08-22 (see below). The encoded version tag
+  covers a change to the token's *shape*, not to the meaning of the position
+  inside it, so a token minted by an older Cave is accepted rather than refused
+  and resumes somewhere the client did not ask for. Measured on the
+  2026-08-22 change: the stale token restarts the walk near the head and
+  re-serves rows the client already had. That change costs duplicates rather
+  than losses — a conversation's `updatedAt` is never below its `createdAt`, so
+  no row can hide above a resumed position — but that is a property of those two
+  fields, not a promise about the next reordering. A client that persists
+  cursors between sessions should discard them when the Cave's version changes
+  and start the walk again.
 - `previous` is never emitted. These reads are forward-only.
 
 Orderings are total — a sort key plus the id as tiebreak — because a page
@@ -580,12 +593,13 @@ both or skip both:
 | `/conversations` | `createdAt` descending, then `id` descending. A conversation with no `createdAt` sorts **last**, ordered among its peers by `id` descending. |
 | `/conversations/:id/messages` | Transcript order, oldest first. **Not** a keyset — see that route. |
 
-**Every sort key here is immutable.** Nothing rewrites a project's or a
-conversation's `createdAt`, and a familiar's id is its identity, so the position
-a cursor names is a position the ordering still has when you resume. A walk that
-starts now serves exactly the rows that existed when it started, in the order it
-started with, however much the Cave is written to underneath it. Two things are
-worth planning for anyway:
+**Every sort key here is immutable, with one narrow exception named in the third
+bullet.** Nothing rewrites a project's `createdAt` or a conversation's, a
+familiar's id is its identity, and saving a conversation stamps only its
+`updatedAt` — so the position a cursor names is a position the ordering still
+has when you resume. A walk that starts now serves the rows that existed when it
+started, in the order it started with, however much the Cave is written to
+underneath it. Three things are worth planning for:
 
 - **A conversation created while you are paging is not served by that walk.**
   Its `createdAt` is *now*, which sorts above every cursor you already hold.
@@ -595,6 +609,15 @@ worth planning for anyway:
 - **A conversation deleted while you are paging simply stops appearing.** The
   cursor names a position in the ordering rather than an index, so the walk
   continues at the next surviving record.
+- **A conversation that has no `createdAt` at all can leave the tail block.**
+  Such a record is served last (see below), and it stays there for as long as it
+  has no `createdAt` — but the moment it acquires one it sorts above every
+  cursor you hold, so the walk in progress will not serve it. This is the one
+  row this ordering can still miss. It is rare (a transcript older than the
+  field, or one Cave could not read on the last scan) and it settles once the
+  record has a `createdAt`, but a walk cannot tell that it happened. If you must
+  not miss a conversation, re-read from the top and dedupe by `id`; that costs
+  nothing and covers this case.
 
 ⚠️ **The ordering of `/conversations` changed.** It was `updatedAt` descending —
 the order the Cave's own sessions list shows — until 2026-08-22. `updatedAt`
@@ -607,11 +630,16 @@ deduplicable by `id`; a skip is silent data loss from a read this document calls
 canonical, so the key moved to the immutable field.
 
 **What that costs you:** this route no longer matches the desktop sessions list
-row for row. `updatedAt` is still served on every conversation record, so sort a
-page by it if you want recency — what you cannot have is recency as a *resumable*
-ordering, because a keyset cursor cannot name a position in an order that moves.
-Deduplicating by `id` still costs nothing and is still worth doing across walks
-you restart.
+row for row, and the cost is more than cosmetic, so it is worth stating exactly.
+`updatedAt` is served on every conversation record, so you can *rank* by
+recency — but only over rows you already hold. Sorting a single page by
+`updatedAt` does not give you the most recently active conversations; it gives
+you one arbitrary slice of the ledger, internally sorted. **To show "most recent
+first" you have to read the ledger to exhaustion and sort client-side.** For a
+Cave with a few hundred conversations that is one walk you can cache and keep
+warm; there is no server-side shortcut, and there cannot be one, because a
+keyset cursor cannot name a position in an order that moves. Deduplicating by
+`id` still costs nothing and is still worth doing across walks you restart.
 
 `createdAt` is optional on a conversation record — a transcript written before
 the field existed has none, and neither does the row Cave substitutes for a file
@@ -706,8 +734,9 @@ registry view, so there is no familiar whose access could be applied.
 
 The conversation ledger — the same rows the Cave's own sessions list is built
 from, **in a different order**: newest-created first, not most-recently-touched
-first. See *Paging* above for why the recency ordering could not be paged
-safely, and sort a page by `updatedAt` if that is the order you want.
+first. See *Paging* above for why the recency ordering could not be paged safely
+and what it costs you — in short, a recency-ordered view has to be assembled
+client-side from a complete walk, not by sorting one page.
 
 **Request:** `Authorization: Bearer …`, the loopback stamp, optional `limit` and
 `cursor`.

--- a/docs/client-v1-conformance-results/2026-08-22-v0.3.9-win32-cave-fhjlu.json
+++ b/docs/client-v1-conformance-results/2026-08-22-v0.3.9-win32-cave-fhjlu.json
@@ -1,0 +1,544 @@
+{
+  "harness": "scripts/client-v1-conformance.mjs",
+  "issues": [
+    "OpenCoven/coven-cave#4832",
+    "OpenCoven/coven-cave#4838"
+  ],
+  "scope": "cave-only",
+  "ranAt": "2026-08-22T23:07:09.516Z",
+  "caveVersion": "0.3.9",
+  "commit": "ed6cc4b1bcd2f4ad21d1611706f46528e20d188e",
+  "platform": "win32-x64",
+  "nodeVersion": "v24.18.0",
+  "includeTtl": true,
+  "notCovered": [
+    "The SDK and Chat halves of #4838. Both live in other repositories; this run is the Cave half only.",
+    "The production Coven daemon. /familiars is served from a loopback fixture daemon in hub mode.",
+    "A genuinely remote peer. Off-machine ingress is exercised by making the listener classify a loopback request as forwarded.",
+    "The write scopes. Nothing enforces them yet — there are no write routes on this surface.",
+    "OAuth-backed flows and the desktop consent UI. Approval is driven through the admin HTTP route.",
+    "Cross-process pairing state. The pairing store is in-memory and process-local by contract."
+  ],
+  "findings": [
+    {
+      "id": "backslash-refusal-is-unreachable",
+      "where": "docs/api/client-v1.md — Reaching the API at all",
+      "says": "a request target inside /api/client/v1 containing \"%\" or \"\\\" is answered 400 {\"ok\":false,\"error\":\"invalid client v1 path\"}",
+      "measured": "the \"%\" half holds; a \"\\\" is normalised to \"/\" by Next and answered 308 to the normalised target before proxy.ts runs, and that target is then refused 401 by the ordinary gate",
+      "severity": "documentation",
+      "why": "no handler is reached and nothing is served, so the gate still holds; the doc describes an answer no client will observe"
+    },
+    {
+      "id": "admin-unauthorized-envelope-is-unreachable",
+      "where": "docs/api/client-v1.md — Administrator routes, Authentication",
+      "says": "a mismatched or absent x-coven-cave-token is 401 unauthorized from requireClientV1Admin",
+      "measured": "the proxy's sidecar-token gate answers first, so the wire carries 401 {\"ok\":false,\"error\":\"unauthorized\"} and requireClientV1Admin's envelope is never produced on a Cave with a token configured",
+      "severity": "documentation",
+      "why": "the refusal is correct and same-status; only its body differs from the documented one, which a handler-level test cannot see"
+    }
+  ],
+  "summary": {
+    "total": 99,
+    "passed": 99,
+    "failed": 0,
+    "skipped": 0,
+    "status": "passed"
+  },
+  "assertions": [
+    {
+      "id": "admin.unconfigured/admin/pairing-requests.GET",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/credentials.GET",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/pairing-requests/:id/decision.POST",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/credentials/:id.DELETE",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured.pairing-still-opens",
+      "result": "pass",
+      "detail": "a tokenless Cave still opens pairing requests"
+    },
+    {
+      "id": "admin.unconfigured.exchange-stays-pending",
+      "result": "pass",
+      "detail": "the documented dead end: no approval route, so the exchange can only ever answer pairing_pending"
+    },
+    {
+      "id": "health.envelope",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "health.instance-stable",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "health.discovery-record",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "ingress.escaped-path.percent",
+      "result": "pass",
+      "detail": "/api/client/v1/pairing/requests/%41"
+    },
+    {
+      "id": "ingress.escaped-path.percent-encoded-separator",
+      "result": "pass",
+      "detail": "/api/client/v1/conversations%2Fx"
+    },
+    {
+      "id": "ingress.backslash-path-reaches-no-handler",
+      "result": "pass",
+      "detail": "answered 308; the documented 400 fires for \"%\" only — see the run's notes"
+    },
+    {
+      "id": "ingress.forwarded.public",
+      "result": "pass",
+      "detail": "/pairing/requests with x-forwarded-for"
+    },
+    {
+      "id": "ingress.forwarded.authenticated",
+      "result": "pass",
+      "detail": "/conversations with x-forwarded-for"
+    },
+    {
+      "id": "ingress.forwarded.admin",
+      "result": "pass",
+      "detail": "/admin/credentials with x-forwarded-for"
+    },
+    {
+      "id": "ingress.exchange-requires-content-length",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "ingress.refuses-transfer-encoding",
+      "result": "pass",
+      "detail": "a chunked control-plane body has no declared length to cap"
+    },
+    {
+      "id": "ingress.body-cap",
+      "result": "pass",
+      "detail": "70072 bytes against the 65536-byte control-plane cap"
+    },
+    {
+      "id": "ingress.pairing-content-type",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.wrong-token",
+      "result": "pass",
+      "detail": "refused by the proxy's sidecar gate, ahead of requireClientV1Admin"
+    },
+    {
+      "id": "admin.no-token",
+      "result": "pass",
+      "detail": "refused by the proxy's sidecar gate, ahead of requireClientV1Admin"
+    },
+    {
+      "id": "admin.mutation-requires-source",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.create",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-pending",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-queue",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-approve",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-approved",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-approve-idempotent",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-decision-conflict",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.exchange",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.bearer-works",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.replay-refused",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-after-exchange",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-denied",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.exchange-denied",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.unknown-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.wrong-secret",
+      "result": "pass",
+      "detail": "one wrong secret charged on the exchange route"
+    },
+    {
+      "id": "pairing.correct-secret-polling-is-free",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-charges-wrong-secret-on-poll",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-locks-out-the-holder",
+      "result": "pass",
+      "detail": "ten wrong secrets across BOTH routes; the correct secret is refused too"
+    },
+    {
+      "id": "pairing.budget-is-shared-across-routes",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-is-per-pairing",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.ttl-poll-expired",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.ttl-exchange-expired",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.empty-first-page/projects",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.empty-first-page/conversations",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.no-bearer",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.unknown-bearer",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.bearer-not-accepted-in-query",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.scope-denied",
+      "result": "pass",
+      "detail": "a credential without chat:read"
+    },
+    {
+      "id": "reads.familiars",
+      "result": "pass",
+      "detail": "against a loopback fixture daemon, not the production daemon"
+    },
+    {
+      "id": "reads.familiars-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.projects-shape",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.projects-paging-partial-final-page",
+      "result": "pass",
+      "detail": "3 pages of at most 3 over 7 rows"
+    },
+    {
+      "id": "reads.cursor-replay-is-stable",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.cursor-current-echoes-the-token",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.cursor-survives-deletion",
+      "result": "pass",
+      "detail": "the token records a position in the ordering, not an index"
+    },
+    {
+      "id": "reads.projects-paging-exact-multiple",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.refuses.limit-zero",
+      "result": "pass",
+      "detail": "/projects?limit=0"
+    },
+    {
+      "id": "reads.refuses.limit-over-ceiling",
+      "result": "pass",
+      "detail": "/projects?limit=101"
+    },
+    {
+      "id": "reads.refuses.limit-leading-zero",
+      "result": "pass",
+      "detail": "/projects?limit=01"
+    },
+    {
+      "id": "reads.refuses.limit-exponent",
+      "result": "pass",
+      "detail": "/projects?limit=1e2"
+    },
+    {
+      "id": "reads.refuses.limit-signed",
+      "result": "pass",
+      "detail": "/projects?limit=%2B5"
+    },
+    {
+      "id": "reads.refuses.limit-repeated",
+      "result": "pass",
+      "detail": "/projects?limit=1&limit=2"
+    },
+    {
+      "id": "reads.refuses.unsupported-parameter",
+      "result": "pass",
+      "detail": "/projects?limt=5"
+    },
+    {
+      "id": "reads.refuses.offset",
+      "result": "pass",
+      "detail": "/projects?offset=1"
+    },
+    {
+      "id": "reads.refuses.cursor-outside-alphabet",
+      "result": "pass",
+      "detail": "/projects?cursor=not*base64url"
+    },
+    {
+      "id": "reads.refuses.cursor-not-canonical",
+      "result": "pass",
+      "detail": "/projects?cursor=eyJ2IjoxfQ=="
+    },
+    {
+      "id": "reads.limit-ceiling-is-served",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.default-page-size",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-shape",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-refuses-limit",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-refuses-cursor",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-not-found",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-touch-unserved-row-is-still-served",
+      "result": "pass",
+      "detail": "touched the unserved conversation-01; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-touch-served-row-is-not-repeated",
+      "result": "pass",
+      "detail": "touched the already-served conversation-06; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-touch-cursor-row-keeps-the-position",
+      "result": "pass",
+      "detail": "touched conversation-05, the row the cursor names; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-row-created-mid-walk-is-not-served",
+      "result": "pass",
+      "detail": "a row created above the cursor is left for the next read from the top"
+    },
+    {
+      "id": "reads.conversations-row-deleted-mid-walk-does-not-strand",
+      "result": "pass",
+      "detail": "deleted the unserved conversation-04; the whole walk served [conversation-06,conversation-05,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-tied-sort-key-breaks-on-id",
+      "result": "pass",
+      "detail": "conversation-04 and conversation-03 share 2026-03-04T00:00:00.000Z"
+    },
+    {
+      "id": "reads.conversations-without-created-at-are-served-last",
+      "result": "pass",
+      "detail": "an optional page key is only safe if the rows that lack it are served, not stranded"
+    },
+    {
+      "id": "reads.messages-active-branch",
+      "result": "pass",
+      "detail": "the abandoned branch turn b-x1 must be absent"
+    },
+    {
+      "id": "reads.messages-values",
+      "result": "pass",
+      "detail": "text, role, parentId, createdAt and both counts, field by field against the fixture"
+    },
+    {
+      "id": "reads.messages-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-counts-not-contents",
+      "result": "pass",
+      "detail": "b-a1 carries two tool calls and one attachment; the counts must say so and the contents must not appear"
+    },
+    {
+      "id": "reads.messages-reconcile-required",
+      "result": "pass",
+      "detail": "activeLeafId moved to the abandoned branch, so the cursor names a turn that is no longer on it"
+    },
+    {
+      "id": "reads.messages-restart-after-reconcile",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-not-found",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-canonical-conversation-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.bearer-works-before",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.admin-listing",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.revoke",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.bearer-refused-after",
+      "result": "pass",
+      "detail": "all five canonical reads"
+    },
+    {
+      "id": "revocation.is-idempotent",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.unknown-credential",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.tombstone-persists",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "harness.assertion-coverage",
+      "result": "pass",
+      "detail": "every declared assertion recorded exactly once (--include-ttl true)"
+    }
+  ]
+}

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -184,7 +184,7 @@ recognisable — but the rule is to not write them, not to scan for them.
 
 The harness is written against what the wire does, not against what the
 reference says, and where the two disagree it asserts the measured behaviour and
-records the gap. Three stand today, all documentation-level — the gates
+records the gap. Two stand today, both documentation-level — the gates
 themselves hold:
 
 1. **The backslash half of the escaped-target refusal is unreachable.**
@@ -202,22 +202,44 @@ themselves hold:
    envelope the reference describes. Same status, different body — and a
    handler-level test cannot tell, because it never runs the proxy.
 
-3. **`/conversations` skips rather than repeats under a mid-walk touch.** The
-   reference and `reads.ts` both say a conversation that receives a turn while
-   you are paging "can appear in two pages". The ordering is `updatedAt`
-   **descending** and a touch only raises the key, so a touched row moves
-   *above* an open cursor: one already served stays served, and one not yet
-   served is skipped by the rest of the walk. No repeat was reproducible. The
-   client-visible consequence is the opposite of the documented one — a repeat
-   is deduplicable by `id`, a skip is silent unless the client re-reads from the
-   top.
+### The finding that became a fix — `/conversations` skipped a touched row
 
-   Measured over the **whole** walk rather than the page after the touch, which
-   is what separates the two claims: a row that came back three pages later
-   would be the documented repeat, and a one-page probe cannot tell. The ledger
-   orders `conversation-06` down to `conversation-01`; the first page serves
-   `[06, 05]`; after touching the unserved `conversation-01` the rest of the walk
-   serves `[04, 03, 02]` and nothing is served twice anywhere in it.
+A third finding stood here until 2026-08-22, and it is recorded rather than
+deleted because the run is what found it and the assertions it left behind are
+what keep it fixed.
+
+`/conversations` keyed on `updatedAt`. That field only ever rises and the
+ordering is descending, so a conversation touched while a client was paging moved
+*above* an open cursor: one already served stayed served, and one **not yet
+served was skipped** by the rest of the walk. The reference and the `reads.ts`
+comment both said such a row "can appear in two pages"; the run could not
+reproduce a repeat at all. A repeat is deduplicable by `id`, a skip is silent —
+so this was data loss from a read the surface calls canonical, not a
+documentation gap, and it was fixed under `cave-fhjlu` by keying on the immutable
+`createdAt`.
+
+Measuring the **whole** walk rather than the page after the touch is what
+separated the two claims, and a one-page probe never could have: the ledger
+ordered `conversation-06` down to `conversation-01`, the first page served
+`[06, 05]`, and after touching the unserved `conversation-01` the rest of the
+walk served `[04, 03, 02]` with nothing served twice anywhere in it.
+
+The single assertion that measured it — `reads.conversations-mutable-key-moves-a-row`,
+which *asserted the skip* — is now a family of seven that assert the walk is
+whole, one per way a ledger can move under an open cursor: a touch of an unserved
+row, a touch of an already-served row, a touch of the row the cursor names, a
+conversation created mid-walk, a conversation deleted mid-walk, two rows tied on
+the sort key, and a row carrying no `createdAt` at all. Each walks to exhaustion
+and compares an **ordered sequence** of ids, never a set.
+
+Two fixture properties make that family able to fail, and both are pinned by
+`scripts/client-v1-conformance.test.mjs` rather than left as convention:
+
+- `createdAt` and `updatedAt` order the fixture in **opposite** directions. They
+  used to agree, so `reads.conversations-shape` passed whichever field keyed the
+  page and the regression was invisible to it.
+- two conversations **share** a `createdAt`, so the id tiebreak that makes the
+  ordering total is exercised rather than merely present.
 
 ## Harness mutation results
 

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -155,11 +155,20 @@ the TTL leg ran. The commit is there for the reason
 a claim about *which bytes* answered, and one that cannot say which has not made
 the claim.
 
-The committed record for `cave-2hjtv` is
-[`2026-08-22-v0.3.9-win32.json`](../client-v1-conformance-results/2026-08-22-v0.3.9-win32.json):
-**93 passed, 0 failed, 0 skipped** at `bc3be685` on `win32-x64`, run with
+The current record is
+[`2026-08-22-v0.3.9-win32-cave-fhjlu.json`](../client-v1-conformance-results/2026-08-22-v0.3.9-win32-cave-fhjlu.json):
+**99 passed, 0 failed, 0 skipped** at `ed6cc4b1` on `win32-x64`, run with
 `--include-ttl`, so `pairing.ttl-poll-expired` and `pairing.ttl-exchange-expired`
-are recorded as passes rather than skips.
+are recorded as passes rather than skips. It is the first record taken after
+`/conversations` moved to an immutable page key, so it carries the seven
+mid-walk assertions described above and two findings rather than three.
+
+The record for `cave-2hjtv` is
+[`2026-08-22-v0.3.9-win32.json`](../client-v1-conformance-results/2026-08-22-v0.3.9-win32.json):
+**93 passed, 0 failed, 0 skipped** at `bc3be685`, the run that *found*
+`cave-fhjlu`. Two records share a date because the fix landed the same day; the
+filename carries the bead rather than a second date, since the date is what
+makes a record findable and inventing one would make it wrong.
 
 ⚠️ **Take the record from a clean tree, and commit the code before the record.**
 The first version of this file named `63f14013` — the *base* commit. The run had
@@ -254,6 +263,18 @@ the source. Measured 2026-08-22 on `win32-x64` against Cave 0.3.9.
 | `ClientV1MessageRecord` widened and `projectClientV1Message` serves `reasoning` + `costUsd` | **caught**, 1 failure naming 12 leaks | `reads.messages-active-branch`, naming both fields on all six turns |
 | `FileCredentialStore.findByBearer` ignores `revokedAt` | **caught**, 1 failure | `revocation.bearer-refused-after` |
 | `parseClientV1PageLimit` clamps instead of refusing | **caught**, 5 failures | every `reads.refuses.limit-*` case: zero, over-ceiling, leading zero, exponent, signed |
+| `clientV1ConversationPageKey` reverted to the mutable `updatedAt` | **caught**, 9 failures | all seven mid-walk ids, plus `reads.conversations-shape` and `reads.conversations-paging`. The run reproduces the skip on the wire: the walk serves `[01, 02, 04, 05, 06]` and `conversation-03` is lost |
+
+Three further mutations were aimed at the assertions rather than the route,
+because a fixture that cannot distinguish two behaviours is the failure mode this
+harness has been burned by twice. Each was applied, run against
+`scripts/client-v1-conformance.test.mjs`, and reverted:
+
+| Mutation | Result | Caught by |
+|---|---|---|
+| the fixture's `updatedAt` ordering agrees with `createdAt` again | **caught** | `the fixture orders by createdAt and by updatedAt in opposite directions` |
+| the fixture's `createdAt` tie removed | **caught** | `the fixture ties exactly two conversations on createdAt` |
+| `expectedConversationOrder` sorts a row with no `createdAt` first | **caught** | `expectedConversationOrder puts a row with no createdAt at the tail` |
 
 ### The four that were NOT caught, and what closed them
 

--- a/scripts/client-v1-conformance.mjs
+++ b/scripts/client-v1-conformance.mjs
@@ -240,7 +240,13 @@ export const EXPECTED_ASSERTION_IDS = [
   "reads.conversation-by-id-refuses-limit",
   "reads.conversation-by-id-refuses-cursor",
   "reads.conversation-by-id-not-found",
-  "reads.conversations-mutable-key-moves-a-row",
+  "reads.conversations-touch-unserved-row-is-still-served",
+  "reads.conversations-touch-served-row-is-not-repeated",
+  "reads.conversations-touch-cursor-row-keeps-the-position",
+  "reads.conversations-row-created-mid-walk-is-not-served",
+  "reads.conversations-row-deleted-mid-walk-does-not-strand",
+  "reads.conversations-tied-sort-key-breaks-on-id",
+  "reads.conversations-without-created-at-are-served-last",
   "reads.messages-active-branch",
   "reads.messages-values",
   "reads.messages-paging",
@@ -793,10 +799,30 @@ export function fixtureProjects() {
   });
 }
 
-/** Six conversations, so a limit of three exercises an exact-multiple walk. */
+/**
+ * Six conversations, so a limit of three exercises an exact-multiple walk.
+ *
+ * Two properties of the timestamps are load-bearing and neither is decoration:
+ *
+ *   - **`createdAt` and `updatedAt` order the set in OPPOSITE directions.**
+ *     `createdAt` runs 01 → 06 while `updatedAt` runs 06 → 01, so
+ *     createdAt-descending is `[06…01]` and updatedAt-descending is `[01…06]`.
+ *     They used to run the same way, which meant the run could not tell which
+ *     field keyed the page: the ordering assertion passed either way, and the
+ *     skip that cave-fhjlu fixed was invisible to it. A build that reverts to
+ *     the mutable key now fails `reads.conversations-shape` outright.
+ *   - **`conversation-03` and `conversation-04` share a `createdAt`.** The key
+ *     is only total because of the id tiebreak, and a tiebreak nothing ties
+ *     cannot be wrong. The tie is placed so the expected order is unchanged
+ *     (`04` before `03`, id descending), which keeps every other leg readable.
+ */
 export function fixtureConversations() {
   return Array.from({ length: 6 }, (_, index) => {
     const n = String(index + 1).padStart(2, "0");
+    // 03 and 04 tie; the rest are distinct. Written as an explicit map rather
+    // than as arithmetic so the tie is visible at the point it is created.
+    const createdDay = index + 1 === 3 ? "04" : n;
+    const updatedDay = String(6 - index).padStart(2, "0");
     return {
       sessionId: `conversation-${n}`,
       familiarId: "archivist",
@@ -807,8 +833,8 @@ export function fixtureConversations() {
       harnessSessionId: `harness-${n}`,
       branch: "feat/fixture",
       prUrl: "https://github.com/OpenCoven/coven-cave/pull/1",
-      createdAt: `2026-03-${n}T00:00:00.000Z`,
-      updatedAt: `2026-04-${n}T00:00:00.000Z`,
+      createdAt: `2026-03-${createdDay}T00:00:00.000Z`,
+      updatedAt: `2026-04-${updatedDay}T00:00:00.000Z`,
       turns: [
         {
           id: `${n}-t1`,
@@ -946,6 +972,29 @@ async function writeConversation(caveHomeDir, conversation) {
     `${JSON.stringify(conversation, null, 2)}\n`,
     "utf8",
   );
+}
+
+async function removeConversation(caveHomeDir, sessionId) {
+  await rm(path.join(caveHomeDir, "conversations", `${sessionId}.json`), { force: true });
+}
+
+/**
+ * The order `/conversations` owes a client: `createdAt` descending, `id`
+ * descending on a tie, and every row without a `createdAt` at the tail.
+ *
+ * Spelled out here rather than reusing the fixture's array order so a leg that
+ * seeds an extra row — one created mid-walk, one with no `createdAt` at all —
+ * can derive its own expectation instead of hand-listing ids that then rot.
+ */
+export function expectedConversationOrder(conversations) {
+  return [...conversations]
+    .sort((left, right) => {
+      const l = left.createdAt ?? "";
+      const r = right.createdAt ?? "";
+      if (l !== r) return l < r ? 1 : -1;
+      return left.sessionId < right.sessionId ? 1 : -1;
+    })
+    .map((conversation) => conversation.sessionId);
 }
 
 // ── a small client bound to one origin ───────────────────────────────────────
@@ -1910,11 +1959,71 @@ async function runQueryRefusalLeg(client, recorder, bearer) {
   );
 }
 
+/**
+ * Walk `/conversations` at limit 2, mutate the ledger with the cursor OPEN, and
+ * follow that cursor to exhaustion.
+ *
+ * The mutation happens between the first page and the first resumed page, which
+ * is the only window in which a client is exposed to the store moving. `mutate`
+ * receives the ids already served and the id the open cursor names, so a leg can
+ * aim at a served row, an unserved row, or the cursor's own row without
+ * hard-coding the fixture's ordering.
+ *
+ * Returns the whole walk rather than the page after the touch. That distinction
+ * is the entire reason cave-fhjlu was misdiagnosed as a repeat for two PRs: a
+ * row that comes back three pages later is a repeat, a row that never comes back
+ * is a skip, and a single-page probe cannot tell them apart.
+ */
+async function walkConversationsAcross(client, bearer, mutate) {
+  const first = await client.read("/conversations?limit=2", bearer);
+  const firstIds = (first.json?.data?.conversations ?? []).map((row) => row.id);
+  const token0 = first.json?.cursor?.next ?? null;
+  await mutate({ served: firstIds, cursorNames: firstIds[firstIds.length - 1] });
+
+  const remainder = [];
+  let status = first.status;
+  let token = token0;
+  for (let page = 0; page < 50 && token; page += 1) {
+    const resumed = await client.read(
+      `/conversations?limit=2&cursor=${encodeURIComponent(token)}`,
+      bearer,
+    );
+    status = resumed.status;
+    if (resumed.status !== 200) break;
+    remainder.push(...(resumed.json?.data?.conversations ?? []).map((row) => row.id));
+    token = resumed.json?.cursor?.next ?? null;
+  }
+  return { firstIds, remainder, served: [...firstIds, ...remainder], status, opened: token0 !== null };
+}
+
+/**
+ * The whole walk, as an ORDERED sequence against what the ledger should have
+ * produced — not as a set, and not as a "did it contain the touched row".
+ *
+ * A set comparison would pass a build that served the right rows in an order no
+ * cursor could resume, which is the weakness this file's own review found in an
+ * earlier assertion: it compared key sets and never values.
+ */
+function checkConversationWalk(walk, expected) {
+  const failures = [];
+  if (walk.status !== 200) failures.push(`the walk answered ${walk.status}, expected 200`);
+  if (walk.served.join(",") !== expected.join(",")) {
+    failures.push(`the whole walk served [${walk.served}], expected [${expected}]`);
+  }
+  const repeated = walk.served.filter((id, index) => walk.served.indexOf(id) !== index);
+  if (repeated.length > 0) failures.push(`the walk served [${repeated}] more than once`);
+  return failures;
+}
+
 async function runConversationsLeg(client, recorder, bearer, caveHomeDir) {
   const conversations = fixtureConversations();
-  const expectedIds = [...conversations]
+  const expectedIds = expectedConversationOrder(conversations);
+  const updatedAtOrder = [...conversations]
     .sort((left, right) => (left.updatedAt < right.updatedAt ? 1 : left.updatedAt > right.updatedAt ? -1 : 0))
     .map((conversation) => conversation.sessionId);
+  const restore = async () => {
+    for (const conversation of conversations) await writeConversation(caveHomeDir, conversation);
+  };
 
   const listed = await client.read("/conversations?limit=100", bearer);
   const failures = [];
@@ -1943,8 +2052,13 @@ async function runConversationsLeg(client, recorder, bearer, caveHomeDir) {
       );
     }
   }
-  if (rows.map((row) => row.id).join(",") !== expectedIds.join(",")) {
-    failures.push(`served [${rows.map((row) => row.id)}], expected the updatedAt-descending [${expectedIds}]`);
+  const servedOrder = rows.map((row) => row.id).join(",");
+  if (servedOrder !== expectedIds.join(",")) {
+    failures.push(
+      servedOrder === updatedAtOrder.join(",")
+        ? `served the updatedAt-descending [${updatedAtOrder}]; /conversations pages by createdAt, expected [${expectedIds}]`
+        : `served [${rows.map((row) => row.id)}], expected the createdAt-descending [${expectedIds}]`,
+    );
   }
   recorder.expect("reads.conversations-shape", failures);
 
@@ -1980,60 +2094,159 @@ async function runConversationsLeg(client, recorder, bearer, caveHomeDir) {
   absentFailures.push(...checkEnvelope(absent.json, { kind: "error", code: "not_found" }));
   recorder.expect("reads.conversation-by-id-not-found", absentFailures);
 
-  // ── the mutable page key ──
+  // ── the page key under a ledger that moves mid-walk (cave-fhjlu) ──
   //
-  // `/conversations` keys on `updatedAt`, which moves while a client pages. The
-  // doc says a touched conversation "can appear in two pages"; what this
-  // measures is the other side of the same coin, and it is the one that costs a
-  // client data — a conversation that has NOT been served yet is touched, jumps
-  // above the open cursor, and is never served by the rest of the walk. The
-  // assertion is written against the measured behaviour rather than the
-  // sentence, and the discrepancy is reported rather than asserted away.
-  const firstPage = await walk(client, "/conversations", bearer, "conversations", 2);
-  const openToken = firstPage[0]?.next;
-  const untouchedRest = firstPage.slice(1).flatMap((page) => page.ids);
-  const touchedId = untouchedRest[untouchedRest.length - 1];
-  if (openToken && touchedId) {
-    const touched = conversations.find((conversation) => conversation.sessionId === touchedId);
-    await writeConversation(caveHomeDir, { ...touched, updatedAt: "2026-12-31T00:00:00.000Z" });
+  // `/conversations` used to key on `updatedAt`. That field only ever rises and
+  // the ordering is descending, so a conversation touched while a client paged
+  // jumped ABOVE the open cursor and — if it had not been served yet — was never
+  // served by the rest of the walk. Silent data loss in a read this surface
+  // calls canonical. Measured here on 2026-08-22: first page `[06, 05]`, touch
+  // the unserved `01`, remainder `[04, 03, 02]`, and no repeat anywhere.
+  //
+  // The key is now `createdAt`, which nothing rewrites, so the six cases below
+  // all reduce to one claim: **the set a walk serves is decided when the walk
+  // starts, and nothing but a deletion changes it.** Each one is a separate
+  // assertion rather than a loop because each fails for a different reason and a
+  // reader of the record has to be able to tell which.
+  const byId = new Map(conversations.map((conversation) => [conversation.sessionId, conversation]));
+  const touch = (sessionId) =>
+    writeConversation(caveHomeDir, { ...byId.get(sessionId), updatedAt: "2026-12-31T00:00:00.000Z" });
 
-    // The REST of the walk, not just the next page. "Skipped" is a claim about
-    // every page after the touch — a row that reappeared three pages later
-    // would be a repeat, which is what the reference used to say happens, and a
-    // single-page probe cannot tell the two apart.
-    const remainder = [];
-    let token = openToken;
-    let resumedStatus = 0;
-    for (let page = 0; page < 50 && token; page += 1) {
-      const resumed = await client.read(`/conversations?limit=2&cursor=${encodeURIComponent(token)}`, bearer);
-      resumedStatus = resumed.status;
-      if (resumed.status !== 200) break;
-      remainder.push(...(resumed.json?.data?.conversations ?? []).map((row) => row.id));
-      token = resumed.json?.cursor?.next ?? null;
-    }
-    const mutableFailures = [];
-    if (resumedStatus !== 200) mutableFailures.push(`resuming the walk answered ${resumedStatus}, expected 200`);
-    if (remainder.includes(touchedId)) {
-      mutableFailures.push(
-        `after touching the unserved ${touchedId} the rest of the walk still served it: [${remainder}]`,
-      );
-    }
-    const alreadyServed = firstPage[0]?.ids ?? [];
-    for (const id of remainder) {
-      if (alreadyServed.includes(id)) mutableFailures.push(`${id} was served before the touch and again after it`);
-    }
-    if (new Set(remainder).size !== remainder.length) {
-      mutableFailures.push(`the rest of the walk repeated a row: [${remainder}]`);
-    }
-    recorder.expect(
-      "reads.conversations-mutable-key-moves-a-row",
-      mutableFailures,
-      `touched ${touchedId}; the rest of the walk served [${remainder}] — a skip, and no repeat anywhere in it`,
-    );
-    await writeConversation(caveHomeDir, touched);
-  } else {
-    recorder.skip("reads.conversations-mutable-key-moves-a-row", "the ledger did not page at limit 2");
+  // 1. A row the walk has NOT reached. This is the case that lost data.
+  const unserved = await walkConversationsAcross(client, bearer, async ({ served }) => {
+    await touch(expectedIds.filter((id) => !served.includes(id)).at(-1));
+  });
+  recorder.expect(
+    "reads.conversations-touch-unserved-row-is-still-served",
+    unserved.opened
+      ? checkConversationWalk(unserved, expectedIds)
+      : ["the ledger did not page at limit 2, so no cursor was open across the touch"],
+    `touched the last unserved row; the whole walk served [${unserved.served}]`,
+  );
+  await restore();
+
+  // 2. A row the walk has ALREADY served. Under the old key this one was
+  //    harmless — it moved above a cursor it was already above — but a key that
+  //    moved the other way would repeat it, and only a whole-walk check sees it.
+  const served = await walkConversationsAcross(client, bearer, async (state) => {
+    await touch(state.served[0]);
+  });
+  recorder.expect(
+    "reads.conversations-touch-served-row-is-not-repeated",
+    served.opened
+      ? checkConversationWalk(served, expectedIds)
+      : ["the ledger did not page at limit 2, so no cursor was open across the touch"],
+    `touched the first row already served; the whole walk served [${served.served}]`,
+  );
+  await restore();
+
+  // 3. The row the open cursor NAMES. The token carries that row's sort key, so
+  //    if the key can move, the cursor is left pointing at a position the
+  //    ordering no longer has.
+  const atCursor = await walkConversationsAcross(client, bearer, async ({ cursorNames }) => {
+    await touch(cursorNames);
+  });
+  recorder.expect(
+    "reads.conversations-touch-cursor-row-keeps-the-position",
+    atCursor.opened
+      ? checkConversationWalk(atCursor, expectedIds)
+      : ["the ledger did not page at limit 2, so no cursor was open across the touch"],
+    `touched the row the cursor names; the whole walk served [${atCursor.served}]`,
+  );
+  await restore();
+
+  // 4. A conversation CREATED mid-walk. Its createdAt is the newest in the
+  //    ledger, so it sorts above every open cursor and this walk does not serve
+  //    it — which is what the reference tells a client to expect, and is not the
+  //    same failure as losing a row that already existed.
+  const created = await walkConversationsAcross(client, bearer, async () => {
+    await writeConversation(caveHomeDir, {
+      ...byId.get("conversation-01"),
+      sessionId: "conversation-new",
+      createdAt: "2026-12-31T00:00:00.000Z",
+      updatedAt: "2026-12-31T00:00:00.000Z",
+    });
+  });
+  recorder.expect(
+    "reads.conversations-row-created-mid-walk-is-not-served",
+    created.opened
+      ? checkConversationWalk(created, expectedIds)
+      : ["the ledger did not page at limit 2, so no cursor was open across the insert"],
+    "a row created above the cursor is left for the next read from the top",
+  );
+  await removeConversation(caveHomeDir, "conversation-new");
+  await restore();
+
+  // 5. A row DELETED mid-walk, and an unserved one, so the walk has to notice.
+  //    The cursor names a position in the ordering rather than an index, so the
+  //    remainder is simply the rest without it.
+  let deletedId = null;
+  const deleted = await walkConversationsAcross(client, bearer, async ({ served: alreadyServed }) => {
+    deletedId = expectedIds.filter((id) => !alreadyServed.includes(id))[0];
+    await removeConversation(caveHomeDir, deletedId);
+  });
+  recorder.expect(
+    "reads.conversations-row-deleted-mid-walk-does-not-strand",
+    deleted.opened
+      ? checkConversationWalk(deleted, expectedIds.filter((id) => id !== deletedId))
+      : ["the ledger did not page at limit 2, so no cursor was open across the deletion"],
+    `deleted the unserved ${deletedId}; the whole walk served [${deleted.served}]`,
+  );
+  await restore();
+
+  // 6. Two rows sharing a createdAt, walked at limit 1 so a page boundary lands
+  //    between every adjacent pair — including theirs. Without the id tiebreak
+  //    the boundary either repeats both or skips both.
+  const tiedKey = conversations.find((conversation) =>
+    conversations.some((other) =>
+      other.sessionId !== conversation.sessionId && other.createdAt === conversation.createdAt))?.createdAt;
+  const tied = conversations
+    .filter((conversation) => conversation.createdAt === tiedKey)
+    .map((conversation) => conversation.sessionId)
+    .sort()
+    .reverse();
+  const singles = await walk(client, "/conversations", bearer, "conversations", 1);
+  const tieFailures = tied.length === 2
+    ? checkPageWalk(singles, { limit: 1, expectedIds })
+    : ["the fixture no longer ties two conversations on createdAt, so the tiebreak is unexercised"];
+  const walkedTie = singles.flatMap((page) => page.ids).filter((id) => tied.includes(id)).join(",");
+  if (tied.length === 2 && walkedTie !== tied.join(",")) {
+    tieFailures.push(`the tied rows were served as [${walkedTie}], expected id-descending [${tied}]`);
   }
+  recorder.expect(
+    "reads.conversations-tied-sort-key-breaks-on-id",
+    tieFailures,
+    `${tied.join(" and ")} share ${tiedKey}`,
+  );
+
+  // 7. A row carrying NO createdAt at all — a transcript written before the
+  //    field existed, or the fallback row a corrupt file produces. Keying on an
+  //    optional field is only safe because these are served rather than
+  //    stranded: they sort as the empty string, which is below every instant, so
+  //    a descending walk reaches them at the tail and reaches them THROUGH a
+  //    cursor rather than on the first page.
+  const { createdAt: _dropped, ...keyless } = byId.get("conversation-01");
+  await writeConversation(caveHomeDir, { ...keyless, sessionId: "conversation-keyless" });
+  const withKeyless = await walk(client, "/conversations", bearer, "conversations", 2);
+  const keylessExpected = [...expectedIds, "conversation-keyless"];
+  const keylessFailures = checkPageWalk(withKeyless, { limit: 2, expectedIds: keylessExpected });
+  const keylessRow = withKeyless
+    .flatMap((page) => page.items ?? [])
+    .find((row) => row.id === "conversation-keyless");
+  if (!keylessRow) keylessFailures.push("the row with no createdAt was never served");
+  else if ("createdAt" in keylessRow) {
+    keylessFailures.push(`the row with no createdAt was served with createdAt ${JSON.stringify(keylessRow.createdAt)}`);
+  }
+  if (withKeyless[0]?.ids.includes("conversation-keyless")) {
+    keylessFailures.push("the row with no createdAt was served on the first page, so no cursor had to reach it");
+  }
+  recorder.expect(
+    "reads.conversations-without-created-at-are-served-last",
+    keylessFailures,
+    "an optional page key is only safe if the rows that lack it are served, not stranded",
+  );
+  await removeConversation(caveHomeDir, "conversation-keyless");
+  await restore();
 }
 
 async function runMessagesLeg(client, recorder, bearer, caveHomeDir) {
@@ -2335,14 +2548,6 @@ export const FINDINGS = [
     measured: 'the proxy\'s sidecar-token gate answers first, so the wire carries 401 {"ok":false,"error":"unauthorized"} and requireClientV1Admin\'s envelope is never produced on a Cave with a token configured',
     severity: "documentation",
     why: "the refusal is correct and same-status; only its body differs from the documented one, which a handler-level test cannot see",
-  },
-  {
-    id: "conversations-mutable-key-skips-rather-than-repeats",
-    where: "docs/api/client-v1.md — Paging, and reads.ts clientV1ConversationPageKey",
-    says: "a conversation that receives a turn mid-pagination moves to the front and can appear in two pages",
-    measured: "the ordering is updatedAt DESCENDING and a touch only raises the key, so a touched row moves ABOVE an open cursor: a row already served stays served, and a row not yet served is SKIPPED by the rest of the walk. No repeat was reproducible.",
-    severity: "documentation",
-    why: "the client-visible consequence is the opposite of the documented one — a repeat is deduplicable, a skip is silent data loss unless the client re-reads from the top",
   },
 ];
 

--- a/scripts/client-v1-conformance.mjs
+++ b/scripts/client-v1-conformance.mjs
@@ -76,6 +76,15 @@ import { fileURLToPath } from "node:url";
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = path.resolve(scriptDirectory, "..");
 
+/**
+ * The `updatedAt` a mid-walk touch writes.
+ *
+ * Far in the future so it is unambiguously the newest row in the ledger by that
+ * field: under the old, mutable page key this value is exactly what lifted a
+ * touched row above an open cursor and lost it (cave-fhjlu).
+ */
+export const TOUCHED_AT = "2026-12-31T00:00:00.000Z";
+
 export const PAIRING_SECRET_HEADER = "x-coven-pairing-secret";
 export const ADMIN_TOKEN_HEADER = "x-coven-cave-token";
 export const CLIENT_V1_PREFIX = "/api/client/v1";
@@ -1980,6 +1989,19 @@ async function walkConversationsAcross(client, bearer, mutate) {
   const token0 = first.json?.cursor?.next ?? null;
   await mutate({ served: firstIds, cursorNames: firstIds[firstIds.length - 1] });
 
+  // Prove the mutation actually reached the server before asserting anything
+  // about how the walk survived it. listConversations caches a summary against
+  // the file's (mtime, ctime, size), so a rewrite that changed nothing else
+  // could be served from cache — and every case below would then pass for the
+  // wrong reason, which is the exact "green against a broken server" failure
+  // this harness exists to avoid. The probe is a separate read at limit 100; it
+  // does not consume the open cursor, because a page is a pure function of
+  // (set, cursor, limit).
+  const probe = await client.read("/conversations?limit=100", bearer);
+  const observed = new Map(
+    (probe.json?.data?.conversations ?? []).map((row) => [row.id, row]),
+  );
+
   const remainder = [];
   let status = first.status;
   let token = token0;
@@ -1993,7 +2015,27 @@ async function walkConversationsAcross(client, bearer, mutate) {
     remainder.push(...(resumed.json?.data?.conversations ?? []).map((row) => row.id));
     token = resumed.json?.cursor?.next ?? null;
   }
-  return { firstIds, remainder, served: [...firstIds, ...remainder], status, opened: token0 !== null };
+  return {
+    firstIds,
+    remainder,
+    served: [...firstIds, ...remainder],
+    status,
+    opened: token0 !== null,
+    observed,
+  };
+}
+
+/** The mutation has to be visible to the server, or the walk survived nothing. */
+function checkTouchLanded(walk, sessionId) {
+  const row = walk.observed.get(sessionId);
+  if (!row) return [`${sessionId} was not in the ledger after the touch, so nothing was touched`];
+  if (row.updatedAt !== TOUCHED_AT) {
+    return [
+      `${sessionId} still reads updatedAt ${JSON.stringify(row.updatedAt)} after the touch — the` +
+      " ledger did not move, so this walk proves nothing",
+    ];
+  }
+  return [];
 }
 
 /**
@@ -2109,49 +2151,64 @@ async function runConversationsLeg(client, recorder, bearer, caveHomeDir) {
   // assertion rather than a loop because each fails for a different reason and a
   // reader of the record has to be able to tell which.
   const byId = new Map(conversations.map((conversation) => [conversation.sessionId, conversation]));
+  // The touch lengthens a WITHHELD field as well as raising updatedAt. Both
+  // timestamps are the same width, so a rewrite that only moved updatedAt left
+  // the file's size unchanged and could be answered from listConversations'
+  // (mtime, ctime, size) cache within the same millisecond. Changing the size
+  // makes the cache miss deterministic; checkTouchLanded still verifies it.
   const touch = (sessionId) =>
-    writeConversation(caveHomeDir, { ...byId.get(sessionId), updatedAt: "2026-12-31T00:00:00.000Z" });
+    writeConversation(caveHomeDir, {
+      ...byId.get(sessionId),
+      harnessSessionId: `${byId.get(sessionId).harnessSessionId}-touched-mid-walk`,
+      updatedAt: TOUCHED_AT,
+    });
 
   // 1. A row the walk has NOT reached. This is the case that lost data.
+  let touchedUnserved = null;
   const unserved = await walkConversationsAcross(client, bearer, async ({ served }) => {
-    await touch(expectedIds.filter((id) => !served.includes(id)).at(-1));
+    touchedUnserved = expectedIds.filter((id) => !served.includes(id)).at(-1);
+    await touch(touchedUnserved);
   });
   recorder.expect(
     "reads.conversations-touch-unserved-row-is-still-served",
     unserved.opened
-      ? checkConversationWalk(unserved, expectedIds)
+      ? [...checkTouchLanded(unserved, touchedUnserved), ...checkConversationWalk(unserved, expectedIds)]
       : ["the ledger did not page at limit 2, so no cursor was open across the touch"],
-    `touched the last unserved row; the whole walk served [${unserved.served}]`,
+    `touched the unserved ${touchedUnserved}; the whole walk served [${unserved.served}]`,
   );
   await restore();
 
   // 2. A row the walk has ALREADY served. Under the old key this one was
   //    harmless — it moved above a cursor it was already above — but a key that
   //    moved the other way would repeat it, and only a whole-walk check sees it.
+  let touchedServed = null;
   const served = await walkConversationsAcross(client, bearer, async (state) => {
-    await touch(state.served[0]);
+    touchedServed = state.served[0];
+    await touch(touchedServed);
   });
   recorder.expect(
     "reads.conversations-touch-served-row-is-not-repeated",
     served.opened
-      ? checkConversationWalk(served, expectedIds)
+      ? [...checkTouchLanded(served, touchedServed), ...checkConversationWalk(served, expectedIds)]
       : ["the ledger did not page at limit 2, so no cursor was open across the touch"],
-    `touched the first row already served; the whole walk served [${served.served}]`,
+    `touched the already-served ${touchedServed}; the whole walk served [${served.served}]`,
   );
   await restore();
 
   // 3. The row the open cursor NAMES. The token carries that row's sort key, so
   //    if the key can move, the cursor is left pointing at a position the
   //    ordering no longer has.
+  let touchedAtCursor = null;
   const atCursor = await walkConversationsAcross(client, bearer, async ({ cursorNames }) => {
-    await touch(cursorNames);
+    touchedAtCursor = cursorNames;
+    await touch(touchedAtCursor);
   });
   recorder.expect(
     "reads.conversations-touch-cursor-row-keeps-the-position",
     atCursor.opened
-      ? checkConversationWalk(atCursor, expectedIds)
+      ? [...checkTouchLanded(atCursor, touchedAtCursor), ...checkConversationWalk(atCursor, expectedIds)]
       : ["the ledger did not page at limit 2, so no cursor was open across the touch"],
-    `touched the row the cursor names; the whole walk served [${atCursor.served}]`,
+    `touched ${touchedAtCursor}, the row the cursor names; the whole walk served [${atCursor.served}]`,
   );
   await restore();
 
@@ -2170,7 +2227,12 @@ async function runConversationsLeg(client, recorder, bearer, caveHomeDir) {
   recorder.expect(
     "reads.conversations-row-created-mid-walk-is-not-served",
     created.opened
-      ? checkConversationWalk(created, expectedIds)
+      ? [
+          ...(created.observed.has("conversation-new")
+            ? []
+            : ["conversation-new never reached the ledger, so nothing was inserted mid-walk"]),
+          ...checkConversationWalk(created, expectedIds),
+        ]
       : ["the ledger did not page at limit 2, so no cursor was open across the insert"],
     "a row created above the cursor is left for the next read from the top",
   );
@@ -2188,7 +2250,12 @@ async function runConversationsLeg(client, recorder, bearer, caveHomeDir) {
   recorder.expect(
     "reads.conversations-row-deleted-mid-walk-does-not-strand",
     deleted.opened
-      ? checkConversationWalk(deleted, expectedIds.filter((id) => id !== deletedId))
+      ? [
+          ...(deleted.observed.has(deletedId)
+            ? [`${deletedId} was still in the ledger after the deletion, so nothing was deleted`]
+            : []),
+          ...checkConversationWalk(deleted, expectedIds.filter((id) => id !== deletedId)),
+        ]
       : ["the ledger did not page at limit 2, so no cursor was open across the deletion"],
     `deleted the unserved ${deletedId}; the whole walk served [${deleted.served}]`,
   );

--- a/scripts/client-v1-conformance.test.mjs
+++ b/scripts/client-v1-conformance.test.mjs
@@ -19,6 +19,7 @@ import {
   createRecorder,
   expectedAssertionIds,
   expectedBranchedMessages,
+  expectedConversationOrder,
   fixtureBranchedConversation,
   fixtureConversations,
   fixtureProjects,
@@ -481,6 +482,64 @@ test("the fixture conversation set exercises an exact multiple at limit 3", () =
     assert.ok(conversation.branch);
     assert.ok(conversation.prUrl);
   }
+});
+
+test("the fixture orders by createdAt and by updatedAt in opposite directions", () => {
+  // Without this the run cannot tell which field keys the page. The two
+  // orderings used to coincide, so `reads.conversations-shape` passed whether
+  // the route keyed on the immutable createdAt or on the mutable updatedAt that
+  // silently skipped a touched row (cave-fhjlu). A fixture edit that lets them
+  // agree again would re-open exactly that blind spot with nothing failing.
+  const conversations = fixtureConversations();
+  const byCreated = expectedConversationOrder(conversations);
+  const byUpdated = [...conversations]
+    .sort((left, right) => (left.updatedAt < right.updatedAt ? 1 : left.updatedAt > right.updatedAt ? -1 : 0))
+    .map((conversation) => conversation.sessionId);
+  assert.deepEqual(byCreated, [
+    "conversation-06",
+    "conversation-05",
+    "conversation-04",
+    "conversation-03",
+    "conversation-02",
+    "conversation-01",
+  ]);
+  assert.notDeepEqual(byCreated, byUpdated, "the two orderings must disagree or the page key is unobservable");
+  assert.deepEqual([...byUpdated].reverse(), byCreated, "the fixture inverts them, so every position disagrees");
+});
+
+test("the fixture ties exactly two conversations on createdAt so the id tiebreak is exercised", () => {
+  // A tiebreak nothing ties cannot be wrong. The tie is also placed so it does
+  // not reorder the expected walk — 04 before 03 is both id-descending and the
+  // order the untied fixture had — which keeps every other leg readable.
+  const conversations = fixtureConversations();
+  const counts = new Map();
+  for (const conversation of conversations) {
+    counts.set(conversation.createdAt, (counts.get(conversation.createdAt) ?? 0) + 1);
+  }
+  const tied = [...counts.entries()].filter(([, count]) => count > 1);
+  assert.equal(tied.length, 1, "exactly one createdAt is shared");
+  assert.equal(tied[0][1], 2);
+  const sharing = conversations
+    .filter((conversation) => conversation.createdAt === tied[0][0])
+    .map((conversation) => conversation.sessionId)
+    .sort();
+  assert.deepEqual(sharing, ["conversation-03", "conversation-04"]);
+});
+
+test("expectedConversationOrder puts a row with no createdAt at the tail, not first", () => {
+  // The empty-string sentinel is what makes an OPTIONAL field safe to key on:
+  // it is below every ISO instant, so a descending walk reaches such a row last
+  // rather than stranding it. An ascending sentinel would put it on the first
+  // page and hide whether a cursor can reach it at all.
+  const conversations = fixtureConversations();
+  const order = expectedConversationOrder([...conversations, { sessionId: "conversation-keyless" }]);
+  assert.equal(order.at(-1), "conversation-keyless");
+  assert.deepEqual(order.slice(0, -1), expectedConversationOrder(conversations));
+  // Two keyless rows fall back to the id tiebreak rather than to input order.
+  assert.deepEqual(
+    expectedConversationOrder([{ sessionId: "a-keyless" }, { sessionId: "b-keyless" }]),
+    ["b-keyless", "a-keyless"],
+  );
 });
 
 test("the branched fixture's active path is the declared sequence and omits the abandoned branch", () => {

--- a/src/app/api/client/v1/conversations/route.test.ts
+++ b/src/app/api/client/v1/conversations/route.test.ts
@@ -15,14 +15,23 @@ import { createClientV1ConversationsGetHandler } from "./route.ts";
 const scratchPrefix = resolve(process.cwd(), ".scratch-client-v1-conversations-");
 const STAMP = "loopback-secret";
 
-function summary(sessionId: string, updatedAt: string): ConversationSummary {
-  return { sessionId, familiarId: "scribe", harness: "claude", updatedAt };
+function summary(sessionId: string, createdAt: string, updatedAt = createdAt): ConversationSummary {
+  return { sessionId, familiarId: "scribe", harness: "claude", createdAt, updatedAt };
 }
 
+/**
+ * Three rows whose `createdAt` and `updatedAt` orderings DISAGREE.
+ *
+ * `createdAt` descending is [b, a, c]; `updatedAt` descending is [c, b, a]. A
+ * route that reverted to the mutable key would serve a perfectly plausible
+ * order, so a fixture where the two agree cannot see the regression this file
+ * exists to pin (cave-fhjlu). `a` and `b` also share a `createdAt`, so the id
+ * tiebreak is exercised rather than merely present.
+ */
 const LEDGER: ConversationSummary[] = [
-  summary("conversation-a", "2026-08-01T00:00:00.000Z"),
-  summary("conversation-b", "2026-08-05T00:00:00.000Z"),
-  summary("conversation-c", "2026-08-05T00:00:00.000Z"),
+  summary("conversation-a", "2026-08-05T00:00:00.000Z", "2026-08-01T00:00:00.000Z"),
+  summary("conversation-b", "2026-08-05T00:00:00.000Z", "2026-08-05T00:00:00.000Z"),
+  summary("conversation-c", "2026-08-01T00:00:00.000Z", "2026-08-05T00:00:00.000Z"),
 ];
 
 function sources(overrides: Partial<ClientV1ReadSources> = {}): ClientV1ReadSources {
@@ -62,7 +71,7 @@ async function withRuntime<T>(
   }
 }
 
-test("conversations are served most-recently-updated first, id breaking the tie", async () => {
+test("conversations are served most-recently-created first, id breaking the tie", async () => {
   await withRuntime(["chat:read"], async (runtime, bearer) => {
     const handler = createClientV1ConversationsGetHandler(runtime, sources());
     const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
@@ -73,12 +82,19 @@ test("conversations are served most-recently-updated first, id breaking the tie"
     };
     assert.deepEqual(
       body.data.conversations.map((row) => row.id),
+      ["conversation-b", "conversation-a", "conversation-c"],
+    );
+    // NOT the updatedAt-descending order, which is the whole point: that key
+    // moves under an open cursor and skipped rows off the bottom of a walk.
+    assert.notDeepEqual(
+      body.data.conversations.map((row) => row.id),
       ["conversation-c", "conversation-b", "conversation-a"],
     );
     assert.deepEqual(body.data.conversations[0], {
-      id: "conversation-c",
+      id: "conversation-b",
       familiarId: "scribe",
       harness: "claude",
+      createdAt: "2026-08-05T00:00:00.000Z",
       updatedAt: "2026-08-05T00:00:00.000Z",
     });
     assert.ok(body.capabilities.includes("conversations"));
@@ -97,13 +113,13 @@ test("the ledger pages through a cursor without repeating a tied conversation", 
     };
     assert.deepEqual(
       firstBody.data.conversations.map((row) => row.id),
-      ["conversation-c", "conversation-b"],
+      ["conversation-b", "conversation-a"],
     );
-    // conversation-b and conversation-c share an updatedAt, so the cursor must
-    // carry the id as well or the second page starts at conversation-c again.
+    // conversation-a and conversation-b share a createdAt, so the cursor must
+    // carry the id as well or the second page starts at conversation-b again.
     assert.deepEqual(decodeClientV1Cursor(firstBody.cursor.next), {
       sort: "2026-08-05T00:00:00.000Z",
-      id: "conversation-b",
+      id: "conversation-a",
     });
 
     const second = await handler(
@@ -113,9 +129,189 @@ test("the ledger pages through a cursor without repeating a tied conversation", 
       cursor: { hasMore: boolean; next?: string };
       data: { conversations: { id: string }[] };
     };
-    assert.deepEqual(secondBody.data.conversations.map((row) => row.id), ["conversation-a"]);
+    assert.deepEqual(secondBody.data.conversations.map((row) => row.id), ["conversation-c"]);
     assert.equal(secondBody.cursor.hasMore, false);
     assert.equal(secondBody.cursor.next, undefined);
+  });
+});
+
+// ── a ledger that moves while the client is paging (cave-fhjlu) ──────────────
+//
+// The route used to key on `updatedAt`. That field only ever rises and the
+// ordering is descending, so a conversation touched mid-walk jumped ABOVE the
+// open cursor and, if the walk had not reached it yet, was never served: silent
+// data loss in a canonical read, and not the deduplicable repeat the reference
+// claimed. Every case below walks to EXHAUSTION rather than checking the page
+// after the mutation — a row that comes back three pages later is a repeat, a
+// row that never comes back is a skip, and one page cannot tell them apart.
+
+/** conversation-06 down to conversation-01, createdAt descending. */
+function ledgerOfSix(): ConversationSummary[] {
+  return Array.from({ length: 6 }, (_, index) => {
+    const n = String(index + 1).padStart(2, "0");
+    return summary(
+      `conversation-${n}`,
+      `2026-03-${n}T00:00:00.000Z`,
+      // updatedAt runs the other way, so an updatedAt-keyed walk serves a
+      // visibly different sequence rather than accidentally the same one.
+      `2026-04-${String(6 - index).padStart(2, "0")}T00:00:00.000Z`,
+    );
+  });
+}
+
+const SIX_IN_ORDER = [
+  "conversation-06",
+  "conversation-05",
+  "conversation-04",
+  "conversation-03",
+  "conversation-02",
+  "conversation-01",
+];
+
+/**
+ * Walk the ledger at limit 2, apply `mutate` with the first cursor OPEN, then
+ * follow that cursor to exhaustion. Returns every id the walk served, in order.
+ */
+async function walkAcrossMutation(
+  runtime: ClientV1Runtime,
+  bearer: string,
+  ledger: { rows: ConversationSummary[] },
+  mutate: (served: string[], cursorNames: string) => void,
+): Promise<{ served: string[]; statuses: number[] }> {
+  const handler = createClientV1ConversationsGetHandler(
+    runtime,
+    sources({ listConversations: async () => ledger.rows }),
+  );
+  const authorization = `Bearer ${bearer}`;
+  const page = async (query: string) => {
+    const response = await handler(request(query, { authorization }));
+    const body = await response.json() as {
+      cursor?: { next?: string };
+      data?: { conversations?: { id: string }[] };
+    };
+    return {
+      status: response.status,
+      ids: (body.data?.conversations ?? []).map((row) => row.id),
+      next: body.cursor?.next,
+    };
+  };
+
+  const first = await page("?limit=2");
+  const statuses = [first.status];
+  const served = [...first.ids];
+  mutate(first.ids, first.ids[first.ids.length - 1]);
+
+  let token = first.next;
+  for (let index = 0; index < 20 && token; index += 1) {
+    const next = await page(`?limit=2&cursor=${encodeURIComponent(token)}`);
+    statuses.push(next.status);
+    if (next.status !== 200) break;
+    served.push(...next.ids);
+    token = next.next;
+  }
+  return { served, statuses };
+}
+
+test("a conversation touched mid-walk is still served by the rest of the walk", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const ledger = { rows: ledgerOfSix() };
+    // conversation-01 is LAST in the ordering, so the first page has not reached
+    // it. Under the old key this touch moved it above the open cursor and the
+    // walk never served it again — measured, not hypothesised.
+    const walk = await walkAcrossMutation(runtime, bearer, ledger, () => {
+      ledger.rows = ledger.rows.map((row) =>
+        row.sessionId === "conversation-01"
+          ? { ...row, updatedAt: "2026-12-31T00:00:00.000Z" }
+          : row);
+    });
+    assert.deepEqual(walk.statuses, [200, 200, 200]);
+    assert.deepEqual(walk.served, SIX_IN_ORDER);
+  });
+});
+
+test("touching a conversation the walk has already served does not repeat it", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const ledger = { rows: ledgerOfSix() };
+    const walk = await walkAcrossMutation(runtime, bearer, ledger, (served) => {
+      ledger.rows = ledger.rows.map((row) =>
+        row.sessionId === served[0] ? { ...row, updatedAt: "2026-12-31T00:00:00.000Z" } : row);
+    });
+    assert.deepEqual(walk.served, SIX_IN_ORDER);
+    assert.equal(new Set(walk.served).size, walk.served.length);
+  });
+});
+
+test("touching the row the open cursor names leaves the cursor's position intact", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const ledger = { rows: ledgerOfSix() };
+    // The token carries this row's sort key. A key that can move leaves the
+    // cursor naming a position the ordering no longer has.
+    const walk = await walkAcrossMutation(runtime, bearer, ledger, (_served, cursorNames) => {
+      ledger.rows = ledger.rows.map((row) =>
+        row.sessionId === cursorNames ? { ...row, updatedAt: "2026-12-31T00:00:00.000Z" } : row);
+    });
+    assert.deepEqual(walk.served, SIX_IN_ORDER);
+  });
+});
+
+test("a conversation created mid-walk sorts above the cursor and waits for the next read", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const ledger = { rows: ledgerOfSix() };
+    const walk = await walkAcrossMutation(runtime, bearer, ledger, () => {
+      ledger.rows = [
+        ...ledger.rows,
+        summary("conversation-new", "2026-12-31T00:00:00.000Z"),
+      ];
+    });
+    // Every pre-existing row exactly once, and the new one left for a read from
+    // the top. That is inherent to a forward keyset over a growing set — it
+    // costs no row that existed when the walk began, which is the difference
+    // between this and the skip.
+    assert.deepEqual(walk.served, SIX_IN_ORDER);
+    assert.equal(walk.served.includes("conversation-new"), false);
+  });
+});
+
+test("a conversation deleted mid-walk does not strand the rest of the walk", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const ledger = { rows: ledgerOfSix() };
+    let deleted = "";
+    const walk = await walkAcrossMutation(runtime, bearer, ledger, (served) => {
+      deleted = SIX_IN_ORDER.filter((id) => !served.includes(id))[0];
+      ledger.rows = ledger.rows.filter((row) => row.sessionId !== deleted);
+    });
+    assert.equal(deleted, "conversation-04");
+    assert.deepEqual(walk.served, SIX_IN_ORDER.filter((id) => id !== deleted));
+    assert.ok(walk.statuses.every((status) => status === 200));
+  });
+});
+
+test("a conversation with no createdAt is served at the tail rather than stranded", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    // A transcript written before the field existed, and the fallback row a
+    // corrupt file produces, both reach the projection with no createdAt. They
+    // are the reason #4856 rejected this key; the empty-string sentinel is the
+    // answer, and it has to be reachable THROUGH a cursor, not just present.
+    const keyless: ConversationSummary = {
+      sessionId: "conversation-keyless",
+      familiarId: "",
+      // The newest updatedAt in the set, so an updatedAt-keyed route would put
+      // it first. It must still come last.
+      updatedAt: "2036-01-01T00:00:00.000Z",
+    };
+    const ledger = { rows: [...ledgerOfSix(), keyless] };
+    const walk = await walkAcrossMutation(runtime, bearer, ledger, () => {});
+    assert.deepEqual(walk.served, [...SIX_IN_ORDER, "conversation-keyless"]);
+
+    const handler = createClientV1ConversationsGetHandler(
+      runtime,
+      sources({ listConversations: async () => ledger.rows }),
+    );
+    const response = await handler(request("?limit=100", { authorization: `Bearer ${bearer}` }));
+    const body = await response.json() as { data: { conversations: Record<string, unknown>[] } };
+    const row = body.data.conversations.at(-1)!;
+    assert.equal(row.id, "conversation-keyless");
+    assert.equal("createdAt" in row, false, "the record must not invent a createdAt the store lacks");
   });
 });
 

--- a/src/app/api/client/v1/conversations/route.ts
+++ b/src/app/api/client/v1/conversations/route.ts
@@ -4,8 +4,15 @@
  * The canonical read of this Cave's conversation ledger, one page at a time.
  * Projected from `listConversations`, which reads
  * `<caveHome>/conversations/*.json` — the same source the Cave's own sessions
- * list is built from, and in the same `updatedAt`-descending order, so a paired
- * client and the desktop never present two different orderings of one ledger.
+ * list is built from.
+ *
+ * Not in the same order, though, and that is the one difference worth stating
+ * here. The sessions list sorts by `updatedAt` descending; this route pages by
+ * `createdAt` descending, because `updatedAt` rises under an open cursor and a
+ * touched row then jumps above it, silently skipping a row the walk had not
+ * reached (cave-fhjlu). `updatedAt` is served on every record, so a client that
+ * wants the desktop's ordering has the field to sort by; what it cannot have is
+ * that ordering as a resumable keyset. See clientV1ConversationPageKey.
  *
  * Transcripts are not included: a conversation's turns are served by
  * `/api/client/v1/conversations/:id/messages`, which pages them. Inlining even

--- a/src/lib/server/client-v1/reads.test.ts
+++ b/src/lib/server/client-v1/reads.test.ts
@@ -213,24 +213,88 @@ test("the conversation projection tolerates the fields the store leaves optional
   );
 });
 
-test("conversations page by updatedAt, the one timestamp the summary always has", () => {
-  // createdAt is optional on a ConversationSummary — a transcript written
-  // before the field existed, or a corrupt-file fallback row, has none — so it
-  // cannot be the sort key. updatedAt is required and is also the order
-  // listConversations already serves, so a client sees one ordering from Cave.
+test("conversations page by createdAt, the one timestamp nothing rewrites", () => {
+  // cave-fhjlu. The key used to be updatedAt, because it is the field the
+  // summary always carries and the order listConversations serves. Both true,
+  // and still the wrong key: updatedAt only ever rises and the ordering is
+  // descending, so a conversation touched mid-walk moved ABOVE an open cursor
+  // and — if the walk had not reached it — was never served. A skip, not a
+  // repeat: silent loss from a read this surface calls canonical.
   assert.deepEqual(clientV1ConversationPageKey(SUMMARY), {
-    sort: "2026-08-09T00:00:00.000Z",
+    sort: "2026-08-01T00:00:00.000Z",
     id: "conversation-1",
   });
+  // The key is decided by createdAt alone: two rows with the same createdAt and
+  // wildly different updatedAt mint the same sort half.
+  assert.equal(
+    clientV1ConversationPageKey({ ...SUMMARY, updatedAt: "2036-01-01T00:00:00.000Z" }).sort,
+    clientV1ConversationPageKey(SUMMARY).sort,
+  );
   const older: ConversationSummary = {
     sessionId: "conversation-0",
     familiarId: "mote",
-    updatedAt: "2026-08-02T00:00:00.000Z",
+    createdAt: "2026-07-20T00:00:00.000Z",
+    updatedAt: "2026-08-30T00:00:00.000Z",
   };
   const tied: ConversationSummary = { ...SUMMARY, sessionId: "conversation-3" };
   assert.deepEqual(
     sortClientV1Conversations([older, SUMMARY, tied]).map((row) => row.sessionId),
     ["conversation-3", "conversation-1", "conversation-0"],
+    "createdAt descending, id descending on a tie — NOT the updatedAt order, which is the reverse here",
+  );
+});
+
+test("a conversation with no createdAt sorts to the tail rather than being stranded", () => {
+  // The objection to keying on createdAt was that it is optional: a transcript
+  // written before the field existed has none, and neither does the fallback
+  // row a corrupt file produces. Answered by a sentinel rather than by keying
+  // on something mutable — the empty string is below every ISO instant, so a
+  // descending walk serves those rows LAST. They are still served, still
+  // reachable through a cursor, and their key is as immutable as any instant.
+  const keyless: ConversationSummary = {
+    sessionId: "conversation-9",
+    familiarId: "",
+    updatedAt: "2036-01-01T00:00:00.000Z",
+  };
+  assert.deepEqual(clientV1ConversationPageKey(keyless), { sort: "", id: "conversation-9" });
+  assert.deepEqual(
+    sortClientV1Conversations([keyless, SUMMARY]).map((row) => row.sessionId),
+    ["conversation-1", "conversation-9"],
+    "even with the newest updatedAt in the set, the keyless row is last",
+  );
+  // Two keyless rows are ordered against each other by the id tiebreak, so the
+  // tail block is a total order too rather than an unordered heap.
+  assert.deepEqual(
+    sortClientV1Conversations([
+      { ...keyless, sessionId: "conversation-a" },
+      { ...keyless, sessionId: "conversation-b" },
+    ]).map((row) => row.sessionId),
+    ["conversation-b", "conversation-a"],
+  );
+});
+
+test("the page key reads createdAt exactly as the projection serves it", () => {
+  // The key and the record must agree, or a client sorting by the createdAt it
+  // was served reconstructs a different ordering than the one the cursor walks.
+  // Both go through optionalText, so a blank or wrongly typed createdAt is
+  // omitted from the record AND sorts to the tail — rather than the record
+  // omitting it while the key sorted it as " " or as a number.
+  for (const createdAt of ["   ", "", undefined, 17 as unknown as string]) {
+    const row = { ...SUMMARY, createdAt };
+    assert.equal(
+      "createdAt" in projectClientV1Conversation(row),
+      false,
+      `projection must omit createdAt ${JSON.stringify(createdAt)}`,
+    );
+    assert.equal(
+      clientV1ConversationPageKey(row).sort,
+      "",
+      `page key must sort createdAt ${JSON.stringify(createdAt)} to the tail`,
+    );
+  }
+  assert.equal(
+    clientV1ConversationPageKey(SUMMARY).sort,
+    projectClientV1Conversation(SUMMARY).createdAt,
   );
 });
 

--- a/src/lib/server/client-v1/reads.ts
+++ b/src/lib/server/client-v1/reads.ts
@@ -340,8 +340,23 @@ export function clientV1ProjectPageKey(project: CaveProject): ClientV1PageKey {
  * below every ISO instant, and the ordering is descending, so every row without
  * a `createdAt` lands in one contiguous block at the TAIL of the walk, ordered
  * among themselves by id. That block is what makes an optional field safe to
- * key on: the rows that lack it are served last, not stranded — and `""` is as
- * immutable as any instant, so they cannot move under an open cursor either.
+ * key on: the rows that lack it are served last, not stranded. `optionalText`
+ * can never return `""` — it demands a non-blank string — so the sentinel
+ * cannot collide with a value a record actually carries.
+ *
+ * ⚠️ The sentinel is stable, but it is NOT unconditionally permanent, and the
+ * difference is the one thing to know before trusting this block. `POST`/`PUT
+ * /api/chat/conversation/:id` builds its record with
+ * `args.existing?.createdAt ?? now` (buildConversation), so a legacy transcript
+ * that never had a `createdAt` acquires one — `now` — on its next write through
+ * that route, and jumps from this tail block to the HEAD of the ordering. A
+ * `/conversations` walk with an open cursor then skips it, which is cave-fhjlu
+ * again on exactly the rows this sentinel exists to protect. It is much
+ * narrower than the original defect (only a row that lacks the field, only on
+ * its first write through that one route, and self-healing afterwards), it is
+ * not reachable from this surface, and closing it belongs to that write path
+ * rather than to this key — cave-wbxcu. Do not restate this block as immutable
+ * until that lands.
  */
 function conversationSortKey(summary: ConversationSummary): string {
   return optionalText(summary.createdAt) ?? "";
@@ -368,9 +383,16 @@ function conversationSortKey(summary: ConversationSummary): string {
  *
  * So the key is `createdAt`, matching {@link clientV1ProjectPageKey} and the
  * daemon's session pager (OpenCoven/coven#783), which keys `created_at, id` for
- * exactly this reason. Nothing writes `conv.createdAt` after the file is
- * created, so the key of a row that exists never changes, and a walk that
- * started before a touch serves the same set after it.
+ * exactly this reason. `saveConversation` stamps `updatedAt` on every write and
+ * never touches `createdAt`, so a turn, a branch switch, a rename and a status
+ * change all leave the key alone: the key of a row that has one never changes,
+ * and a walk that started before a touch serves the same set after it.
+ *
+ * Two writes are outside that "never", both on `POST`/`PUT
+ * /api/chat/conversation/:id` and neither reachable from this surface: a body
+ * that supplies its own `createdAt` overrides the stored one, and a record that
+ * has none is stamped with `now`. The second is the one that costs something
+ * here — see {@link conversationSortKey}.
  *
  * Two costs, both deliberate and both published in docs/api/client-v1.md:
  *

--- a/src/lib/server/client-v1/reads.ts
+++ b/src/lib/server/client-v1/reads.ts
@@ -327,27 +327,69 @@ export function clientV1ProjectPageKey(project: CaveProject): ClientV1PageKey {
 }
 
 /**
- * A conversation's page key is its last write.
+ * The sort half of a conversation's page key: its creation time, or the empty
+ * string when the store cannot supply one.
  *
- * Unlike a project, `createdAt` is *optional* on a ConversationSummary — a
- * transcript written before the field existed has none, and neither does the
- * fallback row a corrupt file produces — so it cannot key the page. `updatedAt`
- * is required, and it is also the order listConversations already sorts by, so
- * a client sees one ordering out of Cave rather than two.
+ * Read through the same `optionalText` the projection uses, so the key and the
+ * served `createdAt` can never disagree — a key built from the raw field would
+ * sort a whitespace-only or numeric `createdAt` as itself while the record
+ * omitted it, and a client comparing the two would be reading two different
+ * orderings.
  *
- * The cost is the mutable-key cost above, and it is worth naming precisely
- * because this comment used to name it backwards. `updatedAt` only ever
- * increases and the ordering is descending, so a conversation that receives a
- * turn mid-pagination moves *above* an open cursor: one already served stays
- * served, and one NOT yet served is skipped by the rest of the walk. It is a
- * skip, not a repeat — measured over a real socket by
- * scripts/client-v1-conformance.mjs, which could not reproduce a repeat from a
- * touch. That is the worse of the two (a repeat is deduplicable by id; a skip
- * is silent), and it is still better than the alternative — keying on a field
- * half the corpus lacks, which strands the rows that lack it entirely.
+ * The empty string is a real position in the ordering rather than a hole. It is
+ * below every ISO instant, and the ordering is descending, so every row without
+ * a `createdAt` lands in one contiguous block at the TAIL of the walk, ordered
+ * among themselves by id. That block is what makes an optional field safe to
+ * key on: the rows that lack it are served last, not stranded — and `""` is as
+ * immutable as any instant, so they cannot move under an open cursor either.
+ */
+function conversationSortKey(summary: ConversationSummary): string {
+  return optionalText(summary.createdAt) ?? "";
+}
+
+/**
+ * A conversation's page key is its creation time — an IMMUTABLE field.
+ *
+ * It used to be `updatedAt`, on the grounds that `createdAt` is optional on a
+ * ConversationSummary while `updatedAt` is required, and that `updatedAt` is
+ * also the order listConversations sorts by, so a client would see one ordering
+ * out of Cave rather than two. Both halves of that were true. The conclusion
+ * was still wrong, because a keyset cursor names a position in an ordering and
+ * an ordering that moves is not one a cursor can name.
+ *
+ * `updatedAt` only ever increases and the ordering is descending, so a
+ * conversation that received a turn mid-pagination moved *above* an open
+ * cursor: one already served stayed served, and one NOT yet served was skipped
+ * by the rest of the walk. A skip, not the repeat this comment used to claim —
+ * measured over a real socket by scripts/client-v1-conformance.mjs, which could
+ * not reproduce a repeat from a touch at all. That is the worse of the two: a
+ * repeat is deduplicable by id, a skip is silent data loss in a read this
+ * surface calls canonical (cave-fhjlu).
+ *
+ * So the key is `createdAt`, matching {@link clientV1ProjectPageKey} and the
+ * daemon's session pager (OpenCoven/coven#783), which keys `created_at, id` for
+ * exactly this reason. Nothing writes `conv.createdAt` after the file is
+ * created, so the key of a row that exists never changes, and a walk that
+ * started before a touch serves the same set after it.
+ *
+ * Two costs, both deliberate and both published in docs/api/client-v1.md:
+ *
+ *   - **The ordering a client sees changed**, from most-recently-touched first
+ *     to most-recently-created first. `/conversations` no longer matches the
+ *     desktop sessions list row for row. `updatedAt` is still on every record,
+ *     so recency is available as a field — it is just not the page key. A
+ *     recency ordering and a resumable walk are in tension, and only one of them
+ *     can be served correctly by a keyset cursor.
+ *   - **A conversation created mid-walk is not served by that walk.** Its
+ *     `createdAt` is `now`, which sorts above every open cursor. That is
+ *     inherent to a forward keyset over a growing set and costs no pre-existing
+ *     row; the doc tells a client to re-read the head for it.
+ *
+ * The optional-field objection is answered by the sentinel above rather than by
+ * keying on something mutable: see {@link conversationSortKey}.
  */
 export function clientV1ConversationPageKey(summary: ConversationSummary): ClientV1PageKey {
-  return { sort: summary.updatedAt, id: summary.sessionId };
+  return { sort: conversationSortKey(summary), id: summary.sessionId };
 }
 
 /**


### PR DESCRIPTION
Fixes the P1 in `cave-fhjlu`. `GET /api/client/v1/conversations` paged by keyset on `updatedAt`. That field only ever rises and the ordering is descending, so a conversation that received a turn mid-pagination moved **above** an open cursor: a row already served stayed served, and a row **not yet served was silently skipped** by the rest of the walk.

A repeat would have been deduplicable by `id`. A skip is silent data loss from a read this surface calls canonical, and every SDK or Chat client built on it inherits it.

## The skip, reproduced before anything changed

At the route level, driving the real handler, real page key and real cursor codec over a ledger mutated between pages:

```
ledger (updatedAt descending): [conversation-06 … conversation-01]
page 1 (limit=2): [conversation-06, conversation-05]  next=yes
touched conversation-01 (unserved) — its updatedAt is now 2026-12-31T00:00:00.000Z
page 2: [conversation-04, conversation-03]
page 3: [conversation-02]
whole walk served: [06, 05, 04, 03, 02]
SKIPPED:  [conversation-01]
REPEATED: []
```

And over a real socket, from the conformance harness against the pre-fix release build:

```
ok reads.conversations-mutable-key-moves-a-row — touched conversation-01;
   the rest of the walk served [04, 03, 02] — a skip, and no repeat anywhere in it
```

The walk was followed to **exhaustion** in both, which is what separates the two claims: a row that comes back three pages later is the repeat #4856 documented, a row that never comes back is a skip, and a one-page probe cannot tell them apart.

## The fix, and what it costs

The page key is now `createdAt`, matching `clientV1ProjectPageKey` and the daemon's session pager (`OpenCoven/coven#783`), which key `created_at, id` for exactly this reason. Nothing rewrites `conv.createdAt` after the file is created, so the key of a row that exists never changes and **the set a walk serves is decided when the walk starts**.

`createdAt` is optional on a `ConversationSummary`, which is why #4856 rejected it — keying on it would strand every row that lacks one. Answered with a sentinel rather than by keying on something mutable: a row whose `createdAt` the store cannot supply sorts as the **empty string**, which is below every ISO instant, so a descending walk serves those rows in one contiguous block **at the tail**, ordered among themselves by `id`. They are served, they are reachable only *through* a cursor, and `""` is as immutable as any instant, so they cannot move under one either. The sentinel is read through the same `optionalText` the projection uses, so the key and the served record can never disagree.

**Costs, stated plainly:**

- **The ordering a client sees changed** — most-recently-touched first becomes most-recently-created first. `/conversations` no longer matches the desktop sessions list row for row. `updatedAt` is still served on every record, so recency is available as a *field*; what it cannot be is a *resumable keyset*, because a cursor cannot name a position in an order that moves. This is the "page by a stable key, expose recency as a field" trade, taken deliberately.
- **A conversation created mid-walk is not served by that walk.** Its `createdAt` is *now*, which sorts above every open cursor. Inherent to a forward keyset over a growing set, it costs no pre-existing row, and the reference now tells a client to re-read the head for it.
- **No migration.** `ConversationSummary` is untouched, `createdAt` stays optional, no store changes, nothing on disk is rewritten. The rejected alternatives all cost more: making `createdAt` required touches the store and every existing record and needs a backfill; snapshotting the ordering per walk is unbounded server state that does not survive a restart; a monotonic per-conversation sequence is a store write on every turn, and a *creation* sequence is `createdAt` with extra steps.

## Whole-walk proof, and the boundary cases

Seven conformance assertions replace the one that *asserted the skip*, each walking to exhaustion and comparing an **ordered sequence** of ids — never a key set, which is the weakness this harness's own review found in an earlier assertion:

| Case | Result |
|---|---|
| touch a row the walk has **not** reached | whole walk `[06, 05, 04, 03, 02, 01]` |
| touch a row already **served** | whole walk `[06 … 01]`, nothing twice |
| touch the row the **cursor names** | whole walk `[06 … 01]` |
| conversation **created** mid-walk | every pre-existing row once, the new one left for the next read |
| conversation **deleted** mid-walk | `[06, 05, 03, 02, 01]`, no strand, all 200 |
| two rows **tied** on the sort key | walked at limit 1 so a boundary lands between them; id-descending |
| row with **no `createdAt`** at all | served last, reached through a cursor, `createdAt` not invented |

The same seven exist at the route level in `conversations/route.test.ts`, plus three key-level ones in `reads.test.ts`.

Two fixture properties were load-bearing and are now pinned by `client-v1-conformance.test.mjs`: the fixture orders by `createdAt` and `updatedAt` in **opposite** directions (they used to agree, so the run could not tell which field keyed the page — `reads.conversations-shape` passed either way), and two rows **share** a `createdAt` so the id tiebreak is exercised rather than merely present.

A second commit closes a soundness hole the new assertions would otherwise have had: `listConversations` caches a summary against the file's `(mtime, ctime, size)`, and a touch that only raised `updatedAt` left the size unchanged, so it could be answered from cache within one millisecond and every mid-walk assertion would pass because *nothing moved*. The touch now also lengthens a withheld field, and each case probes the ledger after mutating and fails loudly if the touch, insert or deletion is not observable.

## Mutation matrix

Every added assertion, against a deliberately broken build. Each mutation was applied, run, and reverted with `git checkout HEAD -- <file>` from a committed tree.

| Mutation | Killed by |
|---|---|
| **A** — revert the fix (`sort: summary.updatedAt`) | `reads.test.ts` 3/3 new · `route.test.ts` 8/8 new · conformance 9 failures, incl. all 7 new ids. Under A the harness reproduces the skip on the wire: `[01, 02, 04, 05, 06]`, `conversation-03` lost |
| **B** — keyless rows sort to the **head** (`?? "￿"`) | `a conversation with no createdAt sorts to the tail`, `the page key reads createdAt exactly as the projection serves it` |
| **C** — raw `summary.createdAt` instead of the projection's `optionalText` | `the page key reads createdAt exactly as the projection serves it` (blank / whitespace / numeric) |
| **D** — fixture `updatedAt` ordering agrees with `createdAt` again | `the fixture orders by createdAt and by updatedAt in opposite directions` |
| **E** — fixture tie removed | `the fixture ties exactly two conversations on createdAt` |
| **F** — `expectedConversationOrder` sorts a keyless row first | `expectedConversationOrder puts a row with no createdAt at the tail` |

## Docs

`docs/api/client-v1.md` documented the skip as the contract; it now documents the immutable key, the ordering change, the tail placement of `createdAt`-less rows, and the two things a client still plans for. The `reads.ts` comment corrected in #4859 now describes the new reality and keeps the history of why the old key was chosen. `docs/workflows/client-v1-conformance.md` moves finding 3 from "a documentation gap" to "the finding that became a fix", and records the seven assertions and the two fixture pins that keep it fixed.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` (1807 wired), `pnpm build` all clean. Green: `pagination.test.ts` 17, `reads.test.ts` 19, `read-guard.test.ts` 10, the five client-v1 route suites (14 / 5 / 10 / 7 / 9), `api-contracts.test.ts` 301 route contracts, `client-v1-doc-contract.test.mjs` 7, `client-v1-conformance.test.mjs` 53, `export-client-v1-contract.test.mjs` 7.

Conformance run against the release build: **99 passed, 0 failed, 0 skipped** with `--include-ttl`, at `ed6cc4b1` on `win32-x64`, taken from a clean tree after the code commits. Committed as `docs/client-v1-conformance-results/2026-08-22-v0.3.9-win32-cave-fhjlu.json`.

The pre-fix baseline on the same tree was **91 passed, 0 failed, 1 skipped** — green, because the assertion it carried *asserted the skip*:

```
ok reads.conversations-mutable-key-moves-a-row — touched conversation-01;
   the rest of the walk served [04, 03, 02] — a skip, and no repeat anywhere in it
```
