### PR TITLE
Say what the last run did, and stay legible while hovered

### DIFF
--- a/docs/design-handoff/IMPLEMENTATION-STATUS.md
+++ b/docs/design-handoff/IMPLEMENTATION-STATUS.md
@@ -96,6 +96,19 @@ surface it describes.
 These are specs, baselines and explorations — read them, don't build them:
 
 - `Agentic Core Spec.dc.html`, `Code Reading Spec Board.dc.html` — specs.
+- **`Scheduling Spec.dc.html`** (project *Coven Cave dark theme specs*) — the
+  implementation-ready spec BEHIND `Rituals Redesign.dc.html`, and the more
+  useful of the two to read first: a severity-rated audit table, the token
+  contrast table (computed WCAG ratios on composited values), and the rules the
+  frame is an expression of — one `ScheduleInput` + one `SchedulePlanPreview`
+  shared by reminders and crons, *create = centered modal / edit = drawer*,
+  initial focus on the describe bar when creating and Name when editing, and
+  "every schedule surface says what will happen and when it will next happen".
+  Skipping it cost real defects: the crons rebuild shipped the exact `Run Jul 9`
+  cell the spec files as a P1 ambiguity, and left row-action labels at
+  `--text-secondary` over `--bg-hover` (4.3:1) where the token table says
+  promote to primary. Both fixed by `cave-8b7fk`. Read it before touching
+  `cave-9f3i3` / `cave-84fp0` / `cave-dsm37` / `cave-cgfx2`.
 - `* - Current.dc.html` (Cave Chat, Daily Report, Coven Podcast, OpenCoven
   Landing, Memories - Current and Critique) — before-pictures.
 - `Chart Room - Astra / Proposal / Today`, `Dependencies - Directions`,

--- a/src/components/automations/schedule-list.tsx
+++ b/src/components/automations/schedule-list.tsx
@@ -13,7 +13,7 @@ import type { IconName } from "@/lib/icon";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { relativeTimeSigned } from "@/lib/relative-time";
 import { runStatusColor } from "@/lib/automations/run-status";
-import { cronHealth, cronHealthLabel, type CronHealth } from "@/lib/automations/cron-health";
+import { cronHealth, cronHealthLabel, cronRunVerb, type CronHealth } from "@/lib/automations/cron-health";
 
 function relTime(iso: string | undefined | null): string {
   return iso ? relativeTimeSigned(iso) : "—";
@@ -35,6 +35,12 @@ export const ScheduleActionsContext = createContext<ScheduleActions | null>(null
 // button (never nested), so a click can't also open the detail panel. It paints
 // on row hover/focus (see .rituals-cron-row__hover-actions) but stays in the tab
 // order, so a keyboard user never has to hover to reach it.
+//
+// The label promotes to --text-primary on hover/focus because that is exactly
+// when it needs to: the handoff spec's token table measures --text-secondary at
+// 4.3:1 over --bg-hover — below AA — and says "promote to primary on hover".
+// Tinting only the background made the text hardest to read at the one moment
+// the user is reaching for it.
 export function RowActionButton({ icon, label, text, onClick, disabled }: { icon: IconName; label: string; text: string; onClick: () => void; disabled?: boolean }) {
   return (
     <Button
@@ -44,7 +50,7 @@ export function RowActionButton({ icon, label, text, onClick, disabled }: { icon
       title={label}
       onClick={onClick}
       disabled={disabled}
-      className="shrink-0 rounded-[var(--radius-control)] px-2 py-1 text-[length:var(--text-xs)] font-medium transition-colors hover:bg-[color-mix(in_oklch,var(--foreground)_10%,transparent)] [color:var(--text-secondary)]!"
+      className="shrink-0 rounded-[var(--radius-control)] px-2 py-1 text-[length:var(--text-xs)] font-medium transition-colors hover:bg-[color-mix(in_oklch,var(--foreground)_10%,transparent)] [color:var(--text-secondary)]! hover:[color:var(--text-primary)]! focus-visible:[color:var(--text-primary)]!"
       leadingIcon={icon}
     >
       {/* Icon-only when the hosting pane runs narrow (e.g. the md split while a
@@ -125,7 +131,7 @@ function AutomationScheduleRow({
         style={lastRun ? { color: runStatusColor(lastRun.status, { quietSuccess: true }) } : undefined}
         title={lastRun?.startedAt ? formatTimestamp(lastRun.startedAt, readDateTimePrefs()) : undefined}
       >
-        {lastRun ? `Run ${relTime(lastRun.startedAt)}` : "—"}
+        {lastRun ? `${cronRunVerb(health)} ${relTime(lastRun.startedAt)}` : "—"}
       </span>
 
       <span className="rituals-cron-row__sched">

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -312,6 +312,21 @@ assert.doesNotMatch(
 );
 assert.match(
   scheduleList,
+  /\$\{cronRunVerb\(health\)\} \$\{relTime\(lastRun\.startedAt\)\}/,
+  "the last-run cell reads verb + state — a bare \"Run <date>\" is the ambiguity the handoff spec files as a P1",
+);
+assert.doesNotMatch(
+  scheduleList,
+  /`Run \$\{relTime/,
+  "no bare Run-plus-timestamp survives: it never said whether it looked forward or back",
+);
+assert.match(
+  scheduleList,
+  /hover:\[color:var\(--text-primary\)\]!/,
+  "row action labels promote to primary on hover — --text-secondary is 4.3:1 over --bg-hover, below AA",
+);
+assert.match(
+  scheduleList,
   /rituals-cron-row__glyph--\$\{health\}/,
   "each health state gets its own glyph shape, so status is never color-only",
 );

--- a/src/lib/automations/cron-health.test.ts
+++ b/src/lib/automations/cron-health.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { AutomationRunStatus } from "../automation-runs.ts";
 import type { CodexAutomation } from "../codex-automations-types.ts";
-import { cronHealth, cronHealthLabel, failingCronIds } from "./cron-health.ts";
+import { cronHealth, cronHealthLabel, cronRunVerb, failingCronIds } from "./cron-health.ts";
 
 function auto(id: string, status: CodexAutomation["status"] = "ACTIVE"): CodexAutomation {
   return {
@@ -73,5 +73,21 @@ describe("failingCronIds", () => {
 
   it("is empty when nothing has run", () => {
     assert.equal(failingCronIds([auto("a"), auto("b")], new Map()).size, 0);
+  });
+});
+
+describe("cronRunVerb", () => {
+  it("names the state instead of leaving a bare timestamp", () => {
+    // The handoff spec files "Run Jul 9" as a P1: ambiguous between last and
+    // next run, and red without saying why. Every verb here answers both.
+    assert.equal(cronRunVerb("failed"), "failed");
+    assert.equal(cronRunVerb("running"), "running");
+    assert.equal(cronRunVerb("healthy"), "ran");
+  });
+
+  it("uses the past tense for a paused cron's last recorded run", () => {
+    // A paused cron still has run history; the cell describes that run, not
+    // the pause.
+    assert.equal(cronRunVerb("paused"), "ran");
   });
 });

--- a/src/lib/automations/cron-health.ts
+++ b/src/lib/automations/cron-health.ts
@@ -32,6 +32,31 @@ export function cronHealth(
   return "healthy";
 }
 
+/**
+ * The last-run cell's leading verb.
+ *
+ * `Rituals Redesign.dc.html`'s companion spec (`Scheduling Spec.dc.html`, §2)
+ * files the bare timestamp as a P1: *"'Run Jul 9' — ambiguous (last run? next
+ * run?) and red without saying why"*, and prescribes **verb + state** —
+ * "ran today, 08:30" / "failed · Aug 13". A cell that only says "Run" leaves
+ * the reader guessing which direction in time they are looking, and colours it
+ * red without ever naming the failure.
+ *
+ * The verbs stay honest about what the store actually holds: `automation-runs
+ * .json` records app-triggered runs only, so "ran" means the newest run this
+ * app recorded, not a claim about the daemon's schedule.
+ */
+export function cronRunVerb(health: CronHealth): string {
+  switch (health) {
+    case "running":
+      return "running";
+    case "failed":
+      return "failed";
+    default:
+      return "ran";
+  }
+}
+
 /** Short status word for the row's `role="img"` label and the detail header. */
 export function cronHealthLabel(health: CronHealth): string {
   switch (health) {


### PR DESCRIPTION
Two defects in the merged crons rebuild (#5019). Both were diagnosed — in writing, with severities — by `Scheduling Spec.dc.html`, the implementation-ready spec sitting beside `Rituals Redesign.dc.html` in the same Claude Design project. The first pass never opened it.

### The last-run cell was the defect the spec exists to fix

It rendered `Run Aug 13`. The spec's crons-list audit files that exact string as a **P1**:

> "Run Jul 9" — ambiguous (last run? next run?) and red without saying why
> **Fix:** verb + state: "ran today, 08:30" / "failed · Aug 13"

So the row was coloured red for a failure it never named, in a cell that never said which direction in time it pointed at. `cronRunVerb` now derives the verb from the same `CronHealth` the status glyph uses, so shape, tint and word cannot drift apart.

The verbs stay honest about what the store holds: `automation-runs.json` records app-triggered runs only, so **"ran" means the newest run this app recorded** — not a claim about the daemon's schedule. A paused cron still reads "ran …", because the cell describes its run history, not the pause.

### Row action labels dropped below AA exactly when reached for

The spec's token table carries computed WCAG ratios on composited values, and marks `--text-secondary` at **4.3:1 over `--bg-hover` ⚠ promote to primary on hover**. `RowActionButton` pinned `[color:var(--text-secondary)]!` and swapped only its background, so hovering made the label *harder* to read at the one moment the user is reaching for it. It now promotes on `hover` and `focus-visible`.

### Ledger

`Scheduling Spec.dc.html` is recorded under "not deliverables" as a spec — and flagged as the more useful of the two files to read first. Every outstanding Rituals bead (`cave-9f3i3`, `cave-84fp0`, `cave-dsm37`, `cave-cgfx2`) now points at it, with the rules it binds: one shared `ScheduleInput` + `SchedulePlanPreview`, create = centered modal / edit = drawer, initial focus on the describe bar when creating and Name when editing.

### Verification

`pnpm lint` clean, `tsc --noEmit` clean, design-token drift ratchets unchanged. New `cronRunVerb` cases in `cron-health.test.ts`; `rituals-tabs.test.ts` pins both the verb+state cell and the hover promotion, and asserts no bare `Run ${relTime}` survives.

cave-8b7fk