### PR TITLE
Make project identity host and worktree aware

### DIFF
--- a/src/components/acting-familiar-gate.test.ts
+++ b/src/components/acting-familiar-gate.test.ts
@@ -309,12 +309,12 @@ assert.match(
 );
 assert.match(
   chatRouterSource,
-  /onNewChat=\{\(projectRoot, familiarId\) => \{[\s\S]{0,180}if \(onRequestNewChat\) \{[\s\S]{0,100}onRequestNewChat\(\);[\s\S]{0,100}return;/,
+  /onNewChat=\{\(projectRoot, familiarId, runtimeHost\) => \{[\s\S]{0,180}if \(onRequestNewChat\) \{[\s\S]{0,100}onRequestNewChat\(\);[\s\S]{0,100}return;/,
   "ChatRouter gates list launches before mutating its local view",
 );
 assert.match(
   chatRouterSource,
-  /<ChatProjectSidebar[\s\S]{0,900}onNewChat=\{\(\) => \{[\s\S]{0,120}if \(onRequestNewChat\) \{[\s\S]{0,80}onRequestNewChat\(\);[\s\S]{0,80}return;/,
+  /<ChatProjectSidebar[\s\S]{0,900}onNewChat=\{\(projectRoot, runtimeHost\) => \{[\s\S]{0,120}if \(onRequestNewChat\) \{[\s\S]{0,80}onRequestNewChat\(\);[\s\S]{0,80}return;/,
   "the project-group sidebar cannot derive a new actor from historical sessions",
 );
 assert.match(

--- a/src/components/chat-compose-instance.test.ts
+++ b/src/components/chat-compose-instance.test.ts
@@ -44,7 +44,7 @@ assert.match(
 // ── 3. ChatList onNewChat increments ─────────────────────────────────────────
 
 const chatListOnNewChat =
-  routerSource.match(/onNewChat=\{\(projectRoot, familiarId\) => \{[\s\S]*?\}\}/)?.[0] ?? "";
+  routerSource.match(/onNewChat=\{\(projectRoot, familiarId, runtimeHost\) => \{[\s\S]*?\}\}/)?.[0] ?? "";
 
 assert.ok(chatListOnNewChat.length > 0, "ChatList onNewChat handler must be present in router");
 
@@ -57,7 +57,7 @@ assert.match(
 // ── 4. ChatProjectSidebar delegates to shell New, with a safe fallback ───────
 
 const sidebarOnNewChat =
-  routerSource.match(/onNewChat=\{\(\) => \{[\s\S]*?\n        \}\}\s*\n        onOpenProjectsTab=/)?.[0] ?? "";
+  routerSource.match(/onNewChat=\{\(projectRoot, runtimeHost\) => \{[\s\S]*?\n        \}\}\s*\n        onOpenProjectsTab=/)?.[0] ?? "";
 
 assert.ok(sidebarOnNewChat.length > 0, "ChatProjectSidebar onNewChat handler must be present in router");
 

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -45,6 +45,7 @@ import { useProjects } from "@/lib/use-projects";
 import {
   applyProjectScope,
   normalizeSelection,
+  selectionKey,
   type ProjectSelection,
 } from "@/lib/chat-project-selection";
 import {
@@ -123,7 +124,11 @@ type Props = {
   onToggleExpanded: (key: string) => void;
   daemonRunning?: boolean;
   onOpen: (sessionId: string, familiarId?: string | null, findQuery?: string) => void;
-  onNewChat: (projectRoot?: string, familiarId?: string | null) => void;
+  onNewChat: (
+    projectRoot?: string,
+    familiarId?: string | null,
+    runtimeHost?: string | null,
+  ) => void;
   onSessionsChanged?: () => void;
   onSessionsDeleted: (sessionIds: readonly string[]) => void;
   /** Open a URL in the in-app browser (the PR-status badge's click-through).
@@ -475,6 +480,7 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
       return [{
         projectId: null,
         projectRoot: null,
+        runtimeHost: null,
         projectName: null,
         sessions: rows,
         defaultFamiliarId: latest?.familiarId ?? scopedFamiliarId,
@@ -1293,7 +1299,7 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
           >
             <SortableContext items={displayIds} strategy={verticalListSortingStrategy}>
           <ul className="divide-y divide-[var(--border-hairline)]">
-            {displayGroups.map(({ projectRoot, sessions: rows }) => {
+            {displayGroups.map(({ projectRoot, runtimeHost, projectName, sessions: rows }) => {
               // Flat "All sessions" view (the phone surface): split the list into a
               // counted PINNED section and a counted SESSIONS section, mirroring
               // the desktop rail. firstPinnedIdx/firstRestIdx place each header
@@ -1304,14 +1310,14 @@ export function ChatList({ familiar, familiars = [], sessions, selection, expand
               const firstPinnedIdx = pinnedFlags.indexOf(true);
               const firstRestIdx = pinnedFlags.indexOf(false);
               return (
-              <li key={projectRoot ?? "__none__"}>
+              <li key={selectionKey(null, projectRoot, runtimeHost)}>
                 {/* Project group header — uppercase label + count + fading rule
                     (rendered for every group in the "Group by project" mode,
                     including the no-project bucket). */}
                 {effectiveSelection === "all" && (projectRoot !== null || groupBy === "project") && (
                   <div className="chat-list-group-header group relative flex items-center gap-2 px-4 pb-1 pt-3">
                     <span className="truncate text-[length:var(--text-2xs)] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">
-                      {projectRoot ? repoName(projectRoot) : "No project"}
+                      {projectName ?? (projectRoot ? repoName(projectRoot) : "No project")}
                     </span>
                     <span className="shrink-0 text-[length:var(--text-xs)] text-[var(--text-muted)]">{rows.length}</span>
                     <span aria-hidden className="h-px min-w-0 flex-1 bg-gradient-to-r from-[var(--border-hairline)] to-transparent" />

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -89,7 +89,7 @@ type Props = {
    *  chat (keyboard twin of drag-to-split). Absent when splits are off
    *  (compact rail, mobile) — the row falls back to a plain open. */
   onOpenSessionInSplit?: (session: SessionRow) => void;
-  onNewChat: (projectRoot: string | null) => void;
+  onNewChat: (projectRoot: string | null, runtimeHost?: string | null) => void;
   onOpenProjectsTab?: () => void;
 };
 
@@ -579,14 +579,16 @@ export function ChatProjectSidebar({
     let target: ChatProjectGroup | undefined;
     if (overId.startsWith("folder:")) {
       const overKey = overId.slice("folder:".length);
-      target = groups.find((g) => selectionKey(g.projectId, g.projectRoot) === overKey);
+      target = groups.find(
+        (g) => selectionKey(g.projectId, g.projectRoot, g.runtimeHost) === overKey,
+      );
     } else {
       target = groups.find((g) => g.sessions.some((s) => s.id === overId));
     }
     if (!target) return;
 
-    const sourceKey = selectionKey(source.projectId, source.projectRoot);
-    const targetKey = selectionKey(target.projectId, target.projectRoot);
+    const sourceKey = selectionKey(source.projectId, source.projectRoot, source.runtimeHost);
+    const targetKey = selectionKey(target.projectId, target.projectRoot, target.runtimeHost);
 
     if (sourceKey === targetKey) {
       // Same folder → reorder via the shared manual-order list.
@@ -625,7 +627,7 @@ export function ChatProjectSidebar({
   const recentRows = allSessions;
 
   function renderProjectGroup(group: ChatProjectGroup) {
-    const key = selectionKey(group.projectId, group.projectRoot);
+    const key = selectionKey(group.projectId, group.projectRoot, group.runtimeHost);
     const projectExpanded = expandedKeys.includes(key);
     const projectVisible = hasSearch || projectExpanded;
     const isSelected = selection === key;
@@ -691,7 +693,7 @@ export function ChatProjectSidebar({
           </button>
           <button
             type="button"
-            onClick={() => onNewChat(group.projectRoot)}
+            onClick={() => onNewChat(group.projectRoot, group.runtimeHost)}
             title={`New session in ${label}`}
             aria-label={`New session in ${label}`}
             className="touch-always-visible focus-ring absolute right-1 grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover:opacity-100"
@@ -881,7 +883,7 @@ export function ChatProjectSidebar({
               {!open && groups.length > 0 ? (
                 <div className="flex flex-col items-center gap-1">
                   {groups.map((group) => {
-                    const key = selectionKey(group.projectId, group.projectRoot);
+                    const key = selectionKey(group.projectId, group.projectRoot, group.runtimeHost);
                     const organizationKey = organizationExpansionKey(group.organization.key);
                     const label = repoLabel(group);
                     return (

--- a/src/components/chat-router-hide-archived.test.ts
+++ b/src/components/chat-router-hide-archived.test.ts
@@ -74,7 +74,7 @@ assert.match(
 );
 assert.match(
   source,
-  /<ChatProjectSidebar[\s\S]*onNewChat=\{\(\) => \{[\s\S]{0,120}if \(onRequestNewChat\) \{[\s\S]{0,80}onRequestNewChat\(\);/,
+  /<ChatProjectSidebar[\s\S]*onNewChat=\{\([^)]*\) => \{[\s\S]{0,120}if \(onRequestNewChat\) \{[\s\S]{0,80}onRequestNewChat\(\);/,
   "the project-grouped new chat asks through the shell gate rather than adopting historical ownership",
 );
 

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -148,11 +148,23 @@ type ChatViewHandle = {
   runSlash: (command: string) => void;
 };
 
-function selectionForProjectRoot(projectRoot: string | null | undefined, groups: ReturnType<typeof deriveChatProjectGroups>): ProjectSelection {
+function selectionForProjectRoot(
+  projectRoot: string | null | undefined,
+  runtimeHost: string | null | undefined,
+  groups: ReturnType<typeof deriveChatProjectGroups>,
+): ProjectSelection {
   if (!projectRoot?.trim()) return "all";
   const normalized = normalizeChatProjectRoot(projectRoot);
-  const group = groups.find((entry) => entry.projectRoot && normalizeChatProjectRoot(entry.projectRoot) === normalized);
-  return group ? selectionKey(group.projectId, group.projectRoot) : "all";
+  const normalizedHost = runtimeHost === "local" ? null : runtimeHost ?? null;
+  const group = groups.find(
+    (entry) =>
+      entry.projectRoot &&
+      normalizeChatProjectRoot(entry.projectRoot) === normalized &&
+      entry.runtimeHost === normalizedHost,
+  );
+  return group
+    ? selectionKey(group.projectId, group.projectRoot, group.runtimeHost)
+    : "all";
 }
 
 export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRouter(
@@ -354,11 +366,19 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
       prev.includes(key) ? prev.filter((entry) => entry !== key) : [...prev, key],
     );
   }, []);
-  const syncSidebarProjectRoot = useCallback((nextProjectRoot: string | null) => {
-    const nextSelection = selectionForProjectRoot(nextProjectRoot, sidebarGroups);
+  const syncSidebarProjectRoot = useCallback((
+    nextProjectRoot: string | null,
+    nextRuntimeHost: string | null,
+  ) => {
+    const nextSelection = selectionForProjectRoot(
+      nextProjectRoot,
+      nextRuntimeHost,
+      sidebarGroups,
+    );
     setSelection(nextSelection);
     const group = sidebarGroups.find(
-      (entry) => selectionKey(entry.projectId, entry.projectRoot) === nextSelection,
+      (entry) =>
+        selectionKey(entry.projectId, entry.projectRoot, entry.runtimeHost) === nextSelection,
     );
     if (nextSelection !== "all" && group) {
       const organizationKey = organizationExpansionKey(group.organization.key);
@@ -895,7 +915,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           const fq = findQuery?.trim();
           if (fq) setPendingFind({ query: fq, nonce: Date.now() });
         }}
-        onNewChat={(projectRoot, familiarId) => {
+        onNewChat={(projectRoot, familiarId, runtimeHost) => {
           if (onRequestNewChat) {
             onRequestNewChat();
             return;
@@ -905,7 +925,13 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           // visibleFamiliars[0] and silently making it the active familiar.
           const next = familiarId ? selectFamiliarForChat(familiarId) : null;
           advanceComposeInstance();
-          setView({ kind: "chat", sessionId: null, projectRoot, familiarId: next?.id ?? familiarId ?? null });
+          setView({
+            kind: "chat",
+            sessionId: null,
+            projectRoot,
+            ...(runtimeHost ? { initialControls: { runtimeHost } } : {}),
+            familiarId: next?.id ?? familiarId ?? null,
+          });
         }}
       />
     );
@@ -1109,7 +1135,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           setView({ kind: "chat", sessionId: s.id, familiarId: next?.id ?? s.familiarId ?? null });
         }}
         onOpenSessionInSplit={enableSplit ? handleOpenSessionInSplit : undefined}
-        onNewChat={() => {
+        onNewChat={(projectRoot, runtimeHost) => {
           if (onRequestNewChat) {
             onRequestNewChat();
             return;
@@ -1121,7 +1147,8 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           setView({
             kind: "chat",
             sessionId: null,
-            projectRoot: undefined,
+            projectRoot: projectRoot ?? undefined,
+            ...(runtimeHost ? { initialControls: { runtimeHost } } : {}),
             familiarId: next?.id ?? nextFamiliarId ?? null,
           });
         }}

--- a/src/components/chat-thread-rail.test.ts
+++ b/src/components/chat-thread-rail.test.ts
@@ -160,8 +160,8 @@ assert.match(
 );
 assert.match(
   chatRouter,
-  /function selectionForProjectRoot\([\s\S]*normalizeChatProjectRoot\(projectRoot\)[\s\S]*selectionKey\(group\.projectId, group\.projectRoot\)/,
-  "ChatRouter can map the active chat project root to the matching rail folder selection",
+  /function selectionForProjectRoot\([\s\S]*normalizeChatProjectRoot\(projectRoot\)[\s\S]*entry\.runtimeHost === normalizedHost[\s\S]*selectionKey\(group\.projectId, group\.projectRoot, group\.runtimeHost\)/,
+  "ChatRouter maps the active host and project root to the matching rail folder selection",
 );
 assert.match(
   chatRouter,
@@ -224,6 +224,16 @@ assert.match(
   source,
   /className="touch-always-visible focus-ring absolute right-1 grid h-5 w-5/,
   "Project folder plus buttons should overlay at the right edge instead of reducing the label row width",
+);
+assert.match(
+  source,
+  /onClick=\{\(\) => onNewChat\(group\.projectRoot, group\.runtimeHost\)\}/,
+  "Project folder launches preserve the runtime host alongside the project root",
+);
+assert.match(
+  source,
+  /selectionKey\(group\.projectId, group\.projectRoot, group\.runtimeHost\)/,
+  "Project folder keys include the runtime host so equal paths on different machines stay distinct",
 );
 // Collapsed rail (SurfaceRail, 56px): project identity tiles remain, and
 // activating one re-expands the rail and opens that group.

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -502,7 +502,10 @@ type Props = {
   onOpenTask?: (cardId: string) => void;
   onOpenUrl?: (url: string) => void;
   onOpenPreview?: (url: string) => void;
-  onProjectRootChange?: (projectRoot: string | null) => void;
+  onProjectRootChange?: (
+    projectRoot: string | null,
+    runtimeHost: string | null,
+  ) => void;
 };
 
 export type ChatViewHandle = {
@@ -2706,8 +2709,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     setSetupBannerDismissed(true);
   };
   useEffect(() => {
-    onProjectRootChange?.(activeProjectRoot || null);
-  }, [activeProjectRoot, onProjectRootChange]);
+    onProjectRootChange?.(
+      activeProjectRoot || null,
+      composerHostValue === LOCAL_HOST_ID ? null : composerHostValue,
+    );
+  }, [activeProjectRoot, composerHostValue, onProjectRootChange]);
   const currentSessionRef = useRef<string | null>(sessionId);
   const liveSessionIdRef = useRef<string | null>(null);
   const creationRefreshStateRef = useRef<CreationRefreshState>({ pendingRuns: {} });

--- a/src/components/familiar-no-silent-default.test.ts
+++ b/src/components/familiar-no-silent-default.test.ts
@@ -58,7 +58,7 @@ assert.match(
 );
 assert.match(
   chatRouter,
-  /<ChatProjectSidebar[\s\S]*onNewChat=\{\(\) => \{[\s\S]{0,120}if \(onRequestNewChat\) \{[\s\S]{0,80}onRequestNewChat\(\);/,
+  /<ChatProjectSidebar[\s\S]*onNewChat=\{\(projectRoot, runtimeHost\) => \{[\s\S]{0,120}if \(onRequestNewChat\) \{[\s\S]{0,80}onRequestNewChat\(\);/,
   "the project-grouped new-chat path asks through the shell gate rather than defaulting",
 );
 assert.doesNotMatch(

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -54,8 +54,8 @@ assert.match(
 );
 assert.match(
   chatView,
-  /onProjectRootChange\?\.\(activeProjectRoot \|\| null\)/,
-  "ChatView reports the same active project root used by send so the rail can stay in sync",
+  /onProjectRootChange\?\.\(\s*activeProjectRoot \|\| null,\s*composerHostValue === LOCAL_HOST_ID \? null : composerHostValue,\s*\)/,
+  "ChatView reports the active project root and runtime host used by send so the rail can stay in sync",
 );
 assert.match(
   chatView,

--- a/src/lib/chat-project-selection.test.ts
+++ b/src/lib/chat-project-selection.test.ts
@@ -29,6 +29,7 @@ const group = (
 ) => ({
   projectId,
   projectRoot,
+  runtimeHost: null,
   organization,
   sessions: Array.from({ length: n }, (_, i) => ({
     id: `${projectId ?? "none"}-${i}`,
@@ -43,6 +44,8 @@ const group = (
 assert.equal(selectionKey("coven-cave"), "coven-cave");
 assert.equal(selectionKey(null), "none");
 assert.equal(selectionKey(null, "/orphan/root"), "root:/orphan/root");
+assert.equal(selectionKey(null, "/orphan/root", "build-box"), "host:build-box:root:/orphan/root");
+assert.equal(selectionKey(null, null, "build-box"), "host:build-box:none");
 
 // applyProjectScope: "all" passes groups through untouched (same reference)
 const groups = [group("alpha", "/alpha"), group(null, null, 1, RECENT, NO_PROJECT_ORGANIZATION)];

--- a/src/lib/chat-project-selection.ts
+++ b/src/lib/chat-project-selection.ts
@@ -23,9 +23,15 @@ export const PROJECT_SIDEBAR_KEYS = {
   selected: "cave:chat:project-selected",
 } as const;
 
-export function selectionKey(projectId: string | null, projectRoot?: string | null): string {
+export function selectionKey(
+  projectId: string | null,
+  projectRoot?: string | null,
+  runtimeHost?: string | null,
+): string {
   if (projectId) return projectId;
+  if (projectRoot && runtimeHost) return `host:${runtimeHost}:root:${projectRoot}`;
   if (projectRoot) return `root:${projectRoot}`;
+  if (runtimeHost) return `host:${runtimeHost}:none`;
   return "none";
 }
 
@@ -34,7 +40,7 @@ export function projectSelectionKeys(groups: ChatProjectGroup[]): string[] {
     ...new Set(
       groups.flatMap((group) => [
         organizationExpansionKey(group.organization.key),
-        selectionKey(group.projectId, group.projectRoot),
+        selectionKey(group.projectId, group.projectRoot, group.runtimeHost),
       ]),
     ),
   ];
@@ -50,7 +56,7 @@ export function migrateOrganizationExpansionKeys(
     { targetKey: string; organizationKey: string }
   >(
     groups.map((group) => {
-      const targetKey = selectionKey(group.projectId, group.projectRoot);
+      const targetKey = selectionKey(group.projectId, group.projectRoot, group.runtimeHost);
       return [
         targetKey,
         {
@@ -111,7 +117,9 @@ export function applyProjectScope(
   selection: ProjectSelection,
 ): ChatProjectGroup[] {
   if (selection === "all") return groups;
-  const match = groups.find((g) => selectionKey(g.projectId, g.projectRoot) === selection);
+  const match = groups.find(
+    (g) => selectionKey(g.projectId, g.projectRoot, g.runtimeHost) === selection,
+  );
   return match ? [match] : [];
 }
 
@@ -122,7 +130,9 @@ export function normalizeSelection(
   groups: ChatProjectGroup[],
 ): ProjectSelection {
   if (selection === "all") return "all";
-  return groups.some((g) => selectionKey(g.projectId, g.projectRoot) === selection) ? selection : "all";
+  return groups.some(
+    (g) => selectionKey(g.projectId, g.projectRoot, g.runtimeHost) === selection,
+  ) ? selection : "all";
 }
 
 /** Group keys that should auto-expand after a sessions refresh (cave-mllp).
@@ -156,7 +166,7 @@ export function autoExpandKeysForNewSessions(args: {
 }): string[] {
   const keys: string[] = [];
   for (const group of args.groups) {
-    const key = selectionKey(group.projectId, group.projectRoot);
+    const key = selectionKey(group.projectId, group.projectRoot, group.runtimeHost);
     const fresh = group.sessions.filter((s) => !args.knownSessionIds.has(s.id));
     if (fresh.length === 0) continue;
     const hasRecentFresh = fresh.some((s) => {

--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -221,6 +221,67 @@ assert.deepEqual(
   "duplicate worktree repo names should include the parent directory and order by recency",
 );
 
+// Linked worktrees can live anywhere, so path-shape heuristics are not enough.
+// The server's git-common-dir enrichment names the owning checkout and the
+// project rail nests the worktree chat beneath that registered project.
+{
+  const linked = {
+    ...session("linked-worktree", "/tmp/feature-a", "2026-06-08T00:00:00.000Z", "cody"),
+    git: {
+      isWorktree: true,
+      worktreeRoot: "/tmp/feature-a",
+      repositoryRoot: "/work/alpha",
+    },
+  };
+  const [linkedGroup] = deriveChatProjectGroups([linked], projects);
+  assert.equal(linkedGroup.projectId, "alpha");
+  assert.equal(linkedGroup.projectRoot, "/work/alpha");
+  assert.equal(linkedGroup.runtimeHost, null);
+  assert.deepEqual(linkedGroup.sessions.map((row) => row.id), ["linked-worktree"]);
+}
+
+// The same path on this machine and an SSH host is two project identities.
+// Remote roots do not borrow a local registry id, and multiple sessions on the
+// same remote host/root still coalesce normally.
+{
+  const local = session("local-alpha", "/work/alpha", "2026-06-08T00:00:00.000Z", "cody");
+  const remote = {
+    ...session("remote-alpha", "/work/alpha", "2026-06-09T00:00:00.000Z", "nova"),
+    runtime: "ssh:build-box:/work/alpha",
+  };
+  const remoteOlder = {
+    ...session("remote-alpha-old", "", "2026-06-07T00:00:00.000Z", "sage"),
+    runtime: "ssh:build-box:/work/alpha",
+  };
+  const hostGroups = deriveChatProjectGroups([local, remote, remoteOlder], projects);
+  assert.equal(hostGroups.length, 2);
+  assert.deepEqual(
+    hostGroups.map((entry) => ({
+      projectId: entry.projectId,
+      root: entry.projectRoot,
+      host: entry.runtimeHost,
+      name: entry.projectName,
+      sessions: entry.sessions.map((row) => row.id),
+    })),
+    [
+      {
+        projectId: null,
+        root: "/work/alpha",
+        host: "build-box",
+        name: "build-box/alpha",
+        sessions: ["remote-alpha", "remote-alpha-old"],
+      },
+      {
+        projectId: "alpha",
+        root: "/work/alpha",
+        host: null,
+        name: "Alpha",
+        sessions: ["local-alpha"],
+      },
+    ],
+  );
+}
+
 // Analytics-spawned discussion threads remain normal chat threads.
 {
   const analyticsThread = { ...session("analytics-1", "/work/alpha", "2026-06-09T00:00:00.000Z", "cody"), origin: "chat" as const };

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -1,6 +1,7 @@
 import type { SessionRow } from "./types.ts";
 import type { CaveProject } from "./cave-projects.ts";
 import { compareProjectsAlphabetically, normalizeProjectRoot } from "./cave-projects-types.ts";
+import { parseConversationRuntime } from "./chat-hosts.ts";
 import {
   NO_PROJECT_ORGANIZATION,
   projectOrganization,
@@ -13,6 +14,8 @@ export type { CaveProject };
 export type ChatProjectGroup = {
   projectId: string | null;
   projectRoot: string | null;
+  /** SSH host that owns projectRoot; null means this Cave host. */
+  runtimeHost: string | null;
   projectName: string | null;
   organization: ProjectOrganization;
   /** Explicit user-set project color, when the root maps to a registered project. */
@@ -21,6 +24,34 @@ export type ChatProjectGroup = {
   defaultFamiliarId: string | null;
   updatedAt: string | null;
 };
+
+/** Host half of the project identity recorded on a session. Local and legacy
+ * rows intentionally share the null host; SSH rows never collide with them. */
+export function chatProjectRuntimeHost(session: Pick<SessionRow, "runtime">): string | null {
+  const runtime = parseConversationRuntime(session.runtime);
+  return runtime?.kind === "ssh" ? runtime.host : null;
+}
+
+/** Filesystem half of a session's identity. The daemon normally supplies
+ * project_root; a Cave-local remote conversation can temporarily exist
+ * without that row, so its recorded runtime cwd is the truthful fallback. */
+function chatProjectRootForSession(
+  session: Pick<SessionRow, "project_root" | "runtime">,
+): string | null {
+  if (session.project_root?.trim()) return normalizeChatProjectRoot(session.project_root);
+  const runtime = parseConversationRuntime(session.runtime);
+  return runtime?.cwd?.trim() ? normalizeChatProjectRoot(runtime.cwd) : null;
+}
+
+/** Stable visible-bucket identity. Local keys stay root-readable for existing
+ * persisted selections; remote roots are namespaced by their runtime host. */
+export function chatProjectIdentityKey(
+  projectRoot: string | null | undefined,
+  runtimeHost: string | null | undefined,
+): string {
+  const root = projectRoot?.trim() ? normalizeChatProjectRoot(projectRoot) : "__no-project__";
+  return runtimeHost ? `host:${runtimeHost}:root:${root}` : `root:${root}`;
+}
 
 /**
  * Canonical project-root form for chat.
@@ -299,6 +330,24 @@ export function filterVisibleChatSessions(
     .sort((a, b) => (sessionTimestamp(a) < sessionTimestamp(b) ? 1 : -1));
 }
 
+/** Registered project represented by a session. Remote roots are deliberately
+ * distinct from this machine's registry. A linked local worktree may map back
+ * to its owning checkout through server-enriched git common-dir context. */
+function registeredProjectForSession(
+  session: SessionRow,
+  projects: CaveProject[],
+  projectIndex: ChatProjectIndex,
+): CaveProject | null {
+  if (chatProjectRuntimeHost(session)) return null;
+  const sessionRoot = chatProjectRootForSession(session);
+  return (
+    projectForRoot(sessionRoot, projects, projectIndex) ??
+    (session.git?.isWorktree
+      ? projectForRoot(session.git.repositoryRoot, projects, projectIndex)
+      : null)
+  );
+}
+
 /** The registered project the most recent visible chat ran in, as a root for
  *  resolveChatProjectSelection's `recentProjectRoot` — so a brand-new chat
  *  starts off in the project the user was just working in instead of the
@@ -315,7 +364,7 @@ export function recentChatProjectRoot(
   if (projects.length === 0) return null;
   const projectIndex = createChatProjectIndex(projects);
   for (const session of filterVisibleChatSessions(sessions, null)) {
-    const project = projectForRoot(session.project_root, projects, projectIndex);
+    const project = registeredProjectForSession(session, projects, projectIndex);
     if (project) return project.root;
   }
   return null;
@@ -327,41 +376,51 @@ export function deriveChatProjectGroups(
   projectIndex: ChatProjectIndex = createChatProjectIndex(projects),
   options: { sessionsNewestFirst?: boolean } = {},
 ): ChatProjectGroup[] {
-  const groups = new Map<string | null, SessionRow[]>();
+  const groups = new Map<
+    string,
+    { projectRoot: string | null; runtimeHost: string | null; sessions: SessionRow[] }
+  >();
 
   for (const session of sessions) {
-    const project = projectForRoot(session.project_root, projects, projectIndex);
+    const runtimeHost = chatProjectRuntimeHost(session);
+    const project = registeredProjectForSession(session, projects, projectIndex);
     const projectRoot = project?.root
-      ?? (session.project_root?.trim() ? normalizeChatProjectRoot(session.project_root) : null);
-    const group = groups.get(projectRoot) ?? [];
-    group.push(session);
-    groups.set(projectRoot, group);
+      ?? chatProjectRootForSession(session);
+    const key = chatProjectIdentityKey(projectRoot, runtimeHost);
+    const group = groups.get(key) ?? { projectRoot, runtimeHost, sessions: [] };
+    group.sessions.push(session);
+    groups.set(key, group);
   }
 
-  const rootEntries = Array.from(groups.keys()).filter((root): root is string => root !== null);
+  const rootEntries = Array.from(groups.values()).filter(
+    (entry): entry is typeof entry & { projectRoot: string } => entry.projectRoot !== null,
+  );
   const leafCounts = new Map<string, number>();
-  for (const root of rootEntries) {
-    const leaf = projectLeafName(root);
+  for (const entry of rootEntries) {
+    const leaf = projectLeafName(entry.projectRoot);
     if (leaf) leafCounts.set(leaf, (leafCounts.get(leaf) ?? 0) + 1);
   }
 
-  return Array.from(groups.entries())
-    .map(([projectRoot, rows]) => {
+  return Array.from(groups.values())
+    .map(({ projectRoot, runtimeHost, sessions: rows }) => {
       const sorted = options.sessionsNewestFirst
         ? rows
         : [...rows].sort((a, b) =>
           sessionTimestamp(a) < sessionTimestamp(b) ? 1 : -1,
         );
       const latest = sorted[0] ?? null;
-      const project = projectForRoot(projectRoot, projects, projectIndex);
+      const project = runtimeHost ? null : projectForRoot(projectRoot, projects, projectIndex);
       const leaf = projectLeafName(projectRoot);
       const inferredProjectName =
-        projectRoot && !project && leaf && (leafCounts.get(leaf) ?? 0) > 1
-          ? projectNameWithParent(projectRoot)
-          : null;
+        runtimeHost
+          ? `${runtimeHost}/${leaf ?? "No project"}`
+          : projectRoot && !project && leaf && (leafCounts.get(leaf) ?? 0) > 1
+            ? projectNameWithParent(projectRoot)
+            : null;
       return {
         projectId: project?.id ?? null,
         projectRoot,
+        runtimeHost,
         projectName: project?.name ?? inferredProjectName,
         organization: project ? projectOrganization(project) : NO_PROJECT_ORGANIZATION,
         projectColor: project?.color ?? null,
@@ -385,7 +444,9 @@ export function deriveChatProjectGroups(
       const bLabel = b.projectName ?? chatProjectName(b.projectRoot, projects, projectIndex);
       const byLabel = aLabel.localeCompare(bLabel, undefined, { sensitivity: "base", numeric: true });
       if (byLabel !== 0) return byLabel;
-      return (a.projectRoot ?? "").localeCompare(b.projectRoot ?? "");
+      return chatProjectIdentityKey(a.projectRoot, a.runtimeHost).localeCompare(
+        chatProjectIdentityKey(b.projectRoot, b.runtimeHost),
+      );
     });
 }
 

--- a/src/lib/session-git-enrich.test.ts
+++ b/src/lib/session-git-enrich.test.ts
@@ -319,6 +319,7 @@ const REPO_SCRIPT = {
     const prCache = fakePrCache({ "feat/thing": mergedPr("feat/thing") });
     const rows = await enrichSessionsWithGitContext([session("wt", root)], runner, prCache);
     assert.equal(rows[0].git.isWorktree, true);
+    assert.equal(rows[0].git.repositoryRoot, root);
     assert.deepEqual(rows[0].pullRequest, { ...mergedPr("feat/thing"), attribution: "branch" });
   }
 }

--- a/src/lib/session-git-enrich.ts
+++ b/src/lib/session-git-enrich.ts
@@ -93,9 +93,18 @@ async function readGitContext(git: GitRunner, projectRoot: string): Promise<Sess
   const gitDir = resolveGitPath(trimmed, gitDirRaw);
   const commonDir = resolveGitPath(trimmed, commonDirRaw);
   const isWorktree = Boolean(gitDir && commonDir && gitDir !== commonDir);
+  const repositoryRoot =
+    isWorktree && commonDir && path.basename(commonDir) === ".git"
+      ? path.dirname(commonDir)
+      : null;
 
   if (!branch && !worktreeRoot && !isWorktree) return null;
-  return { branch, worktreeRoot, isWorktree };
+  return {
+    branch,
+    worktreeRoot,
+    isWorktree,
+    ...(repositoryRoot ? { repositoryRoot } : {}),
+  };
 }
 
 export type DiffStat = { additions: number; deletions: number };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -136,6 +136,9 @@ export type SessionGitContext = {
   branch?: string | null;
   worktreeRoot?: string | null;
   isWorktree?: boolean;
+  /** Main checkout that owns this linked worktree, derived from
+   *  `git rev-parse --git-common-dir`. Present only for linked worktrees. */
+  repositoryRoot?: string | null;
 };
 
 export type SessionPullRequestContext = {


### PR DESCRIPTION
## Summary

- derive a linked worktree’s owning checkout from `git rev-parse --git-common-dir` and group its chats beneath the registered repository
- key chat project buckets and persisted rail selection by runtime host plus normalized root so SSH and local paths cannot collide
- preserve the SSH host when launching a chat from a remote project group, including daemon-down rows that only retain `ssh:<host>:<cwd>` provenance

## Verification

- `node --experimental-strip-types src/lib/chat-projects.test.ts`
- `node --experimental-strip-types src/lib/chat-project-selection.test.ts`
- `node --experimental-strip-types src/lib/session-git-enrich.test.ts`
- `node --experimental-strip-types src/components/chat-thread-rail.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- touched-file ESLint and `git diff --check`

Full `pnpm test:app` stopped after 50 passing files on an unrelated 2-second canonical-memory cleanup timing assertion (2.592 seconds on this NTFS host; the focused rerun also exceeded the timing bound). Full `pnpm test:api` stopped after 34 passing lifecycle tests when the shared maintenance-fence fixture observed `heartbeat-regressed`.

Bead: `cave-4wbi`

Closes #4891