### PR TITLE
Preserve project picker expansion focus (cave-d8547)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -955,6 +955,7 @@ export const SUITES = {
     "src/components/chat-send-routes-links.test.ts",
     "src/components/chat-surface-polish.test.ts",
     "src/components/project-picker.test.ts",
+    "src/components/project-picker-focus.test.tsx",
     "src/components/chat-project-launch-gate.test.ts",
     "src/components/project-setup-modal.test.ts",
     "src/components/directory-picker.test.ts",
@@ -2178,6 +2179,7 @@ const RAW_SOURCE_SCANNER_TESTS = new Set([
 // than Node's type stripper, which intentionally does not transform JSX.
 const VITEST_TESTS = new Set([
   "src/lib/home-composer-context.test.ts",
+  "src/components/project-picker-focus.test.tsx",
   "src/components/streaming-turn-response.test.tsx",
   "src/components/settings-save-feedback.behavior.test.tsx",
   "src/components/chat-preview-card.test.tsx",

--- a/src/components/project-picker-focus.test.tsx
+++ b/src/components/project-picker-focus.test.tsx
@@ -1,0 +1,71 @@
+// @ts-nocheck — react-test-renderer has no declarations in this repository.
+import { createElement } from "react";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: unknown }) => <>{children}</>,
+  PopoverBody: ({ children }: { children: unknown }) => <>{children}</>,
+  PopoverItem: ({ children, onSelect }: { children: unknown; onSelect: () => void }) => (
+    <button type="button" data-popover-item onClick={onSelect}>{children}</button>
+  ),
+  PopoverLabel: ({ children }: { children: unknown }) => <span>{children}</span>,
+  PopoverSeparator: () => <hr />,
+}));
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: { children: unknown }) => createElement("button", props, children),
+}));
+vi.mock("@/components/directory-picker-modal", () => ({ DirectoryPickerModal: () => null }));
+vi.mock("@/components/project-avatar", () => ({ ProjectAvatar: () => <span /> }));
+vi.mock("@/lib/icon", () => ({ Icon: () => <span /> }));
+vi.mock("@/lib/project-frecency", () => ({
+  RECENT_SECTION_SIZE: 4,
+  loadFrecencyStore: () => ({}),
+  rankProjectsByFrecency: () => ({ recent: [] }),
+  rememberProjectPick: vi.fn(),
+}));
+vi.mock("@/lib/chat-add-project", () => ({ addChatProject: vi.fn() }));
+vi.mock("@/lib/tauri-platform", () => ({ isTauri: () => false }));
+
+import { ProjectPickerPopover } from "./project-picker";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function itemWithText(renderer: ReactTestRenderer, text: string): ReactTestInstance {
+  const renderedText = (value: ReactTestInstance | string): string => (
+    typeof value === "string"
+      ? value
+      : value.children.map((child) => renderedText(child)).join("")
+  );
+  return renderer.root.findAllByType("button").find((button) => renderedText(button).includes(text))!;
+}
+
+describe("ProjectPickerPopover expansion focus", () => {
+  test("keeps the expansion control mounted after revealing every project", async () => {
+    const projects = Array.from({ length: 10 }, (_, index) => ({
+      id: `project-${index}`,
+      name: `Project ${index}`,
+      root: `/projects/${index}`,
+    }));
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <ProjectPickerPopover
+          open
+          onOpenChange={vi.fn()}
+          anchorRef={{ current: null }}
+          projects={projects}
+          value="project-0"
+          onChange={vi.fn()}
+          ariaLabel="Choose project"
+        />,
+      );
+    });
+    const expansionControl = itemWithText(renderer, "Show 2 more projects");
+
+    await act(async () => expansionControl.props.onClick());
+
+    const collapseControl = itemWithText(renderer, "Show fewer projects");
+    expect(collapseControl).toBe(expansionControl);
+  });
+});

--- a/src/components/project-picker-frecency.test.ts
+++ b/src/components/project-picker-frecency.test.ts
@@ -99,8 +99,13 @@ assert.match(
 );
 assert.match(
   picker,
-  /Show \{hiddenProjectCount\} more project/,
+  /`Show \$\{hiddenProjectCount\} more project\$\{hiddenProjectCount === 1 \? "" : "s"\}`/,
   "the bounded list exposes the remaining project count",
+);
+assert.match(
+  picker,
+  /key="project-list-toggle"[\s\S]*setShowAllProjects\(\(current\) => !current\)[\s\S]*Show fewer projects/,
+  "the expansion control remains mounted as a collapse control so keyboard focus is preserved",
 );
 
 console.log("project-picker-frecency.test.ts: ok");

--- a/src/components/project-picker.tsx
+++ b/src/components/project-picker.tsx
@@ -324,12 +324,15 @@ export function ProjectPickerPopover({
           </>
         ) : null}
         {displayedProjects.map((entry) => renderProjectRow(entry, entry.id))}
-        {!query.trim() && hiddenProjectCount > 0 ? (
+        {!query.trim() && (showAllProjects || hiddenProjectCount > 0) ? (
           <PopoverItem
-            icon="ph:caret-down"
-            onSelect={() => setShowAllProjects(true)}
+            key="project-list-toggle"
+            icon={showAllProjects ? "ph:caret-up" : "ph:caret-down"}
+            onSelect={() => setShowAllProjects((current) => !current)}
           >
-            Show {hiddenProjectCount} more project{hiddenProjectCount === 1 ? "" : "s"}
+            {showAllProjects
+              ? "Show fewer projects"
+              : `Show ${hiddenProjectCount} more project${hiddenProjectCount === 1 ? "" : "s"}`}
           </PopoverItem>
         ) : null}
         {query.trim() && visible.length === 0 ? (


### PR DESCRIPTION
## Summary

Keep the project-list expansion control mounted when revealing all projects so keyboard focus remains inside the open picker.

## Why

Fresh review of merged PR #4862 found that activating Show N more projects removed the focused PopoverItem. This is the required accessibility follow-up for cave-d8547.

## Changes

- toggle the stable keyed control between Show N more projects and Show fewer projects
- preserve the same rendered control instance across expansion
- add a focused React behavior regression and wire it into CI

## Verification

- project picker source suites passed
- focus behavior regression passed
- all 1,811 test files wired into CI
- pnpm typecheck
- full source lint passed before rebasing; focused suites/typecheck re-passed on current main
- git diff --check

## Risk + rollout notes

UI-only accessibility correction. The project selection and filtering paths are unchanged.