### PR TITLE
Keep Research runnable without Codex launch policy

### DIFF
--- a/src/app/api/daemon/status/route.test.ts
+++ b/src/app/api/daemon/status/route.test.ts
@@ -54,6 +54,12 @@ assert.match(
 
 assert.match(
   source,
+  /scope === "research-local"[\s\S]*localDaemonTarget\(\)[\s\S]*supportsSessionLaunchPolicy\(health\)[\s\S]*sessionLaunchPolicy/,
+  "Research capability checks should probe the owner-local daemon rather than the configured hub target",
+);
+
+assert.match(
+  source,
   /executorStatusesForConfig\(config\)/,
   "daemon status should check configured executor node availability from Cave config",
 );

--- a/src/app/api/daemon/status/route.test.ts
+++ b/src/app/api/daemon/status/route.test.ts
@@ -54,7 +54,7 @@ assert.match(
 
 assert.match(
   source,
-  /scope === "research-local"[\s\S]*localDaemonTarget\(\)[\s\S]*supportsSessionLaunchPolicy\(health\)[\s\S]*sessionLaunchPolicy/,
+  /scope === "research-local"[\s\S]*localDaemonTarget\(\)[\s\S]*isOwnerLocalResearchDaemonTarget\(target\)[\s\S]*supportsSessionLaunchPolicy\(health\)[\s\S]*sessionLaunchPolicy/,
   "Research capability checks should probe the owner-local daemon rather than the configured hub target",
 );
 

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -19,7 +19,7 @@ import { daemonHealthRequest, daemonHealthResponseSucceeded } from "@/lib/server
 import { assessDaemonStartupCompatibility, type DaemonStartupHealth } from "@/lib/daemon-startup-contract";
 import { classifyHubFailure } from "@/lib/server/daemon-probe";
 import { reconcileDaemonTravelState } from "@/lib/server/daemon-travel-reconcile";
-import { supportsSessionLaunchPolicy } from "@/lib/server/research-launch-policy";
+import { isOwnerLocalResearchDaemonTarget, supportsSessionLaunchPolicy } from "@/lib/server/research-launch-policy";
 import {
   daemonDiagnosticContextFromRequest,
   DAEMON_DIAGNOSTIC_CORRELATION_HEADER,

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -103,7 +103,8 @@ export async function GET(request: Request) {
       diagnosticOperation: "research-local-capability",
     });
     const health = daemonHealthResponseSucceeded(res) ? res.data : null;
-    const sessionLaunchPolicy = supportsSessionLaunchPolicy(health);
+    const sessionLaunchPolicy = isOwnerLocalResearchDaemonTarget(target)
+      && supportsSessionLaunchPolicy(health);
     return respond({
       running: health !== null,
       target: targetSummary(target),

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -7,6 +7,7 @@ import {
   callDaemonTarget,
   daemonTargetForConfig,
   extractDaemonError,
+  localDaemonTarget,
   type DaemonResponse,
   type DaemonTarget,
 } from "@/lib/coven-daemon";
@@ -18,6 +19,7 @@ import { daemonHealthRequest, daemonHealthResponseSucceeded } from "@/lib/server
 import { assessDaemonStartupCompatibility, type DaemonStartupHealth } from "@/lib/daemon-startup-contract";
 import { classifyHubFailure } from "@/lib/server/daemon-probe";
 import { reconcileDaemonTravelState } from "@/lib/server/daemon-travel-reconcile";
+import { supportsSessionLaunchPolicy } from "@/lib/server/research-launch-policy";
 import {
   daemonDiagnosticContextFromRequest,
   DAEMON_DIAGNOSTIC_CORRELATION_HEADER,
@@ -92,6 +94,22 @@ export async function GET(request: Request) {
         },
       },
     );
+  const scope = new URL(request.url).searchParams.get("scope");
+  if (scope === "research-local") {
+    const target = localDaemonTarget();
+    const res = await callDaemonTarget<Health>(target, {
+      ...daemonHealthRequest(),
+      diagnostics,
+      diagnosticOperation: "research-local-capability",
+    });
+    const health = daemonHealthResponseSucceeded(res) ? res.data : null;
+    const sessionLaunchPolicy = supportsSessionLaunchPolicy(health);
+    return respond({
+      running: health !== null,
+      target: targetSummary(target),
+      research: { sessionLaunchPolicy },
+    });
+  }
   let snapshot: Awaited<ReturnType<typeof loadDaemonStatusSnapshot>>;
   try {
     snapshot = await loadDaemonStatusSnapshot();

--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -240,6 +240,9 @@ export function ResearchMissionComposer({
   const [harness, setHarness] = useState<string>(RESEARCH_RUNTIME_DEFAULT_HARNESS);
   const [model, setModel] = useState("");
   const modelSelectionDirtyRef = useRef(false);
+  // The familiar whose model state the effect below last loaded, so a daemon
+  // status transition can be told apart from an actual familiar switch.
+  const loadedFamiliarIdRef = useRef<string | null>(null);
   // Dirty latch: once a bound is hand-edited, auto-routing (which re-derives
   // the plan on every keystroke) must stop clobbering it. Explicit mode picks
   // clear the latch below, so a deliberate switch still resets.
@@ -260,9 +263,17 @@ export function ResearchMissionComposer({
   const appliedRecommendedDraftRevision = useRef<number | null>(null);
 
   useEffect(() => {
-    modelSelectionDirtyRef.current = false;
-    setHarness(RESEARCH_RUNTIME_DEFAULT_HARNESS);
-    setModel("");
+    // Only a familiar switch clears the latch and returns to defaults. A
+    // daemon status transition just re-evaluates availability, so an explicit
+    // runtime/model pick survives it.
+    if (loadedFamiliarIdRef.current !== familiarId) {
+      loadedFamiliarIdRef.current = familiarId;
+      modelSelectionDirtyRef.current = false;
+      setHarness(RESEARCH_RUNTIME_DEFAULT_HARNESS);
+      setModel("");
+    } else if (modelSelectionDirtyRef.current) {
+      return;
+    }
     let cancelled = false;
     void (async () => {
       try {

--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -261,18 +261,31 @@ export function ResearchMissionComposer({
 
   useEffect(() => {
     modelSelectionDirtyRef.current = false;
+    setHarness(RESEARCH_RUNTIME_DEFAULT_HARNESS);
+    setModel("");
     let cancelled = false;
     void (async () => {
       try {
-        const response = await fetch(
-          `/api/chat/model-state?familiarId=${encodeURIComponent(familiarId)}`,
-          { cache: "no-store" },
-        );
+        const [response, researchStatus] = await Promise.all([
+          fetch(
+            `/api/chat/model-state?familiarId=${encodeURIComponent(familiarId)}`,
+            { cache: "no-store" },
+          ),
+          fetch("/api/daemon/status?scope=research-local", { cache: "no-store" })
+            .then((result) => result.json() as Promise<{
+              research?: { sessionLaunchPolicy?: boolean };
+            }>)
+            .catch(() => null),
+        ]);
         const json = (await response.json()) as {
           ok?: boolean;
           state?: ChatModelState;
         };
         if (cancelled || modelSelectionDirtyRef.current || !json.ok || !json.state) return;
+        if (
+          json.state.harness === "codex"
+          && researchStatus?.research?.sessionLaunchPolicy !== true
+        ) return;
         setHarness(json.state.harness);
         setModel(json.state.effectiveModel);
       } catch {
@@ -282,7 +295,7 @@ export function ResearchMissionComposer({
     return () => {
       cancelled = true;
     };
-  }, [familiarId]);
+  }, [familiarId, daemonRunning]);
 
   useEffect(() => {
     if (

--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -263,17 +263,17 @@ export function ResearchMissionComposer({
   const appliedRecommendedDraftRevision = useRef<number | null>(null);
 
   useEffect(() => {
-    // Only a familiar switch clears the latch and returns to defaults. A
-    // daemon status transition just re-evaluates availability, so an explicit
-    // runtime/model pick survives it.
-    if (loadedFamiliarIdRef.current !== familiarId) {
+    const familiarChanged = loadedFamiliarIdRef.current !== familiarId;
+    if (familiarChanged) {
       loadedFamiliarIdRef.current = familiarId;
       modelSelectionDirtyRef.current = false;
-      setHarness(RESEARCH_RUNTIME_DEFAULT_HARNESS);
-      setModel("");
     } else if (modelSelectionDirtyRef.current) {
       return;
     }
+    // A clean daemon transition must immediately restore the safe fallback
+    // before capability re-evaluation; an explicit user pick returns above.
+    setHarness(RESEARCH_RUNTIME_DEFAULT_HARNESS);
+    setModel("");
     let cancelled = false;
     void (async () => {
       try {

--- a/src/components/role-surfaces/research-tab-prompt.test.ts
+++ b/src/components/role-surfaces/research-tab-prompt.test.ts
@@ -211,6 +211,23 @@ test("Research Desk starts from the active familiar's shared agent model default
   );
 });
 
+test("inherited Codex defaults require the active local daemon launch policy", () => {
+  assert.match(composer, /\/api\/daemon\/status\?scope=research-local/);
+  assert.match(
+    composer,
+    /modelSelectionDirtyRef\.current = false;\s*setHarness\(RESEARCH_RUNTIME_DEFAULT_HARNESS\);\s*setModel\(""\);/,
+  );
+  assert.match(
+    composer,
+    /json\.state\.harness === "codex"[\s\S]*researchStatus\?\.research\?\.sessionLaunchPolicy !== true[\s\S]*return;/,
+  );
+  assert.match(
+    composer,
+    /Promise\.all\(\[[\s\S]*api\/chat\/model-state[\s\S]*api\/daemon\/status\?scope=research-local/,
+  );
+  assert.match(composer, /\}, \[familiarId, daemonRunning\]\);/);
+});
+
 // ── Quick saves: selected resources are part of the launch contract ──────────
 
 test("quick saves are included in mission creation before the run starts", () => {

--- a/src/components/role-surfaces/research-tab-prompt.test.ts
+++ b/src/components/role-surfaces/research-tab-prompt.test.ts
@@ -215,7 +215,11 @@ test("inherited Codex defaults require the active local daemon launch policy", (
   assert.match(composer, /\/api\/daemon\/status\?scope=research-local/);
   assert.match(
     composer,
-    /modelSelectionDirtyRef\.current = false;\s*setHarness\(RESEARCH_RUNTIME_DEFAULT_HARNESS\);\s*setModel\(""\);/,
+    /const loadedFamiliarIdRef = useRef<string \| null>\(null\);/,
+  );
+  assert.match(
+    composer,
+    /const familiarChanged = loadedFamiliarIdRef\.current !== familiarId;[\s\S]*if \(familiarChanged\) \{[\s\S]*modelSelectionDirtyRef\.current = false;[\s\S]*\} else if \(modelSelectionDirtyRef\.current\) \{[\s\S]*return;[\s\S]*\}[\s\S]*setHarness\(RESEARCH_RUNTIME_DEFAULT_HARNESS\);[\s\S]*setModel\(""\);/,
   );
   assert.match(
     composer,


### PR DESCRIPTION
## Summary
- probe the exact owner-local daemon capability used by Codex Research launches
- inherit a familiar Codex model default only when sessionLaunchPolicy is advertised
- preserve the Copilot/runtime-default fallback on older or incompatible daemon channels
- re-evaluate after daemon availability changes without overwriting explicit user selections

## Verification
- focused daemon-status and Research composer tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `pnpm build`
- isolated `scripts/worktree-lifecycle-create.test.mjs`

Bead: `cave-varke`
