### PR TITLE
fix(cave-lcxc6): keep the toast stack off the shell's top-right chrome

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,7 +39,12 @@ const PERSISTED_SCREEN_SCALE_TEST = /persisted screen magnification scales the a
 const SETUP_FOCUS_VISIBILITY_TEST =
   /keeps setup (?:controls focus-visible|diagnostics focus contained) in WebKit$/;
 const MOBILE_FOUNDATIONS_SPEC = /mobile\/foundations\.spec\.ts/;
-const MOBILE_SURFACE_SPECS = /(?:mobile\/.*|right-chat-panel)\.spec\.ts/;
+// inbox-toast-chrome-clearance lives at the root rather than in tests/mobile/
+// on purpose: the toast-over-chrome collision it guards exists at desktop
+// widths too (cave-lcxc6), so it has to run on all three viewport projects —
+// tests/mobile/ is excluded from the desktop project.
+const MOBILE_SURFACE_SPECS =
+  /(?:mobile\/.*|right-chat-panel|inbox-toast-chrome-clearance)\.spec\.ts/;
 // Not a `.spec.ts`, so no ordinary project's testMatch picks it up.
 const WARMUP_SETUP = /warmup\.setup\.ts/;
 

--- a/src/components/daily-summary-notifications.test.ts
+++ b/src/components/daily-summary-notifications.test.ts
@@ -115,7 +115,17 @@ assert.match(toast, /const urgent = t\.kind === "response-needed"/, "reply reque
 assert.match(toast, /role=\{urgent \? "alert" : "status"\}/, "the live-region role follows urgency");
 assert.match(toast, /\.filter\(\(g\) => !g\.ids\.some\(\(id\) => pausedIds\.has\(id\)\)\)/, "hover/focus pauses the group's auto-hide (WCAG 2.2.1)");
 assert.match(toast, /setTimeout\(\(\) => g\.ids\.forEach\(\(id\) => expire\(id\)\), AUTO_DISMISS_MS\)/, "one timer per group — members expire together, not one re-arm at a time");
-assert.match(toast, /onMouseEnter=\{\(\) => setPaused\(g\.ids, true\)\}/, "hover pauses (the whole group — every member id)");
+// cave-lcxc6 moved this from onMouseEnter to a pointer-type-gated
+// onPointerEnter. Same contract — hover pauses the whole group, every member
+// id — with the touch case excluded, because a tap raises pointerenter but its
+// pointerleave only arrives when the user taps elsewhere, which pinned the
+// auto-hide open and made a transient toast permanent.
+assert.match(
+  toast,
+  /onPointerEnter=\{\(e\) => \{ if \(e\.pointerType !== "touch"\) setPaused\(g\.ids, true\); \}\}/,
+  "hover pauses (the whole group — every member id), for hovering pointers only",
+);
+assert.doesNotMatch(toast, /onMouseEnter=/, "the ungated mouseenter pause stays gone");
 assert.match(toast, /e\.currentTarget\.contains\(e\.relatedTarget as Node \| null\)/, "focus-within keeps the pause until focus leaves the toast");
 assert.match(toast, /aria-label=\{`Dismiss: \$\{title\}`\}/, "the dismiss control names its toast (normalized title)");
 assert.doesNotMatch(toast, />\s*Dismiss\s*<\/button>/, "the duplicate text Dismiss button stays gone");

--- a/src/components/inbox-toast-stack.test.ts
+++ b/src/components/inbox-toast-stack.test.ts
@@ -55,6 +55,36 @@ assert.match(
   /setPaused\(g\.ids, true\)/,
   "hover/focus pauses auto-hide for every member of the group",
 );
+// cave-lcxc6: a touch tap raises pointerenter but pointerleave only lands when
+// the user taps elsewhere, so an ungated hover-pause turned a stray tap into a
+// permanent toast. Focus still pauses without limit for keyboard/AT users.
+assert.match(
+  src,
+  /onPointerEnter=\{\(e\) => \{ if \(e\.pointerType !== "touch"\) setPaused\(g\.ids, true\); \}\}/,
+  "hover-pause is gated on a hovering pointer, so touch keeps its auto-hide window",
+);
+assert.doesNotMatch(
+  src,
+  /onMouseEnter=/,
+  "no ungated mouseenter pause — touch emulates it and never sends the leave",
+);
+
+// ── Stack geometry ───────────────────────────────────────────────────────────
+// cave-lcxc6: the stack was `fixed top-4 right-4 w-80`, a desktop-shaped panel
+// pinned over the shell's top-right chrome. On a 390-393px viewport it took the
+// "Open Chat panel" toggle's own centre in `document.elementFromPoint`. The
+// responsive geometry now lives in dash-act.css; keep it out of utilities here
+// so there is one place that describes both shapes.
+assert.match(
+  src,
+  /className="inbox-toast-stack"/,
+  "the stack carries its geometry as one named class",
+);
+assert.doesNotMatch(
+  src,
+  /className="[^"]*\b(?:fixed|top-4|right-4|w-80)\b/,
+  "no desktop-only positioning utilities back on the stack root",
+);
 
 // ── Surface discipline ───────────────────────────────────────────────────────
 assert.match(src, /glass-overlay/, "toast cards use the shared glass token surface");

--- a/src/components/inbox-toast.tsx
+++ b/src/components/inbox-toast.tsx
@@ -51,9 +51,10 @@ const KIND_ACCENT: Record<NonNullable<Toast["kind"]>, string> = {
 };
 
 export function InboxToastStack({ toasts, onDismiss, onExpire, onSnooze, onOpen }: Props) {
-  // Hover or focus anywhere inside a toast pauses its auto-hide (WCAG 2.2.1) —
-  // content stopped vanishing mid-read. Unpausing re-arms the full window,
-  // the generous simple option (no per-toast remaining-time bookkeeping).
+  // Hover (with a hovering pointer) or focus anywhere inside a toast pauses
+  // its auto-hide (WCAG 2.2.1) — content stopped vanishing mid-read.
+  // Unpausing re-arms the full window, the generous simple option (no
+  // per-toast remaining-time bookkeeping).
   const [pausedIds, setPausedIds] = useState<ReadonlySet<string>>(new Set());
   const setPaused = (ids: readonly string[], paused: boolean) =>
     setPausedIds((prev) => {
@@ -87,7 +88,10 @@ export function InboxToastStack({ toasts, onDismiss, onExpire, onSnooze, onOpen 
   const overflow = groups.length - visible.length;
 
   return (
-    <div className="pointer-events-none fixed top-4 right-4 z-50 flex w-80 flex-col gap-2">
+    // Geometry lives in dash-act.css, not in utilities here: the phone layout
+    // has to clear the shell's top-right chrome, which a single desktop-shaped
+    // set of utilities cannot express (cave-lcxc6).
+    <div className="inbox-toast-stack">
       {visible.map((g) => {
         const t = g.lead;
         const title = normalizeInboxTitle(t.title);
@@ -101,8 +105,15 @@ export function InboxToastStack({ toasts, onDismiss, onExpire, onSnooze, onOpen 
           role={urgent ? "alert" : "status"}
           aria-live={urgent ? "assertive" : "polite"}
           aria-atomic="true"
-          onMouseEnter={() => setPaused(g.ids, true)}
-          onMouseLeave={() => setPaused(g.ids, false)}
+          // Hover-pause is for a pointer that can hover. A touch tap also
+          // raises pointerenter, but the matching pointerleave only arrives
+          // when the user taps somewhere else — so a stray tap on the card
+          // (missing the ✕) pinned the auto-hide open indefinitely and the
+          // "transient" notification became permanent. Gate on pointer type
+          // and the touch case simply keeps its 8s window; keyboard users
+          // still get an unbounded pause through onFocus below.
+          onPointerEnter={(e) => { if (e.pointerType !== "touch") setPaused(g.ids, true); }}
+          onPointerLeave={(e) => { if (e.pointerType !== "touch") setPaused(g.ids, false); }}
           onFocus={() => setPaused(g.ids, true)}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setPaused(g.ids, false);

--- a/src/styles/dash-act.css
+++ b/src/styles/dash-act.css
@@ -1,7 +1,9 @@
 /* dash-act.css — compact action buttons + snooze menu shared by the
  * dashboard, inbox toasts, and calendar (SnoozeMenu). Split out of
  * dashboard.css (#3264) so cross-surface consumers don't pull the
- * whole dashboard sheet. */
+ * whole dashboard sheet. Also carries the inbox toast stack's own
+ * geometry (bottom of this file), because that geometry is responsive
+ * and Tailwind utilities described only its desktop shape. */
 
 .dash-act {
   display: inline-flex;
@@ -86,5 +88,73 @@
   .dash-snooze__menu {
     background: var(--bg-elevated);
     backdrop-filter: none;
+  }
+}
+
+/* ── Inbox toast stack geometry (cave-lcxc6) ─────────────────────────────────
+ *
+ * Lives here rather than in Tailwind utilities on the element because the
+ * phone layout is a different shape, not a tweak — and while it WAS a set of
+ * utilities (`fixed top-4 right-4 w-80`) that one desktop shape was the only
+ * shape there was. On a phone the top-right corner is not empty canvas: it is
+ * the shell's own chrome. Measured on Pixel 5 (393px) with a toast up, the
+ * card spanned x 57..377 / y 17..156 while the persistent "Open Chat panel"
+ * toggle sits at x 353..381 / y 12..40 — `document.elementFromPoint` at the
+ * toggle's own centre returned the toast card, leaving a ~4px sliver of the
+ * control exposed. A transient notification was taking a persistent control's
+ * hit area, so neither a user nor the e2e suite could reach it.
+ *
+ * Desktop is the same defect, milder: the `.shell-top` band is 34px and the
+ * stack started at 16px, so at 1280px the toggle sat at y 3..31 under a card
+ * starting at y 16 — the top half of the control was reachable and its centre,
+ * which is where a click lands, was not. Measured while fixing the phone case;
+ * it is one defect with two expressions, so the stack clears the chrome at
+ * every width rather than only below the breakpoint.
+ *
+ * Both offsets are the shell's own band heights restated as the same
+ * expressions their owners use, so the two move together: 34px is
+ * `.shell-top`'s min-height here in desktop-chrome.css (and equals
+ * `--shell-native-titlebar-height`, which at >=1024 overlays that same row
+ * rather than stacking above it, so the macOS shell needs no separate rule),
+ * and `52px + var(--sai-top)` is the mobile `.top-bar` height from
+ * shell-responsive.css.
+ *
+ * tests/mobile/inbox-toast-chrome-clearance.spec.ts is the geometric guard,
+ * and it asserts both directions: the toggle must win its own centre, and the
+ * toast's own controls must stay clickable. */
+.inbox-toast-stack {
+  position: fixed;
+  top: calc(34px + var(--space-2));
+  right: var(--space-4);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  width: 20rem;
+  /* The column is inert; only the cards inside it are pointer-events: auto,
+     so the gaps between stacked toasts never swallow a tap meant for the app.
+     This is why the fix has to be geometric — the card itself must keep
+     taking pointer events or its Snooze/Open/Dismiss controls go dead. */
+  pointer-events: none;
+}
+
+@media (max-width: 1023px) {
+  .inbox-toast-stack {
+    top: calc(52px + var(--sai-top) + var(--space-2));
+    right: calc(var(--space-3) + var(--sai-right));
+    /* Also fixes an unrelated overflow at the narrow end: a fixed 20rem card
+       ran off the left edge of a 320px viewport. */
+    left: calc(var(--space-3) + var(--sai-left));
+    width: auto;
+    max-width: 20rem;
+    margin-left: auto;
+  }
+}
+
+@media (max-width: 480px) {
+  /* Phone: span the gutters. A right-pinned 20rem panel with dead space
+     beside it is the desktop card wearing a phone's viewport. */
+  .inbox-toast-stack {
+    max-width: none;
   }
 }

--- a/src/styles/dash-act.css
+++ b/src/styles/dash-act.css
@@ -119,7 +119,7 @@
  * and `52px + var(--sai-top)` is the mobile `.top-bar` height from
  * shell-responsive.css.
  *
- * tests/mobile/inbox-toast-chrome-clearance.spec.ts is the geometric guard,
+ * tests/inbox-toast-chrome-clearance.spec.ts is the geometric guard,
  * and it asserts both directions: the toggle must win its own centre, and the
  * toast's own controls must stay clickable. */
 .inbox-toast-stack {

--- a/tests/inbox-toast-chrome-clearance.spec.ts
+++ b/tests/inbox-toast-chrome-clearance.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * cave-lcxc6 — a transient toast must never steal a persistent control's hit
+ * area.
+ *
+ * The toast stack was a `fixed top-4 right-4 z-50` column at a desktop width
+ * (`w-80`, 320px). On a 390-393px viewport it landed directly over the shell's
+ * top-right "Open Chat panel" toggle: measured x 57..377 / y 17..156 against a
+ * toggle at x 353..381 / y 12..40, leaving a ~4px sliver. `elementFromPoint` at
+ * the toggle's own centre returned the toast card, so a real user could not tap
+ * the toggle while a toast was up (and the e2e suite burned a 60s budget across
+ * ~53 retried clicks, because every retry re-entered the card and re-paused its
+ * auto-dismiss).
+ *
+ * It runs at desktop width too, and not as a formality: the same probe at
+ * 1280px returned the card as well. The desktop `.shell-top` band is 34px and
+ * the stack started at 16px, so the toggle's top half was reachable and its
+ * centre — where a click lands — was not.
+ *
+ * The decisive probe is geometric, not "is the toggle visible": the toggle is
+ * perfectly visible underneath. Both directions are asserted, because the two
+ * cheap wrong fixes each break one of them — moving the toggle above the toast
+ * strands the toast's own buttons, and blanket `pointer-events: none` on the
+ * card leaves it undismissable.
+ */
+
+const FAMILIARS = [
+  { id: "cody", display_name: "Cody", role: "Implementer", status: "active", icon: "ph:code" },
+];
+
+const MILESTONE_ITEM = {
+  id: "toast-clearance-milestone",
+  kind: "milestone",
+  title: "Mission complete — Full roster at work",
+  body: "Every familiar has run a working. Nobody is standing idle. +20 renown.",
+  status: "fired",
+  createdAt: "2026-08-22T00:00:00.000Z",
+  updatedAt: "2026-08-22T00:00:00.000Z",
+  firedAt: "2026-08-22T00:00:00.000Z",
+  recurrence: { type: "none" },
+  source: "system",
+};
+
+async function boot(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("cave:onboarding:dismissed", "1");
+    localStorage.setItem("cave:active-familiar", "cody");
+    localStorage.setItem("cave:shell:right-chat-open", "0");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({ json: { ok: true, familiars: FAMILIARS } }),
+  );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions: [] } }),
+  );
+  // Drive the toast deterministically rather than waiting for the milestone
+  // watcher to happen to award one — that accident is exactly what made the
+  // original failure flaky. EventSource reconnects after the stream closes, so
+  // only the first request carries the event; later ones hang open.
+  let streamed = false;
+  await page.route("**/api/inbox/stream**", async (route) => {
+    if (streamed) return route.fulfill({ status: 204, body: "" });
+    streamed = true;
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+      body:
+        `data: ${JSON.stringify({ type: "snapshot", items: [] })}\n\n` +
+        `data: ${JSON.stringify({ type: "created", item: MILESTONE_ITEM })}\n\n`,
+    });
+  });
+  await page.goto("/");
+  await page.waitForSelector(".shell-frame", { timeout: 30_000 });
+}
+
+const TOAST = '[role="status"]';
+
+/** Topmost element at a point, plus a description for the failure message. */
+async function hitTest(page: Page, x: number, y: number, selector: string) {
+  return page.evaluate(
+    ({ x, y, selector }) => {
+      const el = document.elementFromPoint(x, y);
+      return {
+        matched: !!el?.closest(selector),
+        describe: el ? `${el.tagName}.${el.className}`.slice(0, 160) : "none",
+      };
+    },
+    { x, y, selector },
+  );
+}
+
+// The two tests are deliberately short and separate rather than one journey:
+// the card auto-hides after 8s (AUTO_DISMISS_MS), so a single test that walked
+// the drawer open and closed before reaching the dismiss button would be
+// racing that timer on a loaded runner.
+
+test("a toast leaves the shell's top-right Chat toggle usable", async ({ page }, testInfo) => {
+  await boot(page);
+
+  const toggle = page.getByRole("button", { name: "Open Chat panel" });
+  await expect(toggle).toBeVisible();
+  const toast = page.locator(TOAST, { hasText: "Mission complete" }).first();
+  await expect(toast).toBeVisible({ timeout: 30_000 });
+
+  const toggleBox = await toggle.boundingBox();
+  const toastBox = await toast.boundingBox();
+  if (!toggleBox || !toastBox) throw new Error("toggle or toast did not lay out");
+  // Recorded so a regression reads as geometry rather than a bare boolean.
+  testInfo.annotations.push({
+    type: "geometry",
+    description:
+      `toast x ${Math.round(toastBox.x)}..${Math.round(toastBox.x + toastBox.width)}` +
+      ` y ${Math.round(toastBox.y)}..${Math.round(toastBox.y + toastBox.height)}` +
+      ` | toggle x ${Math.round(toggleBox.x)}..${Math.round(toggleBox.x + toggleBox.width)}` +
+      ` y ${Math.round(toggleBox.y)}..${Math.round(toggleBox.y + toggleBox.height)}`,
+  });
+
+  // Visibility is not the question — the toggle was always visible underneath.
+  // The question is which element owns the pixel a finger lands on.
+  const hit = await hitTest(
+    page,
+    toggleBox.x + toggleBox.width / 2,
+    toggleBox.y + toggleBox.height / 2,
+    ".shell-top-toggle--right",
+  );
+  expect(hit.matched, `elementFromPoint at the toggle centre resolved to ${hit.describe}`).toBe(
+    true,
+  );
+
+  // …and it really actuates, with no `force`. Assert via the toggle's own
+  // accessible name rather than the panel it opens: mobile opens a dialog and
+  // desktop a persistent panel, but the control reads the same on both.
+  await toggle.click();
+  await expect(page.getByRole("button", { name: "Close Chat panel" }).first()).toBeVisible();
+});
+
+test("a toast keeps its own controls reachable", async ({ page }) => {
+  await boot(page);
+
+  const toast = page.locator(TOAST, { hasText: "Mission complete" }).first();
+  await expect(toast).toBeVisible({ timeout: 30_000 });
+
+  // The other half of the contract. Clearing the toggle by making the card
+  // pointer-events: none would satisfy the test above and fail here — the
+  // toast would become an undismissable ghost.
+  const dismiss = toast.getByRole("button", { name: /^Dismiss:/ });
+  const box = await dismiss.boundingBox();
+  if (!box) throw new Error("dismiss control did not lay out");
+  const hit = await hitTest(page, box.x + box.width / 2, box.y + box.height / 2, "button");
+  expect(hit.matched, `elementFromPoint at the dismiss centre resolved to ${hit.describe}`).toBe(
+    true,
+  );
+
+  await dismiss.click();
+  await expect(toast).toBeHidden();
+});


### PR DESCRIPTION
Fixes `cave-lcxc6` (P1).

## The defect

The inbox toast stack was `fixed top-4 right-4 z-50` at a desktop width (`w-80`, 320px). On a phone that corner is not empty canvas — it is the shell's own chrome.

Measured with a toast up, before this change:

| viewport | toast card | "Open Chat panel" toggle | `elementFromPoint` at the toggle's centre |
| --- | --- | --- | --- |
| pixel-5 (393px) | x 57..377, y 17..156 | x 353..381, y 12..40 | `DIV.glass-overlay pointer-events-auto …` |
| iphone-13 (390px) | x 54..374, y 16..156 | x 350..378, y 12..40 | `DIV.glass-overlay pointer-events-auto …` |

A ~4px sliver of a 28px control was left exposed. **A real user could not tap the Chat toggle while a toast was up.** The e2e symptom was the same collision: `tests/right-chat-panel.spec.ts` burned its full 60s budget across ~53 retried clicks — each retry re-entered the card and re-paused its 8s auto-hide, so under Playwright the obstruction was unbounded rather than the ~8s a touch user gets.

**Desktop had the same defect, and it was invisible because the desktop half of that spec is `test.fixme`'d.** The `.shell-top` band is 34px and the stack started at 16px, so at 1280px the toggle sat at y 3..31 under a card starting at y 16: its top half was reachable and its centre — where a click lands — was not. Probed at 1024/1100/1280 and under the macOS titlebar shell; all three returned the card. It is one defect with two expressions, so the stack now clears the chrome at every width rather than only below the breakpoint.

## The fix

Geometry moves out of Tailwind utilities into `.inbox-toast-stack` in `dash-act.css` (already the sheet `inbox-toast.tsx` imports), because the phone layout is a different shape rather than a tweak and one set of utilities could only describe the one desktop shape. Both offsets restate the shell's own band heights as the expressions their owners use, so the two move together — `34px` is `.shell-top`'s `min-height`, `52px + var(--sai-top)` is the mobile `.top-bar` height from `shell-responsive.css`. At ≥1024 the macOS `--shell-native-titlebar-height` strip overlays that same row rather than stacking above it, so it needs no separate rule.

**Both controls stay usable, which is what rules out the cheap fixes.** The card keeps `pointer-events: auto` — making it inert would clear the toggle and strand its own Snooze / Open / Dismiss, and raising the toggle above the toast would do the same. Only the column around the cards is inert, so the gaps between stacked toasts never swallow a tap. The fix therefore has to be geometric.

Measured after, at every width probed:

```
 1280 | stack x 944..1264 (w 320) y 42..181 | toggle x 1240..1268 y 3..31 | hit TOGGLE
 1100 | stack x 764..1084 (w 320) y 42..181 | toggle x 1060..1088 y 3..31 | hit TOGGLE
 1024 | stack x 688..1008 (w 320) y 42..181 | toggle x  984..1012 y 3..31 | hit TOGGLE
 1023 | stack x 691..1011 (w 320) y 60..199 | toggle x  983..1011 y 12..40 | hit TOGGLE
  900 | stack x 568.. 888 (w 320) y 60..199 | toggle x  860.. 888 y 12..40 | hit TOGGLE
  600 | stack x 268.. 588 (w 320) y 60..199 | toggle x  560.. 588 y 12..40 | hit TOGGLE
  481 | stack x 149.. 469 (w 320) y 60..199 | toggle x  441.. 469 y 12..40 | hit TOGGLE
  480 | stack x  12.. 468 (w 456) y 60..168 | toggle x  440.. 468 y 12..40 | hit TOGGLE
  393 | stack x  12.. 381 (w 369) y 60..186 | toggle x  353.. 381 y 12..40 | hit TOGGLE
  375 | stack x  12.. 363 (w 351) y 60..186 | toggle x  335.. 363 y 12..40 | hit TOGGLE
  320 | stack x  12.. 308 (w 296) y 60..199 | toggle x  280.. 308 y 12..40 | hit TOGGLE
```

Plus the macOS titlebar shell (`[data-tauri-titlebar]`) at 1440/1280/1024 — `hit TOGGLE` at all three.

Desktop keeps its 320px right-pinned card and only drops below the band (y 16 → 42). Below 481px the card spans the gutters instead of sitting as a narrow desktop-width panel with dead space beside it; the `left` gutter also fixes an unrelated overflow, since a fixed 20rem card ran off the left edge of a 320px viewport.

## Pause-on-hover — changed, deliberately

`onMouseEnter → setPaused` becomes a pointer-type-gated `onPointerEnter`. It is reasonable on a desktop pointer, but a touch tap also raises `pointerenter` and the matching `pointerleave` only arrives when the user taps *somewhere else* — so a stray tap on the card that missed the ✕ pinned the auto-hide open and the transient toast became permanent. Touch now simply keeps its 8s window. Hovering pointers are unchanged, and keyboard/AT users keep the unbounded pause through `onFocus`, so WCAG 2.2.1 is intact.

This is not what fixes the flake — the geometry is. Playwright's `click()` dispatches mouse-type pointer events even on a touch-enabled context, so the harness would still pause the timer; it just no longer has anything to intercept.

## Guard

`tests/inbox-toast-chrome-clearance.spec.ts` drives the toast deterministically through a mocked inbox stream rather than waiting for a milestone award to happen to fire — that accident is what made the original failure flaky. It asserts **both** directions, because the two cheap wrong fixes each break one: the toggle must win its own centre and actuate with no `force`, and the toast's own Dismiss must stay hit-testable and work. It runs on desktop as well as both phone profiles, which is why it sits at the `tests/` root and joins the mobile-surface match in `playwright.config.ts`.

## Verification

`tests/right-chat-panel.spec.ts`, 8 separate invocations per phase (fresh milestone ledger each), `--retries=0`, both mobile projects:

_(measuring; numbers land in an edit to this body)_

No assertion in `tests/right-chat-panel.spec.ts` was weakened, moved, or deleted — the file is untouched by this PR, including the `expect.poll` tripwire added under `cave-m1mgi` (#4865). `daily-summary-notifications.test.ts` pinned the literal `onMouseEnter=…` source text; it is updated to pin the new, stronger contract (same whole-group pause, touch excluded) rather than dropped, and `inbox-toast-stack.test.ts` gains matching assertions plus a guard against desktop-only positioning utilities returning to the stack root.

Gates: `pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` (1814 files wired), `pnpm build` (root CSS 614/640 KB, first-load CSS 918/940 KB, shell 430/650 KB — all within budget) all pass.

## Notes

- No shared style tokens were touched — the change is component-local layout plus one new class in the sheet `inbox-toast.tsx` already imports. It should not collide with the in-flight border-radius/token audit.
- One case left alone: the macOS titlebar shell narrowed *below* 1024px stacks its 34px title strip above the mobile top bar, so the toast would sit ~34px too high there. Untestable from this environment and vanishingly rare; not addressed.
- `design-token-drift` reports `offScaleSpacingPx: 1606 < baseline 1607` and asks for the baseline to be lowered. That is pre-existing banked progress from someone else's change, not this one — this PR adds no off-scale spacing literal — so the baseline is left for its owner.
