### PR TITLE
perf(chat): persist client perf samples and time the transcript fetch

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -193,6 +193,7 @@ export const SUITES = {
     "src/components/home/use-home-model-state.test.ts",
     "src/lib/model-selection-mutation-queue.test.ts",
     "src/lib/perf/web-vitals-format.test.ts",
+    "src/lib/perf/perf-store.test.ts",
     "src/lib/app-version.test.ts",
     "src/lib/endpoint-validators.test.ts",
     "src/lib/x-api.test.ts",

--- a/src/components/perf/web-vitals-reporter.tsx
+++ b/src/components/perf/web-vitals-reporter.tsx
@@ -12,6 +12,7 @@
 
 import { useReportWebVitals } from "next/web-vitals";
 import { rateWebVital, type WebVitalRating } from "@/lib/perf/web-vitals-format";
+import { recordPerfSample } from "@/lib/perf/perf-store";
 
 export type CaveVital = {
   name: string;
@@ -37,6 +38,18 @@ export function WebVitalsReporter() {
     if (typeof window !== "undefined") {
       window.__caveVitals = { ...window.__caveVitals, [metric.name]: entry };
       window.dispatchEvent(new CustomEvent("cave:web-vital", { detail: entry }));
+      // `window.__caveVitals` is inspectable but dies with the page, and the
+      // console.debug below is development-only, so neither could ever support
+      // a before/after comparison. Persist alongside them rather than instead:
+      // the overlay listens for the event and the console line is still the
+      // fastest read during development.
+      recordPerfSample({
+        kind: "vital",
+        name: entry.name,
+        value: entry.value,
+        at: entry.at,
+        rating: entry.rating,
+      });
     }
     if (process.env.NODE_ENV === "development") {
       // eslint-disable-next-line no-console

--- a/src/lib/conversation-cache.ts
+++ b/src/lib/conversation-cache.ts
@@ -11,11 +11,23 @@
 // small cap, and are explicitly dropped when a send starts or a conversation
 // is deleted (see invalidateConversation call sites).
 
+import { markEnd, markStart } from "./perf/marks.ts";
+
 /** Shape callers care about; the payload is stored as parsed JSON verbatim. */
 export type CachedConversationPayload = {
   ok?: boolean;
   conversation?: unknown;
 };
+
+/**
+ * Span name for a real transcript request.
+ *
+ * Read it back with `summarizePerfSamples("chat:transcript-fetch")`, or off the
+ * perf overlay at `?perf=1`. This is the first instrumentation on the chat load
+ * path at all — before it, nothing in chat-list, chat-view, chat-router or this
+ * file recorded a duration, so no client-side before/after could be stated.
+ */
+const TRANSCRIPT_FETCH_SPAN = "chat:transcript-fetch";
 
 const TTL_MS = 45_000;
 const MAX_ENTRIES = 24;
@@ -115,6 +127,10 @@ export function loadConversation(
   ) return pending.promise;
   const entry = { epoch, promise: null as unknown as Promise<CachedConversationPayload | null> };
   entry.promise = (async () => {
+    // Only a real request is timed. The cache-hit and in-flight-dedupe paths
+    // above return before reaching here, deliberately: counting them would add
+    // zero-cost samples and flatter the percentile this span exists to report.
+    markStart(TRANSCRIPT_FETCH_SPAN);
     try {
       const res = await fetch(`/api/chat/conversation/${encodeURIComponent(sessionId)}`, {
         cache: "no-store",
@@ -137,6 +153,11 @@ export function loadConversation(
       if (requestEpochIsCurrent(sessionId, epoch)) storeConversation(sessionId, json);
       return json;
     } finally {
+      // In the `finally`, so a thrown ConversationLoadError still closes the
+      // span. A markStart left dangling would not merely lose one sample — the
+      // next markEnd for this name would measure from the ABANDONED start and
+      // report a wildly inflated duration, quietly corrupting the percentile.
+      markEnd(TRANSCRIPT_FETCH_SPAN);
       if (inflight.get(sessionId) === entry) inflight.delete(sessionId);
     }
   })();

--- a/src/lib/perf/marks.ts
+++ b/src/lib/perf/marks.ts
@@ -6,6 +6,8 @@
 // dev overlay listens for. All calls are no-ops when the User Timing API is
 // absent (SSR, old runtimes), so callers don't need to guard.
 
+import { recordPerfSample } from "./perf-store.ts";
+
 export type PerfMeasure = { name: string; duration: number; at: number };
 
 const RING_MAX = 50;
@@ -39,6 +41,9 @@ export function markEnd(name: string): number | null {
     const entry: PerfMeasure = { name, duration, at: Date.now() };
     ring.push(entry);
     if (ring.length > RING_MAX) ring.shift();
+    // The ring above is 50 entries of module state and dies with the page, so
+    // it can show what just happened but never a before/after. Persist too.
+    recordPerfSample({ kind: "mark", name, value: duration, at: entry.at });
     if (typeof window !== "undefined") {
       window.dispatchEvent(new CustomEvent("cave:perf-measure", { detail: entry }));
     }

--- a/src/lib/perf/perf-store.test.ts
+++ b/src/lib/perf/perf-store.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// A fake sessionStorage, because the point of this module is what happens at
+// the storage boundary: quota rejection, a malformed payload from an older
+// shape, and survival across a reload. jsdom would give a compliant store and
+// hide exactly those cases.
+type FakeStorage = Storage & { __throwOnSet?: boolean; __raw: Map<string, string> };
+
+function fakeStorage(): FakeStorage {
+  const raw = new Map<string, string>();
+  const store = {
+    __raw: raw,
+    __throwOnSet: false,
+    get length() {
+      return raw.size;
+    },
+    clear: () => raw.clear(),
+    getItem: (key: string) => raw.get(key) ?? null,
+    key: (index: number) => [...raw.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      raw.delete(key);
+    },
+    setItem(key: string, value: string) {
+      if ((this as FakeStorage).__throwOnSet) {
+        const error = new Error("The quota has been exceeded.");
+        error.name = "QuotaExceededError";
+        throw error;
+      }
+      raw.set(key, value);
+    },
+  } as FakeStorage;
+  return store;
+}
+
+function installWindow(store: FakeStorage): void {
+  const listeners = new Map<string, Array<() => void>>();
+  (globalThis as Record<string, unknown>).window = {
+    sessionStorage: store,
+    addEventListener: (type: string, fn: () => void) => {
+      listeners.set(type, [...(listeners.get(type) ?? []), fn]);
+    },
+  };
+  (globalThis as Record<string, unknown>).document = {
+    visibilityState: "visible",
+    addEventListener: () => {},
+  };
+}
+
+/** Fresh module instance per test: the store keeps module-level buffer state. */
+async function freshModule(store: FakeStorage) {
+  installWindow(store);
+  return import(`./perf-store.ts?case=${Math.random().toString(36).slice(2)}`);
+}
+
+test("a sample survives the page that produced it", async () => {
+  // The entire reason this module exists. Before it, `marks.ts` kept durations
+  // in a module array and vitals lived on `window` — a reload lost both, so a
+  // client-side before/after could not be stated at all.
+  const store = fakeStorage();
+  const first = await freshModule(store);
+  first.recordPerfSample({ kind: "mark", name: "chat:transcript-fetch", value: 42, at: 1 });
+  first.flushPerfSamples();
+
+  // A "reload": brand new module state, same storage.
+  const second = await freshModule(store);
+  const samples = second.getPerfSamples();
+  assert.equal(samples.length, 1);
+  assert.equal(samples[0].name, "chat:transcript-fetch");
+  assert.equal(samples[0].value, 42);
+});
+
+test("a setItem that throws disables the store and never throws to the caller", async () => {
+  // Cave has already shipped a store whose own cap exceeded the real origin
+  // quota, and WebKit surfaced it as a raw "The quota has been exceeded."
+  // error in the UI. A perf aid that can break the surface it measures is
+  // worse than no perf aid.
+  const store = fakeStorage();
+  store.__throwOnSet = true;
+  const mod = await freshModule(store);
+
+  assert.doesNotThrow(() => {
+    mod.recordPerfSample({ kind: "mark", name: "chat:transcript-fetch", value: 1, at: 1 });
+    mod.flushPerfSamples();
+  });
+  // And it stays disabled rather than retrying into the same wall on every
+  // subsequent sample.
+  store.__throwOnSet = false;
+  mod.recordPerfSample({ kind: "mark", name: "chat:transcript-fetch", value: 2, at: 2 });
+  mod.flushPerfSamples();
+  assert.equal(store.__raw.size, 0, "no write was attempted after the quota failure");
+});
+
+test("the count cap trims oldest-first", async () => {
+  const store = fakeStorage();
+  const mod = await freshModule(store);
+  for (let i = 0; i < 400; i += 1) {
+    mod.recordPerfSample({ kind: "mark", name: "s", value: i, at: i });
+  }
+  mod.flushPerfSamples();
+  const values = mod.getPerfSamples().map((s: { value: number }) => s.value);
+  assert.ok(values.length <= 300, `kept ${values.length}`);
+  assert.equal(values.at(-1), 399, "the newest sample survived");
+  assert.ok(!values.includes(0), "the oldest samples were dropped");
+});
+
+test("the byte cap trims even when the count cap is satisfied", async () => {
+  // A long span name turns a modest sample count into a large payload; the
+  // count cap alone would not notice.
+  const store = fakeStorage();
+  const mod = await freshModule(store);
+  const longName = "chat:".concat("x".repeat(2_000));
+  for (let i = 0; i < 200; i += 1) {
+    mod.recordPerfSample({ kind: "mark", name: longName, value: i, at: i });
+  }
+  mod.flushPerfSamples();
+  const raw = store.__raw.get("cave:perf:samples") ?? "";
+  assert.ok(raw.length <= 128 * 1024, `serialized ${raw.length} bytes`);
+  assert.ok(mod.getPerfSamples().length > 0, "it trimmed rather than emptying");
+});
+
+test("a malformed persisted payload is ignored, not thrown", async () => {
+  const store = fakeStorage();
+  store.__raw.set("cave:perf:samples", "{not json");
+  const mod = await freshModule(store);
+  assert.deepEqual(mod.getPerfSamples(), []);
+  assert.doesNotThrow(() => mod.recordPerfSample({ kind: "mark", name: "s", value: 1, at: 1 }));
+});
+
+test("percentiles are computed per span name", async () => {
+  // A single duration says nothing; percentiles across many opens are the
+  // reason samples are kept at all.
+  const store = fakeStorage();
+  const mod = await freshModule(store);
+  for (const value of [10, 20, 30, 40, 100]) {
+    mod.recordPerfSample({ kind: "mark", name: "chat:transcript-fetch", value, at: value });
+  }
+  mod.recordPerfSample({ kind: "mark", name: "other", value: 9_999, at: 1 });
+  mod.flushPerfSamples();
+
+  const summary = mod.summarizePerfSamples("chat:transcript-fetch");
+  assert.equal(summary.count, 5, "the unrelated span did not contribute");
+  assert.equal(summary.p50, 30);
+  assert.equal(summary.p95, 100);
+  assert.equal(mod.summarizePerfSamples("missing"), null);
+});
+
+test("a single sample reports itself as both p50 and p95", async () => {
+  const store = fakeStorage();
+  const mod = await freshModule(store);
+  mod.recordPerfSample({ kind: "mark", name: "s", value: 7, at: 1 });
+  mod.flushPerfSamples();
+  const summary = mod.summarizePerfSamples("s");
+  assert.deepEqual(summary, { count: 1, p50: 7, p95: 7 });
+});
+
+test("clear empties both the buffer and the persisted key", async () => {
+  const store = fakeStorage();
+  const mod = await freshModule(store);
+  mod.recordPerfSample({ kind: "mark", name: "s", value: 1, at: 1 });
+  mod.flushPerfSamples();
+  mod.recordPerfSample({ kind: "mark", name: "s", value: 2, at: 2 }); // still buffered
+  mod.clearPerfSamples();
+  assert.deepEqual(mod.getPerfSamples(), []);
+  assert.equal(store.__raw.has("cave:perf:samples"), false);
+});

--- a/src/lib/perf/perf-store.ts
+++ b/src/lib/perf/perf-store.ts
@@ -1,0 +1,192 @@
+"use client";
+
+/**
+ * perf-store — make a performance number survive the page that produced it.
+ *
+ * Both existing capture points are amnesiac. `perf/marks.ts` keeps the last 50
+ * durations in a module-level array, and `WebVitalsReporter` stashes each metric
+ * on `window.__caveVitals` and `console.debug`s it in development. Reload the
+ * tab and every one of them is gone, which means there has never been a way to
+ * compare a client-side before against a client-side after — the exact thing
+ * "measure first" requires and the reason the chat-load work has so far only
+ * carried server numbers.
+ *
+ * This adds the missing half: a bounded `sessionStorage` ring the two capture
+ * points write through.
+ *
+ * ## Why sessionStorage, and why bounded twice
+ *
+ * Per-tab and cleared when the tab closes, which is the right lifetime for a
+ * measurement aid — it must not accumulate across days on a user's machine, and
+ * it must not be mistaken for telemetry. Nothing here is sent anywhere; there is
+ * no beacon and no endpoint.
+ *
+ * Bounded by BOTH a sample count and a serialized byte budget because the origin
+ * quota is the real constraint and it is not ours to spend: Cave already shipped
+ * a bug where a store's own cap was generous enough to blow past the ~5 MB
+ * origin limit, and WebKit surfaced it as a raw "The quota has been exceeded."
+ * error in the UI. A perf aid that can break the app it measures is worse than
+ * no perf aid, so every write is wrapped and a quota failure disables the store
+ * for the rest of the page rather than retrying into the same wall.
+ *
+ * ## Why writes are buffered
+ *
+ * `markEnd` fires on every instrumented span — several per chat open. Serializing
+ * and writing the whole ring each time would add JSON work to the very paths
+ * being measured, which would corrupt the measurement. Samples accumulate in
+ * memory and flush on a throttle, plus once on `pagehide`/`visibilitychange` so
+ * a reload keeps the tail.
+ */
+
+export type PerfSample = {
+  /** `mark` for a User Timing span, `vital` for a Core Web Vital. */
+  kind: "mark" | "vital";
+  name: string;
+  /** Milliseconds for a mark; the metric's own unit for a vital. */
+  value: number;
+  at: number;
+  /** Vitals only: good | needs-improvement | poor. */
+  rating?: string;
+};
+
+const STORAGE_KEY = "cave:perf:samples";
+/** Ring length. Enough to hold a session's worth of chat opens, not a day's. */
+const MAX_SAMPLES = 300;
+/**
+ * Serialized ceiling, well under the ~5 MB origin quota this shares with every
+ * other Cave store. The count cap above is the usual binding limit; this exists
+ * so an unexpectedly long span name cannot turn 300 samples into megabytes.
+ */
+const MAX_BYTES = 128 * 1024;
+/** Never write more often than this, however many samples arrive. */
+const FLUSH_THROTTLE_MS = 2_000;
+
+let buffered: PerfSample[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+let lastFlushAt = 0;
+/** Set once a quota failure proves the store unusable for this page. */
+let disabled = false;
+let listenersBound = false;
+
+function storage(): Storage | null {
+  if (disabled || typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage;
+  } catch {
+    // Storage can throw on access alone under some privacy settings.
+    disabled = true;
+    return null;
+  }
+}
+
+function readPersisted(): PerfSample[] {
+  const store = storage();
+  if (!store) return [];
+  try {
+    const raw = store.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as PerfSample[]) : [];
+  } catch {
+    // Malformed payload from an older shape — drop it rather than fail reads.
+    return [];
+  }
+}
+
+/** Trim to the count cap first, then to the byte cap, oldest-first. */
+function withinBudget(samples: PerfSample[]): { kept: PerfSample[]; serialized: string } {
+  let kept = samples.length > MAX_SAMPLES ? samples.slice(-MAX_SAMPLES) : samples;
+  let serialized = JSON.stringify(kept);
+  while (serialized.length > MAX_BYTES && kept.length > 1) {
+    kept = kept.slice(Math.ceil(kept.length / 4));
+    serialized = JSON.stringify(kept);
+  }
+  return { kept, serialized };
+}
+
+export function flushPerfSamples(): void {
+  const store = storage();
+  if (!store || buffered.length === 0) return;
+  const pending = buffered;
+  buffered = [];
+  const { serialized } = withinBudget([...readPersisted(), ...pending]);
+  try {
+    store.setItem(STORAGE_KEY, serialized);
+    lastFlushAt = Date.now();
+  } catch {
+    // Quota, or a private mode that rejects writes. Give up for this page
+    // instead of retrying into the same wall on every subsequent sample —
+    // a measurement aid must never be the thing that breaks a surface.
+    disabled = true;
+    buffered = [];
+  }
+}
+
+function scheduleFlush(): void {
+  if (disabled || flushTimer !== null) return;
+  const elapsed = Date.now() - lastFlushAt;
+  const delay = elapsed >= FLUSH_THROTTLE_MS ? 0 : FLUSH_THROTTLE_MS - elapsed;
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    flushPerfSamples();
+  }, delay);
+}
+
+function bindLifecycleListeners(): void {
+  if (listenersBound || typeof window === "undefined") return;
+  listenersBound = true;
+  // `pagehide` rather than `unload`: the latter is unreliable and blocks the
+  // back/forward cache. `visibilitychange` catches a tab switch that never
+  // returns, which is how most measurement sessions actually end.
+  window.addEventListener("pagehide", flushPerfSamples);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") flushPerfSamples();
+  });
+}
+
+/** Record one sample. Cheap: buffers in memory, writes on a throttle. */
+export function recordPerfSample(sample: PerfSample): void {
+  if (disabled || typeof window === "undefined") return;
+  bindLifecycleListeners();
+  buffered.push(sample);
+  if (buffered.length > MAX_SAMPLES) buffered = buffered.slice(-MAX_SAMPLES);
+  scheduleFlush();
+}
+
+/** Everything persisted plus anything still buffered, oldest first. */
+export function getPerfSamples(): readonly PerfSample[] {
+  return [...readPersisted(), ...buffered];
+}
+
+/** Drop the store. Exposed for the overlay's reset control and for tests. */
+export function clearPerfSamples(): void {
+  buffered = [];
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  const store = storage();
+  if (!store) return;
+  try {
+    store.removeItem(STORAGE_KEY);
+  } catch {
+    /* nothing to do — the store is already unusable */
+  }
+}
+
+/**
+ * p50/p95 for one span name across everything recorded.
+ *
+ * The reason this file exists: a single duration says nothing, and the numbers
+ * that matter for chat load are percentiles across many opens.
+ */
+export function summarizePerfSamples(name: string): { count: number; p50: number; p95: number } | null {
+  const values = getPerfSamples()
+    .filter((sample) => sample.name === name)
+    .map((sample) => sample.value)
+    .sort((a, b) => a - b);
+  if (values.length === 0) return null;
+  const at = (fraction: number) =>
+    values[Math.min(values.length - 1, Math.max(0, Math.ceil(values.length * fraction) - 1))];
+  return { count: values.length, p50: at(0.5), p95: at(0.95) };
+}


### PR DESCRIPTION
Third step of `cave-i65lt`, after #4984 and #4992.

**Every number measured for this bead so far has been server-side, because the
client had nowhere to keep one.** Both capture points are amnesiac:
`perf/marks.ts` keeps the last 50 durations in a module-level array, and
`WebVitalsReporter` stashes each metric on `window.__caveVitals` and
`console.debug`s it in **development only**. Reload the tab and both are gone —
so a client-side before/after could not be stated at all.

That matters now because the remaining plan steps are client-side (a shared
sessions-list store; chat-list row memoization) and neither is worth attempting
without numbers.

There was also **no instrumentation on the chat load path whatsoever**: no
`markStart`/`markEnd` anywhere in `chat-list.tsx`, `chat-view.tsx`,
`chat-router.tsx` or `conversation-cache.ts`. The only three call sites in the
whole app are `lazy-surfaces.tsx` and `use-surface-warmup.ts`.

## What lands

- **`src/lib/perf/perf-store.ts`** — a bounded `sessionStorage` ring both capture
  points write through, plus `summarizePerfSamples(name)` → `{count, p50, p95}`,
  because a single duration says nothing and the numbers that matter are
  percentiles across many opens.
- **One-line hooks** in `marks.ts` and `web-vitals-reporter.tsx`, added
  *alongside* the existing ring, CustomEvent and dev console line — the overlay
  depends on all three, so none of them move.
- **A `chat:transcript-fetch` span** in `conversation-cache.ts`.

## Why it is bounded twice

By a sample count **and** a serialized byte budget. The origin quota is shared
with every other Cave store and is not ours to spend: Cave has already shipped a
store whose own cap exceeded the real ~5 MB origin limit, and WebKit surfaced
that as a raw *"The quota has been exceeded."* error in the UI. So every write is
wrapped, and a quota failure **disables the store for the rest of the page**
rather than retrying into the same wall.

A measurement aid must never be the thing that breaks the surface it measures.

Writes are also buffered and throttled, flushing on `pagehide`/`visibilitychange`.
`markEnd` fires several times per chat open; serializing the whole ring on each
one would add JSON work to the very paths being measured and corrupt the
measurement.

## Two placement decisions carry most of the correctness

- **`markEnd` is in the existing `finally`**, so a thrown `ConversationLoadError`
  still closes the span. A dangling `markStart` would not merely lose one sample
  — the *next* `markEnd` for that name would measure from the **abandoned**
  start and report a wildly inflated duration, silently corrupting the
  percentile.
- **The cache-hit and in-flight-dedupe paths return before the span opens**, so
  only a real request is timed. Counting the hits would flatter the p50 with
  zero-cost samples.

## Not telemetry

Nothing is sent anywhere — no beacon, no endpoint. `sessionStorage` is per-tab
and cleared when the tab closes, which is the right lifetime for a measurement
aid and keeps it from being mistaken for something it is not.

## Tests — 8, at the storage boundary

A fake `Storage` rather than jsdom, because a compliant store would hide exactly
the cases worth pinning:

- a sample survives a simulated reload (the whole reason the module exists)
- a `setItem` that throws disables the store and never throws to the caller
- the count cap trims oldest-first
- the byte cap trims even when the count cap is satisfied (a long span name turns
  a modest sample count into a large payload; the count cap would not notice)
- a malformed persisted payload from an older shape is ignored, not thrown
- percentiles are per span name, and an unrelated span does not contribute
- a single sample reports itself as both p50 and p95
- `clear` empties both the in-memory buffer and the persisted key

Registered in `scripts/run-tests.mjs` — `check:tests-wired` fails CI otherwise.

## Deliberately not in this PR

- **No spans inside `chat-list.tsx` / `chat-view.tsx`.** The render-cost work in
  the next step moves that code anyway. Land the store, read real numbers, then
  decide where a render span actually belongs.
- **No `performance-budgets.ts` entries.** A `performance-report`-gated budget
  whose id the report never emits fails the nightly closed
  ("missing measurements fail closed"), so the harness has to emit the id first.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `src/lib/perf/perf-store.test.ts` — **8/8**
