### PR TITLE
Pin the cache-expiry semantics X hydration depends on (cave-gbqwe)

### DIFF
--- a/src/lib/server/research-mission-x-hydration.test.ts
+++ b/src/lib/server/research-mission-x-hydration.test.ts
@@ -72,6 +72,7 @@ const {
 } = await import("./research-mission-x-runtime.ts");
 const {
   cacheNormalizedXPosts,
+  getCachedXPost,
   listSavedXSources,
   setXSourceMissionAttached,
   upsertSavedXSource,
@@ -386,6 +387,147 @@ test("a mission with no attached X sources touches neither X nor the network, an
   });
 
   assert.deepEqual(hydration.files, []);
+  assert.deepEqual(await runtimeFiles(mission.id), []);
+});
+
+// ---------------------------------------------------------------------------
+// Cache expiry — the boundary every test above reads through blindly
+// ---------------------------------------------------------------------------
+// cave-gbqwe. This suite could not see its own fuse. Every test above seeds
+// through `cacheLivePost`, which anchors to the real clock, so none of them can
+// tell a 24h TTL from an infinite one: mutating `x-sources` to never expire a
+// cache entry ran against this file at 27 passed / 0 failed. That is why the
+// original bomb (cave-p36ov) was invisible from inside its own suite for a
+// whole day — the file exercises hydration heavily and expiry not at all, even
+// though hydration's answer for every attached post turns on it.
+//
+// The dependency is real and unavoidable: `hydrateMissionXSources` resolves a
+// post through `deps.getCachedXPost`, whose production wiring is
+// `(postId) => sources.getCachedXPost(postId)` — one argument, so the clock is
+// `new Date()` and freshness is decided by comparing the stored `expiresAt`
+// against it. An entry that never dies means hydration never re-fetches; an
+// entry that dies too early means it always does. Neither is visible above.
+//
+// These are the only instants in this file read back through the same instants
+// they were written with, and that is deliberate rather than an exception to
+// `cacheLivePost`'s rule. The relationship asserted below holds BETWEEN two
+// fixtures and never consults the wall clock, so these tests behave identically
+// today, tomorrow, and a decade after any date written here — they pin the
+// boundary without re-arming what #4942 defused.
+const CACHED_AT = new Date("2026-05-01T00:00:00.000Z");
+/** One millisecond short of the TTL: the last instant the entry is still served. */
+const LAST_LIVE_AT = new Date("2026-05-01T23:59:59.999Z");
+/** Exactly one TTL after `CACHED_AT`. An entry is dead AT this instant, not after it. */
+const EXPIRES_AT = new Date("2026-05-02T00:00:00.000Z");
+/** One millisecond past the TTL. */
+const EXPIRED_AT = new Date("2026-05-02T00:00:00.001Z");
+
+test("a cached post is served through its TTL and gone at the expiry instant", async () => {
+  await cacheNormalizedXPosts([post("9001"), post("9002")], CACHED_AT);
+
+  // The lifetime the entry itself claims. Asserted against instants spelled out
+  // here rather than against the module's TTL constant, so shortening or
+  // lengthening that constant breaks this test instead of moving with it.
+  const entry = JSON.parse(await readFile(path.join(cacheDir, "9001.json"), "utf8")) as {
+    fetchedAt: string;
+    expiresAt: string;
+  };
+  assert.equal(entry.fetchedAt, CACHED_AT.toISOString(), "the entry is stamped when it is cached");
+  assert.equal(entry.expiresAt, EXPIRES_AT.toISOString(), "and lives exactly 24h from that stamp");
+
+  const stillLive = await getCachedXPost("9001", LAST_LIVE_AT);
+  assert.equal(
+    stillLive?.text,
+    POST_TEXT,
+    "an entry one millisecond short of its TTL is still served from cache",
+  );
+  assert.ok(
+    (await readdir(cacheDir)).includes("9001.json"),
+    "and reading a live entry must not evict it",
+  );
+
+  assert.equal(
+    await getCachedXPost("9001", EXPIRES_AT),
+    null,
+    "an entry is dead AT its expiry instant, not a millisecond later",
+  );
+  await assert.rejects(
+    () => readFile(path.join(cacheDir, "9001.json"), "utf8"),
+    /ENOENT/,
+    "an expired entry is dropped from disk rather than left for the next reader",
+  );
+
+  assert.equal(
+    await getCachedXPost("9002", EXPIRED_AT),
+    null,
+    "an entry past its expiry is not served either",
+  );
+});
+
+test("hydration serves an attached post from cache while its entry is inside the TTL", async () => {
+  const mission = await makeMission();
+  await attachSource("nova", mission.id, "9003");
+  await cacheNormalizedXPosts([post("9003")], CACHED_AT);
+
+  // Production wires `getCachedXPost: (postId) => sources.getCachedXPost(postId)`,
+  // which reads the wall clock. This override is that same call with the
+  // instant named — the only way to drive the boundary hydration depends on
+  // without waiting a day for the calendar to do it.
+  const hydration = await hydrateMissionXSources(mission, {
+    getCachedXPost: (postId) => getCachedXPost(postId, LAST_LIVE_AT),
+  });
+
+  // The default responder throws, so any upstream attempt would fail the call
+  // outright; the count says which side of the boundary answered.
+  assert.equal(upstreamCalls, 0, "a live entry satisfies hydration without asking X");
+  assert.deepEqual(hydration.files.map((file) => file.postId), ["9003"]);
+  assert.deepEqual(await runtimeFiles(mission.id), ["x-post-9003.md"]);
+});
+
+test("hydration treats an attached post past its cache TTL as a miss and re-fetches it", async () => {
+  const stale = "the stale body that must never reach the run";
+  const mission = await makeMission();
+  await attachSource("nova", mission.id, "9004");
+  await cacheNormalizedXPosts([post("9004", stale)], CACHED_AT);
+  respond = async () => lookupResponse("9004");
+
+  const hydration = await hydrateMissionXSources(mission, {
+    getCachedXPost: (postId) => getCachedXPost(postId, EXPIRED_AT),
+  });
+
+  assert.equal(upstreamCalls, 1, "an entry past its expiry cannot answer for the post");
+  const written = await readFile(path.join(runtimeDir(mission.id), "x-post-9004.md"), "utf8");
+  assert.ok(written.includes(POST_TEXT), "the iteration reads the re-fetched post");
+  assert.ok(!written.includes(stale), "an expired entry's body never reaches the iteration");
+  assert.deepEqual(hydration.unavailable, []);
+});
+
+test("an expired cache entry whose refetch fails stops the launch instead of serving stale text", async () => {
+  // The exact shape of the incident, induced deliberately rather than by the
+  // calendar: the seeded entry dies, hydration therefore has to ask X, and X
+  // refuses. An immortal cache turns this failure back into a silent success —
+  // which is what "a failure path resolving instead of failing closed" looked
+  // like from the outside when the real clock crossed the TTL.
+  const mission = await makeMission();
+  await attachSource("nova", mission.id, "9005");
+  await cacheNormalizedXPosts([post("9005")], CACHED_AT);
+  respond = async () => errorResponse(429);
+
+  const error = await hydrateMissionXSources(mission, {
+    getCachedXPost: (postId) => getCachedXPost(postId, EXPIRED_AT),
+  }).then(
+    () => null,
+    (thrown: unknown) => thrown,
+  );
+
+  assert.ok(
+    error instanceof ResearchMissionXHydrationError,
+    "an expired entry is a cache MISS, so the launch fails closed",
+  );
+  assert.equal(
+    (error as InstanceType<typeof ResearchMissionXHydrationError>).code,
+    "rate-limited",
+  );
   assert.deepEqual(await runtimeFiles(mission.id), []);
 });
 


### PR DESCRIPTION
Closes the measured coverage blind spot in `cave-gbqwe`.

## The gap, reproduced first

`src/lib/server/research-mission-x-hydration.test.ts` seeds a TTL-bearing cache and asserts nothing about expiry. Before this change, mutating `x-sources.ts` so a cache entry never expires — dropping the expiry check in `loadLiveCacheEntryUnlocked` — left the suite at **27 passed / 0 failed**. The suite exercises hydration heavily and expiry not at all, which is exactly why the cave-p36ov bomb was invisible from inside its own suite for a day: PR #4867's own CI passed at 09:30Z and the byte-identical code failed at 12:04Z.

#4942 fixed the *shape* (every seed now anchors to the real clock via `cacheLivePost`). It did not make the boundary assertable, and the file has a fixture field literally named `expiresAt`, so any text-matching check would credit it with pinning expiry when the mutation evidence says the opposite.

The dependency is real: `hydrateMissionXSources` resolves every attached post through `deps.getCachedXPost`, whose production wiring is `(postId) => sources.getCachedXPost(postId)` — one argument, so the clock is `new Date()` and freshness is decided by comparing the stored `expiresAt` against it. An immortal cache means hydration never re-fetches; a short TTL means it always does. Neither was visible.

## What was added

Four tests, each asserting observable behaviour rather than a token:

1. **`a cached post is served through its TTL and gone at the expiry instant`** — the entry is served one millisecond short of the TTL, is dead **at** its expiry instant (not a millisecond later), and is dropped from disk when it dies. Reading a live entry must not evict it. The entry's own `fetchedAt` / `expiresAt` are pinned against instants spelled out in the test rather than against the module's TTL constant, so changing that constant breaks the test instead of moving with it.
2. **`hydration serves an attached post from cache while its entry is inside the TTL`** — 0 upstream calls, under a responder that throws on any request.
3. **`hydration treats an attached post past its cache TTL as a miss and re-fetches it`** — exactly one upstream call, and the expired body never reaches the iteration.
4. **`an expired cache entry whose refetch fails stops the launch instead of serving stale text`** — the exact shape of the incident ("a failure path resolving instead of failing closed"), induced by a controlled instant instead of by the calendar.

Tests 2-4 drive the boundary through an override that reproduces the production wiring with the instant named instead of taken from the wall clock — the only way to cross a 24h TTL without waiting a day for it.

## Frozen-write / live-read discipline

These are the only instants in the file read back through the same instants they were written with, and that is deliberate rather than an exception to `cacheLivePost`'s rule: the relationship asserted holds **between two fixtures** and never consults the wall clock.

Verified rather than asserted — shifting every fixture instant to **2036** and to **2016** both gave 31/31. The suite's fixture instants are already 114 days in the past relative to today's run, and the file is green.

`pnpm check:test-clocks` is not on `main` yet (it lives on `fix/cave-wh97u-frozen-write-live-read`), so its script was run against this tree directly: `✓ no frozen-write / live-read time bombs (72 TTL-bearing helpers registered)`. A probe confirmed it is not vacuous here — replacing the explicit instant in test 2 with the live default makes it report `[mixed]` on that exact block.

## Mutation matrix

Every run is the full 31-test suite; baseline is 31 passed / 0 failed.

| # | Mutation (in `x-sources.ts` unless noted) | Result | Verdict | Caught by |
|---|---|---|---|---|
| M8a | never expire a cache entry (drop the expiry check) | 28/3 | **CAUGHT** | 1, 3, 4 |
| M8b | never expire a cache entry (`CACHE_TTL_MS` = 100 years) | 28/3 | **CAUGHT** | 1, 3, 4 |
| M1 | boundary off-by-one: expire strictly *after* `expiresAt`, not at it | 30/1 | **CAUGHT** | 1 only |
| M2 | evict on every read, live or not | 17/14 | **CAUGHT** | 1, 2 + 12 existing |
| M3 | expired entry is not served but is left on disk | 30/1 | **CAUGHT** | 1 only |
| M4 | TTL shortened to 1h | 29/2 | **CAUGHT** | 1, 2 |
| M7 | `getCachedXPost` ignores its `now` and reads the live clock | 29/2 | **CAUGHT** | 1, 2 |
| M5 | hydration never consults the cache (`research-mission-x-runtime.ts`) | 18/13 | **CAUGHT** | 2 + 12 existing |
| S1 | *control:* fixture instants shifted to 2036 | 31/0 | no wall-clock dependence | — |
| S2 | *control:* fixture instants shifted to 2016 | 31/0 | no wall-clock dependence | — |

M1 and M3 are the two that only the new boundary test sees, and M7 is the one that proves these tests exercise the clock they pass rather than its spelling — under it the explicit instants are silently discarded and the assertions fail. No mutant was equivalent; every one changed observable behaviour and every one was caught. The harness restored each file byte-for-byte and verified it.

## Gates

- `pnpm typecheck` — pass
- `pnpm lint` — pass (0 drift, eslint clean)
- `pnpm check:tests-wired` — `✓ all 1837 test files wired into CI`
- `pnpm build` — pass, within bundle and standalone budgets

No production source is touched; the diff is one test file, +142 lines.
