### PR TITLE
fix(chat): narrow code rail

### DIFF
--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -547,9 +547,9 @@ export function ChatSurface({
                 <Panel
                   id="code-rail"
                   className="hidden min-h-0 min-w-0 lg:flex"
-                  defaultSize="320px"
-                  minSize="240px"
-                  maxSize="560px"
+                  defaultSize="280px"
+                  minSize="220px"
+                  maxSize="480px"
                 >
                   <WorkspaceRail
                     changeCount={changeCount ?? 0}

--- a/src/components/code-rail-fit.test.ts
+++ b/src/components/code-rail-fit.test.ts
@@ -36,8 +36,8 @@ assert.match(
 // (id="code-rail"), drag-resizable behind an outer separator.
 assert.match(
   chatSurface,
-  /Panel[\s\S]*id="code-rail"[\s\S]*defaultSize="320px"[\s\S]*minSize="240px"[\s\S]*maxSize="560px"/,
-  "ChatSurface code rail should default to 320px, drag-resizable within a 240–560px band",
+  /Panel[\s\S]*id="code-rail"[\s\S]*defaultSize="280px"[\s\S]*minSize="220px"[\s\S]*maxSize="480px"/,
+  "ChatSurface code rail should default to 280px, drag-resizable within a compact 220–480px band",
 );
 assert.doesNotMatch(
   chatSurface,
@@ -72,8 +72,8 @@ assert.match(
 // it must NOT be absolutely positioned, and it reserves its own width.
 assert.match(
   caveChat,
-  /\.workspace-rail-reopen \{[\s\S]{0,900}?flex: 0 0 44px;/,
-  "the reopen rail reserves in-flow layout width",
+  /\.workspace-rail-reopen \{[\s\S]{0,900}?flex: 0 0 32px;/,
+  "the reopen rail reserves an ultra-minimal in-flow layout width",
 );
 assert.doesNotMatch(
   caveChat,

--- a/src/components/task-work-cockpit.test.ts
+++ b/src/components/task-work-cockpit.test.ts
@@ -107,7 +107,7 @@ assert.match(
 );
 
 // The collapsed code rail is an in-flow flex child sized against a flex ROW
-// (44px wide, full height). The cockpit root is a flex COLUMN, so hosting it
+// (32px wide, full height). The cockpit root is a flex COLUMN, so hosting it
 // there docked it as a stub in the bottom-left corner under the composer.
 // It belongs inside the body row, before the body closes.
 const bodyStart = source.indexOf('<div className="task-work-cockpit__body">');
@@ -121,6 +121,6 @@ assert.ok(bodyEnd > bodyStart, "the cockpit body row closes before the rail shee
 assert.ok(railStart < bodyEnd, "the reopen rail renders inside the cockpit body row, not as a column child");
 assert.match(
   cockpitCss,
-  /\.task-work-cockpit__body > \.workspace-rail-reopen \{[\s\S]{0,200}?flex: 0 0 44px;[\s\S]{0,200}?align-self: stretch;/,
-  "the reopen rail reserves a full-height 44px column beside the conversation",
+  /\.task-work-cockpit__body > \.workspace-rail-reopen \{[\s\S]{0,200}?flex: 0 0 32px;[\s\S]{0,200}?align-self: stretch;/,
+  "the reopen rail reserves an ultra-minimal full-height column beside the conversation",
 );

--- a/src/styles/cave-chat/auxiliary-surfaces.css
+++ b/src/styles/cave-chat/auxiliary-surfaces.css
@@ -982,8 +982,8 @@
   flex-direction: column;
   align-items: center;
   gap: 9px;
-  flex: 0 0 44px;
-  width: 44px;
+  flex: 0 0 32px;
+  width: 32px;
   height: 100%;
   padding: var(--space-3) 0;
   border: 0;

--- a/src/styles/task-work-cockpit.css
+++ b/src/styles/task-work-cockpit.css
@@ -226,7 +226,7 @@
   min-width: 0;
 }
 
-/* The collapsed code rail is an in-flow flex child that reserves its own 44px
+/* The collapsed code rail is an in-flow flex child that reserves its own 32px
  * of layout width beside the conversation (never over it) and runs the full
  * height of the row — the contract .workspace-rail-reopen is written against
  * on the chat surface, whose root is a flex ROW. The cockpit root is a flex
@@ -234,7 +234,7 @@
  * at the bottom-left corner. It lives in the body row instead; this pins the
  * geometry so a future column-child regression is visible. */
 .task-work-cockpit__body > .workspace-rail-reopen {
-  flex: 0 0 44px;
+  flex: 0 0 32px;
   align-self: stretch;
 }
 

--- a/tests/chat-code-workflow.spec.ts
+++ b/tests/chat-code-workflow.spec.ts
@@ -869,7 +869,7 @@ test("resized desktop Chromium pins theme, constrained-pane, responsive-sheet, a
   const constrainedRail = await requiredBounds(page, ".workspace-rail");
   const shellDetail = await requiredBounds(page, ".shell-detail");
   expectBoundsNear(constrainedChat, { x: 9, y: 43, width: 1102, height: 680 });
-  expectBoundsNear(constrainedRail, { x: 791, y: 77, width: 320, height: 646 });
+  expectBoundsNear(constrainedRail, { x: 831, y: 77, width: 280, height: 646 });
   const shellContract = await page.locator(".shell-detail").evaluate((element) => {
     const style = getComputedStyle(element);
     const rootStyle = getComputedStyle(document.documentElement);


### PR DESCRIPTION
## Summary

Narrows the desktop eChat code rail while preserving its resize, persistence, mobile-sheet, and glass treatment contracts.

## Why

Tracks `cave-dkgvc`. The prior 320px open rail and 44px collapsed edge consumed more conversation space than necessary.

## Changes

- default the open code rail to 280px with a 220–480px resize band
- reduce the collapsed right-edge affordance from 44px to 32px
- update chat and task-cockpit geometry contracts

## Verification

- `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/code-rail-fit.test.ts`
- `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/task-work-cockpit.test.ts`
- `pnpm check:tests-wired` (1858/1858)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- Playwright visual check at 1440x1000: collapsed rail 32px; open default 280px

## Risk + rollout notes

Low-risk geometry-only change. Persisted desktop layouts remain supported and clamp to the narrower 220–480px bounds; mobile behavior is unchanged.