### PR TITLE
fix(research): gate X-derived recommendations on the familiar X capability

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1437,6 +1437,7 @@ export const SUITES = {
     "src/app/api/x/research-routes.test.ts",
     "src/app/api/x/sources-route-behavior.test.ts",
     "src/app/api/research/recommendations/route.test.ts",
+    "src/app/api/research/recommendations-x-capability.test.ts",
     "src/app/api/hermes-profiles/route.test.ts",
     "src/lib/server/x-oauth.test.ts",
     "src/app/api/coven-memory/route.test.ts",
@@ -1989,6 +1990,7 @@ const ALIAS_LOADER = new Set([
   "src/app/api/board/[id]/enhance/route.test.ts",
   "src/lib/research-topic-recommendations.test.ts",
   "src/app/api/research/recommendations/route.test.ts",
+  "src/app/api/research/recommendations-x-capability.test.ts",
   "src/lib/chat-live-generation-identity.test.ts",
   // imports the hook, which resolves "@/lib/chat-projects" and sidebar helpers.
   "src/lib/use-auto-expand-new-groups.test.ts",

--- a/src/app/api/research/recommendations-x-capability.test.ts
+++ b/src/app/api/research/recommendations-x-capability.test.ts
@@ -1,0 +1,139 @@
+// cave-mjotl: BEHAVIOURAL test for the X capability gate on
+// GET /api/research/recommendations, driving the real exported handler and its
+// production dependencies rather than the injectable route factory.
+//
+// The acceptance audit of #4816 (criterion 6, "familiar scoping of every read
+// and write") found this route calling listSavedXSources(familiarId) with no
+// capability check, so a familiar whose `xResearchEnabled` was false still got
+// X-derived recommendations and X context counts back. Every /api/x/* handler
+// gates on requireXCapability; this one X-derived read did not.
+//
+// The factory tests next door cover the contract with an injected capability
+// check, which cannot see whether the production wiring supplies one at all —
+// the same blind spot PR #4858 hit from the other direction, where a route
+// source-text scan could not see a call that was never written. So this file
+// exercises `GET` itself: real config, real X source store, real ranking.
+//
+// No network and no X credentials. The capability is resolved from persisted
+// config, which is the whole point of the gate, and every durable path is
+// redirected into a temp directory.
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+
+const root = await mkdtemp(path.join(tmpdir(), "research-recommendations-x-"));
+const caveHome = path.join(root, "cave");
+await mkdir(caveHome, { recursive: true });
+
+process.env.COVEN_HOME = root;
+process.env.COVEN_CAVE_HOME = caveHome;
+process.env.COVEN_X_SOURCES_DIR = path.join(root, "x-sources");
+process.env.COVEN_X_CACHE_DIR = path.join(root, "x-cache");
+process.env.COVEN_CAVE_LOCAL_VAULT_FILE = path.join(root, "local-vault.enc.json");
+process.env.COVEN_CAVE_LOCAL_VAULT_KEY_FILE = path.join(root, "local-vault.key");
+
+const FAMILIAR_ID = "researcher";
+const POST_ID = "1881";
+
+/** The grant only exists server-side, in config.json — a request cannot assert it. */
+async function writeXResearchGrant(granted: boolean): Promise<void> {
+  await writeFile(
+    path.join(caveHome, "config.json"),
+    JSON.stringify({ familiars: { [FAMILIAR_ID]: { xResearchEnabled: granted } } }),
+    "utf8",
+  );
+}
+
+await writeXResearchGrant(false);
+
+const { GET } = await import("./recommendations/route.ts");
+const { canonicalXPostUrl } = await import("@/lib/x-api");
+const { upsertSavedXSource } = await import("@/lib/server/x-sources");
+
+after(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+const canonicalUrl = canonicalXPostUrl(POST_ID, "opencoven");
+const { source } = await upsertSavedXSource({
+  familiarId: FAMILIAR_ID,
+  postId: POST_ID,
+  canonicalUrl,
+  originalUrl: canonicalUrl,
+  note: "Retrieval benchmark discussion worth a mission",
+  tags: [],
+});
+
+function recommendationsRequest(): Request {
+  return new Request(
+    `http://127.0.0.1:3000/api/research/recommendations?familiarId=${FAMILIAR_ID}`,
+    { headers: { host: "127.0.0.1:3000" } },
+  );
+}
+
+type ResponseBody = {
+  ok: boolean;
+  context: { xSources: number };
+  recommendations: Array<{
+    payload: { sourceId?: string };
+    evidenceRefs: Array<{ id: string; label: string }>;
+  }>;
+};
+
+async function read(): Promise<{ status: number; body: ResponseBody }> {
+  const response = await GET(recommendationsRequest());
+  return { status: response.status, body: (await response.json()) as ResponseBody };
+}
+
+test("a familiar without the X research capability gets no X-derived recommendations", async () => {
+  const { status, body } = await read();
+
+  assert.equal(status, 200, "the non-X portion of the route must keep serving");
+  assert.equal(body.ok, true);
+  assert.equal(body.context.xSources, 0, "no saved X source may enter the context");
+  assert.deepEqual(
+    body.recommendations
+      .flatMap((recommendation) => recommendation.evidenceRefs)
+      .filter((ref) => ref.id === `saved-link:${source.id}` || ref.label.includes("X Article")),
+    [],
+    "no recommendation may cite an X source the familiar is not allowed to read",
+  );
+  assert.deepEqual(
+    body.recommendations.filter((recommendation) => recommendation.payload.sourceId === source.id),
+    [],
+  );
+});
+
+test("granting the X research capability restores the same familiar's X-derived recommendations", async () => {
+  // Positive control: the saved source really is on disk and really is
+  // rankable, so the suppression above is the capability gate and not an
+  // unrelated read failure.
+  await writeXResearchGrant(true);
+  const { status, body } = await read();
+
+  assert.equal(status, 200);
+  assert.equal(body.context.xSources, 1);
+  assert.deepEqual(
+    body.recommendations
+      .flatMap((recommendation) => recommendation.evidenceRefs)
+      .map((ref) => ref.id),
+    [`saved-link:${source.id}`],
+  );
+});
+
+test("a malformed X grant fails closed rather than reading the X store", async () => {
+  // The gate tests `=== true`, so a truthy non-boolean is not a grant.
+  await writeFile(
+    path.join(caveHome, "config.json"),
+    JSON.stringify({ familiars: { [FAMILIAR_ID]: { xResearchEnabled: "yes" } } }),
+    "utf8",
+  );
+  const { status, body } = await read();
+
+  assert.equal(status, 200);
+  assert.equal(body.context.xSources, 0);
+});
+
+console.log("research recommendations x-capability test passed");

--- a/src/app/api/research/recommendations/route.test.ts
+++ b/src/app/api/research/recommendations/route.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import type { SavedLink } from "@/lib/link-organizer.ts";
 import type { ResearchMission } from "@/lib/research-missions.ts";
 import type { KnowledgeEntry } from "@/lib/server/knowledge-vault.ts";
+import type { SavedXSource } from "@/lib/server/x-sources.ts";
 import type { AgenticDiagnosticEvent } from "@/lib/agentic-diagnostics.ts";
 import {
   createResearchRecommendationsRoute,
@@ -34,11 +35,28 @@ function savedLink(id: string): SavedLink {
   };
 }
 
+function xSource(id: string): SavedXSource {
+  return {
+    id,
+    familiarId: "researcher",
+    postId: "1881",
+    canonicalUrl: "https://x.com/opencoven/status/1881",
+    originalUrl: "https://x.com/opencoven/status/1881",
+    note: "Retrieval benchmark discussion",
+    tags: [],
+    addedAt: "2026-08-19T10:00:00.000Z",
+    updatedAt: "2026-08-19T10:00:00.000Z",
+    attachedMissionIds: [],
+    availability: "available",
+  };
+}
+
 function baseDeps(overrides: Partial<ResearchRecommendationsRouteDeps> = {}): ResearchRecommendationsRouteDeps {
   return {
     listMissions: async () => [],
     listSavedLinks: async () => [],
     listSavedXSources: async () => [],
+    hasXResearchCapability: async () => true,
     listVaultEntries: async () => [],
     ...overrides,
   };
@@ -280,6 +298,51 @@ test("the route exposes no create or refine mission mutation", () => {
   assert.doesNotMatch(route, /createAndStart|createResearchMission|action:\s*["']refine["']/);
   assert.match(route, /export const GET/);
   assert.doesNotMatch(route, /export (async )?function POST|export const POST/);
+});
+
+test("never reads saved X sources for a familiar without the X research capability", async () => {
+  let xReads = 0;
+  const route = createResearchRecommendationsRoute(baseDeps({
+    hasXResearchCapability: async () => false,
+    listSavedXSources: async () => {
+      xReads += 1;
+      return [xSource("x-1")];
+    },
+    listSavedLinks: async () => [savedLink("link-1")],
+  }));
+
+  const response = await route(request());
+  const body = await response.json();
+
+  // Authorize before read: the X store is never touched without the grant.
+  assert.equal(xReads, 0);
+  assert.equal(response.status, 200);
+  assert.equal(body.context.xSources, 0);
+  assert.deepEqual(
+    body.recommendations.flatMap((recommendation: { evidenceRefs: Array<{ label: string }> }) =>
+      recommendation.evidenceRefs.map((ref) => ref.label).filter((label) => label.startsWith("X Article")),
+    ),
+    [],
+  );
+  // The non-X context still produces its own recommendation.
+  assert.equal(body.recommendations.length, 1);
+});
+
+test("still recommends from saved X sources once the X research capability is granted", async () => {
+  const route = createResearchRecommendationsRoute(baseDeps({
+    hasXResearchCapability: async () => true,
+    listSavedXSources: async () => [xSource("x-1")],
+  }));
+
+  const body = await (await route(request())).json();
+
+  assert.equal(body.context.xSources, 1);
+  assert.deepEqual(
+    body.recommendations.flatMap((recommendation: { evidenceRefs: Array<{ id: string }> }) =>
+      recommendation.evidenceRefs.map((ref) => ref.id),
+    ),
+    ["saved-link:x-1"],
+  );
 });
 
 console.log("research recommendations route.test.ts passed");

--- a/src/app/api/research/recommendations/route.ts
+++ b/src/app/api/research/recommendations/route.ts
@@ -24,6 +24,7 @@ import {
 import { listResearchMissions } from "../../../../lib/server/research-mission-store.ts";
 import { listSavedLinks } from "../../../../lib/server/research-links.ts";
 import { listSavedXSources, type SavedXSource } from "../../../../lib/server/x-sources.ts";
+import { hasXCapability } from "../../../../lib/server/x-access.ts";
 import { rejectNonLocalRequest } from "../../../../lib/server/api-security.ts";
 
 export const dynamic = "force-dynamic";
@@ -33,6 +34,7 @@ export type ResearchRecommendationsRouteDeps = {
   listMissions: () => Promise<readonly ResearchMission[]>;
   listSavedLinks: () => Promise<readonly SavedLink[]>;
   listSavedXSources: (familiarId: string) => Promise<readonly SavedXSource[]>;
+  hasXResearchCapability: (familiarId: string) => Promise<boolean>;
   listVaultEntries: (familiarId: string) => Promise<readonly KnowledgeEntry[]>;
   diagnostics?: AgenticDiagnosticSink;
 };
@@ -41,6 +43,7 @@ const productionDeps: ResearchRecommendationsRouteDeps = {
   listMissions: listResearchMissions,
   listSavedLinks,
   listSavedXSources,
+  hasXResearchCapability: (familiarId) => hasXCapability(familiarId, "research"),
   listVaultEntries: async (familiarId) => selectKnowledgeForFamiliar(await listKnowledgeEntries(), familiarId),
 };
 
@@ -71,6 +74,25 @@ function boundedMissions(values: readonly ResearchMission[]): ResearchMission[] 
   return [...values]
     .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.id.localeCompare(right.id))
     .slice(0, MAX_RESEARCH_TOPIC_MISSIONS);
+}
+
+/**
+ * Authorize before reading. Saved X sources are X-derived data, so they are
+ * readable only for a familiar that holds the X research capability — the same
+ * fail-closed grant every `/api/x/*` handler gates on, resolved from persisted
+ * config and never from the request. Without the grant the read is not issued
+ * at all, rather than issued and filtered afterwards.
+ *
+ * The rest of this route's context — Research Desk missions, saved links and
+ * Vault entries — is not X-scoped, so a disabled capability suppresses the X
+ * slice instead of failing the whole recommendation read.
+ */
+async function readSavedXSourcesIfGranted(
+  deps: ResearchRecommendationsRouteDeps,
+  familiarId: string,
+): Promise<readonly SavedXSource[]> {
+  if (!await deps.hasXResearchCapability(familiarId)) return [];
+  return deps.listSavedXSources(familiarId);
 }
 
 async function readVaultWithOneRetry(
@@ -116,7 +138,7 @@ export function createResearchRecommendationsRoute(deps: ResearchRecommendations
     const [missions, savedLinks, xSources, vault] = await Promise.all([
       deps.listMissions(),
       deps.listSavedLinks(),
-      deps.listSavedXSources(familiarId),
+      readSavedXSourcesIfGranted(deps, familiarId),
       readVaultWithOneRetry(deps.listVaultEntries, familiarId, deps.diagnostics),
     ]);
     if (req.signal.aborted) return cancelled(deps.diagnostics);

--- a/src/lib/server/x-access.ts
+++ b/src/lib/server/x-access.ts
@@ -25,6 +25,10 @@ export type XAccess = {
     familiarId: string,
     capability: XCapability,
   ): Promise<void>;
+  hasXCapability(
+    familiarId: string,
+    capability: XCapability,
+  ): Promise<boolean>;
   withXAuthenticatedRead<T>(
     familiarId: string,
     requiredScopes: XScope[],
@@ -68,6 +72,29 @@ export function createXAccess(dependencies: XAccessDependencies): XAccess {
       ? entry?.xResearchEnabled === true
       : entry?.xPublishEnabled === true;
     if (!granted) throw capabilityDisabled(capability);
+  }
+
+  /**
+   * Non-throwing companion to {@link requireXCapability}, for a surface that
+   * mixes X-derived data with data that is not X-scoped and so must suppress
+   * only the X portion instead of failing the whole read.
+   *
+   * It delegates to the gate above rather than re-deriving the grant, so there
+   * is still exactly one place that decides: the binding is resolved from
+   * persisted config and never from the request, and it still fails closed.
+   * An invalid familiar id, an unreadable or malformed config, and a missing or
+   * non-`true` grant all resolve to `false`.
+   */
+  async function hasXCapability(
+    familiarId: string,
+    capability: XCapability,
+  ): Promise<boolean> {
+    try {
+      await requireXCapability(familiarId, capability);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async function withXAuthenticatedRead<T>(
@@ -123,6 +150,7 @@ export function createXAccess(dependencies: XAccessDependencies): XAccess {
 
   return {
     requireXCapability,
+    hasXCapability,
     withXAuthenticatedRead,
     withXWritePreflight,
     toXErrorResponse,
@@ -135,6 +163,7 @@ const xAccess = createXAccess({
 });
 
 export const requireXCapability = xAccess.requireXCapability;
+export const hasXCapability = xAccess.hasXCapability;
 export const withXAuthenticatedRead = xAccess.withXAuthenticatedRead;
 export const withXWritePreflight = xAccess.withXWritePreflight;
 export const toXErrorResponse = xAccess.toXErrorResponse;


### PR DESCRIPTION
Closes the last familiar-scoping hole the acceptance audit of #4816 found
(comment 5382042465), tracked as `cave-mjotl`.

## The defect

`GET /api/research/recommendations` called `listSavedXSources(familiarId)`
with no X capability check, so it returned X-derived recommendations and a
non-zero `context.xSources` for a familiar whose `xResearchEnabled` is
`false`. All nine `/api/x/*` handlers gate through `requireXCapability`
(`src/lib/server/x-access.ts`), which resolves the binding from persisted
config — never from the request — and tests `=== true` so a missing or
malformed value fails closed. This route was the one X-derived read that
bypassed that gate, which is why acceptance criterion 6 of #4816, *"familiar
scoping of every read and write"*, did not hold literally.

Bounded, familiar-scoped, and no upstream X call, so no credential or quota
exposure — but the invariant is the point.

## Suppress the X slice, not 403 the route

The route builds its recommendation context from **four** sources: Research
Desk missions, saved links, saved X sources, and Vault entries. Only one of
them is X-derived. `xResearchEnabled` grants a familiar the right to work
with X data; it says nothing about that familiar's missions or its Vault.

Refusing the whole route would therefore withdraw evidence the familiar is
plainly entitled to, on the strength of a grant that bounds a quarter of the
input — and it would do so on a read-only surface whose existing degraded
path (an unavailable Vault) is already *reduce the context and keep serving*,
never *fail the request*. A 403 would also be a live behaviour change for
every familiar that has simply never turned X on, which is the default.

So the gate suppresses the X slice: `context.xSources` goes to 0, no
recommendation cites an X Article, and the mission / saved-link / Vault
recommendations are unaffected. Granting the capability restores the X
recommendations with no other change.

## The gate

`x-access.ts` gains `hasXCapability`, a non-throwing companion that
**delegates to `requireXCapability`** rather than re-deriving the grant. That
keeps exactly one place deciding, so the semantics cannot drift apart: still
resolved from persisted config, still `=== true`, and still fails closed —
an invalid familiar id, an unreadable or malformed config, and a missing or
non-`true` value all resolve to `false`. It is a second reader of the same
gate, not a second gate.

Authorize-before-read is preserved. `readSavedXSourcesIfGranted` checks the
capability first and returns `[]` without calling `listSavedXSources` at all,
so the X store is never touched without the grant rather than read and
filtered afterwards. The other three loaders stay concurrent inside the same
`Promise.all`, so the added cost is one config read on a path that already
performs several.

## Tests

`src/app/api/research/recommendations-x-capability.test.ts` is **behavioural**
and drives the real exported `GET` with its production dependencies — real
`config.json`, real X source store, real ranking — against a temp cave home,
with no network and no credentials. Deliberately not a source-text regex scan:
the whole lesson of #4858 is that such a scan cannot see a call that was never
written, and by the same token cannot see a *check* that was never written.

It is a separate file rather than a case in `route.test.ts` because the
capability must come from persisted config, and `COVEN_CAVE_HOME` has to be
set before `cave-config.ts` is imported.

Three cases:

1. capability off → `context.xSources === 0`, no recommendation cites the
   saved X source, route still `200`;
2. capability on → the same saved source produces its recommendation again
   (a positive control, so case 1 cannot pass because the source failed to
   load);
3. `xResearchEnabled: "yes"` → treated as no grant, i.e. fails closed on a
   malformed value.

Cases 1 and 3 **fail against the pre-fix route** (`1 !== 0` on
`context.xSources`); verified by reverting `route.ts` to its parent and
re-running. Case 2 passes either way, as a control should.

`route.test.ts` also gains factory-level coverage that `listSavedXSources` is
never invoked without the grant, and that the non-X recommendation survives.

## Validation

Run in the worktree at `b7127dfe7`:

| check | result |
| --- | --- |
| `pnpm typecheck` | pass (exit 0) |
| `pnpm lint` | pass (exit 0) |
| `pnpm check:tests-wired` | pass — 1842 files wired |
| `recommendations-x-capability.test.ts` | 3/3 pass; 2/3 fail on the pre-fix route |
| `recommendations/route.test.ts` | 12/12 pass (10 before, 2 added) |
| `src/lib/server/x-access.test.ts` | 9/9 pass |
| `src/lib/research-topic-recommendations.test.ts` | 14/14 pass |
| `src/app/api/x/research-routes.test.ts` | pass |
| `src/app/api/x/sources-route-behavior.test.ts` | 3/3 pass |
| `src/app/api/api-contracts.test.ts` | 302 route contracts pass |

`pnpm test:api` aborts locally at file 11 of 426 on
`scripts/worktree-guard.test.mjs` (*"target is not an exactly registered
worktree"*). That is the known Windows-only platform failure, it reproduces on
this checkout without these changes, and it touches no file in this PR. Linux
CI is the real signal for the ~415 api files it prevents running locally.

No route file was added or moved, so the exact-equality route listing in
`api-contracts.test.ts` is unchanged — confirmed by running it.
