### PR TITLE
perf(chat): hold transcripts across requests instead of re-parsing per hover

### DIFF
--- a/src/app/api/chat/conversation/[id]/route.ts
+++ b/src/app/api/chat/conversation/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   isSafeConversationSessionId,
   deleteConversation,
   loadConversation,
+  loadConversationCached,
   saveConversation,
   withConversationLock,
   type ChatTurn,
@@ -486,7 +487,16 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
   }
 
   // Primary: cave-conversations JSON (written by chat/send for UI-originated chats)
-  const conv = await loadConversation(id);
+  //
+  // Cached read. This is the ONLY call site in this file that uses it: the
+  // read-modify-write handlers below deliberately keep `loadConversation`, so a
+  // mutation always re-reads the file it is about to replace rather than
+  // building its next state from a value that was handed to it.
+  //
+  // `context` stays uncached on purpose — it is board-derived and changes
+  // independently of the transcript, so it must not inherit the transcript's
+  // cache key. See loadConversationCached.
+  const conv = await loadConversationCached(id);
   if (conv) {
     const context = await linkedContextForSession(id);
     return NextResponse.json({

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -4,6 +4,7 @@ import { performance } from "node:perf_hooks";
 import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
 import { invalidateSessionsListCache } from "./server/sessions-list-cache.ts";
+import { readCachedStore } from "./server/store-read-cache.ts";
 import type { ChatResponseMetadata } from "./chat-response-metadata.ts";
 import type { ModelApplicationState, ModelScope } from "./chat-model-state.ts";
 import type { ModelControlValues } from "./model-control-capabilities.ts";
@@ -538,6 +539,54 @@ export async function loadConversation(sessionId: string): Promise<ConversationF
   } catch {
     return null;
   }
+}
+
+/**
+ * Total on-disk bytes of transcripts held by the read cache.
+ *
+ * Chosen against the one hard number nearby: `MAX_TURNS_PAYLOAD_BYTES` in
+ * `server/conversation-write-guards.ts` caps a single client write at 8 MiB, so
+ * this holds roughly the working set a reader moves between rather than a fixed
+ * count that could mean 8 MiB or 800. The parsed object is larger than its JSON
+ * text, so the real footprint is a multiple of this — deliberately modest for
+ * that reason, and because the packaged sidecar runs on a heap pinned by
+ * `scripts/heap-limits.mjs`.
+ */
+const CONVERSATION_READ_CACHE_MAX_BYTES = 32 * 1024 * 1024;
+
+/**
+ * {@link loadConversation} with the transcript held across requests.
+ *
+ * `GET /api/chat/conversation/[id]` is not a once-per-open path: `chat-list.tsx`
+ * wires `hoverPrefetchConversation` to every row's `onMouseEnter` and
+ * `prefetchConversation` to `onPointerDown`/`onFocus`, so running a pointer down
+ * the list asks for whole transcripts in sequence. Each one was a full
+ * `readFile` + `JSON.parse` plus the lazy branching migration above.
+ *
+ * Only the transcript is cached. The route's `context` half comes from
+ * `linkedContextForSession` -> `loadBoard`, which changes independently of the
+ * transcript, so caching the assembled payload on the transcript's stat would
+ * let a chat show board links that no longer exist. Keeping the two apart is
+ * what makes this safe; `loadBoard` is separately cheap now that `loadProjects`
+ * is itself cached.
+ *
+ * Invalidation needs no call site: `saveConversation` writes through
+ * `writeJsonAtomic`, and `writeFileAtomic` drops the cached entry for whatever
+ * path it replaced.
+ */
+export async function loadConversationCached(sessionId: string): Promise<ConversationFile | null> {
+  let filePath: string;
+  try {
+    filePath = pathFor(sessionId);
+  } catch {
+    // pathFor rejects an unsafe session id by throwing. loadConversation folds
+    // that into `null` via its own catch, and this must behave identically —
+    // a caching wrapper is not the place to start surfacing a new exception.
+    return null;
+  }
+  return readCachedStore(filePath, () => loadConversation(sessionId), {
+    maxBytes: CONVERSATION_READ_CACHE_MAX_BYTES,
+  });
 }
 
 /** Serialize read-modify-write operations for one conversation. Atomic file

--- a/src/lib/server/store-read-cache.test.ts
+++ b/src/lib/server/store-read-cache.test.ts
@@ -183,6 +183,98 @@ test("an atomic write drops the cached entry for the file it replaced", async (t
   assert.equal(loads, 2, "the write invalidated the entry");
 });
 
+test("a byte-bounded caller evicts the least RECENTLY used entry, not the oldest", async (t) => {
+  // The distinction that makes this an LRU rather than a queue. A reader moving
+  // between two chats must not have the one they keep returning to evicted
+  // just because they opened it first.
+  clearCaveStoreReadCache();
+  const dir = await mkdtemp(path.join(tmpdir(), "store-read-cache-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  const make = async (name: string, bytes: number) => {
+    const file = path.join(dir, name);
+    await writeFile(file, "x".repeat(bytes));
+    return file;
+  };
+  const a = await make("a.json", 100);
+  const b = await make("b.json", 100);
+  const c = await make("c.json", 100);
+
+  const loads: string[] = [];
+  const load = (id: string) => async () => {
+    loads.push(id);
+    return { id };
+  };
+
+  // Budget fits two of the three.
+  const opts = { maxBytes: 250 };
+  await readCachedStore(a, load("a"), opts);
+  await readCachedStore(b, load("b"), opts);
+  await readCachedStore(a, load("a"), opts); // touch a: now b is least-recent
+  await readCachedStore(c, load("c"), opts); // admits c, must evict b
+
+  assert.deepEqual(loads, ["a", "b", "c"], "each file read once so far");
+  await readCachedStore(a, load("a"), opts);
+  assert.deepEqual(loads, ["a", "b", "c"], "a survived — it was touched");
+  await readCachedStore(b, load("b"), opts);
+  assert.deepEqual(loads, ["a", "b", "c", "b"], "b was the evicted one");
+  assert.ok(getStoreReadCacheMetrics().evictions >= 1);
+});
+
+test("the byte account follows evictions and invalidation", async (t) => {
+  clearCaveStoreReadCache();
+  const dir = await mkdtemp(path.join(tmpdir(), "store-read-cache-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const file = path.join(dir, "a.json");
+  await writeFile(file, "x".repeat(100));
+
+  await readCachedStore(file, async () => ({ n: 1 }), { maxBytes: 1_000 });
+  assert.equal(getStoreReadCacheMetrics().cachedBytes, 100);
+  invalidateCachedStore(file);
+  assert.equal(
+    getStoreReadCacheMetrics().cachedBytes,
+    0,
+    "dropping an entry must return its bytes to the budget, or the cache " +
+      "slowly starves itself into evicting everything",
+  );
+});
+
+test("a single entry larger than the whole budget is kept, not thrashed", async (t) => {
+  // Evicting it on admission would mean re-reading that transcript on every
+  // single request — strictly worse than holding one oversized entry.
+  clearCaveStoreReadCache();
+  const dir = await mkdtemp(path.join(tmpdir(), "store-read-cache-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const file = path.join(dir, "big.json");
+  await writeFile(file, "x".repeat(5_000));
+
+  let loads = 0;
+  const load = async () => {
+    loads += 1;
+    return { big: true };
+  };
+  await readCachedStore(file, load, { maxBytes: 100 });
+  await readCachedStore(file, load, { maxBytes: 100 });
+  assert.equal(loads, 1, "the oversized entry was served from cache the second time");
+});
+
+test("an unbounded caller never evicts", async (t) => {
+  // The six fixed ~/.coven store paths pass no maxBytes and must keep behaving
+  // exactly as they did before the bound existed.
+  clearCaveStoreReadCache();
+  const dir = await mkdtemp(path.join(tmpdir(), "store-read-cache-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  for (let i = 0; i < 12; i += 1) {
+    const file = path.join(dir, `s${i}.json`);
+    await writeFile(file, "x".repeat(10_000));
+    await readCachedStore(file, async () => ({ i }));
+  }
+  const metrics = getStoreReadCacheMetrics();
+  assert.equal(metrics.entries, 12);
+  assert.equal(metrics.evictions, 0);
+});
+
 test("distinct paths do not share an entry", async (t) => {
   // Tests repoint COVEN_CAVE_HOME per case; keying on the resolved absolute
   // path is what keeps one case's config out of the next one's.

--- a/src/lib/server/store-read-cache.ts
+++ b/src/lib/server/store-read-cache.ts
@@ -76,8 +76,12 @@ export type StoreReadCacheMetrics = {
   misses: number;
   /** Reads whose stat failed (ENOENT and friends); never cached. */
   statFailures: number;
+  /** Entries dropped to stay under a caller's `maxBytes`. */
+  evictions: number;
   /** Distinct store paths currently held. */
   entries: number;
+  /** Sum of the cached files' on-disk sizes, the quantity `maxBytes` bounds. */
+  cachedBytes: number;
 };
 
 /**
@@ -96,19 +100,63 @@ type Entry = {
   value: unknown;
 };
 
+/**
+ * Unbounded by default, which is right for the handful of fixed `~/.coven`
+ * store paths this started with: there are six of them and they all stay hot.
+ *
+ * A caller reading paths drawn from user data must pass `maxBytes`. The bound
+ * is BYTES rather than an entry count on purpose: conversation transcripts are
+ * the motivating caller, the set is the user's whole chat history, and a single
+ * transcript can exceed the 8 MiB `MAX_TURNS_PAYLOAD_BYTES` that bounds one
+ * write route — so "24 entries" could mean anything from a few KB to hundreds
+ * of MB against a sidecar running on a pinned heap. The file's `size` is
+ * already in hand from the stat this function must take anyway, so a byte bound
+ * costs nothing extra to maintain and actually describes the resource at risk.
+ *
+ * It is an approximation in one direction only: the parsed object is larger
+ * than its JSON text, so the real footprint exceeds the accounted bytes by a
+ * roughly constant factor. Sizing the budget accordingly is the caller's job.
+ *
+ * `Map` preserves insertion order, so eviction is `keys().next()` and a hit
+ * re-inserts to move the entry to the young end — a true LRU rather than
+ * first-in-first-out. That distinction matters here: the hot set is "the chats
+ * the reader is moving between", not "the chats opened earliest".
+ */
 const entries = new Map<string, Entry>();
 let hits = 0;
 let misses = 0;
 let statFailures = 0;
+let evictions = 0;
+let cachedBytes = 0;
+
+function dropEntry(filePath: string): void {
+  const existing = entries.get(filePath);
+  if (!existing) return;
+  cachedBytes -= Number(existing.size);
+  entries.delete(filePath);
+}
+
+function evictToBytes(maxBytes: number): void {
+  // `entries.size > 1` keeps a single over-budget transcript cached rather than
+  // evicting it immediately and re-reading it on every request — the worst of
+  // both worlds. One oversized entry is bounded; a re-read loop is not.
+  while (cachedBytes > maxBytes && entries.size > 1) {
+    const oldest = entries.keys().next();
+    if (oldest.done) return;
+    dropEntry(oldest.value);
+    evictions += 1;
+  }
+}
 
 export function getStoreReadCacheMetrics(): StoreReadCacheMetrics {
-  return { hits, misses, statFailures, entries: entries.size };
+  return { hits, misses, statFailures, evictions, entries: entries.size, cachedBytes };
 }
 
 export function resetStoreReadCacheMetrics(): void {
   hits = 0;
   misses = 0;
   statFailures = 0;
+  evictions = 0;
 }
 
 /**
@@ -117,12 +165,13 @@ export function resetStoreReadCacheMetrics(): void {
  * waiting for the stat to be observed.
  */
 export function invalidateCachedStore(filePath: string): void {
-  entries.delete(filePath);
+  dropEntry(filePath);
 }
 
 /** Drop everything. Tests that repoint `COVEN_HOME` must call this. */
 export function clearCaveStoreReadCache(): void {
   entries.clear();
+  cachedBytes = 0;
   resetStoreReadCacheMetrics();
 }
 
@@ -133,10 +182,11 @@ export function clearCaveStoreReadCache(): void {
 export async function readCachedStore<T>(
   filePath: string,
   load: () => Promise<T>,
-  options: { ttlMs?: number; now?: () => number } = {},
+  options: { ttlMs?: number; now?: () => number; maxBytes?: number } = {},
 ): Promise<T> {
   const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
   const now = options.now ?? Date.now;
+  const maxBytes = options.maxBytes;
 
   let stats: { mtimeNs: bigint; ctimeNs: bigint; size: bigint } | null = null;
   try {
@@ -155,7 +205,7 @@ export async function readCachedStore<T>(
     // A store with no file has no stat to key on, so it is never cached — the
     // moment it appears, the very next read must see it.
     statFailures += 1;
-    entries.delete(filePath);
+    dropEntry(filePath);
     return load();
   }
 
@@ -170,11 +220,17 @@ export async function readCachedStore<T>(
     const copy = cloneStoreValue(cached.value);
     if (copy.ok) {
       hits += 1;
+      // Re-insert so recency, not insertion order, decides what a bounded
+      // caller evicts. Skipped for the unbounded store paths, which never evict.
+      if (maxBytes !== undefined) {
+        entries.delete(filePath);
+        entries.set(filePath, cached);
+      }
       return copy.value as T;
     }
     // A store holding something structuredClone cannot copy would otherwise be
     // shared by reference. Drop it and take the honest path instead.
-    entries.delete(filePath);
+    dropEntry(filePath);
   }
 
   misses += 1;
@@ -185,7 +241,15 @@ export async function readCachedStore<T>(
   // the hit path clones to avoid, just one read earlier. A value that cannot
   // be copied is simply not cached.
   const stored = cloneStoreValue(value);
-  if (stored.ok) entries.set(filePath, { ...stats, readAt: now(), value: stored.value });
+  if (stored.ok) {
+    // Drop before set so a re-read of an existing key moves to the young end
+    // rather than staying at its original insertion position, and so its old
+    // size leaves the byte account before the new one joins.
+    dropEntry(filePath);
+    entries.set(filePath, { ...stats, readAt: now(), value: stored.value });
+    cachedBytes += Number(stats.size);
+    if (maxBytes !== undefined) evictToBytes(maxBytes);
+  }
   return value;
 }
 


### PR DESCRIPTION
Follow-on to #4984, same bead (`cave-i65lt`).

`GET /api/chat/conversation/[id]` is **not a once-per-open path**. `chat-list.tsx`
wires `hoverPrefetchConversation` to every row's `onMouseEnter` and
`prefetchConversation` to `onPointerDown`/`onFocus`, so running a pointer down
the sidebar asks for whole transcripts in sequence. Each request was a full
`readFile` + `JSON.parse` plus the lazy branching migration — on files that
`conversation-write-guards` bounds at 8 MiB for *one* write route and does not
bound at all on disk.

## What it reuses

The stat-keyed cache from #4984, so external-write correctness comes for free.
**Invalidation needs no new call site**: `saveConversation` writes through
`writeJsonAtomic`, and `writeFileAtomic` already drops the cached entry for
whatever path it replaced.

## Two deliberate boundaries

**Only the transcript is cached.** The route returns `{ conversation, context }`.
`context` comes from `linkedContextForSession` → `loadBoard` and changes
*independently* of the transcript, so caching the assembled payload on the
transcript's stat would let a chat show board links that no longer exist. Keeping
the halves apart is what makes this safe — and `loadBoard` is separately cheap
now that `loadProjects` is cached by #4984.

**Only the GET uses it.** The four read-modify-write handlers in the same route
keep `loadConversation`, so a mutation always re-reads the file it is about to
replace rather than building its next state from a value handed to it.

The cache also lives in `cave-conversations.ts` rather than the route, because
`pathFor` is private and performs path-traversal validation; exporting a path
builder to satisfy a cache would have been the wrong trade. `loadConversationCached`
folds `pathFor`'s throw into `null` exactly as `loadConversation` does — a caching
wrapper is not the place to start surfacing a new exception at an existing call site.

## Why the bound is bytes, not entries

`readCachedStore` gains an optional bound, and it counts **bytes**. An entry count
is the wrong unit here: a single transcript can exceed 8 MiB, so "24 entries"
could mean 8 MiB or 800 against a sidecar running on the heap
`scripts/heap-limits.mjs` pins. The file's `size` is already in hand from the stat
the function must take anyway, so a byte bound costs nothing extra to maintain and
describes the resource actually at risk.

It approximates in one direction only — the parsed object is larger than its JSON
text — so the budget is deliberately modest at 32 MiB.

## Tests

Four new ones, each pinning something that would otherwise be an assertion rather
than a proof:

- **eviction is least-*recently*-used, not oldest-first.** A reader moving between
  two chats must not lose the one they keep returning to just because they opened
  it first, so a hit re-inserts to the young end.
- **the byte account is returned on invalidation.** Without that the accounting
  only ever grows and the cache slowly starves itself into evicting everything.
- **a single entry larger than the whole budget is kept, not thrashed.** Evicting
  on admission would mean re-reading that transcript on every request — strictly
  worse than holding one oversized entry.
- **an unbounded caller never evicts**, so the six fixed `~/.coven` store paths
  behave exactly as they did before the bound existed.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `src/lib/server/store-read-cache.test.ts` — **13/13**

⚠️ `pnpm test:app` and `pnpm test:api` **hang in this checkout, and it is not this
change.** `scripts/worktree-lifecycle-retirement.test.mjs` exercises the real
maintenance fence, which concurrent sessions' patrols hold. Running that single
file on **clean `main` with no changes at all** exits `124` (timeout) at the
identical test line — "real git adapter reads tag retention from the remote,
peeling annotated tags". CI runs with an isolated `~/.coven` and no competing
patrol, so it is the authority for those two suites here.
