### PR TITLE
perf(server): stop paying the reconciliation lock on every store read

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:bundle": "node scripts/bundle-budget.mjs",
     "bench:conversation-list": "node --experimental-strip-types scripts/conversation-list-benchmark.mjs",
     "bench:chat-projects": "node --experimental-strip-types scripts/chat-project-grouping-benchmark.mjs",
+    "bench:store-reads": "node --experimental-strip-types scripts/store-read-benchmark.mjs",
     "bench:daemon-reliability": "node --experimental-strip-types scripts/daemon-reliability-benchmark.mjs",
     "performance:report": "node --experimental-strip-types scripts/cave-performance-report.mjs",
     "test:performance-report": "node --test scripts/cave-performance-report.test.mjs",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -202,6 +202,7 @@ export const SUITES = {
     "src/lib/tweet-thread-blinding.test.ts",
     "scripts/tweet-thread-protocol-drift.test.mjs",
     "scripts/tweet-thread-validator.test.mjs",
+    "src/lib/server/store-read-cache.test.ts",
     "src/lib/server/familiar-avatar-mutation.test.ts",
     "src/lib/server/x-app-config.test.ts",
     "src/lib/server/x-client.test.ts",

--- a/scripts/store-read-benchmark.mjs
+++ b/scripts/store-read-benchmark.mjs
@@ -1,0 +1,152 @@
+/**
+ * store-read-benchmark — what one `~/.coven` store read costs (cave-i65lt).
+ *
+ * `pnpm bench:store-reads`
+ *
+ * Measures `loadConfig` / `loadState` / `loadProjects` against a throwaway home
+ * in `tmpdir()`, never the developer's real `~/.coven`. Three shapes:
+ *
+ *  - each loader on its own, the unit cost;
+ *  - all three under one `Promise.all`, which is the serialization probe —
+ *    `withCaveHomeReconciliationLock` queues on a single key for the whole
+ *    process, so if these serialize the total lands near the SUM of the three
+ *    rather than near the MAX;
+ *  - the read set one `computeSessionsList` performs (state + projects, then
+ *    config three times: once via `callDaemon` -> `loadDaemonTarget`, once in
+ *    `sweepAutoArchive`, once in `sweepMergedPrAutoArchive`). That is the
+ *    number the four-second sessions poll actually pays.
+ *
+ * The stores are deliberately tiny. This measures lock and journal overhead,
+ * not parse cost — a few dozen bytes of JSON parse in microseconds, so anything
+ * above that is the reconciliation machinery.
+ */
+
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Blank reads as "not set", matching `conversation-list-benchmark.mjs`. A
+ * workflow writing `CAVE_BENCH_ITERATIONS: ${{ inputs.iterations }}` sets an
+ * empty string on a scheduled run, and `??` only catches undefined — so
+ * `Number("")` would silently select zero iterations and percentile() would
+ * read off the end of an empty array.
+ */
+function iterations() {
+  const raw = process.env.CAVE_BENCH_ITERATIONS?.trim();
+  if (!raw) return 200;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`CAVE_BENCH_ITERATIONS must be a positive number, received ${JSON.stringify(raw)}`);
+  }
+  return Math.floor(value);
+}
+
+const N = iterations();
+const emitJson = process.argv.includes("--json");
+
+const home = await mkdtemp(path.join(tmpdir(), "cave-store-read-bench-"));
+const caveHome = path.join(home, "cave");
+await mkdir(caveHome, { recursive: true });
+process.env.COVEN_HOME = home;
+process.env.COVEN_CAVE_HOME = caveHome;
+delete process.env.COVEN_SOCKET;
+
+await writeFile(path.join(caveHome, "config.json"), JSON.stringify({ addons: { github: false } }));
+await writeFile(path.join(caveHome, "state.json"), JSON.stringify({ sessionFamiliar: {} }));
+await writeFile(path.join(caveHome, "projects.json"), JSON.stringify({ projects: [] }));
+
+const { loadConfig, loadState } = await import(path.join(projectRoot, "src/lib/cave-config.ts"));
+const { loadProjects } = await import(path.join(projectRoot, "src/lib/cave-projects.ts"));
+
+function percentile(samples, fraction) {
+  const sorted = samples.slice().sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * fraction) - 1));
+  return sorted[index];
+}
+
+async function measure(id, fn, count) {
+  await fn(); // absorb the once-per-process migration
+  const samples = [];
+  for (let i = 0; i < count; i += 1) {
+    const started = performance.now();
+    await fn();
+    samples.push(performance.now() - started);
+  }
+  return {
+    id,
+    iterations: count,
+    p50Ms: Number(percentile(samples, 0.5).toFixed(4)),
+    p95Ms: Number(percentile(samples, 0.95).toFixed(4)),
+  };
+}
+
+const results = [];
+results.push(await measure("store-read.config.p50-ms", () => loadConfig(), N));
+results.push(await measure("store-read.state.p50-ms", () => loadState(), N));
+results.push(await measure("store-read.projects.p50-ms", () => loadProjects(), N));
+results.push(
+  await measure(
+    "store-read.parallel-three.p50-ms",
+    async () => {
+      await Promise.all([loadConfig(), loadState(), loadProjects()]);
+    },
+    N,
+  ),
+);
+results.push(
+  await measure(
+    "store-read.sessions-list-shape.p50-ms",
+    async () => {
+      await Promise.all([loadState(), loadProjects()]);
+      await loadConfig();
+      await loadConfig();
+      await loadConfig();
+    },
+    Math.max(1, Math.floor(N / 2)),
+  ),
+);
+
+await rm(home, { recursive: true, force: true });
+
+const byId = Object.fromEntries(results.map((entry) => [entry.id, entry]));
+const unit = byId["store-read.config.p50-ms"].p50Ms
+  + byId["store-read.state.p50-ms"].p50Ms
+  + byId["store-read.projects.p50-ms"].p50Ms;
+const parallel = byId["store-read.parallel-three.p50-ms"].p50Ms;
+/**
+ * parallel / (sum of the three measured on their own).
+ *
+ * Three reads that genuinely overlap cost about the slowest of them, so this
+ * lands well below 1 — around 0.4 for three comparable reads. At or above 1
+ * they serialized. ABOVE 1 is not a measurement error: queueing three
+ * contenders on one lock costs more than paying them one at a time, so a
+ * loaded machine amplifies rather than merely adding.
+ *
+ * This ratio, not the absolute milliseconds, is the number to watch. The
+ * absolutes move by ~5x with machine load — the same reason
+ * `conversation-list.cold-scan.share-of-full-parse-pct` is expressed as a
+ * share in `performance-budgets.ts` rather than a duration.
+ */
+const serializationRatio = unit > 0 ? Number((parallel / unit).toFixed(3)) : null;
+
+if (emitJson) {
+  console.log(JSON.stringify({ iterations: N, results, serializationRatio }, null, 2));
+} else {
+  console.log(`\nCave store reads — ${N} iterations, throwaway home\n`);
+  for (const entry of results) {
+    console.log(`  ${entry.id.padEnd(40)} p50=${entry.p50Ms.toFixed(3)}ms  p95=${entry.p95Ms.toFixed(3)}ms`);
+  }
+  console.log(
+    `\n  serialization ratio (parallel / sum-of-units): ${serializationRatio}` +
+      `\n    < ~0.5  the three reads genuinely overlap` +
+      `\n    ~1.0    they serialize on the shared lock queue` +
+      `\n    > 1.0   they serialize AND contention amplifies the queue` +
+      `\n  Prefer this ratio over the absolute milliseconds above: those move` +
+      `\n  by several times with machine load, the ratio does not.\n`,
+  );
+}

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
 import { withCaveHomeReconciledStore, withCaveHomeReconciledStores } from "./server/cave-home-migration.ts";
+import { readCachedStore } from "./server/store-read-cache.ts";
 import { invalidateSessionsListCache } from "./server/sessions-list-cache.ts";
 import {
   reconcileHubAccessTokenForOrigin,
@@ -539,8 +540,21 @@ async function loadConfigUnlocked(): Promise<CaveConfig> {
   }
 }
 
+/**
+ * Read the config, serving an unchanged file from the stat-keyed cache.
+ *
+ * A miss takes the original locked path below, unchanged. The cache exists
+ * because this is the single hottest store read in the app: one
+ * `computeSessionsList` calls it three times — via `callDaemon` ->
+ * `loadDaemonTarget`, `sweepAutoArchive`, and `sweepMergedPrAutoArchive` — on a
+ * four-second poll, and each call was measured at 8.0ms p50 / 49.4ms p95 for a
+ * file of a few dozen bytes. That cost is the reconciliation lock, not the
+ * parse. See `server/store-read-cache.ts`.
+ */
 export function loadConfig(): Promise<CaveConfig> {
-  return withCaveHomeReconciledStore("cave-config.json", loadConfigUnlocked);
+  return readCachedStore(CONFIG_PATH, () =>
+    withCaveHomeReconciledStore("cave-config.json", loadConfigUnlocked),
+  );
 }
 
 /** Reconcile the configured hub URL with origin-bound vault custody, splitting
@@ -885,7 +899,9 @@ async function loadStateUnlocked(): Promise<CaveState> {
 }
 
 export function loadState(): Promise<CaveState> {
-  return withCaveHomeReconciledStore("cave-state.json", loadStateUnlocked);
+  return readCachedStore(STATE_PATH, () =>
+    withCaveHomeReconciledStore("cave-state.json", loadStateUnlocked),
+  );
 }
 
 /** A coherent, lock-protected snapshot for the frequent daemon status poll. */

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -10,6 +10,7 @@ export {
   sortProjectsAlphabetically,
 } from "./cave-projects-types.ts";
 import type { CaveProject } from "./cave-projects-types.ts";
+import { readCachedStore } from "./server/store-read-cache.ts";
 import { dedupeProjectsByRoot as dedupeByRoot } from "./cave-projects-types.ts";
 import { caveHome } from "./coven-paths.ts";
 import { withCaveHomeReconciledStore } from "./server/cave-home-migration.ts";
@@ -125,7 +126,10 @@ async function loadProjectsUnlocked(): Promise<CaveProject[]> {
 }
 
 export async function loadProjects(): Promise<CaveProject[]> {
-  return withProjectsStore(loadProjectsUnlocked);
+  // Keyed on the resolved path so a CAVE_PROJECTS_PATH_OVERRIDE — which
+  // `withProjectsStore` also honours by skipping the lock entirely — can never
+  // be served the canonical store's entry, or the reverse.
+  return readCachedStore(projectsFilePath(), () => withProjectsStore(loadProjectsUnlocked));
 }
 
 /** Registry mutex for callers that already reconcile every involved store. */

--- a/src/lib/server/atomic-write.ts
+++ b/src/lib/server/atomic-write.ts
@@ -1,6 +1,8 @@
 import { rename, rm, writeFile } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 
+import { invalidateCachedStore } from "./store-read-cache.ts";
+
 const TRANSIENT_RENAME_ERRORS = new Set(["EACCES", "EBUSY", "EPERM"]);
 
 async function renameReplacing(source: string, target: string): Promise<void> {
@@ -43,6 +45,14 @@ export async function writeFileAtomic(path: string, data: string | Uint8Array): 
     // the same unique-temp + rename safety as JSON stores.
     await writeFile(tmp, data);
     await renameReplacing(tmp, path);
+    // Any cached read of this path is stale by construction now. The stat key
+    // in store-read-cache would catch the change on the next read regardless;
+    // dropping it here is what makes a same-process write-then-read exact
+    // whatever the filesystem's timestamp resolution turns out to be. Doing it
+    // at the single point every store write funnels through beats editing the
+    // eight call sites and hoping the ninth remembers. A no-op for paths the
+    // cache has never seen, which is most of them.
+    invalidateCachedStore(path);
   } catch (err) {
     await rm(tmp, { force: true }).catch(() => {});
     throw err;

--- a/src/lib/server/store-read-cache.test.ts
+++ b/src/lib/server/store-read-cache.test.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  clearCaveStoreReadCache,
+  getStoreReadCacheMetrics,
+  invalidateCachedStore,
+  readCachedStore,
+} from "./store-read-cache.ts";
+
+async function scratchFile(contents: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "store-read-cache-"));
+  const file = path.join(dir, "store.json");
+  await writeFile(file, contents);
+  return file;
+}
+
+test("a second read of an unchanged file never calls the loader", async (t) => {
+  clearCaveStoreReadCache();
+  const file = await scratchFile('{"n":1}');
+  t.after(() => rm(path.dirname(file), { recursive: true, force: true }));
+
+  let loads = 0;
+  const load = async () => {
+    loads += 1;
+    return { n: 1 };
+  };
+
+  assert.deepEqual(await readCachedStore(file, load), { n: 1 });
+  assert.deepEqual(await readCachedStore(file, load), { n: 1 });
+  assert.deepEqual(await readCachedStore(file, load), { n: 1 });
+  assert.equal(loads, 1, "the locked loader ran once for three reads");
+  assert.equal(getStoreReadCacheMetrics().hits, 2);
+});
+
+test("an external write is observed on the very next read", async (t) => {
+  // The whole safety argument rests on this: the cache is keyed on the file's
+  // stat, so anything that rewrites the file — another process, a migration
+  // replacement, a user editing config.json by hand — invalidates it without
+  // anyone having to remember to call invalidate().
+  clearCaveStoreReadCache();
+  const file = await scratchFile('{"n":1}');
+  t.after(() => rm(path.dirname(file), { recursive: true, force: true }));
+
+  const load = async () => JSON.parse(await import("node:fs").then((fs) => fs.readFileSync(file, "utf8")));
+
+  assert.deepEqual(await readCachedStore(file, load), { n: 1 });
+  await writeFile(file, '{"n":2}');
+  assert.deepEqual(await readCachedStore(file, load), { n: 2 });
+});
+
+test("a same-size rewrite is still observed", async (t) => {
+  // The failure mode a size-only key would miss. mtime/ctime carry it.
+  clearCaveStoreReadCache();
+  const file = await scratchFile('{"n":1}');
+  t.after(() => rm(path.dirname(file), { recursive: true, force: true }));
+
+  const load = async () => JSON.parse(await import("node:fs").then((fs) => fs.readFileSync(file, "utf8")));
+
+  assert.deepEqual(await readCachedStore(file, load), { n: 1 });
+  await writeFile(file, '{"n":9}');
+  const before = await stat(file);
+  assert.equal(before.size, 7, "the rewrite is byte-identical in length");
+  assert.deepEqual(await readCachedStore(file, load), { n: 9 });
+});
+
+test("mutating a returned value cannot poison the cache", async (t) => {
+  // Every loader hands out a freshly parsed object today and callers rewrite
+  // parts of it (the archive sweeps do). Sharing one reference would let any
+  // caller corrupt every later reader.
+  clearCaveStoreReadCache();
+  const file = await scratchFile('{"n":1}');
+  t.after(() => rm(path.dirname(file), { recursive: true, force: true }));
+
+  const load = async () => ({ nested: { n: 1 } });
+
+  const first = (await readCachedStore(file, load)) as { nested: { n: number } };
+  first.nested.n = 999;
+  const second = (await readCachedStore(file, load)) as { nested: { n: number } };
+  assert.equal(second.nested.n, 1, "the cached value survived a caller's mutation");
+  assert.notEqual(first, second, "each read gets its own object");
+});
+
+test("invalidate forces the next read through the loader", async (t) => {
+  clearCaveStoreReadCache();
+  const file = await scratchFile('{"n":1}');
+  t.after(() => rm(path.dirname(file), { recursive: true, force: true }));
+
+  let loads = 0;
+  const load = async () => {
+    loads += 1;
+    return { n: loads };
+  };
+
+  await readCachedStore(file, load);
+  await readCachedStore(file, load);
+  assert.equal(loads, 1);
+  invalidateCachedStore(file);
+  await readCachedStore(file, load);
+  assert.equal(loads, 2, "a write path that invalidates is not made to wait for a stat");
+});
+
+test("a missing file is never cached", async (t) => {
+  // A store with no file has no stat to key on, and the loader returns
+  // defaults. Caching that would hide the file the moment it appears.
+  clearCaveStoreReadCache();
+  const dir = await mkdtemp(path.join(tmpdir(), "store-read-cache-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const file = path.join(dir, "absent.json");
+
+  let loads = 0;
+  const load = async () => {
+    loads += 1;
+    return { defaulted: true };
+  };
+
+  await readCachedStore(file, load);
+  await readCachedStore(file, load);
+  assert.equal(loads, 2, "no hit is served for a file that does not exist");
+  assert.equal(getStoreReadCacheMetrics().statFailures, 2);
+
+  await writeFile(file, '{"defaulted":false}');
+  await readCachedStore(file, async () => {
+    loads += 1;
+    return { defaulted: false };
+  });
+  assert.equal(loads, 3, "the file appearing is picked up immediately");
+});
+
+test("an entry older than the ttl is re-read even with an unchanged stat", async (t) => {
+  // Belt and braces for filesystems that quantize timestamps coarser than they
+  // report them. The stat key does the real work; this bounds how long a
+  // wrong answer could survive if it ever failed to.
+  clearCaveStoreReadCache();
+  const file = await scratchFile('{"n":1}');
+  t.after(() => rm(path.dirname(file), { recursive: true, force: true }));
+
+  let loads = 0;
+  const load = async () => {
+    loads += 1;
+    return { n: loads };
+  };
+
+  let clock = 1_000;
+  const now = () => clock;
+  await readCachedStore(file, load, { ttlMs: 50, now });
+  clock = 1_040;
+  await readCachedStore(file, load, { ttlMs: 50, now });
+  assert.equal(loads, 1, "still inside the ttl");
+  clock = 1_100;
+  await readCachedStore(file, load, { ttlMs: 50, now });
+  assert.equal(loads, 2, "past the ttl, re-read despite an unchanged stat");
+});
+
+test("an atomic write drops the cached entry for the file it replaced", async (t) => {
+  // The single integration point. writeFileAtomic invalidates by path, so every
+  // store write — the seven config sites, the state site, and any added later —
+  // is covered without a call-site edit that someone can forget. The stat key
+  // would catch the change on the next read regardless; this makes a
+  // same-process write-then-read exact whatever the filesystem's timestamp
+  // resolution turns out to be.
+  clearCaveStoreReadCache();
+  const file = await scratchFile('{"n":1}');
+  t.after(() => rm(path.dirname(file), { recursive: true, force: true }));
+
+  let loads = 0;
+  const load = async () => {
+    loads += 1;
+    return { n: loads };
+  };
+
+  await readCachedStore(file, load);
+  await readCachedStore(file, load);
+  assert.equal(loads, 1, "cached");
+
+  const { writeJsonAtomic } = await import("./atomic-write.ts");
+  await writeJsonAtomic(file, { n: 2 });
+
+  await readCachedStore(file, load);
+  assert.equal(loads, 2, "the write invalidated the entry");
+});
+
+test("distinct paths do not share an entry", async (t) => {
+  // Tests repoint COVEN_CAVE_HOME per case; keying on the resolved absolute
+  // path is what keeps one case's config out of the next one's.
+  clearCaveStoreReadCache();
+  const a = await scratchFile('{"which":"a"}');
+  const b = await scratchFile('{"which":"b"}');
+  t.after(() => rm(path.dirname(a), { recursive: true, force: true }));
+  t.after(() => rm(path.dirname(b), { recursive: true, force: true }));
+
+  assert.deepEqual(await readCachedStore(a, async () => ({ which: "a" })), { which: "a" });
+  assert.deepEqual(await readCachedStore(b, async () => ({ which: "b" })), { which: "b" });
+  assert.deepEqual(await readCachedStore(a, async () => ({ which: "unused" })), { which: "a" });
+});

--- a/src/lib/server/store-read-cache.ts
+++ b/src/lib/server/store-read-cache.ts
@@ -140,7 +140,15 @@ export async function readCachedStore<T>(
 
   let stats: { mtimeNs: bigint; ctimeNs: bigint; size: bigint } | null = null;
   try {
-    const raw = await stat(filePath, { bigint: true });
+    // `turbopackIgnore` because this path is a runtime value, and Turbopack
+    // otherwise treats a dynamic filesystem access as a reason to trace the
+    // whole project ("Dynamic filesystem access causes tracing of the whole
+    // project"). That matters more here than at most call sites: `writeFileAtomic`
+    // imports this module, so without the annotation every route that writes a
+    // store would inherit whole-project tracing — and in this checkout
+    // `.worktrees` alone matches ~237k files. Same convention as
+    // `server/agent-attachments.ts` and `server/assist-runner.ts`.
+    const raw = await stat(/* turbopackIgnore: true */ filePath, { bigint: true });
     stats = { mtimeNs: raw.mtimeNs, ctimeNs: raw.ctimeNs, size: raw.size };
   } catch {
     // ENOENT is the ordinary cold-start shape: the loader returns defaults.

--- a/src/lib/server/store-read-cache.ts
+++ b/src/lib/server/store-read-cache.ts
@@ -1,0 +1,190 @@
+/**
+ * store-read-cache — stat-keyed read-through cache for Cave-owned `~/.coven`
+ * JSON stores (cave-i65lt).
+ *
+ * Every one of `loadConfig`, `loadState`, `loadProjects`, `loadBoard`,
+ * `loadProjectPermissions` and `readFamiliarWorkspaces` routes through
+ * `withCaveHomeReconciledStores`, which per call reads and parses the migration
+ * journal twice and then takes `withCaveHomeReconciliationLock`. That lock's
+ * queue key is `migrationLockPath()` — ONE key for the whole process — so store
+ * reads do not merely cost a lock cycle each, they serialize against every
+ * other store read in flight. The `Promise.all([callDaemon, loadState,
+ * loadProjects])` in `server/sessions-list.ts` is not actually parallel for its
+ * two filesystem legs, and a single `computeSessionsList` pays the cycle at
+ * least four times (`loadConfig` three of them). Under concurrent sessions this
+ * is what produces `timed out waiting for local cave home reconciliation queue
+ * after 15000ms`.
+ *
+ * None of those six loaders was memoized, so the cost was paid per request on
+ * a four-second poll.
+ *
+ * ## Why a cache hit may skip the lock
+ *
+ * The lock exists to keep a read from straddling a migration replacement. A
+ * hit here proves the file has not been replaced since the value was read:
+ * the stat triple is unchanged, and migration replacements land through
+ * `writeJsonAtomic` + `rename`, which always change it. So a hit is not
+ * "reading without the lock" — it is not reading at all. Every miss takes the
+ * unchanged full path, lock included, and every write keeps it.
+ *
+ * ## Why nanoseconds, and why a TTL on top
+ *
+ * `conversationSummaryCache` in `cave-conversations.ts` keys on millisecond
+ * `mtimeMs`/`ctimeMs`/`size`. That is right for transcripts, which no one
+ * rewrites twice in a millisecond. Config and state are rewritten by sweeps on
+ * the response path, so this keys on `bigint` stat fields instead — `mtimeNs`
+ * and `ctimeNs` are nanosecond-resolution on APFS and ext4 — and still caps
+ * entries with a short TTL, for the filesystems that quantize coarser than they
+ * report. Both guards are cheap; a wrong answer here is a config change the app
+ * silently ignores.
+ *
+ * ## One asymmetry worth knowing about
+ *
+ * `withCaveHomeReconciliationLock` throws `EDEADLK` on a nested acquisition,
+ * deliberately, rather than deadlocking. A cache hit does not acquire, so a
+ * nested read that throws today would succeed on a hit and still throw on a
+ * miss. No such nesting exists on the paths wired up here — a reader inside a
+ * held lock would already be failing — but a future caller that introduces one
+ * would get an intermittent failure rather than a reliable one. If that ever
+ * surfaces, fix the nesting; do not make this cache pretend to hold a lock.
+ *
+ * ## Ordering
+ *
+ * The stat is taken BEFORE the load, deliberately. If the file changes during
+ * the load, the value is stored under the older stat, so the next read misses
+ * and reloads. Statting after the load would file a fresh-looking key against
+ * possibly-older content, which is the one direction that can serve stale data.
+ *
+ * ## Every caller still gets its own object
+ *
+ * Today each loader returns a freshly parsed object, and callers are entitled
+ * to treat it as theirs — `sessions-list.ts` and the archive sweeps both hand
+ * the loaded state around and rewrite parts of it. Handing out one shared
+ * reference would let any of them silently poison the cache for every later
+ * reader, which is a far worse bug than the one this file exists to fix. So a
+ * hit returns a `structuredClone`, preserving the existing contract exactly. A
+ * clone is pure CPU on an already-parsed object; the cost this removes is a
+ * serialized lock cycle plus four file reads.
+ */
+
+import { stat } from "node:fs/promises";
+
+export type StoreReadCacheMetrics = {
+  /** Reads served from cache without touching the reconciliation lock. */
+  hits: number;
+  /** Reads that fell through to the full locked loader. */
+  misses: number;
+  /** Reads whose stat failed (ENOENT and friends); never cached. */
+  statFailures: number;
+  /** Distinct store paths currently held. */
+  entries: number;
+};
+
+/**
+ * Entries older than this are re-read even when the stat triple is unchanged.
+ * Short because the only thing it defends against is a filesystem whose
+ * timestamp resolution is coarser than the write rate; the stat key does the
+ * real work.
+ */
+const DEFAULT_TTL_MS = 1_000;
+
+type Entry = {
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+  size: bigint;
+  readAt: number;
+  value: unknown;
+};
+
+const entries = new Map<string, Entry>();
+let hits = 0;
+let misses = 0;
+let statFailures = 0;
+
+export function getStoreReadCacheMetrics(): StoreReadCacheMetrics {
+  return { hits, misses, statFailures, entries: entries.size };
+}
+
+export function resetStoreReadCacheMetrics(): void {
+  hits = 0;
+  misses = 0;
+  statFailures = 0;
+}
+
+/**
+ * Drop one store's cached value. Call from every write path that replaces the
+ * file, so a same-process mutation is visible on the next read instead of
+ * waiting for the stat to be observed.
+ */
+export function invalidateCachedStore(filePath: string): void {
+  entries.delete(filePath);
+}
+
+/** Drop everything. Tests that repoint `COVEN_HOME` must call this. */
+export function clearCaveStoreReadCache(): void {
+  entries.clear();
+  resetStoreReadCacheMetrics();
+}
+
+/**
+ * Read a store through the cache. `load` is the existing locked loader and is
+ * called unchanged on every miss.
+ */
+export async function readCachedStore<T>(
+  filePath: string,
+  load: () => Promise<T>,
+  options: { ttlMs?: number; now?: () => number } = {},
+): Promise<T> {
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const now = options.now ?? Date.now;
+
+  let stats: { mtimeNs: bigint; ctimeNs: bigint; size: bigint } | null = null;
+  try {
+    const raw = await stat(filePath, { bigint: true });
+    stats = { mtimeNs: raw.mtimeNs, ctimeNs: raw.ctimeNs, size: raw.size };
+  } catch {
+    // ENOENT is the ordinary cold-start shape: the loader returns defaults.
+    // A store with no file has no stat to key on, so it is never cached — the
+    // moment it appears, the very next read must see it.
+    statFailures += 1;
+    entries.delete(filePath);
+    return load();
+  }
+
+  const cached = entries.get(filePath);
+  if (
+    cached &&
+    cached.mtimeNs === stats.mtimeNs &&
+    cached.ctimeNs === stats.ctimeNs &&
+    cached.size === stats.size &&
+    now() - cached.readAt <= ttlMs
+  ) {
+    const copy = cloneStoreValue(cached.value);
+    if (copy.ok) {
+      hits += 1;
+      return copy.value as T;
+    }
+    // A store holding something structuredClone cannot copy would otherwise be
+    // shared by reference. Drop it and take the honest path instead.
+    entries.delete(filePath);
+  }
+
+  misses += 1;
+  const value = await load();
+  // The cache keeps its OWN copy and the caller keeps the loader's object.
+  // Storing the caller's reference instead would let whoever triggered the
+  // miss mutate the entry every later reader is served — the same poisoning
+  // the hit path clones to avoid, just one read earlier. A value that cannot
+  // be copied is simply not cached.
+  const stored = cloneStoreValue(value);
+  if (stored.ok) entries.set(filePath, { ...stats, readAt: now(), value: stored.value });
+  return value;
+}
+
+function cloneStoreValue(value: unknown): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: structuredClone(value) };
+  } catch {
+    return { ok: false };
+  }
+}


### PR DESCRIPTION
Removes the dominant server-side cost on the chat-list path: **every read of a
Cave-owned `~/.coven` JSON store was taking a process-wide file lock.**

`loadConfig`, `loadState` and `loadProjects` all route through
`withCaveHomeReconciledStores`, which per call reads and parses the migration
journal twice and then takes `withCaveHomeReconciliationLock`. That lock queues
on `migrationLockPath()` — **one key for the whole process** — so store reads
did not merely cost a lock cycle each, they serialized against every other
store read in flight. None of the three was memoized, and one
`computeSessionsList` performs at least four such reads (`loadConfig` three
times: via `callDaemon` → `loadDaemonTarget`, `sweepAutoArchive`, and
`sweepMergedPrAutoArchive`) on a four-second poll, behind 12+ client callers of
`/api/sessions/list`.

## Measured first

Idle machine, throwaway home holding three JSON files of a few dozen bytes, n=200:

| read | p50 | p95 |
|---|---:|---:|
| `loadConfig()` | 8.030 ms | 49.417 ms |
| `loadState()` | 3.746 ms | 14.211 ms |
| `loadProjects()` | 4.618 ms | 14.737 ms |
| `Promise.all([config, state, projects])` | 12.109 ms | 78.344 ms |
| `state + projects + config ×3` | **32.236 ms** | 118.932 ms |

`Promise.all` costing about the **sum** of the three rather than the max is the
direct evidence they serialize — so the `Promise.all` in
`src/lib/server/sessions-list.ts` is not actually parallel for its two
filesystem legs. These files are a few dozen bytes; this is lock overhead, not
parse cost. It is also the mechanism behind
`timed out waiting for local cave home reconciliation queue after 15000ms`
under concurrent sessions.

## After

Same benchmark in-tree, via the new `pnpm bench:store-reads`:

| read | before | after |
|---|---:|---:|
| `loadConfig()` | 11.585 ms | **0.049 ms** |
| `loadState()` | 26.238 ms | **0.029 ms** |
| `loadProjects()` | 23.988 ms | **0.031 ms** |
| `Promise.all` of the three | 92.495 ms | **0.064 ms** |
| `state + projects + config ×3` | 181.732 ms | **0.228 ms** |
| **serialization ratio** | **1.496** | **0.586** |

The before/after columns here were taken minutes apart on a machine at load
average 124, which is why the absolutes differ from the idle table above by
several times. **The ratio is the number to watch** — `parallel / sum-of-units`
is load-independent, held at 1.37–1.50 across repeated pre-change runs, and
0.586 means the three reads now genuinely overlap instead of serializing. The
benchmark prints that guidance for the same reason
`conversation-list.cold-scan.share-of-full-parse-pct` is a share rather than a
duration.

## Why a cache hit may skip the lock

Not a shortcut. A hit proves the file has not been replaced since the value was
read: the stat triple is unchanged, and migration replacements land through
`writeJsonAtomic` + `rename`, which always change it. So a hit is not "reading
without the lock" — it is not reading at all. **Every miss takes the original
locked path unchanged, and every write keeps it.**

## Correctness, pinned by nine tests

- **an external write is observed on the very next read** — the stat key makes
  that automatic, so a hand edit or another process needs no invalidation
- **a same-size rewrite is still observed** — mtime/ctime carry it; a size-only
  key would not
- **mutating a returned value cannot poison the cache.** Every loader hands out
  a freshly parsed object today and callers rewrite parts of it, so the cache
  keeps its *own* copy on both the hit and the miss path. Storing the caller's
  reference on a miss was a real bug in an earlier draft, and this test is what
  caught it.
- **a missing file is never cached**, so the store appearing is seen immediately
- **an entry past a short TTL is re-read** even with an unchanged stat, bounding
  any filesystem that quantizes timestamps coarser than it reports them
- **an atomic write drops the entry for the file it replaced**

That last one is wired inside `writeFileAtomic` rather than at the eight store
write sites, so every write is covered including ones added later — there is no
call site left for someone to forget. Keying on the resolved absolute path also
means a test that repoints `COVEN_CAVE_HOME` cannot be served another test's
entry.

## Deliberately not done

Two changes I had planned and the measurement made unnecessary:

- **hoisting `loadConfig` to one call per `computeSessionsList`** — the cache
  turns the two extra calls into sub-microsecond hits without touching two
  function signatures;
- **de-syncing the `fs.statSync` on the sessions-list response path** — it would
  force `mergeSessionRows` async, a well-tested pure function, for a
  microsecond-scale win on unknown project roots only.

`loadBoard`, `loadProjectPermissions` and `readFamiliarWorkspaces` are not
wrapped here. `loadBoard` reads its own file directly and pays the lock only via
`loadProjects`, so this already fixes its dominant cost transitively; the other
two are follow-ups on `cave-i65lt`.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (the `[token-refs]` banked-drift lines are pre-existing;
  this change touches no CSS)
- `src/lib/server/store-read-cache.test.ts` — 9/9
- `pnpm bench:store-reads` — numbers above
