### PR TITLE
feat(ui): align Cave with OpenCoven reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,12 +177,14 @@ to describe current behavior. For deeper design context, start with
 [`docs/multi-session-coordination.md`](docs/multi-session-coordination.md).
 
 For interface direction explored outside this repository,
-[**OpenCoven UI**](https://ui.opencoven.ai) is a standalone, dependency-free
-browser of chat-surface specimens — composer, messages, context, and actions.
-It is an exploration workspace
-([`OpenCoven/ui`](https://github.com/OpenCoven/ui)), not a component library and
-not the canonical source for anything in `src/components/`; shipped Cave code
-and `docs/coven-design-language.md` remain authoritative.
+[**OpenCoven UI**](https://ui.opencoven.ai) is a self-contained,
+dependency-free component library and specimen lab for exploring agent-surface
+direction — composer, messages, context, actions, and run rails. Its
+[`OpenCoven/ui`](https://github.com/OpenCoven/ui) repository is a reference
+workspace, not an installable package, production application, or canonical
+source for Cave components; shipped code in `src/components/ui/`,
+`src/styles/globals/primitives.css`, and `docs/coven-design-language.md` remains
+authoritative.
 
 ### Local client access
 

--- a/docs/coven-design-language.md
+++ b/docs/coven-design-language.md
@@ -52,6 +52,26 @@ letting it drift.**
   `src/styles/globals/foundations.css`). Density is a feature; illegibility
   is a bug.
 
+### OpenCoven UI reference boundary
+
+[`OpenCoven/ui`](https://github.com/OpenCoven/ui#what-this-repository-is) is a
+self-contained, dependency-free component library and specimen lab used to
+explore agent-surface direction before it enters a production application. It
+is explicitly **not** a packaged npm library, production app, or canonical
+source for Coven Cave components. Cave's production authority remains this
+document plus `src/components/ui/` and
+`src/styles/globals/primitives.css`; reference ideas enter Cave only by being
+re-expressed through those contracts.
+
+| Decision | Boundary |
+|---|---|
+| **Adopt** | Semantic patterns that clarify the agent surface: composer control grammar; editorial message hierarchy; provenance-first context; direct-verb actions with visible consequences; run-rail/backstage hierarchy; responsive layout, visible focus, keyboard access, and reduced-motion behavior. |
+| **Adapt** | Rebuild an adopted pattern with Cave's existing `ui-*` primitives, Phosphor icon registry, interface-copy contract, and semantic tokens. Preserve the shipped 12-theme × 2-mode model (`data-theme` × `data-mode`), current behavior, and accessibility before changing presentation. |
+| **Reject** | Upstream raw colors, its `data-accent` / `data-density` theme model as a Cave replacement, direct HTML or package dependency, fixture copy, a parallel primitive system, or `bui-*` vocabulary on product surfaces. The Beautiful UI adapter remains confined to `src/components/ui/beautiful/`, `src/styles/beautiful-ui.css`, and its explicit `/aesthetic/beautiful` gallery. |
+
+This is convergence, not vendoring: OpenCoven UI supplies inspectable evidence
+and prompts; Cave owns production implementation and decides what ships.
+
 ## 2. Token contract (summary — authority is `src/styles/globals/foundations.css` + `/aesthetic`)
 
 ### Surfaces (dark defaults)
@@ -448,5 +468,6 @@ decisions; `docs/specs/` holds the frozen predecessors) ·
 `src/styles/globals/foundations.css` (the annotated token contract) ·
 `src/styles/globals/themes.css` (per-theme palettes) ·
 `src/styles/globals/primitives.css` (shared `.ui-*` classes) ·
-[ui.opencoven.ai](https://ui.opencoven.ai) (standalone chat-surface specimens —
-exploratory direction only, never authoritative over shipped code).*
+[ui.opencoven.ai](https://ui.opencoven.ai) (self-contained component library
+and specimen lab — reference direction only, never authoritative over shipped
+code).*

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -915,6 +915,7 @@ export const SUITES = {
     "src/components/thread-signals-section.test.ts",
     "src/lib/thread-signal-dismissals.test.ts",
     "src/components/chat-view.test.ts",
+    "src/components/chat-history-state.test.ts",
     "src/components/chat-error-redaction.test.ts",
     "src/components/chat-composer-rec-autofill.test.ts",
     "src/components/familiars-view-stats.test.ts",

--- a/scripts/ui-consistency.test.mjs
+++ b/scripts/ui-consistency.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -82,6 +82,22 @@ assert.match(
   /\*\*Couldn't load <object>\*\*/,
   "failure grammar names the failed object",
 );
+assert.match(
+  designLanguage,
+  exactHeadingPattern("### OpenCoven UI reference boundary"),
+  "design language defines the cross-repository reference boundary",
+);
+for (const decision of ["**Adopt**", "**Adapt**", "**Reject**"]) {
+  assert.ok(
+    designLanguage.includes(`| ${decision} |`),
+    `OpenCoven UI boundary records the ${decision.slice(2, -2).toLowerCase()} decision`,
+  );
+}
+assert.match(
+  designLanguage,
+  /Cave's production authority remains this\s+document plus `src\/components\/ui\/` and\s+`src\/styles\/globals\/primitives\.css`/,
+  "Cave code and design language remain production authority",
+);
 
 // ── fact pins: the design doc must match the shipped code ──────────────────
 // docs/coven-design-language.md quotes token values, palette counts, and file
@@ -90,11 +106,60 @@ assert.match(
 // carried a full palette's worth of stale values before cave-kf3x).
 
 const repoRoot = new URL("../", import.meta.url);
+const caveReadme = readFileSync(new URL("README.md", repoRoot), "utf8");
 const foundations = readFileSync(
   new URL("src/styles/globals/foundations.css", repoRoot),
   "utf8",
 );
 const agentsNotes = readFileSync(new URL("AGENTS.md", repoRoot), "utf8");
+
+assert.match(
+  caveReadme,
+  /self-contained,\s+dependency-free component library and specimen lab/,
+  "README describes OpenCoven UI's current role",
+);
+assert.match(
+  caveReadme,
+  /reference\s+workspace, not an installable package, production application, or canonical\s+source for Cave components/,
+  "README does not imply OpenCoven UI is an installable Cave dependency",
+);
+
+const allowedBeautifulUiPaths = [
+  "src/components/ui/beautiful/",
+  "src/app/aesthetic/beautiful/",
+];
+const allowedBeautifulUiFiles = new Set(["src/styles/beautiful-ui.css"]);
+const buiLeakage = [];
+const sourceRoot = fileURLToPath(new URL("src/", repoRoot));
+
+function collectSourceFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return collectSourceFiles(entryPath);
+    return /\.(?:css|js|jsx|mdx|mjs|ts|tsx)$/.test(entry.name) ? [entryPath] : [];
+  });
+}
+
+for (const filePath of collectSourceFiles(sourceRoot)) {
+  const relativePath = path.relative(fileURLToPath(repoRoot), filePath).split(path.sep).join("/");
+  if (
+    allowedBeautifulUiFiles.has(relativePath)
+    || allowedBeautifulUiPaths.some((allowedPath) => relativePath.startsWith(allowedPath))
+  ) {
+    continue;
+  }
+  const source = readFileSync(filePath, "utf8");
+  source.split("\n").forEach((line, index) => {
+    if (/\bbui-[a-z0-9-]+\b/.test(line)) {
+      buiLeakage.push(`${relativePath}:${index + 1}: ${line.trim()}`);
+    }
+  });
+}
+assert.deepEqual(
+  buiLeakage,
+  [],
+  "bui-* vocabulary stays inside the Beautiful UI adapter and explicit gallery",
+);
 
 /** First definition wins = the :root dark value. */
 function tokenValue(css, name) {

--- a/scripts/ui-consistency.test.mjs
+++ b/scripts/ui-consistency.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { existsSync, readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -129,32 +130,28 @@ const allowedBeautifulUiPaths = [
   "src/app/aesthetic/beautiful/",
 ];
 const allowedBeautifulUiFiles = new Set(["src/styles/beautiful-ui.css"]);
-const buiLeakage = [];
-const sourceRoot = fileURLToPath(new URL("src/", repoRoot));
-
-function collectSourceFiles(directory) {
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const entryPath = path.join(directory, entry.name);
-    if (entry.isDirectory()) return collectSourceFiles(entryPath);
-    return /\.(?:css|js|jsx|mdx|mjs|ts|tsx)$/.test(entry.name) ? [entryPath] : [];
-  });
+const buiMatches = spawnSync(
+  "git",
+  ["grep", "--untracked", "-n", "-I", "-E", "\\bbui-[a-z0-9-]+\\b", "--", "src"],
+  {
+    cwd: fileURLToPath(repoRoot),
+    encoding: "utf8",
+  },
+);
+if (buiMatches.status !== 0 && buiMatches.status !== 1) {
+  throw new Error(`git grep failed while checking bui-* isolation: ${buiMatches.stderr.trim()}`);
 }
-
-for (const filePath of collectSourceFiles(sourceRoot)) {
-  const relativePath = path.relative(fileURLToPath(repoRoot), filePath).split(path.sep).join("/");
-  if (
-    allowedBeautifulUiFiles.has(relativePath)
-    || allowedBeautifulUiPaths.some((allowedPath) => relativePath.startsWith(allowedPath))
-  ) {
-    continue;
-  }
-  const source = readFileSync(filePath, "utf8");
-  source.split("\n").forEach((line, index) => {
-    if (/\bbui-[a-z0-9-]+\b/.test(line)) {
-      buiLeakage.push(`${relativePath}:${index + 1}: ${line.trim()}`);
-    }
+const buiLeakage = buiMatches.stdout
+  .trim()
+  .split("\n")
+  .filter(Boolean)
+  .filter((match) => {
+    const relativePath = match.slice(0, match.indexOf(":"));
+    return (
+      !allowedBeautifulUiFiles.has(relativePath)
+      && !allowedBeautifulUiPaths.some((allowedPath) => relativePath.startsWith(allowedPath))
+    );
   });
-}
 assert.deepEqual(
   buiLeakage,
   [],

--- a/src/components/chat-history-state.test.ts
+++ b/src/components/chat-history-state.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+
+const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const historyNotice =
+  chatView.match(/function ChatHistoryNotice[\s\S]*?\n}\n\nfunction FlowSessionTranscriptFallback/)?.[0]
+  ?? "";
+assert.ok(historyNotice, "ChatHistoryNotice source block is extractable");
+
+test("chat history empty and failure states use semantic UI primitives", () => {
+  assert.match(
+    chatView,
+    /import \{ EmptyState \} from "@\/components\/ui\/empty-state"/,
+    "missing history uses the shared EmptyState",
+  );
+  assert.match(
+    chatView,
+    /import \{ ErrorState \} from "@\/components\/ui\/error-state"/,
+    "history request failure uses the shared ErrorState",
+  );
+  assert.match(
+    chatView,
+    /variant === "error" \? \([\s\S]*?<ErrorState[\s\S]*?className="mx-auto w-full max-w-sm"[\s\S]*?headline=\{title\}[\s\S]*?subtitle=\{body\}[\s\S]*?actions=\{actions\}/,
+    "the failure path keeps alert semantics through ErrorState",
+  );
+  assert.match(
+    chatView,
+    /<EmptyState[\s\S]*?className="mx-auto w-full max-w-sm"[\s\S]*?icon="ph:chats"[\s\S]*?headline=\{title\}[\s\S]*?subtitle=\{body\}[\s\S]*?actions=\{actions\}/,
+    "the unavailable-history path keeps status semantics through EmptyState",
+  );
+});
+
+test("chat history recovery uses direct verbs and shared buttons", () => {
+  assert.match(
+    chatView,
+    /import \{ Button \} from "@\/components\/ui\/button"/,
+    "history actions use the shared Button primitive",
+  );
+  assert.match(chatView, />\s*Back to chats\s*<\/Button>/, "back action names the user-facing destination");
+  assert.match(chatView, />\s*Retry\s*<\/Button>/, "retry action keeps the recovery verb");
+  assert.match(chatView, /title="Couldn't load chat history"/, "failure copy follows the state grammar");
+  assert.match(
+    chatView,
+    /This chat exists, but Coven Cave couldn't find a saved transcript yet\./,
+    "missing history uses the canonical brand and chat-first vocabulary",
+  );
+  assert.match(
+    chatView,
+    /You can still continue this chat\./,
+    "failure recovery keeps the user-facing chat noun",
+  );
+  assert.doesNotMatch(
+    historyNotice,
+    /cave-btn/,
+    "history states no longer carry a parallel button vocabulary",
+  );
+});

--- a/src/components/chat-history-state.test.ts
+++ b/src/components/chat-history-state.test.ts
@@ -1,11 +1,27 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { readFileSync } from "node:fs";
+import ts from "typescript";
 
 const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
-const historyNotice =
-  chatView.match(/function ChatHistoryNotice[\s\S]*?\n}\n\nfunction FlowSessionTranscriptFallback/)?.[0]
-  ?? "";
+const chatViewSource = ts.createSourceFile(
+  "chat-view.tsx",
+  chatView,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TSX,
+);
+const historyNoticeDeclaration = chatViewSource.statements.find(
+  (statement) =>
+    ts.isFunctionDeclaration(statement)
+    && statement.name?.text === "ChatHistoryNotice",
+);
+const historyNotice = historyNoticeDeclaration
+  ? chatView.slice(
+      historyNoticeDeclaration.getStart(chatViewSource),
+      historyNoticeDeclaration.getEnd(),
+    )
+  : "";
 assert.ok(historyNotice, "ChatHistoryNotice source block is extractable");
 
 test("chat history empty and failure states use semantic UI primitives", () => {

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -126,6 +126,8 @@ import {
 import { useCopy } from "@/lib/use-copy";
 import { parseHarnessFailure, parseHarnessAuthFailure, type HarnessAuthFailure } from "@/lib/harness-failure";
 import { HarnessFixActions } from "@/components/harness-fix-actions";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { useVisualViewport } from "@/lib/use-viewport";
@@ -1196,44 +1198,48 @@ function ChatHistorySkeleton() {
 }
 
 function ChatHistoryNotice({
+  variant,
   title,
   body,
   onRetry,
   onBack,
 }: {
+  variant: "empty" | "error";
   title: string;
   body: string;
   onRetry?: (() => void) | null;
   onBack?: (() => void) | null;
 }) {
-  return (
-    <div className="mx-auto flex max-w-sm flex-col items-center justify-center rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-6 py-7 text-center">
-      <Icon name="ph:chats" width={20} className="mb-3 text-[var(--text-muted)]" />
-      <p className="text-[length:var(--text-base)] font-semibold text-[var(--text-primary)]">{title}</p>
-      <p className="mt-1.5 max-w-[28ch] text-[length:var(--text-sm)] leading-[1.55] text-[var(--text-muted)]">{body}</p>
-      {(onRetry || onBack) && (
-        <div className="mt-4 flex gap-2">
-          {onBack && (
-            <button
-              type="button"
-              className="cave-btn cave-btn--ghost cave-btn--sm"
-              onClick={onBack}
-            >
-              Back to sessions
-            </button>
-          )}
-          {onRetry && (
-            <button
-              type="button"
-              className="cave-btn cave-btn--primary cave-btn--sm"
-              onClick={onRetry}
-            >
-              Retry
-            </button>
-          )}
-        </div>
-      )}
-    </div>
+  const actions = onRetry || onBack ? (
+    <>
+      {onBack ? (
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          Back to chats
+        </Button>
+      ) : null}
+      {onRetry ? (
+        <Button variant="primary" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+      ) : null}
+    </>
+  ) : undefined;
+
+  return variant === "error" ? (
+    <ErrorState
+      className="mx-auto w-full max-w-sm"
+      headline={title}
+      subtitle={body}
+      actions={actions}
+    />
+  ) : (
+    <EmptyState
+      className="mx-auto w-full max-w-sm"
+      icon="ph:chats"
+      headline={title}
+      subtitle={body}
+      actions={actions}
+    />
   );
 }
 
@@ -8126,17 +8132,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               />
             ) : historyState === "missing" ? (
               <ChatHistoryNotice
+                variant="empty"
                 title={flowBackedSession ? "Flow output unavailable" : "Chat history unavailable"}
                 body={flowBackedSession
-                  ? "This flow session exists, but CovenCave could not find saved chat history or flow output for it yet."
-                  : "This session exists, but CovenCave could not find a saved transcript for it yet."}
+                  ? "This flow run exists, but Coven Cave couldn't find saved chat history or output yet."
+                  : "This chat exists, but Coven Cave couldn't find a saved transcript yet."}
                 onRetry={retryHistory}
                 onBack={onBack ? () => onBack(sessionId) : undefined}
               />
             ) : historyState === "error" ? (
               <ChatHistoryNotice
-                title="Could not load chat history"
-                body="The transcript request failed. You can still continue this session."
+                variant="error"
+                title="Couldn't load chat history"
+                body="The transcript request failed. You can still continue this chat."
                 onRetry={retryHistory}
                 onBack={onBack ? () => onBack(sessionId) : undefined}
               />


### PR DESCRIPTION
## Summary
- define the `OpenCoven/ui` adopt/adapt/reject boundary while keeping Coven Cave tokens, primitives, accessibility, themes, and design docs authoritative
- migrate representative missing/error chat-history states to shared `EmptyState`, `ErrorState`, and `Button` primitives with canonical recovery copy
- add source-contract coverage for state semantics, cross-repo ownership wording, and `bui-*` isolation outside the explicit adapter/gallery layer
- capture remaining transcript/run-rail and native convergence as dependent Beads under `cave-xd1b`

## Verification
- `pnpm test:app` — 1,305 files passed before rebase
- `pnpm typecheck`
- `pnpm lint`
- `node --test src/components/chat-history-state.test.ts scripts/ui-consistency.test.mjs`
- `pnpm check:tests-wired` — 1,842 tests wired
- `git diff origin/main...HEAD --check`
- `pnpm build` — passed; only the two existing `skill-scan.ts` Turbopack tracing warnings and within-budget CSS headroom warning remain
- production-browser verification: desktop missing state `role=status`, 420px containment; mobile error state `role=alert`, 338px containment; visible recovery actions; 0px horizontal overflow
- pre-merge code review found no significant issues

## Tracking
- Bead: `cave-xd1b.2`
- Follow-ups: `cave-xd1b.3`, `cave-xd1b.4`, `cave-xd1b.5`, `cave-xd1b.6`
