### PR TITLE
Stop racing the drawer animation to reach the backdrop (cave-m1mgi)

### DIFF
--- a/tests/right-chat-panel.spec.ts
+++ b/tests/right-chat-panel.spec.ts
@@ -201,18 +201,47 @@ test("mobile uses one focus-trapped right drawer and returns focus", async ({ pa
 
   // The drawer intentionally spans the full viewport width on narrow phones
   // (`.mobile-right-chat-drawer` under `@media (max-width: 480px)`), so on
-  // Pixel 5 (393px) and iPhone 13 (390px) its own header can legitimately sit
-  // on top of the backdrop button at every coordinate, including this one —
-  // Playwright's actionability check then waits (flakily) for a visually
-  // uncovered pixel that never appears. `force: true` dispatches the click
-  // straight to the backdrop button regardless of what's visually on top,
-  // which is exactly right here: the assertion is about the backdrop's own
-  // close handler, not about a hit-test that full-width drawers can't pass.
+  // Pixel 5 (393px) and iPhone 13 (390px) it covers the backdrop button at
+  // EVERY coordinate once its slide-in has settled — its own header is what
+  // sits at the top-left pixel.
+  //
+  // `force: true` does not rescue that, and believing it did is what kept
+  // this line flaky across three CI runs (cave-m1mgi). `force` only skips
+  // the actionability checks; Playwright still delivers a real mouse event
+  // at real viewport coordinates, so the click lands on whatever is topmost
+  // there, not on the located element. Whether that was the backdrop or the
+  // drawer depended on how far `mobile-right-chat-in` (translateX(100%) → 0
+  // over `--duration-base`, 180ms) had advanced at the instant the event was
+  // delivered: a fast round trip caught the drawer still off-screen and
+  // passed, a slow one hit the settled drawer and failed, which is why CI
+  // lost both the first attempt and the in-process retry but passed on a
+  // fresh job. Measured on this viewport with CDP CPU throttling, which is
+  // what a loaded runner looks like: 0/10 failures unthrottled, 7/10 at 2×,
+  // 10/10 at 4× and at 8×. The dispatch below was 0/40 across all four.
+  //
+  // So invoke the backdrop button's own click instead of aiming a pointer at
+  // a pixel this layout never exposes. The assertion below is unchanged —
+  // this is still "the backdrop's close handler dismisses the drawer" — it
+  // just no longer races an animation to ask the question.
   await toggle.click();
-  await page
-    .getByRole("button", { name: "Close drawer" })
-    .click({ position: { x: 2, y: 2 }, force: true });
+  await expect(drawer).toBeVisible();
+  const backdrop = page.getByRole("button", { name: "Close drawer" });
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () => !!document.elementFromPoint(2, 2)?.closest("#shell-right-chat-drawer"),
+        ),
+      {
+        message:
+          "the full-width drawer should cover the backdrop at the top-left pixel; if it no longer does, a real pointer click on the backdrop is available again and should replace the dispatch below",
+      },
+    )
+    .toBe(true);
+  await backdrop.dispatchEvent("click");
   await expect(drawer).toBeHidden();
+  await expect(backdrop).toHaveCount(0);
+  await expect(toggle).toBeFocused();
 
   await toggle.click();
   await drawer.getByRole("button", { name: "Close Chat panel" }).click();


### PR DESCRIPTION
Fixes the chronic pixel-5 flake at `tests/right-chat-panel.spec.ts` — the right chat drawer's backdrop close. It has now fired on #4825, #4828 and #4858, none of which touched a component or a spec file, costing a ~24-minute CI round trip each time and three reruns instead of a diagnosis.

## Mechanism

`force: true` was added at this line for an earlier flake, on the belief — stated in the comment it replaced — that it "dispatches the click straight to the backdrop button regardless of what's visually on top". **It does not.** `force` only skips the actionability checks. Playwright still delivers a real mouse event at real viewport coordinates, so the event lands on whatever element is topmost at that point, not on the located one.

On a 393px (Pixel 5) or 390px (iPhone 13) viewport `.mobile-right-chat-drawer` is `width: 100vw`, `position: fixed`, `inset` top/right/bottom, `z-index: 200` against the backdrop's `199` — so once it has settled it covers the backdrop at *every* pixel, including `{x: 2, y: 2}`. The click therefore landed on the drawer's own header and nothing closed.

The test passed at all only when the click arrived early enough that `mobile-right-chat-in` (`translateX(100%)` → `0` over `--duration-base`, **180ms**) still had the drawer off-screen at `x = 2`. That is the entire race, and what decides it is how long the round trip between the two Playwright actions takes:

- fast round trip → drawer still sliding → the backdrop receives the click → pass
- slow round trip (loaded runner) → drawer settled → the header receives it → fail

which is exactly why CI lost the first attempt **and** the in-process `retry1` — the load is still there, and `retry1` additionally turns on tracing — yet passed on a fresh job at the same SHA. That "fails both attempts, passes on a fresh job" signature was the lead recorded on the bead, and it points at process/machine-scoped slowness rather than anything per-test.

Direct evidence, probing `document.elementFromPoint(2, 2)` either side of the click:

```
[probe before-click] {"top":"BUTTON.mobile-drawer-backdrop","drawerLeft":10.65,"anims":"running"}
[probe after-click]  {"top":"HEADER.right-chat__header","drawerLeft":0,"anims":""}
```

The drawer finished its slide-in *between* the probe and the click's delivery.

## Numbers

CDP CPU throttling on a faithful copy of the test (same preamble, only the backdrop step differing), 10 runs per cell, Pixel 5 profile, Chromium, Windows:

| CPU throttle | forced positional click (old) | dispatch the button's click (new) |
| --- | --- | --- |
| 1× (idle) | 0/10 fail | 0/10 fail |
| 2× | **7/10 fail** | 0/10 fail |
| 4× | **10/10 fail** | 0/10 fail |
| 8× | **10/10 fail** | 0/10 fail |

Old: 27/40 failures. New: **0/40**. The real spec then ran 20/20 green across `pixel-5` and `iphone-13` (10 repeats each).

## The fix

The app is **not** changed, and this is a deliberate finding rather than a shortcut: the backdrop's `onClick` dismisses the drawer every single time it is actually invoked (0/40 failures above, plus focus correctly returning to the toggle). The bug was entirely in how the test reached it. On these viewports there is no pointer path to the backdrop at all — the drawer covers it, and the focus trap keeps Tab inside the dialog — so asserting one was asserting something the layout makes impossible.

So the test now invokes the backdrop button's own click instead of aiming a pointer at a pixel that is never exposed.

**The assertion is unchanged** — still `await expect(drawer).toBeHidden()`. No `not.toBeVisible`, no timeout bump, no second `force`. The test in fact gains three checks it did not have:

- the drawer is actually up before the close is attempted,
- the backdrop unmounts along with it,
- focus returns to the toggle on this path too (previously only asserted for Escape).

And the coverage fact the old comment merely asserted in prose is now an actual assertion, with a message saying what to do if it ever flips: if the drawer stops covering the backdrop, a real pointer click becomes available again and should replace the dispatch.

## Separately filed, not fixed here

`cave-lcxc6` — during verification, `iphone-13` hit a **different** flake in this same test: the achievement toast ("Mission complete — Full roster at work, +20 renown") renders into the `fixed top-4 right-4 z-50` toast stack and intercepts pointer events on the "Open Chat panel" toggle underneath it, timing out the reopen for the full 60s budget across 53 retried clicks. It is pre-existing — the failing line is untouched by this change and runs before any of it — and it is not `cave-vkb2d` either. Worth noting it may be a real product defect on phone widths, not just a test artifact.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` (1807 files wired), `pnpm build` (within every budget), and `pnpm exec playwright test tests/right-chat-panel.spec.ts --project=pixel-5 --project=iphone-13` all pass. No component source touched, so no app/unit suites are in scope.
