### PR TITLE
Refine the command palette into a sleek search surface

### DIFF
--- a/src/app/css-module-order.test.ts
+++ b/src/app/css-module-order.test.ts
@@ -17,6 +17,7 @@ const FACADES: Record<string, string[]> = {
     "../styles/globals/rail-header.css",
     "../styles/globals/workspace-context-switcher.css",
     "../styles/globals/primitives.css",
+    "../styles/globals/command-palette.css",
     "../styles/globals/themes.css",
     "../styles/globals/desktop-chrome.css",
     "../styles/globals/shell-responsive.css",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,6 +22,7 @@
 @import "../styles/globals/rail-header.css";
 @import "../styles/globals/workspace-context-switcher.css";
 @import "../styles/globals/primitives.css";
+@import "../styles/globals/command-palette.css";
 @import "../styles/globals/themes.css";
 @import "../styles/globals/desktop-chrome.css";
 @import "../styles/globals/shell-responsive.css";

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -10,6 +10,10 @@ const globalPrimitives = readFileSync(
   new URL("../styles/globals/primitives.css", import.meta.url),
   "utf8",
 );
+const paletteStyles = readFileSync(
+  new URL("../styles/globals/command-palette.css", import.meta.url),
+  "utf8",
+);
 const workspace = readFileSync(
   new URL("./workspace.tsx", import.meta.url),
   "utf8",
@@ -84,6 +88,16 @@ assert.doesNotMatch(
   source,
   /@familiar scopes results/,
   "the footer does not repeat scope syntax as persistent visual noise",
+);
+assert.match(
+  paletteStyles,
+  /@supports \(height: 100dvh\) \{[\s\S]*?\.command-palette \{[\s\S]*?100dvh/,
+  "the palette progressively uses the dynamic viewport height on supported browsers",
+);
+assert.match(
+  paletteStyles,
+  /@supports \(height: 100dvh\) \{[\s\S]*?\.command-palette__results \{[\s\S]*?dvh/,
+  "the result region stays bounded by the dynamic viewport",
 );
 
 // (cave-lzk2) Archived chats never resurface in the browse-mode "Recent chats"

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -64,6 +64,27 @@ assert.match(source, /aria-live="polite"/, "result summaries are announced witho
 assert.match(source, /recentSearches\.map/, "empty-query browse mode exposes recent searches");
 assert.match(source, /Clear recent searches/, "recent search history is explicitly clearable");
 assert.match(source, /aria-label="Clear search query"/, "the palette offers a visible clear-query action");
+assert.match(source, /placeholder="Search Cave…"/, "the palette uses concise search-first placeholder copy");
+assert.match(
+  source,
+  /ph:magnifying-glass[\s\S]*?<input/,
+  "the compact search beam leads with a stable search icon",
+);
+assert.match(
+  source,
+  /className="command-palette__filter focus-ring"/,
+  "category filters use the compact palette control instead of oversized pills",
+);
+assert.match(
+  source,
+  /data-active=\{active\}[\s\S]*?className="command-palette-row focus-ring-inset"/,
+  "result selection is exposed to the compact row styling without weakening listbox semantics",
+);
+assert.doesNotMatch(
+  source,
+  /@familiar scopes results/,
+  "the footer does not repeat scope syntax as persistent visual noise",
+);
 
 // (cave-lzk2) Archived chats never resurface in the browse-mode "Recent chats"
 // jump list; only an explicit typed query can find them.

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -872,9 +872,14 @@ export function CommandPalette({
         aria-modal="true"
         aria-label="Command palette"
         tabIndex={-1}
-        className="glass-overlay mt-[12vh] w-[640px] max-w-[92vw] overflow-hidden rounded-2xl border border-[var(--border-strong)] shadow-2xl [animation:ui-modal-enter_var(--duration-base)_var(--ease-decelerate)]!"
+        className="command-palette glass-overlay [animation:ui-modal-enter_var(--duration-base)_var(--ease-decelerate)]!"
       >
-        <div className="flex items-center border-b border-[var(--border-hairline)]">
+        <div className="command-palette__search">
+          <Icon
+            name="ph:magnifying-glass"
+            className="command-palette__search-icon"
+            aria-hidden
+          />
           <input
             ref={inputRef}
             value={query}
@@ -883,7 +888,7 @@ export function CommandPalette({
               setActiveIdx(0);
             }}
             onKeyDown={onComposerKey}
-            placeholder="Search familiars · chats · tasks · memory · settings… (try @familiar)"
+            placeholder="Search Cave…"
             role="combobox"
             aria-label="Search and jump to anything"
             aria-expanded={rows.length > 0}
@@ -892,12 +897,12 @@ export function CommandPalette({
             aria-activedescendant={
               rows.length > 0 ? `command-palette-option-${activeIdx}` : undefined
             }
-            className="focus-ring-inset min-w-0 flex-1 bg-transparent px-4 py-3 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
+            className="command-palette__input"
           />
           {query ? (
             <button
               type="button"
-              className="focus-ring mr-3 rounded-full p-1.5 text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+              className="command-palette__clear focus-ring"
               aria-label="Clear search query"
               onClick={() => {
                 updateQuery("");
@@ -995,7 +1000,7 @@ export function CommandPalette({
         <div
           role="toolbar"
           aria-label="Filter search results"
-          className="flex items-center gap-1 overflow-x-auto border-b border-[var(--border-hairline)] px-3 py-2"
+          className="command-palette__filters"
         >
           {PALETTE_CATEGORIES.filter(
             // Zero-count scopes are dead tabs — hide them. "All" always shows,
@@ -1007,11 +1012,8 @@ export function CommandPalette({
               key={option}
               type="button"
               aria-pressed={category === option}
-              className={`focus-ring shrink-0 rounded-full border px-2.5 py-1 text-[length:var(--text-2xs)] font-medium transition-colors ${
-                category === option
-                  ? "border-[color-mix(in_oklch,var(--accent-presence)_55%,var(--border-strong))] bg-[var(--accent-presence-soft)] text-[var(--text-primary)]"
-                  : "border-transparent text-[var(--text-muted)] hover:border-[var(--border-hairline)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-              }`}
+              data-active={category === option}
+              className="command-palette__filter focus-ring"
               onClick={() => {
                 setCategory(option);
                 setActiveIdx(0);
@@ -1019,7 +1021,7 @@ export function CommandPalette({
               }}
             >
               {PALETTE_CATEGORY_LABEL[option]}
-              <span className="ml-1 font-mono opacity-70">{counts[option]}</span>
+              <span className="command-palette__filter-count">{counts[option]}</span>
             </button>
           ))}
         </div>
@@ -1037,7 +1039,7 @@ export function CommandPalette({
         <ul
           id="command-palette-listbox"
           role="listbox"
-          className="max-h-[60vh] overflow-y-auto py-1"
+          className="command-palette__results"
         >
           {rows.length === 0 ? (
             <li role="presentation" className="px-4 py-6 text-center text-xs text-[var(--text-muted)]">
@@ -1075,7 +1077,7 @@ export function CommandPalette({
                 {showHeader ? (
                   <li
                     role="presentation"
-                    className="px-4 pb-1 pt-3 text-[length:var(--text-2xs)] font-medium uppercase tracking-widest text-[var(--text-muted)] first:pt-1.5"
+                    className="command-palette__group"
                   >
                     {group}
                   </li>
@@ -1090,11 +1092,8 @@ export function CommandPalette({
                   tabIndex={-1}
                   onMouseEnter={() => setActiveIdx(i)}
                   onClick={() => fire(row)}
-                  className={`command-palette-row focus-ring-inset flex w-full items-center gap-3 border-l-2 px-4 py-2 text-left text-sm transition-colors ${
-                    active
-                      ? "border-l-[var(--accent-presence)] bg-[var(--bg-hover)]"
-                      : "border-l-transparent hover:bg-[var(--bg-hover)]"
-                  }`}
+                  data-active={active}
+                  className="command-palette-row focus-ring-inset"
                 >
                   {row.kind === "familiar" ? (
                     <>
@@ -1244,7 +1243,7 @@ export function CommandPalette({
             );
           })}
         </ul>
-        <div className="flex items-center justify-between gap-3 border-t border-[var(--border-hairline)] px-4 py-2 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+        <div className="command-palette__footer">
           {/* Keyboard hints are desktop vocabulary — hidden on coarse-pointer
               devices where there is no ⌘/esc to press (cave-4gg0). */}
           <span className="touch-hidden flex items-center gap-1">
@@ -1252,9 +1251,8 @@ export function CommandPalette({
             <kbd className="palette-kbd">{keys.enter}</kbd> select ·{" "}
             <kbd className="palette-kbd">esc</kbd> close
           </span>
-          <span className="hidden sm:inline">@familiar scopes results</span>
           <span className="flex items-center gap-1">
-            {counts[category]} local
+            {counts[category]} results
             <span className="touch-hidden flex items-center gap-1">
               {" "}· <kbd className="palette-kbd">{keys.mod}K</kbd>
             </span>

--- a/src/components/glass-overlay-chrome.test.ts
+++ b/src/components/glass-overlay-chrome.test.ts
@@ -86,8 +86,8 @@ assert.deepEqual(
 );
 
 // ── Component-class surfaces ride the shared utility ─────────────────────────
-assert.match(palette, /className="glass-overlay mt-\[12vh\]/, "the command palette dialog is glass");
-assert.doesNotMatch(palette, /mt-\[12vh\][^"]*bg-\[var\(--bg-elevated\)\]/, "the palette's old opaque fill is gone");
+assert.match(palette, /className="command-palette glass-overlay"/, "the command palette dialog is glass");
+assert.doesNotMatch(palette, /command-palette glass-overlay[^"]*bg-\[var\(--bg-elevated\)\]/, "the palette's old opaque fill is gone");
 assert.match(bell, /notification-bell__popover glass-overlay/, "the notification bell popover is glass");
 
 // ── Frosted floating chrome (autopilot: "ultra opaque components → frosty") ──

--- a/src/components/glass-overlay-chrome.test.ts
+++ b/src/components/glass-overlay-chrome.test.ts
@@ -86,7 +86,7 @@ assert.deepEqual(
 );
 
 // ── Component-class surfaces ride the shared utility ─────────────────────────
-assert.match(palette, /className="command-palette glass-overlay"/, "the command palette dialog is glass");
+assert.match(palette, /className="command-palette glass-overlay\b/, "the command palette dialog is glass");
 assert.doesNotMatch(palette, /command-palette glass-overlay[^"]*bg-\[var\(--bg-elevated\)\]/, "the palette's old opaque fill is gone");
 assert.match(bell, /notification-bell__popover glass-overlay/, "the notification bell popover is glass");
 

--- a/src/styles/globals/command-palette.css
+++ b/src/styles/globals/command-palette.css
@@ -194,3 +194,25 @@
     min-height: var(--touch-target);
   }
 }
+
+/* Dynamic viewport units keep the palette above mobile browser chrome and the
+   on-screen keyboard. The vh declarations above remain the fallback. */
+@supports (height: 100dvh) {
+  .command-palette {
+    max-height: calc(100dvh - var(--space-12) - var(--space-12));
+  }
+
+  .command-palette__results {
+    max-height: 54dvh;
+  }
+
+  @media (max-width: 767px) {
+    .command-palette {
+      max-height: calc(100dvh - var(--space-4) - var(--sai-top));
+    }
+
+    .command-palette__results {
+      max-height: 58dvh;
+    }
+  }
+}

--- a/src/styles/globals/command-palette.css
+++ b/src/styles/globals/command-palette.css
@@ -1,0 +1,196 @@
+/* Command palette — compact, search-first global navigation. */
+
+.command-palette {
+  display: flex;
+  flex-direction: column;
+  width: calc(var(--space-10) * 16);
+  max-width: calc(100vw - var(--space-8));
+  max-height: calc(100vh - var(--space-12) - var(--space-12));
+  margin-top: var(--space-12);
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-panel);
+  box-shadow: var(--shadow-popover);
+}
+
+.command-palette__search {
+  display: flex;
+  align-items: center;
+  min-height: var(--touch-target);
+  padding-inline: var(--space-3);
+  border-bottom: 1px solid var(--border-hairline);
+  box-shadow: inset 0 var(--ring-width) 0
+    color-mix(in oklch, var(--accent-presence) 48%, transparent);
+}
+
+.command-palette__search:focus-within {
+  box-shadow:
+    inset 0 var(--ring-width) 0 var(--accent-presence),
+    inset 0 0 0 var(--ring-width) var(--ring-focus);
+}
+
+.command-palette__search-icon {
+  flex: none;
+  width: var(--icon-md);
+  height: var(--icon-md);
+  color: var(--text-muted);
+}
+
+.command-palette__input {
+  min-width: 0;
+  flex: 1;
+  padding: var(--space-3) var(--space-2);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--text-md);
+  line-height: var(--leading-tight);
+  outline: none;
+}
+
+.command-palette__input::placeholder {
+  color: var(--text-muted);
+}
+
+.command-palette__clear {
+  display: grid;
+  flex: none;
+  place-items: center;
+  width: var(--space-8);
+  height: var(--space-8);
+  border-radius: var(--radius-control);
+  color: var(--text-muted);
+}
+
+.command-palette__clear:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.command-palette__filters {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  overflow-x: auto;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.command-palette__filter {
+  display: inline-flex;
+  flex: none;
+  align-items: baseline;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-control);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 560;
+  transition:
+    color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.command-palette__filter:hover {
+  border-color: var(--border-hairline);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.command-palette__filter[data-active="true"] {
+  border-color: color-mix(
+    in oklch,
+    var(--accent-presence) 38%,
+    var(--border-hairline)
+  );
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+  color: var(--text-primary);
+}
+
+.command-palette__filter-count {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 500;
+}
+
+.command-palette__results {
+  min-height: 0;
+  flex: 1;
+  max-height: 54vh;
+  overflow-y: auto;
+  padding: var(--space-1);
+}
+
+.command-palette__group {
+  padding: var(--space-3) var(--space-3) var(--space-1);
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-eyebrow);
+  line-height: var(--leading-tight);
+  text-transform: uppercase;
+}
+
+.command-palette__group:first-child {
+  padding-top: var(--space-2);
+}
+
+.command-palette-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: var(--space-10);
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-control);
+  color: var(--text-secondary);
+  font-size: var(--text-base);
+  text-align: left;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    box-shadow var(--duration-fast) var(--ease-standard);
+}
+
+.command-palette-row:hover {
+  background: var(--bg-hover);
+}
+
+.command-palette-row[data-active="true"] {
+  background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-hover));
+  box-shadow: inset var(--ring-width) 0 0 var(--accent-presence);
+}
+
+.command-palette__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  min-height: var(--space-8);
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--border-hairline);
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+}
+
+@media (max-width: 767px) {
+  .command-palette {
+    max-width: calc(100vw - var(--space-4));
+    max-height: calc(100vh - var(--space-4) - var(--sai-top));
+    margin-top: calc(var(--space-2) + var(--sai-top));
+    border-radius: var(--radius-card);
+  }
+
+  .command-palette__search {
+    min-height: var(--touch-target);
+  }
+
+  .command-palette__results {
+    max-height: 58vh;
+  }
+
+  .command-palette-row {
+    min-height: var(--touch-target);
+  }
+}


### PR DESCRIPTION
## Summary
- compress the command palette into a search-first 640px surface with bounded height
- replace oversized filter pills and row chrome with compact token-driven controls
- simplify the footer and search copy while preserving keyboard, listbox, and focus behavior
- add responsive component styling and source contracts for the new hierarchy

## Verification
- `node src/components/command-palette.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- production Playwright visual pass at 1512x982: 10 fully visible rows, 50px first-row height