### PR TITLE
fix(ci): skip desktop publishing for iOS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1723,7 +1723,7 @@ jobs:
       id-token: write
       attestations: write
     runs-on: ubuntu-24.04
-    if: ${{ success() && (github.event_name != 'workflow_dispatch' || !inputs.windows_diagnostics_only) }}
+    if: ${{ success() && (github.event_name != 'workflow_dispatch' || (inputs.platform != 'ios' && !inputs.windows_diagnostics_only)) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -1891,7 +1891,7 @@ jobs:
     # succeeded" rule for EVERY dependency, so rollback-readiness has to be
     # named explicitly or a failed rollback gate would still publish the
     # manifest that moves users forward.
-    if: ${{ !cancelled() && needs.build.result != 'cancelled' && needs.build.result != 'skipped' && needs.rollback-readiness.result == 'success' && (github.event_name != 'workflow_dispatch' || !inputs.windows_diagnostics_only) }}
+    if: ${{ !cancelled() && needs.build.result != 'cancelled' && needs.build.result != 'skipped' && needs.rollback-readiness.result == 'success' && (github.event_name != 'workflow_dispatch' || (inputs.platform != 'ios' && !inputs.windows_diagnostics_only)) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/scripts/release-promotion-workflow.test.mjs
+++ b/scripts/release-promotion-workflow.test.mjs
@@ -875,6 +875,36 @@ test("checksums publishes SHA256SUMS only for a wholly successful build", async 
   );
 });
 
+test("iOS-only recovery does not run desktop release publication", async () => {
+  const release = await workflow("release.yml");
+  const iosOnly = releaseRun({
+    event: "workflow_dispatch",
+    inputs: { platform: "ios" },
+    needs: {
+      build: { result: "success" },
+      "rollback-readiness": { result: "success" },
+    },
+  });
+
+  for (const name of ["checksums", "updater-manifest"]) {
+    assert.equal(
+      evaluateCondition(release.jobs[name].if, iosOnly),
+      false,
+      `${name} must skip when an iOS-only dispatch intentionally produces no desktop release`,
+    );
+  }
+
+  assert.deepEqual(needs(release.jobs.homebrew), ["checksums"]);
+  assert.equal(
+    evaluateCondition(
+      release.jobs.homebrew.if,
+      releaseRun({ cancelled: false, needs: { checksums: { result: "skipped" } } }),
+    ),
+    false,
+    "Homebrew notification must remain transitively skipped with desktop checksums",
+  );
+});
+
 test("release-ios-build carries its platform selection once, at job level", async () => {
   const release = await workflow("release.yml");
   const ios = release.jobs["release-ios-build"];


### PR DESCRIPTION
## Summary
- skip desktop checksum publication during iOS-only recovery dispatches
- skip updater-manifest publication when no desktop GitHub Release is expected
- pin Homebrew transitive skip behavior with a workflow contract regression

## Verification
- `node --test scripts/release-promotion-workflow.test.mjs scripts/release-packaging-contract.test.mjs scripts/release-macos-signing.test.mjs scripts/release-rollback-readiness.test.mjs scripts/stamp-release.test.mjs` (54/54)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:tests-wired` (1,865 files)
- `git diff --check`

Bead: cave-soobc

Signed-off-by: Val Alexander <68980965+BunsDev@users.noreply.github.com>