### PR TITLE
Require the signed OpenClaw release contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ on:
         required: false
         type: string
       allow_unconfigured_registries:
-        description: "EMERGENCY ONLY: skip the signed OpenCode/Grok schema-registry gates and ship with the built-in baseline parsers. Tag pushes always stay fail-closed."
+        description: "EMERGENCY ONLY: skip the signed OpenCode/Grok/OpenClaw schema-registry gates and ship with the built-in baseline parsers. Tag pushes always stay fail-closed."
         required: false
         default: false
         type: boolean
@@ -1229,11 +1229,34 @@ jobs:
             echo "NEXT_PUBLIC_COVEN_GROK_SCHEMA_REGISTRY_CHECKPOINT=$NEXT_PUBLIC_COVEN_GROK_SCHEMA_REGISTRY_CHECKPOINT"
           } >> "$GITHUB_ENV"
 
+      - name: Require signed OpenClaw compatibility registry
+        # Skippable only via manual workflow_dispatch with an explicit flag;
+        # tag-push releases remain fail-closed (docs/openclaw-compatibility-registry.md).
+        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.allow_unconfigured_registries }}
+        shell: bash
+        env:
+          NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_URL: ${{ secrets.OPENCLAW_SCHEMA_REGISTRY_URL }}
+          NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEY: ${{ secrets.OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEY }}
+          NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEYS: ${{ secrets.OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEYS }}
+          NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_CHECKPOINT: ${{ secrets.OPENCLAW_SCHEMA_REGISTRY_CHECKPOINT }}
+        run: |
+          node scripts/check-openclaw-registry-release.mjs
+          {
+            echo "NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_URL=$NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_URL"
+            echo "NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEY<<COVEN_OPENCLAW_KEY_EOF"
+            printf '%s\n' "$NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEY"
+            echo "COVEN_OPENCLAW_KEY_EOF"
+            echo "NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEYS<<COVEN_OPENCLAW_KEYS_EOF"
+            printf '%s\n' "$NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEYS"
+            echo "COVEN_OPENCLAW_KEYS_EOF"
+            echo "NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_CHECKPOINT=$NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_CHECKPOINT"
+          } >> "$GITHUB_ENV"
+
       # The escape hatch above is deliberately available for emergency manual
       # runs, but using it must never be silent: v0.2.0 shipped with BOTH
       # guards skipped and nobody noticed for four days, because the only
       # evidence was a `skipped` line buried in the job steps (cave-yp21x).
-      # This is the inverse condition of the two guards, so it fires exactly
+      # This is the inverse condition of the registry guards, so it fires exactly
       # when they did not.
       - name: Record skipped compatibility guards
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_registries }}
@@ -1243,8 +1266,8 @@ jobs:
             echo "### ⚠️ Compatibility registry guards SKIPPED"
             echo
             echo "This \`${{ matrix.platform }}\` build ran with \`allow_unconfigured_registries: true\`, so"
-            echo "**neither** the OpenCode nor the Grok signed schema-registry gate verified"
-            echo "anything. The build used the built-in baseline parsers."
+            echo "The signed schema-registry gates for OpenCode, Grok, and OpenClaw verified"
+            echo "**nothing**. The build used the built-in baseline parsers."
             echo
             echo "Tag-push releases cannot do this — the hatch is manual-dispatch only."
             echo "If this run publishes a release, its notes carry the same statement."

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@ A document in `docs/` proper should be one somebody keeps current.
 ### Compatibility registries
 
 - [`grok-compatibility-registry.md`](grok-compatibility-registry.md) — signed schema bundles and trust anchors for Grok Build
+- [`openclaw-compatibility-registry.md`](openclaw-compatibility-registry.md) — the signed release guard, checkpoint, rotation, and rollback contract for OpenClaw event profiles
 - [`opencode-compatibility-registry.md`](opencode-compatibility-registry.md) — the same contract for OpenCode event schemas
 
 ### Design

--- a/docs/openclaw-compatibility-registry.md
+++ b/docs/openclaw-compatibility-registry.md
@@ -1,0 +1,93 @@
+# OpenClaw compatibility registry
+
+Coven Cave accepts structured OpenClaw tool activity only when the authenticated
+Gateway identity matches a bounded profile from a verified compatibility bundle.
+The canonical publisher endpoint is
+`https://opencoven.github.io/coven-runtimes/openclaw/current.json`. Cave owns the
+parser and permits only fixed event names, lifecycle values, and direct field
+aliases; registry data cannot add executable code, arbitrary JSON paths, launch
+arguments, logging behavior, or new envelopes.
+
+## Release configuration
+
+Every desktop release must provide these GitHub Actions secrets:
+
+- `OPENCLAW_SCHEMA_REGISTRY_URL` — the credential-free HTTPS endpoint above.
+- `OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEY`, or
+  `OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEYS` — PEM Ed25519 public verification
+  material. A rotation keyring contains one to four named keys.
+- `OPENCLAW_SCHEMA_REGISTRY_CHECKPOINT` — compact JSON containing exactly the
+  current positive `sequence` and lowercase SHA-256 `payloadHash` of the
+  canonical unsigned bundle.
+
+The release workflow validates these values, then maps them to
+`NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_*` for packaging. They are public
+verification anchors, never signing credentials. Development can use
+`COVEN_OPENCLAW_SCHEMA_REGISTRY_*`; production deliberately ignores those
+development variables.
+
+Without a configured remote registry, the source-trusted built-in profile is
+the offline and development baseline. It pins OpenClaw Gateway protocol v4,
+`@openclaw/gateway-protocol@2026.7.2-beta.5`, the official outer
+`AgentEventSchema` hash, and reviewed upstream revision
+`d66b514a7e7565d89c87ab6f1a509623128093f0`. It is not a substitute for the
+publisher and release anchors required to ship independently refreshable
+compatibility.
+
+## Publishing, checkpoint, and rollback
+
+`OpenCoven/coven-runtimes` owns bundle review, the private signing key, and the
+monotonic publisher. Private material must never enter Cave, GitHub release
+secrets, logs, issue text, diagnostics, or a published bundle.
+
+Publish an immutable bundle for each increasing sequence, then update
+`openclaw/current.json` atomically. Before a Cave release, set the packaged
+checkpoint to that reviewed bundle's sequence and canonical unsigned-payload
+hash. Cave rejects lower sequences, different payloads at an accepted sequence,
+partial snapshots, unauthorized profile retirement, invalid or expired
+signatures, and conflicts with its bounded trust-anchor journal. A rejected
+refresh keeps the last known good bundle; it never enables an opaque payload.
+
+## Signature canonicalization (format 1)
+
+Format 1 signs the UTF-8 bytes of the unsigned bundle. Remove the top-level
+`signature` member, then recursively serialize with no whitespace. Arrays keep
+their order. Object keys sort lexicographically using ECMAScript UTF-16
+code-unit order. Strings and primitives use `JSON.stringify` escaping; object
+separators are `,` and `:`, and there is no trailing newline. The detached
+Ed25519 signature is standard base64 over exactly those bytes.
+
+The format is frozen. Any change to canonicalization, escaping, or signed
+members requires a new bundle format and explicit verifier.
+
+```text
+input unsigned value: { "z":"last", "runtime":"openclaw", "number":0, "nested":{ "unicode":"é", "quote":"\\\"", "line":"a\nb" }, "array":[true,2,null] }
+canonical UTF-8 text: {"array":[true,2,null],"nested":{"line":"a\\nb","quote":"\\\"","unicode":"é"},"number":0,"runtime":"openclaw","z":"last"}
+```
+
+## Rotation and revocation
+
+For routine rotation, first ship a Cave release whose keyring contains both the
+active and retiring public keys. New bundles carry the signed `keyId`. After the
+new signer has been served successfully for one release window, and no later
+than the old bundle expiry, remove the prior key in a later Cave release.
+
+Emergency revocation removes the compromised public key in a new release.
+Caches signed only by that key then fail closed to the source-trusted built-in
+profile or plain chat; Cave does not silently trust them. Record the endpoint,
+public-key fingerprint, publisher owner, checkpoint, rotation date, and
+retirement date in the release checklist.
+
+## Diagnostics and deployment handoff
+
+Compatibility diagnostics may name the runtime version, wire protocol, profile
+ID, registry sequence, and a value-free event-shape fingerprint. They never
+contain prompts, paths, credentials, dynamic keys, tool inputs or outputs, or
+raw frames.
+
+This repository contains the verifier, built-in profile, release guard, and
+runtime projection. Closing the parent compatibility feature additionally
+requires the signed sequence-one bundle to be published from
+`OpenCoven/coven-runtimes` and production release secrets to be configured from
+that reviewed bundle. Those publisher operations are external deployment work,
+not a Cave-side code fallback.

--- a/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
+++ b/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
@@ -17,13 +17,22 @@ the accepted `runId`, subscribes to session events, and accepts only events
 belonging to that exact run. The current CLI bridge stays the authoritative
 fallback for every other runtime.
 
-## Target contract after a tool schema is published
+## Tool compatibility contract
 
-Full tool activity requires a published, versioned `session.tool` event name,
-payload validator, and lifecycle fixtures. Once those exist, Cave must request
-only the documented capabilities, validate the negotiated role/scopes and
-methods, and bind tool events to the Gateway-accepted run ID. Until then, no
-capability string or observed frame is a substitute for a payload contract.
+OpenClaw's official `AgentEventSchema` validates the outer event envelope but
+leaves `data` unrestricted. Cave therefore combines that official outer schema
+with a signed, data-only profile from the OpenClaw compatibility registry. A
+profile may select fixed event names and streams, closed lifecycle values, and
+direct field aliases. It cannot add executable code, arbitrary JSON paths,
+launch arguments, logging behavior, or new envelopes. No capability string or
+observed frame is a substitute for this verified contract.
+
+Negotiation is two-phase. Cave first connects without `tool-events`, validates
+the authenticated hello, and selects a profile against the exact server
+version, protocol, methods, events, server capabilities, client capability, and
+official package-schema hash. Only then does it reconnect advertising
+`tool-events`; the second hello must preserve the selected identity before Cave
+subscribes or dispatches.
 
 The direct dispatcher supplies an idempotency key, receives the accepted run
 identifier, then binds all live state to `(sessionKey, agentId, runId)`. A tool
@@ -43,15 +52,16 @@ reason to guess a field shape.
    authenticate with the reference Gateway client and validate `hello-ok` plus
    negotiated policy limits. Never persist credentials in plaintext or include
    them in logs, caches, SSE, or diagnostics.
-3. Establish the selected canonical-session subscription before dispatching
-   the turn. Add any additional subscription only when its published schema
-   and contract fixture are available.
+3. Resolve the signed compatibility profile, reconnect with `tool-events`, and
+   establish the selected canonical-session subscription before dispatching.
+   Accept `agent` and `session.tool` only when the selected profile names them.
 4. Send `chat.send` with the Cave message, canonical session key, agent ID,
    and an idempotency key derived from the Cave request ID. Record the
    Gateway-accepted `runId`.
 5. Project only matching, schema-validated events to Cave SSE. Maintain a
-   per-run high-water sequence, reject replay, and fail the owned turn on a
-   forward gap until a published history-reconciliation contract is available.
+   per-run high-water sequence and reject replay or regression. Tool sequence
+   values may be sparse because other agent streams share the counter; the
+   Gateway transport gap callback remains the missing-frame authority.
 6. On terminal chat state, persist the response. After a published tool schema
    is supported, also persist reconciled tool cards. On
    cancellation, first persist a per-run `cancelled` terminal fence, then abort
@@ -73,15 +83,16 @@ reason to guess a field shape.
 
 - Depend on the official protocol/client packages rather than local copies of
   WebSocket framing, signing, or schemas.
-- Keep an explicit profile table keyed by protocol version and package release
-  range. A profile declares exact methods, events, scopes, payload validators,
-  limits, and migration behavior.
+- Resolve bounded profiles from the Ed25519-signed OpenClaw registry. A profile
+  declares exact versions, protocol, methods, events, capabilities, official
+  outer-schema hash, lifecycle values, and direct aliases.
 - Generate/capture protocol conformance fixtures from each supported package
   release. Include supported, old/unsupported, future/unknown, missing-scope,
   pairing-required, replay, sequence-gap, disconnect, cancellation, and
   concurrent-run cases.
-- Upgrade only after the schema diff and fixtures pass. Unknown wire versions
-  fail closed to CLI; a new Cave release adds a tested profile.
+- Upgrade only after source review and conformance fixtures pass. Compatible
+  signed profile revisions can ship without a Cave UI release; unknown wire
+  versions and profile shapes fail closed to CLI/plain chat.
 
 ## Current release boundary (2026-07-31)
 
@@ -132,11 +143,10 @@ gaps therefore terminate the owned Gateway path instead of guessing.
 
 ## Delivery slices
 
-1. Add official protocol/client dependencies, capability/profile discovery,
-   paired-device credential storage, and protocol fixtures.
-2. Implement one owned Gateway turn with chat SSE projection and a CLI fallback
-   selected before dispatch.
-3. Implement correlated tool lifecycle, persistence, cancellation, and
-   reconciliation.
-4. Add cross-version conformance and route-level integration tests; document
-   operator setup and upgrade support boundaries.
+The Cave-side slices are implemented: official package pins, paired-device
+storage, signed profile resolution, two-phase dispatch, correlated lifecycle,
+SSE/persistence/resume, quarantine/fallback, and conformance fixtures. The
+remaining deployment slice is owned by `OpenCoven/coven-runtimes`: publish the
+canonical signed sequence-one bundle and configure Cave's production URL,
+public keyring, and checkpoint. Cave remains fail-closed until those public
+trust anchors are present.

--- a/scripts/check-openclaw-registry-release.mjs
+++ b/scripts/check-openclaw-registry-release.mjs
@@ -1,0 +1,29 @@
+// Public verification material is embedded in a desktop release; this guard
+// makes a missing trust anchor a release failure rather than an unsafe default.
+import { createPublicKey } from "node:crypto";
+
+const url = process.env.NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_URL;
+const publicKey = process.env.NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEY;
+const publicKeys = process.env.NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEYS;
+const checkpoint = process.env.NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_CHECKPOINT;
+const fail = (message) => { console.error(`::error::${message}`); process.exitCode = 1; };
+let keyring;
+try { keyring = publicKeys ? JSON.parse(publicKeys) : publicKey ? { legacy: publicKey } : null; } catch { keyring = null; }
+if (!url || !keyring || typeof keyring !== "object" || Array.isArray(keyring) || !checkpoint) {
+  fail("OpenClaw compatibility registry URL, Ed25519 public key/keyring, and immutable sequence checkpoint must be configured for every desktop release.");
+} else {
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.protocol !== "https:" || parsedUrl.username || parsedUrl.password) throw new Error("registry URL must use HTTPS without credentials");
+    const entries = Object.entries(keyring);
+    if (!entries.length || entries.length > 4) throw new Error("registry keyring must contain one to four keys");
+    for (const [id, pem] of entries) {
+      if (!/^[A-Za-z][A-Za-z0-9_-]{0,63}$/.test(id) || typeof pem !== "string") throw new Error("registry keyring has an invalid key id");
+      if (createPublicKey(pem).asymmetricKeyType !== "ed25519") throw new Error("registry key must be Ed25519");
+    }
+    const parsedCheckpoint = JSON.parse(checkpoint);
+    if (!parsedCheckpoint || typeof parsedCheckpoint !== "object" || Array.isArray(parsedCheckpoint)
+      || Object.keys(parsedCheckpoint).length !== 2 || !Number.isSafeInteger(parsedCheckpoint.sequence) || parsedCheckpoint.sequence < 1
+      || typeof parsedCheckpoint.payloadHash !== "string" || !/^[a-f0-9]{64}$/.test(parsedCheckpoint.payloadHash)) throw new Error("registry checkpoint must contain a sequence and SHA-256 payload hash");
+  } catch (error) { fail(`Invalid OpenClaw compatibility registry configuration: ${error instanceof Error ? error.message : "unknown error"}`); }
+}

--- a/scripts/check-openclaw-registry-release.test.mjs
+++ b/scripts/check-openclaw-registry-release.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+
+const workflow = await readFile(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+const guard = await readFile(new URL("./check-openclaw-registry-release.mjs", import.meta.url), "utf8");
+const docs = await readFile(new URL("../docs/openclaw-compatibility-registry.md", import.meta.url), "utf8");
+
+assert.match(workflow, /Require signed OpenClaw compatibility registry[\s\S]*?NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_URL[\s\S]*?check-openclaw-registry-release\.mjs/);
+assert.match(workflow, /NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEYS/);
+assert.match(workflow, /NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_CHECKPOINT/);
+assert.match(workflow, /OpenCode, Grok, and OpenClaw/);
+assert.match(guard, /registry URL must use HTTPS without credentials/);
+assert.match(guard, /asymmetricKeyType !== "ed25519"/);
+assert.match(guard, /keyring must contain one to four keys/);
+assert.match(guard, /payloadHash/);
+assert.match(docs, /Signature canonicalization \(format 1\)/);
+assert.match(docs, /openclaw\/current\.json/);
+assert.match(docs, /source-trusted built-in profile/i);
+assert.match(docs, /rotation/i);
+
+// A registry endpoint is public build metadata, so an HTTPS URL that embeds
+// basic-auth userinfo must fail without echoing its credential into CI output.
+const { publicKey } = generateKeyPairSync("ed25519");
+const credential = "publisher-token-must-not-leak";
+const credentialed = spawnSync(process.execPath, ["scripts/check-openclaw-registry-release.mjs"], {
+  cwd: new URL("..", import.meta.url),
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_URL: `https://publisher:${credential}@registry.example/openclaw.json`,
+    NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_PUBLIC_KEY: publicKey.export({ type: "spki", format: "pem" }).toString(),
+    NEXT_PUBLIC_COVEN_OPENCLAW_SCHEMA_REGISTRY_CHECKPOINT: JSON.stringify({ sequence: 1, payloadHash: "a".repeat(64) }),
+  },
+});
+assert.notEqual(credentialed.status, 0, "credentialed registry URLs must be rejected before packaging");
+assert.match(credentialed.stderr, /without credentials/);
+assert.doesNotMatch(credentialed.stderr, new RegExp(credential));
+console.log("check-openclaw-registry-release.test.mjs: ok");

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -144,8 +144,8 @@ fi
 if [ "$registry_guards_skipped" = "true" ]; then
   cat <<'PROVENANCE'
 This release was built on a manual run with `allow_unconfigured_registries`
-enabled, so the signed OpenCode and Grok compatibility-registry checks did not
-run. The build uses the built-in baseline schema parsers.
+enabled, so the signed OpenCode, Grok, and OpenClaw compatibility-registry
+checks did not run. The build uses the built-in baseline schema parsers.
 
 Releases published from a tag push cannot skip those checks.
 

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -183,6 +183,7 @@ test("the provenance block appears only when the guards were actually skipped", 
   assert.match(skipped, /^## Build provenance/m, "a skipped-guard build states its provenance");
   assert.match(skipped, /allow_unconfigured_registries/, "names the flag that caused it");
   assert.match(skipped, /built-in baseline schema parsers/, "says what it used instead");
+  assert.match(skipped, /OpenCode, Grok, and OpenClaw/, "names every skipped registry guard");
   assert.match(skipped, /tag push cannot skip/, "says the normal path is still fail-closed");
 
   assert.doesNotMatch(render("v7.0.55"), /Build provenance/, "unset flag renders no block");

--- a/scripts/release-promotion-workflow.test.mjs
+++ b/scripts/release-promotion-workflow.test.mjs
@@ -554,6 +554,7 @@ test("no release gate can be switched off by a step-level or job-level if:", asy
     "build: Require OpenCoven X app configuration",
     "build: Require signed OpenCode compatibility registry",
     "build: Require signed Grok compatibility registry",
+    "build: Require signed OpenClaw compatibility registry",
   ]) {
     assert.ok(
       gates.some((gate) => gate.label === required),
@@ -602,7 +603,7 @@ test("no release gate can be switched off by a step-level or job-level if:", asy
     );
   }
 
-  // Exactly two gates are waivable, only by the documented registry hatch, and
+  // Exactly three gates are waivable, only by the documented registry hatch, and
   // only on a dispatch. Anything else that goes quiet when every hatch input is
   // pulled is a gate that acquired an escape route nobody wrote down.
   const hatchedDispatch = releaseRun({
@@ -628,6 +629,7 @@ test("no release gate can be switched off by a step-level or job-level if:", asy
     waived,
     [
       "build: Require signed Grok compatibility registry",
+      "build: Require signed OpenClaw compatibility registry",
       "build: Require signed OpenCode compatibility registry",
     ],
     "a release gate gained an escape hatch — document it here deliberately, with the reason",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -264,6 +264,7 @@ export const SUITES = {
     "scripts/branch-cap-workflow.test.mjs",
     "scripts/check-opencode-registry-release.test.mjs",
     "scripts/check-grok-registry-release.test.mjs",
+    "scripts/check-openclaw-registry-release.test.mjs",
     "scripts/check-x-app-release.test.mjs",
     "src/components/open-coven-tools-update.test.ts",
     "src/lib/opencoven-tools-state.test.ts",

--- a/src/lib/openclaw-bridge.test.ts
+++ b/src/lib/openclaw-bridge.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -67,8 +67,8 @@ const candidateAgents = [
 ];
 
 assert.deepEqual(openClawBridgeCapabilities(), {
-  streaming: false,
-  toolEvents: false,
+  streaming: true,
+  toolEvents: true,
   stableSessionKey: true,
   localFileAttachments: false,
   sshRuntime: false,
@@ -77,6 +77,12 @@ assert.deepEqual(openClawBridgeCapabilities(), {
   nativeSkills: true,
   nativeMessaging: true,
 });
+const bridgeSource = await readFile(new URL("./openclaw-bridge.ts", import.meta.url), "utf8");
+assert.match(
+  bridgeSource,
+  /Bridge implementation support\. Runtime activation remains compatibility-negotiated\./,
+  "capabilities describe implemented negotiation support rather than promising every runtime qualifies",
+);
 
 assert.equal(
   extractOpenClawText({ result: { payloads: [{ content: "scalar reply" }] } }),

--- a/src/lib/openclaw-bridge.ts
+++ b/src/lib/openclaw-bridge.ts
@@ -56,6 +56,7 @@ export type OpenClawAgentBinding = {
 };
 
 export type OpenClawBridgeCapabilities = {
+  /** Bridge implementation support. Runtime activation remains compatibility-negotiated. */
   streaming: boolean;
   toolEvents: boolean;
   stableSessionKey: boolean;
@@ -98,8 +99,8 @@ export class OpenClawAgentResolutionError extends Error {
 
 export function openClawBridgeCapabilities(): OpenClawBridgeCapabilities {
   return {
-    streaming: false,
-    toolEvents: false,
+    streaming: true,
+    toolEvents: true,
     stableSessionKey: true,
     localFileAttachments: false,
     sshRuntime: false,


### PR DESCRIPTION
## Summary

- advertise streaming and tool-event support as compatibility-negotiated bridge capabilities
- fail desktop releases closed unless the public OpenClaw registry URL, Ed25519 keyring, and monotonic checkpoint are configured
- document canonical publication, rotation, revocation, diagnostics, and the external coven-runtimes deployment boundary
- keep emergency release provenance truthful across OpenCode, Grok, and OpenClaw

## Verification

Passed:
- `node --experimental-strip-types src/lib/openclaw-compatibility.test.ts`
- `node --experimental-strip-types src/lib/openclaw-gateway.test.ts`
- `node --experimental-strip-types src/lib/openclaw-bridge.test.ts`
- `node --experimental-strip-types src/lib/openclaw-conversation.test.ts`
- `node --experimental-strip-types src/lib/openclaw-conversation-tools.test.ts`
- `node --experimental-strip-types src/app/api/chat/send/harness-routing-tool-events.test.ts`
- `node scripts/check-openclaw-registry-release.test.mjs`
- `node --test scripts/release-notes.test.mjs` (11/11)
- `pnpm check:tests-wired` (1869 files)
- `pnpm typecheck`
- `git diff --check`

Unrelated current-tree/environment failures:
- `pnpm lint` stops in token-reference scanning on existing CSS/token-bank findings outside this diff
- `pnpm test:app` reached 50 passing files, then a canonical-memory SIGHUP cleanup took 2887 ms against a 2500 ms timing ceiling
- `pnpm test:api` reached 34 passing files, then the shared maintenance fence made a lifecycle-create fixture observe `heartbeat-regressed`

Bead: `cave-53iko.5`
Parent: #4892

This PR closes only the Cave-side Tasks 8/9 release contract. Publishing the signed bundle and configuring production anchors remain in `OpenCoven/coven-runtimes`; this change does not infer opaque OpenClaw payloads or weaken that trust boundary.