### PR TITLE
Compact the full-width chat composer

### DIFF
--- a/src/components/chat-composer-command-capsule.test.ts
+++ b/src/components/chat-composer-command-capsule.test.ts
@@ -43,18 +43,19 @@ assert.match(
 );
 assert.match(
   activityCss,
-  /--cave-chat-measure:\s*64rem;[\s\S]*?--cave-composer-measure:\s*calc\(var\(--space-10\) \* 21\);/,
-  "the transcript keeps its wide reading measure while the composer uses a focused, text-scale-independent measure",
+  /--cave-chat-measure:\s*64rem;/,
+  "the transcript keeps its wide reading measure",
+);
+assert.doesNotMatch(activityCss, /--cave-composer-measure/, "the retired narrow composer measure stays removed");
+assert.match(
+  transcriptCss,
+  /\.cave-chat-linear \.cave-composer-shell \{[\s\S]*?max-width:\s*100%;/,
+  "the composer spans the available chat dock",
 );
 assert.match(
   transcriptCss,
-  /\.cave-chat-linear \.cave-composer-shell \{[\s\S]*?max-width:\s*var\(--cave-composer-measure\);/,
-  "the composer uses its compact intent-entry measure",
-);
-assert.match(
-  transcriptCss,
-  /\.cave-chat-linear \.cave-composer-input \{[\s\S]*?min-height:\s*calc\(var\(--space-10\) \+ var\(--space-4\)\);/,
-  "Chat uses a compact 56px writing field derived from the spacing grid",
+  /\.cave-chat-linear \.cave-composer-input \{[\s\S]*?min-height:\s*var\(--space-10\);/,
+  "desktop Chat uses a compact 40px writing field",
 );
 assert.match(
   transcriptCss,

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -235,9 +235,10 @@ assert.doesNotMatch(css, /\.cave-context-pill/, "the combined pill's CSS is reti
 // ── The reading measure stays on content while the composer uses the full dock
 assert.match(
   activityCss,
-  /\.cave-chat-linear \{[\s\S]*--cave-chat-measure:\s*64rem;[\s\S]*--cave-composer-measure:\s*calc\(var\(--space-10\) \* 21\);/,
-  "chat activity should keep the 64rem reading column and define a narrower spacing-derived composer",
+  /\.cave-chat-linear \{[\s\S]*--cave-chat-measure:\s*64rem;/,
+  "chat activity should keep the 64rem reading column",
 );
+assert.doesNotMatch(activityCss, /--cave-composer-measure/, "the retired narrow composer measure stays removed");
 assert.match(
   activityCss,
   /\.cave-chat-linear \.cave-chat-thread \{[\s\S]*max-width:\s*var\(--cave-chat-measure\);/,
@@ -250,8 +251,13 @@ assert.match(
 );
 assert.match(
   transcriptCss,
-  /\.cave-chat-linear \.cave-composer-shell \{[\s\S]*max-width:\s*var\(--cave-composer-measure\);/,
-  "composer shell should use the focused intent-entry width",
+  /\.cave-chat-linear \.cave-composer-shell \{[\s\S]*max-width:\s*100%;/,
+  "composer shell should span the full dock width",
+);
+assert.match(
+  transcriptCss,
+  /\.cave-followup-card__why-popover \{[\s\S]*width:\s*min\(/,
+  "follow-up rationale should render in a bounded overlay instead of resizing the footer",
 );
 
 // ── Footer action family + circular send ────────────────────────────────────

--- a/src/components/chat-follow-up-cards.test.ts
+++ b/src/components/chat-follow-up-cards.test.ts
@@ -20,7 +20,10 @@ assert.match(source, /Opens Tasks/, "action cards explain their destination");
 assert.match(source, /Recommended/, "the top recommendation carries a visible text marker");
 assert.match(source, /onActivate\(path\)/, "activation is delegated to the owning chat surface");
 assert.doesNotMatch(source, /\bsend\(path\.prompt\)/, "cards never send assistant text directly");
-assert.match(source, /Why this\?/, "contextual follow-ups disclose their rationale");
+assert.match(source, /<Popover[\s\S]*?placement="top-end"/, "rationale opens in the shared overlay above its suggestion");
+assert.match(source, /usePopoverInitialFocus/, "the rationale overlay moves keyboard focus into its close control");
+assert.match(source, /aria-label=\{`Why this suggestion: \$\{label\}`\}/, "each explanation trigger names its suggestion");
+assert.doesNotMatch(source, /<details|<summary/, "rationale no longer expands the composer document flow");
 assert.match(source, /Evidence/, "contextual follow-ups render typed evidence chips");
 assert.match(source, /path\.metadata/, "metadata remains optional for legacy next-path trailers");
 

--- a/src/components/chat-follow-up-cards.test.ts
+++ b/src/components/chat-follow-up-cards.test.ts
@@ -23,6 +23,7 @@ assert.doesNotMatch(source, /\bsend\(path\.prompt\)/, "cards never send assistan
 assert.match(source, /<Popover[\s\S]*?placement="top-end"/, "rationale opens in the shared overlay above its suggestion");
 assert.match(source, /usePopoverInitialFocus/, "the rationale overlay moves keyboard focus into its close control");
 assert.match(source, /aria-label=\{`Why this suggestion: \$\{label\}`\}/, "each explanation trigger names its suggestion");
+assert.match(source, /aria-haspopup="dialog"/, "the rationale trigger exposes its dialog relationship without referencing unmounted content");
 assert.doesNotMatch(source, /<details|<summary/, "rationale no longer expands the composer document flow");
 assert.match(source, /Evidence/, "contextual follow-ups render typed evidence chips");
 assert.match(source, /path\.metadata/, "metadata remains optional for legacy next-path trailers");

--- a/src/components/chat-follow-up-cards.tsx
+++ b/src/components/chat-follow-up-cards.tsx
@@ -56,7 +56,7 @@ function FollowUpRationale({
         className="cave-followup-card__why-trigger focus-ring"
         aria-label={`Why this suggestion: ${label}`}
         aria-expanded={open}
-        aria-controls={panelId}
+        aria-haspopup="dialog"
         onClick={() => setOpen((current) => !current)}
       >
         <Icon name="ph:info" width={12} aria-hidden />

--- a/src/components/chat-follow-up-cards.tsx
+++ b/src/components/chat-follow-up-cards.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useId, useRef, useState } from "react";
+import { Popover, PopoverBody, usePopoverInitialFocus } from "@/components/ui/popover";
 import { Icon, type IconName } from "@/lib/icon";
 import type { NextPath } from "@/lib/next-paths";
 
@@ -33,6 +35,71 @@ const FOLLOW_UP_META: Record<NextPath["kind"], FollowUpMeta> = {
     outcome: "Opens Tasks",
   },
 };
+
+function FollowUpRationale({
+  label,
+  metadata,
+}: {
+  label: string;
+  metadata: NonNullable<NextPath["metadata"]>;
+}) {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+  const panelId = `followup-rationale-${useId().replaceAll(":", "")}`;
+  usePopoverInitialFocus(open, `#${panelId}`);
+
+  return (
+    <>
+      <button
+        ref={anchorRef}
+        type="button"
+        className="cave-followup-card__why-trigger focus-ring"
+        aria-label={`Why this suggestion: ${label}`}
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <Icon name="ph:info" width={12} aria-hidden />
+        <span>Why</span>
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        anchorRef={anchorRef}
+        placement="top-end"
+        className="cave-followup-card__why-popover"
+        ariaLabel={`Why this suggestion: ${label}`}
+      >
+        <PopoverBody className="cave-followup-card__why-body">
+          <div id={panelId} className="cave-followup-card__why-panel">
+            <div className="cave-followup-card__why-header">
+              <span>Why this</span>
+              <button
+                type="button"
+                className="cave-followup-card__why-close focus-ring"
+                aria-label="Close explanation"
+                onClick={() => setOpen(false)}
+              >
+                <Icon name="ph:x" width={12} aria-hidden />
+              </button>
+            </div>
+            <p>{metadata.rationale}</p>
+            <div className="cave-followup-card__evidence" aria-label="Evidence">
+              <span>Evidence</span>
+              <div>
+                {metadata.evidenceRefs.map((evidence) => (
+                  <span className="ui-pill" key={`${evidence.kind}:${evidence.id}`}>
+                    {evidence.kind}: {evidence.label}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </PopoverBody>
+      </Popover>
+    </>
+  );
+}
 
 /**
  * Presentation-only next steps. The chat surface retains ownership of routing
@@ -74,20 +141,7 @@ export function FollowUpCards({ paths, onActivate, recommended = true }: FollowU
                 <span className="cave-followup-card__outcome">{meta.outcome}</span>
               </button>
               {path.metadata ? (
-                <details className="cave-followup-card__details">
-                  <summary className="focus-ring">Why this?</summary>
-                  <p>{path.metadata.rationale}</p>
-                  <div className="cave-followup-card__evidence" aria-label="Evidence">
-                    <span>Evidence</span>
-                    <div>
-                      {path.metadata.evidenceRefs.map((evidence) => (
-                        <span className="ui-pill" key={`${evidence.kind}:${evidence.id}`}>
-                          {evidence.kind}: {evidence.label}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                </details>
+                <FollowUpRationale label={path.label} metadata={path.metadata} />
               ) : null}
             </article>
           );

--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -141,8 +141,8 @@ assert.doesNotMatch(
 const linearComposerShell = /\.cave-chat-linear \.cave-composer-shell \{[^}]*\}/.exec(css)?.[0] ?? "";
 assert.match(
   linearComposerShell,
-  /max-width:\s*var\(--cave-composer-measure\)/,
-  "Linear composer shell should use the focused composer measure",
+  /max-width:\s*100%/,
+  "Linear composer shell should use the full dock width",
 );
 
 // ---------------------------------------------------------------------------

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -614,11 +614,8 @@ details[open] > .cave-tool-summary::before {
 .cave-chat-linear {
   position: relative; /* anchors .cave-drop-overlay */
   /* The transcript keeps a wide reading measure for code and long responses.
-     The composer is deliberately narrower: OpenCoven/ui treats intent entry as
-     a focused card rather than a window-wide command slab. Its cap uses the
-     spacing scale so accessibility text sizing does not widen the dock. */
+     The composer is a separate docked action surface and spans the pane. */
   --cave-chat-measure: 64rem;
-  --cave-composer-measure: calc(var(--space-10) * 21);
   background:
     linear-gradient(to bottom, color-mix(in oklch, var(--bg-raised) 18%, transparent), transparent 150px),
     var(--bg-base);

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -456,9 +456,13 @@
 }
 
 .cave-followup-card__entry {
+  position: relative;
   display: grid;
   min-width: 0;
-  gap: var(--space-1);
+}
+
+.cave-followup-card__entry:has(.cave-followup-card__why-trigger) .cave-followup-card {
+  padding-right: calc(var(--space-10) + var(--space-2));
 }
 
 .cave-followup-card {
@@ -492,24 +496,83 @@
   color: var(--text-secondary);
 }
 
-.cave-followup-card__details {
-  border-top: 1px solid var(--border-hairline);
-  padding-top: var(--space-1);
+.cave-followup-card__why-trigger {
+  position: absolute;
+  top: 50%;
+  right: var(--space-2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  min-width: var(--space-8);
+  height: var(--space-6);
+  padding-inline: var(--space-2);
+  transform: translateY(-50%);
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: var(--text-xs);
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.cave-followup-card__why-trigger:hover,
+.cave-followup-card__why-trigger[aria-expanded="true"] {
+  border-color: color-mix(in oklch, var(--accent-presence) 38%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+  color: var(--text-primary);
+}
+
+.cave-followup-card__why-popover {
+  width: min(calc(var(--space-10) * 9), calc(100vw - var(--space-8)));
+}
+
+.cave-followup-card__why-body {
+  padding: var(--space-3);
+}
+
+.cave-followup-card__why-panel {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.cave-followup-card__why-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  font-weight: 750;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+
+.cave-followup-card__why-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--space-6);
+  height: var(--space-6);
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.cave-followup-card__why-close:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.cave-followup-card__why-panel p {
+  margin: 0;
   color: var(--text-secondary);
   font-size: var(--text-xs);
   line-height: var(--leading-relaxed);
-}
-
-.cave-followup-card__details summary {
-  width: fit-content;
-  border-radius: var(--radius-control);
-  color: var(--text-primary);
-  cursor: pointer;
-  font-weight: 500;
-}
-
-.cave-followup-card__details p {
-  margin: var(--space-1) 0 0;
 }
 
 .cave-followup-card__evidence {
@@ -542,13 +605,23 @@
 
   .cave-chat-followups .cave-followup-card {
     min-height: var(--touch-target);
-    padding-inline: var(--space-2);
+    padding-left: var(--space-2);
+  }
+
+  .cave-followup-card__entry:has(.cave-followup-card__why-trigger) .cave-followup-card {
+    padding-right: calc(var(--touch-target) + var(--space-2));
+  }
+
+  .cave-followup-card__why-trigger {
+    min-width: var(--touch-target);
+    height: var(--touch-target);
   }
 }
 
 
 .cave-chat-linear .cave-composer-shell {
-  max-width: var(--cave-composer-measure);
+  width: 100%;
+  max-width: 100%;
 }
 
 .cave-chat-linear .cave-composer-panel {
@@ -569,11 +642,11 @@
 }
 
 .cave-chat-linear .cave-composer-input {
-  min-height: calc(var(--space-10) + var(--space-4));
+  min-height: var(--space-10);
 }
 
 .cave-chat-linear .cave-composer-controls {
-  padding: 0 var(--space-2) var(--space-2);
+  padding: 0 var(--space-2) var(--space-1);
 }
 
 .cave-chat-linear .cave-composer-footer-band {

--- a/tests/chat-composer-followup-popover.spec.ts
+++ b/tests/chat-composer-followup-popover.spec.ts
@@ -96,6 +96,7 @@ async function setup(page: Page) {
 test("chat composer is full-width and follow-up rationale does not reflow it", async ({
   page,
 }) => {
+  test.setTimeout(90_000);
   await setup(page);
   await page.goto(`/?mode=chat#chat-${SESSION_ID}`, { waitUntil: "domcontentloaded" });
 
@@ -132,7 +133,8 @@ test("chat composer is full-width and follow-up rationale does not reflow it", a
     shellHeight: (await shell.boundingBox())?.height,
     documentHeight: await page.evaluate(() => document.documentElement.scrollHeight),
   };
-  expect(after).toEqual(before);
+  expect(after.documentHeight).toBe(before.documentHeight);
+  expect(Math.abs((after.shellHeight ?? 0) - (before.shellHeight ?? 0))).toBeLessThan(1);
 
   await page.keyboard.press("Escape");
   await expect(dialog).toBeHidden();

--- a/tests/chat-composer-followup-popover.spec.ts
+++ b/tests/chat-composer-followup-popover.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const ISO = "2026-08-24T12:00:00.000Z";
+const SESSION_ID = "composer-followup";
+const RATIONALE = "Keeps the active implementation moving without another navigation step.";
+
+async function setup(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("cave:active-familiar", "nova");
+    localStorage.setItem("cave:familiar:nova:last-surface", "chat");
+    localStorage.setItem("cave:onboarding:dismissed", "1");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        familiars: [
+          {
+            id: "nova",
+            display_name: "Nova",
+            role: "Orchestrator",
+            status: "active",
+            icon: "ph:sparkle-fill",
+          },
+        ],
+      },
+    }),
+  );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        sessions: [
+          {
+            id: SESSION_ID,
+            title: "Composer follow-up",
+            status: "idle",
+            project_root: "/tmp/coven-cave",
+            harness: "claude",
+            familiarId: "nova",
+            model: "test",
+            runtime: "local:/tmp/coven-cave",
+            exit_code: null,
+            archived_at: null,
+            created_at: ISO,
+            updated_at: ISO,
+          },
+        ],
+      },
+    }),
+  );
+  await page.route("**/api/chat/conversation/**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        conversation: {
+          activeLeafId: "assistant-1",
+          turns: [
+            {
+              id: "user-1",
+              parentId: null,
+              role: "user",
+              text: "Polish the composer.",
+              createdAt: ISO,
+            },
+            {
+              id: "assistant-1",
+              parentId: "user-1",
+              role: "assistant",
+              text: `The composer is ready.
+
+<coven:next-paths>
+- [reply:recommended rationale="${RATIONALE}" evidence="message:assistant-1"] Draft the concise follow-up
+- [task rationale="Captures the remaining verification as durable work." evidence="message:assistant-1"] Review the validation task
+- [action:open-tasks rationale="Shows the project queue without changing this conversation." evidence="message:assistant-1"] Open project tasks
+</coven:next-paths>`,
+              createdAt: ISO,
+            },
+          ],
+        },
+      },
+    }),
+  );
+  await page.route("**/api/projects**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        projects: [
+          { id: "p1", name: "Coven Cave", root: "/tmp/coven-cave", access: "write" },
+        ],
+      },
+    }),
+  );
+}
+
+test("chat composer is full-width and follow-up rationale does not reflow it", async ({
+  page,
+}) => {
+  await setup(page);
+  await page.goto(`/?mode=chat#chat-${SESSION_ID}`, { waitUntil: "domcontentloaded" });
+
+  const main = page.getByTestId("chat-main");
+  const shell = main.locator(".cave-chat-linear .cave-composer-shell");
+  const dock = main.locator(".cave-chat-linear .cave-composer-dock");
+  const input = main.locator(".cave-chat-linear .cave-composer-input");
+  const why = main.getByRole("button", {
+    name: "Why this suggestion: Draft the concise follow-up",
+  });
+  await expect(why).toBeVisible({ timeout: 45_000 });
+
+  const before = {
+    shellHeight: (await shell.boundingBox())?.height,
+    documentHeight: await page.evaluate(() => document.documentElement.scrollHeight),
+  };
+  const [shellBox, dockBox, inputBox] = await Promise.all([
+    shell.boundingBox(),
+    dock.boundingBox(),
+    input.boundingBox(),
+  ]);
+  expect(shellBox?.width ?? 0).toBeGreaterThan((dockBox?.width ?? 0) * 0.9);
+  expect(inputBox?.height).toBeLessThanOrEqual(44);
+
+  await why.click();
+  const dialog = page.getByRole("dialog", {
+    name: "Why this suggestion: Draft the concise follow-up",
+  });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText(RATIONALE);
+  await expect(page.getByRole("button", { name: "Close explanation" })).toBeFocused();
+
+  const after = {
+    shellHeight: (await shell.boundingBox())?.height,
+    documentHeight: await page.evaluate(() => document.documentElement.scrollHeight),
+  };
+  expect(after).toEqual(before);
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+  await expect(why).toBeFocused();
+});


### PR DESCRIPTION
## Summary
- let the Chat composer span the available dock and reduce its desktop writing/control height
- replace inline Why-this disclosure with the shared accessible portal popover so explanations never reflow the page
- preserve mobile touch targets and add an exact browser regression for width, height stability, focus, and Escape

## Verification
- focused composer source-contract tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `pnpm build`
- `pnpm test:api`
- `pnpm exec playwright test tests/chat-composer-followup-popover.spec.ts --project=desktop --no-deps`
- `pnpm test:app` reached an unrelated timing failure in `glitter-crypt-chromium.test.ts`; the failing test passed immediately in isolation

Bead: `cave-wy4ah`