### PR TITLE
Polish the chat composer

### DIFF
--- a/scripts/design-system/token-reference-scan.mjs
+++ b/scripts/design-system/token-reference-scan.mjs
@@ -442,7 +442,7 @@ export const BANKED_UNDEFINED_NO_FALLBACK = new Map([
   ["--focus-ring", 2],
   // Scale steps that do not exist: the space scale is 1/2/3/4/5/6/8/10.
   ["--space-7", 8],
-  ["--space-9", 4],
+  ["--space-9", 3],
   // Shadow and motion vocabularies that were never defined here.
   ["--shadow-elevated", 1],
   ["--motion-fast", 13],

--- a/src/components/chat-composer-command-capsule.test.ts
+++ b/src/components/chat-composer-command-capsule.test.ts
@@ -9,6 +9,7 @@ const read = (relativePath: string) =>
 const source = read("./chat-view.tsx");
 const css = read("../styles/cave-composer.css");
 const transcriptCss = read("../styles/cave-chat/transcript.css");
+const activityCss = read("../styles/cave-chat/activity.css");
 
 assert.match(
   source,
@@ -41,18 +42,23 @@ assert.match(
   "the active access mode uses the design-system accent recipe",
 );
 assert.match(
-  transcriptCss,
-  /\.cave-chat-linear \.cave-composer-shell \{[\s\S]*?max-width:\s*var\(--cave-chat-measure\);/,
-  "the composer aligns to the same readable measure as the chat transcript",
+  activityCss,
+  /--cave-chat-measure:\s*64rem;[\s\S]*?--cave-composer-measure:\s*calc\(var\(--space-10\) \* 21\);/,
+  "the transcript keeps its wide reading measure while the composer uses a focused, text-scale-independent measure",
 );
 assert.match(
   transcriptCss,
-  /\.cave-chat-linear \.cave-composer-input \{[\s\S]*?min-height:\s*calc\(var\(--space-10\) \+ var\(--space-9\)\);/,
-  "Chat uses the compact 76px writing field derived from the spacing grid",
+  /\.cave-chat-linear \.cave-composer-shell \{[\s\S]*?max-width:\s*var\(--cave-composer-measure\);/,
+  "the composer uses its compact intent-entry measure",
 );
 assert.match(
   transcriptCss,
-  /\.cave-chat-linear \.cave-composer-send--busy[\s\S]*?width:\s*auto;[\s\S]*?padding-inline:\s*var\(--space-3\);/,
+  /\.cave-chat-linear \.cave-composer-input \{[\s\S]*?min-height:\s*calc\(var\(--space-10\) \+ var\(--space-4\)\);/,
+  "Chat uses a compact 56px writing field derived from the spacing grid",
+);
+assert.match(
+  transcriptCss,
+  /\.cave-chat-linear \.cave-composer-send--busy[\s\S]*?width:\s*auto;[\s\S]*?padding-inline:\s*var\(--space-2\);[\s\S]*?font-size:\s*var\(--text-xs\);/,
   "the stop action expands into a readable danger pill while streaming",
 );
 

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -235,8 +235,8 @@ assert.doesNotMatch(css, /\.cave-context-pill/, "the combined pill's CSS is reti
 // ── The reading measure stays on content while the composer uses the full dock
 assert.match(
   activityCss,
-  /\.cave-chat-linear \{[\s\S]*--cave-chat-measure:\s*64rem;/,
-  "chat activity should define the shared wide-column 64rem measure token",
+  /\.cave-chat-linear \{[\s\S]*--cave-chat-measure:\s*64rem;[\s\S]*--cave-composer-measure:\s*calc\(var\(--space-10\) \* 21\);/,
+  "chat activity should keep the 64rem reading column and define a narrower spacing-derived composer",
 );
 assert.match(
   activityCss,
@@ -250,8 +250,8 @@ assert.match(
 );
 assert.match(
   transcriptCss,
-  /\.cave-chat-linear \.cave-composer-shell \{[\s\S]*max-width:\s*100%;/,
-  "composer shell should use the full dock width",
+  /\.cave-chat-linear \.cave-composer-shell \{[\s\S]*max-width:\s*var\(--cave-composer-measure\);/,
+  "composer shell should use the focused intent-entry width",
 );
 
 // ── Footer action family + circular send ────────────────────────────────────

--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -141,8 +141,8 @@ assert.doesNotMatch(
 const linearComposerShell = /\.cave-chat-linear \.cave-composer-shell \{[^}]*\}/.exec(css)?.[0] ?? "";
 assert.match(
   linearComposerShell,
-  /max-width:\s*var\(--cave-chat-measure\)/,
-  "Linear composer shell should align with the readable chat column",
+  /max-width:\s*var\(--cave-composer-measure\)/,
+  "Linear composer shell should use the focused composer measure",
 );
 
 // ---------------------------------------------------------------------------

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -613,15 +613,12 @@ details[open] > .cave-tool-summary::before {
 /* Dense linear session view */
 .cave-chat-linear {
   position: relative; /* anchors .cave-drop-overlay */
-  /* Centered reading column (cave-xsq.1): the conversation + composer share one
-     comfortable measure and sit in a centered column — the ChatGPT reading
-     model — instead of spanning the full pane (reverses the 2026-06-18
-     full-width choice below). Chat-revamp 1b narrowed cave-973a's 64rem to
-     47.5rem; the 2026-07-21 wide-column pass widens it back to 64rem (1024px)
-     so long responses and diffs get room, with the suggestion row + composer
-     sharing the same measure. The header stays a full-bleed bar (its divider
-     spans the pane); only the reading/writing column is capped + centered. */
+  /* The transcript keeps a wide reading measure for code and long responses.
+     The composer is deliberately narrower: OpenCoven/ui treats intent entry as
+     a focused card rather than a window-wide command slab. Its cap uses the
+     spacing scale so accessibility text sizing does not widen the dock. */
   --cave-chat-measure: 64rem;
+  --cave-composer-measure: calc(var(--space-10) * 21);
   background:
     linear-gradient(to bottom, color-mix(in oklch, var(--bg-raised) 18%, transparent), transparent 150px),
     var(--bg-base);

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -548,30 +548,36 @@
 
 
 .cave-chat-linear .cave-composer-shell {
-  /* Match the chat's readable column instead of expanding into a window-wide
-     command slab. */
-  max-width: var(--cave-chat-measure);
+  max-width: var(--cave-composer-measure);
 }
 
 .cave-chat-linear .cave-composer-panel {
-  /* Slightly rounder than the base --radius-xl (1.4×), but still derived from
-     --radius so the Appearance → Corner radius setting applies: 18px at the
-     default 10px base, squarer at sharp, fuller at round. */
-  border-radius: calc(var(--radius) * 1.8);
-  border-color: color-mix(in oklch, var(--accent-presence) 36%, var(--border-strong));
+  border-radius: var(--radius-panel);
+  border-color: var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 92%, var(--bg-panel));
+  backdrop-filter: none;
   box-shadow:
-    0 0 0 1px color-mix(in oklch, var(--accent-presence) 16%, transparent),
-    0 16px 42px oklch(0 0 0 / 24%),
-    0 0 28px color-mix(in oklch, var(--accent-presence) 12%, transparent),
+    0 var(--space-4) var(--space-10) color-mix(in oklch, var(--bg-panel) 64%, transparent),
     inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
 }
 
+.cave-chat-linear .cave-composer-panel:focus-within {
+  border-color: color-mix(in oklch, var(--accent-presence) 48%, var(--border-strong));
+  box-shadow:
+    0 var(--space-4) var(--space-10) color-mix(in oklch, var(--bg-panel) 64%, transparent),
+    0 0 0 1px var(--ring-focus-soft);
+}
+
 .cave-chat-linear .cave-composer-input {
-  min-height: calc(var(--space-10) + var(--space-9));
+  min-height: calc(var(--space-10) + var(--space-4));
+}
+
+.cave-chat-linear .cave-composer-controls {
+  padding: 0 var(--space-2) var(--space-2);
 }
 
 .cave-chat-linear .cave-composer-footer-band {
-  border-radius: 0 0 calc(var(--radius) * 1.8) calc(var(--radius) * 1.8);
+  border-radius: 0 0 var(--radius-panel) var(--radius-panel);
 }
 
 /* The in-chat action chrome stays compact so the full-width writing surface
@@ -583,7 +589,7 @@
 }
 
 .cave-chat-linear .cave-composer-control-row {
-  min-height: var(--space-10);
+  min-height: calc(var(--space-8) + var(--space-1));
 }
 
 .cave-chat-linear .cave-composer-send {
@@ -615,9 +621,9 @@
 
 .cave-chat-linear .cave-composer-send--busy {
   width: auto;
-  padding-inline: var(--space-3);
+  padding-inline: var(--space-2);
   font-family: var(--font-mono);
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
   font-weight: 650;
   white-space: nowrap;
 }

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -138,8 +138,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  min-height: var(--space-8);
-  padding: 0 var(--space-4);
+  min-height: calc(var(--space-8) - var(--space-1));
+  padding: 0 var(--space-3);
   transform: translateY(-50%);
 }
 
@@ -148,8 +148,8 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
-  height: var(--space-8);
-  padding: 0 var(--space-3);
+  height: calc(var(--space-8) - var(--space-1));
+  padding: 0 var(--space-2);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-panel) 94%, var(--bg-base));
@@ -309,7 +309,7 @@
   justify-content: space-between;
   gap: var(--space-2);
   min-width: 0;
-  padding: 6px 10px;
+  padding: var(--space-1) var(--space-2);
   border-top: 1px solid var(--border-hairline);
   border-radius: 0 0 var(--radius-xl) var(--radius-xl);
   background: color-mix(in oklch, var(--bg-base) 62%, transparent);


### PR DESCRIPTION
## Summary
- constrain the chat composer to a focused, text-scale-independent writing measure while retaining the wider transcript
- reduce draft, action, edge-tab, footer, and streaming-stop chrome for a quieter OpenCoven UI hierarchy
- replace the accent glow with tokenized neutral elevation and preserve accent focus feedback
- update composer source contracts and lower the undefined-token ratchet after removing the final local `--space-9` use

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:app` (1,304 files)
- `pnpm test:api` (434 files)
- `pnpm check:tests-wired` (1,841 files)
- `pnpm build`
- Playwright production review at 1440px and 900px with a 21px accessibility text scale

Bead: `cave-9v9jr`