### PR TITLE
fix(projects): share one root hash between projectTint and the icon prompt (cave-72em)

### DIFF
--- a/src/lib/comux-projects.ts
+++ b/src/lib/comux-projects.ts
@@ -34,14 +34,31 @@ export function projectName(root: string): string {
  * tasteful against both the dark and light themes; callers feed it to the
  * `--tile` custom property the `.project-avatar` glass tile reads.
  */
-export function projectTint(root: string): string {
+/**
+ * The one deterministic root-path hash project identity derives from. Exported
+ * because more than one surface needs to agree with the tile's colour — the
+ * AI project-icon prompt builder derives its palette and motif from this exact
+ * hash so a generated icon lands on the same hue as the monogram tile it
+ * replaces. It used to be copied there by hand, and nothing held the two
+ * copies in sync: changing the multiplier here left every icon a different
+ * colour from its tile with no test failing (cave-72em).
+ */
+export function projectRootHash(root: string): number {
   let hash = 0;
   for (let i = 0; i < root.length; i += 1) {
     // Simple deterministic string hash (xorshift-ish, stays in uint32).
     hash = (hash * 31 + root.charCodeAt(i)) >>> 0;
   }
-  const hue = hash % 360;
-  return `oklch(0.74 0.12 ${hue})`;
+  return hash;
+}
+
+/** Hue, in degrees, that `projectTint` paints a root with. */
+export function projectRootHue(root: string): number {
+  return projectRootHash(root) % 360;
+}
+
+export function projectTint(root: string): string {
+  return `oklch(0.74 0.12 ${projectRootHue(root)})`;
 }
 
 /**

--- a/src/lib/project-icon-prompt.test.ts
+++ b/src/lib/project-icon-prompt.test.ts
@@ -4,6 +4,7 @@ import {
   projectIconHue,
   projectIconMotif,
 } from "./project-icon-prompt.ts";
+import { projectTint } from "./comux-projects.ts";
 
 // Deterministic: same root → same hue/motif every time.
 assert.equal(projectIconHue("/Users/x/coven-cave"), projectIconHue("/Users/x/coven-cave"));
@@ -17,7 +18,28 @@ assert.equal(projectIconMotif("/Users/x/coven-cave"), projectIconMotif("/Users/x
 }
 
 // Hue agrees with projectTint()'s hash so the icon palette matches the tile.
-assert.ok(projectIconHue("/tmp/app") >= 0 && projectIconHue("/tmp/app") < 360);
+// Asserted against the colour projectTint actually paints, not merely against
+// the [0,360) range: the old range check passed for ANY hash function, so the
+// two hand-copied hashes could diverge silently and every icon could land on a
+// different hue from its own tile with nothing failing (cave-72em).
+for (const root of [
+  "/tmp/app",
+  "/Users/x/coven-cave",
+  "/Users/x/coven-github",
+  "/work/alpha",
+  "C:\\Users\\dev\\project",
+  "",
+]) {
+  const tint = projectTint(root);
+  const tintHue = Number(/ (\d{1,3})\)$/.exec(tint)?.[1]);
+  assert.ok(Number.isFinite(tintHue), `projectTint(${root}) should expose a hue`);
+  assert.equal(
+    projectIconHue(root),
+    tintHue,
+    `icon hue for ${root} must equal the tile hue projectTint paints`,
+  );
+  assert.ok(projectIconHue(root) >= 0 && projectIconHue(root) < 360);
+}
 
 // The prompt names the project, bans text, and stays icon-shaped.
 {

--- a/src/lib/project-icon-prompt.ts
+++ b/src/lib/project-icon-prompt.ts
@@ -10,6 +10,8 @@
  * project's palette identity.
  */
 
+import { projectRootHash, projectRootHue } from "./comux-projects.ts";
+
 const MOTIFS = [
   "a faceted geometric crystal",
   "an abstract origami fold",
@@ -29,17 +31,19 @@ const MOTIFS = [
   "an interlocking gear pair",
 ] as const;
 
-/** Same deterministic uint32 string hash projectTint() uses. */
+/**
+ * The deterministic uint32 root hash projectTint() uses — imported, not
+ * re-implemented, so the icon palette cannot drift away from the tile colour.
+ * Relative import, not "@/": this is a value import, and the tests that reach
+ * this file run without the alias loader (see comux-projects.ts).
+ */
 export function projectIconHash(root: string): number {
-  let hash = 0;
-  for (let i = 0; i < root.length; i += 1) {
-    hash = (hash * 31 + root.charCodeAt(i)) >>> 0;
-  }
-  return hash;
+  return projectRootHash(root);
 }
 
+/** Identical to the hue projectTint() paints, by construction. */
 export function projectIconHue(root: string): number {
-  return projectIconHash(root) % 360;
+  return projectRootHue(root);
 }
 
 export function projectIconMotif(root: string): string {


### PR DESCRIPTION
Closes the actionable part of #4899 / `cave-72em`. **Most of that issue already shipped**; this PR is the delta plus a recommendation against the rest.

## What is already on `main`

`cave-72em` was filed 2026-07-12 and its code merged the same day in **#2970** (`95c367a86`). It has never been reverted. Five of the six named deliverables ship today:

| Deliverable in the issue | On `main`? |
| --- | --- |
| `src/lib/project-icon-prompt.ts` (+test) | yes |
| `src/app/api/projects/icon/route.ts` (+test) | yes |
| api-contracts entry | yes (`api-contracts.test.ts:284`) |
| `src/lib/project-icon-image-provider.ts` (+test) | yes — beyond the issue: OpenAI **and** Gemini |
| `src/components/projects/project-detail.tsx` overflow action | **no — the file has never existed** |

The bead's 2026-08-09 triage note ("no commit on main referencing it") is a false negative: it searched for the bead id, and #2970's commit message does not carry one. The artifacts were there the whole time.

**Consequence: `POST /api/projects/icon` has zero callers.** `grep -rn "projects/icon" src/` returns only the route's own docstring and the contract entry. Nothing ever reaches `setProjectImage`, so no icon has ever rendered.

## Recommendation: do not wire the generate/regenerate action as specified

Not included here, deliberately. Evidence:

1. **It would render at 16–20px.** `ProjectAvatar` defines `sm:16 md:20 lg:28 xl:44`, but every project call site — board-kanban, chat-project-sidebar (both), composer-context-pill, project-picker (both), workspace-sidebar — passes `sm` or `md`. No `ProjectAvatar` uses `lg`/`xl` anywhere. The route generates 1024×1024 to be shown at 16px, where "a moebius loop ribbon" and "an interlocking gear pair" are the same blob. The fallback it replaces is `projectMonogram`, explicitly designed for that size: `coven-cave`/`coven-github` read `CC`/`CG` rather than a wall of identical initials. This is plausibly a legibility *regression* against the issue's own goal of distinctness.
2. **The determinism is already free.** Hue and motif are pure functions of the root hash and render today at zero cost with no key. The model only supplies the raster.
3. **Unbounded per-click spend.** `variant` defaults to `Date.now()`, so every press is a fresh generation — no cache, no dedupe. There is no rate limiting on this route; the only limiter in the repo is `client-v1`, a different surface.
4. **No local-origin guard.** 121 of 301 routes call `rejectNonLocalRequest`; this one does not, and `localOriginGuard` in the contract table is an optional field, so omitting it silently skips the check (`api-contracts.test.ts:796`) rather than failing. A route that resolves a vault API key and spends money is a stronger candidate for the guard than most routes that have it.

Graceful degradation is the one part that is already right: no key yields `400 vault_key_unresolved` with a `missingKey` hint, not a 500. `resolveSecret` is correctly synchronous, so the `resolveKey` callback is sound.

## What this PR does fix

A real latent defect in the shipped lib, found by mutation.

`project-icon-prompt.ts` carried a **hand-copied duplicate** of `projectTint`'s hash. The test comment claimed *"Hue agrees with projectTint()'s hash so the icon palette matches the tile"*, but the assertion beneath it was:

```ts
assert.ok(projectIconHue("/tmp/app") >= 0 && projectIconHue("/tmp/app") < 360);
```

Every hash function on earth passes that. The one property the issue names — hue matching `projectTint` — was entirely unguarded, and the two copies could diverge silently.

`projectRootHash` / `projectRootHue` now live in `comux-projects.ts` as the single source; `projectTint` and `projectIconHue` both call them. The import is relative, not `@/` — it is a value import and these tests run without the alias loader.

## Mutation matrix

| # | Mutation | Before this PR | After |
| --- | --- | --- | --- |
| A | `projectRootHash` multiplier `31`→`33` | **survived** (green) | survives — *equivalent by construction*: both sides now derive from the one function, so they cannot disagree. Claimed as no catch. |
| B | `projectIconHue` → `(projectRootHue(root)+1)%360` | n/a | **caught** — `icon hue for /tmp/app must equal the tile hue projectTint paints` |
| C | re-introduce a private `*33` copy inside `projectIconHash` (the original defect, faithfully) | **survived** (green) | **caught** — same assertion |

A and C are the same real-world regression; before this change both were invisible.

## Gates (verbatim)

```
$ pnpm typecheck
> tsc --noEmit
```
```
$ pnpm lint
[tokenize-tsx-design] checked — 0 file(s) with drift
> eslint "src/lib/**/*.ts" ... --max-warnings=0
```
```
$ pnpm check:tests-wired
✓ all 1814 test files wired into CI
```
```
$ pnpm build
✓ bundle-budget: within budget.
✓ standalone-budget: within budget and free of local build roots.
```

Runner argv for the touched test (no new wiring needed — file already in `SUITES`, no `@/` in its graph):

```
$ node -e "import('./scripts/run-tests.mjs').then(m=>console.log(m.nodeArgsFor('src/lib/project-icon-prompt.test.ts').join(' ')))"
--require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/lib/project-icon-prompt.test.ts
```

Related suites, all green:

```
src/lib/project-icon-prompt.test.ts          ok
src/lib/comux-projects.test.ts               dedup + disambiguation + tint + monogram ok
src/lib/project-icon-image-provider.test.ts  ok
src/app/api/projects/icon/route.test.ts      ok
src/components/project-avatar.test.ts        ok
src/lib/project-setup-offer.test.ts          OK
src/app/api/api-contracts.test.ts            301 route contracts passed
```

api-contracts was run deliberately, since it is not reached by a local `pnpm test:api` pass.

## Follow-ups worth a bead (not filed)

- `route.test.ts` is a raw-source regex scanner: `assert.match(route, /status:\s*502/)` proves the digits `502` appear in the file, not that a provider failure returns 502. Behavioural coverage would need `fetch` injection.
- Decide the dead endpoint's fate: add the local-origin guard + throttle and wire a UI, or delete it. Leaving an unreachable money-spending route on `main` is the worst of the three.
