### PR TITLE
Preserve the blocker pin during deletion repair

### DIFF
--- a/src/lib/cave-board-orchestration.test.ts
+++ b/src/lib/cave-board-orchestration.test.ts
@@ -483,6 +483,116 @@ assert.equal(
 );
 assert.equal(repairedDependent.orchestrationAudit?.at(-1)?.resolvedDependencyId, taskDependency.id);
 assert.equal(repairedDependent.orchestrationAudit?.at(-1)?.actor, "cody");
+assert.equal(
+  repairedDependent.primaryBlockerPinned,
+  false,
+  "an unpinned card stays unpinned through deletion repair",
+);
+
+// Deletion repair must not quietly revoke an operator pin. The pinned
+// dependency did not resolve — the card it pointed at was deleted — so the pin
+// carries onto whatever replaces it, and it keeps *working*: a later resolution
+// of that replacement is still refused instead of auto-promoting past it.
+const pinnedUpstream = await board.createCard({ title: "Upstream under a pinned blocker" });
+const pinnedTaskDependency = {
+  ...taskDependency,
+  id: "pinned-deletion-primary",
+  taskId: pinnedUpstream.id,
+};
+const pinnedReplacement = {
+  ...deletionSecondary,
+  id: "pinned-deletion-replacement",
+  label: "Ask the maintainer for the pinned fallback",
+};
+const pinnedTertiary = {
+  ...deletionSecondary,
+  id: "pinned-deletion-tertiary",
+  label: "Never promote past the pin",
+};
+const pinnedDependent = await board.createCard({
+  title: "Preserve the pin through deletion repair",
+  status: "blocked",
+  dependencies: [pinnedTaskDependency, pinnedReplacement, pinnedTertiary],
+  primaryBlockerId: pinnedTaskDependency.id,
+  primaryBlockerPinned: true,
+  nextStep: {
+    summary: pinnedTaskDependency.label,
+    requiresApproval: false,
+    origin: "system",
+    updatedAt: now,
+  },
+});
+assert.equal(pinnedDependent.primaryBlockerPinned, true, "the pin is stored before deletion");
+assert.equal(await board.deleteCard(pinnedUpstream.id, { actor: "cody" }), "deleted");
+const repairedPinned = (await board.loadBoard()).cards.find((card) => card.id === pinnedDependent.id);
+assert.ok(repairedPinned);
+assert.equal(
+  repairedPinned.primaryBlockerId,
+  pinnedReplacement.id,
+  "deletion repair repoints the primary blocker at the next unresolved dependency",
+);
+assert.equal(
+  repairedPinned.primaryBlockerPinned,
+  true,
+  "the operator pin survives deletion repair onto the replacement blocker",
+);
+// The pin is only real if promotion still skips this card. Resolving the
+// replacement leaves a blocked card with a settled primary, which is exactly
+// what an unpinned card would promote away from.
+await assert.rejects(
+  board.updateCard(pinnedDependent.id, {
+    dependencies: [
+      repairedPinned.dependencies![0],
+      {
+        ...pinnedReplacement,
+        state: "resolved",
+        resolvedAt: new Date().toISOString(),
+        evidence: "Maintainer approved the fallback",
+      },
+      pinnedTertiary,
+    ],
+  }),
+  (error) => {
+    assert.ok(errorCodes(error).includes("blocked_requires_primary"));
+    return true;
+  },
+  "a preserved pin still freezes promotion after deletion repair",
+);
+const pinnedAfterResolve = (await board.loadBoard()).cards.find((card) => card.id === pinnedDependent.id);
+assert.equal(pinnedAfterResolve?.primaryBlockerId, pinnedReplacement.id);
+assert.equal(pinnedAfterResolve?.primaryBlockerPinned, true);
+assert.equal(
+  pinnedAfterResolve?.dependencies?.find((dependency) => dependency.id === pinnedReplacement.id)?.state,
+  "unresolved",
+  "the refused resolution is not saved",
+);
+
+// Nothing left to point at means nothing left to pin: the pin clears rather
+// than dangling over a null primary blocker.
+const pinnedSoleUpstream = await board.createCard({ title: "Only upstream under a pin" });
+const pinnedSoleDependent = await board.createCard({
+  title: "Clear the pin when no blocker replaces it",
+  status: "blocked",
+  dependencies: [{ ...taskDependency, id: "pinned-sole-dependency", taskId: pinnedSoleUpstream.id }],
+  primaryBlockerId: "pinned-sole-dependency",
+  primaryBlockerPinned: true,
+  nextStep: {
+    summary: taskDependency.label,
+    requiresApproval: false,
+    origin: "system",
+    updatedAt: now,
+  },
+});
+assert.equal(await board.deleteCard(pinnedSoleUpstream.id, { actor: "cody" }), "deleted");
+const repairedPinnedSole = (await board.loadBoard()).cards.find(
+  (card) => card.id === pinnedSoleDependent.id,
+);
+assert.equal(repairedPinnedSole?.primaryBlockerId, null);
+assert.equal(
+  repairedPinnedSole?.primaryBlockerPinned,
+  false,
+  "a pin over no remaining blocker clears instead of dangling",
+);
 
 const soleUpstream = await board.createCard({ title: "Only upstream task" });
 const soleDependency = {

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -1738,7 +1738,15 @@ function repairDeletedTaskReferences(
     );
     const previousNextStep = card.nextStep ?? null;
     next.primaryBlockerId = promoted?.id ?? null;
-    next.primaryBlockerPinned = false;
+    // Deletion repair is forced maintenance, not an operator re-decision: the
+    // pinned dependency did not resolve, its target card was removed out from
+    // under it. Clearing the pin here silently handed the primary pointer back
+    // to automatic promotion, so the next resolution moved a blocker the
+    // operator had explicitly frozen. Carry the pin onto the replacement.
+    // With nothing left to promote there is no blocker to pin, and a pin over a
+    // null pointer is inert everywhere it is read — so that case clears, the
+    // same way `applyExecutionBlocker` drops a pin whose target is gone.
+    next.primaryBlockerPinned = card.primaryBlockerPinned === true && promoted != null;
     next.nextStep =
       previousNextStep?.origin === "human"
         ? previousNextStep


### PR DESCRIPTION
## Summary

Follow-up to #4712. When a card is deleted, `repairDeletedTaskReferences` waives every task dependency that pointed at it. If the waived dependency was the **pinned** primary blocker, the repair repointed the primary at the next unresolved dependency *and cleared `primaryBlockerPinned`*.

The pin is an operator decision — "this is the blocker, do not promote past it" (`docs/orchestration-ready-tasks.md`: *"A pin survives promotion"*). Deletion repair is forced maintenance, not an operator re-decision: the pinned dependency never resolved, the card it referenced was removed out from under it. Clearing the pin silently handed the primary pointer back to automatic promotion, so the *next* resolution moved a blocker the operator had explicitly frozen.

## Reproduction (before the fix)

A blocked card pinned to a task dependency, with a human fallback dependency behind it:

```
BEFORE  pinned=true   primary=pinned-task-dep
delete upstream card
AFTER   pinned=false  primary=fallback-dep      <-- pin lost
```

Resolving `fallback-dep` afterwards was then accepted and promotion moved on. With the pin preserved, that same update is refused with `blocked_requires_primary`, exactly as it is for a pin that was never disturbed.

## Change

`src/lib/cave-board.ts` — one line in the `removedPrimary` branch:

```ts
next.primaryBlockerPinned = card.primaryBlockerPinned === true && promoted != null;
```

Carry the pin onto the replacement blocker. When nothing remains to promote there is no blocker to pin, so that case still clears — matching how `applyExecutionBlocker` drops a pin whose target is gone, and avoiding a pin dangling over a null `primaryBlockerId`.

## Regression

`src/lib/cave-board-orchestration.test.ts` asserts the **state and the lifecycle**, not a field name:

- the pin survives deletion repair onto the replacement blocker, read back from the store;
- the preserved pin still *works* — resolving the replacement is refused with `blocked_requires_primary` instead of auto-promoting past it, and the refused resolution is not saved;
- an unpinned card stays unpinned through repair;
- a pin with no replacement blocker clears rather than dangling over a null pointer.

### Mutation matrix (`src/lib/cave-board.ts`, run against `cave-board-orchestration.test.ts`)

| # | Mutation | Result | Killed by |
|---|---|---|---|
| M1 | `= false` (restore the original bug) | KILLED | "the operator pin survives deletion repair onto the replacement blocker" |
| M2 | `= true` (always pin) | KILLED | "an unpinned card stays unpinned through deletion repair" |
| M3 | drop the `promoted != null` guard | KILLED | "a pin over no remaining blocker clears instead of dangling" |
| M4 | delete the assignment entirely | KILLED | same as M3 (behaviourally equivalent to M3 for stored cards; `undefined` only differs for legacy records) |
| M5 | keep the deleted primary pointer instead of repointing | KILLED | `blocked_requires_primary` — pre-existing coverage |
| M6 | invert the pin test (`!== true`) | KILLED | "an unpinned card stays unpinned through deletion repair" |

The behavioural assertion was mutation-checked independently: with the two state assertions stripped, M1 is still killed by `Missing expected rejection: a preserved pin still freezes promotion after deletion repair`. It is not a dead assertion riding on the state checks.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (`0 file(s) with drift`, eslint `--max-warnings=0`)
- `pnpm check:tests-wired` — `✓ all 1837 test files wired into CI`
- `pnpm build` — `✓ bundle-budget: within budget`, `✓ standalone-budget: within budget`
- Focused: `cave-board-orchestration`, `task-orchestration`, `board/orchestration-route`, `cave-board-retention`, `cave-board-ops`, `board-agentic-enhance`, `chart-room-model` — all pass

Closes #4904

Bead: cave-rw6ae (executing child of cave-80uja, whose worktree record is held on another machine)
