### PR TITLE
fix(design): rescale --radius-panel with the corner-radius setting, and close the codemod's radius blind spot (#4350)

### DIFF
--- a/public/scripts/theme-init.js
+++ b/public/scripts/theme-init.js
@@ -294,9 +294,12 @@
     if (weight !== "normal" && WEIGHT[weight]) html.style.setProperty("--cave-reading-weight", WEIGHT[weight]);
     if (hyphens === "on") html.style.setProperty("--cave-reading-hyphens", "auto");
 
+    // [base, control, card, panel, pill] — mirrors CORNER_RADIUS_VALUES in
+    // src/lib/appearance-corner-radius.ts. Keep both in sync; the parity is
+    // asserted by src/components/theme-script.test.ts.
     var RADII = {
-      sharp: ["0.125rem","2px","4px","4px"],
-      round: ["0.875rem","12px","16px","999px"]
+      sharp: ["0.125rem","2px","4px","6px","4px"],
+      round: ["0.875rem","12px","16px","20px","999px"]
     };
     var radiusLevel = String(stored("cave:corner-radius", appearance.cornerRadius || "default"));
     var radii = RADII[radiusLevel];
@@ -304,7 +307,8 @@
       html.style.setProperty("--radius", radii[0]);
       html.style.setProperty("--radius-control", radii[1]);
       html.style.setProperty("--radius-card", radii[2]);
-      html.style.setProperty("--radius-pill", radii[3]);
+      html.style.setProperty("--radius-panel", radii[3]);
+      html.style.setProperty("--radius-pill", radii[4]);
     }
 
     var backdropRaw = initialized ? backdrop : stored("cave:backdrop:v1", backdrop);

--- a/src/components/theme-script.test.ts
+++ b/src/components/theme-script.test.ts
@@ -139,7 +139,7 @@ for (const property of [
   "--font-serif", "--font-sans", "--font-mono",
   "--cave-reading-leading", "--cave-reading-tracking", "--cave-reading-align",
   "--cave-reading-width", "--cave-reading-weight", "--cave-reading-hyphens",
-  "--radius", "--radius-control", "--radius-card", "--radius-pill",
+  "--radius", "--radius-control", "--radius-card", "--radius-panel", "--radius-pill",
 ]) {
   assert.equal(
     defaultBoot.inline.has(property),
@@ -168,7 +168,7 @@ for (const property of [
   "--font-sans", "--font-mono",
   "--cave-reading-leading", "--cave-reading-tracking", "--cave-reading-align",
   "--cave-reading-width", "--cave-reading-weight", "--cave-reading-hyphens",
-  "--radius", "--radius-control", "--radius-card", "--radius-pill",
+  "--radius", "--radius-control", "--radius-card", "--radius-panel", "--radius-pill",
 ]) {
   assert.equal(
     explicitBoot.inline.has(property),
@@ -181,5 +181,40 @@ assert.equal(
   false,
   "a default slot in an otherwise non-default approved font pair should still reveal theme CSS",
 );
+
+// Radius ladder parity (cave-uvwhh / #4350). These literals are duplicated from
+// CORNER_RADIUS_VALUES in src/lib/appearance-corner-radius.ts, which the boot
+// script cannot import — it runs before any module resolves. Asserting the same
+// numbers on both sides is what makes that duplication safe: change one without
+// the other and one of the two suites fails.
+//
+// --radius-panel is the one this pins hardest. It was missing from both paths,
+// so "Sharp" left every modal and panel at the :root 16px while the cards inside
+// them dropped to 4px.
+for (const [property, expected] of [
+  ["--radius", "0.875rem"],
+  ["--radius-control", "12px"],
+  ["--radius-card", "16px"],
+  ["--radius-panel", "20px"],
+  ["--radius-pill", "999px"],
+]) {
+  assert.equal(
+    explicitBoot.inline.get(property),
+    expected,
+    `boot script must apply ${property}: ${expected} at corner radius "round" ` +
+      "(keep in sync with CORNER_RADIUS_VALUES in src/lib/appearance-corner-radius.ts)",
+  );
+}
+
+{
+  const px = (v) => Number.parseFloat(v);
+  const control = px(explicitBoot.inline.get("--radius-control"));
+  const card = px(explicitBoot.inline.get("--radius-card"));
+  const panel = px(explicitBoot.inline.get("--radius-panel"));
+  assert.ok(
+    control < card && card < panel,
+    `the pre-paint radius ladder must stay ordered control < card < panel, got ${control} / ${card} / ${panel}`,
+  );
+}
 
 console.log("theme-script.test.ts OK");

--- a/src/lib/appearance-corner-radius.test.ts
+++ b/src/lib/appearance-corner-radius.test.ts
@@ -37,15 +37,48 @@ test("normalize falls back to default for junk/unknown", () => {
   assert.equal(normalizeCornerRadius(undefined), DEFAULT_CORNER_RADIUS);
 });
 
-test("apply(non-default) overrides all four radius tokens and persists", () => {
+test("apply(non-default) overrides all five radius tokens and persists", () => {
   const { store, props } = setupDom();
   applyCornerRadius("round");
   assert.equal(props.get("--radius"), CORNER_RADIUS_VALUES.round.base);
   assert.equal(props.get("--radius-control"), CORNER_RADIUS_VALUES.round.control);
   assert.equal(props.get("--radius-card"), CORNER_RADIUS_VALUES.round.card);
+  assert.equal(props.get("--radius-panel"), CORNER_RADIUS_VALUES.round.panel);
   assert.equal(props.get("--radius-pill"), CORNER_RADIUS_VALUES.round.pill);
   assert.equal(store.get(CORNER_RADIUS_KEY), "round");
   assert.equal(readCornerRadius(), "round");
+});
+
+// The defect this pins (cave-uvwhh / #4350): --radius-panel was absent from
+// CORNER_RADIUS_VALUES, so "Sharp" dropped controls to 2px and cards to 4px
+// while every modal and panel stayed at the :root 16px — a panel rounder than
+// the cards inside it. The ladder must stay ordered and strictly increasing at
+// every level, which is the property that keeps nested surfaces reading right.
+test("every level keeps control < card < panel", () => {
+  for (const level of ["sharp", "round"]) {
+    const { control, card, panel } = CORNER_RADIUS_VALUES[level];
+    const px = (v) => Number.parseFloat(v);
+    assert.ok(
+      px(control) < px(card) && px(card) < px(panel),
+      `${level}: expected control < card < panel, got ${control} / ${card} / ${panel}`,
+    );
+  }
+});
+
+// Every non-pill step of the documented radius scale (design language §2:
+// control 8 · card 12 · panel 16) must be rescaled by the setting. A token
+// that themes.css rescales but this setting ignores is exactly how the two
+// mechanisms drift apart.
+test("the setting covers every radius token themes.css rescales", () => {
+  const themed = ["control", "card", "panel"];
+  for (const level of ["sharp", "round"]) {
+    for (const step of themed) {
+      assert.ok(
+        typeof CORNER_RADIUS_VALUES[level][step] === "string",
+        `${level} is missing a value for --radius-${step}`,
+      );
+    }
+  }
 });
 
 test("sharp squares the signature pill; round keeps the full capsule", () => {
@@ -63,6 +96,7 @@ test("apply(default) removes the overrides so :root token values apply", () => {
   assert.equal(props.has("--radius"), false);
   assert.equal(props.has("--radius-control"), false);
   assert.equal(props.has("--radius-card"), false);
+  assert.equal(props.has("--radius-panel"), false);
   assert.equal(props.has("--radius-pill"), false);
   assert.equal(store.get(CORNER_RADIUS_KEY), "default");
 });

--- a/src/lib/appearance-corner-radius.ts
+++ b/src/lib/appearance-corner-radius.ts
@@ -24,8 +24,11 @@
  * values apply unchanged.
  *
  * NOTE: the level → CSS values below are duplicated, as string literals, in the
- * flash-free boot block inside src/components/theme-script.tsx (which runs
- * before any module resolves). Keep both in sync when changing values.
+ * flash-free boot block — `public/scripts/theme-init.js` (the `RADII` table),
+ * loaded by src/components/theme-script.tsx. It runs before any module
+ * resolves, so it cannot import them. Keep both in sync when changing values;
+ * src/components/theme-script.test.ts asserts the same numbers on both sides,
+ * so a one-sided edit fails there rather than shipping a boot/runtime flash.
  */
 export const CORNER_RADIUS_KEY = "cave:corner-radius";
 

--- a/src/lib/appearance-corner-radius.ts
+++ b/src/lib/appearance-corner-radius.ts
@@ -2,13 +2,22 @@
  * UI corner radius — the global roundedness of buttons, inputs, cards, and the
  * familiar switcher pill.
  *
- * The app's chrome is built on four radius tokens declared in :root
+ * The app's chrome is built on five radius tokens declared in :root
  * (src/app/globals.css): `--radius` (the shadcn base, from which
  * `--radius-sm/md/lg/xl` are derived via calc), `--radius-control` (buttons,
- * inputs, rows), `--radius-card` (panels, cards), and `--radius-pill` (the
- * signature 999px pill — composer icon buttons and chips). Overriding those on
- * <html> rescales every surface that uses them at once, so a single setting
- * standardizes the whole UI instead of touching each component.
+ * inputs, rows), `--radius-card` (cards), `--radius-panel` (modals, sheets,
+ * and full panels — the outermost step of the ladder), and `--radius-pill`
+ * (the signature 999px pill — composer icon buttons and chips). Overriding
+ * those on <html> rescales every surface that uses them at once, so a single
+ * setting standardizes the whole UI instead of touching each component.
+ *
+ * `--radius-panel` MUST stay in this set. It is a peer step of the documented
+ * scale (docs/coven-design-language.md §2: control 8 · card 12 · panel 16),
+ * themes.css rescales it alongside its siblings, and ~70 surfaces consume it.
+ * While it was omitted here, picking "Sharp" left every modal and panel at a
+ * 16px corner while the cards nested inside them dropped to 4px — the panel
+ * read as rounder than its own contents, which is the inconsistency this
+ * setting exists to prevent.
  *
  * Mirrors src/lib/reading-width.ts: a small enum persisted in localStorage and
  * applied to <html>. The default level removes the overrides so the :root token
@@ -35,17 +44,30 @@ export const CORNER_RADIUS_LABELS: Record<CornerRadius, string> = {
 };
 
 /** Per-level token values. `default` is intentionally absent — see {@link CORNER_RADIUS_VALUES}. */
-type RadiusVars = { base: string; control: string; card: string; pill: string };
+type RadiusVars = {
+  base: string;
+  control: string;
+  card: string;
+  panel: string;
+  pill: string;
+};
 
 /**
  * Token values per level. `default` is omitted on purpose: applying it removes
  * the inline overrides so the :root values (--radius 0.625rem / --radius-control
- * 8px / --radius-card 12px / --radius-pill 999px) take over. `pill` squares the
- * signature composer pill at `sharp` and keeps the full capsule at `round`.
+ * 8px / --radius-card 12px / --radius-panel 16px / --radius-pill 999px) take
+ * over. `pill` squares the signature composer pill at `sharp` and keeps the
+ * full capsule at `round`.
+ *
+ * control < card < panel holds at every level, and each level keeps its own
+ * even step, so the nesting order of the ladder survives rescaling:
+ *   sharp   2 · 4 · 6    (step 2 — the compressed ladder)
+ *   default 8 · 12 · 16  (step 4 — :root)
+ *   round   12 · 16 · 20 (step 4)
  */
 export const CORNER_RADIUS_VALUES: Record<Exclude<CornerRadius, "default">, RadiusVars> = {
-  sharp: { base: "0.125rem", control: "2px", card: "4px", pill: "4px" },
-  round: { base: "0.875rem", control: "12px", card: "16px", pill: "999px" },
+  sharp: { base: "0.125rem", control: "2px", card: "4px", panel: "6px", pill: "4px" },
+  round: { base: "0.875rem", control: "12px", card: "16px", panel: "20px", pill: "999px" },
 };
 
 export function normalizeCornerRadius(value: unknown): CornerRadius {
@@ -67,8 +89,8 @@ export function readCornerRadius(): CornerRadius {
 
 /**
  * Apply the level: override `--radius`, `--radius-control`, `--radius-card`,
- * and `--radius-pill` on <html> (or remove them for the default so the :root
- * values apply) and persist the choice.
+ * `--radius-panel`, and `--radius-pill` on <html> (or remove them for the
+ * default so the :root values apply) and persist the choice.
  */
 export function applyCornerRadius(level: CornerRadius, options: { persist?: boolean } = {}) {
   if (typeof document === "undefined") return;
@@ -81,12 +103,14 @@ export function applyCornerRadius(level: CornerRadius, options: { persist?: bool
     root.style.removeProperty("--radius");
     root.style.removeProperty("--radius-control");
     root.style.removeProperty("--radius-card");
+    root.style.removeProperty("--radius-panel");
     root.style.removeProperty("--radius-pill");
   } else {
     const vars = CORNER_RADIUS_VALUES[normalized];
     root.style.setProperty("--radius", vars.base);
     root.style.setProperty("--radius-control", vars.control);
     root.style.setProperty("--radius-card", vars.card);
+    root.style.setProperty("--radius-panel", vars.panel);
     root.style.setProperty("--radius-pill", vars.pill);
   }
   if (typeof window === "undefined") return;

--- a/src/lib/design-token-drift.test.ts
+++ b/src/lib/design-token-drift.test.ts
@@ -173,6 +173,57 @@ for (const rel of files) {
   );
 }
 
+// ── tier 1b: on-scale RADII, including the compressed lines tier 1 cannot see ─
+//
+// cave-uvwhh / #4350. Tier 1 above runs the codemod over the file, and the
+// codemod is line-anchored: DECL_RE is /^(\s*)([a-zA-Z-]+)(\s*:\s*)…/, so it
+// only ever sees a line whose FIRST declaration starts at column 0. This repo
+// writes a lot of CSS in the compressed `.sel { a:1; b:2; }` one-liner style,
+// and every declaration on such a line is invisible to the "zero tolerance"
+// gate — the line does not match, so the whole line is returned untouched.
+//
+// That blind spot was hiding 22 on-scale radius literals (11x 8px, 10x 999px,
+// 1x 12px) that should have been tokens: 162 of the tree's 1938 border-radius
+// declarations sit on compressed lines. Untokenized, they are frozen at their
+// literal value while every neighbouring surface rescales with the theme and
+// with the corner-radius appearance setting — which is precisely the reported
+// "inconsistencies with border radius across the application".
+//
+// Scoped deliberately to border-radius. font-size and spacing have their own
+// hidden counts on these same lines; widening this gate to them is a separate,
+// much larger change and belongs in its own PR (see the issue thread).
+//
+// The check reuses the codemod's own value logic rather than re-implementing a
+// px table: each declaration is replayed as a canonical one-per-line probe,
+// which is the shape DECL_RE does match, so multi-value radii ("8px 8px 0 0")
+// are covered on exactly the same terms as everywhere else.
+{
+  const offenders: string[] = [];
+  for (const rel of files) {
+    const source = stripComments(readFileSync(rel, "utf8"));
+    source.split("\n").forEach((line, i) => {
+      if (line.includes(EXEMPT_MARKER)) return;
+      for (const m of line.matchAll(/border-radius\s*:\s*([^;{}]+)\s*(?=[;}])/g)) {
+        const value = m[1].trim();
+        if (!value) continue;
+        const probe = `  border-radius: ${value};`;
+        if (tokenizeCss(probe) !== probe) {
+          offenders.push(`${rel}:${i + 1}  border-radius: ${value}`);
+        }
+      }
+    });
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `on-scale border-radius literals must use tokens (8px -> --radius-control, ` +
+      `12px -> --radius-card, 16px -> --radius-panel, 999px -> --radius-pill).\n` +
+      `These sit on compressed multi-declaration lines, so ` +
+      `\`node scripts/codemods/tokenize-css.mjs\` will NOT fix them — edit by hand:\n  ` +
+      offenders.join("\n  "),
+  );
+}
+
 // ── tier 2: ratchets ────────────────────────────────────────────────────────
 
 /** Strip block comments so commented-out CSS never counts as drift. */

--- a/src/styles/board/chrome-table.css
+++ b/src/styles/board/chrome-table.css
@@ -35,7 +35,7 @@
 .board-token-input::placeholder { color:var(--text-muted); }
 @media (pointer: fine) { .board-token-input { font-size:13.5px; } }
 .board-token-kbd { flex-shrink:0; font-family:var(--font-mono); font-size:12px; color:var(--text-muted); border:1px solid var(--border-hairline); border-radius:4px; padding:0 6px; line-height:18px; }
-.board-token-suggest { position:absolute; top:45px; left:0; min-width:290px; max-width:380px; background:var(--popover); border:1px solid var(--border-hairline); border-radius:8px; box-shadow:0 14px 36px -10px color-mix(in oklch,var(--shadow-color) 62%,transparent); padding:5px; z-index:40; }
+.board-token-suggest { position:absolute; top:45px; left:0; min-width:290px; max-width:380px; background:var(--popover); border:1px solid var(--border-hairline); border-radius:var(--radius-control); box-shadow:0 14px 36px -10px color-mix(in oklch,var(--shadow-color) 62%,transparent); padding:5px; z-index:40; }
 .board-token-suggest-label { font-size:10px; font-weight:600; letter-spacing:.09em; text-transform:uppercase; color:var(--text-muted); padding:6px 9px 5px; }
 .board-token-suggest-item { display:flex; align-items:center; gap:11px; width:100%; height:33px; padding:0 9px; background:transparent; border:0; border-radius:4px; cursor:pointer; font-family:inherit; font-size:12.5px; color:var(--text-secondary); transition:background .12s,color .12s; }
 .board-token-suggest-item:hover { background:var(--bg-hover); color:var(--text-primary); }
@@ -55,7 +55,7 @@
 
 /* Delete-selected inline confirm popover. */
 .board-confirm-scrim { position:fixed; inset:0; z-index:35; }
-.board-confirm-pop { position:absolute; top:42px; right:0; width:242px; background:var(--popover); border:1px solid var(--border-hairline); border-radius:8px; box-shadow:0 14px 36px -10px color-mix(in oklch,var(--shadow-color) 62%,transparent); padding:14px; z-index:45; text-align:left; }
+.board-confirm-pop { position:absolute; top:42px; right:0; width:242px; background:var(--popover); border:1px solid var(--border-hairline); border-radius:var(--radius-control); box-shadow:0 14px 36px -10px color-mix(in oklch,var(--shadow-color) 62%,transparent); padding:14px; z-index:45; text-align:left; }
 .board-confirm-title { font-size:13px; font-weight:600; color:var(--text-primary); }
 .board-confirm-desc { font-size:12px; color:var(--text-secondary); margin-top:5px; line-height:1.5; }
 .board-confirm-actions { display:flex; justify-content:flex-end; gap:8px; margin-top:14px; }
@@ -69,10 +69,10 @@
 .board-filter-btn:hover { background:var(--bg-hover); color:var(--text-primary); }
 .board-filter-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
 .board-filter-btn--active { color:var(--accent-presence); border-color:color-mix(in oklch,var(--accent-presence) 42%,transparent); }
-.board-filter-count { font-family:var(--font-mono); font-size:11px; font-weight:600; color:var(--accent-presence); background:color-mix(in oklch,var(--accent-presence) 18%,transparent); border-radius:999px; padding:1px 7px; }
+.board-filter-count { font-family:var(--font-mono); font-size:11px; font-weight:600; color:var(--accent-presence); background:color-mix(in oklch,var(--accent-presence) 18%,transparent); border-radius:var(--radius-pill); padding:1px 7px; }
 .board-filter-caret { flex-shrink:0; color:var(--text-muted); transition:transform .15s; }
 .board-filter-caret--open { transform:rotate(180deg); }
-.board-filter-menu { position:absolute; top:42px; right:0; width:262px; background:var(--popover); border:1px solid var(--border-hairline); border-radius:8px; box-shadow:0 14px 36px -10px color-mix(in oklch,var(--shadow-color) 62%,transparent); padding:6px; z-index:46; max-height:420px; overflow-y:auto; }
+.board-filter-menu { position:absolute; top:42px; right:0; width:262px; background:var(--popover); border:1px solid var(--border-hairline); border-radius:var(--radius-control); box-shadow:0 14px 36px -10px color-mix(in oklch,var(--shadow-color) 62%,transparent); padding:6px; z-index:46; max-height:420px; overflow-y:auto; }
 .board-filter-menu-head { display:flex; align-items:center; justify-content:space-between; padding:6px 8px 5px; }
 .board-filter-menu-title { font-size:10px; font-weight:600; letter-spacing:.09em; text-transform:uppercase; color:var(--text-muted); }
 .board-filter-selectall { background:transparent; border:0; color:var(--accent-presence); font-family:inherit; font-size:11.5px; cursor:pointer; padding:0; }
@@ -220,7 +220,7 @@
 .board-table-group-row:first-child td { border-top:none; }
 .board-table-group-row:hover td { background:var(--bg-hover); color:var(--text-primary); }
 .board-table-group-caret { display:inline-flex; align-items:center; margin-right:4px; vertical-align:middle; }
-.board-table-group-badge { display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:16px; padding:0 5px; border-radius:8px; background:var(--bg-base); border:1px solid var(--border-hairline); color:var(--text-muted); font-size:10px; font-weight:500; margin-left:6px; vertical-align:middle; }
+.board-table-group-badge { display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:16px; padding:0 5px; border-radius:var(--radius-control); background:var(--bg-base); border:1px solid var(--border-hairline); color:var(--text-muted); font-size:10px; font-weight:500; margin-left:6px; vertical-align:middle; }
 .board-table-group-dot { display:inline-block; width:7px; height:7px; border-radius:50%; margin-right:7px; vertical-align:middle; box-shadow:0 0 0 3px color-mix(in oklch,currentColor 14%,transparent); position:relative; top:-1px; }
 .board-table-group-dot--backlog { background:var(--text-muted); color:var(--text-muted); }
 .board-table-group-dot--inbox { background:var(--accent-presence); color:var(--accent-presence); }
@@ -293,7 +293,7 @@
 .board-swimlane-header { display:flex; align-items:center; gap:8px; padding:8px 16px 6px; font-size:11px; font-weight:600; color:var(--text-secondary); letter-spacing:.05em; text-transform:uppercase; user-select:none; }
 .board-swimlane-toggle { display:inline-flex; align-items:center; gap:8px; background:none; border:none; padding:0; margin:0; font:inherit; color:inherit; letter-spacing:inherit; text-transform:inherit; cursor:pointer; }
 .board-swimlane-toggle:hover { color:var(--text-primary); }
-.board-swimlane-badge { display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:16px; padding:0 5px; border-radius:8px; background:var(--bg-raised); border:1px solid var(--border-hairline); color:var(--text-muted); font-size:10px; font-weight:500; }
+.board-swimlane-badge { display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:16px; padding:0 5px; border-radius:var(--radius-control); background:var(--bg-raised); border:1px solid var(--border-hairline); color:var(--text-muted); font-size:10px; font-weight:500; }
 .board-swimlane-rail { overflow-x:auto; overflow-y:hidden; scroll-behavior:smooth; cursor:grab; touch-action:pan-x pan-y; }
 .board-swimlane-rail.board-kanban-rail-wrap--grabbing { cursor:grabbing; scroll-behavior:auto; user-select:none; }
 .board-swimlane-rail.board-kanban-rail-wrap--grabbing * { cursor:grabbing !important; }

--- a/src/styles/board/gantt-fallbacks.css
+++ b/src/styles/board/gantt-fallbacks.css
@@ -108,7 +108,7 @@
   min-width: 16px; height: 15px; padding: 0 4px;
   display: inline-flex; align-items: center; justify-content: center;
   font-size: var(--text-2xs); color: var(--text-secondary);
-  background: var(--bg-base); border: 1px solid var(--border-hairline); border-radius: 999px;
+  background: var(--bg-base); border: 1px solid var(--border-hairline); border-radius: var(--radius-pill);
 }
 
 /* task row */

--- a/src/styles/board/kanban-inspector.css
+++ b/src/styles/board/kanban-inspector.css
@@ -4,7 +4,7 @@
 .board-kanban-rail-wrap--grabbing * { cursor:grabbing !important; }
 .board-kanban-rail { display:flex; gap:14px; min-width:max-content; }
 
-.board-kanban-column { display:flex; flex-direction:column; flex-shrink:0; width:288px; height:100%; border-radius:12px; border:1px solid var(--border-hairline); background:color-mix(in oklch,var(--bg-base) 55%,var(--bg-raised)); transition:background .15s,border-color .15s,box-shadow .15s; }
+.board-kanban-column { display:flex; flex-direction:column; flex-shrink:0; width:288px; height:100%; border-radius:var(--radius-card); border:1px solid var(--border-hairline); background:color-mix(in oklch,var(--bg-base) 55%,var(--bg-raised)); transition:background .15s,border-color .15s,box-shadow .15s; }
 .board-kanban-column--drop { border-color:color-mix(in oklch,var(--accent-presence) 60%,transparent); background:color-mix(in oklch,var(--accent-presence) 10%,var(--bg-raised)); box-shadow:0 0 0 3px color-mix(in oklch,var(--accent-presence) 18%,transparent); }
 
 .board-kanban-column-header { display:flex; align-items:center; gap:8px; padding:10px 11px 10px 13px; border-bottom:1px solid var(--border-hairline); border-radius:11px 11px 0 0; background:color-mix(in oklch,var(--bg-base) 82%,var(--foreground) 18%); }
@@ -16,7 +16,7 @@
 .board-kanban-column-dot--blocked { background:var(--color-danger); color:var(--color-danger); }
 .board-kanban-column-dot--done { background:var(--color-success); color:var(--color-success); }
 .board-kanban-column-label { flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:13px; font-weight:700; color:var(--text-primary); letter-spacing:.01em; }
-.board-kanban-column-count { display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:16px; padding:0 5px; border-radius:8px; background:var(--bg-raised); border:1px solid var(--border-hairline); color:var(--text-secondary); font-size:10px; font-weight:600; }
+.board-kanban-column-count { display:inline-flex; align-items:center; justify-content:center; min-width:18px; height:16px; padding:0 5px; border-radius:var(--radius-control); background:var(--bg-raised); border:1px solid var(--border-hairline); color:var(--text-secondary); font-size:10px; font-weight:600; }
 /* WIP-limit control: the count badge becomes a clickable button. "n/limit"
    reads as a budget; over the limit it turns danger and the column gets a
    subtle warning rail. */
@@ -152,7 +152,7 @@
 .board-kanban-card-chip--chat svg { color:var(--accent-presence); }
 /* cave-32ks: the chat chip carries the linked session's live status — dot +
    word, toned per state. Running keeps the accent; done/failed/idle re-tint. */
-.board-kanban-card-chip-dot { width:5px; height:5px; border-radius:999px; background:currentColor; flex-shrink:0; }
+.board-kanban-card-chip-dot { width:5px; height:5px; border-radius:var(--radius-pill); background:currentColor; flex-shrink:0; }
 .board-kanban-card-chip--chat-done { color:var(--color-success); background:color-mix(in oklch,var(--color-success) 10%,transparent); border-color:color-mix(in oklch,var(--color-success) 32%,var(--border-hairline)); }
 .board-kanban-card-chip--chat-failed { color:var(--color-danger); background:color-mix(in oklch,var(--color-danger) 10%,transparent); border-color:color-mix(in oklch,var(--color-danger) 32%,var(--border-hairline)); }
 .board-kanban-card-chip--chat-idle { color:var(--text-secondary); background:var(--bg-elevated); border-color:var(--border-hairline); }
@@ -262,7 +262,7 @@
 .board-drawer-chat-title { font-size:12px; font-weight:500; color:var(--text-primary); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .board-drawer-chat-desc { font-size:10.5px; color:var(--text-muted); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; display:inline-flex; align-items:center; gap:5px; }
 /* cave-32ks: live session status dot in the drawer's chat card. */
-.board-drawer-chat-status-dot { width:5px; height:5px; border-radius:999px; flex-shrink:0; background:var(--text-muted); }
+.board-drawer-chat-status-dot { width:5px; height:5px; border-radius:var(--radius-pill); flex-shrink:0; background:var(--text-muted); }
 .board-drawer-chat-status-dot--running { background:var(--accent-presence); }
 .board-drawer-chat-status-dot--done { background:var(--color-success); }
 .board-drawer-chat-status-dot--failed { background:var(--color-danger); }

--- a/src/styles/cave-chat/auxiliary-surfaces.css
+++ b/src/styles/cave-chat/auxiliary-surfaces.css
@@ -93,7 +93,7 @@
 
 .familiar-inline-card__status { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-primary); flex-wrap: wrap; }
 .familiar-inline-card__status-muted { color: var(--text-secondary); }
-.familiar-inline-card__dot { width: 8px; height: 8px; border-radius: 999px; display: inline-block; }
+.familiar-inline-card__dot { width: 8px; height: 8px; border-radius: var(--radius-pill); display: inline-block; }
 .familiar-inline-card__dot[data-pulse="1"] { animation: familiar-card-pulse 1.6s ease-in-out infinite; }
 @keyframes familiar-card-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/chat-artifact.css
+++ b/src/styles/chat-artifact.css
@@ -96,7 +96,7 @@
   position: absolute; left: 10px; right: 10px; bottom: 10px;
   display: flex; align-items: center; gap: 8px;
   padding: var(--space-2) 10px; font-size: var(--text-xs);
-  color: var(--color-danger-foreground); background: var(--color-danger); border-radius: 8px;
+  color: var(--color-danger-foreground); background: var(--color-danger); border-radius: var(--radius-control);
 }
 .chat-artifact__error-msg { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 .chat-artifact__error-fix { color: var(--color-danger-foreground); background: rgba(0,0,0,0.2); border: 0; border-radius: 6px; padding: 3px 8px; cursor: pointer; }
@@ -123,7 +123,7 @@
 .chat-artifact__refine-text {
   width: 100%; min-height: 52px; resize: vertical; font: inherit; font-size: var(--text-xs);
   line-height: 1.5; color: var(--text-primary); background: var(--bg-base);
-  border: 1px solid var(--border-hairline); border-radius: 8px; padding: 8px 10px; outline: none;
+  border: 1px solid var(--border-hairline); border-radius: var(--radius-control); padding: 8px 10px; outline: none;
   transition: border-color 0.12s ease;
 }
 .chat-artifact__refine-text:focus { border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-hairline)); }
@@ -137,7 +137,7 @@
 .chat-artifact__chips { display: flex; flex-wrap: wrap; gap: 6px; }
 .chat-artifact__chip {
   font-size: var(--text-xs); color: var(--text-secondary);
-  background: var(--bg-base); border: 1px solid var(--border-hairline); border-radius: 999px;
+  background: var(--bg-base); border: 1px solid var(--border-hairline); border-radius: var(--radius-pill);
   padding: 5px 11px; cursor: pointer; text-align: left;
   transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }

--- a/src/styles/composer-host-chip.css
+++ b/src/styles/composer-host-chip.css
@@ -112,6 +112,6 @@
 .cave-connect-host__hint { margin: 0; font-size: 12px; line-height: 1.5; color: var(--text-muted); }
 .cave-connect-host__hint code { font-size: 11px; padding: 0 4px; border-radius: 4px; background: var(--bg-elevated); border: 1px solid var(--border-hairline); }
 .cave-connect-host__field { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: var(--text-secondary); }
-.cave-connect-host__field input { width: 100%; padding: 7px 10px; border-radius: 8px; border: 1px solid var(--border-strong); background: var(--bg-base); color: var(--text-primary); outline: none; }
+.cave-connect-host__field input { width: 100%; padding: 7px 10px; border-radius: var(--radius-control); border: 1px solid var(--border-strong); background: var(--bg-base); color: var(--text-primary); outline: none; }
 .cave-connect-host__field input:focus { border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent); }
 .cave-connect-host__error { margin: 0; font-size: 11px; line-height: 1.4; color: var(--color-danger); }

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -50,7 +50,7 @@
 .dash-inbox__select-toggle { margin-left: auto; }
 .dash-inbox__bulkbar {
   display: flex; align-items: center; justify-content: space-between; gap: 8px;
-  margin: var(--space-1) 0 var(--space-2); padding: 6px 8px; border-radius: 8px;
+  margin: var(--space-1) 0 var(--space-2); padding: 6px 8px; border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-raised) 60%, transparent);
 }
 .dash-inbox__bulkbar-left, .dash-inbox__bulkbar-right { display: flex; align-items: center; gap: 6px; }
@@ -72,7 +72,7 @@
 /* Open items beyond the visible cap drill through to the Rituals surface. */
 .dash-inbox__more {
   display: flex; align-items: center; gap: 6px;
-  margin-top: var(--space-2); padding: 7px 10px; border-radius: 8px;
+  margin-top: var(--space-2); padding: 7px 10px; border-radius: var(--radius-control);
   font-size: 0.8rem; font-weight: 600; color: var(--text-muted);
   text-decoration: none; border: 1px dashed var(--border-hairline);
 }

--- a/src/styles/globals/shell-responsive.css
+++ b/src/styles/globals/shell-responsive.css
@@ -1017,7 +1017,7 @@
 
 /* Remove-confirm strip: detach semantics spelled out inline before scheduling
    the undo-safe delete (danger tint recipe: solid text / 6% fill / 35% border). */
-.familiar-studio-lifecycle__confirm { display: flex; flex-direction: column; gap: 8px; margin: 2px 0 6px; padding: 10px 12px; border: 1px solid color-mix(in oklch, var(--color-danger) 35%, transparent); border-radius: 8px; background: color-mix(in oklch, var(--color-danger) 6%, var(--bg-raised)); }
+.familiar-studio-lifecycle__confirm { display: flex; flex-direction: column; gap: 8px; margin: 2px 0 6px; padding: 10px 12px; border: 1px solid color-mix(in oklch, var(--color-danger) 35%, transparent); border-radius: var(--radius-control); background: color-mix(in oklch, var(--color-danger) 6%, var(--bg-raised)); }
 .familiar-studio-lifecycle__confirm-title { margin: 0; font-size: 12px; font-weight: 600; color: var(--text-primary); }
 .familiar-studio-lifecycle__confirm-copy { margin: 0; font-size: 12px; line-height: 1.5; color: var(--text-secondary); }
 .familiar-studio-lifecycle__confirm-warn { color: var(--color-warning); }

--- a/src/styles/globals/surface-compact-calendar.css
+++ b/src/styles/globals/surface-compact-calendar.css
@@ -1281,7 +1281,7 @@
 .cave-next-path {
   display: inline-flex; align-items: center; flex: 0 0 auto; max-width: 100%;
   white-space: nowrap;
-  padding: 7px var(--space-3); border-radius: 8px;
+  padding: 7px var(--space-3); border-radius: var(--radius-control);
   border: 1px solid color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
   color: var(--text-secondary); font-size: 12px; line-height: 1.2;

--- a/src/styles/globals/surface-marketplace.css
+++ b/src/styles/globals/surface-marketplace.css
@@ -434,7 +434,7 @@
 .craft-dossier__header p { margin: 0; color: var(--text-muted); font-size: 12px; line-height: 1.45; }
 .craft-dossier__close { border: 0; border-radius: 6px; background: transparent; color: var(--text-muted); padding: 6px; }
 .craft-dossier__body { flex: 1; min-height: 0; overflow-y: auto; padding: 16px 18px 22px; }
-.craft-dossier__runtime { display: flex; gap: 10px; margin-bottom: 14px; border: 1px solid var(--border-hairline); border-radius: 8px; background: var(--bg-panel); padding: 11px 12px; }
+.craft-dossier__runtime { display: flex; gap: 10px; margin-bottom: 14px; border: 1px solid var(--border-hairline); border-radius: var(--radius-control); background: var(--bg-panel); padding: 11px 12px; }
 .craft-dossier__runtime > span { display: flex; width: 28px; height: 28px; flex: 0 0 auto; align-items: center; justify-content: center; border-radius: 7px; background: var(--bg-elevated); color: var(--text-secondary); }
 .craft-dossier__runtime strong { display: block; color: var(--text-primary); font-size: 12px; }
 .craft-dossier__runtime p { margin: 3px 0 0; color: var(--text-muted); font-size: 11px; line-height: 1.4; }
@@ -466,13 +466,13 @@
 .craft-dossier__provenance dd { min-width: 0; margin: 0; overflow: hidden; color: var(--text-secondary); text-overflow: ellipsis; white-space: nowrap; }
 .craft-dossier__provenance a { color: var(--text-primary); text-decoration: underline; text-underline-offset: 2px; }
 .craft-dossier__source-list { display: grid; gap: 8px; margin-top: 10px; }
-.craft-dossier__source-list li { display: grid; gap: 3px; min-width: 0; padding: 9px; border: 1px solid var(--border-hairline); border-radius: 8px; background: color-mix(in srgb, var(--bg-panel) 78%, transparent); }
+.craft-dossier__source-list li { display: grid; gap: 3px; min-width: 0; padding: 9px; border: 1px solid var(--border-hairline); border-radius: var(--radius-control); background: color-mix(in srgb, var(--bg-panel) 78%, transparent); }
 .craft-dossier__source-list span { color: var(--text-muted); font-size: 10px; overflow-wrap: anywhere; }
 .craft-dossier__roles { margin-top: 16px; }
 .craft-dossier__section-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 12px; margin-bottom: 7px; }
 .craft-dossier__section-head h3 { margin: 2px 0 0; color: var(--text-primary); font-size: 14px; }
 .craft-dossier__section-head > span { color: var(--text-muted); font-size: 10.5px; }
-.craft-role-grid { display: grid; grid-template-columns: minmax(170px, 0.72fr) minmax(0, 1.4fr); min-height: 230px; overflow: hidden; border: 1px solid var(--border-hairline); border-radius: 8px; background: var(--bg-panel); }
+.craft-role-grid { display: grid; grid-template-columns: minmax(170px, 0.72fr) minmax(0, 1.4fr); min-height: 230px; overflow: hidden; border: 1px solid var(--border-hairline); border-radius: var(--radius-control); background: var(--bg-panel); }
 .craft-role-list { overflow-y: auto; border-right: 1px solid var(--border-hairline); padding: 6px; }
 .craft-role-row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 7px; border-radius: 6px; padding: 7px; }
 .craft-role-row[data-selected],

--- a/src/styles/globals/surface-reporting.css
+++ b/src/styles/globals/surface-reporting.css
@@ -84,7 +84,7 @@
   margin: 0 0 14px;
 }
 .dr-eyebrow__dot {
-  width: 7px; height: 7px; border-radius: 999px;
+  width: 7px; height: 7px; border-radius: var(--radius-pill);
   background: var(--accent-presence);
   box-shadow: 0 0 0 4px color-mix(in oklch, var(--accent-presence) 22%, transparent);
 }
@@ -599,7 +599,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .dr-cta:hover { border-color: var(--accent-presence); transform: translateY(-2px); }
 .dr-cta__icon {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 46px; height: 46px; border-radius: 12px; font-size: 24px; flex-shrink: 0;
+  width: 46px; height: 46px; border-radius: var(--radius-card); font-size: 24px; flex-shrink: 0;
   color: var(--accent-presence);
   background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
 }

--- a/src/styles/globals/surface-role-workspaces.css
+++ b/src/styles/globals/surface-role-workspaces.css
@@ -1060,7 +1060,7 @@
 .research-bound-meter > div { display: flex; justify-content: space-between; gap: 8px; padding: 7px 8px; font-size: 9.5px; background: var(--bg-raised); }
 .research-bound-meter dt { color: var(--text-muted); }
 .research-bound-meter dd { color: var(--text-secondary); display: inline-flex; align-items: center; gap: 5px; }
-.research-bound-badge { font-style: normal; font-size: 8px; line-height: 1; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 4px; border-radius: 999px; border: 1px solid currentColor; }
+.research-bound-badge { font-style: normal; font-size: 8px; line-height: 1; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 4px; border-radius: var(--radius-pill); border: 1px solid currentColor; }
 .research-bound--over dd { color: oklch(0.8 0.13 75); }
 .research-bound--met dd { color: oklch(0.74 0.14 155); }
 .research-automation { display: flex; flex-direction: column; gap: 8px; margin-top: 10px; padding: 9px; border: 1px solid color-mix(in oklch, var(--research-accent) 28%, var(--border)); border-radius: var(--radius-sm); background: linear-gradient(135deg, var(--research-accent-soft), transparent 72%); }
@@ -1068,7 +1068,7 @@
 .research-automation__summary > div { display: flex; min-width: 0; flex-direction: column; gap: 2px; }
 .research-automation__summary span, .research-automation > p { font-size: 9px; color: var(--text-muted); }
 .research-automation__summary strong { font-size: 10px; font-weight: 500; color: var(--text-secondary); overflow-wrap: anywhere; }
-.research-automation__status { flex: 0 0 auto; padding: 2px 6px; font-family: var(--font-mono); text-transform: lowercase; border: 1px solid var(--border); border-radius: 999px; }
+.research-automation__status { flex: 0 0 auto; padding: 2px 6px; font-family: var(--font-mono); text-transform: lowercase; border: 1px solid var(--border); border-radius: var(--radius-pill); }
 .research-automation__status--active { color: oklch(0.75 0.13 155) !important; border-color: color-mix(in oklch, oklch(0.75 0.13 155) 42%, transparent); }
 .research-automation__controls { display: flex; flex-wrap: wrap; gap: 6px; }
 .research-automation__stop { color: oklch(0.84 0.1 75) !important; }
@@ -1105,7 +1105,7 @@
 .research-source-attach-disclosure summary { width: fit-content; cursor: pointer; }
 .research-source-attach-disclosure[open] summary { margin-bottom: 7px; }
 .research-source-filters { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 8px; }
-.research-source-filters button { display: inline-flex; align-items: center; gap: 4px; padding: 3px 7px; font-family: var(--font-mono); font-size: 8.5px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); border: 1px solid var(--border); border-radius: 999px; background: transparent; cursor: pointer; }
+.research-source-filters button { display: inline-flex; align-items: center; gap: 4px; padding: 3px 7px; font-family: var(--font-mono); font-size: 8.5px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--radius-pill); background: transparent; cursor: pointer; }
 .research-source-filters button span { color: var(--text-secondary); }
 .research-source-filters button[aria-pressed="true"] { color: var(--research-accent); border-color: color-mix(in oklch, var(--research-accent) 45%, transparent); background: var(--research-accent-soft); }
 .research-source-filters button[aria-pressed="true"] span { color: inherit; }
@@ -1117,7 +1117,7 @@
 .research-source-revise { display: flex; align-items: center; gap: 6px; font-size: 9.5px; color: var(--text-muted); }
 .research-source-revise select { min-width: 0; padding: 2px 4px; font-size: 16px; color: var(--text-secondary); border: 1px solid var(--input); border-radius: var(--radius-sm); background: var(--bg-base); }
 .research-source-status { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 8.5px !important; text-transform: uppercase; }
-.research-source-status i { width: 5px; height: 5px; border-radius: 999px; background: currentColor; }
+.research-source-status i { width: 5px; height: 5px; border-radius: var(--radius-pill); background: currentColor; }
 .research-source-status--used { color: oklch(0.75 0.13 155) !important; }
 .research-source-status--conflicting { color: oklch(0.82 0.12 75) !important; }
 .research-source-status--rejected { color: var(--destructive) !important; }

--- a/src/styles/sidebar-minimal/activity-rail.css
+++ b/src/styles/sidebar-minimal/activity-rail.css
@@ -9,7 +9,7 @@
   cursor: pointer; color: var(--text-secondary); transition: background 0.12s ease, color 0.12s ease; }
 .recent-activity__head:hover { background: var(--bg-raised); color: var(--text-primary); }
 .recent-activity__label { display: flex; align-items: center; gap: 8px; font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; }
-.recent-activity__label::before { content: ""; width: 2px; height: 11px; border-radius: 999px; background: var(--accent-presence, currentColor); opacity: 0.55; flex: none; }
+.recent-activity__label::before { content: ""; width: 2px; height: 11px; border-radius: var(--radius-pill); background: var(--accent-presence, currentColor); opacity: 0.55; flex: none; }
 .recent-activity__chevron { transition: transform 140ms ease; }
 .recent-activity__chevron--collapsed { transform: rotate(-90deg); }
 .recent-activity__list { display: flex; flex-direction: column; gap: 6px; margin: 0; padding: 0; list-style: none; }
@@ -19,7 +19,7 @@
 .recent-activity__card--active::before { content: ""; position: absolute; left: 0; top: 8px; bottom: 8px; width: 3px; border-radius: 0 3px 3px 0; background: var(--accent-presence); }
 .recent-activity__row1, .recent-activity__row2 { display: flex; align-items: center; justify-content: space-between; gap: 8px; min-width: 0; }
 .recent-activity__title { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12.5px; font-weight: 550; color: var(--text-primary); }
-.recent-activity__status { flex-shrink: 0; width: 7px; height: 7px; border-radius: 999px; background: var(--text-muted); }
+.recent-activity__status { flex-shrink: 0; width: 7px; height: 7px; border-radius: var(--radius-pill); background: var(--text-muted); }
 .recent-activity__status--running { background: var(--color-success); animation: recent-activity-status-pulse 1.6s ease-in-out infinite; }
 .recent-activity__status--failed { background: var(--color-danger); }
 .recent-activity__status--queued { background: var(--color-warning); }


### PR DESCRIPTION
Closes #4350 (bead `cave-uvwhh`).

The issue is one sentence and a screenshot, so this started as an audit. The
short version: the codebase is **not** broadly inconsistent — there is a clear
3-step radius scale and the overwhelming majority of surfaces are on it. Two
specific, mechanical defects were making it *look* inconsistent, and both are
fixed here in ~40 lines. Everything else is deliberately left alone.

## Audit

**The scale** (`src/styles/globals/foundations.css`, documented in
`docs/coven-design-language.md`):

| token | value | rescaled by themes? | rescaled by the appearance setting? |
|---|---|---|---|
| `--radius-control` | 8px | yes | yes |
| `--radius-card` | 12px | yes | yes |
| `--radius-panel` | 16px | yes | **NO** |
| `--radius-pill` | 999px | n/a | yes |
| `--radius-sm/md/lg/xl` | `calc()` off `--radius` | via `--radius` | via `--radius` |

Usage is healthy: 176 `rounded-[var(--radius-control)]`, 21 card, 11 pill, 6
panel in TSX; 1938 `border-radius` declarations across 132 stylesheets. Verified
from the built CSS that Tailwind's `rounded-md`/`lg`/`xl` compile to
`var(--radius-md)` etc. and resolve to *this* repo's `calc()` values, not
Tailwind's defaults — so those 300+ usages do scale correctly. `rounded-full`
(165 uses) is a fixed full pill by design and is not touched.

### Finding 1 — `--radius-panel` never rescaled (the user-visible bug)

Cave ships a **Corner radius** setting (Sharp / Default / Round). It overrode
`--radius`, `--radius-control`, `--radius-card` and `--radius-pill` — but not
`--radius-panel`, in *both* apply paths (`src/lib/appearance-corner-radius.ts`
and the pre-paint `public/scripts/theme-init.js`). `--radius-panel` is a peer
step of the documented scale, `themes.css` rescales it in all four themes that
retune radii, and ~70 surfaces consume it: modals, sheets, the dashboard, the
chat reader, the GitHub detail pane.

So on "Sharp", controls dropped to 2px and cards to 4px while every panel
stayed pinned at 16px — **panels rendered 4x rounder than the cards nested
inside them.** Measured in a real browser, before vs after:

```
Corner radius = "Sharp", computed border-radius

  BEFORE  control   2px | card   4px | panel  16px   panel/card=4.0x
  AFTER   control   2px | card   4px | panel   6px   panel/card=1.5x
```

Only the Default level looked right, which is why this survived. New values
continue each level's own even step and keep `control < card < panel`:

```
sharp    2 - 4 - 6     (step 2)
default  8 - 12 - 16   (:root, unchanged)
round   12 - 16 - 20   (step 4)
```

### Finding 2 — the "zero tolerance" codemod has a blind spot for radii

`scripts/codemods/tokenize-css.mjs` matches declarations with a line-anchored
`DECL_RE`, so it only ever inspects the **first** declaration on a line. This
tree writes a lot of compressed `.sel { a:1; b:2; }` CSS, and every later
declaration on such a line passed the gate untouched.

That was hiding **31 on-scale radius literals** that should have been tokens
(21x `8px`, 11x `999px`, 2x `12px` — 22 on fully-compressed lines, 9 more that
simply were not first on their line). Each is frozen at a literal while its
neighbours rescale with the theme and the corner-radius setting — the same
class of defect as Finding 1, scattered across 14 files. All 31 are now
tokenized; each takes its token from the codemod's own `RADIUS_TOKENS` table
and is byte-identical at the default theme and level.

## Gate

New **tier 1b** in `src/lib/design-token-drift.test.ts` replays every
`border-radius` declaration as a canonical one-per-line probe and asserts the
codemod would not rewrite it — so multi-value radii are covered on the same
terms, and position on the line stops mattering.

Mutation evidence (reintroduced one `border-radius: 999px` on a compressed
line):

```
--- codemod --check (the EXISTING gate) ---
[tokenize-css] checked — 0 file(s) with drift        <- passes the mutation
--- tier 1b (the NEW gate) ---
'src/styles/globals/surface-reporting.css:87  border-radius: 999px'   exit 1
```

Also mutation-checked: dropping `--radius-panel` from the runtime apply path
fails `appearance-corner-radius.test.ts`; skewing the boot script's panel value
fails `theme-script.test.ts` with a message naming both files. All restored.

Scoped deliberately to `border-radius`. `font-size` and spacing have their own
hidden counts behind the same blind spot; widening `DECL_RE` would rewrite
hundreds of unrelated values and belongs in its own PR.

## Deliberately left alone

- **~232 off-scale radii** already banked in the `offScaleRadiusPx` ratchet —
  the documented "short solid mark" exception family (1-4px dots, ticks,
  sparkline bars where a scale step reads as a circle). Not drift.
- **7 inconsistent `var(--radius-panel, 12px|8px|14px)` fallbacks.** Dead code
  (the token is always defined) and zero runtime effect; churning them would
  be noise.
- **`rounded-full`** — a fixed full pill that does not square at "Sharp" while
  `--radius-pill` does. Correct: the deliberate squaring is reserved for the
  signature composer pill, not avatars and status dots.
- **`offScaleSpacingPx` is 1606 vs a 1607 baseline** on this branch. That -1 is
  pre-existing on `main` (spacing props are untouched here), so banking it
  belongs to whoever earned it.

## Verification

`pnpm typecheck`, `pnpm lint` (incl. the design codemod check),
`pnpm check:tests-wired` (1814 wired), `pnpm build` — all green post-rebase.
36 targeted suites pass, run with the exact `nodeArgsFor` argv: the appearance
and preferences set, the CSS contract set (`globals.css`, `css-module-order`,
`themed-chrome-tokens`, `theme-contrast-audit`, `shell-inset-layout`), and the
surface suites for all 14 edited stylesheets.
