### PR TITLE
fix(ios): restore deterministic XCTest gate

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -273,7 +273,7 @@ final class AppModel {
     }
 
     private struct CoordinatedLoadToken: Equatable {
-        enum Scope: Equatable {
+        enum Scope: Hashable {
             case standalone
             case projectContext
         }
@@ -291,10 +291,10 @@ final class AppModel {
         var nextRequestId: UInt64 = 0
         var freshest: CoordinatedLoadToken?
         var lastApplied: CoordinatedLoadToken?
-        var inFlight: (
+        var inFlightByScope: [CoordinatedLoadToken.Scope: (
             token: CoordinatedLoadToken,
             task: Task<CoordinatedLoadOutput<Value>, Never>
-        )?
+        )] = [:]
     }
 
     nonisolated static let projectContextStorageKeyPrefix = "cave.project-context.v2"
@@ -936,9 +936,8 @@ final class AppModel {
         token: CoordinatedLoadToken,
         task: Task<CoordinatedLoadOutput<Value>, Never>
     ) {
-        if let inFlight = state.inFlight,
-           inFlight.token.generation == generation,
-           inFlight.token.scope == scope {
+        if let inFlight = state.inFlightByScope[scope],
+           inFlight.token.generation == generation {
             return inFlight
         }
 
@@ -955,7 +954,7 @@ final class AppModel {
             )
         }
         let handle = (token: token, task: task)
-        state.inFlight = handle
+        state.inFlightByScope[scope] = handle
         return handle
     }
 
@@ -966,8 +965,9 @@ final class AppModel {
         ),
         state: inout CoordinatedLoadState<Value>
     ) {
-        guard state.inFlight?.token == handle.token else { return }
-        state.inFlight = nil
+        let scope = handle.token.scope
+        guard state.inFlightByScope[scope]?.token == handle.token else { return }
+        state.inFlightByScope.removeValue(forKey: scope)
     }
 
     private func coordinatedLoadShouldApply<Value>(

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -273,8 +273,14 @@ final class AppModel {
     }
 
     private struct CoordinatedLoadToken: Equatable {
+        enum Scope: Equatable {
+            case standalone
+            case projectContext
+        }
+
         let generation: UInt64?
         let requestId: UInt64
+        let scope: Scope
     }
 
     private struct CoordinatedLoadOutput<Value>: @unchecked Sendable {
@@ -924,20 +930,23 @@ final class AppModel {
     private func beginCoordinatedLoad<Value>(
         _ state: inout CoordinatedLoadState<Value>,
         generation: UInt64?,
+        scope: CoordinatedLoadToken.Scope,
         operation: @escaping @Sendable () async throws -> Value
     ) -> (
         token: CoordinatedLoadToken,
         task: Task<CoordinatedLoadOutput<Value>, Never>
     ) {
         if let inFlight = state.inFlight,
-           inFlight.token.generation == generation {
+           inFlight.token.generation == generation,
+           inFlight.token.scope == scope {
             return inFlight
         }
 
         state.nextRequestId &+= 1
         let token = CoordinatedLoadToken(
             generation: generation,
-            requestId: state.nextRequestId
+            requestId: state.nextRequestId,
+            scope: scope
         )
         state.freshest = token
         let task = Task {
@@ -994,12 +1003,17 @@ final class AppModel {
 
     private func coordinatedSessionsLoad(
         using client: any ProjectContextLoadingClient,
-        generation: UInt64?
+        generation: UInt64?,
+        scope: CoordinatedLoadToken.Scope = .standalone
     ) async -> (
         token: CoordinatedLoadToken,
         result: Result<[SessionRow], any Error>
     ) {
-        let handle = beginCoordinatedLoad(&sessionsLoadState, generation: generation) {
+        let handle = beginCoordinatedLoad(
+            &sessionsLoadState,
+            generation: generation,
+            scope: scope
+        ) {
             try await client.sessions()
         }
         let output = await handle.task.value
@@ -1009,12 +1023,17 @@ final class AppModel {
 
     private func coordinatedTasksLoad(
         using client: any ProjectContextLoadingClient,
-        generation: UInt64?
+        generation: UInt64?,
+        scope: CoordinatedLoadToken.Scope = .standalone
     ) async -> (
         token: CoordinatedLoadToken,
         result: Result<[BoardCard], any Error>
     ) {
-        let handle = beginCoordinatedLoad(&tasksLoadState, generation: generation) {
+        let handle = beginCoordinatedLoad(
+            &tasksLoadState,
+            generation: generation,
+            scope: scope
+        ) {
             try await client.tasks()
         }
         let output = await handle.task.value
@@ -3803,7 +3822,8 @@ final class AppModel {
         if !haveUsableSessions {
             let loadedSessions = await coordinatedSessionsLoad(
                 using: client,
-                generation: navigationGeneration
+                generation: navigationGeneration,
+                scope: .projectContext
             )
             guard !Task.isCancelled, loadNonce == projectContextLoadNonce else {
                 throw CancellationError()
@@ -3857,7 +3877,8 @@ final class AppModel {
         ) {
             let loadedTasks = await coordinatedTasksLoad(
                 using: client,
-                generation: navigationGeneration
+                generation: navigationGeneration,
+                scope: .projectContext
             )
             guard !Task.isCancelled, loadNonce == projectContextLoadNonce else {
                 throw CancellationError()

--- a/apps/ios/CovenCave/CovenCaveTests/AppModelProjectContextTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppModelProjectContextTests.swift
@@ -4098,6 +4098,7 @@ final class AppModelProjectContextTests: XCTestCase {
         )
         let app = makeApp(coreResourceClientFactory: { _ in initialClient })
         _ = connect(app, host: "http://127.0.0.1:1")
+        await app.loadProjectContext(using: initialClient)
         app.projects = [alpha]
         app.projectsLoaded = true
         app.projectMembership = ProjectMembershipIndex(
@@ -4106,6 +4107,7 @@ final class AppModelProjectContextTests: XCTestCase {
         app.projectMembershipLoaded = true
         app.familiars = [familiar("nova", "Nova")]
         app.projectContext = .project(alpha)
+        let baselineInitialCalls = await initialClient.callLog.snapshot()
 
         let existing = ChatThread(
             title: "Recovered local copy",
@@ -4146,7 +4148,7 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(app.selectedTab, .chats)
         XCTAssertEqual(app.threads.count, 1)
         let initialCalls = await initialClient.callLog.snapshot()
-        XCTAssertEqual(initialCalls.sessions, 1)
+        XCTAssertEqual(initialCalls.sessions, baselineInitialCalls.sessions + 1)
         let refreshedCalls = await refreshedClient.callLog.snapshot()
         XCTAssertEqual(refreshedCalls.sessions, 1)
     }

--- a/apps/ios/CovenCave/CovenCaveTests/AppModelProjectContextTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppModelProjectContextTests.swift
@@ -5901,6 +5901,57 @@ final class AppModelProjectContextTests: XCTestCase {
     }
 
     @MainActor
+    func testTaskLoadsRemainSingleFlightPerScopeWhenScopesInterleave() async {
+        let alpha = project("alpha", "Alpha")
+        let standaloneStarted = Gate()
+        let standaloneRelease = Gate()
+        let standaloneClient = ControlledCoreClient(
+            projects: [alpha],
+            grants: grants(),
+            familiars: [familiar("nova", "Nova")],
+            tasks: [card("standalone-task", familiarId: "nova", projectId: alpha.id)],
+            taskStarted: standaloneStarted,
+            taskRelease: standaloneRelease
+        )
+        let contextStarted = Gate()
+        let contextRelease = Gate()
+        let contextClient = ControlledCoreClient(
+            projects: [alpha],
+            grants: grants(),
+            familiars: [familiar("nova", "Nova")],
+            sessions: [],
+            tasks: [card("context-task", familiarId: "nova", projectId: alpha.id)],
+            taskStarted: contextStarted,
+            taskRelease: contextRelease
+        )
+        let app = makeApp(coreResourceClientFactory: { _ in standaloneClient })
+        _ = connect(app, host: "http://127.0.0.1:1")
+
+        let firstStandalone = Task { await app.loadTasks(using: standaloneClient) }
+        await standaloneStarted.wait()
+        let contextLoad = Task { await app.loadProjectContext(using: contextClient) }
+        await contextStarted.wait()
+
+        let thirdLoadStarted = expectation(description: "third task load started")
+        let secondStandalone = Task {
+            thirdLoadStarted.fulfill()
+            await app.loadTasks(using: standaloneClient)
+        }
+        await fulfillment(of: [thirdLoadStarted], timeout: 1)
+        await Task.yield()
+
+        await standaloneRelease.open()
+        await firstStandalone.value
+        await secondStandalone.value
+
+        let standaloneCalls = await standaloneClient.callLog.snapshot()
+        XCTAssertEqual(standaloneCalls.tasks, 1)
+
+        await contextRelease.open()
+        await contextLoad.value
+    }
+
+    @MainActor
     func testNewerStandaloneSessionsLoadWinsOverOlderSuccessfulSessionSnapshotFallback() async {
         let alpha = project("alpha", "Alpha")
         let beta = project("beta", "Beta")

--- a/apps/ios/CovenCave/CovenCaveTests/CaveVoiceTurnSenderTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/CaveVoiceTurnSenderTests.swift
@@ -193,6 +193,7 @@ final class CaveVoiceTurnSenderTests: XCTestCase {
     func testCancellationAfterSessionBindingReturnsTheLatestBoundSessionWithoutReadingLateReplyFrames() async throws {
         var continuation: AsyncThrowingStream<CaveClient.StreamFrame, Error>.Continuation?
         var publishedSessionIds: [String] = []
+        let sessionBound = expectation(description: "session binding published")
         let sender = CaveVoiceTurnSender { _ in
             AsyncThrowingStream { streamContinuation in
                 continuation = streamContinuation
@@ -207,6 +208,7 @@ final class CaveVoiceTurnSenderTests: XCTestCase {
                 projectRoot: "/repos/alpha",
                 onSessionBound: { sessionId in
                     publishedSessionIds.append(sessionId)
+                    sessionBound.fulfill()
                 }
             )
         }
@@ -219,7 +221,7 @@ final class CaveVoiceTurnSenderTests: XCTestCase {
             id: 1
         ))
 
-        for _ in 0..<20 where publishedSessionIds.isEmpty { await Task.yield() }
+        await fulfillment(of: [sessionBound], timeout: 1)
         XCTAssertEqual(publishedSessionIds, ["session-late"])
 
         replyTask.cancel()

--- a/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
@@ -19,7 +19,10 @@ final class PairingIntentTests: XCTestCase {
     }
 
     func testNonConnectDeepLinkStillRoutesWithoutCreatingPairingIntent() throws {
-        let app = AppModel()
+        let suiteName = "PairingIntentTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let app = AppModel(defaults: defaults, restoreLocalState: false)
         app.selectedTab = .settings
         let url = try XCTUnwrap(URL(string: "covencave://tasks"))
 

--- a/scripts/ios-xctest-summary.mjs
+++ b/scripts/ios-xctest-summary.mjs
@@ -197,15 +197,6 @@ export function countXCTestMethodsInDirectory(dir, { readDir = readdirSync, read
 export const QUARANTINED_FAILURES = new Map([
   // ── Residue after #4958. Each needs a decision, not a patch ──────────────
   [
-    "testNewerStandaloneTasksLoadWinsOverOlderSuccessfulTaskSnapshot",
-    {
-      bead: "cave-dwy2a",
-      reason:
-        "Hangs. It wedged the very first run of this suite for 36 minutes; -test-timeouts-enabled now converts it into a named 60s failure so the rest of the suite still reports.",
-      expires: "2026-09-27",
-    },
-  ],
-  [
     "testConcurrentTaskChatOpensReuseOneAuthoritativeThread",
     { bead: "cave-22b4y", reason: "resolveProjectNavigation answers .pending until .projects has succeeded in the current generation, and openChat treats pending as failure.", expires: "2026-09-27" },
   ],


### PR DESCRIPTION
## Summary

Restores the iOS XCTest release gate after #5009 exposed nondeterministic synchronization and a coordinated-load deadlock.

## Why

PR #5009 ran all 688 native tests but failed on two unquarantined races. A full local replay also exposed a stale quarantine whose underlying same-generation refresh path deadlocked.

Bead: `cave-5wdtz`

## Changes

- wait on the voice session-binding event instead of a bounded yield loop
- bootstrap the recovery-thread fixture before asserting refreshed-session behavior
- isolate the deep-link fixture from process-wide persisted connection state
- preserve same-scope single-flight behavior while allowing standalone history refreshes to supersede project-context fallbacks
- track in-flight work per scope so cross-scope interleaving cannot erase deduplication
- remove the now-stale XCTest quarantine

## Verification

- focused CI blockers: 30/30 repeated passes
- coordinated-load and interleaving contracts: 30/30 repeated passes
- native gate: 689 executed; 681 passed; 8/8 remaining failures matched live quarantines
- `node --test scripts/ios-xctest-summary.test.mjs scripts/ios-build-ci.test.mjs`
- `pnpm test:mobile` (92/92 files)
- `pnpm typecheck`
- `pnpm lint`
- post-main-merge release/parser workflow tests: 42/42

## Risk + rollout notes

Freshness tokens still prevent older completions from overwriting newer results. Per-scope in-flight storage preserves independent single-flight semantics when project-context and standalone refreshes overlap.