### PR TITLE
ci: isolate PR and release E2E servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,7 @@ jobs:
           exit 1
 
   frontend-e2e:
-    name: Frontend E2E (${{ matrix.shard }}/4)
+    name: Frontend E2E (${{ matrix.shard }}/8)
     needs: paths
     if: needs.paths.outputs.e2e == 'true' && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)
     runs-on: ubuntu-latest
@@ -360,7 +360,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       NEXT_PUBLIC_CAVE_CRAFTS: "1"
     steps:
@@ -379,7 +379,7 @@ jobs:
       - run: pnpm exec playwright install --with-deps chromium webkit
 
       - name: Validate end-to-end behavior
-        run: pnpm exec playwright test --shard=${{ matrix.shard }}/4
+        run: pnpm exec playwright test --shard=${{ matrix.shard }}/8 --workers=1
 
   frontend-e2e-agentic:
     name: Frontend E2E (agentic)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,7 +369,7 @@ jobs:
       - daemon-package
       - source-version
     runs-on: ubuntu-24.04
-    timeout-minutes: 75
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -404,7 +404,7 @@ jobs:
           done
           exit 1
       - run: pnpm exec playwright install --with-deps chromium webkit
-      - run: pnpm exec playwright test
+      - run: pnpm exec playwright test --workers=1
 
   release-platform-validation:
     name: Validate release runtime (${{ matrix.os }})

--- a/scripts/ci-recovery-workflow.test.mjs
+++ b/scripts/ci-recovery-workflow.test.mjs
@@ -82,11 +82,11 @@ const defaultE2e = ciWorkflow.jobs["frontend-e2e"].steps.find(
   (step) => step.name === "Validate end-to-end behavior",
 );
 assert.ok(defaultE2e, "CI keeps default-off end-to-end coverage");
-assert.deepEqual(ciWorkflow.jobs["frontend-e2e"].strategy.matrix.shard, [1, 2, 3, 4]);
+assert.deepEqual(ciWorkflow.jobs["frontend-e2e"].strategy.matrix.shard, [1, 2, 3, 4, 5, 6, 7, 8]);
 assert.equal(ciWorkflow.jobs["frontend-e2e"].strategy["fail-fast"], false);
 assert.equal(
   defaultE2e.run,
-  "pnpm exec playwright test --shard=${{ matrix.shard }}/4",
+  "pnpm exec playwright test --shard=${{ matrix.shard }}/8 --workers=1",
   "default end-to-end coverage is distributed across independently retryable runners",
 );
 assert.equal(defaultE2e.env, undefined, "default end-to-end coverage does not enable agentic recommendations");

--- a/scripts/release-promotion-workflow.test.mjs
+++ b/scripts/release-promotion-workflow.test.mjs
@@ -192,6 +192,7 @@ test("final publishing is final-tag-only and transitively promotion-authorized",
   const releaseWeb = release.jobs["release-web-validation"];
 
   assert.deepEqual(release.on.push.tags, ["v*.*.*", "!v*.*.*-*"]);
+  assert.ok(releaseWeb, "release workflow keeps the web validation gate");
   assert.equal(authorization.name, "Authorize release promotion");
   assert.deepEqual(authorization.permissions, { actions: "read", contents: "read" });
   const authorizationCheckout = authorization.steps.find((step) =>

--- a/scripts/release-promotion-workflow.test.mjs
+++ b/scripts/release-promotion-workflow.test.mjs
@@ -189,6 +189,7 @@ test("candidate validation requires signed tag provenance and calls every deferr
 test("final publishing is final-tag-only and transitively promotion-authorized", async () => {
   const release = await workflow("release.yml");
   const authorization = release.jobs["authorize-release-promotion"];
+  const releaseWeb = release.jobs["release-web-validation"];
 
   assert.deepEqual(release.on.push.tags, ["v*.*.*", "!v*.*.*-*"]);
   assert.equal(authorization.name, "Authorize release promotion");
@@ -208,6 +209,11 @@ test("final publishing is final-tag-only and transitively promotion-authorized",
   );
   assert.equal(release.jobs["daemon-package"].needs, "authorize-release-promotion");
   assert.equal(release.jobs["source-version"].needs, "authorize-release-promotion");
+  assert.equal(releaseWeb["timeout-minutes"], 90);
+  assert.ok(
+    releaseWeb.steps.some((step) => step.run === "pnpm exec playwright test --workers=1"),
+    "final release E2E isolates the browser behind one dev-server worker",
+  );
   assert.equal(
     release.jobs["source-version"].outputs["release-commit"],
     "${{ steps.release.outputs.commit }}",


### PR DESCRIPTION
## Summary

- split routine PR Playwright into 8 shards with 1 worker per server
- serialize final release web E2E behind one worker and add timeout headroom
- lock both workflow contracts with focused tests

## Evidence

- `node --test scripts/ci-recovery-workflow.test.mjs scripts/release-promotion-workflow.test.mjs`
- `pnpm check:tests-wired` (1,859 files)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:test-clocks`
- `git diff --check`
- v0.3.10-rc.5 run 32783564206 proved all 8 isolated candidate shards on the same release SHA
- v0.3.10 release run 32786106087 and fresh PR runs #4995/#4998 reproduced shared-server `ECONNRESET`, unrelated timeouts, and hosted-runner shutdown under 2 workers

Bead: cave-a04y4