### PR TITLE
fix(cave-eo0b0): stop the filemode override pinning every Windows worktree active

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -93,6 +93,7 @@ export const SUITES = {
     "scripts/worktree-lifecycle-retirement.test.mjs",
     "scripts/worktree-lifecycle-patrol.test.mjs",
     "scripts/worktree-lifecycle-fence-renewal.test.mjs",
+    "scripts/worktree-lifecycle-filemode.test.mjs",
     "scripts/worktree-status.test.mjs",
     "scripts/worktree-session-exit-retirement.test.mjs",
     "scripts/remote-hygiene.test.mjs",
@@ -1863,6 +1864,8 @@ const STRIP_TYPES_MJS = new Set([
   // imports ./worktree-lifecycle-inventory.ts
   "scripts/worktree-lifecycle-retirement.test.mjs",
   "scripts/worktree-lifecycle-fence-renewal.test.mjs",
+  // imports ./worktree-lifecycle-inventory.ts and ../src/lib/worktree-lifecycle.ts
+  "scripts/worktree-lifecycle-filemode.test.mjs",
 ]);
 
 // Tests whose import graph reaches the "@/..." path alias and therefore need

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -16,6 +16,7 @@ import {
 } from "../src/lib/worktree-lifecycle.ts";
 import {
   collectWorktreeLifecycleInventory,
+  discountUnrepresentableExecutableBitChanges,
   type OrphanedWorktreeMetadataRecord,
   type WorktreeMetadataClaimError,
 } from "./worktree-lifecycle-inventory.ts";
@@ -1298,8 +1299,16 @@ function cleanForCompensation(
     return { ok: false, reason: status.stderr || "git status failed" };
   }
   const entries = status.stdout.split("\0").filter(Boolean);
-  const changes = entries.filter(
-    (entry) => !entry.startsWith("# ") && !entry.startsWith("! "),
+  // Same filesystem artifact as the inventory's statusState: on a filesystem
+  // with no executable bit the forced `core.fileMode=true` above reports every
+  // tracked 100755 file as modified, which made this compensation refuse to roll
+  // back a worktree it had just created seconds earlier.
+  const changes = discountUnrepresentableExecutableBitChanges(
+    worktreePath,
+    entries.filter(
+      (entry) => !entry.startsWith("# ") && !entry.startsWith("! "),
+    ),
+    git,
   );
   const nonDisposableIgnored = entries
     .filter((entry) => entry.startsWith("! "))

--- a/scripts/worktree-lifecycle-filemode.test.mjs
+++ b/scripts/worktree-lifecycle-filemode.test.mjs
@@ -183,9 +183,13 @@ async function makeRepo() {
   await mkdir(path.join(root, "scripts"), { recursive: true });
   writeFileSync(path.join(root, "scripts", "tool.sh"), "#!/bin/sh\necho hi\n");
   writeFileSync(path.join(root, "plain.txt"), "hello\n");
+  // Set the bit on disk first: real on a filesystem that holds it, a no-op on
+  // one that does not. Then force it in the index too, so HEAD and the index
+  // record 100755 on BOTH platforms. The result is a fixture that is genuinely
+  // clean on ext4, and carries the executable-bit artifact on NTFS — which is
+  // exactly the difference under test.
+  chmodSync(path.join(root, "scripts", "tool.sh"), 0o755);
   requireGit(root, ["add", "."]);
-  // Record 100755 in the index independently of what the filesystem can hold,
-  // so the fixture is identical on NTFS and on ext4.
   requireGit(root, ["update-index", "--chmod=+x", "scripts/tool.sh"]);
   requireGit(root, ["commit", "--quiet", "-m", "seed"]);
   return root;

--- a/scripts/worktree-lifecycle-filemode.test.mjs
+++ b/scripts/worktree-lifecycle-filemode.test.mjs
@@ -1,0 +1,300 @@
+// @ts-nocheck
+//
+// The worktree lifecycle gate authorises deleting worktrees. `statusState`
+// forces `-c core.fileMode=true` so repository configuration cannot hide a
+// permission change from it, and on a filesystem with no POSIX executable bit
+// that override manufactures a permanent phantom change for every tracked
+// 100755 file. These tests pin the narrow discount that removes the phantom, and
+// — more importantly — the two things it must never remove:
+//
+//   * a real content change, and
+//   * a real executable-bit change on a filesystem that can hold one.
+//
+// Every assertion here exercises behaviour. The integration half runs real git
+// against a real repository on disk rather than asserting on the text of the
+// command we happen to build.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const {
+  parseUnrepresentableExecutableBitCandidate,
+  retainedStatusChanges,
+} = await import("../src/lib/worktree-lifecycle.ts");
+const { discountUnrepresentableExecutableBitChanges } = await import(
+  "./worktree-lifecycle-inventory.ts"
+);
+
+const OID_A = "cab8485719a664fe7a7c4e8b1282fff20a900d2d";
+const OID_B = "474243c3a063ac342c93db366b35ba5063f4ae70";
+
+/** The exact record a checkout with no executable bit emits for a clean 100755 file. */
+const PHANTOM = `1 .M N... 100755 100755 100644 ${OID_A} ${OID_A} scripts/dev-app.sh`;
+
+const neverCalled = () => {
+  throw new Error("resolver must not be consulted");
+};
+
+// ---------------------------------------------------------------------------
+// The parser: which records can a missing executable bit possibly explain?
+// ---------------------------------------------------------------------------
+
+test("the phantom record is recognised, carrying its path and index oid", () => {
+  assert.deepEqual(parseUnrepresentableExecutableBitCandidate(PHANTOM), {
+    path: "scripts/dev-app.sh",
+    indexOid: OID_A,
+  });
+});
+
+test("records a missing executable bit cannot explain are never candidates", () => {
+  for (const [label, entry] of [
+    ["staged mode change", `1 M. N... 100755 100644 100644 ${OID_A} ${OID_A} a.sh`],
+    ["staged and unstaged", `1 MM N... 100755 100755 100644 ${OID_A} ${OID_B} a.sh`],
+    ["index differs from HEAD", `1 .M N... 100755 100755 100644 ${OID_A} ${OID_B} a.sh`],
+    ["deleted in worktree", `1 .D N... 100755 100755 100644 ${OID_A} ${OID_A} a.sh`],
+    ["type change", `1 .T N... 100755 100755 120000 ${OID_A} ${OID_A} a.sh`],
+    ["submodule", `1 .M SC.. 100755 100755 100644 ${OID_A} ${OID_A} vendor`],
+    // A filesystem that cannot store the bit also cannot invent one, so the
+    // 100644 -> 100755 direction is always a real change.
+    ["executable bit added", `1 .M N... 100644 100644 100755 ${OID_A} ${OID_A} a.sh`],
+    ["no mode delta at all", `1 .M N... 100644 100644 100644 ${OID_A} ${OID_A} a.ts`],
+    ["symlink", `1 .M N... 120000 120000 100644 ${OID_A} ${OID_A} a.sh`],
+    ["untracked", "? scripts/new.sh"],
+    ["unmerged", `u UU N... 100755 100755 100755 ${OID_A} ${OID_A} ${OID_B} a.sh`],
+    ["rename entry", `2 R. N... 100755 100755 100644 ${OID_A} ${OID_A} R100 b.sh\ta.sh`],
+    ["branch header", "# branch.oid abc123"],
+    ["ignored", "! node_modules/x"],
+    ["empty", ""],
+  ]) {
+    assert.equal(
+      parseUnrepresentableExecutableBitCandidate(entry),
+      null,
+      `${label} must not be treated as an executable-bit artifact`,
+    );
+  }
+});
+
+test("paths are taken verbatim, including spaces and a trailing space", () => {
+  assert.equal(
+    parseUnrepresentableExecutableBitCandidate(
+      `1 .M N... 100755 100755 100644 ${OID_A} ${OID_A} scripts/my tool.sh `,
+    ).path,
+    "scripts/my tool.sh ",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The decision: both facts required, every unknown keeps the entry.
+// ---------------------------------------------------------------------------
+
+test("nothing is discounted where the filesystem can hold an executable bit", () => {
+  // This is the POSIX guarantee in its most direct form: a genuine `chmod -x`
+  // produces exactly PHANTOM, and on a filesystem that can store the bit it must
+  // survive untouched, without the resolver even being asked.
+  assert.deepEqual(retainedStatusChanges([PHANTOM], true, neverCalled), [PHANTOM]);
+});
+
+test("a phantom whose content matches the index is discounted", () => {
+  assert.deepEqual(
+    retainedStatusChanges([PHANTOM], false, () => new Map([["scripts/dev-app.sh", OID_A]])),
+    [],
+  );
+});
+
+test("a mode-shaped entry whose content differs is kept", () => {
+  assert.deepEqual(
+    retainedStatusChanges([PHANTOM], false, () => new Map([["scripts/dev-app.sh", OID_B]])),
+    [PHANTOM],
+  );
+});
+
+test("an unanswerable hash keeps every entry", () => {
+  assert.deepEqual(retainedStatusChanges([PHANTOM], false, () => null), [PHANTOM]);
+  assert.deepEqual(retainedStatusChanges([PHANTOM], false, () => new Map()), [PHANTOM]);
+});
+
+test("non-candidate entries are neither hashed nor dropped", () => {
+  const real = `1 .M N... 100644 100644 100644 ${OID_A} ${OID_A} src/app.ts`;
+  const untracked = "? secret.env";
+  let asked = null;
+  const kept = retainedStatusChanges([real, PHANTOM, untracked], false, (paths) => {
+    asked = paths;
+    return new Map([["scripts/dev-app.sh", OID_A]]);
+  });
+  assert.deepEqual(kept, [real, untracked]);
+  assert.deepEqual(asked, ["scripts/dev-app.sh"], "only candidates are hashed");
+});
+
+// ---------------------------------------------------------------------------
+// Real git, real filesystem.
+// ---------------------------------------------------------------------------
+
+function git(cwd, args) {
+  const result = spawnSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return {
+    ok: result.status === 0 && !result.error,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr.trim() : "",
+  };
+}
+
+function requireGit(cwd, args) {
+  const result = git(cwd, args);
+  assert.ok(result.ok, `git ${args.join(" ")} failed: ${result.stderr}`);
+  return result.stdout;
+}
+
+/** The inventory's own status invocation, verbatim, including the forced flag. */
+function statusChanges(root) {
+  const result = git(root, [
+    "-c", "status.relativePaths=false",
+    "-c", "core.fileMode=true",
+    "-c", "core.fsmonitor=false",
+    "-c", "core.untrackedCache=false",
+    "-c", "core.ignoreStat=false",
+    "status", "--porcelain=v2", "-z",
+    "--untracked-files=all", "--ignored=matching",
+    "--ignore-submodules=none", "--no-renames",
+  ]);
+  assert.ok(result.ok, `status failed: ${result.stderr}`);
+  return result.stdout
+    .split("\0")
+    .filter(Boolean)
+    .filter((entry) => !entry.startsWith("# ") && !entry.startsWith("! "));
+}
+
+async function makeRepo() {
+  const root = mkdtempSync(path.join(tmpdir(), "worktree-filemode-"));
+  requireGit(root, ["init", "--quiet", "-b", "main"]);
+  requireGit(root, ["config", "user.email", "test@example.invalid"]);
+  requireGit(root, ["config", "user.name", "Filemode Test"]);
+  requireGit(root, ["config", "commit.gpgsign", "false"]);
+  await mkdir(path.join(root, "scripts"), { recursive: true });
+  writeFileSync(path.join(root, "scripts", "tool.sh"), "#!/bin/sh\necho hi\n");
+  writeFileSync(path.join(root, "plain.txt"), "hello\n");
+  requireGit(root, ["add", "."]);
+  // Record 100755 in the index independently of what the filesystem can hold,
+  // so the fixture is identical on NTFS and on ext4.
+  requireGit(root, ["update-index", "--chmod=+x", "scripts/tool.sh"]);
+  requireGit(root, ["commit", "--quiet", "-m", "seed"]);
+  return root;
+}
+
+function cleanup(root) {
+  try {
+    rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  } catch {
+    // Windows keeps handles on freshly-read git files; leaking a temp directory
+    // must not fail the suite.
+  }
+}
+
+const executableBitHeld = (() => {
+  const dir = mkdtempSync(path.join(tmpdir(), "worktree-filemode-probe-"));
+  const probe = path.join(dir, "probe");
+  try {
+    writeFileSync(probe, "");
+    chmodSync(probe, 0o755);
+    return (statSync(probe).mode & 0o111) !== 0;
+  } finally {
+    cleanup(dir);
+  }
+})();
+
+test("a byte-for-byte clean checkout reports no changes", async () => {
+  const root = await makeRepo();
+  try {
+    const before = statusChanges(root);
+    const after = discountUnrepresentableExecutableBitChanges(root, before, git);
+    if (executableBitHeld) {
+      // The bit round-trips, so git never reported a delta in the first place.
+      assert.deepEqual(before, [], "a clean POSIX checkout has nothing to discount");
+    } else {
+      assert.ok(
+        before.some((entry) => entry.includes("scripts/tool.sh")),
+        "the forced core.fileMode=true must still surface the mode delta",
+      );
+    }
+    assert.deepEqual(after, [], "a clean checkout must classify as clean");
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("an unstaged content edit to an executable stays dirty", async () => {
+  // The guarantee that the obvious fix loses. On a checkout with no executable
+  // bit this file's status record is shaped exactly like the phantom above —
+  // same `.M`, same 100755/100755/100644, same repeated object id — so anything
+  // keying off the record alone would delete this edit.
+  const root = await makeRepo();
+  try {
+    writeFileSync(path.join(root, "scripts", "tool.sh"), "#!/bin/sh\necho EDITED\n");
+    const kept = discountUnrepresentableExecutableBitChanges(root, statusChanges(root), git);
+    assert.ok(
+      kept.some((entry) => entry.endsWith("scripts/tool.sh")),
+      `an edited executable must remain a change; kept: ${JSON.stringify(kept)}`,
+    );
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("an unstaged content edit to a non-executable stays dirty", async () => {
+  const root = await makeRepo();
+  try {
+    writeFileSync(path.join(root, "plain.txt"), "goodbye\n");
+    const kept = discountUnrepresentableExecutableBitChanges(root, statusChanges(root), git);
+    assert.ok(
+      kept.some((entry) => entry.endsWith("plain.txt")),
+      `an edited file must remain a change; kept: ${JSON.stringify(kept)}`,
+    );
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("a staged executable-bit removal stays dirty on every platform", async () => {
+  const root = await makeRepo();
+  try {
+    requireGit(root, ["update-index", "--chmod=-x", "scripts/tool.sh"]);
+    const kept = discountUnrepresentableExecutableBitChanges(root, statusChanges(root), git);
+    assert.ok(
+      kept.some((entry) => entry.endsWith("scripts/tool.sh")),
+      `a staged mode change must remain a change; kept: ${JSON.stringify(kept)}`,
+    );
+  } finally {
+    cleanup(root);
+  }
+});
+
+test("a real chmod -x stays dirty where the filesystem holds the bit", async (t) => {
+  if (!executableBitHeld) {
+    t.skip("filesystem cannot store the executable bit; nothing real to chmod");
+    return;
+  }
+  const root = await makeRepo();
+  try {
+    const target = path.join(root, "scripts", "tool.sh");
+    chmodSync(target, 0o644);
+    const before = statusChanges(root);
+    assert.ok(
+      before.some((entry) => entry.endsWith("scripts/tool.sh")),
+      "git must see the permission change",
+    );
+    const kept = discountUnrepresentableExecutableBitChanges(root, before, git);
+    assert.ok(
+      kept.some((entry) => entry.endsWith("scripts/tool.sh")),
+      `a genuine permission change must remain a change; kept: ${JSON.stringify(kept)}`,
+    );
+  } finally {
+    cleanup(root);
+  }
+});

--- a/scripts/worktree-lifecycle-filemode.test.mjs
+++ b/scripts/worktree-lifecycle-filemode.test.mjs
@@ -54,6 +54,9 @@ test("the phantom record is recognised, carrying its path and index oid", () => 
 test("records a missing executable bit cannot explain are never candidates", () => {
   for (const [label, entry] of [
     ["staged mode change", `1 M. N... 100755 100644 100644 ${OID_A} ${OID_A} a.sh`],
+    // Isolates the "anything staged is a change on its own terms" guard: every
+    // other field here is the phantom's, so only the XY code can reject it.
+    ["staged, otherwise identical to the phantom", `1 M. N... 100755 100755 100644 ${OID_A} ${OID_A} a.sh`],
     ["staged and unstaged", `1 MM N... 100755 100755 100644 ${OID_A} ${OID_B} a.sh`],
     ["index differs from HEAD", `1 .M N... 100755 100755 100644 ${OID_A} ${OID_B} a.sh`],
     ["deleted in worktree", `1 .D N... 100755 100755 100644 ${OID_A} ${OID_A} a.sh`],

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -1,6 +1,15 @@
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
-import { lstatSync, readFileSync, realpathSync, type Stats } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  lstatSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  type Stats,
+} from "node:fs";
 import { devNull } from "node:os";
 
 import path from "node:path";
@@ -10,6 +19,7 @@ import {
   classifyWorktree,
   isDisposableIgnoredPath,
   normalizeAbsoluteWorktreePath,
+  retainedStatusChanges,
   type ManagedCreationException,
   type WorktreeLifecycleBudgets,
   type WorktreeLifecycleItem,
@@ -665,6 +675,110 @@ function processOwnersFor(
     .map(({ pid, command: processCommand }) => ({ pid, command: processCommand }));
 }
 
+/** Minimal shape of this module's `git()` result, so callers can pass their own. */
+export type LifecycleGitRunner = (
+  root: string,
+  args: string[],
+) => { ok: boolean; stdout: string; stderr: string };
+
+/**
+ * Does the filesystem backing this worktree store the POSIX executable bit?
+ *
+ * This is the same question git answers for itself when it auto-detects
+ * `core.fileMode`, asked the same way and in the same place: git probes its own
+ * git directory by writing a file, setting the executable bit, and re-reading
+ * the mode. Probing the git directory rather than the worktree root also means
+ * the scratch file can never appear in the `git status` output we are about to
+ * read.
+ *
+ * Fails closed. Every error — an unreadable git directory, a filesystem that
+ * refuses the write, a chmod that throws — returns `true`, which discounts
+ * nothing and leaves the caller with exactly the behaviour it had before.
+ */
+function executableBitRepresentable(root: string, runGit: LifecycleGitRunner): boolean {
+  const gitDir = runGit(root, ["rev-parse", "--absolute-git-dir"]);
+  if (!gitDir.ok || gitDir.stderr) return true;
+  const resolved = gitDir.stdout.trim();
+  if (resolved.length === 0) return true;
+  const probePath = path.join(resolved, `.filemode-probe-${randomUUID()}`);
+  try {
+    writeFileSync(probePath, "", { mode: 0o644 });
+    try {
+      chmodSync(probePath, 0o755);
+      return (statSync(probePath).mode & 0o111) !== 0;
+    } finally {
+      try {
+        rmSync(probePath, { force: true });
+      } catch {
+        // A probe file we could not remove is inert: it lives inside the git
+        // directory, never enters status output, and is overwritten by name on
+        // no future run. Losing the result would be worse than losing the file.
+      }
+    }
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Hashes worktree files exactly as `git add` would, so the result is directly
+ * comparable with the object ids `git status` reports from the index.
+ *
+ * `git hash-object` without `-w` writes nothing to the object database. Filters
+ * and end-of-line conversion are deliberately left ON (no `--no-filters`): the
+ * index holds post-clean content, so a checkout with `core.autocrlf` would
+ * otherwise mismatch on every text file.
+ *
+ * Returns `null` — meaning "no answer", which callers must treat as "changed" —
+ * if any batch fails or returns the wrong number of ids.
+ */
+function worktreeBlobOids(
+  root: string,
+  paths: string[],
+  runGit: LifecycleGitRunner,
+): Map<string, string> | null {
+  const oids = new Map<string, string>();
+  const batchSize = 64;
+  for (let offset = 0; offset < paths.length; offset += batchSize) {
+    const batch = paths.slice(offset, offset + batchSize);
+    const result = runGit(root, ["hash-object", "--", ...batch]);
+    if (!result.ok || result.stderr) return null;
+    const hashed = result.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+    if (hashed.length !== batch.length) return null;
+    batch.forEach((batchPath, index) => oids.set(batchPath, hashed[index]));
+  }
+  return oids;
+}
+
+/**
+ * Removes the phantom "changes" a filesystem without an executable bit invents,
+ * without weakening what the status probe can see.
+ *
+ * The `-c core.fileMode=true` override on the status call is deliberate and
+ * stays: it stops repository configuration hiding a real permission change from
+ * a gate that authorises deletion. On NTFS, though, that override makes git
+ * compare a mode it recorded (100755) against a mode the filesystem cannot
+ * represent (100644), and every shell script and git hook in the checkout is
+ * reported modified forever. Measured on this repository: 24 such entries in a
+ * byte-for-byte clean worktree, which pinned every Windows worktree to `active`
+ * and made retirement structurally unreachable.
+ *
+ * So the override is kept and the false positive is removed one layer later,
+ * where both facts needed to prove an entry is an artifact are available.
+ */
+export function discountUnrepresentableExecutableBitChanges(
+  root: string,
+  changes: string[],
+  runGit: LifecycleGitRunner,
+): string[] {
+  if (changes.length === 0) return changes;
+  return retainedStatusChanges(
+    changes,
+    executableBitRepresentable(root, runGit),
+    (paths) => worktreeBlobOids(root, paths, runGit),
+  );
+}
+
 function statusState(root: string): {
   changes: string[];
   ignoredPaths: string[];
@@ -699,7 +813,11 @@ function statusState(root: string): {
     };
   }
   const entries = result.stdout.split("\0").filter(Boolean);
-  const changes = entries.filter((entry) => !entry.startsWith("# ") && !entry.startsWith("! "));
+  const changes = discountUnrepresentableExecutableBitChanges(
+    root,
+    entries.filter((entry) => !entry.startsWith("# ") && !entry.startsWith("! ")),
+    git,
+  );
   const ignoredPaths = entries
     .filter((entry) => entry.startsWith("! "))
     .map((entry) => entry.slice(2));

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -398,6 +398,112 @@ export function isDisposableIgnoredPath(candidate: string): boolean {
   );
 }
 
+/**
+ * An "ordinary changed entry" from `git status --porcelain=v2`:
+ *
+ *   1 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <path>
+ *
+ * The path is everything after the eighth field. Under `-z` it is emitted raw,
+ * so it may contain spaces, a trailing space, or a newline, and must never be
+ * trimmed.
+ */
+const PORCELAIN_V2_ORDINARY_ENTRY =
+  /^1 (\S\S) (\S+) (\d{6}) (\d{6}) (\d{6}) ([0-9a-f]+) ([0-9a-f]+) ([\s\S]+)$/;
+
+export interface UnrepresentableExecutableBitCandidate {
+  /** Repository-root-relative path, exactly as git emitted it. */
+  path: string;
+  /** The object id git has recorded in the index for that path. */
+  indexOid: string;
+}
+
+/**
+ * Recognises the ONE status entry shape a filesystem without a POSIX executable
+ * bit can manufacture out of nothing: git has 100755 in both HEAD and the index,
+ * and the filesystem can only ever report 100644 back.
+ *
+ * This is a *candidate*, not a verdict. Matching proves only that the entry's
+ * mode delta is explainable by the missing executable bit — it does NOT prove
+ * the worktree file is unchanged, and callers must establish that separately by
+ * comparing the worktree content against `indexOid`.
+ *
+ * ⚠️ That second step is not optional, and the reason is easy to get wrong. A
+ * porcelain-v2 ordinary entry carries only TWO object ids: the HEAD blob (`hH`)
+ * and the INDEX blob (`hI`). There is no worktree object id — `git status` never
+ * hashes the worktree file. So `hH === hI` says only that the index matches
+ * HEAD, which `X === "."` already said; it says nothing whatsoever about the
+ * bytes on disk. Measured on a Windows checkout of this repository, an untouched
+ * executable and the same executable with an unstaged content edit produce
+ * status records of identical shape, both with equal object ids:
+ *
+ *   1 .M N... 100755 100755 100644 cab8485719a6… cab8485719a6… scripts/dev-app.sh
+ *
+ * Discounting on equal object ids alone would therefore hide real uncommitted
+ * edits from the check that authorises deleting a worktree.
+ */
+export function parseUnrepresentableExecutableBitCandidate(
+  entry: string,
+): UnrepresentableExecutableBitCandidate | null {
+  const match = PORCELAIN_V2_ORDINARY_ENTRY.exec(entry);
+  if (!match) return null;
+  const [, xy, submodule, headMode, indexMode, worktreeMode, headOid, indexOid, entryPath] =
+    match;
+  // Anything staged is a change on its own terms, whatever the modes say.
+  if (xy !== ".M") return null;
+  // A submodule's state is never a file mode.
+  if (submodule !== "N...") return null;
+  // The only delta a missing executable bit can produce. Notably this excludes
+  // 100644 -> 100755: a filesystem that cannot store the bit cannot invent one.
+  if (headMode !== "100755" || indexMode !== "100755" || worktreeMode !== "100644") {
+    return null;
+  }
+  if (headOid !== indexOid) return null;
+  return { path: entryPath, indexOid };
+}
+
+/**
+ * Drops the status entries that a filesystem without a POSIX executable bit
+ * fabricated, and keeps everything else.
+ *
+ * Two independent facts must BOTH hold before an entry is discounted, and each
+ * one alone would be a hole:
+ *
+ *  1. `executableBitIsRepresentable === false` — the worktree's filesystem
+ *     cannot store the bit, so its mode report carries no information. On a
+ *     POSIX filesystem this is `true` and nothing is ever discounted, which is
+ *     what keeps a genuine `chmod -x` counting as dirty.
+ *  2. The worktree content hashes to the object id already in the index, so the
+ *     entry carries no content difference at all.
+ *
+ * Every failure path keeps the entry. `resolveWorktreeOids` returning `null`, a
+ * path missing from its result, or an unparsed entry all mean "cannot prove this
+ * is an artifact", and an unproven entry stays a change.
+ */
+export function retainedStatusChanges(
+  changes: string[],
+  executableBitIsRepresentable: boolean,
+  resolveWorktreeOids: (paths: string[]) => Map<string, string> | null,
+): string[] {
+  if (executableBitIsRepresentable) return changes;
+  const candidates = new Map<string, UnrepresentableExecutableBitCandidate>();
+  for (const entry of changes) {
+    const candidate = parseUnrepresentableExecutableBitCandidate(entry);
+    if (candidate) candidates.set(entry, candidate);
+  }
+  if (candidates.size === 0) return changes;
+  const oids = resolveWorktreeOids([
+    ...new Set([...candidates.values()].map((candidate) => candidate.path)),
+  ]);
+  if (oids === null) return changes;
+  return changes.filter((entry) => {
+    const candidate = candidates.get(entry);
+    if (!candidate) return true;
+    const worktreeOid = oids.get(candidate.path);
+    if (worktreeOid === undefined) return true;
+    return worktreeOid !== candidate.indexOid;
+  });
+}
+
 function activeReasons(observation: WorktreeLifecycleObservation): string[] {
   const reasons: string[] = [];
   if (observation.changes.length > 0) {


### PR DESCRIPTION
Fixes `cave-eo0b0`.

## What was broken

`statusState` (`scripts/worktree-lifecycle-inventory.ts`) runs `git status` with
`-c core.fileMode=true` hard-coded. On a filesystem with no POSIX executable bit
that override compares a mode git recorded (100755) against a mode the
filesystem can never report back (100644), so **every** tracked shell script and
git hook is reported modified, forever. Measured on this checkout: **24 phantom
entries in a byte-for-byte clean worktree**.

`changes.length > 0` is the first lane test after `protected`
(`src/lib/worktree-lifecycle.ts:561`), so no attached worktree in a Windows
checkout could ever reach `cleanup-ready`. The live patrol before this change:

```
Worktree lifecycle: 81 registered | 52 active | 0 recovery | 0 cooldown | 1 cleanup-ready | 26 uncertain | 2 protected
```

— and that single `cleanup-ready` unit is `[branch-only]`, i.e. not an attached
worktree at all. Retirement was never being declined on the merits; it was
structurally unreachable, which is the mechanism behind the 36-vs-28 budget
overrun.

## Why the obvious fix is wrong

**The override is deliberate and it stays.** It is one of a family of
configuration-independent flags (`status.relativePaths`, `core.fsmonitor`,
`core.untrackedCache`, `core.ignoreStat`) whose contract is stated in
`.agents/skills/branch-curator/SKILL.md`:

> Never let status, file-mode, or fsmonitor configuration suppress this check.

A worktree-local `core.fileMode=false` must not be able to hide a real
permission change from the gate that authorises deletion. Dropping the flag, or
forcing it to `false`, would trade a Windows false positive for a POSIX
false negative. `scripts/worktree-lifecycle-patrol.test.mjs:1677` pins that flag
set, and **this PR does not weaken that assertion** — the invocation is
untouched.

**The narrower "identical blob SHAs" rule is also wrong, and this is the
substance of the fix.** A porcelain-v2 ordinary entry carries only *two* object
ids — the HEAD blob and the **index** blob. There is no worktree object id;
`git status` never hashes the worktree file. So `hH == hI` says only that the
index matches HEAD, which `X == "."` already said. Measured on this repository,
an untouched executable and the same executable **with an unstaged content
edit** produce records of identical shape with equal object ids:

```
1 .M N... 100755 100755 100644 cab8485719a6… cab8485719a6… scripts/dev-app.sh
```

Discounting on equal object ids alone would hide real uncommitted edits from a
gate that deletes worktrees.

And on ext4, a genuine `chmod -x` with untouched content produces **that same
shape again**, with the content hash equal to the index hash. So no property of
the record — and no content comparison either — can separate a real POSIX
permission change from a Windows artifact.

## The fix

Keep the invocation; discount at the parse, and only where both independent
facts hold:

1. **The filesystem cannot store the executable bit**, probed the way git probes
   it when auto-detecting `core.fileMode`: write a file into the git directory,
   set the bit, re-read the mode. The git directory is also the one place a
   scratch file can never enter the status output being read. Every error path
   returns "representable", which discounts nothing.
2. **The worktree content hashes to the object id already in the index**, via
   `git hash-object` (no `-w`, so nothing is written; filters left on so the
   comparison matches what the index holds under `core.autocrlf`).

Fact 1 alone would hide real edits. Fact 2 alone would hide a real `chmod -x`.
Every unknown — an unparsed entry, an unresolvable hash, a path missing from the
result — keeps the entry.

`cleanForCompensation` in `scripts/worktree-lifecycle-create.ts` carried the
same override and the same defect, refusing to roll back a worktree it had
created seconds earlier; it now shares the same helper.

## What this changes about deletion

Every consumer of `statusState().changes`:

| Consumer | Uses `changes` for |
| --- | --- |
| `src/lib/worktree-lifecycle.ts:403` `activeReasons` | gates `active` |
| `src/lib/worktree-lifecycle.ts:561` `classifyLifecycleUnitInternal` | first non-protected lane test |
| `src/lib/worktree-lifecycle.ts:1006` `renderWorktreeLifecycleReport` | report text only |
| `scripts/worktree-lifecycle-retirement.ts:928` `stillRetireReady` | **gates deletion**, re-checked at :211, :298 and :565 against a fresh inventory |
| `scripts/worktree-lifecycle-retirement.ts:169` | eligibility filter (via lane) |
| `scripts/worktree-lifecycle-patrol.ts:670,:710` | retirement budget + report (via lane) |
| `scripts/worktree-hygiene.mjs:409` | lane only |
| `scripts/worktree-status.mjs` | **not a consumer** — independent `git status --porcelain` probe |

The sibling `ignoredPaths`, which drives real `rmSync` deletion at
`worktree-lifecycle-retirement.ts:576`, is **untouched**.

Newly retirable *in principle*: an attached worktree that is landed, past
cooldown, and whose only remaining "changes" were mode entries proven to carry
identical content on a filesystem that cannot represent the bit. That is
correct — such a worktree is byte-for-byte clean under the repository's own
configuration, which is exactly what `git status --porcelain` reports today.

**In practice, on Windows, nothing becomes retirable yet, and that is
deliberate.** The `lsof` probe at `worktree-lifecycle-inventory.ts:2103` fails
with `ENOENT`, `processes.error` lands in every unit's `probeErrors`
(inventory:3378), and `probeErrors > 0 → uncertain` sits one branch below
`active`. So this fix moves a unit from `active` to `uncertain`, not to
`cleanup-ready`. Filed as `cave-6r4t4` rather than fixed here: the cheap fix —
suppressing that error — would make units retirable while the patrol is blind to
live process cwds, trading a Windows false positive for a Windows false negative
on liveness inside a deletion gate.

## Verified against the live checkout

Two full `pnpm beads:worktrees` runs from the **same worktree on the same base**,
differing only in the three changed source files:

```
before   81 registered | 52 active | 0 recovery | 0 cooldown | 0 cleanup-ready | 27 uncertain | 2 protected
after    81 registered | 51 active | 0 recovery | 0 cooldown | 1 cleanup-ready | 27 uncertain | 2 protected
```

Mode-only phantom `change:` lines across all 36 attached worktrees: **808 → 0**.

Exactly one unit changed lane because of this PR:
`fix/cave-uuxga-client-v1-ingress-gate`, `active` → `uncertain`. Its only active
reason was `22 tracked or untracked changes`, all of them phantoms; with those
gone it falls through to the `lsof` probe error above.

The `0 → 1 cleanup-ready` delta is **not** attributable to this change and is not
claimed as a result. It is `fix/cave-kza-2-private-research-session-owner`, which
is `[branch-only]` — `statusState` is never called for a unit with no path
(inventory:3164), so this code cannot reach it. It moved because a transient
repository-wide probe failure in the earlier run cleared.

`nonDisposableIgnoredPaths` — the field that drives real `rmSync` deletion — is
identical in both runs, as expected.

(An initial comparison against the primary checkout was discarded as confounded:
that checkout sits on an older commit where `public/pdf.worker.min.mjs` was not
yet in the disposable-ignored list, which moved 21 unrelated reasons.)

## Tests

New `scripts/worktree-lifecycle-filemode.test.mjs`, wired into `SUITES` and
`STRIP_TYPES_MJS`. Half is the parse/decision logic; half runs **real git
against a real repository on disk**, including that a content edit, a staged
mode change, and a genuine `chmod -x` all stay dirty.

Every assertion was mutation-checked — the guarded behaviour was broken, the
test confirmed failing, and the source restored. 9 of 9 mutants caught:

| Mutant | Caught by |
| --- | --- |
| drop the filesystem-capability guard | `nothing is discounted where the filesystem can hold an executable bit` |
| discount without comparing content | `a mode-shaped entry whose content differs is kept`, `an unstaged content edit to an executable stays dirty` |
| the suggested "equal object ids alone" rule | `records a missing executable bit cannot explain are never candidates` |
| fail **open** on an unresolvable hash | `an unanswerable hash keeps every entry` |
| fail **open** on a path missing from the result | `an unanswerable hash keeps every entry` |
| accept staged entries | `records a missing executable bit cannot explain are never candidates` |
| accept the 100644 → 100755 direction | `records …`, `non-candidate entries are neither hashed nor dropped` |
| trim the captured path | `paths are taken verbatim, including spaces and a trailing space` |
| ignore submodule state | `records a missing executable bit cannot explain are never candidates` |

The staged-entry mutant was initially an **equivalent mutant** — the guard was
only ever reached for records the mode check already rejected — so a record
differing from the phantom in the XY field alone was added to make it
observable.

The POSIX guarantee (`a real chmod -x stays dirty where the filesystem holds the
bit`) skips on Windows and runs for real on the Linux runner.

CI earned its keep here: the first run failed on this suite's own fixture —
`git update-index --chmod=+x` writes the index but never chmods the file, so on
ext4 the "clean" fixture was born dirty and `a byte-for-byte clean checkout
reports no changes` failed. Fixed by setting the bit on disk first (real on
ext4, a no-op on NTFS), and confirmed against real git on ext4: the old seeding
leaves a mode delta after commit, the new seeding reports an empty status.
