### PR TITLE
feat(ios): build comprehensive Familiar profile

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/FamiliarDashboard.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/FamiliarDashboard.swift
@@ -380,6 +380,85 @@ struct FamiliarDashboardProfile: Decodable, Hashable, Sendable {
     var contract: ContractSummary?
 }
 
+/// Copy-only projection used by the native Profile surface.
+///
+/// Keeping absent-state decisions here makes them unit-testable and prevents
+/// individual rows from quietly disagreeing about whether nil means zero,
+/// inherited, or unavailable. Section failure is handled one level above this
+/// projection; values that reach these helpers were read successfully and are
+/// therefore either configured or truthfully absent.
+enum FamiliarProfilePresentation {
+    static let notSet = "Not set"
+
+    static func value(_ raw: String?) -> String {
+        guard let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return notSet }
+        return value
+    }
+
+    static func model(_ profile: FamiliarDashboardProfile) -> String {
+        value(profile.runtime.model)
+    }
+
+    static func modelSource(_ profile: FamiliarDashboardProfile) -> String {
+        switch profile.runtime.modelProvenance {
+        case "familiar": return "Familiar default"
+        case "coven_default": return "Coven default"
+        case "unconfigured": return "Runtime default"
+        default: return "Source unavailable"
+        }
+    }
+
+    static func runtime(_ profile: FamiliarDashboardProfile) -> String {
+        if let harness = profile.runtime.harness?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !harness.isEmpty { return harness }
+        if let fallback = profile.runtime.defaultHarness?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !fallback.isEmpty { return "\(fallback) (Coven default)" }
+        return notSet
+    }
+
+    static func voice(_ familiar: Familiar) -> String {
+        joined([
+            familiar.voiceProvider,
+            familiar.voiceModel,
+            familiar.voiceName,
+        ])
+    }
+
+    static func image(_ familiar: Familiar) -> String {
+        joined([
+            familiar.imageProvider,
+            familiar.imageModel,
+            familiar.imageSize,
+            familiar.imageQuality,
+        ])
+    }
+
+    static func memory(
+        _ section: FamiliarDashboardClientSection<FamiliarDashboardOverview>
+    ) -> String {
+        guard let memory = section.data?.memory else { return "Unavailable" }
+        guard let raw = memory.freshestAt, let date = caveParseISO(raw) else {
+            return memory.entries.total == 0 ? "No memory yet" : "Freshness unavailable"
+        }
+        let value = date.formatted(date: .abbreviated, time: .shortened)
+        return section.isStale ? "\(value) · stale" : value
+    }
+
+    static func contract(_ summary: FamiliarDashboardProfile.ContractSummary?) -> String {
+        guard let summary else { return notSet }
+        return "\(summary.propertiesPassed) of \(summary.propertiesTotal) checks passed"
+    }
+
+    private static func joined(_ values: [String?]) -> String {
+        let present = values.compactMap { raw -> String? in
+            let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return value.isEmpty ? nil : value
+        }
+        return present.isEmpty ? notSet : present.joined(separator: " · ")
+    }
+}
+
 struct FamiliarDashboardAnalytics: Decodable, Hashable, Sendable {
     struct Averages: Decodable, Hashable, Sendable {
         var overallConfidence: Double?

--- a/apps/ios/CovenCave/CovenCave/Models/Models.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/Models.swift
@@ -17,6 +17,16 @@ struct Familiar: Identifiable, Codable, Hashable {
     var avatarUrl: String?
     var activeSessions: Int?
     var memoryFreshness: String?
+    /// Profile/configuration fields published by GET /api/familiars. These
+    /// remain optional so a newer phone can still describe an older Cave
+    /// truthfully as "Not set" instead of failing the entire roster decode.
+    var familiarType: String? = nil
+    var note: String? = nil
+    var imageProvider: String? = nil
+    var imageModel: String? = nil
+    var imageSize: String? = nil
+    var imageQuality: String? = nil
+    var autoSelfReport: Bool? = nil
     /// Voice configuration published by Familiar Studio. All three remain
     /// optional so phones can decode familiars created before voice support.
     var voiceProvider: String? = nil
@@ -30,7 +40,9 @@ struct Familiar: Identifiable, Codable, Hashable {
         case avatarUrl
         case activeSessions = "active_sessions"
         case memoryFreshness = "memory_freshness"
+        case familiarType, note
         case voiceProvider, voiceModel, voiceName
+        case imageProvider, imageModel, imageSize, imageQuality, autoSelfReport
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarHubView.swift
@@ -387,20 +387,36 @@ struct FamiliarHubView: View {
         .accessibilityLabel("\(label): \(value)")
     }
 
-    /// The Profile tab keeps the identity, defaults and access surfaces that
-    /// already shipped, driven by the paths that own those mutations today
-    /// (the model inventory, `FamiliarPermissionsSheet`). `cave-9rwd.4`
-    /// replaces this with the dashboard-driven profile — showing nothing here
-    /// meanwhile would be a regression from what the roster used to open.
+    /// Profile intentionally renders a successfully-read EMPTY section instead
+    /// of replacing it with a generic empty note. Identity and configuration
+    /// rows still have truthful "Not set" answers, and model/access controls
+    /// remain useful even when no optional profile prose is configured.
     @ViewBuilder
     private func profileTab(_ snapshot: FamiliarDashboardSnapshot) -> some View {
-        if snapshot.profile.isStale {
-            FamiliarDashboardStaleBanner(
-                generatedAt: snapshot.profile.generatedAt,
-                issues: snapshot.profile.refreshIssues
+        let section = snapshot.profile
+        if let profile = section.data {
+            if section.isStale {
+                FamiliarDashboardStaleBanner(
+                    generatedAt: section.generatedAt,
+                    issues: section.refreshIssues
+                )
+            }
+            FamiliarDetailView(
+                familiar: familiar,
+                identity: snapshot.identity,
+                profile: profile,
+                overview: snapshot.overview
+            )
+            if !section.issues.isEmpty, !section.isStale {
+                FamiliarDashboardIssueNote(issues: section.issues)
+            }
+        } else {
+            FamiliarDashboardUnavailableView(
+                title: "Profile",
+                issues: section.visibleIssues,
+                retry: section.isRetryable ? { Task { await refreshNow() } } : nil
             )
         }
-        FamiliarDetailView(familiar: familiar)
     }
 
     private func analyticsTab(_ snapshot: FamiliarDashboardSnapshot) -> some View {

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarsListView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarsListView.swift
@@ -226,22 +226,20 @@ private struct FamiliarRosterRow: View {
     }
 }
 
-/// The Familiar hub's **Profile** tab body (`cave-9rwd.2` shell).
+/// The Familiar hub's comprehensive native Profile tab (`cave-9rwd.4`).
 ///
-/// This was the roster's standalone detail page until the hub landed. It kept
-/// its identity, defaults and access surfaces and lost the parts the hub now
-/// owns — the avatar hero, the navigation title, the scroll container and the
-/// primary Chat action — so nothing is drawn twice.
-///
-/// It is still driven by the paths that OWN these mutations (the chat model
-/// inventory, `FamiliarPermissionsSheet`) rather than by the dashboard read.
-/// `cave-9rwd.4` replaces it with the comprehensive dashboard-driven profile;
-/// rendering nothing here in the meantime would be a regression from what the
-/// roster used to open.
+/// Read-only facts come from the coherent dashboard snapshot. The two editable
+/// controls deliberately stay on the paths that own those mutations: the model
+/// inventory/mutation contract and `FamiliarPermissionsSheet`. The roster is
+/// used only for fields that `/api/familiars` already owns (voice, image and
+/// revisioned avatar state); no second configuration contract is invented.
 struct FamiliarDetailView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.chrome) private var chrome
     let familiar: Familiar
+    let identity: FamiliarDashboardIdentity
+    let profile: FamiliarDashboardProfile
+    let overview: FamiliarDashboardClientSection<FamiliarDashboardOverview>
 
     @State private var modelState: ChatModelState?
     @State private var modelOptions: [ChatModelOption] = []
@@ -258,14 +256,6 @@ struct FamiliarDetailView: View {
     @State private var showAvatarCamera = false
     @State private var avatarPhotoItem: PhotosPickerItem?
     @State private var changingAvatar = false
-
-    private var scopedContext: ProjectContext? {
-        app.projectContext
-    }
-
-    private var statsModel: FamiliarDetailStatsModel {
-        FamiliarDetailStatsModel.make(app: app, familiar: familiar, context: scopedContext)
-    }
 
     private var modelLoadTarget: ChatModelRequestTarget {
         let harness = (app.familiar(familiar.id)?.harness ?? familiar.harness)?
@@ -304,7 +294,9 @@ struct FamiliarDetailView: View {
     }
 
     private var modelLabel: String {
-        guard let state = presentedModelState else { return familiar.model ?? "Inherited" }
+        guard let state = presentedModelState else {
+            return FamiliarProfilePresentation.model(profile)
+        }
         if state.effectiveModel.isEmpty { return "Runtime default" }
         return presentedModelOptions.first(where: { $0.id == state.effectiveModel })?.label
             ?? state.effectiveModel.split(separator: "/").last.map(String.init)
@@ -313,14 +305,17 @@ struct FamiliarDetailView: View {
 
     private var runtimeLabel: String {
         if let runtime = presentedModelState?.runtime, !runtime.isEmpty { return runtime }
-        return presentedModelState?.harness ?? familiar.harness ?? "Inherited"
+        if let harness = presentedModelState?.harness, !harness.isEmpty { return harness }
+        return FamiliarProfilePresentation.runtime(profile)
     }
 
     var body: some View {
         VStack(spacing: 22) {
-            stats
             identitySection
+            purposeSection
             defaultsSection
+            memoryAndMediaSection
+            contractSection
             accessSection
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -383,33 +378,6 @@ struct FamiliarDetailView: View {
         app.familiar(familiar.id) ?? familiar
     }
 
-    private var stats: some View {
-        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
-            statCard("Chats", value: statsModel.chats, icon: "bubble.left")
-            statCard("Activity", value: statsModel.activity, icon: "clock")
-            statCard("Tasks", value: statsModel.tasks, icon: "checkmark.square")
-            statCard("Memory", value: statsModel.memory, icon: "brain")
-        }
-    }
-
-    private func statCard(_ title: String, value: String, icon: String) -> some View {
-        VStack(alignment: .leading, spacing: 9) {
-            Image(systemName: icon)
-                .foregroundStyle(chrome.accent)
-            Text(value)
-                .font(.title3.weight(.semibold))
-                .lineLimit(1)
-                .minimumScaleFactor(0.72)
-            Text(title)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(14)
-        .glass(.raised, cornerRadius: 14)
-        .accessibilityElement(children: .combine)
-    }
-
     private var identitySection: some View {
         detailGroup {
             Text("Identity")
@@ -445,17 +413,28 @@ struct FamiliarDetailView: View {
             .accessibilityLabel("Edit \(familiar.displayName)’s avatar")
             .accessibilityHint("Choose a photo, take a photo, or remove the current avatar.")
             Divider()
-            detailValue("Role", familiar.role ?? "Not set")
-            if let pronouns = familiar.pronouns, !pronouns.isEmpty {
-                detailValue("Pronouns", pronouns)
-            }
-            if let description = familiar.description, !description.isEmpty {
-                Divider()
-                Text(description)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+            detailValue("Name", FamiliarProfilePresentation.value(identity.displayName))
+            Divider()
+            detailValue("Role", FamiliarProfilePresentation.value(identity.role))
+            Divider()
+            detailValue("Pronouns", FamiliarProfilePresentation.value(identity.pronouns))
+            Divider()
+            detailValue("Familiar ID", identity.id)
+        }
+    }
+
+    private var purposeSection: some View {
+        detailGroup {
+            Text("Purpose and vocation")
+                .font(.headline)
+            detailValue("Purpose", FamiliarProfilePresentation.value(profile.description))
+            Divider()
+            detailValue("Vocation", FamiliarProfilePresentation.value(profile.familiarType))
+            Divider()
+            detailValue(
+                "Configuration note",
+                FamiliarProfilePresentation.value(profile.configuration.note)
+            )
         }
     }
 
@@ -479,7 +458,7 @@ struct FamiliarDetailView: View {
                             Text(modelLabel)
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
-                            Text(ChatModelInventoryProvenancePresentation.compactLabel(for: presentedModelProvenance))
+                            Text(modelSourceLabel)
                                 .font(.caption2)
                                 .foregroundStyle(.tertiary)
                         }
@@ -498,8 +477,76 @@ struct FamiliarDetailView: View {
                     || changingModel
             )
             .accessibilityLabel(
-                "Model: \(modelLabel). \(ChatModelInventoryProvenancePresentation.label(for: presentedModelProvenance))"
+                "Model: \(modelLabel). \(modelSourceLabel)"
             )
+            Divider()
+            detailValue(
+                "Self-reports",
+                profile.configuration.autoSelfReport ? "Enabled" : "Not enabled"
+            )
+        }
+    }
+
+    private var modelSourceLabel: String {
+        if presentedModelState != nil {
+            return ChatModelInventoryProvenancePresentation.label(for: presentedModelProvenance)
+        }
+        return FamiliarProfilePresentation.modelSource(profile)
+    }
+
+    private var memoryAndMediaSection: some View {
+        detailGroup {
+            Text("Memory and media")
+                .font(.headline)
+            detailValue("Memory", memoryLabel)
+            Divider()
+            detailValue("Voice", FamiliarProfilePresentation.voice(currentFamiliar))
+            Divider()
+            detailValue("Image defaults", FamiliarProfilePresentation.image(currentFamiliar))
+        }
+    }
+
+    private var memoryLabel: String {
+        FamiliarProfilePresentation.memory(overview)
+    }
+
+    private var contractSection: some View {
+        detailGroup {
+            Text("Capability contract")
+                .font(.headline)
+            detailValue("Status", FamiliarProfilePresentation.contract(profile.contract))
+            if let contract = profile.contract {
+                contractFindings("Needs attention", contract.violations)
+                contractFindings("Warnings", contract.warnings)
+            } else {
+                Text("No contract files were found for this familiar.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func contractFindings(
+        _ label: String,
+        _ findings: FamiliarDashboardBoundedList<String>
+    ) -> some View {
+        if !findings.items.isEmpty {
+            Divider()
+            Text(label)
+                .font(.subheadline.weight(.medium))
+            ForEach(Array(findings.items.enumerated()), id: \.offset) { _, finding in
+                Label(finding, systemImage: "exclamationmark.circle")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if findings.hidden > 0 {
+                Text("+\(findings.hidden) more")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 
@@ -511,8 +558,13 @@ struct FamiliarDetailView: View {
                 showPermissions = true
             } label: {
                 HStack {
-                    Label("Project and tool permissions", systemImage: "lock.shield")
-                        .foregroundStyle(.primary)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Label("Project and tool access", systemImage: "lock.shield")
+                            .foregroundStyle(.primary)
+                        Text("Review the authoritative access controls")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                     Spacer()
                     Image(systemName: "chevron.right")
                         .font(.caption.weight(.semibold))
@@ -526,15 +578,25 @@ struct FamiliarDetailView: View {
     }
 
     private func detailValue(_ label: String, _ value: String) -> some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text(label)
-            Spacer()
-            Text(value)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.trailing)
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(label)
+                Spacer(minLength: 12)
+                Text(value)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.trailing)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(label)
+                Text(value)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .font(.subheadline)
-        .frame(minHeight: 34)
+        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(label): \(value)")
     }
 
     private func detailGroup<Content: View>(@ViewBuilder content: () -> Content) -> some View {

--- a/apps/ios/CovenCave/CovenCaveTests/FamiliarProfilePresentationTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/FamiliarProfilePresentationTests.swift
@@ -92,14 +92,14 @@ final class FamiliarProfilePresentationTests: XCTestCase {
             "Unavailable")
 
         let unavailable = FamiliarDashboardClientSection<FamiliarDashboardOverview>(
-            wire: .init(
-                state: .unavailable,
-                generatedAt: FamiliarDashboardFixtures.generatedAt,
-                data: nil,
-                issues: [.init(
-                    source: .memory,
-                    code: .memoryUnavailable,
-                    retryable: true)]))
+            presentation: .unavailable,
+            serverState: .unavailable,
+            generatedAt: FamiliarDashboardFixtures.generatedAt,
+            data: nil,
+            issues: [FamiliarDashboardIssue(
+                source: .memory,
+                code: .memoryUnavailable,
+                retryable: true)])
         XCTAssertEqual(FamiliarProfilePresentation.memory(unavailable), "Unavailable")
 
         let emptyPayload = try FamiliarDashboardFixtures.payload(

--- a/apps/ios/CovenCave/CovenCaveTests/FamiliarProfilePresentationTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/FamiliarProfilePresentationTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import CovenCave
+
+final class FamiliarProfilePresentationTests: XCTestCase {
+    private func decodedProfile() throws -> FamiliarDashboardProfile {
+        let payload = try FamiliarDashboardFixtures.payload()
+        return try XCTUnwrap(payload.sections.profile.data)
+    }
+
+    private func decodedFamiliar(_ fields: String = "") throws -> Familiar {
+        let json = """
+        {
+          "id": "nova",
+          "display_name": "Nova"
+          \(fields.isEmpty ? "" : ",\n" + fields)
+        }
+        """
+        return try JSONDecoder().decode(Familiar.self, from: Data(json.utf8))
+    }
+
+    func testConfiguredProfileValuesKeepTheirProvenance() throws {
+        let profile = try decodedProfile()
+
+        XCTAssertEqual(FamiliarProfilePresentation.value(profile.description), "Keeps the loader honest")
+        XCTAssertEqual(FamiliarProfilePresentation.value(profile.familiarType), "engineer")
+        XCTAssertEqual(FamiliarProfilePresentation.runtime(profile), "claude-code")
+        XCTAssertEqual(FamiliarProfilePresentation.model(profile), "opus")
+        XCTAssertEqual(FamiliarProfilePresentation.modelSource(profile), "Familiar default")
+        XCTAssertEqual(
+            FamiliarProfilePresentation.contract(profile.contract),
+            "7 of 9 checks passed")
+    }
+
+    func testAbsentOptionalValuesNeverMasqueradeAsZeroOrUnavailable() throws {
+        let familiar = try decodedFamiliar()
+        let profile = try JSONDecoder().decode(
+            FamiliarDashboardProfile.self,
+            from: Data("""
+            {
+              "description": null,
+              "familiarType": "   ",
+              "runtime": {
+                "harness": null,
+                "defaultHarness": null,
+                "harnessOverride": null,
+                "model": null,
+                "modelProvenance": "unconfigured"
+              },
+              "glyph": { "icon": null, "emoji": null, "color": null },
+              "configuration": { "note": null, "autoSelfReport": false },
+              "contract": null
+            }
+            """.utf8)
+        )
+
+        XCTAssertEqual(FamiliarProfilePresentation.value(profile.description), "Not set")
+        XCTAssertEqual(FamiliarProfilePresentation.value(profile.familiarType), "Not set")
+        XCTAssertEqual(FamiliarProfilePresentation.runtime(profile), "Not set")
+        XCTAssertEqual(FamiliarProfilePresentation.model(profile), "Not set")
+        XCTAssertEqual(FamiliarProfilePresentation.modelSource(profile), "Runtime default")
+        XCTAssertEqual(FamiliarProfilePresentation.voice(familiar), "Not set")
+        XCTAssertEqual(FamiliarProfilePresentation.image(familiar), "Not set")
+        XCTAssertEqual(FamiliarProfilePresentation.contract(profile.contract), "Not set")
+    }
+
+    func testRosterVoiceAndImageDefaultsDecodeWithoutInventedFallbacks() throws {
+        let familiar = try decodedFamiliar("""
+          "voiceProvider": "openai",
+          "voiceModel": "gpt-realtime",
+          "voiceName": "cedar",
+          "imageProvider": "openai",
+          "imageModel": "gpt-image-1",
+          "imageSize": "1536x1024",
+          "imageQuality": "high",
+          "autoSelfReport": true
+        """)
+
+        XCTAssertEqual(
+            FamiliarProfilePresentation.voice(familiar),
+            "openai · gpt-realtime · cedar")
+        XCTAssertEqual(
+            FamiliarProfilePresentation.image(familiar),
+            "openai · gpt-image-1 · 1536x1024 · high")
+        XCTAssertEqual(familiar.autoSelfReport, true)
+    }
+
+    func testMemoryDistinguishesUnavailableFromAReadWithNoEntries() throws {
+        let payload = try FamiliarDashboardFixtures.payload()
+        XCTAssertNotEqual(
+            FamiliarProfilePresentation.memory(
+                .merged(previous: nil, incoming: payload.sections.overview)),
+            "Unavailable")
+
+        let unavailable = FamiliarDashboardClientSection<FamiliarDashboardOverview>(
+            wire: .init(
+                state: .unavailable,
+                generatedAt: FamiliarDashboardFixtures.generatedAt,
+                data: nil,
+                issues: [.init(
+                    source: .memory,
+                    code: .memoryUnavailable,
+                    retryable: true)]))
+        XCTAssertEqual(FamiliarProfilePresentation.memory(unavailable), "Unavailable")
+
+        let emptyPayload = try FamiliarDashboardFixtures.payload(
+            overview: FamiliarDashboardFixtures.section(
+                state: "empty",
+                data: FamiliarDashboardFixtures.emptyOverviewData))
+        XCTAssertEqual(
+            FamiliarProfilePresentation.memory(
+                .merged(previous: nil, incoming: emptyPayload.sections.overview)),
+            "No memory yet")
+    }
+}

--- a/scripts/ios-chat-familiars-home.test.mjs
+++ b/scripts/ios-chat-familiars-home.test.mjs
@@ -78,18 +78,8 @@ assert.match(
 );
 assert.match(
   familiarList,
-  /FamiliarDetailStatsModel\.make\(app: app, familiar: familiar, context: scopedContext\)/,
-  "familiar detail stats should be derived from the explicit active project context",
-);
-assert.match(
-  familiarList,
-  /app\.lastActivity\(for: familiar\.id, in: \$0\)/,
-  "familiar detail activity should stay scoped to the explicit project context",
-);
-assert.match(
-  familiarList,
-  /return "No activity yet"/,
-  "familiar detail stats should fall back cleanly when the active project has no activity for a familiar",
+  /FamiliarHubView\(familiar: familiar\)/,
+  "the roster opens the dashboard-backed Familiar hub",
 );
 
 const home = await read("apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift");

--- a/scripts/ios-claude-design-fidelity.test.mjs
+++ b/scripts/ios-claude-design-fidelity.test.mjs
@@ -985,13 +985,8 @@ assert.match(
 );
 assert.match(
   familiars,
-  /statCard\("Chats", value: statsModel\.chats, icon: "bubble\.left"\)/,
-  "familiar detail chat counts are scoped through the active project stats model",
-);
-assert.match(
-  familiars,
-  /let assignedTasks = context\.map \{ scopedContext in[\s\S]*scopedContext\.matches\(task: \$0, registeredProjects: app\.projects\)[\s\S]*&& \$0\.familiarId == familiar\.id/,
-  "familiar detail task counts are scoped to the explicit active project context",
+  /let profile: FamiliarDashboardProfile[\s\S]{0,180}let overview: FamiliarDashboardClientSection<FamiliarDashboardOverview>/,
+  "the Familiar Profile is driven by the coherent dashboard snapshot",
 );
 assert.match(root, /--ui-open-search/, "simulator validation can launch directly into global search");
 assert.match(root, /--ui-open-projects/, "simulator validation can launch directly into projects");

--- a/scripts/ios-familiar-profile.test.mjs
+++ b/scripts/ios-familiar-profile.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+
+const hub = await read("apps/ios/CovenCave/CovenCave/Views/FamiliarHubView.swift");
+const profile = await read("apps/ios/CovenCave/CovenCave/Views/FamiliarsListView.swift");
+const dashboard = await read("apps/ios/CovenCave/CovenCave/Models/FamiliarDashboard.swift");
+const models = await read("apps/ios/CovenCave/CovenCave/Models/Models.swift");
+
+assert.match(
+  hub,
+  /if let profile = section\.data[\s\S]{0,600}FamiliarDetailView\([\s\S]{0,260}identity: snapshot\.identity[\s\S]{0,180}profile: profile[\s\S]{0,180}overview: snapshot\.overview/,
+  "Profile renders only dashboard data from the current coherent snapshot",
+);
+assert.match(
+  hub,
+  /FamiliarDashboardUnavailableView\([\s\S]{0,180}title: "Profile"[\s\S]{0,180}section\.visibleIssues/,
+  "an unreadable Profile section stays visibly unavailable",
+);
+assert.doesNotMatch(
+  hub,
+  /FamiliarDetailView\(familiar: familiar\)/,
+  "Profile never falls back to a roster-only page that hides section failure",
+);
+assert.match(
+  hub,
+  /else \{\s*loadingSkeleton\s*\}/,
+  "Profile inherits the hub's explicit initial loading state",
+);
+assert.match(
+  hub,
+  /else if let error = entry\.error, entry\.phase == \.failed \{\s*fullSurfaceError\(error\)/,
+  "Profile inherits the hub's full-load error state",
+);
+
+for (const section of [
+  "Identity",
+  "Purpose and vocation",
+  "Defaults",
+  "Memory and media",
+  "Capability contract",
+  "Access",
+]) {
+  assert.match(profile, new RegExp(`Text\\(\"${section}\"\\)`), `Profile includes ${section}`);
+}
+
+for (const field of [
+  "Name",
+  "Role",
+  "Pronouns",
+  "Familiar ID",
+  "Purpose",
+  "Vocation",
+  "Configuration note",
+  "Runtime",
+  "Self-reports",
+  "Memory",
+  "Voice",
+  "Image defaults",
+  "Status",
+]) {
+  assert.match(
+    profile,
+    new RegExp(`detailValue\\(\\s*\"${field}\"`),
+    `Profile renders ${field}`,
+  );
+}
+
+assert.match(
+  dashboard,
+  /enum FamiliarProfilePresentation[\s\S]{0,500}static let notSet = "Not set"/,
+  "successful absent values use one explicit Not set contract",
+);
+assert.match(
+  dashboard,
+  /guard let memory = section\.data\?\.memory else \{ return "Unavailable" \}/,
+  "memory failure is distinct from a successful empty read",
+);
+for (const field of ["imageProvider", "imageModel", "imageSize", "imageQuality"]) {
+  assert.match(models, new RegExp(`var ${field}: String\\? = nil`), `the roster decodes ${field}`);
+}
+
+assert.match(
+  profile,
+  /ViewThatFits\(in: \.horizontal\)[\s\S]{0,900}\.frame\(maxWidth: \.infinity, minHeight: 44/,
+  "profile rows stack under Dynamic Type pressure and retain 44-point targets",
+);
+assert.match(
+  profile,
+  /\.accessibilityLabel\("\\\(label\): \\\(value\)"\)/,
+  "every profile fact exposes its name and value together to VoiceOver",
+);
+assert.match(
+  profile,
+  /ModelPickerSheet\([\s\S]{0,400}application: \.familiarDefault/,
+  "model editing stays on the familiar-default inventory contract",
+);
+assert.match(
+  profile,
+  /FamiliarPermissionsSheet\(familiar: familiar\)/,
+  "project and tool access stays on the authoritative permissions surface",
+);
+assert.match(
+  profile,
+  /uploadFamiliarAvatar\([\s\S]{0,220}applyFamiliarAvatarMutation[\s\S]*deleteFamiliarAvatar\([\s\S]{0,220}applyFamiliarAvatarMutation/,
+  "the avatar affordance is backed by real upload and delete mutations",
+);
+
+console.log("ios-familiar-profile.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1798,6 +1798,7 @@ export const SUITES = {
     "scripts/ios-app-store-assets.test.mjs",
     "scripts/ios-chat-project-contract.test.mjs",
     "scripts/ios-chat-familiars-home.test.mjs",
+    "scripts/ios-familiar-profile.test.mjs",
     "scripts/ios-project-generation.test.mjs",
     "scripts/ios-chat-restyle.test.mjs",
     "scripts/ios-claude-design-fidelity.test.mjs",


### PR DESCRIPTION
## Summary

- replace the roster-only Profile fallback with the coherent Familiar dashboard profile
- show identity, purpose, vocation, runtime/model provenance, memory, voice and image defaults, capability contract, and authoritative access controls
- keep absent, unavailable, stale, loading, and error states distinct
- preserve the real model, permissions, and avatar mutation paths
- add native presentation tests and a wired source-contract regression

Closes #4913
Bead: cave-9rwd.4

## Validation

Passed locally:
- pnpm test:mobile (92 files)
- pnpm typecheck
- pnpm lint
- pnpm check:tests-wired
- node scripts/ios-familiar-profile.test.mjs
- node scripts/ios-claude-design-fidelity.test.mjs
- node scripts/ios-chat-familiars-home.test.mjs
- git diff --check
- node --require ./scripts/css-source-contract-hook.cjs scripts/worktree-lifecycle-create.test.mjs

Local environment limitations:
- pnpm test:app passed 178 files, then mkfifo failed because the checkout is on a Windows-mounted filesystem that does not support FIFOs.
- pnpm test:api passed 34 files, then the lifecycle fixture hit a WSL heartbeat-regression race. The exact failing lifecycle file passes standalone.
- Xcode, an iOS simulator, and native visual verification are unavailable in WSL; the macOS native build job is the authoritative build check.
