### PR TITLE
Refine chat continuation controls

### DIFF
--- a/docs/superpowers/plans/2026-08-24-chat-continuation-controls.md
+++ b/docs/superpowers/plans/2026-08-24-chat-continuation-controls.md
@@ -1,0 +1,20 @@
+# Chat continuation controls refinement
+
+Bead: `cave-bnay4`
+
+## Intent
+
+Make the resting chat surface quieter without removing working behavior:
+
+- replace the labeled earlier-turns pill with one full-width arrow seam;
+- replace the 32px labeled Code rail with a transparent 14px edge pull tab;
+- move the functional Explore/Build access selector into Tools → Response options;
+- keep keyboard, screen-reader, reduced-motion, and reduced-transparency behavior intact.
+
+## Implementation
+
+1. Update source-contract tests to describe the new semantics and geometry.
+2. Refactor `ChatView`, `ChatSurface`, and `TaskWorkCockpit` markup.
+3. Reduce and modernize the corresponding composer, transcript-fold, and rail CSS.
+4. Run focused tests, clean TypeScript, lint, the full app test suite, and real-browser visual checks from the managed worktree.
+5. Commit with signing and DCO, open a protected PR, resolve review/CI findings, squash merge, and close the Bead with delivery proof.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -631,6 +631,7 @@ export const SUITES = {
     "src/components/chat-view-polish-header-composer.test.ts",
     "src/components/chat-view-polish-attachments-mentions.test.ts",
     "src/components/chat-view-polish-edit-review.test.ts",
+    "src/components/chat-continuation-controls.test.ts",
     "src/components/chat-composer-footer-band.test.ts",
     "src/components/chat-composer-command-capsule.test.ts",
     "src/components/task-link-picker.test.ts",

--- a/src/components/chat-composer-command-capsule.test.ts
+++ b/src/components/chat-composer-command-capsule.test.ts
@@ -13,9 +13,10 @@ const activityCss = read("../styles/cave-chat/activity.css");
 
 assert.match(
   source,
-  /className="cave-composer-mode-switch" role="group" aria-label="Access mode"[\s\S]*?aria-pressed=\{permissionMode === "read"\}[\s\S]*?setPermissionMode\("read"\)[\s\S]*?<span>Explore<\/span>[\s\S]*?aria-pressed=\{permissionMode === "full"\}[\s\S]*?setPermissionMode\("full"\)[\s\S]*?<span>Build<\/span>/,
-  "the composer exposes the two enforceable access modes as a direct segmented control",
+  /const composerResponseSections:[\s\S]*?id:\s*"access"[\s\S]*?label:\s*"Access"[\s\S]*?value:\s*permissionMode[\s\S]*?value:\s*"read",\s*label:\s*"Explore · read only"[\s\S]*?value:\s*"full",\s*label:\s*"Build · full access"[\s\S]*?setPermissionMode\(value\)/,
+  "the functional access modes live in the low-profile Response options surface",
 );
+assert.doesNotMatch(source, /cave-composer-mode-switch|cave-composer-mode-option/, "access mode should not consume the composer command rail");
 assert.match(
   source,
   /className="cave-composer-send cave-composer-send--busy[\s\S]*?<span>esc · stop<\/span>/,
@@ -33,14 +34,10 @@ assert.match(
 );
 assert.match(
   css,
-  /\.cave-composer-mode-switch \{[\s\S]*?display:\s*inline-flex;[\s\S]*?border:\s*1px solid var\(--border-strong\);/,
-  "access modes share one compact segmented-control outline",
+  /\.cave-composer-control-row \{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto;/,
+  "the command rail gives context the flexible column and actions only their intrinsic width",
 );
-assert.match(
-  css,
-  /\.cave-composer-mode-option\[aria-pressed="true"\] \{[\s\S]*?border-color:\s*var\(--accent-presence\);[\s\S]*?background:\s*color-mix\(in oklch, var\(--accent-presence\) 14%, transparent\);/,
-  "the active access mode uses the design-system accent recipe",
-);
+assert.doesNotMatch(css, /\.cave-composer-mode-switch|\.cave-composer-mode-option/, "retired access switch CSS should stay removed");
 assert.match(
   activityCss,
   /--cave-chat-measure:\s*64rem;/,

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -48,9 +48,10 @@ assert.match(
 );
 assert.match(
   controlRow,
-  /className="cave-composer-mode-switch"[\s\S]*?<ComposerContextMeter[\s\S]*?<div className="cave-composer-submit-row">[\s\S]*?<EnhanceControl[\s\S]*?aria-label="Voice call"[\s\S]*?aria-label="Send message"/,
-  "the control row should keep direct access modes, truthful context, Enhance, Voice, and Send in order",
+  /<ComposerContextMeter[\s\S]*?<div className="cave-composer-submit-row">[\s\S]*?<EnhanceControl[\s\S]*?aria-label="Voice call"[\s\S]*?aria-label="Send message"/,
+  "the control row should keep truthful context, Enhance, Voice, and Send in order",
 );
+assert.doesNotMatch(controlRow, /cave-composer-mode-switch/, "access mode belongs in the grouped Response options menu");
 assert.match(
   edgeActions,
   /<ComposerActionsMenu\s*\n\s*attach=\{\{\s*\n\s*onSelect: \(\) => fileInputRef\.current\?\.click\(\)/,

--- a/src/components/chat-continuation-controls.test.ts
+++ b/src/components/chat-continuation-controls.test.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const read = (relativePath: string) =>
+  readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), "utf8");
+
+const source = read("./chat-view.tsx");
+const styles = read("../styles/cave-chat/session-chrome.css");
+
+const foldStart = source.indexOf('<div key="__chat-fold" className="cave-chat-fold">');
+const foldEnd = source.indexOf("</div>", foldStart);
+const fold = source.slice(foldStart, foldEnd);
+
+assert.ok(foldStart > -1, "the transcript fold should render");
+assert.match(fold, /className="cave-chat-fold__trigger focus-ring"/);
+assert.match(fold, /aria-label=\{chatFoldAriaLabel\(fold\.hiddenTurns, foldOpen\)\}/);
+assert.match(fold, /title=\{chatFoldLabel\(fold\.hiddenTurns, foldOpen\)\}/);
+assert.match(fold, /<Icon name="ph:caret-up"/);
+assert.doesNotMatch(fold, /cave-chat-fold__rule/, "the full-width seam should not render separate rule nodes");
+assert.equal(fold.match(/chatFoldLabel\(/g)?.length, 1, "the fold label should appear only in the native title, not as visible chrome");
+
+assert.match(
+  styles,
+  /\.cave-chat-fold__trigger \{[\s\S]{0,900}?display:\s*grid;[\s\S]{0,300}?grid-template-columns:\s*minmax\(0, 1fr\) auto minmax\(0, 1fr\);/,
+  "the minimal trigger spans the reading width with the arrow centered between hairlines",
+);
+assert.match(styles, /\.cave-chat-fold__trigger::before,[\s\S]*?\.cave-chat-fold__trigger::after/);
+assert.doesNotMatch(styles, /\.cave-chat-fold__pill|\.cave-chat-fold__rule/, "the oversized pill treatment stays removed");
+
+console.log("chat-continuation-controls.test.ts OK");

--- a/src/components/chat-continuation-controls.test.ts
+++ b/src/components/chat-continuation-controls.test.ts
@@ -8,6 +8,8 @@ const read = (relativePath: string) =>
 
 const source = read("./chat-view.tsx");
 const styles = read("../styles/cave-chat/session-chrome.css");
+const railStyles = read("../styles/cave-chat/auxiliary-surfaces.css");
+const transcriptStyles = read("../styles/cave-chat/transcript.css");
 
 const foldStart = source.indexOf('<div key="__chat-fold" className="cave-chat-fold">');
 const foldEnd = source.indexOf("</div>", foldStart);
@@ -28,5 +30,20 @@ assert.match(
 );
 assert.match(styles, /\.cave-chat-fold__trigger::before,[\s\S]*?\.cave-chat-fold__trigger::after/);
 assert.doesNotMatch(styles, /\.cave-chat-fold__pill|\.cave-chat-fold__rule/, "the oversized pill treatment stays removed");
+assert.match(
+  styles,
+  /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.cave-chat-fold__trigger,[\s\S]*?\.cave-chat-fold__trigger::before,[\s\S]*?\.cave-chat-fold__trigger::after[\s\S]*?transition:\s*none;/,
+  "the fold seam disables every hover and caret transition for reduced motion",
+);
+assert.match(
+  railStyles,
+  /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.workspace-rail-reopen__tab[\s\S]*?transition:\s*none;/,
+  "the Code pull tab does not expand with animation for reduced motion",
+);
+assert.match(
+  transcriptStyles,
+  /@media \(prefers-reduced-transparency: reduce\) \{[\s\S]*?\.cave-chat-linear \.cave-composer-panel[\s\S]*?background:\s*var\(--bg-raised\);[\s\S]*?backdrop-filter:\s*none;/,
+  "the chat composer becomes opaque and drops blur for reduced transparency",
+);
 
 console.log("chat-continuation-controls.test.ts OK");

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -569,12 +569,9 @@ export function ChatSurface({
           </Group>
         )}
       </div>
-      {/* Collapsed code rail: a full-height reopen rail on the right edge that
-          mirrors the left nav's collapsed "Chats" rail (same width, icon over a
-          vertical label — here "Code"). Shown when the rail is available for
-          the active repo session but has been collapsed (or auto-hidden
-          between edit batches). Same desktop-only / wide-enough gate as the
-          mounted rail. */}
+      {/* Collapsed code rail: a transparent full-height edge target with one
+          hover/focus-revealed pull tab. It stays discoverable without leaving
+          a labeled chrome column beside the conversation. */}
       {rail.available && !rail.open && !isMobile && !paneNarrow && (
         <button
           type="button"
@@ -584,8 +581,9 @@ export function ChatSurface({
           className="workspace-rail-reopen focus-ring"
           onClick={rail.reopen}
         >
-          <Icon name="ph:sidebar-simple" width={15} aria-hidden />
-          <span className="workspace-rail-reopen__label">Code</span>
+          <span className="workspace-rail-reopen__tab" aria-hidden>
+            <Icon name="ph:caret-left" width={10} aria-hidden />
+          </span>
         </button>
       )}
       {/* Mobile / narrow code rail: same WorkspaceRail as desktop, but hosted in

--- a/src/components/chat-view-first-class.test.ts
+++ b/src/components/chat-view-first-class.test.ts
@@ -123,9 +123,10 @@ assert.match(
 
 assert.match(
   source,
-  /className="cave-composer-edge-actions"[\s\S]*<ComposerActionsMenu[\s\S]*triggerVariant="tools"[\s\S]*className="cave-composer-control-row"[\s\S]*className="cave-composer-mode-switch"[\s\S]*<ComposerContextMeter[\s\S]*className="cave-composer-submit-row"[\s\S]*<EnhanceControl[\s\S]*aria-label="Voice call"[\s\S]*aria-label="Send message"/,
-  "Composer should keep Tools at its edge plus access, context, enhance, voice, and send actions in the command rail",
+  /className="cave-composer-edge-actions"[\s\S]*<ComposerActionsMenu[\s\S]*triggerVariant="tools"[\s\S]*className="cave-composer-control-row"[\s\S]*<ComposerContextMeter[\s\S]*className="cave-composer-submit-row"[\s\S]*<EnhanceControl[\s\S]*aria-label="Voice call"[\s\S]*aria-label="Send message"/,
+  "Composer should keep Tools at its edge plus context, enhance, voice, and send actions in the command rail",
 );
+assert.doesNotMatch(source, /className="cave-composer-mode-switch"/, "Access should live inside Response options instead of a large direct switch");
 assert.match(
   addMenuSource,
   /ariaLabel="Attach images, videos, or files"[\s\S]{0,400}?icon="ph:paperclip"|icon="ph:paperclip"[\s\S]{0,400}?ariaLabel="Attach images, videos, or files"/,
@@ -141,7 +142,7 @@ assert.match(
 assert.match(
   source,
   /const composerResponseSections:[\s\S]*label:\s*`Model · \$\{inventoryProvenanceLabel\([\s\S]*\.\.\.modelCapabilities\.map\([\s\S]*capability\.delivery === "prompt-only" \? "Prompt guidance" : "Native"[\s\S]*<ComposerActionsMenu[\s\S]*sections:\s*composerResponseSections/,
-  "The grouped Response section exposes model and capability-aware controls while access stays direct",
+  "The grouped Response section exposes access, model, and capability-aware controls",
 );
 assert.match(
   source,

--- a/src/components/chat-view-polish-header-composer.test.ts
+++ b/src/components/chat-view-polish-header-composer.test.ts
@@ -213,8 +213,8 @@ assert.doesNotMatch(
 );
 assert.match(
   styles,
-  /\.cave-composer-control-row\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-columns:\s*auto minmax\(0, 1fr\) auto;/,
-  "composer footer lays out access, live context, and submit controls in one command rail",
+  /\.cave-composer-control-row\s*\{[^}]*display:\s*grid;[^}]*grid-template-columns:\s*minmax\(0, 1fr\) auto;/,
+  "composer footer lays out live context and submit controls in one compact command rail",
 );
 // The extracted response section renders each control inline (no nested
 // popover) and keeps the connect-host dialog available to the grouped surface.

--- a/src/components/chat-view-polish-header-composer.test.ts
+++ b/src/components/chat-view-polish-header-composer.test.ts
@@ -140,12 +140,14 @@ assert.match(
   "composer exposes the permission-mode (Access) control",
 );
 // Context, linked work, prompt-improvement, and response controls collapse into
-// one grouped Tools surface while access and voice stay one click away.
+// one grouped Tools surface while voice stays one click away and functional
+// access control moves into Response options.
 assert.match(
   source,
-  /<div className="cave-composer-edge-actions">[\s\S]*<ComposerActionsMenu[\s\S]*attach=\{\{[\s\S]*triggerVariant="tools"[\s\S]*className="cave-composer-mode-switch"[\s\S]*className="cave-composer-submit-row"[\s\S]*aria-label="Voice call"/,
-  "composer exposes the grouped Tools trigger at its edge while keeping Access and Voice direct in the command rail",
+  /<div className="cave-composer-edge-actions">[\s\S]*<ComposerActionsMenu[\s\S]*attach=\{\{[\s\S]*triggerVariant="tools"[\s\S]*className="cave-composer-control-row"[\s\S]*<ComposerContextMeter[\s\S]*className="cave-composer-submit-row"[\s\S]*aria-label="Voice call"/,
+  "composer exposes grouped Tools at its edge and keeps only context plus direct send actions in the command rail",
 );
+assert.doesNotMatch(source, /className="cave-composer-mode-switch"/, "access mode is demoted into Response options");
 const composerActionsMenuMatch = source.match(/<ComposerActionsMenu\b[\s\S]*?(?:\/>|<\/ComposerActionsMenu>)/);
 assert.ok(composerActionsMenuMatch, "expected the ComposerActionsMenu JSX block in ChatView");
 const composerActionsMenuBlock = composerActionsMenuMatch[0];

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -295,6 +295,7 @@ import { addChatProject, projectNameForRoot } from "@/lib/chat-add-project";
 import { projectAccessLabel } from "@/lib/project-access-levels";
 import {
   COMMAND_CONTROL_DEFAULTS,
+  DEFAULT_PERMISSION_MODE,
   normalizeCommandControls,
   type CommandPermissionMode,
   type CommandResponseSpeed,
@@ -3757,6 +3758,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // Save-as-template (cave-jg6k): snapshots the draft for the modal form.
   const [saveTemplateSeed, setSaveTemplateSeed] = useState<string | null>(null);
   const composerResponseSections: ComposerOptionSection[] = [
+    {
+      id: "access",
+      label: "Access",
+      value: permissionMode,
+      options: [
+        { value: "read", label: "Explore · read only" },
+        { value: "full", label: "Build · full access" },
+      ],
+      onChange: (value: string) => {
+        if (value === "read" || value === "full") setPermissionMode(value);
+      },
+    },
     ...(composerRuntimeOwnsDefault || composerModelOptions.length > 0 || composerModelInventory.loading
       ? [{
           id: "model",
@@ -7654,6 +7667,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     saveAsTemplateDisabled: !input.trim(),
                     indicator:
                       composerHostValue !== LOCAL_HOST_ID ||
+                      permissionMode !== DEFAULT_PERMISSION_MODE ||
                       thinkingEffort !== COMMAND_CONTROL_DEFAULTS.thinkingEffort ||
                       responseSpeed !== COMMAND_CONTROL_DEFAULTS.responseSpeed,
                   }}
@@ -7819,28 +7833,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   }}
                 />
                 <div className="cave-composer-control-row">
-                  <div className="cave-composer-mode-switch" role="group" aria-label="Access mode">
-                    <button
-                      type="button"
-                      className="cave-composer-mode-option focus-ring"
-                      aria-pressed={permissionMode === "read"}
-                      onClick={() => setPermissionMode("read")}
-                      title="Explore — read only"
-                    >
-                      <Icon name="ph:globe" width="var(--icon-md)" aria-hidden />
-                      <span>Explore</span>
-                    </button>
-                    <button
-                      type="button"
-                      className="cave-composer-mode-option focus-ring"
-                      aria-pressed={permissionMode === "full"}
-                      onClick={() => setPermissionMode("full")}
-                      title="Build — full access"
-                    >
-                      <Icon name="ph:flask" width="var(--icon-md)" aria-hidden />
-                      <span>Build</span>
-                    </button>
-                  </div>
                   <ComposerContextMeter usage={lastSettledAssistantTurn?.usage} model={contextRowModel ?? undefined} />
                   <div className="cave-composer-submit-row">
                     {busy && (input.trim() || attachments.length > 0) ? (
@@ -8979,26 +8971,24 @@ const TranscriptRows = memo(function TranscriptRows({
     );
   });
   if (fold.hiddenTurns === 0) return rows;
-  // The pill leads the transcript in both states: closed it names what is
-  // hidden, open it names the way back. The two rules make it read as a seam
-  // in the conversation rather than as a toolbar.
+  // The fold leads the transcript in both states: closed it names what is
+  // hidden, open it names the way back. The visual stays one full-width seam;
+  // the count remains available through its accessible name and title.
   return [
     <div key="__chat-fold" className="cave-chat-fold">
-      <span aria-hidden className="cave-chat-fold__rule" />
       <button
         type="button"
-        className="cave-chat-fold__pill focus-ring"
+        className="cave-chat-fold__trigger focus-ring"
         aria-expanded={foldOpen}
         aria-label={chatFoldAriaLabel(fold.hiddenTurns, foldOpen)}
+        title={chatFoldLabel(fold.hiddenTurns, foldOpen)}
         onClick={onToggleFold}
       >
         {/* The caret's direction is driven off the button's own aria-expanded,
             not a data-prop on the Icon: Icon only forwards aria-* / role, so a
             data attribute here is silently dropped and the caret never turns. */}
         <Icon name="ph:caret-up" width={9} className="cave-chat-fold__caret" aria-hidden />
-        {chatFoldLabel(fold.hiddenTurns, foldOpen)}
       </button>
-      <span aria-hidden className="cave-chat-fold__rule" />
     </div>,
     ...rows,
   ];

--- a/src/components/code-rail-fit.test.ts
+++ b/src/components/code-rail-fit.test.ts
@@ -10,6 +10,7 @@ import { readFile } from "node:fs/promises";
 const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 const projectSidebar = await readFile(new URL("./chat-project-sidebar.tsx", import.meta.url), "utf8");
+const caveChatAux = await readFile(new URL("../styles/cave-chat/auxiliary-surfaces.css", import.meta.url), "utf8");
 const caveChat = (
   await Promise.all(
     ["cave-md", "cave-composer", "chat-list", "calendar", "cave-chat"].map((sheet) =>
@@ -69,35 +70,30 @@ assert.match(
 );
 
 // The rail participates in layout (content beside it, never underneath):
-// it must NOT be absolutely positioned, and it reserves its own width.
+// it must NOT be absolutely positioned, and it reserves only a pull-tab width.
 assert.match(
-  caveChat,
-  /\.workspace-rail-reopen \{[\s\S]{0,900}?flex: 0 0 32px;/,
-  "the reopen rail reserves an ultra-minimal in-flow layout width",
+  caveChatAux,
+  /\.workspace-rail-reopen \{[\s\S]{0,900}?flex: 0 0 14px;[\s\S]{0,300}?background:\s*transparent;/,
+  "the reopen rail reserves a transparent ultra-minimal in-flow pull-tab width",
 );
 assert.doesNotMatch(
-  caveChat,
+  caveChatAux,
   /\.workspace-rail-reopen \{[\s\S]{0,900}?position: absolute;/,
   "the reopen rail must not overlay content (no absolute positioning)",
 );
 
-// Label orientation: reads top→bottom with the glyph face to the
-// right/outside (vertical-rl) — mirroring the left rail's vocabulary.
-assert.match(
-  caveChat,
-  /\.workspace-rail-reopen__label \{\s*writing-mode: vertical-rl;/,
-  "the rail label reads downward with its face to the right/outside",
-);
+assert.doesNotMatch(chatSurface, /workspace-rail-reopen__label|>Code</, "the pull tab has no persistent vertical label");
+assert.match(chatSurface, /workspace-rail-reopen__tab[\s\S]{0,200}?ph:caret-left/, "the pull tab uses a quiet inward caret");
 
 // The rail carries the left panel's glass (with honest fallbacks).
 assert.match(
-  caveChat,
-  /\.workspace-rail-reopen \{[\s\S]{0,900}?color-mix\(in oklch, var\(--bg-raised\) 88%, transparent\)[\s\S]{0,200}?backdrop-filter: blur\(14px\) saturate\(140%\)/,
-  "the rail wears the same glass as the left sidebar",
+  caveChatAux,
+  /\.workspace-rail-reopen:hover \.workspace-rail-reopen__tab,[\s\S]*?\.workspace-rail-reopen:focus-visible \.workspace-rail-reopen__tab[\s\S]{0,500}?color-mix\(in oklch, var\(--bg-raised\) 82%, transparent\)[\s\S]{0,300}?backdrop-filter: blur\(14px\) saturate\(140%\)/,
+  "the pull tab reveals glass only on hover or keyboard focus",
 );
 assert.match(
-  caveChat,
-  /@media \(prefers-reduced-transparency: reduce\) \{\s*\.workspace-rail-reopen \{/,
+  caveChatAux,
+  /@media \(prefers-reduced-transparency: reduce\) \{\s*\.workspace-rail-reopen:hover \.workspace-rail-reopen__tab,/,
   "rail glass respects reduced transparency",
 );
 

--- a/src/components/composer-actions-menu.test.ts
+++ b/src/components/composer-actions-menu.test.ts
@@ -100,8 +100,13 @@ assert.match(
 );
 assert.match(
   actions,
-  /<PopoverSubmenu icon="ph:gear-six" label="Response options"/,
-  "Response options is a cascade flyout carrying host/access/model/thinking/speed",
+  /<PopoverSubmenu icon="ph:gear-six" label="Response options" minWidth=\{300\} panelRole="dialog"/,
+  "Response options is a dialog flyout carrying host/access/model/thinking/speed",
+);
+assert.match(
+  popover,
+  /aria-haspopup=\{panelRole\}[\s\S]*?role=\{panelRole\}/,
+  "submenus expose their configured popup semantics on both trigger and panel",
 );
 assert.match(
   actions,

--- a/src/components/composer-actions-menu.tsx
+++ b/src/components/composer-actions-menu.tsx
@@ -245,7 +245,7 @@ export function ComposerActionsMenu({
                     onSelect={() => openContextPicker("branch")}
                   />
                 ) : null}
-                <PopoverSubmenu icon="ph:gear-six" label="Response options" minWidth={300}>
+                <PopoverSubmenu icon="ph:gear-six" label="Response options" minWidth={300} panelRole="dialog">
                   <ResponseSections
                     hostValue={response.hostValue}
                     hostOptions={hostOptions}

--- a/src/components/task-work-cockpit.test.ts
+++ b/src/components/task-work-cockpit.test.ts
@@ -107,7 +107,7 @@ assert.match(
 );
 
 // The collapsed code rail is an in-flow flex child sized against a flex ROW
-// (32px wide, full height). The cockpit root is a flex COLUMN, so hosting it
+// (14px wide, full height). The cockpit root is a flex COLUMN, so hosting it
 // there docked it as a stub in the bottom-left corner under the composer.
 // It belongs inside the body row, before the body closes.
 const bodyStart = source.indexOf('<div className="task-work-cockpit__body">');
@@ -121,6 +121,7 @@ assert.ok(bodyEnd > bodyStart, "the cockpit body row closes before the rail shee
 assert.ok(railStart < bodyEnd, "the reopen rail renders inside the cockpit body row, not as a column child");
 assert.match(
   cockpitCss,
-  /\.task-work-cockpit__body > \.workspace-rail-reopen \{[\s\S]{0,200}?flex: 0 0 32px;[\s\S]{0,200}?align-self: stretch;/,
-  "the reopen rail reserves an ultra-minimal full-height column beside the conversation",
+  /\.task-work-cockpit__body > \.workspace-rail-reopen \{[\s\S]{0,200}?flex: 0 0 14px;[\s\S]{0,200}?align-self: stretch;/,
+  "the reopen pull tab reserves an ultra-minimal full-height edge beside the conversation",
 );
+assert.doesNotMatch(source, /workspace-rail-reopen__label|>Code</, "the cockpit pull tab has no persistent vertical label");

--- a/src/components/task-work-cockpit.tsx
+++ b/src/components/task-work-cockpit.tsx
@@ -357,8 +357,8 @@ export function TaskWorkCockpit({
             </span>
           </div>
         )}
-        {/* Collapsed code rail: a full-height reopen rail on the cockpit's
-            right edge, mirroring the chat surface. It must sit INSIDE the body
+        {/* Collapsed code rail: the same transparent pull tab as Chat. It must
+            sit INSIDE the body
             row — the cockpit root is a flex column, so as a root child the
             rail collapsed into a 44px stub in the bottom-left corner under the
             composer instead of a full-height edge rail. In flow here it
@@ -375,8 +375,9 @@ export function TaskWorkCockpit({
             className="workspace-rail-reopen focus-ring"
             onClick={railController.rail.reopen}
           >
-            <Icon name="ph:sidebar-simple" width={15} aria-hidden />
-            <span className="workspace-rail-reopen__label">Code</span>
+            <span className="workspace-rail-reopen__tab" aria-hidden>
+              <Icon name="ph:caret-left" width={10} aria-hidden />
+            </span>
           </button>
         ) : null}
       </div>

--- a/src/components/ui/popover-submenu.test.ts
+++ b/src/components/ui/popover-submenu.test.ts
@@ -20,7 +20,7 @@ test("trigger row and flyout expose their configured popup semantics", () => {
   assert.match(src, /panelRole = "menu"/, "ordinary submenus retain menu semantics by default");
   assert.match(
     src,
-    /ui-popover-item ui-popover-subtrigger[\s\S]*?role="menuitem"\s*aria-haspopup=\{panelRole\}\s*aria-expanded=\{open\}/,
+    /ui-popover-item ui-popover-subtrigger[\s\S]*?role="menuitem"[\s\S]*?aria-haspopup=\{panelRole\}\s*aria-expanded=\{open\}/,
     "subtrigger advertises the configured popup role and expansion state",
   );
   assert.match(src, /className="ui-popover ui-popover-submenu"[\s\S]*?role=\{panelRole\}/, "flyout uses the same configured role");

--- a/src/components/ui/popover-submenu.test.ts
+++ b/src/components/ui/popover-submenu.test.ts
@@ -16,12 +16,14 @@ test("flyout portals to document.body and reuses the ui-popover shell", () => {
   assert.match(src, /computeSubmenuPosition\(/, "positioning delegates to the pure helper");
 });
 
-test("trigger row exposes menu semantics and expansion state", () => {
+test("trigger row and flyout expose their configured popup semantics", () => {
+  assert.match(src, /panelRole = "menu"/, "ordinary submenus retain menu semantics by default");
   assert.match(
     src,
-    /ui-popover-item ui-popover-subtrigger[\s\S]*?role="menuitem"\s*aria-haspopup="menu"\s*aria-expanded=\{open\}/,
-    "subtrigger is a menuitem with aria-haspopup/aria-expanded",
+    /ui-popover-item ui-popover-subtrigger[\s\S]*?role="menuitem"\s*aria-haspopup=\{panelRole\}\s*aria-expanded=\{open\}/,
+    "subtrigger advertises the configured popup role and expansion state",
   );
+  assert.match(src, /className="ui-popover ui-popover-submenu"[\s\S]*?role=\{panelRole\}/, "flyout uses the same configured role");
   assert.match(src, /name="ph:caret-right"[\s\S]*?ui-popover-subtrigger__caret/, "trailing caret glyph");
 });
 

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -450,6 +450,7 @@ export function PopoverSubmenu({
   hint,
   disabled,
   minWidth = 200,
+  panelRole = "menu",
   className,
   children,
 }: {
@@ -459,6 +460,7 @@ export function PopoverSubmenu({
   hint?: ReactNode;
   disabled?: boolean;
   minWidth?: number;
+  panelRole?: "menu" | "dialog";
   className?: string;
   children: ReactNode;
 }) {
@@ -593,7 +595,7 @@ export function PopoverSubmenu({
         type="button"
         className={["ui-popover-item ui-popover-subtrigger", className ?? ""].filter(Boolean).join(" ")}
         role="menuitem"
-        aria-haspopup="menu"
+        aria-haspopup={panelRole}
         aria-expanded={open}
         disabled={disabled}
         data-active={open || undefined}
@@ -643,7 +645,7 @@ export function PopoverSubmenu({
                 ref={panelRef}
                 className="ui-popover ui-popover-submenu"
                 style={style}
-                role="menu"
+                role={panelRole}
                 aria-label={typeof label === "string" ? label : undefined}
                 onKeyDown={(e) => {
                   // ArrowLeft/Escape step back to the trigger row; Escape stops

--- a/src/styles/cave-chat/auxiliary-surfaces.css
+++ b/src/styles/cave-chat/auxiliary-surfaces.css
@@ -969,39 +969,54 @@
   color: var(--text-muted);
 }
 
-/* Full-height reopen rail on the chat surface's right edge — the reflection of
-   the left-side shell chrome beside Chat (WorkspaceSidebar is the contextual
-   primary nav in Chat; SidebarMinimal returns outside Chat):
-   icon over a vertical uppercase label ("Code"), reading top→bottom with the
-   glyph face to the right/outside (vertical-rl). An in-flow flex child (NOT
-   absolutely positioned): the rail reserves its own layout width so content
-   sits beside it, never underneath. Carries the same glass as the left panel. */
+/* Ultra-minimal Code pull tab. The full-height button remains an easy target
+   and an in-flow flex child, but reserves only 14px. Its centered tab is nearly
+   transparent at rest and reveals dark-grey glass on hover or keyboard focus. */
 .workspace-rail-reopen {
   position: relative;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 9px;
-  flex: 0 0 32px;
-  width: 32px;
+  justify-content: center;
+  flex: 0 0 14px;
+  width: 14px;
   height: 100%;
-  padding: var(--space-3) 0;
+  padding: 0;
   border: 0;
-  border-left: 1px solid var(--border-hairline);
-  background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
-  backdrop-filter: blur(14px) saturate(140%);
+  background: transparent;
   color: var(--text-muted);
   cursor: pointer;
+}
+.workspace-rail-reopen__tab {
+  display: grid;
+  width: 10px;
+  height: 46px;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill) 0 0 var(--radius-pill);
+  background: transparent;
+  color: color-mix(in oklch, var(--text-muted) 42%, transparent);
   transition:
+    width var(--duration-fast) var(--ease-decelerate),
     color var(--duration-fast) var(--ease-standard),
-    background var(--duration-fast) var(--ease-standard);
+    border-color var(--duration-fast) var(--ease-standard),
+    background-color var(--duration-fast) var(--ease-standard);
+}
+.workspace-rail-reopen:hover .workspace-rail-reopen__tab,
+.workspace-rail-reopen:focus-visible .workspace-rail-reopen__tab {
+  width: 14px;
+  border-color: var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 82%, transparent);
+  backdrop-filter: blur(14px) saturate(140%);
+  color: var(--text-primary);
 }
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
-  .workspace-rail-reopen { background: var(--bg-raised); }
+  .workspace-rail-reopen:hover .workspace-rail-reopen__tab,
+  .workspace-rail-reopen:focus-visible .workspace-rail-reopen__tab { background: var(--bg-raised); }
   .voice-call-overlay__dialog { background: var(--bg-raised); }
 }
 @media (prefers-reduced-transparency: reduce) {
-  .workspace-rail-reopen {
+  .workspace-rail-reopen:hover .workspace-rail-reopen__tab,
+  .workspace-rail-reopen:focus-visible .workspace-rail-reopen__tab {
     background: var(--bg-raised);
     backdrop-filter: none;
   }
@@ -1009,17 +1024,6 @@
     background: var(--bg-raised);
     backdrop-filter: none;
   }
-}
-.workspace-rail-reopen:hover {
-  color: var(--text-primary);
-  background: color-mix(in oklch, var(--bg-hover) 60%, transparent);
-}
-.workspace-rail-reopen__label {
-  writing-mode: vertical-rl;
-  font-size: var(--text-xs);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
 /* ── Chat Settings tab (chat surface → Settings scope) ───────────────────────

--- a/src/styles/cave-chat/auxiliary-surfaces.css
+++ b/src/styles/cave-chat/auxiliary-surfaces.css
@@ -1025,6 +1025,11 @@
     backdrop-filter: none;
   }
 }
+@media (prefers-reduced-motion: reduce) {
+  .workspace-rail-reopen__tab {
+    transition: none;
+  }
+}
 
 /* ── Chat Settings tab (chat surface → Settings scope) ───────────────────────
    Settings.dc.html redesign: page column, kicker + hint over one bordered

--- a/src/styles/cave-chat/session-chrome.css
+++ b/src/styles/cave-chat/session-chrome.css
@@ -532,6 +532,9 @@
   transform: rotate(180deg);
 }
 @media (prefers-reduced-motion: reduce) {
+  .cave-chat-fold__trigger,
+  .cave-chat-fold__trigger::before,
+  .cave-chat-fold__trigger::after,
   .cave-chat-fold__caret {
     transition: none;
   }

--- a/src/styles/cave-chat/session-chrome.css
+++ b/src/styles/cave-chat/session-chrome.css
@@ -482,49 +482,44 @@
   white-space: nowrap;
 }
 
-/* ── Earlier-turns fold ("Chat Session - Prototype.dc.html", cave-u5lq7) ─────
-   A long thread opens on its recent exchange; everything older sits behind one
-   pill on a rule, which reads as a seam in the conversation rather than as a
-   toolbar. Same rule + mono-uppercase vocabulary as the turn-gap divider above,
-   because both mark a discontinuity in the transcript — the difference is that
-   this one is actionable, so it is a real button with a caret. */
+/* ── Earlier-turns fold ─────────────────────────────────────────────────────
+   One full-width arrow seam replaces the labeled pill. The screen-reader name
+   and native title still carry the hidden-turn count; resting chrome stays at
+   one caret between two quiet hairlines. */
 .cave-chat-fold {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
   margin: var(--space-2) 0 var(--space-4);
 }
-.cave-chat-fold__rule {
-  flex: 1;
-  min-width: var(--space-2);
-  height: 1px;
-  background: var(--border-hairline);
-}
-.cave-chat-fold__pill {
-  display: inline-flex;
+.cave-chat-fold__trigger {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
-  gap: var(--space-1);
-  flex: none;
-  height: 22px;
-  padding: 0 var(--space-2);
-  border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-pill);
-  background: color-mix(in oklch, var(--bg-panel) 55%, transparent);
+  gap: var(--space-2);
+  width: 100%;
+  min-height: 24px;
+  padding: 0;
+  border: 0;
+  background: transparent;
   color: var(--text-muted);
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: var(--text-2xs);
-  font-weight: 600;
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
-  white-space: nowrap;
   cursor: pointer;
   transition:
-    color var(--duration-fast) var(--ease-standard),
-    border-color var(--duration-fast) var(--ease-standard);
+    color var(--duration-fast) var(--ease-standard);
 }
-.cave-chat-fold__pill:hover {
+.cave-chat-fold__trigger::before,
+.cave-chat-fold__trigger::after {
+  content: "";
+  height: 1px;
+  background: var(--border-hairline);
+  transition: background-color var(--duration-fast) var(--ease-standard);
+}
+.cave-chat-fold__trigger:hover,
+.cave-chat-fold__trigger:focus-visible {
   color: var(--text-primary);
-  border-color: var(--border-strong);
+}
+.cave-chat-fold__trigger:hover::before,
+.cave-chat-fold__trigger:hover::after,
+.cave-chat-fold__trigger:focus-visible::before,
+.cave-chat-fold__trigger:focus-visible::after {
+  background: color-mix(in oklch, var(--foreground) 22%, transparent);
 }
 /* The caret points at what the press will do: up = fold away, down = reveal.
    Driven off the button's aria-expanded rather than a data attribute on the
@@ -533,7 +528,7 @@
 .cave-chat-fold__caret {
   transition: transform var(--duration-fast) var(--ease-standard);
 }
-.cave-chat-fold__pill[aria-expanded="false"] .cave-chat-fold__caret {
+.cave-chat-fold__trigger[aria-expanded="false"] .cave-chat-fold__caret {
   transform: rotate(180deg);
 }
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -693,6 +693,13 @@
     inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
 }
 
+@media (prefers-reduced-transparency: reduce) {
+  .cave-chat-linear .cave-composer-panel {
+    background: var(--bg-raised);
+    backdrop-filter: none;
+  }
+}
+
 .cave-chat-linear .cave-composer-panel:focus-within {
   border-color: color-mix(in oklch, var(--accent-presence) 48%, var(--border-strong));
   box-shadow:

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -686,10 +686,10 @@
 .cave-chat-linear .cave-composer-panel {
   border-radius: var(--radius-panel);
   border-color: var(--border-hairline);
-  background: color-mix(in oklch, var(--bg-raised) 92%, var(--bg-panel));
-  backdrop-filter: none;
+  background: color-mix(in oklch, var(--bg-raised) 88%, var(--bg-base));
+  backdrop-filter: blur(18px) saturate(115%);
   box-shadow:
-    0 var(--space-4) var(--space-10) color-mix(in oklch, var(--bg-panel) 64%, transparent),
+    0 12px 32px color-mix(in oklch, var(--bg-panel) 52%, transparent),
     inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
 }
 
@@ -720,14 +720,10 @@
   height: var(--space-8);
 }
 
-/* The governing control-row height for the chat surface — two classes deep, so
-   it beats the one-class rule in cave-composer.css (cave-9v4qt).
-   Left at 36px deliberately. Lowering it to 32 was measured and changed
-   nothing: the row's CONTENT (send button, mic, mode pill) renders 38px tall,
-   so min-height is not the binding constraint and shrinking it is a no-op.
-   Anyone shortening this row has to shrink those controls, not this number. */
+/* The direct access switch moved into Tools → Response options, so the
+   remaining icon controls can set the command rail's compact floor. */
 .cave-chat-linear .cave-composer-control-row {
-  min-height: calc(var(--space-8) + var(--space-1));
+  min-height: var(--space-8);
 }
 
 .cave-chat-linear .cave-composer-send {

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -68,7 +68,7 @@
    lives in transcript.css; change it there. */
 .cave-composer-control-row {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--space-2);
   color: var(--text-muted);
@@ -84,62 +84,6 @@
 
 .cave-composer-submit-row {
   justify-content: flex-end;
-}
-
-.cave-composer-mode-switch {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--ring-offset);
-  padding: var(--ring-offset);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius-control);
-  background: color-mix(in oklch, var(--bg-base) 46%, transparent);
-}
-
-.cave-composer-mode-option {
-  display: inline-flex;
-  min-width: var(--space-8);
-  height: var(--space-8);
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-1);
-  padding-inline: var(--space-2);
-  border: 1px solid transparent;
-  border-radius: calc(var(--radius-control) - var(--ring-offset));
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  transition:
-    background-color var(--duration-fast) var(--ease-standard),
-    border-color var(--duration-fast) var(--ease-standard),
-    color var(--duration-fast) var(--ease-standard);
-}
-
-.cave-composer-mode-option span {
-  max-width: 0;
-  overflow: hidden;
-  opacity: 0;
-  white-space: nowrap;
-  transition:
-    max-width var(--duration-fast) var(--ease-standard),
-    opacity var(--duration-fast) var(--ease-standard);
-}
-
-.cave-composer-mode-option:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.cave-composer-mode-option[aria-pressed="true"] {
-  border-color: var(--accent-presence);
-  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
-  color: var(--text-primary);
-  box-shadow: 0 0 0 1px color-mix(in oklch, var(--accent-presence) 28%, transparent);
-}
-
-.cave-composer-mode-option[aria-pressed="true"] span {
-  max-width: 5rem;
-  opacity: 1;
 }
 
 .cave-composer-edge-actions {
@@ -1070,7 +1014,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .hc-mic-live { animation: none; }
-  .cave-composer-mode-option span { transition: none; }
 }
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/src/styles/task-work-cockpit.css
+++ b/src/styles/task-work-cockpit.css
@@ -226,7 +226,7 @@
   min-width: 0;
 }
 
-/* The collapsed code rail is an in-flow flex child that reserves its own 32px
+/* The collapsed code pull tab is an in-flow flex child that reserves 14px
  * of layout width beside the conversation (never over it) and runs the full
  * height of the row — the contract .workspace-rail-reopen is written against
  * on the chat surface, whose root is a flex ROW. The cockpit root is a flex
@@ -234,13 +234,13 @@
  * at the bottom-left corner. It lives in the body row instead; this pins the
  * geometry so a future column-child regression is visible. */
 .task-work-cockpit__body > .workspace-rail-reopen {
-  flex: 0 0 32px;
+  flex: 0 0 14px;
   align-self: stretch;
 }
 
 .task-work-cockpit__state {
   display: flex;
-  width: min(420px, calc(100% - 32px));
+  width: min(420px, calc(100% - 14px));
   margin: auto;
   flex-direction: column;
   align-items: center;

--- a/tests/chat-composer-access.spec.ts
+++ b/tests/chat-composer-access.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const ISO = "2026-08-25T02:00:00.000Z";
+const SESSION_ID = "composer-access";
+
+async function setup(page: Page, sends: Array<Record<string, unknown>>) {
+  await page.addInitScript(() => {
+    localStorage.setItem("cave:active-familiar", "nova");
+    localStorage.setItem("cave:familiar:nova:last-surface", "chat");
+    localStorage.setItem("cave:onboarding:dismissed", "1");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        familiars: [{
+          id: "nova",
+          display_name: "Nova",
+          role: "Orchestrator",
+          status: "active",
+          icon: "ph:sparkle-fill",
+        }],
+      },
+    }));
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        sessions: [{
+          id: SESSION_ID,
+          title: "Composer access",
+          status: "idle",
+          project_root: "/tmp/coven-cave",
+          harness: "claude",
+          familiarId: "nova",
+          model: "test",
+          runtime: "local:/tmp/coven-cave",
+          exit_code: null,
+          archived_at: null,
+          created_at: ISO,
+          updated_at: ISO,
+        }],
+      },
+    }));
+  await page.route("**/api/projects**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        projects: [{ id: "p1", name: "Coven Cave", root: "/tmp/coven-cave", access: "write" }],
+      },
+    }));
+  await page.route("**/api/chat/conversation/**", (route) =>
+    route.request().method() === "GET"
+      ? route.fulfill({
+          json: {
+            ok: true,
+            conversation: {
+              activeLeafId: "assistant-1",
+              turns: [{
+                id: "assistant-1",
+                parentId: null,
+                role: "assistant",
+                text: "Choose the access level for the next request.",
+                createdAt: ISO,
+              }],
+            },
+          },
+        })
+      : route.fulfill({ json: { ok: true } }));
+  await page.route("**/api/chat/send", (route) => {
+    sends.push(route.request().postDataJSON() as Record<string, unknown>);
+    return route.fulfill({
+      contentType: "text/event-stream",
+      body: 'data: {"type":"done"}\n\n',
+    });
+  });
+  await page.goto(`/?mode=chat#chat-${SESSION_ID}`, { waitUntil: "domcontentloaded" });
+  await expect(page.getByTestId("chat-main").locator(".cave-composer-input")).toBeVisible({ timeout: 45_000 });
+}
+
+async function chooseAccess(page: Page, label: "Explore · read only" | "Build · full access") {
+  await page.getByTestId("chat-main").getByRole("button", { name: "Tools" }).click();
+  const responseTrigger = page.getByRole("menuitem", { name: /Response options/ });
+  await responseTrigger.hover();
+  const dialog = page.getByRole("dialog", { name: "Response options" });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("radio", { name: label }).click();
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("Escape");
+}
+
+async function send(page: Page, prompt: string) {
+  const main = page.getByTestId("chat-main");
+  await main.locator(".cave-composer-input").fill(prompt);
+  await main.getByRole("button", { name: "Send message" }).click();
+}
+
+test("Response options preserves Explore and Build permission payloads", async ({ page }) => {
+  const sends: Array<Record<string, unknown>> = [];
+  await setup(page, sends);
+
+  await chooseAccess(page, "Explore · read only");
+  await send(page, "Inspect the repository.");
+  await expect.poll(() => sends.find((entry) => entry.prompt === "Inspect the repository.")?.permissionMode)
+    .toBe("read");
+
+  await chooseAccess(page, "Build · full access");
+  await send(page, "Apply the focused patch.");
+  await expect.poll(() => sends.find((entry) => entry.prompt === "Apply the focused patch.")?.permissionMode)
+    .toBe("full");
+});

--- a/tests/chat-transcript-fold.spec.ts
+++ b/tests/chat-transcript-fold.spec.ts
@@ -55,7 +55,7 @@ const SESSION = {
   hasLocalConversation: true,
 };
 
-const foldPill = (page: Page) => page.locator(".cave-chat-fold__pill");
+const foldTrigger = (page: Page) => page.locator(".cave-chat-fold__trigger");
 const turns = (page: Page) => page.locator("[data-turn-id]");
 
 async function openFoldedThread(page: Page) {
@@ -101,28 +101,29 @@ test.describe("earlier-turns fold", () => {
   test("a long thread opens folded, names what it hides, and reveals every turn", async ({ page }) => {
     await openFoldedThread(page);
 
-    // Closed: only the recent exchange is mounted, and the pill counts TURNS —
-    // not groups. Counting groups would print "1 earlier turn" over a fold
-    // hiding a whole voice call.
+    // Closed: only the recent exchange is mounted. The visible control is a
+    // minimal seam, while its accessible label and title still count TURNS —
+    // not groups.
     const foldedCount = await turns(page).count();
     expect(foldedCount, "a closed fold mounts only the kept tail").toBeLessThan(TURNS.length);
-    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "false");
-    await expect(foldPill(page)).toContainText(`${TURNS.length - foldedCount} earlier`);
+    await expect(foldTrigger(page)).toHaveAttribute("aria-expanded", "false");
+    await expect(foldTrigger(page)).toHaveAttribute("title", `${TURNS.length - foldedCount} earlier turns`);
+    await expect(foldTrigger(page)).toHaveText("");
 
     // The accessible name is a sentence, not the terse mono chrome.
-    await expect(foldPill(page)).toHaveAttribute("aria-label", /^Show \d+ earlier turns?$/);
+    await expect(foldTrigger(page)).toHaveAttribute("aria-label", /^Show \d+ earlier turns?$/);
 
-    // Open: every turn is reachable, and the label names the way back rather
-    // than continuing to claim turns are hidden while they are on screen.
-    await foldPill(page).click();
-    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "true");
+    // Open: every turn is reachable, and the accessible copy names the way
+    // back rather than claiming turns are hidden while they are on screen.
+    await foldTrigger(page).click();
+    await expect(foldTrigger(page)).toHaveAttribute("aria-expanded", "true");
     await expect(turns(page)).toHaveCount(TURNS.length);
-    await expect(foldPill(page)).toContainText("hide earlier turns");
-    await expect(foldPill(page)).toHaveAttribute("aria-label", "Hide earlier turns");
+    await expect(foldTrigger(page)).toHaveAttribute("title", "hide earlier turns");
+    await expect(foldTrigger(page)).toHaveAttribute("aria-label", "Hide earlier turns");
 
     // And it folds back, so the control is a toggle rather than a one-way door.
-    await foldPill(page).click();
-    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "false");
+    await foldTrigger(page).click();
+    await expect(foldTrigger(page)).toHaveAttribute("aria-expanded", "false");
     await expect(turns(page)).toHaveCount(foldedCount);
   });
 
@@ -146,8 +147,8 @@ test.describe("earlier-turns fold", () => {
       .poll(transform, { message: "closed, the caret points down (press to reveal)" })
       .toBe(ROTATED_180);
 
-    await foldPill(page).click();
-    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "true");
+    await foldTrigger(page).click();
+    await expect(foldTrigger(page)).toHaveAttribute("aria-expanded", "true");
 
     // Open, the rotation is dropped entirely — the caret points up, at what the
     // press now does.
@@ -158,7 +159,7 @@ test.describe("earlier-turns fold", () => {
 
   test("opening find clears the fold so a hit in a hidden turn is reachable", async ({ page }) => {
     await openFoldedThread(page);
-    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "false");
+    await expect(foldTrigger(page)).toHaveAttribute("aria-expanded", "false");
     expect(await turns(page).count(), "starts folded").toBeLessThan(TURNS.length);
 
     // Find searches the WHOLE transcript and jumps by resolving [data-turn-id]
@@ -167,7 +168,7 @@ test.describe("earlier-turns fold", () => {
     // Find therefore has to clear the fold as well as the render cap.
     await page.keyboard.press(process.platform === "darwin" ? "Meta+f" : "Control+f");
 
-    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "true", { timeout: 10_000 });
+    await expect(foldTrigger(page)).toHaveAttribute("aria-expanded", "true", { timeout: 10_000 });
     await expect(turns(page)).toHaveCount(TURNS.length);
 
     // The oldest turn — the one furthest behind the fold — is now addressable,


### PR DESCRIPTION
## Summary

- replace the labeled earlier-turns pill with a full-width arrow seam
- move Explore/Build access selection into Tools → Response options
- replace the labeled Code rail with a hover/focus-revealed 14px pull tab
- refine the composer glass treatment toward a quieter dark-grey surface

## Verification

- `pnpm exec tsc --noEmit --incremental false`
- `pnpm lint`
- focused continuation/composer/rail contract tests
- `pnpm test:app` — 1320 test files passed
- real-app browser verification on port 3001, including folded-thread accessibility and response-options access selection
- `git diff --check`

Bead: `cave-bnay4`