### PR TITLE
Fix explicit research title provenance (cave-d1p8s)

### DIFF
--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -87,6 +87,7 @@ test("mission parser preserves valid title provenance and rejects unknown values
   const explicit = { ...validMission(), titleSource: "explicit" } as const;
   assert.deepEqual(parseResearchMission(explicit), explicit);
   assert.equal(parseResearchMission({ ...validMission(), titleSource: "inferred" }), null);
+  assert.equal(parseResearchMission({ ...validMission(), titleSource: new String("explicit") }), null);
 });
 
 test("research prompt limits validate intent capacity and pin the shared direction ceiling", () => {

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -83,6 +83,12 @@ test("mission parser validates shared-state fields and reconstructs safe data", 
   }), null);
 });
 
+test("mission parser preserves valid title provenance and rejects unknown values", () => {
+  const explicit = { ...validMission(), titleSource: "explicit" } as const;
+  assert.deepEqual(parseResearchMission(explicit), explicit);
+  assert.equal(parseResearchMission({ ...validMission(), titleSource: "inferred" }), null);
+});
+
 test("research prompt limits validate intent capacity and pin the shared direction ceiling", () => {
   assert.equal(RESEARCH_INTENT_MAX_LENGTH, 25_000);
   assert.equal(RESEARCH_DIRECTION_MAX_LENGTH, 10_000);

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -635,7 +635,9 @@ export function parseResearchMission(value: unknown): ResearchMission | null {
     || typeof value.familiarId !== "string"
     || !FAMILIAR_ID_RE.test(value.familiarId)
     || !validResearchPromptText(value.title, RESEARCH_TITLE_MAX_LENGTH)
-    || (value.titleSource !== undefined && !["explicit", "generated"].includes(String(value.titleSource)))
+    || (value.titleSource !== undefined
+      && (typeof value.titleSource !== "string"
+        || !["explicit", "generated"].includes(value.titleSource)))
     || !validResearchPromptText(value.intent, RESEARCH_INTENT_MAX_LENGTH)
     || !RESEARCH_MISSION_MODES.includes(value.mode as ResearchMissionMode)
     || !["auto", "user"].includes(String(value.modeSource))

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -181,6 +181,8 @@ export type ResearchMission = {
   id: string;
   familiarId: string;
   title: string;
+  /** Whether the title was supplied by the caller or derived from intent. */
+  titleSource?: "explicit" | "generated";
   intent: string;
   direction?: string;
   mode: ResearchMissionMode;
@@ -633,6 +635,7 @@ export function parseResearchMission(value: unknown): ResearchMission | null {
     || typeof value.familiarId !== "string"
     || !FAMILIAR_ID_RE.test(value.familiarId)
     || !validResearchPromptText(value.title, RESEARCH_TITLE_MAX_LENGTH)
+    || (value.titleSource !== undefined && !["explicit", "generated"].includes(String(value.titleSource)))
     || !validResearchPromptText(value.intent, RESEARCH_INTENT_MAX_LENGTH)
     || !RESEARCH_MISSION_MODES.includes(value.mode as ResearchMissionMode)
     || !["auto", "user"].includes(String(value.modeSource))
@@ -708,6 +711,9 @@ export function parseResearchMission(value: unknown): ResearchMission | null {
     id: value.id,
     familiarId: value.familiarId,
     title: value.title,
+    ...(value.titleSource !== undefined
+      ? { titleSource: value.titleSource as ResearchMission["titleSource"] }
+      : {}),
     intent: value.intent,
     ...(direction !== undefined ? { direction } : {}),
     mode: value.mode as ResearchMissionMode,

--- a/src/lib/research-prompt-brief.test.ts
+++ b/src/lib/research-prompt-brief.test.ts
@@ -177,6 +177,22 @@ test("promptRecommendations preserves explicit mission titles", () => {
   assert.equal(rec.brief.question, rec.title);
 });
 
+test("promptRecommendations preserves an explicit title that matches the generated title", () => {
+  const title = "Research brief: Planning systems landscape. Focus on team workflows";
+  const namedMission = {
+    ...mission({
+      id: "m-named-collision",
+      title,
+      intent: title,
+      status: "completed",
+    }),
+    titleSource: "explicit",
+  } as ResearchMission;
+  const [rec] = promptRecommendations([namedMission]);
+  assert.equal(rec.title, title);
+  assert.equal(rec.brief.question, title);
+});
+
 test("promptRecommendations flags a run short of its source target", () => {
   const thin = mission({
     id: "m4",

--- a/src/lib/research-prompt-brief.ts
+++ b/src/lib/research-prompt-brief.ts
@@ -264,6 +264,7 @@ function subject(mission: ResearchMission): string {
   const intent = mission.intent.replace(/\s+/g, " ").trim();
   const generatedTitle = intent.length <= 80 ? intent : `${intent.slice(0, 77)}…`;
   const title = mission.title.replace(/\s+/g, " ").trim();
+  if (mission.titleSource === "explicit") return title;
   if (title !== generatedTitle) return title;
 
   let value = intent;

--- a/src/lib/server/research-mission-lifecycle.test.ts
+++ b/src/lib/server/research-mission-lifecycle.test.ts
@@ -38,6 +38,17 @@ test("createMissionRecord registers the primary and all standard artifact refs",
   }
 });
 
+test("createMissionRecord records whether the mission title was explicit or generated", () => {
+  const explicit = createMissionRecord(INPUT, "mission-explicit", new Date("2026-07-24T00:00:00.000Z"));
+  const generated = createMissionRecord(
+    { ...INPUT, title: undefined },
+    "mission-generated",
+    new Date("2026-07-24T00:00:00.000Z"),
+  );
+  assert.equal(explicit.titleSource, "explicit");
+  assert.equal(generated.titleSource, "generated");
+});
+
 test("applyStartResult keeps private process-owner provenance out of mission state", () => {
   const mission = createMissionRecord(INPUT, "mission-1", new Date("2026-07-24T00:00:00.000Z"));
   const sessionAuthority = {

--- a/src/lib/server/research-mission-lifecycle.ts
+++ b/src/lib/server/research-mission-lifecycle.ts
@@ -54,6 +54,7 @@ export function createMissionRecord(
     id,
     familiarId: input.familiarId,
     title: missionTitle(input),
+    titleSource: input.title?.trim() ? "explicit" : "generated",
     intent: input.intent.trim(),
     mode: input.mode,
     modeSource: input.modeSource,


### PR DESCRIPTION
## Summary

Preserve whether a research mission title was caller-supplied so prompt recommendations never rewrite an explicit title that happens to equal the generated intent title.

## Why

Post-merge review of #4860 reproduced an explicit-title collision: provenance was inferred only from title equality, so an explicit title could be stripped as generated. This is the required follow-up for cave-d1p8s.

## Changes

- record explicit/generated title provenance when creating missions
- validate and preserve provenance through mission parsing while keeping legacy records compatible
- honor explicit provenance in prompt recommendations
- cover creation, parsing, and the exact collision regression

## Verification

- research mission/parser/lifecycle suites: 58 passed
- research prompt brief suite: 17 passed
- ESLint on all six changed files
- pnpm typecheck
- git diff --check

## Risk + rollout notes

Legacy persisted missions without titleSource retain the pre-existing title-equality heuristic. New records carry exact provenance.