### PR TITLE
Stop a legacy conversation leaving the keyless tail mid-walk (cave-wbxcu)

### DIFF
--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -593,13 +593,15 @@ both or skip both:
 | `/conversations` | `createdAt` descending, then `id` descending. A conversation with no `createdAt` sorts **last**, ordered among its peers by `id` descending. |
 | `/conversations/:id/messages` | Transcript order, oldest first. **Not** a keyset — see that route. |
 
-**Every sort key here is immutable, with one narrow exception named in the third
-bullet.** Nothing rewrites a project's `createdAt` or a conversation's, a
-familiar's id is its identity, and saving a conversation stamps only its
-`updatedAt` — so the position a cursor names is a position the ordering still
-has when you resume. A walk that starts now serves the rows that existed when it
-started, in the order it started with, however much the Cave is written to
-underneath it. Three things are worth planning for:
+**Every sort key here is immutable.** Nothing rewrites a project's `createdAt`
+or a conversation's, a familiar's id is its identity, and saving a conversation
+stamps only its `updatedAt` — so the position a cursor names is a position the
+ordering still has when you resume. A conversation's `createdAt` is decided when
+the record is created and is read-only after that: a client body cannot rewrite
+it, and a transcript that has none is never given one. A walk that starts now
+serves the rows that existed when it started, in the order it started with,
+however much the Cave is written to underneath it. Three things are worth
+planning for:
 
 - **A conversation created while you are paging is not served by that walk.**
   Its `createdAt` is *now*, which sorts above every cursor you already hold.
@@ -609,15 +611,15 @@ underneath it. Three things are worth planning for:
 - **A conversation deleted while you are paging simply stops appearing.** The
   cursor names a position in the ordering rather than an index, so the walk
   continues at the next surviving record.
-- **A conversation that has no `createdAt` at all can leave the tail block.**
-  Such a record is served last (see below), and it stays there for as long as it
-  has no `createdAt` — but the moment it acquires one it sorts above every
-  cursor you hold, so the walk in progress will not serve it. This is the one
-  row this ordering can still miss. It is rare (a transcript older than the
-  field, or one Cave could not read on the last scan) and it settles once the
-  record has a `createdAt`, but a walk cannot tell that it happened. If you must
-  not miss a conversation, re-read from the top and dedupe by `id`; that costs
-  nothing and covers this case.
+- **A conversation that has no `createdAt` at all stays in the tail block.**
+  Such a record is served last (see below), and it stays there: nothing in Cave
+  gives a stored record a `createdAt` it did not already have. It used to —
+  writing a turn to a transcript older than the field stamped it with *now*,
+  which moved the row from the tail to the head, past every open cursor, and the
+  rest of that walk never served it. Fixed on 2026-08-23; if you are talking to
+  an older Cave, that row can still be missed. Re-reading from the top and
+  deduping by `id` costs nothing and covers it, as it covers every other reason
+  a ledger might have moved.
 
 ⚠️ **The ordering of `/conversations` changed.** It was `updatedAt` descending —
 the order the Cave's own sessions list shows — until 2026-08-22. `updatedAt`
@@ -641,11 +643,18 @@ warm; there is no server-side shortcut, and there cannot be one, because a
 keyset cursor cannot name a position in an order that moves. Deduplicating by
 `id` still costs nothing and is still worth doing across walks you restart.
 
-`createdAt` is optional on a conversation record — a transcript written before
-the field existed has none, and neither does the row Cave substitutes for a file
-it cannot read. Those rows are **served at the end of the walk**, not stranded
-and not skipped: they sort as if their key were empty, which is below every
-timestamp.
+`createdAt` is optional on a conversation record: a transcript written before
+the field existed has none. Those rows are **served at the end of the walk**,
+not stranded and not skipped — they sort as if their key were empty, which is
+below every timestamp — and they stay there, because Cave never adds the field
+to a record that lacks it.
+
+Cave substitutes a placeholder row for a transcript it cannot read or parse this
+scan; you can recognise one by its empty `familiarId`. It carries the `createdAt`
+Cave last read from that file, so it holds its place in the ordering rather than
+dropping to the tail and climbing back out as the file becomes readable again. A
+file Cave has *never* managed to read has no such value and is served in the tail
+block with the legacy rows.
 
 ### `GET /api/client/v1/familiars`
 

--- a/docs/client-v1-conformance-results/2026-08-23-v0.3.9-win32-cave-wbxcu.json
+++ b/docs/client-v1-conformance-results/2026-08-23-v0.3.9-win32-cave-wbxcu.json
@@ -1,0 +1,569 @@
+{
+  "harness": "scripts/client-v1-conformance.mjs",
+  "issues": [
+    "OpenCoven/coven-cave#4832",
+    "OpenCoven/coven-cave#4838"
+  ],
+  "scope": "cave-only",
+  "ranAt": "2026-08-23T03:59:21.326Z",
+  "caveVersion": "0.3.9",
+  "commit": "d64ab9640af6e0016872a24c3882e314272896e0",
+  "platform": "win32-x64",
+  "nodeVersion": "v24.18.0",
+  "includeTtl": true,
+  "notCovered": [
+    "The SDK and Chat halves of #4838. Both live in other repositories; this run is the Cave half only.",
+    "The production Coven daemon. /familiars is served from a loopback fixture daemon in hub mode.",
+    "A genuinely remote peer. Off-machine ingress is exercised by making the listener classify a loopback request as forwarded.",
+    "The write scopes. Nothing enforces them yet — there are no write routes on this surface.",
+    "OAuth-backed flows and the desktop consent UI. Approval is driven through the admin HTTP route.",
+    "Cross-process pairing state. The pairing store is in-memory and process-local by contract."
+  ],
+  "findings": [
+    {
+      "id": "backslash-refusal-is-unreachable",
+      "where": "docs/api/client-v1.md — Reaching the API at all",
+      "says": "a request target inside /api/client/v1 containing \"%\" or \"\\\" is answered 400 {\"ok\":false,\"error\":\"invalid client v1 path\"}",
+      "measured": "the \"%\" half holds; a \"\\\" is normalised to \"/\" by Next and answered 308 to the normalised target before proxy.ts runs, and that target is then refused 401 by the ordinary gate",
+      "severity": "documentation",
+      "why": "no handler is reached and nothing is served, so the gate still holds; the doc describes an answer no client will observe"
+    },
+    {
+      "id": "admin-unauthorized-envelope-is-unreachable",
+      "where": "docs/api/client-v1.md — Administrator routes, Authentication",
+      "says": "a mismatched or absent x-coven-cave-token is 401 unauthorized from requireClientV1Admin",
+      "measured": "the proxy's sidecar-token gate answers first, so the wire carries 401 {\"ok\":false,\"error\":\"unauthorized\"} and requireClientV1Admin's envelope is never produced on a Cave with a token configured",
+      "severity": "documentation",
+      "why": "the refusal is correct and same-status; only its body differs from the documented one, which a handler-level test cannot see"
+    }
+  ],
+  "summary": {
+    "total": 104,
+    "passed": 104,
+    "failed": 0,
+    "skipped": 0,
+    "status": "passed"
+  },
+  "assertions": [
+    {
+      "id": "admin.unconfigured/admin/pairing-requests.GET",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/credentials.GET",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/pairing-requests/:id/decision.POST",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/credentials/:id.DELETE",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured.pairing-still-opens",
+      "result": "pass",
+      "detail": "a tokenless Cave still opens pairing requests"
+    },
+    {
+      "id": "admin.unconfigured.exchange-stays-pending",
+      "result": "pass",
+      "detail": "the documented dead end: no approval route, so the exchange can only ever answer pairing_pending"
+    },
+    {
+      "id": "health.envelope",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "health.instance-stable",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "health.discovery-record",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "ingress.escaped-path.percent",
+      "result": "pass",
+      "detail": "/api/client/v1/pairing/requests/%41"
+    },
+    {
+      "id": "ingress.escaped-path.percent-encoded-separator",
+      "result": "pass",
+      "detail": "/api/client/v1/conversations%2Fx"
+    },
+    {
+      "id": "ingress.backslash-path-reaches-no-handler",
+      "result": "pass",
+      "detail": "answered 308; the documented 400 fires for \"%\" only — see the run's notes"
+    },
+    {
+      "id": "ingress.forwarded.public",
+      "result": "pass",
+      "detail": "/pairing/requests with x-forwarded-for"
+    },
+    {
+      "id": "ingress.forwarded.authenticated",
+      "result": "pass",
+      "detail": "/conversations with x-forwarded-for"
+    },
+    {
+      "id": "ingress.forwarded.admin",
+      "result": "pass",
+      "detail": "/admin/credentials with x-forwarded-for"
+    },
+    {
+      "id": "ingress.exchange-requires-content-length",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "ingress.refuses-transfer-encoding",
+      "result": "pass",
+      "detail": "a chunked control-plane body has no declared length to cap"
+    },
+    {
+      "id": "ingress.body-cap",
+      "result": "pass",
+      "detail": "70072 bytes against the 65536-byte control-plane cap"
+    },
+    {
+      "id": "ingress.pairing-content-type",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.wrong-token",
+      "result": "pass",
+      "detail": "refused by the proxy's sidecar gate, ahead of requireClientV1Admin"
+    },
+    {
+      "id": "admin.no-token",
+      "result": "pass",
+      "detail": "refused by the proxy's sidecar gate, ahead of requireClientV1Admin"
+    },
+    {
+      "id": "admin.mutation-requires-source",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.create",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-pending",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-queue",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-approve",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-approved",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-approve-idempotent",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-decision-conflict",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.exchange",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.bearer-works",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.replay-refused",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-after-exchange",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-denied",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.exchange-denied",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.unknown-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.wrong-secret",
+      "result": "pass",
+      "detail": "one wrong secret charged on the exchange route"
+    },
+    {
+      "id": "pairing.correct-secret-polling-is-free",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-charges-wrong-secret-on-poll",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-locks-out-the-holder",
+      "result": "pass",
+      "detail": "ten wrong secrets across BOTH routes; the correct secret is refused too"
+    },
+    {
+      "id": "pairing.budget-is-shared-across-routes",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-is-per-pairing",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.ttl-poll-expired",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.ttl-exchange-expired",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.empty-first-page/projects",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.empty-first-page/conversations",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.no-bearer",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.unknown-bearer",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.bearer-not-accepted-in-query",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.scope-denied",
+      "result": "pass",
+      "detail": "a credential without chat:read"
+    },
+    {
+      "id": "reads.familiars",
+      "result": "pass",
+      "detail": "against a loopback fixture daemon, not the production daemon"
+    },
+    {
+      "id": "reads.familiars-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.projects-shape",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.projects-paging-partial-final-page",
+      "result": "pass",
+      "detail": "3 pages of at most 3 over 7 rows"
+    },
+    {
+      "id": "reads.cursor-replay-is-stable",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.cursor-current-echoes-the-token",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.cursor-survives-deletion",
+      "result": "pass",
+      "detail": "the token records a position in the ordering, not an index"
+    },
+    {
+      "id": "reads.projects-paging-exact-multiple",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.refuses.limit-zero",
+      "result": "pass",
+      "detail": "/projects?limit=0"
+    },
+    {
+      "id": "reads.refuses.limit-over-ceiling",
+      "result": "pass",
+      "detail": "/projects?limit=101"
+    },
+    {
+      "id": "reads.refuses.limit-leading-zero",
+      "result": "pass",
+      "detail": "/projects?limit=01"
+    },
+    {
+      "id": "reads.refuses.limit-exponent",
+      "result": "pass",
+      "detail": "/projects?limit=1e2"
+    },
+    {
+      "id": "reads.refuses.limit-signed",
+      "result": "pass",
+      "detail": "/projects?limit=%2B5"
+    },
+    {
+      "id": "reads.refuses.limit-repeated",
+      "result": "pass",
+      "detail": "/projects?limit=1&limit=2"
+    },
+    {
+      "id": "reads.refuses.unsupported-parameter",
+      "result": "pass",
+      "detail": "/projects?limt=5"
+    },
+    {
+      "id": "reads.refuses.offset",
+      "result": "pass",
+      "detail": "/projects?offset=1"
+    },
+    {
+      "id": "reads.refuses.cursor-outside-alphabet",
+      "result": "pass",
+      "detail": "/projects?cursor=not*base64url"
+    },
+    {
+      "id": "reads.refuses.cursor-not-canonical",
+      "result": "pass",
+      "detail": "/projects?cursor=eyJ2IjoxfQ=="
+    },
+    {
+      "id": "reads.limit-ceiling-is-served",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.default-page-size",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-shape",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-refuses-limit",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-refuses-cursor",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-not-found",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-touch-unserved-row-is-still-served",
+      "result": "pass",
+      "detail": "touched the unserved conversation-01; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-touch-served-row-is-not-repeated",
+      "result": "pass",
+      "detail": "touched the already-served conversation-06; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-touch-cursor-row-keeps-the-position",
+      "result": "pass",
+      "detail": "touched conversation-05, the row the cursor names; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-row-created-mid-walk-is-not-served",
+      "result": "pass",
+      "detail": "a row created above the cursor is left for the next read from the top"
+    },
+    {
+      "id": "reads.conversations-row-deleted-mid-walk-does-not-strand",
+      "result": "pass",
+      "detail": "deleted the unserved conversation-04; the whole walk served [conversation-06,conversation-05,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-tied-sort-key-breaks-on-id",
+      "result": "pass",
+      "detail": "conversation-04 and conversation-03 share 2026-03-04T00:00:00.000Z"
+    },
+    {
+      "id": "reads.conversations-without-created-at-are-served-last",
+      "result": "pass",
+      "detail": "an optional page key is only safe if the rows that lack it are served, not stranded"
+    },
+    {
+      "id": "reads.conversations-keyless-row-written-mid-walk-is-still-served",
+      "result": "pass",
+      "detail": "wrote a turn to the unserved conversation-keyless-written; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01,conversation-keyless-written,conversation-keyless-quiet]"
+    },
+    {
+      "id": "reads.conversations-keyless-rows-tie-on-the-id-tiebreak",
+      "result": "pass",
+      "detail": "two rows with no createdAt share the sentinel, so only the id makes their order total"
+    },
+    {
+      "id": "reads.conversations-keyless-row-keyed-between-walks-moves-once",
+      "result": "pass",
+      "detail": "conversation-keyless-written acquired 2026-03-05T12:00:00.000Z between two walks and the next walk placed it"
+    },
+    {
+      "id": "reads.conversations-unreadable-row-keeps-its-position-mid-walk",
+      "result": "pass",
+      "detail": "conversation-flaky became unreadable mid-walk; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-flaky,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-recovering-row-keeps-its-position-mid-walk",
+      "result": "pass",
+      "detail": "conversation-recovering became readable again mid-walk; the whole walk served [conversation-recovering,conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.messages-active-branch",
+      "result": "pass",
+      "detail": "the abandoned branch turn b-x1 must be absent"
+    },
+    {
+      "id": "reads.messages-values",
+      "result": "pass",
+      "detail": "text, role, parentId, createdAt and both counts, field by field against the fixture"
+    },
+    {
+      "id": "reads.messages-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-counts-not-contents",
+      "result": "pass",
+      "detail": "b-a1 carries two tool calls and one attachment; the counts must say so and the contents must not appear"
+    },
+    {
+      "id": "reads.messages-reconcile-required",
+      "result": "pass",
+      "detail": "activeLeafId moved to the abandoned branch, so the cursor names a turn that is no longer on it"
+    },
+    {
+      "id": "reads.messages-restart-after-reconcile",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-not-found",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-canonical-conversation-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.bearer-works-before",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.admin-listing",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.revoke",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.bearer-refused-after",
+      "result": "pass",
+      "detail": "all five canonical reads"
+    },
+    {
+      "id": "revocation.is-idempotent",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.unknown-credential",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.tombstone-persists",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "harness.assertion-coverage",
+      "result": "pass",
+      "detail": "every declared assertion recorded exactly once (--include-ttl true)"
+    }
+  ]
+}

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -156,12 +156,19 @@ a claim about *which bytes* answered, and one that cannot say which has not made
 the claim.
 
 The current record is
+[`2026-08-23-v0.3.9-win32-cave-wbxcu.json`](../client-v1-conformance-results/2026-08-23-v0.3.9-win32-cave-wbxcu.json):
+**104 passed, 0 failed, 0 skipped** at `d64ab964` on `win32-x64`, run with
+`--include-ttl`. It is the first record taken after the keyless tail block was
+made immutable in the write and store paths, so it carries all twelve mid-walk
+assertions.
+
+The record before it is
 [`2026-08-22-v0.3.9-win32-cave-fhjlu.json`](../client-v1-conformance-results/2026-08-22-v0.3.9-win32-cave-fhjlu.json):
-**99 passed, 0 failed, 0 skipped** at `ed6cc4b1` on `win32-x64`, run with
-`--include-ttl`, so `pairing.ttl-poll-expired` and `pairing.ttl-exchange-expired`
-are recorded as passes rather than skips. It is the first record taken after
+**99 passed, 0 failed, 0 skipped** at `ed6cc4b1`, also with `--include-ttl`, so
+`pairing.ttl-poll-expired` and `pairing.ttl-exchange-expired` are recorded as
+passes rather than skips there too. It is the first record taken after
 `/conversations` moved to an immutable page key, so it carries the seven
-mid-walk assertions described above and two findings rather than three.
+mid-walk assertions and two findings rather than three.
 
 The record for `cave-2hjtv` is
 [`2026-08-22-v0.3.9-win32.json`](../client-v1-conformance-results/2026-08-22-v0.3.9-win32.json):

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -305,6 +305,27 @@ the source. Measured 2026-08-22 on `win32-x64` against Cave 0.3.9.
 | `parseClientV1PageLimit` clamps instead of refusing | **caught**, 5 failures | every `reads.refuses.limit-*` case: zero, over-ceiling, leading zero, exponent, signed |
 | `clientV1ConversationPageKey` reverted to the mutable `updatedAt` | **caught**, 9 failures | all seven mid-walk ids, plus `reads.conversations-shape` and `reads.conversations-paging`. The run reproduces the skip on the wire: the walk serves `[01, 02, 04, 05, 06]` and `conversation-03` is lost |
 
+Five more were run for `cave-wbxcu`, measured 2026-08-23 on `win32-x64` against
+Cave 0.3.9. Same method: patch source, full `pnpm build`, run, restore.
+
+| Mutation | Result | Assertions that caught it |
+|---|---|---|
+| `buildConversation` stamps a keyless existing record again (`existing?.createdAt ?? now`) | **caught**, 1 failure | `reads.conversations-keyless-row-written-mid-walk-is-still-served`, alone. The run reproduces the skip on the wire: the row is stamped mid-walk and the walk serves 7 of 8 |
+| the fallback row drops the carried-forward `createdAt` again | **caught**, 2 failures | `…-unreadable-row-keeps-its-position-mid-walk` and `…-recovering-row-keeps-its-position-mid-walk`, and nothing else — the two triggers are independently attributed |
+| the id tiebreak runs ascending | **caught**, 13 failures | every conversations assertion including all five new ones; the two tie assertions name the reversed pair explicitly |
+| the page key reverted to the mutable `updatedAt` (the `cave-fhjlu` regression, re-measured against the larger family) | **caught**, 14 failures | as above plus `…-row-deleted-mid-walk-does-not-strand` |
+| the keyless sentinel sorts to the HEAD instead of the tail (`?? "9999"`) | **caught**, 4 failures | `…-without-created-at-are-served-last`, `…-keyless-row-written-mid-walk-is-still-served`, `…-keyless-rows-tie-on-the-id-tiebreak`, `…-keyless-row-keyed-between-walks-moves-once` — and *not* the two fallback cases, which is the point: the tail-block assertions have power independent of the fallback fix |
+
+⚠️ **Two mutations were written first in a form that made the build fail, and a
+failed build is not a caught mutation — it is a run that never happened.**
+Deleting the `createdAt` spread from `fallbackConversationSummary` leaves its
+parameter unused, and `return ""` from `conversationSortKey` leaves `summary`
+unused; `tsconfig.json` sets `noUnusedLocals` and `noUnusedParameters`, so both
+died in `pnpm build` and the harness printed nothing. Both were rewritten to
+mutate a *behaviour* while leaving every symbol used. If a build-and-run
+mutation reports no assertion output at all, check the build before recording it
+as a miss.
+
 Three further mutations were aimed at the assertions rather than the route,
 because a fixture that cannot distinguish two behaviours is the failure mode this
 harness has been burned by twice. Each was applied, run against

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -250,6 +250,46 @@ Two fixture properties make that family able to fail, and both are pinned by
 - two conversations **share** a `createdAt`, so the id tiebreak that makes the
   ordering total is exercised rather than merely present.
 
+### The residual that family then found — the tail block was not immutable
+
+The seven assertions above prove a row with no `createdAt` is *served*, at the
+tail. They did not prove it *stays* there, and it did not: `buildConversation`
+composed `args.existing?.createdAt ?? now`, so writing a turn to a transcript
+older than the field stamped it with `now` and moved the row from the tail to
+the head of the ordering, past every open cursor — `cave-fhjlu` again, on
+exactly the rows the sentinel exists to protect (`cave-wbxcu`). A second trigger
+needed no writer at all: the row Cave substitutes for a file it cannot read
+carried no `createdAt` either, so a file flipping between readable and
+unreadable moved a row into and out of the tail block under an open cursor.
+
+Five more assertions close the family, and three of them **reproduced the loss
+on the wire** against the build before the fix:
+
+| Assertion | On the unfixed build |
+|---|---|
+| `reads.conversations-keyless-row-written-mid-walk-is-still-served` | **failed** — the row was stamped `2026-08-23T03:30:29.860Z` mid-walk and the whole walk served 7 of 8 rows, losing `conversation-keyless-written` |
+| `reads.conversations-recovering-row-keeps-its-position-mid-walk` | **failed** — a file that became readable again mid-walk rose above the open cursor and was never served |
+| `reads.conversations-unreadable-row-keeps-its-position-mid-walk` | **failed** — a file that became unreadable mid-walk fell to the tail, reordering the walk |
+| `reads.conversations-keyless-rows-tie-on-the-id-tiebreak` | passed — an invariant that already held, kept so a sentinel tie is covered as the `createdAt` tie is |
+| `reads.conversations-keyless-row-keyed-between-walks-moves-once` | passed — the promise is scoped to one walk; the next walk must still see a consistent ledger |
+
+Two things about how they are written are worth copying rather than
+re-deriving:
+
+- **The write is driven through `POST /api/chat/conversation/:id`, over the
+  socket.** That route is where the defect lived. A case that simulated the
+  stamp by rewriting the transcript file would have kept passing after the write
+  path was fixed and kept failing after it was broken again — it would be
+  asserting the fixture, not Cave.
+- **The two readability directions need rows in different places.** A walk at
+  limit 2 opens its cursor after the two newest rows, so a recovering row is
+  only *skipped* if its real `createdAt` is above that cursor. The first version
+  of the recovering case used a row whose `createdAt` was the oldest in the
+  ledger: it rose to a position the walk had not reached yet, was served
+  normally, and **passed against the unfixed build**. That is the vacuous
+  assertion this harness exists to refuse, caught by running the new cases
+  against the broken build before trusting them.
+
 ## Harness mutation results
 
 A conformance run that passes against a broken server is worse than none, so the

--- a/scripts/client-v1-conformance.mjs
+++ b/scripts/client-v1-conformance.mjs
@@ -256,6 +256,11 @@ export const EXPECTED_ASSERTION_IDS = [
   "reads.conversations-row-deleted-mid-walk-does-not-strand",
   "reads.conversations-tied-sort-key-breaks-on-id",
   "reads.conversations-without-created-at-are-served-last",
+  "reads.conversations-keyless-row-written-mid-walk-is-still-served",
+  "reads.conversations-keyless-rows-tie-on-the-id-tiebreak",
+  "reads.conversations-keyless-row-keyed-between-walks-moves-once",
+  "reads.conversations-unreadable-row-keeps-its-position-mid-walk",
+  "reads.conversations-recovering-row-keeps-its-position-mid-walk",
   "reads.messages-active-branch",
   "reads.messages-values",
   "reads.messages-paging",
@@ -985,6 +990,46 @@ async function writeConversation(caveHomeDir, conversation) {
 
 async function removeConversation(caveHomeDir, sessionId) {
   await rm(path.join(caveHomeDir, "conversations", `${sessionId}.json`), { force: true });
+}
+
+/**
+ * A transcript file Cave can stat but cannot parse.
+ *
+ * `listConversations` answers with `fallbackConversationSummary` for one of
+ * these — the row a walk has to keep serving, and keep in the same place, or a
+ * file that flips between readable and unreadable moves a row under an open
+ * cursor. Truncated JSON rather than a deleted file on purpose: the trigger the
+ * defect named is a torn write that a later atomic replace completes.
+ */
+async function writeCorruptConversation(caveHomeDir, sessionId) {
+  const dir = path.join(caveHomeDir, "conversations");
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, `${sessionId}.json`), '{"sessionId": "', "utf8");
+}
+
+/**
+ * Append a turn through `POST /api/chat/conversation/:id` — Cave's own write
+ * path, over the socket, not a rewritten file.
+ *
+ * This is the route that used to stamp `createdAt` onto a record that had none
+ * (`args.existing?.createdAt ?? now`), which is the whole of cave-wbxcu. A test
+ * that simulated the stamp by writing the file would keep passing after the
+ * write path was fixed, and would keep failing after it was broken again.
+ */
+async function appendChatTurn(client, sessionId) {
+  return client.request({
+    method: "POST",
+    path: `/api/chat/conversation/${encodeURIComponent(sessionId)}`,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      turn: {
+        id: `${sessionId}-mid-walk`,
+        role: "user",
+        text: "written while a cursor was open",
+        createdAt: "2026-04-09T00:00:00.000Z",
+      },
+    }),
+  });
 }
 
 /**
@@ -2039,6 +2084,67 @@ function checkTouchLanded(walk, sessionId) {
 }
 
 /**
+ * The chat write has to have reached the ledger, AND it has to have left the
+ * row keyless — those are two different claims and a walk proves neither.
+ *
+ * `saveConversation` stamps `updatedAt` on every write and the appended turn
+ * changes the file's size, so the (mtime, ctime, size) summary cache cannot
+ * answer the probe from a stale entry: if `updatedAt` still reads the seeded
+ * value, nothing was written and the walk below survived nothing. The second
+ * check is the fix stated directly — a row that came back carrying a
+ * `createdAt` was stamped, which is the defect whatever the walk then did.
+ */
+function checkChatWriteLanded(response, walk, sessionId, seededUpdatedAt) {
+  const failures = [];
+  if (!response || response.status !== 200) {
+    failures.push(
+      `POST /api/chat/conversation/${sessionId} answered ${response?.status ?? "nothing"}` +
+      `${response?.text ? `: ${response.text.slice(0, 160)}` : ""} — nothing was written`,
+    );
+  }
+  const row = walk.observed.get(sessionId);
+  if (!row) {
+    failures.push(`${sessionId} was not in the ledger after the write, so nothing was written`);
+    return failures;
+  }
+  if (row.updatedAt === seededUpdatedAt) {
+    failures.push(
+      `${sessionId} still reads updatedAt ${JSON.stringify(row.updatedAt)} after the write — the` +
+      " ledger did not move, so this walk proves nothing",
+    );
+  }
+  if ("createdAt" in row) {
+    failures.push(
+      `${sessionId} had no createdAt and was written; it now reads` +
+      ` ${JSON.stringify(row.createdAt)}, so the write path stamped it`,
+    );
+  }
+  return failures;
+}
+
+/**
+ * The readability flip has to have reached the ledger too.
+ *
+ * A file Cave cannot parse projects as `fallbackConversationSummary`, whose
+ * `familiarId` is the empty string — the one field that says, over the wire,
+ * which of the two rows a walk is looking at. Without this probe both cases
+ * below pass against a Cave that never noticed the file changed at all.
+ */
+function checkFallbackRow(walk, sessionId, expectFallback) {
+  const row = walk.observed.get(sessionId);
+  if (!row) return [`${sessionId} left the ledger entirely, which is neither state under test`];
+  const isFallback = row.familiarId === "";
+  if (isFallback === expectFallback) return [];
+  return [
+    expectFallback
+      ? `${sessionId} still reads familiarId ${JSON.stringify(row.familiarId)}, so Cave never saw the` +
+        " file become unreadable and this walk proves nothing"
+      : `${sessionId} still projects as the unreadable-file fallback, so Cave never saw the file` +
+        " recover and this walk proves nothing",
+  ];
+}
+
+/**
  * The whole walk, as an ORDERED sequence against what the ledger should have
  * produced — not as a set, and not as a "did it contain the touched row".
  *
@@ -2313,6 +2419,178 @@ async function runConversationsLeg(client, recorder, bearer, caveHomeDir) {
     "an optional page key is only safe if the rows that lack it are served, not stranded",
   );
   await removeConversation(caveHomeDir, "conversation-keyless");
+  await restore();
+
+  // ── the keyless tail block, under writes (cave-wbxcu) ────────────────────
+  //
+  // Case 7 proves the rows with no `createdAt` are SERVED. That is only half of
+  // what keying on an optional field needs: the block also has to be STABLE,
+  // because a row that leaves it mid-walk sorts above every open cursor and is
+  // then skipped by the rest of the walk — cave-fhjlu again, on exactly the rows
+  // the sentinel exists to protect.
+  //
+  // One writer could move a row out of it: `buildConversation` on POST/PUT
+  // /api/chat/conversation/:id composed `args.existing?.createdAt ?? now`, so a
+  // legacy transcript that never had the field was STAMPED with `now` on its
+  // next turn and jumped to the head of the ordering. The three cases below
+  // drive that real route over the socket rather than rewriting the file,
+  // because the file is not where the defect lived.
+  const keylessSeed = (sessionId) => ({ ...keyless, sessionId });
+  const keylessIds = ["conversation-keyless-written", "conversation-keyless-quiet"];
+  const seedKeyless = async () => {
+    for (const sessionId of keylessIds) await writeConversation(caveHomeDir, keylessSeed(sessionId));
+  };
+  const dropKeyless = async () => {
+    for (const sessionId of keylessIds) await removeConversation(caveHomeDir, sessionId);
+  };
+  const keylessOrder = expectedConversationOrder([
+    ...conversations,
+    ...keylessIds.map((sessionId) => keylessSeed(sessionId)),
+  ]);
+
+  // 8. A keyless row WRITTEN mid-walk, through the route that used to stamp it,
+  //    walked alongside a keyless row that is not written at all. The quiet row
+  //    is the control: if the walk lost both, the ledger moved for some reason
+  //    other than the write.
+  await seedKeyless();
+  let chatWrite = null;
+  const written = await walkConversationsAcross(client, bearer, async () => {
+    chatWrite = await appendChatTurn(client, "conversation-keyless-written");
+  });
+  const writtenFailures = written.opened
+    ? [
+        ...checkChatWriteLanded(chatWrite, written, "conversation-keyless-written", keyless.updatedAt),
+        ...checkConversationWalk(written, keylessOrder),
+      ]
+    : ["the ledger did not page at limit 2, so no cursor was open across the write"];
+  recorder.expect(
+    "reads.conversations-keyless-row-written-mid-walk-is-still-served",
+    writtenFailures,
+    `wrote a turn to the unserved conversation-keyless-written; the whole walk served [${written.served}]`,
+  );
+
+  // 9. The two keyless rows share the empty-string sort key, so a page boundary
+  //    at limit 1 lands between them. Case 6 covers a tie between two real
+  //    instants; this covers a tie between two sentinels, which is a different
+  //    pair of values reaching the same comparator. Re-seeded first: case 8
+  //    leaves the ledger in whatever state its write produced, and a tie
+  //    assertion that inherits a stamped row is asserting case 8 again.
+  await seedKeyless();
+  const keylessSingles = await walk(client, "/conversations", bearer, "conversations", 1);
+  const keylessTie = [...keylessIds].sort().reverse();
+  const tiedKeylessFailures = checkPageWalk(keylessSingles, { limit: 1, expectedIds: keylessOrder });
+  const walkedKeylessTie = keylessSingles
+    .flatMap((page) => page.ids)
+    .filter((id) => keylessIds.includes(id))
+    .join(",");
+  if (walkedKeylessTie !== keylessTie.join(",")) {
+    tiedKeylessFailures.push(
+      `the tied keyless rows were served as [${walkedKeylessTie}], expected id-descending [${keylessTie}]`,
+    );
+  }
+  recorder.expect(
+    "reads.conversations-keyless-rows-tie-on-the-id-tiebreak",
+    tiedKeylessFailures,
+    "two rows with no createdAt share the sentinel, so only the id makes their order total",
+  );
+
+  // 10. A keyless row that acquires a `createdAt` BETWEEN two walks. Nothing in
+  //     Cave does this any more, but an external writer can, and the promise is
+  //     scoped to one walk: the second walk sees a consistent ledger and serves
+  //     the row exactly once at its new position. If this ever fails while 8
+  //     passes, the ordering — not the write path — is what moved.
+  const keyedAt = "2026-03-05T12:00:00.000Z";
+  await writeConversation(caveHomeDir, {
+    ...keylessSeed("conversation-keyless-written"),
+    createdAt: keyedAt,
+  });
+  const afterKeyed = await walk(client, "/conversations", bearer, "conversations", 2);
+  const keyedOrder = expectedConversationOrder([
+    ...conversations,
+    { ...keylessSeed("conversation-keyless-written"), createdAt: keyedAt },
+    keylessSeed("conversation-keyless-quiet"),
+  ]);
+  recorder.expect(
+    "reads.conversations-keyless-row-keyed-between-walks-moves-once",
+    checkPageWalk(afterKeyed, { limit: 2, expectedIds: keyedOrder }),
+    `conversation-keyless-written acquired ${keyedAt} between two walks and the next walk placed it`,
+  );
+  await dropKeyless();
+  await restore();
+
+  // ── the fallback row a file Cave cannot read produces (cave-wbxcu) ───────
+  //
+  // `fallbackConversationSummary` is the row `listConversations` substitutes for
+  // a transcript it cannot read or parse. It carried no `createdAt`, so a file
+  // that flipped between readable and unreadable moved a row into and out of the
+  // tail block under an open cursor — the same skip as case 8, reached without
+  // any writer at all, and recurring every time the flip happens.
+  //
+  // The transcript's real `createdAt` is immutable, so the last one Cave read is
+  // still true for a file it cannot read this time. That is what these two cases
+  // pin: an unreadable scan does not move the row, and neither does the scan
+  // that recovers it.
+  // The two directions need rows in different PLACES, which is the detail that
+  // makes one of them prove anything at all. A walk at limit 2 opens its cursor
+  // after the two newest rows, so:
+  //
+  //   - falling out of the ledger's middle into the tail is visible as a
+  //     reordering, whichever side of the cursor it happens on;
+  //   - rising out of the tail is only a SKIP if the row's real position is
+  //     ABOVE the open cursor. A recovering row whose createdAt is older than
+  //     the cursor rises to a position the walk has not passed yet and is still
+  //     served — measured, and it passed against the unfixed build, which is
+  //     exactly the vacuous assertion this harness exists to refuse.
+  const flaky = { ...byId.get("conversation-01"), sessionId: "conversation-flaky" };
+  const recovering = {
+    ...byId.get("conversation-01"),
+    sessionId: "conversation-recovering",
+    createdAt: "2026-03-07T00:00:00.000Z",
+  };
+
+  // 11. Readable at the start of the walk, unreadable mid-walk. Its createdAt
+  //     ties conversation-01's, so it sits sixth of seven and the fall to the
+  //     tail is a reordering the whole walk can see.
+  await writeConversation(caveHomeDir, flaky);
+  await client.read("/conversations?limit=100", bearer); // Cave reads it once, while it can.
+  const corrupted = await walkConversationsAcross(client, bearer, () =>
+    writeCorruptConversation(caveHomeDir, "conversation-flaky"));
+  recorder.expect(
+    "reads.conversations-unreadable-row-keeps-its-position-mid-walk",
+    corrupted.opened
+      ? [
+          ...checkFallbackRow(corrupted, "conversation-flaky", true),
+          ...checkConversationWalk(corrupted, expectedConversationOrder([...conversations, flaky])),
+        ]
+      : ["the ledger did not page at limit 2, so no cursor was open across the corruption"],
+    `conversation-flaky became unreadable mid-walk; the whole walk served [${corrupted.served}]`,
+  );
+  await removeConversation(caveHomeDir, "conversation-flaky");
+
+  // 12. Unreadable at the start of the walk, readable again mid-walk — the torn
+  //     write a later atomic replace completes, or the sharing violation that
+  //     clears. Its createdAt is the newest in the ledger, so recovering puts it
+  //     above the open cursor: this is the direction that SKIPS.
+  await writeConversation(caveHomeDir, recovering);
+  await client.read("/conversations?limit=100", bearer); // Cave reads it once, while it can.
+  await writeCorruptConversation(caveHomeDir, "conversation-recovering");
+  const recovered = await walkConversationsAcross(client, bearer, async () => {
+    await writeConversation(caveHomeDir, recovering);
+  });
+  recorder.expect(
+    "reads.conversations-recovering-row-keeps-its-position-mid-walk",
+    recovered.opened
+      ? [
+          ...checkFallbackRow(recovered, "conversation-recovering", false),
+          ...checkConversationWalk(
+            recovered,
+            expectedConversationOrder([...conversations, recovering]),
+          ),
+        ]
+      : ["the ledger did not page at limit 2, so no cursor was open across the recovery"],
+    `conversation-recovering became readable again mid-walk; the whole walk served [${recovered.served}]`,
+  );
+  await removeConversation(caveHomeDir, "conversation-recovering");
   await restore();
 }
 

--- a/src/app/api/chat/conversation/[id]/route.test.ts
+++ b/src/app/api/chat/conversation/[id]/route.test.ts
@@ -666,3 +666,149 @@ test("GET redacts legacy secret-bearing response metadata and model intent", asy
   assert.equal(json.conversation.turns[0].responseMetadata.model, "anthropic/claude-sonnet-4-6");
   assert.equal(json.conversation.modelIntent.reason, undefined);
 });
+
+// --- cave-wbxcu: createdAt is decided at creation and read-only afterwards ---
+//
+// `GET /api/client/v1/conversations` pages on createdAt descending, so the
+// field is a keyset cursor's coordinate: a record whose createdAt moves moves
+// under every open cursor, and if it moves UP the rest of that walk never
+// serves it. This route was the only writer in Cave that could move one — it
+// composed `body.createdAt || existing?.createdAt || now`, so a transcript
+// older than the field was stamped with `now` on its next turn (wrong fact,
+// and a silent skip), and any client body could rewrite a stored value.
+
+function writeKeylessConversation(id: string, turns: unknown[] = []) {
+  mkdirSync(CONV_DIR, { recursive: true });
+  // No createdAt at all — the shape a transcript written before the field has.
+  writeFileSync(
+    join(CONV_DIR, `${id}.json`),
+    JSON.stringify({
+      sessionId: id,
+      familiarId: "milo",
+      harness: "claude",
+      title: "Legacy chat",
+      updatedAt: "2026-06-01T00:00:00Z",
+      turns,
+    }),
+  );
+}
+
+function postReq(bodyObj: unknown) {
+  return new Request("http://test/api/chat/conversation/x", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(bodyObj),
+  });
+}
+
+function storedConversation(id: string) {
+  return JSON.parse(readFileSync(conversationPath(id), "utf8"));
+}
+
+test("POST leaves a legacy record with no createdAt without one", async () => {
+  writeKeylessConversation("sess-legacy-keyless-post", [
+    { id: "t1", role: "user", text: "hi", createdAt: "2026-06-01T00:00:00Z" },
+  ]);
+  const res = await POST(
+    postReq({ turn: { id: "t2", role: "user", text: "again", createdAt: "2026-06-02T00:00:00Z" } }),
+    paramsFor("sess-legacy-keyless-post"),
+  );
+  assert.equal(res.status, 200);
+  const json = await res.json();
+  // The turn landed — a record that refused the write would pass the createdAt
+  // assertion for the wrong reason.
+  assert.equal(json.conversation.turns.length, 2);
+  assert.equal(
+    "createdAt" in json.conversation,
+    false,
+    "the response must not invent a createdAt the store does not have",
+  );
+  const stored = storedConversation("sess-legacy-keyless-post");
+  assert.equal(stored.turns.length, 2, "the turn was persisted, so the write really happened");
+  assert.equal(
+    "createdAt" in stored,
+    false,
+    "stamping `now` here moves the row from the tail of the client-v1 ordering to its head",
+  );
+});
+
+test("PUT leaves a legacy record with no createdAt without one", async () => {
+  writeKeylessConversation("sess-legacy-keyless-put", [
+    { id: "t1", role: "user", text: "hi", createdAt: "2026-06-01T00:00:00Z" },
+  ]);
+  const res = await PUT(
+    writeReq({
+      turns: [{ id: "t9", role: "user", text: "replaced", createdAt: "2026-06-03T00:00:00Z" }],
+    }),
+    paramsFor("sess-legacy-keyless-put"),
+  );
+  assert.equal(res.status, 200);
+  const stored = storedConversation("sess-legacy-keyless-put");
+  assert.equal(stored.turns.length, 1);
+  assert.equal(stored.turns[0].id, "t9", "the turns really were replaced");
+  assert.equal("createdAt" in stored, false);
+});
+
+test("POST creating a conversation stamps createdAt, because that IS the creation", async () => {
+  const res = await POST(
+    postReq({
+      familiarId: "milo",
+      harness: "claude",
+      turn: { id: "t1", role: "user", text: "new", createdAt: "2026-06-04T00:00:00Z" },
+    }),
+    paramsFor("sess-brand-new"),
+  );
+  assert.equal(res.status, 200);
+  const stored = storedConversation("sess-brand-new");
+  assert.equal(
+    Number.isFinite(Date.parse(stored.createdAt)),
+    true,
+    "a record created now has been created now — this is the one write that may stamp",
+  );
+});
+
+test("a body createdAt seeds a NEW conversation and cannot rewrite a stored one", async () => {
+  // An import or an offline replay knows the real creation time better than the
+  // clock does, so the body is honoured while there is no record to contradict
+  // it...
+  const created = await POST(
+    postReq({
+      familiarId: "milo",
+      harness: "claude",
+      createdAt: "2024-01-02T03:04:05.000Z",
+      turn: { id: "t1", role: "user", text: "imported", createdAt: "2024-01-02T03:04:05.000Z" },
+    }),
+    paramsFor("sess-imported"),
+  );
+  assert.equal(created.status, 200);
+  assert.equal(storedConversation("sess-imported").createdAt, "2024-01-02T03:04:05.000Z");
+
+  // ...and refused afterwards. A stored createdAt is a cursor coordinate, and a
+  // client that can rewrite it can move any row past any open walk.
+  const rewritten = await PUT(
+    writeReq({
+      createdAt: "2036-12-31T00:00:00.000Z",
+      turns: [{ id: "t2", role: "user", text: "again", createdAt: "2036-12-31T00:00:00.000Z" }],
+    }),
+    paramsFor("sess-imported"),
+  );
+  assert.equal(rewritten.status, 200);
+  const stored = storedConversation("sess-imported");
+  assert.equal(stored.turns[0].id, "t2", "the write landed, so the refusal below is not vacuous");
+  assert.equal(stored.createdAt, "2024-01-02T03:04:05.000Z");
+
+  // Nor can a body ADD one to a record that has none — the same rewrite, onto
+  // the rows the empty-string sentinel exists to protect.
+  writeKeylessConversation("sess-legacy-body-createdat", []);
+  const forced = await PUT(
+    writeReq({
+      createdAt: "2036-12-31T00:00:00.000Z",
+      turns: [{ id: "t1", role: "user", text: "hi", createdAt: "2026-06-01T00:00:00Z" }],
+    }),
+    paramsFor("sess-legacy-body-createdat"),
+  );
+  assert.equal(forced.status, 200);
+  const legacy = storedConversation("sess-legacy-body-createdat");
+  assert.equal(legacy.turns.length, 1, "the write landed");
+  assert.equal("createdAt" in legacy, false);
+});

--- a/src/app/api/chat/conversation/[id]/route.ts
+++ b/src/app/api/chat/conversation/[id]/route.ts
@@ -398,6 +398,44 @@ function conversationTitle(id: string, body: ConversationWriteBody, existing: Co
   return defaultChatTitleForSession(id);
 }
 
+/**
+ * The record's creation time, which is the one field on it that must never move.
+ *
+ * `GET /api/client/v1/conversations` pages on `createdAt` descending, so it is a
+ * keyset cursor's coordinate: a record whose `createdAt` changes moves under
+ * every open cursor, and if it moves upward the rest of that walk never serves
+ * it — a silent skip in a read that surface calls canonical (cave-fhjlu).
+ *
+ * This function used to be the one place in Cave that could do that. It composed
+ * the field as `body.createdAt || existing?.createdAt || now`, which is two
+ * different mistakes wearing one expression:
+ *
+ *   - a stored record with NO `createdAt` — a transcript older than the field —
+ *     was stamped with `now` on its next turn. That is a wrong fact (the
+ *     conversation was not created today) and it moved the row from the tail of
+ *     the client-v1 ordering to the head, past every open cursor (cave-wbxcu).
+ *   - a client body could rewrite a stored `createdAt` to anything at all, on a
+ *     record it did not create. Same movement, fewer excuses.
+ *
+ * Both are closed the same way: `createdAt` is decided once, when the record is
+ * created, and is read-only afterwards. A body may still supply one — an import
+ * or a replay creating a transcript knows its real creation time better than the
+ * clock does — but only while there is no stored record to contradict it. A
+ * legacy record with none keeps none: absence is a stable position in the
+ * ordering (the empty-string sentinel), and inventing a value to fill it is
+ * exactly the move that loses the row.
+ */
+function conversationCreatedAt(args: {
+  body: ConversationWriteBody;
+  existing: ConversationFile | null;
+  now: string;
+}): string | undefined {
+  if (args.existing) return args.existing.createdAt;
+  return typeof args.body.createdAt === "string" && args.body.createdAt.trim()
+    ? args.body.createdAt
+    : args.now;
+}
+
 function buildConversation(args: {
   id: string;
   body: ConversationWriteBody;
@@ -414,6 +452,7 @@ function buildConversation(args: {
       : args.existing?.harness;
   if (!familiarId || !harness) return null;
   const now = new Date().toISOString();
+  const createdAt = conversationCreatedAt({ body: args.body, existing: args.existing, now });
   return {
     sessionId: args.id,
     ...(args.existing?.harnessSessionId ? { harnessSessionId: args.existing.harnessSessionId } : {}),
@@ -426,10 +465,7 @@ function buildConversation(args: {
     ...(args.existing?.modelIntent ? { modelIntent: args.existing.modelIntent } : {}),
     ...(args.existing?.runtime ? { runtime: args.existing.runtime } : {}),
     title: conversationTitle(args.id, args.body, args.existing),
-    createdAt:
-      typeof args.body.createdAt === "string" && args.body.createdAt.trim()
-        ? args.body.createdAt
-        : args.existing?.createdAt ?? now,
+    ...(createdAt ? { createdAt } : {}),
     updatedAt:
       typeof args.body.updatedAt === "string" && args.body.updatedAt.trim()
         ? args.body.updatedAt

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -3000,3 +3000,94 @@ console.log("cave-conversations model-lock test OK");
   await deleteConversation("structural-root-long-root-siblings");
 }
 console.log("cave-conversations structural-root perf/regression test OK");
+
+// cave-wbxcu: `createdAt` is the client-v1 conversations page key, so the store
+// has to keep a row's value STILL — including for the rows it cannot read.
+{
+  const {
+    clearConversationListMetadataCache,
+    CONV_DIR,
+  } = await import("./cave-conversations.ts");
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  await mkdir(CONV_DIR, { recursive: true });
+
+  const rowFor = async (sessionId) =>
+    (await listConversations()).find((row) => row.sessionId === sessionId);
+  const writeRaw = (sessionId, body) =>
+    writeFile(path.join(CONV_DIR, `${sessionId}.json`), body, "utf8");
+  const goodTranscript = (sessionId) => JSON.stringify({
+    sessionId,
+    familiarId: "charm",
+    harness: "codex",
+    title: "Readable",
+    createdAt: "2026-02-01T00:00:00.000Z",
+    updatedAt: "2026-02-02T00:00:00.000Z",
+    turns: [{ id: `${sessionId}-t1`, role: "user", text: "hello", createdAt: "2026-02-01T00:00:00.000Z" }],
+  });
+  // Truncated JSON: what a torn write leaves behind, and what a later atomic
+  // replace completes. Deliberately a different size from the good transcript,
+  // so the (mtime, ctime, size) summary cache cannot answer from a stale entry
+  // and every assertion below is measuring a fresh read.
+  const tornTranscript = '{"sessionId": "';
+
+  // 1. A transcript older than the field round-trips WITHOUT one. If saving
+  //    invented a createdAt here, every legacy row would move to the head of
+  //    the client-v1 ordering the first time anything touched it.
+  await saveConversation({
+    sessionId: "keyless-roundtrip",
+    familiarId: "charm",
+    harness: "codex",
+    updatedAt: "2026-02-02T00:00:00.000Z",
+    turns: [],
+  });
+  const reloadedKeyless = await loadConversation("keyless-roundtrip");
+  assert.equal(reloadedKeyless.createdAt, undefined, "saveConversation must not stamp createdAt");
+  assert.equal((await rowFor("keyless-roundtrip"))?.createdAt, undefined);
+  assert.equal(await deleteConversation("keyless-roundtrip"), true);
+
+  // 2. A file that becomes unreadable keeps the createdAt the last readable
+  //    scan saw. It is immutable, so the last value read is still the true one
+  //    — and dropping it drops the row to the tail of the client-v1 ordering
+  //    under any open cursor.
+  await writeRaw("flaky-transcript", goodTranscript("flaky-transcript"));
+  assert.equal((await rowFor("flaky-transcript"))?.createdAt, "2026-02-01T00:00:00.000Z");
+  await writeRaw("flaky-transcript", tornTranscript);
+  const tornRow = await rowFor("flaky-transcript");
+  assert.equal(tornRow?.familiarId, "", "the row really is the unreadable-file fallback");
+  assert.equal(
+    tornRow?.createdAt,
+    "2026-02-01T00:00:00.000Z",
+    "an unreadable scan must not move the row",
+  );
+  // ...and recovering does not move it either, which is the direction that
+  // skips: a row rising out of the tail passes every open cursor.
+  await writeRaw("flaky-transcript", goodTranscript("flaky-transcript"));
+  const healedRow = await rowFor("flaky-transcript");
+  assert.equal(healedRow?.familiarId, "charm", "the file really did become readable again");
+  assert.equal(healedRow?.createdAt, "2026-02-01T00:00:00.000Z");
+  assert.equal(await deleteConversation("flaky-transcript"), true);
+
+  // 3. A file this process has NEVER read has nothing to carry forward — the
+  //    contents are exactly what cannot be reached — so it carries no createdAt
+  //    and sorts to the tail, where it is served rather than stranded.
+  clearConversationListMetadataCache();
+  await writeRaw("never-readable", tornTranscript);
+  const strangerRow = await rowFor("never-readable");
+  assert.equal(strangerRow?.familiarId, "");
+  assert.equal(strangerRow?.createdAt, undefined, "nothing may be invented for a file never read");
+  assert.equal(await deleteConversation("never-readable"), true);
+
+  // 4. The memory belongs to the transcript, not to the id. A deleted
+  //    conversation whose id is reused must not inherit the old createdAt.
+  await writeRaw("recycled-id", goodTranscript("recycled-id"));
+  assert.equal((await rowFor("recycled-id"))?.createdAt, "2026-02-01T00:00:00.000Z");
+  assert.equal(await deleteConversation("recycled-id"), true);
+  await writeRaw("recycled-id", tornTranscript);
+  assert.equal(
+    (await rowFor("recycled-id"))?.createdAt,
+    undefined,
+    "a different conversation reusing the id inherits nothing",
+  );
+  assert.equal(await deleteConversation("recycled-id"), true);
+}
+console.log("cave-conversations createdAt-stability test OK");

--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -3089,5 +3089,49 @@ console.log("cave-conversations structural-root perf/regression test OK");
     "a different conversation reusing the id inherits nothing",
   );
   assert.equal(await deleteConversation("recycled-id"), true);
+
+  // 5. Only a createdAt the transcript really carried may be remembered. A
+  //    legacy transcript that has none, read successfully and then torn, must
+  //    still produce a fallback row with none: substituting any other timestamp
+  //    would lift the row out of the tail block on nothing but a read failure,
+  //    which is the move this whole change exists to stop.
+  const keylessTranscript = JSON.stringify({
+    sessionId: "keyless-then-torn",
+    familiarId: "charm",
+    harness: "codex",
+    updatedAt: "2026-02-02T00:00:00.000Z",
+    turns: [],
+  });
+  await writeRaw("keyless-then-torn", keylessTranscript);
+  assert.equal((await rowFor("keyless-then-torn"))?.familiarId, "charm", "read successfully first");
+  await writeRaw("keyless-then-torn", tornTranscript);
+  const tornKeylessRow = await rowFor("keyless-then-torn");
+  assert.equal(tornKeylessRow?.familiarId, "", "the row really is the fallback");
+  assert.equal(
+    tornKeylessRow?.createdAt,
+    undefined,
+    "a transcript with no createdAt must not gain one from being unreadable",
+  );
+  assert.equal(await deleteConversation("keyless-then-torn"), true);
+
+  // 6. ...and a remembered value is forgotten when a later readable scan finds
+  //    the field gone, so an externally rewritten transcript cannot keep being
+  //    sorted by a createdAt it no longer carries.
+  await writeRaw("createdat-removed", goodTranscript("createdat-removed"));
+  assert.equal((await rowFor("createdat-removed"))?.createdAt, "2026-02-01T00:00:00.000Z");
+  await writeRaw("createdat-removed", JSON.stringify({
+    sessionId: "createdat-removed",
+    familiarId: "charm",
+    harness: "codex",
+    title: "Rewritten without a createdAt",
+    updatedAt: "2026-02-03T00:00:00.000Z",
+    turns: [],
+  }));
+  assert.equal((await rowFor("createdat-removed"))?.createdAt, undefined);
+  await writeRaw("createdat-removed", tornTranscript);
+  const staleRow = await rowFor("createdat-removed");
+  assert.equal(staleRow?.familiarId, "");
+  assert.equal(staleRow?.createdAt, undefined, "the remembered value did not outlive the field");
+  assert.equal(await deleteConversation("createdat-removed"), true);
 }
 console.log("cave-conversations createdAt-stability test OK");

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -134,7 +134,24 @@ export type ConversationFile = {
    * never feeds the merged-PR auto-archive sweep.
    */
   prUrl?: string;
-  createdAt: string;
+  /**
+   * When this conversation was created — and the ONLY timestamp on the record
+   * that never moves. `/api/client/v1/conversations` pages on it, so a keyset
+   * cursor names a position built from this field (cave-fhjlu).
+   *
+   * Optional because the store really does hold records without it: transcripts
+   * written before the field existed. The type claimed `string` and the files
+   * disagreed, which is how `buildConversation` came to stamp `now` onto one of
+   * them — recording a wrong creation time, and moving the row from the tail of
+   * the client-v1 ordering to its head under an open cursor, where the rest of
+   * the walk skipped it (cave-wbxcu).
+   *
+   * So: a record that has one keeps it, and a record that has none never
+   * acquires one. Absence is stable, and every writer here treats it that way —
+   * `saveConversation` passes the record through untouched, and the creation
+   * paths stamp `now` only when they are genuinely creating the record.
+   */
+  createdAt?: string;
   updatedAt: string;
   turns: ChatTurn[];
   /** Branching: id of the turn at the tip of the currently selected path. The
@@ -200,6 +217,17 @@ type ConversationSummaryCacheEntry = {
   summary: ConversationSummary | null;
 };
 const conversationSummaryCache = new Map<string, ConversationSummaryCacheEntry>();
+/**
+ * The last `createdAt` a successful read saw on each transcript, kept for the
+ * rows a FAILED read has to substitute (see fallbackConversationSummary).
+ *
+ * Separate from the summary cache above on purpose. That cache is keyed on the
+ * file's stat triple and is dropped the moment the file changes — which is
+ * precisely when the fallback row is needed — whereas this survives every
+ * change to the file, because `createdAt` does not change with them. It is
+ * dropped only when the transcript itself goes away.
+ */
+const conversationCreatedAtByFile = new Map<string, string>();
 let conversationListScanCount = 0;
 let conversationListMetrics: ConversationListMetrics = {
   scanCount: 0,
@@ -219,6 +247,7 @@ export function getConversationListMetrics(): ConversationListMetrics {
 
 export function clearConversationListMetadataCache(): void {
   conversationSummaryCache.clear();
+  conversationCreatedAtByFile.clear();
 }
 
 function hasDuplicateTurnIds(turns: Pick<ChatTurn, "id">[]): boolean {
@@ -778,6 +807,7 @@ export async function deleteConversation(sessionId: string): Promise<boolean> {
     const file = pathFor(sessionId);
     await unlink(file);
     conversationSummaryCache.delete(file);
+    conversationCreatedAtByFile.delete(file);
     invalidateSessionsListCache();
     return true;
   } catch {
@@ -785,8 +815,35 @@ export async function deleteConversation(sessionId: string): Promise<boolean> {
   }
 }
 
-function fallbackConversationSummary(sessionId: string, mtimeMs: number): ConversationSummary {
-  return { sessionId, familiarId: "", updatedAt: new Date(mtimeMs).toISOString() };
+/**
+ * The row substituted for a transcript this scan could not read or parse.
+ *
+ * `createdAt` is carried over from the last scan that COULD read the file,
+ * because it is the one field on the record that never changes: the last value
+ * read is still the true one, however unreadable the file is now. Serving it is
+ * not a guess, and dropping it is not free — `/api/client/v1/conversations`
+ * pages on `createdAt`, and a row that loses it falls to the tail of that
+ * ordering while a client's cursor is open, so a file that flips between
+ * readable and unreadable moves a row past the cursor in one direction or the
+ * other every time it flips (cave-wbxcu).
+ *
+ * A file this process has NEVER read has no such value, and there is nothing to
+ * derive one from — the contents are exactly what cannot be reached. Those rows
+ * carry no `createdAt` and sort to the tail, which is the same place they have
+ * always sorted; a walk that starts and ends while the file is unreadable sees
+ * them in one stable position.
+ */
+function fallbackConversationSummary(
+  sessionId: string,
+  mtimeMs: number,
+  lastKnownCreatedAt: string | undefined,
+): ConversationSummary {
+  return {
+    sessionId,
+    familiarId: "",
+    ...(lastKnownCreatedAt ? { createdAt: lastKnownCreatedAt } : {}),
+    updatedAt: new Date(mtimeMs).toISOString(),
+  };
 }
 
 async function readConversationSummary(
@@ -795,6 +852,7 @@ async function readConversationSummary(
   mtimeMs: number,
   fileSize: number,
 ): Promise<{ summary: ConversationSummary | null; bytesRead: number; cacheable: boolean }> {
+  const lastKnownCreatedAt = conversationCreatedAtByFile.get(file);
   let raw: string;
   try {
     raw = await readFile(file, "utf8");
@@ -802,7 +860,7 @@ async function readConversationSummary(
     // A sharing violation or other transient read failure must be retried on
     // the next scan even when the file's stat key did not change.
     return {
-      summary: fallbackConversationSummary(fallbackSessionId, mtimeMs),
+      summary: fallbackConversationSummary(fallbackSessionId, mtimeMs, lastKnownCreatedAt),
       bytesRead: 0,
       cacheable: false,
     };
@@ -813,7 +871,7 @@ async function readConversationSummary(
     conv = JSON.parse(raw) as ConversationFile;
   } catch {
     return {
-      summary: fallbackConversationSummary(fallbackSessionId, mtimeMs),
+      summary: fallbackConversationSummary(fallbackSessionId, mtimeMs, lastKnownCreatedAt),
       bytesRead: fileSize,
       cacheable: true,
     };
@@ -824,6 +882,14 @@ async function readConversationSummary(
     // truly-linear transcripts still project a synthetic path, while corrupt or
     // ambiguous branch state fails quiet instead of picking a branch implicitly.
     const signals = deriveConversationSignals(conv);
+    // Remember it for the scans that cannot read this file. Recorded only from a
+    // read that actually parsed, and only for a value the record really carries,
+    // so a fallback row never serves a `createdAt` no transcript ever had.
+    if (typeof conv.createdAt === "string" && conv.createdAt.trim()) {
+      conversationCreatedAtByFile.set(file, conv.createdAt);
+    } else {
+      conversationCreatedAtByFile.delete(file);
+    }
     return {
       summary: {
         sessionId: conv.sessionId,
@@ -852,7 +918,7 @@ async function readConversationSummary(
     // loadConversation() treats any invalid conversation shape like a parse
     // failure, so preserve listConversations()'s filename/mtime fallback row.
     return {
-      summary: fallbackConversationSummary(fallbackSessionId, mtimeMs),
+      summary: fallbackConversationSummary(fallbackSessionId, mtimeMs, lastKnownCreatedAt),
       bytesRead: fileSize,
       cacheable: true,
     };
@@ -888,6 +954,12 @@ export async function listConversations(): Promise<ConversationSummary[]> {
   const liveFiles = new Set(files);
   for (const file of conversationSummaryCache.keys()) {
     if (!liveFiles.has(file)) conversationSummaryCache.delete(file);
+  }
+  // The remembered createdAt outlives every change to a file, but not the file:
+  // a transcript that is gone has no row to substitute, and a later transcript
+  // reusing the id is a different conversation.
+  for (const file of conversationCreatedAtByFile.keys()) {
+    if (!liveFiles.has(file)) conversationCreatedAtByFile.delete(file);
   }
 
   const results: Array<ConversationSummary | null | undefined> = new Array(names.length);

--- a/src/lib/server/client-v1/reads.test.ts
+++ b/src/lib/server/client-v1/reads.test.ts
@@ -271,6 +271,24 @@ test("a conversation with no createdAt sorts to the tail rather than being stran
     ]).map((row) => row.sessionId),
     ["conversation-b", "conversation-a"],
   );
+  // The tail block is for rows with no createdAt, NOT for the fallback row a
+  // file Cave could not read. Those are the same shape — familiarId "" — and
+  // fallbackConversationSummary now carries over the createdAt the last
+  // readable scan saw, because the field is immutable and the last value read
+  // is still the true one. A key that read the fallback shape rather than the
+  // field would drop such a row to the tail every time the file flickered, and
+  // lift it back out mid-walk when the file recovered (cave-wbxcu).
+  const unreadable: ConversationSummary = {
+    sessionId: "conversation-8",
+    familiarId: "",
+    createdAt: "2026-08-02T00:00:00.000Z",
+    updatedAt: "2026-08-02T00:00:00.000Z",
+  };
+  assert.deepEqual(
+    sortClientV1Conversations([keyless, SUMMARY, unreadable]).map((row) => row.sessionId),
+    ["conversation-8", "conversation-1", "conversation-9"],
+    "a row Cave could not read this scan keeps the position its createdAt names",
+  );
 });
 
 test("the page key reads createdAt exactly as the projection serves it", () => {

--- a/src/lib/server/client-v1/reads.ts
+++ b/src/lib/server/client-v1/reads.ts
@@ -344,19 +344,24 @@ export function clientV1ProjectPageKey(project: CaveProject): ClientV1PageKey {
  * can never return `""` — it demands a non-blank string — so the sentinel
  * cannot collide with a value a record actually carries.
  *
- * ⚠️ The sentinel is stable, but it is NOT unconditionally permanent, and the
- * difference is the one thing to know before trusting this block. `POST`/`PUT
- * /api/chat/conversation/:id` builds its record with
- * `args.existing?.createdAt ?? now` (buildConversation), so a legacy transcript
- * that never had a `createdAt` acquires one — `now` — on its next write through
- * that route, and jumps from this tail block to the HEAD of the ordering. A
- * `/conversations` walk with an open cursor then skips it, which is cave-fhjlu
- * again on exactly the rows this sentinel exists to protect. It is much
- * narrower than the original defect (only a row that lacks the field, only on
- * its first write through that one route, and self-healing afterwards), it is
- * not reachable from this surface, and closing it belongs to that write path
- * rather than to this key — cave-wbxcu. Do not restate this block as immutable
- * until that lands.
+ * The sentinel is as permanent as an instant, because absence is: no writer in
+ * Cave adds a `createdAt` to a record that has none. It was not always so.
+ * `buildConversation` (`POST`/`PUT /api/chat/conversation/:id`) composed
+ * `args.existing?.createdAt ?? now`, so a legacy transcript acquired one — `now`
+ * — on its next turn and jumped from this tail block to the HEAD of the
+ * ordering, where a walk with an open cursor skipped it: cave-fhjlu again, on
+ * exactly the rows this sentinel exists to protect. Closed in the write path,
+ * where it belonged, rather than by making this key cleverer (cave-wbxcu). That
+ * route now decides `createdAt` once, when it creates the record, and treats it
+ * as read-only afterwards — so a legacy row keeps no `createdAt` and keeps this
+ * position.
+ *
+ * The other producer of a row without one is `fallbackConversationSummary`, the
+ * row `listConversations` substitutes for a transcript it cannot read. It now
+ * carries over the `createdAt` the last readable scan saw — immutable, so still
+ * true — and only a file this process has never read successfully lands here.
+ * That row has nothing derivable behind it, and it sorts to this block in one
+ * stable position for as long as the file stays unreadable.
  */
 function conversationSortKey(summary: ConversationSummary): string {
   return optionalText(summary.createdAt) ?? "";
@@ -388,11 +393,13 @@ function conversationSortKey(summary: ConversationSummary): string {
  * change all leave the key alone: the key of a row that has one never changes,
  * and a walk that started before a touch serves the same set after it.
  *
- * Two writes are outside that "never", both on `POST`/`PUT
- * /api/chat/conversation/:id` and neither reachable from this surface: a body
- * that supplies its own `createdAt` overrides the stored one, and a record that
- * has none is stamped with `now`. The second is the one that costs something
- * here — see {@link conversationSortKey}.
+ * Two writes used to be outside that "never", both on `POST`/`PUT
+ * /api/chat/conversation/:id`: a body that supplied its own `createdAt`
+ * overrode the stored one, and a record that had none was stamped with `now`.
+ * Neither was reachable from this surface and both are closed (cave-wbxcu) —
+ * that route decides `createdAt` at creation and treats it as read-only after,
+ * so nothing in Cave now moves a conversation's key. See
+ * {@link conversationSortKey} for the rows that have no key at all.
  *
  * Two costs, both deliberate and both published in docs/api/client-v1.md:
  *


### PR DESCRIPTION
`GET /api/client/v1/conversations` pages on `createdAt` descending (cave-fhjlu,
#4863). A conversation record with no `createdAt` sorts as the empty-string
sentinel — one contiguous, id-ordered block at the tail of the walk. That block
was documented as stable, and it was not.

## The defect

**Trigger 1 — the write path stamped it.** `buildConversation`
(`POST`/`PUT /api/chat/conversation/:id`) composed the field as
`body.createdAt || existing?.createdAt || now`. A transcript older than the
field therefore acquired one — `now` — on its next turn, and jumped from the
tail of the ordering to the **head**, above every open cursor, where the rest of
that walk never served it. cave-fhjlu again, on exactly the rows the sentinel
exists to protect. The stamp was also a wrong fact: the conversation was not
created today. The same expression let any client body rewrite a *stored*
`createdAt`, which moves a row just as freely, and on any record rather than
only a legacy one.

**Trigger 2 — the row Cave substitutes for a file it cannot read.**
`fallbackConversationSummary` carried no `createdAt` at all, so a transcript
flickering between readable and unreadable moved a row into the tail block and
back out of it under an open cursor, every time it flickered. Unlike trigger 1
this needs no writer and does not self-heal.

## Reproduced first, over the whole walk

Five assertions were added to `scripts/client-v1-conformance.mjs` and run
against the **unfixed** build before anything was changed. Three failed, on the
wire:

| Assertion | Unfixed build |
|---|---|
| `reads.conversations-keyless-row-written-mid-walk-is-still-served` | the row was stamped `2026-08-23T03:30:29.860Z` mid-walk; the whole walk served 7 of 8 rows and **lost `conversation-keyless-written`** |
| `reads.conversations-recovering-row-keeps-its-position-mid-walk` | a file that became readable again mid-walk rose above the open cursor and **was never served** |
| `reads.conversations-unreadable-row-keeps-its-position-mid-walk` | a file that became unreadable mid-walk fell to the tail, reordering the walk |

The write is driven through `POST /api/chat/conversation/:id` **over the
socket** — the route the defect lived in. A case that simulated the stamp by
rewriting the transcript file would have kept passing after the write path was
fixed, and kept failing after it was broken again.

One of the five was vacuous on its first draft and the reproduction run is what
caught it: the recovering row's `createdAt` was the *oldest* in the ledger, so
it rose to a position the walk had not reached yet, was served normally, and
passed against the broken build. It now carries the newest `createdAt` in the
ledger, so recovering puts it above the open cursor. That detail is written into
the harness comment and the runbook.

## The fix, and why not the alternatives

`createdAt` is decided once, when the record is created, and is read-only after
that.

- `existing === null` → stamp `now`, or honour a body-supplied value. That is a
  genuine creation, and an import or offline replay knows its real creation time
  better than the clock does.
- `existing !== null` → carry the stored value through **exactly**, absence
  included. A body cannot rewrite it and cannot add one.
- `ConversationFile.createdAt` becomes optional, which is what the files on disk
  have always said. `tsc --noEmit` is clean with no other change: the only
  consumers are the summary projection and `session-list-merge.ts`, which
  already wrote `conv.createdAt ?? conv.updatedAt` for exactly this case.
- The fallback row carries over the `createdAt` the last readable scan saw. The
  field is immutable, so the last value read is still the true one — a recovered
  fact, not a guess. Only a value the transcript really carried is remembered,
  and it is forgotten when the file is deleted or when a later readable scan
  finds the field gone.

**Not** a derived value (the earliest turn's `createdAt`, the file's `ctime`).
A derivation is only safe if it is invariant under every write that can happen
while the record is still keyless, and none is: deleting the first turn moves an
earliest-turn key, and an atomic replace moves a `ctime` key. Trading a
guarantee for a prettier position is the wrong side of this trade — the sentinel
tail is already served, already reachable through a cursor, and already
published.

**Not** a startup backfill (option (b) on the bead). A backfill is a mass write
that moves every keyless row at once — a skip for any walk open across it — it
writes a fabricated creation time permanently into the records that are the
*reason* the field is optional, and it cannot help trigger 2 at all, because the
contents of an unreadable file are exactly what cannot be reached.

## Records already on disk

No migration, and none needed. A record with a `createdAt` keeps it. A record
without one keeps none — it holds the tail position it already holds instead of
acquiring a wrong value the first time anything writes to it. The desktop
sessions list already displayed `createdAt ?? updatedAt` for these rows and is
unchanged.

The one behaviour that is genuinely narrowed: a legacy transcript no longer
*acquires* a creation time by being written to. It never had a true one, and the
value it used to acquire was false.

## What is still not covered, stated plainly

A transcript this process has **never** read successfully has nothing to carry
forward, so it sits in the tail block until a scan can read it, and then takes
its real position. There is nothing to derive a key from for a file whose
contents cannot be reached, and inventing one is the move this PR removes. It is
one stable position for as long as the file stays unreadable, and it is
documented in `docs/api/client-v1.md`.

## Verification

- **Conformance, end to end.** After: `104 passed, 0 failed, 0 skipped` with
  `--include-ttl`, recorded at `d64ab964` in
  `docs/client-v1-conformance-results/2026-08-23-v0.3.9-win32-cave-wbxcu.json`
  (taken from a clean tree after the code commit, as the runbook requires).
  Before: `99 passed, 3 failed`.
- **Mutation matrix.** Nine unit mutations and five build-and-run mutations,
  every new assertion caught by at least one. Two build-and-run mutations were
  first written in a form that failed `pnpm build` (`noUnusedParameters`), which
  prints nothing and reads exactly like a miss; both were rewritten to mutate a
  behaviour while leaving every symbol used, and the trap is written into the
  runbook. One unit mutation — remembering `conv.createdAt ?? conv.updatedAt` —
  **was not caught** by the first draft of the store tests, and two cases were
  added for it.
- **Gates.** `pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` and
  `pnpm build` all exit 0. Suites green: `cave-conversations.test.ts`,
  `reads.test.ts` (19), `pagination.test.ts` (17), the five client-v1 route
  suites, `client-v1-doc-contract.test.mjs` (7),
  `client-v1-conformance.test.mjs` (53), and the chat conversation route suites
  (`[id]` 22, `[id]/turns/[turnId]` 14, `conversation/route`).

`docs/api/client-v1.md` no longer claims the tail block can be left, and the
`clientV1ConversationPageKey` / `conversationSortKey` comments describe what the
code now does rather than what it used to.

Closes cave-wbxcu. With this landed, cave-fhjlu has no surviving skip path.
