### PR TITLE
ci: shard release candidate E2E validation

### DIFF
--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -98,9 +98,13 @@ jobs:
           cargo test --locked --lib
 
   e2e:
-    name: Validate candidate E2E
+    name: Validate candidate E2E (${{ matrix.shard }}/4)
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -116,11 +120,30 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps chromium webkit
-      - run: pnpm exec playwright test
-      - name: Validate flag-enabled agentic journeys
-        env:
-          NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS: "1"
-        run: pnpm exec playwright test tests/agentic-enhance.spec.ts tests/research-desk-tabs.spec.ts --project=desktop --workers=1 --no-deps
+      - run: pnpm exec playwright test --shard=${{ matrix.shard }}/4
+
+  e2e-agentic:
+    name: Validate candidate E2E (agentic)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS: "1"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium webkit
+      - run: pnpm exec playwright test tests/agentic-enhance.spec.ts tests/research-desk-tabs.spec.ts --project=desktop --workers=1 --no-deps
 
   runtime:
     name: Validate candidate runtime (${{ matrix.os }})
@@ -300,7 +323,7 @@ jobs:
   release-candidate-validated:
     name: Release candidate validated
     if: always()
-    needs: [frontend, rust, e2e, runtime, windows-native]
+    needs: [frontend, rust, e2e, e2e-agentic, runtime, windows-native]
     runs-on: ubuntu-24.04
     steps:
       - name: Require every deferred validation job
@@ -308,6 +331,7 @@ jobs:
           FRONTEND_RESULT: ${{ needs.frontend.result }}
           RUST_RESULT: ${{ needs.rust.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
+          E2E_AGENTIC_RESULT: ${{ needs.e2e-agentic.result }}
           RUNTIME_RESULT: ${{ needs.runtime.result }}
           WINDOWS_NATIVE_RESULT: ${{ needs.windows-native.result }}
         run: |
@@ -315,6 +339,7 @@ jobs:
           test "$FRONTEND_RESULT" = "success"
           test "$RUST_RESULT" = "success"
           test "$E2E_RESULT" = "success"
+          test "$E2E_AGENTIC_RESULT" = "success"
           test "$RUNTIME_RESULT" = "success"
           test "$WINDOWS_NATIVE_RESULT" = "success"
 
@@ -324,6 +349,7 @@ jobs:
           FRONTEND_RESULT: ${{ needs.frontend.result }}
           RUST_RESULT: ${{ needs.rust.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
+          E2E_AGENTIC_RESULT: ${{ needs.e2e-agentic.result }}
           RUNTIME_RESULT: ${{ needs.runtime.result }}
           WINDOWS_NATIVE_RESULT: ${{ needs.windows-native.result }}
         run: |
@@ -334,7 +360,8 @@ jobs:
             echo "| --- | --- |"
             echo "| Frontend | $FRONTEND_RESULT |"
             echo "| Rust | $RUST_RESULT |"
-            echo "| Playwright | $E2E_RESULT |"
+            echo "| Playwright shards | $E2E_RESULT |"
+            echo "| Playwright agentic | $E2E_AGENTIC_RESULT |"
             echo "| Ubuntu / Windows / macOS runtime | $RUNTIME_RESULT |"
             echo "| Windows native | $WINDOWS_NATIVE_RESULT |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/release-promotion-workflow.test.mjs
+++ b/scripts/release-promotion-workflow.test.mjs
@@ -87,6 +87,7 @@ test("candidate validation requires signed tag provenance and calls every deferr
   assert.ok(full.on.workflow_call, "full validation is reusable only");
   assert.deepEqual(Object.keys(full.jobs).sort(), [
     "e2e",
+    "e2e-agentic",
     "frontend",
     "release-candidate-validated",
     "runtime",
@@ -122,17 +123,33 @@ test("candidate validation requires signed tag provenance and calls every deferr
     "candidate E2E installs both required browser engines",
   );
   assert.ok(
-    full.jobs.e2e.steps.some((step) => step.run === "pnpm exec playwright test"),
-    "candidate E2E retains the default Chromium and WebKit coverage",
+    full.jobs.e2e.steps.some(
+      (step) => step.run === "pnpm exec playwright test --shard=${{ matrix.shard }}/4",
+    ),
+    "candidate E2E shards the default Chromium and WebKit coverage",
   );
-  const agenticE2e = full.jobs.e2e.steps.find(
-    (step) =>
-      step.run ===
-      "pnpm exec playwright test tests/agentic-enhance.spec.ts tests/research-desk-tabs.spec.ts --project=desktop --workers=1 --no-deps",
-  );
-  assert.deepEqual(agenticE2e?.env, {
+  assert.equal(full.jobs.e2e.strategy["fail-fast"], false);
+  assert.deepEqual(full.jobs.e2e.strategy.matrix.shard, [1, 2, 3, 4]);
+  assert.equal(full.jobs.e2e["timeout-minutes"], 30);
+  const agenticE2e = full.jobs["e2e-agentic"];
+  assert.equal(agenticE2e.name, "Validate candidate E2E (agentic)");
+  assert.equal(agenticE2e["timeout-minutes"], 30);
+  assert.deepEqual(agenticE2e.env, {
     NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS: "1",
   });
+  assert.ok(
+    agenticE2e.steps.some(
+      (step) =>
+        step.run ===
+        "pnpm exec playwright test tests/agentic-enhance.spec.ts tests/research-desk-tabs.spec.ts --project=desktop --workers=1 --no-deps",
+    ),
+    "candidate E2E retains flag-enabled agentic coverage in an isolated job",
+  );
+  const agenticCheckout = agenticE2e.steps.find(
+    (step) =>
+      typeof step.uses === "string" && step.uses.startsWith("actions/checkout@"),
+  );
+  assert.equal(agenticCheckout?.with?.ref, "${{ inputs.ref }}");
   assert.deepEqual(full.jobs.runtime.strategy.matrix.os, [
     "ubuntu-24.04",
     "windows-latest",
@@ -151,10 +168,17 @@ test("candidate validation requires signed tag provenance and calls every deferr
   const rollup = full.jobs["release-candidate-validated"];
   assert.equal(rollup.name, "Release candidate validated");
   assert.equal(rollup.if, "always()");
-  assert.deepEqual(rollup.needs, ["frontend", "rust", "e2e", "runtime", "windows-native"]);
+  assert.deepEqual(rollup.needs, [
+    "frontend",
+    "rust",
+    "e2e",
+    "e2e-agentic",
+    "runtime",
+    "windows-native",
+  ]);
   assert.match(
     rollup.steps[0].run,
-    /test "\$FRONTEND_RESULT" = "success"[\s\S]*test "\$WINDOWS_NATIVE_RESULT" = "success"/,
+    /test "\$FRONTEND_RESULT" = "success"[\s\S]*test "\$E2E_AGENTIC_RESULT" = "success"[\s\S]*test "\$WINDOWS_NATIVE_RESULT" = "success"/,
     "the rollup must fail closed for failed, skipped, or cancelled dependencies",
   );
 });


### PR DESCRIPTION
## Summary
- split release-candidate Playwright validation into four deterministic shards
- run flag-enabled agentic journeys once in an isolated job
- keep the release rollup fail-closed across both E2E lanes
- pin the sharding and aggregation contract in workflow tests

## Validation
- `node --test scripts/*workflow.test.mjs`
- `pnpm check:tests-wired`
- `pnpm release:verify --version 0.3.10`
- `git diff --check`

Bead: `cave-wijh8`