### PR TITLE
Make the first magnification step a nudge, not a jump

### DIFF
--- a/src/lib/preferences-schema.ts
+++ b/src/lib/preferences-schema.ts
@@ -106,7 +106,7 @@ export type CavePreferences = {
   appearance: {
     theme: CaveThemePreferences;
     fonts: CaveFontPreferences;
-    screenScale: 100 | 110 | 125 | 150;
+    screenScale: 100 | 105 | 125 | 150;
     reading: CaveReadingPreferences;
     datetime: CaveDateTimePreferences;
     recentColors: string[];
@@ -324,7 +324,28 @@ const FONT_IDS_BY_SLOT = {
   sans: new Set(FONT_OPTIONS.filter((option) => option.slot === "sans").map((option) => option.id)),
   mono: new Set(FONT_OPTIONS.filter((option) => option.slot === "mono").map((option) => option.id)),
 };
-const SCREEN_SCALES = [100, 110, 125, 150] as const;
+const SCREEN_SCALES = [100, 105, 125, 150] as const;
+
+/**
+ * Steps this app used to offer → the nearest one it still does.
+ *
+ * Applied on the READ path only, and that placement is the point: stored
+ * preferences are normalized here BEFORE `screen-magnification.ts` ever sees
+ * them, so migrating only there would be dead code — `oneOf` would already
+ * have answered a stored 110 with the 100 default and silently taken a user's
+ * magnification away. The write path stays strict: 110 is no longer a choice
+ * anyone may set.
+ *
+ * Kept in step with SCREEN_SCALE_OPTIONS by screen-magnification.test.ts
+ * rather than imported, because this module sits underneath that one.
+ */
+const LEGACY_SCREEN_SCALES: Record<number, (typeof SCREEN_SCALES)[number]> = { 110: 105 };
+
+function migrateScreenScale(value: unknown): unknown {
+  return typeof value === "number" && value in LEGACY_SCREEN_SCALES
+    ? LEGACY_SCREEN_SCALES[value]
+    : value;
+}
 const MODE_PREFERENCES = ["light", "dark", "system"] as const;
 const MODES = ["light", "dark"] as const;
 const READING_LEADING = ["compact", "normal", "relaxed"] as const;
@@ -505,7 +526,7 @@ export function normalizeCavePreferences(input: unknown): CavePreferences {
         mono: typeof fonts.mono === "string" && FONT_IDS_BY_SLOT.mono.has(fonts.mono)
           ? fonts.mono : "jetbrains-mono",
       },
-      screenScale: oneOf(appearance.screenScale, SCREEN_SCALES, 100),
+      screenScale: oneOf(migrateScreenScale(appearance.screenScale), SCREEN_SCALES, 100),
       reading: {
         size: oneOf(reading.size, [0, 1, 2, 3, 4] as const, 1),
         leading: oneOf(reading.leading, READING_LEADING, "normal"),

--- a/src/lib/screen-magnification.test.ts
+++ b/src/lib/screen-magnification.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+const SCREEN_SCALES_EXPECTED = [100, 105, 125, 150] as const;
+
 import {
   DEFAULT_SCREEN_SCALE,
   SCREEN_SCALE_OPTIONS,
@@ -8,19 +10,51 @@ import {
 
 assert.deepEqual(
   SCREEN_SCALE_OPTIONS,
-  [100, 110, 125, 150],
+  [100, 105, 125, 150],
   "Screen magnification should expose the expected scale ladder",
 );
+
+// The first step off the default is a nudge, not a jump: 110 read as dramatic
+// in use, which is the whole reason this ladder changed.
+assert.equal(stepScreenScale(100, 1), 105, "the first step up is gentle");
 
 assert.equal(normalizeScreenScale("125"), 125);
 assert.equal(normalizeScreenScale(150), 150);
 assert.equal(normalizeScreenScale("999"), DEFAULT_SCREEN_SCALE);
 assert.equal(normalizeScreenScale("nope"), DEFAULT_SCREEN_SCALE);
 
-assert.equal(stepScreenScale(100, 1), 110);
-assert.equal(stepScreenScale(110, 1), 125);
+assert.equal(stepScreenScale(105, 1), 125);
 assert.equal(stepScreenScale(150, 1), 150);
-assert.equal(stepScreenScale(125, -1), 110);
+assert.equal(stepScreenScale(125, -1), 105);
 assert.equal(stepScreenScale(100, -1), 100);
 
-console.log("screen-magnification.test.ts OK");
+// Migration, and the reason it exists: normalizeScreenScale answers anything
+// outside the ladder with the DEFAULT, so without this a user already on 110
+// would come back at 100 with their magnification silently gone. Losing an
+// accessibility setting is worse than the step it was on being coarse.
+assert.equal(normalizeScreenScale(110), 105, "a legacy 110 lands on the nearest surviving step");
+assert.equal(normalizeScreenScale("110"), 105, "including when it comes back from storage as a string");
+assert.notEqual(normalizeScreenScale(110), DEFAULT_SCREEN_SCALE, "and is never quietly reset to 100");
+
+
+// The ladder exists TWICE — SCREEN_SCALE_OPTIONS here and SCREEN_SCALES in
+// preferences-schema.ts, which sits underneath this module and so cannot
+// import it. Two hand-kept copies drift; this is the thing that notices.
+{
+  const schema = await import("./preferences-schema.ts");
+  const declared = /const SCREEN_SCALES = \[([^\]]+)\]/.exec(
+    (await import("node:fs")).readFileSync(
+      new URL("./preferences-schema.ts", import.meta.url), "utf8",
+    ),
+  );
+  assert.ok(declared, "preferences-schema still declares a SCREEN_SCALES ladder");
+  const schemaLadder = declared[1].split(",").map((n) => Number(n.trim()));
+  assert.deepEqual(
+    schemaLadder,
+    [...SCREEN_SCALES_EXPECTED],
+    "the preferences schema's ladder matches the one the UI offers",
+  );
+  void schema;
+}
+
+console.log("screen-magnification.test.ts OK (ladder parity checked)");

--- a/src/lib/screen-magnification.ts
+++ b/src/lib/screen-magnification.ts
@@ -2,7 +2,21 @@ import { readAppPreferences, updateAppPreferences } from "./app-preferences.ts";
 
 export const SCREEN_SCALE_KEY = "cave:screen-scale";
 
-export const SCREEN_SCALE_OPTIONS = [100, 110, 125, 150] as const;
+export const SCREEN_SCALE_OPTIONS = [100, 105, 125, 150] as const;
+
+/**
+ * Steps this app used to offer, mapped to the nearest surviving one.
+ *
+ * The first step above 100 was 110 — a 10% jump off the default, which reads
+ * as dramatic rather than as the gentle nudge a first step should be. Moving
+ * it to 105 would otherwise be silently destructive: `normalizeScreenScale`
+ * answers anything outside SCREEN_SCALE_OPTIONS with the DEFAULT, so every
+ * user already sitting on 110 would come back at 100 with their magnification
+ * gone. For an accessibility setting, losing it is a worse outcome than the
+ * step being coarse, so a legacy value lands on the nearest step that still
+ * exists instead of resetting.
+ */
+const LEGACY_SCREEN_SCALES: Record<number, ScreenScale> = { 110: 105 };
 
 export type ScreenScale = (typeof SCREEN_SCALE_OPTIONS)[number];
 
@@ -12,9 +26,8 @@ export const SCREEN_SCALE_EVENT = "cave:screen-scale-change";
 
 export function normalizeScreenScale(value: unknown): ScreenScale {
   const parsed = typeof value === "number" ? value : Number.parseInt(String(value ?? ""), 10);
-  return SCREEN_SCALE_OPTIONS.includes(parsed as ScreenScale)
-    ? (parsed as ScreenScale)
-    : DEFAULT_SCREEN_SCALE;
+  if (SCREEN_SCALE_OPTIONS.includes(parsed as ScreenScale)) return parsed as ScreenScale;
+  return LEGACY_SCREEN_SCALES[parsed] ?? DEFAULT_SCREEN_SCALE;
 }
 
 export function readScreenScale(): ScreenScale {

--- a/src/styles/globals/foundations.css
+++ b/src/styles/globals/foundations.css
@@ -337,8 +337,8 @@
   --cave-screen-scale: 1;
 }
 
-:root[data-screen-scale="110"] {
-  --cave-screen-scale: 1.1;
+:root[data-screen-scale="105"] {
+  --cave-screen-scale: 1.05;
 }
 
 :root[data-screen-scale="125"] {


### PR DESCRIPTION
The app-wide magnification ladder was `[100, 110, 125, 150]`, so the first step off the default was a **10% jump**. That reads as dramatic in use, when a first step should be the gentle one. Now `[100, 105, 125, 150]`.

### The migration is the load-bearing half

`normalizeScreenScale` answers anything outside the ladder with `DEFAULT_SCREEN_SCALE` (100). So changing the value alone would have **silently removed magnification entirely** for every user already sitting on 110 — and for an accessibility setting, losing it is a worse outcome than the step being coarse. A legacy `110` now resolves to `105`.

### It has to happen in two places, and only one is obvious

The ladder exists **twice**:

| Copy | Role |
|---|---|
| `SCREEN_SCALE_OPTIONS` — `screen-magnification.ts` | what the UI offers and steps through |
| `SCREEN_SCALES` — `preferences-schema.ts` | what stored preferences are validated against |

The schema normalizes stored preferences **before** the magnification module ever sees them, so migrating only the obvious copy would have been dead code: `oneOf(…, SCREEN_SCALES, 100)` would already have collapsed a stored `110` to `100`. The typecheck is what surfaced the second copy.

So the **read** path migrates, and the **write** path stays strict — `110` is no longer a choice anyone may set, but one already stored is honoured.

Those two copies can't be deduped by an import (`preferences-schema` sits underneath `screen-magnification`), so a parity assertion now holds them together rather than trusting them to stay in step by hand.

### Verification

`pnpm lint` clean, `tsc --noEmit` clean. `screen-magnification.test.ts` extended with the gentle-first-step assertion, both string and number legacy migration, an explicit "never quietly reset to 100" check, and the ladder-parity guard. Also passing: `preferences-schema`, `settings-appearance`, `app-preferences`, `preferences-store`, `theme-script`.

cave-kmrd3