### PR TITLE
Let a hardened Windows host boot, and restrict the raw mobile token (cave-37fxr, cave-fawvh)

### DIFF
--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -1121,7 +1121,16 @@ ordinary user; no elevation is needed).
 withheld, `clientV1DiscoveryPublished` stays false, and a banner naming the
 failure goes to stderr, but the server finishes starting and serves everything
 else. That is not a relaxation of the check: no path the guard refused is used,
-and the request-side guard keeps refusing every client v1 call. It is a
+and the request-side guard keeps refusing every client v1 call that presents a
+credential — the credential store re-asserts ownership on every read and write,
+so `findByBearer` cannot answer on a path the guard refused. Measured on a host
+with no reachable `powershell.exe`: the server answers `Ready on …`, the record
+is absent, `GET /api/client/v1/health` still answers (it is unauthenticated by
+design and carries no user data), and a bearer-carrying request is refused. The
+one case that survives is narrow and deliberate: if the discovery *file* alone
+is unverifiable while the store's root is exclusive, a client that already
+holds a credential and a cached endpoint keeps working against the real server
+— it is the record, not the server, that could have been redirected. It is a
 correction of blast radius — this used to close the listener and exit 1, which
 on a host that cannot read a DACL at all (PowerShell in Constrained Language
 Mode, or no `powershell.exe` under `%SystemRoot%`, both measured on Windows 11

--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -1106,11 +1106,43 @@ before it prints `Ready on …`:
 The file is 0600 inside a 0700 directory verified not to be a symlink, written
 temp-file → `fsync` → rename, and deleted on shutdown — but only if the record
 still carries *this* process's `nonce` and the same inode, so a Cave that has
-been restarted underneath never deletes its successor's record. **A publish
-failure is fatal**: the listener closes and the process exits 1 rather than
-serving on an endpoint nothing can discover. Both the directory and the file are
-also checked to be owned by the current user, but only where `process.getuid`
-exists — that check is a no-op on Windows.
+been restarted underneath never deletes its successor's record.
+
+Both the directory and the file are also checked to be owned by the current
+user, and to be writable by nobody else. On POSIX that is a `uid` comparison.
+On Windows it is a DACL read: `process.getuid` is undefined there and `lstat`
+reports uid 0 for every path, so the uid comparison alone passed unconditionally
+on the platform — the defect GitHub #4842 was filed for. `server.ts` now shells
+out to PowerShell, refuses a path any other principal can write, and repairs a
+DACL that merely inherited one (`icacls <path> /reset` undoes the repair as the
+ordinary user; no elevation is needed).
+
+**A publish failure disables client v1; it does not stop Cave.** The record is
+withheld, `clientV1DiscoveryPublished` stays false, and a banner naming the
+failure goes to stderr, but the server finishes starting and serves everything
+else. That is not a relaxation of the check: no path the guard refused is used,
+and the request-side guard keeps refusing every client v1 call. It is a
+correction of blast radius — this used to close the listener and exit 1, which
+on a host that cannot read a DACL at all (PowerShell in Constrained Language
+Mode, or no `powershell.exe` under `%SystemRoot%`, both measured on Windows 11
+under WDAC/AppLocker-shaped configurations) meant Cave would not start and there
+was no remedy reachable from inside it.
+
+An operator on such a host can opt back in, explicitly:
+
+```
+COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP=i-accept-unverified-path-ownership
+COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP_REASON="<who accepted this, and why>"
+```
+
+Both are required; the reason must be at least 12 characters. The value is that
+exact sentence, so `1`, `true` and `yes` do nothing and say so. It waives **one**
+condition — a DACL that could not be *read* — and never a DACL that was read and
+found shared, a POSIX uid mismatch, or a platform with neither a uid nor an ACL.
+Every waived path logs a `SECURITY WAIVER` line naming the path and the reason
+given. The same waiver covers the mobile pairing secret
+(`src/lib/server/mobile-access-provision.ts`), which is restricted by the same
+guard because its `chmod(0o600)` is equally inert on Windows.
 
 `endpoint` is validated before it is written: `http:`, a loopback host, an
 explicit port, no credentials, no path, query, or fragment. Treat `pid` and

--- a/server.mjs
+++ b/server.mjs
@@ -83,6 +83,42 @@ function clientV1DiscoveryFile() {
 }
 const WINDOWS_SYSTEM_SID = "S-1-5-18";
 const WINDOWS_ADMINISTRATORS_SID = "S-1-5-32-544";
+const UNVERIFIED_OWNERSHIP_ENV = "COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP";
+const UNVERIFIED_OWNERSHIP_REASON_ENV = "COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP_REASON";
+const UNVERIFIED_OWNERSHIP_TOKEN = "i-accept-unverified-path-ownership";
+const UNVERIFIED_OWNERSHIP_MIN_REASON = 12;
+function resolveUnverifiedOwnershipWaiver(env) {
+  const requested = env[UNVERIFIED_OWNERSHIP_ENV]?.trim() ?? "";
+  if (!requested) {
+    return {
+      granted: false,
+      note: `If the DACL genuinely cannot be read on this host \u2014 PowerShell in Constrained Language Mode, or no powershell.exe under %SystemRoot% \u2014 set ${UNVERIFIED_OWNERSHIP_ENV}=${UNVERIFIED_OWNERSHIP_TOKEN} and ${UNVERIFIED_OWNERSHIP_REASON_ENV} to a sentence naming who accepted that and why. It waives only an unreadable DACL, never one that was read and found shared.`
+    };
+  }
+  if (requested !== UNVERIFIED_OWNERSHIP_TOKEN) {
+    return {
+      granted: false,
+      note: `${UNVERIFIED_OWNERSHIP_ENV} is set, but not to the waiver: the only accepted value is the exact string ${UNVERIFIED_OWNERSHIP_TOKEN}. A boolean-shaped value ("1", "true", "yes") never waives this check.`
+    };
+  }
+  const reason = env[UNVERIFIED_OWNERSHIP_REASON_ENV]?.trim() ?? "";
+  if (reason.length < UNVERIFIED_OWNERSHIP_MIN_REASON) {
+    return {
+      granted: false,
+      note: `${UNVERIFIED_OWNERSHIP_ENV} is set, but ${UNVERIFIED_OWNERSHIP_REASON_ENV} must carry at least ${UNVERIFIED_OWNERSHIP_MIN_REASON} characters naming who accepted an unverified path and why. The waiver stays closed without that attribution.`
+    };
+  }
+  return { granted: true, reason };
+}
+function unverifiableOwnershipRefusal(subject, path, cause, note) {
+  return `${subject} ownership could not be verified on Windows: ${cause.message}. Refusing ${path}; inspect it with: icacls "${path}". ${note}`;
+}
+function unverifiedOwnershipDisclosure(subject, path, cause, reason) {
+  return `SECURITY WAIVER \u2014 ${subject} is being used UNVERIFIED. Its DACL could not be read on this host (${cause.message}), and ${UNVERIFIED_OWNERSHIP_ENV} is set, so ${path} is trusted on the operator's word alone: reason given \u2014 ${reason}. Any principal that can write ${path} can mint credentials or point a paired client at another server. Unset ${UNVERIFIED_OWNERSHIP_ENV} to restore the check.`;
+}
+function sharedOwnershipRefusal(subject, path, findings, waiver) {
+  return `${subject} is not exclusive to the current user: ${findings.join("; ")}. Refusing ${path}; inspect it with: icacls "${path}"` + (waiver.granted ? `. ${UNVERIFIED_OWNERSHIP_ENV} does not cover a DACL that was read: this one was, and it is shared. Repair it with: icacls "${path}" /reset` : "");
+}
 const WINDOWS_ACL_SCRIPT = `
 $ErrorActionPreference = 'Stop'
 $item = Get-Item -LiteralPath $env:COVEN_CAVE_CLIENT_V1_ACL_PATH -Force
@@ -147,8 +183,12 @@ if (-not (Test-Exclusive $state)) {
 } | ConvertTo-Json -Compress -Depth 4
 `;
 const standaloneVerifiedWindowsPaths = /* @__PURE__ */ new Set();
+const standaloneWaivedWindowsPaths = /* @__PURE__ */ new Set();
 function assertStandaloneWindowsExclusive(path, label) {
   if (standaloneVerifiedWindowsPaths.has(path)) return;
+  if (standaloneWaivedWindowsPaths.has(path)) return;
+  const subject = `Client v1 discovery ${label}`;
+  const waiver = resolveUnverifiedOwnershipWaiver(process.env);
   const systemRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
   const probeEnv = {
     COVEN_CAVE_CLIENT_V1_ACL_PATH: path,
@@ -188,10 +228,17 @@ function assertStandaloneWindowsExclusive(path, label) {
       throw new Error("the ACL probe returned a malformed report");
     }
   } catch (cause) {
-    throw new Error(
-      `Client v1 discovery ${label} ownership could not be verified on Windows: ${cause.message}. Refusing ${path}; inspect it with: icacls "${path}"`,
-      { cause }
+    if (!waiver.granted) {
+      throw new Error(
+        unverifiableOwnershipRefusal(subject, path, cause, waiver.note),
+        { cause }
+      );
+    }
+    standaloneWaivedWindowsPaths.add(path);
+    console.warn(
+      unverifiedOwnershipDisclosure(subject, path, cause, waiver.reason)
     );
+    return;
   }
   const trusted = /* @__PURE__ */ new Set([report.self, WINDOWS_SYSTEM_SID, WINDOWS_ADMINISTRATORS_SID]);
   const findings = [];
@@ -204,13 +251,11 @@ function assertStandaloneWindowsExclusive(path, label) {
     findings.push(`access granted to ${[...new Set(foreign)].join(", ")}`);
   }
   if (findings.length > 0) {
-    throw new Error(
-      `Client v1 discovery ${label} is not exclusive to the current user: ${findings.join("; ")}. Refusing ${path}; inspect it with: icacls "${path}"`
-    );
+    throw new Error(sharedOwnershipRefusal(subject, path, findings, waiver));
   }
   if (report.repaired) {
     console.warn(
-      `Client v1 discovery ${label} had no enforced access control on Windows; restricted ${path} to the current user and revoked ${report.removed.length > 0 ? report.removed.join(", ") : "inherited entries"}.`
+      `${subject} had no enforced access control on Windows; restricted ${path} to the current user and revoked ${report.removed.length > 0 ? report.removed.join(", ") : "inherited entries"}.`
     );
   }
   standaloneVerifiedWindowsPaths.add(path);
@@ -1087,13 +1132,24 @@ server.on("upgrade", (req, socket, head) => {
 });
 server.keepAliveTimeout = 75e3;
 server.headersTimeout = 8e4;
+function reportClientV1DiscoveryUnavailable(error) {
+  clientV1DiscoveryPublished = false;
+  const detail = error instanceof Error ? error.message : String(error);
+  console.error("[cave] \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 CLIENT V1 DISABLED \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500");
+  console.error(`[cave] ${detail}`);
+  console.error(
+    "[cave] The client v1 discovery record was NOT published, so paired clients cannot find this server and every client v1 request stays refused. Everything else on this server is running normally."
+  );
+  console.error(
+    `[cave] Repair the path and restart. If \u2014 and only if \u2014 this host cannot read a DACL at all, ${UNVERIFIED_OWNERSHIP_ENV}=${UNVERIFIED_OWNERSHIP_TOKEN} with ${UNVERIFIED_OWNERSHIP_REASON_ENV} set admits an unreadable one; it never admits a DACL that was read and found shared.`
+  );
+  console.error("[cave] \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500");
+}
 server.listen(port, hostname, () => {
   try {
     publishStandaloneClientV1DiscoveryRecord(loopbackHttpEndpoint(hostname, port));
   } catch (error) {
-    console.error("[cave] failed to publish client-v1 discovery", error);
-    server.close(() => process.exit(1));
-    return;
+    reportClientV1DiscoveryUnavailable(error);
   }
   console.log(`> Ready on ${loopbackHttpEndpoint(hostname, port)}`);
 });

--- a/server.ts
+++ b/server.ts
@@ -147,6 +147,96 @@ function clientV1DiscoveryFile(): string {
 const WINDOWS_SYSTEM_SID = "S-1-5-18";
 const WINDOWS_ADMINISTRATORS_SID = "S-1-5-32-544";
 
+// The unverified-ownership waiver, inlined from path-ownership.ts for the same
+// reason as the script below. See that module for why it is shaped this way;
+// discovery.test.ts pins every part of it byte-for-byte, because a copy that
+// drifts is a copy that opts out on terms the module never agreed to.
+const UNVERIFIED_OWNERSHIP_ENV = "COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP";
+const UNVERIFIED_OWNERSHIP_REASON_ENV = "COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP_REASON";
+const UNVERIFIED_OWNERSHIP_TOKEN = "i-accept-unverified-path-ownership";
+const UNVERIFIED_OWNERSHIP_MIN_REASON = 12;
+
+type UnverifiedOwnershipWaiver =
+  | { granted: true; reason: string }
+  | { granted: false; note: string };
+
+function resolveUnverifiedOwnershipWaiver(
+  env: Record<string, string | undefined>,
+): UnverifiedOwnershipWaiver {
+  const requested = env[UNVERIFIED_OWNERSHIP_ENV]?.trim() ?? "";
+  if (!requested) {
+    return {
+      granted: false,
+      note:
+        `If the DACL genuinely cannot be read on this host — PowerShell in `
+        + `Constrained Language Mode, or no powershell.exe under %SystemRoot% — `
+        + `set ${UNVERIFIED_OWNERSHIP_ENV}=${UNVERIFIED_OWNERSHIP_TOKEN} and `
+        + `${UNVERIFIED_OWNERSHIP_REASON_ENV} to a sentence naming who accepted `
+        + `that and why. It waives only an unreadable DACL, never one that was `
+        + `read and found shared.`,
+    };
+  }
+  if (requested !== UNVERIFIED_OWNERSHIP_TOKEN) {
+    return {
+      granted: false,
+      note:
+        `${UNVERIFIED_OWNERSHIP_ENV} is set, but not to the waiver: the only `
+        + `accepted value is the exact string ${UNVERIFIED_OWNERSHIP_TOKEN}. A `
+        + `boolean-shaped value ("1", "true", "yes") never waives this check.`,
+    };
+  }
+  const reason = env[UNVERIFIED_OWNERSHIP_REASON_ENV]?.trim() ?? "";
+  if (reason.length < UNVERIFIED_OWNERSHIP_MIN_REASON) {
+    return {
+      granted: false,
+      note:
+        `${UNVERIFIED_OWNERSHIP_ENV} is set, but ${UNVERIFIED_OWNERSHIP_REASON_ENV} `
+        + `must carry at least ${UNVERIFIED_OWNERSHIP_MIN_REASON} characters naming `
+        + `who accepted an unverified path and why. The waiver stays closed `
+        + `without that attribution.`,
+    };
+  }
+  return { granted: true, reason };
+}
+
+function unverifiableOwnershipRefusal(
+  subject: string,
+  path: string,
+  cause: Error,
+  note: string,
+): string {
+  return `${subject} ownership could not be verified on Windows: ${cause.message}. `
+    + `Refusing ${path}; inspect it with: icacls "${path}". ${note}`;
+}
+
+function unverifiedOwnershipDisclosure(
+  subject: string,
+  path: string,
+  cause: Error,
+  reason: string,
+): string {
+  return `SECURITY WAIVER — ${subject} is being used UNVERIFIED. Its DACL could not `
+    + `be read on this host (${cause.message}), and ${UNVERIFIED_OWNERSHIP_ENV} is `
+    + `set, so ${path} is trusted on the operator's word alone: reason given — `
+    + `${reason}. Any principal that can write ${path} can mint credentials or `
+    + `point a paired client at another server. Unset ${UNVERIFIED_OWNERSHIP_ENV} `
+    + `to restore the check.`;
+}
+
+function sharedOwnershipRefusal(
+  subject: string,
+  path: string,
+  findings: string[],
+  waiver: UnverifiedOwnershipWaiver,
+): string {
+  return `${subject} is not exclusive to the current user: ${findings.join("; ")}. `
+    + `Refusing ${path}; inspect it with: icacls "${path}"`
+    + (waiver.granted
+      ? `. ${UNVERIFIED_OWNERSHIP_ENV} does not cover a DACL that was read: this `
+        + `one was, and it is shared. Repair it with: icacls "${path}" /reset`
+      : "");
+}
+
 const WINDOWS_ACL_SCRIPT = `
 $ErrorActionPreference = 'Stop'
 $item = Get-Item -LiteralPath $env:COVEN_CAVE_CLIENT_V1_ACL_PATH -Force
@@ -212,9 +302,18 @@ if (-not (Test-Exclusive $state)) {
 `;
 
 const standaloneVerifiedWindowsPaths = new Set<string>();
+// Paths admitted UNVERIFIED under the operator's waiver. Separate from the set
+// above because nothing here was verified — and cached for the same reason the
+// module caches it: on a host where the probe can never answer, re-driving it
+// would fork a doomed subprocess per request and repeat a disclosure nobody
+// would then read.
+const standaloneWaivedWindowsPaths = new Set<string>();
 
 function assertStandaloneWindowsExclusive(path: string, label: string): void {
   if (standaloneVerifiedWindowsPaths.has(path)) return;
+  if (standaloneWaivedWindowsPaths.has(path)) return;
+  const subject = `Client v1 discovery ${label}`;
+  const waiver = resolveUnverifiedOwnershipWaiver(process.env);
   const systemRoot = process.env.SystemRoot || process.env.windir || "C:\\Windows";
   // The smallest environment PowerShell needs, never this server's own: it
   // holds COVEN_CAVE_ACCESS_TOKEN and COVEN_CAVE_AUTH_TOKEN, and a subprocess
@@ -282,11 +381,19 @@ function assertStandaloneWindowsExclusive(path: string, label: string): void {
       throw new Error("the ACL probe returned a malformed report");
     }
   } catch (cause) {
-    throw new Error(
-      `Client v1 discovery ${label} ownership could not be verified on Windows: `
-      + `${(cause as Error).message}. Refusing ${path}; inspect it with: icacls "${path}"`,
-      { cause },
+    // The ONE condition the waiver covers: the host cannot answer the
+    // question. Everything below this point had an answer.
+    if (!waiver.granted) {
+      throw new Error(
+        unverifiableOwnershipRefusal(subject, path, cause as Error, waiver.note),
+        { cause },
+      );
+    }
+    standaloneWaivedWindowsPaths.add(path);
+    console.warn(
+      unverifiedOwnershipDisclosure(subject, path, cause as Error, waiver.reason),
     );
+    return;
   }
 
   const trusted = new Set([report.self, WINDOWS_SYSTEM_SID, WINDOWS_ADMINISTRATORS_SID]);
@@ -302,14 +409,11 @@ function assertStandaloneWindowsExclusive(path: string, label: string): void {
     findings.push(`access granted to ${[...new Set(foreign)].join(", ")}`);
   }
   if (findings.length > 0) {
-    throw new Error(
-      `Client v1 discovery ${label} is not exclusive to the current user: `
-      + `${findings.join("; ")}. Refusing ${path}; inspect it with: icacls "${path}"`,
-    );
+    throw new Error(sharedOwnershipRefusal(subject, path, findings, waiver));
   }
   if (report.repaired) {
     console.warn(
-      `Client v1 discovery ${label} had no enforced access control on Windows; `
+      `${subject} had no enforced access control on Windows; `
       + `restricted ${path} to the current user and revoked `
       + `${report.removed.length > 0 ? report.removed.join(", ") : "inherited entries"}.`,
     );
@@ -1654,13 +1758,51 @@ server.on("upgrade", (req, socket, head) => {
 server.keepAliveTimeout = 75_000;
 server.headersTimeout = 80_000;
 
+/**
+ * Turn off client v1 — loudly — instead of refusing to boot (cave-37fxr).
+ *
+ * Publishing was fail-closed to `server.close(() => process.exit(1))`, which
+ * is right about the record and wrong about the process. The guard learned to
+ * read a Windows DACL in #4852, which made it able to throw on win32 for the
+ * first time, and on a host where the DACL cannot be read at all — PowerShell
+ * in Constrained Language Mode, or no `powershell.exe` under `%SystemRoot%`,
+ * both measured — that throw is permanent and there is no remedy reachable
+ * from inside an app that will not start.
+ *
+ * Withholding the record is the correct fail-closed response and it costs
+ * exactly one surface: the discovery file is what a paired client reads to
+ * find this server, and the request-side guard refuses every client v1 call on
+ * such a host anyway. Nothing else here — the terminal, chat, the board — has
+ * anything to do with client v1 or with that path. So the degraded state is
+ * "client v1 off, everything else up", and the crash is replaced by a banner
+ * loud enough to be the thing that gets noticed. `clientV1DiscoveryPublished`
+ * stays false, so shutdown will not try to unlink a record this process does
+ * not own.
+ */
+function reportClientV1DiscoveryUnavailable(error: unknown): void {
+  clientV1DiscoveryPublished = false;
+  const detail = error instanceof Error ? error.message : String(error);
+  console.error("[cave] ─────────────── CLIENT V1 DISABLED ───────────────");
+  console.error(`[cave] ${detail}`);
+  console.error(
+    "[cave] The client v1 discovery record was NOT published, so paired clients"
+    + " cannot find this server and every client v1 request stays refused."
+    + " Everything else on this server is running normally.",
+  );
+  console.error(
+    `[cave] Repair the path and restart. If — and only if — this host cannot`
+    + ` read a DACL at all, ${UNVERIFIED_OWNERSHIP_ENV}=${UNVERIFIED_OWNERSHIP_TOKEN}`
+    + ` with ${UNVERIFIED_OWNERSHIP_REASON_ENV} set admits an unreadable one; it`
+    + ` never admits a DACL that was read and found shared.`,
+  );
+  console.error("[cave] ────────────────────────────────────────────────────");
+}
+
 server.listen(port, hostname, () => {
   try {
     publishStandaloneClientV1DiscoveryRecord(loopbackHttpEndpoint(hostname, port));
   } catch (error) {
-    console.error("[cave] failed to publish client-v1 discovery", error);
-    server.close(() => process.exit(1));
-    return;
+    reportClientV1DiscoveryUnavailable(error);
   }
   console.log(`> Ready on ${loopbackHttpEndpoint(hostname, port)}`);
 });

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -258,10 +258,13 @@ function mobileAccessUnavailableResponse() {
  * cookie so the freshly armed gate never locks out the session that turned
  * pairing on.
  */
-function resolveMobileAccessSecret(): { secret: string; provisioned: boolean } | null {
+async function resolveMobileAccessSecret(): Promise<{ secret: string; provisioned: boolean } | null> {
   const existing = mobileAccessSecret();
   if (existing) return { secret: existing, provisioned: false };
-  const provisioned = provisionMobileAccessSecret();
+  // Async since cave-fawvh: provisioning now restricts the state directory and
+  // the token file to this user before handing back a plaintext secret, and on
+  // Windows that means reading a DACL out of a subprocess.
+  const provisioned = await provisionMobileAccessSecret();
   if (!provisioned) return null;
   armMobileAccessSecret(provisioned);
   return { secret: provisioned, provisioned: true };
@@ -297,7 +300,7 @@ async function ensureNativeAppServe(req: Request, chatId?: string | null) {
   const hostPortRejection = rejectMismatchedHostPort(req);
   if (hostPortRejection) return hostPortRejection;
 
-  const access = resolveMobileAccessSecret();
+  const access = await resolveMobileAccessSecret();
   if (!access) {
     return mobileAccessUnavailableResponse();
   }
@@ -499,7 +502,7 @@ async function mobileHandoff(req: Request, chatId?: string | null) {
   const hostPortRejection = rejectMismatchedHostPort(req);
   if (hostPortRejection) return hostPortRejection;
 
-  const access = resolveMobileAccessSecret();
+  const access = await resolveMobileAccessSecret();
   if (!access) {
     return mobileAccessUnavailableResponse();
   }

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -181,10 +181,15 @@ assert.doesNotMatch(
   "API must not use the request URL Host port as the backend Serve target",
 );
 assert.match(handoffRoute, /NODE_ENV !== "production"[\s\S]*pnpm mobile:tailscale/, "API should give an actionable dev hint when the access token is missing");
+// `await` since cave-fawvh: provisioning restricts the state directory and the
+// token file to this user before handing back a plaintext secret, and on
+// Windows that means reading a DACL out of a subprocess. The `await` is part of
+// what this pin protects — dropping it would resolve the guard to a Promise,
+// which is truthy, so `if (!access)` would sail past a refusal.
 assert.match(
   handoffRoute,
-  /async function ensureNativeAppServe[\s\S]*?const access = resolveMobileAccessSecret\(\);[\s\S]*?if \(!access\) \{[\s\S]*?return mobileAccessUnavailableResponse\(\)/,
-  "native app mobile-mode start must resolve (or self-provision) the mobile access secret before starting Tailscale Serve",
+  /async function ensureNativeAppServe[\s\S]*?const access = await resolveMobileAccessSecret\(\);[\s\S]*?if \(!access\) \{[\s\S]*?return mobileAccessUnavailableResponse\(\)/,
+  "native app mobile-mode start must await resolving (or self-provisioning) the mobile access secret before starting Tailscale Serve",
 );
 assert.match(settingsShell, /<PhoneSection onUseAsHub=/, "Settings should render the focused Phone section");
 assert.match(settings, /mobileModeEnabled/, "Settings should receive the live mobile mode enabled state");

--- a/src/lib/server/client-v1/discovery.test.ts
+++ b/src/lib/server/client-v1/discovery.test.ts
@@ -375,6 +375,18 @@ test("the standalone server enforces ownership on Windows with this module's scr
       "the exclusivity findings",
       /if \(report\.owner !== report\.self\) \{[\s\S]*?if \(foreign\.length > 0\) \{[\s\S]*?\n {2}\}/,
     ],
+    // The waiver (cave-37fxr) is the one thing in here that can ADMIT a path,
+    // so a copy that drifts is a copy that opts out on terms the module never
+    // agreed to — a laxer token, a shorter reason, a note that forgets to say
+    // a read-and-shared DACL is not covered.
+    ["the waiver variable", /const UNVERIFIED_OWNERSHIP_ENV = "([^"]+)";/],
+    ["the waiver reason variable", /const UNVERIFIED_OWNERSHIP_REASON_ENV = "([^"]+)";/],
+    ["the waiver token", /const UNVERIFIED_OWNERSHIP_TOKEN = "([^"]+)";/],
+    ["the minimum reason length", /const UNVERIFIED_OWNERSHIP_MIN_REASON = (\d+);/],
+    ["the waiver resolver", /function resolveUnverifiedOwnershipWaiver\([\s\S]*?\n\}/],
+    ["the unreadable-DACL refusal", /function unverifiableOwnershipRefusal\([\s\S]*?\n\}/],
+    ["the waived-path disclosure", /function unverifiedOwnershipDisclosure\([\s\S]*?\n\}/],
+    ["the shared-DACL refusal", /function sharedOwnershipRefusal\([\s\S]*?\n\}/],
   ];
   for (const [what, pattern] of parts) {
     assert.equal(
@@ -387,5 +399,64 @@ test("the standalone server enforces ownership on Windows with this module's scr
     source,
     /if \(findings\.length > 0\) \{\s*throw new Error\(/,
     "the standalone server must refuse on any finding, not merely collect them",
+  );
+});
+
+test("a client-v1 discovery failure degrades that surface instead of killing the server", async () => {
+  // cave-37fxr. The guard learning to read a DACL made it able to throw on
+  // win32 for the first time, and `server.listen`'s handler answered that with
+  // `server.close(() => process.exit(1))` — so a host where the DACL cannot be
+  // read at all could not start Cave, with no remedy reachable from inside the
+  // app. Measured on Windows 11: PowerShell in Constrained Language Mode exits
+  // 1 with `MethodInvocationNotSupportedInConstrainedLanguage`, and a
+  // `powershell.exe` absent from %SystemRoot% exits with ENOENT.
+  //
+  // Refusing to PUBLISH is still right; refusing to BOOT never was. Client v1
+  // is the only surface the record serves, and the request-side guard refuses
+  // every client v1 call on such a host anyway, so withholding the record
+  // costs exactly the surface that cannot be secured and nothing else.
+  const source = await readFile(resolve(process.cwd(), "server.ts"), "utf8");
+
+  const listenBlock = /server\.listen\(port, hostname, \(\) => \{[\s\S]*?\n\}\);/.exec(source);
+  assert.ok(listenBlock, "server.ts must define the listener-readiness callback");
+  const handler = listenBlock![0];
+  assert.doesNotMatch(
+    handler,
+    /process\.exit/,
+    "a discovery failure must not exit the process: the whole app is not client v1",
+  );
+  assert.match(
+    handler,
+    /catch \(error\) \{\s*reportClientV1DiscoveryUnavailable\(error\)/,
+    "the failure must go to the loud reporter",
+  );
+  assert.match(
+    handler,
+    /Ready on/,
+    "the server still announces readiness — everything but client v1 is running",
+  );
+
+  const reporter =
+    /function reportClientV1DiscoveryUnavailable\([\s\S]*?\n\}/.exec(source);
+  assert.ok(reporter, "server.ts must define reportClientV1DiscoveryUnavailable");
+  assert.match(
+    reporter![0],
+    /clientV1DiscoveryPublished = false/,
+    "an unpublished record must never be treated as published, or shutdown unlinks a file it does not own",
+  );
+  assert.match(
+    reporter![0],
+    /console\.error/,
+    "the degraded state has to be loud: it is the only thing standing in for the crash",
+  );
+  assert.match(
+    reporter![0],
+    /CLIENT V1 DISABLED/,
+    "the banner must name what is off, not merely that something failed",
+  );
+  assert.match(
+    reporter![0],
+    /UNVERIFIED_OWNERSHIP_ENV/,
+    "the banner must name the waiver, which is the only remedy on a host that cannot read a DACL",
   );
 });

--- a/src/lib/server/client-v1/path-ownership.test.ts
+++ b/src/lib/server/client-v1/path-ownership.test.ts
@@ -53,6 +53,9 @@ function windows(
     platform: "win32",
     getuid: null,
     warn: () => {},
+    // Hermetic by default: the waiver below is read from this env, never the
+    // runner's, so one exported variable cannot quietly disarm the suite.
+    env: {},
     probeWindowsAcl: async () => report(),
     ...overrides,
   };
@@ -341,6 +344,223 @@ test("a malformed probe report is refused rather than read as an empty DACL", ()
     { sid: "", type: "" },
     { sid: USERS_SID, type: "" },
   ]);
+});
+
+// ── The unverified-ownership waiver (cave-37fxr) ─────────────────────────────
+// A DACL the host cannot read at all is a different condition from a DACL that
+// was read and found shared, and only the first one has no remedy from inside
+// the app. Measured on Windows 11: PowerShell in Constrained Language Mode
+// answers the probe with `MethodInvocationNotSupportedInConstrainedLanguage`
+// and exit 1, and a `powershell.exe` absent from %SystemRoot% answers with
+// ENOENT — on either host the pre-waiver guard threw at boot and server.ts
+// turned that into `process.exit(1)`.
+//
+// Every assertion below is injectable (`env`, `platform`, `getuid`,
+// `probeWindowsAcl`), so the Linux runners exercise the same branch. A
+// Windows-only assertion here would be vacuous in CI, which is how the bug
+// this file exists for survived in the first place.
+const WAIVER_ENV = "COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP";
+const WAIVER_REASON_ENV = "COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP_REASON";
+const WAIVER_TOKEN = "i-accept-unverified-path-ownership";
+const WAIVER_REASON = "opsdesk@example.com: WDAC host, PowerShell is blocked";
+
+/** The measured Constrained Language Mode failure, as execFile reports it. */
+function constrainedLanguageProbe(): () => Promise<ClientV1WindowsAclReport> {
+  return async () => {
+    throw new Error(
+      "Command failed: powershell.exe\nCannot invoke method. Method invocation is "
+      + "supported only on core types in this language mode.\n"
+      + "FullyQualifiedErrorId : MethodInvocationNotSupportedInConstrainedLanguage",
+    );
+  };
+}
+
+test("an unreadable DACL is refused by default, and the refusal names the waiver", async () => {
+  await assert.rejects(
+    assertClientV1PathOwnership(
+      uniquePath(),
+      { uid: 0 },
+      "credential store root",
+      windows({ env: {}, probeWindowsAcl: constrainedLanguageProbe() }),
+    ),
+    (error: Error) => {
+      assert.match(error.message, /ownership could not be verified on Windows/);
+      assert.match(error.message, /MethodInvocationNotSupportedInConstrainedLanguage/);
+      assert.match(error.message, new RegExp(`${WAIVER_ENV}=${WAIVER_TOKEN}`));
+      assert.match(error.message, new RegExp(WAIVER_REASON_ENV));
+      return true;
+    },
+  );
+});
+
+test("the waiver admits an unreadable DACL, loudly and with the operator's reason", async () => {
+  const warnings: string[] = [];
+  const path = uniquePath();
+  await assertClientV1PathOwnership(
+    path,
+    { uid: 0 },
+    "credential store root",
+    windows({
+      env: { [WAIVER_ENV]: WAIVER_TOKEN, [WAIVER_REASON_ENV]: WAIVER_REASON },
+      warn: (message) => warnings.push(message),
+      probeWindowsAcl: constrainedLanguageProbe(),
+    }),
+  );
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0]!, /UNVERIFIED/);
+  assert.match(warnings[0]!, new RegExp(WAIVER_REASON.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.ok(warnings[0]!.includes(path), "the disclosure must name the path it waived");
+  assert.match(warnings[0]!, new RegExp(WAIVER_ENV), "the disclosure must name how to undo it");
+});
+
+test("the waiver never covers a DACL that was read and found shared", async () => {
+  // The whole point of #4842: a guard that reads as protection and provides
+  // none. A shared DACL has a remedy the operator can run (`icacls /reset`),
+  // so no amount of opting out may admit it.
+  await assert.rejects(
+    assertClientV1PathOwnership(
+      uniquePath(),
+      { uid: 0 },
+      "credential store root",
+      windows({
+        env: { [WAIVER_ENV]: WAIVER_TOKEN, [WAIVER_REASON_ENV]: WAIVER_REASON },
+        probeWindowsAcl: async () =>
+          report({
+            aces: [
+              { sid: SELF_SID, type: "Allow" },
+              { sid: USERS_SID, type: "Allow" },
+            ],
+          }),
+      }),
+    ),
+    (error: Error) => {
+      assert.match(error.message, /is not exclusive to the current user/);
+      assert.match(error.message, new RegExp(`Allow:${USERS_SID}`));
+      assert.match(
+        error.message,
+        /does not cover a DACL that was read/,
+        "the refusal must say the waiver is set and still does not apply",
+      );
+      return true;
+    },
+  );
+
+  // Nor does it cover a platform that has neither a uid nor a Windows ACL:
+  // there the question was never asked of a Windows host at all.
+  await assert.rejects(
+    assertClientV1PathOwnership(uniquePath(), { uid: 0 }, "credential store root", {
+      platform: "sunos",
+      getuid: null,
+      env: { [WAIVER_ENV]: WAIVER_TOKEN, [WAIVER_REASON_ENV]: WAIVER_REASON },
+    }),
+    /ownership cannot be verified on sunos/,
+  );
+
+  // Nor a uid mismatch on a POSIX host, where the waiver has no business.
+  await assert.rejects(
+    assertClientV1PathOwnership(uniquePath(), { uid: 1001 }, "credential store root", {
+      getuid: () => 1000,
+      env: { [WAIVER_ENV]: WAIVER_TOKEN, [WAIVER_REASON_ENV]: WAIVER_REASON },
+    }),
+    /must be owned by the current user\./,
+  );
+});
+
+test("a boolean-shaped value never waives the check", async () => {
+  // The failure mode this guards is muscle memory: every other switch in this
+  // codebase is `=1`, so an operator who half-remembers the hatch reaches for
+  // that. It has to do nothing, and say so.
+  for (const value of ["1", "true", "TRUE", "yes", "on", WAIVER_TOKEN.toUpperCase()]) {
+    await assert.rejects(
+      assertClientV1PathOwnership(
+        uniquePath(),
+        { uid: 0 },
+        "credential store root",
+        windows({
+          env: { [WAIVER_ENV]: value, [WAIVER_REASON_ENV]: WAIVER_REASON },
+          probeWindowsAcl: constrainedLanguageProbe(),
+        }),
+      ),
+      (error: Error) => {
+        assert.match(
+          error.message,
+          new RegExp(`only accepted value is the exact string ${WAIVER_TOKEN}`),
+          `${JSON.stringify(value)} must not waive the check`,
+        );
+        return true;
+      },
+    );
+  }
+
+  // A blank value is "not set", so it earns the how-to note rather than the
+  // wrong-value one — but it must still refuse.
+  await assert.rejects(
+    assertClientV1PathOwnership(
+      uniquePath(),
+      { uid: 0 },
+      "credential store root",
+      windows({
+        env: { [WAIVER_ENV]: "   ", [WAIVER_REASON_ENV]: WAIVER_REASON },
+        probeWindowsAcl: constrainedLanguageProbe(),
+      }),
+    ),
+    /ownership could not be verified on Windows/,
+  );
+});
+
+test("the waiver stays closed without an attributable reason", async () => {
+  for (const reason of [undefined, "", "   ", "because"]) {
+    await assert.rejects(
+      assertClientV1PathOwnership(
+        uniquePath(),
+        { uid: 0 },
+        "credential store root",
+        windows({
+          env: { [WAIVER_ENV]: WAIVER_TOKEN, ...(reason === undefined ? {} : { [WAIVER_REASON_ENV]: reason }) },
+          probeWindowsAcl: constrainedLanguageProbe(),
+        }),
+      ),
+      (error: Error) => {
+        assert.match(
+          error.message,
+          new RegExp(`${WAIVER_REASON_ENV} must carry`),
+          `reason ${JSON.stringify(reason)} must not satisfy the attribution requirement`,
+        );
+        return true;
+      },
+    );
+  }
+});
+
+test("a waived path is disclosed once and never re-probed per request", async () => {
+  // The probe is ~290ms and runs per authenticated request. On a host where it
+  // can never succeed, re-driving it every time would be strictly worse than
+  // the crash it replaces (cave-okfb2 R6), and a disclosure repeated on every
+  // request is one nobody reads.
+  const path = uniquePath();
+  const warnings: string[] = [];
+  let probes = 0;
+  const options = windows({
+    env: { [WAIVER_ENV]: WAIVER_TOKEN, [WAIVER_REASON_ENV]: WAIVER_REASON },
+    warn: (message) => warnings.push(message),
+    probeWindowsAcl: async () => {
+      probes += 1;
+      throw new Error("spawn powershell.exe ENOENT");
+    },
+  });
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await assertClientV1PathOwnership(path, { uid: 0 }, "credential store root", options);
+  }
+  assert.equal(probes, 1, "a waived path must not re-spawn the probe per request");
+  assert.equal(warnings.length, 1, "the disclosure is once per path, not once per request");
+
+  // Installing PowerShell is an out-of-band repair, so the waiver — like the
+  // success cache — is dropped by the same reset seam and re-driven.
+  resetClientV1PathOwnershipCache();
+  await assertClientV1PathOwnership(path, { uid: 0 }, "credential store root", options);
+  assert.equal(probes, 2, "resetting the cache must re-drive a waived path");
+  assert.equal(warnings.length, 2);
 });
 
 test("the ACL probe is spawned without this process's environment", async () => {

--- a/src/lib/server/client-v1/path-ownership.ts
+++ b/src/lib/server/client-v1/path-ownership.ts
@@ -17,6 +17,149 @@ const execFileAsync = promisify(execFile);
 const WINDOWS_SYSTEM_SID = "S-1-5-18";
 const WINDOWS_ADMINISTRATORS_SID = "S-1-5-32-544";
 
+// ── The unverified-ownership waiver ─────────────────────────────────────────
+// Everything from here to the end of `resolveUnverifiedOwnershipWaiver` is
+// duplicated verbatim in server.ts, for the same reason the PowerShell above
+// is, and discovery.test.ts fails if the two ever drift.
+//
+// This exists because reading the DACL is not possible on every Windows host.
+// Measured on Windows 11: PowerShell under Constrained Language Mode answers
+// the probe with `MethodInvocationNotSupportedInConstrainedLanguage` and exit
+// 1, and a `powershell.exe` absent from %SystemRoot% answers with ENOENT. Both
+// are WDAC/AppLocker-managed configurations, and on both the guard threw at
+// boot — which server.ts turned into `process.exit(1)`, so the app would not
+// start and there was no remedy reachable from inside it.
+//
+// The waiver is deliberately narrow. It covers ONE condition: the probe could
+// not answer at all. It never covers a DACL that WAS read and found shared —
+// that has a remedy the operator can run (`icacls <path> /reset`), and
+// admitting it is exactly the "reads as protection, provides none" defect
+// #4842 was filed about. Nor does it cover a POSIX uid mismatch, or a platform
+// with neither a uid nor an ACL.
+const UNVERIFIED_OWNERSHIP_ENV = "COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP";
+const UNVERIFIED_OWNERSHIP_REASON_ENV = "COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP_REASON";
+const UNVERIFIED_OWNERSHIP_TOKEN = "i-accept-unverified-path-ownership";
+const UNVERIFIED_OWNERSHIP_MIN_REASON = 12;
+
+type UnverifiedOwnershipWaiver =
+  | { granted: true; reason: string }
+  | { granted: false; note: string };
+
+/**
+ * Whether the operator has explicitly, attributably waived an unreadable DACL.
+ *
+ * Three properties make this impossible to trip by accident, and they are the
+ * point rather than ceremony:
+ *
+ * 1. The value is an exact sentence, not a boolean. Every other switch in this
+ *    codebase is `=1`, so an operator working from memory reaches for that —
+ *    and `1`, `true`, `yes` and a case-shifted token all do nothing here and
+ *    say so. Nothing an init script, a container image, or a CI matrix sets by
+ *    habit can satisfy it.
+ * 2. A second variable must carry a real sentence naming who accepted this and
+ *    why. Setting one variable is never enough, and the text is what turns up
+ *    in the log line the app then prints on every boot.
+ * 3. It is consulted at exactly one place — an unreadable DACL — so even a
+ *    correctly-set waiver cannot admit a path the probe read and refused.
+ *
+ * The house pattern for this is `release.yml`'s `allow_unconfigured_*` inputs:
+ * the hatch exists, it is manual and named, and pulling it is *disclosed* in
+ * the artifact it produces (cave-yp21x). The disclosure here is the warning the
+ * caller prints, once per waived path, plus the boot banner in server.ts.
+ */
+function resolveUnverifiedOwnershipWaiver(
+  env: Record<string, string | undefined>,
+): UnverifiedOwnershipWaiver {
+  const requested = env[UNVERIFIED_OWNERSHIP_ENV]?.trim() ?? "";
+  if (!requested) {
+    return {
+      granted: false,
+      note:
+        `If the DACL genuinely cannot be read on this host — PowerShell in `
+        + `Constrained Language Mode, or no powershell.exe under %SystemRoot% — `
+        + `set ${UNVERIFIED_OWNERSHIP_ENV}=${UNVERIFIED_OWNERSHIP_TOKEN} and `
+        + `${UNVERIFIED_OWNERSHIP_REASON_ENV} to a sentence naming who accepted `
+        + `that and why. It waives only an unreadable DACL, never one that was `
+        + `read and found shared.`,
+    };
+  }
+  if (requested !== UNVERIFIED_OWNERSHIP_TOKEN) {
+    return {
+      granted: false,
+      note:
+        `${UNVERIFIED_OWNERSHIP_ENV} is set, but not to the waiver: the only `
+        + `accepted value is the exact string ${UNVERIFIED_OWNERSHIP_TOKEN}. A `
+        + `boolean-shaped value ("1", "true", "yes") never waives this check.`,
+    };
+  }
+  const reason = env[UNVERIFIED_OWNERSHIP_REASON_ENV]?.trim() ?? "";
+  if (reason.length < UNVERIFIED_OWNERSHIP_MIN_REASON) {
+    return {
+      granted: false,
+      note:
+        `${UNVERIFIED_OWNERSHIP_ENV} is set, but ${UNVERIFIED_OWNERSHIP_REASON_ENV} `
+        + `must carry at least ${UNVERIFIED_OWNERSHIP_MIN_REASON} characters naming `
+        + `who accepted an unverified path and why. The waiver stays closed `
+        + `without that attribution.`,
+    };
+  }
+  return { granted: true, reason };
+}
+
+/** The refusal an unreadable DACL earns when no waiver is in force. */
+function unverifiableOwnershipRefusal(
+  subject: string,
+  path: string,
+  cause: Error,
+  note: string,
+): string {
+  return `${subject} ownership could not be verified on Windows: ${cause.message}. `
+    + `Refusing ${path}; inspect it with: icacls "${path}". ${note}`;
+}
+
+/** The disclosure a waived path earns — once per path, never suppressed. */
+function unverifiedOwnershipDisclosure(
+  subject: string,
+  path: string,
+  cause: Error,
+  reason: string,
+): string {
+  return `SECURITY WAIVER — ${subject} is being used UNVERIFIED. Its DACL could not `
+    + `be read on this host (${cause.message}), and ${UNVERIFIED_OWNERSHIP_ENV} is `
+    + `set, so ${path} is trusted on the operator's word alone: reason given — `
+    + `${reason}. Any principal that can write ${path} can mint credentials or `
+    + `point a paired client at another server. Unset ${UNVERIFIED_OWNERSHIP_ENV} `
+    + `to restore the check.`;
+}
+
+/**
+ * The refusal a DACL that WAS read and found shared earns.
+ *
+ * Never waivable, which is why the waiver appears here only to say it does not
+ * apply: this path has a remedy the operator can run, and admitting it would
+ * be the unconditional pass #4842 was filed about wearing an env var.
+ */
+function sharedOwnershipRefusal(
+  subject: string,
+  path: string,
+  findings: string[],
+  waiver: UnverifiedOwnershipWaiver,
+): string {
+  return `${subject} is not exclusive to the current user: ${findings.join("; ")}. `
+    + `Refusing ${path}; inspect it with: icacls "${path}"`
+    + (waiver.granted
+      ? `. ${UNVERIFIED_OWNERSHIP_ENV} does not cover a DACL that was read: this `
+        + `one was, and it is shared. Repair it with: icacls "${path}" /reset`
+      : "");
+}
+
+/** The waiver's contract, for callers that have to name it in their own output. */
+export const UNVERIFIED_PATH_OWNERSHIP_WAIVER = {
+  env: UNVERIFIED_OWNERSHIP_ENV,
+  reasonEnv: UNVERIFIED_OWNERSHIP_REASON_ENV,
+  token: UNVERIFIED_OWNERSHIP_TOKEN,
+} as const;
+
 /** Result of one `windows-acl` probe: the state of the path after any repair. */
 export interface ClientV1WindowsAclReport {
   /** SID of the identity this process runs as. */
@@ -46,6 +189,13 @@ export interface ClientV1PathOwnershipOptions {
   getuid?: (() => number) | null;
   probeWindowsAcl?: ClientV1WindowsAclProbe;
   warn?: (message: string) => void;
+  /**
+   * Where the unverified-ownership waiver is read from. Injectable for the
+   * same reason as everything above it: the waiver only matters on Windows, so
+   * reading `process.env` directly would leave every assertion about it
+   * unreachable on the Linux runners.
+   */
+  env?: Record<string, string | undefined>;
 }
 
 /**
@@ -264,9 +414,23 @@ function exclusivityFindings(report: ClientV1WindowsAclReport): string[] {
  */
 const verifiedWindowsPaths = new Map<string, ClientV1WindowsAclReport>();
 
+/**
+ * Paths admitted UNVERIFIED under the operator's waiver, keyed by path.
+ *
+ * Separate from the success cache above because nothing here was verified. It
+ * exists for two reasons and both are about the host where it applies: on such
+ * a host the probe can *never* succeed, so re-driving it per authenticated
+ * request would fork a doomed ~290 ms subprocess every time (cave-okfb2 R6 in
+ * its worst form), and a disclosure repeated on every request is one nobody
+ * reads. Like the success cache this is per process, so installing PowerShell
+ * out of band takes effect at the next restart.
+ */
+const waivedWindowsPaths = new Map<string, string>();
+
 /** Test seam: drop cached verifications so a suite can re-drive the probe. */
 export function resetClientV1PathOwnershipCache(): void {
   verifiedWindowsPaths.clear();
+  waivedWindowsPaths.clear();
 }
 
 /**
@@ -291,43 +455,66 @@ export async function assertClientV1PathOwnership(
   label: string,
   options: ClientV1PathOwnershipOptions = {},
 ): Promise<void> {
+  return assertExclusivePathOwnership(path, metadata, `Client v1 ${label}`, options);
+}
+
+/**
+ * The same guard for a path that is not a client v1 path.
+ *
+ * `subject` is the whole noun phrase every message opens with, because the
+ * caller knows what the path is for and this module does not. The mobile
+ * pairing secret goes through here: it is a PLAINTEXT credential, not the
+ * SHA-256 hashes `client-v1-credentials.json` holds, and its `chmod(0o600)`
+ * was the same no-op on win32 that #4842 was filed about (cave-fawvh).
+ */
+export async function assertExclusivePathOwnership(
+  path: string,
+  metadata: { uid: number | bigint },
+  subject: string,
+  options: ClientV1PathOwnershipOptions = {},
+): Promise<void> {
   const platform = options.platform ?? process.platform;
   const getuid = options.getuid === undefined ? process.getuid : options.getuid;
 
   if (typeof getuid === "function") {
     if (metadata.uid !== getuid()) {
-      throw new Error(`Client v1 ${label} must be owned by the current user.`);
+      throw new Error(`${subject} must be owned by the current user.`);
     }
     return;
   }
 
   if (platform !== "win32") {
     throw new Error(
-      `Client v1 ${label} ownership cannot be verified on ${platform}: `
+      `${subject} ownership cannot be verified on ${platform}: `
       + `this platform exposes neither a uid nor a Windows ACL, so ${path} is refused.`,
     );
   }
 
-  if (verifiedWindowsPaths.has(path)) return;
+  if (verifiedWindowsPaths.has(path) || waivedWindowsPaths.has(path)) return;
 
+  const warn = options.warn ?? console.warn;
+  const waiver = resolveUnverifiedOwnershipWaiver(options.env ?? process.env);
   const probe = options.probeWindowsAcl ?? probeWindowsAcl;
   let report: ClientV1WindowsAclReport;
   try {
     report = await probe(path);
   } catch (cause) {
-    throw new Error(
-      `Client v1 ${label} ownership could not be verified on Windows: `
-      + `${(cause as Error).message}. Refusing ${path}; inspect it with: icacls "${path}"`,
-      { cause },
-    );
+    // The ONE condition the waiver covers: the host cannot answer the
+    // question. Everything below this point had an answer.
+    if (!waiver.granted) {
+      throw new Error(
+        unverifiableOwnershipRefusal(subject, path, cause as Error, waiver.note),
+        { cause },
+      );
+    }
+    waivedWindowsPaths.set(path, waiver.reason);
+    warn(unverifiedOwnershipDisclosure(subject, path, cause as Error, waiver.reason));
+    return;
   }
 
   const findings = exclusivityFindings(report);
   if (findings.length > 0) {
-    throw new Error(
-      `Client v1 ${label} is not exclusive to the current user: ${findings.join("; ")}. `
-      + `Refusing ${path}; inspect it with: icacls "${path}"`,
-    );
+    throw new Error(sharedOwnershipRefusal(subject, path, findings, waiver));
   }
 
   if (report.repaired) {
@@ -338,8 +525,8 @@ export async function assertClientV1PathOwnership(
     const removed = report.removed.length > 0
       ? report.removed.join(", ")
       : "inherited entries";
-    (options.warn ?? console.warn)(
-      `Client v1 ${label} had no enforced access control on Windows; `
+    warn(
+      `${subject} had no enforced access control on Windows; `
       + `restricted ${path} to the current user and revoked ${removed}.`,
     );
   }

--- a/src/lib/server/client-v1/path-ownership.ts
+++ b/src/lib/server/client-v1/path-ownership.ts
@@ -18,9 +18,11 @@ const WINDOWS_SYSTEM_SID = "S-1-5-18";
 const WINDOWS_ADMINISTRATORS_SID = "S-1-5-32-544";
 
 // ── The unverified-ownership waiver ─────────────────────────────────────────
-// Everything from here to the end of `resolveUnverifiedOwnershipWaiver` is
-// duplicated verbatim in server.ts, for the same reason the PowerShell above
-// is, and discovery.test.ts fails if the two ever drift.
+// The four constants below, `resolveUnverifiedOwnershipWaiver`, and the three
+// message builders after it are duplicated verbatim in server.ts, for the same
+// reason the PowerShell above is (`build:server` runs esbuild with
+// `--bundle=false`, so server.mjs cannot import this module). discovery.test.ts
+// compares each of those regions byte-for-byte and fails if they drift.
 //
 // This exists because reading the DACL is not possible on every Windows host.
 // Measured on Windows 11: PowerShell under Constrained Language Mode answers
@@ -152,13 +154,6 @@ function sharedOwnershipRefusal(
         + `one was, and it is shared. Repair it with: icacls "${path}" /reset`
       : "");
 }
-
-/** The waiver's contract, for callers that have to name it in their own output. */
-export const UNVERIFIED_PATH_OWNERSHIP_WAIVER = {
-  env: UNVERIFIED_OWNERSHIP_ENV,
-  reasonEnv: UNVERIFIED_OWNERSHIP_REASON_ENV,
-  token: UNVERIFIED_OWNERSHIP_TOKEN,
-} as const;
 
 /** Result of one `windows-acl` probe: the state of the path after any repair. */
 export interface ClientV1WindowsAclReport {

--- a/src/lib/server/mobile-access-provision.test.ts
+++ b/src/lib/server/mobile-access-provision.test.ts
@@ -5,7 +5,13 @@ import assert from "node:assert/strict";
 import { mkdtempSync, readFileSync, statSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test } from "node:test";
+import { test, type TestContext } from "node:test";
+import {
+  probeWindowsAcl,
+  resetClientV1PathOwnershipCache,
+  type ClientV1PathOwnershipOptions,
+  type ClientV1WindowsAclReport,
+} from "./client-v1/path-ownership.ts";
 import {
   armMobileAccessSecret,
   loadPersistedMobileAccessSecret,
@@ -23,47 +29,281 @@ function devEnv(overrides: Record<string, string | undefined> = {}): Record<stri
   };
 }
 
+// ── Windows seams (cave-fawvh) ───────────────────────────────────────────────
+// This file holds the RAW pairing secret, and `writeFileSync(…, { mode: 0o600 })`
+// plus `chmodSync(0o600)` set nothing on win32 — #4852's measured table has
+// `mode & 0o777 === 0o666` afterwards, not even the read-only bit. The fix is
+// the DACL guard that module already owns, and, exactly as there, every Windows
+// assertion below is injected so the Linux runners exercise the same branch.
+const WINDOWS_SELF = "S-1-5-21-77-88-99-1001";
+const WINDOWS_USERS = "S-1-5-32-545";
+const WAIVER_ENV = "COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP";
+const WAIVER_REASON_ENV = "COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP_REASON";
+const WAIVER_TOKEN = "i-accept-unverified-path-ownership";
+
+function exclusiveReport(): ClientV1WindowsAclReport {
+  return {
+    self: WINDOWS_SELF,
+    owner: WINDOWS_SELF,
+    protected: true,
+    repaired: false,
+    removed: [],
+    aces: [{ sid: WINDOWS_SELF, type: "Allow" }],
+  };
+}
+
+/** A Windows host as the guard sees one, with a recorder for the probed paths. */
+function windowsOwnership(
+  probed: string[],
+  probe: (target: string) => Promise<ClientV1WindowsAclReport> = async () => exclusiveReport(),
+): ClientV1PathOwnershipOptions {
+  return {
+    platform: "win32",
+    getuid: null,
+    warn: () => {},
+    env: {},
+    probeWindowsAcl: async (target) => {
+      probed.push(target);
+      return probe(target);
+    },
+  };
+}
+
+/**
+ * Assert an owner-only POSIX mode where the platform actually enforces one.
+ *
+ * These two assertions have failed on win32 since this file was written, and
+ * that standing red is the signal nobody acted on (cave-fawvh). They are not
+ * deleted and not loosened: on POSIX they still assert 0o600/0o700 exactly. On
+ * win32 they were measuring the platform rather than the code — `stat` reports
+ * 0o666/0o777 there whatever mode was passed — so the real Windows contract is
+ * asserted instead, by reading the DACL. Same treatment discovery.test.ts
+ * already gives its mode assertions.
+ */
+function assertRestricted(
+  t: TestContext,
+  target: string,
+  expectedMode: number,
+  what: string,
+): Promise<void> | void {
+  if (process.platform !== "win32") {
+    assert.equal(statSync(target).mode & 0o777, expectedMode, what);
+    return;
+  }
+  t.diagnostic(`${what}: POSIX mode bits are inert on win32; asserting the DACL instead`);
+  return probeWindowsAcl(target).then((report) => {
+    // `repaired` is what makes this non-vacuous. The probe REPAIRS as it reads,
+    // so asserting only the state it returns would pass whether or not the code
+    // under test had ever restricted anything — the probe would simply have
+    // done it here. `repaired: false` says the path was ALREADY exclusive when
+    // this assertion arrived, which is the only claim worth making.
+    assert.equal(
+      report.repaired,
+      false,
+      `${what} was still inheriting when the test looked; the provisioner did not restrict it`,
+    );
+    assert.equal(report.owner, report.self, `${what} must be owned by this process`);
+    assert.equal(report.protected, true, `${what} DACL must not inherit`);
+    for (const ace of report.aces) {
+      assert.equal(ace.type, "Allow", `${what} must carry no Deny entry`);
+      assert.ok(
+        [report.self, "S-1-5-18", "S-1-5-32-544"].includes(ace.sid),
+        `${what} grants ${ace.sid}, which is neither this user, SYSTEM, nor Administrators`,
+      );
+    }
+  });
+}
+
 test("state file mirrors scripts/mobile-tailscale.sh layout (root/port scoped)", () => {
+  // Built with path.join rather than a POSIX literal: the contract is the
+  // root/port layout the shell script uses, not the separator, and a literal
+  // made this assertion fail on win32 for a reason unrelated to what it tests.
   const file = mobileAccessSecretFile({
-    COVEN_CAVE_MOBILE_STATE_ROOT: "/tmp/state-root",
+    COVEN_CAVE_MOBILE_STATE_ROOT: path.join(path.sep, "tmp", "state-root"),
     PORT: "3007",
   });
-  assert.equal(file, "/tmp/state-root/mobile-tailscale-3007/access-token");
+  assert.equal(file, path.join(path.sep, "tmp", "state-root", "mobile-tailscale-3007", "access-token"));
 
   const explicitDir = mobileAccessSecretFile({
-    COVEN_CAVE_MOBILE_STATE_DIR: "/tmp/custom-dir",
+    COVEN_CAVE_MOBILE_STATE_DIR: path.join(path.sep, "tmp", "custom-dir"),
   });
-  assert.equal(explicitDir, "/tmp/custom-dir/access-token");
+  assert.equal(explicitDir, path.join(path.sep, "tmp", "custom-dir", "access-token"));
 
-  const xdg = mobileAccessSecretFile({ XDG_STATE_HOME: "/tmp/xdg-state" });
-  assert.equal(xdg, "/tmp/xdg-state/coven-cave/mobile-tailscale-3000/access-token");
+  const xdg = mobileAccessSecretFile({ XDG_STATE_HOME: path.join(path.sep, "tmp", "xdg-state") });
+  assert.equal(
+    xdg,
+    path.join(path.sep, "tmp", "xdg-state", "coven-cave", "mobile-tailscale-3000", "access-token"),
+  );
 });
 
-test("provision mints, persists (0600), and is idempotent", () => {
+test("provision mints, persists (0600), and is idempotent", async (t: TestContext) => {
   const env = devEnv();
-  const first = provisionMobileAccessSecret(env);
+  const first = await provisionMobileAccessSecret(env);
   assert.ok(first && first.length >= 32, "mints a strong secret");
 
   const file = mobileAccessSecretFile(env);
   assert.equal(readFileSync(file, "utf8").trim(), first);
-  assert.equal(statSync(file).mode & 0o777, 0o600, "secret file is 0600");
-  assert.equal(statSync(path.dirname(file)).mode & 0o777, 0o700, "state dir is 0700");
+  await assertRestricted(t, file, 0o600, "secret file");
+  await assertRestricted(t, path.dirname(file), 0o700, "state dir");
 
-  assert.equal(provisionMobileAccessSecret(env), first, "reuses the persisted secret");
+  assert.equal(await provisionMobileAccessSecret(env), first, "reuses the persisted secret");
   assert.equal(loadPersistedMobileAccessSecret(env), first);
 });
 
-test("provision reuses a secret the mobile:tailscale script already persisted", () => {
+test("provision reuses a secret the mobile:tailscale script already persisted", async () => {
   const env = devEnv();
   const file = mobileAccessSecretFile(env);
   mkdirSync(path.dirname(file), { recursive: true });
   writeFileSync(file, "script-minted-secret\n", "utf8");
-  assert.equal(provisionMobileAccessSecret(env), "script-minted-secret");
+  assert.equal(await provisionMobileAccessSecret(env), "script-minted-secret");
 });
 
-test("provision refuses the packaged bundle and e2e runs", () => {
-  assert.equal(provisionMobileAccessSecret(devEnv({ COVEN_CAVE_BUNDLE: "1" })), null);
-  assert.equal(provisionMobileAccessSecret(devEnv({ COVEN_CAVE_E2E: "1" })), null);
+test("provision refuses the packaged bundle and e2e runs", async () => {
+  assert.equal(await provisionMobileAccessSecret(devEnv({ COVEN_CAVE_BUNDLE: "1" })), null);
+  assert.equal(await provisionMobileAccessSecret(devEnv({ COVEN_CAVE_E2E: "1" })), null);
+});
+
+test("restricts the state directory and the token file on Windows, where chmod does nothing", async () => {
+  const env = devEnv();
+  const probed: string[] = [];
+  const secret = await provisionMobileAccessSecret(env, {
+    ownership: windowsOwnership(probed),
+  });
+  assert.ok(secret, "an exclusive Windows path still provisions");
+
+  const file = mobileAccessSecretFile(env);
+  assert.deepEqual(
+    probed,
+    [path.dirname(file), file],
+    "the directory is restricted BEFORE the secret is written into it, then the file is verified",
+  );
+
+  // And the reuse path re-verifies rather than trusting a file because it is
+  // already there — that is the upgrade path for every install that ran the
+  // version whose chmod did nothing. Reset the per-process verification cache
+  // first, since the upgrade this covers happens in a NEW process.
+  resetClientV1PathOwnershipCache();
+  const again: string[] = [];
+  assert.equal(
+    await provisionMobileAccessSecret(env, { ownership: windowsOwnership(again) }),
+    secret,
+  );
+  assert.deepEqual(again, [path.dirname(file), file]);
+});
+
+test("a token file that cannot be restricted is never left on disk", async () => {
+  // A shared directory is refused before anything is written.
+  const shared = devEnv();
+  const sharedProbes: string[] = [];
+  assert.equal(
+    await provisionMobileAccessSecret(shared, {
+      warn: () => {},
+      ownership: windowsOwnership(sharedProbes, async () => ({
+        ...exclusiveReport(),
+        aces: [
+          { sid: WINDOWS_SELF, type: "Allow" },
+          { sid: WINDOWS_USERS, type: "Allow" },
+        ],
+      })),
+    }),
+    null,
+    "a state directory another principal can write must not receive a plaintext secret",
+  );
+  assert.deepEqual(sharedProbes, [path.dirname(mobileAccessSecretFile(shared))]);
+  assert.equal(existsSync(mobileAccessSecretFile(shared)), false);
+
+  // And when only the file itself fails the check, the secret written a moment
+  // earlier is removed rather than left readable.
+  const late = devEnv();
+  const lateFile = mobileAccessSecretFile(late);
+  assert.equal(
+    await provisionMobileAccessSecret(late, {
+      warn: () => {},
+      ownership: windowsOwnership([], async (target) => {
+        if (target === lateFile) throw new Error("spawn powershell.exe ENOENT");
+        return exclusiveReport();
+      }),
+    }),
+    null,
+  );
+  assert.equal(
+    existsSync(lateFile),
+    false,
+    "a plaintext secret must not survive on a path whose ACL could not be verified",
+  );
+});
+
+test("a refusal to restrict the token path is announced, not swallowed", async () => {
+  // The route answers a null with a terse "couldn't set up pairing", so without
+  // this the operator sees a broken Settings pane and no reason for it.
+  const env = devEnv();
+  const warnings: string[] = [];
+  assert.equal(
+    await provisionMobileAccessSecret(env, {
+      warn: (message) => warnings.push(message),
+      ownership: windowsOwnership([], async () => {
+        throw new Error("Method invocation is supported only on core types in this language mode.");
+      }),
+    }),
+    null,
+  );
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0]!, /mobile access token/i);
+  assert.match(warnings[0]!, /core types in this language mode/);
+});
+
+test("the unverified-ownership waiver reaches the mobile token too", async () => {
+  // Same hatch, same terms, same disclosure as client v1 (cave-37fxr): a host
+  // that cannot read a DACL at all should not lose phone pairing silently, and
+  // the operator who accepts that has to say so and be named.
+  const env = devEnv();
+  const warnings: string[] = [];
+  const secret = await provisionMobileAccessSecret(env, {
+    ownership: {
+      platform: "win32",
+      getuid: null,
+      warn: (message) => warnings.push(message),
+      env: {
+        [WAIVER_ENV]: WAIVER_TOKEN,
+        [WAIVER_REASON_ENV]: "opsdesk@example.com: WDAC host, PowerShell blocked",
+      },
+      probeWindowsAcl: async () => {
+        throw new Error("spawn powershell.exe ENOENT");
+      },
+    },
+  });
+  assert.ok(secret, "the waiver provisions rather than dead-ending pairing");
+  assert.equal(readFileSync(mobileAccessSecretFile(env), "utf8").trim(), secret);
+  assert.ok(
+    warnings.some((message) => /SECURITY WAIVER/.test(message) && /opsdesk@example\.com/.test(message)),
+    "the waiver must disclose itself and name the operator",
+  );
+
+  // A waiver never covers a DACL that WAS read and found shared, here either.
+  const readAndShared = devEnv();
+  assert.equal(
+    await provisionMobileAccessSecret(readAndShared, {
+      warn: () => {},
+      ownership: {
+        platform: "win32",
+        getuid: null,
+        warn: () => {},
+        env: {
+          [WAIVER_ENV]: WAIVER_TOKEN,
+          [WAIVER_REASON_ENV]: "opsdesk@example.com: WDAC host, PowerShell blocked",
+        },
+        probeWindowsAcl: async () => ({
+          ...exclusiveReport(),
+          aces: [
+            { sid: WINDOWS_SELF, type: "Allow" },
+            { sid: WINDOWS_USERS, type: "Allow" },
+          ],
+        }),
+      },
+    }),
+    null,
+  );
+  assert.equal(existsSync(mobileAccessSecretFile(readAndShared)), false);
 });
 
 test("arm sets the request-time gate env", () => {
@@ -72,9 +312,9 @@ test("arm sets the request-time gate env", () => {
   assert.equal(env.COVEN_CAVE_ACCESS_TOKEN, "s3cret");
 });
 
-test("rearm arms from disk only when tokenless outside the bundle", () => {
+test("rearm arms from disk only when tokenless outside the bundle", async () => {
   const env = devEnv();
-  const secret = provisionMobileAccessSecret(env);
+  const secret = await provisionMobileAccessSecret(env);
   assert.ok(secret);
 
   assert.equal(rearmPersistedMobileAccessSecret(env), secret, "boot re-arm loads the persisted secret");
@@ -90,9 +330,9 @@ test("rearm arms from disk only when tokenless outside the bundle", () => {
   assert.equal(rearmPersistedMobileAccessSecret(bundle), null, "bundle never re-arms from dev state");
 });
 
-test("retire disarms and removes the persisted secret", () => {
+test("retire disarms and removes the persisted secret", async () => {
   const env = devEnv();
-  const secret = provisionMobileAccessSecret(env);
+  const secret = await provisionMobileAccessSecret(env);
   assert.ok(secret);
   armMobileAccessSecret(secret, env);
 

--- a/src/lib/server/mobile-access-provision.ts
+++ b/src/lib/server/mobile-access-provision.ts
@@ -87,14 +87,6 @@ export function loadPersistedMobileAccessSecret(
   }
 }
 
-/**
- * Load the persisted pairing secret, minting and persisting a fresh one when
- * missing. Returns null when provisioning is not allowed here (packaged
- * bundle, e2e) or persistence fails — callers fall back to the existing
- * "unavailable" response. Does NOT arm the process env; callers arm
- * explicitly (armMobileAccessSecret) right before the serve route goes live
- * so the gate and the exposure switch on together.
- */
 export interface MobileAccessProvisionOptions {
   /**
    * Seams for the ownership guard, so the win32 branch below is reachable on
@@ -132,6 +124,19 @@ async function restrictToCurrentUser(
   });
 }
 
+/**
+ * Load the persisted pairing secret, minting and persisting a fresh one when
+ * missing. Returns null when provisioning is not allowed here (packaged
+ * bundle, e2e), when persistence fails, or when the path holding a plaintext
+ * secret cannot be restricted to this user — callers fall back to the existing
+ * "unavailable" response, and the reason is logged rather than swallowed. Does
+ * NOT arm the process env; callers arm explicitly (armMobileAccessSecret) right
+ * before the serve route goes live so the gate and the exposure switch on
+ * together.
+ *
+ * Async since cave-fawvh: restricting the path on Windows means reading a DACL
+ * out of a subprocess, because `chmod` there sets nothing.
+ */
 export async function provisionMobileAccessSecret(
   env: Record<string, string | undefined> = process.env,
   options: MobileAccessProvisionOptions = {},

--- a/src/lib/server/mobile-access-provision.ts
+++ b/src/lib/server/mobile-access-provision.ts
@@ -17,10 +17,22 @@
 // minting a second secret would fork the pairing identity.
 
 import { randomBytes } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { CAVE_PORTS, CAVE_PORT_ENV, parsePort } from "../../../scripts/ports.mjs";
+import {
+  assertExclusivePathOwnership,
+  type ClientV1PathOwnershipOptions,
+} from "./client-v1/path-ownership.ts";
 
 /**
  * Same resolution order as server.ts `cavePort()` and the Rust
@@ -83,20 +95,92 @@ export function loadPersistedMobileAccessSecret(
  * explicitly (armMobileAccessSecret) right before the serve route goes live
  * so the gate and the exposure switch on together.
  */
-export function provisionMobileAccessSecret(
+export interface MobileAccessProvisionOptions {
+  /**
+   * Seams for the ownership guard, so the win32 branch below is reachable on
+   * the Linux runners. Without this the only assertions covering the platform
+   * whose `chmod` does nothing would be the ones that cannot run in CI.
+   */
+  ownership?: ClientV1PathOwnershipOptions;
+  /** Where a refusal is announced. The route only ever sees `null`. */
+  warn?: (message: string) => void;
+}
+
+/**
+ * Restrict a path to the current user, or refuse it (cave-fawvh).
+ *
+ * `mode: 0o600` and `chmodSync(0o600)` are the whole of the access control
+ * this module used to apply, and on win32 they apply nothing — #4852 measured
+ * `mode & 0o777 === 0o666` afterwards, not even the read-only bit. That file
+ * was about `client-v1-credentials.json`, which holds SHA-256 hashes; THIS
+ * file holds the pairing secret in plaintext, so the same defect is worse
+ * here. The POSIX modes above stay (they are real on POSIX); this adds the
+ * DACL the platform actually enforces, using the guard #4852 already built.
+ */
+async function restrictToCurrentUser(
+  target: string,
+  subject: string,
+  env: Record<string, string | undefined>,
+  options: MobileAccessProvisionOptions,
+): Promise<void> {
+  await assertExclusivePathOwnership(target, lstatSync(target), subject, {
+    // The waiver is read from the same environment this module was handed, so
+    // a test can drive it and a caller cannot accidentally consult a different
+    // one than the rest of the module.
+    env,
+    ...options.ownership,
+  });
+}
+
+export async function provisionMobileAccessSecret(
   env: Record<string, string | undefined> = process.env,
-): string | null {
+  options: MobileAccessProvisionOptions = {},
+): Promise<string | null> {
   if (!provisioningAllowed(env)) return null;
-  const existing = loadPersistedMobileAccessSecret(env);
-  if (existing) return existing;
   const file = mobileAccessSecretFile(env);
+  const warn = options.warn ?? console.warn;
   try {
+    // Directory first, and before anything is written into it. The repair
+    // marks the directory's DACL inheritable, so the secret file created below
+    // is born exclusive rather than restricted a moment after it exists.
     mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    await restrictToCurrentUser(
+      path.dirname(file),
+      "Mobile access token directory",
+      env,
+      options,
+    );
+
+    // Re-verified on the reuse path too, not trusted because it is already
+    // there: every install that ran the version whose chmod did nothing has a
+    // readable secret on disk right now, and this is the path they come back
+    // through.
+    const existing = loadPersistedMobileAccessSecret(env);
+    if (existing) {
+      await restrictToCurrentUser(file, "Mobile access token file", env, options);
+      return existing;
+    }
+
     const secret = randomBytes(32).toString("base64url");
     writeFileSync(file, secret, { encoding: "utf8", mode: 0o600 });
     chmodSync(file, 0o600);
+    try {
+      await restrictToCurrentUser(file, "Mobile access token file", env, options);
+    } catch (error) {
+      // Never leave a plaintext credential on a path we could not restrict.
+      rmSync(file, { force: true });
+      throw error;
+    }
     return secret;
-  } catch {
+  } catch (error) {
+    // The route answers `null` with a terse "couldn't set up pairing", so
+    // without this line the operator sees a broken Settings pane and no reason
+    // for it — and an access-control refusal is the last thing that should be
+    // indistinguishable from a full disk.
+    warn(
+      `Mobile access token could not be provisioned; phone pairing stays off. `
+      + `${error instanceof Error ? error.message : String(error)}`,
+    );
     return null;
   }
 }

--- a/src/lib/server/mobile-access-provision.ts
+++ b/src/lib/server/mobile-access-provision.ts
@@ -157,9 +157,17 @@ export async function provisionMobileAccessSecret(
     );
 
     // Re-verified on the reuse path too, not trusted because it is already
-    // there: every install that ran the version whose chmod did nothing has a
-    // readable secret on disk right now, and this is the path they come back
-    // through.
+    // there: an install that ran the version whose chmod did nothing has a
+    // readable secret on disk right now.
+    //
+    // ⚠️ This does NOT reach every such install, and it would be worth more if
+    // it did. server.ts arms COVEN_CAVE_ACCESS_TOKEN from that same file at
+    // boot with no ownership check at all, and `resolveMobileAccessSecret`
+    // returns that armed value before it ever calls this function — so on any
+    // install whose token file already exists, provisioning is never entered
+    // and this repair never runs. What it does reach is a fresh mint, and a
+    // secret the `mobile:tailscale` script persisted after this server booted.
+    // Closing the gap means guarding the two sync readers; that is cave-8pd39.
     const existing = loadPersistedMobileAccessSecret(env);
     if (existing) {
       await restrictToCurrentUser(file, "Mobile access token file", env, options);


### PR DESCRIPTION
Fixes two P1 regressions from PR #4852 (`1c03df359`), which gave the client-v1 filesystem-ownership guard a real Windows implementation.

## cave-37fxr — a hardened Windows host could not boot Cave

`publishStandaloneClientV1DiscoveryRecord` throwing ran `server.close(() => process.exit(1))`. The guard could not throw on win32 before #4852; now it can, and on a host where the DACL cannot be read *at all* it always does — so Cave would not start, with no remedy reachable from inside an app that will not start.

**Measured on this Windows 11 host** (nothing assumed):

| condition | result |
| --- | --- |
| PowerShell, default | `FullLanguage`; probe returns the report, exit 0 |
| PowerShell forced to `ConstrainedLanguage` | exit 1, empty stdout, `MethodInvocationNotSupportedInConstrainedLanguage` on `[WindowsIdentity]::GetCurrent()` |
| `powershell.exe` absent from `%SystemRoot%` | `spawnSync … ENOENT` |
| **pre-fix `server.mjs`, powershell unreachable** | **process exits 1; port refuses connections; no record** |
| **this branch, same host** | **alive, `Ready on …`, HTTP answering, no record, banner on stderr** |

### Was a non-PowerShell ACL read viable? Measured: only half of one.

- `icacls <file> /save <out>` works per file and writes real SDDL with the `P` (protected) flag and raw SIDs — `D:PAI(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;S-1-5-21-…-1001)`. So the **DACL** is readable without PowerShell.
- **The owner is not.** `icacls` has `/setowner` but no owner display, and no shipped native tool prints an owner SID. The nearest thing, `cmd /c dir /q`, prints an owner *name* in a fixed-width column that truncates and localises.
- The owner implicitly holds `WRITE_DAC`, so dropping the owner check would leave a guard that reads as protection and provides less than it claims — the shape of #4842 itself.

So an `icacls` path would have to be sold as a partial verification, and I did not build one. Left as measurement, not a change.

### The escape hatch

```
COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP=i-accept-unverified-path-ownership
COVEN_CAVE_UNVERIFIED_PATH_OWNERSHIP_REASON="<who accepted this, and why>"
```

Three properties, each of which is the point rather than ceremony:

1. **The value is a sentence, not a boolean.** Every other switch here is `=1`, so an operator working from memory reaches for that — and `1`, `true`, `yes`, and a case-shifted token all do nothing *and say so*. Nothing an init script, image, or CI matrix sets by habit satisfies it. (Same shape as `release.yml`'s `allow_unconfigured_*`, which are also opt-in-and-disclosed.)
2. **Two variables, one of them free text ≥ 12 characters.** That text is the attribution, and it is reprinted in the disclosure the app then logs.
3. **It is consulted at exactly one place** — the `catch` around the probe. It cannot reach a DACL that was *read*. A read-and-shared DACL, a POSIX uid mismatch, and a platform with neither a uid nor an ACL all still refuse, with the waiver in force; the shared-DACL refusal gains a sentence saying so and printing `icacls "<path>" /reset`.

Every waived path logs a `SECURITY WAIVER —` line naming the subject, the path, the underlying failure, the operator's reason, and how to undo it — once per path, because a line repeated per request is one nobody reads, and because re-driving a doomed ~290 ms subprocess per authenticated request would be strictly worse than the crash it replaces.

### What the degraded state does, and why that

**Client v1 off, everything else up.** Withholding the record stays fail-closed — no path the guard refused is used, and the request-side guard keeps refusing every client v1 call. The record is *only* what a paired client reads to find this server, and on such a host client v1 is dead either way; the terminal, chat, and board have nothing to do with that path. Exiting made the blast radius the whole app. The crash is replaced by a banner loud enough to be the thing that gets noticed, and `clientV1DiscoveryPublished` stays `false` so shutdown never unlinks a record this process does not own.

```
[cave] ─────────────── CLIENT V1 DISABLED ───────────────
[cave] Client v1 discovery root ownership could not be verified on Windows: spawnSync …\powershell.exe ENOENT. Refusing …
[cave] The client v1 discovery record was NOT published, so paired clients cannot find this server and every client v1 request stays refused. Everything else on this server is running normally.
[cave] Repair the path and restart. If — and only if — this host cannot read a DACL at all, …
[cave] ────────────────────────────────────────────────────
```

## cave-fawvh — the raw mobile token, written with a chmod Windows ignores

`mobile-access-provision.ts` wrote the **plaintext** pairing secret with `mode: 0o600` + `chmodSync(0o600)`. #4852's own measured table has `mode & 0o777 === 0o666` afterwards on win32 — not even the read-only bit. Worse than what #4842 was about: `client-v1-credentials.json` holds SHA-256 hashes; this holds the secret itself.

It now applies the merged guard (`assertExclusivePathOwnership`, extracted from `assertClientV1PathOwnership` so messages can name a non-client-v1 subject):

- **Directory first, before anything is written into it.** The repair marks the directory's DACL inheritable, so the secret file is born exclusive rather than restricted a moment after it exists.
- **The reuse path re-verifies** rather than trusting a file because it is already there — that is the upgrade path for every install that ran the version whose chmod did nothing.
- **A secret whose own check fails is removed**, not left readable.
- **A refusal is announced.** The route answers a bare `null` with a terse "couldn't set up pairing", so an access-control refusal used to be indistinguishable from a full disk.
- The same waiver applies, on the same terms.

`provisionMobileAccessSecret` is now `async` (the Windows check reads a DACL out of a subprocess); `resolveMobileAccessSecret` in `mobile-handoff/route.ts` awaits it. Both existing wiring pins still match.

### The two pre-existing win32 assertion failures

Made **platform-aware, not deleted or loosened**. On POSIX they still assert `0o600` / `0o700` exactly. On win32 they were measuring the platform rather than the code, so they now assert the DACL contract those bits cannot express — and, critically, assert `report.repaired === false`, because the probe *repairs as it reads*: asserting only the state it returns would pass whether or not the code under test had ever restricted anything. A third assertion in the same file compared a `path.join` result against a POSIX string literal; it is now built with `path.join` and still pins the root/port layout it exists for.

## Tests

Failing-test-first for both defects, and every Windows assertion is injected (`platform` / `getuid` / `probeWindowsAcl` / `env`) so it runs on the Linux runners — a vacuous Windows-only assertion here would recreate the original bug exactly.

- Red first: 6 new `path-ownership.test.ts` cases, 2 new `discovery.test.ts` cases, 5 `mobile-access-provision.test.ts` cases (4 new + the mode assertions once they stopped being vacuous).
- Every message the two copies of the guard share is now pinned byte-for-byte by `discovery.test.ts` — the waiver constants, the resolver, and all three message builders — because a copy that drifts is a copy that opts out on terms the module never agreed to.

**Mutation matrix** — each fix reverted in isolation, suites re-run, then restored. All 10 caught:

| mutant | caught by |
| --- | --- |
| M1 waiver never consulted for an unreadable DACL | waiver admits an unreadable DACL / disclosed once |
| M2 any value waives | a boolean-shaped value never waives the check |
| M3 no reason required | the waiver stays closed without an attributable reason |
| M4 waiver also covers a read-and-shared DACL | the waiver never covers a DACL that was read and found shared |
| M5 boot exits again on a discovery failure | degrades that surface instead of killing the server |
| M6 `server.ts` waiver token drifts from the module | the standalone server enforces ownership … with this module's script |
| M7 no ownership guard on the mobile token | provision mints / restricts the state directory / never left on disk |
| M8 a secret whose check failed is left on disk | a token file that cannot be restricted is never left on disk |
| M9 the reuse path trusts an existing file | restricts the state directory and the token file on Windows |
| M10 a refusal is swallowed | a refusal to restrict the token path is announced, not swallowed |

Green locally on Windows: `typecheck`, `lint`, `check:tests-wired` (1807 wired), `build`, and `path-ownership` (18/18), `mobile-access-provision` (13/13, previously 2 failing), `discovery`, `credential-store`, `auth`, `runtime`, `server-pty-ws`, `client-v1-doc-contract`. `src/server-pty-ws.test.ts`'s subprocess-environment ban is untouched — no subprocess environment changed in this PR.

## Not fixed here, deliberately

`cave-okfb2` (R6 negative-TTL, and recording the pre-repair DACL) is untouched and not made worse: only successes are cached as before, and the new waived-path cache is a separate map that exists precisely to stop the unbounded spawn amplification on the host it applies to.

Closes cave-37fxr. Closes cave-fawvh.


---

## Review addendum — independent adversarial review (head `6e788d7d7`)

The two fixes stand. Everything below was re-derived rather than taken from the
sections above; where the two disagree, this section is the later measurement.

**Confirmed independently.** Pre-fix `server.mjs` (the artifact committed on
`main`, not a rebuild) with `%SystemRoot%` pointed at a non-existent directory:
`exit 1`, port refuses connections, no record. This branch on the same host:
`Ready on http://127.0.0.1:3014`, `HTTP 200`, banner, record absent. With the
waiver set: record published, one `SECURITY WAIVER` line from each copy of the
guard, and a bearer request answered with the normalized `unauthorized`
envelope. With `…OWNERSHIP=1`, and with the exact token plus an 8-character
reason: both still degrade, each with the diagnostic that names what is wrong.

**The waiver cannot fire by accident.** 29 spellings driven through the real
module: `1`, `true`, `TRUE`, `yes`, `on`, `0`, `false`, the uppercased and
capitalised token, the token with `_` for `-`, quoted, prefixed, suffixed, and
a reason of 11 characters or of 12 spaces all refuse. Only the exact token —
whitespace-padded or not — with a ≥12-character non-blank reason waives.
Nothing in `.env` handling, `next.config.ts`, `src-tauri`, `.github`,
`scripts`, or any test sets either variable; the suites inject `env: {}`.

**With the waiver fully in force, all four refusals hold**, driven through the
real module: a read-and-shared DACL, a foreign owner, an unprotected DACL, a
`Deny` ACE, a POSIX uid mismatch, and a platform with neither a uid nor an ACL.

**Two claims were over-stated and are corrected in `6e788d7d7`** (comment and
doc only, no behaviour change):

1. *"the request-side guard keeps refusing every client v1 call."* Every call
   **that presents a credential** — `GET /api/client/v1/health` still answers
   200, by design. And if the discovery *file* alone fails while the store root
   is exclusive, an already-paired client keeps working; that is the right
   outcome, but it is not "client v1 off".
2. *"the reuse path … is the upgrade path for every install that ran the
   version whose chmod did nothing."* It is not. `server.ts` arms
   `COVEN_CAVE_ACCESS_TOKEN` from that file at boot with no ownership check,
   and `resolveMobileAccessSecret` returns that armed value before it reaches
   `provisionMobileAccessSecret` — so on an install whose token file already
   exists the repair is never entered. It reaches a fresh mint and a secret the
   `mobile:tailscale` script persisted after boot. `cave-8pd39` is now named at
   the call site and updated to record the mechanism.

**Two properties worth stating plainly, neither a blocker.**

- The waiver's condition is "the probe threw", which includes a report that
  parsed as malformed — so on a waivered host, anything that stops the probe
  answering is admitted, not only an absent `powershell.exe`. That is what an
  unreadable-DACL waiver means; the code cannot distinguish threw-before-read
  from threw-after-read.
- Only successes are cached, so on a **non**-waivered degraded host every
  bearer-carrying request re-drives the failed probe and re-prints the full
  refusal, and the response is a bare `HTTP 500` with an empty body rather than
  the normalized envelope. Before this PR the process exited, so that window
  did not exist. The caching half is `cave-okfb2` R6; the unshaped 500 is not
  covered anywhere.

**Independent mutation matrix — 16 designed, 16 killed.** Five on the waiver
(never consulted / any value waives / no reason required / also covers a
read-and-shared DACL / blank value waives), five on `server.ts` (boot exits
again, token drift, reason-length drift, standalone waives a shared DACL,
banner drops `clientV1DiscoveryPublished = false`), four on the mobile guard
(no directory guard, secret left on disk, reuse path trusts the file, refusal
swallowed), and two on the async conversion (dropping the `await` in
`resolveMobileAccessSecret`, and at the `mobileHandoff` call site) — both of
those are killed by `tsc`, not by a test, because every caller dereferences the
result; there is no type-aware `no-floating-promises` rule, so a future caller
that ignores the return value would not be caught.

**The win32 assertions are load-bearing, and `report.repaired === false` is
what makes them so.** Making the non-injected `restrictToCurrentUser` a no-op
fails `secret file was still inheriting when the test looked` on this Windows
host; removing only the `repaired` assertion makes that same mutant pass. The
POSIX branch still asserts `0o600` / `0o700` exactly.

**Filed by this review, none of them blocking this PR.**

- `cave-hdt3f` (P1) — **`cave-fawvh` is closed for the dev path only.**
  `src-tauri/src/sidecar_auth.rs` `write_secret_file()` persists the same
  plaintext pairing secret to `app_data_dir/mobile-access-token` with
  `options.mode(0o600)` under `#[cfg(unix)]` and **nothing** under Windows, and
  that is the copy the packaged desktop ships. The JS fix cannot reach it:
  `provisioningAllowed()` returns false when `COVEN_CAVE_BUNDLE=1`, which is
  exactly what the Tauri launcher sets, so the new guard never runs in a
  packaged install. Neither bead nor the description above says so.
- `cave-e7xwk` (P2) — a bearer-carrying client-v1 request on an unverifiable
  path answers a bare `HTTP 500` with an empty body rather than the normalized
  envelope, and re-drives the probe on every request because only successes are
  cached.
- `cave-8p0hn` (P2) — `restrictToCurrentUser` guards the path it was handed
  with no `realpath` and no is-a-symlink refusal, which is what the sibling
  `credential-store.ts` call site does before the identical guard call.
- `cave-8pd39` — updated with the mechanism by which the boot re-arm
  short-circuits the reuse-path repair, and two options for closing it.

**MERGE-READY: yes** — for what this PR sets out to do. `cave-hdt3f` is the
thing to weigh before treating `cave-fawvh` as finished.
