### PR TITLE
Remove recurring local access pairing prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+- Remove the recurring fresh-pairing-token interruption for trusted local browser REST and terminal access.
+
 ## [0.3.9] - 2026-08-21
 
 > Restores the release pipeline and ships the refreshed desktop chrome.

--- a/docs/daemon-connectivity-reliability.md
+++ b/docs/daemon-connectivity-reliability.md
@@ -280,7 +280,7 @@ work.
 | No cross-component correlation/export contract | `cave-58eoq.3` |
 | Full OS fault-injection and lifecycle stress matrix is incomplete | `cave-58eoq.4` |
 | Exhaustive remaining CLI spawn and socket/pipe security proof is incomplete after closing the PTY and remote tokenless-development authentication bypasses | `cave-58eoq.6` |
-| Access-token-only loopback mode still treats a verified local TCP peer as sufficient for REST and PTY, which does not distinguish OS users on shared machines | `cave-ruw4z` |
+| Direct loopback is intentionally sufficient for prompt-free browser REST and PTY access; this does not distinguish OS users on shared machines | Accepted product tradeoff in `cave-99eon` |
 | One-click repairs are not yet implemented for every classified failure | Follow from the issue whose evidence identifies the repair boundary |
 | Hardware-only Windows installer/Defender and macOS signing/quarantine behavior still require release-host validation | Release validation checklist |
 ## Reliability measurement contract

--- a/docs/mobile-tailscale.md
+++ b/docs/mobile-tailscale.md
@@ -122,7 +122,7 @@ pnpm mobile:tailscale:invite
 
 The agent should verify that the invite redirects, stores the cookie, and loads the app shell before reporting success. It should not paste the raw invite into chat by default. If a fresh invite expires while you are away from the laptop, ask the agent to run `pnpm mobile:tailscale:invite`; the command refreshes the invite without restarting the dev server.
 
-Do not open the Serve URL without the invite query. When `COVEN_CAVE_ACCESS_TOKEN` is set, CovenCave rejects requests until a valid signed `coven_access_token` invite is supplied by query, cookie, bearer header, or the equivalent internal request path. A loopback-looking `Host` header is not treated as proof of a local connection because remote clients can spoof it.
+Do not open the Serve URL without the invite query. When `COVEN_CAVE_ACCESS_TOKEN` is set, CovenCave rejects remote requests until a valid signed `coven_access_token` invite is supplied by query, cookie, bearer header, or the equivalent internal request path. Direct loopback is recognized only from the custom server's socket evidence and per-boot stamp; a client-supplied loopback-looking `Host` or peer header cannot earn that trust.
 
 Independent of the mobile token, every `/api/*` request also has to satisfy loopback/same-origin/referer/content-type checks — those guards apply in plain browser dev too, not just in bundled mode. A valid mobile token lets Tailscale Serve satisfy the host/origin/referer gates while it proxies to the loopback dev server; anything else (LAN scanners, accidental `-H 0.0.0.0`, mismatched origins without the token) hits a 403 before any handler runs.
 

--- a/docs/superpowers/specs/2026-08-10-loopback-user-bound-auth-design.md
+++ b/docs/superpowers/specs/2026-08-10-loopback-user-bound-auth-design.md
@@ -1,8 +1,14 @@
 # User-bound authentication for loopback callers — design
 
-Status: design for review
+Status: superseded on 2026-08-22 by `cave-99eon`
 Bead: `cave-ruw4z`
 Source: final security review of the daemon-connectivity audit (`cave-58eoq`)
+
+> **Superseding product decision:** direct, server-stamped, unforwarded
+> loopback is again a first-class browser caller for REST and PTY. The owner
+> explicitly prioritized eliminating the recurring pairing-token interruption.
+> Forwarded, Tailscale, and non-loopback ingress remain credential-gated. The
+> shared-machine tradeoff documented below is accepted rather than accidental.
 
 ## The defect
 

--- a/server.mjs
+++ b/server.mjs
@@ -718,9 +718,10 @@ function isPtyAuthRequired() {
 function shouldRejectUnauthenticatedPtyUpgrade({
   sidecarTokenConfigured = false,
   accessTokenConfigured = false,
-  tokenAuthenticated = false
+  tokenAuthenticated = false,
+  directLoopback = false
 } = {}) {
-  if (tokenAuthenticated) return false;
+  if (tokenAuthenticated || directLoopback) return false;
   return sidecarTokenConfigured || accessTokenConfigured;
 }
 function isAuthorized(req, query) {
@@ -1093,7 +1094,8 @@ server.on("upgrade", (req, socket, head) => {
   if (shouldRejectUnauthenticatedPtyUpgrade({
     sidecarTokenConfigured: Boolean(SIDECAR_TOKEN),
     accessTokenConfigured: Boolean(accessToken()),
-    tokenAuthenticated
+    tokenAuthenticated,
+    directLoopback: isDirectLoopbackRequest(req)
   })) {
     socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
     socket.destroy();

--- a/server.ts
+++ b/server.ts
@@ -1177,8 +1177,9 @@ function shouldRejectUnauthenticatedPtyUpgrade({
   sidecarTokenConfigured = false,
   accessTokenConfigured = false,
   tokenAuthenticated = false,
+  directLoopback = false,
 } = {}) {
-  if (tokenAuthenticated) return false;
+  if (tokenAuthenticated || directLoopback) return false;
   return sidecarTokenConfigured || accessTokenConfigured;
 }
 
@@ -1684,21 +1685,14 @@ server.on("upgrade", (req, socket, head) => {
     return;
   }
 
-  // Any configured PTY credential closes the credential-less path, including
-  // direct loopback: another local account or process is not the paired app.
-  // Plain development remains credential-less only when neither token exists.
-  //
-  // Keep the credential-less case exactly that narrow. #714 removed it and
-  // 401'd every local terminal, reintroducing the v0.0.72 "Terminal connection
-  // failed" regression that server-pty-ws.test.ts still guards. What makes
-  // closing it safe HERE is that both peers now have a credential to present:
-  // the Tauri shell its per-launch sidecar token, and a local browser the
-  // access gate. TCP loopback proves only that the caller is on this machine,
-  // never which OS user it is.
+  // Direct, unforwarded loopback is the browser's no-prompt PTY path. Remote
+  // and forwarded clients still need a configured credential before they can
+  // spawn or adopt a shell.
   if (shouldRejectUnauthenticatedPtyUpgrade({
     sidecarTokenConfigured: Boolean(SIDECAR_TOKEN),
     accessTokenConfigured: Boolean(accessToken()),
     tokenAuthenticated,
+    directLoopback: isDirectLoopbackRequest(req),
   })) {
     socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
     socket.destroy();

--- a/src/components/workspace-daemon-connection.test.ts
+++ b/src/components/workspace-daemon-connection.test.ts
@@ -145,16 +145,11 @@ test("Workspace applies connection polls through the existing classifier-driven 
     /if \(result\.kind === "running"\) \{[\s\S]*setAcceptedLocalDaemonHealthy\(result\.targetMode === "local"\)[\s\S]*\} else \{[\s\S]*setAcceptedLocalDaemonHealthy\(false\)/,
     "acceptedLocalDaemonHealthy should still only latch when the active target is a healthy local daemon",
   );
-  assert.match(
-    applyPoll,
-    /if \(poll\.responseStatus !== 401\) setAuthExpired\(false\)/,
-    "any non-401 connection response should clear the auth-expired latch",
-  );
   assert.match(applyPoll, /setDaemonStatusResolved\(true\)/, "the first accepted connection poll should still resolve the unknown boot state");
   assert.match(
     applyPoll,
-    /if \(result\.kind === "auth-expired"\) \{[\s\S]*setAuthExpired\(true\)[\s\S]*setDaemonStatusUnavailable\(null\)[\s\S]*return;/,
-    "401s should remain distinct from transport availability failures",
+    /if \(result\.kind === "auth-expired"\) \{[\s\S]*daemonHealthyStreakRef\.current = 0[\s\S]*setDaemonOffline\(false\)[\s\S]*setDaemonStatusUnavailable\("access check failed"\)[\s\S]*return;/,
+    "unexpected 401s should use retryable status-unavailable recovery without reintroducing a pairing prompt",
   );
   assert.match(
     applyPoll,
@@ -206,30 +201,15 @@ test("Workspace keeps automatic recovery quiet but restores truthful banners aft
   );
   assert.match(
     workspace,
-    /if \(!daemonOffline \|\| authExpired \|\| daemonRecovery\.quiet\)/,
+    /if \(!daemonOffline \|\| daemonRecovery\.quiet\)/,
     "offline and start-error banners should stay dismissed only while bounded recovery is quiet",
   );
 });
 
-test("Workspace routes expired browser access to the existing token prompt", () => {
-  assert.match(
-    workspace,
-    /import \{ accessPromptUrl \} from "@\/proxy-helpers";/,
-    "Workspace should share the proxy's access-prompt URL contract",
-  );
-  assert.match(
-    workspace,
-    /title: "Access required — sign in with a fresh pairing token\."/,
-    "the auth banner should name the required action without promising that reload is enough",
-  );
-  assert.match(
-    workspace,
-    /label: "Sign in"[\s\S]*window\.location\.assign\(accessPromptUrl\(window\.location\.href\)\)/,
-    "the banner CTA should navigate to the explicitly marked access prompt",
-  );
+test("Workspace never renders a pairing-token access banner", () => {
   assert.doesNotMatch(
     workspace,
-    /id: "auth-expired"[\s\S]*window\.location\.reload\(\)/,
-    "auth recovery should not repeat the trusted-navigation bypass loop",
+    /Access required|fresh pairing token|accessPromptUrl|id: "auth-expired"/,
+    "trusted local recovery must not direct users into a pairing-token loop",
   );
 });

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -7,7 +7,6 @@ import { ActingFamiliarGate } from "@/components/acting-familiar-gate";
 import { stampFirstOpenOnce } from "@/lib/first-run-stamps";
 import { groupInboxFeed, unreadInboxCount } from "@/lib/inbox-feed";
 import { parseGitHubItemUrl } from "@/lib/github-item-url";
-import { accessPromptUrl } from "@/proxy-helpers";
 import { filterDeletedSessions, recordDeletedSessionIds } from "@/lib/session-list-deletes";
 import { sameSessionList } from "@/lib/session-list-equal";
 import { invalidateConversation } from "@/lib/conversation-cache";
@@ -1094,10 +1093,6 @@ export function Workspace() {
   // "running" doesn't flicker it away — it shows on the first definitive local-
   // offline poll and only clears after the daemon is *consistently* healthy.
   const [daemonOffline, setDaemonOffline] = useState(false);
-  // The access-token gate rejected our credential (401 on the status poll).
-  // Distinct from daemonOffline: the daemon may be fine — WE can't see it, and
-  // the fix is re-auth (reload to the gate page), not "Start daemon" (cave-wkp5).
-  const [authExpired, setAuthExpired] = useState(false);
   const [daemonStatusUnavailable, setDaemonStatusUnavailable] = useState<string | null>(null);
   const [daemonRecovery, setDaemonRecovery] = useState(initialDaemonRecoveryPresentation);
   const daemonHealthyStreakRef = useRef(0);
@@ -1348,13 +1343,11 @@ export function Workspace() {
     } else {
       setAcceptedLocalDaemonHealthy(false);
     }
-    // A real non-401 response proves the Cave credential is accepted again.
-    if (poll.responseStatus !== 401) setAuthExpired(false);
-
     setDaemonStatusResolved(true);
     if (result.kind === "auth-expired") {
-      setAuthExpired(true);
-      setDaemonStatusUnavailable(null);
+      daemonHealthyStreakRef.current = 0;
+      setDaemonOffline(false);
+      setDaemonStatusUnavailable("access check failed");
       return;
     }
     if (result.kind === "unavailable") {
@@ -1680,10 +1673,10 @@ export function Workspace() {
 
   // Push / dismiss the daemon-offline banner into the shared shell channel so
   // it appears at the top of every surface, not just Chat. While the access
-  // token is rejected the daemon state is unknowable — suppress this banner
-  // in favour of the re-auth one (cave-wkp5).
+  // token is rejected the daemon state is unknowable, so the status-unavailable
+  // path below owns recovery instead of offering Start daemon.
   useEffect(() => {
-    if (!daemonOffline || authExpired || daemonRecovery.quiet) {
+    if (!daemonOffline || daemonRecovery.quiet) {
       dismissBanner("daemon-offline");
       dismissBanner("daemon-start-error");
     } else if (daemonStatusResolved) {
@@ -1701,13 +1694,13 @@ export function Workspace() {
         },
       });
     }
-  }, [daemonOffline, daemonStatusResolved, authExpired, daemonRecovery.quiet, pushBanner, dismissBanner, startDaemon]);
+  }, [daemonOffline, daemonStatusResolved, daemonRecovery.quiet, pushBanner, dismissBanner, startDaemon]);
 
   // A status-service failure, timeout, malformed response, or non-local target
   // problem does not prove the local daemon is stopped. Keep that uncertainty
   // accurate and retryable instead of offering the misleading Start daemon CTA.
   useEffect(() => {
-    if (!daemonStatusUnavailable || authExpired || daemonOffline) {
+    if (!daemonStatusUnavailable || daemonOffline) {
       dismissBanner("daemon-status-unavailable");
       return;
     }
@@ -1722,28 +1715,7 @@ export function Workspace() {
         },
       },
     });
-  }, [daemonStatusUnavailable, authExpired, daemonOffline, pushBanner, dismissBanner, refreshDaemonStatus]);
-
-  // Re-auth banner: the access-token gate is rejecting every request, so all
-  // surfaces are degrading at once. Explicitly request the existing gate page;
-  // an ordinary trusted local reload intentionally bypasses it.
-  useEffect(() => {
-    if (!authExpired) {
-      dismissBanner("auth-expired");
-      return;
-    }
-    pushBanner({
-      id: "auth-expired",
-      severity: "error",
-      title: "Access required — sign in with a fresh pairing token.",
-      cta: {
-        label: "Sign in",
-        onClick: () => {
-          window.location.assign(accessPromptUrl(window.location.href));
-        },
-      },
-    });
-  }, [authExpired, pushBanner, dismissBanner]);
+  }, [daemonStatusUnavailable, daemonOffline, pushBanner, dismissBanner, refreshDaemonStatus]);
 
   const loadFamiliars = useCallback(async () => {
     const requestGeneration = ++loadFamiliarsReqRef.current;

--- a/src/lib/pty-upgrade-auth.test.ts
+++ b/src/lib/pty-upgrade-auth.test.ts
@@ -15,14 +15,14 @@ const shouldRejectUnauthenticatedPtyUpgrade = new Function(
 
 for (const [name, input, expected] of [
   [
-    "packaged sidecar rejects credential-less loopback clients",
+    "packaged sidecar permits direct loopback browser clients",
     {
       sidecarTokenConfigured: true,
       accessTokenConfigured: false,
       tokenAuthenticated: false,
       directLoopback: true,
     },
-    true,
+    false,
   ],
   [
     "packaged sidecar accepts its authenticated webview",
@@ -45,14 +45,14 @@ for (const [name, input, expected] of [
     false,
   ],
   [
-    "access-token-only servers reject credential-less loopback clients",
+    "access-token-only servers permit direct loopback browser clients",
     {
       sidecarTokenConfigured: false,
       accessTokenConfigured: true,
       tokenAuthenticated: false,
       directLoopback: true,
     },
-    true,
+    false,
   ],
   [
     "access-token-only forwarded clients still need authentication",

--- a/src/lib/server/client-v1/auth.test.ts
+++ b/src/lib/server/client-v1/auth.test.ts
@@ -585,12 +585,16 @@ test("reviewed client-v1 routes use loopback ingress without exposing private ro
       "/api/client/v1/admin/credentials",
       "/api/client/v1/private",
       "/api/client/v1/messages/send",
-      "/api/chat/conversation",
     ]) {
       const response = await proxy(proxyRequest(route, { headers }));
       assert.equal(passedThrough(response), false, route);
       assert.equal(response.status, 401, route);
     }
+
+    // Ordinary app APIs use the trusted-loopback browser exemption. They are
+    // outside Client v1's separately reviewed ingress and admin boundaries.
+    const appResponse = await proxy(proxyRequest("/api/chat/conversation", { headers }));
+    assert.equal(passedThrough(appResponse), true);
   } finally {
     restoreProxyEnv();
   }

--- a/src/lib/server/client-v1/auth.test.ts
+++ b/src/lib/server/client-v1/auth.test.ts
@@ -19,6 +19,7 @@ import {
   ACCESS_TOKEN_QUERY_PARAM,
   CLIENT_V1_AUTHENTICATED_PATHS,
   CLIENT_V1_PUBLIC_INGRESS,
+  LEGACY_ACCESS_PROMPT_QUERY_PARAM,
   LOCAL_PEER_HEADER,
   TAILNET_PEER_HEADER,
   TOKEN_HEADER,
@@ -640,6 +641,46 @@ test("client-v1 ingress is classified before legacy mobile query-token redirects
 
     assert.equal(response.status, 403);
     assert.equal(response.headers.has("location"), false);
+  } finally {
+    restoreProxyEnv();
+  }
+});
+
+test("trusted loopback pairing query tokens are stripped before the prompt-free bypass", async () => {
+  try {
+    setProxyEnv({
+      COVEN_CAVE_ACCESS_TOKEN: "configured-mobile-secret",
+      COVEN_CAVE_LOCAL_PEER_SECRET: "loopback-secret",
+    });
+
+    for (const [token, shouldSetCookie] of [
+      ["configured-mobile-secret", true],
+      ["wrong-secret", false],
+    ] as const) {
+      const query = new URLSearchParams({
+        [ACCESS_TOKEN_QUERY_PARAM]: token,
+        [LEGACY_ACCESS_PROMPT_QUERY_PARAM]: "1",
+        mode: "focus",
+      });
+      const response = await proxy(proxyRequest(`/chat?${query}`, {
+        headers: {
+          accept: "text/html",
+          [LOCAL_PEER_HEADER]: "loopback-secret",
+        },
+      }));
+
+      assert.equal(response.status, 307);
+      assert.equal(response.headers.get("location"), `${ORIGIN}/chat?mode=focus`);
+      const cookie = response.headers.get("set-cookie");
+      if (shouldSetCookie) {
+        assert.match(cookie ?? "", /coven_cave_access=configured-mobile-secret/);
+        assert.match(cookie ?? "", /Path=\//);
+        assert.match(cookie ?? "", /HttpOnly/);
+        assert.match(cookie ?? "", /SameSite=lax/);
+      } else {
+        assert.equal(cookie, null);
+      }
+    }
   } finally {
     restoreProxyEnv();
   }

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -121,8 +121,8 @@ assert.match(source, /missing request source/, "tokenless GET webhooks should re
 // extend to mobile-cookie-authenticated requests in exchange.
 assert.match(
   source,
-  /if \(!sidecarAuthenticated && !mobileAccessVerified\) \{/,
-  "the final sidecar gate must independently admit a verified access token",
+  /if \(!sidecarAuthenticated && !mobileAccessVerified && !trustedLocalPeer\) \{/,
+  "the final sidecar gate must independently admit a verified access token or trusted direct loopback",
 );
 assert.match(
   source,
@@ -206,19 +206,14 @@ assert.match(source, /maxAge/, "signed mobile cookie lifetime should track token
 assert.match(source, /req\.method === "GET" \|\| req\.method === "HEAD"/, "mobile token bootstrap should avoid redirects for mutating requests");
 assert.match(
   source,
-  /const accessPromptRequested =\s*req\.nextUrl\.searchParams\.get\(ACCESS_PROMPT_QUERY_PARAM\) === "1"/,
-  "proxy should recognize the explicit browser access-prompt marker",
-);
-assert.match(
-  source,
-  /url\.searchParams\.delete\(ACCESS_TOKEN_QUERY_PARAM\)[\s\S]*url\.searchParams\.delete\(ACCESS_PROMPT_QUERY_PARAM\)/,
-  "successful access-token exchange should remove both authentication query parameters",
+  /url\.searchParams\.delete\(ACCESS_TOKEN_QUERY_PARAM\)[\s\S]*url\.searchParams\.delete\(LEGACY_ACCESS_PROMPT_QUERY_PARAM\)/,
+  "successful access-token exchange should remove the token and any retired prompt marker",
 );
 
-// ── User-bound local authentication (cave-ruw4z) ──────────────────────────
-// The local-peer stamp still distinguishes direct from forwarded ingress, but
-// cannot bypass authentication because TCP loopback does not identify an OS
-// user. Only the per-launch sidecar credential exempts the owning Tauri app.
+// ── Prompt-free trusted local browser access (cave-99eon) ─────────────────
+// The server-stamped peer proof distinguishes direct loopback from forwarded
+// ingress. Direct local browser traffic stays prompt-free; remote traffic still
+// needs the mobile or sidecar credential.
 assert.match(
   source,
   /isTrustedLocalPeer\(\s*req\.headers\.get\(LOCAL_PEER_HEADER\),\s*process\.env\.COVEN_CAVE_LOCAL_PEER_SECRET,?\s*\)/,
@@ -232,26 +227,17 @@ assert.doesNotMatch(
 assert.match(
   source,
   /shouldRequireMobileAccessCredential\(\s*req\.headers\.get\("host"\),\s*suppliedTokens\.length > 0,\s*trustedLocalPeer,\s*tailnetPeerVerified,\s*sidecarAuthenticated,?\s*\)/,
-  "the mobile gate must require user-bound sidecar or mobile credentials even for local peers",
+  "the mobile gate should share the trusted local and sidecar evidence",
 );
-// ...with exactly one exemption: a stamped direct-loopback DOCUMENT navigation.
-// That request cannot carry a credential (a navigation is not a fetch, so
-// SidecarAuthBridge never sees it, and the sidecar token gets no cookie), so
-// gating it serves the access page instead of the app on every hard reload —
-// the v0.3.0 lockout. The stamp is only ever applied to unforwarded loopback
-// sockets, so Serve/tailnet traffic can never reach this branch.
 assert.match(
   source,
-  /if \(\s*shouldBypassMobileAccessGate\(\s*trustedLocalPeer,\s*accessPromptRequested,\s*req\.method,\s*req\.nextUrl\.pathname,\s*req\.headers\.get\("accept"\),?\s*\)\s*\) \{\s*return null;/,
-  "a stamped local-peer document navigation must skip the mobile gate unless it explicitly requests the prompt",
+  /if \(\s*shouldBypassMobileAccessGate\(\s*trustedLocalPeer,\s*req\.method,\s*req\.nextUrl\.pathname,\s*req\.headers\.get\("accept"\),?\s*\)\s*\) \{\s*return null;/,
+  "a stamped local-peer document navigation must always skip the mobile gate",
 );
-// The exemption must be navigation-scoped, never a blanket local-peer bypass:
-// `/api/*` keeps requiring the sidecar credential, which is what distinguishes
-// this user from other OS users on a shared machine.
-assert.doesNotMatch(
+assert.match(
   source,
-  /if \(trustedLocalPeer\) return null;/,
-  "the local-peer exemption must not extend past document navigations to the API surface",
+  /if \(!sidecarAuthenticated && !mobileAccessVerified && !trustedLocalPeer\) \{/,
+  "the final API credential gate must preserve prompt-free trusted loopback access",
 );
 assert.match(
   source,

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -121,8 +121,13 @@ assert.match(source, /missing request source/, "tokenless GET webhooks should re
 // extend to mobile-cookie-authenticated requests in exchange.
 assert.match(
   source,
-  /if \(!sidecarAuthenticated && !mobileAccessVerified && !trustedLocalPeer\) \{/,
-  "the final sidecar gate must independently admit a verified access token or trusted direct loopback",
+  /const trustedLocalBrowserApi =\s*trustedLocalPeer && !isClientV1Path\(req\.nextUrl\.pathname\)/,
+  "the trusted-loopback browser exemption must not cross Client v1's private boundary",
+);
+assert.match(
+  source,
+  /if \(!sidecarAuthenticated && !mobileAccessVerified && !trustedLocalBrowserApi\) \{/,
+  "the final sidecar gate must independently admit a verified access token or a trusted ordinary app API",
 );
 assert.match(
   source,
@@ -236,8 +241,8 @@ assert.match(
 );
 assert.match(
   source,
-  /if \(!sidecarAuthenticated && !mobileAccessVerified && !trustedLocalPeer\) \{/,
-  "the final API credential gate must preserve prompt-free trusted loopback access",
+  /if \(!sidecarAuthenticated && !mobileAccessVerified && !trustedLocalBrowserApi\) \{/,
+  "the final API credential gate must preserve prompt-free trusted loopback access outside Client v1",
 );
 assert.match(
   source,

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -241,6 +241,11 @@ assert.match(
 );
 assert.match(
   source,
+  /const queryToken = req\.nextUrl\.searchParams\.get\(ACCESS_TOKEN_QUERY_PARAM\);[\s\S]*?if \(\s*trustedLocalPeer\s*&& queryToken\s*&& \(req\.method === "GET" \|\| req\.method === "HEAD"\)\s*\) \{\s*return mobileAccessQueryTokenRedirect\(req, expected, queryToken\);\s*\}[\s\S]*?shouldBypassMobileAccessGate/,
+  "trusted local pairing links must exchange and remove query credentials before the prompt-free bypass",
+);
+assert.match(
+  source,
   /if \(!sidecarAuthenticated && !mobileAccessVerified && !trustedLocalBrowserApi\) \{/,
   "the final API credential gate must preserve prompt-free trusted loopback access outside Client v1",
 );

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -15,7 +15,6 @@
 
 import assert from "node:assert/strict";
 import {
-  accessPromptUrl,
   shouldBypassMobileAccessGate,
   isLoopbackHost,
   isTailscaleServeHost,
@@ -33,26 +32,18 @@ import {
   isHtmlNavigationRequest,
   accessGatePage,
   ACCESS_TOKEN_QUERY_PARAM,
-  ACCESS_PROMPT_QUERY_PARAM,
 } from "./proxy-helpers.ts";
-
-// ─── accessPromptUrl ──────────────────────────────────────────────────────
-assert.equal(
-  accessPromptUrl("http://127.0.0.1:3000/chat?mode=focus#session-123"),
-  "http://127.0.0.1:3000/chat?mode=focus&coven_access_prompt=1#session-123",
-  "the access prompt URL should preserve the current route, query, and hash",
-);
 
 // ─── shouldBypassMobileAccessGate ─────────────────────────────────────────
 assert.equal(
-  shouldBypassMobileAccessGate(true, false, "GET", "/", "text/html"),
+  shouldBypassMobileAccessGate(true, "GET", "/", "text/html"),
   true,
   "ordinary trusted local navigation should still load the app shell",
 );
 assert.equal(
-  shouldBypassMobileAccessGate(true, true, "GET", "/", "text/html"),
-  false,
-  "an explicit access-prompt navigation must reach the credential gate",
+  shouldBypassMobileAccessGate(true, "GET", "/?coven_access_prompt=1", "text/html"),
+  true,
+  "a stale explicit-prompt URL must not re-arm the local credential gate",
 );
 
 // ─── isLoopbackHost ────────────────────────────────────────────────────────
@@ -405,8 +396,13 @@ assert.equal(
 );
 assert.equal(
   shouldRequireMobileAccessCredential("localhost:3000", false, true),
-  true,
-  "a direct loopback peer still needs user-bound credentials on a shared machine",
+  false,
+  "a server-stamped direct loopback peer must not require a pairing credential",
+);
+assert.equal(
+  shouldRequireMobileAccessCredential("localhost:3000", true, true),
+  false,
+  "a stale local access cookie must not re-arm the pairing gate",
 );
 assert.equal(
   shouldRequireMobileAccessCredential("localhost:3000", false, true, false, true),
@@ -506,15 +502,11 @@ assert.equal(isHtmlNavigationRequest("GET", "/", null), false, "no Accept header
 // ─── accessGatePage ────────────────────────────────────────────────────────
 {
   const page = accessGatePage();
-  assert.match(page, /Access token required/);
+  assert.match(page, /Pair this device/);
   // The form re-enters the audited query-token exchange — the input MUST be
   // named exactly ACCESS_TOKEN_QUERY_PARAM and submit via GET.
   assert.match(page, new RegExp(`name="${ACCESS_TOKEN_QUERY_PARAM}"`));
-  assert.match(
-    page,
-    new RegExp(`name="${ACCESS_PROMPT_QUERY_PARAM}" value="1"`),
-    "the token form should retain the explicit prompt marker during GET submission",
-  );
+  assert.doesNotMatch(page, /coven_access_prompt/, "the remote pairing form should not retain the retired prompt marker");
   assert.match(page, /method="get"/);
   assert.match(page, /type="password"/, "token input must not echo on screen");
   assert.doesNotMatch(page, /<script/i, "gate page must be script-free (CSP-immune, no new surface)");

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -136,17 +136,16 @@ export function isAllowedRequestSourceAny(value: string | null, expectedOrigins:
 export function shouldRequireMobileAccessCredential(
   _host: string | null,
   _hasSuppliedCredential: boolean,
-  _trustedLocalPeer = false,
+  trustedLocalPeer = false,
   tailnetPeerVerified = false,
   sidecarAuthenticated = false,
 ) {
   // Forwarded tailnet identity is context for presence policy, not a bearer
   // credential: a local process can forge proxy headers on a loopback socket.
   void tailnetPeerVerified;
-  // The Tauri sidecar credential is minted per launch and delivered only to
-  // the owning app. Unlike TCP loopback, it distinguishes the intended local
-  // user from other OS users on a shared machine.
-  return !sidecarAuthenticated;
+  // Direct, unforwarded loopback is the no-prompt browser path. Remote ingress
+  // still needs the mobile credential, while Tauri may use its sidecar token.
+  return !trustedLocalPeer && !sidecarAuthenticated;
 }
 
 /**
@@ -403,22 +402,14 @@ export function isHtmlNavigationRequest(
   return Boolean(accept && accept.toLowerCase().includes("text/html"));
 }
 
-export function accessPromptUrl(value: string) {
-  const url = new URL(value);
-  url.searchParams.set(ACCESS_PROMPT_QUERY_PARAM, "1");
-  return url.toString();
-}
-
 export function shouldBypassMobileAccessGate(
   trustedLocalPeer: boolean,
-  promptRequested: boolean,
   method: string,
   pathname: string,
   accept: string | null,
 ) {
   return (
     trustedLocalPeer &&
-    !promptRequested &&
     isHtmlNavigationRequest(method, pathname, accept)
   );
 }
@@ -441,7 +432,7 @@ export function accessGatePage({ invalidToken = false }: { invalidToken?: boolea
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
-<title>Access required · Coven Cave</title>
+<title>Pair this device · Coven Cave</title>
 <style>
   :root { color-scheme: dark; }
   body {
@@ -502,11 +493,10 @@ export function accessGatePage({ invalidToken = false }: { invalidToken?: boolea
 <body>
 <main>
   <div class="dot" aria-hidden="true"></div>
-  <h1>Access token required</h1>
+  <h1>Pair this device</h1>
   <p>This Cave is protected. Open your pairing link, or paste an access token below.</p>
   ${note}
   <form method="get" action="">
-    <input type="hidden" name="${ACCESS_PROMPT_QUERY_PARAM}" value="1">
     <input type="password" name="${ACCESS_TOKEN_QUERY_PARAM}" autocomplete="off" required aria-label="Access token" placeholder="Access token">
     <button type="submit">Unlock</button>
   </form>
@@ -548,7 +538,7 @@ export function requiresPasskeyPresence(
 }
 
 export const ACCESS_TOKEN_QUERY_PARAM = "coven_access_token";
-export const ACCESS_PROMPT_QUERY_PARAM = "coven_access_prompt";
+export const LEGACY_ACCESS_PROMPT_QUERY_PARAM = "coven_access_prompt";
 export const TOKEN_PARAM = "covenCaveToken";
 export const TOKEN_HEADER = "x-coven-cave-token";
 export const MOBILE_ACCESS_HEADER = "x-coven-cave-mobile-access";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import {
   ACCESS_TOKEN_COOKIE,
   ACCESS_TOKEN_QUERY_PARAM,
-  ACCESS_PROMPT_QUERY_PARAM,
+  LEGACY_ACCESS_PROMPT_QUERY_PARAM,
   TOKEN_PARAM,
   TOKEN_HEADER,
   MOBILE_ACCESS_HEADER,
@@ -112,8 +112,6 @@ async function mobileAccessGate(
 ) {
   const expected = configuredMobileAccessToken();
   if (!expected) return null;
-  const accessPromptRequested =
-    req.nextUrl.searchParams.get(ACCESS_PROMPT_QUERY_PARAM) === "1";
 
   // A server.ts-stamped direct loopback DOCUMENT navigation is this machine's
   // own window asking for a page, and it is the one request shape that cannot
@@ -126,14 +124,12 @@ async function mobileAccessGate(
   // This does NOT reopen the bypass this change exists to close. The stamp is
   // minted per boot, never leaves server.ts, and is applied only to loopback
   // sockets carrying no forwarding markers — Tailscale-Serve traffic always
-  // arrives with x-forwarded-*, so it can never earn the stamp. `/api/*` is
-  // deliberately still gated: there the sidecar credential keeps doing the work
-  // the comment on shouldRequireMobileAccessCredential describes, distinguishing
-  // the intended local user from other OS users on a shared machine.
+  // arrives with x-forwarded-*, so it can never earn the stamp. `/api/*`
+  // follows the same direct-loopback decision below, so a browser tab does not
+  // fall into a pairing loop merely because mobile access is armed.
   if (
     shouldBypassMobileAccessGate(
       trustedLocalPeer,
-      accessPromptRequested,
       req.method,
       req.nextUrl.pathname,
       req.headers.get("accept"),
@@ -178,7 +174,7 @@ async function mobileAccessGate(
   if (queryToken && (req.method === "GET" || req.method === "HEAD")) {
     const url = req.nextUrl.clone();
     url.searchParams.delete(ACCESS_TOKEN_QUERY_PARAM);
-    url.searchParams.delete(ACCESS_PROMPT_QUERY_PARAM);
+    url.searchParams.delete(LEGACY_ACCESS_PROMPT_QUERY_PARAM);
     const res = NextResponse.redirect(url);
     const queryVerification = await isValidMobileAccessCredential({
       supplied: queryToken,
@@ -292,10 +288,9 @@ export async function proxy(req: NextRequest) {
   const sidecarAuthenticatedAtGate = sidecarTokenMatches(
     req.headers.get(TOKEN_HEADER) ?? req.nextUrl.searchParams.get(TOKEN_PARAM),
   ) || mediaTicketAuthenticated;
-  // The local-peer stamp distinguishes direct from forwarded traffic, but TCP
-  // loopback is not OS-user identity. When mobile access is armed, the Tauri
-  // app must also present its per-launch sidecar credential and a plain local
-  // browser must use the same access-token gate as remote browsers.
+  // The local-peer stamp distinguishes direct from forwarded traffic. Direct,
+  // unforwarded loopback is the browser's no-prompt path; remote traffic still
+  // requires a mobile or sidecar credential.
   const trustedLocalPeer = isTrustedLocalPeer(
     req.headers.get(LOCAL_PEER_HEADER),
     process.env.COVEN_CAVE_LOCAL_PEER_SECRET,
@@ -520,7 +515,7 @@ export async function proxy(req: NextRequest) {
     return nextWithMobileAccessMarker(req, remoteIngress);
   }
 
-  if (!sidecarAuthenticated && !mobileAccessVerified) {
+  if (!sidecarAuthenticated && !mobileAccessVerified && !trustedLocalPeer) {
     if (mediaTicketAuthenticated) {
       return nextWithMobileAccessMarker(req, remoteIngress);
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -29,6 +29,7 @@ import {
   requiresPasskeyPresence,
   clientV1IngressKind,
   isClientV1AdminPath,
+  isClientV1Path,
   isRefusedClientV1Path,
 } from "./proxy-helpers";
 import { isValidMobileAccessCredential } from "./lib/mobile-access-token.ts";
@@ -515,7 +516,13 @@ export async function proxy(req: NextRequest) {
     return nextWithMobileAccessMarker(req, remoteIngress);
   }
 
-  if (!sidecarAuthenticated && !mobileAccessVerified && !trustedLocalPeer) {
+  // Direct loopback is the prompt-free browser path for ordinary app APIs.
+  // Client v1 is different: its reviewed public/authenticated routes returned
+  // above, while every remaining path intentionally stays on this credential
+  // boundary (especially the human-consent admin surface).
+  const trustedLocalBrowserApi =
+    trustedLocalPeer && !isClientV1Path(req.nextUrl.pathname);
+  if (!sidecarAuthenticated && !mobileAccessVerified && !trustedLocalBrowserApi) {
     if (mediaTicketAuthenticated) {
       return nextWithMobileAccessMarker(req, remoteIngress);
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -105,6 +105,34 @@ async function mobileAccessVerification(
   return null;
 }
 
+async function mobileAccessQueryTokenRedirect(
+  req: NextRequest,
+  expected: string,
+  queryToken: string,
+) {
+  const url = req.nextUrl.clone();
+  url.searchParams.delete(ACCESS_TOKEN_QUERY_PARAM);
+  url.searchParams.delete(LEGACY_ACCESS_PROMPT_QUERY_PARAM);
+  const res = NextResponse.redirect(url);
+  const queryVerification = await isValidMobileAccessCredential({
+    supplied: queryToken,
+    expectedSecret: expected,
+  });
+  if (queryVerification.ok) {
+    const maxAge = queryVerification.legacy
+      ? undefined
+      : Math.max(1, Math.floor((queryVerification.expiresAt - Date.now()) / 1000));
+    res.cookies.set(ACCESS_TOKEN_COOKIE, queryToken, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: req.nextUrl.protocol === "https:",
+      path: "/",
+      maxAge,
+    });
+  }
+  return res;
+}
+
 async function mobileAccessGate(
   req: NextRequest,
   trustedLocalPeer: boolean,
@@ -113,6 +141,18 @@ async function mobileAccessGate(
 ) {
   const expected = configuredMobileAccessToken();
   if (!expected) return null;
+  const queryToken = req.nextUrl.searchParams.get(ACCESS_TOKEN_QUERY_PARAM);
+
+  // A local pairing link is already trusted for app access, but its query
+  // credential still needs the audited cookie exchange and URL cleanup before
+  // the prompt-free loopback bypass runs.
+  if (
+    trustedLocalPeer
+    && queryToken
+    && (req.method === "GET" || req.method === "HEAD")
+  ) {
+    return mobileAccessQueryTokenRedirect(req, expected, queryToken);
+  }
 
   // A server.ts-stamped direct loopback DOCUMENT navigation is this machine's
   // own window asking for a page, and it is the one request shape that cannot
@@ -152,7 +192,6 @@ async function mobileAccessGate(
     return null;
   }
 
-  const queryToken = req.nextUrl.searchParams.get(ACCESS_TOKEN_QUERY_PARAM);
   const verification = await mobileAccessVerification(req, expected, suppliedTokens);
   if (!verification) {
     // Browser page navigations get an HTML access page instead of a raw JSON
@@ -173,27 +212,7 @@ async function mobileAccessGate(
   }
 
   if (queryToken && (req.method === "GET" || req.method === "HEAD")) {
-    const url = req.nextUrl.clone();
-    url.searchParams.delete(ACCESS_TOKEN_QUERY_PARAM);
-    url.searchParams.delete(LEGACY_ACCESS_PROMPT_QUERY_PARAM);
-    const res = NextResponse.redirect(url);
-    const queryVerification = await isValidMobileAccessCredential({
-      supplied: queryToken,
-      expectedSecret: expected,
-    });
-    if (queryVerification.ok) {
-      const maxAge = queryVerification.legacy
-        ? undefined
-        : Math.max(1, Math.floor((queryVerification.expiresAt - Date.now()) / 1000));
-      res.cookies.set(ACCESS_TOKEN_COOKIE, queryToken, {
-        httpOnly: true,
-        sameSite: "lax",
-        secure: req.nextUrl.protocol === "https:",
-        path: "/",
-        maxAge,
-      });
-    }
-    return res;
+    return mobileAccessQueryTokenRedirect(req, expected, queryToken);
   }
 
   return null;

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -53,25 +53,19 @@ assert.match(
   /const secret = accessToken\(\);\s*if \(!secret \|\| !value\) return false/,
   "PTY WebSocket access-token auth fails closed when no access token is configured, reading the token lazily so mid-session arming (cave-os73) reaches the gate",
 );
-// The 401 applies when a remote/mobile credential is configured. With neither
-// token (plain local development) the loopback host+origin gate is the
-// protection. Once either credential exists, even loopback callers must prove
-// they hold it before the server will spawn or adopt a shell.
+// Remote/mobile callers need a configured credential. Direct, unforwarded
+// loopback remains the prompt-free browser path even while mobile access is
+// armed.
 assert.match(src, /function isPtyAuthRequired\(\): boolean \{\s*return Boolean\(accessToken\(\) \|\| SIDECAR_TOKEN\);\s*\}/, "PTY auth is required when either the mobile access token or sidecar token is configured");
 assert.match(
   src,
-  /sidecarTokenConfigured: Boolean\(SIDECAR_TOKEN\),\s*accessTokenConfigured: Boolean\(accessToken\(\)\),\s*tokenAuthenticated,/,
-  "PTY upgrade authentication closes the credential-less path whenever either token is configured",
+  /sidecarTokenConfigured: Boolean\(SIDECAR_TOKEN\),\s*accessTokenConfigured: Boolean\(accessToken\(\)\),\s*tokenAuthenticated,\s*directLoopback: isDirectLoopbackRequest\(req\),/,
+  "PTY upgrade authentication preserves direct-loopback access while keeping remote credentials required",
 );
-// ...and it decides that WITHOUT consulting loopback at all. The positive
-// assertion above would still pass if someone re-introduced a direct-loopback
-// escape hatch beside it, which is exactly the bypass cave-ruw4z removed: TCP
-// loopback proves the caller is on this machine, never which OS user it is, so
-// any local account could otherwise adopt a shell as the Cave process owner.
-assert.doesNotMatch(
+assert.match(
   src,
-  /shouldRejectUnauthenticatedPtyUpgrade\([\s\S]{0,400}?isDirectLoopbackRequest/,
-  "no direct-loopback term may re-enter the PTY rejection decision",
+  /if \(tokenAuthenticated \|\| directLoopback\) return false;/,
+  "a verified direct-loopback caller must never be redirected into pairing for PTY access",
 );
 // Direct-loopback classification (cave-vn2r): trusted only because ALL three
 // hold — the socket peer is loopback, no forwarding markers are present

--- a/src/tailnet-identity.test.ts
+++ b/src/tailnet-identity.test.ts
@@ -93,8 +93,8 @@ assert.equal(
 );
 assert.equal(
   shouldRequireMobileAccessCredential("127.0.0.1:3000", false, true, false),
-  true,
-  "socket-verified loopback is not OS-user identity",
+  false,
+  "socket-verified direct loopback is the prompt-free local browser path",
 );
 assert.equal(
   shouldRequireMobileAccessCredential("127.0.0.1:3000", false, false, false),


### PR DESCRIPTION
## Summary
- trust server-verified direct, unforwarded loopback requests across REST and PTY without requiring pairing credentials
- remove the workspace's recurring access-expired pairing interruption and recover unexpected local 401s through normal retry handling
- retain credential enforcement for forwarded, Tailscale, and other remote traffic while cleaning stale local pairing state

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` (1,282 files)
- `pnpm check:tests-wired` (1,810 files)
- focused proxy, middleware, tailnet, workspace daemon, PTY auth, and PTY WebSocket tests
- `pnpm build:server`
- production build and bundle budgets
- real-server REST/PTY direct-loopback versus forwarded matrix
- hydrated Chromium shell load with stale prompt query and cookie

`pnpm test:api` was also run. It currently has the same two pre-existing macOS-only credential-store fixture failures on `main`: `/var` versus `/private/var` path canonicalization and a simulated Windows ACL rejection. The required Linux CI run remains authoritative for the PR head.

Bead: `cave-99eon`
