### PR TITLE
Show details for skills used in chat runs

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -2259,6 +2259,7 @@ const VITEST_TESTS = new Set([
   "src/components/settings-client-access.test.tsx",
   "src/components/settings-save-feedback.behavior.test.tsx",
   "src/components/chat-preview-card.test.tsx",
+  "src/components/skill-stage-card.test.tsx",
   "src/components/composer-markdown-layer.test.tsx",
   "src/components/document-reader-view.test.ts",
   "src/components/document-reader-text-size.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1014,6 +1014,7 @@ export const SUITES = {
     "src/lib/file-ref-open.test.ts",
     "src/lib/gh-card-commands.test.ts",
     "src/lib/gh-review-draft.test.ts",
+    "src/components/skill-stage-card.test.tsx",
     "src/components/skill-stage-card-wiring.test.ts",
     "src/lib/github-stage.test.ts",
     "src/components/familiar-no-silent-default.test.ts",

--- a/src/components/chat-archive-nudge.test.ts
+++ b/src/components/chat-archive-nudge.test.ts
@@ -101,8 +101,8 @@ assert.match(
 );
 assert.match(
   chatViewSrc,
-  /\[archivingChat, setArchivingChat\] = useState\(false\)/,
-  "chat-view tracks an in-flight archive request",
+  /\[archiving, setArchiving\] = useState\(false\)/,
+  "chat-view tracks one shared in-flight archive request",
 );
 // Re-sync the dismiss flag when the active sessionId changes.
 assert.match(
@@ -110,12 +110,12 @@ assert.match(
   /setArchiveNudgeDismissed\(isChatArchiveNudgeDismissed\(sessionId \?\? "", window\.localStorage\)\)/,
   "chat-view re-reads the per-session dismiss flag whenever sessionId changes",
 );
-// archiveChat handler PATCHes /api/sessions/[id] with archived:true and
-// triggers the existing onSessionsChanged + onBack flow.
+// The shared reversible handler PATCHes /api/sessions/[id] and leaves after
+// archive while keeping an unarchived chat open.
 assert.match(
   chatViewSrc,
-  /const archiveChat = useCallback\(async \(\) => \{[\s\S]*\/api\/sessions\/\$\{encodeURIComponent\(sessionId\)\}[\s\S]*archived: true[\s\S]*onSessionsChanged\?\.\(\)[\s\S]*onBack\?\.\(sessionId\)/,
-  "archiveChat PATCHes the session as archived and tells the host to refresh + leave",
+  /const setChatArchived = useCallback\(async \(archived: boolean\) => \{[\s\S]*\/api\/sessions\/\$\{encodeURIComponent\(sessionId\)\}[\s\S]*JSON\.stringify\(\{ archived \}\)[\s\S]*onSessionsChanged\?\.\(\)[\s\S]*if \(archived\)[\s\S]*onBack\?\.\(sessionId\)/,
+  "the shared archive handler PATCHes the requested state and leaves only after archive",
 );
 assert.match(
   chatViewSrc,
@@ -126,8 +126,8 @@ assert.match(
 // turn appears below it visually.
 assert.match(
   chatViewSrc,
-  /shouldShowChatArchiveNudge\(\{\s*taskLifecycle: linkedContext\?\.task\?\.lifecycle \?\? null,\s*sessionArchived: Boolean\(session\?\.archived_at\),\s*dismissed: archiveNudgeDismissed,\s*\}\) \? \(\s*<ChatArchiveNudge[\s\S]*taskTitle=\{linkedContext\?\.task\?\.title \?\? ""\}[\s\S]*onArchive=\{\(\) => void archiveChat\(\)\}[\s\S]*onDismiss=\{dismissArchiveNudge\}[\s\S]*archiving=\{archivingChat\}/,
-  "chat-view renders ChatArchiveNudge gated on shouldShowChatArchiveNudge with the live task lifecycle, session.archived, and dismissed",
+  /shouldShowChatArchiveNudge\(\{\s*taskLifecycle: linkedContext\?\.task\?\.lifecycle \?\? null,\s*sessionArchived: Boolean\(session\?\.archived_at\),\s*dismissed: archiveNudgeDismissed,\s*\}\) \? \(\s*<ChatArchiveNudge[\s\S]*taskTitle=\{linkedContext\?\.task\?\.title \?\? ""\}[\s\S]*onArchive=\{\(\) => void setChatArchived\(true\)\}[\s\S]*onDismiss=\{dismissArchiveNudge\}[\s\S]*archiving=\{archiving\}/,
+  "the nudge and header button share the same archive mutation and busy state",
 );
 
 console.log("chat-archive-nudge.test.ts ok");

--- a/src/components/chat-inline-composer.test.ts
+++ b/src/components/chat-inline-composer.test.ts
@@ -24,8 +24,8 @@ test("one composer element, rendered in exactly one of two positions", () => {
   );
   assert.match(
     chatView,
-    /\{inlineComposer \? null : composerNode\}/,
-    "the docked position yields when the composer goes inline",
+    /\{inlineComposer \? null : following \? composerNode : null\}/,
+    "the docked position yields when the composer goes inline or the reader leaves the latest turn",
   );
   assert.match(chatView, /composer=\{composerNode\}/, "the same node is handed to the dashboard");
   // Exactly one <footer className="cave-composer-dock"> in the tree.

--- a/src/components/chat-view-polish-header-composer.test.ts
+++ b/src/components/chat-view-polish-header-composer.test.ts
@@ -937,6 +937,11 @@ assert.match(
 );
 assert.match(
   source,
+  /\{inlineComposer \? null : following \? composerNode : null\}/,
+  "The active-chat composer disappears while the reader is away from latest and returns when following resumes",
+);
+assert.match(
+  source,
   /useEffect\(\(\) => \{\s*updateFollowing\(true\);[\s\S]*?\}, \[sessionId, updateFollowing\]\)/,
   "A freshly opened chat / session switch must re-engage following by default",
 );

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -281,7 +281,7 @@ import { ChatFileReader, type ChatFileReaderTarget } from "@/components/chat-fil
 import { joinProjectPath } from "@/components/message-dom-wiring";
 import { ChatPreviewCard } from "@/components/chat-preview-card";
 import { GitHubActionCard } from "@/components/github-action-card";
-import { SkillStageCard } from "@/components/skill-stage-card";
+import { SkillRunSummary, SkillStageCard } from "@/components/skill-stage-card";
 import { AutoStatusCard } from "@/components/auto-status-card";
 import { AutoModeFeedbackModal } from "@/components/auto-mode-feedback-modal";
 import {
@@ -488,7 +488,7 @@ type Props = {
    *  below always pass their own (non-null) sessionId; the two "Back to
    *  sessions" render buttons pass whatever is currently shown. ChatRouter
    *  only actually navigates when it's still displaying that exact session
-   *  (cave-rl980 Task 4 final review): archiveChat/deleteChat/setChatArchived
+   *  (cave-rl980 Task 4 final review): setChatArchived/deleteChat
    *  are async, and by the time the request settles the user may have
    *  already switched to a different thread or familiar, whose view must
    *  never be clobbered by a now-irrelevant completion. */
@@ -2355,7 +2355,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       ? false
       : isChatArchiveNudgeDismissed(sessionId ?? "", window.localStorage),
   );
-  const [archivingChat, setArchivingChat] = useState(false);
   const [modelState, setModelState] = useState<ChatModelState | null>(null);
   const [modelCapabilities, setModelCapabilities] = useState<readonly ModelControlCapability[]>([]);
   const [modelControls, setModelControls] = useState<ModelControlValues>({});
@@ -7066,30 +7065,34 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     setArchiveNudgeDismissed(true);
   }, [sessionId]);
 
-  const archiveChat = useCallback(async () => {
-    if (!sessionId || archivingChat) return;
-    setArchivingChat(true);
+  const setChatArchived = useCallback(async (archived: boolean) => {
+    if (!sessionId || archiving) return;
+    setArchiving(true);
     setError(null);
     try {
       const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
         method: "PATCH",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ archived: true }),
+        body: JSON.stringify({ archived }),
       });
       const json = await res.json().catch(() => ({ ok: false }));
       if (!res.ok || !json.ok) {
-        setError(json.error ?? "archive failed");
+        setError(json.error ?? (archived ? "archive failed" : "unarchive failed"));
         return;
       }
+      announce(archived ? "Chat archived — it won't appear in the rail." : "Chat restored to the rail.");
       onSessionsChanged?.();
-      onSessionRemoved?.(sessionId, "archived");
-      onBack?.(sessionId);
+      // Leaving mirrors delete only for archive; unarchive keeps you in place.
+      if (archived) {
+        onSessionRemoved?.(sessionId, "archived");
+        onBack?.(sessionId);
+      }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "archive failed");
+      setError(err instanceof Error ? err.message : archived ? "archive failed" : "unarchive failed");
     } finally {
-      setArchivingChat(false);
+      setArchiving(false);
     }
-  }, [sessionId, archivingChat, onSessionsChanged, onSessionRemoved, onBack]);
+  }, [announce, archiving, onBack, onSessionRemoved, onSessionsChanged, sessionId]);
 
   const deleteChat = async () => {
     if (!sessionId || deleting) return;
@@ -7190,35 +7193,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     },
     [familiar.id, familiarDrag, promoteToCoven, promotableFamiliarIds],
   );
-
-  const setChatArchived = async (archived: boolean) => {
-    if (!sessionId || archiving) return;
-    setArchiving(true);
-    setError(null);
-    try {
-      const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ archived }),
-      });
-      const json = await res.json().catch(() => ({ ok: false }));
-      if (!res.ok || !json.ok) {
-        setError(json.error ?? (archived ? "archive failed" : "unarchive failed"));
-        return;
-      }
-      announce(archived ? "Chat archived — it won't appear in the rail." : "Chat restored to the rail.");
-      onSessionsChanged?.();
-      // Leaving mirrors delete only for archive; unarchive keeps you in place.
-      if (archived) {
-        onSessionRemoved?.(sessionId, "archived");
-        onBack?.(sessionId);
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : archived ? "archive failed" : "unarchive failed");
-    } finally {
-      setArchiving(false);
-    }
-  };
 
   useImperativeHandle(
     ref,
@@ -8319,9 +8293,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           }) ? (
             <ChatArchiveNudge
               taskTitle={linkedContext?.task?.title ?? ""}
-              onArchive={() => void archiveChat()}
+              onArchive={() => void setChatArchived(true)}
               onDismiss={dismissArchiveNudge}
-              archiving={archivingChat}
+              archiving={archiving}
             />
           ) : null}
           <div ref={tailRef} />
@@ -8483,7 +8457,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         />
       ) : null}
 
-      {inlineComposer ? null : composerNode}
+      {inlineComposer ? null : following ? composerNode : null}
       {taskSuggestion && sessionId && !offlineReadOnly ? (
         <FollowUpTaskReview
           open
@@ -9414,16 +9388,7 @@ function TurnRowImpl({
       {/* Skill stage cards (design §5): one per skill name per turn,
           updated in place by repeated <coven:skill> markers. */}
       {skillUpdates.length ? (
-        <div className="mt-2 space-y-1.5">
-          {skillUpdates.map((update) => (
-            <SkillStageCard
-              key={update.name}
-              name={update.name}
-              stage={update.stage}
-              note={update.note}
-            />
-          ))}
-        </div>
+        <SkillRunSummary skills={skillUpdates} />
       ) : null}
       {autoStatusUpdate ? (
         <div className="mt-2">

--- a/src/components/quick-chat-controls.test.ts
+++ b/src/components/quick-chat-controls.test.ts
@@ -36,7 +36,7 @@ assert.match(
   /const formatted = formatQuickChatAssistantMessage\([\s\S]*message\.text[\s\S]*streaming/,
   "quick chat uses the shared marker-safe formatter for human-readable reply details",
 );
-assert.match(thread, /<SkillStageCard/, "quick chat renders live skill details as readable status cards");
+assert.match(thread, /<SkillRunSummary/, "quick chat renders selectable run-wide skill details");
 assert.match(thread, /<GitHubCard/, "quick chat renders settled GitHub details as preview cards");
 assert.match(thread, /<GitHubActionCard/, "quick chat renders GitHub write proposals as explicit action cards");
 assert.match(

--- a/src/components/quick-chat-thread.tsx
+++ b/src/components/quick-chat-thread.tsx
@@ -3,7 +3,7 @@ import { GitHubActionCard } from "@/components/github-action-card";
 import { GitHubCard } from "@/components/github-card";
 import { ProgressiveMarkdownBlock } from "@/components/message-bubble";
 import { ResearchRunInlineCard } from "@/components/research-run-surface";
-import { SkillStageCard } from "@/components/skill-stage-card";
+import { SkillRunSummary } from "@/components/skill-stage-card";
 import { StreamingTurnResponse } from "@/components/streaming-turn-response";
 import { Button } from "@/components/ui/button";
 import { shouldUseEmptySuccessfulFallback } from "@/lib/chat-assistant-output";
@@ -188,16 +188,7 @@ function QuickChatBubble({
       ) : null}
 
       {skillUpdates.length ? (
-        <div className="mt-2 space-y-2">
-          {skillUpdates.map((update) => (
-            <SkillStageCard
-              key={update.name}
-              name={update.name}
-              stage={update.stage}
-              note={update.note}
-            />
-          ))}
-        </div>
+        <SkillRunSummary skills={skillUpdates} />
       ) : null}
 
       {message.error ? <p className="quick-chat-turn__error">{message.error}</p> : null}

--- a/src/components/skill-stage-card-wiring.test.ts
+++ b/src/components/skill-stage-card-wiring.test.ts
@@ -36,8 +36,8 @@ assert.doesNotMatch(
 );
 assert.match(
   chatView,
-  /skillUpdates\.map\(\((\w+)\) => \(\s*<SkillStageCard\s+key=\{\1\.name\}\s+name=\{\1\.name\}\s+stage=\{\1\.stage\}\s+note=\{\1\.note\}/,
-  "assistant turns render one card per skill name",
+  /<SkillRunSummary skills=\{skillUpdates\} \/>/,
+  "assistant turns render the shared run-wide skill summary",
 );
 assert.match(
   chatView,
@@ -49,5 +49,15 @@ assert.match(chatView, /stage="invoked"/, "deterministic invocation card renders
 // Card contract.
 assert.match(card, /role="status"/, "card announces stage changes to assistive tech");
 assert.match(card, /data-skill-stage=\{stage\}/, "stage is machine-readable for styling/e2e");
+assert.match(
+  card,
+  /breadcrumb=\{\["Chat", "Run skills"\]\}/,
+  "selectable cards open the shared focus-trapped run skills modal",
+);
+assert.match(
+  card,
+  /skills\.map\(\(skill\) => \{[\s\S]*data-selected=\{isSelected \|\| undefined\}/,
+  "the modal shows every run skill and marks the card that opened it",
+);
 
 console.log("skill stage card wiring: ok");

--- a/src/components/skill-stage-card-wiring.test.ts
+++ b/src/components/skill-stage-card-wiring.test.ts
@@ -48,6 +48,11 @@ assert.match(chatView, /stage="invoked"/, "deterministic invocation card renders
 
 // Card contract.
 assert.match(card, /role="status"/, "card announces stage changes to assistive tech");
+assert.match(
+  card,
+  /<button[\s\S]*<\/button>\s*<span className="sr-only" role="status" aria-live="polite"/,
+  "selectable cards retain button semantics and announce streaming stage changes through a sibling live region",
+);
 assert.match(card, /data-skill-stage=\{stage\}/, "stage is machine-readable for styling/e2e");
 assert.match(
   card,
@@ -58,6 +63,11 @@ assert.match(
   card,
   /skills\.map\(\(skill\) => \{[\s\S]*data-selected=\{isSelected \|\| undefined\}/,
   "the modal shows every run skill and marks the card that opened it",
+);
+assert.match(
+  card,
+  /allDone[\s\S]*"ph:circle-notch-bold"[\s\S]*`\$\{completed\} of \$\{skills\.length\} done`/,
+  "the footer reports explicit progress instead of success while skills are still running",
 );
 
 console.log("skill stage card wiring: ok");

--- a/src/components/skill-stage-card.test.tsx
+++ b/src/components/skill-stage-card.test.tsx
@@ -73,6 +73,7 @@ describe("SkillRunSummary", () => {
   it("opens one run-wide modal from every skill card and highlights the selected skill", async () => {
     const renderer = await renderSummary();
     expect(renderer.root.findAllByProps({ "data-modal": true })).toHaveLength(0);
+    expect(renderer.root.findAllByProps({ role: "status" })).toHaveLength(3);
 
     const trigger = renderer.root.findByProps({
       "aria-label":
@@ -88,9 +89,35 @@ describe("SkillRunSummary", () => {
     expect(textContent(modal)).toContain("Applicability gate confirms direct implementation.");
     expect(textContent(modal)).toContain("Governance and CI contracts passed red-green.");
     expect(textContent(modal)).toContain("No significant issues found.");
+    expect(textContent(modal)).toContain("3 done");
     expect(modal.findAllByProps({ "data-selected": true })).toHaveLength(1);
     expect(textContent(modal.findByProps({ "data-selected": true }))).toContain(
       "test-driven-development",
+    );
+  });
+
+  it("reports explicit progress until every skill is complete", async () => {
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <SkillRunSummary
+          skills={[
+            { name: "brainstorming", stage: "done" },
+            { name: "verification-before-completion", stage: "running" },
+          ]}
+        />,
+      );
+    });
+
+    const trigger = renderer!.root.findByProps({
+      "aria-label": "Open details for skill verification-before-completion: running",
+    });
+    await act(async () => {
+      trigger.props.onClick();
+    });
+
+    expect(textContent(renderer!.root.findByProps({ "data-modal": true }))).toContain(
+      "1 of 2 done",
     );
   });
 });

--- a/src/components/skill-stage-card.test.tsx
+++ b/src/components/skill-stage-card.test.tsx
@@ -1,0 +1,96 @@
+// @ts-nocheck — react-test-renderer ships no types; matches the repository convention.
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+
+import { SkillRunSummary } from "./skill-stage-card";
+
+vi.mock("@/components/ui/modal", () => ({
+  Modal: ({
+    open,
+    breadcrumb,
+    children,
+    footerPills,
+    footerActions,
+  }: {
+    open: boolean;
+    breadcrumb?: unknown[];
+    children: unknown;
+    footerPills?: unknown;
+    footerActions?: unknown;
+  }) =>
+    open ? (
+      <div data-modal={true} data-breadcrumb={breadcrumb?.join(" › ")}>
+        {children}
+        {footerPills}
+        {footerActions}
+      </div>
+    ) : null,
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function renderSummary(): Promise<ReactTestRenderer> {
+  let renderer: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(
+      <SkillRunSummary
+        skills={[
+          {
+            name: "brainstorming",
+            stage: "done",
+            note: "Applicability gate confirms direct implementation.",
+          },
+          {
+            name: "test-driven-development",
+            stage: "done",
+            note: "Governance and CI contracts passed red-green.",
+          },
+          {
+            name: "requesting-code-review",
+            stage: "done",
+            note: "No significant issues found.",
+          },
+        ]}
+      />,
+    );
+  });
+  return renderer!;
+}
+
+function textContent(node: { children?: unknown[] }): string {
+  return (node.children ?? [])
+    .map((child) =>
+      typeof child === "string"
+        ? child
+        : child && typeof child === "object"
+          ? textContent(child as { children?: unknown[] })
+          : "",
+    )
+    .join("");
+}
+
+describe("SkillRunSummary", () => {
+  it("opens one run-wide modal from every skill card and highlights the selected skill", async () => {
+    const renderer = await renderSummary();
+    expect(renderer.root.findAllByProps({ "data-modal": true })).toHaveLength(0);
+
+    const trigger = renderer.root.findByProps({
+      "aria-label":
+        "Open details for skill test-driven-development: done — Governance and CI contracts passed red-green.",
+    });
+    await act(async () => {
+      trigger.props.onClick();
+    });
+
+    const modal = renderer.root.findByProps({ "data-modal": true });
+    expect(modal.props["data-breadcrumb"]).toBe("Chat › Run skills");
+    expect(textContent(modal)).toContain("Skills used in this run");
+    expect(textContent(modal)).toContain("Applicability gate confirms direct implementation.");
+    expect(textContent(modal)).toContain("Governance and CI contracts passed red-green.");
+    expect(textContent(modal)).toContain("No significant issues found.");
+    expect(modal.findAllByProps({ "data-selected": true })).toHaveLength(1);
+    expect(textContent(modal.findByProps({ "data-selected": true }))).toContain(
+      "test-driven-development",
+    );
+  });
+});

--- a/src/components/skill-stage-card.tsx
+++ b/src/components/skill-stage-card.tsx
@@ -8,8 +8,12 @@
  * "invoked" form under the user turn.
  */
 
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+import { PropertyPill } from "@/components/ui/property-pill";
 import { Icon } from "@/lib/icon";
-import type { SkillStage } from "@/lib/skill-blocks";
+import type { SkillStage, SkillStageUpdate } from "@/lib/skill-blocks";
 
 const STAGE_ORDER: SkillStage[] = ["loaded", "running", "done"];
 
@@ -32,19 +36,16 @@ export function SkillStageCard({
   name,
   stage,
   note,
+  onSelect,
 }: {
   name: string;
   stage: SkillStage | "invoked";
   note?: string;
+  onSelect?: () => void;
 }) {
   const v = stageVisual(stage);
-  return (
-    <div
-      className="cave-skill-card flex items-center gap-2 rounded-md border border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-raised)_78%,transparent)] px-3 py-1.5 text-[length:var(--text-xs)]"
-      data-skill-stage={stage}
-      role="status"
-      aria-label={`Skill ${name}: ${v.label}${note ? ` — ${note}` : ""}`}
-    >
+  const content = (
+    <>
       <span aria-hidden className="inline-flex shrink-0 text-[var(--accent-presence)]">
         <Icon name="ph:sparkle" width={13} />
       </span>
@@ -68,6 +69,145 @@ export function SkillStageCard({
       ) : null}
       <span className={`${v.cls} shrink-0`}>{v.label}</span>
       {note ? <span className="min-w-0 truncate text-[var(--text-secondary)]" title={note}>{note}</span> : null}
+      {onSelect ? (
+        <Icon
+          name="ph:caret-right"
+          width={12}
+          className="ml-auto shrink-0 text-[var(--text-muted)]"
+          aria-hidden
+        />
+      ) : null}
+    </>
+  );
+
+  const className =
+    "cave-skill-card flex w-full items-center gap-2 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-raised)_78%,transparent)] px-3 py-1.5 text-left text-[length:var(--text-xs)]";
+
+  return onSelect ? (
+    <button
+      type="button"
+      className={`${className} focus-ring transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--bg-hover)]`}
+      data-skill-stage={stage}
+      aria-label={`Open details for skill ${name}: ${v.label}${note ? ` — ${note}` : ""}`}
+      onClick={onSelect}
+    >
+      {content}
+    </button>
+  ) : (
+    <div
+      className={className}
+      data-skill-stage={stage}
+      role="status"
+      aria-label={`Skill ${name}: ${v.label}${note ? ` — ${note}` : ""}`}
+    >
+      {content}
     </div>
+  );
+}
+
+export function SkillRunSummary({ skills }: { skills: SkillStageUpdate[] }) {
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+  const selected = selectedName
+    ? skills.find((skill) => skill.name === selectedName) ?? null
+    : null;
+  const completed = skills.filter((skill) => skill.stage === "done").length;
+  const errors = skills.filter((skill) => skill.stage === "error").length;
+
+  return (
+    <>
+      <div
+        className="mt-2 space-y-1.5"
+        role="list"
+        aria-label={`${skills.length} ${skills.length === 1 ? "skill" : "skills"} used in this run`}
+      >
+        {skills.map((skill) => (
+          <div key={skill.name} role="listitem">
+            <SkillStageCard
+              name={skill.name}
+              stage={skill.stage}
+              note={skill.note}
+              onSelect={() => setSelectedName(skill.name)}
+            />
+          </div>
+        ))}
+      </div>
+
+      <Modal
+        open={selected !== null}
+        onClose={() => setSelectedName(null)}
+        breadcrumb={["Chat", "Run skills"]}
+        wide
+        ariaDescribedBy="skill-run-details-description"
+        footerPills={
+          <>
+            <PropertyPill
+              icon="ph:sparkle"
+              label={`${skills.length} ${skills.length === 1 ? "skill" : "skills"}`}
+            />
+            <PropertyPill
+              icon={errors ? "ph:warning-circle" : "ph:check-circle"}
+              label={errors ? `${errors} ${errors === 1 ? "issue" : "issues"}` : `${completed} done`}
+              filled
+            />
+          </>
+        }
+        footerActions={
+          <Button variant="secondary" onClick={() => setSelectedName(null)}>
+            Done
+          </Button>
+        }
+      >
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-[length:var(--text-lg)] font-semibold text-[var(--text-primary)]">
+              Skills used in this run
+            </h2>
+            <p
+              id="skill-run-details-description"
+              className="mt-1 text-[length:var(--text-sm)] leading-relaxed text-[var(--text-secondary)]"
+            >
+              Each skill shows its latest reported stage and execution detail.
+            </p>
+          </div>
+
+          <div className="space-y-2" role="list" aria-label="Run skill details">
+            {skills.map((skill) => {
+              const visual = stageVisual(skill.stage);
+              const isSelected = skill.name === selectedName;
+              return (
+                <article
+                  key={skill.name}
+                  role="listitem"
+                  data-selected={isSelected || undefined}
+                  className={`rounded-[var(--radius-card)] border p-3 ${
+                    isSelected
+                      ? "border-[color-mix(in_oklch,var(--accent-presence)_48%,var(--border-strong))] bg-[color-mix(in_oklch,var(--accent-presence)_10%,var(--bg-raised))]"
+                      : "border-[var(--border-hairline)] bg-[var(--bg-raised)]"
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <Icon
+                      name="ph:sparkle"
+                      width={14}
+                      className="shrink-0 text-[var(--accent-presence)]"
+                      aria-hidden
+                    />
+                    <strong className="min-w-0 flex-1 truncate text-[length:var(--text-base)] text-[var(--text-primary)]">
+                      {skill.name}
+                    </strong>
+                    <span className={`${visual.cls} shrink-0 text-[length:var(--text-xs)]`}>
+                      {visual.label}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-[length:var(--text-sm)] leading-relaxed text-[var(--text-secondary)]">
+                    {skill.note ?? "No execution detail was reported for this skill."}
+                  </p>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </Modal>
+    </>
   );
 }

--- a/src/components/skill-stage-card.tsx
+++ b/src/components/skill-stage-card.tsx
@@ -84,15 +84,20 @@ export function SkillStageCard({
     "cave-skill-card flex w-full items-center gap-2 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-raised)_78%,transparent)] px-3 py-1.5 text-left text-[length:var(--text-xs)]";
 
   return onSelect ? (
-    <button
-      type="button"
-      className={`${className} focus-ring transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--bg-hover)]`}
-      data-skill-stage={stage}
-      aria-label={`Open details for skill ${name}: ${v.label}${note ? ` — ${note}` : ""}`}
-      onClick={onSelect}
-    >
-      {content}
-    </button>
+    <>
+      <button
+        type="button"
+        className={`${className} focus-ring transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--bg-hover)]`}
+        data-skill-stage={stage}
+        aria-label={`Open details for skill ${name}: ${v.label}${note ? ` — ${note}` : ""}`}
+        onClick={onSelect}
+      >
+        {content}
+      </button>
+      <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        Skill {name}: {v.label}{note ? ` — ${note}` : ""}
+      </span>
+    </>
   ) : (
     <div
       className={className}
@@ -112,6 +117,7 @@ export function SkillRunSummary({ skills }: { skills: SkillStageUpdate[] }) {
     : null;
   const completed = skills.filter((skill) => skill.stage === "done").length;
   const errors = skills.filter((skill) => skill.stage === "error").length;
+  const allDone = completed === skills.length;
 
   return (
     <>
@@ -145,8 +151,20 @@ export function SkillRunSummary({ skills }: { skills: SkillStageUpdate[] }) {
               label={`${skills.length} ${skills.length === 1 ? "skill" : "skills"}`}
             />
             <PropertyPill
-              icon={errors ? "ph:warning-circle" : "ph:check-circle"}
-              label={errors ? `${errors} ${errors === 1 ? "issue" : "issues"}` : `${completed} done`}
+              icon={
+                errors
+                  ? "ph:warning-circle"
+                  : allDone
+                    ? "ph:check-circle"
+                    : "ph:circle-notch-bold"
+              }
+              label={
+                errors
+                  ? `${errors} ${errors === 1 ? "issue" : "issues"}`
+                  : allDone
+                    ? `${completed} done`
+                    : `${completed} of ${skills.length} done`
+              }
               filled
             />
           </>

--- a/src/components/streaming-chat-wiring.test.ts
+++ b/src/components/streaming-chat-wiring.test.ts
@@ -92,7 +92,7 @@ assert.doesNotMatch(
 );
 assert.match(
   supplementary,
-  /<ResponseModelStatus[\s\S]*?<ResponseControlStatus[\s\S]*?<InlineImageAttachments[\s\S]*?<SkillStageCard[\s\S]*?<AutoStatusCard[\s\S]*?editCards\.map[\s\S]*?<ArtifactComments/,
+  /<ResponseModelStatus[\s\S]*?<ResponseControlStatus[\s\S]*?<InlineImageAttachments[\s\S]*?<SkillRunSummary[\s\S]*?<AutoStatusCard[\s\S]*?editCards\.map[\s\S]*?<ArtifactComments/,
   "supplementaryContent preserves metadata, attachments, skill status, edits, and comments",
 );
 assert.match(

--- a/tests/chat-response-output.spec.ts
+++ b/tests/chat-response-output.spec.ts
@@ -43,6 +43,14 @@ The response stays readable and stable while preserving the familiar's authored 
 - Keep supporting details beneath the primary conclusion.
 
 Use \`[READY]\` literally in code, while standalone [REVIEW] and [BLOCKED] tokens become badges.
+
+${Array.from(
+  { length: 32 },
+  (_, index) => `Supporting detail ${index + 1} keeps the transcript scrollable.`,
+).join("\n\n")}
+
+<coven:skill name="brainstorming" stage="done" note="Mapped the response structure" />
+<coven:skill name="verification-before-completion" stage="running" note="Checking the rendered result" />
 `;
 
 async function setup(page: Page) {
@@ -168,4 +176,62 @@ test("interrupted responses preserve partial text and keep Retry visible", async
   });
   await expect(bubble.getByText("Response interrupted")).toBeVisible();
   await expect(bubble.getByRole("button", { name: "Retry response" })).toBeVisible();
+});
+
+test("run skills open one complete ledger and reading older output hides the composer", async ({
+  page,
+}) => {
+  await setup(page);
+  await page.goto("/?mode=chat#chat-s-response-complete", { waitUntil: "domcontentloaded" });
+
+  const verificationCard = page.getByRole("button", {
+    name: /Open details for skill verification-before-completion/,
+  });
+  await expect(verificationCard).toBeVisible({ timeout: 30_000 });
+  await verificationCard.click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByRole("heading", { name: "Skills used in this run" })).toBeVisible();
+  await expect(dialog.getByText("brainstorming", { exact: true })).toBeVisible();
+  await expect(dialog.getByText("verification-before-completion", { exact: true })).toBeVisible();
+  await expect(dialog.locator('[data-selected="true"]')).toContainText(
+    "verification-before-completion",
+  );
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+  await expect(verificationCard).toBeFocused();
+
+  const mainChat = page.getByTestId("chat-main");
+  const transcript = mainChat.locator(".cave-chat-transcript");
+  const composer = mainChat.locator(".cave-composer-dock");
+  await expect(composer).toBeVisible();
+  await transcript.hover();
+  await page.mouse.wheel(0, -900);
+  await expect(composer).toHaveCount(0);
+  await mainChat.getByRole("button", { name: "Latest" }).click();
+  await expect(composer).toBeVisible();
+});
+
+test("the header archive button sends one archive mutation and leaves the session", async ({
+  page,
+}) => {
+  await setup(page);
+  let archiveRequests = 0;
+  await page.route("**/api/sessions/s-response-complete", async (route) => {
+    if (route.request().method() !== "PATCH") {
+      await route.fallback();
+      return;
+    }
+    archiveRequests += 1;
+    expect(route.request().postDataJSON()).toEqual({ archived: true });
+    await route.fulfill({ json: { ok: true } });
+  });
+  await page.goto("/?mode=chat#chat-s-response-complete", { waitUntil: "domcontentloaded" });
+
+  const archive = page.getByRole("button", { name: "Archive this chat" });
+  await expect(archive).toBeVisible({ timeout: 30_000 });
+  await archive.click();
+
+  await expect.poll(() => archiveRequests).toBe(1);
+  await expect(page).not.toHaveURL(/#chat-s-response-complete$/);
 });


### PR DESCRIPTION
## Summary
- make every reported run skill selectable in Chat and Quick Chat
- open one focus-trapped ledger showing all skills, final stages, notes, and the selected skill
- hide the active composer while reading older output and restore it through Latest
- consolidate the archive header and nudge onto one mutation and busy state

## Verification
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm test:mobile`
- `pnpm check:tests-wired`
- `pnpm build`
- `pnpm exec vitest run src/components/skill-stage-card.test.tsx`
- `pnpm exec playwright test tests/chat-response-output.spec.ts --project=desktop --no-deps --workers=1`

Bead: `cave-uqord`