### PR TITLE
Fix local Client access authorization

### DIFF
--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -176,7 +176,9 @@ has to consult a table to avoid calling something it can never reach:
   `.admin.` that is not one of the four above. **This is the only class an
   external application can ever hold.**
 - **admin** — any id containing **`.admin.`**. These require the Cave's own
-  per-launch sidecar token over direct loopback and back the Cave's settings UI.
+  per-launch sidecar token over direct loopback in packaged Cave. Tokenless
+  local development instead accepts only the proxy's secret-valued
+  direct-loopback admin marker. These routes back the Cave's settings UI.
   **A paired bearer never satisfies one, whatever scopes it holds.** An SDK
   should treat a `.admin.` id as present-but-not-yours.
 
@@ -269,7 +271,7 @@ are reachable on the thirteen routes that exist.
 | `pairing_expired` | 410 | yes | Terminal for this request. Start a new pairing request. |
 | `rate_limited` | 429 | yes | Retryable. Honour `Retry-After`; `details.limit` and `details.resetAt` (epoch ms) carry the budget. |
 | `internal_error` | 500 | yes | Retryable where the route says so — see the exchange route, where a failed credential write restores the pairing precisely so a retry works. On the canonical reads it is **not** retryable: it means a stored record could not be projected, and the store answers the same way next second. |
-| `service_unavailable` | 503 | yes | The Cave cannot answer right now. On admin routes it means `COVEN_CAVE_AUTH_TOKEN` is unset and is not fixable by retrying; on `GET /familiars` it means the daemon roster could not be read and **is** retryable. |
+| `service_unavailable` | 503 | yes | The Cave cannot answer right now. On admin routes it means neither packaged sidecar authorization nor the proxy's tokenless-development authorization is available, and is not fixable by retrying; on `GET /familiars` it means the daemon roster could not be read and **is** retryable. |
 | `reconcile_required` | 409 | yes | The client's position is no longer valid against canonical state. Today that is exactly one case: a messages cursor naming a turn that has left the conversation's active branch (`details.reason: "resume_from_canonical_state"`). Not retryable — restart the read. |
 | `incompatible_version` | 426 | no | Reserved. Version incompatibility is currently discovered by reading `minimumClientVersion` off `/health`, not by being told. |
 
@@ -1073,13 +1075,12 @@ business calling them and holds nothing that would authenticate it if it tried.
 
 All four call `requireClientV1Admin`, which:
 
-1. Reads `COVEN_CAVE_AUTH_TOKEN`. **If it is unset or blank, every admin route
-   answers `503 service_unavailable`** with *"Cave admin authorization is not
-   configured. Start Cave through the desktop app."* This is a fail-closed
-   default, and it is the state a plain `pnpm dev` is in. The practical
-   consequence is worth stating plainly: on a tokenless Cave, a client can open
-   a pairing request and can never get it approved, because the approval route
-   is 503. The exchange keeps answering `pairing_pending` until the TTL expires.
+1. Reads `COVEN_CAVE_AUTH_TOKEN`. If it is unset or blank in non-bundled
+   development, it accepts only the secret-valued internal admin marker that
+   `proxy.ts` stamps after proving a direct-loopback peer and stripping any
+   caller-supplied marker. This keeps the Settings page and local pairing flow
+   usable under plain `pnpm dev`. Bundled Cave still fails closed with a missing
+   sidecar token before the route runs.
 2. Compares the `x-coven-cave-token` header against it in constant time.
    Mismatch or absence is `401 unauthorized`.
 

--- a/src/app/api/client/v1/admin/security.e2e.test.ts
+++ b/src/app/api/client/v1/admin/security.e2e.test.ts
@@ -363,6 +363,30 @@ test("proxy replaces caller-supplied development admin markers", async () => {
   }
 });
 
+test("tokenless development normalizes the local peer secret before stamping admin authority", async () => {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    const paddedSecret = `  ${loopbackSecret}  `;
+    setEnv({ COVEN_CAVE_LOCAL_PEER_SECRET: paddedSecret });
+    const runtime = createClientV1Runtime({
+      credentialRoot: root,
+      loopbackSecret,
+      now: () => 27_000,
+    });
+    const response = await throughProxy(
+      request("GET", "/api/client/v1/admin/credentials", {
+        headers: { [LOCAL_PEER_HEADER]: paddedSecret },
+      }),
+      createAdminCredentialsGetHandler(runtime),
+    );
+    assert.equal(response.status, 200);
+  } finally {
+    restoreEnv();
+    assert.equal(resolve(root).startsWith(scratchPrefix), true);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("configured Cave admin authorization works and mutations require CSRF", async () => {
   const root = await mkdtemp(scratchPrefix);
   try {

--- a/src/app/api/client/v1/admin/security.e2e.test.ts
+++ b/src/app/api/client/v1/admin/security.e2e.test.ts
@@ -12,6 +12,7 @@ import {
 import { createClientV1Runtime } from "@/lib/server/client-v1/runtime.ts";
 import {
   ACCESS_TOKEN_COOKIE,
+  CLIENT_V1_ADMIN_HEADER,
   LOCAL_PEER_HEADER,
   MOBILE_ACCESS_HEADER,
   TAILNET_PEER_HEADER,
@@ -106,10 +107,21 @@ async function throughProxy(
   route: (request: Request) => Promise<Response>,
 ): Promise<Response> {
   const gate = await proxy(req);
-  return passedThrough(gate) ? route(req) : gate;
+  if (!passedThrough(gate)) return gate;
+  const forwardedHeaders = new Headers();
+  const overridden = gate.headers
+    .get("x-middleware-override-headers")
+    ?.split(",")
+    .filter(Boolean) ?? [];
+  for (const name of overridden) {
+    const value = gate.headers.get(`x-middleware-request-${name}`);
+    if (value === null) forwardedHeaders.delete(name);
+    else forwardedHeaders.set(name, value);
+  }
+  return route(new Request(req, { headers: forwardedHeaders }));
 }
 
-test("tokenless loopback cannot list, decide, or revoke client-v1 authority", async () => {
+test("tokenless direct loopback can administer client-v1 in non-bundled development", async () => {
   const root = await mkdtemp(scratchPrefix);
   try {
     setEnv({ COVEN_CAVE_LOCAL_PEER_SECRET: loopbackSecret });
@@ -192,19 +204,13 @@ test("tokenless loopback cannot list, decide, or revoke client-v1 authority", as
     );
 
     for (const response of [pairingList, credentialList, approve, deny, revoke]) {
-      assert.equal(response.status, 503);
-      const payload = await response.json() as {
-        error: { code: string; message: string };
-      };
-      assert.equal(payload.error.code, "service_unavailable");
-      assert.match(payload.error.message, /desktop app/i);
-      assert.equal(JSON.stringify(payload).includes(loopbackSecret), false);
+      assert.equal(response.status, 200);
     }
-    assert.equal(runtime.pairingStore.get(approved.id)?.status, "pending");
-    assert.equal(runtime.pairingStore.get(denied.id)?.status, "pending");
+    assert.equal(runtime.pairingStore.get(approved.id)?.status, "approved");
+    assert.equal(runtime.pairingStore.get(denied.id)?.status, "denied");
     assert.equal(
       (await runtime.credentialStore.reload()).get(credential.credential.id)?.revokedAt,
-      null,
+      10_000,
     );
   } finally {
     restoreEnv();
@@ -213,7 +219,7 @@ test("tokenless loopback cannot list, decide, or revoke client-v1 authority", as
   }
 });
 
-test("tokenless create cannot become a bearer through unauthenticated approval", async () => {
+test("tokenless direct-loopback approval can complete local development pairing", async () => {
   const root = await mkdtemp(scratchPrefix);
   try {
     setEnv({ COVEN_CAVE_LOCAL_PEER_SECRET: loopbackSecret });
@@ -278,19 +284,82 @@ test("tokenless create cannot become a bearer through unauthenticated approval",
       ),
     );
 
-    assert.equal(approval.status, 503);
-    assert.equal(exchange.status, 409);
+    assert.equal(approval.status, 200);
+    assert.equal(exchange.status, 200);
     const exchangePayload = await exchange.json() as {
-      error: { code: string };
       data?: { bearer?: string };
     };
-    assert.equal(exchangePayload.error.code, "pairing_pending");
-    assert.equal(exchangePayload.data?.bearer, undefined);
-    assert.equal((await runtime.credentialStore.reload()).size, 0);
+    assert.equal(typeof exchangePayload.data?.bearer, "string");
+    assert.equal((await runtime.credentialStore.reload()).size, 1);
   } finally {
     restoreEnv();
     assert.equal(resolve(root).startsWith(scratchPrefix), true);
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("missing packaged admin token and caller-spoofed development marker fail closed", async () => {
+  const root = await mkdtemp(scratchPrefix);
+  try {
+    setEnv({
+      COVEN_CAVE_BUNDLE: "1",
+      COVEN_CAVE_LOCAL_PEER_SECRET: loopbackSecret,
+    });
+    const runtime = createClientV1Runtime({
+      credentialRoot: root,
+      loopbackSecret,
+      now: () => 25_000,
+    });
+    const bundled = await throughProxy(
+      request("GET", "/api/client/v1/admin/credentials"),
+      createAdminCredentialsGetHandler(runtime),
+    );
+    assert.equal(bundled.status, 500);
+
+    setEnv({ COVEN_CAVE_LOCAL_PEER_SECRET: loopbackSecret });
+    const spoofed = await throughProxy(
+      request("GET", "/api/client/v1/admin/credentials", {
+        headers: {
+          [CLIENT_V1_ADMIN_HEADER]: loopbackSecret,
+          [LOCAL_PEER_HEADER]: "forged-loopback-secret",
+        },
+      }),
+      createAdminCredentialsGetHandler(runtime),
+    );
+    assert.equal(spoofed.status, 403);
+
+    const direct = await createAdminCredentialsGetHandler(runtime)(
+      request("GET", "/api/client/v1/admin/credentials", {
+        headers: {
+          [CLIENT_V1_ADMIN_HEADER]: "1",
+        },
+      }),
+    );
+    assert.equal(direct.status, 503);
+  } finally {
+    restoreEnv();
+    assert.equal(resolve(root).startsWith(scratchPrefix), true);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("proxy replaces caller-supplied development admin markers", async () => {
+  try {
+    setEnv({ COVEN_CAVE_LOCAL_PEER_SECRET: loopbackSecret });
+    const response = await throughProxy(
+      request("GET", "/api/client/v1/admin/credentials", {
+        headers: {
+          [CLIENT_V1_ADMIN_HEADER]: "caller-spoof",
+        },
+      }),
+      async (forwarded) => Response.json({
+        marker: forwarded.headers.get(CLIENT_V1_ADMIN_HEADER),
+      }),
+    );
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { marker: loopbackSecret });
+  } finally {
+    restoreEnv();
   }
 });
 

--- a/src/lib/server/client-v1/admin-auth.ts
+++ b/src/lib/server/client-v1/admin-auth.ts
@@ -1,4 +1,5 @@
 import {
+  CLIENT_V1_ADMIN_HEADER,
   TOKEN_HEADER,
   expectedRequestOrigins,
   isAllowedRequestSourceAny,
@@ -54,9 +55,10 @@ export function requireClientV1Admin(
   options: { mutation?: boolean } = {},
 ): Response | null {
   // The listener's loopback stamp proves transport locality, not the Cave
-  // administrator. Only the configured per-launch sidecar credential grants
-  // this route family, so that is what this function checks — and it still
-  // reads no stamp of its own.
+  // administrator. Packaged Cave therefore requires its configured per-launch
+  // sidecar credential. Tokenless browser development has no such credential,
+  // so proxy() converts its verified direct-loopback decision into a separate,
+  // secret-valued admin marker after stripping any caller-supplied value.
   //
   // Locality is now required as well, one layer up: proxy() answers
   // `403 forbidden peer: client v1 admin requires direct loopback` for
@@ -69,7 +71,21 @@ export function requireClientV1Admin(
   // could read the credential list and the pending-pairing queue from off the
   // machine.
   const secret = process.env.COVEN_CAVE_AUTH_TOKEN?.trim();
-  if (!secret) return adminAuthorizationUnavailable();
+  if (!secret) {
+    const localPeerSecret = process.env.COVEN_CAVE_LOCAL_PEER_SECRET?.trim();
+    const suppliedLocalAdmin = req.headers.get(CLIENT_V1_ADMIN_HEADER);
+    if (
+      process.env.COVEN_CAVE_BUNDLE !== "1"
+      && localPeerSecret
+      && suppliedLocalAdmin
+      && timingSafeEqualString(suppliedLocalAdmin, localPeerSecret)
+    ) {
+      return options.mutation && !hasValidMutationSource(req)
+        ? adminMutationSourceRequired()
+        : null;
+    }
+    return adminAuthorizationUnavailable();
+  }
 
   const supplied = req.headers.get(TOKEN_HEADER);
   if (!supplied || !timingSafeEqualString(supplied, secret)) {

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -94,7 +94,12 @@ assert.match(
 );
 assert.match(
   source,
-  /isClientV1AdminPath\(req\.nextUrl\.pathname\)\s*\?\s*process\.env\.COVEN_CAVE_LOCAL_PEER_SECRET/,
+  /const localPeerSecret = process\.env\.COVEN_CAVE_LOCAL_PEER_SECRET\?\.trim\(\)/,
+  "proxy should normalize the per-boot secret once before validating or forwarding it",
+);
+assert.match(
+  source,
+  /isClientV1AdminPath\(req\.nextUrl\.pathname\)\s*\?\s*localPeerSecret/,
   "tokenless local Client v1 admin requests must receive only the proxy's verified per-boot secret",
 );
 assert.match(source, /const origin = req\.headers\.get\("origin"\)/, "API origin gate should read the source origin header once");
@@ -231,7 +236,7 @@ assert.match(
 // needs the mobile or sidecar credential.
 assert.match(
   source,
-  /isTrustedLocalPeer\(\s*req\.headers\.get\(LOCAL_PEER_HEADER\),\s*process\.env\.COVEN_CAVE_LOCAL_PEER_SECRET,?\s*\)/,
+  /isTrustedLocalPeer\(\s*req\.headers\.get\(LOCAL_PEER_HEADER\),\s*localPeerSecret,?\s*\)/,
   "local-peer classification must verify the server-stamped per-boot secret",
 );
 assert.doesNotMatch(

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -77,15 +77,25 @@ assert.match(
 );
 assert.match(
   source,
-  /nextWithMobileAccessMarker\(req, remoteIngress\)/,
+  /nextWithInternalAuthMarkers\(req, remoteIngress\)/,
   "proxy should forward the verified remote-ingress state into downstream request headers",
 );
 // A tailnet device is remote by construction, so it must carry the mobile
 // marker — otherwise desktop-only routes would treat a phone as local.
 assert.doesNotMatch(
   source,
-  /nextWithMobileAccessMarker\(req, mobileAccessAuthenticated\)/,
+  /nextWithInternalAuthMarkers\(req, mobileAccessAuthenticated\)/,
   "tailnet ingress must not be excluded from the mobile marker (desktop-only routes rely on it)",
+);
+assert.match(
+  source,
+  /requestHeaders\.delete\(CLIENT_V1_ADMIN_HEADER\)/,
+  "proxy must strip caller-supplied Client v1 admin markers",
+);
+assert.match(
+  source,
+  /isClientV1AdminPath\(req\.nextUrl\.pathname\)\s*\?\s*process\.env\.COVEN_CAVE_LOCAL_PEER_SECRET/,
+  "tokenless local Client v1 admin requests must receive only the proxy's verified per-boot secret",
 );
 assert.match(source, /const origin = req\.headers\.get\("origin"\)/, "API origin gate should read the source origin header once");
 assert.match(source, /const referer = req\.headers\.get\("referer"\)/, "API referer gate should read the source referer header once");

--- a/src/passkey-proxy-gate.test.ts
+++ b/src/passkey-proxy-gate.test.ts
@@ -84,7 +84,7 @@ assert.match(
 // reach route handlers carrying remote-ingress authority.
 assert.ok(
   proxySource.indexOf("passkey presence required") <
-    proxySource.lastIndexOf("return nextWithMobileAccessMarker"),
+    proxySource.lastIndexOf("return nextWithInternalAuthMarkers"),
   "the gate precedes the pass-through",
 );
 

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -544,6 +544,7 @@ export const LEGACY_ACCESS_PROMPT_QUERY_PARAM = "coven_access_prompt";
 export const TOKEN_PARAM = "covenCaveToken";
 export const TOKEN_HEADER = "x-coven-cave-token";
 export const MOBILE_ACCESS_HEADER = "x-coven-cave-mobile-access";
+export const CLIENT_V1_ADMIN_HEADER = "x-coven-cave-client-v1-admin";
 export const SAFE_CONTENT_TYPES = [
   "application/json",
   "application/x-www-form-urlencoded",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -320,9 +320,10 @@ export async function proxy(req: NextRequest) {
   // The local-peer stamp distinguishes direct from forwarded traffic. Direct,
   // unforwarded loopback is the browser's no-prompt path; remote traffic still
   // requires a mobile or sidecar credential.
+  const localPeerSecret = process.env.COVEN_CAVE_LOCAL_PEER_SECRET?.trim();
   const trustedLocalPeer = isTrustedLocalPeer(
     req.headers.get(LOCAL_PEER_HEADER),
-    process.env.COVEN_CAVE_LOCAL_PEER_SECRET,
+    localPeerSecret,
   );
   if (isAuthenticatedDevReadinessProbe(req, trustedLocalPeer)) {
     const response = NextResponse.next();
@@ -545,7 +546,7 @@ export async function proxy(req: NextRequest) {
       req,
       remoteIngress,
       isClientV1AdminPath(req.nextUrl.pathname)
-        ? process.env.COVEN_CAVE_LOCAL_PEER_SECRET
+        ? localPeerSecret
         : undefined,
     );
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,6 +7,7 @@ import {
   TOKEN_PARAM,
   TOKEN_HEADER,
   MOBILE_ACCESS_HEADER,
+  CLIENT_V1_ADMIN_HEADER,
   LOCAL_PEER_HEADER,
   SAFE_CONTENT_TYPES,
   timingSafeEqualString,
@@ -290,10 +291,18 @@ function isProductionWebhookGet(pathname: string, method: string) {
   );
 }
 
-function nextWithMobileAccessMarker(req: NextRequest, mobileAccessAuthenticated: boolean) {
+function nextWithInternalAuthMarkers(
+  req: NextRequest,
+  mobileAccessAuthenticated: boolean,
+  clientV1AdminSecret?: string,
+) {
   const requestHeaders = new Headers(req.headers);
   requestHeaders.delete(MOBILE_ACCESS_HEADER);
+  requestHeaders.delete(CLIENT_V1_ADMIN_HEADER);
   if (mobileAccessAuthenticated) requestHeaders.set(MOBILE_ACCESS_HEADER, "1");
+  if (clientV1AdminSecret) {
+    requestHeaders.set(CLIENT_V1_ADMIN_HEADER, clientV1AdminSecret);
+  }
   return NextResponse.next({ request: { headers: requestHeaders } });
 }
 
@@ -516,7 +525,7 @@ export async function proxy(req: NextRequest) {
     if (!trustedLocalPeer || remoteIngress) {
       return jsonError(403, "forbidden peer: client v1 requires direct loopback");
     }
-    return nextWithMobileAccessMarker(req, false);
+    return nextWithInternalAuthMarkers(req, false);
   }
 
   const suppliedToken =
@@ -532,7 +541,13 @@ export async function proxy(req: NextRequest) {
     if (!isTokenlessApiPeerAllowed(trustedLocalPeer, remoteIngress)) {
       return jsonError(403, "forbidden peer: missing trusted local peer or verified remote ingress");
     }
-    return nextWithMobileAccessMarker(req, remoteIngress);
+    return nextWithInternalAuthMarkers(
+      req,
+      remoteIngress,
+      isClientV1AdminPath(req.nextUrl.pathname)
+        ? process.env.COVEN_CAVE_LOCAL_PEER_SECRET
+        : undefined,
+    );
   }
 
   // Direct loopback is the prompt-free browser path for ordinary app APIs.
@@ -543,7 +558,7 @@ export async function proxy(req: NextRequest) {
     trustedLocalPeer && !isClientV1Path(req.nextUrl.pathname);
   if (!sidecarAuthenticated && !mobileAccessVerified && !trustedLocalBrowserApi) {
     if (mediaTicketAuthenticated) {
-      return nextWithMobileAccessMarker(req, remoteIngress);
+      return nextWithInternalAuthMarkers(req, remoteIngress);
     }
     // A verified signed mobile invite is the paired phone's credential: the
     // token is minted by this desktop from its access secret and already
@@ -555,7 +570,7 @@ export async function proxy(req: NextRequest) {
     return jsonError(401, "unauthorized");
   }
 
-  return nextWithMobileAccessMarker(req, remoteIngress);
+  return nextWithInternalAuthMarkers(req, remoteIngress);
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- authorize direct-loopback Client v1 admin requests in tokenless non-bundled development through a proxy-stamped per-boot secret
- strip caller-supplied internal markers and preserve packaged sidecar-token enforcement
- expand security regression coverage and document the development/packaged boundary

## Validation
- focused Client v1 admin, proxy, middleware, API contract, and Settings tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- real isolated HTTP pairing, approval, exchange, and credential-list flow

Bead: cave-pisle