### PR TITLE
Polish titlebar control geometry

### DIFF
--- a/src/components/nav-section-tabs.test.ts
+++ b/src/components/nav-section-tabs.test.ts
@@ -145,7 +145,7 @@ assert.match(
 );
 assert.match(
   workspaceContextSwitcherCss,
-  /\.workspace-context-switcher--titlebar \.workspace-context-switcher__project \.cave-project-picker__trigger,[\s\S]*?max-width:\s*144px;[\s\S]*?height:\s*28px;/,
+  /\.workspace-context-switcher--titlebar \.workspace-context-switcher__project \.cave-project-picker__trigger,\s*\.workspace-context-switcher--titlebar \.workspace-context-switcher__crew \.familiar-switcher__trigger--labeled \{[\s\S]*?max-width:\s*144px;[\s\S]*?height:\s*28px;/,
   "title-bar project and familiar controls stay compact and align with adjacent chrome",
 );
 assert.match(

--- a/src/components/nav-section-tabs.test.ts
+++ b/src/components/nav-section-tabs.test.ts
@@ -130,6 +130,26 @@ assert.match(
 assert.match(styles, /\.nav-sections\b/, "the switcher ships its own tokenized styles");
 assert.match(
   styles,
+  /\.nav-sections--titlebar \{[\s\S]*?height:\s*28px;[\s\S]*?border-radius:\s*var\(--radius-control\);/,
+  "the title-bar switcher matches the height and control radius of adjacent chrome",
+);
+assert.match(
+  styles,
+  /\.nav-sections--titlebar \.nav-sections__tab \{[\s\S]*?min-height:\s*22px;[\s\S]*?border-radius:\s*calc\(var\(--radius-control\) - 2px\);/,
+  "the title-bar segments fit inside the shared control geometry",
+);
+assert.match(
+  workspaceContextSwitcherCss,
+  /\.workspace-context-switcher--titlebar \{[\s\S]*?padding-inline-start:\s*var\(--space-2\);[\s\S]*?border-inline-start:\s*1px solid var\(--border-hairline\);/,
+  "workspace scope is quietly separated from room navigation",
+);
+assert.match(
+  workspaceContextSwitcherCss,
+  /\.workspace-context-switcher--titlebar \.workspace-context-switcher__project \.cave-project-picker__trigger,[\s\S]*?max-width:\s*144px;[\s\S]*?height:\s*28px;/,
+  "title-bar project and familiar controls stay compact and align with adjacent chrome",
+);
+assert.match(
+  styles,
   /color-mix\(in oklch, var\(--accent-presence\) 14%, transparent\)/,
   "the active tint derives from one solid token per the state-tint recipe",
 );

--- a/src/styles/globals/workspace-context-switcher.css
+++ b/src/styles/globals/workspace-context-switcher.css
@@ -106,6 +106,8 @@
   gap: var(--space-1);
   width: auto;
   min-width: 0;
+  padding-inline-start: var(--space-2);
+  border-inline-start: 1px solid var(--border-hairline);
 }
 
 .workspace-context-switcher--titlebar :is(
@@ -129,8 +131,10 @@
 .workspace-context-switcher--titlebar .workspace-context-switcher__crew .familiar-switcher__trigger--labeled {
   width: auto;
   min-width: 120px;
-  max-width: 160px;
+  max-width: 144px;
+  height: 28px;
   min-height: 28px;
+  padding-block: 0;
   padding-inline: var(--space-2);
   gap: var(--space-1);
   border-color: transparent;

--- a/src/styles/sidebar-minimal/section-tabs.css
+++ b/src/styles/sidebar-minimal/section-tabs.css
@@ -75,20 +75,21 @@
 .nav-sections--titlebar {
   display: inline-flex;
   align-items: center;
-  gap: 0;
+  gap: 2px;
   margin: 0;
   padding: 2px;
+  height: 28px;
   border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-pill);
-  background: var(--bg-subtle);
+  border-radius: var(--radius-control);
+  background: transparent;
 }
 
 .nav-sections--titlebar .nav-sections__tab {
-  width: 28px;
-  min-height: 28px;
+  width: 24px;
+  min-height: 22px;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: var(--radius-pill);
+  border-radius: calc(var(--radius-control) - 2px);
 }
 
 .nav-sections--titlebar .nav-sections__tab.is-active {


### PR DESCRIPTION
## Summary
- align the Home/Chat segmented control with the 28px, 8px-radius title-bar button family
- separate room navigation from project/familiar scope with a quiet hairline divider
- cap context control width while preserving readable labels and consistent height
- pin the geometry in the existing navigation source-contract test

## Validation
- `node --test src/components/nav-section-tabs.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm exec playwright test tests/chat-sidebar-nav.spec.ts` (12 passed)
- browser measurement at 1440px: all adjacent title-bar controls resolve to 28px high and 8px outer radius