### PR TITLE
Open Rituals daily summaries directly

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -257,6 +257,16 @@ assert.match(source, /onClick=\{\(\) => void load\(true\)\}[\s\S]{0,180}>\s*Retr
 // reference would re-fire the form reset (cron) or is pointless churn (reminder).
 assert.match(source, /if \(JSON\.stringify\(fresh\) !== JSON\.stringify\(selectedCodex\)\) setSelectedCodex\(fresh\)/, "cron detail sync is content-guarded");
 assert.match(source, /if \(JSON\.stringify\(fresh\) !== JSON\.stringify\(selectedItem\)\) setSelectedItem\(fresh\)/, "reminder detail panel re-syncs after polls");
+assert.match(
+  source,
+  /const openInboxItem = useCallback\(\(item: InboxItem\) => \{[\s\S]*?item\.kind === "daily-summary"[\s\S]*?item\.link[\s\S]*?onOpenLink\(item\.link\);[\s\S]*?setSelectedItem\(item\)/,
+  "daily summaries open their canonical report link while other inbox items keep the detail panel",
+);
+assert.match(
+  source,
+  /onSelect=\{openInboxItem\}/,
+  "every Rituals list presentation shares the daily-summary navigation boundary",
+);
 
 // ── 2026-07-03 a11y batch ─────────────────────────────────────────────────────
 assert.match(source, /const \{ announce \} = useAnnouncer\(\)/, "AutomationsView consumes the shared announcer");

--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -2,8 +2,9 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
+const automationsView = readFileSync(new URL("./automations-view.tsx", import.meta.url), "utf8");
 const source = [
-  readFileSync(new URL("./automations-view.tsx", import.meta.url), "utf8"),
+  automationsView,
   readFileSync(new URL("./automations/status-icon.tsx", import.meta.url), "utf8"),
   readFileSync(new URL("./automations/cron-detail-primitives.tsx", import.meta.url), "utf8"),
   readFileSync(new URL("./automations/cron-detail-panel.tsx", import.meta.url), "utf8"),
@@ -258,14 +259,18 @@ assert.match(source, /onClick=\{\(\) => void load\(true\)\}[\s\S]{0,180}>\s*Retr
 assert.match(source, /if \(JSON\.stringify\(fresh\) !== JSON\.stringify\(selectedCodex\)\) setSelectedCodex\(fresh\)/, "cron detail sync is content-guarded");
 assert.match(source, /if \(JSON\.stringify\(fresh\) !== JSON\.stringify\(selectedItem\)\) setSelectedItem\(fresh\)/, "reminder detail panel re-syncs after polls");
 assert.match(
-  source,
-  /const openInboxItem = useCallback\(\(item: InboxItem\) => \{[\s\S]*?item\.kind === "daily-summary"[\s\S]*?item\.link[\s\S]*?onOpenLink\(item\.link\);[\s\S]*?setSelectedItem\(item\)/,
+  automationsView,
+  /const openInboxItem = useCallback\(\(item: InboxItem\) => \{\s*if \(item\.kind === "daily-summary" && item\.link && onOpenLink\) \{\s*onOpenLink\(item\.link\);\s*return;\s*\}\s*setSelectedItem\(item\);\s*setSelectedCodex\(null\);/,
   "daily summaries open their canonical report link while other inbox items keep the detail panel",
 );
-assert.match(
-  source,
-  /onSelect=\{openInboxItem\}/,
-  "every Rituals list presentation shares the daily-summary navigation boundary",
+assert.match(automationsView, /<InboxFeedList[\s\S]*?onSelect=\{openInboxItem\}/, "the grouped inbox feed uses the daily-summary navigation boundary");
+assert.match(automationsView, /<RitualNeedsRow[\s\S]*?onSelect=\{openInboxItem\}/, "Needs you uses the daily-summary navigation boundary");
+assert.match(automationsView, /<RitualItemRow[\s\S]*?onSelect=\{openInboxItem\}/, "the ritual log uses the daily-summary navigation boundary");
+assert.match(automationsView, /<RitualAgendaThread[\s\S]*?onSelect=\{openInboxItem\}/, "the agenda thread uses the daily-summary navigation boundary");
+assert.equal(
+  [...automationsView.matchAll(/onSelect=\{openInboxItem\}/g)].length,
+  4,
+  "all four Rituals inbox presentations use the shared navigation boundary",
 );
 
 // ── 2026-07-03 a11y batch ─────────────────────────────────────────────────────

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -144,6 +144,14 @@ export function AutomationsView({ familiars, onNewReminder, onEdit, onOpenLink, 
   // Selected item is either an InboxItem or a CodexAutomation — track by kind
   const [selectedItem, setSelectedItem] = useState<InboxItem | null>(null);
   const [selectedCodex, setSelectedCodex] = useState<CodexAutomation | null>(null);
+  const openInboxItem = useCallback((item: InboxItem) => {
+    if (item.kind === "daily-summary" && item.link && onOpenLink) {
+      onOpenLink(item.link);
+      return;
+    }
+    setSelectedItem(item);
+    setSelectedCodex(null);
+  }, [onOpenLink]);
   const [createOpen, setCreateOpen] = useState(false);
   // GitHub subscriptions manager, reachable from the Inbox tab (cave-hlxn).
   const [subsOpen, setSubsOpen] = useState(false);
@@ -1028,7 +1036,7 @@ export function AutomationsView({ familiars, onNewReminder, onEdit, onOpenLink, 
                       onToggleGroup={(group) => inboxSelect.toggleSelectAll(group.items)}
                       onToggle={inboxSelect.toggle}
                       familiarLabel={familiarLabel}
-                      onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }}
+                      onSelect={openInboxItem}
                       onDone={(item) => void completeInboxItem(item)}
                       onSnooze={(item) => void snoozeInboxItem(item)}
                       onDismiss={(item) => void dismissInboxItem(item)}
@@ -1078,7 +1086,7 @@ export function AutomationsView({ familiars, onNewReminder, onEdit, onOpenLink, 
                               key={item.id}
                               item={item}
                               familiarLabel={familiarLabel}
-                              onSelect={(next) => { setSelectedItem(next); setSelectedCodex(null); }}
+                              onSelect={openInboxItem}
                               onDone={(next) => void completeInboxItem(next)}
                               onSnooze={(next) => void snoozeInboxItem(next)}
                               onDismiss={(next) => void dismissInboxItem(next)}
@@ -1119,12 +1127,12 @@ export function AutomationsView({ familiars, onNewReminder, onEdit, onOpenLink, 
                           <div className="rituals-overview__log">
                             {ritualLog.length > 0 ? ritualLog.map((item) => (
                               <RitualItemRow key={item.id} item={item} familiarLabel={familiarLabel} timeMode="log"
-                                onSelect={(next) => { setSelectedItem(next); setSelectedCodex(null); }} />
+                                onSelect={openInboxItem} />
                             )) : <p className="rituals-overview__empty">No quiet activity yet.</p>}
                           </div>
                         ) : (
                           <RitualAgendaThread items={ritualAgenda} familiarLabel={familiarLabel}
-                            onSelect={(next) => { setSelectedItem(next); setSelectedCodex(null); }} />
+                            onSelect={openInboxItem} />
                         )}
                       </div>
                     </section>


### PR DESCRIPTION
## Summary
- route daily-summary activation directly through the item canonical `/daily-report/<date>` link
- share the behavior across Needs you, Log, Agenda, and feed presentations
- preserve generic detail panels for reminders and fallback behavior when no link handler exists
- leave bulk selection mode unchanged

## Validation
- `src/components/automations-view.test.ts`
- `pnpm typecheck`
- `pnpm lint`

Bead: cave-33apy