### PR TITLE
feat(shell): unify destination policy

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -57,6 +57,8 @@ export const SUITES = {
     "src/lib/nav-section.test.ts",
     "src/lib/workspace-mode.test.ts",
     "src/lib/workspace-page-registry.test.ts",
+    "src/lib/workspace-destination-policy.test.ts",
+    "src/components/workspace-destination-consistency.test.ts",
     "src/lib/workspace-pane-request.test.ts",
     "src/lib/workspace-pane-error.test.ts",
     "src/lib/workspace-url-state.test.ts",

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -154,18 +154,43 @@ assert.match(
 );
 assert.match(
   source,
-  /import \{ WORKSPACE_NAV_ITEMS, type WorkspaceNavMode \} from "@\/lib\/workspace-navigation"/,
-  "surface rows are built from the shared workspace navigation registry",
+  /import \{ paletteDestinations \} from "@\/lib\/workspace-destination-policy"/,
+  "surface rows are built from the shared destination policy",
 );
 assert.match(
   source,
-  /name:\s*`Go to \$\{fm\.label\}`/,
+  /name:\s*`Go to \$\{destination\.title\}`/,
   "each navigable surface renders a 'Go to <label>' row",
+);
+assert.match(
+  source,
+  /paletteDestinations\(\)/,
+  "surface rows iterate the shared palette destination selector",
+);
+assert.match(
+  source,
+  /destination\.description\.toLowerCase\(\)\.includes\(q\)/,
+  "surface rows fuzzy-match the shared long-form destination descriptions",
+);
+assert.match(
+  source,
+  /destination\.kbd \? `\$\{destination\.description\} · \$\{destination\.kbd\}` : destination\.description/,
+  "surface rows build hints from the shared destination metadata",
 );
 assert.doesNotMatch(
   source,
   /addons\?\.github|addons\?\.browser|addons\?\.flow|addons\?\.journal|addons\?: AddonsConfig/,
   "surface rows are no longer hidden behind add-on config",
+);
+assert.doesNotMatch(
+  source,
+  /WORKSPACE_NAV_ITEMS[\s\S]*Go to \$\{fm\.label\}/,
+  "surface rows no longer rebuild their visible destinations from a private nav array",
+);
+assert.doesNotMatch(
+  source,
+  /if \(!metadata\) return false;/,
+  "surface rows do not silently filter out destinations when metadata is missing",
 );
 assert.match(
   source,

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -11,7 +11,8 @@ import { fuzzyMatch, bestFuzzyScore } from "@/lib/fuzzy-match";
 import { relativeTime } from "@/lib/relative-time";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { MarkdownBlock } from "@/components/message-bubble";
-import { WORKSPACE_NAV_ITEMS, type WorkspaceNavMode } from "@/lib/workspace-navigation";
+import { type WorkspaceNavMode } from "@/lib/workspace-navigation";
+import { paletteDestinations } from "@/lib/workspace-destination-policy";
 import { useProjects } from "@/lib/use-projects";
 import {
   PALETTE_CATEGORIES,
@@ -539,18 +540,27 @@ export function CommandPalette({
     const surfaceRows: Row[] = (scoped || slashToken)
       ? []
       : [
-          ...rank(WORKSPACE_NAV_ITEMS
-          // Fuzzy on the short label/id; substring-only on the long description
-          // (subsequence-matching prose surfaces irrelevant items).
-          .filter((fm) => !q || fz(fm.label) || fz(fm.id) || fm.description.toLowerCase().includes(q)),
-          (fm) => [fm.label, fm.id])
-          .map((fm) => ({
-            id: `surface:${fm.id}`,
-            kind: "command" as const,
-            name: `Go to ${fm.label}`,
-            hint: fm.kbd ? `${fm.description} · ${fm.kbd}` : fm.description,
-            intent: { kind: "go-to-surface", mode: fm.id } as PaletteIntent,
-          })),
+          ...rank(
+            paletteDestinations().filter((destination) => {
+              // Fuzzy on the short title/id; substring-only on the long
+              // description (subsequence-matching prose surfaces irrelevant items).
+              return (
+                !q ||
+                fz(destination.title) ||
+                fz(destination.id) ||
+                destination.description.toLowerCase().includes(q)
+              );
+            }),
+            (destination) => [destination.title, destination.id, destination.description, destination.kbd],
+          ).map((destination) => {
+            return {
+              id: `surface:${destination.id}`,
+              kind: "command" as const,
+              name: `Go to ${destination.title}`,
+              hint: destination.kbd ? `${destination.description} · ${destination.kbd}` : destination.description,
+              intent: { kind: "go-to-surface", mode: destination.id } as PaletteIntent,
+            };
+          }),
           ...rank(
             (roleSurfaces ?? []).filter(
               (room) => !q || fz(room.label) || room.description.toLowerCase().includes(q),

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -3,6 +3,9 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./familiar-menu-bar.tsx", import.meta.url), "utf8");
+
+assert.match(source, /const SEARCH_LABEL = "Search Cave"/, "desktop search keeps a scoped accessible name");
+assert.match(source, /aria-label=\{SEARCH_LABEL\}/, "desktop search uses the scoped label constant");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const desktopChrome = readFileSync(
   new URL("../styles/globals/desktop-chrome.css", import.meta.url),

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -78,17 +78,30 @@ assert.doesNotMatch(
   /computePresence\(|<FamiliarAvatar/,
   "presence/avatar computation does not live in the menu bar",
 );
-// The New chat control now lives at the top of the left sidebar
-// (SidebarMinimal), not the desktop menu bar.
-assert.doesNotMatch(
+assert.match(
   source,
-  /menu-bar__new|menu-bar__compose|NewChatMenu/,
-  "the New chat / quick-compose control has moved out of the desktop menu bar",
+  /data-quick-chat-trigger[\s\S]{0,180}onClick=\{onOpenQuickChat\}[\s\S]{0,180}aria-label=\{NEW_CHAT_LABEL\}/,
+  "the menu bar keeps a shell-owned New chat action",
 );
-assert.doesNotMatch(
+assert.match(
   source,
-  /onChatWithFamiliar|onComposeChat/,
-  "the menu bar no longer owns the chat-start handlers",
+  /const newChatShortcut = platformizeHint\("⌘J", keys\);[\s\S]*title=\{`\$\{NEW_CHAT_LABEL\} \(\$\{newChatShortcut\}\)`\}/,
+  "the menu bar platformizes the New chat shortcut hint",
+);
+assert.match(
+  source,
+  /const searchShortcut = platformizeHint\("⌘K", keys\);[\s\S]*title=\{`Search everything in your Cave \(\$\{searchShortcut\} opens the command palette\)`\}/,
+  "the menu bar platformizes the Search shortcut hint",
+);
+assert.match(
+  source,
+  /workspacePageDefinition\("settings"\)/,
+  "Settings naming comes from the shared page registry",
+);
+assert.match(
+  source,
+  /const settingsShortcut = platformizeHint\("⌘,", keys\);[\s\S]*onClick=\{onOpenSettings\}[\s\S]{0,180}title=\{`\$\{SETTINGS_LABEL\} \(\$\{settingsShortcut\}\)`\}/,
+  "the menu bar exposes Settings through the existing shell handler",
 );
 
 // Right group — tasks. A Tasks button (board) and a Schedules button, each
@@ -97,6 +110,11 @@ assert.match(
   source,
   /className="menu-bar__task focus-ring"[\s\S]*onClick=\{onViewTasks\}/,
   "the Tasks button jumps to the board",
+);
+assert.match(
+  source,
+  /workspacePageDefinition\("board"\)/,
+  "Tasks naming comes from the shared page registry",
 );
 assert.match(
   source,
@@ -119,7 +137,7 @@ assert.match(
 );
 assert.match(
   source,
-  /<Icon name="ph:calendar-check"[\s\S]{0,160}<span className="menu-bar__task-label">Rituals<\/span>/,
+  /<Icon name="ph:calendar-check"[\s\S]{0,160}<span className="menu-bar__task-label">\{RITUALS_LABEL\}<\/span>/,
   "the Rituals button matches the sidebar's Rituals label + icon (label CSS-demoted in the seamless bar; aria-label carries the name)",
 );
 assert.doesNotMatch(
@@ -236,6 +254,11 @@ assert.match(
 );
 assert.match(
   workspace,
+  /<FamiliarMenuBar[\s\S]*onOpenSettings=\{\(\) => nextRouter\.push\("\/settings"\)\}/,
+  "workspace wires the desktop menu bar Settings action to the shared settings route",
+);
+assert.match(
+  workspace,
   /<FamiliarMenuBar[\s\S]*searchQuery=\{topSearchQuery\}[\s\S]*onSearchQueryChange=\{\(query\) => \{[\s\S]*setTopSearchQuery\(query\);[\s\S]*openPalette\(\);/,
   "desktop menu bar search shares the same palette query/open wiring as mobile top bar",
 );
@@ -285,8 +308,8 @@ assert.match(
 // it as a dropdown from this menubar.
 assert.match(
   source,
-  /data-quick-chat-trigger[\s\S]{0,140}onClick=\{onOpenQuickChat\}[\s\S]{0,140}aria-label="Quick chat"/,
-  "the desktop menu bar renders a data-quick-chat-trigger button wired to onOpenQuickChat",
+  /data-quick-chat-trigger[\s\S]{0,140}onClick=\{onOpenQuickChat\}[\s\S]{0,140}aria-label=\{NEW_CHAT_LABEL\}/,
+  "the desktop menu bar renders a New chat trigger wired to onOpenQuickChat",
 );
 // cave-xsq.6 + project-primary navigation: the quick-chat trigger enters the
 // shared shell launch path, which resolves project and acting-familiar authority

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -2,7 +2,8 @@
 
 import type { ReactNode } from "react";
 import { Icon } from "@/lib/icon";
-import { useKeySymbols } from "@/lib/platform-keys";
+import { workspacePageDefinition } from "@/lib/workspace-page-registry";
+import { platformizeHint, useKeySymbols } from "@/lib/platform-keys";
 
 type Props = {
   /** Gates the Enhance action (needs a selected familiar). Familiar SELECTION
@@ -33,12 +34,19 @@ type Props = {
   enrichProgress?: { done: number; total: number } | null;
   /** Jump to the Schedules surface (calendar + crons). */
   onViewSchedules: () => void;
+  /** Open Settings. */
+  onOpenSettings: () => void;
   /** Start a blank chat through the shell's acting-familiar gate. */
   onOpenQuickChat: () => void;
 };
 
 const ENRICH_TASKS_TITLE =
   "Enhance assigned familiar tasks: update subtasks, dates, description, status, priority, links, issues, and chats";
+const SEARCH_LABEL = "Search";
+const NEW_CHAT_LABEL = "New chat";
+const TASKS_LABEL = workspacePageDefinition("board")?.title ?? "Tasks";
+const RITUALS_LABEL = workspacePageDefinition("inbox")?.title ?? "Rituals";
+const SETTINGS_LABEL = workspacePageDefinition("settings")?.title ?? "Settings";
 
 function fmtBadge(n: number): string {
   // Cap at 9+: two adjacent three-glyph "99+" pills read as duplicate noise
@@ -68,9 +76,13 @@ export function FamiliarMenuBar({
   enrichingTasks,
   enrichProgress,
   onViewSchedules,
+  onOpenSettings,
   onOpenQuickChat,
 }: Props) {
   const keys = useKeySymbols();
+  const searchShortcut = platformizeHint("⌘K", keys);
+  const newChatShortcut = platformizeHint("⌘J", keys);
+  const settingsShortcut = platformizeHint("⌘,", keys);
   const enrichLabel = enrichingTasks
     ? enrichProgress
       ? `${enrichProgress.done}/${enrichProgress.total}`
@@ -100,12 +112,12 @@ export function FamiliarMenuBar({
           value={searchQuery}
           onChange={(e) => onSearchQueryChange(e.target.value)}
           placeholder="Search Cave..."
-          aria-label="Search Cave"
-          title="Search everything in your Cave (⌘K opens the command palette)"
+          aria-label={SEARCH_LABEL}
+          title={`Search everything in your Cave (${searchShortcut} opens the command palette)`}
           autoComplete="off"
           spellCheck={false}
         />
-        <kbd>{keys.mod}K</kbd>
+        <kbd>{searchShortcut}</kbd>
       </form>
 
       <div className="menu-bar__group menu-bar__group--tasks">
@@ -114,11 +126,11 @@ export function FamiliarMenuBar({
           data-quick-chat-trigger
           className="menu-bar__task focus-ring"
           onClick={onOpenQuickChat}
-          aria-label="Quick chat"
-          title="Quick chat"
+          aria-label={NEW_CHAT_LABEL}
+          title={`${NEW_CHAT_LABEL} (${newChatShortcut})`}
         >
           <Icon name="ph:note-pencil" width={22} height={22} aria-hidden />
-          <span className="menu-bar__task-label">Quick chat</span>
+          <span className="menu-bar__task-label">{NEW_CHAT_LABEL}</span>
         </button>
         {onEnrichTasks ? (
           <button
@@ -141,11 +153,11 @@ export function FamiliarMenuBar({
           type="button"
           className="menu-bar__task focus-ring"
           onClick={onViewTasks}
-          aria-label={taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
-          title={taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
+          aria-label={taskCount > 0 ? `${TASKS_LABEL} — ${taskCount} open` : TASKS_LABEL}
+          title={taskCount > 0 ? `${TASKS_LABEL} — ${taskCount} open` : TASKS_LABEL}
         >
           <Icon name="ph:kanban" width={22} height={22} aria-hidden />
-          <span className="menu-bar__task-label">Tasks</span>
+          <span className="menu-bar__task-label">{TASKS_LABEL}</span>
           {taskCount > 0 ? <span className="menu-bar__badge">{fmtBadge(taskCount)}</span> : null}
         </button>
         {/* This button lands on the Rituals surface (workspace mode "inbox"
@@ -160,10 +172,20 @@ export function FamiliarMenuBar({
           title={scheduleNeedsCount > 0 ? `View rituals — ${scheduleNeedsCount} need attention` : "View rituals"}
         >
           <Icon name="ph:calendar-check" width={22} height={22} aria-hidden />
-          <span className="menu-bar__task-label">Rituals</span>
+          <span className="menu-bar__task-label">{RITUALS_LABEL}</span>
           {scheduleNeedsCount > 0 ? (
             <span className="menu-bar__badge">{fmtBadge(scheduleNeedsCount)}</span>
           ) : null}
+        </button>
+        <button
+          type="button"
+          className="menu-bar__task focus-ring"
+          onClick={onOpenSettings}
+          aria-label={SETTINGS_LABEL}
+          title={`${SETTINGS_LABEL} (${settingsShortcut})`}
+        >
+          <Icon name="ph:user" width={22} height={22} aria-hidden />
+          <span className="menu-bar__task-label">{SETTINGS_LABEL}</span>
         </button>
       </div>
 

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -42,7 +42,7 @@ type Props = {
 
 const ENRICH_TASKS_TITLE =
   "Enhance assigned familiar tasks: update subtasks, dates, description, status, priority, links, issues, and chats";
-const SEARCH_LABEL = "Search";
+const SEARCH_LABEL = "Search Cave";
 const NEW_CHAT_LABEL = "New chat";
 const TASKS_LABEL = workspacePageDefinition("board")?.title ?? "Tasks";
 const RITUALS_LABEL = workspacePageDefinition("inbox")?.title ?? "Rituals";

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -31,7 +31,11 @@ assert.match(
 assert.match(workspace, /if \(next === "journal"\) \{[\s\S]{0,400}setGrimoireView\("journal"\);\s*\n\s*commitMode\("grimoire", "journal"\);/, "the journal mode routes into the Grimoire Journal tab and preserves that destination in history");
 assert.match(navigation, /export type WorkspaceNavMode = WorkspaceMode/, "the shared registry uses the WorkspaceMode union (no drifting copy)");
 assert.match(navigation, /id: "grimoire", label: "Memories"/, "grimoire has a navigation row labeled Memories (and a ⌘K palette entry)");
-assert.match(sidebar, /navItemsForSection\(section\)/, "the sidebar renders rows from the section-filtered visible registry");
+assert.match(
+  sidebar,
+  /sidebarDestinations\(section\)/,
+  "the sidebar renders rows from the section-filtered shared destination policy",
+);
 assert.match(
   view,
   /<Link\s+href="\/weaves"\s+role="menuitem"/,

--- a/src/components/journal-redirect.test.ts
+++ b/src/components/journal-redirect.test.ts
@@ -82,7 +82,11 @@ assert.match(ws, /case "\/journal":\s*\n\s*setMode\("journal"\)/, "/journal rout
 // Memories now. ─────
 assert.match(navigation, /id: "journal", label: "Journal", iconName: "ph:book-open"/, "the navigation registry keeps Journal reachable through the palette");
 assert.doesNotMatch(navigation, /generated sketches/, "the Journal description no longer promises the canvas");
-assert.match(sidebar, /navItemsForSection\(section\)/, "the sidebar consumes the section-filtered visible registry");
+assert.match(
+  sidebar,
+  /sidebarDestinations\(section\)/,
+  "the sidebar consumes the section-filtered shared destination policy",
+);
 
 // ── Journal is a registered Memories variant, so split requests preserve it ─
 assert.match(

--- a/src/components/nav-section-tabs.test.ts
+++ b/src/components/nav-section-tabs.test.ts
@@ -41,8 +41,8 @@ assert.doesNotMatch(sidebar, /<NavSectionTabs/, "the Home rail no longer hosts t
 assert.match(sidebar, /role="tabpanel"/, "the destination list is the switcher's panel");
 assert.match(
   sidebar,
-  /navItemsForSection\(section\)/,
-  "the destination rows are filtered to the open section",
+  /sidebarDestinations\(section\)/,
+  "the destination rows are derived from the shared policy for the open section",
 );
 assert.match(
   sidebar,

--- a/src/components/palette-canonical-names.test.ts
+++ b/src/components/palette-canonical-names.test.ts
@@ -1,83 +1,96 @@
 // @ts-nocheck
 // Canonical names in the command palette + shortcut help (issue #3283, bead
 // cave-m4ih.6): the ⌘K launcher and the shortcuts sheet must speak the same
-// vocabulary as the shared workspace navigation registry. "Go to …" rows
-// already derive from WORKSPACE_NAV_ITEMS at runtime, so this pins the
-// derivation itself plus the two hand-written
-// spots that CAN drift: the "Tasks: …" board-view rows and the ⌘1–⌘5 help
-// entry, both cross-checked against the sidebar's labels so a future rename
-// fails here instead of shipping a stale name.
+// vocabulary as the shared workspace destination policy. The policy itself
+// now composes page-registry titles with the workspace navigation metadata, so
+// this pins the cross-check plus the two hand-written spots that CAN drift:
+// the "Tasks: …" board-view rows and the ⌘1–⌘5 help entry.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { SHORTCUT_GROUPS } from "../lib/keyboard-shortcuts.ts";
+import { paletteDestinations } from "../lib/workspace-destination-policy.ts";
+import { workspacePageDefinition } from "../lib/workspace-page-registry.ts";
+import { WORKSPACE_NAV_ITEMS } from "../lib/workspace-navigation.ts";
 
 const palette = readFileSync(new URL("./command-palette.tsx", import.meta.url), "utf8");
-const registry = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
-const shortcuts = readFileSync(new URL("../lib/keyboard-shortcuts.ts", import.meta.url), "utf8");
 const sheet = readFileSync(new URL("./shortcuts-sheet.tsx", import.meta.url), "utf8");
 
-// Canonical id -> label (and id -> kbd) from WORKSPACE_NAV_ITEMS — the same
-// source of truth canonical-nav-names.test.ts pins all navigation hosts against.
-const navigationBlock = registry.match(/export const WORKSPACE_NAV_ITEMS[\s\S]*?\n\];/)?.[0];
-assert.ok(navigationBlock, "WORKSPACE_NAV_ITEMS block should be extractable");
-const labels = new Map();
-const kbds = new Map();
-for (const m of navigationBlock.matchAll(/\{ id: "([a-z-]+)", label: "([^"]+)"(?:[^\n]*?kbd: "([^"]+)")?/g)) {
-  labels.set(m[1], m[2]);
-  if (m[3]) kbds.set(m[1], m[3]);
-}
-assert.ok(labels.size > 0, "WORKSPACE_NAV_ITEMS should declare id/label rows");
+const labels = new Map(WORKSPACE_NAV_ITEMS.map((item) => [item.id, item.label]));
+const kbds = new Map(WORKSPACE_NAV_ITEMS.map((item) => [item.id, item.kbd]));
+const destinations = paletteDestinations();
+assert.ok(destinations.length > 0, "paletteDestinations() should stay populated");
 
-// ── "Go to <surface>" rows derive from WORKSPACE_NAV_ITEMS at runtime ────────
+for (const destination of destinations) {
+  const navLabel = labels.get(destination.id);
+  assert.ok(navLabel, `palette destination "${destination.id}" needs shared navigation metadata`);
+  assert.equal(
+    destination.title,
+    navLabel,
+    `palette destination "${destination.id}" must use the shared navigation label "${navLabel}"`,
+  );
+  const pageDefinition = workspacePageDefinition(destination.id);
+  assert.ok(pageDefinition, `palette destination "${destination.id}" needs a page definition`);
+  assert.equal(
+    destination.title,
+    pageDefinition.title,
+    `palette destination "${destination.id}" must keep the page registry title in sync with navigation`,
+  );
+}
+
+// ── "Go to <surface>" rows derive from the shared destination policy ─────────
 assert.match(
   palette,
-  /import \{ WORKSPACE_NAV_ITEMS, type WorkspaceNavMode \} from "@\/lib\/workspace-navigation"/,
-  "the palette imports the shared workspace navigation registry rather than its own surface list",
+  /import \{ paletteDestinations \} from "@\/lib\/workspace-destination-policy"/,
+  "the palette imports the shared destination policy rather than its own surface list",
 );
 assert.match(
   palette,
-  /name: `Go to \$\{fm\.label\}`/,
-  "Go-to rows interpolate the canonical sidebar label (renames flow through automatically)",
+  /name: `Go to \$\{destination\.title\}`/,
+  "Go-to rows interpolate the canonical destination title (renames flow through automatically)",
 );
 
 // ── Board-view rows carry the canonical Tasks label as their prefix ──────────
-const boardLabel = labels.get("board");
-assert.ok(boardLabel, "the sidebar declares a board surface");
+const boardDestination = destinations.find(({ id }) => id === "board");
+assert.ok(boardDestination, "paletteDestinations() should include the board surface");
 const boardViewsBlock = palette.match(/const BOARD_VIEWS[\s\S]*?\n\s*\];/)?.[0];
 assert.ok(boardViewsBlock, "BOARD_VIEWS block should be extractable");
 const boardViewLabels = [...boardViewsBlock.matchAll(/label: "([^"]+)"/g)].map((m) => m[1]);
 assert.ok(boardViewLabels.length >= 3, "the palette offers the board's views");
 for (const label of boardViewLabels) {
   assert.ok(
-    label.startsWith(`${boardLabel}: `),
-    `board-view row "${label}" must lead with the canonical "${boardLabel}" label`,
+    label.startsWith(`${boardDestination.title}: `),
+    `board-view row "${label}" must lead with the canonical "${boardDestination.title}" label`,
   );
 }
 
 // ── ⌘1–⌘5 help lists exactly the shortcut surfaces, in order, by canonical
-//    name — cross-checked against workspace.tsx's SURFACE_ORDER dispatch ──────
+//    name — cross-checked against workspace.tsx's SURFACE_ORDER dispatch and
+//    the shared destination metadata ──────────────────────────────────────────
 const surfaceOrderBlock = workspace.match(/const SURFACE_ORDER: WorkspaceMode\[\] = \[([\s\S]*?)\]/)?.[1];
 assert.ok(surfaceOrderBlock, "SURFACE_ORDER should be extractable from workspace.tsx");
 const surfaceOrder = [...surfaceOrderBlock.matchAll(/"([a-z-]+)"/g)].map((m) => m[1]);
 assert.equal(surfaceOrder.length, 5, "⌘1–⌘5 dispatches five surfaces");
 
 const orderedLabels = surfaceOrder.map((id) => {
-  const label = labels.get(id);
-  assert.ok(label, `SURFACE_ORDER mode "${id}" must be a sidebar surface`);
-  return label;
+  const destination = destinations.find((candidate) => candidate.id === id);
+  assert.ok(destination, `SURFACE_ORDER mode "${id}" must stay palette-reachable`);
+  return destination.title;
 });
-assert.match(
-  shortcuts,
-  new RegExp(`keys: "⌘1–⌘5", description: "Jump to a surface \\(${orderedLabels.join(", ")}\\)"`),
+assert.equal(
+  SHORTCUT_GROUPS.find(
+    (group) => group.id === "panels",
+  )?.entries.find((entry) => entry.keys === "⌘1–⌘5")?.description,
+  `Jump to a surface (${orderedLabels.join(", ")})`,
   `the shortcut help must list the ⌘1–⌘5 surfaces as "${orderedLabels.join(", ")}" (canonical, dispatch order)`,
 );
 
-// The sidebar's per-row kbd hints agree with the same dispatch order.
+// The navigation registry's per-row kbd hints agree with the same dispatch order.
 surfaceOrder.forEach((id, i) => {
   assert.equal(
     kbds.get(id),
     `⌘${i + 1}`,
-    `sidebar surface "${id}" should advertise ⌘${i + 1} to match SURFACE_ORDER`,
+    `surface "${id}" should advertise ⌘${i + 1} to match SURFACE_ORDER`,
   );
 });
 

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -48,7 +48,7 @@ assert.match(
 // no inbox tab and inbox items live in the notification bell instead.
 assert.match(
   menuBar,
-  /<Icon name="ph:calendar-check"[\s\S]{0,160}<span className="menu-bar__task-label">Rituals<\/span>/,
+  /<Icon name="ph:calendar-check"[\s\S]{0,160}<span className="menu-bar__task-label">\{RITUALS_LABEL\}<\/span>/,
   "Desktop menu bar names the surface Rituals with the calendar-check icon (label CSS-demoted in the seamless bar; aria-label carries the name)",
 );
 assert.doesNotMatch(

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -89,7 +89,7 @@ assert.match(
 );
 assert.match(
   sidebar,
-  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes\)\}/,
+  /state=\{sidebarRowState\(destination\.id, mode, props\.splitPageModes\)\}/,
   "Sidebar rows derive their highlight (marketplace + journal aliasing, cave-s9p6) from sidebarRowState",
 );
 

--- a/src/components/settings-shortcut.test.ts
+++ b/src/components/settings-shortcut.test.ts
@@ -1,15 +1,57 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { platformizeHint } from "../lib/platform-keys.ts";
 
-// The TopBar account button's tooltip advertises "Settings (⌘,)", but the
-// shortcut was never wired. workspace.tsx's global keydown handler must handle
-// ⌘/Ctrl+, and navigate to /settings.
+// The desktop shell promises cross-platform shortcuts. Pin both the shell
+// wiring and the Windows/Linux rendering so no host quietly falls back to
+// macOS-only glyphs.
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 const topBar = await readFile(new URL("./top-bar.tsx", import.meta.url), "utf8");
+const familiarMenuBar = await readFile(new URL("./familiar-menu-bar.tsx", import.meta.url), "utf8");
 
-// The tooltip that promises the shortcut (the contract this fix honors).
-assert.match(topBar, /Settings \(⌘,\)/, "TopBar advertises the ⌘, settings shortcut");
+// Source contracts: the shell chrome calls through the platformizer for each
+// hard-coded hint it owns.
+assert.match(
+  topBar,
+  /platformizeHint\("⌘K", keys\)/,
+  "TopBar platformizes the Search shortcut hint",
+);
+assert.match(
+  topBar,
+  /platformizeHint\("⌘B", keys\)/,
+  "TopBar platformizes the sidebar toggle shortcut hint",
+);
+assert.match(
+  topBar,
+  /platformizeHint\("⌘\\\\", keys\)/,
+  "TopBar platformizes the list-panel shortcut hint",
+);
+assert.match(
+  topBar,
+  /platformizeHint\("⌘J", keys\)/,
+  "TopBar platformizes the New chat shortcut hint",
+);
+assert.match(
+  topBar,
+  /platformizeHint\("⌘,", keys\)/,
+  "TopBar platformizes the Settings shortcut hint",
+);
+assert.match(
+  familiarMenuBar,
+  /platformizeHint\("⌘K", keys\)/,
+  "FamiliarMenuBar platformizes the Search shortcut hint",
+);
+assert.match(
+  familiarMenuBar,
+  /platformizeHint\("⌘J", keys\)/,
+  "FamiliarMenuBar platformizes the New chat shortcut hint",
+);
+assert.match(
+  familiarMenuBar,
+  /platformizeHint\("⌘,", keys\)/,
+  "FamiliarMenuBar platformizes the Settings shortcut hint",
+);
 
 // ⌘/Ctrl+, is handled in the global keydown handler and opens settings.
 assert.match(
@@ -22,6 +64,34 @@ assert.match(
   workspace,
   /meta && !alt && e\.key === ","/,
   "the ',' shortcut requires the meta/ctrl modifier",
+);
+
+const pcKeys = {
+  mod: "Ctrl",
+  alt: "Alt",
+  shift: "Shift",
+  ctrl: "Ctrl",
+  enter: "Enter",
+  up: "↑",
+  down: "↓",
+};
+
+assert.deepEqual(
+  {
+    search: platformizeHint("⌘K", pcKeys),
+    sidebar: platformizeHint("⌘B", pcKeys),
+    list: platformizeHint("⌘\\", pcKeys),
+    newChat: platformizeHint("⌘J", pcKeys),
+    settings: platformizeHint("⌘,", pcKeys),
+  },
+  {
+    search: "CtrlK",
+    sidebar: "CtrlB",
+    list: "Ctrl\\",
+    newChat: "CtrlJ",
+    settings: "Ctrl,",
+  },
+  "desktop shell shortcut hints should render Ctrl-based labels off macOS",
 );
 
 console.log("settings-shortcut.test.ts: ok");

--- a/src/components/shell-chrome-revamp.test.ts
+++ b/src/components/shell-chrome-revamp.test.ts
@@ -222,8 +222,28 @@ assert.match(
 );
 assert.match(
   workspace,
+  /const primaryStatusPageId = primaryPaneRequest\?\.requestedPageId \?\? mode;/,
+  "workspace derives the status-policy page from the requested primary pane before falling back to mode",
+);
+assert.match(
+  workspace,
+  /const statusBarVisibility = statusContextPolicy\(primaryStatusPageId\);/,
+  "workspace derives strip visibility from the shared destination policy using the effective primary page",
+);
+assert.match(
+  workspace,
+  /const statusBarHasContext = Boolean\(/,
+  "contextual surfaces only render the strip when existing shell context is present",
+);
+assert.match(
+  workspace,
+  /statusBarVisibility === "persistent" \|\| \(statusBarVisibility === "contextual" && statusBarHasContext\)/,
+  "the strip stays visible for persistent surfaces and contextual surfaces with real context",
+);
+assert.doesNotMatch(
+  workspace,
   /mode === "home" \|\| mode === "chat" \? \(\s*\n\s*<StatusBar/,
-  "the strip renders only on Home and Chat",
+  "the strip no longer hardcodes Home and Chat as the only visible pages",
 );
 assert.match(
   workspace,
@@ -232,8 +252,13 @@ assert.match(
 );
 assert.match(
   workspace,
-  /\{detailContent\}\s*<\/div>[\s\S]{0,400}?\{firstProjectGateOpen \? null : statusBar\}/,
-  "the strip mounts under the detail content and hides while the first-project gate is up",
+  /const primaryDetail = primaryPaneRequest[\s\S]*renderPaneRequest\(primaryPaneRequest, \(\) => setPrimaryPaneRequest\(null\)\)[\s\S]*: defaultDetail;/,
+  "workspace resolves a single primary page before mounting the shared status-strip chrome",
+);
+assert.match(
+  workspace,
+  /const detail = \(\s*<div className="flex h-full min-h-0 min-w-0 flex-col">[\s\S]*<div className="min-h-0 min-w-0 flex-1">\{primaryDetail\}<\/div>[\s\S]*\{firstProjectGateOpen \? null : statusBar\}\s*<\/div>\s*\);/,
+  "the strip mounts in shared primary-pane chrome and hides while the first-project gate is up",
 );
 
 console.log("shell-chrome-revamp.test.ts: ok");

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -22,6 +22,10 @@ const workspaceContextSwitcherCss = readFileSync(
   "utf8",
 );
 const navigation = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
+const destinationPolicy = readFileSync(
+  new URL("../lib/workspace-destination-policy.ts", import.meta.url),
+  "utf8",
+);
 // The Home/Code split itself — the sidebar reaches the registry only through
 // this module, so a committed artifact here breaks the rail just as badly.
 const navSection = readFileSync(new URL("../lib/nav-section.ts", import.meta.url), "utf8");
@@ -94,7 +98,7 @@ assert.match(
 );
 
 assert.doesNotMatch(source, /<NavSectionTabs/, "sidebar destinations no longer duplicate the title-bar section switcher");
-assert.match(source, /navItemsForSection\(section\)\.map/, "the active tab filters destination rows through the shared registry");
+assert.match(source, /sidebarDestinations\(section\)\.map/, "the active tab filters destination rows through the shared destination policy");
 assert.match(source, /sectionRooms\.map\(\(room\) =>/, "dynamic role-surface rooms follow the active section");
 assert.match(source, /itemSelector: "\.sidebar-folder-row"/, "visible destinations share one roving keyboard sequence");
 assert.match(source, /role="tabpanel"[\s\S]*?aria-labelledby=\{`nav-section-tab-\$\{section\}`\}/, "the destination list is labeled by its active tab");
@@ -140,8 +144,38 @@ assert.match(
 );
 assert.match(
   source,
-  /import \{[\s\S]*navItemsForSection,[\s\S]*\} from "@\/lib\/nav-section"/,
-  "the sidebar consumes the shared registry's visible rows through the section split",
+  /import \{ sidebarDestinations \} from "@\/lib\/workspace-destination-policy"/,
+  "the sidebar consumes the shared destination selector through the section split",
+);
+assert.doesNotMatch(
+  source,
+  /navItemsForSection/,
+  "sidebar no longer keeps a private visible-destination selector",
+);
+assert.match(
+  source,
+  /iconName=\{destination\.iconName\}/,
+  "sidebar renders each destination's shared icon metadata directly from the policy row",
+);
+assert.match(
+  source,
+  /description=\{destination\.description\}/,
+  "sidebar renders each destination's shared description metadata directly from the policy row",
+);
+assert.match(
+  source,
+  /kbd=\{destination\.kbd\}/,
+  "sidebar renders each destination's shared shortcut metadata directly from the policy row",
+);
+assert.doesNotMatch(
+  source,
+  /WORKSPACE_NAV_ITEMS\.map\(\(\{ id, iconName, description, kbd \}\) => \[/,
+  "sidebar does not rebuild a private metadata table from the nav registry",
+);
+assert.doesNotMatch(
+  source,
+  /if \(!metadata\) return null;/,
+  "sidebar does not silently drop destinations when metadata is missing",
 );
 
 assert.match(
@@ -553,7 +587,7 @@ assert.match(
 );
 assert.match(
   source,
-  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes\)\}/,
+  /state=\{sidebarRowState\(destination\.id, mode, props\.splitPageModes\)\}/,
   "each row derives active/split/idle from mode + open split pages",
 );
 assert.match(
@@ -650,16 +684,16 @@ for (const [name, text] of [
 // list is the whole registry, unsplit — mapping it here would render every Home
 // destination under Code and every Code destination under Home, while each
 // individual row assertion above kept passing, because the rows themselves are
-// unchanged. Only the section split is allowed to reach the registry.
+// unchanged. Only the shared destination policy is allowed to reach the registry.
 assert.doesNotMatch(
   source,
   /VISIBLE_WORKSPACE_NAV_ITEMS/,
-  "the sidebar must reach nav rows through navItemsForSection(section), never the unsplit VISIBLE_WORKSPACE_NAV_ITEMS list",
+  "the sidebar must not reach the unsplit visible navigation list directly",
 );
 assert.match(
-  navSection,
-  /export function navItemsForSection\(section: NavSection\)[\s\S]{0,160}navSectionForMode\(item\.id\) === section/,
-  "navItemsForSection must keep filtering by section — a passthrough would un-split the rail without failing a row assertion",
+  destinationPolicy,
+  /home:\s*Object\.freeze\([\s\S]{0,240}navSectionForMode\(definition\.id\) === "home"[\s\S]{0,240}code:\s*Object\.freeze\([\s\S]{0,240}navSectionForMode\(definition\.id\) === "code"/,
+  "sidebarDestinations must keep filtering canonical destinations by section — a passthrough would un-split the rail without failing a row assertion",
 );
 
 // Recent Activity is Code-only (cave-24d2r): Home is destinations, Code is live

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -24,18 +24,15 @@ import { RecentActivityRollup } from "@/components/recent-activity-rollup";
 import { SidebarFooter } from "@/components/sidebar-footer";
 import {
   DEFAULT_NAV_SECTION,
-  navItemsForSection,
   roomBelongsToSection,
   type NavSection,
 } from "@/lib/nav-section";
+import { sidebarDestinations } from "@/lib/workspace-destination-policy";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
-import {
-  type WorkspaceNavItem,
-  type WorkspaceNavMode,
-} from "@/lib/workspace-navigation";
+import { type WorkspaceNavMode } from "@/lib/workspace-navigation";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import type { CreateProjectOptions } from "@/lib/chat-add-project";
 export type SidebarRoleSurfaceRow = {
@@ -115,7 +112,6 @@ const MODE_BADGES: Partial<Record<WorkspaceNavMode, (props: SidebarMinimalProps)
   board: (props) => badgeText(props.boardOpenCount),
   inbox: (props) => badgeText(props.scheduleNeedsCount),
 };
-
 
 function FolderRow({
   id,
@@ -265,26 +261,30 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         id={`nav-section-panel-${section}`}
         aria-labelledby={`nav-section-tab-${section}`}
       >
-          {navItemsForSection(section).map((fm: WorkspaceNavItem, i, rows) => (
-            <FolderRow
-              key={fm.id}
-              id={fm.id}
-              label={fm.label}
-              iconName={fm.iconName}
-              // Active follows the primary mode (Roles/Capabilities keep the
-              // Marketplace hub lit); pages open as split tiles get a lighter
-              // "open in split" state instead. Derivation in lib/sidebar-nav-state.
-              state={sidebarRowState(fm.id, mode, props.splitPageModes)}
-              badge={MODE_BADGES[fm.id]?.(props)}
-              kbd={fm.kbd}
-              description={fm.description}
-              quiet={fm.quiet}
-              // Index the RENDERED list — a navHidden entry between quiet rows
-              // must not throw off the "first quiet row" gap.
-              quietLead={Boolean(fm.quiet) && !rows[i - 1]?.quiet}
-              onClick={() => handleModeSelect(fm.id)}
-            />
-          ))}
+          {sidebarDestinations(section).map((destination, i, rows) => {
+            const quiet = destination.nav === "quiet";
+            return (
+              <FolderRow
+                key={destination.id}
+                id={destination.id}
+                label={destination.title}
+                iconName={destination.iconName}
+                // Active follows the primary mode (Roles/Capabilities keep the
+                // Marketplace hub lit); pages open as split tiles get a lighter
+                // "open in split" state instead. Derivation in lib/sidebar-nav-state.
+                state={sidebarRowState(destination.id, mode, props.splitPageModes)}
+                badge={MODE_BADGES[destination.id]?.(props)}
+                kbd={destination.kbd}
+                description={destination.description}
+                quiet={quiet}
+                // Index the rendered list — the policy selector already hides
+                // non-sidebar destinations, so the first quiet row still owns
+                // the visual step regardless of hidden companions.
+                quietLead={quiet && rows[i - 1]?.nav !== "quiet"}
+                onClick={() => handleModeSelect(destination.id)}
+              />
+            );
+          })}
           {/* Role Surface rooms — the active familiar's or selected scope's
             vocation workspaces, filtered to the open section (the coding
             workbench belongs to Code; every other room to Home).

--- a/src/components/sidepanel-badges.test.ts
+++ b/src/components/sidepanel-badges.test.ts
@@ -13,7 +13,11 @@ assert.doesNotMatch(sidebar, /githubAssignedCount\?: number/, "sidebar no longer
 assert.match(sidebar, /board: \(props\) => badgeText\(props\.boardOpenCount\)/, "Board nav badge wired");
 assert.match(sidebar, /inbox: \(props\) => badgeText\(props\.scheduleNeedsCount\)/, "Rituals nav badge wired");
 assert.doesNotMatch(sidebar, /github: \(props\) => badgeText\(props\.githubAssignedCount\)/, "GitHub nav badge removed with the standalone row");
-assert.match(sidebar, /badge=\{MODE_BADGES\[fm\.id\]\?\.\(props\)\}/, "registry rows receive host-specific badges");
+assert.match(
+  sidebar,
+  /badge=\{MODE_BADGES\[destination\.id\]\?\.\(props\)\}/,
+  "policy-derived destination rows receive host-specific badges",
+);
 
 assert.match(workspace, /boardOpenCount=\{boardTaskCount\}/, "board count passed to sidebar");
 assert.match(workspace, /scheduleNeedsCount=\{scheduleNeedsCount\}/, "schedules count passed");

--- a/src/components/top-bar-polish.test.ts
+++ b/src/components/top-bar-polish.test.ts
@@ -23,14 +23,14 @@ assert.match(
 // The overflow-menu ROW keeps the exact count — a menu row has room for data.
 assert.match(
   topBar,
-  /View tasks — \$\{taskCount > 99 \? "99\+" : taskCount\} open/,
+  /`\$\{TASKS_LABEL\} — \$\{taskCount > 99 \? "99\+" : taskCount\} open`/,
   "The overflow-menu row keeps the exact open-task count",
 );
 
 // ── Counter buttons carry sighted tooltips, not just aria-labels ────────────
 assert.match(
   menuBar,
-  /aria-label=\{taskCount > 0 \? `View tasks — \$\{taskCount\} open` : "View tasks"\}\s*\n\s*title=\{taskCount > 0 \? `View tasks — \$\{taskCount\} open` : "View tasks"\}/,
+  /aria-label=\{taskCount > 0 \? `\$\{TASKS_LABEL\} — \$\{taskCount\} open` : TASKS_LABEL\}\s*\n\s*title=\{taskCount > 0 \? `\$\{TASKS_LABEL\} — \$\{taskCount\} open` : TASKS_LABEL\}/,
   "Tasks button exposes the exact count as a hover tooltip",
 );
 assert.match(

--- a/src/components/top-bar.test.ts
+++ b/src/components/top-bar.test.ts
@@ -3,6 +3,13 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./top-bar.tsx", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /const SEARCH_LABEL = "Search anything or ask Salem, the docs familiar"/,
+  "mobile search keeps its scoped accessible name",
+);
+assert.match(source, /aria-label=\{SEARCH_LABEL\}/, "mobile search uses the scoped label constant");
 const iconSource = readFileSync(new URL("../lib/icon.tsx", import.meta.url), "utf8");
 
 assert.match(

--- a/src/components/top-bar.test.ts
+++ b/src/components/top-bar.test.ts
@@ -70,6 +70,11 @@ assert.match(
   /<input[\s\S]*type="search"[\s\S]*className="top-bar__search-input"/,
   "Top bar search should expose a real search input, not only a button",
 );
+assert.match(
+  source,
+  /const searchShortcut = platformizeHint\("⌘K", keys\);[\s\S]*title=\{`Search everything — or ask Salem, the familiar trained on the OpenCoven docs \(\$\{searchShortcut\}\)`\}/,
+  "Top bar platformizes the Search shortcut hint",
+);
 
 assert.match(
   source,
@@ -108,8 +113,13 @@ assert.match(
 
 assert.match(
   source,
-  /top-bar__mobile-toggle[\s\S]*onToggleNav/,
+  /const navShortcut = platformizeHint\("⌘B", keys\);[\s\S]*onToggleNav[\s\S]*aria-label=\{navDrawerOpen \? "Close navigation" : `Open navigation \(\$\{navShortcut\}\)`\}/,
   "Mobile nav drawer toggle is preserved",
+);
+assert.match(
+  source,
+  /const listShortcut = platformizeHint\("⌘\\\\", keys\);[\s\S]*onToggleList[\s\S]*aria-label=\{listDrawerOpen \? "Close list" : `Open list \(\$\{listShortcut\}\)`\}/,
+  "Mobile list drawer toggle platformizes its shortcut hint",
 );
 
 assert.match(
@@ -159,20 +169,14 @@ assert.match(
 );
 
 // Mobile quick actions: Tasks. New chat lives in WorkspaceSidebar, the
-// contextual primary nav in Chat; SidebarMinimal returns outside Chat. The top
-// bar therefore no longer renders a New chat button. The task quick actions moved
-// into the shared overflow menu (§8 chrome budget — occasional verbs don't
-// earn always-visible chrome), with the live open-task badge kept on the
-// trigger.
+// task quick actions moved into the shared overflow menu (§8 chrome budget —
+// occasional verbs don't earn always-visible chrome), with the live open-task
+// badge kept on the trigger. The chat launcher now uses the canonical "New chat"
+// name while preserving the shell-owned onOpenQuickChat handler.
 assert.match(
   source,
   /onViewTasks\?: \(\) => void/,
   "Top bar accepts a View tasks handler for the mobile quick action",
-);
-assert.doesNotMatch(
-  source,
-  /aria-label="New chat"/,
-  "New chat belongs to Chat's contextual WorkspaceSidebar; SidebarMinimal returns outside Chat",
 );
 assert.match(
   source,
@@ -194,17 +198,32 @@ assert.match(
 assert.match(
   source,
   /onOpenQuickChat\?: \(\) => void/,
-  "Top bar accepts an onOpenQuickChat handler to reveal the in-app quick chat",
+  "Top bar accepts an onOpenQuickChat handler to reveal the shell-owned chat launcher",
 );
 assert.match(
   source,
   /onClick=\{onOpenQuickChat\}/,
-  "Top bar wires the quick-chat button to the onOpenQuickChat handler",
+  "Top bar wires the New chat button to the onOpenQuickChat handler",
 );
 assert.match(
   source,
-  /aria-label="Quick chat"/,
-  "Quick-chat top-bar button is accessibly labeled",
+  /aria-label=\{NEW_CHAT_LABEL\}/,
+  "Top-bar New chat button is accessibly labeled",
+);
+assert.match(
+  source,
+  /const newChatShortcut = platformizeHint\("⌘J", keys\);[\s\S]*title=\{`\$\{NEW_CHAT_LABEL\} \(\$\{newChatShortcut\}\)`\}/,
+  "Top-bar New chat button platformizes its shortcut hint",
+);
+assert.match(
+  source,
+  /workspacePageDefinition\("settings"\)/,
+  "Top bar derives Settings naming from the shared page registry",
+);
+assert.match(
+  source,
+  /const settingsShortcut = platformizeHint\("⌘,", keys\);[\s\S]*onClick=\{onOpenSettings\}[\s\S]{0,180}title=\{`\$\{SETTINGS_LABEL\} \(\$\{settingsShortcut\}\)`\}/,
+  "Top bar platformizes the Settings shortcut hint",
 );
 
 console.log("top-bar.test.ts: ok");

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -64,7 +64,7 @@ type Props = {
 
 const ENRICH_TASKS_TITLE =
   "Enhance assigned familiar tasks: update subtasks, dates, description, status, priority, links, issues, and chats";
-const SEARCH_LABEL = "Search";
+const SEARCH_LABEL = "Search anything or ask Salem, the docs familiar";
 const NEW_CHAT_LABEL = "New chat";
 const TASKS_LABEL = workspacePageDefinition("board")?.title ?? "Tasks";
 const SETTINGS_LABEL = workspacePageDefinition("settings")?.title ?? "Settings";

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -5,7 +5,8 @@ import { NotificationBell } from "@/components/notification-bell";
 import { FamiliarQuickSwitch } from "@/components/familiar-quick-switch";
 import { OverflowMenu } from "@/components/ui/overflow-menu";
 import { PopoverItem } from "@/components/ui/popover";
-import { useKeySymbols } from "@/lib/platform-keys";
+import { platformizeHint, useKeySymbols } from "@/lib/platform-keys";
+import { workspacePageDefinition } from "@/lib/workspace-page-registry";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -63,6 +64,10 @@ type Props = {
 
 const ENRICH_TASKS_TITLE =
   "Enhance assigned familiar tasks: update subtasks, dates, description, status, priority, links, issues, and chats";
+const SEARCH_LABEL = "Search";
+const NEW_CHAT_LABEL = "New chat";
+const TASKS_LABEL = workspacePageDefinition("board")?.title ?? "Tasks";
+const SETTINGS_LABEL = workspacePageDefinition("settings")?.title ?? "Settings";
 
 export function TopBar(props: Props) {
   const keys = useKeySymbols();
@@ -101,6 +106,11 @@ export function TopBar(props: Props) {
   // handler is wired (the menu offers "All", so it's reachable even before a
   // familiar is the global-active one — e.g. the Home surface).
   const showFamiliarSwitcher = Boolean(onSelectFamiliar && (familiarOptions?.length ?? 0) > 0);
+  const searchShortcut = platformizeHint("⌘K", keys);
+  const navShortcut = platformizeHint("⌘B", keys);
+  const listShortcut = platformizeHint("⌘\\", keys);
+  const newChatShortcut = platformizeHint("⌘J", keys);
+  const settingsShortcut = platformizeHint("⌘,", keys);
   const enrichLabel = enrichingTasks
     ? enrichProgress
       ? `${enrichProgress.done}/${enrichProgress.total}`
@@ -117,10 +127,10 @@ export function TopBar(props: Props) {
             type="button"
             className="top-bar__mobile-toggle"
             onClick={onToggleNav}
-            aria-label={navDrawerOpen ? "Close navigation" : "Open navigation (⌘B)"}
+            aria-label={navDrawerOpen ? "Close navigation" : `Open navigation (${navShortcut})`}
             aria-expanded={Boolean(navDrawerOpen)}
             aria-controls="nav"
-            title={navDrawerOpen ? "Close navigation" : "Open navigation"}
+            title={navDrawerOpen ? "Close navigation" : `Open navigation (${navShortcut})`}
           >
             <Icon name="ph:sidebar-simple" width={CAVE_ICON_SIZE.headerToggle} height={CAVE_ICON_SIZE.headerToggle} />
           </button>
@@ -130,11 +140,11 @@ export function TopBar(props: Props) {
             type="button"
             className="top-bar__mobile-toggle"
             onClick={onToggleList}
-            aria-label={listDrawerOpen ? "Close list" : "Open list (⌘\\)"}
+            aria-label={listDrawerOpen ? "Close list" : `Open list (${listShortcut})`}
             aria-expanded={Boolean(listDrawerOpen)}
             aria-pressed={Boolean(listDrawerOpen)}
             aria-controls="list"
-            title={listDrawerOpen ? "Close list" : "Open list"}
+            title={listDrawerOpen ? "Close list" : `Open list (${listShortcut})`}
           >
             <Icon name="ph:list-checks-bold" width={CAVE_ICON_SIZE.headerToggle} height={CAVE_ICON_SIZE.headerToggle} />
           </button>
@@ -161,12 +171,12 @@ export function TopBar(props: Props) {
           value={searchQuery}
           onChange={(e) => onSearchQueryChange(e.target.value)}
           placeholder="Search or ask Salem..."
-          aria-label="Search anything or ask Salem, the docs familiar"
-          title="Search everything — or ask Salem, the familiar trained on the OpenCoven docs"
+          aria-label={SEARCH_LABEL}
+          title={`Search everything — or ask Salem, the familiar trained on the OpenCoven docs (${searchShortcut})`}
           autoComplete="off"
           spellCheck={false}
         />
-        <kbd>{keys.mod}K</kbd>
+        <kbd>{searchShortcut}</kbd>
       </form>
 
       <div className="top-bar__actions">
@@ -187,8 +197,8 @@ export function TopBar(props: Props) {
             className="top-bar__icon-btn"
             data-quick-chat-trigger
             onClick={onOpenQuickChat}
-            aria-label="Quick chat"
-            title="Quick chat (⌘J)"
+            aria-label={NEW_CHAT_LABEL}
+            title={`${NEW_CHAT_LABEL} (${newChatShortcut})`}
           >
             <Icon name="ph:chat-circle-dots" width={CAVE_ICON_SIZE.headerAction} height={CAVE_ICON_SIZE.headerAction} />
           </button>
@@ -213,8 +223,8 @@ export function TopBar(props: Props) {
               {onViewTasks ? (
                 <PopoverItem icon="ph:kanban" onSelect={onViewTasks}>
                   {taskCount && taskCount > 0
-                    ? `View tasks — ${taskCount > 99 ? "99+" : taskCount} open`
-                    : "View tasks"}
+                    ? `${TASKS_LABEL} — ${taskCount > 99 ? "99+" : taskCount} open`
+                    : TASKS_LABEL}
                 </PopoverItem>
               ) : null}
             </OverflowMenu>
@@ -247,8 +257,8 @@ export function TopBar(props: Props) {
           type="button"
           className="top-bar__account"
           onClick={onOpenSettings}
-          aria-label="Account / settings"
-          title="Settings (⌘,)"
+          aria-label={SETTINGS_LABEL}
+          title={`${SETTINGS_LABEL} (${settingsShortcut})`}
         >
           <Icon name="ph:user" width={CAVE_ICON_SIZE.headerAction} height={CAVE_ICON_SIZE.headerAction} />
         </button>

--- a/src/components/workspace-alias-modes.test.ts
+++ b/src/components/workspace-alias-modes.test.ts
@@ -129,8 +129,18 @@ assert.match(
 );
 assert.match(
   sidebar,
-  /type WorkspaceNavMode,[\s\S]*from "@\/lib\/workspace-navigation"/,
-  "the sidebar consumes the registry's mode type instead of declaring a component-local alias",
+  /import \{\s*type WorkspaceNavMode\s*\} from "@\/lib\/workspace-navigation";/,
+  "the sidebar type-imports the registry's navigation mode instead of declaring a component-local alias",
+);
+assert.match(
+  sidebar,
+  /const MODE_BADGES: Partial<Record<WorkspaceNavMode, \(/,
+  "the sidebar uses the shared navigation mode type in its badge registry",
+);
+assert.match(
+  sidebar,
+  /const handleModeSelect = \(id: WorkspaceNavMode\) =>/,
+  "the sidebar uses the shared navigation mode type in its selection handler",
 );
 
 console.log("workspace-alias-modes: ok");

--- a/src/components/workspace-destination-consistency.test.ts
+++ b/src/components/workspace-destination-consistency.test.ts
@@ -1,0 +1,175 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  paletteDestinations,
+  sidebarDestinations,
+  statusContextPolicy,
+} from "../lib/workspace-destination-policy.ts";
+
+const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const palette = readFileSync(new URL("./command-palette.tsx", import.meta.url), "utf8");
+const familiarMenuBar = readFileSync(new URL("./familiar-menu-bar.tsx", import.meta.url), "utf8");
+const topBar = readFileSync(new URL("./top-bar.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+
+assert.deepEqual(
+  sidebarDestinations("home").map(({ id }) => id),
+  ["home", "board", "inbox", "marketplace", "grimoire"],
+  "Home sidebar destinations stay policy-driven",
+);
+assert.deepEqual(
+  sidebarDestinations("code").map(({ id }) => id),
+  ["chat"],
+  "Code sidebar destinations stay policy-driven",
+);
+assert.match(
+  sidebar,
+  /import \{[\s\S]*sidebarDestinations[\s\S]*\} from "@\/lib\/workspace-destination-policy"/,
+  "SidebarMinimal imports the shared sidebar destination selector",
+);
+assert.match(
+  sidebar,
+  /sidebarDestinations\(section\)\.map/,
+  "SidebarMinimal renders visible rows from sidebarDestinations(section)",
+);
+assert.match(
+  sidebar,
+  /iconName=\{destination\.iconName\}/,
+  "SidebarMinimal renders each policy row with its shared icon metadata",
+);
+assert.match(
+  sidebar,
+  /description=\{destination\.description\}/,
+  "SidebarMinimal renders each policy row with its shared description metadata",
+);
+assert.match(
+  sidebar,
+  /kbd=\{destination\.kbd\}/,
+  "SidebarMinimal renders each policy row with its shared shortcut metadata",
+);
+assert.doesNotMatch(
+  sidebar,
+  /navItemsForSection\(section\)\.map/,
+  "SidebarMinimal does not keep its own destination selector",
+);
+assert.doesNotMatch(
+  sidebar,
+  /if \(!metadata\) return null;/,
+  "SidebarMinimal does not silently drop destinations when metadata is missing",
+);
+
+assert.deepEqual(
+  paletteDestinations().map(({ id }) => id),
+  ["chat", "home", "inbox", "board", "salem", "browser", "marketplace", "grimoire"],
+  "Palette destinations stay policy-driven",
+);
+assert.match(
+  palette,
+  /import \{[\s\S]*paletteDestinations[\s\S]*\} from "@\/lib\/workspace-destination-policy"/,
+  "CommandPalette imports the shared palette destination selector",
+);
+assert.match(
+  palette,
+  /paletteDestinations\(\)/,
+  "CommandPalette derives Go to rows from paletteDestinations()",
+);
+assert.match(
+  palette,
+  /destination\.description\.toLowerCase\(\)\.includes\(q\)/,
+  "CommandPalette fuzzy-matches long-form copy from the shared destination metadata",
+);
+assert.match(
+  palette,
+  /destination\.kbd \? `\$\{destination\.description\} · \$\{destination\.kbd\}` : destination\.description/,
+  "CommandPalette builds each hint from the shared destination metadata",
+);
+assert.doesNotMatch(
+  palette,
+  /WORKSPACE_NAV_ITEMS[\s\S]*Go to \$\{fm\.label\}/,
+  "CommandPalette does not rebuild Go to rows from a private nav array",
+);
+assert.doesNotMatch(
+  palette,
+  /if \(!metadata\) return false;/,
+  "CommandPalette does not silently filter out destinations when metadata is missing",
+);
+
+for (const [source, label] of [
+  [familiarMenuBar, "Desktop chrome"],
+  [topBar, "Mobile chrome"],
+]) {
+  assert.match(
+    source,
+    /workspacePageDefinition\("board"\)/,
+    `${label} derives the Tasks action from the shared page registry`,
+  );
+  assert.match(
+    source,
+    /workspacePageDefinition\("settings"\)/,
+    `${label} derives the Settings action from the shared page registry`,
+  );
+  assert.doesNotMatch(
+    source,
+    /\[[\s\S]{0,240}id:\s*"(?:board|settings)"/,
+    `${label} does not keep a private destination array for Tasks or Settings`,
+  );
+}
+assert.match(
+  familiarMenuBar,
+  /aria-label=\{NEW_CHAT_LABEL\}/,
+  "Desktop chrome exposes a New chat action",
+);
+assert.match(
+  topBar,
+  /aria-label=\{NEW_CHAT_LABEL\}/,
+  "Mobile chrome exposes a New chat action",
+);
+
+assert.equal(statusContextPolicy("home"), "persistent");
+assert.equal(statusContextPolicy("board"), "persistent");
+assert.equal(statusContextPolicy("settings"), "contextual");
+assert.equal(statusContextPolicy("memory"), "hidden");
+assert.match(
+  workspace,
+  /import \{[\s\S]*statusContextPolicy[\s\S]*\} from "@\/lib\/workspace-destination-policy"/,
+  "Workspace imports the shared status-context policy",
+);
+assert.match(
+  workspace,
+  /const primaryStatusPageId = primaryPaneRequest\?\.requestedPageId \?\? mode;/,
+  "Workspace derives the primary status-policy target from the requested primary page before falling back to mode",
+);
+assert.match(
+  workspace,
+  /const statusBarVisibility = statusContextPolicy\(primaryStatusPageId\);/,
+  "Workspace derives strip visibility from the effective primary page id, not stale workspace mode",
+);
+assert.match(
+  workspace,
+  /const statusBarHasContext = Boolean\(/,
+  "Workspace computes explicit status-bar context before rendering contextual pages",
+);
+assert.match(
+  workspace,
+  /statusBarVisibility === "persistent" \|\| \(statusBarVisibility === "contextual" && statusBarHasContext\)/,
+  "Workspace shows the strip for persistent pages or contextual pages with real context",
+);
+assert.doesNotMatch(
+  workspace,
+  /mode === "home" \|\| mode === "chat" \? \(\s*\n\s*<StatusBar/,
+  "Workspace no longer hardcodes Home/Chat as the only status-bar pages",
+);
+assert.match(
+  workspace,
+  /const primaryDetail = primaryPaneRequest[\s\S]*renderPaneRequest\(primaryPaneRequest, \(\) => setPrimaryPaneRequest\(null\)\)[\s\S]*: defaultDetail;/,
+  "Workspace resolves a single primary detail page before mounting shared primary chrome",
+);
+assert.match(
+  workspace,
+  /const detail = \(\s*<div className="flex h-full min-h-0 min-w-0 flex-col">[\s\S]*<div className="min-h-0 min-w-0 flex-1">\{primaryDetail\}<\/div>[\s\S]*\{firstProjectGateOpen \? null : statusBar\}\s*<\/div>\s*\);/,
+  "Workspace mounts the status strip in shared primary-pane chrome so supplemental primary pages inherit it without affecting split panes",
+);
+
+console.log("workspace-destination-consistency.test.ts: ok");

--- a/src/components/workspace-page-registry-wiring.test.ts
+++ b/src/components/workspace-page-registry-wiring.test.ts
@@ -14,7 +14,18 @@ test("workspace stores normalized split pane requests", () => {
 
 test("workspace titles and split state derive from the page registry", () => {
   assert.match(source, /workspacePageDefinition\(request\.requestedPageId\)/);
-  assert.match(source, /workspacePageDefinition\(primaryPaneRequest\?\.requestedPageId \?\? mode\)/);
+  assert.match(source, /import \{ statusContextPolicy \} from "@\/lib\/workspace-destination-policy";/);
+  assert.match(source, /const primaryStatusPageId = primaryPaneRequest\?\.requestedPageId \?\? mode;/);
+  assert.match(source, /const statusBarVisibility = statusContextPolicy\(primaryStatusPageId\);/);
+  assert.match(source, /const primaryDefinition = workspacePageDefinition\(primaryStatusPageId\);/);
+  assert.match(
+    source,
+    /<WorkspacePanePage[\s\S]*instanceId="workspace-primary"[\s\S]*landmark=\{primaryDefinition\?\.landmark \?\? "Workspace"\}/,
+  );
+  assert.match(
+    source,
+    /<div className="min-h-0 min-w-0 flex-1">\{primaryDetail\}<\/div>\s*\{firstProjectGateOpen \? null : statusBar\}/,
+  );
   assert.match(source, /renderSurface\(request\.pageId, \{ variant: request\.variant, instanceId: request\.instanceId \}\)/);
   assert.doesNotMatch(source, /const WORKSPACE_MODE_TITLES: Record/);
 });

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -17,6 +17,7 @@ import {
   type WorkspaceMode as WorkspaceModeFromDaemon,
 } from "@/lib/workspace-mode";
 import { workspacePageDefinition, type WorkspacePageVariant } from "@/lib/workspace-page-registry";
+import { statusContextPolicy } from "@/lib/workspace-destination-policy";
 import {
   normalizeWorkspacePaneRequest,
   workspacePaneRequestKey,
@@ -4457,9 +4458,10 @@ export function Workspace() {
   // Quiet context strip under the Home/Chat detail column. Chat feeds it the
   // ACTIVE session's metadata (registered-project name, model, per-session
   // workBranch — falling back to the poll-time checkout branch — cwd, and the
-  // attached PR via the shared sessionPrStatus derivation). Home has no session
-  // context, so it degrades to the active familiar's model + the Tasks count;
-  // other surfaces don't render the strip at all.
+  // attached PR via the shared sessionPrStatus derivation). Visibility is
+  // policy-driven: persistent destinations always keep the strip, while
+  // contextual destinations show it only when the shell already has real
+  // project/task/run context to publish.
   const statusSessionId = activeChatSessionId;
   const statusSession =
     mode === "chat" && statusSessionId
@@ -4471,11 +4473,29 @@ export function Workspace() {
       ) ?? null
     : null;
   const statusPr = sessionPrStatus(statusSession?.pullRequest);
+  const primaryStatusPageId = primaryPaneRequest?.requestedPageId ?? mode;
+  const statusBarVisibility = statusContextPolicy(primaryStatusPageId);
+  const statusModel =
+    mode === "home" || mode === "chat"
+      ? statusSession?.model ?? active?.model ?? null
+      : null;
+  const statusBarHasContext = Boolean(
+    statusProject?.name
+    || selectedWorkspaceProject?.name
+    || statusModel
+    || (statusSession ? statusSession.workBranch ?? statusSession.git?.branch ?? null : null)
+    || statusSession?.project_root
+    || statusPr
+    || covenRun
+    || boardTaskCount > 0,
+  );
   const statusBar =
-    mode === "home" || mode === "chat" ? (
+    statusBarVisibility === "hidden"
+      ? null
+      : statusBarVisibility === "persistent" || (statusBarVisibility === "contextual" && statusBarHasContext) ? (
       <StatusBar
-        projectName={statusProject?.name ?? null}
-        model={statusSession?.model ?? active?.model ?? null}
+        projectName={statusProject?.name ?? selectedWorkspaceProject?.name ?? null}
+        model={statusModel}
         branch={statusSession ? statusSession.workBranch ?? statusSession.git?.branch ?? null : null}
         cwd={statusSession?.project_root ?? null}
         pr={statusPr}
@@ -4494,9 +4514,9 @@ export function Workspace() {
           );
         }}
       />
-    ) : null;
+      ) : null;
 
-  const primaryDefinition = workspacePageDefinition(primaryPaneRequest?.requestedPageId ?? mode);
+  const primaryDefinition = workspacePageDefinition(primaryStatusPageId);
   const detailContent = renderSurface(mode);
   const defaultDetail = (
     <WorkspacePanePage
@@ -4525,7 +4545,6 @@ export function Workspace() {
         >
           {detailContent}
         </div>
-        {firstProjectGateOpen ? null : statusBar}
       </div>
     </WorkspacePanePage>
   );
@@ -4604,9 +4623,15 @@ export function Workspace() {
     );
   }
 
-  const detail = primaryPaneRequest
+  const primaryDetail = primaryPaneRequest
     ? renderPaneRequest(primaryPaneRequest, () => setPrimaryPaneRequest(null))
     : defaultDetail;
+  const detail = (
+    <div className="flex h-full min-h-0 min-w-0 flex-col">
+      <div className="min-h-0 min-w-0 flex-1">{primaryDetail}</div>
+      {firstProjectGateOpen ? null : statusBar}
+    </div>
+  );
 
   const splitTiles: DetailSplitTile[] = splitTargets
     .map((request) => ({
@@ -4770,6 +4795,7 @@ export function Workspace() {
               enrichingTasks={enrichingTasks}
               enrichProgress={enrichProgress}
               onViewSchedules={() => setMode("inbox")}
+              onOpenSettings={() => nextRouter.push("/settings")}
               onOpenQuickChat={startWorkspaceChat}
             />
             <TopBar

--- a/src/lib/workspace-destination-policy.test.ts
+++ b/src/lib/workspace-destination-policy.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { NAV_SECTIONS } from "./nav-section.ts";
+import {
+  paletteDestinations,
+  sidebarDestinations,
+  statusContextPolicy,
+} from "./workspace-destination-policy.ts";
+import { WORKSPACE_NAV_ITEMS } from "./workspace-navigation.ts";
+import { WORKSPACE_CANONICAL_PAGE_DEFINITIONS } from "./workspace-page-registry.ts";
+
+test("palette destinations expose only visible canonical destinations", () => {
+  const destinations = paletteDestinations();
+  assert.deepEqual(
+    destinations.map(({ id }) => id),
+    ["chat", "home", "inbox", "board", "salem", "browser", "marketplace", "grimoire"],
+  );
+  assert.ok(destinations.every(({ id, canonicalId, palette }) => id === canonicalId && palette !== "hidden"));
+  assert.equal(new Set(destinations.map(({ id }) => id)).size, destinations.length);
+});
+
+test("every visible destination carries exactly one shared navigation metadata row", () => {
+  const navItemsById = new Map(WORKSPACE_NAV_ITEMS.map((item) => [item.id, item]));
+
+  for (const destination of paletteDestinations()) {
+    const navItem = navItemsById.get(destination.id);
+    assert.ok(navItem, `${destination.id} needs shared navigation metadata`);
+    assert.equal(destination.iconName, navItem.iconName);
+    assert.equal(destination.description, navItem.description);
+    assert.equal(destination.kbd, navItem.kbd);
+  }
+
+  for (const section of NAV_SECTIONS.map(({ id }) => id)) {
+    for (const destination of sidebarDestinations(section)) {
+      const navItem = navItemsById.get(destination.id);
+      assert.ok(navItem, `${destination.id} needs shared navigation metadata`);
+      assert.equal(destination.iconName, navItem.iconName);
+      assert.equal(destination.description, navItem.description);
+      assert.equal(destination.kbd, navItem.kbd);
+    }
+  }
+});
+
+test("every sidebar destination in Home and Chat stays palette-reachable", () => {
+  const paletteIds = new Set(paletteDestinations().map(({ id }) => id));
+  const sections = NAV_SECTIONS.map(({ id }) => id);
+  assert.deepEqual(sections, ["home", "code"]);
+
+  assert.deepEqual(
+    sidebarDestinations("home").map(({ id }) => id),
+    ["home", "board", "inbox", "marketplace", "grimoire"],
+  );
+  assert.deepEqual(sidebarDestinations("code").map(({ id }) => id), ["chat"]);
+
+  for (const section of sections) {
+    for (const definition of sidebarDestinations(section)) {
+      assert.ok(
+        paletteIds.has(definition.id),
+        `${definition.id} should stay reachable from the palette`,
+      );
+    }
+  }
+});
+
+test("aliases do not create duplicate visible canonical destinations", () => {
+  const paletteIds = paletteDestinations().map(({ id }) => id);
+  const visiblePaletteIds = new Set<string>(paletteIds);
+  for (const alias of [
+    "groupchat",
+    "calendar",
+    "journal",
+    "roles",
+    "capabilities",
+    "flow",
+    "familiar-work-queue",
+    "code",
+    "github",
+  ]) {
+    assert.equal(visiblePaletteIds.has(alias), false, `${alias} should stay hidden from palette results`);
+  }
+
+  assert.equal(paletteIds.filter((id) => id === "grimoire").length, 1);
+  assert.equal(sidebarDestinations("home").filter(({ id }) => id === "grimoire").length, 1);
+});
+
+test("status context policy stays explicit for canonical pages and hides unknown ids", () => {
+  for (const definition of WORKSPACE_CANONICAL_PAGE_DEFINITIONS) {
+    assert.equal(
+      statusContextPolicy(definition.id),
+      definition.statusContext,
+      `${definition.id} should publish an explicit status-context policy`,
+    );
+  }
+
+  assert.equal(statusContextPolicy("home"), "persistent");
+  assert.equal(statusContextPolicy("chat"), "persistent");
+  assert.equal(statusContextPolicy("board"), "persistent");
+  assert.equal(statusContextPolicy("inbox"), "persistent");
+  assert.equal(statusContextPolicy("browser"), "contextual");
+  assert.equal(statusContextPolicy("settings"), "contextual");
+  assert.equal(statusContextPolicy("memory"), "hidden");
+  assert.equal(statusContextPolicy("terminal"), "hidden");
+  assert.equal(statusContextPolicy("surface:code"), "contextual");
+  assert.equal(statusContextPolicy("not-a-page"), "hidden");
+});

--- a/src/lib/workspace-destination-policy.test.ts
+++ b/src/lib/workspace-destination-policy.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 import { NAV_SECTIONS } from "./nav-section.ts";
@@ -9,6 +10,15 @@ import {
 } from "./workspace-destination-policy.ts";
 import { WORKSPACE_NAV_ITEMS } from "./workspace-navigation.ts";
 import { WORKSPACE_CANONICAL_PAGE_DEFINITIONS } from "./workspace-page-registry.ts";
+
+const policySource = readFileSync(new URL("./workspace-destination-policy.ts", import.meta.url), "utf8");
+
+test("destination metadata lookup is indexed and policy validation stays test-owned", () => {
+  assert.match(policySource, /const WORKSPACE_NAV_ITEMS_BY_ID = new Map/);
+  assert.match(policySource, /WORKSPACE_NAV_ITEMS_BY_ID\.get\(definition\.id\)/);
+  assert.doesNotMatch(policySource, /NAV_SECTIONS\.some/);
+  assert.doesNotMatch(policySource, /Sidebar destination policy must keep every navigation section populated/);
+});
 
 test("palette destinations expose only visible canonical destinations", () => {
   const destinations = paletteDestinations();

--- a/src/lib/workspace-destination-policy.ts
+++ b/src/lib/workspace-destination-policy.ts
@@ -1,0 +1,83 @@
+import { NAV_SECTIONS, navSectionForMode, type NavSection } from "./nav-section.ts";
+import {
+  WORKSPACE_NAV_ITEMS,
+  type WorkspaceNavItem,
+  type WorkspaceNavMode,
+} from "./workspace-navigation.ts";
+import {
+  WORKSPACE_NAVIGATION_PAGE_DEFINITIONS,
+  WORKSPACE_PALETTE_PAGE_DEFINITIONS,
+  workspacePageDefinition,
+  type WorkspacePageDefinition,
+  type WorkspaceStatusContext,
+} from "./workspace-page-registry.ts";
+
+const PALETTE_RANK = {
+  primary: 0,
+  secondary: 1,
+  hidden: 2,
+} as const;
+
+export type WorkspaceDestinationDefinition = Omit<WorkspacePageDefinition, "id" | "canonicalId"> & {
+  readonly id: WorkspaceNavMode;
+  readonly canonicalId: WorkspaceNavMode;
+  readonly iconName: WorkspaceNavItem["iconName"];
+  readonly description: string;
+  readonly kbd?: string;
+};
+
+function attachDestinationMetadata(
+  definition: WorkspacePageDefinition,
+): WorkspaceDestinationDefinition {
+  const navItem = WORKSPACE_NAV_ITEMS.find((item) => item.id === definition.id);
+  if (!navItem) {
+    throw new Error(`Missing workspace destination metadata for ${definition.id}`);
+  }
+  return Object.freeze({
+    ...definition,
+    id: navItem.id,
+    canonicalId: navItem.id,
+    iconName: navItem.iconName,
+    description: navItem.description,
+    kbd: navItem.kbd,
+  });
+}
+
+const PALETTE_DESTINATIONS = Object.freeze(
+  [...WORKSPACE_PALETTE_PAGE_DEFINITIONS]
+    .sort(
+      (left, right) =>
+        PALETTE_RANK[left.palette] - PALETTE_RANK[right.palette] ||
+        left.title.localeCompare(right.title),
+    )
+    .map(attachDestinationMetadata),
+);
+
+const SIDEBAR_DESTINATIONS = Object.freeze({
+  home: Object.freeze(
+    WORKSPACE_NAVIGATION_PAGE_DEFINITIONS
+      .filter((definition) => navSectionForMode(definition.id) === "home")
+      .map(attachDestinationMetadata),
+  ),
+  code: Object.freeze(
+    WORKSPACE_NAVIGATION_PAGE_DEFINITIONS
+      .filter((definition) => navSectionForMode(definition.id) === "code")
+      .map(attachDestinationMetadata),
+  ),
+} satisfies Record<NavSection, readonly WorkspaceDestinationDefinition[]>);
+
+export function paletteDestinations(): readonly WorkspaceDestinationDefinition[] {
+  return PALETTE_DESTINATIONS;
+}
+
+export function sidebarDestinations(section: NavSection): readonly WorkspaceDestinationDefinition[] {
+  return SIDEBAR_DESTINATIONS[section];
+}
+
+export function statusContextPolicy(pageId: string): WorkspaceStatusContext {
+  return workspacePageDefinition(pageId)?.statusContext ?? "hidden";
+}
+
+if (NAV_SECTIONS.some(({ id }) => SIDEBAR_DESTINATIONS[id].length === 0)) {
+  throw new Error("Sidebar destination policy must keep every navigation section populated");
+}

--- a/src/lib/workspace-destination-policy.ts
+++ b/src/lib/workspace-destination-policy.ts
@@ -1,4 +1,4 @@
-import { NAV_SECTIONS, navSectionForMode, type NavSection } from "./nav-section.ts";
+import { navSectionForMode, type NavSection } from "./nav-section.ts";
 import {
   WORKSPACE_NAV_ITEMS,
   type WorkspaceNavItem,
@@ -18,6 +18,10 @@ const PALETTE_RANK = {
   hidden: 2,
 } as const;
 
+const WORKSPACE_NAV_ITEMS_BY_ID = new Map<string, WorkspaceNavItem>(
+  WORKSPACE_NAV_ITEMS.map((item) => [item.id, item] as const),
+);
+
 export type WorkspaceDestinationDefinition = Omit<WorkspacePageDefinition, "id" | "canonicalId"> & {
   readonly id: WorkspaceNavMode;
   readonly canonicalId: WorkspaceNavMode;
@@ -29,7 +33,7 @@ export type WorkspaceDestinationDefinition = Omit<WorkspacePageDefinition, "id" 
 function attachDestinationMetadata(
   definition: WorkspacePageDefinition,
 ): WorkspaceDestinationDefinition {
-  const navItem = WORKSPACE_NAV_ITEMS.find((item) => item.id === definition.id);
+  const navItem = WORKSPACE_NAV_ITEMS_BY_ID.get(definition.id);
   if (!navItem) {
     throw new Error(`Missing workspace destination metadata for ${definition.id}`);
   }
@@ -76,8 +80,4 @@ export function sidebarDestinations(section: NavSection): readonly WorkspaceDest
 
 export function statusContextPolicy(pageId: string): WorkspaceStatusContext {
   return workspacePageDefinition(pageId)?.statusContext ?? "hidden";
-}
-
-if (NAV_SECTIONS.some(({ id }) => SIDEBAR_DESTINATIONS[id].length === 0)) {
-  throw new Error("Sidebar destination policy must keep every navigation section populated");
 }

--- a/src/lib/workspace-navigation.test.ts
+++ b/src/lib/workspace-navigation.test.ts
@@ -15,6 +15,7 @@ const sidebar = read("../components/sidebar-minimal.tsx");
 const standalone = read("../components/analytics-page-shell.tsx");
 const mobile = read("../components/mobile-bottom-tabs.tsx");
 const palette = read("../components/command-palette.tsx");
+const destinationPolicy = read("./workspace-destination-policy.ts");
 
 assert.match(
   registry,
@@ -49,13 +50,23 @@ assert.match(
 
 assert.match(
   sidebar,
-  /import \{[\s\S]*?navItemsForSection,[\s\S]*?\} from "@\/lib\/nav-section"/,
-  "the desktop sidebar takes its rows from the section-filtered registry derivation",
+  /import \{ sidebarDestinations \} from "@\/lib\/workspace-destination-policy"/,
+  "the desktop sidebar takes its rows from the shared destination policy",
 );
 assert.match(
-  read("./nav-section.ts"),
-  /VISIBLE_WORKSPACE_NAV_ITEMS\.filter\(\(item\) => navSectionForMode\(item\.id\) === section\)/,
-  "the section split derives from the shared visible registry rather than a second list",
+  destinationPolicy,
+  /home:\s*Object\.freeze\([\s\S]*navSectionForMode\(definition\.id\) === "home"[\s\S]*code:\s*Object\.freeze\([\s\S]*navSectionForMode\(definition\.id\) === "code"/,
+  "the section split derives from the canonical page registry rather than a second list",
+);
+assert.match(
+  destinationPolicy,
+  /WORKSPACE_NAV_ITEMS\.find\(\(item\) => item\.id === definition\.id\)/,
+  "the destination policy reuses shared navigation metadata for every consumer row",
+);
+assert.match(
+  destinationPolicy,
+  /throw new Error\(`Missing workspace destination metadata for \$\{definition\.id\}`\);/,
+  "missing consumer metadata fails loudly instead of disappearing silently",
 );
 assert.doesNotMatch(sidebar, /const FOLDER_MODES/, "the sidebar no longer owns a duplicate route registry");
 assert.doesNotMatch(sidebar, /export \{ FOLDER_MODES \}/, "the obsolete component-level registry export is removed");
@@ -78,8 +89,13 @@ assert.match(
 );
 assert.match(
   palette,
+  /import \{ paletteDestinations \} from "@\/lib\/workspace-destination-policy"/,
+  "the command palette derives visible Go to destinations from the shared policy",
+);
+assert.doesNotMatch(
+  palette,
   /import \{ WORKSPACE_NAV_ITEMS, type WorkspaceNavMode \} from "@\/lib\/workspace-navigation"/,
-  "the command palette consumes all canonical and on-demand destinations",
+  "the command palette no longer keeps a private metadata view of navigation destinations",
 );
 
 console.log("workspace-navigation registry: ok");

--- a/src/lib/workspace-navigation.test.ts
+++ b/src/lib/workspace-navigation.test.ts
@@ -60,8 +60,8 @@ assert.match(
 );
 assert.match(
   destinationPolicy,
-  /WORKSPACE_NAV_ITEMS\.find\(\(item\) => item\.id === definition\.id\)/,
-  "the destination policy reuses shared navigation metadata for every consumer row",
+  /WORKSPACE_NAV_ITEMS_BY_ID\.get\(definition\.id\)/,
+  "the destination policy reuses indexed shared navigation metadata for every consumer row",
 );
 assert.match(
   destinationPolicy,

--- a/src/lib/workspace-page-registry.test.ts
+++ b/src/lib/workspace-page-registry.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
   BUILT_IN_WORKSPACE_PAGE_IDS,
+  WORKSPACE_CANONICAL_PAGE_DEFINITIONS,
   workspacePageDefinition,
   workspacePageKey,
 } from "./workspace-page-registry.ts";
@@ -49,6 +50,8 @@ test("dynamic role rooms resolve without turning unknown pages into Home", () =>
   assert.ok(dynamic);
   assert.equal(dynamic.canonicalId, "surface:research-desk");
   assert.equal(dynamic.title, "Research Desk");
+  assert.equal(dynamic.palette, "hidden");
+  assert.equal(dynamic.statusContext, "contextual");
   assert.equal(workspacePageDefinition("not-a-page"), null);
 });
 
@@ -56,4 +59,40 @@ test("the ordered built-in registry is immutable", () => {
   assert.ok(BUILT_IN_WORKSPACE_PAGE_IDS.includes("settings"));
   assert.ok(BUILT_IN_WORKSPACE_PAGE_IDS.includes("terminal"));
   assert.ok(Object.isFrozen(BUILT_IN_WORKSPACE_PAGE_IDS));
+});
+
+test("literal definitions classify palette and status context explicitly", () => {
+  for (const id of BUILT_IN_WORKSPACE_PAGE_IDS) {
+    const definition = workspacePageDefinition(id);
+    assert.ok(definition, `${id} needs a registry definition`);
+    assert.ok(["primary", "secondary", "hidden"].includes(definition.palette));
+    assert.ok(["persistent", "contextual", "hidden"].includes(definition.statusContext));
+  }
+
+  assert.equal(workspacePageDefinition("home")?.palette, "primary");
+  assert.equal(workspacePageDefinition("chat")?.palette, "primary");
+  assert.equal(workspacePageDefinition("groupchat")?.palette, "hidden");
+  assert.equal(workspacePageDefinition("calendar")?.palette, "hidden");
+  assert.equal(workspacePageDefinition("marketplace")?.palette, "secondary");
+  assert.equal(workspacePageDefinition("browser")?.palette, "secondary");
+  assert.equal(workspacePageDefinition("home")?.statusContext, "persistent");
+  assert.equal(workspacePageDefinition("inbox")?.statusContext, "persistent");
+  assert.equal(workspacePageDefinition("settings")?.statusContext, "contextual");
+  assert.equal(workspacePageDefinition("memory")?.statusContext, "hidden");
+  assert.equal(workspacePageDefinition("terminal")?.statusContext, "hidden");
+});
+
+test("canonical built-in definitions stay unique and alias-free", () => {
+  const canonicalIds = WORKSPACE_CANONICAL_PAGE_DEFINITIONS.map(({ id, canonicalId }) => {
+    assert.equal(id, canonicalId);
+    return id;
+  });
+  const canonicalIdSet = new Set<string>(canonicalIds);
+
+  assert.equal(new Set(canonicalIds).size, canonicalIds.length);
+  for (const alias of Object.keys(MODE_ALIASES) as (keyof typeof MODE_ALIASES)[]) {
+    const definition = workspacePageDefinition(alias);
+    assert.ok(definition);
+    assert.equal(canonicalIdSet.has(definition.id), false, `${alias} should not appear as a canonical destination`);
+  }
 });

--- a/src/lib/workspace-page-registry.ts
+++ b/src/lib/workspace-page-registry.ts
@@ -24,12 +24,17 @@ export type WorkspacePageVariant =
   | "code"
   | "activity";
 
+export type WorkspacePagePalette = "primary" | "secondary" | "hidden";
+export type WorkspaceStatusContext = "persistent" | "contextual" | "hidden";
+
 export type WorkspacePageDefinition = {
   readonly id: WorkspacePageId;
   readonly title: string;
   readonly canonicalId: WorkspacePageId;
   readonly variant: WorkspacePageVariant;
   readonly nav: "daily" | "quiet" | "hidden" | "footer" | "companion" | "dynamic";
+  readonly palette: WorkspacePagePalette;
+  readonly statusContext: WorkspaceStatusContext;
   readonly split: "always" | "contextual";
   readonly landmark: string;
 };
@@ -50,6 +55,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "agents",
     variant: "default",
     nav: "hidden",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "contextual",
     landmark: "Familiars",
   },
@@ -59,6 +66,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "home",
     variant: "default",
     nav: "daily",
+    palette: "primary",
+    statusContext: "persistent",
     split: "always",
     landmark: "Home",
   },
@@ -68,6 +77,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "chat",
     variant: "default",
     nav: "daily",
+    palette: "primary",
+    statusContext: "persistent",
     split: "contextual",
     landmark: "Chat",
   },
@@ -77,6 +88,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "chat",
     variant: "group",
     nav: "hidden",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "contextual",
     landmark: "Group chat",
   },
@@ -86,6 +99,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "board",
     variant: "default",
     nav: "daily",
+    palette: "primary",
+    statusContext: "persistent",
     split: "always",
     landmark: "Tasks",
   },
@@ -95,6 +110,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "inbox",
     variant: "calendar",
     nav: "hidden",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "always",
     landmark: "Rituals / Calendar",
   },
@@ -104,6 +121,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "inbox",
     variant: "default",
     nav: "daily",
+    palette: "primary",
+    statusContext: "persistent",
     split: "always",
     landmark: "Rituals",
   },
@@ -113,6 +132,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "browser",
     variant: "default",
     nav: "companion",
+    palette: "secondary",
+    statusContext: "contextual",
     split: "contextual",
     landmark: "Browser",
   },
@@ -122,6 +143,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: CODE_ROLE_SURFACE_MODE,
     variant: "activity",
     nav: "hidden",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "contextual",
     landmark: "Coding Desk / GitHub activity",
   },
@@ -131,6 +154,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: CODE_ROLE_SURFACE_MODE,
     variant: "code",
     nav: "hidden",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "contextual",
     landmark: "Coding Desk",
   },
@@ -140,6 +165,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "marketplace",
     variant: "roles",
     nav: "hidden",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "always",
     landmark: "Marketplace / Roles",
   },
@@ -149,6 +176,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "marketplace",
     variant: "default",
     nav: "quiet",
+    palette: "secondary",
+    statusContext: "contextual",
     split: "always",
     landmark: "Marketplace",
   },
@@ -158,6 +187,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "inbox",
     variant: "flow",
     nav: "hidden",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "always",
     landmark: "Rituals / Flow",
   },
@@ -167,6 +198,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "submissions",
     variant: "default",
     nav: "hidden",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "contextual",
     landmark: "Submissions",
   },
@@ -176,6 +209,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "marketplace",
     variant: "capabilities",
     nav: "hidden",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "always",
     landmark: "Marketplace / Capabilities",
   },
@@ -185,6 +220,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "board",
     variant: "queue",
     nav: "hidden",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "contextual",
     landmark: "Tasks / Work queue",
   },
@@ -194,6 +231,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "grimoire",
     variant: "journal",
     nav: "quiet",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "contextual",
     landmark: "Memories / Journal",
   },
@@ -203,6 +242,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "grimoire",
     variant: "default",
     nav: "quiet",
+    palette: "secondary",
+    statusContext: "contextual",
     split: "contextual",
     landmark: "Memories",
   },
@@ -212,6 +253,8 @@ const WORKSPACE_MODE_PAGES = freezePageMap({
     canonicalId: "salem",
     variant: "default",
     nav: "hidden",
+    palette: "secondary",
+    statusContext: "contextual",
     split: "contextual",
     landmark: "Ask Salem",
   },
@@ -224,6 +267,8 @@ const SUPPLEMENTAL_PAGES = freezePageMap({
     canonicalId: "settings",
     variant: "default",
     nav: "footer",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "always",
     landmark: "Settings",
   },
@@ -233,6 +278,8 @@ const SUPPLEMENTAL_PAGES = freezePageMap({
     canonicalId: "dashboard",
     variant: "default",
     nav: "footer",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "always",
     landmark: "Dashboard",
   },
@@ -242,6 +289,8 @@ const SUPPLEMENTAL_PAGES = freezePageMap({
     canonicalId: "memory",
     variant: "default",
     nav: "companion",
+    palette: "hidden",
+    statusContext: "hidden",
     split: "contextual",
     landmark: "Memory",
   },
@@ -251,6 +300,8 @@ const SUPPLEMENTAL_PAGES = freezePageMap({
     canonicalId: "terminal",
     variant: "default",
     nav: "companion",
+    palette: "hidden",
+    statusContext: "hidden",
     split: "contextual",
     landmark: "Terminal",
   },
@@ -272,26 +323,28 @@ const BUILT_IN_PAGE_DEFINITIONS = Object.freeze(
   BUILT_IN_WORKSPACE_PAGE_IDS.map((id) => STATIC_PAGE_DEFINITIONS[id]),
 );
 
+export const WORKSPACE_CANONICAL_PAGE_DEFINITIONS = Object.freeze(
+  BUILT_IN_PAGE_DEFINITIONS.filter(({ id, canonicalId }) => id === canonicalId),
+);
+
 export const WORKSPACE_DAILY_PAGE_DEFINITIONS = Object.freeze(
-  BUILT_IN_PAGE_DEFINITIONS.filter(({ nav }) => nav === "daily"),
+  WORKSPACE_CANONICAL_PAGE_DEFINITIONS.filter(({ nav }) => nav === "daily"),
 );
 
 export const WORKSPACE_NAVIGATION_PAGE_DEFINITIONS = Object.freeze(
-  BUILT_IN_PAGE_DEFINITIONS.filter(({ nav }) => nav === "daily" || nav === "quiet"),
+  WORKSPACE_CANONICAL_PAGE_DEFINITIONS.filter(({ nav }) => nav === "daily" || nav === "quiet"),
 );
 
 export const WORKSPACE_PALETTE_PAGE_DEFINITIONS = Object.freeze(
-  BUILT_IN_PAGE_DEFINITIONS.filter(
-    ({ nav }) => nav === "daily" || nav === "quiet" || nav === "hidden",
-  ),
+  WORKSPACE_CANONICAL_PAGE_DEFINITIONS.filter(({ palette }) => palette !== "hidden"),
 );
 
 export const WORKSPACE_FOOTER_PAGE_DEFINITIONS = Object.freeze(
-  BUILT_IN_PAGE_DEFINITIONS.filter(({ nav }) => nav === "footer"),
+  WORKSPACE_CANONICAL_PAGE_DEFINITIONS.filter(({ nav }) => nav === "footer"),
 );
 
 export const WORKSPACE_COMPANION_PAGE_DEFINITIONS = Object.freeze(
-  BUILT_IN_PAGE_DEFINITIONS.filter(({ nav }) => nav === "companion"),
+  WORKSPACE_CANONICAL_PAGE_DEFINITIONS.filter(({ nav }) => nav === "companion"),
 );
 
 function roleSurfaceTitle(id: RoleSurfaceMode): string {
@@ -316,6 +369,8 @@ export function workspacePageDefinition(id: string): WorkspacePageDefinition | n
     canonicalId: id,
     variant: "default",
     nav: "dynamic",
+    palette: "hidden",
+    statusContext: "contextual",
     split: "contextual",
     landmark: title,
   });

--- a/tests/chat-sidebar-nav.spec.ts
+++ b/tests/chat-sidebar-nav.spec.ts
@@ -149,7 +149,7 @@ async function ensureChatSurface(page: Page) {
     const nav = page.locator('aside[aria-label="Sidebar"]');
     const chatDestination = nav.getByRole("button", { name: /^Chat\b/ }).first();
     if (!(await chatDestination.isVisible().catch(() => false))) {
-      const openNav = page.getByRole("button", { name: "Open navigation (⌘B)" });
+      const openNav = page.getByRole("button", { name: /^Open navigation \((?:⌘|Ctrl)B\)$/ });
       if (await openNav.isVisible().catch(() => false)) await openNav.click();
     }
     // The persistent title-bar section switch is the way into Chat when the
@@ -411,7 +411,7 @@ test.describe("chat sidebar on mobile", () => {
     const shell = page.locator(".shell-root");
     const sidebar = page.locator('aside[aria-label="Sidebar"] .chat-sidebar');
     const search = sidebar.getByRole("searchbox", { name: "Search chats" });
-    const openNav = page.getByRole("button", { name: "Open navigation (⌘B)" });
+    const openNav = page.getByRole("button", { name: /^Open navigation \((?:⌘|Ctrl)B\)$/ });
 
     await expect(openNav).toBeVisible();
     await expect(openNav).toHaveAttribute("aria-expanded", "false");
@@ -428,7 +428,7 @@ test.describe("chat sidebar on mobile", () => {
 
     await backdrop.click({ position: { x: 380, y: 420 } });
     await expect(shell).not.toHaveAttribute("data-mobile-drawer");
-    await expect(page.getByRole("button", { name: "Open navigation (⌘B)" })).toHaveAttribute("aria-expanded", "false");
+    await expect(page.getByRole("button", { name: /^Open navigation \((?:⌘|Ctrl)B\)$/ })).toHaveAttribute("aria-expanded", "false");
     await expect(page.locator(".mobile-drawer-backdrop")).toHaveCount(0);
   });
 });

--- a/tests/settings-familiar-picker.spec.ts
+++ b/tests/settings-familiar-picker.spec.ts
@@ -36,7 +36,7 @@ async function gotoChatFamiliarSettings(page: Page) {
     const nav = page.locator('aside[aria-label="Sidebar"]');
     const chatDestination = nav.getByRole("button", { name: /^Chat\b/ }).first();
     if (!(await chatDestination.isVisible().catch(() => false))) {
-      const openNav = page.getByRole("button", { name: "Open navigation (⌘B)" });
+      const openNav = page.getByRole("button", { name: /^Open navigation \((?:⌘|Ctrl)B\)$/ });
       if (await openNav.isVisible().catch(() => false)) await openNav.click();
     }
     // The Chat row lives in the rail's second section (cave-24d2r); when the


### PR DESCRIPTION
## Summary

- make the workspace page registry the canonical source for sidebar, palette, status-context, alias, and shortcut policy
- derive desktop and mobile destination surfaces from that shared policy while preserving role rooms and canonical URLs
- keep status context explicit per destination and retain platform-aware shortcut labels
- add exhaustive consistency coverage so navigation surfaces cannot drift independently

## Verification

- 20 affected destination, shell, palette, alias, and registry suites
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` (1,849 files)
- `pnpm check:conflict-markers`
- `git diff --check`
- broad `pnpm test:app` exercised 966 files on the feature tree; production tests remained green and the only stops were stale source-contract assertions corrected in this commit

Closes cave-uxwmu