### PR TITLE
Clarify Beads skill trigger boundary

### DIFF
--- a/.agents/skills/beads/SKILL.md
+++ b/.agents/skills/beads/SKILL.md
@@ -1,11 +1,26 @@
 ---
 name: beads
-description: Use when working in a repository that uses bd or Beads for durable project task tracking, issue dependencies, blocker management, multi-session handoff, or shared work memory. Trigger when the user asks to find ready work, claim or close tasks, create follow-up work, inspect blockers, recover project context, or choose between local planning and persistent project tracking.
+description: Use when the user asks to manage durable project work with bd or Beads: find ready work, claim or close tasks, create shared follow-up work, inspect dependencies or blockers, recover cross-session context, or choose between local planning and persistent tracking. Do not load merely because a repository uses Beads, or for routine one-turn coding, styling, explanation, or review work that needs no task-tracker operation.
 ---
 
 # Beads
 
 Use Beads as the shared project task system. Local plans, scratch files, and personal memories are useful, but they are not the durable source of truth for project work.
+
+## When to Load
+
+Load this skill when the current request needs a Beads operation or durable shared task state, including:
+
+- finding, claiming, updating, or closing project work
+- creating follow-up work, dependencies, or blocker records
+- preserving a handoff or recovering context across sessions
+- deciding whether work belongs in local planning or the project tracker
+
+## When Not to Load
+
+Do not load this skill merely because the repository uses Beads. Skip it for routine one-turn implementation, styling, explanation, review, search, or test requests unless the user also needs a task-tracker operation, blocker or dependency management, durable handoff, or context recovery.
+
+Repository workflow may still require running `bd` commands around implementation. Following that workflow does not by itself make Beads expertise part of the user's request.
 
 ## First Step
 

--- a/.agents/skills/beads/agents/openai.yaml
+++ b/.agents/skills/beads/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Beads"
-  short_description: "Project task tracking with bd"
-  default_prompt: "Use $beads to inspect ready work and manage durable project tasks."
+  short_description: "Durable project task tracking with bd"
+  default_prompt: "Use $beads only when the request needs durable shared tasks, blockers, dependencies, handoffs, context recovery, or direct task-tracker operations. Do not use it merely because the repository has Beads, or for routine one-turn coding or styling."

--- a/scripts/beads-skill-trigger-contract.test.mjs
+++ b/scripts/beads-skill-trigger-contract.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const skill = readFileSync(".agents/skills/beads/SKILL.md", "utf8");
+const launcher = readFileSync(".agents/skills/beads/agents/openai.yaml", "utf8");
+const description = /^description: (.+)$/m.exec(skill)?.[1];
+
+test("trigger retains durable Beads operations", () => {
+  assert.ok(description, "Beads skill must declare a trigger description");
+  assert.ok(description.length <= 500, "skill description must fit the 500-character metadata limit");
+
+  for (const cue of [
+    "find ready work",
+    "claim or close tasks",
+    "create shared follow-up work",
+    "inspect dependencies or blockers",
+    "recover cross-session context",
+    "local planning and persistent tracking",
+  ]) {
+    assert.ok(description.includes(cue), `trigger is missing durable-work cue: ${cue}`);
+  }
+});
+
+test("trigger excludes routine one-turn work in Beads repositories", () => {
+  assert.match(description, /Do not load merely because a repository uses Beads/);
+  assert.match(description, /routine one-turn coding, styling, explanation, or review work/);
+  assert.match(skill, /## When Not to Load/);
+  assert.match(skill, /Following that workflow does not by itself make Beads expertise part of the user's request/);
+});
+
+test("launcher prompt carries the same negative boundary", () => {
+  assert.match(launcher, /only when the request needs durable shared tasks/);
+  assert.match(launcher, /Do not use it merely because the repository has Beads/);
+  assert.match(launcher, /routine one-turn coding or styling/);
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -93,6 +93,7 @@ export const SUITES = {
     "scripts/beads-create.test.mjs",
     "scripts/beads-sync.test.mjs",
     "scripts/beads-surface-audit.test.mjs",
+    "scripts/beads-skill-trigger-contract.test.mjs",
     "scripts/install-git-hooks.test.mjs",
     "scripts/worktree-lifecycle-retirement.test.mjs",
     "scripts/worktree-lifecycle-rest-pr-inventory.test.mjs",


### PR DESCRIPTION
## Summary
- narrow the Beads trigger to explicit durable task-tracker operations
- add a negative boundary for routine one-turn coding, styling, explanation, and review work
- align the launcher prompt and pin both boundaries with a CI-wired contract test

## Review
- scoped review found no blocking issues; all four changed paths directly support the trigger contract

## Verification
- `node --test scripts/beads-skill-trigger-contract.test.mjs` (3 passed)
- `pnpm typecheck`
- `env -u NPM_CONFIG_PREFIX -u npm_config_prefix pnpm test:app` (1,324 test files passed)
- `pnpm test:api`
- `pnpm check:tests-wired` (all 1,872 test files wired)
- `pnpm lint` reaches the pre-existing token-reference baseline in untouched files and reports undefined/banked token drift

Bead: `cave-203ob`