### PR TITLE
Let an operator discharge the retirement cooldown, on the record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -554,6 +554,40 @@ closed** on absent data. `=== false` would be the bug — it would treat a
 missing or malformed entry as "not disabled, therefore fine" and waive the
 exclusion silently. Don't tidy it in that direction.
 
+### The three-hour cooldown, and how to discharge it deliberately
+
+A just-merged unit classifies `cooldown` — *"landed work remains inside the
+mandatory 3-hour cooldown"* — and the patrol will not retire it. Read what that
+gate is before reaching past it: by the time it applies, the unit is **already**
+proven landed, clean, non-divergent and retained on a remote ref. It is not a
+correctness check. It is a *"let a concurrent session notice"* window, and the
+one risk it covers — somebody else still sitting in that directory — is the one
+thing no amount of git evidence can answer. It was 8h (#4215), 3h since #4991.
+
+If you know the unit is idle, say so explicitly (`cave-jinkd`):
+
+```bash
+pnpm beads:worktrees:apply --allow-unenforced-planes --allow-cooldown-override
+```
+
+The patrol prints that exact line for you whenever cooldown is the only thing
+left, so you never have to look it up — the same affordance the create gate
+gives for its budget exception.
+
+**What the flag can and cannot do.** `cooldownIsTheOnlyBlocker` answers
+admission by re-running the real classifier one cooldown into the future and
+requiring `retire-after-gate`; it never matches the `cooldown` lane string.
+That is the whole safety property: dirty, unlanded, divergent, `uncertain` and
+protected units classify identically at *any* clock, so the flag can only ever
+discharge elapsed time. A unit whose recency is unknowable stays `uncertain`
+rather than being treated as "wait a bit longer". Every overridden retirement
+is recorded as `admitted by --allow-cooldown-override` in the attempt log.
+
+⚠️ **`scripts/worktree-sweep.sh` must never pass it.** A cron job has nobody to
+assert that a worktree is idle, and that assertion is the entire basis of the
+flag. Do not lower `RETIREMENT_COOLDOWN_MS` to avoid typing it either — the
+constant also governs the unattended sweep.
+
 **So retirement is either the degraded apply above or hand-retirement — both
 are sanctioned, neither is a workaround.** For a unit the patrol already
 classified `cleanup-ready`, use the archive-tag route in the worktree-guard

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import {
   renderWorktreeLifecycleReport,
   summarizeWorktreeLifecycle,
+  cooldownIsTheOnlyBlocker,
 } from "../src/lib/worktree-lifecycle.ts";
 import {
   acquireMaintenanceGate,
@@ -42,6 +43,18 @@ type Options = {
    * required — see assessMaintenancePlaneAdmission.
    */
   allowUnenforcedPlanes: boolean;
+  /**
+   * Operator assertion that the cooldown units are idle — nobody is working in
+   * them — so the "let a concurrent session notice" window can be discharged.
+   * It widens eligibility by exactly one lane, and only for units the gate
+   * itself clears once the clock advances (`cooldownIsTheOnlyBlocker` re-runs
+   * the classifier rather than matching a lane string), so it can never admit
+   * dirty, unlanded, divergent, uncertain or protected work.
+   *
+   * The scheduled sweep (scripts/worktree-sweep.sh) must never pass it: a cron
+   * job has nobody to make that assertion.
+   */
+  allowCooldownOverride: boolean;
 };
 
 type PatrolInventory = ReturnType<typeof collectWorktreeLifecycleInventory>;
@@ -151,6 +164,7 @@ export function parseArgs(argv: string[]): Options {
     apply: false,
     maxRetire: parseMaxRetire(undefined),
     allowUnenforcedPlanes: false,
+    allowCooldownOverride: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -171,6 +185,9 @@ export function parseArgs(argv: string[]): Options {
         break;
       case "--allow-unenforced-planes":
         options.allowUnenforcedPlanes = true;
+        break;
+      case "--allow-cooldown-override":
+        options.allowCooldownOverride = true;
         break;
       case "--max-retire": {
         const value = argv[++index];
@@ -572,8 +589,49 @@ function renderPatrolReport(
   if (malformedClaims) {
     lines.push(malformedClaims);
   }
+  const cooldownHint = renderCooldownOverrideHint(inventory.items, nowMs, false);
+  if (cooldownHint) {
+    lines.push("", cooldownHint);
+  }
   lines.push("", "Report only. No worktree, branch, or Bead metadata was changed.");
   return lines.join("\n");
+}
+
+
+/**
+ * When the ONLY thing between a unit and retirement is the clock, print the
+ * exact rerun that admits it.
+ *
+ * The create gate learned this lesson first (`cave-no5nr`): a refusal that
+ * names a policy but not the command teaches sessions to reach for an
+ * unmanaged workaround. "Wait three hours" is the same shape — so say what to
+ * run instead, and let the operator decide whether the assertion it makes is
+ * true.
+ */
+function renderCooldownOverrideHint(
+  items: readonly PatrolItem[],
+  nowMs: number,
+  applying: boolean,
+): string | null {
+  const waiting = items.filter((item) => cooldownIsTheOnlyBlocker(item, nowMs));
+  if (waiting.length === 0) return null;
+  const names = waiting
+    .map((item) => `  - ${formatItemIdentity(item)}`)
+    .sort(compareText);
+  return [
+    `${waiting.length} unit(s) are retirable except for the cooldown:`,
+    ...names,
+    "",
+    "The cooldown is the 'let a concurrent session notice' window — the work is",
+    "already proven landed, clean and retained. If you know nobody is working in",
+    "them, discharge it explicitly:",
+    "",
+    `  pnpm beads:worktrees:apply --allow-unenforced-planes --allow-cooldown-override`,
+    "",
+    applying
+      ? "Every overridden retirement is recorded as such in the attempt log."
+      : "That runs --apply. Re-read the units above first.",
+  ].join("\n");
 }
 
 function compareText(left: string, right: string): number {
@@ -667,7 +725,9 @@ export function runRetirementApply(
     // (worktree-lifecycle-retirement.ts:161); anything else would reserve a
     // slot for work that cannot happen.
     const retirableAtGate = inventory.items.some(
-      (item) => item.lane === "retire-after-gate",
+      (item) =>
+        item.lane === "retire-after-gate" ||
+        (options.allowCooldownOverride && cooldownIsTheOnlyBlocker(item, options.nowMs)),
     );
     // Only reserve when there is more than one slot to divide. With
     // --max-retire 1 a reservation would not share the budget, it would just
@@ -702,6 +762,8 @@ export function runRetirementApply(
             gateHandle: acquired.handle,
             operations,
             maxRetire: String(gitLimit),
+            allowCooldownOverride: options.allowCooldownOverride,
+            nowMs: options.nowMs,
           })
         : {
             retired: [],

--- a/scripts/worktree-lifecycle-retirement.ts
+++ b/scripts/worktree-lifecycle-retirement.ts
@@ -6,6 +6,7 @@ import {
   normalizeAbsoluteWorktreePath,
   type WorktreeLifecycleItem,
   type WorktreeRemoteRef,
+  cooldownIsTheOnlyBlocker,
 } from "../src/lib/worktree-lifecycle.ts";
 import { collectWorktreeLifecycleInventory } from "./worktree-lifecycle-inventory.ts";
 import {
@@ -151,11 +152,17 @@ export function retireLifecycleUnits({
   gateHandle,
   operations,
   maxRetire,
+  allowCooldownOverride = false,
+  nowMs = Date.now(),
 }: {
   items: WorktreeLifecycleItem[];
   gateHandle: RetirementGateHandle;
   operations: RetirementOperations;
   maxRetire?: string;
+  /** Operator assertion that the cooldown units are idle — see the flag's
+   *  documentation in worktree-lifecycle-patrol.ts. Never set by the sweep. */
+  allowCooldownOverride?: boolean;
+  nowMs?: number;
 }): RetirementReport {
   const report: RetirementReport = {
     retired: [],
@@ -166,8 +173,22 @@ export function retireLifecycleUnits({
   };
   const maxSuccessfulRetirements = parseMaxRetire(maxRetire);
   const attemptBudget = retirementAttemptBudget(maxSuccessfulRetirements);
+  // The override widens eligibility by exactly one lane, and only for units the
+  // gate itself would clear once the clock advances (cooldownIsTheOnlyBlocker
+  // re-runs the classifier rather than matching a lane string). Everything the
+  // gate refuses for a substantive reason stays refused.
+  // Keyed on the same identity beginAttempt reports, because `path` is null for
+  // a bare local ref with no worktree — which is exactly a unit this can admit.
+  const overriddenKey = (item: WorktreeLifecycleItem) => item.ref ?? item.head;
+  const overridden = new Set<string>();
   const eligible = [...items]
-    .filter((item) => item.lane === "retire-after-gate")
+    .filter((item) => {
+      if (item.lane === "retire-after-gate") return true;
+      if (!allowCooldownOverride) return false;
+      if (!cooldownIsTheOnlyBlocker(item, nowMs)) return false;
+      overridden.add(overriddenKey(item));
+      return true;
+    })
     .sort(compareRetirementCandidates);
 
   let gateFailed = false;
@@ -180,7 +201,7 @@ export function retireLifecycleUnits({
     index += 1
   ) {
     const item = eligible[index]!;
-    const attempt = beginAttempt(item);
+    const attempt = beginAttempt(item, overridden.has(overriddenKey(item)));
     const state: RetirementState = {
       destructiveMutation: false,
       worktreeRemoved: false,
@@ -820,7 +841,11 @@ function retirementSortKey(item: WorktreeLifecycleItem): string {
   return item.ref ?? item.branch ?? item.path ?? item.head;
 }
 
-function beginAttempt(item: WorktreeLifecycleItem): RetirementAttempt {
+/** `cooldownOverridden` marks a unit admitted by an operator assertion rather
+ *  than by the clock, so the attempt log says which retirements were waived
+ *  into. A destructive action taken on someone's say-so has to be legible
+ *  afterwards — the same reason every guard bypass in this repo is logged. */
+function beginAttempt(item: WorktreeLifecycleItem, cooldownOverridden = false): RetirementAttempt {
   return {
     ref: item.ref ?? item.head,
     oid: item.head,
@@ -828,7 +853,7 @@ function beginAttempt(item: WorktreeLifecycleItem): RetirementAttempt {
     worktreePostcondition: item.path === null ? "not-applicable" : "failed",
     localRefPostcondition: "not-attempted",
     outcome: "blocked",
-    reason: null,
+    reason: cooldownOverridden ? "admitted by --allow-cooldown-override" : null,
   };
 }
 

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -9,6 +9,7 @@ const {
   calculateLifecycleBudgets,
   classifyLifecycleUnit,
   classifyWorktree,
+  cooldownIsTheOnlyBlocker,
   isDisposableIgnoredPath,
   normalizeAbsoluteWorktreePath,
   renderWorktreeLifecycleReport,
@@ -1294,3 +1295,76 @@ function legacyObservation(overrides = {}) {
 }
 
 console.log("worktree-lifecycle.test.ts: ok");
+
+// ── cooldownIsTheOnlyBlocker — the --allow-cooldown-override admission test ──
+// The property under test is NOT "does it spot the cooldown lane". It is that
+// the override can discharge elapsed time and NOTHING else.
+{
+  const landedInsideCooldown = observation({
+    metadata: metadata({ disposition: "pr" }),
+    mergedPr: { number: 90, headOid: "a".repeat(40), url: "https://example.test/90" },
+    updatedAtMs: NOW - RETIREMENT_COOLDOWN_MS + 1,
+  });
+  assert.equal(
+    classifyLifecycleUnit(landedInsideCooldown, NOW).lane,
+    "cooldown",
+    "fixture really is waiting on the clock",
+  );
+  assert.equal(
+    cooldownIsTheOnlyBlocker(landedInsideCooldown, NOW),
+    true,
+    "landed, clean, non-divergent work waiting only on the clock is admissible",
+  );
+}
+
+{
+  const alreadyClear = observation({
+    metadata: metadata({ disposition: "pr" }),
+    mergedPr: { number: 91, headOid: "a".repeat(40), url: "https://example.test/91" },
+    updatedAtMs: NOW - RETIREMENT_COOLDOWN_MS - 1,
+  });
+  assert.equal(classifyLifecycleUnit(alreadyClear, NOW).lane, "retire-after-gate");
+  assert.equal(
+    cooldownIsTheOnlyBlocker(alreadyClear, NOW),
+    false,
+    "a unit the gate already clears does not need the override, and must not claim to",
+  );
+}
+
+{
+  // The safety case: blocked for a REASON, not for time. Advancing the clock
+  // must not launder it into eligibility.
+  const heldForOwner = observation({
+    metadata: metadata({
+      disposition: "recovery",
+      reviewAfter: "2026-07-28T12:00:00Z",
+    }),
+    mergedPr: { number: 92, headOid: "a".repeat(40), url: "https://example.test/92" },
+    updatedAtMs: NOW - RETIREMENT_COOLDOWN_MS + 1,
+  });
+  assert.equal(
+    cooldownIsTheOnlyBlocker(heldForOwner, NOW),
+    false,
+    "a recovery unit stays refused at every clock — the override is not a general bypass",
+  );
+  assert.equal(
+    cooldownIsTheOnlyBlocker(heldForOwner, NOW + 10 * DAY),
+    false,
+    "and waiting ten days does not change that either",
+  );
+}
+
+{
+  // Fail-closed on unknowable recency: "uncertain" is not "wait a bit longer".
+  const noRecency = observation({
+    metadata: metadata({ disposition: "pr" }),
+    mergedPr: { number: 93, headOid: "a".repeat(40), url: "https://example.test/93" },
+    updatedAtMs: null,
+  });
+  assert.equal(classifyLifecycleUnit(noRecency, NOW).lane, "uncertain");
+  assert.equal(
+    cooldownIsTheOnlyBlocker(noRecency, NOW),
+    false,
+    "unknown recency is refused, never overridden — the clock cannot answer it",
+  );
+}

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -336,6 +336,20 @@ function headMismatchReason(pr: WorktreeMergedPrRef): string {
   return `local HEAD does not match merged PR #${pr.number} head ${pr.headOid.slice(0, 9)} — fast-forward with \`git merge --ff-only ${pr.headOid}\` if this unit holds nothing else`;
 }
 
+/**
+ * How long landed work rests before automated retirement will touch it.
+ *
+ * By the time this applies the unit is ALREADY proven landed, clean,
+ * non-divergent and retained — so this is not a correctness check. It is a
+ * "let a concurrent session notice" window: the one risk left is that someone
+ * else is still sitting in the directory, and no amount of git evidence can
+ * answer that. 8h originally (#4215), 3h since #4991 (`cave-vwt75`).
+ *
+ * An operator who KNOWS the unit is idle can discharge the wait explicitly
+ * with `--allow-cooldown-override` — see {@link cooldownIsTheOnlyBlocker}.
+ * The scheduled sweep never passes it, because a cron job has nobody to make
+ * that assertion.
+ */
 export const RETIREMENT_COOLDOWN_MS = 3 * 60 * 60 * 1000;
 /** Branch namespaces whose content is a snapshot to preserve, never retire.
  *
@@ -859,6 +873,33 @@ export function classifyLifecycleUnit(
     allowLegacyMissingMetadata: false,
   });
 }
+
+/**
+ * Would this unit be retirable if the ONLY thing in its way — the mandatory
+ * cooldown — had already elapsed?
+ *
+ * Answered by re-running the real classifier one cooldown into the future,
+ * never by matching the "cooldown" lane string. That distinction IS the safety
+ * property. A unit that is dirty, unlanded, divergent, uncertain or protected
+ * classifies exactly the same at any clock, so this can only ever discharge one
+ * thing: elapsed time. It cannot be widened by accident into "retire anything
+ * the gate refused", because the answer still comes from the gate.
+ *
+ * Requiring the present lane to be `cooldown` as well is not redundant: it
+ * keeps the predicate honest about what it claims. Without it a unit that is
+ * already `retire-after-gate` would answer true, and callers would be told the
+ * override was needed when it was not.
+ */
+export function cooldownIsTheOnlyBlocker(
+  observation: WorktreeLifecycleObservation,
+  nowMs = Date.now(),
+): boolean {
+  if (classifyLifecycleUnit(observation, nowMs).lane !== "cooldown") return false;
+  return (
+    classifyLifecycleUnit(observation, nowMs + RETIREMENT_COOLDOWN_MS).lane === "retire-after-gate"
+  );
+}
+
 
 function normalizeLegacyRef(branch: string | null, ref: string | null | undefined): string | null {
   return ref ?? (branch ? `refs/heads/${branch}` : null);


### PR DESCRIPTION
Retiring a just-merged worktree means waiting out a three-hour window. Worth reading what that window actually is before reaching past it: by the time it applies, the unit is **already** proven landed, clean, non-divergent and retained on a remote ref. It is not a correctness check. It is a *"let a concurrent session notice"* window — and the one risk it covers, somebody else still sitting in that directory, is precisely the thing no amount of git evidence can answer.

That is what makes it a good candidate for an **explicit operator assertion** rather than a shorter timer.

### The flag

`--allow-cooldown-override`, following the `--allow-unenforced-planes` precedent already in this script — never implicit, always attributable:

```bash
pnpm beads:worktrees:apply --allow-unenforced-planes --allow-cooldown-override
```

### The safety property is in *how* admission is decided

`cooldownIsTheOnlyBlocker` re-runs the **real classifier** one cooldown into the future and requires the result to be `retire-after-gate`. It never matches the `"cooldown"` lane string.

That distinction is the whole thing. Dirty, unlanded, divergent, `uncertain` and protected units classify identically at *any* clock, so the flag can only ever discharge elapsed time — it cannot be widened by accident into "retire whatever the gate rejected". The tests pin that property rather than the happy path:

- a `recovery` unit is still refused **ten days later**;
- unknowable recency fails closed as `uncertain`, rather than reading as "wait a bit longer";
- a unit the gate already clears returns `false`, so callers are never told the override was needed when it wasn't.

Overridden retirements record `admitted by --allow-cooldown-override` in the attempt log, because a destructive action taken on somebody's say-so has to be legible afterwards — the same reason every guard bypass in this repo is logged.

### The half that actually removes the friction

When cooldown is the only thing left, the patrol now **prints the exact admissible rerun**. A refusal that names a policy but not the command is what teaches sessions to reach for an unmanaged workaround; the create gate learned that in `cave-no5nr`.

### What this deliberately does *not* do

`RETIREMENT_COOLDOWN_MS` is unchanged. It also governs `scripts/worktree-sweep.sh`, and a cron job has nobody to assert a worktree is idle — lowering it would spend the unattended sweep's safety margin to save an interactive operator some typing. The constant does gain the rationale comment it never had, despite being tuned twice (8h in #4215, 3h in #4991).

`CLAUDE.md` documents the gate, the flag, and the sweep prohibition.

cave-jinkd