### PR TITLE
fix(cave-3458e): give the unsupervised research fallback an actionable remedy

### DIFF
--- a/src/lib/server/flow-copilot-session.test.ts
+++ b/src/lib/server/flow-copilot-session.test.ts
@@ -1201,12 +1201,15 @@ test("app shutdown seals admission, proves trees before persistence, and retains
   assert.equal(isCopilotFlowRunActive(failed.sessionId), false);
 });
 
-// ─── degraded direct-spawn fallback (cave-hhwc5) ─────────────────────────────
-// #4524 routed every launch through Coven's native process supervisor, but no
-// published @opencoven/cli ships it — `coven --print-native-binary-path` is an
-// unrecognized flag as of 0.3.1, the newest release — so every research mission
-// failed at its first iteration. The fallback restores the pre-#4524 transport
-// when, and only when, the supervisor is genuinely absent.
+// ─── degraded direct-spawn fallback (cave-hhwc5, cave-3458e) ─────────────────
+// #4524 routed every launch through Coven's native process supervisor, which
+// no published @opencoven/cli shipped at the time — `coven
+// --print-native-binary-path` was an unrecognized flag through 0.3.1 — so every
+// research mission failed at its first iteration. 0.4.0's wrapper implements
+// that flag, so a current install takes the supervised path and none of these
+// tests describes its steady state. They pin what happens on an older CLI:
+// the fallback restores the pre-#4524 transport when, and only when, the
+// supervisor is genuinely absent, and says how to get supervision back.
 const { CovenProcessSupervisorUnavailableError } = await import("./coven-process-supervisor.ts");
 
 // The shutdown tests above seal admission through a process-global flag that
@@ -1251,6 +1254,34 @@ test("an absent native supervisor falls back to spawning Copilot directly", asyn
   // one, and the difference only shows up when someone cancels.
   assert.match(assistant.text, /native process supervisor is unavailable/i);
   assert.match(assistant.text, /may keep running/i);
+});
+
+test("the degraded run names the upgrade that restores supervision", async () => {
+  admitStarts();
+  const started = await startCopilotFlowRun({
+    spec: SPEC,
+    prompt: "hello",
+    projectRoot: TMP,
+    familiarId: null,
+    spawnCommand: FAKE_LAUNCH,
+  }, {
+    resolveSupervisorCommand: async () => {
+      throw new CovenProcessSupervisorUnavailableError();
+    },
+  });
+  started.confirmBookkeeping();
+  await started.done;
+
+  const assistant = readConversation(started.sessionId).turns.find((t) => t.role === "assistant");
+  assert.ok(assistant, "a degraded run still persists its transcript");
+  // Stating the degradation is only half the contract — whoever reads the run
+  // has to be able to get supervision back. The published CLI that first
+  // implements the wrapper's machine-path contract is 0.4.0; 0.3.1, the newest
+  // release when this fallback landed, did not, which is why the original
+  // wording told readers to wait for a build. That build shipped, so the
+  // remedy must name the floor and the command instead of a wait.
+  assert.match(assistant.text, /0\.4\.0 or newer/);
+  assert.match(assistant.text, /npm i -g @opencoven\/cli@latest/);
 });
 
 test("the degraded fallback cancels by terminating the direct Copilot child", async () => {

--- a/src/lib/server/flow-copilot-session.ts
+++ b/src/lib/server/flow-copilot-session.ts
@@ -761,15 +761,16 @@ export async function startCopilotFlowRun(
   const spawnArgs = [...command.fixedArgs, ...args];
   const platform = runtime.platform ?? process.platform;
   assertCopilotCommandLineFitsWindows(command.command, spawnArgs, platform);
-  // The native supervisor is the supported transport, but no PUBLISHED
-  // @opencoven/cli provides it: `coven --print-native-binary-path` is an
-  // unrecognized flag as of 0.3.1, which is the newest release. Since #4524
-  // every research mission has therefore failed at its first iteration with
-  // "Coven's native process supervisor is unavailable", and the error's own
-  // advice — update the CLI — cannot be followed because there is nothing
-  // newer to install.
+  // The native supervisor is the supported transport, and on a current CLI it
+  // is the one taken: @opencoven/cli 0.4.0's npm wrapper implements
+  // `--print-native-binary-path`, so resolveCovenProcessSupervisorCommand()
+  // succeeds. This fallback exists for installs still on 0.3.1 or older, where
+  // the wrapper had no such flag and every research mission failed at its first
+  // iteration (#4578). Those installs are now behind a release, not waiting on
+  // one, so the diagnostic below names the upgrade rather than telling the
+  // reader to wait for a build that already shipped.
   //
-  // So fall back to the pre-#4524 transport: spawn Copilot directly. Only
+  // The fallback is the pre-#4524 transport: spawn Copilot directly. Only
   // CovenProcessSupervisorUnavailableError is caught, so a supervisor that
   // exists but misbehaves still fails loudly rather than silently degrading.
   let supervisorCommand: { command: string; fixedArgs: string[] } | null = null;
@@ -784,7 +785,8 @@ export async function startCopilotFlowRun(
     unsupervisedReason =
       "Coven's native process supervisor is unavailable, so this run was launched directly. " +
       "Cancelling or timing out stops Copilot itself, but any processes it spawns are not owned " +
-      "and may keep running. Update the Coven CLI once a build ships the process supervisor.";
+      "and may keep running. Process supervision needs @opencoven/cli 0.4.0 or newer; " +
+      "restore it with `npm i -g @opencoven/cli@latest`, then retry.";
   }
   // Resolution can yield to a wrapper probe. App shutdown may seal admission
   // while that probe is in flight, so re-check immediately before the single


### PR DESCRIPTION
Closes cave-3458e. Closes cave-hhwc5. Follow-up filed as cave-kvgtd.

## The reported defect does not exist

`cave-hhwc5` (P0) and `cave-3458e` (P0) both say Cave probes the Coven CLI with
an argument the CLI never implemented, so every research mission fails at
iteration 1. Measured against the installed CLI (`coven v0.4.0`, engine
`coven-code 0.7.0`), neither half holds.

`--print-native-binary-path` is a flag on the **npm wrapper**
(`@opencoven/cli/bin/coven.js`), not on the native `process-supervisor`
subcommand — and the wrapper rejects it outright when combined with any other
argument:

```js
if (args.includes(PRINT_NATIVE_BINARY_PATH_ARG)) {
  if (args.length !== 1) { /* error, exit 1 */ }
  process.stdout.write(`${binary}\n`);
```

`coven-process-supervisor.ts` invokes it in exactly that single-argument form
(`[...launch.fixedArgs, PRINT_NATIVE_BINARY_PATH_ARG]`, where `launch.fixedArgs`
is the node-script prefix, not the supervisor's args). The re-measurement on
`cave-3458e` ran it as `coven process-supervisor --protocol … --print-native-binary-path`,
which is a different program and a shape Cave never sends.

Reproduced end-to-end against the real module, on this machine:

```
covenBin(): C:\Users\timot\AppData\Roaming\npm\coven.cmd
covenLaunchCommand(): {"command":"…\\node.exe","fixedArgs":["…\\@opencoven\\cli\\bin\\coven.js"]}
RESOLVED OK: {"command":"…\\@opencoven\\cli-windows\\bin\\coven.exe",
              "fixedArgs":["process-supervisor","--protocol","coven.process-supervisor.v1"]}
```

The supervisor resolves. Research runs supervised. Nothing is broken.

## What was real, and when

The flag's history is exactly what the original report described — it just
closed upstream:

| published wrapper | implements `--print-native-binary-path` |
| --- | --- |
| 0.3.0 | no |
| 0.3.1 | no |
| 0.4.0 | yes |

So `cave-hhwc5` was accurate at filing, #4578's direct-spawn fallback was the
right call then, and a CLI release fixed the cause.

## The residue this PR fixes

The fallback's user-facing text still speaks from 0.3.1. A run that degrades
tells the reader:

> Update the Coven CLI **once a build ships the process supervisor.**

That build shipped. The only people who ever see this string are on 0.3.1 or
older — the exact population for whom `npm i -g @opencoven/cli@latest` restores
process-tree ownership — and they were being told to wait. The message now names
the version floor and the command.

Two comment blocks asserting *"no published `@opencoven/cli` provides it"* are
corrected in the same change. Those are load-bearing: they are what filed two
P0 beads and what pointed the first at a blanket direct-spawn fallback, which
would have degraded a transport that works.

## Why neither proposed option was taken

- **(a) stop probing / resolve the path another way** — nothing to stop. The
  probe is correct and succeeds, and the native path is genuinely needed: it is
  what makes the supervised child the native binary rather than the Node
  wrapper, so a kill owns the real process handle instead of Node's.
- **(b) treat a non-zero probe as "present, path unknown"** — the probe is not
  returning non-zero. Adding that state would soften a check that currently
  fails closed, for a condition that does not occur.
- **upstream CLI work** — already done, in 0.4.0.

## Blast radius, verified

The bead's *"every research mission fails at iteration 1"* has not been true
since #4578: `startCopilotFlowRun` catches `CovenProcessSupervisorUnavailableError`
and spawns directly, recording an `unsupervised-process-tree` diagnostic on the
run. On a current CLI it does not even reach that path. Today the fallback is
unreachable on 0.4.0 and correct-but-misdirecting on 0.3.1; that misdirection is
what this changes.

## Failing test first

`the degraded run names the upgrade that restores supervision` — added before
the fix, run against unmodified source:

```
✖ the degraded run names the upgrade that restores supervision
  AssertionError: The input did not match /0\.4\.0 or newer/. Input:
  "…may keep running. Update the Coven CLI once a build ships the process supervisor."
ℹ pass 31  ℹ fail 1
```

After the fix: `ℹ tests 35  ℹ pass 32  ℹ fail 0  ℹ skipped 3`.

## Mutation matrix

Each mutation applied to `flow-copilot-session.ts`, suite re-run, source restored
with `git checkout HEAD --` and re-verified clean between runs. Baseline is
`pass 32 / fail 0`.

| # | mutation | killed by | result |
| --- | --- | --- | --- |
| M1 | replace `0.4.0 or newer` with a vague "a newer @opencoven/cli" | `/0\.4\.0 or newer/` | `pass 31 / fail 1` |
| M2 | replace `` `npm i -g @opencoven/cli@latest` `` with "reinstalling the Coven CLI" | `/npm i -g @opencoven\/cli@latest/` | `pass 31 / fail 1` |
| M3 | never set the `unsupervised-process-tree` diagnostic | new test **+** `an absent native supervisor falls back to spawning Copilot directly` | `pass 30 / fail 2` |
| M4 | `isSupervisorUnavailable` returns `false` (rethrow instead of degrade) | new test **+** 3 existing tests | `pass 28 / fail 4` |

M1 and M2 show each assertion is individually load-bearing — neither is
satisfied by the other's text. M3 and M4 show they bind to the real degraded
path rather than to incidental transcript content: remove the diagnostic or the
degradation itself and the new test dies alongside the pre-existing coverage.
Under M4, `requireProcessSupervisor refuses the degraded fallback` correctly
still passes, since it asserts a rejection either way.

No existing assertion was weakened, deleted, or reworded.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` (1814 files wired),
`pnpm build`, plus `src/lib/server/coven-process-supervisor.test.ts` (4/4) and
`src/lib/server/flow-copilot-session.test.ts` (32 pass / 0 fail / 3 pre-existing
skips), each run through the exact `nodeArgsFor` argv.

## Follow-up filed separately

`onboarding-prerequisites.ts` pins `coven-cli` at `minimumVersion: "0.2.5"`, so
onboarding still admits a CLI that cannot supervise. Filed as `cave-kvgtd` (P2);
raising that floor needs a
fresh integrity hash and is out of scope here.
