### PR TITLE
fix(lifecycle): move PR inventory to REST

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,8 @@
     exception cannot rescue this: the inventory throws before admission is ever
     assessed. **Almost every exit 1 is transient — retry before you conclude
     otherwise.** Two failures dominate, and both clear on their own:
-    - the GraphQL quota is exhausted (`API rate limit already exceeded`) — that
-      pool is separate from REST and refills hourly, so `gh api rate_limit --jq
-      .resources.graphql` tells you when to retry;
+    - GitHub's REST quota is exhausted (`API rate limit already exceeded`) —
+      `gh api rate_limit --jq .resources.core` tells you when to retry;
     - a commit's PR association comes back malformed or absent (`commit
       association connection is unavailable`, `pull request node returned
       malformed fields or a mismatched head OID`) — usually a degraded or

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1908,6 +1908,7 @@ const STRIP_TYPES_MJS = new Set([
   "scripts/tweet-thread-protocol-drift.test.mjs",
   // imports ./worktree-lifecycle-inventory.ts
   "scripts/worktree-lifecycle-retirement.test.mjs",
+  "scripts/worktree-lifecycle-rest-pr-inventory.test.mjs",
   "scripts/worktree-lifecycle-fence-renewal.test.mjs",
   // imports ./worktree-lifecycle-inventory.ts and ../src/lib/worktree-lifecycle.ts
   "scripts/worktree-lifecycle-filemode.test.mjs",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -95,6 +95,7 @@ export const SUITES = {
     "scripts/beads-surface-audit.test.mjs",
     "scripts/install-git-hooks.test.mjs",
     "scripts/worktree-lifecycle-retirement.test.mjs",
+    "scripts/worktree-lifecycle-rest-pr-inventory.test.mjs",
     "scripts/worktree-lifecycle-patrol.test.mjs",
     "scripts/worktree-lifecycle-fence-renewal.test.mjs",
     "scripts/worktree-lifecycle-filemode.test.mjs",

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -270,22 +270,18 @@ case "$1 $2" in
     ;;
 esac
 case "$*" in
-  *"graphql"*"associatedPullRequests"*)
-    OID_ARG=
-    for arg in "$@"; do
-      case "$arg" in
-        oid=*) OID_ARG=\${arg#oid=} ;;
-      esac
-    done
-    if [ "$OID_ARG" = "${initialOid}" ]; then
-      printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":1,"url":"https://github.com/OpenCoven/coven-cave/pull/1","state":"MERGED","isDraft":false,"mergedAt":"2026-07-31T12:00:00Z","headRefName":"fixture-main","headRefOid":"${initialOid}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]'
-    else
-      printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]'
-    fi
-
+  *"commits/${initialOid}/pulls?per_page=100"*)
+    printf '%s\\n' '[[{"number":1,"html_url":"https://github.com/OpenCoven/coven-cave/pull/1","state":"closed","draft":false,"merged_at":"2026-07-31T12:00:00Z","head":{"ref":"fixture-main","sha":"${initialOid}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+    ;;
+  *"/commits/"*"/pulls?per_page=100"*)
+    printf '%s\\n' '[[]]'
+    ;;
+  *"/pulls?state=all&per_page=100"*)
+    printf '%s\\n' '[[{"number":1,"html_url":"https://github.com/OpenCoven/coven-cave/pull/1","state":"closed","draft":false,"merged_at":"2026-07-31T12:00:00Z","head":{"ref":"fixture-main","sha":"${initialOid}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
     ;;
   *"graphql"*)
-    printf '%s\\n' '[{"data":{"search":{"issueCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}]'
+    printf '%s\\n' 'unexpected GraphQL call' >&2
+    exit 2
     ;;
   "api "*)
     printf '%s\\n' '[{"total_count":0,"workflow_runs":[]}]'

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -277,7 +277,7 @@ case "$*" in
     printf '%s\\n' '[[]]'
     ;;
   *"/pulls?state=all&per_page=100"*)
-    printf '%s\\n' '[[{"number":1,"html_url":"https://github.com/OpenCoven/coven-cave/pull/1","state":"closed","draft":false,"merged_at":"2026-07-31T12:00:00Z","head":{"ref":"fixture-main","sha":"${initialOid}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+    printf '%s\\n' '{"number":1,"html_url":"https://github.com/OpenCoven/coven-cave/pull/1","state":"closed","draft":false,"merged_at":"2026-07-31T12:00:00Z","head":{"ref":"fixture-main","sha":"${initialOid}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}'
     ;;
   *"graphql"*)
     printf '%s\\n' 'unexpected GraphQL call' >&2

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -59,11 +59,13 @@ export interface WorktreeLifecycleInventoryOptions {
   /**
    * Restrict the per-unit GitHub probing to these full local refs.
    *
-   * The pull-request probe costs one GraphQL round trip per head oid and
-   * another per branch — measured at ~2 calls and ~2s per unit, so ~104 calls
-   * and ~95s of a ~134s inventory on a 47-unit checkout. Retirement's reprobe
-   * pays all of it to re-verify ONE candidate and then discards every other
-   * unit, twice per retirement (cave-imhf0).
+   * The pull-request probe costs one REST round trip per distinct head oid and
+   * one paginated repository pull-list request for all branches in scope.
+   * Before cave-zxgjs the second half was another GraphQL request per branch,
+   * measured at ~2 calls and ~2s per unit, so ~104 calls and ~95s of a ~134s
+   * inventory on a 47-unit checkout. Retirement's reprobe paid all of it to
+   * re-verify ONE candidate and then discarded every other unit, twice per
+   * retirement (cave-imhf0).
    *
    * Scoping narrows ONLY that GitHub probing. Every unit is still enumerated
    * locally, so cross-unit checks that do not need the network — conflicting
@@ -907,55 +909,6 @@ function updatedAt(
   return { value: Math.max(...epochs), error: null };
 }
 
-const ASSOCIATED_PULL_REQUESTS_QUERY = `
-query($owner: String!, $name: String!, $oid: GitObjectID!, $endCursor: String) {
-  repository(owner: $owner, name: $name) {
-    nameWithOwner
-    object(oid: $oid) {
-      ... on Commit {
-        associatedPullRequests(first: 100, after: $endCursor) {
-          totalCount
-          nodes {
-            number
-            url
-            state
-            isDraft
-            mergedAt
-            headRefName
-            headRefOid
-            headRepository { nameWithOwner }
-            baseRefName
-            baseRepository { nameWithOwner }
-          }
-          pageInfo { hasNextPage endCursor }
-        }
-      }
-    }
-  }
-}`;
-
-const EXACT_HEAD_PULL_REQUESTS_QUERY = `
-query($searchQuery: String!, $endCursor: String) {
-  search(query: $searchQuery, type: ISSUE, first: 100, after: $endCursor) {
-    issueCount
-    nodes {
-      ... on PullRequest {
-        number
-        url
-        state
-        isDraft
-        mergedAt
-        headRefName
-        headRefOid
-        headRepository { nameWithOwner }
-        baseRefName
-        baseRepository { nameWithOwner }
-      }
-    }
-    pageInfo { hasNextPage endCursor }
-  }
-}`;
-
 function repositoryName(value: unknown): string | null {
   if (!isRecord(value) || typeof value.nameWithOwner !== "string") return null;
   return GITHUB_REPOSITORY.test(value.nameWithOwner) ? value.nameWithOwner : null;
@@ -1040,35 +993,6 @@ function parsePullRequestNode(value: unknown, expectedOid: string | null): PullR
   };
 }
 
-function validatePageInfo(
-  value: unknown,
-  pageIndex: number,
-  pageCount: number,
-  cursors: Set<string>,
-): void {
-  if (
-    !isRecord(value) ||
-    typeof value.hasNextPage !== "boolean" ||
-    !(
-      value.endCursor === null ||
-      (typeof value.endCursor === "string" && value.endCursor.length > 0)
-    )
-  ) {
-    throw new Error("pagination returned malformed pageInfo");
-  }
-  const finalPage = pageIndex === pageCount - 1;
-  if (finalPage ? value.hasNextPage : !value.hasNextPage) {
-    throw new Error("pagination is incomplete");
-  }
-  if (!finalPage && typeof value.endCursor !== "string") {
-    throw new Error("pagination omitted an intermediate cursor");
-  }
-  if (typeof value.endCursor === "string") {
-    if (cursors.has(value.endCursor)) throw new Error("pagination repeated a cursor");
-    cursors.add(value.endCursor);
-  }
-}
-
 function samePullRequest(left: PullRequest, right: PullRequest): boolean {
   return (
     left.number === right.number &&
@@ -1097,138 +1021,66 @@ function dedupePullRequests(pullRequests: PullRequest[]): PullRequest[] {
   return [...deduped.values()];
 }
 
-function assertUniqueConnectionPullRequest(
-  pullRequest: PullRequest,
-  identities: Set<string>,
-  urls: Set<string>,
-): void {
-  const identity = `${pullRequest.baseRepository.toLowerCase()}#${pullRequest.number}`;
-  if (identities.has(identity) || urls.has(pullRequest.url)) {
-    throw new Error(`duplicate pull request ${identity}`);
+function restRepository(value: unknown): { nameWithOwner: string } | null {
+  if (!isRecord(value) || typeof value.full_name !== "string" || value.full_name.length === 0) {
+    return null;
   }
-  identities.add(identity);
-  urls.add(pullRequest.url);
+  return { nameWithOwner: value.full_name };
 }
 
-function parseAssociatedPullRequestPages(
+function parseRestPullRequest(
+  value: unknown,
+  expectedRepo: string,
+  expectedOid: string | null,
+): PullRequest {
+  if (!isRecord(value) || !isRecord(value.head) || !isRecord(value.base)) {
+    throw new Error("REST pull request is not an object");
+  }
+  const baseRepository = restRepository(value.base.repo);
+  const headRepository = value.head.repo === null ? null : restRepository(value.head.repo);
+  if (
+    baseRepository === null ||
+    (expectedOid === null &&
+      baseRepository.nameWithOwner.toLowerCase() !== expectedRepo.toLowerCase())
+  ) {
+    throw new Error("canonical repository identity mismatch");
+  }
+  if (value.state !== "open" && value.state !== "closed") {
+    throw new Error("REST pull request returned malformed state");
+  }
+  const state = value.merged_at === null
+    ? value.state === "open" ? "OPEN" : "CLOSED"
+    : "MERGED";
+  return parsePullRequestNode(
+    {
+      number: value.number,
+      url: value.html_url,
+      state,
+      isDraft: value.draft,
+      mergedAt: value.merged_at,
+      headRefName: value.head.ref,
+      headRefOid: value.head.sha,
+      headRepository,
+      baseRefName: value.base.ref,
+      baseRepository,
+    },
+    expectedOid,
+  );
+}
+
+export function parseRestPullRequestPages(
   raw: string,
   expectedRepo: string,
-  oid: string,
-): { canonicalRepo: string; pullRequests: PullRequest[] } {
-  const pages = parseJson<unknown>(raw, "associated PR inventory");
-  if (!Array.isArray(pages) || pages.length === 0) {
-    throw new Error("pagination returned no pages");
-  }
-  const cursors = new Set<string>();
-  let canonicalRepo: string | null = null;
-  let totalCount: number | null = null;
-  const identities = new Set<string>();
-  const urls = new Set<string>();
-  const pullRequests: PullRequest[] = [];
-  pages.forEach((page, pageIndex) => {
-    if (!isRecord(page) || "errors" in page || !isRecord(page.data)) {
-      throw new Error("page returned malformed GraphQL data");
-    }
-    const repository = page.data.repository;
-    const pageRepo = repositoryName(repository);
-    if (
-      !isRecord(repository) ||
-      pageRepo === null ||
-      pageRepo.toLowerCase() !== expectedRepo.toLowerCase()
-    ) {
-      throw new Error("canonical repository identity mismatch");
-    }
-    if (canonicalRepo !== null && pageRepo !== canonicalRepo) {
-      throw new Error("canonical repository identity changed between pages");
-    }
-    canonicalRepo = pageRepo;
-    if (!isRecord(repository.object) || !isRecord(repository.object.associatedPullRequests)) {
-      throw new Error("commit association connection is unavailable");
-    }
-    const connection = repository.object.associatedPullRequests;
-    if (
-      !Number.isSafeInteger(connection.totalCount) ||
-      (connection.totalCount as number) < 0 ||
-      !Array.isArray(connection.nodes)
-    ) {
-      throw new Error("association nodes are malformed");
-    }
-    if (totalCount !== null && totalCount !== connection.totalCount) {
-      throw new Error("association page totals are inconsistent");
-    }
-    totalCount = connection.totalCount as number;
-    validatePageInfo(connection.pageInfo, pageIndex, pages.length, cursors);
-    if (
-      pageIndex < pages.length - 1 &&
-      connection.nodes.length === 0
-    ) {
-      throw new Error("pagination returned an empty intermediate page");
-    }
-    for (const node of connection.nodes) {
-      const pullRequest = parsePullRequestNode(node, oid);
-      assertUniqueConnectionPullRequest(pullRequest, identities, urls);
-      pullRequests.push(pullRequest);
-    }
-  });
-  if (canonicalRepo === null) throw new Error("canonical repository identity is unavailable");
-  if (totalCount === null || pullRequests.length !== totalCount) {
-    throw new Error("association pagination is incomplete relative to totalCount");
-  }
-  return { canonicalRepo, pullRequests };
-}
-
-function parseExactHeadPullRequestPages(
-  raw: string,
-  canonicalRepo: string,
-  branch: string,
+  expectedOid: string | null = null,
 ): PullRequest[] {
-  const pages = parseJson<unknown>(raw, "exact-head PR search");
-  if (!Array.isArray(pages) || pages.length === 0) {
-    throw new Error("pagination returned no pages");
+  const pages = parseJson<unknown>(raw, "REST pull request inventory");
+  if (!Array.isArray(pages) || pages.length === 0 || pages.some((page) => !Array.isArray(page))) {
+    throw new Error("REST pagination returned malformed pages");
   }
-  const cursors = new Set<string>();
-  let issueCount: number | null = null;
-  const identities = new Set<string>();
-  const urls = new Set<string>();
-  const pullRequests: PullRequest[] = [];
-  pages.forEach((page, pageIndex) => {
-    if (!isRecord(page) || "errors" in page || !isRecord(page.data)) {
-      throw new Error("page returned malformed GraphQL data");
-    }
-    const search = page.data.search;
-    if (
-      !isRecord(search) ||
-      !Number.isSafeInteger(search.issueCount) ||
-      (search.issueCount as number) < 0 ||
-      !Array.isArray(search.nodes)
-    ) {
-      throw new Error("search page returned malformed data");
-    }
-    if ((search.issueCount as number) > 1_000) {
-      throw new Error("reached GitHub's 1000-result cap");
-    }
-    if (issueCount !== null && issueCount !== search.issueCount) {
-      throw new Error("search page totals are inconsistent");
-    }
-    issueCount = search.issueCount as number;
-    validatePageInfo(search.pageInfo, pageIndex, pages.length, cursors);
-    if (pageIndex < pages.length - 1 && search.nodes.length === 0) {
-      throw new Error("pagination returned an empty intermediate page");
-    }
-    for (const node of search.nodes) {
-      const pullRequest = parsePullRequestNode(node, null);
-      assertUniqueConnectionPullRequest(pullRequest, identities, urls);
-      pullRequests.push(pullRequest);
-    }
-  });
-  if (issueCount === null || pullRequests.length !== issueCount) {
-    throw new Error("search pagination is incomplete");
-  }
-  return pullRequests.filter(
-    (pullRequest) =>
-      pullRequest.headRepository?.toLowerCase() === canonicalRepo.toLowerCase() &&
-      pullRequest.headRefName === branch,
+  const pullRequests = pages.flatMap((page) =>
+    (page as unknown[]).map((value) => parseRestPullRequest(value, expectedRepo, expectedOid)),
   );
+  return dedupePullRequests(pullRequests);
 }
 
 function fetchPullRequests(
@@ -1263,17 +1115,9 @@ function fetchPullRequests(
         "api",
         "--hostname",
         "github.com",
-        "graphql",
         "--paginate",
         "--slurp",
-        "-F",
-        `owner=${owner}`,
-        "-F",
-        `name=${name}`,
-        "-F",
-        `oid=${oid}`,
-        "-f",
-        `query=${ASSOCIATED_PULL_REQUESTS_QUERY}`,
+        `repos/${owner}/${name}/commits/${encodeURIComponent(oid)}/pulls?per_page=100`,
       ],
       root,
       120_000,
@@ -1288,13 +1132,8 @@ function fetchPullRequests(
       continue;
     }
     try {
-      const parsed = parseAssociatedPullRequestPages(result.stdout, repo, oid);
-      if (canonicalRepo !== null && parsed.canonicalRepo !== canonicalRepo) {
-        globalErrors.push("pull request inventory canonical repository identity changed");
-      } else if (canonicalRepo === null) {
-        canonicalRepo = parsed.canonicalRepo;
-      }
-      byOid.set(oid, parsed.pullRequests);
+      byOid.set(oid, parseRestPullRequestPages(result.stdout, repo, oid));
+      canonicalRepo = repo;
     } catch (error) {
       const detail = error instanceof Error ? error.message : "malformed response";
       const message = `associated PR inventory returned malformed data for ${oid}: ${detail}`;
@@ -1308,10 +1147,8 @@ function fetchPullRequests(
     // Distinguish "GitHub did not answer" from "GitHub answered and the
     // repository identity was wrong". Both used to surface as the latter, which
     // sent the reader looking at repository configuration when the real cause
-    // was an exhausted GraphQL budget (its 5000/hr pool is separate from REST,
-    // so `gh api rate_limit` can look healthy while every graphql call fails).
-    // The per-OID errors already carry the true reason; this promotes it
-    // instead of overwriting it (cave-v59dk).
+    // was an exhausted API budget. The per-OID errors already carry the true
+    // reason; this promotes it instead of overwriting it (cave-v59dk).
     const attempted = new Set(heads).size;
     const firstFailure = [...errorsByOid.values()][0] ?? null;
     globalErrors.push(
@@ -1323,53 +1160,55 @@ function fetchPullRequests(
     );
   }
 
-  if (
-    canonicalRepo !== null &&
-    !globalErrors.some((error) => /canonical repository/i.test(error))
-  ) {
-    for (const branch of [...new Set(branches)].filter(
-      (candidate) =>
-        !PROTECTED_BRANCHES.has(candidate) && candidate !== defaultBranch,
-    )) {
-      const searchQuery = `is:pr head:${branch}`;
-      const result = command(
-        "gh",
-        [
-          "api",
-          "--hostname",
-          "github.com",
-          "graphql",
-          "--paginate",
-          "--slurp",
-          "-F",
-          `searchQuery=${searchQuery}`,
-          "-f",
-          `query=${EXACT_HEAD_PULL_REQUESTS_QUERY}`,
-        ],
-        root,
-        120_000,
-      );
-      if (!result.ok || result.stderr) {
+  const probedBranches = [...new Set(branches)].filter(
+    (candidate) => !PROTECTED_BRANCHES.has(candidate) && candidate !== defaultBranch,
+  );
+  if (probedBranches.length > 0) {
+    const result = command(
+      "gh",
+      [
+        "api",
+        "--hostname",
+        "github.com",
+        "--paginate",
+        "--slurp",
+        `repos/${owner}/${name}/pulls?state=all&per_page=100`,
+      ],
+      root,
+      120_000,
+    );
+    if (!result.ok || result.stderr) {
+      for (const branch of probedBranches) {
         errorsByBranch.set(
           branch,
-          `exact-head PR search failed for ${branch}: ${
+          `exact-head PR inventory failed for ${branch}: ${
             result.stderr || `status ${result.status ?? "unknown"}`
           }`,
         );
-        continue;
       }
+    } else {
       try {
-        byBranch.set(
-          branch,
-          parseExactHeadPullRequestPages(result.stdout, canonicalRepo, branch),
-        );
+        const pullRequests = parseRestPullRequestPages(result.stdout, repo);
+        canonicalRepo = repo;
+        for (const branch of probedBranches) {
+          byBranch.set(
+            branch,
+            pullRequests.filter(
+              (pullRequest) =>
+                pullRequest.headRepository?.toLowerCase() === repo.toLowerCase() &&
+                pullRequest.headRefName === branch,
+            ),
+          );
+        }
       } catch (error) {
-        errorsByBranch.set(
-          branch,
-          `exact-head PR search returned malformed or incomplete data for ${branch}: ${
-            error instanceof Error ? error.message : "malformed response"
-          }`,
-        );
+        for (const branch of probedBranches) {
+          errorsByBranch.set(
+            branch,
+            `exact-head PR inventory returned malformed or incomplete data for ${branch}: ${
+              error instanceof Error ? error.message : "malformed response"
+            }`,
+          );
+        }
       }
     }
   }

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -1038,6 +1038,9 @@ function parseRestPullRequest(
   }
   const baseRepository = restRepository(value.base.repo);
   const headRepository = value.head.repo === null ? null : restRepository(value.head.repo);
+  // Commit associations can legitimately include outbound PRs whose base is a
+  // different repository. Only the repository-wide branch inventory is
+  // required to be canonical; exact-OID outbound PRs still own the commit.
   if (
     baseRepository === null ||
     (expectedOid === null &&

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -1083,6 +1083,19 @@ export function parseRestPullRequestPages(
   return dedupePullRequests(pullRequests);
 }
 
+export function parseRestPullRequestLines(raw: string, expectedRepo: string): PullRequest[] {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return [];
+  return dedupePullRequests(
+    trimmed
+      .split("\n")
+      .map((line) => parseRestPullRequest(parseJson<unknown>(line, "REST pull request"), expectedRepo, null)),
+  );
+}
+
+const REST_PULL_REQUEST_PROJECTION =
+  '.[] | {number,html_url,state,draft,merged_at,head:{ref:.head.ref,sha:.head.sha,repo:(if .head.repo == null then null else {full_name:.head.repo.full_name} end)},base:{ref:.base.ref,repo:{full_name:.base.repo.full_name}}}';
+
 function fetchPullRequests(
   repo: string,
   root: string,
@@ -1171,8 +1184,9 @@ function fetchPullRequests(
         "--hostname",
         "github.com",
         "--paginate",
-        "--slurp",
         `repos/${owner}/${name}/pulls?state=all&per_page=100`,
+        "--jq",
+        REST_PULL_REQUEST_PROJECTION,
       ],
       root,
       120_000,
@@ -1188,7 +1202,7 @@ function fetchPullRequests(
       }
     } else {
       try {
-        const pullRequests = parseRestPullRequestPages(result.stdout, repo);
+        const pullRequests = parseRestPullRequestLines(result.stdout, repo);
         canonicalRepo = repo;
         for (const branch of probedBranches) {
           byBranch.set(

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -2170,6 +2170,84 @@ require_query() {
 if [ "$1" = "api" ] &&
    [ "$2" = "--hostname" ] &&
    [ "$3" = "github.com" ] &&
+   [ "$4" = "--paginate" ] &&
+   [ "$5" = "--slurp" ]; then
+  case "$6" in
+    repos/OpenCoven/coven-cave/commits/*/pulls?per_page=100)
+      OID_ARG=\${6#*/commits/}
+      OID_ARG=\${OID_ARG%/pulls?per_page=100}
+      ASSOCIATION_MARKER=${JSON.stringify(
+        path.join(fixtureRoot, "associated-query-"),
+      )}"\${LIFECYCLE_TEST_INVOCATION:-unknown}-$OID_ARG"
+      [ ! -e "$ASSOCIATION_MARKER" ] || fail "associated PR query repeated for duplicate OID $OID_ARG"
+      : > "$ASSOCIATION_MARKER"
+      if [ "\${LIFECYCLE_GRAPHQL_BUDGET_EXHAUSTED:-0}" = "1" ]; then
+        printf '%s\\n' 'API rate limit already exceeded for user ID 68980965.' >&2
+        exit 1
+      fi
+      BASE_REF=main
+      if [ "\${LIFECYCLE_DEFAULT_TRUNK:-0}" = "1" ]; then BASE_REF=trunk; fi
+      if [ "$OID_ARG" = "${oldHead}" ]; then
+        if [ "\${LIFECYCLE_INCOMPLETE_ASSOCIATED_PAGINATION:-0}" = "1" ] ||
+           [ "\${LIFECYCLE_MALFORMED_ASSOCIATED_PAGINATION:-0}" = "1" ] ||
+           [ "\${LIFECYCLE_OMITTED_ASSOCIATED_NODE:-0}" = "1" ] ||
+           [ "\${LIFECYCLE_UNSTABLE_ASSOCIATED_TOTAL:-0}" = "1" ]; then
+          printf '%s\\n' '{}'
+        elif [ "\${LIFECYCLE_DUPLICATE_ASSOCIATED_NODE:-0}" = "1" ]; then
+          printf '%s\\n' '[[{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}],[{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+        elif [ "\${LIFECYCLE_MISMATCHED_ASSOCIATED_OID:-0}" = "1" ]; then
+          printf '%s\\n' '[[{"number":42,"html_url":"https://github.com/OpenCoven/coven-cave/pull/42","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${"c".repeat(oldHead.length)}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+        elif [ "\${LIFECYCLE_SQUASH_MERGED_ASSOCIATED_OID:-0}" = "1" ]; then
+          printf '%s\\n' '[[{"number":42,"html_url":"https://github.com/OpenCoven/coven-cave/pull/42","state":"closed","draft":false,"merged_at":"2026-07-21T12:00:00Z","head":{"ref":"feat/old","sha":"${"c".repeat(oldHead.length)}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+        elif [ "\${LIFECYCLE_OUTBOUND_OPEN:-0}" = "1" ]; then
+          printf '%s\\n' '[[{"number":142,"html_url":"https://github.com/ArchiveOrg/archive/pull/142","state":"closed","draft":false,"merged_at":null,"head":{"ref":"archived-name","sha":"${oldHead}","repo":{"full_name":"ForkOwner/fork"}},"base":{"ref":"archive","repo":{"full_name":"ArchiveOrg/archive"}}}],[{"number":99,"html_url":"https://github.com/OtherOrg/other-repo/pull/99","state":"open","draft":false,"merged_at":null,"head":{"ref":"different-head-name","sha":"${oldHead}","repo":{"full_name":"ForkOwner/fork"}},"base":{"ref":"main","repo":{"full_name":"OtherOrg/other-repo"}}}]]'
+        elif [ "\${LIFECYCLE_EXACT_MERGED_DIFFERENT_HEAD:-0}" = "1" ]; then
+          printf '%s\\n' '[[{"number":98,"html_url":"https://github.com/OpenCoven/coven-cave/pull/98","state":"closed","draft":false,"merged_at":"2026-08-10T21:30:00Z","head":{"ref":"different-merged-head","sha":"${oldHead}","repo":{"full_name":"ForkOwner/fork"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+        elif [ "\${LIFECYCLE_CLOSED_UNMERGED:-0}" = "1" ] ||
+             [ "\${LIFECYCLE_CLOSED_DRAFT:-0}" = "1" ]; then
+          DRAFT=false
+          NUMBER=97
+          if [ "\${LIFECYCLE_CLOSED_DRAFT:-0}" = "1" ]; then DRAFT=true; NUMBER=96; fi
+          printf '[[{"number":%s,"html_url":"https://github.com/OpenCoven/coven-cave/pull/%s","state":"closed","draft":%s,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]\\n' "$NUMBER" "$NUMBER" "$DRAFT"
+        elif [ "\${LIFECYCLE_DUPLICATE_PR:-0}" = "1" ]; then
+          printf '%s\\n' '[[{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+        else
+          if [ "\${LIFECYCLE_NON_MAIN_MERGE:-0}" = "1" ]; then BASE_REF=staging; fi
+          printf '[[{"number":42,"html_url":"https://github.com/OpenCoven/coven-cave/pull/42","state":"closed","draft":false,"merged_at":"2026-07-21T12:00:00Z","head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"%s","repo":{"full_name":"OpenCoven/coven-cave"}}}]]\\n' "$BASE_REF"
+        fi
+      elif [ "$OID_ARG" = "${recentMergeHead}" ]; then
+        printf '[[{"number":43,"html_url":"https://github.com/OpenCoven/coven-cave/pull/43","state":"closed","draft":false,"merged_at":"2026-08-10T21:00:00Z","head":{"ref":"feat/recent-merge","sha":"${recentMergeHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"%s","repo":{"full_name":"OpenCoven/coven-cave"}}}]]\\n' "$BASE_REF"
+      elif [ "$OID_ARG" = "${recentReflogHead}" ]; then
+        printf '[[{"number":44,"html_url":"https://github.com/OpenCoven/coven-cave/pull/44","state":"closed","draft":false,"merged_at":"2026-07-21T12:00:00Z","head":{"ref":"feat/recent-reflog","sha":"${recentReflogHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"%s","repo":{"full_name":"OpenCoven/coven-cave"}}}]]\\n' "$BASE_REF"
+      elif [ "$OID_ARG" = "${fastForwardHead}" ] &&
+           [ "\${LIFECYCLE_FAST_FORWARD_MERGED_PR:-0}" = "1" ]; then
+        printf '[[{"number":45,"html_url":"https://github.com/OpenCoven/coven-cave/pull/45","state":"closed","draft":false,"merged_at":"2026-08-10T21:30:00Z","head":{"ref":"feat/fast-forward","sha":"${fastForwardHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"%s","repo":{"full_name":"OpenCoven/coven-cave"}}}]]\\n' "$BASE_REF"
+      else
+        printf '%s\\n' '[[]]'
+      fi
+      exit 0
+      ;;
+    repos/OpenCoven/coven-cave/pulls?state=all\\&per_page=100)
+      if [ "\${LIFECYCLE_MALFORMED_HEAD_SEARCH:-0}" = "1" ]; then
+        printf '%s\\n' '{}'
+      elif [ "\${LIFECYCLE_DUPLICATE_SEARCH_NODE:-0}" = "1" ]; then
+        printf '%s\\n' '[[{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}],[{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+      elif [ "\${LIFECYCLE_HEAD_ONLY_DRAFT:-0}" = "1" ]; then
+        printf '%s\\n' '[[{"number":78,"html_url":"https://github.com/OpenCoven/coven-cave/pull/78","state":"open","draft":true,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+      elif [ "\${LIFECYCLE_SAME_NAME_OPEN_SEARCH:-0}" = "1" ] ||
+           [ "\${LIFECYCLE_DUPLICATE_PR:-0}" = "1" ]; then
+        printf '%s\\n' '[[{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+      else
+        printf '%s\\n' '[[]]'
+      fi
+      exit 0
+      ;;
+  esac
+fi
+
+if [ "$1" = "api" ] &&
+   [ "$2" = "--hostname" ] &&
+   [ "$3" = "github.com" ] &&
    [ "$4" = "graphql" ] &&
    [ "$5" = "--paginate" ] &&
    [ "$6" = "--slurp" ]; then
@@ -2715,6 +2793,7 @@ exit 0
   const report = JSON.parse(stdout);
 
   const byBranch = new Map(report.items.map((item) => [item.branch, item]));
+  assert.deepEqual(report.globalErrors, [], "baseline patrol completes every live inventory probe");
   const workflowCalls = readFileSync(
     path.join(fixtureRoot, `workflow-calls-${lastPatrolInvocation}`),
     "utf8",
@@ -3577,17 +3656,15 @@ exit 0
       "LIFECYCLE_ALWAYS_UNSTABLE_WORKFLOW",
       /workflow inventory changed between verification sweeps \(unstable across \d+ verification attempts/i,
     ],
-    // A dead GraphQL budget names itself rather than blaming the repository.
-    // Its 5000/hr pool is separate from REST, so `gh api rate_limit` can look
-    // healthy while every graphql call fails — the old message sent readers to
-    // check repository configuration instead (cave-v59dk).
+    // A dead REST budget names itself rather than blaming the repository.
+    // The old message sent readers to check repository configuration instead
+    // of the API failure carried by every commit association (cave-v59dk).
     [
       "LIFECYCLE_GRAPHQL_BUDGET_EXHAUSTED",
       /could not query GitHub — all \d+ commit association quer(?:y|ies) failed:[\s\S]*rate limit/i,
     ],
     ["LIFECYCLE_BAD_TASKS", /Beads inventory returned malformed data/],
     ["LIFECYCLE_BEADS_STDERR", /Beads inventory omitted records/],
-    ["LIFECYCLE_PR_CAP", /exact-head PR search.*(?:cap|1000)/i],
     [
       "LIFECYCLE_INCOMPLETE_ASSOCIATED_PAGINATION",
       /associated PR inventory.*(?:incomplete|pagination)/i,
@@ -3601,24 +3678,33 @@ exit 0
       /associated PR inventory.*(?:OID|malformed)/i,
     ],
     [
-      "LIFECYCLE_DUPLICATE_ASSOCIATED_NODE",
-      /associated PR inventory.*duplicate pull request/i,
-    ],
-    [
       "LIFECYCLE_OMITTED_ASSOCIATED_NODE",
-      /associated PR inventory.*(?:incomplete|total)/i,
+      /associated PR inventory.*malformed/i,
     ],
     [
       "LIFECYCLE_UNSTABLE_ASSOCIATED_TOTAL",
-      /associated PR inventory.*totals.*inconsistent/i,
+      /associated PR inventory.*malformed/i,
     ],
-    ["LIFECYCLE_DUPLICATE_SEARCH_NODE", /exact-head PR search.*duplicate pull request/i],
-    ["LIFECYCLE_MALFORMED_HEAD_SEARCH", /exact-head PR search.*(?:incomplete|malformed)/i],
+    ["LIFECYCLE_MALFORMED_HEAD_SEARCH", /exact-head PR inventory.*(?:incomplete|malformed)/i],
   ]) {
     const failedReport = JSON.parse(patrol(["--json"], { [environment]: "1" }));
     const failedOld = failedReport.items.find((item) => item.branch === "feat/old");
     assert.equal(failedOld.lane, "uncertain", `${environment} fails closed`);
     assert.match(failedOld.probeErrors.join("\n"), expectedReason);
+  }
+
+  for (const environment of [
+    "LIFECYCLE_PR_CAP",
+    "LIFECYCLE_DUPLICATE_ASSOCIATED_NODE",
+    "LIFECYCLE_DUPLICATE_SEARCH_NODE",
+  ]) {
+    const restReport = JSON.parse(patrol(["--json"], { [environment]: "1" }));
+    const restOld = restReport.items.find((item) => item.branch === "feat/old");
+    assert.notEqual(
+      restOld.lane,
+      "uncertain",
+      `${environment} is harmless under REST pagination and identical-node deduplication`,
+    );
   }
 
   // A MERGED PR whose headRefOid is NOT the commit we asked about is the normal
@@ -4054,8 +4140,11 @@ exit 0
   );
   for (const branch of ["feat/old", "feat/branch-only"]) {
     const item = badCanonicalReport.items.find((candidate) => candidate.branch === branch);
-    assert.equal(item.lane, "uncertain", "canonical repository failure is global");
-    assert.match(item.probeErrors.join("\n"), /canonical.*repository/i);
+    assert.doesNotMatch(
+      item.probeErrors.join("\n"),
+      /canonical.*repository/i,
+      "REST endpoint identity comes from the validated repository path, not response metadata",
+    );
   }
 
   const linkedReport = JSON.parse(patrol(["--json"], { LIFECYCLE_LINKED_TASK: "1" }));

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -2170,11 +2170,12 @@ require_query() {
 if [ "$1" = "api" ] &&
    [ "$2" = "--hostname" ] &&
    [ "$3" = "github.com" ] &&
-   [ "$4" = "--paginate" ] &&
-   [ "$5" = "--slurp" ]; then
-  case "$6" in
+   [ "$4" = "--paginate" ]; then
+  REST_ENDPOINT=$5
+  if [ "$REST_ENDPOINT" = "--slurp" ]; then REST_ENDPOINT=$6; fi
+  case "$REST_ENDPOINT" in
     repos/OpenCoven/coven-cave/commits/*/pulls?per_page=100)
-      OID_ARG=\${6#*/commits/}
+      OID_ARG=\${REST_ENDPOINT#*/commits/}
       OID_ARG=\${OID_ARG%/pulls?per_page=100}
       ASSOCIATION_MARKER=${JSON.stringify(
         path.join(fixtureRoot, "associated-query-"),
@@ -2231,14 +2232,14 @@ if [ "$1" = "api" ] &&
       if [ "\${LIFECYCLE_MALFORMED_HEAD_SEARCH:-0}" = "1" ]; then
         printf '%s\\n' '{}'
       elif [ "\${LIFECYCLE_DUPLICATE_SEARCH_NODE:-0}" = "1" ]; then
-        printf '%s\\n' '[[{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}],[{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+        printf '%s\\n' '{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}' '{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}'
       elif [ "\${LIFECYCLE_HEAD_ONLY_DRAFT:-0}" = "1" ]; then
-        printf '%s\\n' '[[{"number":78,"html_url":"https://github.com/OpenCoven/coven-cave/pull/78","state":"open","draft":true,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+        printf '%s\\n' '{"number":78,"html_url":"https://github.com/OpenCoven/coven-cave/pull/78","state":"open","draft":true,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}'
       elif [ "\${LIFECYCLE_SAME_NAME_OPEN_SEARCH:-0}" = "1" ] ||
            [ "\${LIFECYCLE_DUPLICATE_PR:-0}" = "1" ]; then
-        printf '%s\\n' '[[{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+        printf '%s\\n' '{"number":77,"html_url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"open","draft":false,"merged_at":null,"head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}'
       else
-        printf '%s\\n' '[[]]'
+        :
       fi
       exit 0
       ;;

--- a/scripts/worktree-lifecycle-rest-pr-inventory.test.mjs
+++ b/scripts/worktree-lifecycle-rest-pr-inventory.test.mjs
@@ -6,6 +6,7 @@ import {
   parseRestPullRequestLines,
   parseRestPullRequestPages,
 } from "./worktree-lifecycle-inventory.ts";
+import { nodeArgsFor } from "./run-tests.mjs";
 
 const inventorySource = readFileSync(
   new URL("./worktree-lifecycle-inventory.ts", import.meta.url),
@@ -59,6 +60,14 @@ test("the lifecycle PR inventory uses REST endpoints and never invokes GraphQL",
   assert.match(source, /commits\/\$\{encodeURIComponent\(oid\)\}\/pulls\?per_page=100/);
   assert.match(source, /pulls\?state=all&per_page=100/);
   assert.match(source, /"--jq"/);
+});
+
+test("the normal test runner enables TypeScript stripping for this suite", () => {
+  assert.ok(
+    nodeArgsFor("scripts/worktree-lifecycle-rest-pr-inventory.test.mjs").includes(
+      "--experimental-strip-types",
+    ),
+  );
 });
 
 test("projected REST JSONL stays bounded without losing branch inventory fields", () => {

--- a/scripts/worktree-lifecycle-rest-pr-inventory.test.mjs
+++ b/scripts/worktree-lifecycle-rest-pr-inventory.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { parseRestPullRequestPages } from "./worktree-lifecycle-inventory.ts";
+
+const inventorySource = readFileSync(
+  new URL("./worktree-lifecycle-inventory.ts", import.meta.url),
+  "utf8",
+);
+
+test("REST pull request pages preserve lifecycle fields and deduplicate identical pages", () => {
+  const pull = {
+    number: 4979,
+    html_url: "https://github.com/OpenCoven/coven-cave/pull/4979",
+    state: "closed",
+    draft: false,
+    merged_at: "2026-08-24T14:12:15Z",
+    head: {
+      ref: "feat/cave-yssqw-surface-toolbar",
+      sha: "b".repeat(40),
+      repo: { full_name: "OpenCoven/coven-cave" },
+    },
+    base: {
+      ref: "main",
+      repo: { full_name: "OpenCoven/coven-cave" },
+    },
+  };
+
+  assert.deepEqual(
+    parseRestPullRequestPages(JSON.stringify([[pull], [pull]]), "OpenCoven/coven-cave"),
+    [
+      {
+        number: 4979,
+        url: pull.html_url,
+        state: "MERGED",
+        isDraft: false,
+        mergedAt: pull.merged_at,
+        headRefName: pull.head.ref,
+        headRefOid: pull.head.sha,
+        headRepository: pull.head.repo.full_name,
+        baseRefName: pull.base.ref,
+        baseRepository: pull.base.repo.full_name,
+      },
+    ],
+  );
+});
+
+test("the lifecycle PR inventory uses REST endpoints and never invokes GraphQL", () => {
+  const start = inventorySource.indexOf("function fetchPullRequests(");
+  const end = inventorySource.indexOf("\nfunction lifecycleUnitKey(", start);
+  assert.ok(start >= 0 && end > start, "fetchPullRequests source boundary exists");
+  const source = inventorySource.slice(start, end);
+
+  assert.doesNotMatch(source, /["']graphql["']/, "inventory must not spend GraphQL quota");
+  assert.match(source, /commits\/\$\{encodeURIComponent\(oid\)\}\/pulls\?per_page=100/);
+  assert.match(source, /pulls\?state=all&per_page=100/);
+});

--- a/scripts/worktree-lifecycle-rest-pr-inventory.test.mjs
+++ b/scripts/worktree-lifecycle-rest-pr-inventory.test.mjs
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { parseRestPullRequestPages } from "./worktree-lifecycle-inventory.ts";
+import {
+  parseRestPullRequestLines,
+  parseRestPullRequestPages,
+} from "./worktree-lifecycle-inventory.ts";
 
 const inventorySource = readFileSync(
   new URL("./worktree-lifecycle-inventory.ts", import.meta.url),
@@ -55,4 +58,38 @@ test("the lifecycle PR inventory uses REST endpoints and never invokes GraphQL",
   assert.doesNotMatch(source, /["']graphql["']/, "inventory must not spend GraphQL quota");
   assert.match(source, /commits\/\$\{encodeURIComponent\(oid\)\}\/pulls\?per_page=100/);
   assert.match(source, /pulls\?state=all&per_page=100/);
+  assert.match(source, /"--jq"/);
+});
+
+test("projected REST JSONL stays bounded without losing branch inventory fields", () => {
+  const line = JSON.stringify({
+    number: 4989,
+    html_url: "https://github.com/OpenCoven/coven-cave/pull/4989",
+    state: "open",
+    draft: false,
+    merged_at: null,
+    head: {
+      ref: "fix/cave-zxgjs-rest-pr-inventory",
+      sha: "c".repeat(40),
+      repo: { full_name: "OpenCoven/coven-cave" },
+    },
+    base: { ref: "main", repo: { full_name: "OpenCoven/coven-cave" } },
+  });
+  assert.deepEqual(
+    parseRestPullRequestLines(`${line}\n${line}\n`, "OpenCoven/coven-cave"),
+    [
+      {
+        number: 4989,
+        url: "https://github.com/OpenCoven/coven-cave/pull/4989",
+        state: "OPEN",
+        isDraft: false,
+        mergedAt: null,
+        headRefName: "fix/cave-zxgjs-rest-pr-inventory",
+        headRefOid: "c".repeat(40),
+        headRepository: "OpenCoven/coven-cave",
+        baseRefName: "main",
+        baseRepository: "OpenCoven/coven-cave",
+      },
+    ],
+  );
 });

--- a/scripts/worktree-lifecycle-retirement.test.mjs
+++ b/scripts/worktree-lifecycle-retirement.test.mjs
@@ -248,11 +248,15 @@ function createGitFixture() {
     path.join(bin, "gh"),
     `#!/bin/sh
 case "$*" in
-  *"associatedPullRequests"*)
-    printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]'
+  *"repos/OpenCoven/coven-cave/commits/"*"/pulls?per_page=100"*)
+    printf '%s\\n' '[[]]'
     ;;
-  *"search(query:"*|*"searchQuery="*)
-    printf '%s\\n' '[{"data":{"search":{"issueCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}]'
+  *"repos/OpenCoven/coven-cave/pulls?state=all&per_page=100"*)
+    :
+    ;;
+  *"graphql"*)
+    printf '%s\\n' 'retirement fixture must not invoke GraphQL' >&2
+    exit 2
     ;;
   *"repos/OpenCoven/coven-cave/actions/runs"*)
     printf '%s\\n' '[{"total_count":0,"workflow_runs":[]}]'
@@ -1577,9 +1581,10 @@ process.stdout.write(JSON.stringify(output) + "\\n");
 
 test("a scoped inventory keeps the focused unit's verdict and fails every other unit closed", () => {
   // reprobe asks about ONE candidate but used to probe every unit's pull
-  // request association: ~2 GraphQL round trips per unit, ~104 calls and ~95s
-  // of a ~134s inventory on a 47-unit checkout, all but one result discarded.
-  // focusRefs narrows that probing (cave-imhf0).
+  // request association: one REST round trip per distinct head OID, all but
+  // one result discarded during a focused reprobe. focusRefs narrows that work
+  // while the repository-wide branch inventory remains a single REST sweep
+  // (cave-imhf0).
   //
   // The danger is not the saving, it is the direction of the error. A unit with
   // no pull request association looks landed, and landed is what makes a unit

--- a/scripts/worktree-status.mjs
+++ b/scripts/worktree-status.mjs
@@ -2,7 +2,7 @@
 // worktree-status.mjs — fast, local, network-free worktree dashboard.
 //
 // This is the "at a glance" companion to `beads:worktrees` (the lifecycle
-// patrol). The patrol is authoritative: it does live GitHub GraphQL sweeps, a
+// patrol). The patrol is authoritative: it does live GitHub REST sweeps, a
 // maintenance gate, and drift detection before it will retire anything. That
 // makes it slow and network-bound. This script does none of that — it reads
 // only local git state (merge base, dirty tree, ahead/behind, lock reason) and


### PR DESCRIPTION
Bead: `cave-zxgjs`

## What changed
- replace per-OID GraphQL association queries with `GET /commits/{sha}/pulls`
- replace per-branch GraphQL searches with one paginated repository pull-list REST request indexed locally by `head.ref`
- project the repository-wide response to lifecycle fields with `--jq` and parse bounded JSONL, avoiding `spawnSync gh ENOBUFS` on the live 4,400-PR repository
- normalize and validate REST PR payloads while preserving fail-closed classification, outbound exact-OID ownership, and exact-head checks
- update managed-create, retirement, and the 147-scenario patrol fixtures to reject obsolete GraphQL assumptions
- wire the focused REST suite through the normal TypeScript-stripping runner path
- update operator guidance to the REST core quota

## Verification
- live report-only patrol: 44 items, no global, branch-probe, or orphaned-metadata errors; projected pull inventory was ~1.53 MB / 4,400 lines
- `node --experimental-strip-types scripts/worktree-lifecycle-rest-pr-inventory.test.mjs` (4/4)
- `node --experimental-strip-types scripts/worktree-lifecycle-retirement.test.mjs`
- `node scripts/worktree-lifecycle-patrol.test.mjs` (147/147)
- `node scripts/worktree-lifecycle-create.test.mjs`
- `pnpm check:tests-wired` (1,858 files)
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`

Signed-off-by: Val Alexander <68980965+BunsDev@users.noreply.github.com>