### PR TITLE
Raise the v0.3.10 sidecar runtime budget

### DIFF
--- a/scripts/sidecar-runtime-budget.json
+++ b/scripts/sidecar-runtime-budget.json
@@ -1,15 +1,15 @@
 {
   "note": "Single source of truth for the sidecar runtime file-count budget. Edit fileCount HERE and nowhere else: scripts/sidecar-runtime-closure.mjs reads this file, scripts/sidecar-runtime-smoke.mjs derives from that, and src-tauri/build.rs generates the Rust MAX_FILE_COUNT const from it. Before cave-0ia8h the same number was hand-synced across six places and drifted; sidecar-bundle-deps.test.mjs now fails if a literal reappears.",
   "raising": "Raising this is a deliberate, reviewed act, not a reflex when CI goes red. Set it from the GOVERNING platform measurement (Windows runs a few files above Ubuntu; a budget set from an Ubuntu-only figure has reddened windows-latest more than once) and record that measurement below. The reasoning history lives beside SIDECAR_RUNTIME_BUDGETS in scripts/sidecar-runtime-closure.mjs.",
-  "fileCount": 6306,
+  "fileCount": 6785,
   "measurement": {
-    "on": "2026-08-16",
+    "on": "2026-08-24",
     "governingPlatform": "windows",
-    "windows": 6156,
-    "ubuntu": 6154,
-    "macos": 6150,
+    "windows": 6635,
+    "ubuntu": 6631,
+    "macos": 6627,
     "headroom": 150,
-    "headroomRationale": "About one week of organic drift. The 197-file increase over the ten days since the 5,959-file Windows baseline is ~19.7 files/day, consistent with the previously measured ~21 files/day. Intermediate release runs measured 5,960 Windows files on August 9, 6,036 on August 11, and 6,035 on August 12, so this is gradual closure growth rather than one sudden subtree inclusion. At this headroom the gate ignores expected drift but still catches a single change adding hundreds of files.",
-    "bead": "cave-boem6"
+    "headroomRationale": "Release candidate v0.3.10-rc.1 measured 6,627 files on macOS, 6,631 on Ubuntu, and 6,635 on Windows. A clean v0.3.9 reconstruction measured 6,242 files on macOS. Exact path comparison attributes the +385 net files to generated runtime growth: .next server/static output +315, Next 16.3.1 runtime +52, SWC runtime +16, and two workflow files. The release adds 18 API routes and upgrades Next 16.2.12 to 16.3.1; no new file class, dependency subtree, source map set, test tree, or duplicated package tree entered the closure. Preserve the established 150-file one-week headroom from the governing Windows measurement.",
+    "bead": "cave-3t37b"
   }
 }

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -277,6 +277,16 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // August 12, confirming gradual growth rather than a sudden subtree inclusion.
   // Restore the same one-week, 150-file headroom from the Windows maximum;
   // leave the expanded-byte ceiling unchanged.
+  //
+  // 2026-08-24 (cave-3t37b): v0.3.10-rc.1 measured 6,627 files on macOS,
+  // 6,631 on Ubuntu, and 6,635 on Windows. A clean v0.3.9 reconstruction
+  // measured 6,242 files on macOS. Exact path comparison accounted for the
+  // +385 net files: generated .next server/static output +315, Next 16.3.1
+  // runtime +52, SWC runtime +16, and two workflow files. The release added
+  // 18 API routes and upgraded Next 16.2.12 -> 16.3.1; no new file class,
+  // dependency subtree, source maps, tests, or duplicate package tree entered
+  // the closure. Keep the established 150-file headroom from the governing
+  // Windows measurement without relaxing the expanded-byte ceiling.
   fileCount: readSidecarFileCountBudget(),
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });


### PR DESCRIPTION
## Summary
- raise the single-source sidecar file-count budget from 6,306 to 6,785
- set the budget from the governing v0.3.10-rc.1 Windows measurement of 6,635 files plus the established 150-file headroom
- document the reconstructed v0.3.9 comparison and exact source of the +385-file runtime growth

## Evidence
- v0.3.9 reconstruction: 6,242 macOS files
- v0.3.10-rc.1: 6,627 macOS / 6,631 Ubuntu / 6,635 Windows
- delta: `.next` +315, Next runtime +52, SWC runtime +16, workflows +2
- no new file class, dependency subtree, source maps, tests, or duplicate package tree

## Validation
- `node scripts/sidecar-runtime-closure.test.mjs`
- `node scripts/sidecar-bundle-deps.test.mjs`
- `bash scripts/sidecar-bundle.sh` (6,627 files, 113,864,039 bytes)

Bead: cave-3t37b