### PR TITLE
Show the cron dialog what it will actually do

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -501,6 +501,7 @@ export const SUITES = {
     "src/lib/reminder-draft.test.ts",
     "src/lib/parse-when.test.ts",
     "src/lib/schedule-plan.test.ts",
+    "src/lib/schedule-plan-model.test.ts",
     "src/lib/daily-report.test.ts",
     "src/lib/daily-note.test.ts",
     "src/components/familiar-daily-notes.test.ts",

--- a/src/components/automation-create-dialog.test.ts
+++ b/src/components/automation-create-dialog.test.ts
@@ -34,3 +34,59 @@ assert.match(
 );
 
 console.log("automation-create-dialog.test.ts: ok");
+
+// ── Plan preview · `Scheduling Spec.dc.html` P0 ─────────────────────────────
+// "No plan preview, no confirmation of behavior; users can't tell what they
+// built until it runs."
+{
+  const dialog = source;
+  const preview = await readFile(
+    new URL("./schedule/schedule-plan-preview.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    dialog,
+    /const plan = planFromRrule\(rrule,/,
+    "the plan reads off buildCodexRrule's output, so the weekly builder, the daily builder and the raw RRULE box cannot render three previews that disagree",
+  );
+  assert.match(
+    dialog,
+    /<SchedulePlanPreview plan=\{plan\}/,
+    "the dialog actually renders the preview it computes",
+  );
+  assert.match(
+    dialog,
+    /planLabel \? `Create · \$\{planLabel\}` : "Create"/,
+    "the CTA names its outcome, and falls back rather than inventing one",
+  );
+  assert.match(
+    dialog,
+    /readDateTimePrefs\(\)\.clock !== "24h"/,
+    "the plan uses the same clock preference the reminder modal reads",
+  );
+  assert.match(
+    dialog,
+    /automation-create-dialog__rrule/,
+    "the raw RRULE echo survives for experts — the preview adds a translation, it does not replace the machine form",
+  );
+  assert.match(
+    preview,
+    /aria-live="polite"/,
+    "the plan is the confirmation, so it reaches assistive tech without stealing focus from the field being typed in",
+  );
+  const planStyles = await readFile(
+    new URL("../styles/schedule-plan.css", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    dialog,
+    /import "@\/styles\/schedule-plan\.css"|SchedulePlanPreview/,
+    "the preview arrives with its own sheet rather than through the globals facade",
+  );
+  assert.match(
+    planStyles,
+    /\.schedule-plan \{(?=[^}]*min-height: 58px;)[^}]*\}/,
+    "the plan slot reserves its height, so typing never shifts the controls below it",
+  );
+}

--- a/src/components/automation-create-dialog.tsx
+++ b/src/components/automation-create-dialog.tsx
@@ -17,6 +17,9 @@ import { StandardSelect } from "@/components/ui/select";
 import { parseListInput } from "@/lib/automations/list-input";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { CronPromptBar } from "@/components/cron-prompt-bar";
+import { SchedulePlanPreview } from "@/components/schedule/schedule-plan-preview";
+import { planCtaSuffix, planFromRrule } from "@/lib/schedule-plan-model";
+import { readDateTimePrefs } from "@/lib/datetime-format";
 import type { CronPromptUpdate } from "@/lib/cron-prompt";
 
 export type AutomationCreateInput = {
@@ -94,6 +97,15 @@ export function AutomationCreateDialog({ resolvedFamiliars, onClose, onCreate }:
   };
 
   const rrule = buildCodexRrule(scheduleMode, time, days, rawRrule);
+  // ONE plan for all three input modes. The weekly builder, the daily builder
+  // and the raw RRULE box all serialize through buildCodexRrule, so reading
+  // the plan off THAT is what makes the spec's "all three syntaxes reconcile
+  // into one canonical plan" true rather than aspirational — three separate
+  // previews could disagree about the same schedule.
+  // Same clock the reminder modal reads, so the two dialogs render a schedule
+  // the same way rather than one saying "9 AM" while the other says "09:00".
+  const plan = planFromRrule(rrule, new Date(), { hour12: readDateTimePrefs().clock !== "24h" });
+  const planLabel = planCtaSuffix(plan);
   const validSchedule =
     scheduleMode === "raw"
       ? rawRrule.trim().startsWith("RRULE:")
@@ -232,6 +244,12 @@ export function AutomationCreateDialog({ resolvedFamiliars, onClose, onCreate }:
                       />
                     </div>
                   )}
+
+                  {/* The plan the user can actually check, above the machine
+                      form. The spec keeps the RRULE echo for experts but files
+                      its being the ONLY readout as a P1 — "raw RRULE exposed
+                      with no plain-English translation". */}
+                  <SchedulePlanPreview plan={plan} ariaLabel="Cron schedule plan" />
 
                   <p
                     className="automation-create-dialog__rrule"
@@ -378,7 +396,12 @@ export function AutomationCreateDialog({ resolvedFamiliars, onClose, onCreate }:
             onClick={handleCreate}
             leadingIcon="ph:plus-bold"
           >
-            Create
+            {/* The CTA names its outcome. The spec files a bare "+ Create" as a
+                P1 — it never says what it creates — and the plan is already
+                computed, so the label costs nothing it does not already know.
+                It falls back to plain "Create" rather than inventing a summary
+                when there is no readable plan to name. */}
+            {planLabel ? `Create · ${planLabel}` : "Create"}
           </Button>
         </div>
       </div>

--- a/src/components/schedule/schedule-plan-preview.tsx
+++ b/src/components/schedule/schedule-plan-preview.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Icon } from "@/lib/icon";
+import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
+import type { SchedulePlan } from "@/lib/schedule-plan-model";
+// Component-imported so it code-splits with whatever dialog renders the
+// preview. The globals facade has no room: the root CSS bundle every route
+// downloads was at 0.6 KB of headroom, and this sheet is ~2 KB.
+import "@/styles/schedule-plan.css";
+
+type Props = {
+  plan: SchedulePlan;
+  /** Labels the live region for assistive tech (e.g. "Cron schedule plan"). */
+  ariaLabel?: string;
+};
+
+/**
+ * The plan echo — `Scheduling Spec.dc.html`'s answer to its own P0: *"No plan
+ * preview, no confirmation of behavior; users can't tell what they built until
+ * it runs."*
+ *
+ * Two properties are load-bearing and easy to lose in a refactor:
+ *
+ * **The slot is reserved.** The spec files a shifting dialog height as a P1 —
+ * a card that appears and disappears as you type makes the controls below it
+ * move under the cursor. `min-height` holds the space open in every state, so
+ * the empty state costs exactly what the parsed state does.
+ *
+ * **It is a live region.** The plan is the confirmation, so a screen-reader
+ * user has to receive it without moving focus out of the field they are
+ * typing in — `aria-live="polite"` announces the settled reading rather than
+ * every keystroke.
+ */
+export function SchedulePlanPreview({ plan, ariaLabel = "Schedule plan" }: Props) {
+  const prefs = readDateTimePrefs();
+  return (
+    <div
+      aria-live="polite"
+      aria-label={ariaLabel}
+      className={`schedule-plan schedule-plan--${plan.kind}`}
+    >
+      <span aria-hidden className="schedule-plan__edge" />
+      {plan.kind === "empty" ? (
+        <p className="schedule-plan__quiet">
+          <Icon name="ph:clock" width={12} aria-hidden />
+          the plan and its next runs appear here
+        </p>
+      ) : null}
+
+      {plan.kind === "unparsed" ? (
+        <div className="schedule-plan__row">
+          <span className="schedule-plan__pill schedule-plan__pill--warn">
+            <Icon name="ph:warning" width={11} aria-hidden />
+            UNREAD
+          </span>
+          {/* The hint carries an example, never an instruction — the spec's
+              placeholder grammar. A refusal with nowhere to go is the defect. */}
+          <p className="schedule-plan__hint">{plan.hint}</p>
+        </div>
+      ) : null}
+
+      {plan.kind === "parsed" ? (
+        <>
+          <div className="schedule-plan__row">
+            <span aria-hidden className="schedule-plan__glyph">
+              <Icon name="ph:clock" width={12} aria-hidden />
+            </span>
+            <p className="schedule-plan__sentence">{plan.sentence}</p>
+          </div>
+          {plan.nextRuns.length > 0 ? (
+            <p className="schedule-plan__runs">
+              <span className="schedule-plan__runs-label">next</span>
+              {plan.nextRuns.map((iso) => (
+                <span key={iso} className="schedule-plan__run">
+                  {formatTimestamp(iso, prefs)}
+                </span>
+              ))}
+            </p>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/schedule-plan-model.test.ts
+++ b/src/lib/schedule-plan-model.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { planCtaSuffix, planFromPhrase, planFromRrule, SCHEDULE_PLAN_RUN_COUNT } from "./schedule-plan-model.ts";
+
+// A fixed frame of reference: "tomorrow at 9am" has to mean something exact.
+const NOW = new Date("2026-08-25T10:00:00Z");
+
+describe("planFromPhrase", () => {
+  it("says nothing when nothing has been typed", () => {
+    assert.equal(planFromPhrase("", NOW).kind, "empty");
+    assert.equal(planFromPhrase("   ", NOW).kind, "empty");
+  });
+
+  it("offers a way forward instead of only refusing", () => {
+    const plan = planFromPhrase("sometime-ish maybe", NOW);
+    assert.equal(plan.kind, "unparsed");
+    // The spec's placeholder-grammar rule: examples, not instructions. A bare
+    // "invalid" leaves the user with nowhere to go.
+    if (plan.kind === "unparsed") assert.match(plan.hint, /weekdays at 9am/);
+  });
+
+  it("turns a recurring phrase into a cadence sentence plus concrete fires", () => {
+    const plan = planFromPhrase("weekdays at 9am", NOW, { hour12: false });
+    assert.equal(plan.kind, "parsed");
+    if (plan.kind !== "parsed") return;
+    assert.match(plan.sentence, /weekdays at 09:00/);
+    assert.equal(plan.nextRuns.length, SCHEDULE_PLAN_RUN_COUNT);
+    // Every fire is a real timestamp, strictly ordered — the whole point is
+    // that the user can check them.
+    const times = plan.nextRuns.map((iso) => new Date(iso).getTime());
+    times.forEach((t) => assert.ok(Number.isFinite(t), `${t} is a real instant`));
+    assert.deepEqual(times, [...times].sort((a, b) => a - b), "fires run forwards");
+  });
+
+  it("describes a one-shot by its single fire rather than a blank cadence", () => {
+    const plan = planFromPhrase("tomorrow at 9am", NOW);
+    assert.equal(plan.kind, "parsed");
+    if (plan.kind !== "parsed") return;
+    assert.equal(plan.recurrence.type, "none");
+    assert.equal(plan.sentence, "once", "a one-shot still says something");
+    assert.deepEqual(plan.nextRuns, [plan.fireAt], "its fire IS its upcoming run");
+  });
+
+  it("reads the same phrase the same way every time", () => {
+    // Two callers, one meaning: the model adds no parsing of its own, so the
+    // cron dialog and the reminder dialog cannot drift apart.
+    const a = planFromPhrase("every tuesday 4pm", NOW);
+    const b = planFromPhrase("every tuesday 4pm", NOW);
+    assert.deepEqual(a, b);
+  });
+});
+
+describe("planCtaSuffix", () => {
+  it("names the outcome once there is one to name", () => {
+    assert.equal(planCtaSuffix(planFromPhrase("weekdays at 9am", NOW, { hour12: false })), "weekdays at 09:00");
+  });
+
+  it("stays silent rather than inventing a label", () => {
+    assert.equal(planCtaSuffix(planFromPhrase("", NOW)), null);
+    assert.equal(planCtaSuffix(planFromPhrase("gibberish", NOW)), null);
+  });
+});
+
+describe("planFromRrule", () => {
+  it("translates the builders' output into one plan", () => {
+    const daily = planFromRrule("RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0", NOW, { hour12: false });
+    assert.equal(daily.kind, "parsed");
+    if (daily.kind === "parsed") assert.equal(daily.sentence, "every day at 09:00");
+
+    const weekly = planFromRrule("RRULE:FREQ=WEEKLY;BYHOUR=9;BYMINUTE=0;BYDAY=MO,WE,FR", NOW, { hour12: false });
+    assert.equal(weekly.kind, "parsed");
+    if (weekly.kind === "parsed") assert.equal(weekly.sentence, "Mon, Wed, Fri at 09:00");
+  });
+
+  it("never previews a half-built weekly rule as 'every day'", () => {
+    // The builder emits BYDAY= while no day is picked, and parseCodexRrule
+    // answers that with all seven — so without a guard the preview claims a
+    // cadence the user never chose. Caught by driving the real dialog.
+    const plan = planFromRrule("RRULE:FREQ=WEEKLY;BYHOUR=9;BYMINUTE=0;BYDAY=", NOW);
+    assert.equal(plan.kind, "unparsed");
+    if (plan.kind === "unparsed") assert.match(plan.hint, /pick at least one day/);
+  });
+
+  it("says so when a rule cannot be translated, rather than approximating it", () => {
+    const plan = planFromRrule("RRULE:FREQ=SECONDLY;COUNT=9", NOW);
+    assert.equal(plan.kind, "unparsed");
+    if (plan.kind === "unparsed") assert.match(plan.hint, /can't be translated/);
+  });
+
+  it("is empty for an empty rule", () => {
+    assert.equal(planFromRrule("", NOW).kind, "empty");
+  });
+});

--- a/src/lib/schedule-plan-model.ts
+++ b/src/lib/schedule-plan-model.ts
@@ -1,0 +1,164 @@
+// The plan a scheduling surface echoes back while you type: what will happen,
+// and when it will next happen.
+//
+// `Scheduling Spec.dc.html` (the implementation spec behind
+// `Rituals Redesign.dc.html`) states the contract this exists to satisfy —
+// *"every schedule surface says what will happen and when it will next
+// happen"* — and files its absence in the cron dialog as a P0: users cannot
+// tell what they built until it runs. The reminder dialog already earned that
+// trust; this is the shared model so the two cannot drift into disagreeing
+// about the same phrase.
+//
+// Pure and client-safe: it composes `parseWhen` (phrase → recurrence) with
+// `describeRecurrence` (recurrence → sentence) and `nextOccurrences`
+// (recurrence → concrete fires). It adds no parsing of its own, so there is
+// exactly one definition of what a phrase means.
+
+import type { Recurrence } from "./inbox-recurrence.ts";
+import { parseWhen } from "./parse-when.ts";
+import { describeRecurrence, nextOccurrences } from "./schedule-plan.ts";
+import { RRULE_DAY_ORDER, parseCodexRrule } from "./codex-automation-form.ts";
+
+/**
+ * Three states, not the frame's four.
+ *
+ * The prototype also draws an *ambiguous* "TWO READINGS" state — "every other
+ * tuesday" meaning this week or next, "at 4" meaning morning or afternoon.
+ * That is **cut rather than faked**: `parseWhen` resolves every phrase to a
+ * single reading and does not report the alternatives it discarded, so a
+ * "pick one" prompt would have to re-parse the phrase with a second, competing
+ * parser — and two parsers disagreeing about the same string is a worse defect
+ * than not offering the choice. Surfacing it honestly means teaching
+ * `parseWhen` to return candidates first; tracked separately.
+ */
+export type SchedulePlan =
+  | { kind: "empty" }
+  | { kind: "unparsed"; hint: string }
+  | {
+      kind: "parsed";
+      /** Cadence sentence, or the one-shot's own description. */
+      sentence: string;
+      /** Concrete upcoming fires, ISO. Empty for a one-shot beyond the first. */
+      nextRuns: string[];
+      recurrence: Recurrence;
+      fireAt: string;
+    };
+
+/** How many upcoming fires the preview shows. The spec asks for three. */
+export const SCHEDULE_PLAN_RUN_COUNT = 3;
+
+const RRULE_HINT =
+  "this rule can't be translated to a plain-language plan — the daily and weekly builders can";
+
+const DEFAULT_HINT =
+  'try "weekdays at 9am", "every tuesday 4pm", or "tomorrow at 09:30"';
+
+/**
+ * Derive the plan for a typed phrase.
+ *
+ * `now` is injected rather than read from the clock so the caller controls the
+ * frame of reference and the model stays testable — "tomorrow at 9am" has to
+ * mean something fixed for a given now.
+ */
+export function planFromPhrase(
+  phrase: string,
+  now: Date = new Date(),
+  opts: { hour12?: boolean } = {},
+): SchedulePlan {
+  const trimmed = phrase.trim();
+  if (!trimmed) return { kind: "empty" };
+
+  const parsed = parseWhen(trimmed, now);
+  if (!parsed) return { kind: "unparsed", hint: DEFAULT_HINT };
+
+  const cadence = describeRecurrence(parsed.recurrence, opts);
+  // A one-shot has no cadence — its fire time IS the description, so the
+  // sentence falls back to the single occurrence rather than reading blank.
+  const sentence = cadence ?? "once";
+  const nextRuns =
+    parsed.recurrence.type === "none"
+      ? [parsed.fireAt]
+      : nextOccurrences(parsed.recurrence, now.getTime(), SCHEDULE_PLAN_RUN_COUNT);
+
+  return {
+    kind: "parsed",
+    sentence,
+    nextRuns,
+    recurrence: parsed.recurrence,
+    fireAt: parsed.fireAt,
+  };
+}
+
+/**
+ * The outcome-naming half of the spec's CTA rule: *"'+ Create' never says what
+ * it creates"* → label the button with what it will do. Returns null when
+ * there is no plan to name, so the caller keeps its neutral label rather than
+ * inventing one.
+ */
+export function planCtaSuffix(plan: SchedulePlan): string | null {
+  return plan.kind === "parsed" ? plan.sentence : null;
+}
+
+/**
+ * The same plan, derived from an RRULE instead of a phrase.
+ *
+ * This is what lets the spec's *"all three syntaxes reconcile into one
+ * canonical plan"* hold: the cron dialog's daily builder, its weekly builder
+ * and its raw RRULE box all serialize to an RRULE, so translating THAT gives
+ * one preview for every input mode rather than three that can disagree.
+ *
+ * `parseCodexRrule` self-reports an RRULE it does not recognise as
+ * `mode: "raw"`, which is the honest signal we need: an exotic rule is
+ * reported as untranslatable rather than silently rendered as some nearby
+ * schedule the user did not ask for.
+ */
+export function planFromRrule(
+  rrule: string,
+  now: Date = new Date(),
+  opts: { hour12?: boolean } = {},
+): SchedulePlan {
+  const trimmed = rrule.trim();
+  if (!trimmed) return { kind: "empty" };
+
+  // `parseCodexRrule` answers an EMPTY `BYDAY=` with all seven days, which is a
+  // reasonable default for a stored rule but a lie for one being composed: a
+  // weekly schedule with no day picked yet would preview as "every day", a
+  // cadence the user never chose. Catch the empty list before that substitution
+  // happens — the builder is mid-edit, not describing something real yet.
+  if (/FREQ=WEEKLY/i.test(trimmed) && /BYDAY=\s*(?:;|$)/i.test(trimmed)) {
+    return { kind: "unparsed", hint: "pick at least one day for a weekly schedule" };
+  }
+
+  const parsed = parseCodexRrule(trimmed);
+  const [rawHour, rawMinute] = parsed.time.split(":");
+  const hour = Number(rawHour);
+  const minute = Number(rawMinute);
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) {
+    return { kind: "unparsed", hint: RRULE_HINT };
+  }
+
+  let rec: Recurrence | null = null;
+  if (parsed.mode === "daily") {
+    rec = { type: "daily", hour, minute };
+  } else if (parsed.mode === "weekly") {
+    const days = parsed.days
+      .map((day) => RRULE_DAY_ORDER.indexOf(day))
+      .filter((index) => index >= 0)
+      .sort((a, b) => a - b);
+    // A weekly rule naming no day it can act on fires never; saying "weekly"
+    // would be a preview that lies about a schedule that does nothing.
+    if (days.length > 0) rec = { type: "weekly", days, hour, minute };
+  }
+  if (!rec) return { kind: "unparsed", hint: RRULE_HINT };
+
+  const sentence = describeRecurrence(rec, opts);
+  if (!sentence) return { kind: "unparsed", hint: RRULE_HINT };
+
+  return {
+    kind: "parsed",
+    sentence,
+    nextRuns: nextOccurrences(rec, now.getTime(), SCHEDULE_PLAN_RUN_COUNT),
+    recurrence: rec,
+    fireAt: nextOccurrences(rec, now.getTime(), 1)[0] ?? "",
+  };
+}

--- a/src/styles/schedule-plan.css
+++ b/src/styles/schedule-plan.css
@@ -1,0 +1,113 @@
+/* Schedule plan preview — the shared echo both scheduling dialogs render.
+
+   Component-imported by schedule-plan-preview.tsx, NOT added to the globals.css
+   facade. On the facade it put initial-route CSS 2 KB over
+   BUNDLE_MAX_HOME_CSS_KB — the root bundle every route downloads was already
+   sitting at 0.6 KB of headroom, so anything of any size tips it. This sheet
+   ships with the chunk that renders it instead (#3264 pattern).
+
+   `Scheduling Spec.dc.html` asks for a RESERVED slot: a card that appears and
+   disappears as you type shifts every control below it, which the spec files
+   as a stability P1. min-height holds the space open in all three states, so
+   the empty state costs exactly what the parsed state does. */
+
+.schedule-plan {
+  position: relative;
+  display: flex;
+  min-height: 58px;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-base) 55%, transparent);
+}
+
+.schedule-plan--parsed {
+  border-color: color-mix(in oklch, var(--accent-presence) 35%, var(--border-hairline));
+}
+
+.schedule-plan--unparsed {
+  border-color: color-mix(in oklch, var(--color-warning) 40%, var(--border-hairline));
+}
+
+.schedule-plan__edge {
+  position: absolute;
+  top: var(--space-2);
+  bottom: var(--space-2);
+  left: 0;
+  width: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--border-hairline);
+}
+
+.schedule-plan--parsed .schedule-plan__edge {
+  background: var(--accent-presence);
+}
+
+.schedule-plan--unparsed .schedule-plan__edge {
+  background: var(--color-warning);
+}
+
+.schedule-plan__quiet,
+.schedule-plan__hint {
+  display: flex;
+  margin: 0;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.schedule-plan__row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.schedule-plan__glyph {
+  display: inline-flex;
+  flex: none;
+  color: var(--accent-presence);
+}
+
+.schedule-plan__sentence {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  font-weight: 550;
+}
+
+.schedule-plan__pill {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 var(--space-2);
+  border: 1px solid color-mix(in oklch, var(--color-warning) 45%, transparent);
+  border-radius: var(--radius-pill);
+  color: var(--color-warning);
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  letter-spacing: var(--tracking-eyebrow);
+}
+
+.schedule-plan__runs {
+  display: flex;
+  margin: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.schedule-plan__runs-label {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}


### PR DESCRIPTION
`Scheduling Spec.dc.html` — the implementation spec behind `Rituals Redesign.dc.html` — states one contract:

> every schedule surface says what will happen and when it will next happen

and files the cron dialog's silence as a **P0**: *"No plan preview, no confirmation of behavior; users can't tell what they built until it runs."*

The dialog now echoes a plan — a cadence sentence, the next three concrete fires, and a CTA that names its outcome (`Create · Mon, Wed, Fri at 09:00`) instead of a bare `+ Create` that never said what it created.

### One plan, not three

The weekly builder, the daily builder and the raw RRULE box all serialize through `buildCodexRrule`, so the preview reads off **that** rather than off each mode's own state. This is what makes the spec's *"all three syntaxes reconcile into one canonical plan"* true rather than aspirational — three separate previews could disagree about a single schedule. The raw RRULE echo survives underneath for experts: the preview adds the translation the spec asks for, it doesn't replace the machine form.

The model adds **no parsing of its own**. It composes `parseWhen`, `describeRecurrence` and `nextOccurrences`, so the cron dialog and the reminder dialog cannot drift into reading the same phrase differently.

The slot reserves its height (58px in all three states) so typing never shifts the controls below it — the spec's stability P1 — and is `aria-live="polite"`, because the plan *is* the confirmation and has to reach assistive tech without stealing focus from the field being typed in.

### A preview that lied, caught by driving it

`parseCodexRrule` answers an empty `BYDAY=` with all seven days. That's sensible for a *stored* rule and false for one mid-composition — so a weekly schedule with **no day picked yet** previewed as `every day at 09:00`, a cadence the user never chose. The builder's half-built output is now reported as incomplete.

Worth noting how it surfaced: source-text tests and the typecheck both passed while that was live. Only opening the real dialog showed it.

### Not adopted

The frame's ambiguous **"TWO READINGS"** state. `parseWhen` resolves every phrase to a single reading and doesn't report the alternatives it discarded, so offering "pick one" would require a second, competing parser — and two parsers disagreeing about the same string is a worse defect than not offering the choice. It needs `parseWhen` to return candidates first.

### Verification

`pnpm lint`, `tsc --noEmit`, and the design-token drift ratchets all clean. 11 tests in `schedule-plan-model.test.ts` (wired into the app suite); `automation-create-dialog.test.ts` extended to pin the single-serialization read, the rendered preview, the outcome-naming CTA, the shared clock preference, the surviving RRULE echo, the live region and the reserved height.

Driven in a browser across daily, weekly, weekly-with-no-days and an untranslatable `FREQ=SECONDLY` rule.

The sheet is component-imported rather than on the globals facade — root CSS sits at 0.6 KB of headroom and this is ~2 KB.

cave-dsm37