### PR TITLE
Show the run you just started

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -950,6 +950,7 @@ export const SUITES = {
     "src/lib/automations/automation-entry.test.ts",
     "src/lib/automations/cron-health.test.ts",
     "src/lib/automations/cron-detail-state.test.ts",
+    "src/lib/automations/live-run.test.ts",
     "src/lib/automations/list-input.test.ts",
     "src/lib/automations/run-status.test.ts",
     "src/lib/inbox-feed.test.ts",

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -36,6 +36,8 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { automationMatchesFilter } from "@/lib/familiar-multiselect";
 import { buildRitualWeek, ritualAgendaItems, ritualLogItems, type RitualDay } from "@/lib/rituals-overview";
 import { failingCronIds } from "@/lib/automations/cron-health";
+import { liveRunView, newestRunFor } from "@/lib/automations/live-run";
+import { LiveRunCard } from "@/components/automations/live-run-card";
 import { FamiliarCarousel } from "@/components/automations/familiar-carousel";
 import { AutomationCreateDialog, type AutomationCreateInput } from "@/components/automation-create-dialog";
 import { CodexDetailPanel } from "@/components/automations/cron-detail-panel";
@@ -158,6 +160,11 @@ export function AutomationsView({ familiars, onNewReminder, onEdit, onOpenLink, 
   const [subsOpen, setSubsOpen] = useState(false);
   const [subsHasPat, setSubsHasPat] = useState(false);
   const [automationRuns, setAutomationRuns] = useState<AutomationRunRecord[]>([]);
+  // The run the card follows after a manual trigger. "Run now" already
+  // announces itself into an sr-only live region, so a sighted user currently
+  // sees a button stop being busy and nothing else — cave-06qka is the same
+  // asymmetry on the Review Deck.
+  const [liveRunFor, setLiveRunFor] = useState<string | null>(null);
   const [lastRunById, setLastRunById] = useState<Map<string, AutomationRunRecord>>(new Map());
   // Guards async setState after unmount; runsReqRef drops a stale per-automation
   // runs fetch when a faster, later selection won.
@@ -584,6 +591,7 @@ export function AutomationsView({ familiars, onNewReminder, onEdit, onOpenLink, 
       const json = await res.json().catch(() => null);
       if (!res.ok || !json?.ok) throw new Error(json?.error ?? `http ${res.status}`);
       announce(`Run started for '${auto.name}'.`);
+      setLiveRunFor(auto.id);
       await refreshRuns(auto.id);
       await refreshLastRuns();
     } catch (err) {
@@ -780,6 +788,21 @@ export function AutomationsView({ familiars, onNewReminder, onEdit, onOpenLink, 
       soonest: undefined as string | undefined,
     };
   }, [liveAutos, failingIds.size]);
+
+  // The card's view of the followed run, recomputed each render so the elapsed
+  // readout stays honest without this component owning a timer of its own.
+  const liveRun = liveRunFor
+    ? liveRunView(newestRunFor(automationRuns, liveRunFor), Date.now())
+    : null;
+
+  // Poll only while the run is unsettled. A finished run needs no polling, and
+  // an unfollowed one needs none either — this is the whole reason the card
+  // tracks `settled` rather than just a phase.
+  useEffect(() => {
+    if (!liveRunFor || !liveRun || liveRun.settled) return;
+    const id = window.setInterval(() => { void refreshRuns(liveRunFor); }, 2500);
+    return () => window.clearInterval(id);
+  }, [liveRunFor, liveRun?.settled, refreshRuns]);
 
   const selectTab = (tab: AutomationTab) => {
     setActiveTab(tab);
@@ -1348,6 +1371,17 @@ export function AutomationsView({ familiars, onNewReminder, onEdit, onOpenLink, 
           onClose={() => setSubsOpen(false)}
         />
       )}
+
+      {liveRun ? (
+        <LiveRunCard
+          view={liveRun}
+          onDismiss={() => setLiveRunFor(null)}
+          onOpenCron={() => {
+            const auto = codexAutos.find((a) => a.id === liveRun.automationId);
+            if (auto) { selectTab("crons"); setSelectedCodex(auto); setSelectedItem(null); }
+          }}
+        />
+      ) : null}
 
       {deletePending ? (
         <UndoToast

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -798,11 +798,17 @@ export function AutomationsView({ familiars, onNewReminder, onEdit, onOpenLink, 
   // Poll only while the run is unsettled. A finished run needs no polling, and
   // an unfollowed one needs none either — this is the whole reason the card
   // tracks `settled` rather than just a phase.
-  useEffect(() => {
-    if (!liveRunFor || !liveRun || liveRun.settled) return;
-    const id = window.setInterval(() => { void refreshRuns(liveRunFor); }, 2500);
-    return () => window.clearInterval(id);
-  }, [liveRunFor, liveRun?.settled, refreshRuns]);
+  //
+  // usePausablePoll rather than a raw interval: it stops while the tab is
+  // hidden and refreshes on return, so a run card left open in a background
+  // tab does not keep hitting /runs. `pausable-poll-discipline.test.ts` gates
+  // exactly this, and it was right to — the raw version polled regardless of
+  // visibility.
+  usePausablePoll(
+    () => { if (liveRunFor) void refreshRuns(liveRunFor); },
+    2500,
+    { enabled: Boolean(liveRunFor && liveRun && !liveRun.settled) },
+  );
 
   const selectTab = (tab: AutomationTab) => {
     setActiveTab(tab);

--- a/src/components/automations/live-run-card.tsx
+++ b/src/components/automations/live-run-card.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { IconButton } from "@/components/ui/icon-button";
+import { formatElapsed, type LiveRunView } from "@/lib/automations/live-run";
+import "@/styles/live-run-card.css";
+
+type Props = {
+  view: LiveRunView;
+  onDismiss: () => void;
+  /** Opens the cron's detail pane, where the run history and logs live. */
+  onOpenCron?: () => void;
+};
+
+/**
+ * The visible half of a run you started.
+ *
+ * "Run now" already announces itself through `useAnnouncer`, which writes into
+ * an `sr-only` live region — so assistive tech hears the run start and a
+ * sighted user sees a button stop being busy and nothing else. `cave-06qka`
+ * records the same asymmetry on the Review Deck. This is the seen half.
+ *
+ * `aria-hidden` for exactly that reason: the announcement already exists, and
+ * a screen reader should not hear every run twice.
+ *
+ * What it deliberately does NOT draw — because `AutomationRunRecord` carries
+ * none of it — is a progress bar, a stage breakdown, or output chips. A bar
+ * advancing on a duration nothing predicts would be the card lying about a run
+ * in flight, which is worse than a card that says "Running… 40s".
+ */
+export function LiveRunCard({ view, onDismiss, onOpenCron }: Props) {
+  // Tick only while unsettled, so a finished card is not re-rendering forever
+  // in the corner of the surface.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (view.settled) return;
+    const id = window.setInterval(() => setTick((n) => n + 1), 1000);
+    return () => window.clearInterval(id);
+  }, [view.settled]);
+
+  return (
+    <div aria-hidden className={`live-run-card live-run-card--${view.phase}`}>
+      <span className="live-run-card__mark">
+        {view.phase === "running" ? (
+          <span className="live-run-card__pulse" />
+        ) : (
+          <Icon name={view.phase === "failed" ? "ph:x-circle-fill" : "ph:check-circle-fill"} width={14} />
+        )}
+      </span>
+
+      <span className="live-run-card__body">
+        <span className="live-run-card__head">
+          <span className="live-run-card__name">{view.name}</span>
+          <span className="live-run-card__elapsed">{formatElapsed(view.elapsedMs)}</span>
+        </span>
+        <span className="live-run-card__headline">{view.headline}</span>
+        {view.summary ? <span className="live-run-card__summary">{view.summary}</span> : null}
+      </span>
+
+      {onOpenCron ? (
+        <button type="button" className="live-run-card__link focus-ring" onClick={onOpenCron}>
+          details
+        </button>
+      ) : null}
+      <IconButton
+        icon="ph:x"
+        size="xs"
+        aria-label={`Dismiss run card for ${view.name}`}
+        onClick={onDismiss}
+        className="live-run-card__dismiss"
+      />
+    </div>
+  );
+}

--- a/src/lib/automations/live-run.test.ts
+++ b/src/lib/automations/live-run.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AutomationRunRecord, AutomationRunStatus } from "../automation-runs.ts";
+import { formatElapsed, liveRunView, newestRunFor } from "./live-run.ts";
+
+const START = "2026-08-25T10:00:00.000Z";
+const NOW = new Date("2026-08-25T10:00:40.000Z").getTime();
+
+function run(status: AutomationRunStatus, over: Partial<AutomationRunRecord> = {}): AutomationRunRecord {
+  return {
+    id: "r1",
+    automationId: "a1",
+    automationName: "Daily brief",
+    startedAt: START,
+    status,
+    ...over,
+  };
+}
+
+describe("formatElapsed", () => {
+  it("stays narrow and stops jittering once past a minute", () => {
+    assert.equal(formatElapsed(8_000), "8s");
+    // Zero-padded seconds so the readout does not change width every tick
+    // while someone is watching a run.
+    assert.equal(formatElapsed(64_000), "1m 04s");
+    assert.equal(formatElapsed(4_320_000), "1h 12m");
+  });
+
+  it("never renders a negative duration", () => {
+    assert.equal(formatElapsed(-5_000), "0s");
+  });
+});
+
+describe("liveRunView", () => {
+  it("shows nothing when there is no run to follow", () => {
+    assert.equal(liveRunView(null, NOW), null);
+    assert.equal(liveRunView(run("running", { startedAt: "not-a-date" }), NOW), null);
+  });
+
+  it("counts up against the wall clock while in flight", () => {
+    const view = liveRunView(run("running"), NOW)!;
+    assert.equal(view.phase, "running");
+    assert.equal(view.settled, false, "an in-flight run keeps the card polling");
+    assert.equal(view.elapsedMs, 40_000);
+    assert.equal(view.headline, "Running…");
+  });
+
+  it("treats a queued run as in flight rather than inventing a fourth state", () => {
+    const view = liveRunView(run("queued"), NOW)!;
+    assert.equal(view.phase, "running");
+    assert.equal(view.settled, false);
+  });
+
+  it("freezes the duration once the run finished", () => {
+    const view = liveRunView(
+      run("succeeded", { finishedAt: "2026-08-25T10:00:25.000Z" }),
+      // Later wall clock must NOT keep the number climbing after it settled.
+      new Date("2026-08-25T10:05:00.000Z").getTime(),
+    )!;
+    assert.equal(view.settled, true);
+    assert.equal(view.elapsedMs, 25_000);
+    assert.equal(view.headline, "Finished in 25s");
+  });
+
+  it("names the exit code on failure rather than sending you to the log for it", () => {
+    const view = liveRunView(
+      run("failed", { finishedAt: "2026-08-25T10:00:10.000Z", exitCode: 1 }),
+      NOW,
+    )!;
+    assert.equal(view.phase, "failed");
+    assert.match(view.headline, /Failed \(exit 1\) after 10s/);
+  });
+
+  it("falls back to wall clock when finishedAt is nonsense, never a negative", () => {
+    const view = liveRunView(
+      run("succeeded", { finishedAt: "2026-08-25T09:00:00.000Z" }), // before the start
+      NOW,
+    )!;
+    assert.ok(view.elapsedMs >= 0);
+    assert.equal(view.elapsedMs, 40_000, "wall clock, rather than a negative duration");
+  });
+
+  it("surfaces a summary only when the run left one", () => {
+    assert.equal(liveRunView(run("succeeded", { finishedAt: START }), NOW)!.summary, null);
+    assert.equal(liveRunView(run("succeeded", { finishedAt: START, summary: "  " }), NOW)!.summary, null);
+    assert.equal(
+      liveRunView(run("succeeded", { finishedAt: START, summary: " wrote 3 files " }), NOW)!.summary,
+      "wrote 3 files",
+    );
+  });
+});
+
+describe("newestRunFor", () => {
+  it("follows the newest run for THIS cron, not whatever came first", () => {
+    // Re-established rather than assumed: a card following the wrong run would
+    // report someone else's outcome.
+    const runs = [
+      run("succeeded", { id: "old", startedAt: "2026-08-25T09:00:00.000Z" }),
+      run("running", { id: "new", startedAt: "2026-08-25T10:00:00.000Z" }),
+      run("running", { id: "other", automationId: "a2", startedAt: "2026-08-25T11:00:00.000Z" }),
+    ];
+    assert.equal(newestRunFor(runs, "a1")?.id, "new");
+  });
+
+  it("returns null when this cron has no runs at all", () => {
+    assert.equal(newestRunFor([run("running", { automationId: "a2" })], "a1"), null);
+  });
+});

--- a/src/lib/automations/live-run.ts
+++ b/src/lib/automations/live-run.ts
@@ -1,0 +1,135 @@
+// The visible half of a cron run you started.
+//
+// Clicking "Run now" calls `announce()`, which writes into an `sr-only` live
+// region: assistive tech hears "Run started for X" and a sighted user sees
+// nothing but a button that stops being busy. That asymmetry is a defect this
+// repository has already paid for once — `cave-06qka` on the Review Deck, where
+// every verdict was announced and none was shown.
+//
+// So this models what a run card can HONESTLY say. Deliberately absent, because
+// `AutomationRunRecord` carries none of it:
+//
+//   • a progress percentage — nothing knows a run's total duration, so a bar
+//     would advance on invented data;
+//   • a stage breakdown — there are no stages recorded, at all;
+//   • structured outputs — there is one free-text `summary`, not a set of
+//     produced artifacts.
+//
+// Building those would be a card that lies about a run in flight, which is
+// worse than a card that simply says "running, 40s".
+
+import type { AutomationRunRecord } from "../automation-runs.ts";
+
+export type LiveRunPhase = "running" | "succeeded" | "failed";
+
+export type LiveRunView = {
+  runId: string;
+  automationId: string;
+  name: string;
+  phase: LiveRunPhase;
+  /** Wall-clock so far (running) or total (finished), in ms. */
+  elapsedMs: number;
+  /** One short line describing where the run stands. */
+  headline: string;
+  /** The run's own summary, when it left one. */
+  summary: string | null;
+  /** True once the run has settled — the card can be dismissed and stops polling. */
+  settled: boolean;
+};
+
+/** Compact elapsed readout: 8s, 1m 04s, 1h 12m. Seconds are zero-padded past a
+ *  minute so the number does not jitter in width while a run is in flight. */
+export function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.round(ms / 1000));
+  if (total < 60) return `${total}s`;
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  if (minutes < 60) return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${String(minutes % 60).padStart(2, "0")}m`;
+}
+
+function phaseOf(status: AutomationRunRecord["status"]): LiveRunPhase {
+  if (status === "failed") return "failed";
+  if (status === "succeeded") return "succeeded";
+  // `queued` is not yet running, but from the card's point of view the run is
+  // in flight and has not settled — collapsing it into "running" keeps the
+  // card's contract (settled or not) rather than inventing a fourth state the
+  // dismiss/poll logic would have to special-case.
+  return "running";
+}
+
+/**
+ * Build the card's view of a run, or null when there is nothing to show.
+ *
+ * `nowMs` is injected so elapsed time is testable and so the caller owns the
+ * ticking rather than the model reading the clock behind its back.
+ */
+export function liveRunView(
+  run: AutomationRunRecord | null | undefined,
+  nowMs: number,
+): LiveRunView | null {
+  if (!run) return null;
+  const startedMs = new Date(run.startedAt).getTime();
+  if (!Number.isFinite(startedMs)) return null;
+
+  const phase = phaseOf(run.status);
+  const settled = phase !== "running";
+  const endMs = settled && run.finishedAt ? new Date(run.finishedAt).getTime() : nowMs;
+  // A finishedAt that is unparseable or before the start would render a
+  // negative or absurd duration; fall back to wall clock rather than show it.
+  const elapsedMs =
+    Number.isFinite(endMs) && endMs >= startedMs ? endMs - startedMs : Math.max(0, nowMs - startedMs);
+
+  const summary = run.summary?.trim() ? run.summary.trim() : null;
+  let headline: string;
+  if (phase === "running") {
+    headline = "Running…";
+  } else if (phase === "succeeded") {
+    headline = `Finished in ${formatElapsed(elapsedMs)}`;
+  } else {
+    // Name the exit code when there is one: "failed" alone sends the reader to
+    // the log for something the record already knows.
+    headline =
+      run.exitCode != null && run.exitCode !== 0
+        ? `Failed (exit ${run.exitCode}) after ${formatElapsed(elapsedMs)}`
+        : `Failed after ${formatElapsed(elapsedMs)}`;
+  }
+
+  return {
+    runId: run.id,
+    automationId: run.automationId,
+    name: run.automationName,
+    phase,
+    elapsedMs,
+    headline,
+    summary,
+    settled,
+  };
+}
+
+/**
+ * Pick the run a card should follow after a manual trigger: the newest run
+ * belonging to `automationId`.
+ *
+ * Runs arrive newest-first from the store, but that is the store's ordering
+ * contract rather than this module's, so it is re-established here instead of
+ * assumed — a card following the wrong run would report someone else's outcome.
+ */
+export function newestRunFor(
+  runs: readonly AutomationRunRecord[],
+  automationId: string,
+): AutomationRunRecord | null {
+  let best: AutomationRunRecord | null = null;
+  let bestMs = -Infinity;
+  for (const run of runs) {
+    if (run.automationId !== automationId) continue;
+    const ms = new Date(run.startedAt).getTime();
+    if (!Number.isFinite(ms)) continue;
+    if (ms > bestMs) {
+      best = run;
+      bestMs = ms;
+    }
+  }
+  return best;
+}

--- a/src/lib/pausable-poll-discipline.test.ts
+++ b/src/lib/pausable-poll-discipline.test.ts
@@ -33,6 +33,7 @@ const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
  */
 const RAW_INTERVAL_ALLOWLIST = new Map([
   ["components/ui/thinking-indicator.tsx", "elapsed-time ticker while a turn is pending; no network"],
+  ["components/automations/live-run-card.tsx", "elapsed-time ticker for a run in flight; no network — the runs poll itself is usePausablePoll in automations-view"],
   ["components/voice-call-overlay.tsx", "live call-duration ticker; pausing it would misreport the call"],
   ["components/home/home-feed.tsx", "minute ticker for relative timestamps; no network"],
   ["components/calendar-view-primitives.tsx", "wall-clock minute ticker for the now-line; no network"],

--- a/src/styles/live-run-card.css
+++ b/src/styles/live-run-card.css
@@ -1,0 +1,137 @@
+/* Live run card — the visible half of an app-triggered cron run.
+
+   Component-imported by live-run-card.tsx, NOT on the globals.css facade: the
+   root CSS bundle every route downloads has no headroom, and this is a
+   dialog-gated surface. See the CSS section in CLAUDE.md. */
+
+.live-run-card {
+  position: fixed;
+  z-index: 60;
+  right: var(--space-4);
+  bottom: var(--space-8);
+  display: flex;
+  width: 340px;
+  max-width: calc(100vw - var(--space-8));
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-elevated);
+  box-shadow: 0 14px 40px color-mix(in oklch, var(--shadow-color) 52%, transparent);
+}
+
+.live-run-card--running {
+  border-color: color-mix(in oklch, var(--accent-presence) 32%, var(--border-hairline));
+}
+
+.live-run-card--failed {
+  border-color: color-mix(in oklch, var(--color-danger) 40%, var(--border-hairline));
+}
+
+.live-run-card__mark {
+  display: grid;
+  flex: none;
+  padding-top: 2px;
+  place-items: center;
+}
+
+.live-run-card--succeeded .live-run-card__mark {
+  color: var(--color-success);
+}
+
+.live-run-card--failed .live-run-card__mark {
+  color: var(--color-danger);
+}
+
+.live-run-card__pulse {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-presence);
+  animation: liveRunPulse 1.6s var(--ease-standard) infinite;
+}
+
+@keyframes liveRunPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  }
+
+  55% {
+    box-shadow: 0 0 0 5px color-mix(in oklch, var(--accent-presence) 0%, transparent);
+  }
+}
+
+/* The pulse is the only thing moving, and it carries no information the
+   headline does not already state in words. */
+@media (prefers-reduced-motion: reduce) {
+  .live-run-card__pulse {
+    animation: none;
+  }
+}
+
+.live-run-card__body {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.live-run-card__head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.live-run-card__name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.live-run-card__elapsed {
+  flex: none;
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.live-run-card__headline {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+
+.live-run-card--failed .live-run-card__headline {
+  color: var(--color-danger);
+}
+
+.live-run-card__summary {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.live-run-card__link {
+  flex: none;
+  align-self: center;
+  border: 0;
+  background: none;
+  color: var(--accent-presence);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--text-xs);
+}
+
+.live-run-card__dismiss {
+  flex: none;
+}


### PR DESCRIPTION
"Run now" called `announce()`, which writes into an **`sr-only`** live region. Assistive tech heard *"Run started for X"*; a sighted user saw a button stop being busy and nothing else.

This repository has already paid for that exact asymmetry once — `cave-06qka`, where the Review Deck announced every verdict and showed none.

### What lands

A run card appears when you trigger a run: the cron's name, elapsed time ticking while it is in flight, and on completion the outcome, the duration, and whatever summary the run left. It polls only while the run is unsettled and stops the moment it finishes.

It is **`aria-hidden` on purpose**. The announcement already exists and is already correct; this is the *seen* half, and a screen reader should not hear every run twice.

### Three of the frame's five card elements are cut, not deferred

`AutomationRunRecord` carries `startedAt`, `finishedAt`, `status`, `exitCode`, `summary`, `logPath` — and nothing else.

| Frame element | Why it is absent |
|---|---|
| `liveProgress` bar | Nothing predicts a run's total duration; the bar would advance on invented data |
| `liveStages` breakdown | There are no stages recorded. Not sparse ones — **none** |
| `liveOutputs` chips | There is one free-text `summary`, not a set of produced artifacts |

A bar creeping across a card while a run is in flight is a surface lying about something the reader cannot check, which is worse than a card that says "Running… 40s". Same call as the `stale` status, the reliability tile, and the weekly rule that previewed as "every day".

### Details that are easy to get wrong

- `newestRunFor` re-establishes ordering rather than trusting the store's newest-first contract — a card following the wrong run would report **someone else's outcome**.
- A settled run's duration **freezes** instead of climbing with the wall clock.
- A nonsensical `finishedAt` (before the start, unparseable) falls back to wall clock rather than rendering a negative duration.
- `queued` collapses into "running" rather than adding a fourth state the poll/dismiss logic would have to special-case — the card's contract is *settled or not*.

### Verification

11 tests in `live-run.test.ts` (wired into the app suite). Lint, typecheck, drift ratchets and the bundle budget all clean — the sheet is component-imported, so the facade trap did not recur.

Driven through the **real UI with the run API mocked**: no agent was executed and no store was mutated, since "Run now" genuinely executes an agent against a working directory and that is not a side effect worth causing to look at a card.

| Stage | Result |
|---|---|
| Running | `Simulated run · 12s · Running…`, pulsing, `aria-hidden="true"` |
| Settled | `Finished in 12s · wrote 3 files` — flipped automatically via polling |
| Dismissed | card removed |

cave-cgfx2