### PR TITLE
Repair two connection-bootstrap XCTest failures (cave-jiox8)

### DIFF
--- a/apps/ios/CovenCave/CovenCaveTests/AppModelProjectContextTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppModelProjectContextTests.swift
@@ -987,6 +987,31 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(app.toast?.style, .success, file: file, line: line)
     }
 
+    /// Relocating the connection posts a success notice: when discovery moves
+    /// the shell to a different port, `AppModel` announces "Connected on port
+    /// N". That is deliberate, user-facing behaviour, so a test that forces a
+    /// relocation cannot assert `toast == nil` and mean "the pending navigation
+    /// reported nothing".
+    ///
+    /// Asserting the toast is EXACTLY this notice says the same thing without
+    /// being wrong about the relocation: `showToast` replaces `app.toast`
+    /// outright, so any navigation toast would have displaced this one.
+    private func assertOnlyPortRelocationNoticeToast(
+        _ app: AppModel,
+        port: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        assertToast(
+            app,
+            text: "Connected on port \(port)",
+            systemImage: "antenna.radiowaves.left.and.right",
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(app.toast?.style, .success, file: file, line: line)
+    }
+
     private func waitFor(
         _ condition: @escaping @MainActor () -> Bool,
         iterations: Int = 20,
@@ -4709,7 +4734,17 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(calls.grants, 1)
         XCTAssertEqual(calls.familiars, 1)
         XCTAssertEqual(calls.sessions, 1)
-        XCTAssertEqual(calls.tasks, 0)
+        // Task history IS consulted here, and one fetch is correct. The cold
+        // selection is staged local threads -> server sessions -> task history
+        // -> alphabetical, and `shouldFetchTaskHistoryForProjectContextSelection`
+        // fetches whenever the decision would otherwise land on the alphabetical
+        // or unassigned fallback. This client serves an EMPTY session list, so
+        // sessions succeed without identifying a registered project and the
+        // task-history stage runs — which is the point of that stage: it picks
+        // the project the operator actually worked in instead of the one that
+        // happens to sort first. Asserting 0 here asserted that the fallback
+        // never runs, which was never true; it had simply never executed.
+        XCTAssertEqual(calls.tasks, 1)
     }
 
     func testColdLaunchChoosesMostRecentHydratedLocalThreadProjectBeforeServerHistory() async {
@@ -5294,11 +5329,19 @@ final class AppModelProjectContextTests: XCTestCase {
         Task { await historyStarted.wait(); started.fulfill() }
         await fulfillment(of: [started], timeout: 1)
 
+        // `historyStarted` is opened by BOTH `sessions()` and `tasks()`, and the
+        // cold selection stages sessions FIRST — so the gate we just waited on
+        // was opened by the sessions call, while `tasks()` has not run and
+        // cannot yet: sessions is still parked on the shared `historyRelease`.
+        // Asserting `tasks == 1` here asserted an ordering the staging makes
+        // impossible. What this moment actually proves is that the bootstrap
+        // fan-out has begun and the intent has NOT hydrated off the back of it.
         let postBootstrapCalls = await controlledClient.callLog.snapshot()
-        XCTAssertEqual(postBootstrapCalls.tasks, 1)
+        XCTAssertEqual(postBootstrapCalls.sessions, 1)
+        XCTAssertEqual(postBootstrapCalls.tasks, 0)
         XCTAssertEqual(app.pendingProjectNavigationIntent?.taskId, target.id)
         XCTAssertNil(app.cardToOpen)
-        XCTAssertNil(app.toast)
+        assertOnlyPortRelocationNoticeToast(app, port: 4000)
 
         await historyRelease.open()
         await refreshTask.value
@@ -5308,7 +5351,12 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(app.projectContext, .project(alpha))
         XCTAssertEqual(app.selectedTab, .tasks)
         XCTAssertNil(app.pendingProjectNavigationIntent)
-        XCTAssertNil(app.toast)
+        assertOnlyPortRelocationNoticeToast(app, port: 4000)
+        // The hydration the mid-flight snapshot was too early to see: once the
+        // release gate opens, the staged task fetch does run, and it is what
+        // resolves `cardToOpen` above.
+        let hydratedCalls = await controlledClient.callLog.snapshot()
+        XCTAssertEqual(hydratedCalls.tasks, 1)
     }
 
     func testPendingTaskIntentFailsOnlyAfterSuccessfulCurrentGenerationTaskLoad() async throws {

--- a/scripts/ios-xctest-summary.mjs
+++ b/scripts/ios-xctest-summary.mjs
@@ -234,16 +234,19 @@ export const QUARANTINED_FAILURES = new Map([
     { bead: "cave-22b4y", reason: "openChat(for:) returns nil while project navigation is .pending; which side is wrong needs a decision.", expires: "2026-09-27" },
   ],
   [
-    "testPendingTaskIntentWaitsForRelocatedBootstrapBeforeHydrating",
-    { bead: "cave-vz17i", reason: "XCTAssertEqual 0 != 1 — a relocated bootstrap does not hydrate the pending task intent.", expires: "2026-09-27" },
-  ],
-  [
-    "testRefreshConnectionWaitsForFirstProjectContextLoadBeforeConnected",
-    { bead: "cave-vz17i", reason: "XCTAssertEqual 1 != 0 — the shell reports connected before the first project-context load settles.", expires: "2026-09-27" },
-  ],
-  [
     "testSessionUnlinkRelinkKeepsTheLatestOptimisticState",
-    { bead: "cave-vz17i", reason: "XCTAssertTrue failed — an unlink/relink cycle does not retain the latest optimistic state.", expires: "2026-09-27" },
+    {
+      bead: "cave-jiox8",
+      reason:
+        "linkedThread(for:) returns nil after an optimistic relink: BOTH of its " +
+        "branches require cachedSessionRow(for: card.sessionId) to be non-nil, and " +
+        "this test never populates the session-row cache. Undecided on purpose — " +
+        "either the gate is too strict and defeats optimistic linking for a " +
+        "session the server has not confirmed yet (product bug), or the fixture " +
+        "omits a row production always has (test bug). Deciding it needs the suite " +
+        "run, not source reading.",
+      expires: "2026-09-27",
+    },
   ],
 ]);
 


### PR DESCRIPTION
Two of the three failures in `cave-jiox8` were **stale assertions, not product defects**. Neither had ever executed before `cave-ac372` turned the iOS suite on.

### 1. `testRefreshConnectionWaitsForFirstProjectContextLoadBeforeConnected`

Asserted `calls.tasks == 0`. The cold selection is staged **local threads → server sessions → task history → alphabetical**, and `shouldFetchTaskHistoryForProjectContextSelection` fetches whenever the decision would otherwise land on the alphabetical or unassigned fallback:

```swift
guard !hasUsableTasks else { return false }
switch decision.reason {
case .suppliedSelection, .localThread, .serverSession, .taskHistory: return false
case .alphabeticalFallback, .unassignedFallback, .none: return true
}
```

This client serves an **empty session list**, so sessions succeed without identifying a registered project and the task-history stage runs — which is the point of that stage: it picks the project the operator actually worked in rather than the one that sorts first. Asserting `0` asserted that the fallback never runs.

### 2. `testPendingTaskIntentWaitsForRelocatedBootstrapBeforeHydrating`

Asserted `postBootstrapCalls.tasks == 1` after waiting on `historyStarted`. That gate is opened by **both** `sessions()` and `tasks()`:

```swift
func sessions() { recordSessions(); sessionStarted?.open(); historyStarted?.open(); … }
func tasks()    { recordTasks();    taskStarted?.open();    historyStarted?.open(); … }
```

The staging runs sessions first, so the gate fires from the **sessions** call while `tasks()` has not run and *cannot* — sessions is still parked on the shared `historyRelease`. The assertion required an ordering the staging makes impossible. That moment now asserts what it actually proves (the fan-out began; the intent has not hydrated), and a post-release block asserts the task fetch that does happen.

Its two `XCTAssertNil(app.toast)` assertions could not hold either: the test forces a relocation to port 4000, and relocating deliberately posts `"Connected on port N"`. Asserting the toast is *exactly* that notice says what the test meant — `showToast` replaces `app.toast` outright, so any other toast would have displaced it. Mirrors `assertOnlyReconnectNoticeToast` from `cave-vz17i`.

### Ratchet

Both entries removed, since a listed test that passes fails the gate as a stale entry. Remaining deferred: **7 `cave-22b4y` + 1 `cave-dwy2a` + 1 `cave-jiox8`**.

### Still deferred, with the mechanism now named

`testSessionUnlinkRelinkKeepsTheLatestOptimisticState` stays deferred. Its reason moves from *"not investigated"* to the actual mechanism: `linkedThread(for:)` returns `nil` after an optimistic relink because **both** of its branches require `cachedSessionRow(for: card.sessionId)` to be non-nil, and the test never populates that cache. Whether the gate is too strict for optimistic linking (**product bug**) or the fixture omits a row production always has (**test bug**) needs the suite run to decide, not source reading — so it is left honest rather than guessed.

### Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm check:tests-wired` — `✓ all 1856 test files wired into CI`
- `node --test scripts/ios-xctest-summary.test.mjs` — 30 pass, 0 fail (via the runner's own argv)
- `node scripts/ios-build-ci.test.mjs` — ok

No Xcode on this host, so the Swift reasoning is **read from source**; the `iOS build` job is the real verification.