### PR TITLE
fix(ui): define --bg-surface so the Thread Signal card stops rendering see-through

### DIFF
--- a/scripts/design-system/token-reference-scan.mjs
+++ b/scripts/design-system/token-reference-scan.mjs
@@ -425,7 +425,10 @@ export const BANKED_UNDEFINED_NO_FALLBACK = new Map([
   // foundations sheet spells these --text-primary / --text-secondary /
   // --bg-panel / --border-hairline; these are the ones that got typed anyway.
   ["--bg-inset", 2],
-  ["--bg-surface", 12],
+  // --bg-surface is gone: defined in foundations.css as an alias of --bg-base
+  // (cave-w387r). It was the worst entry in this bank — the Thread Signal card
+  // asked for a mix with NO transparent component and still rendered
+  // see-through.
   ["--border-muted", 1],
   ["--border-panel", 11],
   ["--border-subtle", 3],
@@ -461,7 +464,9 @@ export const BANKED_UNDEFINED_NO_FALLBACK = new Map([
  */
 export const BANKED_UNDEFINED_WITH_FALLBACK = new Map([
   ["--accent-fg", 1],
-  ["--bg-surface", 1],
+  // --bg-surface is defined now (cave-w387r). This entry was the sole usage
+  // that carried a fallback, and its `var(--bg-surface, var(--background))` is
+  // what told us the token's intended value.
   ["--citation-card-w", 2],
   ["--composer-pill-gold", 11],
   ["--gh-diff-gutter", 2],

--- a/src/components/chat-follow-up-cards.tsx
+++ b/src/components/chat-follow-up-cards.tsx
@@ -59,8 +59,11 @@ function FollowUpRationale({
         aria-haspopup="dialog"
         onClick={() => setOpen((current) => !current)}
       >
-        <Icon name="ph:info" width={12} aria-hidden />
-        <span>Why</span>
+        {/* Icon-only. The accessible name is unaffected: `aria-label` above
+            already reads "Why this suggestion: <label>", which is strictly
+            more informative than the word it replaces, and the visible "Why"
+            was never the accessible name anyway. */}
+        <Icon name="ph:info" width={14} height={14} aria-hidden />
       </button>
       <Popover
         open={open}

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -461,8 +461,13 @@
   min-width: 0;
 }
 
+/* Reserves the lane the absolutely-positioned trigger sits in, so card text
+   never runs under it. Shrunk with the trigger when it became icon-only
+   (cave-w387r) — this rule is the trigger's width plus its right offset, and
+   leaving it at the old pill width would have left a dead gap the text could
+   not use and nothing occupied. */
 .cave-followup-card__entry:has(.cave-followup-card__why-trigger) .cave-followup-card {
-  padding-right: calc(var(--space-10) + var(--space-2));
+  padding-right: calc(var(--space-6) + var(--space-3));
 }
 
 .cave-followup-card {
@@ -503,10 +508,11 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--space-1);
-  min-width: var(--space-8);
+  /* Square icon button (cave-w387r). `gap` and `padding-inline` existed to
+     space the icon from the word "Why"; with no label they would only make it
+     oblong, and `min-width: var(--space-8)` would hold the old pill's width. */
+  width: var(--space-6);
   height: var(--space-6);
-  padding-inline: var(--space-2);
   transform: translateY(-50%);
   border: 1px solid transparent;
   border-radius: var(--radius-pill);

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -48,17 +48,24 @@
   scrollbar-color: color-mix(in oklch, var(--accent-presence) 22%, transparent) transparent;
 }
 
+/* Composer chrome is deliberately the ONLY thing trimmed for height
+   (cave-w387r). The textarea's 44px floor is exactly one line — 24px
+   line-height plus its 12/8 padding — and its padding is mirrored into the
+   markdown decoration layer from computed style at runtime, so shaving it
+   would slide the decoration off the glyphs it belongs to (see the metrics
+   warning above .cave-composer-md-layer). Trimming the control row and the
+   bottom pad takes ~10px off the panel and cannot move a single character. */
 .cave-composer-controls {
   display: flex;
   flex-direction: column;
   gap: 0;
-  padding: 0 var(--space-3) var(--space-3);
+  padding: 0 var(--space-3) var(--space-2);
 }
 
 .cave-composer-control-row {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  min-height: 34px;
+  min-height: 28px;
   align-items: center;
   gap: var(--space-2);
   color: var(--text-muted);

--- a/src/styles/globals/foundations.css
+++ b/src/styles/globals/foundations.css
@@ -107,6 +107,20 @@
      base. Referenced while undefined (cave-309m); derived from --bg-base so
      every theme tracks. Light mode overrides below. */
   --bg-sunken: color-mix(in oklch, var(--bg-base) 88%, black);
+  /* The ground a floating in-chat surface sits on. Third token in this block
+     referenced while undefined (after --bg-subtle/cave-fdt5 and
+     --bg-sunken/cave-309m), and the most visible: the Thread Signal card asks
+     for color-mix(in oklch, var(--accent-presence) 7%, var(--bg-surface)) —
+     no transparent component anywhere — yet rendered fully see-through,
+     because an undefined custom property invalidates the whole declaration at
+     computed-value time. Twelve composer chips asking for
+     color-mix(var(--bg-surface) 50%, transparent) were transparent for the
+     same reason rather than half-translucent.
+
+     Aliased to --bg-base rather than guessed: the single usage that carried a
+     fallback wrote var(--bg-surface, var(--background)), which is what
+     --bg-base already resolves to per theme (cave-w387r). */
+  --bg-surface: var(--bg-base);
   --bg-elevated: oklch(0.275 0.006 291);     /* dropdowns / popovers */
   --bg-hover: oklch(0.305 0.007 291);        /* hover state */
   /* Fixed "document page" ground for embedded light-page content — sketch


### PR DESCRIPTION
Reported from a screenshot: the in-chat **Thread Signal card was transparent**,
with transcript text bleeding through its score tiles and rationale strip.

## This is a bug, not a styling choice

`--bg-surface` was referenced **13 times** across `src/styles` and **defined zero
times**. An undefined custom property invalidates the whole declaration at
computed-value time, so every background referencing it fell back to
`transparent`.

The card asks for:

```css
color-mix(in oklch, var(--accent-presence) 7%, var(--bg-surface))
```

— which contains **no transparent component at all** — and still rendered
see-through.

Twelve of the thirteen were the same latent bug: the composer git/runtime/host
chips ask for `color-mix(var(--bg-surface) 50%, transparent)`, i.e.
half-translucent, and were rendering **fully** transparent.

This is the **third** token in that `foundations.css` block to hit this, after
`--bg-subtle` (cave-fdt5) and `--bg-sunken` (cave-309m), so it follows their
pattern and comment style.

## The value is derived, not guessed

The single usage that carried a fallback wrote `var(--bg-surface, var(--background))`.
`--bg-base` already resolves to exactly that per theme, so `--bg-surface` aliases
`--bg-base` — one line that tracks all 22 theme blocks without touching any of
them.

Both drift-ratchet bank entries are removed (`BANKED_UNDEFINED_NO_FALLBACK` 12,
`BANKED_UNDEFINED_WITH_FALLBACK` 1). The scan confirms the effect:

| | before | after |
|---|---:|---:|
| undefined `var()` references | 108 | **95** |

Exactly the thirteen.

## Bundled UI asks from the same report

**Composer height** — trimmed ~10px of **chrome only**: `.cave-composer-control-row`
28px (was 34) and `.cave-composer-controls` bottom pad `--space-2` (was `--space-3`).

I deliberately did **not** touch the textarea's 44px floor or its padding. That
floor is exactly one line (24px line-height + 12/8 padding), and
`cave-composer.css` carries an explicit warning that the textarea's metrics are
mirrored into the markdown decoration layer from computed style at runtime — so
shaving them slides the decoration off the glyphs it belongs to. If more height
needs to come out, that is the lever, and it needs the decoration layer verified
alongside.

**Follow-up card "Why" trigger** — now icon-only. The `<span>Why</span>` is gone,
the button is a square `--space-6`, and the `gap` / `padding-inline` / `min-width`
that existed to space the icon from the word are removed so it cannot sit oblong.

The card's `padding-right` reservation shrinks with it
(`--space-6 + --space-3`, was `--space-10 + --space-2`) — that rule reserves the
lane the absolutely-positioned trigger sits in, and leaving it at the old pill
width would have held open a dead gap the text could not use and nothing
occupied.

**Accessibility is unchanged, and verified rather than assumed.** The accessible
name has always come from `aria-label="Why this suggestion: <label>"`, never the
visible word — which makes the label strictly more informative than the text it
replaces. `chat-follow-up-cards.test.ts` asserts that label's source pattern and
`tests/chat-composer-followup-popover.spec.ts` resolves the button by that
accessible name; both still hold.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (design ESLint gates, TSX + CSS codemod checks, token scan)
- `src/components/chat-follow-up-cards.test.ts` — passes
- token scan: 13 undefined references eliminated, both bank entries removed

The two remaining `[token-refs]` warnings (`--destructive`, `--shadow-popover`)
are pre-existing and unrelated.
