### PR TITLE
fix(gate): report a coven spawn that never ran as a timeout, not a bad version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,6 +433,27 @@ the `0.2.5` floor (prereleases are refused whatever their numbers), and the
 `COVEN_BIN` override. Read those four lines before doing anything else; a
 supported install is often already present further along the same PATH.
 
+⚠️ **`coven-version-unsupported` and `coven-version-did-not-run` are different
+failures with opposite remedies, and the paragraph above applies only to the
+first.** Conflating them cost a session ~40 minutes on 2026-08-24: a bare
+`coven-version-unavailable` (the old spelling, before `cave-a8uza`) sent it
+auditing three `coven` installs when the CLI was never the problem.
+
+- `coven-version-unsupported` — a binary was found, RAN, and reported a version
+  below the floor. Deterministic. Fix PATH or set `COVEN_BIN`.
+- `coven-version-did-not-run` — nothing executed: the spawn timed out or could
+  not start. **Transient. Retry.** The reason now says which, plus the elapsed
+  time and the binary it tried, so the two are no longer guesswork.
+
+The usual cause of the second is load, not configuration. `covenSpawnEnv()`
+learns the child's PATH by running `$SHELL -ilc 'echo $PATH'`, which sources the
+user's entire interactive profile — measured at 3.8s idle on a developer machine
+(already at that probe's own 4s budget) and 11.7s for the whole env build, with
+74s observed at load average 124. It is memoised only per process, so every
+fresh `beads:worktrees:*` invocation pays it again. `defaultRunCoven` now bounds
+that discovery with its own deadline so it cannot consume the whole budget
+before the spawn starts.
+
 The reason it was ever filed as "not reproducible" (`cave-6bb4m`, issue #4897)
 is worth knowing, because the shape recurs: `covenBin()` composed its
 priority-ordered search path with `{ ...env, PATH: value }`, which on Windows

--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -115,6 +115,25 @@ function asText(value) {
  * for the rest of it.
  */
 function commandFailure(operation, result) {
+  // A command that never RAN is not an unavailable version, and saying so cost
+  // a session ~40 minutes (cave-a8uza): a spawn that timed out arrived here
+  // with no stderr and was reported as a bare `coven-version-unavailable`,
+  // which names the wrong subsystem entirely and reads as the deterministic
+  // "your CLI is too old" refusal. The reader then goes hunting a toolchain
+  // fault that does not exist. `spawnFailure` is the runner's own account of
+  // why nothing executed, so report that instead and say it is retryable.
+  if (result?.spawnFailure) {
+    const { kind, code, timeoutMs, elapsedMs, binary } = result.spawnFailure;
+    const parts = [
+      kind === "timeout"
+        ? `timed out after ${timeoutMs}ms`
+        : `could not be started${code ? ` (${code})` : ""}`,
+      elapsedMs === undefined ? null : `elapsed ${elapsedMs}ms`,
+      binary ? `binary ${binary}` : null,
+      "transient — retry",
+    ].filter(Boolean);
+    return { ok: false, reason: `coven-${operation}-did-not-run: ${parts.join("; ")}` };
+  }
   // Horizontal whitespace only in the leading class — `\s` would span newlines
   // and let the match start on a blank line, defeating the "non-empty" part.
   const detail = asText(result?.stderr).match(/^[^\S\n]*(\S[^\n]*)/m)?.[1];
@@ -198,22 +217,56 @@ function heldBy(status, handle, nowSeconds) {
  * reports the argv it executed — every other test injects `run`, so nothing
  * else reaches this function.
  */
-export function defaultRunCoven({ args, cwd }) {
+/** Wall-clock ceiling on the spawn itself. */
+const COVEN_SPAWN_TIMEOUT_MS = 35_000;
+
+/**
+ * Ceiling on building the child's PATH, which is NOT covered by the spawn
+ * timeout above: `covenSpawnEnv()` is evaluated as an argument, so it runs to
+ * completion before `spawnSync` starts its own clock.
+ *
+ * That mattered more than it sounds. `covenSpawnEnv()` runs a `$SHELL -ilc
+ * 'echo $PATH'` probe to learn the interactive-login PATH, and an interactive
+ * shell sources the user's whole profile. Measured on a developer machine:
+ * 3.8s idle — already at that probe's own 4s budget — and 11.7s for the full
+ * env build. Under load it is far worse, and the result is memoised only in a
+ * module-level variable, so every fresh CLI process pays it again.
+ *
+ * `covenSpawnEnv` deliberately declines to cache a value produced past its
+ * deadline, so bounding it here degrades this one call without poisoning the
+ * cache for a later caller that can afford the full probe.
+ */
+const COVEN_ENV_DISCOVERY_BUDGET_MS = 5_000;
+
+export function defaultRunCoven({ args, cwd, now = Date.now }) {
   const launch = covenLaunchCommand();
+  const binary = [launch.command, ...launch.fixedArgs].join(" ");
   if (launch.resolutionTimedOut || launch.unresolvedWindowsShim) {
     // Nothing was executed, but resolution did pick something — name it, so a
     // refusal from here is as readable as one from a spawn that ran.
-    return { ok: false, stdout: "", stderr: "", status: null, binary: launch.command };
+    return {
+      ok: false,
+      stdout: "",
+      stderr: "",
+      status: null,
+      binary: launch.command,
+      spawnFailure: {
+        kind: launch.resolutionTimedOut ? "timeout" : "unresolved",
+        binary: launch.command,
+      },
+    };
   }
+  const startedAt = now();
   const result = spawnSync(launch.command, [...launch.fixedArgs, ...args], {
     cwd,
     encoding: "utf8",
-    env: covenSpawnEnv(),
+    env: covenSpawnEnv({ discoveryDeadline: startedAt + COVEN_ENV_DISCOVERY_BUDGET_MS }),
     shell: false,
     windowsHide: true,
     stdio: ["ignore", "pipe", "pipe"],
-    timeout: 35_000,
+    timeout: COVEN_SPAWN_TIMEOUT_MS,
   });
+  const elapsedMs = now() - startedAt;
   return {
     ok: result.status === 0 && !result.error,
     stdout: asText(result.stdout),
@@ -223,7 +276,22 @@ export function defaultRunCoven({ args, cwd }) {
     // judged instead of leaving the reader to re-derive resolution by hand.
     // Several `coven` binaries commonly coexist on one machine and only the
     // resolver knows which one it picked (cave-6bb4m).
-    binary: [launch.command, ...launch.fixedArgs].join(" "),
+    binary,
+    // Why nothing usable came back, when that is the reason (cave-a8uza).
+    // `result.error` was previously collapsed into `ok` and dropped, which left
+    // `commandFailure` unable to tell a timeout from a clean non-zero exit and
+    // reporting both as an unavailable VERSION.
+    ...(result.error
+      ? {
+          spawnFailure: {
+            kind: result.error.code === "ETIMEDOUT" ? "timeout" : "spawn-error",
+            code: result.error.code,
+            timeoutMs: COVEN_SPAWN_TIMEOUT_MS,
+            elapsedMs,
+            binary,
+          },
+        }
+      : {}),
   };
 }
 

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -135,6 +135,66 @@ test("Coven client fails closed for malformed or unavailable CLI responses", () 
   );
 });
 
+test("a command that never ran is reported as such, not as an unavailable version", () => {
+  // cave-a8uza. A spawn that timed out used to arrive at commandFailure with no
+  // stderr and be reported as a bare `coven-version-unavailable` — a message
+  // about the CLI's VERSION for a failure that was a timeout, and one that
+  // reads exactly like the deterministic "too old" refusal. A session spent
+  // ~40 minutes auditing three coven installs because of it. These two cases
+  // must stay distinguishable.
+  const timedOut = createCovenMaintenanceClient({
+    run: () => ({
+      ok: false,
+      stdout: "",
+      stderr: "",
+      status: null,
+      binary: "/usr/local/bin/coven",
+      spawnFailure: {
+        kind: "timeout",
+        code: "ETIMEDOUT",
+        timeoutMs: 35_000,
+        elapsedMs: 35_004,
+        binary: "/usr/local/bin/coven",
+      },
+    }),
+  });
+  const result = timedOut.acquire({ ownerId: "cave-maintenance", repoDir });
+  assert.equal(result.ok, false);
+  assert.match(
+    result.reason,
+    /^coven-version-did-not-run: /,
+    "a spawn that never produced output must not be reported as a version verdict",
+  );
+  assert.match(result.reason, /timed out after 35000ms/, "says what actually happened");
+  assert.match(result.reason, /transient — retry/, "says the remedy, unlike the version refusal");
+  assert.match(result.reason, /\/usr\/local\/bin\/coven/, "names the binary it tried");
+  assert.doesNotMatch(
+    result.reason,
+    /unavailable/,
+    "must not reuse the vocabulary of a genuine version failure",
+  );
+});
+
+test("a command that RAN and failed still reports the version vocabulary", () => {
+  // The other side of the same contract: a real non-zero exit with stderr is a
+  // version verdict and must keep saying so, or the fix above would just move
+  // the ambiguity rather than remove it.
+  const ranAndFailed = createCovenMaintenanceClient({
+    run: () => ({
+      ok: false,
+      stdout: "",
+      stderr: "coven: unknown subcommand 'owner'\n",
+      status: 2,
+      binary: "/usr/local/bin/coven",
+    }),
+  });
+  const result = ranAndFailed.acquire({ ownerId: "cave-maintenance", repoDir });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /^coven-version-unavailable: /);
+  assert.match(result.reason, /unknown subcommand/, "keeps the client's own first stderr line");
+  assert.doesNotMatch(result.reason, /did-not-run/);
+});
+
 test("Coven client rejects maintenance protocols below the reviewed release", () => {
   assert.equal(supportsCovenMaintenanceVersion("coven 0.2.5"), true);
   assert.equal(supportsCovenMaintenanceVersion("coven v0.3.0"), true);


### PR DESCRIPTION
A `spawnSync` that **timed out** arrived at `commandFailure` with no stderr and
was reported as a bare **`coven-version-unavailable`** — a verdict about the
CLI's *version* for a failure that was a *timeout*, phrased exactly like the
deterministic "your CLI is too old" refusal.

A session spent **~40 minutes** auditing three `coven` installs on PATH because
of it. The CLI was never the problem.

## The bead's original diagnosis was wrong

It blamed cold **binary resolution**. Timing the pieces says otherwise:

| call | cold |
|---|---:|
| `covenBin()` | **0 ms** |
| `covenLaunchCommand()` | **0 ms** |
| **`covenSpawnEnv()`** | **11,681 ms** |
| `covenSpawnEnv()` (warm) | 0 ms |

`covenSpawnEnv()` learns the child's PATH by running `$SHELL -ilc 'echo $PATH'`,
which sources the user's entire interactive profile — **3.8 s idle** on this
machine (already at that probe's own 4 s budget), and **74 s at load average
124**. It is memoised only in a module-level variable, so **every fresh
`beads:worktrees:*` process pays it again**.

And critically: that call is an **argument** to `spawnSync`, so the 35 s spawn
timeout never covered it.

## Two fixes

**1 — bound the env build.** `defaultRunCoven` now passes
`covenSpawnEnv({ discoveryDeadline })`, an existing sanctioned seam.
`covenSpawnEnv` deliberately declines to cache a value produced past its
deadline, so bounding this one call degrades *it* without poisoning the module
cache for a later caller that can afford the full probe.

**2 — stop discarding the reason.** `defaultRunCoven` collapsed `result.error`
into `ok` and dropped it, leaving `commandFailure` unable to tell a timeout from
a clean non-zero exit. It now carries
`spawnFailure { kind, code, timeoutMs, elapsedMs, binary }`, and the reason reads:

```
coven-version-did-not-run: timed out after 35000ms; elapsed 35004ms;
binary /usr/local/bin/coven; transient — retry
```

instead of naming the wrong subsystem and offering no remedy.

## Tests pin both sides

- a spawn that never ran **must not** use version vocabulary
- a genuine non-zero exit with stderr **must still** use it

Without the second, the fix would move the ambiguity rather than remove it.

## CLAUDE.md corrected

It stated a version refusal is *"deterministic given PATH, not intermittent —
retrying it changes nothing."* That holds for `coven-version-unsupported` and is
**false** for the did-not-run case — and believing it is exactly what cost the
40 minutes. The two now appear with their opposite remedies:

- `coven-version-unsupported` — ran, reported a version below the floor.
  Deterministic. Fix PATH or set `COVEN_BIN`.
- `coven-version-did-not-run` — nothing executed. **Transient. Retry.**

plus the measured cause, so the next reader doesn't re-derive it.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `scripts/maintenance-gate.test.mjs` — **21/21**
- `defaultRunCoven` against the real CLI still returns `ok: true` with the
  correct banner and no `spawnFailure`

Closes `cave-a8uza`.
