### PR TITLE
fix(chat): unify familiar response status

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -587,8 +587,8 @@ assert.match(
 );
 assert.match(
   source,
-  /\{turnStatus !== "complete" && !indicatorVisible && \(/,
-  "Lifecycle chip is suppressed while the turn's own ThinkingIndicator is visible (CHAT-D12-01)",
+  /\{turnStatus !== "complete" && !indicatorVisible && !turn\.pending && \(/,
+  "Lifecycle chip is suppressed while the unified response status or ThinkingIndicator is visible (CHAT-D12-01)",
 );
 assert.match(
   source,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -9406,9 +9406,9 @@ function TurnRowImpl({
               trailing cluster that reveals on turn hover / keyboard focus
               (reveal-scope on the turn content above). Nothing is removed; the
               default view just reads "Name · 2h ago" like ChatGPT. */}
-          <div className="cave-linear-turn-meta">
+          <div className={`cave-linear-turn-meta${turn.pending ? " cave-linear-turn-meta--streaming" : ""}`}>
             <span className="cave-linear-turn-name">{familiar.display_name}</span>
-            {turnStatus !== "complete" && !indicatorVisible && (
+            {turnStatus !== "complete" && !indicatorVisible && !turn.pending && (
               <span className={`cave-turn-status cave-turn-status--${turnStatus}`}>
                 {lifecycleLabel(turnStatus)}
               </span>
@@ -9467,6 +9467,7 @@ function TurnRowImpl({
                 timestamp={turn.createdAt}
                 showTimestamp={false}
                 pending={turn.pending}
+                hideCopyAction
                 isError={Boolean(turn.error) || showEmptySuccessfulFallback}
                 label={familiar.display_name}
                 messageId={turn.id}
@@ -9487,12 +9488,14 @@ function TurnRowImpl({
                       model={streamingModel}
                       density="full"
                       announceLifecycle={announceLifecycle}
+                      startedAt={turn.createdAt}
+                      durationMs={turn.durationMs}
                       onStop={pending ? () => handlersRef.current.cancelSend?.() : undefined}
                       canContinue={false}
                       onRetry={turn.error ? onRegenerate : undefined}
                       onCopyCompleted={
-                        pending && streamingModel.committedText
-                          ? () => { void copyText(streamingModel.committedText); }
+                        streamingModel.committedText
+                          ? () => copyText(streamingModel.committedText)
                           : undefined
                       }
                       proseContent={proseContent}

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -1102,6 +1102,8 @@ export type MessageBubbleProps = {
   /** Shared assistant presentation. `content` remains the complete source for
    * copy, reader, feedback, reply, and settled actions. */
   assistantBody?: ReactNode;
+  /** The supplied assistant body owns its own primary Copy action. */
+  hideCopyAction?: boolean;
   /** The turn's tool events, forwarded to the reader's "How this was made"
    *  footer (batches, skills, error count). Assistant role only; absent turns
    *  simply have no footer — see message-reader.tsx. */
@@ -1130,7 +1132,7 @@ export type MessageBubbleProps = {
   };
 };
 
-export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label, onEdit, onRegenerate, onReply, onOpenUrl, messageId, feedbackContext, segments, assistantBody, readerTools, readerDurationMs, onAskAbout, readerPrompt, onRerunWith, readerFamiliarId, collapsible = true, branchNav }: MessageBubbleProps) {
+export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label, onEdit, onRegenerate, onReply, onOpenUrl, messageId, feedbackContext, segments, assistantBody, hideCopyAction = false, readerTools, readerDurationMs, onAskAbout, readerPrompt, onRerunWith, readerFamiliarId, collapsible = true, branchNav }: MessageBubbleProps) {
   const [tsVisible, setTsVisible] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
   const [readerOpen, setReaderOpen] = useState(false);
@@ -1315,7 +1317,7 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
           actions are reachable by keyboard (Tab), screen readers, and touch. */}
       {!pending && (content || isError) ? (
         <div className="cave-bubble-actions" role="group" aria-label="Response actions">
-          {content ? <CopyBubble text={content} response /> : null}
+          {content && !hideCopyAction ? <CopyBubble text={content} response /> : null}
           {onRegenerate ? (
             <button
               type="button"

--- a/src/components/quick-chat-controls.test.ts
+++ b/src/components/quick-chat-controls.test.ts
@@ -56,7 +56,11 @@ assert.doesNotMatch(
   /GitHubCard|GitHubActionCard/,
   "ordered GitHub pieces are not duplicated in supplementary content",
 );
-assert.match(thread, /copyText\(visible\)/, "each familiar reply can be copied to the clipboard — the visible text, not the raw next-paths trailer");
+assert.match(
+  thread,
+  /onCopyCompleted=\{[\s\S]*streamingModel\.committedText[\s\S]*\(\) => copyText\(streamingModel\.committedText\)/,
+  "the unified status copies only the marker-safe committed projection, never the raw next-paths trailer",
+);
 assert.match(
   thread,
   /formatQuickChatAssistantMessage\([\s\S]*useStreamingPresentationSource\([\s\S]*formatted\.visibleProse/,
@@ -92,13 +96,13 @@ assert.match(
 );
 assert.match(
   streamingResponse,
-  /role=\{announceLifecycle \? "status" : undefined\}/,
-  "status announcements can be removed without hiding visible lifecycle copy",
+  /role=\{announceLifecycle && \(live \|\| model\.status === "interrupted"\) \? "status" : undefined\}/,
+  "only the current live or interrupted response announces replace-in-place status",
 );
 assert.match(
   streamingResponse,
-  /role=\{announceLifecycle \? "alert" : undefined\}/,
-  "alert announcements can be removed from historical failed turns",
+  /announceLifecycle && model\.status === "complete"[\s\S]*role="status"[\s\S]*aria-live="polite"/,
+  "the latest response announces completion without making historical status rows live",
 );
 assert.match(
   quickHook,
@@ -378,8 +382,8 @@ assert.match(
 
 // ── Copy affordance resets ────────────────────────────────────────────────────
 assert.match(
-  thread,
-  /setTimeout\(\(\) => setCopied\(false\), 1500\)/,
+  streamingResponse,
+  /setTimeout\(\(\) => setCopied\(false\), 1_500\)/,
   "the copied ✓ hands the button back to copy after a beat (it used to stick forever)",
 );
 

--- a/src/components/quick-chat-polish.test.ts
+++ b/src/components/quick-chat-polish.test.ts
@@ -65,8 +65,8 @@ assert.doesNotMatch(
 );
 assert.match(
   response,
-  /role=\{announceLifecycle \? "status" : undefined\}[\s\S]{0,300}<span>Response stopped<\/span>/,
-  "The latest rendered interrupted state can own the explicit accessible Stop announcement",
+  /role=\{announceLifecycle && \(live \|\| model\.status === "interrupted"\) \? "status" : undefined\}/,
+  "The unified status row announces the latest interrupted state without a duplicate Stop region",
 );
 assert.doesNotMatch(
   controls,

--- a/src/components/quick-chat-thread.tsx
+++ b/src/components/quick-chat-thread.tsx
@@ -6,7 +6,6 @@ import { ResearchRunInlineCard } from "@/components/research-run-surface";
 import { SkillStageCard } from "@/components/skill-stage-card";
 import { StreamingTurnResponse } from "@/components/streaming-turn-response";
 import { Button } from "@/components/ui/button";
-import { IconButton } from "@/components/ui/icon-button";
 import { shouldUseEmptySuccessfulFallback } from "@/lib/chat-assistant-output";
 import { copyText } from "@/lib/clipboard";
 import { Icon, type IconName } from "@/lib/icon";
@@ -93,7 +92,6 @@ function QuickChatBubble({
   onSuggestion?: (value: string) => void;
   onStop?: () => void;
 }) {
-  const [copied, setCopied] = useState(false);
   const streaming = message.role === "assistant" && Boolean(message.pending);
   const formatted = formatQuickChatAssistantMessage(
     message.role === "assistant" ? message.text : "",
@@ -103,12 +101,6 @@ function QuickChatBubble({
     formatted.visibleProse,
     streaming,
   );
-
-  useEffect(() => {
-    if (!copied) return;
-    const timer = window.setTimeout(() => setCopied(false), 1500);
-    return () => window.clearTimeout(timer);
-  }, [copied]);
 
   if (message.role === "user") {
     return (
@@ -212,24 +204,12 @@ function QuickChatBubble({
 
       <QuickChatResponseMetadata lines={responseMetadataLines} />
 
-      {canAct ? (
+      {canAct && isLastAssistant && onRegenerate && !message.error ? (
         <div className="quick-chat-turn__actions">
-          <IconButton
-            icon={copied ? "ph:check" : "ph:copy"}
-            size="xs"
-            aria-label={copied ? "Copied" : "Copy reply"}
-            title="Copy reply"
-            onClick={() => { void copyText(visible).then((ok) => { if (ok) setCopied(true); }); }}
-          />
-          {isLastAssistant && onRegenerate && !message.error ? (
-            <IconButton
-              icon="ph:arrow-clockwise"
-              size="xs"
-              aria-label="Regenerate reply"
-              title="Regenerate"
-              onClick={onRegenerate}
-            />
-          ) : null}
+          <Button size="xs" variant="ghost" className="focus-ring" onClick={onRegenerate}>
+            <Icon name="ph:arrow-clockwise" width={12} aria-hidden />
+            Regenerate
+          </Button>
         </div>
       ) : null}
 
@@ -270,13 +250,15 @@ function QuickChatBubble({
             model={streamingModel}
             density="compact"
             announceLifecycle={announceLifecycle}
+            startedAt={message.startedAt}
+            durationMs={message.durationMs}
             proseContent={orderedProseContent}
             onStop={streaming ? onStop : undefined}
             onRetry={message.error && isLastAssistant ? onRegenerate : undefined}
             canContinue={false}
             onCopyCompleted={
               streamingModel.committedText
-                ? () => { void copyText(streamingModel.committedText); }
+                ? () => copyText(streamingModel.committedText)
                 : undefined
             }
             supplementaryContent={quickChatSupplementaryContent}

--- a/src/components/streaming-chat-wiring.test.ts
+++ b/src/components/streaming-chat-wiring.test.ts
@@ -134,9 +134,12 @@ assert.match(
 assert.match(main, /canContinue=\{false\}/, "Main Chat does not claim unsupported continuation");
 assert.match(
   main,
-  /pending && streamingModel\.committedText[\s\S]*copyText\(streamingModel\.committedText\)/,
-  "live copy is absent until committed text exists and copies only committed text",
+  /streamingModel\.committedText[\s\S]*copyText\(streamingModel\.committedText\)/,
+  "the unified status owns Copy once committed text exists",
 );
+assert.match(main, /hideCopyAction/, "Main Chat suppresses the duplicate MessageBubble Copy action");
+assert.match(main, /startedAt=\{turn\.createdAt\}/, "Main Chat supplies live elapsed timing");
+assert.match(main, /durationMs=\{turn\.durationMs\}/, "Main Chat supplies settled completion timing");
 assert.match(
   main,
   /content=\{visible \|\| \(turn\.pending \? "…" : ""\)\}/,

--- a/src/components/streaming-turn-response.test.tsx
+++ b/src/components/streaming-turn-response.test.tsx
@@ -646,8 +646,8 @@ describe("StreamingTurnResponse", () => {
       }),
     );
     let disclosure = renderer.root.findByProps({ "data-turn-activity": true });
-    expect(disclosure.props.open).toBe(true);
-    expect(disclosure.findByType("summary").children.join("")).toBe("View activity · 1 update");
+    expect(disclosure.props.open).toBeUndefined();
+    expect(textContent(disclosure.findByType("summary"))).toBe("1 activity update");
 
     await act(async () => {
       disclosure.findByType("summary").props.onClick();
@@ -677,7 +677,7 @@ describe("StreamingTurnResponse", () => {
 
     disclosure = renderer.root.findByProps({ "data-turn-activity": true });
     expect(disclosure.props.open).toBeUndefined();
-    expect(disclosure.findByType("summary").children.join("")).toBe("View activity · 2 updates");
+    expect(textContent(disclosure.findByType("summary"))).toBe("2 activity updates");
   });
 
   it("closes on the first completion transition when the disclosure was untouched", async () => {
@@ -687,7 +687,7 @@ describe("StreamingTurnResponse", () => {
         activityDetails: <div>Activity detail</div>,
       }),
     );
-    expect(renderer.root.findByProps({ "data-turn-activity": true }).props.open).toBe(true);
+    expect(renderer.root.findByProps({ "data-turn-activity": true }).props.open).toBeUndefined();
 
     await act(async () => {
       renderer.update(
@@ -738,7 +738,8 @@ describe("StreamingTurnResponse", () => {
         onRetry: vi.fn(),
       }),
     );
-    expect(buttons(completed)).toHaveLength(0);
+    expect(buttons(completed, "Copy completed text")).toHaveLength(1);
+    expect(buttons(completed, "Stop response")).toHaveLength(0);
 
     const interruptedWithoutCapability = await render(
       response({
@@ -780,18 +781,42 @@ describe("StreamingTurnResponse", () => {
     }
   });
 
+  it("confirms a successful unified Copy action and resets its label", async () => {
+    vi.useFakeTimers();
+    const onCopyCompleted = vi.fn().mockResolvedValue(true);
+    const renderer = await render(response({ onCopyCompleted }));
+
+    await act(async () => {
+      buttons(renderer, "Copy completed text")[0]!.props.onClick();
+      await Promise.resolve();
+    });
+    expect(onCopyCompleted).toHaveBeenCalledTimes(1);
+    expect(buttons(renderer, "Copied")).toHaveLength(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_500);
+    });
+    expect(buttons(renderer, "Copy completed text")).toHaveLength(1);
+    vi.useRealTimers();
+  });
+
   it("distinguishes failed and interrupted state copy from completed responses", async () => {
     const failed = await render(
       response({ model: model({ status: "failed", activeBlock: null }) }),
     );
-    expect(JSON.stringify(failed.toJSON())).toContain("Response failed");
-    expect(JSON.stringify(failed.toJSON())).not.toContain("Response stopped");
+    expect(textContent(failed.root)).toContain("Nova · Failed");
+    expect(textContent(failed.root)).not.toContain("Nova · Stopped");
 
     const interrupted = await render(
       response({ model: model({ status: "interrupted", activeBlock: null }) }),
     );
-    expect(JSON.stringify(interrupted.toJSON())).toContain("Response stopped");
-    expect(JSON.stringify(interrupted.toJSON())).not.toContain("Response failed");
+    expect(textContent(interrupted.root)).toContain("Nova · Stopped");
+    expect(textContent(interrupted.root)).not.toContain("Nova · Failed");
+    const interruptedRegions = interrupted.root.findAll(
+      (node) => node.props.role === "status" || node.props["aria-live"] !== undefined,
+    );
+    expect(interruptedRegions).toHaveLength(1);
+    expect(interruptedRegions[0].props.className).toBe("streaming-turn-current");
 
     const completed = await render(
       response({ model: model({ status: "complete", activeBlock: null }) }),
@@ -805,7 +830,7 @@ describe("StreamingTurnResponse", () => {
     const working = await render(
       response({ familiarName: "Sage", model: model({ status: "working" }) }),
     );
-    expect(JSON.stringify(working.toJSON())).toContain("Sage is working");
+    expect(textContent(working.root)).toContain("Sage · Using tools");
     expect(working.root.findAllByProps({ role: "status" })).toHaveLength(1);
     expect(working.root.findByProps({ role: "status" }).props.className).toBe(
       "streaming-turn-current",
@@ -814,8 +839,57 @@ describe("StreamingTurnResponse", () => {
     const answering = await render(
       response({ familiarName: "Echo", model: model({ status: "answering" }) }),
     );
-    expect(JSON.stringify(answering.toJSON())).toContain("Echo is responding");
+    expect(textContent(answering.root)).toContain("Echo · Responding");
     expect(answering.root.findAllByProps({ role: "status" })).toHaveLength(1);
+  });
+
+  it("shows elapsed and completed timing in the same status row", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-23T12:00:18Z"));
+    const renderer = await render(response({
+      startedAt: "2026-08-23T12:00:00Z",
+      model: model({ status: "working" }),
+    }));
+    expect(textContent(renderer.root)).toContain("Nova · Using tools0:18");
+
+    await act(async () => {
+      renderer.update(response({
+        startedAt: "2026-08-23T12:00:00Z",
+        durationMs: 24_000,
+        model: model({ status: "complete", activeBlock: null, currentActivity: null }),
+      }));
+    });
+    expect(textContent(renderer.root)).toContain("Nova · Completed in 0:24");
+    vi.useRealTimers();
+  });
+
+  it("moves a short process preamble into the live detail and restores it when settled", async () => {
+    const preamble = "Let me look at the attached reference first.";
+    const renderer = await render(response({
+      model: model({
+        status: "answering",
+        committedText: preamble,
+        currentActivity: null,
+        activity: [],
+      }),
+      proseContent: <p data-prose={true}>{preamble}</p>,
+    }));
+    expect(renderer.root.findByProps({ "data-turn-current-activity": true }).children.join("")).toBe(preamble);
+    expect(renderer.root.findAllByProps({ "data-prose": true })).toHaveLength(0);
+
+    await act(async () => {
+      renderer.update(response({
+        model: model({
+          status: "complete",
+          committedText: preamble,
+          activeBlock: null,
+          currentActivity: null,
+          activity: [],
+        }),
+        proseContent: <p data-prose={true}>{preamble}</p>,
+      }));
+    });
+    expect(renderer.root.findAllByProps({ "data-prose": true })).toHaveLength(1);
   });
 
   it("renders one current activity line before prose, results, state, supplementary content, and disclosure", async () => {
@@ -1037,8 +1111,8 @@ describe("StreamingTurnResponse", () => {
     );
     expect(liveRegions).toHaveLength(1);
     expect(liveRegions[0].props.className).toBe("streaming-turn-current");
-    expect(textContent(renderer.root)).toContain("Response stopped");
-    expect(textContent(renderer.root)).toContain("Response failed");
+    expect(textContent(renderer.root)).toContain("Unknown familiar · Stopped");
+    expect(textContent(renderer.root)).toContain("Unknown familiar · Failed");
     expect(textContent(renderer.root)).toContain("No response.");
     expect(
       renderer.root.findAll(

--- a/src/components/streaming-turn-response.test.tsx
+++ b/src/components/streaming-turn-response.test.tsx
@@ -721,7 +721,7 @@ describe("StreamingTurnResponse", () => {
       }),
     );
     expect(buttons(live, "Stop response")).toHaveLength(1);
-    expect(buttons(live, "Copy completed text")).toHaveLength(1);
+    expect(buttons(live, "Copy current response")).toHaveLength(1);
     expect(buttons(live, "Continue response")).toHaveLength(0);
     expect(buttons(live, "Retry response")).toHaveLength(0);
 
@@ -738,7 +738,7 @@ describe("StreamingTurnResponse", () => {
         onRetry: vi.fn(),
       }),
     );
-    expect(buttons(completed, "Copy completed text")).toHaveLength(1);
+    expect(buttons(completed, "Copy completed response")).toHaveLength(1);
     expect(buttons(completed, "Stop response")).toHaveLength(0);
 
     const interruptedWithoutCapability = await render(
@@ -787,7 +787,7 @@ describe("StreamingTurnResponse", () => {
     const renderer = await render(response({ onCopyCompleted }));
 
     await act(async () => {
-      buttons(renderer, "Copy completed text")[0]!.props.onClick();
+      buttons(renderer, "Copy current response")[0]!.props.onClick();
       await Promise.resolve();
     });
     expect(onCopyCompleted).toHaveBeenCalledTimes(1);
@@ -796,27 +796,35 @@ describe("StreamingTurnResponse", () => {
     await act(async () => {
       vi.advanceTimersByTime(1_500);
     });
-    expect(buttons(renderer, "Copy completed text")).toHaveLength(1);
+    expect(buttons(renderer, "Copy current response")).toHaveLength(1);
     vi.useRealTimers();
   });
 
   it("distinguishes failed and interrupted state copy from completed responses", async () => {
     const failed = await render(
-      response({ model: model({ status: "failed", activeBlock: null }) }),
+      response({
+        model: model({ status: "failed", activeBlock: null }),
+        onCopyCompleted: vi.fn(),
+      }),
     );
     expect(textContent(failed.root)).toContain("Nova · Failed");
     expect(textContent(failed.root)).not.toContain("Nova · Stopped");
+    expect(buttons(failed, "Copy partial response")).toHaveLength(1);
 
     const interrupted = await render(
-      response({ model: model({ status: "interrupted", activeBlock: null }) }),
+      response({
+        model: model({ status: "interrupted", activeBlock: null }),
+        onCopyCompleted: vi.fn(),
+      }),
     );
     expect(textContent(interrupted.root)).toContain("Nova · Stopped");
     expect(textContent(interrupted.root)).not.toContain("Nova · Failed");
+    expect(buttons(interrupted, "Copy partial response")).toHaveLength(1);
     const interruptedRegions = interrupted.root.findAll(
       (node) => node.props.role === "status" || node.props["aria-live"] !== undefined,
     );
     expect(interruptedRegions).toHaveLength(1);
-    expect(interruptedRegions[0].props.className).toBe("streaming-turn-current");
+    expect(interruptedRegions[0].props.className).toBe("streaming-turn-current__phase");
 
     const completed = await render(
       response({ model: model({ status: "complete", activeBlock: null }) }),
@@ -833,7 +841,7 @@ describe("StreamingTurnResponse", () => {
     expect(textContent(working.root)).toContain("Sage · Using tools");
     expect(working.root.findAllByProps({ role: "status" })).toHaveLength(1);
     expect(working.root.findByProps({ role: "status" }).props.className).toBe(
-      "streaming-turn-current",
+      "streaming-turn-current__phase",
     );
 
     const answering = await render(
@@ -841,6 +849,50 @@ describe("StreamingTurnResponse", () => {
     );
     expect(textContent(answering.root)).toContain("Echo · Responding");
     expect(answering.root.findAllByProps({ role: "status" })).toHaveLength(1);
+  });
+
+  it("keeps the ticking elapsed time outside the live status region", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-23T12:00:18Z"));
+    const renderer = await render(response({
+      startedAt: "2026-08-23T12:00:00Z",
+      model: model({ status: "working" }),
+    }));
+    const liveRegion = renderer.root.findByProps({ role: "status" });
+    expect(textContent(liveRegion)).toBe("Nova · Using tools");
+
+    await act(async () => {
+      vi.advanceTimersByTime(2_000);
+    });
+
+    expect(textContent(renderer.root.findByProps({ role: "status" }))).toBe("Nova · Using tools");
+    expect(textContent(renderer.root.findByType("time"))).toBe("0:20");
+    expect(renderer.root.findByType("time").props["aria-hidden"]).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("announces a live-to-failed transition once without making failed history live", async () => {
+    const renderer = await render(response({
+      announceLifecycle: true,
+      model: model({ status: "answering" }),
+    }));
+
+    await act(async () => {
+      renderer.update(response({
+        announceLifecycle: true,
+        model: model({ status: "failed", activeBlock: null, currentActivity: null }),
+      }));
+    });
+
+    const alerts = renderer.root.findAllByProps({ role: "alert" });
+    expect(alerts).toHaveLength(1);
+    expect(textContent(alerts[0])).toBe("Nova response failed");
+
+    const failedHistory = await render(response({
+      announceLifecycle: true,
+      model: model({ status: "failed", activeBlock: null, currentActivity: null }),
+    }));
+    expect(failedHistory.root.findAllByProps({ role: "alert" })).toHaveLength(0);
   });
 
   it("shows elapsed and completed timing in the same status row", async () => {
@@ -851,6 +903,7 @@ describe("StreamingTurnResponse", () => {
       model: model({ status: "working" }),
     }));
     expect(textContent(renderer.root)).toContain("Nova · Using tools0:18");
+    expect(renderer.root.findByType("time").props["aria-hidden"]).toBe(true);
 
     await act(async () => {
       renderer.update(response({
@@ -861,6 +914,16 @@ describe("StreamingTurnResponse", () => {
     });
     expect(textContent(renderer.root)).toContain("Nova · Completed in 0:24");
     vi.useRealTimers();
+  });
+
+  it("rounds a nonzero sub-second completed duration up instead of showing 0:00", async () => {
+    const renderer = await render(response({
+      durationMs: 200,
+      model: model({ status: "complete", activeBlock: null, currentActivity: null }),
+    }));
+
+    expect(textContent(renderer.root)).toContain("Nova · Completed in 0:01");
+    expect(textContent(renderer.root)).not.toContain("Completed in 0:00");
   });
 
   it("moves a short process preamble into the live detail and restores it when settled", async () => {
@@ -889,6 +952,25 @@ describe("StreamingTurnResponse", () => {
         proseContent: <p data-prose={true}>{preamble}</p>,
       }));
     });
+    expect(renderer.root.findAllByProps({ "data-prose": true })).toHaveLength(1);
+  });
+
+  it.each([
+    "I'll review the code. The bug is in the retry path.",
+    "Let me inspect the logs! The timeout is upstream.",
+    "I'll check the request? The response is malformed.",
+  ])("never hides substantive multi-sentence prose as transient activity: %s", async (prose) => {
+    const renderer = await render(response({
+      model: model({
+        status: "answering",
+        committedText: prose,
+        currentActivity: null,
+        activity: [],
+      }),
+      proseContent: <p data-prose={true}>{prose}</p>,
+    }));
+
+    expect(renderer.root.findAllByProps({ "data-turn-current-activity": true })).toHaveLength(0);
     expect(renderer.root.findAllByProps({ "data-prose": true })).toHaveLength(1);
   });
 
@@ -1110,7 +1192,7 @@ describe("StreamingTurnResponse", () => {
         node.props["aria-live"] !== undefined,
     );
     expect(liveRegions).toHaveLength(1);
-    expect(liveRegions[0].props.className).toBe("streaming-turn-current");
+    expect(liveRegions[0].props.className).toBe("streaming-turn-current__phase");
     expect(textContent(renderer.root)).toContain("Unknown familiar · Stopped");
     expect(textContent(renderer.root)).toContain("Unknown familiar · Failed");
     expect(textContent(renderer.root)).toContain("No response.");
@@ -1164,7 +1246,7 @@ describe("StreamingTurnResponse", () => {
         node.props["aria-live"] !== undefined,
     );
     expect(liveRegions).toHaveLength(1);
-    expect(liveRegions[0].props.className).toBe("streaming-turn-current");
+    expect(liveRegions[0].props.className).toBe("streaming-turn-current__phase");
     expect(textContent(renderer.root)).not.toContain("Nova completed response");
   });
 

--- a/src/components/streaming-turn-response.tsx
+++ b/src/components/streaming-turn-response.tsx
@@ -97,9 +97,14 @@ function TurnActivityDisclosure({
   );
 }
 
-function formatDuration(durationMs?: number): string | null {
+function formatDuration(durationMs?: number, roundNonzeroUp = false): string | null {
   if (durationMs === undefined || !Number.isFinite(durationMs)) return null;
-  const totalSeconds = Math.max(0, Math.floor(durationMs / 1_000));
+  const totalSeconds = Math.max(
+    0,
+    roundNonzeroUp && durationMs > 0
+      ? Math.ceil(durationMs / 1_000)
+      : Math.floor(durationMs / 1_000),
+  );
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
@@ -108,8 +113,7 @@ function formatDuration(durationMs?: number): string | null {
 function transientPreambleFrom(text: string): string | null {
   const candidate = text.trim();
   if (!candidate || candidate.length > 120 || candidate.includes("\n")) return null;
-  if (!/[.!…]$/.test(candidate)) return null;
-  return /^(?:let me|i(?:'ll| will)|i'm going to)\s+(?:take a look|look|check|inspect|review|search|open|read)\b/i.test(candidate)
+  return /^(?:let me|i(?:'ll| will)|i'm going to)\s+(?:take a look|look|check|inspect|review|search|open|read)\b[^.!?…]*[.!?…]$/i.test(candidate)
     ? candidate
     : null;
 }
@@ -134,6 +138,7 @@ export function StreamingTurnResponse({
   const live = isLive(model);
   const [activityOpen, setActivityOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [announceFailure, setAnnounceFailure] = useState(false);
   const [now, setNow] = useState(() => Date.now());
   const userToggledActivityRef = useRef(false);
   const previousStatusRef = useRef(model.status);
@@ -141,7 +146,7 @@ export function StreamingTurnResponse({
   const elapsedMs = live && Number.isFinite(startedAtMs)
     ? Math.max(0, now - startedAtMs)
     : durationMs;
-  const elapsedLabel = formatDuration(elapsedMs);
+  const elapsedLabel = formatDuration(elapsedMs, !live);
   const statusLabel =
     model.status === "working"
       ? "Using tools"
@@ -157,15 +162,25 @@ export function StreamingTurnResponse({
   const transientPreamble = live && !model.currentActivity
     ? transientPreambleFrom(model.committedText)
     : null;
+  const copyLabel = copied
+    ? "Copied"
+    : live
+      ? "Copy current response"
+      : model.status === "complete"
+        ? "Copy completed response"
+        : "Copy partial response";
 
   useEffect(() => {
     const enteredComplete =
       previousStatusRef.current !== "complete" && model.status === "complete";
+    const enteredFailure =
+      previousStatusRef.current !== "failed" && model.status === "failed";
     if (enteredComplete && !userToggledActivityRef.current) {
       setActivityOpen(false);
     }
+    setAnnounceFailure(announceLifecycle && enteredFailure);
     previousStatusRef.current = model.status;
-  }, [model.status]);
+  }, [announceLifecycle, model.status]);
 
   useEffect(() => {
     if (!live || !startedAt) return;
@@ -192,10 +207,7 @@ export function StreamingTurnResponse({
       data-streaming-turn-response={true}
       data-streaming-turn-id={turnId}
     >
-      <div
-        className="streaming-turn-current"
-        role={announceLifecycle && (live || model.status === "interrupted") ? "status" : undefined}
-      >
+      <div className="streaming-turn-current">
         <div className="streaming-turn-current__row">
           <Icon
             name={
@@ -211,13 +223,16 @@ export function StreamingTurnResponse({
             aria-hidden
             className={live ? "streaming-turn-current__spinner" : undefined}
           />
-          <div className="streaming-turn-current__phase">
+          <div
+            className="streaming-turn-current__phase"
+            role={announceLifecycle && (live || model.status === "interrupted") ? "status" : undefined}
+          >
             <strong>{familiarName}</strong>
             <span aria-hidden> · </span>
             {statusLabel}
           </div>
           {live && elapsedLabel ? (
-            <time className="streaming-turn-current__time">{elapsedLabel}</time>
+            <time className="streaming-turn-current__time" aria-hidden={true}>{elapsedLabel}</time>
           ) : null}
           <div className="streaming-turn-current__actions">
             {live && onStop ? (
@@ -236,7 +251,7 @@ export function StreamingTurnResponse({
                 size="xs"
                 variant="ghost"
                 className="focus-ring"
-                aria-label={copied ? "Copied" : "Copy completed text"}
+                aria-label={copyLabel}
                 onClick={() => {
                   void Promise.resolve(onCopyCompleted()).then((succeeded) => {
                     if (succeeded !== false) setCopied(true);
@@ -274,6 +289,11 @@ export function StreamingTurnResponse({
           {announceLifecycle && model.status === "complete" ? (
             <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
               {`${familiarName} completed response`}
+            </span>
+          ) : null}
+          {announceFailure ? (
+            <span className="sr-only" role="alert">
+              {`${familiarName} response failed`}
             </span>
           ) : null}
         </div>

--- a/src/components/streaming-turn-response.tsx
+++ b/src/components/streaming-turn-response.tsx
@@ -25,11 +25,13 @@ export type StreamingTurnResponseProps = {
   activityDetails?: ReactNode;
   supplementaryContent?: ReactNode;
   announceLifecycle?: boolean;
+  startedAt?: string;
+  durationMs?: number;
   onStop?: () => void;
   canContinue?: boolean;
   onContinue?: () => void;
   onRetry?: () => void;
-  onCopyCompleted?: () => void;
+  onCopyCompleted?: () => void | boolean | Promise<void | boolean>;
 };
 
 function isLive(model: StreamingTurnViewModel): boolean {
@@ -66,70 +68,6 @@ function TurnResults({ model }: { model: StreamingTurnViewModel }) {
   );
 }
 
-function TurnState({
-  model,
-  onContinue,
-  canContinue,
-  onRetry,
-  announceLifecycle,
-}: {
-  model: StreamingTurnViewModel;
-  onContinue?: () => void;
-  canContinue?: boolean;
-  onRetry?: () => void;
-  announceLifecycle: boolean;
-}) {
-  if (model.status === "interrupted") {
-    return (
-      <section
-        className="streaming-turn-state streaming-turn-state--interrupted"
-        role={announceLifecycle ? "status" : undefined}
-        data-turn-state={true}
-      >
-        <Icon name="ph:warning-circle" width={14} aria-hidden={true} />
-        <span>Response stopped</span>
-        {canContinue && onContinue ? (
-          <Button
-            size="xs"
-            variant="ghost"
-            className="focus-ring"
-            aria-label="Continue response"
-            onClick={onContinue}
-          >
-            Continue
-          </Button>
-        ) : null}
-      </section>
-    );
-  }
-
-  if (model.status === "failed") {
-    return (
-      <section
-        className="streaming-turn-state streaming-turn-state--failed"
-        role={announceLifecycle ? "alert" : undefined}
-        data-turn-state={true}
-      >
-        <Icon name="ph:x-circle" width={14} aria-hidden={true} />
-        <span>Response failed</span>
-        {onRetry ? (
-          <Button
-            size="xs"
-            variant="ghost"
-            className="focus-ring"
-            aria-label="Retry response"
-            onClick={onRetry}
-          >
-            Retry
-          </Button>
-        ) : null}
-      </section>
-    );
-  }
-
-  return null;
-}
-
 function TurnActivityDisclosure({
   activityDetails,
   activityOpen,
@@ -151,11 +89,29 @@ function TurnActivityDisclosure({
       onToggle={(event) => onOpenChange(event.currentTarget.open)}
     >
       <summary className="focus-ring" onClick={onUserToggle}>
-        {`View activity · ${activityCount} ${activityCount === 1 ? "update" : "updates"}`}
+        <Icon name={activityOpen ? "ph:caret-down" : "ph:caret-right"} width={12} aria-hidden />
+        {`${activityCount} activity ${activityCount === 1 ? "update" : "updates"}`}
       </summary>
       {activityDetails}
     </details>
   );
+}
+
+function formatDuration(durationMs?: number): string | null {
+  if (durationMs === undefined || !Number.isFinite(durationMs)) return null;
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1_000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+function transientPreambleFrom(text: string): string | null {
+  const candidate = text.trim();
+  if (!candidate || candidate.length > 120 || candidate.includes("\n")) return null;
+  if (!/[.!…]$/.test(candidate)) return null;
+  return /^(?:let me|i(?:'ll| will)|i'm going to)\s+(?:take a look|look|check|inspect|review|search|open|read)\b/i.test(candidate)
+    ? candidate
+    : null;
 }
 
 export function StreamingTurnResponse({
@@ -167,6 +123,8 @@ export function StreamingTurnResponse({
   activityDetails,
   supplementaryContent,
   announceLifecycle = true,
+  startedAt,
+  durationMs,
   onStop,
   canContinue,
   onContinue,
@@ -174,11 +132,31 @@ export function StreamingTurnResponse({
   onCopyCompleted,
 }: StreamingTurnResponseProps) {
   const live = isLive(model);
-  const [activityOpen, setActivityOpen] = useState(
-    density === "full" && model.status === "working",
-  );
+  const [activityOpen, setActivityOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
   const userToggledActivityRef = useRef(false);
   const previousStatusRef = useRef(model.status);
+  const startedAtMs = startedAt ? Date.parse(startedAt) : Number.NaN;
+  const elapsedMs = live && Number.isFinite(startedAtMs)
+    ? Math.max(0, now - startedAtMs)
+    : durationMs;
+  const elapsedLabel = formatDuration(elapsedMs);
+  const statusLabel =
+    model.status === "working"
+      ? "Using tools"
+      : model.status === "answering"
+        ? "Responding"
+        : model.status === "complete"
+          ? elapsedLabel
+            ? `Completed in ${elapsedLabel}`
+            : "Completed"
+          : model.status === "interrupted"
+            ? "Stopped"
+            : "Failed";
+  const transientPreamble = live && !model.currentActivity
+    ? transientPreambleFrom(model.committedText)
+    : null;
 
   useEffect(() => {
     const enteredComplete =
@@ -189,6 +167,24 @@ export function StreamingTurnResponse({
     previousStatusRef.current = model.status;
   }, [model.status]);
 
+  useEffect(() => {
+    if (!live || !startedAt) return;
+    setNow(Date.now());
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = () => {
+      setNow(Date.now());
+      timer = globalThis.setTimeout(tick, 1_000);
+    };
+    timer = globalThis.setTimeout(tick, 1_000);
+    return () => globalThis.clearTimeout(timer);
+  }, [live, startedAt]);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = globalThis.setTimeout(() => setCopied(false), 1_500);
+    return () => globalThis.clearTimeout(timer);
+  }, [copied]);
+
   return (
     <div
       className="streaming-turn-response"
@@ -196,60 +192,103 @@ export function StreamingTurnResponse({
       data-streaming-turn-response={true}
       data-streaming-turn-id={turnId}
     >
-      {live ? (
-        <div
-          className="streaming-turn-current"
-          role={announceLifecycle ? "status" : undefined}
-        >
+      <div
+        className="streaming-turn-current"
+        role={announceLifecycle && (live || model.status === "interrupted") ? "status" : undefined}
+      >
+        <div className="streaming-turn-current__row">
+          <Icon
+            name={
+              live
+                ? "ph:circle-notch-bold"
+                : model.status === "failed"
+                  ? "ph:x-circle"
+                  : model.status === "interrupted"
+                    ? "ph:warning-circle"
+                    : "ph:check-circle"
+            }
+            width={14}
+            aria-hidden
+            className={live ? "streaming-turn-current__spinner" : undefined}
+          />
           <div className="streaming-turn-current__phase">
-            {`${familiarName} is ${model.status === "working" ? "working" : "responding"}`}
+            <strong>{familiarName}</strong>
+            <span aria-hidden> · </span>
+            {statusLabel}
           </div>
-          {model.currentActivity ? (
-            <div
-              className="streaming-turn-current__detail"
-              data-turn-current-activity={true}
-            >
-              {model.currentActivity.label}
-            </div>
+          {live && elapsedLabel ? (
+            <time className="streaming-turn-current__time">{elapsedLabel}</time>
           ) : null}
-          {onStop ? (
-            <Button
-              size="xs"
-              variant="ghost"
-              className="focus-ring"
-              aria-label="Stop response"
-              onClick={onStop}
-            >
-              Stop
-            </Button>
-          ) : null}
-          {onCopyCompleted ? (
-            <Button
-              size="xs"
-              variant="ghost"
-              className="focus-ring"
-              aria-label="Copy completed text"
-              onClick={onCopyCompleted}
-            >
-              Copy
-            </Button>
+          <div className="streaming-turn-current__actions">
+            {live && onStop ? (
+              <Button
+                size="xs"
+                variant="ghost"
+                className="focus-ring"
+                aria-label="Stop response"
+                onClick={onStop}
+              >
+                Stop
+              </Button>
+            ) : null}
+            {onCopyCompleted && model.committedText ? (
+              <Button
+                size="xs"
+                variant="ghost"
+                className="focus-ring"
+                aria-label={copied ? "Copied" : "Copy completed text"}
+                onClick={() => {
+                  void Promise.resolve(onCopyCompleted()).then((succeeded) => {
+                    if (succeeded !== false) setCopied(true);
+                  });
+                }}
+              >
+                <Icon name={copied ? "ph:check" : "ph:copy"} width={12} aria-hidden />
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            ) : null}
+            {model.status === "interrupted" && canContinue && onContinue ? (
+              <Button
+                size="xs"
+                variant="ghost"
+                className="focus-ring"
+                aria-label="Continue response"
+                onClick={onContinue}
+              >
+                Continue
+              </Button>
+            ) : null}
+            {model.status === "failed" && onRetry ? (
+              <Button
+                size="xs"
+                variant="ghost"
+                className="focus-ring"
+                aria-label="Retry response"
+                onClick={onRetry}
+              >
+                Retry
+              </Button>
+            ) : null}
+          </div>
+
+          {announceLifecycle && model.status === "complete" ? (
+            <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+              {`${familiarName} completed response`}
+            </span>
           ) : null}
         </div>
-      ) : null}
-
-      {announceLifecycle && model.status === "complete" ? (
-        <span
-          className="sr-only"
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-        >
-          {`${familiarName} completed response`}
-        </span>
-      ) : null}
+        {live && (model.currentActivity?.label || transientPreamble) ? (
+          <div
+            className="streaming-turn-current__detail"
+            data-turn-current-activity={true}
+          >
+            {model.currentActivity?.label ?? transientPreamble}
+          </div>
+        ) : null}
+      </div>
 
       <div className="streaming-turn-prose">
-        {proseContent !== undefined ? (
+        {transientPreamble ? null : proseContent !== undefined ? (
           proseContent
         ) : (
           <StreamingMarkdownBlocks
@@ -261,14 +300,6 @@ export function StreamingTurnResponse({
       </div>
 
       <TurnResults model={model} />
-
-      <TurnState
-        model={model}
-        canContinue={canContinue}
-        onContinue={onContinue}
-        onRetry={onRetry}
-        announceLifecycle={announceLifecycle}
-      />
 
       {supplementaryContent}
 

--- a/src/lib/streaming-turn-view-model.test.ts
+++ b/src/lib/streaming-turn-view-model.test.ts
@@ -207,14 +207,14 @@ test("interruption settles prose and downgrades unproved running rows while pres
   assert.equal(model.results.find((row) => row.id === "tests")?.state, "passed");
 });
 
-test("unknown tools fall back to Working…", () => {
+test("unknown tools use a specific neutral activity phrase", () => {
   const model = createStreamingTurnViewModel(
     input({
       tools: [{ id: "read-1", name: "Read", input: '{"path":"README.md"}', status: "running" }],
     }),
   );
 
-  assert.equal(model.currentActivity?.label, "Working…");
+  assert.equal(model.currentActivity?.label, "Inspecting project context…");
 });
 
 test("unknown tools stay neutral even when inputs and outputs contain activity keywords", () => {
@@ -232,7 +232,7 @@ test("unknown tools stay neutral even when inputs and outputs contain activity k
     }),
   );
 
-  assert.equal(model.currentActivity?.label, "Working…");
+  assert.equal(model.currentActivity?.label, "Inspecting project context…");
   assert.equal(model.currentActivity?.detail, undefined);
   assert.doesNotMatch(model.currentActivity?.label ?? "", /search|test|build|review|docs\/review\.md/i);
 });

--- a/src/lib/streaming-turn-view-model.ts
+++ b/src/lib/streaming-turn-view-model.ts
@@ -81,7 +81,7 @@ function normalizeProgressEvent(progress: ProgressEvent): ActivityEvent {
 }
 
 function toolActivityLabel(tool: ToolEvent): string {
-  return TOOL_ACTIVITY.find(([pattern]) => pattern.test(tool.name))?.[1] ?? "Working…";
+  return TOOL_ACTIVITY.find(([pattern]) => pattern.test(tool.name))?.[1] ?? "Inspecting project context…";
 }
 
 function normalizeToolEvent(tool: ToolEvent): ActivityEvent {

--- a/src/lib/use-quick-chat.test.tsx
+++ b/src/lib/use-quick-chat.test.tsx
@@ -341,6 +341,8 @@ describe("useQuickChat send cancellation", () => {
       text: "Final answer",
       pending: false,
       lifecycle: "complete",
+      startedAt: expect.any(String),
+      durationMs: expect.any(Number),
       error: null,
     });
     expect(state!.sendState).toBe("done");

--- a/src/lib/use-quick-chat.ts
+++ b/src/lib/use-quick-chat.ts
@@ -59,6 +59,8 @@ export type QuickChatMessage = {
   /** Assistant turn still streaming in. */
   pending?: boolean;
   lifecycle?: ChatTurnLifecycle;
+  startedAt?: string;
+  durationMs?: number;
   /** Per-turn error (the familiar failed / reported an error). */
   error?: string | null;
   /** Local note (slash-command output like /help) — rendered as an assistant
@@ -393,6 +395,7 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
               pending: false,
               lifecycle: "cancelled",
               error: null,
+              durationMs: message.startedAt ? Date.now() - Date.parse(message.startedAt) : undefined,
             }
           : message,
       ),
@@ -698,6 +701,7 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
         return "stopped";
       }
       const assistantId = nextId("a");
+      const startedAt = new Date().toISOString();
       const controller = new AbortController();
       const runId = crypto.randomUUID();
       const activeSend: ActiveQuickChatSend = {
@@ -717,6 +721,7 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
           text: "",
           pending: true,
           lifecycle: "streaming",
+          startedAt,
           error: null,
         },
       ]);
@@ -786,6 +791,7 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
                   ...m,
                   pending: false,
                   lifecycle: aborted ? "cancelled" : "failed",
+                  durationMs: m.startedAt ? Date.now() - Date.parse(m.startedAt) : undefined,
                   error: aborted ? null : (err as Error)?.message ?? "Generation failed.",
                 }
               : m,
@@ -826,7 +832,13 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
         setMessages((prev) =>
           prev.map((m) =>
             m.id === assistantId
-              ? { ...m, pending: false, lifecycle: "cancelled", error: null }
+              ? {
+                  ...m,
+                  pending: false,
+                  lifecycle: "cancelled",
+                  durationMs: m.startedAt ? Date.now() - Date.parse(m.startedAt) : undefined,
+                  error: null,
+                }
               : m,
           ),
         );
@@ -842,6 +854,7 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
                 error: result.error,
                 pending: false,
                 lifecycle: result.error ? "failed" : "complete",
+                durationMs: m.startedAt ? Date.now() - Date.parse(m.startedAt) : undefined,
               }
             : m,
         ),

--- a/src/styles/cave-chat/bubbles.css
+++ b/src/styles/cave-chat/bubbles.css
@@ -982,8 +982,14 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 }
 
 .cave-response-frame[data-state="streaming"]::before {
+  bottom: auto;
+  height: calc(var(--space-12) + var(--space-10));
   background: var(--accent-presence);
   animation: cave-response-presence var(--duration-slow) var(--ease-standard) infinite alternate;
+}
+
+.cave-linear-turn-meta--streaming {
+  display: none;
 }
 
 .cave-response-frame[data-state="error"]::before {

--- a/src/styles/globals/surface-chat-overlays.css
+++ b/src/styles/globals/surface-chat-overlays.css
@@ -1156,3 +1156,92 @@
 @media (prefers-reduced-motion: reduce) {
   .cave-chat-drop { transition: none; }
 }
+.streaming-turn-response {
+  display: grid;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.streaming-turn-current {
+  display: grid;
+  gap: var(--space-1);
+  color: var(--text-secondary);
+}
+
+.streaming-turn-current__row {
+  display: flex;
+  min-height: var(--space-8);
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.streaming-turn-current__spinner {
+  color: var(--accent-presence);
+  animation: streaming-turn-spin var(--duration-slow) linear infinite;
+}
+
+.streaming-turn-current__phase {
+  min-width: 0;
+  flex: 1;
+  font-size: var(--text-sm);
+}
+
+.streaming-turn-current__phase strong {
+  color: var(--text-primary);
+  font-weight: var(--font-weight-semibold);
+}
+
+.streaming-turn-current__time {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.streaming-turn-current__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.streaming-turn-current__detail {
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.streaming-turn-activity {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.streaming-turn-activity > summary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-height: var(--space-8);
+  cursor: pointer;
+  list-style: none;
+}
+
+.streaming-turn-activity > summary::-webkit-details-marker {
+  display: none;
+}
+
+.streaming-turn-prose:empty {
+  display: none;
+}
+
+@keyframes streaming-turn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .streaming-turn-current__spinner {
+    animation: none;
+  }
+}

--- a/tests/chat-response-output.spec.ts
+++ b/tests/chat-response-output.spec.ts
@@ -131,8 +131,9 @@ test("completed assistant responses render editorial Markdown and accessible con
     "status",
   );
   await expect(bubble.getByText("threads-dgg")).toBeVisible();
-  await expect(bubble.locator("strong")).toContainText("bold");
-  await expect(bubble.locator("em")).toContainText("italics");
+  const prose = bubble.locator(".streaming-turn-prose");
+  await expect(prose.locator("strong")).toContainText("bold");
+  await expect(prose.locator("em")).toContainText("italics");
 
   const width = await bubble.locator(".cave-response-frame").evaluate(
     (element) => element.getBoundingClientRect().width,
@@ -140,7 +141,9 @@ test("completed assistant responses render editorial Markdown and accessible con
   expect(width).toBeLessThanOrEqual(768);
 
   await bubble.hover();
-  await expect(bubble.getByRole("button", { name: "Copy message" })).toBeVisible();
+  await expect(
+    bubble.getByRole("button", { name: "Copy completed response" }),
+  ).toBeVisible();
   await expect(bubble.getByRole("button", { name: "Retry response" })).toBeVisible();
   await bubble.getByRole("button", { name: "Collapse", exact: true }).click();
   await expect(bubble.getByText("Response collapsed")).toBeVisible();


### PR DESCRIPTION
## Summary

- replace duplicate live-response chrome with one shared familiar status row in Main and Quick Chat
- keep elapsed timing, transient activity, collapsed history, Stop, Copy, Retry, and completion state lifecycle-correct
- preserve one polite lifecycle announcement and reduced-motion behavior

## Verification

- `pnpm test:app` (1,304 test files)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` (1,841 test files)
- `git diff --check`

Closes cave-ppqm8