### PR TITLE
Modernize branded destination cards

### DIFF
--- a/src/components/settings-about.test.ts
+++ b/src/components/settings-about.test.ts
@@ -101,6 +101,8 @@ test("About ports the handoff link grid with production destinations", () => {
 
 test("About follows the revised handoff artwork and full-width release rail", () => {
   assert.match(component, /className="settings-about-grimoire-mark"/);
+  assert.match(component, /className="settings-about-github-art"/);
+  assert.match(component, /className="settings-about-link-card__art"/);
   assert.match(component, />Open Coven Weekly</);
   assert.match(component, />Shipping notes, every Friday\.</);
   assert.match(component, />OCW</);
@@ -120,7 +122,7 @@ test("About podcast fills the default four-column row remainder", () => {
 
   assert.match(
     defaultCss,
-    /\.settings-about-link-card--podcast\s*\{[^}]*grid-column:\s*span 3;/,
+    /\.settings-about-link-card--podcast\s*\{[^}]*grid-column:\s*span 2;/,
   );
 });
 
@@ -134,7 +136,7 @@ test("About podcast shares the intermediate two-column row", () => {
 
   assert.match(
     intermediateCss,
-    /\.settings-about-link-card--podcast\s*\{[^}]*grid-column:\s*span 1;/,
+    /\.settings-about-link-card--podcast\s*\{[^}]*grid-column:\s*span 2;/,
   );
 });
 

--- a/src/components/settings-about.tsx
+++ b/src/components/settings-about.tsx
@@ -38,6 +38,7 @@ type LinkCard = {
   hint: string;
   href: string;
   icon: IconName;
+  tone: "docs" | "x" | "discord";
 };
 
 const SMALL_LINKS: LinkCard[] = [
@@ -46,18 +47,21 @@ const SMALL_LINKS: LinkCard[] = [
     hint: "docs.opencoven.ai",
     href: "https://docs.opencoven.ai",
     icon: "ph:file-text",
+    tone: "docs",
   },
   {
     label: "X",
     hint: "@OpenCvn",
     href: "https://x.com/OpenCvn",
     icon: "ph:x-logo-bold",
+    tone: "x",
   },
   {
     label: "Discord",
     hint: "the coven hall",
     href: "https://discord.gg/opencoven",
     icon: "ph:discord-logo",
+    tone: "discord",
   },
 ];
 
@@ -173,12 +177,14 @@ function ElsewhereCard({
   return (
     <Button
       variant="ghost"
-      className="settings-about-link-card settings-about-link-card--small focus-ring"
+      className={`settings-about-link-card settings-about-link-card--small settings-about-link-card--${card.tone} focus-ring`}
       onClick={() => openExternalUrl(card.href)}
       aria-label={`Open ${card.label}`}
     >
-      <span className="settings-about-link-card__glyph" aria-hidden="true">
-        <Icon name={card.icon} width={16} />
+      <span className="settings-about-link-card__art" aria-hidden="true">
+        <span className="settings-about-link-card__glyph">
+          <Icon name={card.icon} width={18} />
+        </span>
       </span>
       <span className="settings-about-link-card__copy">
         <strong>{card.label}</strong>
@@ -530,6 +536,9 @@ export function AboutSection() {
             }
             aria-label="Open CovenCave on GitHub"
           >
+            <span className="settings-about-github-art" aria-hidden="true">
+              <Icon name="ph:github-logo" width={28} />
+            </span>
             <span className="settings-about-link-card__heading">
               <Icon name="ph:github-logo" width={16} aria-hidden />
               <strong>GitHub</strong>
@@ -549,8 +558,10 @@ export function AboutSection() {
             aria-label="Listen to the OpenCoven podcast"
           >
             <span className="settings-about-podcast-art" aria-hidden="true">
-              <Icon name="ph:waveform-bold" width={24} />
-              <small>OCW</small>
+              <span>
+                <Icon name="ph:waveform-bold" width={24} />
+                <small>OCW</small>
+              </span>
             </span>
             <span className="settings-about-link-card__copy">
               <small>Podcast</small>

--- a/src/components/sidebar-rail-header.test.ts
+++ b/src/components/sidebar-rail-header.test.ts
@@ -193,23 +193,24 @@ for (const [label, rule] of [
 ]) {
   assert.match(rule, /border-radius: var\(--radius-control\);/, `the ${label} takes its radius from the token`);
   assert.doesNotMatch(rule, /border-radius:\s*\d+px/, `the ${label} does not hardcode a radius`);
-  // min-height, not height: the control has to grow with a longer label or a
-  // larger touch target rather than clipping. The value is the shared rail
-  // constant, so these two controls are also the same box as their own
-  // collapsed-rail squares and as the nav rows below (#4351).
-  assert.match(
-    rule,
-    /min-height: var\(--rail-control\);/,
-    `the ${label} shares the rail control height`,
-  );
   assert.doesNotMatch(rule, /\n\s*height:\s*\d+px/, `the ${label} does not pin a fixed height`);
 }
 
+assert.match(
+  scopeRule,
+  /min-height: calc\(var\(--rail-control\) \+ var\(--space-3\)\);/,
+  "the two-line scope trigger grows from the shared rail control token",
+);
+assert.match(
+  newRule,
+  /min-height: var\(--rail-control\);/,
+  "New chat shares the rail control height",
+);
 assert.match(newRule, /font-size: var\(--text-base\);/, "the New chat label uses the rail's base type size");
 assert.match(
   workspaceContextSwitcherCss,
-  /\.sidebar-scope-selector__label \{[\s\S]*?font-size: var\(--text-sm\);/,
-  "the compact scope trigger uses the denser sidebar label size",
+  /\.sidebar-scope-selector__identity-copy strong \{[\s\S]*?font-size: var\(--text-sm\);/,
+  "the scope identities use the denser sidebar label size",
 );
 assert.match(
   scopeRule,
@@ -223,23 +224,23 @@ assert.match(
 );
 assert.match(
   scopeRule,
-  /width: fit-content;/,
-  "the scope selector remains content-sized instead of becoming another full-width row",
+  /width: 100%;/,
+  "the scope selector fills the available rail width",
 );
 assert.match(
   workspaceContextSwitcherCss,
-  /\.sidebar-scope-selector__project \{[\s\S]*?width: var\(--rail-control\);[\s\S]*?border-right: 1px solid var\(--border-hairline\);/,
-  "the project segment keeps the rail icon column and a quiet divider",
+  /\.sidebar-scope-selector__project \{[\s\S]*?min-width: 0;[\s\S]*?border-right: 1px solid var\(--border-hairline\);/,
+  "the project segment shares the row and keeps a quiet divider",
 );
 assert.match(
   workspaceContextSwitcherCss,
-  /\.sidebar-scope-selector__familiar \{[\s\S]*?background: color-mix\(in oklch, var\(--accent-presence\) 14%, transparent\);[\s\S]*?box-shadow: inset 0 0 0 1px color-mix\(in oklch, var\(--accent-presence\) 40%, transparent\);/,
-  "the active familiar segment derives its selected tint and inset ring from one accent token",
+  /\.sidebar-scope-selector__familiar \{[\s\S]*?background: color-mix\(in oklch, var\(--accent-presence\) 14%, transparent\);/,
+  "the active familiar segment derives its selected tint from one accent token",
 );
 assert.match(
   sidebarScopeSelector,
-  /sidebar-scope-selector__project[\s\S]*?ph:globe[\s\S]*?sidebar-scope-selector__familiar[\s\S]*?\{familiarLabel\}/,
-  "the trigger presents project first and the active familiar second",
+  /sidebar-scope-selector__project[\s\S]*?>Project<[\s\S]*?\{projectLabel\}[\s\S]*?sidebar-scope-selector__familiar[\s\S]*?>Familiar<[\s\S]*?\{familiarLabel\}/,
+  "the full-width trigger names project first and the active familiar second",
 );
 assert.match(
   sectionTabsCss,
@@ -455,8 +456,8 @@ assert.doesNotMatch(
 // ── Collapsed segmented control ─────────────────────────────────────────────
 assert.match(
   workspaceContextSwitcherCss,
-  /\.shell-nav--rail \.sidebar-scope-selector__project,[\s\S]*?\.shell-nav--rail \.sidebar-scope-selector__label \{[\s\S]*?display: none;/,
-  "the collapsed rail hides the project segment and familiar label",
+  /\.shell-nav--rail \.sidebar-scope-selector__project,[\s\S]*?\.shell-nav--rail \.sidebar-scope-selector__identity-copy,[\s\S]*?\.shell-nav--rail \.sidebar-scope-selector__caret \{[\s\S]*?display: none;/,
+  "the collapsed rail hides the project segment, identity copy, and caret",
 );
 assert.doesNotMatch(
   workspaceContextSwitcherCss,

--- a/src/components/sidebar-scope-selector.tsx
+++ b/src/components/sidebar-scope-selector.tsx
@@ -98,27 +98,39 @@ export function SidebarScopeSelector({
         title={scopeLabel}
         disabled={disabled}
       >
-        <span className="sidebar-scope-selector__project" aria-hidden>
-          {project ? (
-            <ProjectAvatar
-              name={project.name}
-              root={project.root}
-              color={project.color}
-              size="sm"
-            />
-          ) : (
-            <Icon name="ph:globe" width={14} />
-          )}
+        <span className="sidebar-scope-selector__project">
+          <span className="sidebar-scope-selector__identity-icon" aria-hidden>
+            {project ? (
+              <ProjectAvatar
+                name={project.name}
+                root={project.root}
+                color={project.color}
+                size="sm"
+              />
+            ) : (
+              <Icon name="ph:globe" width={14} />
+            )}
+          </span>
+          <span className="sidebar-scope-selector__identity-copy">
+            <small>Project</small>
+            <strong>{projectLabel}</strong>
+          </span>
         </span>
         <span className="sidebar-scope-selector__familiar">
-          <span className="sidebar-scope-selector__icon" aria-hidden>
+          <span className="sidebar-scope-selector__identity-icon" aria-hidden>
             {activeFamiliar && !multiScope ? (
               <FamiliarAvatar familiar={activeFamiliar} size="sm" />
             ) : (
               <Icon name="ph:sparkle" width={14} />
             )}
           </span>
-          <span className="sidebar-scope-selector__label">{familiarLabel}</span>
+          <span className="sidebar-scope-selector__identity-copy">
+            <small>Familiar</small>
+            <strong>{familiarLabel}</strong>
+          </span>
+        </span>
+        <span className="sidebar-scope-selector__caret" aria-hidden>
+          <Icon name="ph:caret-down" width={12} />
         </span>
       </button>
 

--- a/src/styles/globals/workspace-context-switcher.css
+++ b/src/styles/globals/workspace-context-switcher.css
@@ -21,13 +21,12 @@
 }
 
 .sidebar-scope-selector__trigger {
-  display: inline-flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: flex-start;
-  width: fit-content;
+  width: 100%;
   min-width: 0;
-  max-width: 100%;
-  min-height: var(--rail-control);
+  min-height: calc(var(--rail-control) + var(--space-3));
   gap: 0;
   padding: 0;
   overflow: hidden;
@@ -55,27 +54,23 @@
 }
 
 .sidebar-scope-selector__project {
-  display: grid;
-  flex: none;
-  place-items: center;
-  align-self: stretch;
-  width: var(--rail-control);
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: var(--space-2);
+  padding: 0 var(--space-2);
   border-right: 1px solid var(--border-hairline);
-  color: var(--text-muted);
 }
 
 .sidebar-scope-selector__familiar {
   display: flex;
   align-items: center;
-  align-self: stretch;
-  min-width: 0;
-  gap: var(--space-1);
+  gap: var(--space-2);
   padding: 0 var(--space-2);
   background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--accent-presence) 40%, transparent);
 }
 
-.sidebar-scope-selector__icon {
+.sidebar-scope-selector__identity-icon {
   display: grid;
   flex: none;
   place-items: center;
@@ -84,15 +79,40 @@
   color: var(--text-secondary);
 }
 
-.sidebar-scope-selector__label {
-  flex: 0 1 auto;
+.sidebar-scope-selector__identity-copy {
+  display: flex;
+  flex: 1 1 auto;
   min-width: 0;
+  flex-direction: column;
+  gap: calc(var(--space-1) / 2);
+}
+
+.sidebar-scope-selector__identity-copy small {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+}
+
+.sidebar-scope-selector__identity-copy strong {
   overflow: hidden;
   color: var(--text-primary);
   font-size: var(--text-sm);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.sidebar-scope-selector__caret {
+  display: grid;
+  align-self: stretch;
+  place-items: center;
+  padding: 0 var(--space-2);
+  color: var(--text-muted);
+  transition: transform var(--duration-fast) var(--ease-standard);
+}
+
+.sidebar-scope-selector__trigger[aria-expanded="true"]
+  .sidebar-scope-selector__caret {
+  transform: rotate(180deg);
 }
 
 .sidebar-scope-selector__item-copy {
@@ -285,7 +305,8 @@
 }
 
 .shell-nav--rail .sidebar-scope-selector__project,
-.shell-nav--rail .sidebar-scope-selector__label {
+.shell-nav--rail .sidebar-scope-selector__identity-copy,
+.shell-nav--rail .sidebar-scope-selector__caret {
   display: none;
 }
 

--- a/src/styles/settings-about.css
+++ b/src/styles/settings-about.css
@@ -363,7 +363,7 @@
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-auto-flow: dense;
-  grid-auto-rows: minmax(7rem, auto);
+  grid-auto-rows: minmax(8rem, auto);
   gap: var(--space-2);
 }
 
@@ -396,7 +396,7 @@
     var(--accent-presence) 6%,
     var(--bg-panel)
   );
-  transform: translateY(calc(var(--space-1) / -2));
+  transform: translateY(calc(var(--space-1) * -1));
 }
 
 .settings-about-link-card__copy {
@@ -432,9 +432,9 @@
 }
 
 .settings-about-link-card--grimoire {
-  grid-column: span 2;
+  grid-column: span 3;
   grid-row: span 2;
-  min-height: 14rem;
+  min-height: 20rem;
   justify-content: flex-end;
 }
 
@@ -450,16 +450,52 @@
   pointer-events: none;
 }
 
+.settings-about-grimoire-art,
+.settings-about-github-art,
+.settings-about-link-card__art,
+.settings-about-podcast-art {
+  position: absolute;
+  inset: 0;
+  background-image: url("../../assets/brand/coven-discord-banner.png");
+  background-position: center;
+  background-size: cover;
+}
+
 .settings-about-grimoire-art {
+  background-position: center 48%;
+}
+
+.settings-about-grimoire-art::after,
+.settings-about-github-art::after,
+.settings-about-link-card__art::after,
+.settings-about-podcast-art::after {
   position: absolute;
   inset: 0;
   background:
     radial-gradient(
-      120% 90% at 78% 12%,
-      color-mix(in oklch, var(--accent-presence) 34%, transparent),
+      110% 100% at 76% 14%,
+      color-mix(in oklch, var(--accent-presence) 18%, transparent),
       transparent 62%
     ),
-    linear-gradient(155deg, var(--bg-raised), var(--bg-sunken) 70%);
+    linear-gradient(
+      to bottom,
+      color-mix(in oklch, var(--bg-panel) 6%, transparent),
+      color-mix(in oklch, var(--bg-panel) 86%, transparent)
+    );
+  content: "";
+  pointer-events: none;
+}
+
+.settings-about-github-art {
+  display: grid;
+  place-items: center;
+  background-position: 28% 44%;
+}
+
+.settings-about-github-art > svg {
+  position: relative;
+  z-index: 1;
+  opacity: 0.82;
   color: var(--accent-presence);
 }
 
@@ -498,10 +534,18 @@
 }
 
 .settings-about-link-card--github {
-  grid-column: span 2;
+  grid-column: span 1;
+  grid-row: span 2;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-end;
   gap: var(--space-2);
+  min-height: 20rem;
+}
+
+.settings-about-link-card--github > :not(.settings-about-github-art),
+.settings-about-link-card--podcast > :not(.settings-about-podcast-art) {
+  position: relative;
+  z-index: 1;
 }
 
 .settings-about-link-card__heading {
@@ -533,12 +577,30 @@
 }
 
 .settings-about-link-card--small {
+  min-height: 10rem;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: var(--space-3);
 }
 
+.settings-about-link-card--docs .settings-about-link-card__art {
+  background-position: 32% 48%;
+}
+
+.settings-about-link-card--x .settings-about-link-card__art {
+  background-position: 68% 42%;
+}
+
+.settings-about-link-card--discord .settings-about-link-card__art {
+  background-image: url("../../assets/brand/coven-discord-banner-wordmark.png");
+  background-position: center;
+}
+
 .settings-about-link-card__glyph {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  z-index: 1;
   display: inline-flex;
   width: var(--space-8);
   height: var(--space-8);
@@ -547,43 +609,39 @@
   justify-content: center;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
-  background: var(--bg-sunken);
-  color: var(--text-secondary);
+  background: color-mix(in oklch, var(--bg-panel) 78%, transparent);
+  color: var(--text-primary);
+}
+
+.settings-about-link-card--small .settings-about-link-card__copy {
+  position: relative;
+  z-index: 1;
 }
 
 .settings-about-link-card--podcast {
-  grid-column: span 3;
+  grid-column: span 2;
+  min-height: 10rem;
   flex-direction: row;
-  align-items: center;
+  align-items: flex-end;
   gap: var(--space-3);
 }
 
-/* Sized to the copy beside it rather than to itself: at 4.5rem the art was the
-   tallest thing in the row and set the card's height on its own. */
 .settings-about-podcast-art {
+  background-position: center 52%;
+}
+
+.settings-about-podcast-art > span {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  z-index: 1;
   display: inline-flex;
-  width: 3rem;
-  height: 3rem;
-  align-self: center;
-  flex: none;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: var(--space-1);
-  border: 1px solid
-    color-mix(in oklch, var(--accent-presence) 34%, transparent);
-  border-radius: var(--radius-card);
-  background:
-    linear-gradient(
-      145deg,
-      color-mix(in oklch, var(--accent-presence) 26%, transparent),
-      color-mix(in oklch, var(--accent-presence) 8%, var(--bg-sunken))
-    );
-  color: var(--accent-presence);
+  gap: var(--space-2);
 }
 
 .settings-about-podcast-art small {
-  color: var(--text-muted);
+  color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: var(--text-2xs);
   font-weight: 600;
@@ -681,7 +739,17 @@
   }
 
   .settings-about-link-card--podcast {
-    grid-column: span 1;
+    grid-column: span 2;
+  }
+
+  .settings-about-link-card--grimoire {
+    grid-column: span 2;
+  }
+
+  .settings-about-link-card--github {
+    grid-column: span 2;
+    grid-row: span 1;
+    min-height: 10rem;
   }
 }
 
@@ -707,6 +775,10 @@
 
   .settings-about-link-card--grimoire {
     grid-row: span 1;
+    min-height: 16rem;
+  }
+
+  .settings-about-link-card--github {
     min-height: 12rem;
   }
 
@@ -774,4 +846,5 @@
   .settings-about-sigil[data-pokes] {
     transform: none;
   }
+
 }


### PR DESCRIPTION
## Summary
- turn Settings About destinations into image-led OpenCoven brand cards
- make the combined project/familiar scope selector full-width with clearer context hierarchy
- preserve responsive rail collapse, focus behavior, themes, and reduced-motion handling

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test:app
- pnpm test:api
- pnpm check:tests-wired
- pnpm build
- production Playwright visual pass on Settings About

Bead: cave-oqlya