### PR TITLE
fix(research): anchor the X hydration test's cache seeding to the real clock (cave-p36ov)

### DIFF
--- a/src/lib/server/research-mission-x-hydration.test.ts
+++ b/src/lib/server/research-mission-x-hydration.test.ts
@@ -101,6 +101,11 @@ globalThis.fetch = (async () => {
 }) as typeof globalThis.fetch;
 
 const POST_TEXT = "Bounded reads are the whole point of a cost-aware client.";
+// The mission RECORDS' timestamps, and only those. A mission is loaded back by
+// id and none of these instants is ever compared against the real clock, so a
+// fixed date is safe here — and deliberate, since it keeps the fixtures stable.
+//
+// It must NOT be used to seed the X post cache. See `cacheLivePost`.
 const NOW = new Date("2026-08-22T12:00:00.000Z");
 
 function post(postId: string, text = POST_TEXT): NormalizedXPost {
@@ -111,6 +116,25 @@ function post(postId: string, text = POST_TEXT): NormalizedXPost {
     author: { id: "42", username: "opencoven", name: "Open Coven" },
     createdAt: "2026-08-20T09:00:00.000Z",
   };
+}
+
+/**
+ * Seed the bounded X post cache with an entry that is LIVE right now.
+ *
+ * Cache freshness is the one thing in this file measured against the real
+ * clock: `hydrateMissionXSources` reads through `getCachedXPost`, which
+ * defaults its `now` to `new Date()`, and an entry is live for `CACHE_TTL_MS`
+ * (24 hours) after the instant it was cached. Seeding at a fixed calendar
+ * instant therefore yields an entry that is live only while real time happens
+ * to fall within 24h of that instant — so the tests below would pass until
+ * that window closed and fail every run afterwards, on a wall clock rather
+ * than on anything they mean to assert.
+ *
+ * Anchoring to the real clock is what makes "this post is already cached" mean
+ * what the tests say it means. Never pass `NOW` here.
+ */
+async function cacheLivePost(postId: string, text = POST_TEXT): Promise<void> {
+  await cacheNormalizedXPosts([post(postId, text)]);
 }
 
 /** The exact upstream payload `lookupXPost` accepts. */
@@ -257,7 +281,7 @@ beforeEach(() => {
 test("hydration writes each attached post into runtime/x and returns identity-only refs", async () => {
   const mission = await makeMission();
   await attachSource("nova", mission.id, "1001", "why this thread matters");
-  await cacheNormalizedXPosts([post("1001")], NOW);
+  await cacheLivePost("1001");
 
   const hydration = await hydrateMissionXSources(mission);
 
@@ -311,7 +335,7 @@ test("a saved source not attached to this mission is never hydrated into it", as
   const mission = await makeMission();
   const other = await makeMission();
   await attachSource("nova", other.id, "1003");
-  await cacheNormalizedXPosts([post("1003")], NOW);
+  await cacheLivePost("1003");
 
   const hydration = await hydrateMissionXSources(mission);
 
@@ -324,7 +348,7 @@ test("hydration is familiar-scoped: another familiar's source cannot reach this 
   // `dusk` claims nova's mission id on its own saved source. Only sources saved
   // under the MISSION's familiar are ever read, so the claim goes nowhere.
   await attachSource("dusk", mission.id, "1004");
-  await cacheNormalizedXPosts([post("1004")], NOW);
+  await cacheLivePost("1004");
 
   const hydration = await hydrateMissionXSources(mission);
 
@@ -337,7 +361,7 @@ test("hydration replaces residue from a previous run instead of presenting it as
   await mkdir(runtimeDir(mission.id), { recursive: true });
   await writeFile(path.join(runtimeDir(mission.id), "x-post-9999.md"), "stale run residue", "utf8");
   await attachSource("nova", mission.id, "1005");
-  await cacheNormalizedXPosts([post("1005")], NOW);
+  await cacheLivePost("1005");
 
   await hydrateMissionXSources(mission);
 
@@ -372,7 +396,7 @@ test("a mission with no attached X sources touches neither X nor the network, an
 test("a deleted post is recorded durably, omitted from runtime/x, and reported to the run", async () => {
   const mission = await makeMission();
   await attachSource("nova", mission.id, "1006", "keep this note");
-  await cacheNormalizedXPosts([post("1006")], NOW);
+  await cacheLivePost("1006");
   // Expire the cache entry so hydration has to ask X, which answers 404.
   await rm(path.join(cacheDir, "1006.json"), { force: true });
   respond = async () => errorResponse(404);
@@ -473,7 +497,7 @@ test("an authorization X rejects even after one refresh refuses the launch", asy
 test("an attached source on a familiar without X research refuses the launch", async () => {
   const mission = await makeMission("dusk");
   await attachSource("dusk", mission.id, "2001");
-  await cacheNormalizedXPosts([post("2001")], NOW);
+  await cacheLivePost("2001");
 
   const error = await hydrateMissionXSources(mission).then(
     () => null,
@@ -495,7 +519,7 @@ test("an attached source on a familiar without X research refuses the launch", a
 test("dropping the runtime removes every hydrated file and is safe to repeat", async () => {
   const mission = await makeMission();
   await attachSource("nova", mission.id, "3001");
-  await cacheNormalizedXPosts([post("3001")], NOW);
+  await cacheLivePost("3001");
   await hydrateMissionXSources(mission);
   assert.equal((await runtimeFiles(mission.id)).length, 1);
 
@@ -636,7 +660,7 @@ function settlingRunner(
 test("continuing a mission hydrates before the iteration starts and names the files in its prompt", async () => {
   const mission = await makeMission();
   await attachSource("nova", mission.id, "5001");
-  await cacheNormalizedXPosts([post("5001")], NOW);
+  await cacheLivePost("5001");
   const harness = runnerFor();
 
   const updated = await harness.runner.act(mission.id, { action: "continue" });
@@ -672,7 +696,7 @@ test("continuing a mission hydrates before the iteration starts and names the fi
 test("the run's post text is removed when the mission settles", async () => {
   const mission = await makeMission();
   await attachSource("nova", mission.id, "5002");
-  await cacheNormalizedXPosts([post("5002")], NOW);
+  await cacheLivePost("5002");
   const harness = runnerFor();
   await harness.runner.act(mission.id, { action: "continue" });
   assert.equal((await runtimeFiles(mission.id)).length, 1, "hydrated before the settle under test");
@@ -694,7 +718,7 @@ test("the run's post text is removed when the mission settles", async () => {
 test("a still-running mission keeps its hydrated post text", async () => {
   const mission = await makeMission();
   await attachSource("nova", mission.id, "5003");
-  await cacheNormalizedXPosts([post("5003")], NOW);
+  await cacheLivePost("5003");
   const harness = runnerFor();
   await harness.runner.act(mission.id, { action: "continue" });
 
@@ -711,7 +735,7 @@ test("a still-running mission keeps its hydrated post text", async () => {
 test("cancelling a running mission removes its hydrated post text", async () => {
   const mission = await makeMission();
   await attachSource("nova", mission.id, "5004");
-  await cacheNormalizedXPosts([post("5004")], NOW);
+  await cacheLivePost("5004");
   const harness = runnerFor();
   await harness.runner.act(mission.id, { action: "continue" });
   assert.equal((await runtimeFiles(mission.id)).length, 1);
@@ -767,7 +791,7 @@ test("a deleted attached post lets the run proceed, visibly short of that source
 test("a normal iteration completion settles to checkpoint and removes the hydrated post text", async () => {
   const mission = await makeMission();
   await attachSource("nova", mission.id, "6001");
-  await cacheNormalizedXPosts([post("6001")], NOW);
+  await cacheLivePost("6001");
   const harness = runnerFor();
   await harness.runner.act(mission.id, { action: "continue" });
   assert.equal((await runtimeFiles(mission.id)).length, 1, "hydrated before the settle under test");
@@ -815,7 +839,7 @@ test("only an active mission may hold hydrated post text", () => {
 test("an agent's own sources.json entry cannot strip the X identity off an attached post", async () => {
   const mission = await makeMission();
   await attachSource("nova", mission.id, "6003");
-  await cacheNormalizedXPosts([post("6003")], NOW);
+  await cacheLivePost("6003");
   const harness = runnerFor();
   await harness.runner.act(mission.id, { action: "continue" });
 
@@ -854,7 +878,7 @@ test("no author display data reaches a durable record, on either surface", async
   // @opencoven / "Open Coven", the stored URL carries neither.
   const mission = await makeMission();
   await attachSource("nova", mission.id, "7001", "", "https://x.com/i/web/status/7001");
-  await cacheNormalizedXPosts([post("7001")], NOW);
+  await cacheLivePost("7001");
 
   const hydration = await hydrateMissionXSources(mission);
   assert.equal(
@@ -885,7 +909,7 @@ test("no author display data reaches a durable record, on either surface", async
 test("removal leaves no empty runtime/ scaffolding in the workspace", async () => {
   const mission = await makeMission();
   await attachSource("nova", mission.id, "7002");
-  await cacheNormalizedXPosts([post("7002")], NOW);
+  await cacheLivePost("7002");
   await hydrateMissionXSources(mission);
 
   await dropMissionXRuntime(mission.id);
@@ -900,7 +924,7 @@ test("removal leaves no empty runtime/ scaffolding in the workspace", async () =
 test("a populated runtime/ directory survives removal of runtime/x", async () => {
   const mission = await makeMission();
   await attachSource("nova", mission.id, "7003");
-  await cacheNormalizedXPosts([post("7003")], NOW);
+  await cacheLivePost("7003");
   await hydrateMissionXSources(mission);
   const sibling = path.join(researchMissionWorkspacePath(mission.id), "runtime", "notes.md");
   await writeFile(sibling, "something else is using runtime/", "utf8");


### PR DESCRIPTION
Repairs the red `main`. Fixes `cave-p36ov`.

## The failure

`src/lib/server/research-mission-x-hydration.test.ts` fails in **Frontend validation (app tests)** — 12 of 27 tests, with repeated:

```
ResearchMissionXHydrationError: An X source attached to this mission could not be retrieved
  (X is temporarily unavailable). Resolve it or detach the source, then retry.
```

## The cause: a time bomb in the test, not a semantic merge conflict

`main` broke at **2026-08-23T12:00:00.000Z**, and that instant is not a coincidence — it is exactly 24 hours after the fixed date the test seeded the X post cache with.

- `hydrateMissionXSources` reads a saved post through `getCachedXPost`, which defaults its `now` to `new Date()`.
- `x-sources` holds a cache entry live for `CACHE_TTL_MS` — **24 hours** — after the instant it was cached.
- Sixteen call sites seeded it with `NOW`, hard-coded to `2026-08-22T12:00:00.000Z`. Every seeded entry therefore expired at **2026-08-23T12:00:00.000Z**.

After that instant the cache read misses, hydration falls through to the stubbed upstream, the stub throws its `unexpected upstream X request` guard, and every test that needs a cached post fails.

The CI timings show it exactly:

| run | contains the test | app-tests job (UTC) | result |
|---|---|---|---|
| #4867 (own CI) | **yes** | 09:30–09:38 | pass — 2h22m before expiry |
| #4929 | no | 11:05–11:12 | pass |
| #4931 | no | 11:29–11:36 | pass |
| #4937 | no | 11:56–12:03 | pass |
| #4939 | **yes** | 12:04–12:08 | **fail** — 4m after expiry |

**#4867's own run is the discriminating case**: it contained the test and passed, so containment alone does not predict the outcome. Every run of a tree holding this file before 12:00:00Z passed; every one after it failed. No sibling commit is involved — #4921 and #4887 touch no file in `src/lib/server/` and nothing in the test's runtime import graph.

## The fix

Cache freshness is the one thing in this file measured against the real clock, so it is seeded through a new `cacheLivePost`, which caches at `new Date()`. `NOW` keeps the mission records' timestamps — never compared against real time — and both roles are now documented so they do not get conflated again.

## No assertion was weakened

Nothing was skipped, relaxed, or deleted; the change is to fixture setup only. Four sites that seeded an entry hydration is *expected to ignore* (a source attached to another mission, another familiar's source, a source on a familiar without the X capability, and a post whose entry is then explicitly removed) had been seeding an already-expired entry, so they had quietly stopped exercising the guard they name. A live entry **restores** that coverage.

## Mutation matrix

Every mutation was applied to a tree that otherwise passes 27/27, then reverted.

| # | Mutation | Expected | Result |
|---|---|---|---|
| M1 | Re-seed post `1001` at `NOW` (restore the bug) | fail | see below |
| M2 | Never write the hydrated file into `runtime/x` | fail | |
| M3 | Drop familiar scoping on the saved-source read | fail | |
| M4 | Drop the mission-attachment filter | fail | |
| M5 | Leak author display data into the durable ledger ref | fail | |
| M6 | Make a non-404 upstream failure resolve instead of throwing | fail | |
| M7 | Make runtime removal a no-op | fail | |
| M8 | Never expire a cache entry | fail | |

Verbatim results are in the PR discussion.

## Verification

`27/27 pass, exit 0` on this branch.