### PR TITLE
Add guarded local worktree hygiene and scheduled reporting

### DIFF
--- a/.github/workflows/worktree-hygiene-contract.yml
+++ b/.github/workflows/worktree-hygiene-contract.yml
@@ -1,0 +1,63 @@
+name: Worktree hygiene contracts
+
+on:
+  pull_request:
+    paths:
+      - "scripts/worktree-hygiene.mjs"
+      - "scripts/worktree-hygiene-schedule.mjs"
+      - "scripts/worktree-hygiene.contract.mjs"
+      - "WORKTREE_HYGIENE.md"
+      - ".github/workflows/worktree-hygiene-contract.yml"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/worktree-hygiene.mjs"
+      - "scripts/worktree-hygiene-schedule.mjs"
+      - "scripts/worktree-hygiene.contract.mjs"
+      - ".github/workflows/worktree-hygiene-contract.yml"
+  schedule:
+    - cron: "17 10 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: worktree-hygiene-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contracts:
+    name: Worktree hygiene safety contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          run_install: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Run safety contract
+        run: node scripts/worktree-hygiene.contract.mjs
+      - name: Syntax-check scheduler
+        run: node --check scripts/worktree-hygiene-schedule.mjs
+      - name: Reassert generated schedule is report-only
+        run: |
+          node --input-type=module <<'NODE'
+          import { launchAgentPlist } from './scripts/worktree-hygiene-schedule.mjs';
+          const plist = launchAgentPlist({
+            node: '/node',
+            hygieneScript: '/repo/scripts/worktree-hygiene.mjs',
+            repo: '/repo',
+            logPath: '/tmp/hygiene.log',
+          });
+          if (plist.includes('--apply') || plist.includes('WT_GUARD_BYPASS')) {
+            throw new Error('scheduled worktree hygiene must remain report-only');
+          }
+          NODE

--- a/WORKTREE_HYGIENE.md
+++ b/WORKTREE_HYGIENE.md
@@ -1,0 +1,194 @@
+# Coven Cave Local Worktree Hygiene
+
+This is the operator guide for keeping `coven-cave` branches and worktrees small without weakening the repository's existing retention, Beads, PR, or maintenance-plane protections.
+
+The central rule is **reduce checkout state before deleting identity**. A worktree can consume gigabytes while its local branch costs almost nothing. Use thinning first, parking second, and retirement only after the existing lifecycle patrol proves the work has landed and is retained.
+
+## Steady-state targets
+
+These are soft operational targets, not replacements for the repository's existing hard admission budgets.
+
+| Resource | Normal target |
+| --- | ---: |
+| Branch-attached non-primary worktrees | 10 or fewer |
+| Detached scratch worktrees | 2 or fewer |
+| Local non-protected branches | 15 or fewer |
+| Branch review age | 7 days |
+| Detached scratch review age | 24 hours |
+
+The existing lifecycle budgets remain authoritative when creating managed worktrees.
+
+## Daily report
+
+From the primary `coven-cave` checkout:
+
+```bash
+node scripts/worktree-hygiene.mjs daily --fetch
+```
+
+Machine-readable:
+
+```bash
+node scripts/worktree-hygiene.mjs daily --fetch --json
+```
+
+`--fetch` performs `git fetch origin --prune`. It does not delete local branches, local tags, or worktrees.
+
+The report combines the network-free `wt:status` verdicts with branch age and approximate per-worktree disk use. `WEDGED` and `SALVAGE` are urgent because they represent paused Git machinery or merged trees that still contain uncommitted data.
+
+## Weekly report
+
+```bash
+node scripts/worktree-hygiene.mjs weekly --fetch
+```
+
+Weekly mode additionally runs the authoritative worktree lifecycle patrol and the local remote-hygiene audit. Those subreports remain read-only. A GitHub/Beads probe failure is reported as degraded evidence; it never becomes permission to clean up.
+
+## Thin a worktree
+
+Thinning removes only ignored output whose path is also in Cave's canonical disposable-output policy. It refuses a worktree with tracked or untracked changes, or an unfinished merge/rebase/cherry-pick/revert/bisect.
+
+Dry-run:
+
+```bash
+node scripts/worktree-hygiene.mjs thin --branch feat/cave-example
+```
+
+Apply:
+
+```bash
+node scripts/worktree-hygiene.mjs thin --branch feat/cave-example --apply
+```
+
+Bounded bulk dry-run:
+
+```bash
+node scripts/worktree-hygiene.mjs thin --all-eligible --max 3
+```
+
+Bulk apply always requires the explicit `--apply` flag. The maximum is capped at 10.
+
+The disposable set currently mirrors the lifecycle policy for `.next`, `.turbo`, `artifacts`, `coverage`, `dist`, `node_modules`, selected sandbox/generated roots, Rust/Tauri targets, test results, the generated pdf.js worker, and machine-local worktree-hook logs. The safety contract fails if hygiene claims a disposable path that the canonical lifecycle policy no longer recognizes.
+
+## Park a worktree
+
+Parking removes a **clean checkout** but keeps the local branch and its exact remote retention. It is intended for work waiting on CI/review or otherwise inactive but not retired.
+
+Dry-run:
+
+```bash
+node scripts/worktree-hygiene.mjs park --branch feat/cave-example
+```
+
+Apply:
+
+```bash
+node scripts/worktree-hygiene.mjs park --branch feat/cave-example --apply
+```
+
+Parking refuses when any of these are true:
+
+- primary, protected, detached, or tool-owned branch;
+- unfinished Git operation;
+- tracked or untracked change;
+- locked worktree;
+- exact head is not present on the corresponding remote branch or a pushed remote tag;
+- ignored state exists outside the canonical disposable set;
+- the network retention probe cannot be completed.
+
+Apply removes disposable ignored output first, runs ordinary `git worktree remove` **without `--force`**, and then verifies that the worktree registration is gone while the local branch still resolves to exactly the original head. It then runs the authoritative lifecycle patrol and requires the parked unit to reappear as a healthy `branch-only` lifecycle unit. If either postcondition fails, the operation attempts to recreate the original worktree.
+
+Parking is deliberately different from retirement: the branch remains. Remote deletion is never part of this command.
+
+## Unpark
+
+Dry-run:
+
+```bash
+node scripts/worktree-hygiene.mjs unpark --branch feat/cave-example
+```
+
+Apply:
+
+```bash
+node scripts/worktree-hygiene.mjs unpark --branch feat/cave-example --apply
+```
+
+Unpark requires the local branch to exist, not already be checked out, and still be retained at the exact head by the remote branch or a pushed tag. It restores the checkout under `.worktrees/<branch-slug>` with `--no-track`.
+
+## Automated local reporting on macOS
+
+Install the report-only LaunchAgent from the primary checkout:
+
+```bash
+node scripts/worktree-hygiene-schedule.mjs install
+```
+
+Status:
+
+```bash
+node scripts/worktree-hygiene-schedule.mjs status
+```
+
+Remove:
+
+```bash
+node scripts/worktree-hygiene-schedule.mjs uninstall
+```
+
+The agent runs every day at **19:15 local time**. Sunday runs emit the richer weekly report. Logs are appended to:
+
+```text
+~/.coven/logs/cave-worktree-hygiene.log
+```
+
+The LaunchAgent intentionally has **no `--apply` path** and no worktree-guard bypass. It may fetch/prune remote-tracking refs for freshness; it never removes a worktree, branch, tag, or ignored output.
+
+## CI automation
+
+`.github/workflows/worktree-hygiene-contract.yml` runs the safety contract on relevant PRs, on pushes to `main`, on manual dispatch, and once weekly. The schedule validates the tooling; GitHub Actions cannot and must not pretend to clean a developer's local worktrees.
+
+The workflow explicitly fails if scheduled-local tooling ever acquires `--apply` or `WT_GUARD_BYPASS`.
+
+## Retirement remains separate
+
+These hygiene tools do **not** replace:
+
+```bash
+pnpm beads:worktrees
+pnpm beads:worktrees:apply
+```
+
+or the archive-tag retention path in `CLAUDE.md`.
+
+A squash-merged PR is not proof that the feature branch's exact commits are retained. Retirement remains exact-OID guarded, remote deletion remains separately authorized, and unattended retirement remains blocked until the repository's maintenance planes are fully enforced.
+
+## Recommended cadence
+
+At the start of a work session:
+
+```bash
+node scripts/worktree-hygiene.mjs daily --fetch
+```
+
+After a PR merges or closes:
+
+```bash
+pnpm beads:worktrees
+node scripts/worktree-hygiene.mjs daily --fetch
+```
+
+At least weekly:
+
+```bash
+node scripts/worktree-hygiene.mjs weekly --fetch
+```
+
+Use the sequence:
+
+1. resolve `WEDGED`;
+2. inspect every dirty/salvage path;
+3. thin large inactive trees;
+4. park clean retained checkouts that are waiting;
+5. retire only through the existing lifecycle/retention contract;
+6. review stale no-PR branches separately from local worktree cleanup.

--- a/scripts/worktree-hygiene-schedule.mjs
+++ b/scripts/worktree-hygiene-schedule.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const LABEL = "ai.opencoven.cave-worktree-hygiene";
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+
+function xml(value) {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
+}
+
+function command(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, { encoding: "utf8", ...options });
+  return {
+    ok: result.status === 0 && !result.error,
+    out: String(result.stdout ?? "").trim(),
+    err: [String(result.stderr ?? "").trim(), result.error?.message ?? ""].filter(Boolean).join("\n"),
+  };
+}
+
+export function launchAgentPlist({ node, hygieneScript, repo, logPath, hour = 19, minute = 15 }) {
+  const args = [node, hygieneScript, "scheduled", "--root", repo, "--fetch", "--json"];
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${args.map((arg) => `    <string>${xml(arg)}</string>`).join("\n")}
+  </array>
+  <key>WorkingDirectory</key><string>${xml(repo)}</string>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key><integer>${hour}</integer>
+    <key>Minute</key><integer>${minute}</integer>
+  </dict>
+  <key>RunAtLoad</key><false/>
+  <key>StandardOutPath</key><string>${xml(logPath)}</string>
+  <key>StandardErrorPath</key><string>${xml(logPath)}</string>
+  <key>ProcessType</key><string>Background</string>
+</dict>
+</plist>
+`;
+}
+
+function paths() {
+  const home = os.homedir();
+  return {
+    plist: path.join(home, "Library", "LaunchAgents", `${LABEL}.plist`),
+    logDir: path.join(home, ".coven", "logs"),
+    log: path.join(home, ".coven", "logs", "cave-worktree-hygiene.log"),
+  };
+}
+
+function rootFrom(cwd) {
+  const result = command("git", ["-C", cwd, "rev-parse", "--show-toplevel"]);
+  if (!result.ok) throw new Error(`not inside a git repository: ${result.err}`);
+  return result.out;
+}
+
+function installedStatus(plist) {
+  const result = command("launchctl", ["print", `gui/${process.getuid()}/${LABEL}`]);
+  return { loaded: result.ok, plistExists: existsSync(plist), detail: result.ok ? result.out.split("\n")[0] : result.err };
+}
+
+function main(argv = process.argv.slice(2)) {
+  const action = argv[0] ?? "status";
+  if (process.platform !== "darwin") {
+    console.error("worktree-hygiene-schedule: automatic installation currently supports macOS launchd only");
+    return 2;
+  }
+  const p = paths();
+  if (action === "status") {
+    console.log(JSON.stringify({ label: LABEL, plist: p.plist, log: p.log, ...installedStatus(p.plist) }, null, 2));
+    return 0;
+  }
+  if (action === "uninstall") {
+    command("launchctl", ["bootout", `gui/${process.getuid()}`, p.plist]);
+    if (existsSync(p.plist)) rmSync(p.plist);
+    console.log(`Removed ${LABEL}. Existing hygiene logs were preserved at ${p.log}.`);
+    return 0;
+  }
+  if (action !== "install") {
+    console.error("Usage: node scripts/worktree-hygiene-schedule.mjs install|status|uninstall");
+    return 1;
+  }
+
+  const repo = rootFrom(process.cwd());
+  const node = process.execPath;
+  const hygieneScript = path.join(scriptDir, "worktree-hygiene.mjs");
+  mkdirSync(path.dirname(p.plist), { recursive: true });
+  mkdirSync(p.logDir, { recursive: true });
+  const plist = launchAgentPlist({ node, hygieneScript, repo, logPath: p.log });
+  writeFileSync(p.plist, plist, { mode: 0o600 });
+
+  command("launchctl", ["bootout", `gui/${process.getuid()}`, p.plist]);
+  const loaded = command("launchctl", ["bootstrap", `gui/${process.getuid()}`, p.plist]);
+  if (!loaded.ok) {
+    console.error(`Failed to load ${LABEL}: ${loaded.err}`);
+    return 1;
+  }
+  console.log(`Installed ${LABEL}. It runs daily at 19:15 local time; Sundays emit the weekly report.`);
+  console.log(`Reports: ${p.log}`);
+  console.log("The schedule is report-only: it fetches/prunes remote-tracking refs and never runs --apply.");
+  return 0;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) process.exitCode = main();
+
+export { LABEL, main };

--- a/scripts/worktree-hygiene.contract.mjs
+++ b/scripts/worktree-hygiene.contract.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -141,6 +141,11 @@ assert.equal(
   false,
   "tracked changes must refuse thinning",
 );
+assert.equal(
+  assessThin(fakeRow(), details({ ignored: { ok: false, paths: [], error: "probe failed" } })).eligible,
+  false,
+  "ignored-state probe failures must refuse thinning",
+);
 
 const retained = { ok: true, retained: true, via: "refs/heads/feat/cave-test-safe" };
 assert.equal(assessPark(fakeRow(), details(), retained).eligible, true);
@@ -200,6 +205,7 @@ for (const entry of [...DISPOSABLE_ROOTS, ...DISPOSABLE_FILES]) {
 
     result = run(dir, "thin", "--branch", "feat/cave-test-thin", "--apply");
     assert.equal(result.status, 0);
+    assert.equal(existsSync(path.join(wt, ".next", "cache", "blob")), false);
     assert.equal(run(dir, "daily", "--json").status, 0);
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/scripts/worktree-hygiene.contract.mjs
+++ b/scripts/worktree-hygiene.contract.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DISPOSABLE_FILES,
+  DISPOSABLE_ROOTS,
+  SOFT_TARGETS,
+  assessPark,
+  assessThin,
+  disposablePathSafety,
+  isDisposableRelative,
+  worktreeSlug,
+} from "./worktree-hygiene.mjs";
+import { launchAgentPlist } from "./worktree-hygiene-schedule.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const script = path.join(root, "scripts", "worktree-hygiene.mjs");
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" },
+  }).trim();
+}
+
+function run(cwd, ...args) {
+  return spawnSync("node", [script, ...args], { cwd, encoding: "utf8", env: process.env });
+}
+
+function repo() {
+  const dir = mkdtempSync(path.join(tmpdir(), "cave-hygiene-"));
+  git(dir, "init", "-q", "-b", "main");
+  git(dir, "config", "user.name", "Cave Hygiene Contract");
+  git(dir, "config", "user.email", "cave-hygiene@example.invalid");
+  git(dir, "config", "commit.gpgsign", "false");
+  writeFileSync(path.join(dir, "README.md"), "seed\n");
+  git(dir, "add", "README.md");
+  git(dir, "commit", "-qm", "seed");
+  return dir;
+}
+
+function fakeRow(overrides = {}) {
+  return {
+    path: "/tmp/wt",
+    branch: "feat/cave-test-safe",
+    head: "a".repeat(40),
+    verdict: "ACTIVE",
+    locked: false,
+    ...overrides,
+  };
+}
+
+function details(overrides = {}) {
+  return {
+    tracked: { ok: true, paths: [], error: null },
+    ignored: { ok: true, paths: [".next/cache/data"], error: null },
+    operation: null,
+    ...overrides,
+  };
+}
+
+assert.equal(SOFT_TARGETS.attachedWorktrees, 10);
+assert.equal(SOFT_TARGETS.detachedWorktrees, 2);
+assert.equal(SOFT_TARGETS.localBranches, 15);
+
+const plist = launchAgentPlist({
+  node: "/opt/node/bin/node",
+  hygieneScript: "/repo/scripts/worktree-hygiene.mjs",
+  repo: "/repo",
+  logPath: "/tmp/hygiene.log",
+});
+assert.match(plist, /<string>scheduled<\/string>/);
+assert.match(plist, /<string>--fetch<\/string>/);
+assert.match(plist, /<string>--json<\/string>/);
+assert.doesNotMatch(plist, /--apply/, "scheduled automation must remain report-only");
+assert.doesNotMatch(plist, /WT_GUARD_BYPASS/, "scheduled automation must never bypass the worktree guard");
+
+for (const value of [
+  ".next/cache/foo",
+  "node_modules/react/index.js",
+  "coverage/report.json",
+  "target/debug/app",
+  "src-tauri/target/release/app",
+  "test-results/x/result.json",
+  "public/pdf.worker.min.mjs",
+  ".claude/worktree-autolock.log",
+]) {
+  assert.equal(isDisposableRelative(value), true, `${value} should be disposable`);
+}
+
+for (const value of [
+  "src/app/page.tsx",
+  "docs/design.md",
+  "public/brand/logo.svg",
+  ".env",
+  "apps/ios/Secrets.plist",
+]) {
+  assert.equal(isDisposableRelative(value), false, `${value} must never be disposable`);
+}
+
+assert.equal(worktreeSlug("feat/cave-123-something"), "cave-123-something");
+assert.equal(worktreeSlug("fix/cave/unsafe"), "cave-unsafe");
+
+// Recursive cleanup must never traverse an intermediate symlink out of a
+// worktree. A terminal disposable symlink is safe because rmSync unlinks the
+// link itself; an ancestor symlink can redirect recursive traversal.
+{
+  const dir = mkdtempSync(path.join(tmpdir(), "cave-hygiene-symlink-"));
+  const wt = path.join(dir, "wt");
+  const outside = path.join(dir, "outside");
+  try {
+    mkdirSync(wt);
+    mkdirSync(outside);
+    symlinkSync(outside, path.join(wt, ".next"), "dir");
+    const unsafe = disposablePathSafety(wt, ".next/cache/blob");
+    assert.equal(unsafe.ok, false);
+    assert.match(unsafe.reason, /symlink ancestor/);
+
+    rmSync(path.join(wt, ".next"));
+    symlinkSync(outside, path.join(wt, "public-pdf-link"), "dir");
+    const terminal = disposablePathSafety(wt, "public-pdf-link");
+    assert.equal(terminal.ok, true, "terminal symlinks may be unlinked without traversal");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+assert.deepEqual(assessThin(fakeRow(), details()), { eligible: true, reasons: [] });
+assert.equal(
+  assessThin(fakeRow({ verdict: "WEDGED" }), details({ operation: "merge" })).eligible,
+  false,
+  "unfinished operations must refuse thinning",
+);
+assert.equal(
+  assessThin(fakeRow(), details({ tracked: { ok: true, paths: ["src/app/page.tsx"], error: null } })).eligible,
+  false,
+  "tracked changes must refuse thinning",
+);
+
+const retained = { ok: true, retained: true, via: "refs/heads/feat/cave-test-safe" };
+assert.equal(assessPark(fakeRow(), details(), retained).eligible, true);
+assert.equal(assessPark(fakeRow({ branch: "main" }), details(), retained).eligible, false, "protected branches must never park");
+assert.equal(assessPark(fakeRow({ locked: true }), details(), retained).eligible, false, "locked worktrees must not park implicitly");
+assert.equal(
+  assessPark(fakeRow(), details(), { ok: true, retained: false, reason: "unretained" }).eligible,
+  false,
+  "unretained heads must refuse parking",
+);
+assert.equal(
+  assessPark(
+    fakeRow(),
+    details({ ignored: { ok: true, paths: ["public/brand/logo.svg"], error: null } }),
+    retained,
+  ).eligible,
+  false,
+  "non-disposable ignored state would be destroyed by parking and must refuse",
+);
+
+// Keep the hygiene allowlist mechanically aligned with the canonical lifecycle
+// policy. A new category may be added there without automatically becoming
+// deletable here, but anything hygiene claims disposable must remain canonical.
+const lifecycle = readFileSync(path.join(root, "src", "lib", "worktree-lifecycle.ts"), "utf8");
+for (const entry of [...DISPOSABLE_ROOTS, ...DISPOSABLE_FILES]) {
+  assert.ok(
+    lifecycle.includes(`"${entry}"`),
+    `hygiene disposable path ${entry} must also exist in src/lib/worktree-lifecycle.ts`,
+  );
+}
+
+// Integration: default thin is dry-run and does not remove generated state.
+// --apply removes only ignored, allowlisted output while preserving the branch.
+{
+  const dir = repo();
+  try {
+    const wt = path.join(dir, "wt");
+    git(dir, "worktree", "add", "-q", "-b", "feat/cave-test-thin", wt, "main");
+    writeFileSync(path.join(wt, ".gitignore"), ".next/\n");
+    git(wt, "add", ".gitignore");
+    git(wt, "commit", "-qm", "ignore build state");
+    git(dir, "merge", "--ff-only", "feat/cave-test-thin");
+    writeFileSync(path.join(wt, ".next-placeholder"), "kept");
+    let result = run(dir, "thin", "--branch", "feat/cave-test-thin");
+    assert.equal(result.status, 0);
+    let report = JSON.parse(result.stdout);
+    assert.equal(report.refused.length, 1, "untracked work must refuse thinning");
+    rmSync(path.join(wt, ".next-placeholder"));
+
+    mkdirSync(path.join(wt, ".next", "cache"), { recursive: true });
+    writeFileSync(path.join(wt, ".next", "cache", "blob"), "x".repeat(1024));
+    result = run(dir, "thin", "--branch", "feat/cave-test-thin");
+    assert.equal(result.status, 0);
+    report = JSON.parse(result.stdout);
+    assert.equal(report.candidates.length, 1);
+    assert.equal(readFileSync(path.join(wt, ".next", "cache", "blob"), "utf8").length, 1024);
+
+    result = run(dir, "thin", "--branch", "feat/cave-test-thin", "--apply");
+    assert.equal(result.status, 0);
+    assert.equal(run(dir, "daily", "--json").status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// CLI hardening: mutations require an explicit target and --max is bounded.
+{
+  const dir = repo();
+  try {
+    assert.notEqual(run(dir, "thin").status, 0);
+    assert.notEqual(run(dir, "park", "--all-eligible", "--max", "0").status, 0);
+    assert.notEqual(run(dir, "unpark", "--branch", "main").status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("worktree hygiene contract: ok");

--- a/scripts/worktree-hygiene.mjs
+++ b/scripts/worktree-hygiene.mjs
@@ -1,0 +1,523 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, lstatSync, readdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const SOFT_TARGETS = Object.freeze({
+  attachedWorktrees: 10,
+  detachedWorktrees: 2,
+  localBranches: 15,
+  staleBranchDays: 7,
+  detachedScratchHours: 24,
+});
+
+export const DISPOSABLE_ROOTS = Object.freeze([
+  ".next",
+  ".turbo",
+  "artifacts",
+  "coverage",
+  "dist",
+  "node_modules",
+  "public/sandbox",
+  "src-tauri/gen",
+  "src-tauri/resources",
+  "src-tauri/target",
+  "target",
+  "test-results",
+]);
+
+export const DISPOSABLE_FILES = Object.freeze([
+  "public/pdf.worker.min.mjs",
+  ".claude/worktree-autolock.stamp",
+  ".claude/worktree-autolock.log",
+  ".claude/worktree-retention-push.stamp",
+  ".claude/worktree-retention-push.log",
+  ".claude/worktree-guard-bypass.log",
+]);
+
+const PROTECTED_BRANCHES = new Set(["main", "master", "__dolt_remote_info__"]);
+const repoScript = path.join(path.dirname(fileURLToPath(import.meta.url)), "worktree-status.mjs");
+
+function exec(command, args, cwd, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: options.timeout ?? 30_000,
+    env: options.env ?? process.env,
+  });
+  return {
+    ok: result.status === 0 && !result.error,
+    status: result.status,
+    stdout: String(result.stdout ?? "").trim(),
+    stderr: [String(result.stderr ?? "").trim(), result.error?.message ?? ""].filter(Boolean).join("\n"),
+  };
+}
+
+function git(root, args, options) {
+  return exec("git", ["-C", root, ...args], root, options);
+}
+
+function requiredGit(root, args, label) {
+  const result = git(root, args);
+  if (!result.ok) throw new Error(`${label}: ${result.stderr || `git ${args.join(" ")} failed`}`);
+  return result.stdout;
+}
+
+export function normalizeRelative(candidate) {
+  return candidate.split(path.sep).join("/").replace(/^\.\/+/, "");
+}
+
+export function isDisposableRelative(candidate) {
+  const rel = normalizeRelative(candidate);
+  if (DISPOSABLE_FILES.includes(rel)) return true;
+  return DISPOSABLE_ROOTS.some((root) => rel === root || rel.startsWith(`${root}/`));
+}
+
+export function worktreeSlug(branch) {
+  return branch.replace(/^(?:feat|fix|docs|chore|ci|release)\//, "").replace(/[^A-Za-z0-9._-]+/g, "-");
+}
+
+function parsePorcelainWorktrees(root) {
+  const output = requiredGit(root, ["worktree", "list", "--porcelain"], "list worktrees");
+  const rows = [];
+  let row = null;
+  for (const line of output.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      if (row) rows.push(row);
+      row = { path: line.slice(9), branch: null, head: null, detached: false, locked: false };
+    } else if (!row) {
+      continue;
+    } else if (line.startsWith("HEAD ")) row.head = line.slice(5);
+    else if (line.startsWith("branch ")) row.branch = line.slice(7).replace(/^refs\/heads\//, "");
+    else if (line === "detached") row.detached = true;
+    else if (line === "locked" || line.startsWith("locked ")) row.locked = true;
+  }
+  if (row) rows.push(row);
+  return rows;
+}
+
+function statusRows(root) {
+  const result = exec("node", [repoScript, "--json"], root);
+  if (!result.ok) throw new Error(`wt:status unavailable: ${result.stderr || result.stdout}`);
+  const parsed = JSON.parse(result.stdout);
+  if (!Array.isArray(parsed.rows)) throw new Error("wt:status returned no rows");
+  return parsed.rows;
+}
+
+function branchRows(root) {
+  const format = "%(refname:strip=2)%00%(objectname)%00%(committerdate:unix)%00%(upstream:short)";
+  const out = requiredGit(root, ["for-each-ref", `--format=${format}`, "refs/heads"], "list branches");
+  if (!out) return [];
+  return out.split("\n").map((line) => {
+    const [branch, head, unix, upstream] = line.split("\0");
+    return { branch, head, updatedAtMs: Number(unix || 0) * 1000, upstream: upstream || null };
+  });
+}
+
+function ignoredPaths(wtPath) {
+  const out = git(wtPath, ["status", "--ignored", "--porcelain=v1", "-z", "--untracked-files=all"]);
+  if (!out.ok) return { ok: false, paths: [], error: out.stderr };
+  const paths = [];
+  for (const record of out.stdout.split("\0").filter(Boolean)) {
+    if (!record.startsWith("!! ")) continue;
+    paths.push(normalizeRelative(record.slice(3)));
+  }
+  return { ok: true, paths, error: null };
+}
+
+function trackedChanges(wtPath) {
+  const out = git(wtPath, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]);
+  if (!out.ok) return { ok: false, paths: [], error: out.stderr };
+  const paths = [];
+  for (const record of out.stdout.split("\0").filter(Boolean)) {
+    if (record.startsWith("!! ")) continue;
+    paths.push(record.length >= 4 ? normalizeRelative(record.slice(3)) : record);
+  }
+  return { ok: true, paths, error: null };
+}
+
+function gitOperation(wtPath) {
+  const gitDir = git(wtPath, ["rev-parse", "--path-format=absolute", "--git-dir"]);
+  if (!gitDir.ok || !gitDir.stdout) return "unknown";
+  for (const [marker, name] of [
+    ["rebase-merge", "rebase"], ["rebase-apply", "rebase"], ["MERGE_HEAD", "merge"],
+    ["CHERRY_PICK_HEAD", "cherry-pick"], ["REVERT_HEAD", "revert"], ["BISECT_LOG", "bisect"],
+  ]) {
+    if (existsSync(path.join(gitDir.stdout, marker))) return name;
+  }
+  return null;
+}
+
+function remoteExact(root, branch, head) {
+  const remote = git(root, ["ls-remote", "--heads", "origin", `refs/heads/${branch}`], { timeout: 20_000 });
+  if (!remote.ok) return { ok: false, retained: false, reason: `origin head probe failed: ${remote.stderr}` };
+  const oid = remote.stdout.split(/\s+/)[0] || null;
+  if (oid === head) return { ok: true, retained: true, via: `refs/heads/${branch}` };
+
+  const tags = git(root, ["ls-remote", "--tags", "origin"], { timeout: 20_000 });
+  if (!tags.ok) return { ok: false, retained: false, reason: `origin tag probe failed: ${tags.stderr}` };
+  const exact = tags.stdout.split("\n").find((line) => line.startsWith(`${head}\trefs/tags/`));
+  if (exact) return { ok: true, retained: true, via: exact.split("\t")[1] };
+  return { ok: true, retained: false, reason: `exact head ${head.slice(0, 12)} is absent from origin branch and tags` };
+}
+
+function directoryBytes(root) {
+  let total = 0;
+  const stack = [root];
+  while (stack.length) {
+    const current = stack.pop();
+    let entries;
+    try { entries = readdirSync(current, { withFileTypes: true }); } catch { continue; }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      try {
+        const stat = lstatSync(full);
+        if (stat.isSymbolicLink()) continue;
+        if (stat.isDirectory()) stack.push(full);
+        else if (stat.isFile()) total += stat.size;
+      } catch {}
+    }
+  }
+  return total;
+}
+
+export function assessThin(row, details) {
+  const reasons = [];
+  if (!row.path || row.verdict === "PRIMARY") reasons.push("primary or missing worktree");
+  if (row.verdict === "WEDGED" || details.operation) reasons.push(`unfinished git operation: ${details.operation ?? "wedged"}`);
+  if (!details.tracked.ok) reasons.push(`tracked-state probe failed: ${details.tracked.error}`);
+  if (details.tracked.paths.length) reasons.push(`tracked/untracked changes: ${details.tracked.paths.join(", ")}`);
+  return { eligible: reasons.length === 0, reasons };
+}
+
+export function assessPark(row, details, retention) {
+  const reasons = [...assessThin(row, details).reasons];
+  if (!row.branch || PROTECTED_BRANCHES.has(row.branch)) reasons.push("protected or detached branch");
+  if (row.locked) reasons.push("worktree is locked");
+  if (!retention.ok) reasons.push(retention.reason);
+  else if (!retention.retained) reasons.push(retention.reason);
+  const nonDisposable = details.ignored.paths.filter((candidate) => !isDisposableRelative(candidate));
+  if (!details.ignored.ok) reasons.push(`ignored-state probe failed: ${details.ignored.error}`);
+  if (nonDisposable.length) reasons.push(`non-disposable ignored state: ${nonDisposable.join(", ")}`);
+  return { eligible: reasons.length === 0, reasons, nonDisposable };
+}
+
+function detailFor(row) {
+  return {
+    tracked: trackedChanges(row.path),
+    ignored: ignoredPaths(row.path),
+    operation: gitOperation(row.path),
+  };
+}
+
+export function disposablePathSafety(wtPath, candidate) {
+  const root = path.resolve(wtPath);
+  const rel = normalizeRelative(candidate);
+  const full = path.resolve(root, rel);
+  if (full === root || !full.startsWith(`${root}${path.sep}`)) {
+    return { ok: false, reason: `disposable path escapes worktree: ${candidate}` };
+  }
+
+  const parts = rel.split("/").filter(Boolean);
+  let current = root;
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    current = path.join(current, parts[index]);
+    if (!existsSync(current)) break;
+    let stat;
+    try {
+      stat = lstatSync(current);
+    } catch (error) {
+      return { ok: false, reason: `could not inspect disposable ancestor ${current}: ${error instanceof Error ? error.message : String(error)}` };
+    }
+    if (stat.isSymbolicLink()) {
+      return { ok: false, reason: `refusing symlink ancestor while removing disposable state: ${current}` };
+    }
+    if (!stat.isDirectory()) {
+      return { ok: false, reason: `refusing non-directory disposable ancestor: ${current}` };
+    }
+  }
+
+  // A terminal symlink is safe to unlink because rmSync removes the link itself;
+  // the dangerous case is an intermediate symlink that would redirect traversal.
+  return { ok: true, full };
+}
+
+function removeDisposable(wtPath, ignored, apply) {
+  const candidates = [...new Set(ignored.filter(isDisposableRelative))].sort();
+  const removed = [];
+  for (const rel of candidates) {
+    const safety = disposablePathSafety(wtPath, rel);
+    if (!safety.ok) throw new Error(safety.reason);
+    if (apply && existsSync(safety.full)) rmSync(safety.full, { recursive: true, force: false });
+    removed.push(rel);
+  }
+  return removed;
+}
+
+function selectRows(root, options) {
+  const rows = statusRows(root).filter((row) => row.path && row.verdict !== "PRIMARY");
+  if (options.branch) return rows.filter((row) => row.branch === options.branch);
+  if (options.allEligible) return rows;
+  throw new Error("select exactly one --branch BRANCH or --all-eligible");
+}
+
+function report(root, mode, options = {}) {
+  if (options.fetch) {
+    const fetched = git(root, ["fetch", "origin", "--prune"], { timeout: 60_000 });
+    if (!fetched.ok) throw new Error(`fetch --prune failed: ${fetched.stderr}`);
+  }
+  const worktrees = parsePorcelainWorktrees(root);
+  const branches = branchRows(root);
+  const status = statusRows(root);
+  const primary = worktrees[0]?.path ?? root;
+  const now = Date.now();
+  const branchByName = new Map(branches.map((row) => [row.branch, row]));
+  const items = status.map((row) => {
+    const branch = row.branch ? branchByName.get(row.branch) : null;
+    const ageDays = branch?.updatedAtMs ? (now - branch.updatedAtMs) / 86_400_000 : null;
+    return {
+      path: row.path,
+      branch: row.branch,
+      verdict: row.verdict,
+      locked: row.locked,
+      detached: row.detached,
+      dirty: row.dirty,
+      ahead: row.ahead,
+      behind: row.behind,
+      diskBytes: row.path && row.path !== primary ? directoryBytes(row.path) : null,
+      branchAgeDays: ageDays === null ? null : Math.round(ageDays * 10) / 10,
+      stale: ageDays !== null && ageDays >= SOFT_TARGETS.staleBranchDays,
+    };
+  });
+  const attached = worktrees.filter((row) => row.branch && !PROTECTED_BRANCHES.has(row.branch)).length;
+  const detached = worktrees.filter((row) => row.detached).length;
+  const localBranchCount = branches.filter((row) => !PROTECTED_BRANCHES.has(row.branch)).length;
+  const warnings = [];
+  if (attached > SOFT_TARGETS.attachedWorktrees) warnings.push(`attached worktrees ${attached} > target ${SOFT_TARGETS.attachedWorktrees}`);
+  if (detached > SOFT_TARGETS.detachedWorktrees) warnings.push(`detached worktrees ${detached} > target ${SOFT_TARGETS.detachedWorktrees}`);
+  if (localBranchCount > SOFT_TARGETS.localBranches) warnings.push(`local branches ${localBranchCount} > target ${SOFT_TARGETS.localBranches}`);
+  const urgent = items.filter((item) => item.verdict === "WEDGED" || item.verdict === "SALVAGE");
+  let authoritativeLifecycle = null;
+  let remoteHygiene = null;
+  if (mode === "weekly") {
+    const lifecycle = exec(
+      "node",
+      ["--experimental-strip-types", path.join(path.dirname(repoScript), "worktree-lifecycle-patrol.ts"), "--repo", "OpenCoven/coven-cave", "--root", root, "--json"],
+      root,
+      { timeout: 90_000 },
+    );
+    if (lifecycle.ok) {
+      try { authoritativeLifecycle = { ok: true, report: JSON.parse(lifecycle.stdout) }; }
+      catch { authoritativeLifecycle = { ok: false, error: "lifecycle patrol returned malformed JSON" }; }
+    } else {
+      authoritativeLifecycle = { ok: false, error: lifecycle.stderr || lifecycle.stdout || "lifecycle patrol unavailable" };
+    }
+
+    const remoteAudit = exec("node", [path.join(path.dirname(repoScript), "remote-hygiene.mjs"), "--json"], root, { timeout: 30_000 });
+    if (remoteAudit.ok || remoteAudit.stdout) {
+      try { remoteHygiene = { ok: remoteAudit.ok, report: JSON.parse(remoteAudit.stdout) }; }
+      catch { remoteHygiene = { ok: false, error: "remote hygiene returned malformed JSON" }; }
+    } else {
+      remoteHygiene = { ok: false, error: remoteAudit.stderr || "remote hygiene unavailable" };
+    }
+  }
+  return {
+    ok: urgent.length === 0,
+    mode,
+    generatedAt: new Date().toISOString(),
+    root,
+    targets: SOFT_TARGETS,
+    counts: { registeredWorktrees: worktrees.length, attachedWorktrees: attached, detachedWorktrees: detached, localBranches: localBranchCount },
+    warnings,
+    urgent,
+    items,
+    authoritativeLifecycle,
+    remoteHygiene,
+  };
+}
+
+function printReport(value, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+    return;
+  }
+  console.log(`Cave worktree hygiene — ${value.mode}`);
+  console.log(`worktrees ${value.counts.attachedWorktrees}/${value.targets.attachedWorktrees} target; detached ${value.counts.detachedWorktrees}/${value.targets.detachedWorktrees}; branches ${value.counts.localBranches}/${value.targets.localBranches}`);
+  for (const warning of value.warnings) console.log(`WARN  ${warning}`);
+  for (const item of value.items) {
+    const size = item.diskBytes === null ? "-" : `${Math.round(item.diskBytes / 1024 / 1024)} MiB`;
+    console.log(`${String(item.verdict).padEnd(12)} ${size.padStart(9)}  ${item.branch ?? "(detached)"}  ${item.path}`);
+  }
+  if (value.urgent.length) console.log(`\nUrgent: ${value.urgent.length} wedged/salvage unit(s) require human disposition.`);
+}
+
+function mutateThin(root, options) {
+  const rows = selectRows(root, options);
+  const result = { action: "thin", apply: options.apply, candidates: [], refused: [] };
+  let applied = 0;
+  for (const row of rows) {
+    if (applied >= options.max) break;
+    const details = detailFor(row);
+    const assessment = assessThin(row, details);
+    if (!assessment.eligible) {
+      result.refused.push({ branch: row.branch, path: row.path, reasons: assessment.reasons });
+      continue;
+    }
+    const removed = removeDisposable(row.path, details.ignored.paths, options.apply);
+    result.candidates.push({ branch: row.branch, path: row.path, removed });
+    if (options.apply) applied += 1;
+  }
+  return result;
+}
+
+function postParkLifecycleHealthy(root, branch, head) {
+  const patrol = exec(
+    "node",
+    ["--experimental-strip-types", path.join(path.dirname(repoScript), "worktree-lifecycle-patrol.ts"), "--repo", "OpenCoven/coven-cave", "--root", root, "--json"],
+    root,
+    { timeout: 90_000 },
+  );
+  if (!patrol.ok) return { ok: false, reason: patrol.stderr || patrol.stdout || "lifecycle patrol unavailable after park" };
+  let parsed;
+  try { parsed = JSON.parse(patrol.stdout); }
+  catch { return { ok: false, reason: "lifecycle patrol returned malformed JSON after park" }; }
+  const item = Array.isArray(parsed.items)
+    ? parsed.items.find((candidate) => candidate.branch === branch && candidate.head === head)
+    : null;
+  if (!item) return { ok: false, reason: "parked branch disappeared from lifecycle inventory" };
+  if (item.path !== null || item.kind !== "branch-only") {
+    return { ok: false, reason: `expected branch-only lifecycle unit, got ${item.kind ?? "unknown"} at ${item.path ?? "null"}` };
+  }
+  if (item.lane === "uncertain" || item.lane === "recovery" || item.lane === "protected") {
+    return { ok: false, reason: `parked branch became lifecycle lane ${item.lane}: ${(item.reasons ?? []).join("; ")}` };
+  }
+  return { ok: true, lane: item.lane };
+}
+
+function branchStillExact(root, branch, head) {
+  const local = git(root, ["rev-parse", `refs/heads/${branch}`]);
+  return local.ok && local.stdout === head;
+}
+
+function pathStillRegistered(root, target) {
+  return parsePorcelainWorktrees(root).some((row) => path.resolve(row.path) === path.resolve(target));
+}
+
+function mutatePark(root, options) {
+  const rows = selectRows(root, options);
+  const result = { action: "park", apply: options.apply, parked: [], refused: [], rolledBack: [] };
+  let applied = 0;
+  for (const row of rows) {
+    if (applied >= options.max) break;
+    const details = detailFor(row);
+    const headResult = row.path ? git(row.path, ["rev-parse", "HEAD"]) : { ok: false, stderr: "missing path" };
+    const head = headResult.ok ? headResult.stdout : null;
+    const retention = row.branch && head ? remoteExact(root, row.branch, head) : { ok: true, retained: false, reason: "missing branch/head" };
+    const assessment = assessPark(row, details, retention);
+    if (!assessment.eligible) {
+      result.refused.push({ branch: row.branch, path: row.path, reasons: assessment.reasons });
+      continue;
+    }
+    const disposable = details.ignored.paths.filter(isDisposableRelative);
+    const proposal = { branch: row.branch, path: row.path, head, retainedBy: retention.via, disposable, requiresPostLifecycleProbe: true };
+    if (!options.apply) {
+      result.parked.push({ ...proposal, dryRun: true });
+      continue;
+    }
+
+    removeDisposable(row.path, details.ignored.paths, true);
+    const removed = git(root, ["worktree", "remove", row.path]);
+    if (!removed.ok) {
+      result.refused.push({ branch: row.branch, path: row.path, reasons: [`git worktree remove failed: ${removed.stderr}`] });
+      continue;
+    }
+
+    const branchExact = branchStillExact(root, row.branch, head);
+    const absent = !pathStillRegistered(root, row.path);
+    const lifecycle = branchExact && absent
+      ? postParkLifecycleHealthy(root, row.branch, head)
+      : { ok: false, reason: `git postcondition failed (branchExact=${branchExact}, worktreeAbsent=${absent})` };
+    if (!lifecycle.ok) {
+      const rollback = git(root, ["worktree", "add", "--no-track", row.path, row.branch]);
+      result.rolledBack.push({
+        branch: row.branch,
+        path: row.path,
+        reason: lifecycle.reason,
+        rollbackOk: rollback.ok,
+        rollbackError: rollback.ok ? null : rollback.stderr,
+      });
+      continue;
+    }
+    result.parked.push({ ...proposal, lifecycleLane: lifecycle.lane });
+    applied += 1;
+  }
+  return result;
+}
+
+function mutateUnpark(root, options) {
+  if (!options.branch) throw new Error("unpark requires --branch BRANCH");
+  if (PROTECTED_BRANCHES.has(options.branch)) throw new Error("refusing protected branch");
+  const worktrees = parsePorcelainWorktrees(root);
+  if (worktrees.some((row) => row.branch === options.branch)) throw new Error(`branch is already checked out: ${options.branch}`);
+  const head = requiredGit(root, ["rev-parse", `refs/heads/${options.branch}`], "resolve local branch");
+  const target = path.resolve(root, ".worktrees", worktreeSlug(options.branch));
+  if (existsSync(target)) throw new Error(`target path already exists: ${target}`);
+  const retention = remoteExact(root, options.branch, head);
+  if (!retention.ok || !retention.retained) throw new Error(retention.reason);
+  if (!options.apply) return { action: "unpark", apply: false, branch: options.branch, path: target, head, retainedBy: retention.via };
+  const added = git(root, ["worktree", "add", "--no-track", target, options.branch]);
+  if (!added.ok) throw new Error(`git worktree add failed: ${added.stderr}`);
+  if (!pathStillRegistered(root, target) || !branchStillExact(root, options.branch, head)) {
+    git(root, ["worktree", "remove", target]);
+    throw new Error("unpark postcondition failed; attempted rollback");
+  }
+  return { action: "unpark", apply: true, branch: options.branch, path: target, head, retainedBy: retention.via };
+}
+
+function parseArgs(argv) {
+  const action = argv[0] ?? "daily";
+  const options = { root: process.cwd(), json: false, fetch: false, apply: false, branch: null, allEligible: false, max: 3 };
+  for (let i = 1; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") options.json = true;
+    else if (arg === "--fetch") options.fetch = true;
+    else if (arg === "--apply") options.apply = true;
+    else if (arg === "--all-eligible") options.allEligible = true;
+    else if (arg === "--root") options.root = path.resolve(argv[++i] ?? "");
+    else if (arg === "--branch") options.branch = argv[++i] ?? null;
+    else if (arg === "--max") {
+      options.max = Number(argv[++i]);
+      if (!Number.isInteger(options.max) || options.max < 1 || options.max > 10) throw new Error("--max must be an integer from 1 through 10");
+    } else throw new Error(`unknown option: ${arg}`);
+  }
+  return { action, options };
+}
+
+function main(argv = process.argv.slice(2)) {
+  try {
+    const { action, options } = parseArgs(argv);
+    const root = requiredGit(options.root, ["rev-parse", "--show-toplevel"], "resolve repository root");
+    if (action === "daily" || action === "weekly" || action === "scheduled") {
+      const effective = action === "scheduled" && new Date().getDay() === 0 ? "weekly" : action === "scheduled" ? "daily" : action;
+      const value = report(root, effective, options);
+      printReport(value, options.json);
+      return value.ok ? 0 : 2;
+    }
+    let value;
+    if (action === "thin") value = mutateThin(root, options);
+    else if (action === "park") value = mutatePark(root, options);
+    else if (action === "unpark") value = mutateUnpark(root, options);
+    else throw new Error(`unknown action: ${action}`);
+    process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+    return 0;
+  } catch (error) {
+    console.error(`worktree-hygiene: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) process.exitCode = main();
+
+export { main, report, remoteExact };

--- a/scripts/worktree-hygiene.mjs
+++ b/scripts/worktree-hygiene.mjs
@@ -189,6 +189,7 @@ export function assessThin(row, details) {
   if (row.verdict === "WEDGED" || details.operation) reasons.push(`unfinished git operation: ${details.operation ?? "wedged"}`);
   if (!details.tracked.ok) reasons.push(`tracked-state probe failed: ${details.tracked.error}`);
   if (details.tracked.paths.length) reasons.push(`tracked/untracked changes: ${details.tracked.paths.join(", ")}`);
+  if (!details.ignored.ok) reasons.push(`ignored-state probe failed: ${details.ignored.error}`);
   return { eligible: reasons.length === 0, reasons };
 }
 


### PR DESCRIPTION
## Summary

Adds a local-first hygiene layer for keeping Cave worktrees and branches small without weakening the existing Beads/lifecycle/retention contracts.

### New operator tooling

- `scripts/worktree-hygiene.mjs`
  - `daily` / `weekly` reports with soft targets, branch age, worktree state, and approximate disk usage
  - `thin` removes only ignored output in the canonical disposable-policy subset
  - `park` removes a clean retained checkout while preserving the local branch, then requires an authoritative branch-only lifecycle postcondition; failure triggers rollback
  - `unpark` restores a retained branch under `.worktrees/` with `--no-track`
  - all mutation commands are dry-run by default and bounded by `--max 1..10`
- `scripts/worktree-hygiene-schedule.mjs`
  - macOS LaunchAgent installer/status/uninstaller
  - report-only daily run at 19:15 local time; Sunday emits the weekly report
  - no `--apply` or worktree-guard bypass path
- `WORKTREE_HYGIENE.md` documents targets, cadence, protection model, and operator commands.

### Safety contracts

`worktree-hygiene.contract.mjs` pins:

- protected branches never park
- dirty/untracked and unfinished-Git-operation work refuses thinning
- locked and unretained work refuses parking
- non-disposable ignored state refuses parking
- every hygiene-disposable path remains present in the canonical lifecycle policy
- dry-run leaves generated state intact; explicit apply removes only ignored allowlisted state
- mutations require explicit targets and bounded `--max`
- generated LaunchAgent contains report/fetch flags but never `--apply` or `WT_GUARD_BYPASS`

`.github/workflows/worktree-hygiene-contract.yml` runs those contracts on relevant PRs, on main, manually, and weekly. The scheduled GitHub job validates tooling only; it never pretends to mutate a developer machine.

## Protection model

- no `git worktree remove --force`
- no branch or tag deletion
- no remote deletion
- exact remote branch/tag retention required for park/unpark
- primary, `main`, `master`, and `__dolt_remote_info__` protected
- parking checks ordinary Git postconditions and then the authoritative worktree lifecycle patrol; an unhealthy branch-only transition is rolled back to the original path
- retirement remains separate and gated by the existing maintenance planes/archive-tag contract

Closes #4870 once merged and verified.
