### PR TITLE
Make the runtime-chip spec hermetic and warm the `board` chunk (cave-18kpz)

### DIFF
--- a/tests/composer-runtime-chip.spec.ts
+++ b/tests/composer-runtime-chip.spec.ts
@@ -1,4 +1,11 @@
 import { expect, test, type Page } from "@playwright/test";
+import {
+  catalogForRuntime,
+  runtimeModelInventoryAvailability,
+  runtimeModelInventoryFreshness,
+  runtimeModelInventoryRefreshState,
+  runtimeModelInventoryScope,
+} from "../src/lib/runtime-models";
 
 // Verifies the composer runtime picker (cave-yq5l / cave-v25g / cave-bfwk,
 // split-chip grammar since cave-g21f): the chat composer footer's model chip
@@ -46,6 +53,43 @@ async function seed(page: Page): Promise<Mutable> {
     state.familiarsServed += 1;
     return route.fulfill({
       json: { ok: true, familiars: [{ ...FAMILIAR_BASE, harness: state.harness }] },
+    });
+  });
+  // Claude, Copilot, OpenClaw, Grok and Hermes are DYNAMIC-inventory runtimes:
+  // selecting one empties the Model group and refills it only when
+  // `/api/runtime-models/<runtime>` answers (see useRuntimeModelInventory).
+  // Leaving that route unmocked made the "Claude Sonnet 5" assertion below
+  // depend on a live server round-trip — one that compiles the route on first
+  // hit under `next dev` and spawns `claude --version` behind it — inside the
+  // only default (5s) expect budget in this file. That is why this test was
+  // the first thing to fail whenever CI got slow (cave-18kpz). Reproduced by
+  // delaying this route 6s locally: it fails at exactly the assertion below,
+  // on both the attempt and the retry, with the CI message verbatim.
+  //
+  // Mocked from the product's own catalog so the seed cannot drift, matching
+  // the shape a desktop without the runtime CLI installed really returns.
+  await page.route(/\/api\/runtime-models\/([^/?]+)(?:\?.*)?$/, (route) => {
+    expect(route.request().method()).toBe("GET");
+    const url = new URL(route.request().url());
+    const runtime = decodeURIComponent(url.pathname.split("/").pop() ?? "");
+    const catalog = catalogForRuntime(runtime);
+    if (!catalog) {
+      return route.fulfill({ status: 404, json: { ok: false, error: "runtime not found" } });
+    }
+    const provenance = "fallback" as const;
+    return route.fulfill({
+      json: {
+        ok: true,
+        runtime,
+        models: catalog.models,
+        provenance,
+        freshness: runtimeModelInventoryFreshness(provenance),
+        refreshState: runtimeModelInventoryRefreshState(provenance),
+        availability: runtimeModelInventoryAvailability(provenance),
+        defaultOwner: catalog.defaultOwner,
+        allowCustom: catalog.allowCustom,
+        scope: runtimeModelInventoryScope(runtime, url.searchParams.get("familiarId")),
+      },
     });
   });
   await page.route("**/api/sessions/list**", (route) =>

--- a/tests/warmup.setup.ts
+++ b/tests/warmup.setup.ts
@@ -180,12 +180,20 @@ test("warm the code-split surface chunks", async ({ page }) => {
   await reopen.click();
   await expect(page.locator(".workspace-rail")).toBeVisible({ timeout: CHUNK_TIMEOUT });
 
-  // `board` — the last heavy surface this file did not warm, and the one two
-  // specs rotate on (cave-18kpz). `BoardInspector` is a static import of
-  // `board-view`, so the "Card inspector" dialog ships inside the same lazy
-  // chunk: chat-task-chip-nav clicks the task chip and gives that dialog 10s,
-  // against a cold compile the header above measured at 28.3s. Deep-link to
-  // the card so the drawer itself renders, not just the empty board shell.
+  // `board` — the last heavy surface this file did not warm. `BoardInspector`
+  // is a static import of `board-view`, so the "Card inspector" dialog ships
+  // inside the same lazy chunk, and the two specs that need it
+  // (chat-task-chip-nav, task-work-fit) were paying its compile inside their
+  // own budgets — chat-task-chip-nav allows the dialog 10s. Measured on a cold
+  // `.next`: adding this step moves the warmup from 20.1s to 29.2s, which is
+  // that compile being paid here instead of there. Deep-link to the card so
+  // the drawer itself renders, not just the empty board shell.
+  //
+  // ⚠️ This closes a real gap but did NOT fix chat-task-chip-nav on CI
+  // (cave-18kpz): run 32621714561 still failed it with the chunk warmed. That
+  // spec is failing because hosted runners are ~3.3x slower than they were
+  // before 2026-08-23T02:00Z, not because of this chunk — see the bead. Do not
+  // read this step as that spec's fix.
   await page.goto(`/?mode=board#card-${WARMUP_CARD.id}`);
   await page.waitForSelector(".board-shell", { timeout: CHUNK_TIMEOUT });
   await expect(page.getByRole("dialog", { name: "Card inspector" }))

--- a/tests/warmup.setup.ts
+++ b/tests/warmup.setup.ts
@@ -12,6 +12,7 @@ import { expect, test, type Page } from "@playwright/test";
 //
 //   keyboard-shortcuts.spec.ts:44  — ⌘K, waiting on the `command-palette` chunk
 //   task-work-fit.spec.ts:277      — reopen strip, waiting on `workspace-rail`
+//   chat-task-chip-nav.spec.ts:119 — the task chip, waiting on `board`
 //
 // Measured in this worktree (2026-08-12, M-series laptop):
 //
@@ -71,6 +72,27 @@ const REPO_PROJECT = {
   updatedAt: ISO,
 };
 
+// One card, so the board warm-up below can open the inspector drawer rather
+// than only rendering an empty board shell.
+const WARMUP_CARD = {
+  id: "warmup-card",
+  title: "Warmup card",
+  notes: "",
+  status: "backlog",
+  priority: "medium",
+  familiarId: "nova",
+  links: [],
+  github: [],
+  labels: [],
+  createdAt: ISO,
+  updatedAt: ISO,
+  lifecycle: "queued",
+  lifecycleAt: ISO,
+  retryCount: 0,
+  maxRetries: 2,
+  steps: [],
+};
+
 // Four times the cold serial measurement above. A chunk that cannot compile in
 // two minutes is a genuine dev-server problem, and failing here says so once
 // rather than leaving every spec to time out on its own.
@@ -105,6 +127,11 @@ async function boot(page: Page) {
         context: {},
       },
     }),
+  );
+  await page.route("**/api/board**", (route) =>
+    route.request().method() === "GET"
+      ? route.fulfill({ json: { ok: true, cards: [WARMUP_CARD] } })
+      : route.continue(),
   );
 
   await page.goto("/?mode=chat");
@@ -152,4 +179,15 @@ test("warm the code-split surface chunks", async ({ page }) => {
   await expect(reopen).toBeVisible({ timeout: CHUNK_TIMEOUT });
   await reopen.click();
   await expect(page.locator(".workspace-rail")).toBeVisible({ timeout: CHUNK_TIMEOUT });
+
+  // `board` — the last heavy surface this file did not warm, and the one two
+  // specs rotate on (cave-18kpz). `BoardInspector` is a static import of
+  // `board-view`, so the "Card inspector" dialog ships inside the same lazy
+  // chunk: chat-task-chip-nav clicks the task chip and gives that dialog 10s,
+  // against a cold compile the header above measured at 28.3s. Deep-link to
+  // the card so the drawer itself renders, not just the empty board shell.
+  await page.goto(`/?mode=board#card-${WARMUP_CARD.id}`);
+  await page.waitForSelector(".board-shell", { timeout: CHUNK_TIMEOUT });
+  await expect(page.getByRole("dialog", { name: "Card inspector" }))
+    .toBeVisible({ timeout: CHUNK_TIMEOUT });
 });


### PR DESCRIPTION
Two Playwright fixes for `tests/`. Both were measured on their own and stand on
their own; neither of them fixes the red required check, and this PR no longer
claims to.

## What is here

**1. `tests/composer-runtime-chip.spec.ts` mocks `/api/runtime-models/<runtime>`.**

`claude` is a dynamic-inventory runtime: selecting it empties the Model group and
refills it only once `/api/runtime-models/claude` answers (see
`useRuntimeModelInventory`). Every other endpoint this spec touches is mocked via
`page.route`, and the file header claims the whole surface is — but that route was
never intercepted, so the "Claude Sonnet 5" assertion depended on a live server
round-trip that compiles the route on first hit under `next dev` and spawns
`claude --version` behind it.

That assertion is also the only one in the file still on the default 5s expect
budget; its neighbours carry 10-45s. So it is the first thing in the file to break
whenever latency inflates. Reproduced locally and deterministically by delaying
that one route by 6s: the spec fails at exactly that line, on the attempt and on
the retry.

Mocked from the product's own catalog (`catalogForRuntime` and the
`runtimeModelInventory*` helpers), matching the pattern
`tests/chat-code-workflow.spec.ts` already uses, so the seed cannot drift from the
real response shape. No timeout is raised and no assertion is relaxed.

**2. `tests/warmup.setup.ts` warms the `board` chunk.**

`BoardInspector` is a plain static import of `board-view`, which is a
`next/dynamic` chunk, so the Card inspector dialog ships inside the `board` chunk
and the first spec to open it under `next dev` pays the whole Turbopack compile.
Exactly two specs need it (`chat-task-chip-nav`, `task-work-fit`) and whichever
runs first pays. Warmed here once, serially, like the other three chunks: on a
cold `.next` the warm-up step goes 20.1s -> 29.2s, which is that compile being
paid once instead of inside a 10s assertion.

Wired at `playwright.config.ts:134` (already present). No timeout is raised and no
spec is skipped.

## What was withdrawn, and why

An earlier revision of this PR also changed the cave-home store lock in
`src/lib/server/cave-home-reconciliation.ts`. **That change is withdrawn in favour
of #4890**, and this branch now contains no store-lock code at all —
`git diff main...HEAD --stat` is two test files.

#4890 is the better fix, and the decider is not the starvation both of them
address. Measured locally, a nested `withCaveHomeReconciledStore` on the same
store:

| branch | nested-call outcome |
| --- | --- |
| `main` | `ETIMEDOUT` @ 15063 ms |
| this PR's withdrawn hunk | `ETIMEDOUT` @ 15072 ms |
| #4890 | `EDEADLK` @ 29 ms |

`repairOrphanProjectPermissions()` — reached from
`src/app/api/project-grants/route.ts:98` — nests the global reconciliation lock
and so deadlocks unconditionally today. On `main` it fails at `ETIMEDOUT` @
15025 ms; with this PR's withdrawn hunk it was still broken; on #4890 it resolves
in 24 ms. That endpoint is broken on `main` right now and only #4890 fixes it.
#4890 also passes this PR's test file verbatim, while this PR's implementation
**fails** #4890's test file at its reentrancy assertion — it is a strict superset,
not a competing approach.

The one thing #4890 lacks is a guard on the starvation property itself. That
59-line concurrency test has been offered to #4890 directly (it passes there
unmodified) rather than carried here behind an implementation that is being
dropped.

The live `/api/project-grants` deadlock is tracked separately so it does not
depend on #4890 landing.

## What this PR does *not* do

It does not fix the red required check. The `Validate end-to-end behavior` step
executed in 38 of the last 100 runs: 14/14 passed before 2026-08-23T01:52Z, 0/24
after 02:07Z, on every branch including `main`. Throughput fell ~8.4s -> ~28s per
test-slot (~3.3x), the suite exceeds the cap, and the runner kills the job
(`exit 143`). Runner image, provisioner and runner version are identical across
that boundary; heads on the same lockfile sit on both sides of it. That is an
infrastructure incident, not something a spec change can close.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (0 files with drift, eslint `--max-warnings=0`)
- `pnpm check:tests-wired` — 1814 test files wired
- `pnpm build` — clean
- `tests/composer-runtime-chip.spec.ts` — passes locally

cave-18kpz
