### PR TITLE
Fill the Rituals activity pane

### DIFF
--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -171,17 +171,17 @@ assert.match(
 );
 assert.match(
   compactCalendarStyles,
-  /\.rituals-overview\s*\{[^}]*display:\s*flex;[^}]*min-height:\s*0;[^}]*flex-direction:\s*column;/,
+  /\.rituals-overview\s*\{(?=[^}]*display:\s*flex;)(?=[^}]*min-height:\s*0;)(?=[^}]*flex-direction:\s*column;)[^}]*\}/,
   "overview should expose its remaining height to the activity pane",
 );
 assert.match(
   compactCalendarStyles,
-  /\.rituals-overview__lower\s*\{[^}]*display:\s*flex;[^}]*min-height:\s*180px;[^}]*flex:\s*1;[^}]*flex-direction:\s*column;/,
+  /\.rituals-overview__lower\s*\{(?=[^}]*display:\s*flex;)(?=[^}]*min-height:\s*180px;)(?=[^}]*flex:\s*1;)(?=[^}]*flex-direction:\s*column;)[^}]*\}/,
   "the Log and Agenda region should consume the remaining overview height",
 );
 assert.match(
   compactCalendarStyles,
-  /\.rituals-overview__pane\s*\{[^}]*min-height:\s*0;[^}]*flex:\s*1;[^}]*overflow:\s*hidden;/,
+  /\.rituals-overview__pane\s*\{(?=[^}]*min-height:\s*0;)(?=[^}]*flex:\s*1;)(?=[^}]*overflow:\s*hidden;)[^}]*\}/,
   "the selected activity pane should shrink correctly and contain its own scroller",
 );
 assert.doesNotMatch(
@@ -191,12 +191,12 @@ assert.doesNotMatch(
 );
 assert.match(
   compactCalendarStyles,
-  /\.rituals-overview__log\s*\{[^}]*height:\s*100%;[^}]*overflow-y:\s*auto;/,
+  /\.rituals-overview__log\s*\{(?=[^}]*height:\s*100%;)(?=[^}]*overflow-y:\s*auto;)[^}]*\}/,
   "the Log list should fill and scroll within the available pane height",
 );
 assert.match(
   compactCalendarStyles,
-  /\.rituals-overview__thread\s*\{[^}]*height:\s*100%;[^}]*overflow-y:\s*auto;/,
+  /\.rituals-overview__thread\s*\{(?=[^}]*height:\s*100%;)(?=[^}]*overflow-y:\s*auto;)[^}]*\}/,
   "the Agenda thread should fill and scroll within the available pane height",
 );
 assert.match(automations, /function useRitualNow\(\): Date \| null[\s\S]{0,560}setNow\(new Date\(\)\);[\s\S]{0,80}scheduleMidnight/, "the hydration-stable week clock starts in the browser and refreshes at local midnight");

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -169,6 +169,36 @@ assert.match(
   /\.rituals-overview__selection\s*\{[^}]*width:\s*100%/,
   "selection should expand to full width",
 );
+assert.match(
+  compactCalendarStyles,
+  /\.rituals-overview\s*\{[^}]*display:\s*flex;[^}]*min-height:\s*0;[^}]*flex-direction:\s*column;/,
+  "overview should expose its remaining height to the activity pane",
+);
+assert.match(
+  compactCalendarStyles,
+  /\.rituals-overview__lower\s*\{[^}]*display:\s*flex;[^}]*min-height:\s*180px;[^}]*flex:\s*1;[^}]*flex-direction:\s*column;/,
+  "the Log and Agenda region should consume the remaining overview height",
+);
+assert.match(
+  compactCalendarStyles,
+  /\.rituals-overview__pane\s*\{[^}]*min-height:\s*0;[^}]*flex:\s*1;[^}]*overflow:\s*hidden;/,
+  "the selected activity pane should shrink correctly and contain its own scroller",
+);
+assert.doesNotMatch(
+  compactCalendarStyles,
+  /max-height:\s*min\(42vh,\s*360px\)/,
+  "Log and Agenda should not stop at the old half-height cap",
+);
+assert.match(
+  compactCalendarStyles,
+  /\.rituals-overview__log\s*\{[^}]*height:\s*100%;[^}]*overflow-y:\s*auto;/,
+  "the Log list should fill and scroll within the available pane height",
+);
+assert.match(
+  compactCalendarStyles,
+  /\.rituals-overview__thread\s*\{[^}]*height:\s*100%;[^}]*overflow-y:\s*auto;/,
+  "the Agenda thread should fill and scroll within the available pane height",
+);
 assert.match(automations, /function useRitualNow\(\): Date \| null[\s\S]{0,560}setNow\(new Date\(\)\);[\s\S]{0,80}scheduleMidnight/, "the hydration-stable week clock starts in the browser and refreshes at local midnight");
 assert.match(automations, /ritualNow \? buildRitualWeek\(inboxVisible, ritualNow\) : \[\]/, "the week ribbon waits for the browser-local date before derivation");
 assert.doesNotMatch(navigation, /\{ id: "flow", label: "Flow"/, "Flow nav is hidden from the active branch");

--- a/src/styles/globals/surface-compact-calendar.css
+++ b/src/styles/globals/surface-compact-calendar.css
@@ -46,6 +46,9 @@
 /* Rituals overview — option 3a from the minimalist design handoff. The week
    ribbon stays quiet; the Needs-you queue is the only raised, glowing surface. */
 .rituals-overview {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
   padding: var(--space-3) clamp(var(--space-3), 4vw, var(--space-6)) var(--space-6);
   color: var(--text-primary);
   background:
@@ -66,6 +69,18 @@
 .rituals-overview__lower {
   width: 100%;
   max-width: 100%;
+}
+
+.rituals-overview__events,
+.rituals-overview__needs {
+  flex: none;
+}
+
+.rituals-overview__lower {
+  display: flex;
+  min-height: 180px;
+  flex: 1;
+  flex-direction: column;
 }
 
 .rituals-overview__section-toggle {
@@ -310,19 +325,21 @@
 }
 
 .rituals-overview__pane {
-  min-height: 180px;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
   touch-action: pan-y;
 }
 
 .rituals-overview__log {
-  max-height: min(42vh, 360px);
+  height: 100%;
   overflow-y: auto;
   scrollbar-width: thin;
 }
 
 .rituals-overview__thread {
   display: flex;
-  max-height: min(42vh, 360px);
+  height: 100%;
   flex-direction: column;
   gap: var(--space-1);
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- let the Rituals Log and Agenda pane consume all remaining vertical space
- keep the selected pane internally scrollable with a minimum usable height
- add a source contract preventing the previous 42vh/360px cap from returning

## Verification
- targeted Rituals contract
- typecheck and lint
- production build and bundle budgets
- full app, API, and test-wiring suites
- rendered verification at 1440x900; activity pane reaches the viewport bottom

Bead: cave-clh51