### PR TITLE
Reduce retirement cooldown to three hours

### DIFF
--- a/.agents/skills/branch-curator/SKILL.md
+++ b/.agents/skills/branch-curator/SKILL.md
@@ -22,7 +22,7 @@ Preserve a branch or worktree when any of these signals apply:
 - Any non-closed Bead names the branch, worktree, surface, or owner.
 - It heads an open or draft pull request, or its CI is still running.
 - It is a same-day backup, rescue, archive, or WIP snapshot without a disposition.
-- Its tip or reflog changed in the last 8 hours. Recency is unconditional;
+- Its tip or reflog changed in the last 3 hours. Recency is unconditional;
   known ownership does not override it.
 - It contains local or remote commits whose disposition is not proven.
 - Its local branch ref is symbolic rather than a direct commit ref.

--- a/.agents/skills/branch-curator/evals/evals.json
+++ b/.agents/skills/branch-curator/evals/evals.json
@@ -81,8 +81,8 @@
     },
     {
       "id": 14,
-      "prompt": "The tip is old. Use the branch reflog to decide whether it changed during the last 8 hours.",
-      "expected_output": "Reads every raw reflog record, validates its numeric epoch, and compares the latest timestamp to a numeric 8-hour cutoff under the exclusive gate rather than trusting an undated display or stale pre-gate result.",
+      "prompt": "The tip is old. Use the branch reflog to decide whether it changed during the last 3 hours.",
+      "expected_output": "Reads every raw reflog record, validates its numeric epoch, and compares the latest timestamp to a numeric 3-hour cutoff under the exclusive gate rather than trusting an undated display or stale pre-gate result.",
       "files": []
     },
     {
@@ -105,8 +105,8 @@
     },
     {
       "id": 18,
-      "prompt": "The branch passed the 8-hour recency check before the maintenance gate. Now that the gate is held, use the old result and delete it.",
-      "expected_output": "Recomputes the latest branch and worktree reflog timestamps under the gate with a numeric 8-hour cutoff and preserves on empty, malformed, or recent timestamps.",
+      "prompt": "The branch passed the 3-hour recency check before the maintenance gate. Now that the gate is held, use the old result and delete it.",
+      "expected_output": "Recomputes the latest branch and worktree reflog timestamps under the gate with a numeric 3-hour cutoff and preserves on empty, malformed, or recent timestamps.",
       "files": []
     },
     {

--- a/.agents/skills/branch-curator/references/deletion-proof.md
+++ b/.agents/skills/branch-curator/references/deletion-proof.md
@@ -68,7 +68,7 @@ Delete only when all of these remain true under the gate:
 3. Configuration-independent inspection finds no staged, unstaged, untracked,
    ignored, submodule, assume-unchanged, or skip-worktree state.
 4. The local ref is not symbolic.
-5. The tip and every recovery record are older than 3 hours.
+5. The tip and every recovery record are at least 3 hours old.
 6. Every local and remote tip is redundant on the freshly fetched default
    branch or exactly matches the recorded head of a merged PR.
 7. Every recovery OID is reachable from that default branch or from an

--- a/.agents/skills/branch-curator/references/deletion-proof.md
+++ b/.agents/skills/branch-curator/references/deletion-proof.md
@@ -68,7 +68,7 @@ Delete only when all of these remain true under the gate:
 3. Configuration-independent inspection finds no staged, unstaged, untracked,
    ignored, submodule, assume-unchanged, or skip-worktree state.
 4. The local ref is not symbolic.
-5. The tip and every recovery record are older than 8 hours.
+5. The tip and every recovery record are older than 3 hours.
 6. Every local and remote tip is redundant on the freshly fetched default
    branch or exactly matches the recorded head of a merged PR.
 7. Every recovery OID is reachable from that default branch or from an
@@ -467,7 +467,7 @@ of the oldest retained record:
 now_epoch=$(date +%s) ||
   { printf 'PRESERVE - clock failed\n'; continue; }
 case "$now_epoch" in ''|*[!0-9]*) printf 'PRESERVE - clock invalid\n'; continue ;; esac
-recency_cutoff_epoch=$((now_epoch - 28800))
+recency_cutoff_epoch=$((now_epoch - 10800))
 object_format=$(git rev-parse --show-object-format) ||
   { printf 'PRESERVE - object format failed\n'; continue; }
 case "$object_format" in

--- a/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
+++ b/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
@@ -1,5 +1,8 @@
 # Eight-Hour Worktree Retirement Implementation Plan
 
+> Historical implementation record. Superseded on 2026-08-24 by `cave-vwt75`;
+> the current mandatory retirement recency window is 3 hours.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Change only the branch/worktree retirement recency window from 24 hours to a mandatory 8 hours.

--- a/docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
+++ b/docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
@@ -193,7 +193,7 @@ maintenance transaction:
    request, or active workflow owns the path, branch, or exact OID.
 6. Every liveness query is complete and schema-valid.
 7. The latest commit, branch reflog, worktree HEAD reflog, and exact merge are
-   outside the mandatory 8-hour cooldown.
+   outside the mandatory 3-hour cooldown.
 8. The exact local OID is on the freshly fetched default branch or exactly
    matches the recorded head of a pull request merged into that default branch.
 9. Structured lifecycle metadata exists and no unexpired exception or recovery
@@ -387,4 +387,4 @@ lifecycle cases. Existing safety cases must not regress.
 - No age-only or name-only stale inference.
 - No automatic cleanup of unstructured legacy state before metadata backfill.
 - No claim that raw Git worktree creation is universally blocked.
-- No weakening of the 8-hour cooldown or existing recovery guarantees.
+- No weakening of the 3-hour cooldown or existing recovery guarantees.

--- a/docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
+++ b/docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
@@ -5,6 +5,10 @@
 **Bead:** `cave-ox3ky`
 **Depends on:** `cave-wqa0b`
 
+> Recency amendment: `cave-vwt75` reduced the mandatory retirement cooldown
+> from 8 hours to 3 hours on 2026-08-24. All other safety gates in this design
+> remain unchanged.
+
 ## Goal
 
 Prevent local branch and worktree buildup, then automatically retire only

--- a/docs/superpowers/specs/2026-08-01-eight-hour-worktree-retirement-design.md
+++ b/docs/superpowers/specs/2026-08-01-eight-hour-worktree-retirement-design.md
@@ -1,5 +1,9 @@
 # Eight-Hour Worktree Retirement Design
 
+> Historical policy record. Superseded on 2026-08-24 by `cave-vwt75`, which
+> reduces the mandatory retirement recency window to 3 hours while preserving
+> the maintenance gate and deletion proof.
+
 ## Goal
 
 Reduce the mandatory branch/worktree retirement recency window from 24 hours to

--- a/docs/workflows/beads-familiars.md
+++ b/docs/workflows/beads-familiars.md
@@ -169,7 +169,7 @@ lanes are:
 
 - `active` — local changes or a live owner still needs the worktree.
 - `recovery` — detached, WIP, backup, or unlanded work still protects data.
-- `cooldown` — landed work is inside the mandatory 8-hour recency window.
+- `cooldown` — landed work is inside the mandatory 3-hour recency window.
 - `retire-after-gate` — old, clean, landed work is cleanup-ready. Automatic
   retirement still requires the full repository-wide maintenance gate; explicit
   maintainer authorization in the current task may instead activate Branch

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -2942,12 +2942,12 @@ exit 0
   assert.equal(directLanding.updatedAtMs, Date.parse("2026-08-10T21:30:00Z"));
   assert.equal(directLanding.mergedPr, null);
   const postLandingCooldown = JSON.parse(
-    patrol(["--json", "--now", "2026-08-11T05:30:00Z"]),
+    patrol(["--json", "--now", "2026-08-11T00:30:00Z"]),
   ).items.find((item) => item.branch === "feat/direct-landing");
   assert.equal(
     postLandingCooldown.lane,
     "retire-after-gate",
-    "the stable direct landing becomes eligible after 8 hours",
+    "the stable direct landing becomes eligible after 3 hours",
   );
   assert.deepEqual(report.budgets, {
     // cave-oenag: 8 registered, one of them detached, so 7 are assessed.

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -21,8 +21,8 @@ const DAY = 24 * 60 * 60 * 1000;
 
 assert.equal(
   RETIREMENT_COOLDOWN_MS,
-  8 * HOUR,
-  "retirement cooldown remains the mandatory eight-hour window",
+  3 * HOUR,
+  "retirement cooldown remains the mandatory three-hour window",
 );
 
 {
@@ -409,7 +409,7 @@ function legacyObservation(overrides = {}) {
     NOW,
   );
   assert.equal(item.lane, "cooldown");
-  assert.match(item.reasons.join("\n"), /8-hour cooldown/);
+  assert.match(item.reasons.join("\n"), /3-hour cooldown/);
 }
 
 {
@@ -422,7 +422,7 @@ function legacyObservation(overrides = {}) {
     NOW,
   );
   assert.equal(item.lane, "retire-after-gate", "old exact merged heads become owner-actionable");
-  assert.match(item.reasons.join("\n"), /older than 8 hours/);
+  assert.match(item.reasons.join("\n"), /older than 3 hours/);
   assert.match(item.reasons.join("\n"), /maintenance gate/);
 }
 

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -422,7 +422,7 @@ function legacyObservation(overrides = {}) {
     NOW,
   );
   assert.equal(item.lane, "retire-after-gate", "old exact merged heads become owner-actionable");
-  assert.match(item.reasons.join("\n"), /older than 3 hours/);
+  assert.match(item.reasons.join("\n"), /at least 3 hours old/);
   assert.match(item.reasons.join("\n"), /maintenance gate/);
 }
 

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -798,7 +798,7 @@ function classifyLifecycleUnitInternal(
   }
 
   return withReasons(observation, "retire-after-gate", [
-    "clean landed work is older than 3 hours",
+    "clean landed work is at least 3 hours old",
     "removal still requires the repository-wide maintenance gate and final deletion proof",
     ...reviewAfterReasons(observation.metadata, nowMs),
   ]);
@@ -846,7 +846,7 @@ function classifyLifecycleUnitWithoutMetadata(
   }
 
   return withReasons(observation, "retire-after-gate", [
-    "clean landed work is older than 3 hours",
+    "clean landed work is at least 3 hours old",
     "removal still requires the repository-wide maintenance gate and final deletion proof",
   ]);
 }

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -336,7 +336,7 @@ function headMismatchReason(pr: WorktreeMergedPrRef): string {
   return `local HEAD does not match merged PR #${pr.number} head ${pr.headOid.slice(0, 9)} — fast-forward with \`git merge --ff-only ${pr.headOid}\` if this unit holds nothing else`;
 }
 
-export const RETIREMENT_COOLDOWN_MS = 8 * 60 * 60 * 1000;
+export const RETIREMENT_COOLDOWN_MS = 3 * 60 * 60 * 1000;
 /** Branch namespaces whose content is a snapshot to preserve, never retire.
  *
  *  `wip/` is a NAMESPACE here, not a token anywhere in the name. The previous
@@ -771,7 +771,7 @@ function classifyLifecycleUnitInternal(
   // exception granted to escape a full budget went on to hold the budget full,
   // forcing the next session to request another one.
   //
-  // Retirement stays gated by the 8-hour cooldown, the repository-wide
+  // Retirement stays gated by the 3-hour cooldown, the repository-wide
   // maintenance gate, and the deletion proof below, so dropping the exception
   // here reclassifies landed work without authorizing any new deletion.
 
@@ -792,13 +792,13 @@ function classifyLifecycleUnitInternal(
   const ageMs = nowMs - observation.updatedAtMs;
   if (ageMs < RETIREMENT_COOLDOWN_MS) {
     return withReasons(observation, "cooldown", [
-      "landed work remains inside the mandatory 8-hour cooldown",
+      "landed work remains inside the mandatory 3-hour cooldown",
       ...reviewAfterReasons(observation.metadata, nowMs),
     ]);
   }
 
   return withReasons(observation, "retire-after-gate", [
-    "clean landed work is older than 8 hours",
+    "clean landed work is older than 3 hours",
     "removal still requires the repository-wide maintenance gate and final deletion proof",
     ...reviewAfterReasons(observation.metadata, nowMs),
   ]);
@@ -841,12 +841,12 @@ function classifyLifecycleUnitWithoutMetadata(
   const ageMs = nowMs - observation.updatedAtMs;
   if (ageMs < RETIREMENT_COOLDOWN_MS) {
     return withReasons(observation, "cooldown", [
-      "landed work remains inside the mandatory 8-hour cooldown",
+      "landed work remains inside the mandatory 3-hour cooldown",
     ]);
   }
 
   return withReasons(observation, "retire-after-gate", [
-    "clean landed work is older than 8 hours",
+    "clean landed work is older than 3 hours",
     "removal still requires the repository-wide maintenance gate and final deletion proof",
   ]);
 }


### PR DESCRIPTION
## Summary
- reduce the mandatory landed worktree/branch retirement cooldown from 8 hours to 3 hours
- preserve the repository-wide maintenance gate, exact retention proof, and fail-closed recency checks
- update Branch Curator policy, deletion proof, evals, workflow docs, and historical supersession notes

## Verification
- `node --experimental-strip-types src/lib/worktree-lifecycle.test.ts`
- `node scripts/worktree-lifecycle-patrol.test.mjs`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `node scripts/canonical-memory-smoke-lifecycle.test.mjs`
- `git diff --check`

Full `pnpm test:app` was attempted twice; unrelated timing tests failed independently (patrol subprocess ETIMEDOUT, then canonical-memory SIGHUP cleanup at 5.6s). Both implicated tests pass standalone.

Bead: `cave-vwt75`