### PR TITLE
Move workspace context into title bar

### DIFF
--- a/src/components/familiar-quick-switch.test.ts
+++ b/src/components/familiar-quick-switch.test.ts
@@ -22,21 +22,21 @@ assert.doesNotMatch(source, /computeQuickSwitch/, "the strip's pin/recency selec
 assert.doesNotMatch(familiarStyles, /\.familiar-quickswitch__strip \{/, "strip CSS removed");
 assert.match(familiarStyles, /\.familiar-quickswitch \{/, "wrapper CSS remains for the top-bar call site");
 
-// ── Familiar selection follows the active primary sidebar ─────────────────────
-// WorkspaceSidebar replaces SidebarMinimal as the primary contextual nav in the
-// Code section. Each host keeps a labeled switcher for the section where it is
-// active, and SidebarMinimal returns outside Code.
+// ── Familiar selection stays in persistent title-bar context ─────────────────
 assert.doesNotMatch(menuBar, /FamiliarQuickSwitch|FamiliarSwitcher/, "the menu bar no longer hosts familiar selection");
-// Chat reaches the labeled switcher through the shared SidebarRailHeader and
-// WorkspaceContextSwitcher, so project and crew stay one stable shell block.
-assert.match(sidebar, /<SidebarRailHeader[\s\S]*?familiars=\{familiars\}/, "the Chats list header keeps a labeled familiar switcher beside thread navigation");
+assert.match(sidebar, /<SidebarRailHeader[\s\S]*?showContext=\{false\}/, "the Chats list header suppresses duplicate scope controls");
 assert.match(railHeader, /<WorkspaceContextSwitcher/, "the shared header mounts the project-and-crew context switcher");
 assert.match(contextSwitcher, /<FamiliarSwitcher[\s\S]*?labeled/, "the context switcher mounts the crew switcher in its labeled form");
 const sidenav = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 assert.match(
   sidenav,
-  /<SidebarRailHeader[\s\S]*?onSelectFamiliar=\{onFamiliarScopeChange\}/,
-  "the normal sidenav header keeps the labeled familiar switcher when Chat is inactive",
+  /<SidebarRailHeader[\s\S]*?showContext=\{false\}/,
+  "the normal sidenav header also suppresses duplicate scope controls",
+);
+assert.match(
+  workspace,
+  /<WorkspaceContextSwitcher[\s\S]*?variant="titlebar"/,
+  "Workspace owns the persistent title-bar familiar selector",
 );
 assert.match(
   workspace,

--- a/src/components/familiar-quick-switch.test.ts
+++ b/src/components/familiar-quick-switch.test.ts
@@ -24,14 +24,14 @@ assert.match(familiarStyles, /\.familiar-quickswitch \{/, "wrapper CSS remains f
 
 // ── Familiar selection stays in persistent title-bar context ─────────────────
 assert.doesNotMatch(menuBar, /FamiliarQuickSwitch|FamiliarSwitcher/, "the menu bar no longer hosts familiar selection");
-assert.match(sidebar, /<SidebarRailHeader[\s\S]*?showContext=\{false\}/, "the Chats list header suppresses duplicate scope controls");
+assert.match(sidebar, /<SidebarRailHeader[\s\S]*?contextMode="mobile"/, "the Chats list header keeps scope controls only in the mobile drawer");
 assert.match(railHeader, /<WorkspaceContextSwitcher/, "the shared header mounts the project-and-crew context switcher");
 assert.match(contextSwitcher, /<FamiliarSwitcher[\s\S]*?labeled/, "the context switcher mounts the crew switcher in its labeled form");
 const sidenav = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 assert.match(
   sidenav,
-  /<SidebarRailHeader[\s\S]*?showContext=\{false\}/,
-  "the normal sidenav header also suppresses duplicate scope controls",
+  /<SidebarRailHeader[\s\S]*?contextMode="mobile"/,
+  "the normal sidenav header also keeps scope controls only in the mobile drawer",
 );
 assert.match(
   workspace,

--- a/src/components/nav-section-tabs.test.ts
+++ b/src/components/nav-section-tabs.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
-// Pins the global Home | Chat section switcher (cave-24d2r): both siderail
-// hosts mount it, the tabs carry real tab semantics, and the shell derives the
-// section from the active surface rather than storing a second source of truth.
+// Pins the global Home | Chat section switcher (cave-24d2r): Workspace mounts
+// it in the title bar, the tabs carry real tab semantics, and the shell derives
+// the section from the active surface rather than storing a second source of truth.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -36,12 +36,7 @@ assert.match(tabs, /tabIndex=\{active \? 0 : -1\}/, "the switcher is one tab sto
 assert.match(tabs, /ArrowLeft|ArrowRight/, "arrow keys move between sections");
 assert.match(tabs, /focus-ring/, "tabs carry the shared focus ring");
 
-assert.match(sidebar, /<NavSectionTabs section=\{section\} onSectionChange=\{onSectionChange\}/, "the Home rail hosts the switcher");
-assert.match(
-  sidebar,
-  /<NavSectionTabs section=\{section\} onSectionChange=\{onSectionChange\}[\s\S]*?<SidebarRailHeader[\s\S]*?onNewChat=\{onNewChat\}/,
-  "the Home rail keeps section tabs and the shared scope + New chat header in order",
-);
+assert.doesNotMatch(sidebar, /<NavSectionTabs/, "the Home rail no longer hosts the switcher");
 assert.match(sidebar, /role="tabpanel"/, "the destination list is the switcher's panel");
 assert.match(
   sidebar,
@@ -67,16 +62,7 @@ assert.match(
   "the shared New chat action is a tinted quiet button, not a solid accent fill",
 );
 
-assert.match(
-  chatSidebar,
-  /<NavSectionTabs section="code" onSectionChange=\{onSectionChange\}/,
-  "the Chat-time rail hosts the same switcher so it never moves between rooms",
-);
-assert.match(
-  chatSidebar,
-  /<NavSectionTabs section="code" onSectionChange=\{onSectionChange\}[\s\S]*?<SidebarRailHeader[\s\S]*?onNewChat=\{onNewChat\}[\s\S]*?newChatTitle="New chat \(⌘N\)"/,
-  "the Chat rail keeps section tabs and the same shared scope + New chat header in order",
-);
+assert.doesNotMatch(chatSidebar, /<NavSectionTabs/, "the Chat rail no longer hosts the switcher");
 assert.doesNotMatch(
   chatSidebar,
   /<SidebarRailHeader[\s\S]{0,600}?Sidebar options/,
@@ -122,6 +108,16 @@ assert.match(
 );
 
 assert.match(workspace, /const navSection = navSectionForMode\(mode\)/, "the shell derives the section from the surface");
+assert.match(
+  workspace,
+  /workspace-titlebar-context[\s\S]*?<NavSectionTabs[\s\S]*?variant="titlebar"/,
+  "Workspace mounts the compact section switcher in the title bar",
+);
+assert.match(
+  workspace,
+  /workspace-titlebar-context[\s\S]*?<WorkspaceContextSwitcher[\s\S]*?variant="titlebar"/,
+  "project and familiar scope sit beside the title-bar section switcher",
+);
 assert.match(
   workspace,
   /setMode\(next === "code" \? "chat" : "home"\)/,

--- a/src/components/nav-section-tabs.test.ts
+++ b/src/components/nav-section-tabs.test.ts
@@ -32,6 +32,7 @@ assert.match(
 assert.match(tabs, /role="tablist"/, "the switcher is a tablist, not a second row of destinations");
 assert.match(tabs, /role="tab"/, "each section renders as a tab");
 assert.match(tabs, /aria-selected=\{active\}/, "the open section is announced as selected");
+assert.match(tabs, /aria-label=\{entry\.label\}/, "icon-only title-bar tabs retain concise accessible names");
 assert.match(tabs, /tabIndex=\{active \? 0 : -1\}/, "the switcher is one tab stop with roving focus");
 assert.match(tabs, /ArrowLeft|ArrowRight/, "arrow keys move between sections");
 assert.match(tabs, /focus-ring/, "tabs carry the shared focus ring");
@@ -118,6 +119,8 @@ assert.match(
   /workspace-titlebar-context[\s\S]*?<WorkspaceContextSwitcher[\s\S]*?variant="titlebar"/,
   "project and familiar scope sit beside the title-bar section switcher",
 );
+assert.match(sidebar, /contextMode="mobile"/, "the Home drawer retains project and familiar scope on mobile");
+assert.match(chatSidebar, /contextMode="mobile"/, "the Chat drawer retains project and familiar scope on mobile");
 assert.match(
   workspace,
   /setMode\(next === "code" \? "chat" : "home"\)/,

--- a/src/components/nav-section-tabs.tsx
+++ b/src/components/nav-section-tabs.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 /**
- * NavSectionTabs — the global Home / Chat switcher that tops the left siderail
- * (cave-24d2r).
- *
- * Rendered by both siderail hosts (SidebarMinimal and the Chat-time
- * WorkspaceSidebar) so the switcher stays in the same place no matter which
- * room is open. It is presentation only: the active section and the change
- * handler are owned by the workspace shell.
+ * NavSectionTabs — the global Home / Chat switcher.
  */
 
 import { Icon, CAVE_ICON_SIZE } from "@/lib/icon";
@@ -16,12 +10,14 @@ import { NAV_SECTIONS, type NavSection } from "@/lib/nav-section";
 export function NavSectionTabs({
   section,
   onSectionChange,
+  variant = "rail",
 }: {
   section: NavSection;
   onSectionChange: (section: NavSection) => void;
+  variant?: "rail" | "titlebar";
 }) {
   return (
-    <div className="nav-sections" role="tablist" aria-label="Workspace sections">
+    <div className={`nav-sections nav-sections--${variant}`} role="tablist" aria-label="Workspace sections">
       {NAV_SECTIONS.map((entry) => {
         const active = entry.id === section;
         return (

--- a/src/components/nav-section-tabs.tsx
+++ b/src/components/nav-section-tabs.tsx
@@ -28,6 +28,7 @@ export function NavSectionTabs({
             id={`nav-section-tab-${entry.id}`}
             aria-selected={active}
             aria-controls={`nav-section-panel-${entry.id}`}
+            aria-label={entry.label}
             tabIndex={active ? 0 : -1}
             title={`${entry.label} — ${entry.description} (${entry.kbd})`}
             className={`nav-sections__tab focus-ring${active ? " is-active" : ""}`}

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -93,7 +93,7 @@ assert.match(
   "Sidebar should keep the main navigation in one continuous scrollable rail",
 );
 
-assert.match(source, /<NavSectionTabs section=\{section\} onSectionChange=\{onSectionChange\}/, "sidebar destinations use the shared Home and Code tabs");
+assert.doesNotMatch(source, /<NavSectionTabs/, "sidebar destinations no longer duplicate the title-bar section switcher");
 assert.match(source, /navItemsForSection\(section\)\.map/, "the active tab filters destination rows through the shared registry");
 assert.match(source, /sectionRooms\.map\(\(room\) =>/, "dynamic role-surface rooms follow the active section");
 assert.match(source, /itemSelector: "\.sidebar-folder-row"/, "visible destinations share one roving keyboard sequence");

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -21,7 +21,6 @@ import {
 } from "@/lib/page-drag";
 import { sidebarRowState, type SidebarRowState } from "@/lib/sidebar-nav-state";
 import { RecentActivityRollup } from "@/components/recent-activity-rollup";
-import { NavSectionTabs } from "@/components/nav-section-tabs";
 import { SidebarFooter } from "@/components/sidebar-footer";
 import {
   DEFAULT_NAV_SECTION,
@@ -194,7 +193,6 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
   const {
     mode,
     section = DEFAULT_NAV_SECTION,
-    onSectionChange,
     onNewChat,
     onOpenSettings,
     onModeChange,
@@ -234,13 +232,8 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
       {/* Static wordmark. Collapsing the sidebar is now owned by the shell's
           floating top-left toggle (and ⌘B), so the header is no longer a
           button — it just leaves room for the float. */}
-      {onSectionChange ? <NavSectionTabs section={section} onSectionChange={onSectionChange} /> : null}
-
-      {/* Familiar scope + New chat (cave-vtk9) — SHARED with the Chat section
-          via SidebarRailHeader, so the two controls cannot drift apart across
-          the Home/Chat toggle the way the forked copies did. The collapsed rail
-          keeps the avatar-only trigger; the mobile top bar keeps its own
-          switcher (the drawer hides this one). */}
+      {/* New chat remains in the rail; section and scope controls live in the
+          persistent title bar so they do not move with the drawer. */}
       <SidebarRailHeader
         familiars={familiars}
         activeFamiliarId={activeFamiliarId ?? null}
@@ -262,6 +255,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         projectCrewError={props.projectCrewError}
         reloadProjectCrew={props.reloadProjectCrew}
         contextNotice={props.contextNotice}
+        showContext={false}
       />
 
       <div

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -255,7 +255,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         projectCrewError={props.projectCrewError}
         reloadProjectCrew={props.reloadProjectCrew}
         contextNotice={props.contextNotice}
-        showContext={false}
+        contextMode="mobile"
       />
 
       <div

--- a/src/components/sidebar-rail-header.tsx
+++ b/src/components/sidebar-rail-header.tsx
@@ -73,7 +73,7 @@ export type SidebarRailHeaderProps = {
   projectCrewError?: string | null;
   reloadProjectCrew?: () => void;
   contextNotice?: string | null;
-  showContext?: boolean;
+  contextMode?: "all" | "mobile" | "hidden";
 };
 
 export function SidebarRailHeader({
@@ -101,7 +101,7 @@ export function SidebarRailHeader({
   projectCrewError,
   reloadProjectCrew,
   contextNotice,
-  showContext = true,
+  contextMode = "all",
 }: SidebarRailHeaderProps) {
   // Context is ready when every required Task6 prop has been supplied. A prop
   // that is null or false is supplied; undefined means the caller has not wired
@@ -122,7 +122,7 @@ export function SidebarRailHeader({
 
   return (
     <div className="rail-header">
-      {showContext ? <div className="rail-header__scope">
+      {contextMode !== "hidden" ? <div className={`rail-header__scope${contextMode === "mobile" ? " rail-header__scope--mobile" : ""}`}>
         <WorkspaceContextSwitcher
           projects={workspaceContextReady ? projects! : EMPTY_PROJECTS}
           projectId={workspaceContextReady ? projectId! : null}

--- a/src/components/sidebar-rail-header.tsx
+++ b/src/components/sidebar-rail-header.tsx
@@ -73,6 +73,7 @@ export type SidebarRailHeaderProps = {
   projectCrewError?: string | null;
   reloadProjectCrew?: () => void;
   contextNotice?: string | null;
+  showContext?: boolean;
 };
 
 export function SidebarRailHeader({
@@ -100,6 +101,7 @@ export function SidebarRailHeader({
   projectCrewError,
   reloadProjectCrew,
   contextNotice,
+  showContext = true,
 }: SidebarRailHeaderProps) {
   // Context is ready when every required Task6 prop has been supplied. A prop
   // that is null or false is supplied; undefined means the caller has not wired
@@ -120,7 +122,7 @@ export function SidebarRailHeader({
 
   return (
     <div className="rail-header">
-      <div className="rail-header__scope">
+      {showContext ? <div className="rail-header__scope">
         <WorkspaceContextSwitcher
           projects={workspaceContextReady ? projects! : EMPTY_PROJECTS}
           projectId={workspaceContextReady ? projectId! : null}
@@ -142,7 +144,7 @@ export function SidebarRailHeader({
           onSelectFamiliar={onSelectFamiliar}
           contextNotice={contextNotice}
         />
-      </div>
+      </div> : null}
       <div className="rail-header__actions">
         <button type="button" className="rail-header__new focus-ring" onClick={onNewChat} title={newChatTitle}>
           <Icon

--- a/src/components/workspace-context-switcher.tsx
+++ b/src/components/workspace-context-switcher.tsx
@@ -32,6 +32,7 @@ export type WorkspaceContextSwitcherProps = {
   sessions: SessionRow[];
   responseNeeded?: Set<string>;
   contextNotice?: string | null;
+  variant?: "rail" | "titlebar";
 };
 
 /**
@@ -62,9 +63,10 @@ export function WorkspaceContextSwitcher({
   sessions,
   responseNeeded,
   contextNotice,
+  variant = "rail",
 }: WorkspaceContextSwitcherProps) {
   return (
-    <div className="workspace-context-switcher">
+    <div className={`workspace-context-switcher workspace-context-switcher--${variant}`}>
       {projectError ? (
         <div className="workspace-context-switcher__error" role="alert">
           <span>{projectError}</span>

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -700,7 +700,7 @@ export function WorkspaceSidebar({
           projectCrewError={workspaceProjectCrewError}
           reloadProjectCrew={reloadWorkspaceProjectCrew}
           contextNotice={workspaceContextNotice}
-          showContext={false}
+          contextMode="mobile"
         />
 
         <div className="cnav__search-wrap">

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -39,7 +39,6 @@ import {
 } from "@/lib/chat-split";
 import { Popover, PopoverBody, PopoverItem, PopoverLabel } from "@/components/ui/popover";
 import { type CreateProjectOptions } from "@/lib/chat-add-project";
-import { NavSectionTabs } from "@/components/nav-section-tabs";
 import type { NavSection } from "@/lib/nav-section";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { CaveProject } from "@/lib/cave-projects-types";
@@ -677,17 +676,7 @@ export function WorkspaceSidebar({
   return (
     <div className="workspace-sidebar chat-sidebar flex h-full min-h-0 flex-col">
       <div className="workspace-sidebar__full chat-sidebar__full cnav">
-        {/* Global section switcher — Home | Chat (cave-24d2r). This sidebar IS
-            the Code room, so switching to Home hands the rail back to the
-            standard destination list. */}
-        {onSectionChange ? <NavSectionTabs section="code" onSectionChange={onSectionChange} /> : null}
-        {/* Header — the labeled familiar switcher (#2747) and New chat, SHARED
-            with the Home section via SidebarRailHeader so the two controls
-            cannot drift apart across the Home/Chat toggle. WorkspaceSidebar
-            owns the primary Shell nav during Chat; Home exits Chat and restores
-            the normal navigation. This scope control was restored by cave-l3ay
-            after #2750 removed it as a supposed duplicate. The ⌘N hint rides
-            the shared button's trailing slot rather than forking it. */}
+        {/* Section and scope controls live in the persistent title bar. */}
         <SidebarRailHeader
           familiars={familiars}
           activeFamiliarId={activeFamiliarId}
@@ -711,6 +700,7 @@ export function WorkspaceSidebar({
           projectCrewError={workspaceProjectCrewError}
           reloadProjectCrew={reloadWorkspaceProjectCrew}
           contextNotice={workspaceContextNotice}
+          showContext={false}
         />
 
         <div className="cnav__search-wrap">

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -66,6 +66,8 @@ import { Shell, type ShellHandle } from "@/components/shell";
 import type { DetailSplitTile } from "@/components/detail-split-host";
 import { WorkspacePanePage } from "@/components/workspace-pane-page";
 import { MobileBottomTabs } from "@/components/mobile-bottom-tabs";
+import { NavSectionTabs } from "@/components/nav-section-tabs";
+import { WorkspaceContextSwitcher } from "@/components/workspace-context-switcher";
 import { openGrimoireDoc } from "@/lib/grimoire-link";
 import { FamiliarStudioProvider } from "@/lib/familiar-studio-context";
 import { useSurfacePreference } from "@/lib/surface-preferences";
@@ -4699,6 +4701,34 @@ export function Workspace() {
         onRightChatOpenChange={setRightChatOpen}
         topBar={({ navDrawerOpen }) => (
           <>
+            <div className="workspace-titlebar-context">
+              <NavSectionTabs
+                section={navSection}
+                onSectionChange={handleSectionChange}
+                variant="titlebar"
+              />
+              <WorkspaceContextSwitcher
+                projects={registeredProjects}
+                projectId={selectedWorkspaceProjectId}
+                onProjectChange={selectWorkspaceProject}
+                projectLoading={projectsLoading}
+                projectError={projectsError}
+                reloadProjects={reloadProjects}
+                project={selectedWorkspaceProject}
+                createProjectOrThrow={createProjectOrThrow}
+                allFamiliars={resolvedFamiliars}
+                projectCrew={resolvedProjectCrew}
+                projectCrewLoading={effectiveProjectCrewLoading}
+                projectCrewError={projectCrewError}
+                reloadProjectCrew={reloadProjectCrew}
+                activeFamiliarId={activeId}
+                selectedFamiliarIds={scopeIds}
+                onSelectFamiliar={selectFamiliarScope}
+                sessions={sessions}
+                responseNeeded={responseNeeded}
+                variant="titlebar"
+              />
+            </div>
             <FamiliarMenuBar
               activeFamiliarId={activeId}
               // Running processes: clicking the waveform trigger lists each

--- a/src/styles/globals/rail-header.css
+++ b/src/styles/globals/rail-header.css
@@ -33,6 +33,10 @@
   flex-shrink: 0;
 }
 
+.rail-header__scope--mobile {
+  display: none;
+}
+
 /* The scope control and New-chat button are the same box; workspace-context-switcher.css
    owns the selector-specific trigger rules. */
 
@@ -98,6 +102,12 @@
   font-family: var(--font-mono);
   font-size: var(--text-2xs);
   color: var(--text-muted);
+}
+
+@media (max-width: 1023px) {
+  .rail-header__scope--mobile {
+    display: flex;
+  }
 }
 
 /* ── Collapsed 56px icon rail ─────────────────────────────────────────────── */

--- a/src/styles/globals/workspace-context-switcher.css
+++ b/src/styles/globals/workspace-context-switcher.css
@@ -109,11 +109,20 @@
 }
 
 .workspace-context-switcher--titlebar :is(
-  .workspace-context-switcher__error,
   .workspace-context-switcher__empty,
   .workspace-context-switcher__notice
 ) {
   display: none;
+}
+
+.workspace-context-switcher--titlebar .workspace-context-switcher__error {
+  max-width: 200px;
+  white-space: nowrap;
+}
+
+.workspace-context-switcher--titlebar .workspace-context-switcher__error > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .workspace-context-switcher--titlebar .workspace-context-switcher__project .cave-project-picker__trigger,

--- a/src/styles/globals/workspace-context-switcher.css
+++ b/src/styles/globals/workspace-context-switcher.css
@@ -92,6 +92,61 @@
   font-size: var(--text-xs);
 }
 
+.workspace-titlebar-context {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  margin-inline-end: var(--space-2);
+}
+
+.workspace-context-switcher--titlebar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  width: auto;
+  min-width: 0;
+}
+
+.workspace-context-switcher--titlebar :is(
+  .workspace-context-switcher__error,
+  .workspace-context-switcher__empty,
+  .workspace-context-switcher__notice
+) {
+  display: none;
+}
+
+.workspace-context-switcher--titlebar .workspace-context-switcher__project .cave-project-picker__trigger,
+.workspace-context-switcher--titlebar .workspace-context-switcher__crew .familiar-switcher__trigger--labeled {
+  width: auto;
+  min-width: 120px;
+  max-width: 160px;
+  min-height: 28px;
+  padding-inline: var(--space-2);
+  gap: var(--space-1);
+  border-color: transparent;
+  background: transparent;
+}
+
+.workspace-context-switcher--titlebar .workspace-context-switcher__project .cave-project-picker__trigger:hover,
+.workspace-context-switcher--titlebar .workspace-context-switcher__crew .familiar-switcher__trigger--labeled:hover {
+  border-color: var(--border-hairline);
+  background: var(--bg-hover);
+}
+
+.workspace-context-switcher--titlebar :is(
+  .cave-project-picker__trigger-label,
+  .familiar-switcher__trigger-label
+) {
+  font-size: var(--text-sm);
+}
+
+@media (max-width: 1023px) {
+  .workspace-titlebar-context {
+    display: none;
+  }
+}
+
 /* ── Collapsed 56px icon rail ─────────────────────────────────────────────── */
 /* Both context controls collapse to --rail-control squares centred on the rail,
    labels and carets hidden. Status rows are suppressed since there is no room. */

--- a/src/styles/sidebar-minimal/section-tabs.css
+++ b/src/styles/sidebar-minimal/section-tabs.css
@@ -87,6 +87,7 @@
   width: 28px;
   min-height: 28px;
   padding: 0;
+  border: 1px solid transparent;
   border-radius: var(--radius-pill);
 }
 

--- a/src/styles/sidebar-minimal/section-tabs.css
+++ b/src/styles/sidebar-minimal/section-tabs.css
@@ -72,6 +72,35 @@
   text-overflow: ellipsis;
 }
 
+.nav-sections--titlebar {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  margin: 0;
+  padding: 2px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  background: var(--bg-subtle);
+}
+
+.nav-sections--titlebar .nav-sections__tab {
+  width: 28px;
+  min-height: 28px;
+  padding: 0;
+  border-radius: var(--radius-pill);
+}
+
+.nav-sections--titlebar .nav-sections__tab.is-active {
+  padding: 0;
+  background: var(--bg-raised);
+  border-color: var(--border-strong);
+  box-shadow: 0 1px 3px color-mix(in oklch, var(--shadow-color) 18%, transparent);
+}
+
+.nav-sections--titlebar .nav-sections__label {
+  display: none;
+}
+
 /* Collapsed 56px rail: labels drop, the control stacks so both rooms stay
    reachable as icons (same treatment as the destination rows), and each tab
    takes the rail's shared --rail-control width so the strip sits on the same

--- a/tests/chat-sidebar-nav.spec.ts
+++ b/tests/chat-sidebar-nav.spec.ts
@@ -152,17 +152,12 @@ async function ensureChatSurface(page: Page) {
       const openNav = page.getByRole("button", { name: "Open navigation (⌘B)" });
       if (await openNav.isVisible().catch(() => false)) await openNav.click();
     }
-    // The Chat row lives in the rail's second section (cave-24d2r); when the
-    // Home section is open, that section's tab is the way in. Its LABEL is
-    // "Chat" while its id stays "code" (NAV_SECTIONS) — the label was flipped
-    // from "Code" by 68342e3 (fix/cave-vqh94-home-chat-tabs), which left this
-    // helper waiting 60s for a tab name that no longer exists. Scoped to the
-    // "Workspace sections" tablist so it collides with neither the mobile
-    // bottom tab of the same name nor the nav row inside the section.
+    // The persistent title-bar section switch is the way into Chat when the
+    // destination row is not currently visible.
     if (await chatDestination.isVisible().catch(() => false)) {
       await chatDestination.click();
     } else {
-      await nav
+      await page
         .getByRole("tablist", { name: "Workspace sections" })
         .getByRole("tab", { name: "Chat", exact: true })
         .first()

--- a/tests/right-chat-panel.spec.ts
+++ b/tests/right-chat-panel.spec.ts
@@ -99,12 +99,11 @@ test("desktop keeps the panel across surfaces and supports a second Chat convers
   await expect(panel).toContainText("Newest Cody chat");
   await expect(panel).not.toContainText("Nova must not be selected");
 
-  await page.getByRole("button", { name: "Expand navigation" }).click();
-  const navigation = page.locator(".shell-nav");
-  await expect(navigation).toHaveAttribute("aria-hidden", "false");
+  const titlebarContext = page.locator(".workspace-titlebar-context");
+  await expect(titlebarContext).toBeVisible();
 
   const chooseFamiliar = async (name: string) => {
-    await navigation.locator('button[aria-label^="Switch familiar"]').click();
+    await titlebarContext.locator('button[aria-label^="Switch familiar"]').click();
     await page.getByRole("dialog", { name: "Familiars" }).getByText(name, { exact: true }).last().click();
   };
 

--- a/tests/sidebar-hidden-push.spec.ts
+++ b/tests/sidebar-hidden-push.spec.ts
@@ -41,6 +41,7 @@ test("closing navigation removes the rail and opening pushes the main panel", as
   const detail = page.locator(".shell-detail");
   const toggle = page.locator(".shell-top-toggle--nav");
 
+  await expect(page.locator(".shell-frame")).toHaveAttribute("data-settled", "");
   await expect(toggle).toHaveAttribute("aria-expanded", "false");
   await expect(page.locator(".shell-nav--rail, .shell-nav--peek")).toHaveCount(0);
   await expect(page.locator(".shell-nav")).toHaveAttribute("aria-hidden", "true");


### PR DESCRIPTION
## Summary
- move the Home/Chat switch into the persistent title bar as a compact raised icon segment
- place project and familiar selectors beside sidebar and history controls
- remove duplicate section and scope controls from both desktop siderails while retaining New chat
- preserve mobile chrome, keyboard tab semantics, arrow navigation, and tokenized theme behavior

## Validation
- related navigation, sidebar, familiar, and context-switcher contract tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- production browser verification at 1440x900; title-bar controls visible and rail duplicates absent

Bead: cave-npg64