### PR TITLE
Validate project folders before starting Code sessions

### DIFF
--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -24,6 +24,7 @@ assert.doesNotMatch(
 );
 assert.match(listRoute, /export async function GET\(req: Request\)/, "projects route should expose GET");
 assert.match(listRoute, /searchParams\.get\("familiarId"\)/, "GET /api/projects should accept familiar-scoped listing");
+assert.match(listRoute, /searchParams\.get\("launchable"\) === "1"/, "GET /api/projects should offer a launchable-only listing");
 assert.match(listRoute, /isValidFamiliarId\(familiarId\)/, "GET /api/projects should validate familiar id before scoping");
 assert.match(
   listRoute,
@@ -32,8 +33,8 @@ assert.match(
 );
 assert.match(
   listRoute,
-  /validateCaveProjectRoot\(project\.root\)/,
-  "familiar-scoped project choices should omit roots that no longer resolve to directories",
+  /Promise\.all\([\s\S]*validateCaveProjectRootAsync\(project\.root\)/,
+  "launchable project choices should validate roots concurrently without blocking the event loop",
 );
 assert.match(
   listRoute,

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -9,21 +9,36 @@ import {
 import { listAccessibleProjects } from "@/lib/project-permissions";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
-import { isAllowedNewProjectRoot, validateCaveProjectRoot } from "@/lib/server/project-paths";
+import {
+  isAllowedNewProjectRoot,
+  validateCaveProjectRoot,
+  validateCaveProjectRootAsync,
+} from "@/lib/server/project-paths";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   await seedDefaultProjectsIfEmpty();
   const projects = await loadProjects();
-  const familiarId = new URL(req.url).searchParams.get("familiarId")?.trim() || null;
-  if (!familiarId) return NextResponse.json({ ok: true, projects });
-  if (!isValidFamiliarId(familiarId)) {
+  const searchParams = new URL(req.url).searchParams;
+  const familiarId = searchParams.get("familiarId")?.trim() || null;
+  const launchableOnly = searchParams.get("launchable") === "1";
+  if (!familiarId && !launchableOnly) return NextResponse.json({ ok: true, projects });
+  if (familiarId && !isValidFamiliarId(familiarId)) {
     return NextResponse.json({ ok: false, error: "invalid familiar id" }, { status: 400 });
   }
-  const accessibleProjects = await listAccessibleProjects(projects, familiarId);
-  const launchableProjects = accessibleProjects.flatMap(({ project, access }) =>
-    validateCaveProjectRoot(project.root).ok ? [{ ...project, access }] : [],
+  const accessibleProjects = familiarId
+    ? await listAccessibleProjects(projects, familiarId)
+    : projects.map((project) => ({ project, access: undefined }));
+  const validatedProjects = await Promise.all(
+    accessibleProjects.map(async ({ project, access }) => ({
+      project,
+      access,
+      valid: (await validateCaveProjectRootAsync(project.root)).ok,
+    })),
+  );
+  const launchableProjects = validatedProjects.flatMap(({ project, access, valid }) =>
+    valid ? [access ? { ...project, access } : project] : [],
   );
   return NextResponse.json({
     ok: true,

--- a/src/components/code-new-session.tsx
+++ b/src/components/code-new-session.tsx
@@ -11,7 +11,7 @@
  * running server-side; the transcript lives in Chat.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import { StandardSelect } from "@/components/ui/select";
@@ -47,6 +47,10 @@ export function CodeNewSession({
   const [prompt, setPrompt] = useState("");
   const [phase, setPhase] = useState<Phase>({ kind: "idle" });
   const busy = phase.kind === "provisioning" || phase.kind === "starting";
+  const projectIdRef = useRef(projectId);
+  const familiarIdRef = useRef(familiarId);
+  projectIdRef.current = projectId;
+  familiarIdRef.current = familiarId;
 
   // Seed once per opening, not on every `initialPrompt` change: the caller
   // holds the seed in state for as long as the modal is mounted, and re-running
@@ -61,6 +65,8 @@ export function CodeNewSession({
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
+    const previousProjectId = projectIdRef.current;
+    const previousFamiliarId = familiarIdRef.current;
     setPhase({ kind: "idle" });
     setProjects([]);
     setFamiliars([]);
@@ -87,14 +93,14 @@ export function CodeNewSession({
         const familiarRows = fam?.ok && Array.isArray(fam.familiars) ? fam.familiars : [];
         setProjects(projectRows);
         setFamiliars(familiarRows);
-        setProjectId((prev) =>
-          projectRows.some((project) => project.id === prev)
-            ? prev
+        setProjectId(
+          projectRows.some((project) => project.id === previousProjectId)
+            ? previousProjectId
             : (projectRows[0]?.id ?? ""),
         );
-        setFamiliarId((prev) =>
-          familiarRows.some((familiar) => familiar.id === prev)
-            ? prev
+        setFamiliarId(
+          familiarRows.some((familiar) => familiar.id === previousFamiliarId)
+            ? previousFamiliarId
             : (familiarRows[0]?.id ?? ""),
         );
         if (projectRows.length === 0) {

--- a/src/components/code-new-session.tsx
+++ b/src/components/code-new-session.tsx
@@ -61,23 +61,50 @@ export function CodeNewSession({
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
+    setPhase({ kind: "idle" });
+    setProjects([]);
+    setFamiliars([]);
+    setProjectId("");
+    setFamiliarId("");
     (async () => {
       try {
         const [projRes, famRes] = await Promise.all([
-          fetch("/api/projects", { cache: "no-store" }),
+          fetch("/api/projects?launchable=1", { cache: "no-store" }),
           fetch("/api/familiars", { cache: "no-store" }),
         ]);
         const proj = (await projRes.json().catch(() => null)) as { ok?: boolean; projects?: CaveProject[] } | null;
         const fam = (await famRes.json().catch(() => null)) as { ok?: boolean; familiars?: Familiar[] } | null;
         if (cancelled) return;
+        if (!projRes.ok || proj?.ok !== true) {
+          setPhase({ kind: "error", message: "Couldn’t check project folders." });
+          return;
+        }
+        if (!famRes.ok || fam?.ok !== true) {
+          setPhase({ kind: "error", message: "Couldn’t load familiars." });
+          return;
+        }
         const projectRows = proj?.ok && Array.isArray(proj.projects) ? proj.projects : [];
         const familiarRows = fam?.ok && Array.isArray(fam.familiars) ? fam.familiars : [];
         setProjects(projectRows);
         setFamiliars(familiarRows);
-        setProjectId((prev) => prev || (projectRows[0]?.id ?? ""));
-        setFamiliarId((prev) => prev || (familiarRows[0]?.id ?? ""));
+        setProjectId((prev) =>
+          projectRows.some((project) => project.id === prev)
+            ? prev
+            : (projectRows[0]?.id ?? ""),
+        );
+        setFamiliarId((prev) =>
+          familiarRows.some((familiar) => familiar.id === prev)
+            ? prev
+            : (familiarRows[0]?.id ?? ""),
+        );
+        if (projectRows.length === 0) {
+          setPhase({
+            kind: "error",
+            message: "No available project folders. Update a project folder before starting a session.",
+          });
+        }
       } catch {
-        if (!cancelled) setPhase({ kind: "error", message: "Couldn’t load projects/familiars." });
+        if (!cancelled) setPhase({ kind: "error", message: "Couldn’t check project folders or load familiars." });
       }
     })();
     return () => {

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -565,6 +565,21 @@ assert.match(
 );
 assert.match(
   newSession,
+  /fetch\("\/api\/projects\?launchable=1", \{ cache: "no-store" \}\)/,
+  "new sessions request only projects whose folders are currently available",
+);
+assert.match(
+  newSession,
+  /setProjects\(\[\]\);[\s\S]*setProjectId\(""\);/,
+  "opening the modal clears stale project choices until fresh folder validation completes",
+);
+assert.match(
+  newSession,
+  /No available project folders\. Update a project folder before starting a session\./,
+  "new sessions explain when every registered project folder is unavailable",
+);
+assert.match(
+  newSession,
   /action: "create-worktree", branch: branch\.trim\(\)/,
   "fresh-worktree option provisions through the existing /api/changes action",
 );

--- a/src/lib/server/project-paths.test.ts
+++ b/src/lib/server/project-paths.test.ts
@@ -53,7 +53,12 @@ try {
     }),
   );
 
-  const { isAllowedNewProjectRoot, resolveAllowedProjectPath, validateCaveProjectRoot } = await import("./project-paths.ts");
+  const {
+    isAllowedNewProjectRoot,
+    resolveAllowedProjectPath,
+    validateCaveProjectRoot,
+    validateCaveProjectRootAsync,
+  } = await import("./project-paths.ts");
   const legacy = path.join(process.env.COVEN_HOME, "workspace", "familiars", "sage");
 
   assert.equal(
@@ -193,6 +198,21 @@ try {
     validateCaveProjectRoot(sensitiveFileRoot),
     { ok: false, error: "root must be a directory" },
     "project roots must be existing directories",
+  );
+  assert.deepEqual(
+    await validateCaveProjectRootAsync(sensitiveFileRoot),
+    { ok: false, error: "root must be a directory" },
+    "async project validation rejects files without blocking a list endpoint",
+  );
+  assert.deepEqual(
+    await validateCaveProjectRootAsync(savedProjectRoot),
+    { ok: true, root: await realpath(savedProjectRoot) },
+    "async project validation resolves existing directories canonically",
+  );
+  assert.deepEqual(
+    await validateCaveProjectRootAsync(path.join(tmp, "missing-project")),
+    { ok: false, error: "root does not exist" },
+    "async project validation rejects missing roots",
   );
 
   assert.equal(

--- a/src/lib/server/project-paths.ts
+++ b/src/lib/server/project-paths.ts
@@ -53,6 +53,33 @@ export function validateCaveProjectRoot(value: string): { ok: true; root: string
   return { ok: true, root: realpathOrResolve(root) };
 }
 
+/**
+ * Async counterpart for list endpoints that validate multiple saved roots.
+ * Running these probes concurrently avoids blocking the server event loop and
+ * prevents one unavailable project from serially delaying every other result.
+ */
+export async function validateCaveProjectRootAsync(
+  value: string,
+): Promise<{ ok: true; root: string } | { ok: false; error: string }> {
+  const root = expandHomeShortcut(value).trim();
+  if (!root) return { ok: false, error: "root is required" };
+  if (!path.isAbsolute(root)) return { ok: false, error: "root must be an absolute path" };
+
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(/* turbopackIgnore: true */ root);
+  } catch {
+    return { ok: false, error: "root does not exist" };
+  }
+  if (!stat.isDirectory()) return { ok: false, error: "root must be a directory" };
+
+  try {
+    return { ok: true, root: await fs.promises.realpath(/* turbopackIgnore: true */ root) };
+  } catch {
+    return { ok: false, error: "root does not exist" };
+  }
+}
+
 function savedCaveProjectRoots(): string[] {
   try {
     const parsed = JSON.parse(fs.readFileSync(/* turbopackIgnore: true */ caveProjectsFilePath(), "utf8")) as {


### PR DESCRIPTION
## Summary
- add an explicit launchable-project listing that validates registered roots asynchronously and concurrently
- make the Code New session modal use that listing and clear stale selections while validation is in flight
- show actionable errors when project folders cannot be checked or none remain available

## Validation
- targeted project-path, projects-route, and Code surface tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`

Bead: cave-8i5m0