### PR TITLE
Remove project scope disclaimer from left rail

### DIFF
--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -302,12 +302,12 @@ assert.doesNotMatch(
   /if \(!id\) return;[\s\S]*getLastSurface\(id\)/,
   "main context selection no longer restores an unrelated familiar surface",
 );
-assert.match(
+assert.doesNotMatch(
   workspace,
-  /This view is not filtered by project yet/,
-  "non-pilot surfaces do not imply filtering that Stage 1 has not implemented",
+  /Applies to new chats\. This view is not filtered by project yet\./,
+  "the left rail does not show the obsolete project-scope disclaimer",
 );
-// Both rail components receive the full project/crew/notice context so
+// Both rail components receive the full project/crew context, with no notice, so
 // workspaceContextReady becomes true in SidebarRailHeader.
 assert.match(
   workspace,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -4109,11 +4109,6 @@ export function Workspace() {
     [setMode],
   );
 
-  const workspaceContextNotice =
-    mode === "home" || mode === "chat"
-      ? null
-      : "Applies to new chats. This view is not filtered by project yet.";
-
   const sidebar = (
     <SidebarMinimal
       mode={mode}
@@ -4175,7 +4170,7 @@ export function Workspace() {
       projectCrewLoading={effectiveProjectCrewLoading}
       projectCrewError={projectCrewError}
       reloadProjectCrew={reloadProjectCrew}
-      contextNotice={workspaceContextNotice}
+      contextNotice={null}
     />
   );
 
@@ -4236,7 +4231,7 @@ export function Workspace() {
       projectCrewLoading={effectiveProjectCrewLoading}
       projectCrewError={projectCrewError}
       reloadProjectCrew={reloadProjectCrew}
-      contextNotice={workspaceContextNotice}
+      contextNotice={null}
       selectedFamiliarIds={scopeIds}
     />
   );


### PR DESCRIPTION
## Summary
- remove the obsolete project-scope disclaimer from both left-rail variants
- keep project and crew context controls unchanged
- pin the copy removal with a source-contract regression

## Verification
- focused workspace familiars landing contract
- `pnpm typecheck`
- `pnpm lint --quiet`
- `git diff --check`

Bead: `cave-sccd1`