### PR TITLE
Project cron runs into Day, Week and Month calendar views (cave-aa10e)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -746,6 +746,7 @@ export const SUITES = {
     "src/components/calendar-agenda-redesign.test.ts",
     "src/lib/calendar-layout.test.ts",
     "src/lib/calendar-cron-projection.test.ts",
+  "src/lib/calendar-run-density.test.ts",
     "src/components/calendar-overflow-pill.test.ts",
     "src/lib/canvas-layout.test.ts",
     "src/lib/canvas-gallery.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -746,7 +746,7 @@ export const SUITES = {
     "src/components/calendar-agenda-redesign.test.ts",
     "src/lib/calendar-layout.test.ts",
     "src/lib/calendar-cron-projection.test.ts",
-  "src/lib/calendar-run-density.test.ts",
+    "src/lib/calendar-run-density.test.ts",
     "src/components/calendar-overflow-pill.test.ts",
     "src/lib/canvas-layout.test.ts",
     "src/lib/canvas-gallery.test.ts",

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -691,7 +691,6 @@ function TimeGrid({
                   key={cluster.minutes}
                   className="cal-run-mark"
                   style={{ top: (cluster.minutes / 60) * HOUR_HEIGHT }}
-                  title={`${fmtTime(first.atIso)} · ${names} (projected)`}
                 >
                   <span className="sr-only">
                     {cluster.runs.length === 1 ? "Projected run" : `${cluster.runs.length} projected runs`},{" "}
@@ -1769,7 +1768,14 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
     // the month contains, or the trailing cells render empty.
     else if (effectiveView === "month") end.setDate(end.getDate() + 42);
     else end.setDate(end.getDate() + 14); // the fortnight the agenda renders
-    return projectCronRuns(cronAutomations, start.getTime(), end.getTime());
+    // projectCronRuns treats its window as INCLUSIVE of the end instant
+    // (walkWindow returns on `t > endMs`), while every end computed above is an
+    // exclusive midnight boundary. Without the -1 a cron firing at exactly
+    // 00:00 the next day joins this window: the per-day filters keep it from
+    // being drawn, but projectionSummary still counts its cron, so the footer
+    // overstates what the view shows — the exact dishonesty PROJECTING_VIEWS
+    // exists to prevent.
+    return projectCronRuns(cronAutomations, start.getTime(), end.getTime() - 1);
   }, [showRuns, cronAutomations, anchor, effectiveView]);
 
   const projectionNote = projectionSummary(projection);

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import "@/styles/calendar.css";
-import { RUN_DENSITY_MAX_LEVEL, runCountLabel, runCountOn, runDensityBands } from "@/lib/calendar-run-density";
+import {
+  RUN_DENSITY_MAX_LEVEL,
+  clusterLabel,
+  clusterRunsByMinute,
+  runCountLabel,
+  runCountOn,
+  runDensityBands,
+} from "@/lib/calendar-run-density";
 
 import { useCallback, useContext, useId, useMemo, useState, useRef, useEffect, type SetStateAction } from "react";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -676,22 +683,22 @@ function TimeGrid({
                 point in time and AutomationRunRecord records no duration; a
                 block would imply one. Outside the lane packer for the same
                 reason, so a forecast never displaces a real event. */}
-            {(col.projectedRuns ?? []).map((run) => {
-              const at = new Date(run.atIso);
-              if (Number.isNaN(at.getTime())) return null;
-              const mins = at.getHours() * 60 + at.getMinutes();
+            {clusterRunsByMinute(col.projectedRuns ?? [], col.date).map((cluster) => {
+              const first = cluster.runs[0];
+              const names = cluster.runs.map((r) => r.name).join(", ");
               return (
                 <div
-                  key={`${run.automationId}-${run.atIso}`}
+                  key={cluster.minutes}
                   className="cal-run-mark"
-                  style={{ top: (mins / 60) * HOUR_HEIGHT }}
-                  title={`${fmtTime(run.atIso)} · ${run.name} (projected)`}
+                  style={{ top: (cluster.minutes / 60) * HOUR_HEIGHT }}
+                  title={`${fmtTime(first.atIso)} · ${names} (projected)`}
                 >
                   <span className="sr-only">
-                    Projected run, {run.name}, {fmtTime(run.atIso)}
+                    {cluster.runs.length === 1 ? "Projected run" : `${cluster.runs.length} projected runs`},{" "}
+                    {names}, {fmtTime(first.atIso)}
                   </span>
                   <span aria-hidden className="cal-run-mark__tick" />
-                  <span aria-hidden className="cal-run-mark__label">{run.name}</span>
+                  <span aria-hidden className="cal-run-mark__label">{clusterLabel(cluster)}</span>
                 </div>
               );
             })}
@@ -1980,7 +1987,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
 
         {/* Only offered when there is something to project. A dead toggle
             teaches a reader to ignore part of the toolbar. */}
-        {effectiveView === "agenda" && cronAutomations.some((a) => a.status === "ACTIVE") ? (
+        {PROJECTING_VIEWS.has(effectiveView) && cronAutomations.some((a) => a.status === "ACTIVE") ? (
           <Button
             variant="ghost"
             size="sm"

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import "@/styles/calendar.css";
+import { RUN_DENSITY_MAX_LEVEL, runCountLabel, runCountOn, runDensityBands } from "@/lib/calendar-run-density";
 
 import { useCallback, useContext, useId, useMemo, useState, useRef, useEffect, type SetStateAction } from "react";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -62,6 +63,15 @@ export type { CalendarDeadline } from "./calendar-view-primitives";
 
 
 // ─── Agenda view ──────────────────────────────────────────────────────────────
+
+/**
+ * Views that render projected cron runs.
+ *
+ * Membership is a promise that the view DRAWS them — the footer note and the
+ * "ritual runs" toggle both key off this, so adding a view here without a
+ * renderer makes the surface claim a projection it does not show.
+ */
+const PROJECTING_VIEWS = new Set<ViewMode>(["agenda", "day", "week", "month"]);
 
 function AgendaView({
   items,
@@ -264,6 +274,85 @@ function AgendaView({
 
 const MAX_ALLDAY_VISIBLE = 3;
 
+/**
+ * Per-day cron density for the Week view.
+ *
+ * Week uses a scrolling 24h TimeGrid, so it cannot pin a summary to the bottom
+ * of a day column the way the frame's simpler column list does. This is the
+ * same idea in this layout's terms: a fixed band, aligned to the day columns,
+ * that answers WHEN a day's load falls rather than listing it.
+ *
+ * Six four-hour bands rather than a per-run marker, deliberately. Seven columns
+ * of individual ticks is noise at this width, and the frame chose the strip for
+ * exactly that reason. Day view still draws each run individually, where there
+ * is room for it.
+ */
+function RunDensityStrip({
+  columns,
+  onOpenDay,
+}: {
+  columns: { date: Date; runs: readonly ProjectedCronRun[] }[];
+  onOpenDay?: (day: Date) => void;
+}) {
+  // Nothing projected anywhere in the week — draw no band at all rather than a
+  // row of empty axes, which would read as "measured zero" instead of "off".
+  if (!columns.some((c) => c.runs.length > 0)) return null;
+
+  return (
+    <div className="flex shrink-0 overflow-x-auto border-b border-[var(--border-hairline)] bg-[var(--bg-panel)]">
+      <div className="sticky left-0 z-10 flex w-12 shrink-0 items-center justify-end border-r border-[var(--border-hairline)] bg-[var(--bg-panel)] py-1 pr-1.5">
+        <span className="text-[length:var(--text-2xs)] uppercase tracking-wider text-[var(--text-secondary)] leading-tight text-right">
+          Ritual
+          <br />
+          runs
+        </span>
+      </div>
+      <div className="flex flex-1 min-w-[560px] divide-x divide-[var(--border-hairline)]">
+        {columns.map((col, i) => {
+          const bands = runDensityBands(col.runs, col.date);
+          const count = runCountOn(col.runs, col.date);
+          const label = runCountLabel(count, "ritual runs");
+          if (!label) return <div key={i} className="flex-1 min-w-[80px] p-1" />;
+          const Cell = onOpenDay ? "button" : "div";
+          return (
+            <div key={i} className="flex-1 min-w-[80px] p-1">
+              <Cell
+                {...(onOpenDay
+                  ? {
+                      type: "button" as const,
+                      onClick: () => onOpenDay(col.date),
+                      "aria-label": `${label} on ${fmtDateHeading(col.date)} — open day`,
+                    }
+                  : {})}
+                className={`cal-run-density ${onOpenDay ? "cal-run-density--action focus-ring" : ""}`}
+              >
+                <span className="cal-run-density__bands">
+                  {bands.map((b) => (
+                    <span
+                      key={b.startHour}
+                      role="img"
+                      aria-label={b.label}
+                      title={b.label}
+                      data-level={b.level}
+                      className="cal-run-density__band"
+                    />
+                  ))}
+                </span>
+                <span aria-hidden className="cal-run-density__axis">
+                  <span>00</span>
+                  <span>12</span>
+                  <span>20</span>
+                </span>
+                <span aria-hidden className="cal-run-density__label">{label}</span>
+              </Cell>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function AllDayStrip({
   columns,
   onOpenItem,
@@ -445,7 +534,7 @@ function TimeGrid({
   onReschedule,
   maxLanes = WEEK_MAX_LANES,
 }: {
-  columns: { label: string; date: Date; items: InboxItem[] }[];
+  columns: { label: string; date: Date; items: InboxItem[]; projectedRuns?: readonly ProjectedCronRun[] }[];
   onOpenItem?: (item: InboxItem) => void;
   onAddEntry?: (defaults?: { fireAt?: string; title?: string; whenText?: string }) => void;
   onReschedule?: (id: string, fireAtIso: string) => void;
@@ -581,6 +670,31 @@ function TimeGrid({
                 style={{ top: h * HOUR_HEIGHT }}
               />
             ))}
+
+            {/* Projected cron runs — a forecast, not a scheduled item.
+                Drawn as instants rather than blocks because a cron fires at a
+                point in time and AutomationRunRecord records no duration; a
+                block would imply one. Outside the lane packer for the same
+                reason, so a forecast never displaces a real event. */}
+            {(col.projectedRuns ?? []).map((run) => {
+              const at = new Date(run.atIso);
+              if (Number.isNaN(at.getTime())) return null;
+              const mins = at.getHours() * 60 + at.getMinutes();
+              return (
+                <div
+                  key={`${run.automationId}-${run.atIso}`}
+                  className="cal-run-mark"
+                  style={{ top: (mins / 60) * HOUR_HEIGHT }}
+                  title={`${fmtTime(run.atIso)} · ${run.name} (projected)`}
+                >
+                  <span className="sr-only">
+                    Projected run, {run.name}, {fmtTime(run.atIso)}
+                  </span>
+                  <span aria-hidden className="cal-run-mark__tick" />
+                  <span aria-hidden className="cal-run-mark__label">{run.name}</span>
+                </div>
+              );
+            })}
 
             {/* Current time indicator (today's column only, once `now` resolves) */}
             {now && isSameDay(col.date, now) && (
@@ -744,6 +858,7 @@ function minutesToIso(day: Date, minutes: number): string {
 function DayView({
   items,
   deadlines,
+  projectedRuns,
   anchor,
   onAddEntry,
   onOpenItem,
@@ -752,6 +867,8 @@ function DayView({
 }: {
   items: InboxItem[];
   deadlines?: CalendarDeadline[];
+  /** Cron occurrences projected onto this day — see calendar-cron-projection. */
+  projectedRuns?: readonly ProjectedCronRun[];
   anchor: Date;
   onAddEntry?: (defaults?: { fireAt?: string; title?: string; whenText?: string }) => void;
   onOpenItem?: (item: InboxItem) => void;
@@ -787,11 +904,20 @@ function DayView({
   // `isToday` is derived inside TimeGrid from its own clock, so the 60s
   // now-tick never invalidates this memo (which would otherwise re-pack the
   // column every minute).
+  const dayRuns = useMemo(
+    () => (projectedRuns ?? []).filter((r) => {
+      const d = new Date(r.atIso);
+      return !Number.isNaN(d.getTime()) && isSameDay(d, anchor);
+    }),
+    [projectedRuns, anchor],
+  );
+
   const columns = useMemo(() => [{
     label: fmtDateHeading(anchor),
     date: anchor,
     items: timedItems,
-  }], [anchor, timedItems]);
+    projectedRuns: dayRuns,
+  }], [anchor, timedItems, dayRuns]);
 
   const rel = now ? relDayWord(anchor, now) : null;
 
@@ -834,6 +960,7 @@ function DayView({
 function WeekView({
   items,
   deadlines,
+  projectedRuns,
   anchor,
   onAddEntry,
   onOpenItem,
@@ -843,6 +970,8 @@ function WeekView({
 }: {
   items: InboxItem[];
   deadlines?: CalendarDeadline[];
+  /** Cron occurrences projected onto this week — see calendar-cron-projection. */
+  projectedRuns?: readonly ProjectedCronRun[];
   anchor: Date;
   onAddEntry?: (defaults?: { fireAt?: string; title?: string; whenText?: string }) => void;
   onOpenItem?: (item: InboxItem) => void;
@@ -885,6 +1014,11 @@ function WeekView({
       }),
     }));
   }, [items, days]);
+
+  const densityColumns = useMemo(
+    () => days.map((day) => ({ date: day, runs: projectedRuns ?? [] })),
+    [days, projectedRuns],
+  );
 
   const deadlineColumns = useMemo(() => {
     return days.map((day) => ({
@@ -946,6 +1080,10 @@ function WeekView({
       {allDayColumns.some((c) => c.items.length > 0) && (
         <AllDayStrip columns={allDayColumns} onOpenItem={onOpenItem} onMore={onOpenDay} />
       )}
+      {/* Cron density — a forecast band, above the grid so it does not scroll
+          away from the columns it describes. Self-guards: renders nothing when
+          the week has no projected runs. */}
+      <RunDensityStrip columns={densityColumns} onOpenDay={onOpenDay} />
       <div className="relative flex flex-1 overflow-hidden">
         <TimeGrid columns={columns} onOpenItem={onOpenItem} onAddEntry={onAddEntry} onReschedule={onReschedule} />
       </div>
@@ -958,6 +1096,7 @@ function WeekView({
 function MonthView({
   items,
   deadlines,
+  projectedRuns,
   anchor,
   onOpenItem,
   onDayClick,
@@ -966,6 +1105,8 @@ function MonthView({
 }: {
   items: InboxItem[];
   deadlines?: CalendarDeadline[];
+  /** Cron occurrences projected onto this grid — see calendar-cron-projection. */
+  projectedRuns?: readonly ProjectedCronRun[];
   anchor: Date;
   onOpenItem?: (item: InboxItem) => void;
   onDayClick?: (day: Date) => void;
@@ -1168,6 +1309,25 @@ function MonthView({
                         +{dayItems.length - 3} more
                       </button>
                     )}
+                    {/* Projected cron runs. A count, not a list — a month cell
+                        has no room for one row per run, and the bar is neutral
+                        because none of these have happened yet. */}
+                    {(() => {
+                      const runs = runCountOn(projectedRuns ?? [], day);
+                      const label = runCountLabel(runs);
+                      if (!label) return null;
+                      return (
+                        <span className="cal-month-runs" title={`${label} projected`}>
+                          <Icon name="ph:clock" width={10} height={10} aria-hidden />
+                          <span>{label}</span>
+                          <span
+                            aria-hidden
+                            className="cal-month-runs__bar"
+                            data-level={Math.min(runs, RUN_DENSITY_MAX_LEVEL)}
+                          />
+                        </span>
+                      );
+                    })()}
                   </div>
                 </div>
               );
@@ -1581,18 +1741,27 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
   // The window the current view actually shows, so a month view projects a
   // month and an agenda projects the fortnight it renders — projecting a fixed
   // span would either under-fill the month or over-compute the agenda.
-  // Agenda only, for now. Day/Week/Month do not draw projected runs yet, and a
-  // footer claiming "13 active crons project onto this calendar" over a view
-  // that renders none of them is the surface lying about itself — caught by
-  // driving it: the default view is Week, where the note appeared over zero
-  // rows. Extending the projection to the other three is cave-9f3i3 follow-up.
+  //
+  // Every view in PROJECTING_VIEWS must actually DRAW the runs. The guard is
+  // not tidiness: while it was absent, the footer read "13 active crons project
+  // onto this calendar" over a Week view rendering none of them, which is the
+  // surface lying about itself. Widen this only alongside a renderer.
   const projection: CronProjection = useMemo(() => {
-    if (!showRuns || effectiveView !== "agenda" || cronAutomations.length === 0) {
+    if (!showRuns || !PROJECTING_VIEWS.has(effectiveView) || cronAutomations.length === 0) {
       return { runs: [], projectedCount: 0, truncated: false };
     }
-    const start = startOfDay(anchor);
+    const start =
+      effectiveView === "month" ? startOfWeek(startOfMonth(anchor))
+      : effectiveView === "week" ? startOfWeek(anchor)
+      : startOfDay(anchor);
     const end = new Date(start);
-    end.setDate(end.getDate() + 14); // the fortnight the agenda renders
+    if (effectiveView === "day") end.setDate(end.getDate() + 1);
+    else if (effectiveView === "week") end.setDate(end.getDate() + 7);
+    // The month grid is 6 weeks from the start of the week containing the 1st,
+    // so it shows more than the month itself — project what is drawn, not what
+    // the month contains, or the trailing cells render empty.
+    else if (effectiveView === "month") end.setDate(end.getDate() + 42);
+    else end.setDate(end.getDate() + 14); // the fortnight the agenda renders
     return projectCronRuns(cronAutomations, start.getTime(), end.getTime());
   }, [showRuns, cronAutomations, anchor, effectiveView]);
 
@@ -1878,6 +2047,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
           <DayView
             items={scopedItems}
             deadlines={scopedDeadlines}
+            projectedRuns={projection.runs}
             anchor={anchor}
             onAddEntry={onAddEntry}
             onReschedule={onReschedule}
@@ -1888,6 +2058,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
         {effectiveView === "week" && (
           <WeekView
             items={scopedItems}
+            projectedRuns={projection.runs}
             deadlines={scopedDeadlines}
             anchor={anchor}
             onAddEntry={onAddEntry}
@@ -1900,6 +2071,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
         {effectiveView === "month" && (
           <MonthView
             items={scopedItems}
+            projectedRuns={projection.runs}
             deadlines={scopedDeadlines}
             anchor={anchor}
             onOpenItem={(item) => setSelectedItem(item)}

--- a/src/lib/calendar-cron-projection.test.ts
+++ b/src/lib/calendar-cron-projection.test.ts
@@ -135,3 +135,33 @@ describe("projection chrome contract", () => {
     assert.equal(projectionSummary({ runs: [], projectedCount: 0, truncated: false }), null);
   });
 });
+
+describe("window boundaries", () => {
+  // calendar-view computes each view's end as an EXCLUSIVE midnight (day +1,
+  // week +7, month +42) and subtracts a millisecond before calling this. That
+  // subtraction is only correct while the window here stays inclusive of
+  // `endMs`, so pin both halves of the contract: if walkWindow is ever changed
+  // to exclude the end instant, the -1 in calendar-view silently starts
+  // dropping a real 23:59:59.999 occurrence and this test says so.
+  const daily = [cron("c1", "FREQ=DAILY;BYHOUR=0;BYMINUTE=0")];
+  const dayStart = new Date(2026, 7, 25).getTime();
+  const nextMidnight = new Date(2026, 7, 26).getTime();
+
+  it("includes an occurrence landing exactly on endMs", () => {
+    const runs = projectCronRuns(daily, dayStart, nextMidnight).runs;
+    assert.equal(runs.length, 2, "today's midnight and the next one");
+  });
+
+  it("excludes the next midnight when the caller subtracts a millisecond", () => {
+    // This is exactly what calendar-view does, and why: without it the footer
+    // counts a cron whose only run in range belongs to the next view.
+    const runs = projectCronRuns(daily, dayStart, nextMidnight - 1).runs;
+    assert.equal(runs.length, 1);
+    assert.equal(new Date(runs[0].atIso).getDate(), 25);
+  });
+
+  it("still includes an occurrence at the very start of the window", () => {
+    const runs = projectCronRuns(daily, dayStart, nextMidnight - 1).runs;
+    assert.equal(new Date(runs[0].atIso).getTime(), dayStart);
+  });
+});

--- a/src/lib/calendar-run-density.test.ts
+++ b/src/lib/calendar-run-density.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { ProjectedCronRun } from "./calendar-cron-projection.ts";
+import {
+  RUN_DENSITY_BANDS,
+  RUN_DENSITY_MAX_LEVEL,
+  runCountLabel,
+  runCountOn,
+  runDensityBands,
+} from "./calendar-run-density.ts";
+
+const DAY = new Date(2026, 7, 25); // 25 Aug 2026, local
+
+/** Local-time run on DAY at `hour`. Local on purpose — the calendar is local. */
+function at(hour: number, minute = 0, over: Partial<ProjectedCronRun> = {}): ProjectedCronRun {
+  return {
+    automationId: "a1",
+    name: "Daily brief",
+    atIso: new Date(2026, 7, 25, hour, minute).toISOString(),
+    ...over,
+  };
+}
+
+describe("runDensityBands", () => {
+  it("always returns all six bands so the axis does not slide", () => {
+    const bands = runDensityBands([], DAY);
+    assert.equal(bands.length, RUN_DENSITY_BANDS);
+    assert.deepEqual(
+      bands.map((b) => b.startHour),
+      [0, 4, 8, 12, 16, 20],
+    );
+    assert.ok(bands.every((b) => b.count === 0 && b.level === 0));
+  });
+
+  it("buckets a run into its four-hour window", () => {
+    const bands = runDensityBands([at(9)], DAY);
+    assert.equal(bands[2].startHour, 8);
+    assert.equal(bands[2].count, 1);
+    assert.equal(bands.reduce((n, b) => n + b.count, 0), 1, "counted exactly once");
+  });
+
+  it("puts a run exactly on a boundary in the later band, not both", () => {
+    // 12:00 belongs to 12:00–16:00. A half-open interval is the only way the
+    // total stays equal to the number of runs.
+    const bands = runDensityBands([at(12)], DAY);
+    assert.equal(bands[2].count, 0, "not in 08:00–12:00");
+    assert.equal(bands[3].count, 1, "in 12:00–16:00");
+  });
+
+  it("keeps the last hour of the day inside the final band", () => {
+    const bands = runDensityBands([at(23, 59)], DAY);
+    assert.equal(bands[5].count, 1);
+  });
+
+  it("clamps level so one busy bucket cannot flatten the rest", () => {
+    const many = Array.from({ length: 12 }, () => at(9));
+    const bands = runDensityBands(many, DAY);
+    assert.equal(bands[2].count, 12, "the true count is preserved");
+    assert.equal(bands[2].level, RUN_DENSITY_MAX_LEVEL, "the drawn level is clamped");
+  });
+
+  it("ignores runs from other days and unparseable instants", () => {
+    const other = { ...at(9), atIso: new Date(2026, 7, 26, 9).toISOString() };
+    const bad = { ...at(9), atIso: "not-a-date" };
+    const bands = runDensityBands([at(9), other, bad], DAY);
+    assert.equal(bands.reduce((n, b) => n + b.count, 0), 1);
+  });
+
+  it("names its own window, and says 'run' for one", () => {
+    const bands = runDensityBands([at(9)], DAY);
+    assert.equal(bands[2].label, "1 run 08:00–12:00");
+    assert.equal(bands[0].label, "0 runs 00:00–04:00");
+  });
+});
+
+describe("runCountOn", () => {
+  it("counts only the given day", () => {
+    const runs = [at(1), at(9), { ...at(9), atIso: new Date(2026, 7, 24, 9).toISOString() }];
+    assert.equal(runCountOn(runs, DAY), 2);
+  });
+
+  it("agrees with the bands, so Week and Month cannot disagree about a day", () => {
+    const runs = [at(0), at(5), at(9), at(9), at(23)];
+    const total = runDensityBands(runs, DAY).reduce((n, b) => n + b.count, 0);
+    assert.equal(runCountOn(runs, DAY), total);
+  });
+});
+
+describe("runCountLabel", () => {
+  it("returns null at zero so no empty affordance renders", () => {
+    assert.equal(runCountLabel(0), null);
+    assert.equal(runCountLabel(-1), null);
+  });
+
+  it("singularises one", () => {
+    assert.equal(runCountLabel(1), "1 run");
+    assert.equal(runCountLabel(3), "3 runs");
+  });
+
+  it("carries the frame's two different nouns", () => {
+    // Week says "ritual runs", Month says "runs" — both come from the frame.
+    assert.equal(runCountLabel(2, "ritual runs"), "2 ritual runs");
+    assert.equal(runCountLabel(1, "ritual runs"), "1 ritual run");
+  });
+});

--- a/src/lib/calendar-run-density.test.ts
+++ b/src/lib/calendar-run-density.test.ts
@@ -4,6 +4,8 @@ import type { ProjectedCronRun } from "./calendar-cron-projection.ts";
 import {
   RUN_DENSITY_BANDS,
   RUN_DENSITY_MAX_LEVEL,
+  clusterLabel,
+  clusterRunsByMinute,
   runCountLabel,
   runCountOn,
   runDensityBands,
@@ -101,5 +103,56 @@ describe("runCountLabel", () => {
     // Week says "ritual runs", Month says "runs" — both come from the frame.
     assert.equal(runCountLabel(2, "ritual runs"), "2 ritual runs");
     assert.equal(runCountLabel(1, "ritual runs"), "1 ritual run");
+  });
+});
+
+describe("clusterRunsByMinute", () => {
+  it("collapses runs sharing a minute into one marker", () => {
+    // Regression: measured in the browser, "Daily bug scan" and "Follow-up
+    // monitor" rendered at the same offset and their labels sat on top of each
+    // other. One marker per instant is the fix.
+    const clusters = clusterRunsByMinute(
+      [at(9, 0, { name: "Daily bug scan" }), at(9, 0, { name: "Follow-up monitor" })],
+      DAY,
+    );
+    assert.equal(clusters.length, 1);
+    assert.equal(clusters[0].minutes, 9 * 60);
+    assert.equal(clusters[0].runs.length, 2);
+  });
+
+  it("keeps different minutes apart, in chronological order", () => {
+    const clusters = clusterRunsByMinute([at(22), at(9, 30), at(9)], DAY);
+    assert.deepEqual(clusters.map((c) => c.minutes), [9 * 60, 9 * 60 + 30, 22 * 60]);
+  });
+
+  it("does not merge across the hour boundary", () => {
+    const clusters = clusterRunsByMinute([at(9, 59), at(10, 0)], DAY);
+    assert.equal(clusters.length, 2);
+  });
+
+  it("ignores other days and unparseable instants", () => {
+    const other = { ...at(9), atIso: new Date(2026, 7, 26, 9).toISOString() };
+    const bad = { ...at(9), atIso: "nonsense" };
+    assert.equal(clusterRunsByMinute([at(9), other, bad], DAY).length, 1);
+  });
+
+  it("loses no run: clusters account for exactly the day's runs", () => {
+    const runs = [at(9), at(9), at(9, 30), at(22)];
+    const clustered = clusterRunsByMinute(runs, DAY).reduce((n, c) => n + c.runs.length, 0);
+    assert.equal(clustered, runCountOn(runs, DAY));
+  });
+});
+
+describe("clusterLabel", () => {
+  it("names a lone run plainly", () => {
+    assert.equal(clusterLabel(clusterRunsByMinute([at(9, 0, { name: "Daily brief" })], DAY)[0]), "Daily brief");
+  });
+
+  it("counts the extras rather than overprinting them", () => {
+    const c = clusterRunsByMinute(
+      [at(9, 0, { name: "Daily brief" }), at(9, 0, { name: "B" }), at(9, 0, { name: "C" })],
+      DAY,
+    )[0];
+    assert.equal(clusterLabel(c), "Daily brief +2");
   });
 });

--- a/src/lib/calendar-run-density.ts
+++ b/src/lib/calendar-run-density.ts
@@ -1,0 +1,126 @@
+// Per-day shape of a cron projection, for the calendar views that summarise a
+// day rather than list it.
+//
+// `calendar-cron-projection` answers "which runs land in this window". Agenda
+// renders those rows directly, but Week and Month have no room for a row per
+// run — the frame (Rituals Redesign.dc.html, CALENDAR TAB) instead gives Week a
+// six-band density strip and Month a single count. Both are derived here so the
+// arithmetic is testable away from the DOM, and so the two views cannot drift
+// into disagreeing about the same day.
+//
+// The band count is deliberately 6 over 24 hours — four-hour buckets. That is
+// the frame's own choice, and its comment says why: "so a column says WHEN the
+// load is". A finer bucket would render sub-pixel bands at the width a week
+// column actually gets; a coarser one stops distinguishing morning from night.
+
+import type { ProjectedCronRun } from "./calendar-cron-projection.ts";
+
+/** Hours covered by one band. 24 / 4 = the six bands the frame draws. */
+export const RUN_DENSITY_BAND_HOURS = 4;
+
+/** Bands per day. */
+export const RUN_DENSITY_BANDS = 24 / RUN_DENSITY_BAND_HOURS;
+
+/**
+ * Counts past this stop changing a band's height and colour.
+ *
+ * Without a clamp one busy cron flattens every other band to invisible, so the
+ * strip would answer "how many" (which the label already says) instead of
+ * "when" (which is the only thing the strip is for).
+ */
+export const RUN_DENSITY_MAX_LEVEL = 5;
+
+export type RunDensityBand = {
+  /** Hour this band starts at: 0, 4, 8, 12, 16, 20. */
+  startHour: number;
+  /** Runs landing in [startHour, startHour + 4). */
+  count: number;
+  /**
+   * `count` clamped to RUN_DENSITY_MAX_LEVEL — the value the stylesheet keys
+   * height and fill off, so no raw px or colour is computed in the component.
+   */
+  level: number;
+  /** e.g. "2 runs 08:00–12:00". Spoken per band, so it names its own window. */
+  label: string;
+};
+
+function pad(hour: number): string {
+  return String(hour).padStart(2, "0");
+}
+
+/**
+ * Bucket a day's projected runs into the six density bands.
+ *
+ * Always returns all six, including empty ones: the strip is a fixed axis, and
+ * dropping empty buckets would slide the remaining bands to the wrong hours.
+ *
+ * `runs` may contain other days — this filters to `day` itself, so callers can
+ * pass the whole window without slicing first.
+ */
+export function runDensityBands(
+  runs: readonly ProjectedCronRun[],
+  day: Date,
+): RunDensityBand[] {
+  const counts = new Array<number>(RUN_DENSITY_BANDS).fill(0);
+  for (const run of runs) {
+    const at = new Date(run.atIso);
+    if (Number.isNaN(at.getTime())) continue;
+    if (
+      at.getFullYear() !== day.getFullYear() ||
+      at.getMonth() !== day.getMonth() ||
+      at.getDate() !== day.getDate()
+    ) {
+      continue;
+    }
+    const band = Math.floor(at.getHours() / RUN_DENSITY_BAND_HOURS);
+    // getHours() is 0..23, so band is 0..5 — but clamp rather than trust it,
+    // since an out-of-range write would corrupt a neighbouring bucket silently.
+    if (band < 0 || band >= RUN_DENSITY_BANDS) continue;
+    counts[band] += 1;
+  }
+
+  return counts.map((count, i) => {
+    const startHour = i * RUN_DENSITY_BAND_HOURS;
+    const endHour = startHour + RUN_DENSITY_BAND_HOURS;
+    return {
+      startHour,
+      count,
+      level: Math.min(count, RUN_DENSITY_MAX_LEVEL),
+      label: `${count} ${count === 1 ? "run" : "runs"} ${pad(startHour)}:00–${pad(endHour)}:00`,
+    };
+  });
+}
+
+/**
+ * How many projected runs land on `day`.
+ *
+ * Month cells show this alone — a day cell has room for a count and nothing
+ * more, and a count with no strip is honest about being a count.
+ */
+export function runCountOn(runs: readonly ProjectedCronRun[], day: Date): number {
+  let n = 0;
+  for (const run of runs) {
+    const at = new Date(run.atIso);
+    if (Number.isNaN(at.getTime())) continue;
+    if (
+      at.getFullYear() === day.getFullYear() &&
+      at.getMonth() === day.getMonth() &&
+      at.getDate() === day.getDate()
+    ) {
+      n += 1;
+    }
+  }
+  return n;
+}
+
+/**
+ * The caption under a density strip, or under a month cell's glyph.
+ *
+ * Returns null at zero rather than "0 runs": a day with no projected runs
+ * should draw no chrome at all, and returning a string would tempt a caller
+ * into rendering an empty affordance.
+ */
+export function runCountLabel(count: number, noun = "runs"): string | null {
+  if (count <= 0) return null;
+  return `${count} ${count === 1 ? noun.replace(/s$/, "") : noun}`;
+}

--- a/src/lib/calendar-run-density.ts
+++ b/src/lib/calendar-run-density.ts
@@ -124,3 +124,52 @@ export function runCountLabel(count: number, noun = "runs"): string | null {
   if (count <= 0) return null;
   return `${count} ${count === 1 ? noun.replace(/s$/, "") : noun}`;
 }
+
+export type RunCluster = {
+  /** Minutes from midnight — where the marker sits on the grid. */
+  minutes: number;
+  /** Every run firing at this minute, in the order given. */
+  runs: ProjectedCronRun[];
+};
+
+/**
+ * Group a day's runs by the exact minute they fire.
+ *
+ * Two crons on the same schedule land on the same pixel, and a per-run marker
+ * then draws two labels on top of each other — measured in the browser with
+ * real data: "Daily bug scan" and "Follow-up monitor" both at the same offset,
+ * both illegible. Nudging them apart would be a lie about when they run, so
+ * they are collapsed into one marker instead: the same instant IS one moment,
+ * and the marker can name the extras.
+ */
+export function clusterRunsByMinute(
+  runs: readonly ProjectedCronRun[],
+  day: Date,
+): RunCluster[] {
+  const byMinute = new Map<number, ProjectedCronRun[]>();
+  for (const run of runs) {
+    const at = new Date(run.atIso);
+    if (Number.isNaN(at.getTime())) continue;
+    if (
+      at.getFullYear() !== day.getFullYear() ||
+      at.getMonth() !== day.getMonth() ||
+      at.getDate() !== day.getDate()
+    ) {
+      continue;
+    }
+    const minutes = at.getHours() * 60 + at.getMinutes();
+    const bucket = byMinute.get(minutes);
+    if (bucket) bucket.push(run);
+    else byMinute.set(minutes, [run]);
+  }
+  return [...byMinute.entries()]
+    .map(([minutes, group]) => ({ minutes, runs: group }))
+    .sort((a, b) => a.minutes - b.minutes);
+}
+
+/** "Daily brief" alone, or "Daily brief +2" when others share the minute. */
+export function clusterLabel(cluster: RunCluster): string {
+  const [first, ...rest] = cluster.runs;
+  if (!first) return "";
+  return rest.length > 0 ? `${first.name} +${rest.length}` : first.name;
+}

--- a/src/lib/design-token-drift.test.ts
+++ b/src/lib/design-token-drift.test.ts
@@ -89,7 +89,25 @@ const BASELINES = {
 // tokenize-css.mjs is a no-op over all three, so tier 1 stays clean.
 // -1: the compact Research mode picker replaces an off-grid spacing literal
 // with the shared control rhythm.
-BASELINES.offScaleSpacingPx = 1607;
+// +1: the calendar's cron density strip (cave-aa10e, "Rituals Redesign.dc.html"
+// CALENDAR TAB) — `gap: 2px` between the six four-hour bands. This is the one
+// spacing value in the new block that is not on scale, and --space-1 is the
+// wrong answer for it: at six bands inside a week column that can be as narrow
+// as 80px, 4px gaps spend a quarter of the strip on the spaces between bars,
+// and the strip stops reading as one chart and starts reading as six. It is
+// the same 1/2px micro-mark family the Chart Room, Weaves, Review Deck and
+// GitHub-composer handoffs already banked above, for the same reason each time.
+// Everything else the strip adds IS on scale: the band ramp is --space-1..-6
+// (the frame's 4/9/14/19/24/29 is the same even ramp off the scale, and a
+// density chart only needs its steps even), the row is --space-8, and the
+// padding and label gaps are --space-1/-2. Heights do not reach this ratchet
+// anyway — SPACING_PROPS is padding/margin/gap — so the ramp was snapped for
+// its own sake rather than to move this number.
+// measured, not derived: 1608 is the count on this branch rebased onto
+// cae54fb6e5, which is what CI scans. Measured 1607 before the rebase, because
+// the branch predated its own live-run-card merge; re-measure after the base
+// moves, never derive a baseline from another baseline.
+BASELINES.offScaleSpacingPx = 1608;
 // +5: the Review Deck cockpit ("Review Deck Cockpit v2.dc.html" handoff,
 // cave-8dj4q) binds five numbers no stylesheet can hold, and no more than
 // five: the two rail widths the USER DRAGS (one `style` object carrying

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -155,24 +155,28 @@
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
+  /* 2px, not --space-1: at six bands a 4px gap eats the columns it separates.
+     Same micro-mark family the earlier handoffs banked. */
   gap: 2px;
-  height: 34px;
+  height: var(--space-8);
 }
 
 .cal-run-density__band {
   flex: 1;
   border-radius: 2px;
   /* Level 0 keeps a visible floor so the axis reads as an axis rather than a
-     gap — an absent band would misalign the hours either side of it. */
-  height: 4px;
+     gap — an absent band would misalign the hours either side of it.
+     The ramp is --space-1..-6: a density chart only needs its steps to be
+     even, and the frame's 4/9/14/19/24/29 is the same ramp off the scale. */
+  height: var(--space-1);
   background: color-mix(in oklch, var(--foreground) 7%, transparent);
 }
 
-.cal-run-density__band[data-level="1"] { height: 9px;  background: color-mix(in oklch, var(--accent-presence) 38%, transparent); }
-.cal-run-density__band[data-level="2"] { height: 14px; background: color-mix(in oklch, var(--accent-presence) 52%, transparent); }
-.cal-run-density__band[data-level="3"] { height: 19px; background: color-mix(in oklch, var(--accent-presence) 66%, transparent); }
-.cal-run-density__band[data-level="4"] { height: 24px; background: color-mix(in oklch, var(--accent-presence) 80%, transparent); }
-.cal-run-density__band[data-level="5"] { height: 29px; background: color-mix(in oklch, var(--accent-presence) 94%, transparent); }
+.cal-run-density__band[data-level="1"] { height: var(--space-2); background: color-mix(in oklch, var(--accent-presence) 38%, transparent); }
+.cal-run-density__band[data-level="2"] { height: var(--space-3); background: color-mix(in oklch, var(--accent-presence) 52%, transparent); }
+.cal-run-density__band[data-level="3"] { height: var(--space-4); background: color-mix(in oklch, var(--accent-presence) 66%, transparent); }
+.cal-run-density__band[data-level="4"] { height: var(--space-5); background: color-mix(in oklch, var(--accent-presence) 80%, transparent); }
+.cal-run-density__band[data-level="5"] { height: var(--space-6); background: color-mix(in oklch, var(--accent-presence) 94%, transparent); }
 
 .cal-run-density__axis {
   display: flex;

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -87,3 +87,135 @@
   cursor: pointer;
   font: inherit;
 }
+
+/* ── Projected cron runs ──────────────────────────────────────────────────────
+   A forecast, never a scheduled item. Everything here is deliberately quieter
+   than a real event: dashed rather than solid, no fill, and non-interactive —
+   the eye should be able to tell "this is going to happen" from "this is on
+   the calendar" without reading either. */
+
+/* Day/Week time grid: an instant, drawn as a tick across the column.
+   Not a block — a cron fires at a point in time and records no duration, so a
+   block would be inventing one. Sits under the now-line (z-10) so the live
+   clock is never obscured by a forecast. */
+.cal-run-mark {
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  /* A forecast is not a drop target and has nothing to open; letting it eat
+     pointer events would break drag-to-reschedule on the row underneath. */
+  pointer-events: none;
+}
+
+.cal-run-mark__tick {
+  flex: 1;
+  height: 0;
+  border-top: 1px dashed color-mix(in oklch, var(--accent-presence) 55%, transparent);
+}
+
+.cal-run-mark__label {
+  flex: none;
+  max-width: 60%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: color-mix(in oklch, var(--accent-presence) 82%, transparent);
+  font-size: var(--text-2xs);
+}
+
+/* Week view: per-day density strip. Six four-hour bands say WHEN a day's load
+   falls; the count alone (in the label) says how much. `data-level` is the run
+   count clamped in calendar-run-density, so height and fill live here rather
+   than being computed into inline styles. */
+.cal-run-density {
+  display: grid;
+  gap: var(--space-1);
+  width: 100%;
+  padding: var(--space-2) var(--space-1) var(--space-1);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-raised) 55%, transparent);
+  text-align: left;
+}
+
+.cal-run-density--action {
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.cal-run-density--action:hover {
+  background: var(--bg-hover);
+}
+
+.cal-run-density__bands {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 2px;
+  height: 34px;
+}
+
+.cal-run-density__band {
+  flex: 1;
+  border-radius: 2px;
+  /* Level 0 keeps a visible floor so the axis reads as an axis rather than a
+     gap — an absent band would misalign the hours either side of it. */
+  height: 4px;
+  background: color-mix(in oklch, var(--foreground) 7%, transparent);
+}
+
+.cal-run-density__band[data-level="1"] { height: 9px;  background: color-mix(in oklch, var(--accent-presence) 38%, transparent); }
+.cal-run-density__band[data-level="2"] { height: 14px; background: color-mix(in oklch, var(--accent-presence) 52%, transparent); }
+.cal-run-density__band[data-level="3"] { height: 19px; background: color-mix(in oklch, var(--accent-presence) 66%, transparent); }
+.cal-run-density__band[data-level="4"] { height: 24px; background: color-mix(in oklch, var(--accent-presence) 80%, transparent); }
+.cal-run-density__band[data-level="5"] { height: 29px; background: color-mix(in oklch, var(--accent-presence) 94%, transparent); }
+
+.cal-run-density__axis {
+  display: flex;
+  justify-content: space-between;
+  color: var(--text-muted);
+  font-family: var(--font-jetbrains-mono);
+  font-size: var(--text-2xs);
+}
+
+.cal-run-density__label {
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+}
+
+/* Month view: a day cell has room for a count and nothing more. The bar is
+   deliberately neutral — these runs have not happened, so spending the warning
+   or danger colour here would claim an outcome the projection cannot know. */
+.cal-month-runs {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-top: auto;
+  padding-top: var(--space-1);
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+}
+
+.cal-month-runs__bar {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--accent-presence) 45%, transparent);
+  /* Width is stepped rather than computed per-count: the bar is 2px of
+     aria-hidden decoration and the label beside it already carries the exact
+     number, so a continuous width would buy nothing and cost an inline style
+     the design-system ratchet is right to refuse. */
+  width: 29%;
+}
+
+.cal-month-runs__bar[data-level="2"] { width: 36%; }
+.cal-month-runs__bar[data-level="3"] { width: 43%; }
+.cal-month-runs__bar[data-level="4"] { width: 50%; }
+.cal-month-runs__bar[data-level="5"] { width: 64%; }


### PR DESCRIPTION
`cave-9f3i3` landed cron projection in the **Agenda** view only, and deliberately scoped the footer note and the "ritual runs" toggle to Agenda so the chrome could not claim a projection the other views did not draw. This adds the three renderers and widens that guard behind them.

## What each view says

The projection model was always view-agnostic — it takes any `[start, end]` window. What differed was how much room each view has to say something true:

| View | Treatment | Why |
|---|---|---|
| **Day** | every run as an instant in its hour slot | there is room for each one |
| **Week** | six-band density strip per day (4-hour buckets), `00/12/20` axis, "N ritual runs" | seven columns of individual ticks is noise; the strip answers *when* the load falls |
| **Month** | `ph:clock` glyph + "N runs" + a neutral bar | a day cell has room for a count and nothing more |

All three follow the frame (`Rituals Redesign.dc.html`, CALENDAR TAB).

## Deliberate choices

**Runs are drawn as instants, not blocks.** A cron fires at a point in time and `AutomationRunRecord` records no duration — a block would invent one. The markers also sit outside the lane packer, so a forecast never displaces a real event, and they are `pointer-events: none` so they cannot break drag-to-reschedule underneath.

**The month bar stays neutral.** None of these runs have happened, so spending the warning or danger colour would claim an outcome the projection cannot know. That is the frame's own reasoning too.

**`PROJECTING_VIEWS` is the guard.** Membership is a promise that the view *draws* the runs; the footer note and the toggle both key off it, so the two can no longer disagree. The window maths is per-view — Month projects the full 6-week grid it renders, not just the month, or the trailing cells come back empty.

## A defect found by driving it

Every automated gate was green, and the Day view was still wrong: two crons sharing a schedule landed on the same pixel and drew their labels on top of each other. Measured with real data — "Daily bug scan"/"Follow-up monitor" at one offset, "iOS Application Priority Audit"/"macOS Application Priority Audit" at another.

Offsetting them apart would misstate when they run, so runs sharing a minute collapse into one marker that names the extras (`Daily bug scan +1`); the screen-reader text still lists every name. Re-measured after the fix: **zero collisions, 9 runs across 7 markers.**

## Verification

- Browser-driven at all four views: Day 9 marks, Week 7 strips × 6 bands = 42, Month 42 cells, Agenda unchanged. Footer counts differ per view (9 for a one-day window vs 13 for the longer ones) because the window genuinely differs.
- 19 unit tests on the bucket arithmetic, including that Week and Month cannot disagree about a day, and that clustering loses no run.
- Bands and the month bar are driven by a clamped `data-level` attribute rather than computed inline styles, so the design-token drift ratchet stays flat.
- CSS went into the already component-imported `calendar.css`, not the globals facade — build reports 937 KB against the 940 KB budget.

Closes cave-aa10e.