### PR TITLE
Verify the Chat v1 Phase 2 canonical reads gate (cave-ma00l)

### DIFF
--- a/docs/client-v1-conformance-results/2026-08-23-v0.3.9-win32-cave-ma00l.json
+++ b/docs/client-v1-conformance-results/2026-08-23-v0.3.9-win32-cave-ma00l.json
@@ -1,0 +1,574 @@
+{
+  "harness": "scripts/client-v1-conformance.mjs",
+  "issues": [
+    "OpenCoven/coven-cave#4832",
+    "OpenCoven/coven-cave#4838"
+  ],
+  "scope": "cave-only",
+  "ranAt": "2026-08-23T19:41:11.553Z",
+  "caveVersion": "0.3.9",
+  "commit": "87ebf78026b316fce5c0f7099f840a1aa579ab12",
+  "platform": "win32-x64",
+  "nodeVersion": "v24.18.0",
+  "includeTtl": true,
+  "notCovered": [
+    "The SDK and Chat halves of #4838. Both live in other repositories; this run is the Cave half only.",
+    "The production Coven daemon. /familiars is served from a loopback fixture daemon in hub mode.",
+    "A genuinely remote peer. Off-machine ingress is exercised by making the listener classify a loopback request as forwarded.",
+    "The write scopes. Nothing enforces them yet — there are no write routes on this surface.",
+    "OAuth-backed flows and the desktop consent UI. Approval is driven through the admin HTTP route.",
+    "Cross-process pairing state. The pairing store is in-memory and process-local by contract."
+  ],
+  "findings": [
+    {
+      "id": "backslash-refusal-is-unreachable",
+      "where": "docs/api/client-v1.md — Reaching the API at all",
+      "says": "a request target inside /api/client/v1 containing \"%\" or \"\\\" is answered 400 {\"ok\":false,\"error\":\"invalid client v1 path\"}",
+      "measured": "the \"%\" half holds; a \"\\\" is normalised to \"/\" by Next and answered 308 to the normalised target before proxy.ts runs, and that target is then refused 401 by the ordinary gate",
+      "severity": "documentation",
+      "why": "no handler is reached and nothing is served, so the gate still holds; the doc describes an answer no client will observe"
+    },
+    {
+      "id": "admin-unauthorized-envelope-is-unreachable",
+      "where": "docs/api/client-v1.md — Administrator routes, Authentication",
+      "says": "a mismatched or absent x-coven-cave-token is 401 unauthorized from requireClientV1Admin",
+      "measured": "the proxy's sidecar-token gate answers first, so the wire carries 401 {\"ok\":false,\"error\":\"unauthorized\"} and requireClientV1Admin's envelope is never produced on a Cave with a token configured",
+      "severity": "documentation",
+      "why": "the refusal is correct and same-status; only its body differs from the documented one, which a handler-level test cannot see"
+    }
+  ],
+  "summary": {
+    "total": 105,
+    "passed": 105,
+    "failed": 0,
+    "skipped": 0,
+    "status": "passed"
+  },
+  "assertions": [
+    {
+      "id": "admin.unconfigured/admin/pairing-requests.GET",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/credentials.GET",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/pairing-requests/:id/decision.POST",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured/admin/credentials/:id.DELETE",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.unconfigured.pairing-still-opens",
+      "result": "pass",
+      "detail": "a tokenless Cave still opens pairing requests"
+    },
+    {
+      "id": "admin.unconfigured.exchange-stays-pending",
+      "result": "pass",
+      "detail": "the documented dead end: no approval route, so the exchange can only ever answer pairing_pending"
+    },
+    {
+      "id": "health.envelope",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "health.live-inventory",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "health.instance-stable",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "health.discovery-record",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "ingress.escaped-path.percent",
+      "result": "pass",
+      "detail": "/api/client/v1/pairing/requests/%41"
+    },
+    {
+      "id": "ingress.escaped-path.percent-encoded-separator",
+      "result": "pass",
+      "detail": "/api/client/v1/conversations%2Fx"
+    },
+    {
+      "id": "ingress.backslash-path-reaches-no-handler",
+      "result": "pass",
+      "detail": "answered 308; the documented 400 fires for \"%\" only — see the run's notes"
+    },
+    {
+      "id": "ingress.forwarded.public",
+      "result": "pass",
+      "detail": "/pairing/requests with x-forwarded-for"
+    },
+    {
+      "id": "ingress.forwarded.authenticated",
+      "result": "pass",
+      "detail": "/conversations with x-forwarded-for"
+    },
+    {
+      "id": "ingress.forwarded.admin",
+      "result": "pass",
+      "detail": "/admin/credentials with x-forwarded-for"
+    },
+    {
+      "id": "ingress.exchange-requires-content-length",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "ingress.refuses-transfer-encoding",
+      "result": "pass",
+      "detail": "a chunked control-plane body has no declared length to cap"
+    },
+    {
+      "id": "ingress.body-cap",
+      "result": "pass",
+      "detail": "70072 bytes against the 65536-byte control-plane cap"
+    },
+    {
+      "id": "ingress.pairing-content-type",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "admin.wrong-token",
+      "result": "pass",
+      "detail": "refused by the proxy's sidecar gate, ahead of requireClientV1Admin"
+    },
+    {
+      "id": "admin.no-token",
+      "result": "pass",
+      "detail": "refused by the proxy's sidecar gate, ahead of requireClientV1Admin"
+    },
+    {
+      "id": "admin.mutation-requires-source",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.create",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-pending",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-queue",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-approve",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-approved",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-approve-idempotent",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.admin-decision-conflict",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.exchange",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.bearer-works",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.replay-refused",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-after-exchange",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.poll-denied",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.exchange-denied",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.unknown-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.wrong-secret",
+      "result": "pass",
+      "detail": "one wrong secret charged on the exchange route"
+    },
+    {
+      "id": "pairing.correct-secret-polling-is-free",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-charges-wrong-secret-on-poll",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-locks-out-the-holder",
+      "result": "pass",
+      "detail": "ten wrong secrets across BOTH routes; the correct secret is refused too"
+    },
+    {
+      "id": "pairing.budget-is-shared-across-routes",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.budget-is-per-pairing",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.ttl-poll-expired",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "pairing.ttl-exchange-expired",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.empty-first-page/projects",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.empty-first-page/conversations",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.no-bearer",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.unknown-bearer",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.bearer-not-accepted-in-query",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.scope-denied",
+      "result": "pass",
+      "detail": "a credential without chat:read"
+    },
+    {
+      "id": "reads.familiars",
+      "result": "pass",
+      "detail": "against a loopback fixture daemon, not the production daemon"
+    },
+    {
+      "id": "reads.familiars-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.projects-shape",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.projects-paging-partial-final-page",
+      "result": "pass",
+      "detail": "3 pages of at most 3 over 7 rows"
+    },
+    {
+      "id": "reads.cursor-replay-is-stable",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.cursor-current-echoes-the-token",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.cursor-survives-deletion",
+      "result": "pass",
+      "detail": "the token records a position in the ordering, not an index"
+    },
+    {
+      "id": "reads.projects-paging-exact-multiple",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.refuses.limit-zero",
+      "result": "pass",
+      "detail": "/projects?limit=0"
+    },
+    {
+      "id": "reads.refuses.limit-over-ceiling",
+      "result": "pass",
+      "detail": "/projects?limit=101"
+    },
+    {
+      "id": "reads.refuses.limit-leading-zero",
+      "result": "pass",
+      "detail": "/projects?limit=01"
+    },
+    {
+      "id": "reads.refuses.limit-exponent",
+      "result": "pass",
+      "detail": "/projects?limit=1e2"
+    },
+    {
+      "id": "reads.refuses.limit-signed",
+      "result": "pass",
+      "detail": "/projects?limit=%2B5"
+    },
+    {
+      "id": "reads.refuses.limit-repeated",
+      "result": "pass",
+      "detail": "/projects?limit=1&limit=2"
+    },
+    {
+      "id": "reads.refuses.unsupported-parameter",
+      "result": "pass",
+      "detail": "/projects?limt=5"
+    },
+    {
+      "id": "reads.refuses.offset",
+      "result": "pass",
+      "detail": "/projects?offset=1"
+    },
+    {
+      "id": "reads.refuses.cursor-outside-alphabet",
+      "result": "pass",
+      "detail": "/projects?cursor=not*base64url"
+    },
+    {
+      "id": "reads.refuses.cursor-not-canonical",
+      "result": "pass",
+      "detail": "/projects?cursor=eyJ2IjoxfQ=="
+    },
+    {
+      "id": "reads.limit-ceiling-is-served",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.default-page-size",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-shape",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-refuses-limit",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-refuses-cursor",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversation-by-id-not-found",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.conversations-touch-unserved-row-is-still-served",
+      "result": "pass",
+      "detail": "touched the unserved conversation-01; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-touch-served-row-is-not-repeated",
+      "result": "pass",
+      "detail": "touched the already-served conversation-06; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-touch-cursor-row-keeps-the-position",
+      "result": "pass",
+      "detail": "touched conversation-05, the row the cursor names; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-row-created-mid-walk-is-not-served",
+      "result": "pass",
+      "detail": "a row created above the cursor is left for the next read from the top"
+    },
+    {
+      "id": "reads.conversations-row-deleted-mid-walk-does-not-strand",
+      "result": "pass",
+      "detail": "deleted the unserved conversation-04; the whole walk served [conversation-06,conversation-05,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-tied-sort-key-breaks-on-id",
+      "result": "pass",
+      "detail": "conversation-04 and conversation-03 share 2026-03-04T00:00:00.000Z"
+    },
+    {
+      "id": "reads.conversations-without-created-at-are-served-last",
+      "result": "pass",
+      "detail": "an optional page key is only safe if the rows that lack it are served, not stranded"
+    },
+    {
+      "id": "reads.conversations-keyless-row-written-mid-walk-is-still-served",
+      "result": "pass",
+      "detail": "wrote a turn to the unserved conversation-keyless-written; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01,conversation-keyless-written,conversation-keyless-quiet]"
+    },
+    {
+      "id": "reads.conversations-keyless-rows-tie-on-the-id-tiebreak",
+      "result": "pass",
+      "detail": "two rows with no createdAt share the sentinel, so only the id makes their order total"
+    },
+    {
+      "id": "reads.conversations-keyless-row-keyed-between-walks-moves-once",
+      "result": "pass",
+      "detail": "conversation-keyless-written acquired 2026-03-05T12:00:00.000Z between two walks and the next walk placed it"
+    },
+    {
+      "id": "reads.conversations-unreadable-row-keeps-its-position-mid-walk",
+      "result": "pass",
+      "detail": "conversation-flaky became unreadable mid-walk; the whole walk served [conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-flaky,conversation-01]"
+    },
+    {
+      "id": "reads.conversations-recovering-row-keeps-its-position-mid-walk",
+      "result": "pass",
+      "detail": "conversation-recovering became readable again mid-walk; the whole walk served [conversation-recovering,conversation-06,conversation-05,conversation-04,conversation-03,conversation-02,conversation-01]"
+    },
+    {
+      "id": "reads.messages-active-branch",
+      "result": "pass",
+      "detail": "the abandoned branch turn b-x1 must be absent"
+    },
+    {
+      "id": "reads.messages-values",
+      "result": "pass",
+      "detail": "text, role, parentId, createdAt and both counts, field by field against the fixture"
+    },
+    {
+      "id": "reads.messages-paging",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-counts-not-contents",
+      "result": "pass",
+      "detail": "b-a1 carries two tool calls and one attachment; the counts must say so and the contents must not appear"
+    },
+    {
+      "id": "reads.messages-reconcile-required",
+      "result": "pass",
+      "detail": "activeLeafId moved to the abandoned branch, so the cursor names a turn that is no longer on it"
+    },
+    {
+      "id": "reads.messages-restart-after-reconcile",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-not-found",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "reads.messages-canonical-conversation-id",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.bearer-works-before",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.admin-listing",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.revoke",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.bearer-refused-after",
+      "result": "pass",
+      "detail": "all five canonical reads"
+    },
+    {
+      "id": "revocation.is-idempotent",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.unknown-credential",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "revocation.tombstone-persists",
+      "result": "pass",
+      "detail": ""
+    },
+    {
+      "id": "harness.assertion-coverage",
+      "result": "pass",
+      "detail": "every declared assertion recorded exactly once (--include-ttl true)"
+    }
+  ]
+}

--- a/docs/workflows/chat-v1-phase-2-canonical-reads-gate.md
+++ b/docs/workflows/chat-v1-phase-2-canonical-reads-gate.md
@@ -1,0 +1,268 @@
+# Chat v1 Phase 2 gate — canonical reads verified
+
+Gate issue: [#4839](https://github.com/OpenCoven/coven-cave/issues/4839) · bead `cave-8ywi2`
+(mirrored as [#4906](https://github.com/OpenCoven/coven-cave/issues/4906)) · executed as
+`cave-ma00l`.
+
+A phase gate closes on verified evidence, not on code. This is that evidence, and the
+verdict it supports.
+
+---
+
+## Verdict
+
+**The gate does not pass. The Cave lane does.**
+
+The criterion that fails is *"All Phase 2 beads are closed"*. Three of the gate's five
+blockers are open, and two of those are in repositories this one does not own. Nothing in
+Cave can close them, and no amount of Cave evidence substitutes for them: the gate's own
+framing is *canonical reads across Cave, SDK and Chat*, and a third of that is what has
+been proven.
+
+What **is** proven, to a standard worth stating plainly: the Cave canonical read surface
+does what it claims. Five routes, real-authority conformance over a socket against a
+release build, and — the part that is new here — a mutation matrix showing the tests that
+guard it fail when the behaviour they name is broken. Forty-three mutations, thirty-six
+caught on the first pass, seven survivors, all seven since closed. No mutation found a
+defect in the shipped code; the seven survivors were all cases where correct code was
+guarded by nothing.
+
+The honest summary is therefore: **Cave's half is gate-quality. The gate is not closeable
+from here.**
+
+---
+
+## Acceptance criteria → evidence
+
+The gate's criteria are the three on the bead card (#4906) plus its five blocking beads.
+
+### 1. All Phase 2 beads are closed — ❌ **FAILS**
+
+| Bead | Issue | Owner | State |
+| --- | --- | --- | --- |
+| `cave-mfcsz` | [#4834](https://github.com/OpenCoven/coven-cave/issues/4834) Cave canonical read projections and routes | Cave | **CLOSED** — shipped in #4856, referenced in #4850 |
+| `cave-g9d49` | [#4835](https://github.com/OpenCoven/coven-cave/issues/4835) Coven Rust session and event read APIs | Coven | **CLOSED** — `OpenCoven/coven#783`, squash-merged `83443a55` |
+| `cave-3yax4` | [#4836](https://github.com/OpenCoven/coven-cave/issues/4836) SDK read clients, pagination, CLI output | SDK | **OPEN** |
+| `cave-ff3j6` | [#4837](https://github.com/OpenCoven/coven-cave/issues/4837) Chat shell, filters, search, canonical transcript | Chat | **OPEN** |
+| `cave-hjy2f` | [#4838](https://github.com/OpenCoven/coven-cave/issues/4838) Real-authority canonical read conformance | Cross-repo | **OPEN** — Cave third recorded, SDK and Chat thirds outstanding |
+
+The blocking prerequisite [#4841](https://github.com/OpenCoven/coven-cave/issues/4841) —
+the proxy pre-authorizing thirteen client-v1 paths with no handler behind them — is
+**CLOSED**, and `CLIENT_V1_AUTHENTICATED_PATHS` (`src/proxy-helpers.ts:322-328`) now lists
+exactly the five paths that have a `route.ts` calling `requireScope`.
+
+`#4838` staying open is deliberate rather than an oversight, and the reasoning on that
+issue is right: its Work section says *"across Cave, SDK, and Chat"*, and closing it on a
+third would overclaim two repositories' worth of work.
+
+`#4834`'s stated purpose was to make an advertisement true — `CLIENT_V1_CAPABILITIES` was
+already publishing `familiars`, `projects`, `conversations`, `conversation-messages` and
+`cursors` before any of them had a handler. It now lists exactly eight capabilities
+(`contract.ts:48-57`), every one of them served, and the conformance run's
+`health.live-inventory` compares the live inventory — order included — against the
+generated `contract-fixture.json`, so the advertisement and the surface cannot drift apart
+silently. #4882 made that check operational rather than declarative.
+
+### 2. No second conversation database or browser canonical storage exists — ⚠️ **holds for the canonical read surface; one adjacent surface is not covered by it**
+
+See *Second-store audit* below.
+
+### 3. Real Cave and Coven read journeys pass — ✅ **for Cave**, ⚠️ **Coven by proxy only**
+
+Cave: `scripts/client-v1-conformance.mjs` against a release build over a real socket —
+**105 assertions, 105 passed, 0 failed, 0 skipped**, with `--include-ttl`. Recorded at
+`docs/client-v1-conformance-results/2026-08-23-v0.3.9-win32-cave-ma00l.json`.
+
+Coven: the daemon read APIs are closed on their own lane (`OpenCoven/coven#783`), but this
+run does not drive the production daemon — `/familiars` is served from a loopback fixture
+daemon in hub mode, which is the first entry in the record's own `notCovered` list. So
+"real Coven read journeys pass" rests on that repository's evidence, not on this one's.
+
+---
+
+## The conformance run
+
+Taken per `docs/workflows/client-v1-conformance.md` on a clean tree, at commit
+`87ebf7802`, against `pnpm build` output — never a dev server, and never the operator's
+real `~/.coven` (the harness mints a temp `COVEN_HOME`/`COVEN_CAVE_HOME` under the system
+temp dir, binds ephemeral loopback ports, and tears the tree and the server down by PID).
+
+```
+client-v1-conformance: passed (105 passed, 0 failed, 0 skipped)
+client-v1-conformance: evidence written to docs/client-v1-conformance-results/2026-08-23-v0.3.9-win32-cave-ma00l.json
+```
+
+The assertion count moved 104 → 105 against the previous record
+(`2026-08-23-v0.3.9-win32-cave-wbxcu.json`); `harness.assertion-coverage` requires every
+declared id to be recorded exactly once, so the movement is an addition and not a drop.
+
+Two things in that run are worth naming here because they answer questions the unit suites
+leave open:
+
+- **`reads.messages-reconcile-required`** actually moves `activeLeafId` to the abandoned
+  branch between requests and then follows the client's cursor, rather than hand-minting a
+  cursor against a static transcript. `reads.messages-restart-after-reconcile` then proves
+  the recovery path. The unit-level test only pins the 409's *shape*.
+- **Twelve mid-walk cases** on `/conversations` — touch-unserved, touch-served,
+  touch-the-cursor-row, created-mid-walk, deleted-mid-walk, tied sort key, keyless rows,
+  a keyless row written mid-walk, a keyless row that acquires a key between walks, and a
+  row that becomes unreadable and then readable again. This is the surface where
+  `cave-fhjlu` (a silent skip under a mutable `updatedAt` page key) was found, and it is
+  now the most heavily exercised part of the read surface.
+
+The record's `notCovered` is unchanged from the previous two and is the honest boundary of
+this evidence: the SDK and Chat halves of #4838, the production Coven daemon, a genuinely
+remote peer, the write scopes (there are no write routes to enforce them against), the
+OAuth/consent UI, and cross-process pairing state.
+
+---
+
+## Mutation matrix
+
+A gate that only checks *"is there a test mentioning this?"* is the failure mode this
+repository has hit repeatedly — most sharply on this very surface, where the conformance
+harness's `checkRecordShape` compared key sets and never values and so passed 89/0 against
+a server returning `cat ~/.ssh/id_ed25519` as a field value. So every criterion below was
+checked by breaking the behaviour and requiring the test to fail.
+
+Forty-three mutations across `pagination.ts`, `reads.ts`, `read-guard.ts` and the five
+route modules. Two no-op controls were included and correctly survived, so a `CAUGHT`
+verdict is not the harness failing everything.
+
+### Caught on the first pass (36)
+
+| # | Mutation | Caught by |
+| --- | --- | --- |
+| M1 | `hasMore` always true | pagination · conversations |
+| M2 | over-fetch removed (`limit+1` → `limit`) | pagination · conversations |
+| M3 | keyset resume inclusive (`> 0` → `>= 0`), repeating the cursor row | pagination · conversations |
+| M4 | non-canonical cursor encoding accepted | pagination |
+| M5 | cursor version unchecked | pagination |
+| M6 | `limit` ceiling lifted | pagination · conversations |
+| M7 | `limit` spelling parsed with `Number` (`1e2`, `" 10"`) | pagination |
+| M8 | comparator coercion removed (restores the cyclic order) | pagination |
+| M9 | unresolvable sequence cursor restarts at 0 instead of refusing | pagination · messages |
+| M10 | `assertMintableKey` disabled | pagination |
+| M11 | recency tiebreak dropped | pagination · reads · conversations |
+| M12 | conversation page key back to `updatedAt` (the `cave-fhjlu` bug) | reads · conversations |
+| M13 | project page key to `updatedAt` | reads · projects |
+| M14 | message projection leaks `tools` and `reasoning` | reads · messages |
+| M15 | `requiredText` permissive | reads |
+| M16 | `requiredRole` permissive | reads |
+| M17 | transcript sequence ignores the active branch | reads · messages |
+| M18 | `requiredId` allows the empty string | reads |
+| M19 | familiars sorted descending | reads · familiars |
+| M20 | unsupported query parameter accepted | read-guard |
+| M21 | repeated query parameter accepted | read-guard |
+| M22 | single-record route ignores query parameters | read-guard · conversation detail |
+| M23 | bearer accepted from a bare `Authorization` header | read-guard |
+| M24 | auth failure not metered against a bucket | read-guard |
+| M25 | conversations route drops the scope check | conversations · authenticated-route-refusal |
+| M26 | conversations route drops the loopback check | conversations · authenticated-route-refusal |
+| B1 | cursor length ceiling lowered by 200 | pagination |
+| B2 | spurious `next` on a full final continuation page | conversations |
+| B8 | `runtime`'s path duplicated into `origin` | reads |
+| B9 | `invalid_request` `details` emptied | read-guard |
+| B10 | messages route ignores the `limit` ceiling | messages |
+| C1b | cursor length ceiling raised by 200 | pagination |
+| C3 | messages route lets a store throw escape | messages |
+| C5 | familiars route swallows a bad query | familiars |
+| C6 | conversations route swallows a bad query | conversations |
+| C7 | conversation detail route swallows a bad query | conversation detail |
+
+### Survived — every one a test gap, none a code defect (7)
+
+The shipped code is correct in all seven. What was missing was the evidence.
+
+| # | Mutation | Why nothing caught it |
+| --- | --- | --- |
+| B3 | **projects route swallows a malformed query** and serves the default page instead of a 400 | The route had no query-refusal test at all. Every other list route had one. The shared `parseClientV1ReadPage` is thoroughly unit-tested — but "the helper refuses" is not the claim "this route calls the helper". |
+| B4 | **messages route swallows a malformed query** | Same shape. This is the one canonical read whose page cost scales with how much was said, so an unenforced ceiling matters most here. |
+| B5 | **projects route lets an unprojectable row or a throwing store escape** as a non-envelope Next error page | The conversations list route had both tests; projects had neither. |
+| B6 | **familiars route** — same | The roster is an unschema'd daemon HTTP response, so a renamed field reaching the projection is ordinary, not exotic. |
+| C2 | **conversation detail route** — same | |
+| B7 | **`factory.length` undercounts dependencies behind a default parameter** | `authenticated-route-refusal.test.ts` derives its tripwire count from `factory.length`, which stops counting at the first defaulted parameter. Giving a route's `sources` a default installs **zero** tripwires, hands the route its real production sources, and makes every *"nothing was consulted before the credential settled"* assertion pass against an empty list. The mechanism silently becomes a no-op. |
+| C1 | **cursor length ceiling refuses a token exactly at the budget** | The budget-boundary case encoded a 120-character sort key and asserted only `<= 512`. That token is ~180 characters, so the test's own comment — *"the budget boundary itself is admissible, not merely one below it"* — was a claim it did not make. Moving the check to `cursorCharacters - 200` left it green. |
+
+B7 and C1 are the `cave-gbqwe` class the brief names: state is seeded, the interesting
+boundary is set up, and then something trivial is asserted. C1 is the clearer of the two —
+a comment asserting a property the code below it does not test.
+
+### After repair
+
+All seven, re-measured against the repaired suites: **caught**. Two additional mutations
+in the same neighbourhood (`C1b`, the ceiling raised rather than lowered; `B2`, a spurious
+`next` on a full final continuation page, previously caught only incidentally at the
+conversations route and not by the primitive itself) are now caught at the unit layer too.
+A no-op control still survives.
+
+No source file was modified. `git diff` for the repair commit touches six `*.test.ts`
+files and nothing else — which is the strongest single statement this gate can make about
+the surface: forty-three attempts to break it found nothing to fix.
+
+---
+
+## Weak assertions found but not repaired
+
+Named here rather than fixed, because each is already backed by a stronger assertion
+elsewhere and rewriting them would be churn:
+
+- `reads.test.ts:60` — `deepEqual(Object.keys(projected).sort(), [...])` checks the key
+  set and never a value. Masked by the full-object `deepEqual` at `:38`.
+- `familiars/route.test.ts:220` — `assert.notEqual(body.error.details, undefined)` checks
+  that a field is *defined*, never its value; a route answering `details: {}` passes.
+  Masked by `read-guard.test.ts:143`, which asserts the reason names the offending
+  parameter. The new projects and messages refusal tests assert the value directly.
+- `authenticated-route-refusal.test.ts:246` — `assertRefused` asserts set membership
+  (status ∈ {401, 403} **and** code ∈ {`unauthorized`, `scope_denied`}), so a route
+  answering 403/`scope_denied` to a request carrying no `Authorization` header at all
+  would pass. The pairing is not pinned per-probe.
+- `authenticated-route-refusal.test.ts:536-548` — the positive control passes when the
+  outcome is `threw` or "not a response". It proves *not a refusal*, not *reached the
+  handler body*. Documented as intentional in the file.
+- Four of the five conversations walk tests discard `walk.statuses` entirely.
+- `scripts/client-v1-conformance.mjs` — `familiar`, `credential`, `pairingRequest` and
+  `pairingStatus` records go through `checkRecordShape` (keys) with no `checkRecordValues`
+  call. `project`, `conversation` and `message` records get both. That is the residue of
+  the 89/0 defect, narrowed but not eliminated.
+- `scripts/client-v1-doc-contract.test.mjs` pins routes, operations, scopes, capabilities
+  and the error-code→status table against real code and the generated fixture — but **not**
+  the doc's projection field lists. `docs/api/client-v1.md`'s withheld-field prose and the
+  harness's hand-maintained `RECORD_SHAPES` table can drift apart with nothing failing.
+
+---
+
+## Second-store audit
+
+Criterion 2 asks that no second conversation database and no browser canonical storage
+exists. For the surface this gate is about, it holds:
+
+- The five client-v1 read routes take their stores through one injectable seam
+  (`src/lib/server/client-v1/read-sources.ts`) bound to `cave-conversations.ts`,
+  `cave-projects.ts` and the familiar roster. There is no second read path.
+- `src/lib/search-index-store.ts` is a SQLite/FTS5 index and is **derivative by
+  construction** — its own header states every row is rebuildable from an authoritative
+  source, which is why a corrupt database is quarantined and recreated rather than
+  repaired. It is not a second canonical store.
+
+One adjacent surface is outside that guarantee and is recorded here so the gate is not
+read as covering it: **group chat transcripts live only in the browser**.
+`src/lib/group-chat.ts:16` defines `cave:group-chat:transcript:<groupId>` and
+`saveTranscript`/`loadTranscript` (`:1055-1096`) are `localStorage` wrappers with a
+`TRANSCRIPT_CAP` that silently discards the oldest turns. That content is not in
+`<caveHome>/conversations/`, is not served by any client-v1 route, and is not reachable by
+any canonical read. Whether group chat is in scope for Chat v1 is a program question, not
+a Cave one — but if it is, criterion 2 is not satisfied by this gate's evidence.
+
+---
+
+## What would close the gate
+
+1. `cave-3yax4` (#4836) — SDK read clients. Note that the account working this program is
+   pull-only on `OpenCoven/sdk`, so it needs a fork PR.
+2. `cave-ff3j6` (#4837) — the Chat shell.
+3. `cave-hjy2f` (#4838) — the SDK and Chat halves of real-authority conformance. The Cave
+   half is recorded and the harness is reusable as a model; what it cannot do is drive
+   another repository's client.
+
+Cave-side, nothing is outstanding for this gate.

--- a/docs/workflows/chat-v1-phase-2-canonical-reads-gate.md
+++ b/docs/workflows/chat-v1-phase-2-canonical-reads-gate.md
@@ -63,7 +63,7 @@ already publishing `familiars`, `projects`, `conversations`, `conversation-messa
 generated `contract-fixture.json`, so the advertisement and the surface cannot drift apart
 silently. #4882 made that check operational rather than declarative.
 
-### 2. No second conversation database or browser canonical storage exists — ⚠️ **holds for the canonical read surface; one adjacent surface is not covered by it**
+### 2. No second conversation database or browser canonical storage exists — ✅ **for this surface**, ⚠️ **one adjacent surface keeps structure the server does not**
 
 See *Second-store audit* below.
 
@@ -235,24 +235,57 @@ elsewhere and rewriting them would be churn:
 ## Second-store audit
 
 Criterion 2 asks that no second conversation database and no browser canonical storage
-exists. For the surface this gate is about, it holds:
+exists.
+
+### No second conversation database — holds
 
 - The five client-v1 read routes take their stores through one injectable seam
   (`src/lib/server/client-v1/read-sources.ts`) bound to `cave-conversations.ts`,
-  `cave-projects.ts` and the familiar roster. There is no second read path.
-- `src/lib/search-index-store.ts` is a SQLite/FTS5 index and is **derivative by
-  construction** — its own header states every row is rebuildable from an authoritative
-  source, which is why a corrupt database is quarantined and recreated rather than
-  repaired. It is not a second canonical store.
+  `cave-projects.ts` and the familiar roster. There is no second read path, and the route
+  modules import nothing else.
+- `src/lib/search-index-store.ts` (SQLite/FTS5) is **derivative by construction** — its
+  header states every row is rebuildable from an authoritative source, which is why a
+  corrupt database is quarantined and recreated rather than repaired. Two facts beyond the
+  comment: the sessions provider indexes metadata only, never turn text
+  (`search-indexed-providers.ts:238-245`), and `openSearchIndex` has no production caller
+  at all today (`/api/search` passes `providers: []`).
+- `~/.coven/coven.sqlite3`, the Coven daemon's own database, is foreign, opened
+  `readOnly: true`, and deliberately excluded from backup as disposable
+  (`backup-manifest.ts:96-99`).
+- `~/.openclaw/agents/<familiarId>/sessions/<sessionId>.jsonl` is a genuine second on-disk
+  transcript store, but it belongs to the harness: Cave only reads it, only as a fallback
+  when the ledger has no record, and only from `/api/chat/conversation/:id`. **It is not
+  reachable from any client-v1 route** — `/api/client/v1/conversations/:id` reads the
+  ledger on purpose, because `status` and `exitCode` are derived while the ledger is built.
 
-One adjacent surface is outside that guarantee and is recorded here so the gate is not
-read as covering it: **group chat transcripts live only in the browser**.
-`src/lib/group-chat.ts:16` defines `cave:group-chat:transcript:<groupId>` and
-`saveTranscript`/`loadTranscript` (`:1055-1096`) are `localStorage` wrappers with a
-`TRANSCRIPT_CAP` that silently discards the oldest turns. That content is not in
-`<caveHome>/conversations/`, is not served by any client-v1 route, and is not reachable by
-any canonical read. Whether group chat is in scope for Chat v1 is a program question, not
-a Cave one — but if it is, criterion 2 is not satisfied by this gate's evidence.
+### No browser canonical storage — holds for this surface and for 1:1 chat; group chat is a partial exception
+
+The Cache API is explicitly out (`public/sw.js` returns early for any `/api/` path and
+its header names chat sessions as not cached), and IndexedDB holds only images.
+
+**Group chat is the exception, and it is narrower than it first looks.** Every settled
+coven reply — and the user's prompt — is POSTed to `/api/chat/send` with the coven's
+per-familiar `sessionId` (`group-chat-view.tsx:810-819`), and that route writes an
+ordinary conversation file per familiar into `<caveHome>/conversations/`. So the *text* is
+on disk and is served by the canonical reads like any other conversation.
+
+What is browser-only, in `cave:group-chat:groups:v1` and
+`cave:group-chat:transcript:<groupId>` (`group-chat.ts:16`), is the **structure**: the
+coven's identity and membership, speaking order, response mode, the map linking a coven to
+its per-familiar conversation ids, and the transcript's assembly — which reply answers
+which turn, delegation lineage, per-reply status and cost — plus the user's text as typed
+rather than as wrapped in the roster framing, and anything past `TRANSCRIPT_CAP = 200`.
+There is no `/api/coven` route to persist any of it.
+
+Clearing that key does not lose the replies; it loses the ability to read them *as a
+group*, leaving N orphaned 1:1 conversations. That is an index loss rather than a content
+loss — but it is not covered by backup either, and `backup-manifest.ts:110-112` describes
+what browser state it omits as *"localStorage preferences"*, which is not what a coven
+definition is.
+
+So: criterion 2 holds for the canonical read surface this gate is about. Whether group
+chat's structure counts as "browser canonical storage" for Chat v1 is a program question,
+and it is recorded here rather than decided.
 
 ---
 

--- a/src/app/api/client/v1/authenticated-route-refusal.test.ts
+++ b/src/app/api/client/v1/authenticated-route-refusal.test.ts
@@ -356,12 +356,72 @@ function handlerFactories(module: RouteModule, probe: string, file: string): [st
   return factories;
 }
 
+/**
+ * The parameter list a factory declares, as source text.
+ *
+ * `Function.prototype.toString` returns the definition verbatim. Under Node's
+ * type stripper the annotations are blanked to whitespace rather than removed,
+ * so a default value's `=` and a rest parameter's `...` both survive while a
+ * type's punctuation does not.
+ */
+function parameterSource(factory: Function): string {
+  const source = Function.prototype.toString.call(factory);
+  const open = source.indexOf("(");
+  if (open < 0) return "";
+  let depth = 0;
+  for (let index = open; index < source.length; index += 1) {
+    if (source[index] === "(") depth += 1;
+    else if (source[index] === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(open + 1, index);
+    }
+  }
+  return "";
+}
+
+/**
+ * Refuse a factory whose `length` cannot be trusted as a dependency count.
+ *
+ * `builtHandlers` derives the number of tripwires to install from
+ * `factory.length`, and `Function.length` counts only the parameters BEFORE the
+ * first one with a default value or a rest parameter. So a route that gave its
+ * data dependency a default —
+ * `(clientV1: ClientV1Runtime, sources: ClientV1ReadSources = clientV1ReadSources())`
+ * — reports `length === 1`, gets ZERO tripwires, and every
+ * `assertNothingConsulted` in this file then passes trivially against an empty
+ * array. The route would also be handed its REAL production sources instead of
+ * the instrumented ones, so the whole second layer silently stops testing
+ * anything.
+ *
+ * Measured: applying exactly that default to
+ * `createClientV1ConversationsGetHandler` left this file green.
+ *
+ * This is the "seeded mechanism that degrades to a no-op" shape, so it fails
+ * closed and names the remedy rather than being detected by whatever downstream
+ * assertion happens to notice.
+ */
+function assertTrustworthyArity(factory: Function, name: string, probe: string): void {
+  const parameters = parameterSource(factory);
+  assert.equal(
+    /[^=!<>]=[^=>]/.test(parameters) || parameters.includes("..."),
+    false,
+    `${probe}: ${name} declares a default or rest parameter, so Function.length undercounts its`
+      + ` dependencies and this file would install no tripwires for them — every`
+      + ` "nothing was consulted before the credential settled" assertion below would then pass`
+      + ` against an empty list, and the factory would be handed its real production sources.`
+      + `\nDeclare every dependency as a plain required parameter and let the HTTP export supply`
+      + ` the production binding, as createClientV1FamiliarsGetHandler does in ${REFERENCE_ROUTE}.`
+      + `\nDeclared parameters: ${parameters.replace(/\s+/g, " ").trim()}`,
+  );
+}
+
 function builtHandlers(
   factory: Function,
   name: string,
   runtime: ClientV1Runtime,
   probe: string,
 ): { handlers: [string, Handler][]; deps: { touched: string[] }[] } {
+  assertTrustworthyArity(factory, name, probe);
   const deps = Array.from({ length: Math.max(0, factory.length - 1) }, (_unused, index) =>
     tripwire(`${name}#dep${index + 1}`),
   );

--- a/src/app/api/client/v1/conversations/[id]/messages/route.test.ts
+++ b/src/app/api/client/v1/conversations/[id]/messages/route.test.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 import type { ChatTurn, ConversationFile } from "@/lib/cave-conversations.ts";
+import { CLIENT_V1_LIMITS } from "@/lib/server/client-v1/contract.ts";
 import { encodeClientV1Cursor } from "@/lib/server/client-v1/pagination.ts";
 import type { ClientV1ReadSources } from "@/lib/server/client-v1/read-sources.ts";
 import { createClientV1Runtime, type ClientV1Runtime } from "@/lib/server/client-v1/runtime.ts";
@@ -201,6 +202,71 @@ test("an empty transcript is an empty page with no cursor", async () => {
     const body = await response.json() as { cursor?: unknown; data: { messages: unknown[] } };
     assert.deepEqual(body.data.messages, []);
     assert.equal("cursor" in body, false);
+  });
+});
+
+test("the route refuses a query it does not serve instead of guessing a page", async () => {
+  // This route had no refusal test of its own, so replacing its `catch` with a
+  // silent fallback to the default page survived the whole suite — the shared
+  // helper's unit coverage says the helper refuses, not that this route calls
+  // it. The ceiling matters most here: a transcript is the one canonical read
+  // whose page cost scales with how much was said.
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationMessagesGetHandler(runtime, sources());
+    const authorization = `Bearer ${bearer}`;
+    for (const query of [
+      `?limit=${CLIENT_V1_LIMITS.maxPageSize + 1}`,
+      "?limit=0",
+      "?limit=1e2",
+      "?cursor=not%2Ba%2Bcursor",
+      "?offset=10",
+      "?limit=2&limit=3",
+    ]) {
+      const response = await handler(
+        request("conversation-1", { authorization }, query),
+        context("conversation-1"),
+      );
+      assert.equal(response.status, 400, query);
+      const body = await response.json() as {
+        error: { code: string; retryable: boolean; details?: { reason?: unknown } };
+      };
+      assert.equal(body.error.code, "invalid_request", query);
+      assert.equal(body.error.retryable, false, query);
+      assert.equal(typeof body.error.details?.reason, "string", query);
+    }
+    // The ceiling itself is served, and the transcript is shorter than it, so
+    // the whole active branch comes back on one page.
+    const atCeiling = await handler(
+      request("conversation-1", { authorization }, `?limit=${CLIENT_V1_LIMITS.maxPageSize}`),
+      context("conversation-1"),
+    );
+    assert.equal(atCeiling.status, 200);
+    const body = await atCeiling.json() as { data: { messages: { id: string }[] } };
+    assert.deepEqual(body.data.messages.map((row) => row.id), ["t1", "t3", "t4"]);
+  });
+});
+
+test("a query is refused before the transcript is read", async () => {
+  // The refusal above must not be reachable only after the file has been
+  // opened: a malformed `limit` is a client bug, and answering it should cost
+  // no disk read at all.
+  let reads = 0;
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationMessagesGetHandler(
+      runtime,
+      sources({
+        loadConversation: async () => {
+          reads += 1;
+          return BRANCHED;
+        },
+      }),
+    );
+    const response = await handler(
+      request("conversation-1", { authorization: `Bearer ${bearer}` }, "?offset=10"),
+      context("conversation-1"),
+    );
+    assert.equal(response.status, 400);
+    assert.equal(reads, 0);
   });
 });
 

--- a/src/app/api/client/v1/conversations/[id]/route.test.ts
+++ b/src/app/api/client/v1/conversations/[id]/route.test.ts
@@ -131,6 +131,64 @@ test("an id no conversation carries is not_found, whatever shape it has", async 
   });
 });
 
+test("an unprojectable ledger row answers an envelope, not a Next error page", async () => {
+  // The list route had this test and the detail route did not, so removing
+  // this route's guard left the whole suite green. A transcript that PARSES
+  // but carries no `updatedAt` does not take listConversations' fallback row —
+  // that substitution is keyed on a parse failure — so the field reaches the
+  // projection as `undefined` and is refused there. Uncaught, Next answers
+  // with its own error body on a surface whose contract is that every response
+  // is an envelope.
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationGetHandler(
+      runtime,
+      sources({
+        listConversations: async () => [
+          { sessionId: "conversation-broken", familiarId: "scribe" } as ConversationSummary,
+        ],
+      }),
+    );
+    const response = await handler(
+      request("conversation-broken", { authorization: `Bearer ${bearer}` }),
+      context("conversation-broken"),
+    );
+    assert.equal(response.status, 500);
+    const body = await response.json() as {
+      apiVersion: string;
+      error: { code: string; message: string; retryable: boolean; details?: unknown };
+    };
+    assert.equal(body.error.code, "internal_error");
+    // Not `not_found`: the row exists and the client asked for it by its real
+    // id. Answering `not_found` would tell a client the conversation is gone.
+    assert.equal(body.error.retryable, false);
+    assert.equal(body.apiVersion, "1.0");
+    assert.equal(body.error.details, undefined);
+    assert.equal(body.error.message.includes("updatedAt"), false);
+  });
+});
+
+test("a ledger read that throws answers an envelope too", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ConversationGetHandler(
+      runtime,
+      sources({
+        listConversations: async () => {
+          throw new Error("EACCES: permission denied, scandir '/home/me/.coven/cave/conversations'");
+        },
+      }),
+    );
+    const response = await handler(
+      request("conversation-1", { authorization: `Bearer ${bearer}` }),
+      context("conversation-1"),
+    );
+    assert.equal(response.status, 500);
+    const body = await response.json() as { error: { code: string; message: string } };
+    assert.equal(body.error.code, "internal_error");
+    // The path the store named must not reach the wire.
+    assert.equal(body.error.message.includes("/home/me"), false);
+  });
+});
+
 test("the detail route serves no page parameters at all", async () => {
   // A single record has nothing to page, so `limit` and `cursor` are as
   // meaningless here as `offset` — and answering a request that carries one as

--- a/src/app/api/client/v1/familiars/route.test.ts
+++ b/src/app/api/client/v1/familiars/route.test.ts
@@ -138,6 +138,67 @@ test("an unreadable roster is service_unavailable, never a credential problem", 
   }
 });
 
+test("an unprojectable roster entry answers an envelope, not a Next error page", async () => {
+  // The roster is a daemon HTTP response with no schema in front of it, so a
+  // renamed or retyped field reaches projectClientV1Familiar and is refused
+  // there. Uncaught, that refusal escapes the handler and Next answers with
+  // its own error body — not a Client v1 envelope. The route's guard was
+  // covered by nothing until now: removing it left this suite green.
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1FamiliarsGetHandler(
+      runtime,
+      sources({
+        listFamiliars: async () => ({
+          ok: true,
+          config: {} as never,
+          target: {} as never,
+          roster: [
+            ...roster("adept"),
+            // The daemon renamed `display_name`; the entry parses and the field
+            // is simply absent.
+            { id: "mote", role: "Familiar" } as VisibleFamiliarRosterEntry,
+          ],
+        }),
+      }),
+    );
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 500);
+    const body = await response.json() as {
+      apiVersion: string;
+      error: { code: string; message: string; retryable: boolean; details?: unknown };
+    };
+    assert.equal(body.error.code, "internal_error");
+    // Not `service_unavailable`: the daemon answered, and retrying will produce
+    // the same record. The operator has to repair it.
+    assert.equal(body.error.retryable, false);
+    assert.equal(body.apiVersion, "1.0");
+    assert.equal(body.error.details, undefined);
+    assert.equal(body.error.message.includes("display_name"), false);
+  });
+});
+
+test("a roster read that throws answers an envelope too", async () => {
+  // `loadVisibleFamiliarRoster` returns its failure rather than throwing, but
+  // the config load beneath it does not, so the guard has to cover the read as
+  // well as the projection over it.
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1FamiliarsGetHandler(
+      runtime,
+      sources({
+        listFamiliars: async () => {
+          throw new Error("EACCES: permission denied, open '/home/me/.coven/familiars.toml'");
+        },
+      }),
+    );
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 500);
+    const body = await response.json() as { error: { code: string; message: string } };
+    assert.equal(body.error.code, "internal_error");
+    // The path the store named must not reach the wire.
+    assert.equal(body.error.message.includes("/home/me"), false);
+  });
+});
+
 test("an empty roster is an empty page with no cursor rather than a 404", async () => {
   await withRuntime(["chat:read"], async (runtime, bearer) => {
     const handler = createClientV1FamiliarsGetHandler(

--- a/src/app/api/client/v1/projects/route.test.ts
+++ b/src/app/api/client/v1/projects/route.test.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 import type { CaveProject } from "@/lib/cave-projects-types.ts";
+import { CLIENT_V1_LIMITS } from "@/lib/server/client-v1/contract.ts";
 import { encodeClientV1Cursor } from "@/lib/server/client-v1/pagination.ts";
 import type { ClientV1ReadSources } from "@/lib/server/client-v1/read-sources.ts";
 import { createClientV1Runtime, type ClientV1Runtime } from "@/lib/server/client-v1/runtime.ts";
@@ -171,6 +172,98 @@ test("an empty continuation page still echoes the cursor the client sent", async
     assert.equal(body.cursor.hasMore, false);
     assert.equal(body.cursor.next, undefined);
     assert.equal(body.cursor.current, exhausted);
+  });
+});
+
+test("the route refuses a query it does not serve instead of guessing a page", async () => {
+  // Every other list route on this surface had this test and this one did not,
+  // so the whole refusal path was unguarded HERE while the shared helper it
+  // delegates to stayed green: replacing this route's `catch` with a silent
+  // fallback to the default page survived the entire suite. A shared helper
+  // being covered is not the same claim as this route calling it.
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ProjectsGetHandler(runtime, sources());
+    const authorization = `Bearer ${bearer}`;
+    for (const query of [
+      `?limit=${CLIENT_V1_LIMITS.maxPageSize + 1}`,
+      "?limit=0",
+      "?limit=1e2",
+      "?cursor=not%2Ba%2Bcursor",
+      "?offset=10",
+      "?limit=2&limit=3",
+    ]) {
+      const response = await handler(request(query, { authorization }));
+      assert.equal(response.status, 400, query);
+      const body = await response.json() as {
+        error: { code: string; retryable: boolean; details?: { reason?: unknown } };
+      };
+      assert.equal(body.error.code, "invalid_request", query);
+      assert.equal(body.error.retryable, false, query);
+      // The reason is asserted as a VALUE, not merely as a defined field: a
+      // route answering `details: {}` tells a client author nothing about
+      // which parameter was wrong, and `notEqual(details, undefined)` would
+      // pass for it.
+      assert.equal(typeof body.error.details?.reason, "string", query);
+      assert.ok((body.error.details!.reason as string).length > 0, query);
+    }
+    // The ceiling itself is served rather than refused — the refusals above
+    // are a boundary, not a blanket.
+    const atCeiling = await handler(
+      request(`?limit=${CLIENT_V1_LIMITS.maxPageSize}`, { authorization }),
+    );
+    assert.equal(atCeiling.status, 200);
+    const body = await atCeiling.json() as { data: { projects: { id: string }[] } };
+    assert.deepEqual(body.data.projects.map((row) => row.id), ["delta", "bravo", "alpha"]);
+  });
+});
+
+test("an unprojectable registry row answers an envelope, not a Next error page", async () => {
+  // `loadProjects` returns whatever `projects.json` parsed to, so a
+  // hand-edited row missing `createdAt` reaches the projection as `undefined`
+  // and is refused there. Uncaught, that refusal escapes the handler and Next
+  // answers with its own error body — not a Client v1 envelope, on a surface
+  // whose whole contract is that every response is one.
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ProjectsGetHandler(
+      runtime,
+      sources({
+        listProjects: async () => [
+          ...REGISTRY,
+          { id: "broken", name: "Broken", root: "/Users/me/code/broken" } as CaveProject,
+        ],
+      }),
+    );
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 500);
+    const body = await response.json() as {
+      apiVersion: string;
+      error: { code: string; message: string; retryable: boolean; details?: unknown };
+    };
+    assert.equal(body.error.code, "internal_error");
+    assert.equal(body.error.retryable, false);
+    assert.equal(body.apiVersion, "1.0");
+    assert.equal(body.error.details, undefined);
+    // The refusal names no field of a stored record.
+    assert.equal(body.error.message.includes("createdAt"), false);
+  });
+});
+
+test("a registry read that throws answers an envelope too", async () => {
+  await withRuntime(["chat:read"], async (runtime, bearer) => {
+    const handler = createClientV1ProjectsGetHandler(
+      runtime,
+      sources({
+        listProjects: async () => {
+          throw new Error("EACCES: permission denied, open '/home/me/.coven/cave/projects.json'");
+        },
+      }),
+    );
+    const response = await handler(request("", { authorization: `Bearer ${bearer}` }));
+    assert.equal(response.status, 500);
+    const body = await response.json() as { error: { code: string; message: string } };
+    assert.equal(body.error.code, "internal_error");
+    // The path the store named must not reach the wire.
+    assert.equal(body.error.message.includes("/home/me"), false);
   });
 });
 

--- a/src/lib/server/client-v1/pagination.test.ts
+++ b/src/lib/server/client-v1/pagination.test.ts
@@ -120,12 +120,66 @@ test("cursor decoding refuses everything that is not a cursor this Cave minted",
     assert.throws(() => decodeClientV1Cursor(candidate), /cursor/i, label);
   }
   // The budget boundary itself is admissible, not merely one below it.
-  assert.doesNotThrow(() => {
-    const key = { sort: "s".repeat(120), id: "i" };
-    const encoded = encodeClientV1Cursor(key);
-    assert.ok(encoded.length <= CLIENT_V1_LIMITS.cursorCharacters);
-    decodeClientV1Cursor(encoded);
-  });
+  //
+  // This used to encode a 120-character sort key and assert only that the token
+  // came out `<= cursorCharacters`. That token is around 180 characters — it
+  // never reaches the ceiling, so the sentence above was a claim the test did
+  // not make, and the ceiling could be wrong by hundreds of characters with
+  // nothing failing. Measured: moving the check to
+  // `cursorCharacters - 200` left this case green. So the key is now grown
+  // until the encoded token sits EXACTLY on the budget, and one character more
+  // is required to be refused — which is what makes `>` rather than `>=` the
+  // tested comparison.
+  let sortLength = 1;
+  let encoded = encodeClientV1Cursor({ sort: "s".repeat(sortLength), id: "i" });
+  while (encoded.length < CLIENT_V1_LIMITS.cursorCharacters && sortLength < 2000) {
+    sortLength += 1;
+    encoded = encodeClientV1Cursor({ sort: "s".repeat(sortLength), id: "i" });
+  }
+  // base64url of a 3-byte-aligned payload lands on the ceiling exactly; if the
+  // arithmetic ever stops working out the loop above overshoots and this fails
+  // loudly rather than testing a token below the boundary again.
+  assert.equal(
+    encoded.length,
+    CLIENT_V1_LIMITS.cursorCharacters,
+    "no key encodes to a token exactly on the cursor budget",
+  );
+  assert.deepEqual(decodeClientV1Cursor(encoded), { sort: "s".repeat(sortLength), id: "i" });
+  // One character past the budget is refused, so the boundary is a boundary
+  // rather than a suggestion.
+  assert.throws(
+    () => decodeClientV1Cursor(`${encoded}A`),
+    /exceeds 512 characters/,
+  );
+});
+
+test("a full continuation page that is also the last page publishes no next", () => {
+  // The over-fetch is the ONLY evidence for `hasMore`, and this is the case
+  // where a page is full and the set is nonetheless exhausted. Getting it wrong
+  // hands the client a `next` that leads to an empty page — which terminates,
+  // so a walk-to-exhaustion test cannot see it, and every route-level walk here
+  // is one. Only asserting `hasMore`/`next` on the boundary page catches it.
+  const first = page(2, null);
+  const second = page(2, decodeClientV1Cursor(first.cursor!.next!));
+  assert.deepEqual(second.items.map((row) => row.id), ["c", "b"]);
+  assert.equal(second.cursor!.hasMore, true);
+  // The set holds five rows, so the third page is exactly one short of full and
+  // must not publish a token. The exact-multiple case is the fourth page below.
+  const third = page(2, decodeClientV1Cursor(second.cursor!.next!));
+  assert.deepEqual(third.items.map((row) => row.id), ["a"]);
+  assert.equal(third.cursor!.hasMore, false);
+  assert.equal(third.cursor!.next, undefined);
+
+  // Now the exact multiple: a limit that divides the remaining set evenly, so
+  // the final page comes back FULL. `hasMore` must still be false.
+  const firstOfFour = page(4, null);
+  assert.equal(firstOfFour.items.length, 4);
+  assert.equal(firstOfFour.cursor!.hasMore, true);
+  const finalFull = page(1, decodeClientV1Cursor(firstOfFour.cursor!.next!));
+  assert.deepEqual(finalFull.items.map((row) => row.id), ["a"]);
+  assert.equal(finalFull.items.length, 1, "the final page is exactly full at this limit");
+  assert.equal(finalFull.cursor!.hasMore, false);
+  assert.equal(finalFull.cursor!.next, undefined);
 });
 
 test("page limit defaults to the contract page size and is bounded by its ceiling", () => {


### PR DESCRIPTION
Refs #4839 - **this gate does NOT pass.** Deliberately not `Closes`: the failing criterion is 'all Phase 2 beads are closed', and it is not a Cave criterion. cave-3yax4 (#4836, SDK), cave-ff3j6 (#4837, Chat) and cave-hjy2f (#4838, cross-repo) are open. Cave's half does pass. The issue stays open until the other repositories land. This PR lands the Cave-side evidence and repairs the seven gaps the gate found.

Executes bead `cave-ma00l`. #4839's own bead (`cave-8ywi2`) lives in the macOS
tracker store and does not resolve here; the parent record is untouched.
Full record: `docs/workflows/chat-v1-phase-2-canonical-reads-gate.md`.

## Verdict: the gate does NOT pass. Cave's half does.

The criterion that fails is *"all Phase 2 beads are closed"*, and it is not a
Cave criterion.

| Bead | Issue | Owner | State, measured 2026-08-23 |
|---|---|---|---|
| `cave-mfcsz` | #4834 | Cave | **Closed** — routes shipped in #4856, referenced in #4850 |
| `cave-g9d49` | #4835 | Coven | **Closed** — `OpenCoven/coven#783`, squash-merged `83443a55` |
| `cave-3yax4` | #4836 | SDK | **Open.** This account is pull-only on `OpenCoven/sdk`; needs a fork PR |
| `cave-ff3j6` | #4837 | Chat | **Open** |
| `cave-hjy2f` | #4838 | Cross-repo | **Open** — Cave third recorded, SDK and Chat thirds outstanding |

Its blocking prerequisite #4841 is closed, and `CLIENT_V1_AUTHENTICATED_PATHS`
now lists exactly the five paths that have a `route.ts` calling `requireScope`.

Reporting green would have been the cheaper answer and the wrong one. Two of the
five blockers are in repositories this one does not own; no Cave evidence closes
them.

## What the gate measured

A gate asks whether the tests **could have failed**. Forty-three mutations were
applied to shipped canonical-read behaviour and run against every suite that
plausibly covered them.

**36 caught. 7 survived. Zero code defects.**

That second number is the finding worth reading, and the third is the one worth
believing: not one of the forty-three found a bug. Every survivor was correct
behaviour that nothing proved. The diff is six `*.test.ts` files and no source
file at all.

Two no-op controls were included and correctly survived throughout, so a
`CAUGHT` verdict is not the harness failing everything.

### The seven survivors

**Five are the same shape, and it is a shape worth naming: a shared helper being
covered is not the claim that a route calls it.**

| Mutation | Result |
|---|---|
| `/projects` swallows a malformed query and serves the default page instead of a 400 | **SURVIVED** |
| `/conversations/:id/messages` — the same | **SURVIVED** |
| `/projects` lets an unprojectable row or a throwing store escape as a non-envelope Next error page | **SURVIVED** |
| `/familiars` — the same | **SURVIVED** |
| `/conversations/:id` — the same | **SURVIVED** |

`parseClientV1ReadPage` and `clientV1ReadFailure` are thoroughly unit-tested, and
the conversations *list* route had both a query-refusal test and both envelope
tests. Four sibling routes had neither, so their own `catch` blocks could be
deleted with every suite still green. The messages route is the one that matters
most: it is the single canonical read whose page cost scales with how much was
said, so an unenforced ceiling there is unbounded.

**Two are the "seeds the interesting case, asserts something trivial" class** —
the same shape as `cave-gbqwe`:

- **The cursor budget boundary.** The test encoded a 120-character sort key and
  asserted only `<= 512`. That token is around 180 characters, so the comment
  directly above it — *"the budget boundary itself is admissible, not merely one
  below it"* — was a claim the test did not make. Moving the ceiling to
  `cursorCharacters - 200` left it green. The key is now grown until the token
  sits **exactly** on the budget, and one character past it is required to be
  refused, which is what makes `>` rather than `>=` the tested comparison.

- **`factory.length` undercounts dependencies behind a default parameter.**
  `authenticated-route-refusal.test.ts` — the file that exists specifically to be
  behavioural rather than a source regex — derives its tripwire count from
  `factory.length`, which stops counting at the first defaulted parameter. Giving
  a route's `sources` a default installs **zero** tripwires, hands the route its
  real production sources instead of the instrumented ones, and makes every
  *"nothing was consulted before the credential settled"* assertion pass against
  an empty list. Applying that default to the conversations factory left the file
  green. It now fails closed and names the remedy.

All seven are re-measured as caught. Two neighbouring mutations are now caught at
the unit layer as well: the cursor ceiling *raised* rather than lowered, and a
spurious `next` on a continuation page that is both full and final — which no
walk-to-exhaustion test can see, because the extra page comes back empty and the
walk stops anyway, and every route-level walk on this surface is one.

## Conformance

Taken per `docs/workflows/client-v1-conformance.md` on a clean tree at
`87ebf7802`, against `pnpm build` output over a real socket — temp
`COVEN_HOME`/`COVEN_CAVE_HOME`, ephemeral loopback ports, server torn down by PID,
never the operator's real `~/.coven`.

```
client-v1-conformance: passed (105 passed, 0 failed, 0 skipped)
```

Recorded at `docs/client-v1-conformance-results/2026-08-23-v0.3.9-win32-cave-ma00l.json`.
104 to 105 against the previous record; `harness.assertion-coverage` requires every
declared id exactly once, so that is an addition, not a drop.

Two legs in that run answer questions the unit suites leave open, and the gate
doc says so rather than double-counting them: `reads.messages-reconcile-required`
actually moves `activeLeafId` between requests instead of hand-minting a cursor
against a static transcript, and twelve mid-walk cases exercise the surface where
`cave-fhjlu` was found.

## Weak assertions found and deliberately not repaired

Recorded in the gate doc rather than churned, each because a stronger assertion
already backs it: a key-set-only projection check, a `notEqual(details, undefined)`
that a route answering `details: {}` would pass, `assertRefused`'s set-membership
pairing of status and code, and the positive control that proves *not a refusal*
rather than *reached the handler*. Two are structural and worth someone's
attention later:

- `checkRecordShape` still compares keys only. The 89/0 defect is fixed by a
  second helper (`checkRecordValues`) rather than by changing it, and that helper
  is called for `project`, `conversation` and `message` records but **not** for
  `familiar`, `credential`, `pairingRequest` or `pairingStatus`. Narrowed, not
  eliminated.
- `client-v1-doc-contract.test.mjs` pins routes, operations, scopes, capabilities
  and the error-code to HTTP-status table against real code — but not the doc's
  projection field lists. `docs/api/client-v1.md`'s withheld-field prose and the
  harness's hand-maintained `RECORD_SHAPES` can drift apart with nothing failing.

## One boundary named rather than left implied

Criterion 2 is *"no second conversation database or browser canonical storage
exists"*. It holds for this surface. Three near misses are named in the gate doc
rather than left unmentioned, because the claim is stronger with them listed: the
FTS5 index (derivative by construction, metadata-only, and with no production
caller at all today), the Coven daemon's own sqlite (foreign, `readOnly: true`,
backup-excluded), and the openclaw `.jsonl` transcripts — a real second on-disk
transcript store, owned by the harness, read-only to Cave, and reachable only
from `/api/chat/conversation/:id`, never from client-v1.

**Group chat is a partial exception, and my first draft got it wrong** — the
correction is its own commit. Every settled coven reply is POSTed to
`/api/chat/send` with the coven's per-familiar `sessionId`, so the reply text and
the user's prompt *are* written to `<caveHome>/conversations/` and *are* served by
the canonical reads. What is browser-only is the **structure**: the coven's
identity and membership, speaking order, the map linking a coven to its
per-familiar conversation ids, and the transcript's assembly (which reply answers
which turn, delegation lineage, per-reply status and cost), plus anything past
`TRANSCRIPT_CAP = 200`. There is no `/api/coven` route to persist any of it, and
clearing the key leaves N orphaned 1:1 conversations rather than nothing. An index
loss, not a content loss — recorded here rather than decided.

## Gates

`pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` (1837 wired) and
`pnpm build` all pass. No source file changed, so the app-suite file count is
unchanged from `main` at **1301** — the ten new cases live inside existing files.

