### PR TITLE
perf(chat): share large-list project grouping

### DIFF
--- a/docs/superpowers/plans/2026-08-24-chat-list-grouping-latency.md
+++ b/docs/superpowers/plans/2026-08-24-chat-list-grouping-latency.md
@@ -1,0 +1,160 @@
+# Chat List Grouping Latency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the duplicate full project-grouping pass from the default large chat-list render and preserve a reproducible before/after benchmark.
+
+**Architecture:** Add one pure grouping coordinator that applies overrides once and reuses the grouped result when the visible list and rail list are the same array. Keep the existing `deriveChatProjectGroups` implementation and all filtering, sorting, drag/drop, and accessibility behavior unchanged; `ChatList` only selects the no-op filter fast path and delegates the two grouping outputs.
+
+**Tech Stack:** TypeScript, React `useMemo`, Node test runner, existing chat-project benchmark.
+
+---
+
+### Task 1: Pin shared grouping semantics
+
+**Files:**
+- Create: `src/lib/chat-list-grouping.ts`
+- Create: `src/lib/chat-list-grouping.test.ts`
+
+- [x] **Step 1: Write the failing shared-input tests**
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import { deriveChatListProjectGroups } from "./chat-list-grouping.ts";
+
+test("shared list input reuses one grouped result", () => {
+  const sessions = [session("one", "/work/one")];
+  const result = deriveChatListProjectGroups(sessions, sessions, projects, projectIndex, {});
+  assert.equal(result.sidebarGroups, result.grouped);
+});
+
+test("different filtered and rail inputs preserve distinct scopes", () => {
+  const sessions = [session("one", "/work/one"), session("two", "/work/two")];
+  const result = deriveChatListProjectGroups(sessions.slice(0, 1), sessions, projects, projectIndex, {});
+  assert.deepEqual(result.grouped.flatMap((group) => group.sessions.map((row) => row.id)), ["one"]);
+  assert.deepEqual(result.sidebarGroups.flatMap((group) => group.sessions.map((row) => row.id)), ["one", "two"]);
+});
+```
+
+- [x] **Step 2: Run the focused test and verify it fails**
+
+Run: `node --test src/lib/chat-list-grouping.test.ts`
+
+Expected: FAIL because `src/lib/chat-list-grouping.ts` does not exist.
+
+- [x] **Step 3: Implement the grouping coordinator**
+
+```ts
+export function deriveChatListProjectGroups(
+  filteredSessions: SessionRow[],
+  railSessions: SessionRow[],
+  projects: CaveProject[],
+  projectIndex: ChatProjectIndex,
+  overrides: ProjectOverrides,
+): { grouped: ChatProjectGroup[]; sidebarGroups: ChatProjectGroup[] } {
+  const groupedSessions = applyProjectOverrides(filteredSessions, overrides);
+  const railGroupedSessions = filteredSessions === railSessions
+    ? groupedSessions
+    : applyProjectOverrides(railSessions, overrides);
+  const grouped = deriveChatProjectGroups(groupedSessions, projects, projectIndex, {
+    sessionsNewestFirst: true,
+  });
+  const sidebarGroups = railGroupedSessions === groupedSessions
+    ? grouped
+    : deriveChatProjectGroups(railGroupedSessions, projects, projectIndex, {
+      sessionsNewestFirst: true,
+    });
+  return { grouped, sidebarGroups };
+}
+```
+
+- [x] **Step 4: Run the focused test and verify it passes**
+
+Run: `node --test src/lib/chat-list-grouping.test.ts`
+
+Expected: both shared-input and split-scope tests pass.
+
+### Task 2: Wire the fast path and benchmark it
+
+**Files:**
+- Modify: `src/components/chat-list.tsx:299-350`
+- Modify: `src/components/chat-all-familiars-project-list.test.ts`
+- Modify: `src/components/chat-siderail-hide-archived.test.ts`
+- Modify: `scripts/chat-project-grouping-benchmark.mjs`
+- Modify: `scripts/run-tests.mjs`
+
+- [x] **Step 1: Preserve array identity for no-op list filters**
+
+```ts
+const railSessions = useMemo(
+  () => mine.some((session) => session.archived_at) ? mine.filter((session) => !session.archived_at) : mine,
+  [mine],
+);
+const searched = useMemo(
+  () => search.trim() ? filterChatListRows(mine, search, false) : mine,
+  [mine, search],
+);
+const filtered = useMemo(() => {
+  if (statusFilter === "all" && kindFilter === "all") return searched;
+  return filterChatRowsByKind(filterChatRowsByStatus(searched, statusFilter), kindFilter);
+}, [searched, statusFilter, kindFilter]);
+```
+
+- [x] **Step 2: Replace the two grouping memos with one coordinated memo**
+
+```ts
+const { grouped, sidebarGroups } = useMemo(
+  () => deriveChatListProjectGroups(
+    filtered,
+    railSessions,
+    projects,
+    projectIndex,
+    projectOverrides,
+  ),
+  [filtered, railSessions, projects, projectIndex, projectOverrides],
+);
+```
+
+- [x] **Step 3: Extend the existing benchmark with legacy-double and shared-pass measurements**
+
+```js
+const doubleGroupingMs = measure(() => {
+  const main = deriveChatProjectGroups(sessions, projects, projectIndex, { sessionsNewestFirst: true });
+  const rail = deriveChatProjectGroups(sessions, projects, projectIndex, { sessionsNewestFirst: true });
+  return groupChecksum(main) ^ groupChecksum(rail);
+});
+const sharedGroupingMs = measure(() => {
+  const { grouped, sidebarGroups } = deriveChatListProjectGroups(
+    sessions,
+    sessions,
+    projects,
+    projectIndex,
+    {},
+  );
+  return groupChecksum(grouped) ^ groupChecksum(sidebarGroups);
+});
+```
+
+- [x] **Step 4: Run focused correctness and benchmark proof**
+
+Run: `node --test src/lib/chat-list-grouping.test.ts src/lib/chat-list-model.test.ts src/lib/chat-projects.test.ts`
+
+Expected: all tests pass.
+
+Run: `pnpm bench:chat-projects`
+
+Expected: JSON includes `doubleGroupingP50Ms`, `sharedGroupingP50Ms`, and `sharedGroupingSpeedup`; the shared path is faster on the 10,000-session fixture.
+
+- [x] **Step 5: Run repository verification**
+
+Run: `pnpm lint && pnpm typecheck && pnpm check:tests-wired && git diff --check`
+
+Expected: all commands pass.
+
+- [x] **Step 6: Commit the verified unit**
+
+```bash
+git add docs/superpowers/plans/2026-08-24-chat-list-grouping-latency.md src/lib/chat-list-grouping.ts src/lib/chat-list-grouping.test.ts src/components/chat-list.tsx src/components/chat-all-familiars-project-list.test.ts src/components/chat-siderail-hide-archived.test.ts scripts/chat-project-grouping-benchmark.mjs scripts/run-tests.mjs
+git commit -S -s -m "perf(chat): share large-list project grouping (cave-i65lt)"
+```

--- a/scripts/chat-project-grouping-benchmark.mjs
+++ b/scripts/chat-project-grouping-benchmark.mjs
@@ -5,6 +5,7 @@ import {
   deriveChatProjectGroups,
   projectForRoot,
 } from "../src/lib/chat-projects.ts";
+import { deriveChatListProjectGroups } from "../src/lib/chat-list-grouping.ts";
 
 function positiveInteger(name, fallback) {
   const raw = process.env[name];
@@ -116,6 +117,43 @@ const linearFullGroupingMs = measure(() => groupChecksum(
 const indexedFullGroupingMs = measure(() => groupChecksum(
   deriveChatProjectGroups(sessions, projects, projectIndex, { sessionsNewestFirst: true }),
 ));
+const sharedResult = deriveChatListProjectGroups(
+  sessions,
+  sessions,
+  projects,
+  projectIndex,
+  {},
+);
+assert.equal(
+  sharedResult.sidebarGroups,
+  sharedResult.grouped,
+  "the default chat list must reuse one project-grouping result",
+);
+const doubleGroupingMs = measure(() => {
+  const main = deriveChatProjectGroups(
+    sessions,
+    projects,
+    projectIndex,
+    { sessionsNewestFirst: true },
+  );
+  const rail = deriveChatProjectGroups(
+    sessions,
+    projects,
+    projectIndex,
+    { sessionsNewestFirst: true },
+  );
+  return groupChecksum(main) + groupChecksum(rail);
+});
+const sharedGroupingMs = measure(() => {
+  const { grouped, sidebarGroups } = deriveChatListProjectGroups(
+    sessions,
+    sessions,
+    projects,
+    projectIndex,
+    {},
+  );
+  return groupChecksum(grouped) + groupChecksum(sidebarGroups);
+});
 
 console.log(JSON.stringify({
   fixture: { sessionCount, projectCount, iterations },
@@ -123,6 +161,9 @@ console.log(JSON.stringify({
   indexedLookupP50Ms: indexedLookupMs,
   linearFullGroupingP50Ms: linearFullGroupingMs,
   indexedFullGroupingP50Ms: indexedFullGroupingMs,
+  doubleGroupingP50Ms: doubleGroupingMs,
+  sharedGroupingP50Ms: sharedGroupingMs,
   lookupSpeedup: Number((linearLookupMs / indexedLookupMs).toFixed(1)),
   fullGroupingSpeedup: Number((linearFullGroupingMs / indexedFullGroupingMs).toFixed(1)),
+  sharedGroupingSpeedup: Number((doubleGroupingMs / sharedGroupingMs).toFixed(1)),
 }, null, 2));

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -599,6 +599,7 @@ export const SUITES = {
     "src/components/chat-list-delete.test.ts",
     "src/components/chat-list-filter-defaults.test.ts",
     "src/lib/chat-list-model.test.ts",
+    "src/lib/chat-list-grouping.test.ts",
     "src/components/chat-list-collapse.test.ts",
     "src/components/chat-list-render-optimization.test.ts",
     "src/components/chat-router-hide-archived.test.ts",

--- a/src/components/chat-all-familiars-project-list.test.ts
+++ b/src/components/chat-all-familiars-project-list.test.ts
@@ -41,7 +41,7 @@ assert.match(
 
 assert.match(
   chatList,
-  /createChatProjectIndex\(projects\)[\s\S]*deriveChatProjectGroups\(\s*applyProjectOverrides\(filtered, projectOverrides\),\s*projects,\s*projectIndex/,
+  /createChatProjectIndex\(projects\)[\s\S]*deriveChatListProjectGroups\(\s*filtered,\s*railSessions,\s*projects,\s*projectIndex,\s*projectOverrides/,
   "ChatList should group from the live project registry through its shared index, with Cave-local project overrides applied",
 );
 

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -33,10 +33,9 @@ import { useMinuteTick } from "@/lib/use-minute-tick";
 import { useDateTimePrefs, formatDate, type DateTimePrefs } from "@/lib/datetime-format";
 import {
   createChatProjectIndex,
-  deriveChatProjectGroups,
   filterVisibleChatSessions,
 } from "@/lib/chat-projects";
-import { applyProjectOverrides } from "@/lib/chat-project-overrides";
+import { deriveChatListProjectGroups } from "@/lib/chat-list-grouping";
 import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { ChatProjectSidebar } from "@/components/chat-project-sidebar";
 import { useProjects } from "@/lib/use-projects";
@@ -302,47 +301,47 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
 
   // The siderail never shows archived chats: even while the list's "Show
   // archived" toggle is on, rail groups build from an archive-free view.
-  const railSessions = useMemo(() => mine.filter((s) => !s.archived_at), [mine]);
+  const railSessions = useMemo(
+    () => mine.some((session) => session.archived_at)
+      ? mine.filter((session) => !session.archived_at)
+      : mine,
+    [mine],
+  );
 
   // Search first, then status. The chip counts describe the SEARCHED set, so
   // pressing one chip never renumbers the others — the number under "Failed"
   // means "failed among what you searched for", not "failed among what is
   // already filtered to failed".
-  const searched = useMemo(() => filterChatListRows(mine, search, false), [mine, search]);
+  const searched = useMemo(
+    () => search.trim() ? filterChatListRows(mine, search, false) : mine,
+    [mine, search],
+  );
   const statusCounts = useMemo(() => countChatSessionStatuses(searched), [searched]);
   const kindCounts = useMemo(() => countChatSessionKinds(searched), [searched]);
-  const filtered = useMemo(
-    () => filterChatRowsByKind(filterChatRowsByStatus(searched, statusFilter), kindFilter),
-    [searched, statusFilter, kindFilter],
-  );
+  const filtered = useMemo(() => {
+    if (statusFilter === "all" && kindFilter === "all") return searched;
+    return filterChatRowsByKind(filterChatRowsByStatus(searched, statusFilter), kindFilter);
+  }, [searched, statusFilter, kindFilter]);
 
   const hasAny = mine.length > 0;
 
   // ── Grouped by project_root ──────────────────────────────────────────────
 
   const projectIndex = useMemo(() => createChatProjectIndex(projects), [projects]);
-  const grouped = useMemo(() => {
-    return deriveChatProjectGroups(
-      applyProjectOverrides(filtered, projectOverrides),
-      projects,
-      projectIndex,
-      { sessionsNewestFirst: true },
-    );
-  }, [filtered, projects, projectOverrides, projectIndex]);
-
   // Sidebar tree builds from familiar-scoped sessions BEFORE search/unreads,
   // so it stays stable while typing. The view-local selection is normalized
   // every render: stale projects degrade to "all" silently. Below lg the
   // sidebar is hidden, so a project selection must not scope the list there —
   // no affordance would exist to unscope it.
-  const sidebarGroups = useMemo(
-    () => deriveChatProjectGroups(
-      applyProjectOverrides(railSessions, projectOverrides),
+  const { grouped, sidebarGroups } = useMemo(
+    () => deriveChatListProjectGroups(
+      filtered,
+      railSessions,
       projects,
       projectIndex,
-      { sessionsNewestFirst: true },
+      projectOverrides,
     ),
-    [railSessions, projects, projectOverrides, projectIndex],
+    [filtered, railSessions, projects, projectIndex, projectOverrides],
   );
   const effectiveSelection = useMemo(
     () => normalizeSelection(isMobile ? "all" : selection, sidebarGroups),

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -35,7 +35,10 @@ import {
   createChatProjectIndex,
   filterVisibleChatSessions,
 } from "@/lib/chat-projects";
-import { deriveChatListProjectGroups } from "@/lib/chat-list-grouping";
+import {
+  deriveChatListProjectGroups,
+  withoutArchivedChatSessions,
+} from "@/lib/chat-list-grouping";
 import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { ChatProjectSidebar } from "@/components/chat-project-sidebar";
 import { useProjects } from "@/lib/use-projects";
@@ -301,12 +304,7 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
 
   // The siderail never shows archived chats: even while the list's "Show
   // archived" toggle is on, rail groups build from an archive-free view.
-  const railSessions = useMemo(
-    () => mine.some((session) => session.archived_at)
-      ? mine.filter((session) => !session.archived_at)
-      : mine,
-    [mine],
-  );
+  const railSessions = useMemo(() => withoutArchivedChatSessions(mine), [mine]);
 
   // Search first, then status. The chip counts describe the SEARCHED set, so
   // pressing one chip never renumbers the others — the number under "Failed"

--- a/src/components/chat-siderail-hide-archived.test.ts
+++ b/src/components/chat-siderail-hide-archived.test.ts
@@ -50,7 +50,7 @@ assert.match(
 // …but the rail builds from an archive-free view of the same rows.
 assert.match(
   chatList,
-  /const railSessions = useMemo\([\s\S]{0,180}?mine\.some\(\(session\) => session\.archived_at\)[\s\S]{0,120}?mine\.filter\(\(session\) => !session\.archived_at\)[\s\S]{0,80}?: mine/,
+  /const railSessions = useMemo\(\(\) => withoutArchivedChatSessions\(mine\), \[mine\]\)/,
   "the siderail's session source strips archived rows even while the toggle is on",
 );
 assert.match(

--- a/src/components/chat-siderail-hide-archived.test.ts
+++ b/src/components/chat-siderail-hide-archived.test.ts
@@ -50,12 +50,12 @@ assert.match(
 // …but the rail builds from an archive-free view of the same rows.
 assert.match(
   chatList,
-  /const railSessions = useMemo\(\(\) => mine\.filter\(\(s\) => !s\.archived_at\), \[mine\]\);/,
+  /const railSessions = useMemo\([\s\S]{0,180}?mine\.some\(\(session\) => session\.archived_at\)[\s\S]{0,120}?mine\.filter\(\(session\) => !session\.archived_at\)[\s\S]{0,80}?: mine/,
   "the siderail's session source strips archived rows even while the toggle is on",
 );
 assert.match(
   chatList,
-  /const sidebarGroups = useMemo\([\s\S]{0,160}?deriveChatProjectGroups\(\s*applyProjectOverrides\(railSessions, projectOverrides\),\s*projects,\s*projectIndex/,
+  /deriveChatListProjectGroups\(\s*filtered,\s*railSessions,\s*projects,\s*projectIndex,\s*projectOverrides/,
   "sidebar groups must derive from the archive-free railSessions view",
 );
 

--- a/src/lib/chat-list-grouping.test.ts
+++ b/src/lib/chat-list-grouping.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { NO_CHAT_ATTENTION } from "./chat-attention.ts";
 import { createChatProjectIndex, type CaveProject } from "./chat-projects.ts";
 import { deriveChatListProjectGroups } from "./chat-list-grouping.ts";
 import type { SessionRow } from "./types.ts";
@@ -33,6 +34,7 @@ function session(id: string, projectRoot: string): SessionRow {
     archived_at: null,
     created_at: "2026-08-24T00:00:00.000Z",
     updated_at: "2026-08-24T00:00:00.000Z",
+    attention: NO_CHAT_ATTENTION,
     familiarId: "nova",
     origin: "chat",
   };

--- a/src/lib/chat-list-grouping.test.ts
+++ b/src/lib/chat-list-grouping.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { NO_CHAT_ATTENTION } from "./chat-attention.ts";
 import { createChatProjectIndex, type CaveProject } from "./chat-projects.ts";
-import { deriveChatListProjectGroups } from "./chat-list-grouping.ts";
+import {
+  deriveChatListProjectGroups,
+  withoutArchivedChatSessions,
+} from "./chat-list-grouping.ts";
 import type { SessionRow } from "./types.ts";
 
 const projects: CaveProject[] = [
@@ -79,4 +82,13 @@ test("project overrides stay identical across the shared result", () => {
 
   assert.equal(result.grouped[0]?.projectRoot, "/work/two");
   assert.equal(result.sidebarGroups, result.grouped);
+});
+
+test("archive filtering preserves identity or copies once from the first archived row", () => {
+  const current = [session("one", "/work/one"), session("two", "/work/two")];
+  assert.equal(withoutArchivedChatSessions(current), current);
+
+  const archived = { ...current[1], archived_at: "2026-08-24T01:00:00.000Z" };
+  const filtered = withoutArchivedChatSessions([current[0], archived, session("three", "/work/two")]);
+  assert.deepEqual(filtered.map((row) => row.id), ["one", "three"]);
 });

--- a/src/lib/chat-list-grouping.test.ts
+++ b/src/lib/chat-list-grouping.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createChatProjectIndex, type CaveProject } from "./chat-projects.ts";
+import { deriveChatListProjectGroups } from "./chat-list-grouping.ts";
+import type { SessionRow } from "./types.ts";
+
+const projects: CaveProject[] = [
+  {
+    id: "one",
+    name: "One",
+    root: "/work/one",
+    createdAt: "2026-08-24T00:00:00.000Z",
+    updatedAt: "2026-08-24T00:00:00.000Z",
+  },
+  {
+    id: "two",
+    name: "Two",
+    root: "/work/two",
+    createdAt: "2026-08-24T00:00:00.000Z",
+    updatedAt: "2026-08-24T00:00:00.000Z",
+  },
+];
+const projectIndex = createChatProjectIndex(projects);
+
+function session(id: string, projectRoot: string): SessionRow {
+  return {
+    id,
+    project_root: projectRoot,
+    harness: "codex",
+    title: id,
+    status: "completed",
+    exit_code: 0,
+    archived_at: null,
+    created_at: "2026-08-24T00:00:00.000Z",
+    updated_at: "2026-08-24T00:00:00.000Z",
+    familiarId: "nova",
+    origin: "chat",
+  };
+}
+
+test("shared list input reuses one grouped result", () => {
+  const sessions = [session("one", "/work/one")];
+  const result = deriveChatListProjectGroups(sessions, sessions, projects, projectIndex, {});
+
+  assert.equal(result.sidebarGroups, result.grouped);
+});
+
+test("different filtered and rail inputs preserve distinct scopes", () => {
+  const sessions = [session("one", "/work/one"), session("two", "/work/two")];
+  const result = deriveChatListProjectGroups(
+    sessions.slice(0, 1),
+    sessions,
+    projects,
+    projectIndex,
+    {},
+  );
+
+  assert.deepEqual(
+    result.grouped.flatMap((group) => group.sessions.map((row) => row.id)),
+    ["one"],
+  );
+  assert.deepEqual(
+    result.sidebarGroups.flatMap((group) => group.sessions.map((row) => row.id)),
+    ["one", "two"],
+  );
+});
+
+test("project overrides stay identical across the shared result", () => {
+  const sessions = [session("one", "/work/one")];
+  const result = deriveChatListProjectGroups(
+    sessions,
+    sessions,
+    projects,
+    projectIndex,
+    { one: "/work/two" },
+  );
+
+  assert.equal(result.grouped[0]?.projectRoot, "/work/two");
+  assert.equal(result.sidebarGroups, result.grouped);
+});

--- a/src/lib/chat-list-grouping.ts
+++ b/src/lib/chat-list-grouping.ts
@@ -1,0 +1,44 @@
+import { applyProjectOverrides, type ProjectOverrides } from "./chat-project-overrides.ts";
+import {
+  deriveChatProjectGroups,
+  type CaveProject,
+  type ChatProjectGroup,
+  type ChatProjectIndex,
+} from "./chat-projects.ts";
+import type { SessionRow } from "./types.ts";
+
+export type ChatListProjectGroups = {
+  grouped: ChatProjectGroup[];
+  sidebarGroups: ChatProjectGroup[];
+};
+
+/**
+ * Build the filtered-list and stable-rail project groups together.
+ *
+ * The default chat-list view feeds the same sessions to both surfaces. Keep
+ * that identity through project overrides so the O(sessions + projects)
+ * grouping pass runs once instead of twice. Search, status, archive, and kind
+ * filters still produce distinct inputs and therefore distinct group sets.
+ */
+export function deriveChatListProjectGroups(
+  filteredSessions: SessionRow[],
+  railSessions: SessionRow[],
+  projects: CaveProject[],
+  projectIndex: ChatProjectIndex,
+  overrides: ProjectOverrides,
+): ChatListProjectGroups {
+  const groupedSessions = applyProjectOverrides(filteredSessions, overrides);
+  const railGroupedSessions = filteredSessions === railSessions
+    ? groupedSessions
+    : applyProjectOverrides(railSessions, overrides);
+  const grouped = deriveChatProjectGroups(groupedSessions, projects, projectIndex, {
+    sessionsNewestFirst: true,
+  });
+  const sidebarGroups = railGroupedSessions === groupedSessions
+    ? grouped
+    : deriveChatProjectGroups(railGroupedSessions, projects, projectIndex, {
+      sessionsNewestFirst: true,
+    });
+
+  return { grouped, sidebarGroups };
+}

--- a/src/lib/chat-list-grouping.ts
+++ b/src/lib/chat-list-grouping.ts
@@ -12,6 +12,22 @@ export type ChatListProjectGroups = {
   sidebarGroups: ChatProjectGroup[];
 };
 
+/** Strip archived rows in one pass while retaining identity when no work is needed. */
+export function withoutArchivedChatSessions(sessions: SessionRow[]): SessionRow[] {
+  let visible: SessionRow[] | null = null;
+
+  for (let index = 0; index < sessions.length; index += 1) {
+    const session = sessions[index];
+    if (session.archived_at) {
+      visible ??= sessions.slice(0, index);
+    } else if (visible) {
+      visible.push(session);
+    }
+  }
+
+  return visible ?? sessions;
+}
+
 /**
  * Build the filtered-list and stable-rail project groups together.
  *


### PR DESCRIPTION
## Summary
- reuse one project-grouping result when the default chat list and stable rail share the same session array
- preserve array identity across no-op archive, search, status, and kind filters
- add focused coordinator coverage and benchmark the shared path

## Why
The default large chat list derived identical project groups twice. On the 10,000-session fixture, the shared path reduces that work from 33.36 ms p50 to 15.58 ms p50.

## Changes
- add a pure chat-list grouping coordinator that applies overrides once
- wire ChatList through one memo while preserving distinct filtered scopes
- register regression coverage and extend the existing project-grouping benchmark

## Verification
- `pnpm test:app` (1,319/1,319 test files)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:tests-wired` (1,866 files)
- `pnpm bench:chat-projects` (2.1x shared-grouping speedup)
- `git diff --check`

## Risk + rollout notes
Low-risk client-side derivation change. Search, archive, status, and kind filters still receive distinct grouping passes whenever their session arrays differ.

Bead: cave-i65lt

Signed-off-by: Val Alexander <68980965+BunsDev@users.noreply.github.com>