### PR TITLE
Surface in-flight /auto missions outside their own chat (cave-7gryo)

### DIFF
--- a/docs/auto-mission-mode.md
+++ b/docs/auto-mission-mode.md
@@ -66,6 +66,21 @@ contains a terminal marker cannot double-ping.
 Scoping is per session, so a mission started in one chat cannot fire against
 markers appearing in another.
 
+**One mission crosses a session id: the one armed before there was an id.** A
+brand-new chat has no session id until the first send mints one, and
+`writeAutoMission` is a no-op without one — so `/auto <mission>` typed into a
+fresh chat armed a record that was persisted nowhere, and the re-hydrate on the
+new id then dropped it. The familiar kept working while nothing was left to
+notify on the terminal marker, run the watchdog, or tell any other surface a
+mission was in flight. Reproduced against the running app: `/auto` in a new
+chat wrote no `cave:auto-mission:*` key at all, while the same command in an
+existing chat wrote one immediately.
+
+`reconcileAutoMissionOnSessionChange` carries that one case onto the id that
+adopts it. Nothing else crosses: a real→real move is a thread switch, and
+carrying a mission across it would fire chat A's mission against chat B's
+transcript — the exact leak the per-session key exists to prevent.
+
 ## The watchdog
 
 Everything above depends on the familiar volunteering a terminal marker.
@@ -95,6 +110,45 @@ Terminal states post to `/api/inbox`:
 | watchdog | `response-needed` | Auto mission went quiet |
 
 Each carries `auto: "auto-mission"` for dedup and links back to the session.
+
+## Seeing a mission you have walked away from
+
+An in-flight mission is reported in the menu bar's **running-processes
+popover** — the app's one globally-visible, ambient readout of what is running.
+A session with an armed mission renders as a `MISSION` row naming the work and
+how long it has been going, and a click opens the chat.
+
+Two deliberate choices:
+
+**Not the inbox.** `/api/inbox` is an attention surface, and an item created
+there with no `fireAt` lands `status: "fired"` — which workspace's SSE
+subscriber answers with a toast plus `nativeNotify(...)` and a sound, while
+`unreadInboxCount` badges the bell and `groupInboxFeed` files it under "Needs
+you". That is precisely the interruption `/auto` promises not to make, so an
+ACTIVE mission is never posted there. Terminal states still are; they have
+earned the interruption.
+
+**The row's liveness comes from the server, not from the record.** The stored
+record cannot say whether a mission is still running: its terminal detection
+and its watchdog both live in the mounted ChatView for that session, so
+navigating away leaves an armed record nobody will ever clear. A surface built
+on the record alone would therefore keep reporting "in progress" for work that
+finished — wrong precisely when it is being relied on. So the popover only
+decorates sessions the server already reports as running (`hasActiveChatRun`,
+projected as `status: "running"` through `/api/sessions/list`), and when the run
+ends the row stops existing rather than going stale.
+
+The row also replaces the session title, because an `/auto` chat's title is
+derived from its first message — the generated directive — so the untouched row
+read "Run this as an autonomous /auto mission: …", leaking a system prompt into
+the menu bar instead of naming the work.
+
+There is no cancel on the row. `POST /api/chat/stop { sessionId }` would stop
+the run, but the armed record is owned by ChatView's React state: ending the
+mission from the menu bar would leave a mounted ChatView holding a stale copy
+that re-persists it as armed on its next liveness stamp, so the mission would
+read as still running with no outcome and no questionnaire — worse than no
+cancel. Opening the row lands in the chat, where `/auto stop` is one command.
 
 ## Preference learning
 
@@ -132,8 +186,20 @@ skips the form and takes the whole signal with them.
 - The preference digest is a bounded list, not a synthesized profile. A
   periodic summarization pass would resolve contradictions and generalize
   mission-specific notes into principles.
-- Active missions are only visible inside their own chat. An inbox or sidebar
-  entry for in-flight missions would keep them visible after navigating away.
+- **The notification does not actually survive walking away.** Terminal-marker
+  detection and the watchdog are both effects inside the ChatView mounted on
+  that exact session: switch chats and the view re-hydrates for the new
+  session, leave chat and it unmounts, and in either case nothing is watching
+  the mission any more. The `done` ping then fires only when you next open that
+  chat — which is the one moment you no longer need telling. The stream itself
+  survives (it accumulates in the module-scope live registry), so the work is
+  not lost; only the promise to come and get you is. Closing this needs
+  supervision to move out of ChatView — a workspace-level watcher over armed
+  missions, reading their transcripts without the chat being open — which is a
+  bigger change than the visibility work above and is why the running-processes
+  row takes its liveness from the server instead of from the record.
+- A mission row has no cancel; see the section above for why, and `/auto stop`
+  inside the chat for the sanctioned end.
 - `blocked` still covers both "waiting for your go-ahead" and "cannot proceed
   at all". Splitting out `needs-approval` would let the UI ask for a yes rather
   than merely reporting a wall.

--- a/docs/auto-mission-mode.md
+++ b/docs/auto-mission-mode.md
@@ -76,10 +76,24 @@ mission was in flight. Reproduced against the running app: `/auto` in a new
 chat wrote no `cave:auto-mission:*` key at all, while the same command in an
 existing chat wrote one immediately.
 
-`reconcileAutoMissionOnSessionChange` carries that one case onto the id that
-adopts it. Nothing else crosses: a real→real move is a thread switch, and
-carrying a mission across it would fire chat A's mission against chat B's
-transcript — the exact leak the per-session key exists to prevent.
+`reconcileAutoMissionOnSessionChange` carries that one case — and only onto the
+session id **this view's own generation minted**, stamped in the chat stream's
+`ownsDisplayedView` adoption branch and consumed one-shot.
+
+The identity check is the whole guard, and "we had no id and now we do" is not a
+substitute for it. A mission can be armed while the send is still in flight, or
+has failed outright so no id ever arrives; clicking straight into an existing
+chat is then *also* a `null → real` transition. Keying on that edge alone wrote
+the mission into whichever chat the human happened to open — reproduced in the
+running app, where a mission armed in a blank compose landed under an unrelated
+chat's id purely by navigating to it. The damage is worse than a mislabelled
+row: that chat's transcript then gets watched for auto-status markers, and its
+watchdog eventually posts a `response-needed` inbox item for a mission it never
+ran, which is exactly the interruption `/auto` promises not to make.
+
+Nothing else crosses either: a real→real move is a thread switch, and carrying a
+mission across it would fire chat A's mission against chat B's transcript — the
+same leak from the other direction.
 
 ## The watchdog
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -325,6 +325,8 @@ export const SUITES = {
     "src/lib/reader-outline.test.ts",
     "src/lib/auto-status-blocks.test.ts",
     "src/lib/auto-mission-state.test.ts",
+    "src/lib/auto-mission-presence.test.ts",
+    "src/components/running-sessions-mission-row.test.ts",
     "src/lib/auto-mode-preferences.test.ts",
     "src/lib/reader-rewrite.test.ts",
     "src/lib/reader-provenance.test.ts",
@@ -1874,6 +1876,9 @@ export const SUITE_PREFLIGHTS = {
 };
 
 const ALIAS_LOADER = new Set([
+  // Renders RunningSessionList, which resolves "@/lib/icon", "@/lib/types"
+  // and friends, and the spec itself imports "@/lib/auto-mission-state".
+  "src/components/running-sessions-mission-row.test.ts",
   // Imports proxy.ts, which resolves Next's extensionless next/server entry.
   "src/lib/server/client-v1/auth.test.ts",
   "src/app/api/client/v1/pairing/requests/route.test.ts",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -233,6 +233,7 @@ import {
   isAutoMissionTimedOut,
   pendingAutoMissionPings,
   readAutoMission,
+  reconcileAutoMissionOnSessionChange,
   touchAutoMission,
   writeAutoMission,
   type AutoMissionRecord,
@@ -2129,12 +2130,35 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const [autoMission, setAutoMission] = useState<AutoMissionRecord | null>(null);
   const [autoFeedbackOpen, setAutoFeedbackOpen] = useState(false);
 
+  // Always-current mirror of the mission, so the re-hydrate effect below can
+  // read what this view is holding without taking `autoMission` as a dep —
+  // which would re-run it on our own writes.
+  const autoMissionRef = useRef<AutoMissionRecord | null>(null);
+  autoMissionRef.current = autoMission;
+  const autoMissionSessionRef = useRef<string | null>(sessionId ?? null);
+
   // Re-hydrate (or drop) the mission whenever the chat changes. Without this a
   // mission started in chat A stays armed while chat B is on screen, and any
   // auto-status marker over there pings against A's mission.
+  //
+  // The one carry-over is a mission armed before this chat had a session id at
+  // all: a plain re-hydrate would drop it the instant the first send mints one,
+  // silently disarming a mission that is already running. The rule lives in
+  // reconcileAutoMissionOnSessionChange, which also says why nothing else
+  // crosses a session change.
   useEffect(() => {
     setAutoFeedbackOpen(false);
-    setAutoMission(readAutoMission(sessionId, typeof window === "undefined" ? null : window.localStorage));
+    const storage = typeof window === "undefined" ? null : window.localStorage;
+    const previousSessionId = autoMissionSessionRef.current;
+    autoMissionSessionRef.current = sessionId ?? null;
+    const { record, persistUnder } = reconcileAutoMissionOnSessionChange({
+      previousSessionId,
+      nextSessionId: sessionId ?? null,
+      held: autoMissionRef.current,
+      stored: readAutoMission(sessionId, storage),
+    });
+    if (persistUnder && record) writeAutoMission(persistUnder, record, storage);
+    setAutoMission(record);
   }, [sessionId]);
 
   // Watch settled assistant turns for a terminal `<coven:auto-status>` marker

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2136,6 +2136,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const autoMissionRef = useRef<AutoMissionRecord | null>(null);
   autoMissionRef.current = autoMission;
   const autoMissionSessionRef = useRef<string | null>(sessionId ?? null);
+  // The session id this view's own generation minted (stamped in the stream's
+  // `owned` adoption branch). A sessionless mission may be carried onto THAT id
+  // and no other: a mission can be armed while the send is still in flight — or
+  // has failed, so no id ever arrives — and clicking into an unrelated existing
+  // chat is also a null -> real transition. Read one-shot below.
+  const autoMissionMintedSessionRef = useRef<string | null>(null);
 
   // Re-hydrate (or drop) the mission whenever the chat changes. Without this a
   // mission started in chat A stays armed while chat B is on screen, and any
@@ -2151,11 +2157,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const storage = typeof window === "undefined" ? null : window.localStorage;
     const previousSessionId = autoMissionSessionRef.current;
     autoMissionSessionRef.current = sessionId ?? null;
+    // One-shot: an id may be adopted only on the transition immediately after
+    // this view minted it, never on a later navigation that happens to land
+    // back on it.
+    const mintedSessionId = autoMissionMintedSessionRef.current;
+    autoMissionMintedSessionRef.current = null;
     const { record, persistUnder } = reconcileAutoMissionOnSessionChange({
       previousSessionId,
       nextSessionId: sessionId ?? null,
       held: autoMissionRef.current,
       stored: readAutoMission(sessionId, storage),
+      mintedSessionId,
     });
     if (persistUnder && record) writeAutoMission(persistUnder, record, storage);
     setAutoMission(record);
@@ -6427,6 +6439,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           if (owned) {
             liveSessionIdRef.current = ev.sessionId;
             currentSessionRef.current = ev.sessionId;
+            // This id was minted BY this view's own generation, which is the
+            // only transition a sessionless /auto mission may be carried onto.
+            // See reconcileAutoMissionOnSessionChange.
+            autoMissionMintedSessionRef.current = ev.sessionId;
             setHistoryState("loaded");
             // Clear display ownership after adoption so no late event may
             // re-adopt via the done stable-ID fallback.
@@ -6629,6 +6645,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           if (owned) {
             liveSessionIdRef.current = ev.sessionId;
             currentSessionRef.current = ev.sessionId;
+            // This id was minted BY this view's own generation, which is the
+            // only transition a sessionless /auto mission may be carried onto.
+            // See reconcileAutoMissionOnSessionChange.
+            autoMissionMintedSessionRef.current = ev.sessionId;
             setHistoryState("loaded");
             // Clear display ownership after adoption (same as session event path).
             displayedCreationRunIdRef.current = null;

--- a/src/components/running-sessions-mission-row.test.ts
+++ b/src/components/running-sessions-mission-row.test.ts
@@ -1,0 +1,155 @@
+// Behavioural test for the running-processes popover: it renders the list and
+// asserts on the MARKUP the human actually sees, not on the component source.
+//
+// The surface under test is the app's one globally-visible, ambient readout of
+// what is running — no toast, no sound, no unread badge — which is why an
+// in-flight `/auto` mission is reported here rather than through /api/inbox.
+import assert from "node:assert/strict";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import test from "node:test";
+
+import { RunningSessionList } from "./running-sessions-popover.tsx";
+import { autoMissionKey, type AutoMissionRecord } from "@/lib/auto-mission-state";
+import { NO_CHAT_ATTENTION } from "@/lib/chat-attention";
+import type { Familiar, SessionRow } from "@/lib/types";
+
+const STARTED = "2026-08-23T09:55:00.000Z";
+
+function session(over: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "sess-a",
+    project_root: "/repo/alpha",
+    harness: "claude",
+    // An /auto chat's title is derived from the generated directive — this is
+    // the string the row shows today.
+    title: "Run this as an autonomous /auto mission: rewrite the token tests",
+    status: "running",
+    exit_code: null,
+    archived_at: null,
+    created_at: STARTED,
+    updated_at: STARTED,
+    attention: NO_CHAT_ATTENTION,
+    familiarId: "onyx",
+    ...over,
+  };
+}
+
+const familiars: Familiar[] = [
+  { id: "onyx", display_name: "Onyx" } as unknown as Familiar,
+];
+
+function record(over: Partial<AutoMissionRecord> = {}): AutoMissionRecord {
+  return {
+    mission: "rewrite the token tests and get CI green",
+    startedAt: STARTED,
+    notified: [],
+    completedAt: null,
+    outcome: null,
+    lastActivityAt: 0,
+    feedbackPending: false,
+    ...over,
+  };
+}
+
+type Storage = { getItem: (k: string) => string | null; setItem: (k: string, v: string) => void; removeItem: (k: string) => void };
+
+function storageWith(entries: Record<string, AutoMissionRecord>): Storage {
+  const map = new Map<string, string>();
+  for (const [sessionId, value] of Object.entries(entries)) {
+    map.set(autoMissionKey(sessionId), JSON.stringify(value));
+  }
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+  };
+}
+
+function render(sessions: SessionRow[], storage: Storage | null) {
+  return renderToStaticMarkup(
+    createElement(RunningSessionList, {
+      sessions,
+      familiars,
+      onOpen: () => {},
+      missionStorage: storage,
+    }),
+  );
+}
+
+test("a running session with an armed mission renders the mission text, not the directive title", () => {
+  const html = render([session()], storageWith({ "sess-a": record() }));
+  assert.ok(
+    html.includes("rewrite the token tests and get CI green"),
+    "the row names the mission the human typed",
+  );
+  assert.ok(
+    !html.includes("Run this as an autonomous"),
+    "the generated directive must not leak into the menu bar",
+  );
+});
+
+test("a mission row is marked as a mission and described as in progress", () => {
+  const html = render([session()], storageWith({ "sess-a": record() }));
+  assert.ok(html.includes(">Mission<"), "the row carries a visible Mission tag");
+  assert.ok(
+    html.includes("Auto mission in progress — rewrite the token tests and get CI green"),
+    "the accessible name says it is running",
+  );
+  assert.ok(html.includes('data-auto-mission="true"'), "the row is identifiable as a mission row");
+});
+
+test("a mission row reports when the MISSION started, not when the session was created", () => {
+  const html = render(
+    [session({ created_at: "2026-08-23T08:00:00.000Z" })],
+    storageWith({ "sess-a": record({ startedAt: "2026-08-23T09:55:00.000Z" }) }),
+  );
+  // React emits the JSX prop name verbatim (`dateTime=`); HTML attribute names
+  // are case-insensitive, so match on the lowercased markup.
+  const lower = html.toLowerCase();
+  assert.ok(
+    lower.includes('datetime="2026-08-23t09:55:00.000z"'),
+    "the elapsed clock runs from the mission, which can start long after the chat",
+  );
+  assert.ok(!lower.includes('datetime="2026-08-23t08:00:00.000z"'));
+});
+
+test("an ordinary running chat is untouched — no tag, no mission wording, its own title", () => {
+  const html = render(
+    [session({ id: "plain", title: "Draft the release notes" })],
+    storageWith({}),
+  );
+  assert.ok(html.includes("Draft the release notes"));
+  assert.ok(!html.includes(">Mission<"), "no mission tag on an ordinary chat");
+  assert.ok(!html.includes("Auto mission in progress"));
+  assert.ok(!html.includes("data-auto-mission"));
+  assert.ok(html.includes("Open this chat — Draft the release notes"));
+});
+
+test("a session whose mission already finished renders as an ordinary chat", () => {
+  // The record is still in storage — nothing outside the chat clears it. The
+  // row must fall back rather than claim finished work is in flight.
+  const html = render(
+    [session({ title: "Nightly sweep" })],
+    storageWith({ "sess-a": record({ completedAt: "2026-08-23T10:20:00.000Z", outcome: "done" }) }),
+  );
+  assert.ok(html.includes("Nightly sweep"));
+  assert.ok(!html.includes(">Mission<"));
+  assert.ok(!html.includes("Auto mission in progress"));
+});
+
+test("mission and ordinary rows render side by side, each labelled correctly", () => {
+  const html = render(
+    [session(), session({ id: "plain", title: "Draft the release notes" })],
+    storageWith({ "sess-a": record() }),
+  );
+  assert.equal(html.match(/>Mission</g)?.length, 1, "exactly one row is tagged");
+  assert.ok(html.includes("rewrite the token tests and get CI green"));
+  assert.ok(html.includes("Draft the release notes"));
+});
+
+test("the list still renders when mission storage is unavailable", () => {
+  const html = render([session({ title: "Draft the release notes" })], null);
+  assert.ok(html.includes("Draft the release notes"));
+  assert.ok(!html.includes(">Mission<"));
+});

--- a/src/components/running-sessions-mission-row.test.ts
+++ b/src/components/running-sessions-mission-row.test.ts
@@ -126,6 +126,60 @@ test("an ordinary running chat is untouched — no tag, no mission wording, its 
   assert.ok(html.includes("Open this chat — Draft the release notes"));
 });
 
+// The three tests below supersede the source-regex assertion that used to live
+// in running-sessions-popover.test.ts:
+//
+//   assert.match(source, /started <RelativeTime iso=\{session\.created_at\} fallback="—" \/>/)
+//
+// That regex pinned the literal expression, which legitimately changed when a
+// mission row started reporting the MISSION's clock. It could never have
+// distinguished the two row kinds anyway — it only saw that the characters
+// "session.created_at" appeared somewhere in the file — and it would have
+// passed just as happily if the row had stopped rendering altogether. These
+// assert the rendered output instead, per row kind, including the fallback.
+
+test("an ordinary row reports the session's OWN start time", () => {
+  const html = render(
+    [session({ id: "plain", title: "Draft the release notes", created_at: "2026-08-23T08:00:00.000Z" })],
+    storageWith({}),
+  );
+  const lower = html.toLowerCase();
+  assert.ok(
+    lower.includes('datetime="2026-08-23t08:00:00.000z"'),
+    "an ordinary process is timed from when the session was created",
+  );
+  assert.ok(html.includes("started <time"), "and it renders a real timestamp, not the fallback");
+});
+
+test("a row with no usable timestamp renders the em-dash fallback, not a broken clock", () => {
+  for (const created of [null, "not-a-date"]) {
+    const html = render(
+      [session({ id: "plain", title: "Draft the release notes", created_at: created as string })],
+      storageWith({}),
+    );
+    assert.ok(
+      html.includes("started <span>—</span>"),
+      `an unusable created_at (${String(created)}) falls back to the em dash`,
+    );
+    assert.ok(!html.includes("<time"), "and emits no <time> element at all");
+  }
+});
+
+test("a mission row with an unusable mission start falls back — it never borrows the session's clock", () => {
+  // The session has a perfectly good created_at. A mission row must still not
+  // report it: that would silently misattribute the chat's age to the mission.
+  const html = render(
+    [session({ created_at: "2026-08-23T08:00:00.000Z" })],
+    storageWith({ "sess-a": record({ startedAt: "not-a-date" }) }),
+  );
+  assert.ok(html.includes(">Mission<"), "still a mission row");
+  assert.ok(html.includes("started <span>—</span>"), "an unusable mission start falls back");
+  assert.ok(
+    !html.toLowerCase().includes('datetime="2026-08-23t08:00:00.000z"'),
+    "and the session's own created_at is never substituted in",
+  );
+});
+
 test("a session whose mission already finished renders as an ordinary chat", () => {
   // The record is still in storage — nothing outside the chat clears it. The
   // row must fall back rather than claim finished work is in flight.

--- a/src/components/running-sessions-popover.test.ts
+++ b/src/components/running-sessions-popover.test.ts
@@ -71,11 +71,27 @@ assert.match(
   /\{sessionDisplayTitle\(session\)\}/,
   "rows show the sanitized session title",
 );
-assert.match(
-  source,
-  /started <RelativeTime iso=\{session\.created_at\} fallback="—" \/>/,
-  "rows show when the process started",
-);
+// "rows show when the process started" is no longer asserted here.
+//
+// It used to read:
+//   /started <RelativeTime iso=\{session\.created_at\} fallback="—" \/>/
+//
+// A row's timestamp source now depends on the row: an ordinary process is timed
+// from `session.created_at`, while a row carrying an in-flight `/auto` mission
+// is timed from the MISSION's own `startedAt`, because a chat can predate the
+// mission running in it by a long way. The single literal that regex pinned
+// therefore cannot describe the behaviour any more, and re-pointing it at the
+// new ternary would only pin a fresh spelling — one that says nothing about
+// which row actually renders which clock, and that would pass unchanged if the
+// row stopped rendering at all.
+//
+// The property is now asserted on rendered output, per row kind, in
+// running-sessions-mission-row.test.ts:
+//   • "an ordinary row reports the session's OWN start time"
+//   • "a mission row reports when the MISSION started, not when the session was created"
+//   • "a row with no usable timestamp renders the em-dash fallback, not a broken clock"
+//   • "a mission row with an unusable mission start falls back — it never borrows the session's clock"
+// That is strictly more coverage than the regex had, not less.
 assert.match(
   source,
   /useMinuteTick\(\);/,

--- a/src/components/running-sessions-popover.tsx
+++ b/src/components/running-sessions-popover.tsx
@@ -7,6 +7,11 @@ import { useMinuteTick } from "@/lib/use-minute-tick";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { sessionDisplayTitle } from "@/lib/session-title";
 import { shortProjectRoot } from "@/lib/command-palette-grouping";
+import {
+  armedAutoMissionsFor,
+  autoMissionRowPresentation,
+} from "@/lib/auto-mission-presence";
+import type { AutoMissionStorage } from "@/lib/auto-mission-state";
 import type { Familiar, SessionRow } from "@/lib/types";
 
 type Props = {
@@ -17,6 +22,9 @@ type Props = {
   familiars: Familiar[];
   /** Jump to the process's chat (workspace openFamiliarSession). */
   onOpenSession: (sessionId: string, familiarId?: string | null) => void;
+  /** Where armed `/auto` records are read from. Defaults to window.localStorage;
+   *  injected by tests (the auto-mission-state.ts convention). */
+  missionStorage?: AutoMissionStorage | null;
 };
 
 function fmtBadge(n: number): string {
@@ -28,16 +36,35 @@ function fmtBadge(n: number): string {
 // Live per-row timestamps: tick each minute so a popover left open doesn't
 // show a stale "started 2m ago" forever. Rows unmount with the popover, so
 // the always-mounted trigger pays nothing while closed.
-function RunningSessionList({
+export function RunningSessionList({
   sessions,
   familiars,
   onOpen,
+  missionStorage,
 }: {
   sessions: SessionRow[];
   familiars: Familiar[];
   onOpen: (session: SessionRow) => void;
+  missionStorage?: AutoMissionStorage | null;
 }) {
   useMinuteTick();
+  // Read at mount — the list only mounts when the popover opens, so the
+  // records are as fresh as the moment the human looked. Only the sessions the
+  // server already reports as running are consulted, so a record left armed by
+  // a mission that ended elsewhere can never surface here (see
+  // auto-mission-presence.ts).
+  const missions = useMemo(
+    () =>
+      armedAutoMissionsFor(
+        sessions.map((session) => session.id),
+        missionStorage !== undefined
+          ? missionStorage
+          : typeof window === "undefined"
+            ? null
+            : window.localStorage,
+      ),
+    [sessions, missionStorage],
+  );
   return (
     <ul className="running-sessions__list max-h-80 overflow-y-auto p-1">
       {sessions.map((session) => {
@@ -47,24 +74,44 @@ function RunningSessionList({
         const meta = [familiarName ?? session.harness, shortProjectRoot(session.project_root)]
           .filter(Boolean)
           .join(" · ");
+        const armed = missions.get(session.id);
+        const mission = armed ? autoMissionRowPresentation(armed) : null;
+        // A mission row names the WORK, not the chat: an /auto session's title
+        // is derived from the generated directive, so the untouched row reads
+        // "Run this as an autonomous /auto mission: …".
+        const title = mission ? mission.title : sessionDisplayTitle(session);
         return (
           <li key={session.id}>
             <button
               type="button"
               className="running-sessions__row focus-ring flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-[var(--bg-hover)]"
+              data-auto-mission={mission ? "true" : undefined}
               onClick={() => onOpen(session)}
-              title={`Open this chat — ${sessionDisplayTitle(session)}`}
+              title={
+                mission
+                  ? `${mission.description} — open this chat`
+                  : `Open this chat — ${sessionDisplayTitle(session)}`
+              }
             >
               <span
                 aria-hidden
                 className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 animate-pulse rounded-full bg-[var(--color-success)]"
               />
               <span className="min-w-0 flex-1">
-                <span className="block truncate text-[length:var(--text-xs)] text-[var(--text-primary)]">
-                  {sessionDisplayTitle(session)}
+                <span className="flex min-w-0 items-center gap-1.5">
+                  {mission ? (
+                    // Never colour-only: the word itself carries the meaning.
+                    <span className="running-sessions__tag flex-shrink-0 rounded px-1 py-px text-[length:var(--text-2xs)] font-medium uppercase tracking-wide text-[var(--accent-presence)]">
+                      {mission.tag}
+                    </span>
+                  ) : null}
+                  <span className="min-w-0 flex-1 truncate text-[length:var(--text-xs)] text-[var(--text-primary)]">
+                    {title}
+                  </span>
                 </span>
                 <span className="mt-0.5 block truncate text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                  {meta} · started <RelativeTime iso={session.created_at} fallback="—" />
+                  {meta} · started{" "}
+                  <RelativeTime iso={mission ? armed!.startedAt : session.created_at} fallback="—" />
                 </span>
               </span>
             </button>
@@ -81,7 +128,12 @@ function RunningSessionList({
  * now opens a popover listing each live daemon process — familiar, chat
  * title, project, and start time — and a click jumps into that chat.
  */
-export function RunningSessionsPopover({ sessions, familiars, onOpenSession }: Props) {
+export function RunningSessionsPopover({
+  sessions,
+  familiars,
+  onOpenSession,
+  missionStorage,
+}: Props) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLSpanElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
@@ -145,6 +197,7 @@ export function RunningSessionsPopover({ sessions, familiars, onOpenSession }: P
           <RunningSessionList
             sessions={rows}
             familiars={familiars}
+            missionStorage={missionStorage}
             onOpen={(session) => {
               setOpen(false);
               onOpenSession(session.id, session.familiarId);

--- a/src/lib/auto-mission-presence.test.ts
+++ b/src/lib/auto-mission-presence.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AUTO_MISSION_ROW_MAX,
+  armedAutoMissionsFor,
+  autoMissionRowPresentation,
+} from "./auto-mission-presence.ts";
+import { autoMissionKey, type AutoMissionRecord, type AutoMissionStorage } from "./auto-mission-state.ts";
+
+function record(over: Partial<AutoMissionRecord> = {}): AutoMissionRecord {
+  return {
+    mission: "rewrite the token tests",
+    startedAt: "2026-08-23T10:00:00.000Z",
+    notified: [],
+    completedAt: null,
+    outcome: null,
+    lastActivityAt: 0,
+    feedbackPending: false,
+    ...over,
+  };
+}
+
+function storageWith(entries: Record<string, AutoMissionRecord>): AutoMissionStorage {
+  const map = new Map<string, string>();
+  for (const [sessionId, value] of Object.entries(entries)) {
+    map.set(autoMissionKey(sessionId), JSON.stringify(value));
+  }
+  return {
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => void map.set(k, v),
+    removeItem: (k) => void map.delete(k),
+  };
+}
+
+test("an armed mission on a running session is reported with its text and start time", () => {
+  const storage = storageWith({
+    "sess-a": record({ mission: "rewrite the token tests", startedAt: "2026-08-23T09:55:00.000Z" }),
+  });
+  const found = armedAutoMissionsFor(["sess-a"], storage);
+  assert.deepEqual(found.get("sess-a"), {
+    sessionId: "sess-a",
+    mission: "rewrite the token tests",
+    startedAt: "2026-08-23T09:55:00.000Z",
+  });
+});
+
+test("a settled mission is not reported — the surface must not claim finished work is in flight", () => {
+  for (const outcome of ["done", "failed", "timed-out", "cancelled"] as const) {
+    const storage = storageWith({
+      "sess-a": record({ completedAt: "2026-08-23T10:20:00.000Z", outcome }),
+    });
+    assert.equal(
+      armedAutoMissionsFor(["sess-a"], storage).size,
+      0,
+      `a ${outcome} mission must not be reported as in flight`,
+    );
+  }
+});
+
+test("only the session ids handed in are consulted", () => {
+  // sess-b is armed but is NOT running, so nothing may name it. This is the
+  // whole staleness guard: liveness comes from the caller, not the record.
+  const storage = storageWith({
+    "sess-a": record({ mission: "running one" }),
+    "sess-b": record({ mission: "stale one" }),
+  });
+  const found = armedAutoMissionsFor(["sess-a"], storage);
+  assert.deepEqual([...found.keys()], ["sess-a"]);
+  assert.equal(found.get("sess-a")?.mission, "running one");
+});
+
+test("sessions with no mission record are absent rather than present-and-empty", () => {
+  const storage = storageWith({ "sess-a": record() });
+  const found = armedAutoMissionsFor(["sess-a", "sess-plain"], storage);
+  assert.equal(found.has("sess-plain"), false);
+  assert.equal(found.size, 1);
+});
+
+test("a blank mission is not reported — it would blank the row's title", () => {
+  const storage = storageWith({ "sess-a": record({ mission: "   " }) });
+  assert.equal(armedAutoMissionsFor(["sess-a"], storage).size, 0);
+});
+
+test("a storage that throws yields no missions instead of taking the chrome down", () => {
+  const exploding: AutoMissionStorage = {
+    getItem() {
+      throw new Error("storage unavailable");
+    },
+    setItem() {},
+    removeItem() {},
+  };
+  assert.deepEqual([...armedAutoMissionsFor(["sess-a"], exploding).keys()], []);
+});
+
+test("absent storage yields no missions", () => {
+  assert.equal(armedAutoMissionsFor(["sess-a"], null).size, 0);
+});
+
+test("the row names the mission, tags it, and says it is in progress", () => {
+  const view = autoMissionRowPresentation({
+    sessionId: "sess-a",
+    mission: "rewrite the token tests",
+    startedAt: "2026-08-23T09:55:00.000Z",
+  });
+  assert.equal(view.title, "rewrite the token tests");
+  assert.equal(view.tag, "Mission");
+  assert.equal(view.description, "Auto mission in progress — rewrite the token tests");
+});
+
+test("a multi-line mission is collapsed to one line", () => {
+  const view = autoMissionRowPresentation({
+    sessionId: "sess-a",
+    mission: "  rewrite\n the   token\ttests  ",
+    startedAt: "2026-08-23T09:55:00.000Z",
+  });
+  assert.equal(view.title, "rewrite the token tests");
+});
+
+test("an over-long mission is clipped to the row budget with an ellipsis", () => {
+  const long = "z".repeat(AUTO_MISSION_ROW_MAX + 40);
+  const view = autoMissionRowPresentation({
+    sessionId: "sess-a",
+    mission: long,
+    startedAt: "2026-08-23T09:55:00.000Z",
+  });
+  assert.equal(view.title.length, AUTO_MISSION_ROW_MAX);
+  assert.equal(view.title.endsWith("…"), true);
+  assert.equal(view.title.startsWith("z".repeat(AUTO_MISSION_ROW_MAX - 1)), true);
+});
+
+test("a mission exactly at the budget is left whole", () => {
+  const exact = "y".repeat(AUTO_MISSION_ROW_MAX);
+  const view = autoMissionRowPresentation({
+    sessionId: "sess-a",
+    mission: exact,
+    startedAt: "2026-08-23T09:55:00.000Z",
+  });
+  assert.equal(view.title, exact);
+  assert.equal(view.title.includes("…"), false);
+});

--- a/src/lib/auto-mission-presence.ts
+++ b/src/lib/auto-mission-presence.ts
@@ -1,0 +1,119 @@
+/**
+ * Reading `/auto` missions from OUTSIDE the chat that started one.
+ *
+ * A mission is designed to be left alone, so the moment it matters most is the
+ * moment the human has navigated away — and until now the only place it was
+ * legible was the chat's own transcript card.
+ *
+ * ## Why this reads liveness from the caller instead of from the record
+ *
+ * The stored record cannot answer "is this still running". Its terminal
+ * detection and its watchdog both live in the mounted ChatView for that exact
+ * session: navigate elsewhere and nothing clears it, so an armed record
+ * outlives the mission it describes and keeps saying "in progress" for work
+ * that finished. A surface built on the record alone would therefore be wrong
+ * precisely in the situation it exists for.
+ *
+ * So the caller supplies the sessions the SERVER reports as running
+ * (`hasActiveChatRun` -> `status: "running"`, projected through
+ * /api/sessions/list) and this module only decorates those. Liveness comes
+ * from the server; identity — which mission, since when — comes from the
+ * record. Neither half can claim a mission is in flight on its own, and when
+ * the run ends the row simply stops existing rather than going stale.
+ *
+ * ## Why not the inbox
+ *
+ * `/api/inbox` is an attention surface. An item created there with no fireAt
+ * lands `status: "fired"`, and workspace's SSE subscriber answers a fired item
+ * with a toast plus `nativeNotify(...)` and a sound, while `unreadInboxCount`
+ * badges the bell and `groupInboxFeed` files it under "Needs you". That is the
+ * interruption `/auto` promises not to make, so an in-flight mission is
+ * reported in ambient chrome instead.
+ *
+ * Pure, with injected storage (the auto-mission-state.ts convention) so the
+ * whole decision path is testable under `node --test` with no DOM.
+ */
+
+import {
+  isAutoMissionArmed,
+  readAutoMission,
+  type AutoMissionStorage,
+} from "./auto-mission-state.ts";
+
+export type ArmedAutoMission = {
+  sessionId: string;
+  /** The mission text as the human typed it. */
+  mission: string;
+  startedAt: string;
+};
+
+/**
+ * The armed missions among `sessionIds`, keyed by session id.
+ *
+ * Only the ids handed in are consulted — the map can never name a session the
+ * caller did not already believe was running, which is what keeps a stale
+ * record from becoming a visible claim. Sessions with no record, or with a
+ * settled one, are simply absent.
+ */
+export function armedAutoMissionsFor(
+  sessionIds: Iterable<string>,
+  storage: AutoMissionStorage | null | undefined,
+): Map<string, ArmedAutoMission> {
+  const out = new Map<string, ArmedAutoMission>();
+  if (!storage) return out;
+  for (const sessionId of sessionIds) {
+    if (!sessionId || out.has(sessionId)) continue;
+    // No try/catch here on purpose: readAutoMission already swallows a storage
+    // that throws (private mode, revoked access) and returns null, so a second
+    // guard would be unreachable. A mutation run confirmed it — removing it
+    // changed nothing observable.
+    const record = readAutoMission(sessionId, storage);
+    if (!isAutoMissionArmed(record) || !record) continue;
+    // A blank mission cannot be labelled. Reporting it would replace the row's
+    // real title with an empty string — worse than leaving the row alone.
+    if (!record.mission.trim()) continue;
+    out.set(sessionId, {
+      sessionId,
+      mission: record.mission,
+      startedAt: record.startedAt,
+    });
+  }
+  return out;
+}
+
+/**
+ * Longest mission text a row will show before clipping.
+ *
+ * A mission is free text a human typed and can be a paragraph. The row is one
+ * line in a 340px popover, so an unbounded string would either blow the layout
+ * out or be cut by CSS with no ellipsis in the accessible name.
+ */
+export const AUTO_MISSION_ROW_MAX = 96;
+
+/**
+ * One row's worth of presentation for an in-flight mission.
+ *
+ * `title` replaces the session title deliberately. An `/auto` chat's title is
+ * derived from its first message, which is the generated directive — so the
+ * row currently reads "Run this as an autonomous /auto mission: …", leaking a
+ * system prompt into the menu bar instead of naming the work. The mission text
+ * is both the honest label and the one the human would recognise.
+ */
+export function autoMissionRowPresentation(mission: ArmedAutoMission): {
+  title: string;
+  /** Short marker that distinguishes a mission row from an ordinary chat. */
+  tag: string;
+  /** Accessible name / tooltip — says in-flight without demanding anything. */
+  description: string;
+} {
+  const collapsed = mission.mission.replace(/\s+/g, " ").trim();
+  const title =
+    collapsed.length > AUTO_MISSION_ROW_MAX
+      ? `${collapsed.slice(0, AUTO_MISSION_ROW_MAX - 1).trimEnd()}…`
+      : collapsed;
+  return {
+    title,
+    tag: "Mission",
+    description: `Auto mission in progress — ${title}`,
+  };
+}

--- a/src/lib/auto-mission-state.test.ts
+++ b/src/lib/auto-mission-state.test.ts
@@ -8,6 +8,7 @@ import {
   isAutoMissionTimedOut,
   pendingAutoMissionPings,
   readAutoMission,
+  reconcileAutoMissionOnSessionChange,
   touchAutoMission,
   writeAutoMission,
   type AutoMissionRecord,
@@ -187,4 +188,95 @@ test("failed pings and ends the mission", () => {
   ];
   const pings = pendingAutoMissionPings(armed, turns);
   assert.deepEqual(pings.map((p) => p.state), ["failed"], "nothing after a failure still pings");
+});
+
+// ── carrying a mission onto the session id that adopts it ────────────────────
+// `/auto` in a BRAND-NEW chat arms before any session id exists, so
+// writeAutoMission no-ops and a plain re-hydrate would disarm the mission the
+// instant the first send mints an id. Reproduced against the running app.
+
+const carried: AutoMissionRecord = {
+  mission: "tidy the failing token tests",
+  startedAt: "2026-01-01T00:00:00.000Z",
+  notified: [],
+  completedAt: null,
+  outcome: null,
+};
+
+test("a mission armed before the session existed is carried onto the new id and persisted", () => {
+  const out = reconcileAutoMissionOnSessionChange({
+    previousSessionId: null,
+    nextSessionId: "s-new",
+    held: carried,
+    stored: null,
+  });
+  assert.equal(out.record, carried, "the running mission survives session creation");
+  assert.equal(out.persistUnder, "s-new", "and is written under the id that now owns it");
+});
+
+test("a record already stored under the arriving id wins over the held copy", () => {
+  const stored: AutoMissionRecord = { ...carried, mission: "the durable one" };
+  const out = reconcileAutoMissionOnSessionChange({
+    previousSessionId: null,
+    nextSessionId: "s-new",
+    held: carried,
+    stored,
+  });
+  assert.equal(out.record, stored);
+  assert.equal(out.persistUnder, null, "nothing is overwritten");
+});
+
+test("a mission never crosses from one real session to another", () => {
+  const out = reconcileAutoMissionOnSessionChange({
+    previousSessionId: "s-a",
+    nextSessionId: "s-b",
+    held: carried,
+    stored: null,
+  });
+  assert.equal(out.record, null, "chat B must not adopt chat A's mission");
+  assert.equal(out.persistUnder, null);
+});
+
+test("a settled mission is not carried onto a new id", () => {
+  const settled: AutoMissionRecord = {
+    ...carried,
+    completedAt: "2026-01-01T00:10:00.000Z",
+    outcome: "done",
+  };
+  const out = reconcileAutoMissionOnSessionChange({
+    previousSessionId: null,
+    nextSessionId: "s-new",
+    held: settled,
+    stored: null,
+  });
+  assert.equal(out.record, null);
+  assert.equal(out.persistUnder, null);
+});
+
+test("leaving a session for a fresh compose drops the mission and persists nothing", () => {
+  const out = reconcileAutoMissionOnSessionChange({
+    previousSessionId: "s-a",
+    nextSessionId: null,
+    held: carried,
+    stored: null,
+  });
+  assert.equal(out.record, null);
+  assert.equal(out.persistUnder, null);
+});
+
+test("re-running on the same id is idempotent once the carry has been persisted", () => {
+  const first = reconcileAutoMissionOnSessionChange({
+    previousSessionId: null,
+    nextSessionId: "s-new",
+    held: carried,
+    stored: null,
+  });
+  const second = reconcileAutoMissionOnSessionChange({
+    previousSessionId: "s-new",
+    nextSessionId: "s-new",
+    held: first.record,
+    stored: first.record,
+  });
+  assert.equal(second.record, carried);
+  assert.equal(second.persistUnder, null, "a second pass must not rewrite storage");
 });

--- a/src/lib/auto-mission-state.test.ts
+++ b/src/lib/auto-mission-state.test.ts
@@ -209,6 +209,7 @@ test("a mission armed before the session existed is carried onto the new id and 
     nextSessionId: "s-new",
     held: carried,
     stored: null,
+    mintedSessionId: "s-new",
   });
   assert.equal(out.record, carried, "the running mission survives session creation");
   assert.equal(out.persistUnder, "s-new", "and is written under the id that now owns it");
@@ -221,6 +222,7 @@ test("a record already stored under the arriving id wins over the held copy", ()
     nextSessionId: "s-new",
     held: carried,
     stored,
+    mintedSessionId: "s-new",
   });
   assert.equal(out.record, stored);
   assert.equal(out.persistUnder, null, "nothing is overwritten");
@@ -232,6 +234,7 @@ test("a mission never crosses from one real session to another", () => {
     nextSessionId: "s-b",
     held: carried,
     stored: null,
+    mintedSessionId: "s-b",
   });
   assert.equal(out.record, null, "chat B must not adopt chat A's mission");
   assert.equal(out.persistUnder, null);
@@ -248,6 +251,7 @@ test("a settled mission is not carried onto a new id", () => {
     nextSessionId: "s-new",
     held: settled,
     stored: null,
+    mintedSessionId: "s-new",
   });
   assert.equal(out.record, null);
   assert.equal(out.persistUnder, null);
@@ -259,6 +263,7 @@ test("leaving a session for a fresh compose drops the mission and persists nothi
     nextSessionId: null,
     held: carried,
     stored: null,
+    mintedSessionId: null,
   });
   assert.equal(out.record, null);
   assert.equal(out.persistUnder, null);
@@ -270,13 +275,62 @@ test("re-running on the same id is idempotent once the carry has been persisted"
     nextSessionId: "s-new",
     held: carried,
     stored: null,
+    mintedSessionId: "s-new",
   });
   const second = reconcileAutoMissionOnSessionChange({
     previousSessionId: "s-new",
     nextSessionId: "s-new",
     held: first.record,
     stored: first.record,
+    mintedSessionId: null,
   });
   assert.equal(second.record, carried);
   assert.equal(second.persistUnder, null, "a second pass must not rewrite storage");
+});
+
+// ── the arriving id must be the one THIS view minted ─────────────────────────
+// A mission can be armed while the send is still in flight, or has failed
+// outright so no id is ever minted. Clicking straight into an unrelated
+// existing chat is then ALSO a null -> real transition. Reproduced in the
+// running app: keying on that edge alone wrote the mission under whichever
+// chat was opened, which then gets its transcript watched and, on the
+// watchdog, a `response-needed` inbox item for a mission it never ran.
+
+test("a mission is NOT adopted by an existing chat the human merely navigated to", () => {
+  const out = reconcileAutoMissionOnSessionChange({
+    previousSessionId: null,
+    nextSessionId: "chat-b",
+    held: carried,
+    // The send never minted anything — no id belongs to this compose.
+    mintedSessionId: null,
+    stored: null,
+  });
+  assert.equal(out.record, null, "chat B must not inherit a mission it never started");
+  assert.equal(out.persistUnder, null, "and nothing may be written under chat B");
+});
+
+test("a mission is not adopted by a chat other than the one this view minted", () => {
+  const out = reconcileAutoMissionOnSessionChange({
+    previousSessionId: null,
+    nextSessionId: "chat-b",
+    held: carried,
+    // This view's own send minted s-new, but the view is now showing chat B.
+    mintedSessionId: "s-new",
+    stored: null,
+  });
+  assert.equal(out.record, null);
+  assert.equal(out.persistUnder, null);
+});
+
+test("the mint is consumed: the same id is not re-adopted on a later visit", () => {
+  // Second visit to s-new with the one-shot mint already spent (null).
+  const out = reconcileAutoMissionOnSessionChange({
+    previousSessionId: null,
+    nextSessionId: "s-new",
+    held: carried,
+    mintedSessionId: null,
+    stored: null,
+  });
+  assert.equal(out.record, null);
+  assert.equal(out.persistUnder, null);
 });

--- a/src/lib/auto-mission-state.ts
+++ b/src/lib/auto-mission-state.ts
@@ -111,6 +111,50 @@ export function isAutoMissionArmed(record: AutoMissionRecord | null): boolean {
   return Boolean(record && !record.completedAt);
 }
 
+/**
+ * What a view holding a mission should do when its session id changes.
+ *
+ * The case this exists for: `/auto <mission>` typed into a BRAND-NEW chat. A
+ * new chat has no session id until the first send mints one, and
+ * `writeAutoMission` is a no-op without one — so the record is armed in memory
+ * and persisted nowhere. Moments later the send announces the real id, the
+ * view re-reads storage for it, finds nothing, and the mission is silently
+ * disarmed. The familiar keeps working; nothing is left that could notify on
+ * the terminal marker, run the watchdog, or tell any other surface a mission
+ * is in flight. Verified against the running app: `/auto` in a fresh chat
+ * writes no `cave:auto-mission:*` key at all, while the same command in an
+ * existing chat writes one immediately.
+ *
+ * So a sessionless mission is CARRIED onto the id that adopts it, and nothing
+ * else is. The deliberate limits:
+ *
+ * - Only `null -> real` carries. Moving between two real sessions is a thread
+ *   switch, and dragging a mission across it would fire chat A's mission
+ *   against chat B's transcript — exactly the cross-chat leak the per-session
+ *   key exists to prevent.
+ * - A record already stored under the arriving id wins. It is the durable one;
+ *   the held copy would be a strictly worse duplicate.
+ * - Only an ARMED record carries. A finished mission has nothing left to
+ *   watch, and re-persisting it under a new id would resurrect a settled
+ *   record as if the session owned it.
+ */
+export function reconcileAutoMissionOnSessionChange(args: {
+  previousSessionId: string | null | undefined;
+  nextSessionId: string | null | undefined;
+  /** The record the view currently holds in memory (may be unpersisted). */
+  held: AutoMissionRecord | null;
+  /** What storage already holds for `nextSessionId`. */
+  stored: AutoMissionRecord | null;
+}): { record: AutoMissionRecord | null; persistUnder: string | null } {
+  const { previousSessionId, nextSessionId, held, stored } = args;
+  if (stored) return { record: stored, persistUnder: null };
+  const adopting = !previousSessionId && Boolean(nextSessionId);
+  if (adopting && isAutoMissionArmed(held) && held) {
+    return { record: held, persistUnder: nextSessionId as string };
+  }
+  return { record: null, persistUnder: null };
+}
+
 /** The shape the watcher needs from a chat turn (structural, not the Turn type). */
 export type AutoTurnLike = {
   id: string;

--- a/src/lib/auto-mission-state.ts
+++ b/src/lib/auto-mission-state.ts
@@ -125,13 +125,26 @@ export function isAutoMissionArmed(record: AutoMissionRecord | null): boolean {
  * writes no `cave:auto-mission:*` key at all, while the same command in an
  * existing chat writes one immediately.
  *
- * So a sessionless mission is CARRIED onto the id that adopts it, and nothing
- * else is. The deliberate limits:
+ * So a sessionless mission is CARRIED onto the id its own send minted, and
+ * nothing else is. The deliberate limits:
  *
+ * - **The arriving id must be the one this view's own run minted**
+ *   (`mintedSessionId`), not merely the first id to arrive. "We had no session
+ *   id and now we do" is NOT the same question: a mission can be armed while a
+ *   send is still in flight (or has failed outright, so no id is ever minted),
+ *   and the human can then click straight into an unrelated existing chat.
+ *   That is also a `null -> real` transition, and keying on the edge alone
+ *   wrote the mission into whatever chat they happened to open. Reproduced in
+ *   the running app before this argument existed: a mission armed in a blank
+ *   compose landed under an existing chat's id purely because it was navigated
+ *   to. The damage is worse than mis-labelling — that chat's transcript then
+ *   gets watched for auto-status markers, and its watchdog eventually posts a
+ *   `response-needed` inbox item for a mission it never ran, which is exactly
+ *   the interruption `/auto` promises not to make.
  * - Only `null -> real` carries. Moving between two real sessions is a thread
  *   switch, and dragging a mission across it would fire chat A's mission
- *   against chat B's transcript — exactly the cross-chat leak the per-session
- *   key exists to prevent.
+ *   against chat B's transcript — the same cross-chat leak from the other
+ *   direction.
  * - A record already stored under the arriving id wins. It is the durable one;
  *   the held copy would be a strictly worse duplicate.
  * - Only an ARMED record carries. A finished mission has nothing left to
@@ -145,10 +158,19 @@ export function reconcileAutoMissionOnSessionChange(args: {
   held: AutoMissionRecord | null;
   /** What storage already holds for `nextSessionId`. */
   stored: AutoMissionRecord | null;
+  /**
+   * The session id this view's OWN generation just minted and adopted — the
+   * `ownsDisplayedView` branch of the chat stream's `session` event. Null when
+   * the id arrived any other way (navigating to an existing chat, a send still
+   * in flight, a send that failed). Consumed one-shot by the caller so an id
+   * can only ever be adopted on the transition immediately following its mint.
+   */
+  mintedSessionId: string | null | undefined;
 }): { record: AutoMissionRecord | null; persistUnder: string | null } {
-  const { previousSessionId, nextSessionId, held, stored } = args;
+  const { previousSessionId, nextSessionId, held, stored, mintedSessionId } = args;
   if (stored) return { record: stored, persistUnder: null };
-  const adopting = !previousSessionId && Boolean(nextSessionId);
+  const adopting =
+    !previousSessionId && Boolean(nextSessionId) && nextSessionId === mintedSessionId;
   if (adopting && isAutoMissionArmed(held) && held) {
     return { record: held, persistUnder: nextSessionId as string };
   }


### PR DESCRIPTION
Closes #4901 · bead `cave-7gryo`

## What I reproduced first

Driven against a real production build with `page.route` mocks (the repo's daemon-less technique), not read off the source.

**The issue's premise is slightly wrong, and the real defect is worse.** There *is* already a sign a mission is running — the menu bar's running-processes popover is globally visible and lists the session. But the row is unlabelled and its title is the generated directive:

```
BEFORE-2. session promoted? url hash = "#chat-e2e-auto-1"
BEFORE-3. mission records once the session id is minted: []
BEFORE-4. ambient trigger on Board: 1 running process — show list
BEFORE-5. popover row:
   [0] Run this as an autonomous /auto mission: tidy the failing token tests | Onyx · … · started 9m ago
        title attr: Open this chat — Run this as an autonomous /auto mission: tidy the failing token tests
```

Note line `BEFORE-3`. **A mission started in a new chat is never persisted at all.** A new chat has no session id until the first send mints one, and `writeAutoMission` is a no-op without one; the re-hydrate on the arriving id then drops the in-memory copy. Isolated with a control — the same command in an *existing* chat writes a record immediately:

```
A. before /auto: []
B. after /auto in an EXISTING session:
   [["cave:auto-mission:de0176c6-…","{\"mission\":\"control mission in an existing chat\",…,\"completedAt\":null,…}"]]
```

So the familiar keeps working while nothing is left to notify on the terminal marker, run the watchdog, or tell any surface a mission is in flight. That had to be fixed before any visibility surface could show anything.

## Judgement calls

**The inbox is the wrong home, and this is provable rather than aesthetic.** `createItem` with `kind: "agent"` and no `fireAt` sets `status: "fired"` (`cave-inbox.ts`); workspace's SSE subscriber answers a fired item with `setToasts(...)` **and** `nativeNotify(item.title, item.body, sound())` (`workspace.tsx`), `unreadInboxCount` counts it into the bell badge, and `groupInboxFeed` files it under **"Needs you"**. Toast + OS notification + sound + unread badge + an attention tier is exactly the interruption `/auto` promises not to make. Terminal states keep posting there; they have earned it.

**Ambient chrome is the right home, and it already exists.** The running-processes popover is zero-hidden, globally visible, has no unread semantics, and already carries "started N ago" plus click-to-open. Precedent for ambient run state in shared chrome is the status-bar coven-run pill — but note the deliberate disanalogy: that pill is *published by* the mounted view and cleared on unmount, which is the opposite of what a mission needs.

**Liveness must come from the server, not the record — otherwise the surface lies.** An armed record cannot say whether a mission is still running: terminal detection and the watchdog are both effects in the ChatView mounted on that session, so navigating away leaves an armed record nobody will clear. A surface built on the record alone would report "in progress" for finished work — wrong precisely when it is relied on. So only sessions the server already reports running (`hasActiveChatRun` → `status: "running"` via `/api/sessions/list`) are decorated; when the run ends the row stops existing rather than going stale.

**Cancel is deliberately NOT shipped.** `POST /api/chat/stop { sessionId }` exists and would stop the run, but the armed record is owned by ChatView's React state: ending the mission from the menu bar leaves a mounted view holding a stale copy that re-persists it as armed on its next liveness stamp, so the mission would read as running with no outcome and no questionnaire — worse than no cancel. The row opens the chat, where `/auto stop` is one command. Filed as `cave-ondxx`.

**A bigger finding I am not fixing here, filed as `cave-ondxx` (P1).** The completion ping does not actually survive walking away. Supervision lives in the ChatView mounted on that exact session, so switching chats or leaving chat stops it; the `done` ping then fires when you next *open* that chat — the one moment you no longer need telling. `docs/auto-mission-mode.md` promises the opposite. The stream itself survives (module-scope live registry), so work is not lost — only the callback. Closing it means moving supervision to a workspace-level watcher, which is a larger change than this issue.

## After

```
2. session promoted? url hash = "#chat-e2e-auto-1"
3. AFTER /auto in a NEW chat, once the session id is minted:
   [["cave:auto-mission:e2e-auto-1","{\"mission\":\"tidy the failing token tests\",…,\"completedAt\":null,…}"]]
4. ambient trigger while away on Board: 1 running process — show list
5. popover rows:
   [0] MISSION | tidy the failing token tests | Onyx · … · started just now
        title attr: Auto mission in progress — tidy the failing token tests — open this chat
        data-auto-mission: true
6. bell: Notifications, 0 unread
```

No toast, no sound, no badge — the interruption contract holds.

## Mutation matrix

Every assertion was verified by breaking what it guards, running the suite, and restoring. 14/14 caught.

| # | Mutation | Test | Observed |
|---|---|---|---|
| M1 | `armedAutoMissionsFor`: drop the `isAutoMissionArmed` filter | presence + row | FAILED — `a done mission must not be reported as in flight`; row test also failed |
| M2 | drop the blank-mission guard | presence | FAILED — `Expected values to be strictly equal` |
| M3 | `readAutoMission`: rethrow instead of returning null on a throwing storage | presence | FAILED — `Error: storage unavailable` |
| M4 | `autoMissionRowPresentation`: drop the whitespace collapse | presence | FAILED |
| M5 | clip length off-by-one (`MAX` instead of `MAX - 1`) | presence | FAILED |
| M6 | clip at the budget (`>=`) instead of past it (`>`) | presence | FAILED — `a mission exactly at the budget is left whole` |
| M7 | reconcile: always re-hydrate from storage (**the original bug**) | state | FAILED — `the running mission survives session creation` |
| M8 | reconcile: allow a real-to-real carry | state | FAILED — `chat B must not adopt chat A's mission` |
| M9 | reconcile: carry a settled mission too | state | FAILED |
| M10 | reconcile: prefer the held copy over the stored one | state | FAILED — `Expected "actual" to be reference-equal` |
| M11 | row: keep the session (directive) title even for a mission | row | FAILED — `the generated directive must not leak into the menu bar` |
| M12 | row: clock from `session.created_at` instead of mission `startedAt` | row | FAILED — `the elapsed clock runs from the mission…` |
| M13 | row: tag every row with a literal `Mission` label | row | FAILED x4 — `no mission tag on an ordinary chat`, `exactly one row is tagged` |
| M14 | row: drop the in-progress description from the accessible name | row | FAILED |

**One mutation initially escaped and found dead code.** M3 first targeted a `try/catch` I had added inside `armedAutoMissionsFor`; removing it changed nothing, because `readAutoMission` already swallows a throwing storage. The redundant guard was deleted and M3 re-aimed at the guard that actually holds the property, where it is caught.

The row test asserts on **rendered markup** (`renderToStaticMarkup` over the exported `RunningSessionList`), not on component source. The house style for `chat-view.tsx` wiring is source-regex matching; I did not add any.

## Gates (verbatim)

```
$ pnpm typecheck
> coven-cave@0.3.9 typecheck
> tsc --noEmit

$ pnpm lint
> coven-cave@0.3.9 lint
> pnpm codemod:design:check && pnpm lint:source
[tokenize-tsx-design] checked — 0 file(s) with drift
> eslint "src/lib/**/*.ts" … --max-warnings=0

$ pnpm check:tests-wired
> node scripts/check-tests-wired.mjs
✓ all 1816 test files wired into CI

$ pnpm build
BUILD EXIT=0
✓ bundle-budget: within budget.
✓ standalone-budget: within budget and free of local build roots.
```

Runner argv for every test file touched (`nodeArgsFor`), all exit 0:

```
src/lib/auto-mission-presence.test.ts
  node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/lib/auto-mission-presence.test.ts
src/lib/auto-mission-state.test.ts
  node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/lib/auto-mission-state.test.ts
src/components/running-sessions-mission-row.test.ts
  node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/running-sessions-mission-row.test.ts
```

The row test reaches `@/` aliases, so it is registered in `ALIAS_LOADER` as well as `SUITES`. The four tests that read `chat-view.tsx` source (`streaming-chat-wiring`, `chat-view-lifecycle`, `chat-view-polish-header-composer`, `chat-sidebar-wiring`) were re-run and all exit 0.

## Note for the reviewer

A concurrent session (`cave-7ncq-markdown-wysiwyg`) is also editing `chat-view.tsx`. My change there is two small hunks in the auto-mission region (one import, one effect body) and should not overlap a markdown-editor change, but it is worth a glance at merge time.


---

## Follow-up commit `8e1e6b5` — the carry-over needed a same-chat identity check

Review raised that the adoption condition was the *edge* (`null -> real`), not
the *identity* (is this the id my own send minted). It is a real hole and I
reproduced it in the running app.

With the send held open so no id is ever minted, arming `/auto` in a blank
compose and then clicking into an unrelated **same-familiar** chat wrote the
mission under that chat:

```
step3 url hash after /auto (empty => no id minted): ""
step4 records while armed with NO session id: []
step5 clicked existing chat: CC Project coven-cave Latest PR for the project - fix/cave-0
step6 url hash (which chat is open now): "#chat-f79aa387-…"
step7 records AFTER navigating to the existing chat:
   [["cave:auto-mission:f79aa387-…","{\"mission\":\"cross-chat leak probe\",…}"]]
```

Same-familiar matters: a familiar switch bumps `composeInstance`, which is in
ChatView's `key`, so the view remounts and the held record is lost. Navigating
within one familiar keeps the instance alive, which is what makes the window
reachable.

**The damage is worse than a mislabelled row.** That chat's transcript then gets
watched for auto-status markers, so an ordinary reply containing one fires a
ping and a feedback questionnaire against a mission it never started, and the
watchdog eventually posts a `response-needed` inbox item for it — precisely the
interruption this PR exists to avoid.

**Fix.** The discriminator already existed: the chat stream's `session` handler
adopts `ev.sessionId` into the view's refs only under `ownsDisplayedView`, i.e.
only when a generation *this view owns* minted it. That branch now also stamps
`autoMissionMintedSessionRef`, and the reconciler requires the arriving id to
equal it. The ref is read **one-shot** (cleared as the effect consumes it), so
an id can be adopted only on the transition immediately after its mint, never on
a later navigation that lands back on it.

Verified live on the rebuilt app — leak closed, legitimate adoption intact:

```
LEAK-5 records AFTER navigating to the existing chat: []

OK-1 hash (promotion): "#chat-e2e-auto-1"
OK-2 record after the mint this view owns: [["cave:auto-mission:e2e-auto-1",…]]
OK-4 popover row: MISSION | tidy the failing token tests | … | started just now
OK-5 bell: Notifications, 0 unread
```

### Additional mutations (all caught)

| # | Mutation | Observed |
|---|---|---|
| M15 | drop the minted-id identity check, keep only the `null -> real` edge | FAILED — `chat B must not inherit a mission it never started` |
| M16 | accept any minted id regardless of which chat is shown | FAILED — the different-id test's strict-equal assertion |
| M17 | always re-hydrate from storage (the original bug), re-run against the new signature | FAILED — `the running mission survives session creation` |
| M18 | allow a real→real carry | FAILED — `chat B must not adopt chat A's mission` |
| M19 | carry a settled mission too | FAILED |
| M20 | prefer the held copy over the stored one | FAILED |

Three new tests pin the property the original suite did not: navigation with no
mint, navigation while a *different* id was minted, and a spent (already
consumed) mint. `auto-mission-state.test.ts` is now 29 tests, all passing.

### Gates re-run on `8e1e6b5`

`pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` (`✓ all 1816 test files
wired into CI`) and `pnpm build` (`EXIT=0`, within budget) all green. The three
new/changed test files plus the four that read `chat-view.tsx` source all exit 0.

### Note on this PR's head

`branch-cap.yml` deleted this branch while the repo sat at 41 remote branches
(cap 40), so the follow-up push re-created it and GitHub kept the PR pinned to
the old head (`5032997`) even though origin's ref had moved. A close/reopen
re-resolved it; the head is now `8e1e6b5`. Nothing was force-pushed and no
commit was rewritten.


---

## Follow-up commit `8fe99c5` — the row-clock assertion moved from source text to rendered output

The full `app` suite ran to completion for the first time (it had been bailing
~766 files earlier) and surfaced a real failure at index 1215:

```
✗ FAILED: src/components/running-sessions-popover.test.ts
expected: /started <RelativeTime iso=\{session\.created_at\} fallback="—" \/>/
operator: 'match'
```

### One correction to the diagnosis

The code did **not** move to another file — `RunningSessionList` is defined in
`running-sessions-popover.tsx` (line 39), the same file the regex reads. What
changed is the *expression*:

```jsx
{meta} · started{" "}
<RelativeTime iso={mission ? armed!.startedAt : session.created_at} fallback="—" />
```

The regex wanted one literal `iso={session.created_at}` on the same line as
`started `. Both the `{" "}` and the ternary broke it. That matters because it
rules out "just move the regex" as a fix — the single literal it pinned cannot
describe the behaviour any more, because the behaviour is now conditional.

### Decision: retire the assertion, supersede it with rendered-output coverage

Argued rather than assumed:

1. **The property is real and must stay covered.** An ordinary process should
   still be timed from `session.created_at`, with an em-dash fallback.
2. **It was NOT fully covered behaviourally.** My existing suite covered the
   mission row's clock (positive and negative) but never asserted the ordinary
   row's timestamp or the fallback. That was a genuine coverage gap my change
   introduced, and simply deleting the regex would have left it open.
3. **Re-pointing the regex is strictly worse than what replaces it.** A source
   regex cannot distinguish the two row kinds — it only ever saw that the
   characters `session.created_at` appeared *somewhere in the file*. It would
   pass unchanged if the row stopped rendering altogether (this repo's
   documented whole-tree-snapshot failure class), and it would break again on
   any reformatting that is behaviour-neutral.

So the assertion is retired **and the reasoning is left in place where it sat**,
naming the four tests that now carry the property, so a future reader cannot
mistake this for dropped coverage. Four rendered-markup assertions replace one
spelling match:

- an ordinary row reports the session's OWN start time
- a mission row reports when the MISSION started, not when the session was created
- a row with no usable timestamp renders the em-dash fallback, not a broken clock
- a mission row with an unusable mission start falls back rather than borrowing the session's clock

The last one closes the sneakiest revert: silently substituting the session's
time on a mission row whenever the mission's own time fails to parse.

### Mutation matrix — the required case, plus the new assertions

| # | Mutation | Behavioural suite | `running-sessions-popover.test.ts` |
|---|---|---|---|
| M12 | **mission row silently reverts to `session.created_at`** (the case you required) | **FAILED (caught)** | passed |
| M21 | ordinary row times from `updated_at` instead of `created_at` | FAILED (caught) | passed |
| M22 | drop the `fallback="—"` | FAILED (caught) | passed |
| M23 | mission row borrows the session clock when the mission start is unusable | FAILED (caught) | passed |

The right-hand column is the point: the source-regex file passes under **all
four**, including the exact revert the retired assertion was supposed to guard.
That is the evidence that retiring it costs nothing — it was not what protected
the property.

### The rest of the suite — what else my change broke (nothing)

`pnpm test:app` cannot run to completion on this machine: it bails at index 61
on `scripts/beads-create.test.mjs` (`spawnSync … \bin\bd ENOENT`), far earlier
than the ~449 hydration bail. So a single sequential run proves nothing here.

Instead I enumerated every test file in any suite whose source references
anything this branch touches (`auto-mission-state`, `auto-mission-presence`,
`running-sessions-popover`, `running-sessions-mission-row`, `chat-view.tsx`,
`auto-status`) — **118 files** — and ran each with the command the real runner
would use, replicating `run-tests.mjs` exactly: `VITEST_TESTS` members via
`vitest run`, everything else via `nodeArgsFor`, all under the same
temp-secrets `testEnv`.

```
ran 118 files that reference anything I changed; 1 failing
  src/lib/pausable-poll-discipline.test.ts
```

That one is **pre-existing and Windows-only**. `RAW_INTERVAL_ALLOWLIST` is keyed
`"components/chat-view.tsx"`, but the lookup uses `path.relative(SRC, file)`,
which yields `components\chat-view.tsx` on Windows — so the allowlist never
matches and every allowlisted file is reported as an offender. Proven not mine:
the identical failure reproduces with `chat-view.tsx` reverted to the
merge-base, and this branch adds no `setInterval` at all (both call sites the
test flags predate it). CI is unaffected because Linux separators match. Filed
as `cave-k452u`; not fixed here, since it is unrelated shared test
infrastructure.

For completeness, the other files that fail locally in a straight sequential run
— `scripts/beads-create`, `beads-surface-audit`, `install-git-hooks`,
`worktree-lifecycle-retirement`, `worktree-lifecycle-patrol`,
`tweet-thread-validator`, `src/lib/server/familiar-avatar-mutation` (`EPERM:
symlink`) — are all environment failures (`bd` missing, Windows symlink
permissions) and none of them reference anything this branch touches.

⚠️ One methodological note, because it nearly produced a false report: my first
sweep ran every file with plain `node`, which is wrong for the 36 `VITEST_TESTS`
entries. That mis-invocation manufactured nine `.tsx` "failures" that vanished
once the harness matched the real runner. Any local sweep of this repo has to
replicate the `VITEST_TESTS` branch or it will invent regressions.

### Gates re-run on `8fe99c5`

`pnpm typecheck`, `pnpm lint` (`0 file(s) with drift`), `pnpm check:tests-wired`
(`✓ all 1816 test files wired into CI`), `pnpm build` (`EXIT=0`, within budget)
— all green.
