### PR TITLE
Use dropdowns for podcast voices

### DIFF
--- a/src/components/role-surfaces/research-studio-modals.tsx
+++ b/src/components/role-surfaces/research-studio-modals.tsx
@@ -924,7 +924,14 @@ export function GenerationConfigModal({
                       ? "Loading voices…"
                       : "Choose a voice"
                   }
+                  showCaret={false}
                   aria-describedby="research-studio-config-voice-help"
+                  aria-invalid={mediaConfigurationError ? true : undefined}
+                  aria-errormessage={
+                    mediaConfigurationError
+                      ? "research-studio-config-media-error"
+                      : undefined
+                  }
                   onChange={onMediaVoiceChange}
                 />
                 <span
@@ -1029,7 +1036,14 @@ export function GenerationConfigModal({
                     ]}
                     disabled={elevenLabsCatalogUnavailable}
                     placeholder="Same as host voice"
+                    showCaret={false}
                     aria-describedby="research-studio-config-guest-voice-help"
+                    aria-invalid={mediaConfigurationError ? true : undefined}
+                    aria-errormessage={
+                      mediaConfigurationError
+                        ? "research-studio-config-media-error"
+                        : undefined
+                    }
                     onChange={onMediaGuestVoiceChange}
                   />
                 )}
@@ -1055,6 +1069,7 @@ export function GenerationConfigModal({
                     id="research-studio-config-delivery"
                     label="Delivery"
                     className="research-studio__select focus-ring"
+                    showCaret={false}
                     value={mediaDelivery}
                     aria-describedby="research-studio-config-delivery-help"
                     onChange={onMediaDeliveryChange}
@@ -1083,6 +1098,7 @@ export function GenerationConfigModal({
                     id="research-studio-config-model"
                     label="Render model"
                     className="research-studio__select focus-ring"
+                    showCaret={false}
                     value={mediaModel}
                     aria-describedby="research-studio-config-model-help"
                     onChange={onMediaModelChange}

--- a/src/components/role-surfaces/research-studio-modals.tsx
+++ b/src/components/role-surfaces/research-studio-modals.tsx
@@ -33,7 +33,10 @@ import { MarkdownBlock } from "@/components/message-bubble";
 import { PodcastTranscript } from "@/components/role-surfaces/podcast-transcript";
 import { AuthedImage } from "@/components/ui/authed-image";
 import { RelativeTime } from "@/components/ui/relative-time";
-import { StandardSelect } from "@/components/ui/select";
+import {
+  StandardSelect,
+  type StandardSelectOption,
+} from "@/components/ui/select";
 import { copyText } from "@/lib/clipboard";
 import { useResearchMediaUrl } from "@/lib/research-media-client";
 import {
@@ -59,6 +62,7 @@ import {
   isValidElevenLabsSeed,
   type ElevenLabsDeliveryPresetId,
 } from "@/lib/voice/elevenlabs-shared";
+import type { ElevenLabsCatalogState } from "@/lib/voice/settings-client";
 import type { ResearchMission } from "@/lib/research-missions";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useAnnouncer } from "@/components/ui/live-region";
@@ -602,6 +606,8 @@ export function GenerationConfigModal({
   onMediaVoiceChange,
   mediaGuestVoice,
   onMediaGuestVoiceChange,
+  elevenLabsCatalog,
+  onRetryElevenLabsCatalog,
   mediaStyle,
   onMediaStyleChange,
   mediaLength,
@@ -631,6 +637,10 @@ export function GenerationConfigModal({
   /** Podcast-only guest voice; empty string means one voice for both speakers. */
   mediaGuestVoice: string;
   onMediaGuestVoiceChange: (voice: string) => void;
+  elevenLabsCatalog:
+    | { status: "idle" | "loading" }
+    | ElevenLabsCatalogState;
+  onRetryElevenLabsCatalog: () => void;
   /** Podcast-only drafting style; ignored for video kinds. */
   mediaStyle: ResearchPodcastStyle;
   onMediaStyleChange: (style: ResearchPodcastStyle) => void;
@@ -654,6 +664,37 @@ export function GenerationConfigModal({
   const meta = studioMetaForKind(kind);
   const isMedia = !isResearchGenerationKind(kind);
   const nearCap = directions.length >= RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH * 0.9;
+  const elevenLabsVoiceOptions: StandardSelectOption<string>[] =
+    elevenLabsCatalog.status === "ready"
+      ? [
+          ...[
+            mediaVoice,
+            ...(mediaGuestVoice ? [mediaGuestVoice] : []),
+          ]
+            .filter(
+              (voice, index, voices) =>
+                voice &&
+                voices.indexOf(voice) === index &&
+                !elevenLabsCatalog.voices.some(
+                  (option) => option.id === voice,
+                ),
+            )
+            .map((voice) => ({
+              value: voice,
+              label: "Current voice",
+              detail: voice,
+            })),
+          ...elevenLabsCatalog.voices.map((voice) => ({
+            value: voice.id,
+            label: voice.name,
+            detail: voice.category ?? voice.id,
+          })),
+        ]
+      : [];
+  const elevenLabsCatalogUnavailable =
+    elevenLabsCatalog.status === "idle" ||
+    elevenLabsCatalog.status === "loading" ||
+    elevenLabsCatalog.status === "error";
   const mediaConfigurationError = (() => {
     if (!isMedia) return null;
     if (!readiness) return "Media readiness is still loading.";
@@ -688,7 +729,16 @@ export function GenerationConfigModal({
           "ElevenLabs voice rendering is not ready."
         );
       }
-      if (!mediaVoice.trim()) return "Enter an ElevenLabs voice ID.";
+      if (
+        elevenLabsCatalog.status === "idle" ||
+        elevenLabsCatalog.status === "loading"
+      ) {
+        return "ElevenLabs voices are still loading.";
+      }
+      if (elevenLabsCatalog.status === "error") {
+        return elevenLabsCatalog.message;
+      }
+      if (!mediaVoice.trim()) return "Choose an ElevenLabs voice.";
     }
     if (kind === "short-video" && mediaLength === "extended") {
       return "Short video length must be brief or standard.";
@@ -859,30 +909,40 @@ export function GenerationConfigModal({
                   className="research-studio-config__label"
                   htmlFor="research-studio-config-elevenlabs-voice"
                 >
-                  ElevenLabs voice ID
+                  Host voice
                 </label>
-                <input
+                <StandardSelect
                   id="research-studio-config-elevenlabs-voice"
-                  className="research-studio-config__input focus-ring"
+                  label="Host voice"
+                  className="research-studio__select focus-ring"
                   value={mediaVoice}
+                  options={elevenLabsVoiceOptions}
+                  disabled={elevenLabsCatalogUnavailable}
                   placeholder={
-                    readiness?.providers.elevenlabs.defaultVoiceId ?? ""
+                    elevenLabsCatalog.status === "loading" ||
+                    elevenLabsCatalog.status === "idle"
+                      ? "Loading voices…"
+                      : "Choose a voice"
                   }
                   aria-describedby="research-studio-config-voice-help"
-                  aria-invalid={mediaConfigurationError ? true : undefined}
-                  aria-errormessage={
-                    mediaConfigurationError
-                      ? "research-studio-config-media-error"
-                      : undefined
-                  }
-                  onChange={(event) => onMediaVoiceChange(event.target.value)}
+                  onChange={onMediaVoiceChange}
                 />
                 <span
                   id="research-studio-config-voice-help"
                   className="research-studio-config__hint"
                 >
-                  The exact voice ID is frozen on this draft.
+                  Saved voices in your ElevenLabs library. The selected voice is
+                  frozen on this draft.
                 </span>
+                {elevenLabsCatalog.status === "error" ? (
+                  <button
+                    type="button"
+                    className="research-studio-act research-studio-act--tiny focus-ring"
+                    onClick={onRetryElevenLabsCatalog}
+                  >
+                    Retry voices
+                  </button>
+                ) : null}
               </div>
             )}
 
@@ -955,21 +1015,22 @@ export function GenerationConfigModal({
                     ))}
                   </select>
                 ) : (
-                  <input
+                  <StandardSelect
                     id="research-studio-config-guest-voice"
-                    className="research-studio-config__input focus-ring"
+                    label="Guest voice (optional)"
+                    className="research-studio__select focus-ring"
                     value={mediaGuestVoice}
+                    options={[
+                      {
+                        value: "",
+                        label: "Same as host voice",
+                      },
+                      ...elevenLabsVoiceOptions,
+                    ]}
+                    disabled={elevenLabsCatalogUnavailable}
                     placeholder="Same as host voice"
                     aria-describedby="research-studio-config-guest-voice-help"
-                    aria-invalid={mediaConfigurationError ? true : undefined}
-                    aria-errormessage={
-                      mediaConfigurationError
-                        ? "research-studio-config-media-error"
-                        : undefined
-                    }
-                    onChange={(event) =>
-                      onMediaGuestVoiceChange(event.target.value)
-                    }
+                    onChange={onMediaGuestVoiceChange}
                   />
                 )}
                 <span

--- a/src/components/role-surfaces/research-studio-podcast-direction.test.tsx
+++ b/src/components/role-surfaces/research-studio-podcast-direction.test.tsx
@@ -56,8 +56,10 @@ const readiness = {
 function renderConfig(overrides: Record<string, unknown> = {}) {
   const calls: Record<string, unknown[]> = {
     delivery: [],
+    guestVoice: [],
     model: [],
     seed: [],
+    voice: [],
   };
   const props = {
     kind: "podcast",
@@ -70,9 +72,18 @@ function renderConfig(overrides: Record<string, unknown> = {}) {
     mediaProvider: "elevenlabs",
     onMediaProviderChange: () => {},
     mediaVoice: "21m00Tcm4TlvDq8ikWAM",
-    onMediaVoiceChange: () => {},
+    onMediaVoiceChange: (value: unknown) => calls.voice.push(value),
     mediaGuestVoice: "",
-    onMediaGuestVoiceChange: () => {},
+    onMediaGuestVoiceChange: (value: unknown) => calls.guestVoice.push(value),
+    elevenLabsCatalog: {
+      status: "ready",
+      voices: [
+        { id: "21m00Tcm4TlvDq8ikWAM", name: "Rachel", category: "premade" },
+        { id: "AZnzlk1XvdvUeBnXmlld", name: "Domi", category: "premade" },
+      ],
+      models: [],
+    },
+    onRetryElevenLabsCatalog: () => {},
     mediaStyle: "breakdown",
     onMediaStyleChange: () => {},
     mediaLength: "standard",
@@ -135,6 +146,68 @@ const DIRECTION_IDS = [
 ];
 
 describe("Studio podcast delivery controls", () => {
+  test("use ElevenLabs dropdowns for both podcast voices", () => {
+    const { renderer, calls } = renderConfig();
+    const host = selectById(
+      renderer,
+      "research-studio-config-elevenlabs-voice",
+    );
+    const guest = selectById(
+      renderer,
+      "research-studio-config-guest-voice",
+    );
+
+    expect(host).not.toBeNull();
+    expect(guest).not.toBeNull();
+    expect(
+      host.props.options.map((option: { value: string }) => option.value),
+    ).toEqual(["21m00Tcm4TlvDq8ikWAM", "AZnzlk1XvdvUeBnXmlld"]);
+    expect(
+      guest.props.options.map((option: { value: string }) => option.value),
+    ).toEqual(["", "21m00Tcm4TlvDq8ikWAM", "AZnzlk1XvdvUeBnXmlld"]);
+
+    act(() => {
+      host.props.onChange("AZnzlk1XvdvUeBnXmlld");
+      guest.props.onChange("21m00Tcm4TlvDq8ikWAM");
+    });
+    expect(calls.voice).toEqual(["AZnzlk1XvdvUeBnXmlld"]);
+    expect(calls.guestVoice).toEqual(["21m00Tcm4TlvDq8ikWAM"]);
+  });
+
+  test("block drafting while the ElevenLabs voice catalog is unavailable", () => {
+    const loading = renderConfig({
+      elevenLabsCatalog: { status: "loading" },
+    });
+    expect(
+      selectById(
+        loading.renderer,
+        "research-studio-config-elevenlabs-voice",
+      ).props.disabled,
+    ).toBe(true);
+    expect(
+      loading.renderer.root
+        .findAllByType("button")
+        .find((button) => textOf(button).includes("Draft for review")).props
+        .disabled,
+    ).toBe(true);
+
+    const failed = renderConfig({
+      elevenLabsCatalog: {
+        status: "error",
+        code: "network_error",
+        message: "Couldn’t reach ElevenLabs. Try again.",
+      },
+    });
+    expect(
+      textOf(byId(failed.renderer, "research-studio-config-media-error")),
+    ).toContain("Couldn’t reach ElevenLabs");
+    expect(
+      failed.renderer.root
+        .findAllByType("button")
+        .some((button) => textOf(button) === "Retry voices"),
+    ).toBe(true);
+  });
+
   test("appear for an ElevenLabs podcast", () => {
     const { renderer } = renderConfig();
     for (const id of DIRECTION_IDS) {

--- a/src/components/role-surfaces/research-studio-podcast-direction.test.tsx
+++ b/src/components/role-surfaces/research-studio-podcast-direction.test.tsx
@@ -178,6 +178,7 @@ describe("Studio podcast delivery controls", () => {
     const loading = renderConfig({
       elevenLabsCatalog: { status: "loading" },
     });
+
     expect(
       selectById(
         loading.renderer,
@@ -206,6 +207,27 @@ describe("Studio podcast delivery controls", () => {
         .findAllByType("button")
         .some((button) => textOf(button) === "Retry voices"),
     ).toBe(true);
+  });
+
+  test("associate invalid voice dropdowns with the media error", () => {
+    const { renderer } = renderConfig({
+      elevenLabsCatalog: {
+        status: "error",
+        message: "Voice catalog unavailable.",
+      },
+    });
+
+    for (const id of [
+      "research-studio-config-elevenlabs-voice",
+      "research-studio-config-guest-voice",
+    ]) {
+      const trigger = byId(renderer, id);
+      expect(trigger.props["aria-invalid"]).toBe(true);
+      expect(trigger.props["aria-errormessage"]).toBe(
+        "research-studio-config-media-error",
+      );
+      expect(selectById(renderer, id).props.showCaret).toBe(false);
+    }
   });
 
   test("appear for an ElevenLabs podcast", () => {

--- a/src/components/role-surfaces/research-tab-studio.test.ts
+++ b/src/components/role-surfaces/research-tab-studio.test.ts
@@ -96,6 +96,22 @@ test("media configuration is controlled, readiness-backed, and kind-specific", (
   assert.match(modals, /aria-describedby="research-studio-config-length-help"/);
 });
 
+test("ElevenLabs podcast voices come from the authenticated catalog", () => {
+  assert.match(tab, /loadElevenLabsCatalog/);
+  assert.match(tab, /elevenLabsCatalog=\{elevenLabsCatalog\}/);
+  assert.match(tab, /onRetryElevenLabsCatalog=\{loadElevenLabsCatalogForStudio\}/);
+  assert.match(modals, /<StandardSelect[\s\S]*id="research-studio-config-elevenlabs-voice"/);
+  assert.match(modals, /<StandardSelect[\s\S]*id="research-studio-config-guest-voice"/);
+  assert.doesNotMatch(
+    modals,
+    /<input[\s\S]{0,220}id="research-studio-config-elevenlabs-voice"/,
+  );
+  assert.doesNotMatch(
+    modals,
+    /<input[\s\S]{0,220}id="research-studio-config-guest-voice"/,
+  );
+});
+
 test("media drafts reopen review and retry creates a replacement draft", () => {
   assert.match(tab, /generation\.status === "draft"/);
   assert.match(tab, />\s*Review draft\s*</);

--- a/src/components/role-surfaces/research-tab-studio.tsx
+++ b/src/components/role-surfaces/research-tab-studio.tsx
@@ -38,6 +38,10 @@ import {
   type ResearchPodcastStyle,
 } from "@/lib/research-generations";
 import type { ElevenLabsDeliveryPresetId } from "@/lib/voice/elevenlabs-shared";
+import {
+  loadElevenLabsCatalog,
+  type ElevenLabsCatalogState,
+} from "@/lib/voice/settings-client";
 import type { ResearchTabProps } from "./researcher-surface";
 import { describeProviderChips, researchProviderChips } from "./research-studio-providers";
 import {
@@ -74,6 +78,9 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
     useState<ResearchMediaProvider>("local");
   const [mediaVoice, setMediaVoice] = useState("");
   const [mediaGuestVoice, setMediaGuestVoice] = useState("");
+  const [elevenLabsCatalog, setElevenLabsCatalog] = useState<
+    { status: "idle" | "loading" } | ElevenLabsCatalogState
+  >({ status: "idle" });
   const [mediaStyle, setMediaStyle] = useState<ResearchPodcastStyle>("breakdown");
   const [mediaLength, setMediaLength] =
     useState<ResearchMediaLength>("standard");
@@ -115,6 +122,7 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
   const listControllerRef = useRef<AbortController | null>(null);
   const readinessInFlightRef = useRef(false);
   const readinessControllerRef = useRef<AbortController | null>(null);
+  const elevenLabsCatalogControllerRef = useRef<AbortController | null>(null);
   const retryInFlightRef = useRef<string | null>(null);
 
   const loadGenerations = useCallback(async (showLoading: boolean) => {
@@ -200,6 +208,20 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
     }
   }, []);
 
+  const loadElevenLabsCatalogForStudio = useCallback(async () => {
+    elevenLabsCatalogControllerRef.current?.abort();
+    const controller = new AbortController();
+    elevenLabsCatalogControllerRef.current = controller;
+    setElevenLabsCatalog({ status: "loading" });
+    const result = await loadElevenLabsCatalog(fetch, controller.signal);
+    if (!controller.signal.aborted) {
+      setElevenLabsCatalog(result);
+    }
+    if (elevenLabsCatalogControllerRef.current === controller) {
+      elevenLabsCatalogControllerRef.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     if (loadedFamiliarRef.current !== familiarId) {
       loadedFamiliarRef.current = familiarId;
@@ -224,6 +246,24 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
       readinessInFlightRef.current = false;
     };
   }, [loadReadiness]);
+
+  useEffect(() => {
+    if (
+      configKind === null ||
+      isResearchGenerationKind(configKind) ||
+      mediaProvider !== "elevenlabs"
+    ) {
+      elevenLabsCatalogControllerRef.current?.abort();
+      elevenLabsCatalogControllerRef.current = null;
+      setElevenLabsCatalog({ status: "idle" });
+      return;
+    }
+    void loadElevenLabsCatalogForStudio();
+    return () => {
+      elevenLabsCatalogControllerRef.current?.abort();
+      elevenLabsCatalogControllerRef.current = null;
+    };
+  }, [configKind, loadElevenLabsCatalogForStudio, mediaProvider]);
 
   const hasActiveMediaGeneration = generations.some((generation) =>
     !isResearchGenerationKind(generation.kind) &&
@@ -849,6 +889,8 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
           onMediaVoiceChange={setMediaVoice}
           mediaGuestVoice={mediaGuestVoice}
           onMediaGuestVoiceChange={setMediaGuestVoice}
+          elevenLabsCatalog={elevenLabsCatalog}
+          onRetryElevenLabsCatalog={loadElevenLabsCatalogForStudio}
           mediaStyle={mediaStyle}
           onMediaStyleChange={setMediaStyle}
           mediaLength={mediaLength}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -36,6 +36,8 @@ export type StandardSelectProps<T extends string> = {
   showCaret?: boolean;
   renderValue?: (selected: StandardSelectOption<T> | null) => ReactNode;
   "aria-describedby"?: string;
+  "aria-errormessage"?: string;
+  "aria-invalid"?: boolean;
 };
 
 function isGroup<T extends string>(entry: SelectEntry<T>): entry is StandardSelectGroup<T> {
@@ -73,6 +75,8 @@ export function StandardSelect<T extends string>({
   showCaret = true,
   renderValue,
   "aria-describedby": ariaDescribedBy,
+  "aria-errormessage": ariaErrorMessage,
+  "aria-invalid": ariaInvalid,
 }: StandardSelectProps<T>) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
@@ -96,6 +100,8 @@ export function StandardSelect<T extends string>({
         title={title}
         aria-label={label}
         aria-describedby={ariaDescribedBy}
+        aria-errormessage={ariaErrorMessage}
+        aria-invalid={ariaInvalid}
         aria-haspopup="menu"
         aria-expanded={open}
         disabled={disabled}

--- a/tests/research-studio-media.spec.ts
+++ b/tests/research-studio-media.spec.ts
@@ -4,6 +4,7 @@ import { DEFAULT_ELEVENLABS_VOICE_ID } from "../src/lib/voice/elevenlabs-shared"
 const FAMILIAR_ID = "rida";
 const MISSION_ID = "m-media";
 const ELEVENLABS_VOICE_ID = DEFAULT_ELEVENLABS_VOICE_ID;
+const ELEVENLABS_GUEST_VOICE_ID = "AZnzlk1XvdvUeBnXmlld";
 const now = new Date().toISOString();
 
 function createSilentWav() {
@@ -250,6 +251,26 @@ async function boot(
   await page.route("**/api/sessions/list**", (route) =>
     route.fulfill({ json: { ok: true, sessions: [] } }),
   );
+  await page.route("**/api/voice/elevenlabs/catalog", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        voices: [
+          {
+            id: ELEVENLABS_VOICE_ID,
+            name: "Rachel",
+            category: "premade",
+          },
+          {
+            id: ELEVENLABS_GUEST_VOICE_ID,
+            name: "Domi",
+            category: "premade",
+          },
+        ],
+        models: [],
+      },
+    }),
+  );
   await page.route(/\/api\/roles(?:\?|$)/, (route) =>
     route.fulfill({ json: { roles: [] } }),
   );
@@ -463,9 +484,7 @@ test.describe("Research Studio media honesty and playback", () => {
     ]);
     await expect(config.getByLabel("Local voice")).toHaveValue("piper-amy");
     await provider.selectOption("elevenlabs");
-    await expect(config.getByLabel("ElevenLabs voice ID")).toHaveValue(
-      ELEVENLABS_VOICE_ID,
-    );
+    await expect(config.getByLabel("Host voice")).toContainText("Rachel");
     await expect(config.getByLabel("Length").locator("option")).toHaveCount(3);
     await expect(config.getByLabel("Style").locator("option")).toHaveText([
       "Breakdown",
@@ -483,13 +502,19 @@ test.describe("Research Studio media honesty and playback", () => {
 
     await podcastCard.click();
     await config.getByLabel("Style").selectOption("debate");
-    await config.getByLabel("Guest voice (optional)").fill("eleven-guest");
+    await config.getByLabel("Guest voice (optional)").click();
+    await page
+      .getByRole("menuitemradio", { name: /Domi/ })
+      .click();
     await config.getByRole("button", { name: /Draft for review Podcast/ }).click();
     expect(controls.createBodies.at(-1)?.renderConfig).toEqual({
       provider: "elevenlabs",
       voice: ELEVENLABS_VOICE_ID,
       length: "standard",
-      voices: { host: ELEVENLABS_VOICE_ID, guest: "eleven-guest" },
+      voices: {
+        host: ELEVENLABS_VOICE_ID,
+        guest: ELEVENLABS_GUEST_VOICE_ID,
+      },
       style: "debate",
     });
     let review = page.getByRole("dialog", {
@@ -499,7 +524,7 @@ test.describe("Research Studio media honesty and playback", () => {
       "An extracted finding for the podcast.",
     );
     await expect(review).toContainText("ElevenLabs");
-    await expect(review).toContainText("eleven-guest");
+    await expect(review).toContainText(ELEVENLABS_GUEST_VOICE_ID);
     await expect(review).toContainText("debate");
     await review.getByRole("button", { name: "Keep draft" }).click();
     const row = studio.locator(".research-studio-row").first();
@@ -538,9 +563,7 @@ test.describe("Research Studio media honesty and playback", () => {
 
     const config = page.getByRole("dialog", { name: "Generate Short video" });
     await expect(config.getByLabel("Voice provider")).toHaveValue("elevenlabs");
-    await expect(config.getByLabel("ElevenLabs voice ID")).toHaveValue(
-      ELEVENLABS_VOICE_ID,
-    );
+    await expect(config.getByLabel("Host voice")).toContainText("Rachel");
     await expect(config.getByLabel("Length")).toHaveValue("standard");
     await config.getByLabel("Research run").focus();
     await page.keyboard.press("Tab");


### PR DESCRIPTION
## Summary
- replace ElevenLabs host and guest voice ID inputs with accessible catalog-backed dropdowns
- preserve current voice IDs and support same-as-host guest selection
- gate drafting during catalog loading/errors and provide retry behavior

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- targeted Research Studio podcast Playwright test
- `pnpm build`
- production-browser dropdown and overflow verification

Bead: `cave-9zb09`