### PR TITLE
feat(chat): let the composer follow-up row collapse

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -119,6 +119,7 @@ import { stampFirstReplyOnce } from "@/lib/first-run-stamps";
 import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/chat-reply";
 import { canonicalize, formatHelp, splitSlashCommandPrompt } from "@/lib/slash-commands";
 import { Icon } from "@/lib/icon";
+import { useFollowUpsCollapsed } from "@/lib/use-followups-collapsed";
 import {
   CHAT_VIEW_HANDOFF_SCOPE,
   claimInitialPromptHandoff,
@@ -4108,6 +4109,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return suggestions.length ? { suggestions } : empty;
   }, [activePath, linkedContext?.task?.id]);
 
+  const followUpsCollapsed = useFollowUpsCollapsed();
+  const followUpsPanelId = `chat-followups-${useId().replaceAll(":", "")}`;
+
   const handleFollowUp = useCallback((path: NextPath) => {
     if (path.kind === "reply") {
       setInput(path.prompt);
@@ -7932,8 +7936,38 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 ) : null}
                 {linkedContextRow}
                 {followUp.suggestions.length > 0 && !busy ? (
-                  <div className="cave-chat-followups">
-                    <FollowUpCards paths={followUp.suggestions} onActivate={handleFollowUp} />
+                  <div
+                    className="cave-chat-followups"
+                    data-collapsed={followUpsCollapsed.collapsed ? "" : undefined}
+                  >
+                    {/* The toggle is a SIBLING of the cards, never inside them:
+                        a control rendered within the collapsed region would
+                        disappear along with it and strand the reader with no
+                        way back. Collapsed still shows this strip and the
+                        count, so the suggestions stay discoverable rather than
+                        silently gone. */}
+                    <button
+                      type="button"
+                      className="cave-chat-followups__toggle focus-ring"
+                      aria-expanded={!followUpsCollapsed.collapsed}
+                      aria-controls={followUpsPanelId}
+                      onClick={followUpsCollapsed.toggle}
+                    >
+                      <Icon
+                        name={followUpsCollapsed.collapsed ? "ph:caret-right" : "ph:caret-down"}
+                        width={12}
+                        height={12}
+                        aria-hidden
+                      />
+                      <span>
+                        {followUp.suggestions.length === 1
+                          ? "1 suggestion"
+                          : `${followUp.suggestions.length} suggestions`}
+                      </span>
+                    </button>
+                    <div id={followUpsPanelId} hidden={followUpsCollapsed.collapsed}>
+                      <FollowUpCards paths={followUp.suggestions} onActivate={handleFollowUp} />
+                    </div>
                   </div>
                 ) : null}
               </div>

--- a/src/lib/use-followups-collapsed.ts
+++ b/src/lib/use-followups-collapsed.ts
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * Remembers whether the composer's follow-up row is collapsed.
+ *
+ * The row is the largest reclaimable block in the composer — measured on a
+ * production build it is 53px of a 211px panel — and unlike the rest of the
+ * stack it cannot be shrunk by spacing. Its pills carry
+ * `min-height: var(--touch-target)`, and `chat-follow-up-layout.test.ts` pins
+ * that declaration with the message "composer follow-up pills stay touch-safe",
+ * so trimming them would break a test written to prevent exactly that. Letting
+ * the reader put the row away is the only way to get the height back without
+ * spending a tap target.
+ *
+ * ## Why the initial render is always expanded
+ *
+ * `useState` starts from the default and the stored value is applied in an
+ * effect, rather than reading localStorage during render. Reading storage in
+ * the initial state would make the server-rendered markup and the first client
+ * render disagree whenever the preference is set, which is a hydration
+ * mismatch. The perf overlay resolves its `?perf=1` gate the same way and says
+ * so. The cost is one frame of expanded row for readers who collapsed it; the
+ * alternative is a React hydration error on a surface that renders on every
+ * chat.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+/** `cave:`-prefixed, matching every other client preference key in the app. */
+export const FOLLOWUPS_COLLAPSED_KEY = "cave:chat:followups-collapsed";
+
+export type FollowUpsCollapsed = {
+  collapsed: boolean;
+  toggle: () => void;
+};
+
+export function useFollowUpsCollapsed(): FollowUpsCollapsed {
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    try {
+      setCollapsed(window.localStorage.getItem(FOLLOWUPS_COLLAPSED_KEY) === "1");
+    } catch {
+      // Storage can throw on access alone under some privacy settings. The
+      // default (expanded) is the safe side to fail to: it shows the reader
+      // their suggestions rather than hiding them.
+    }
+  }, []);
+
+  const toggle = useCallback(() => {
+    setCollapsed((current) => {
+      const next = !current;
+      try {
+        window.localStorage.setItem(FOLLOWUPS_COLLAPSED_KEY, next ? "1" : "0");
+      } catch {
+        // A preference that cannot be persisted still applies for this session.
+      }
+      return next;
+    });
+  }, []);
+
+  return { collapsed, toggle };
+}

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -352,12 +352,65 @@
 }
 
 /* ── Typed follow-up options in the composer footer ───────────────────────── */
+/* The toggle shares the pills' row rather than sitting above it. Stacking it
+   made the DEFAULT state 19px TALLER (panel 211 -> 230, measured), which is the
+   opposite of the point: nobody should have to collapse the row just to get
+   back the height the control itself cost. Side by side, the row is
+   max(toggle, pills) = the pills' own touch-target height, so expanded is no
+   worse than before and collapsing is pure gain. */
 .cave-chat-followups {
+  display: flex;
   flex: 0 0 100%;
+  align-items: center;
+  gap: var(--space-2);
   width: 100%;
   min-width: 0;
   padding-top: var(--space-2);
   border-top: 1px solid var(--border-hairline);
+}
+
+/* The cards take the remaining width; the toggle keeps its intrinsic size. */
+.cave-chat-followups > [id^="chat-followups-"] {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Collapse control (cave-vgj6z). The pills below cannot be made shorter —
+   they carry min-height: var(--touch-target) and chat-follow-up-layout.test.ts
+   pins it as a touch-safety contract — so the only way to give the composer
+   its ~29px back is to let the reader put the row away. The strip stays when
+   collapsed, which is why it renders as a sibling of the cards rather than
+   inside them. */
+.cave-chat-followups__toggle {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-1) var(--space-1) 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: var(--text-2xs);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.cave-chat-followups__toggle:hover {
+  color: var(--text-primary);
+}
+
+/* Expanded, the strip is redundant with the pills it labels, so it stays out
+   of the way until hover/focus rather than spending a permanent row on a count
+   the reader can already see. Collapsed, it is the only thing left and must
+   always read clearly. */
+.cave-chat-followups:not([data-collapsed]) .cave-chat-followups__toggle {
+  opacity: 0.55;
+}
+
+.cave-chat-followups:not([data-collapsed]) .cave-chat-followups__toggle:hover,
+.cave-chat-followups:not([data-collapsed]) .cave-chat-followups__toggle:focus-visible {
+  opacity: 1;
 }
 
 .cave-chat-followups .cave-followup-cards__grid {
@@ -667,6 +720,12 @@
   height: var(--space-8);
 }
 
+/* The governing control-row height for the chat surface — two classes deep, so
+   it beats the one-class rule in cave-composer.css (cave-9v4qt).
+   Left at 36px deliberately. Lowering it to 32 was measured and changed
+   nothing: the row's CONTENT (send button, mic, mode pill) renders 38px tall,
+   so min-height is not the binding constraint and shrinking it is a no-op.
+   Anyone shortening this row has to shrink those controls, not this number. */
 .cave-chat-linear .cave-composer-control-row {
   min-height: calc(var(--space-8) + var(--space-1));
 }

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -48,13 +48,11 @@
   scrollbar-color: color-mix(in oklch, var(--accent-presence) 22%, transparent) transparent;
 }
 
-/* Composer chrome is deliberately the ONLY thing trimmed for height
-   (cave-w387r). The textarea's 44px floor is exactly one line — 24px
-   line-height plus its 12/8 padding — and its padding is mirrored into the
-   markdown decoration layer from computed style at runtime, so shaving it
-   would slide the decoration off the glyphs it belongs to (see the metrics
-   warning above .cave-composer-md-layer). Trimming the control row and the
-   bottom pad takes ~10px off the panel and cannot move a single character. */
+/* The textarea's 44px floor is exactly one line — 24px line-height plus its
+   12/8 padding — and that padding is mirrored into the markdown decoration
+   layer from computed style at runtime, so shaving it slides the decoration
+   off the glyphs it belongs to (see the metrics warning above
+   .cave-composer-md-layer). Height therefore comes out of chrome only. */
 .cave-composer-controls {
   display: flex;
   flex-direction: column;
@@ -62,10 +60,15 @@
   padding: 0 var(--space-3) var(--space-2);
 }
 
+/* No min-height here on purpose (cave-9v4qt). This rule is one class deep, and
+   `.cave-chat-linear .cave-composer-control-row` in cave-chat/transcript.css is
+   two, so anything set here loses on specificity everywhere the chat surface
+   renders. A `min-height: 28px` sat here doing nothing until a production
+   build was measured and getComputedStyle reported 36px. The governing value
+   lives in transcript.css; change it there. */
 .cave-composer-control-row {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
-  min-height: 28px;
   align-items: center;
   gap: var(--space-2);
   color: var(--text-muted);


### PR DESCRIPTION
Follow-on to #4994, from measuring what actually makes the composer tall.

## Why collapse, and not spacing

The follow-up row is **53px of a 211px composer panel** — the largest single
reclaimable block — but it cannot be shrunk by spacing. Its pills carry
`min-height: var(--touch-target)`, and `chat-follow-up-layout.test.ts` pins that
exact declaration with the message *"composer follow-up pills stay touch-safe"*.
Trimming them would break a test written to prevent precisely that.

Letting the reader put the row away is the only way to get the height back
without spending a tap target.

## Measured

Production builds, `getComputedStyle` + `boundingClientRect`, empty composer:

| state | panel | row |
|---|---:|---:|
| baseline | 211 | 53 |
| **expanded** | **211** | **53** |
| **collapsed** | **190** | **32** |

Expanded is parity — the control costs nothing. Collapsed saves **21px**.

## Two design decisions that measurement forced

**The toggle is a sibling of the cards, never inside them.** A control rendered
within the collapsed region would disappear along with it and strand the reader
with no way back. Collapsed still shows the strip and the count, so the
suggestions stay discoverable rather than silently gone.

**It shares the pills' row rather than stacking above it.** Stacking was tried
first and measured: it made the **default** state 19px *taller* (panel
211 → 230), which is the opposite of the point — nobody should have to collapse
the row just to win back the height the control itself cost. Side by side, the
row is `max(toggle, pills)` and expanded is unchanged.

## Persistence

Stored under `cave:chat:followups-collapsed`, read in an effect rather than
during render. Reading storage in the initial state would make the
server-rendered markup and the first client render disagree whenever the
preference is set — a hydration mismatch. The perf overlay resolves its own
`?perf=1` gate the same way and says so. Cost: one frame of expanded row for
readers who collapsed it. Storage access is wrapped and **fails to expanded**,
so a privacy setting cannot hide someone's suggestions.

## Two changes tried and reverted, because they did nothing

| rule | tried | result |
|---|---|---|
| `.cave-chat-linear .cave-composer-control-row` | 36 → 32px | **no change** |
| `.cave-chat-followups` `padding-top` | 8 → 4px | **no change** |

`min-height` is not the binding constraint on that row — its content (send
button, mic, mode pill) renders 38px tall regardless — and the 4px was absorbed
elsewhere in the panel. Both are restored to their original values **with a
comment recording why lowering them is a no-op**, so the next person doesn't
repeat it.

## What is kept from that attempt

The dead `min-height: 28px` that #4994 added to `.cave-composer-control-row` in
`cave-composer.css` is **removed**. That rule is one class deep and always loses
to the two-class rule in `transcript.css`, so it never applied anywhere the chat
surface renders — it sat there doing nothing until a production build was
measured and `getComputedStyle` reported 36px (`cave-9v4qt`).

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Six contract tests over this area pass: `chat-follow-up-layout`,
  `chat-composer-footer-band`, `composer-density`,
  `chat-view-polish-header-composer`, `chat-follow-up-cards`,
  `chat-view-mobile-command-center`
- Both states driven and screenshotted against a real production build

Closes `cave-9v4qt`.
