### PR TITLE
Scale Research resources and ground topic suggestions

### DIFF
--- a/src/app/api/research/recommendations/route.test.ts
+++ b/src/app/api/research/recommendations/route.test.ts
@@ -7,6 +7,7 @@ import type { ResearchMission } from "@/lib/research-missions.ts";
 import type { KnowledgeEntry } from "@/lib/server/knowledge-vault.ts";
 import type { SavedXSource } from "@/lib/server/x-sources.ts";
 import type { AgenticDiagnosticEvent } from "@/lib/agentic-diagnostics.ts";
+import type { SessionRow } from "@/lib/types.ts";
 import {
   createResearchRecommendationsRoute,
   type ResearchRecommendationsRouteDeps,
@@ -51,11 +52,27 @@ function xSource(id: string): SavedXSource {
   };
 }
 
+function session(id: string): SessionRow {
+  return {
+    id,
+    title: `Session topic ${id}`,
+    project_root: "/tmp/coven",
+    harness: "copilot",
+    status: "completed",
+    exit_code: 0,
+    archived_at: null,
+    created_at: "2026-08-19T09:00:00.000Z",
+    updated_at: "2026-08-19T10:00:00.000Z",
+    attention: { state: "none", since: null, reason: null },
+  };
+}
+
 function baseDeps(overrides: Partial<ResearchRecommendationsRouteDeps> = {}): ResearchRecommendationsRouteDeps {
   return {
     listMissions: async () => [],
     listSavedLinks: async () => [],
     listSavedXSources: async () => [],
+    listSessions: async () => [],
     hasXResearchCapability: async () => true,
     listVaultEntries: async () => [],
     ...overrides,
@@ -74,6 +91,7 @@ test("bounds every context source and returns only an ephemeral read-only projec
     listMissions: async () => Array.from({ length: 40 }, (_, index) => mission(`mission-${index}`)),
     listSavedLinks: async () => Array.from({ length: 40 }, (_, index) => savedLink(`link-${index}`)),
     listSavedXSources: async () => [],
+    listSessions: async () => Array.from({ length: 80 }, (_, index) => session(`session-${index}`)),
     listVaultEntries: async () => Array.from({ length: 40 }, (_, index) => ({
       id: `vault-${index}`,
       title: `Retrieval note ${index}`,
@@ -93,7 +111,22 @@ test("bounds every context source and returns only an ephemeral read-only projec
   assert.ok(body.context.savedLinks <= 12);
   assert.ok(body.context.xSources <= 12);
   assert.ok(body.context.vaultEntries <= 8);
+  assert.ok(body.context.sessions <= 24);
   assert.ok(body.recommendations.length <= 12);
+});
+
+test("grounds topic recommendations in the familiar-accessible Coven session history", async () => {
+  const route = createResearchRecommendationsRoute(baseDeps({
+    listSessions: async () => [session("collective-session")],
+  }));
+
+  const body = await (await route(request())).json();
+
+  assert.equal(body.context.sessions, 1);
+  assert.equal(body.recommendations[0].payload.topic, "Session topic collective-session");
+  assert.deepEqual(body.recommendations[0].evidenceRefs.map((ref: { id: string }) => ref.id), [
+    "session:collective-session",
+  ]);
 });
 
 test("keeps the most recently updated mission inside the bounded Desk snapshot", async () => {

--- a/src/app/api/research/recommendations/route.ts
+++ b/src/app/api/research/recommendations/route.ts
@@ -3,6 +3,7 @@ import {
   MAX_RESEARCH_TOPIC_MISSIONS,
   MAX_RESEARCH_TOPIC_SAVED_LINKS,
   MAX_RESEARCH_TOPIC_X_SOURCES,
+  MAX_RESEARCH_TOPIC_SESSIONS,
   recommendResearchTopics,
   researchTopicContextRevision,
 } from "../../../../lib/research-topic-recommendations.ts";
@@ -26,6 +27,7 @@ import { listSavedLinks } from "../../../../lib/server/research-links.ts";
 import { listSavedXSources, type SavedXSource } from "../../../../lib/server/x-sources.ts";
 import { hasXCapability } from "../../../../lib/server/x-access.ts";
 import { rejectNonLocalRequest } from "../../../../lib/server/api-security.ts";
+import type { SessionRow } from "../../../../lib/types.ts";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -36,6 +38,7 @@ export type ResearchRecommendationsRouteDeps = {
   listSavedXSources: (familiarId: string) => Promise<readonly SavedXSource[]>;
   hasXResearchCapability: (familiarId: string) => Promise<boolean>;
   listVaultEntries: (familiarId: string) => Promise<readonly KnowledgeEntry[]>;
+  listSessions: (familiarId: string) => Promise<readonly SessionRow[]>;
   diagnostics?: AgenticDiagnosticSink;
 };
 
@@ -45,6 +48,14 @@ const productionDeps: ResearchRecommendationsRouteDeps = {
   listSavedXSources,
   hasXResearchCapability: (familiarId) => hasXCapability(familiarId, "research"),
   listVaultEntries: async (familiarId) => selectKnowledgeForFamiliar(await listKnowledgeEntries(), familiarId),
+  listSessions: async (familiarId) => {
+    const { computeSessionsList } = await import("../../../../lib/server/sessions-list.ts");
+    const result = await computeSessionsList(false, familiarId, false, {
+      sweepArchives: false,
+      enrichGit: false,
+    });
+    return result.payload.sessions;
+  },
 };
 
 function recordResearchDiagnostic(
@@ -74,6 +85,15 @@ function boundedMissions(values: readonly ResearchMission[]): ResearchMission[] 
   return [...values]
     .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.id.localeCompare(right.id))
     .slice(0, MAX_RESEARCH_TOPIC_MISSIONS);
+}
+
+function boundedSessions(values: readonly SessionRow[]): SessionRow[] {
+  return [...values]
+    .filter((session) => !session.generated)
+    .sort((left, right) =>
+      right.updated_at.localeCompare(left.updated_at) || left.id.localeCompare(right.id)
+    )
+    .slice(0, MAX_RESEARCH_TOPIC_SESSIONS);
 }
 
 /**
@@ -135,11 +155,12 @@ export function createResearchRecommendationsRoute(deps: ResearchRecommendations
       return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
     }
 
-    const [missions, savedLinks, xSources, vault] = await Promise.all([
+    const [missions, savedLinks, xSources, vault, sessions] = await Promise.all([
       deps.listMissions(),
       deps.listSavedLinks(),
       readSavedXSourcesIfGranted(deps, familiarId),
       readVaultWithOneRetry(deps.listVaultEntries, familiarId, deps.diagnostics),
+      deps.listSessions(familiarId),
     ]);
     if (req.signal.aborted) return cancelled(deps.diagnostics);
 
@@ -151,6 +172,7 @@ export function createResearchRecommendationsRoute(deps: ResearchRecommendations
       savedLinks: bounded(savedLinks, MAX_RESEARCH_TOPIC_SAVED_LINKS),
       xSources: bounded(xSources, MAX_RESEARCH_TOPIC_X_SOURCES),
       vaultEntries: vault.entries,
+      sessions: boundedSessions(sessions),
       reducedContext: vault.reducedContext,
     };
     const revision = researchTopicContextRevision(recommendationContext);
@@ -163,7 +185,8 @@ export function createResearchRecommendationsRoute(deps: ResearchRecommendations
             recommendationContext.missions.length
             + recommendationContext.savedLinks.length
             + recommendationContext.xSources.length
-            + recommendationContext.vaultEntries.length,
+            + recommendationContext.vaultEntries.length
+            + recommendationContext.sessions.length,
         },
       });
       return NextResponse.json({

--- a/src/app/api/research/recommendations/route.ts
+++ b/src/app/api/research/recommendations/route.ts
@@ -49,12 +49,18 @@ const productionDeps: ResearchRecommendationsRouteDeps = {
   hasXResearchCapability: (familiarId) => hasXCapability(familiarId, "research"),
   listVaultEntries: async (familiarId) => selectKnowledgeForFamiliar(await listKnowledgeEntries(), familiarId),
   listSessions: async (familiarId) => {
-    const { computeSessionsList } = await import("../../../../lib/server/sessions-list.ts");
-    const result = await computeSessionsList(false, familiarId, false, {
-      sweepArchives: false,
-      enrichGit: false,
-    });
-    return result.payload.sessions;
+    const [{ computeSessionsList }, { sessionsListCache }] = await Promise.all([
+      import("../../../../lib/server/sessions-list.ts"),
+      import("../../../../lib/server/sessions-list-cache.ts"),
+    ]);
+    const cacheKey = `research-recommendations:sessions:active:${familiarId}`;
+    const result = await sessionsListCache.get(cacheKey, () =>
+      computeSessionsList(false, familiarId, false, {
+        sweepArchives: false,
+        enrichGit: false,
+      })
+    );
+    return result.payload.ok ? result.payload.sessions : [];
   },
 };
 

--- a/src/components/role-surfaces/research-tab-prompt.test.ts
+++ b/src/components/role-surfaces/research-tab-prompt.test.ts
@@ -232,6 +232,15 @@ test("inherited Codex defaults require the active local daemon launch policy", (
   assert.match(composer, /\}, \[familiarId, daemonRunning\]\);/);
 });
 
+test("agentic topic recommendations are always available and include Coven sessions", () => {
+  assert.doesNotMatch(promptTab, /caveAgenticRecommendations/);
+  assert.doesNotMatch(promptTab, /agenticRecommendationsEnabled\s*\?/);
+  assert.match(
+    promptTab,
+    /Grounded in collective Coven sessions, current missions, saved sources, and relevant Vault evidence\./,
+  );
+});
+
 // ── Quick saves: selected resources are part of the launch contract ──────────
 
 test("quick saves are included in mission creation before the run starts", () => {
@@ -267,7 +276,7 @@ test("quick saves support search-scoped bulk selection without losing hidden pic
 test("agentic topic recommendations keep client and server evidence freshness separate", () => {
   // The shared lifecycle sees durable client-visible Desk state only. The
   // composer draft remains absent, so ordinary typing never starts a request.
-  assert.match(promptTab, /caveAgenticRecommendations\(\)/);
+  assert.doesNotMatch(promptTab, /caveAgenticRecommendations/);
   assert.match(promptTab, /useAgenticRecommendations<ResearchRecommendationClientContext>/);
   assert.match(promptTab, /buildResearchRecommendationContext/);
   assert.match(recommendationContext, /MAX_CLIENT_RECOMMENDATION_MISSIONS = 12/);
@@ -278,7 +287,7 @@ test("agentic topic recommendations keep client and server evidence freshness se
   assert.match(recommendationContext, /mission\.artifacts/);
   assert.match(recommendationContext, /const bounded = value\.slice\(0, MAX_REVISION_TEXT_CHARS\)/);
   assert.doesNotMatch(recommendationContext, /intent: mission\.intent/);
-  assert.match(promptTab, /enabled: agenticRecommendationsEnabled/);
+  assert.match(promptTab, /enabled: !research\.loading && !links\.loading/);
   // The backend's fingerprint is the bounded revision for server-only X and
   // Vault evidence. It must survive transport and gate every explicit action.
   assert.match(promptTab, /serverContextFingerprint: body\.contextFingerprint/);

--- a/src/components/role-surfaces/research-tab-prompt.tsx
+++ b/src/components/role-surfaces/research-tab-prompt.tsx
@@ -35,7 +35,6 @@ import {
   type AgenticRecommendation,
   type RankedAgenticRecommendation,
 } from "@/lib/agentic-recommendations";
-import { caveAgenticRecommendations } from "@/lib/feature-flags";
 import { linkCategoryMeta, type SavedLinkSummary } from "@/lib/link-organizer";
 import {
   buildResearchRecommendationContext,
@@ -174,7 +173,6 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
   const [topicActionId, setTopicActionId] = useState<string | null>(null);
   const [topicActionError, setTopicActionError] = useState<string | null>(null);
   const [recommendationReducedContext, setRecommendationReducedContext] = useState(false);
-  const agenticRecommendationsEnabled = caveAgenticRecommendations();
   const serverRecommendationSnapshot = useRef<ResearchRecommendationSnapshot | null>(null);
   const revisionRequestRef = useRef<Promise<void> | null>(null);
   const draftRef = useRef(draft);
@@ -240,7 +238,7 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
 
   const agentic = useAgenticRecommendations<ResearchRecommendationClientContext>({
     context: recommendationContext,
-    enabled: agenticRecommendationsEnabled && !research.loading && !links.loading,
+    enabled: !research.loading && !links.loading,
     meaningfulContextKey: researchRecommendationContextKey,
     createRunId: () => `research-topics-${crypto.randomUUID()}`,
     parseOutput: parseResearchTopicRecommendations,
@@ -292,7 +290,7 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
   });
   const checkRecommendationRevision = useCallback(() => {
     if (revisionRequestRef.current) return revisionRequestRef.current;
-    if (!agenticRecommendationsEnabled || research.loading || links.loading) return Promise.resolve();
+    if (research.loading || links.loading) return Promise.resolve();
     const snapshot = serverRecommendationSnapshot.current;
     if (!snapshot || snapshot.clientContextKey !== recommendationContextKey) return Promise.resolve();
 
@@ -321,7 +319,6 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
     return request;
   }, [
     agentic,
-    agenticRecommendationsEnabled,
     context.activeFamiliar.id,
     links.loading,
     recommendationContextKey,
@@ -329,7 +326,6 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
   ]);
 
   useEffect(() => {
-    if (!agenticRecommendationsEnabled) return;
     const onForeground = () => {
       if (!document.hidden) void checkRecommendationRevision();
     };
@@ -339,7 +335,7 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
       window.removeEventListener("focus", onForeground);
       document.removeEventListener("visibilitychange", onForeground);
     };
-  }, [agenticRecommendationsEnabled, checkRecommendationRevision]);
+  }, [checkRecommendationRevision]);
 
   const recommendationItems = agentic.state.items
     .filter((item) => item.phase !== "dismissed")
@@ -475,21 +471,20 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
             }}
           />
 
-          {agenticRecommendationsEnabled ? (
-            <section
-              className="research-topic-recommendations"
-              aria-labelledby="research-topic-recommendations-heading"
-              onFocusCapture={(event) => {
-                if (didFocusEnterRecommendations(event)) {
-                  void checkRecommendationRevision();
-                }
-              }}
-            >
+          <section
+            className="research-topic-recommendations"
+            aria-labelledby="research-topic-recommendations-heading"
+            onFocusCapture={(event) => {
+              if (didFocusEnterRecommendations(event)) {
+                void checkRecommendationRevision();
+              }
+            }}
+          >
               <header className="research-topic-recommendations__header">
                 <div>
                   <p className="research-topic-recommendations__kicker">Contextual research</p>
                   <h3 id="research-topic-recommendations-heading">Suggested next topics</h3>
-                  <p>Grounded in current missions, saved sources, and relevant Vault evidence.</p>
+                  <p>Grounded in collective Coven sessions, current missions, saved sources, and relevant Vault evidence.</p>
                 </div>
                 <button
                   type="button"
@@ -556,8 +551,7 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode }
                   })}
                 </div>
               )}
-            </section>
-          ) : null}
+          </section>
         </div>
       </div>
 

--- a/src/lib/agentic-recommendations.test.ts
+++ b/src/lib/agentic-recommendations.test.ts
@@ -114,6 +114,7 @@ assert.deepEqual(AGENTIC_EVIDENCE_KINDS, [
   "mission",
   "saved-link",
   "vault",
+  "session",
   "message",
   "artifact",
 ]);

--- a/src/lib/agentic-recommendations.ts
+++ b/src/lib/agentic-recommendations.ts
@@ -10,6 +10,7 @@ export const AGENTIC_EVIDENCE_KINDS = [
   "mission",
   "saved-link",
   "vault",
+  "session",
   "message",
   "artifact",
 ] as const;

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -13,8 +13,8 @@ export function caveCrafts(): boolean {
   return envFlag(process.env.NEXT_PUBLIC_CAVE_CRAFTS);
 }
 
-/** Agentic Board and Research recommendations stay gated while legacy Chat
- * Enhance remains available independently. */
+/** Agentic Board recommendations stay gated while Research topic assistance
+ * and legacy Chat Enhance remain available independently. */
 export function caveAgenticRecommendations(): boolean {
   return envFlag(process.env.NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS);
 }

--- a/src/lib/research-topic-recommendations.test.ts
+++ b/src/lib/research-topic-recommendations.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./research-topic-recommendations.ts";
 import type { KnowledgeEntry } from "./server/knowledge-vault.ts";
 import type { SavedXSource } from "./server/x-sources.ts";
+import type { SessionRow } from "./types.ts";
 
 function mission(
   id: string,
@@ -66,6 +67,21 @@ function vaultEntry(id: string, title: string, body: string): KnowledgeEntry {
   };
 }
 
+function session(id: string, title: string): SessionRow {
+  return {
+    id,
+    title,
+    project_root: "/tmp/coven",
+    harness: "copilot",
+    status: "completed",
+    exit_code: 0,
+    archived_at: null,
+    created_at: "2026-08-19T09:00:00.000Z",
+    updated_at: "2026-08-19T10:00:00.000Z",
+    attention: { state: "none", since: null, reason: null },
+  };
+}
+
 function context(
   overrides: Partial<ResearchTopicRecommendationContext> = {},
 ): ResearchTopicRecommendationContext {
@@ -75,10 +91,22 @@ function context(
     savedLinks: [],
     xSources: [],
     vaultEntries: [],
+    sessions: [],
     reducedContext: false,
     ...overrides,
   };
 }
+
+test("proposes a new topic from collective Coven session history", () => {
+  const result = recommendResearchTopics(context({
+    sessions: [session("session-1", "Evaluate durable agent memory architectures")],
+  }));
+
+  assert.equal(result.recommendations[0]?.payload.recommendationKind, "start-mission");
+  assert.equal(result.recommendations[0]?.payload.topic, "Evaluate durable agent memory architectures");
+  assert.deepEqual(result.recommendations[0]?.evidenceRefs.map((ref) => ref.id), ["session:session-1"]);
+  assert.equal(result.context.sessions, 1);
+});
 
 test("returns no fallback topics without resolved Research Desk or Vault evidence", () => {
   const result = recommendResearchTopics(context());

--- a/src/lib/research-topic-recommendations.ts
+++ b/src/lib/research-topic-recommendations.ts
@@ -13,12 +13,14 @@ import { allowedResearchActions, type ResearchMission } from "./research-mission
 import { containsSecretText } from "./secret-redaction.ts";
 import type { KnowledgeEntry } from "./server/knowledge-vault.ts";
 import type { SavedXSource } from "./server/x-sources.ts";
+import type { SessionRow } from "./types.ts";
 
 export const MAX_RESEARCH_TOPIC_RECOMMENDATIONS = 12;
 export const MAX_RESEARCH_TOPIC_MISSIONS = 12;
 export const MAX_RESEARCH_TOPIC_SAVED_LINKS = 12;
 export const MAX_RESEARCH_TOPIC_X_SOURCES = 12;
 export const MAX_RESEARCH_TOPIC_VAULT_ENTRIES = 8;
+export const MAX_RESEARCH_TOPIC_SESSIONS = 24;
 
 export type ResearchRecommendationKind =
   | "start-mission"
@@ -42,6 +44,7 @@ export type ResearchTopicRecommendationContext = {
   savedLinks: readonly SavedLink[];
   xSources: readonly SavedXSource[];
   vaultEntries: readonly KnowledgeEntry[];
+  sessions: readonly SessionRow[];
   /**
    * True only when the route could not retrieve the optional Vault snapshot.
    * Desk evidence remains usable and every returned card labels this limitation.
@@ -58,6 +61,7 @@ export type ResearchTopicRecommendationResult = {
     savedLinks: number;
     xSources: number;
     vaultEntries: number;
+    sessions: number;
   };
 };
 
@@ -69,6 +73,7 @@ export type ResearchTopicContextRevision = {
     savedLinks: number;
     xSources: number;
     vaultEntries: number;
+    sessions: number;
   };
 };
 
@@ -104,12 +109,19 @@ type SafeVaultEntry = {
   modified: string;
 };
 
+type SafeSession = {
+  id: string;
+  title: string;
+  updatedAt: string;
+};
+
 type SafeContext = {
   familiarId: string;
   missions: SafeMission[];
   savedLinks: SafeSavedLink[];
   xSources: SafeXSource[];
   vaultEntries: SafeVaultEntry[];
+  sessions: SafeSession[];
   reducedContext: boolean;
 };
 
@@ -299,6 +311,7 @@ function safeVaultEntries(entries: readonly KnowledgeEntry[]): SafeVaultEntry[] 
       ) {
         return null;
       }
+
       return {
         id,
         collection,
@@ -312,17 +325,32 @@ function safeVaultEntries(entries: readonly KnowledgeEntry[]): SafeVaultEntry[] 
     .sort((left, right) => left.id.localeCompare(right.id));
 }
 
+function safeSessions(sessions: readonly SessionRow[]): SafeSession[] {
+  return sessions
+    .map((session) => {
+      const id = safeRecordId(session.id);
+      const title = safeText(session.title);
+      if (!id || !title) return null;
+      return { id, title, updatedAt: safeText(session.updated_at, 64) ?? "" };
+    })
+    .filter((session): session is SafeSession => session !== null)
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.id.localeCompare(right.id))
+    .slice(0, MAX_RESEARCH_TOPIC_SESSIONS);
+}
+
 function toSafeContext(context: ResearchTopicRecommendationContext): SafeContext {
   const missions = safeMissions(context.missions);
   const savedLinks = safeSavedLinks(context.savedLinks);
   const xSources = safeXSources(context.xSources);
-  const topicTokens = researchTopicTokens({ missions, savedLinks, xSources });
+  const sessions = safeSessions(context.sessions);
+  const topicTokens = researchTopicTokens({ missions, savedLinks, xSources, sessions });
   return {
     familiarId: safeRecordId(context.familiarId) ?? "research",
     missions,
     savedLinks,
     xSources,
     vaultEntries: relevantVaultEntries(safeVaultEntries(context.vaultEntries), topicTokens),
+    sessions,
     reducedContext: context.reducedContext === true,
   };
 }
@@ -412,11 +440,14 @@ function vaultRelevance(entry: SafeVaultEntry, topicTokens: readonly string[]): 
   return topicTokens.reduce((score, token) => score + (searchable.has(token) ? 1 : 0), 0);
 }
 
-function researchTopicTokens(context: Pick<SafeContext, "missions" | "savedLinks" | "xSources">): string[] {
+function researchTopicTokens(
+  context: Pick<SafeContext, "missions" | "savedLinks" | "xSources" | "sessions">,
+): string[] {
   return tokenize([
     ...context.missions.map((mission) => `${mission.title} ${mission.intent}`),
     ...context.savedLinks.map((link) => link.title),
     ...context.xSources.map((source) => source.note),
+    ...context.sessions.map((session) => session.title),
   ].join(" "));
 }
 
@@ -481,6 +512,11 @@ function fingerprintContext(context: SafeContext): Record<string, unknown> {
       entry.modified,
       stableHash(`${entry.title}\0${entry.tags.join("\0")}\0${entry.body}`),
     ]),
+    sessions: context.sessions.map((session) => [
+      session.id,
+      session.updatedAt,
+      stableHash(session.title),
+    ]),
     reducedContext: context.reducedContext,
   };
 }
@@ -494,6 +530,7 @@ function contextRevision(context: SafeContext): ResearchTopicContextRevision {
       savedLinks: context.savedLinks.length,
       xSources: context.xSources.length,
       vaultEntries: context.vaultEntries.length,
+      sessions: context.sessions.length,
     },
   };
 }
@@ -674,6 +711,36 @@ export function recommendResearchTopics(
       evidenceRefs: [
         ...(existing ? [evidence(existing.id, "mission", existing.title)] : []),
         evidence(entry.id, "vault", entry.title),
+      ],
+    }));
+  }
+
+  for (const session of context.sessions) {
+    const action = topicMissionAction(context.missions, session.title);
+    const existing = action.target;
+    candidates.push(candidate(fingerprint, context.reducedContext, {
+      key: `session:${session.id}`,
+      priority: existing ? 3 : 6,
+      recommendationKind: action.kind,
+      topic: existing?.title ?? session.title,
+      ...(existing ? { targetMissionId: existing.id } : { sourceId: session.id }),
+      rationale: action.kind === "refine-mission"
+        ? `This Coven session matches active mission "${existing!.title}", so it can refine that work without starting a duplicate.`
+        : action.kind === "review-mission"
+          ? `This Coven session matches "${existing!.title}", which should be reviewed before starting duplicate research.`
+          : "This recent Coven session identifies a concrete topic that has not yet become durable research.",
+      inferredGoal: existing
+        ? `Build on the collective session history for ${existing.title}.`
+        : `Turn the session "${session.title}" into durable, evidence-backed knowledge.`,
+      rankReasons: [
+        existing
+          ? "Connects collective Coven session history to existing Research Desk work."
+          : "Grounded in collective Coven session history that is not yet represented by a mission.",
+        "Ranks after active evidence gaps and saved durable sources.",
+      ],
+      evidenceRefs: [
+        ...(existing ? [evidence(existing.id, "mission", existing.title)] : []),
+        evidence(session.id, "session", session.title),
       ],
     }));
   }

--- a/src/lib/server/research-links.test.ts
+++ b/src/lib/server/research-links.test.ts
@@ -28,11 +28,16 @@ const {
   listSavedLinks,
   listSavedLinkSummaries,
   MAX_LINKS_PER_SAVE,
+  MAX_SAVED_LINKS,
   removeSavedLink,
   reserveXArticleCandidates,
   saveResearchLinks,
   toSavedLinkSummary,
 } = await import("./research-links.ts");
+
+test("saved Research resources retain a 10,000-item searchable catalog", () => {
+  assert.equal(MAX_SAVED_LINKS, 10_000);
+});
 
 const STORE_PATH = () => process.env.CAVE_RESEARCH_LINKS_PATH_OVERRIDE!;
 const ARTICLE_URL = "https://x.com/OpenCoven/status/123456789";

--- a/src/lib/server/research-links.ts
+++ b/src/lib/server/research-links.ts
@@ -44,7 +44,7 @@ import { xArticleContentSha256 } from "./x-article-content-sha.ts";
 
 export { MAX_LINKS_PER_SAVE };
 
-export const MAX_SAVED_LINKS = 500;
+export const MAX_SAVED_LINKS = 10_000;
 
 type UnknownRecord = Record<string, unknown>;
 

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -1,9 +1,5 @@
 import { expect, test, type Page, type Route } from "@playwright/test";
 
-const agenticRecommendationsEnabled = ["1", "true", "yes", "on"].includes(
-  process.env.NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS?.trim().toLowerCase() ?? "",
-);
-
 // Research Desk five-tab surface (cave-dl74) — Prompt / Desk / Library /
 // Studio / Resources inside the researcher role room (surface:researcher-desk).
 //
@@ -1358,19 +1354,7 @@ test.describe("research desk tabs", () => {
     await expect(intake.getByText("1 ready for the first pass")).toBeVisible();
   });
 
-  test("keeps Research recommendations hidden and idle when the capability is disabled", async ({ page }) => {
-    test.skip(agenticRecommendationsEnabled, "this behavioral gate runs in the disabled capability build");
-    const handles = await openResearchDesk(page);
-
-    await deskTab(page, /^Prompt/).click();
-    await expect(page.getByRole("heading", { name: "Suggested next topics" })).toHaveCount(0);
-    await page.waitForTimeout(1_200);
-    expect(handles.recommendationRequests).toBe(0);
-  });
-
   test.describe("agentic topic recommendations", () => {
-    test.skip(!agenticRecommendationsEnabled, "run with NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS=1");
-
     test("grounds next topics in Desk evidence, ignores prompt typing, and only starts after activation", async ({ page }) => {
       const handles = await openResearchDesk(page);
       handles.recommendationResponse = {


### PR DESCRIPTION
## Summary
- raise the durable Research resource catalog ceiling from 500 to 10,000 while keeping all saved resources searchable
- make contextual topic assistance available by default instead of hiding it behind the Board recommendation feature flag
- ground recommendations in up to 24 recent, familiar-accessible Coven sessions alongside missions, saved sources, X sources, and Vault evidence
- keep recommendations reviewable, evidence-resolved, permission-scoped, and duplicate-aware

## Verification
- focused Research resource, recommendation, route, and prompt tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm build`

Bead: `cave-inz91`
