### PR TITLE
Tell the cron detail pane when the cron next runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -999,6 +999,40 @@ command with `WT_RETENTION_PUSH_DISABLE=1`. It never blocks a tool call and
 always exits 0.
 
 
+## New surface CSS goes in its own sheet, never the globals facade
+
+**Rule:** a new stylesheet for a mode- or dialog-gated surface is
+component-imported by the component that renders it. Do **not** add it to the
+`@import` list in `src/app/globals.css`, and do not append it to an existing
+sheet that is on that list (`surface-compact-calendar.css`, `calendar-agenda.css`,
+…).
+
+**Why:** the root CSS bundle every route downloads runs at essentially zero
+headroom against `BUNDLE_MAX_HOME_CSS_KB`. A build after adding ~2 KB to a
+faceted sheet reads:
+
+```text
+✗ bundle-budget: initial / route CSS 942 KB exceeds budget 940 KB.
+```
+
+The failure is *not* about your 2 KB — every route pays for CSS only one gated
+surface uses. **This was hit three separate times in one session** (the Rituals
+crons sheet, the schedule-plan preview, the cron-detail state band), each time
+costing a full rebuild, because the mistake looks natural: the related rules
+already live in a faceted sheet, so appending seems like tidiness.
+
+**How to apply:**
+
+```ts
+// in the component that renders it
+import "@/styles/<surface>.css";
+```
+
+The `surface-research-*.css` family and `marketplace-view.tsx` are the existing
+precedents. Note the facade order is also pinned by
+`src/app/css-module-order.test.ts`, so adding an import there is a two-file
+change with a test to update — another sign it is the wrong move for surface CSS.
+
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:6cd5cc61 -->
 ## Beads Issue Tracker
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -948,6 +948,7 @@ export const SUITES = {
     "src/components/palette-canonical-names.test.ts",
     "src/lib/automations/automation-entry.test.ts",
     "src/lib/automations/cron-health.test.ts",
+    "src/lib/automations/cron-detail-state.test.ts",
     "src/lib/automations/list-input.test.ts",
     "src/lib/automations/run-status.test.ts",
     "src/lib/inbox-feed.test.ts",

--- a/src/components/automations/cron-detail-panel.tsx
+++ b/src/components/automations/cron-detail-panel.tsx
@@ -8,6 +8,9 @@ import { StandardSelect } from "@/components/ui/select";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { CodexAutomation, CodexAutomationPatch } from "@/lib/codex-automations-types";
 import type { AutomationRunRecord } from "@/lib/automation-runs";
+import { cronInsight, cronNextRuns, recordedRunStats } from "@/lib/automations/cron-detail-state";
+// Component-imported: the globals facade has no headroom left (see the sheet).
+import "@/styles/cron-detail-state.css";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import { Icon } from "@/lib/icon";
 import { RRULE_DAY_LABEL, RRULE_DAY_ORDER, buildCodexRrule, parseCodexRrule, composeAutomationPrompt, splitAutomationPrompt } from "@/lib/codex-automation-form";
@@ -31,6 +34,18 @@ const monoTextareaClass = `${textareaClass} font-mono text-[length:var(--text-xs
 // never reads "3d ago" in the list but "Jul 20, 2:15 PM" in this panel.
 function relTime(iso: string | undefined | null): string {
   return iso ? relativeTimeSigned(iso) : "—";
+}
+
+/** Compact duration for the run-history summary: 45s, 2m 10s, 1h 4m. */
+function formatDurationMs(ms: number): string {
+  const total = Math.round(ms / 1000);
+  if (total < 60) return `${total}s`;
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  if (minutes < 60) return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const restMinutes = minutes % 60;
+  return restMinutes ? `${hours}h ${restMinutes}m` : `${hours}h`;
 }
 
 export function CodexDetailPanel({
@@ -182,6 +197,13 @@ export function CodexDetailPanel({
     });
   };
   const latestRun = runs[0];
+  // The *state* half the pane never had: when this fires next, and one
+  // sentence explaining where it stands. Shares recurrenceFromRrule with the
+  // create dialog's preview and the calendar's projection, so all three
+  // answer "when does this run" the same way.
+  const upcoming = cronNextRuns(auto, Date.now(), 3);
+  const insight = cronInsight(auto, latestRun, upcoming[0] ?? null);
+  const runStats = recordedRunStats(runs);
   const latestRunLabel = latestRun
     ? `${latestRun.status} ${relTime(latestRun.startedAt)}`
     : "No runs yet";
@@ -384,7 +406,19 @@ export function CodexDetailPanel({
     </CronDetailSection>
   );
   const runsSection = runs.length > 0 ? (
-    <CronDetailSection title="Recent runs" description="Open a run to inspect its log without leaving this cron.">
+    <CronDetailSection
+      title="Recent runs"
+      // Scoped on purpose: this store holds runs started FROM Cave, so the
+      // durations describe those and not the daemon's schedule. Saying
+      // "recent runs" unqualified would read as the cron's whole history —
+      // the same overclaim the crons list refuses when it declines to invent
+      // a stale status. No reliability percentage for the same reason.
+      description={
+        runStats.medianMs !== null
+          ? `Runs started from Cave — median ${formatDurationMs(runStats.medianMs)}, longest ${formatDurationMs(runStats.maxMs ?? 0)}. Open one to inspect its log.`
+          : "Runs started from Cave. Open one to inspect its log without leaving this cron."
+      }
+    >
       <ul className="mt-1 space-y-1">
         {runs.slice(0, 10).map((r) => (
           <li key={r.id}>
@@ -479,7 +513,30 @@ export function CodexDetailPanel({
           <CronSummaryTile label="Status" value={isActive ? "Active" : "Paused"} tone={isActive ? "active" : "paused"} />
           <CronSummaryTile label="Model" value={model.trim() || "Default"} />
           <CronSummaryTile label="Last run" value={latestRunLabel} tone={latestRun?.status === "failed" ? "danger" : "default"} />
+          {/* The tile the pane was missing. A surface that can describe a cron
+              in nine configuration fields without ever saying when it next
+              fires is exactly the gap the handoff spec names. "—" when the
+              rule cannot be read or the cron is paused: both are honest, and
+              the insight line above says which. */}
+          <CronSummaryTile
+            label="Next run"
+            value={upcoming[0] ? formatTimestamp(upcoming[0], readDateTimePrefs()) : "—"}
+          />
         </div>
+
+        {/* One sentence for the state, above the fields that configure it. */}
+        <p className="cron-detail-insight" role="status">{insight}</p>
+
+        {upcoming.length > 1 ? (
+          <p className="cron-detail-upcoming">
+            <span className="cron-detail-upcoming__label">then</span>
+            {upcoming.slice(1).map((iso) => (
+              <span key={iso} className="cron-detail-upcoming__at">
+                {formatTimestamp(iso, readDateTimePrefs())}
+              </span>
+            ))}
+          </p>
+        ) : null}
 
         {expanded ? (
           <div className="grid items-start gap-5 lg:grid-cols-2">

--- a/src/lib/automations/cron-detail-state.test.ts
+++ b/src/lib/automations/cron-detail-state.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AutomationRunRecord, AutomationRunStatus } from "../automation-runs.ts";
+import type { CodexAutomation } from "../codex-automations-types.ts";
+import { cronInsight, cronNextRuns, recordedRunStats } from "./cron-detail-state.ts";
+
+function auto(over: Partial<CodexAutomation> = {}): CodexAutomation {
+  return {
+    id: "a",
+    name: "a",
+    kind: "codex",
+    status: "ACTIVE",
+    rrule: "RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+    model: null,
+    reasoningEffort: null,
+    executionEnvironment: null,
+    cwds: [],
+    tags: [],
+    familiars: [],
+    prompt: "",
+    skillPath: null,
+    scheduleHuman: "daily 09:00",
+    ...over,
+  };
+}
+
+function run(status: AutomationRunStatus, over: Partial<AutomationRunRecord> = {}): AutomationRunRecord {
+  return {
+    id: "r",
+    automationId: "a",
+    automationName: "a",
+    startedAt: "2026-08-25T09:00:00.000Z",
+    status,
+    ...over,
+  };
+}
+
+const NOW = new Date("2026-08-25T10:00:00Z").getTime();
+
+describe("cronNextRuns", () => {
+  it("answers when an active cron next fires", () => {
+    const next = cronNextRuns(auto(), NOW, 3);
+    assert.equal(next.length, 3);
+    const times = next.map((iso) => new Date(iso).getTime());
+    assert.ok(times.every((t) => t > NOW), "every upcoming run is in the future");
+    assert.deepEqual(times, [...times].sort((a, b) => a - b));
+  });
+
+  it("gives a paused cron no upcoming runs at all", () => {
+    // Listing the times it *would have* fired describes a schedule that is off.
+    assert.deepEqual(cronNextRuns(auto({ status: "PAUSED" }), NOW, 3), []);
+  });
+
+  it("returns nothing for a rule it cannot read, rather than guessing", () => {
+    assert.deepEqual(cronNextRuns(auto({ rrule: "RRULE:FREQ=SECONDLY;COUNT=9" }), NOW, 3), []);
+    assert.deepEqual(cronNextRuns(auto({ rrule: null }), NOW, 3), []);
+  });
+});
+
+describe("recordedRunStats", () => {
+  it("summarises only runs that actually finished", () => {
+    const stats = recordedRunStats([
+      run("succeeded", { startedAt: "2026-08-25T09:00:00.000Z", finishedAt: "2026-08-25T09:00:10.000Z" }),
+      run("succeeded", { startedAt: "2026-08-25T09:00:00.000Z", finishedAt: "2026-08-25T09:00:30.000Z" }),
+      run("running", { startedAt: "2026-08-25T09:00:00.000Z" }), // no finish — excluded
+    ]);
+    assert.equal(stats.sampled, 2, "an in-flight run has no duration to report");
+    assert.equal(stats.medianMs, 20_000);
+    assert.equal(stats.maxMs, 30_000);
+  });
+
+  it("reports nothing rather than zero when there is nothing to measure", () => {
+    const stats = recordedRunStats([run("running")]);
+    assert.equal(stats.sampled, 0);
+    assert.equal(stats.medianMs, null, "null reads as 'unknown'; 0 would read as 'instant'");
+    assert.equal(stats.maxMs, null);
+  });
+});
+
+describe("cronInsight", () => {
+  it("says a paused cron will not run", () => {
+    assert.match(cronInsight(auto({ status: "PAUSED" }), undefined, null), /will not run until you resume/);
+  });
+
+  it("names the failure reason when one was recorded", () => {
+    const insight = cronInsight(auto(), run("failed", { summary: "exit 1: MCP timeout" }), "2026-08-26T09:00:00Z");
+    assert.match(insight, /last recorded run failed: exit 1: MCP timeout/);
+  });
+
+  it("scopes a failure to what was RECORDED, never to the cron at large", () => {
+    // The run store holds app-triggered runs only, so "this cron is failing"
+    // would overclaim from a single manual run.
+    assert.match(cronInsight(auto(), run("failed"), null), /last recorded run/);
+  });
+
+  it("distinguishes 'nothing recorded here' from 'never ran'", () => {
+    const insight = cronInsight(auto(), undefined, "2026-08-26T09:00:00Z");
+    assert.match(insight, /No runs recorded in Cave yet/);
+    assert.match(insight, /daemon/, "and says where the scheduled runs actually happen");
+  });
+
+  it("admits when it cannot work out the next run", () => {
+    const insight = cronInsight(auto(), run("succeeded"), null);
+    assert.match(insight, /can't be read, so the next run is unknown/);
+  });
+});

--- a/src/lib/automations/cron-detail-state.ts
+++ b/src/lib/automations/cron-detail-state.ts
@@ -1,0 +1,114 @@
+// The *state* half of a cron's detail pane: what this cron is doing, when it
+// will next do it, and how the runs we have recorded went.
+//
+// The existing panel is entirely configuration — name, prompt, model,
+// environment, working directories. `Scheduling Spec.dc.html` states the
+// contract it misses: *every schedule surface says what will happen and when it
+// will next happen*. A pane that can describe a cron in nine fields without
+// ever saying when it next fires is exactly that gap.
+//
+// Pure and client-safe.
+
+import type { AutomationRunRecord } from "../automation-runs.ts";
+import type { CodexAutomation } from "../codex-automations-types.ts";
+import { nextOccurrences } from "../schedule-plan.ts";
+import { recurrenceFromRrule } from "../schedule-plan-model.ts";
+import { cronHealth, type CronHealth } from "./cron-health.ts";
+
+/**
+ * Upcoming fires for a cron, or [] when its rule cannot be read.
+ *
+ * Shares `recurrenceFromRrule` with the create dialog's plan preview and the
+ * calendar's projection, so all three answer "when does this run" identically.
+ */
+export function cronNextRuns(
+  auto: Pick<CodexAutomation, "rrule" | "status">,
+  fromMs: number,
+  count: number,
+): string[] {
+  // A paused cron has no upcoming runs — it is not going to fire. Listing the
+  // times it *would have* fired is a pane describing a schedule that is off.
+  if (auto.status !== "ACTIVE") return [];
+  if (!auto.rrule) return [];
+  const rec = recurrenceFromRrule(auto.rrule);
+  if (!rec) return [];
+  return nextOccurrences(rec, fromMs, count);
+}
+
+export type RecordedRunStats = {
+  /** Runs that finished and carry a usable duration. */
+  sampled: number;
+  medianMs: number | null;
+  maxMs: number | null;
+};
+
+/**
+ * Duration statistics over the runs THIS APP RECORDED.
+ *
+ * Deliberately named `recorded` rather than anything implying completeness:
+ * `automation-runs.json` holds app-triggered "run now" executions only, so
+ * these describe manual runs, never the daemon's schedule. Every surface that
+ * renders them has to say so — the same reason the crons list refuses to
+ * report a `stale` status it cannot know.
+ *
+ * That is also why there is no reliability percentage here. A "96% reliable"
+ * figure computed from this store would be a claim about the handful of runs
+ * someone kicked off by hand, presented as the health of the cron itself.
+ */
+export function recordedRunStats(runs: readonly AutomationRunRecord[]): RecordedRunStats {
+  const durations: number[] = [];
+  for (const run of runs) {
+    if (!run.startedAt || !run.finishedAt) continue;
+    const ms = new Date(run.finishedAt).getTime() - new Date(run.startedAt).getTime();
+    if (Number.isFinite(ms) && ms >= 0) durations.push(ms);
+  }
+  if (durations.length === 0) return { sampled: 0, medianMs: null, maxMs: null };
+  durations.sort((a, b) => a - b);
+  const mid = Math.floor(durations.length / 2);
+  const medianMs =
+    durations.length % 2 === 0
+      ? Math.round((durations[mid - 1]! + durations[mid]!) / 2)
+      : durations[mid]!;
+  return { sampled: durations.length, medianMs, maxMs: durations[durations.length - 1]! };
+}
+
+/**
+ * One sentence that explains the cron's current state.
+ *
+ * The frame leads its detail pane with this, and the value is that a reader
+ * gets the answer without assembling it from a status dot, a timestamp and a
+ * schedule string. Every branch says only what the data supports — a cron with
+ * no recorded run says so, rather than implying it has never run at all.
+ */
+export function cronInsight(
+  auto: Pick<CodexAutomation, "status" | "scheduleHuman">,
+  lastRun: AutomationRunRecord | undefined,
+  nextRunIso: string | null,
+): string {
+  const health: CronHealth = cronHealth(auto, lastRun);
+
+  if (health === "paused") {
+    return "Paused — it will not run until you resume it.";
+  }
+  if (health === "running") {
+    return "Running now.";
+  }
+  if (health === "failed") {
+    const why = lastRun?.summary?.trim();
+    return why
+      ? `The last recorded run failed: ${why}`
+      : "The last recorded run failed.";
+  }
+  // Healthy. Say when it next fires if we can, and be explicit that an absent
+  // run history means "nothing recorded here", not "never ran" — the daemon's
+  // scheduled runs never reach this store.
+  const cadence = auto.scheduleHuman ? ` Runs ${auto.scheduleHuman}.` : "";
+  // An unreadable rule is worth saying out loud: the pane cannot tell the
+  // reader when this fires next, and silence would read as "nothing upcoming"
+  // rather than "we could not work it out".
+  const unreadable = !nextRunIso ? " Its schedule rule can't be read, so the next run is unknown." : "";
+  if (!lastRun) {
+    return `No runs recorded in Cave yet — scheduled runs happen on the daemon.${cadence}${unreadable}`;
+  }
+  return `Healthy.${cadence}${unreadable}`;
+}

--- a/src/styles/cron-detail-state.css
+++ b/src/styles/cron-detail-state.css
@@ -1,0 +1,46 @@
+/* Cron detail — the state band.
+
+   Component-imported by cron-detail-panel.tsx, NOT on the globals.css facade.
+   The root CSS bundle every route downloads sits at zero headroom against
+   BUNDLE_MAX_HOME_CSS_KB, so ANY addition there fails the build — this is the
+   third sheet this session to learn that. Surface CSS ships with the chunk
+   that renders it (#3264 pattern).
+
+   surface says what will happen and when it will next happen. The pane was all
+   configuration; this is the sentence that answers the first half. */
+
+.cron-detail-insight {
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  border-left: 2px solid color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  border-radius: 0 var(--radius-control) var(--radius-control) 0;
+  background: color-mix(in oklch, var(--accent-presence) 6%, transparent);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  text-wrap: pretty;
+}
+
+.cron-detail-upcoming {
+  display: flex;
+  margin: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.cron-detail-upcoming__label {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+
+.cron-detail-upcoming__at {
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+}


### PR DESCRIPTION
The pane could describe a cron across **nine configuration fields** — name, prompt, model, reasoning, environment, working directories, tags, skill, schedule string — without ever saying when it fires next. `Scheduling Spec.dc.html` states the contract it was missing:

> every schedule surface says what will happen and when it will next happen

It now leads with the state: a **Next run** tile, one sentence explaining where the cron stands, the two fires after that, and median/longest durations over the runs we actually hold.

### One definition of a schedule

`cronNextRuns` reads the rule through `recurrenceFromRrule`, so the detail pane, the create dialog's plan preview (#5026) and the calendar's projection (#5027) all answer *"when does this run"* from a single definition rather than three that can drift.

### A paused cron gets no upcoming runs at all

Listing the times it *would have* fired describes a schedule that is off — the same refusal the calendar projection makes.

### Reliability is cut, not deferred

The frame has a reliability tile. `automation-runs.json` records app-triggered "run now" executions **only**, so a "96% reliable" figure computed from it would be a claim about however many runs someone kicked off by hand, presented as the health of the cron itself. That is the same trap as the `stale` status the crons list refuses to invent.

For the same reason the run history is now labelled **"Runs started from Cave"** rather than "Recent runs", which reads as the cron's whole record.

The insight line keeps exactly the distinctions the data supports: *"No runs recorded in Cave yet — scheduled runs happen on the daemon"* is not "never ran", and a rule it cannot read is reported as such rather than leaving a silence that reads as "nothing upcoming".

### Verified in a browser

| | Active cron | Paused cron |
|---|---|---|
| Status | Active | Paused |
| **Next run** | `08.26 01:00` | **`—`** |
| Insight | "No runs recorded in Cave yet — scheduled runs happen on the daemon. Runs Daily at 01:00." | "Paused — it will not run until you resume it." |
| Upcoming | `then 08.27 01:00 · 08.28 01:00` | *(none)* |

10 tests in `cron-detail-state.test.ts` (wired into the app suite). `pnpm lint`, `tsc --noEmit`, drift ratchets and the bundle budget all clean; `automations-view`, `automations-detail-inputs` and `rituals-tabs` still pass.

### One process note

This sheet was the **third** this session to fail the bundle budget by landing on the globals facade (942 KB against 940 KB). The root CSS bundle has no headroom and every route pays for one gated surface's CSS. Now documented in `CLAUDE.md` so the next person doesn't rediscover it — the mistake looks like tidiness, because the related rules already live in a faceted sheet.

cave-84fp0