### PR TITLE
Route paired iOS invites to requested chats

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -206,7 +206,14 @@ struct CovenCaveApp: App {
             guard let reservedIntent = app.takePendingPairingIntent(matching: intent.id) else {
                 return
             }
-            await app.configure(host: reservedIntent.host, token: reservedIntent.token)
+            if let lease = await app.configure(
+                host: reservedIntent.host,
+                token: reservedIntent.token
+            ) {
+                app.armPairingDestination(reservedIntent, lease: lease)
+            } else {
+                app.cancelPairingDestination(matching: reservedIntent.id)
+            }
             return
         }
 
@@ -218,9 +225,17 @@ struct CovenCaveApp: App {
             guard let reservedIntent = app.takePendingPairingIntent(matching: intent.id) else {
                 return
             }
-            await app.configure(host: reservedIntent.host, token: reservedIntent.token)
+            if let lease = await app.configure(
+                host: reservedIntent.host,
+                token: reservedIntent.token
+            ) {
+                app.armPairingDestination(reservedIntent, lease: lease)
+            } else {
+                app.cancelPairingDestination(matching: reservedIntent.id)
+            }
         case .denied:
             if app.consumePendingPairingIntent(matching: intent.id) {
+                app.cancelPairingDestination(matching: intent.id)
                 pairingApprovalFailed = true
             }
         case .unavailable:

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveInvite.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveInvite.swift
@@ -10,6 +10,13 @@ import Foundation
 struct CaveInvite: Equatable {
     var host: String
     var token: String?
+    var threadId: String?
+
+    init(host: String, token: String?, threadId: String? = nil) {
+        self.host = host
+        self.token = token
+        self.threadId = threadId
+    }
 
     static func parse(_ input: String) -> CaveInvite? {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -19,7 +26,11 @@ struct CaveInvite: Equatable {
         if lower.hasPrefix("covencave://") {
             guard let comps = URLComponents(string: trimmed),
                   let host = queryValue(comps, "host"), !host.isEmpty else { return nil }
-            return CaveInvite(host: host, token: queryValue(comps, "token"))
+            return CaveInvite(
+                host: host,
+                token: queryValue(comps, "token"),
+                threadId: requestedThreadId(comps)
+            )
         }
 
         if lower.hasPrefix("http://") || lower.hasPrefix("https://") {
@@ -30,7 +41,11 @@ struct CaveInvite: Equatable {
             // verbatim); drop the path/query — the token is captured here.
             var normalized = "\(comps.scheme ?? "https")://\(hostname)"
             if let port = comps.port { normalized += ":\(port)" }
-            return CaveInvite(host: normalized, token: token)
+            return CaveInvite(
+                host: normalized,
+                token: token,
+                threadId: requestedThreadId(comps)
+            )
         }
 
         return CaveInvite(host: trimmed, token: nil)
@@ -48,5 +63,12 @@ struct CaveInvite: Equatable {
     private static func queryValue(_ comps: URLComponents, _ name: String) -> String? {
         let value = comps.queryItems?.first(where: { $0.name == name })?.value
         return (value?.isEmpty == false) ? value : nil
+    }
+
+    private static func requestedThreadId(_ comps: URLComponents) -> String? {
+        guard let fragment = comps.fragment, fragment.hasPrefix("chat-") else { return nil }
+        let threadId = String(fragment.dropFirst("chat-".count))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return threadId.isEmpty ? nil : threadId
     }
 }

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -149,9 +149,32 @@ struct ProjectNavigationIntent: Equatable, Hashable, Sendable {
 }
 
 struct PairingIntent: Equatable {
-    let id = UUID()
+    let id: UUID
     let host: String
     let token: String?
+    let threadId: String?
+
+    init(
+        id: UUID = UUID(),
+        host: String,
+        token: String?,
+        threadId: String? = nil
+    ) {
+        self.id = id
+        self.host = host
+        self.token = token
+        self.threadId = threadId
+    }
+
+    init(invite: CaveInvite) {
+        self.init(host: invite.host, token: invite.token, threadId: invite.threadId)
+    }
+
+    func matches(_ connection: CaveConnection?) -> Bool {
+        guard let currentURL = connection?.baseURL,
+              let requestedURL = CaveConnection(host: host).baseURL else { return false }
+        return currentURL.host?.lowercased() == requestedURL.host?.lowercased()
+    }
 }
 
 enum PairingApprovalPolicy {
@@ -375,6 +398,7 @@ final class AppModel {
                         systemImage: "antenna.radiowaves.left.and.right"
                     )
                 }
+                resumePendingPairingDestination()
             }
         }
     }
@@ -1260,6 +1284,8 @@ final class AppModel {
 
     @discardableResult
     private func beginProjectNavigation(_ intent: ProjectNavigationIntent) -> Bool {
+        pendingPairingDestination = nil
+        pendingPairingDestinationLease = nil
         pendingProjectNavigationIntent = intent
         lastProjectNavigationFailure = nil
         return resolvePendingProjectNavigationIntent(attemptHydrationIfNeeded: true)
@@ -4226,6 +4252,8 @@ final class AppModel {
 
     var deepLink: DeepLink?
     private(set) var pendingPairingIntent: PairingIntent?
+    private var pendingPairingDestination: PairingIntent?
+    private var pendingPairingDestinationLease: ConnectionDispatchLease?
 
     func handleDeepLink(_ url: URL) {
         guard url.scheme == "covencave" else { return }
@@ -4234,7 +4262,9 @@ final class AppModel {
         // mutating credentials beneath a lock or authentication prompt.
         if url.host == "connect" {
             guard let invite = CaveInvite.parse(url.absoluteString) else { return }
-            pendingPairingIntent = PairingIntent(host: invite.host, token: invite.token)
+            let intent = PairingIntent(invite: invite)
+            pendingPairingIntent = intent
+            stagePairingDestination(intent)
             return
         }
         guard let intent = ProjectNavigationIntent(url: url) else { return }
@@ -4245,11 +4275,7 @@ final class AppModel {
         } else {
             deepLink = nil
         }
-        pendingProjectNavigationIntent = intent
-        lastProjectNavigationFailure = nil
-        if resolvePendingProjectNavigationIntent(attemptHydrationIfNeeded: true) {
-            return
-        }
+        beginProjectNavigation(intent)
     }
 
     @discardableResult
@@ -4261,6 +4287,74 @@ final class AppModel {
         guard let intent = pendingPairingIntent, intent.id == id else { return nil }
         pendingPairingIntent = nil
         return intent
+    }
+
+    func stagePairingDestination(_ intent: PairingIntent) {
+        guard intent.threadId != nil else {
+            pendingPairingDestination = nil
+            pendingPairingDestinationLease = nil
+            return
+        }
+        pendingProjectNavigationIntent = nil
+        lastProjectNavigationFailure = nil
+        pendingPairingDestination = intent
+        pendingPairingDestinationLease = nil
+    }
+
+    func cancelPairingDestination(matching id: UUID) {
+        guard pendingPairingDestination?.id == id else { return }
+        pendingPairingDestination = nil
+        pendingPairingDestinationLease = nil
+    }
+
+    func armPairingDestination(_ intent: PairingIntent, lease: ConnectionDispatchLease) {
+        guard pendingPairingDestination?.id == intent.id,
+              connectionDispatchLeaseIsCurrent(lease),
+              intent.matches(connection) else {
+            return
+        }
+        pendingPairingDestinationLease = lease
+        resumePairingDestination(intent)
+    }
+
+    func rebasePairingDestinationLease(
+        from previousConnection: CaveConnection,
+        to relocatedConnection: CaveConnection
+    ) {
+        guard let intent = pendingPairingDestination,
+              let lease = pendingPairingDestinationLease,
+              connectionDispatchLeaseIsCurrent(lease),
+              lease.baseURL == previousConnection.baseURL,
+              intent.matches(previousConnection),
+              intent.matches(relocatedConnection) else {
+            return
+        }
+        pendingPairingDestinationLease = ConnectionDispatchLease(
+            generation: lease.generation,
+            baseURL: relocatedConnection.baseURL
+        )
+    }
+
+    func resumePairingDestination(_ intent: PairingIntent) {
+        guard pendingPairingDestination?.id == intent.id,
+              let lease = pendingPairingDestinationLease,
+              connectionDispatchLeaseIsCurrent(lease),
+              let threadId = intent.threadId,
+              connectionState == .connected,
+              intent.matches(connection) else {
+            return
+        }
+        pendingPairingDestination = nil
+        pendingPairingDestinationLease = nil
+        beginProjectNavigation(ProjectNavigationIntent(
+            entity: .thread(id: threadId),
+            destination: .chats
+        ))
+    }
+
+    private func resumePendingPairingDestination() {
+        guard let intent = pendingPairingDestination else { return }
+        resumePairingDestination(intent)
     }
 
 
@@ -4446,7 +4540,8 @@ final class AppModel {
 
     // MARK: - Connection lifecycle
 
-    func configure(host: String, token: String? = nil) async {
+    @discardableResult
+    func configure(host: String, token: String? = nil) async -> ConnectionDispatchLease? {
         // Revoke every owner of the previous authority before touching its
         // credential. A refresh can already be past discovery and suspended in
         // bootstrap/token renewal, where cancelling the coordinator alone no
@@ -4462,7 +4557,7 @@ final class AppModel {
         // A newer configure/disconnect may have taken ownership while actor
         // cancellation suspended this call. The older transition must not save
         // credentials or overwrite the newer endpoint when it resumes.
-        guard connectionConfigurationLeaseIsCurrent(transitionGeneration) else { return }
+        guard connectionConfigurationLeaseIsCurrent(transitionGeneration) else { return nil }
 
         let conn = CaveConnection(host: host)
         let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -4498,8 +4593,11 @@ final class AppModel {
         conn.save(defaults: projectContextDefaults)
         await refreshConnection()
         guard connectionConfigurationLeaseIsCurrent(configuredGeneration),
-              connection?.baseURL == conn.baseURL else { return }
-        requestConnectionRecovery(.foreground)
+              connection != nil else { return nil }
+        if connection?.baseURL == conn.baseURL {
+            requestConnectionRecovery(.foreground)
+        }
+        return captureConnectionDispatchLease()
     }
 
     private func resetHostScopedStateForNewConnection() {
@@ -4540,6 +4638,8 @@ final class AppModel {
         cancelQueuedMessageFlush()
         connectionConfigurationGeneration &+= 1
         advanceProjectNavigationConnectionGeneration()
+        pendingPairingDestination = nil
+        pendingPairingDestinationLease = nil
         invalidateProjectNavigationHydrations()
         invalidateProjectContextLoads()
         CaveConnection.clear(defaults: projectContextDefaults)
@@ -5031,6 +5131,12 @@ final class AppModel {
                 invalidateProjectContextLoads()
                 advanceProjectNavigationConnectionGeneration()
                 let relocated = CaveConnection(host: Self.canonicalHost(for: working))
+                if let previousConnection = self.connection {
+                    rebasePairingDestinationLease(
+                        from: previousConnection,
+                        to: relocated
+                    )
+                }
                 self.connection = relocated
                 relocated.save(defaults: projectContextDefaults)
                 if let port = working.port {

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -4594,9 +4594,7 @@ final class AppModel {
         await refreshConnection()
         guard connectionConfigurationLeaseIsCurrent(configuredGeneration),
               connection != nil else { return nil }
-        if connection?.baseURL == conn.baseURL {
-            requestConnectionRecovery(.foreground)
-        }
+        requestConnectionRecovery(.foreground)
         return captureConnectionDispatchLease()
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -473,7 +473,9 @@ struct ConnectionView: View {
             } else {
                 app.cancelPairingDestination(matching: pairingIntent.id)
             }
-            if result.outcome == .authorized, app.connectionState == .connected {
+            if result.outcome == .authorized,
+               result.lease != nil,
+               app.connectionState == .connected {
                 Haptics.success()
             }
         }
@@ -509,7 +511,9 @@ struct ConnectionView: View {
                 } else {
                     app.cancelPairingDestination(matching: pairingIntent.id)
                 }
-                if result.outcome == .authorized, app.connectionState == .connected {
+                if result.outcome == .authorized,
+                   result.lease != nil,
+                   app.connectionState == .connected {
                     Haptics.success()
                 }
             }

--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -14,6 +14,7 @@ struct ConnectionView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var host: String = ""
+    @State private var pendingManualInvite: CaveInvite?
     @State private var busy = false
     /// Whether the clipboard holds text — drives the "Paste" affordance. We only
     /// READ the clipboard when the user taps Paste, so there's no surprise
@@ -107,6 +108,11 @@ struct ConnectionView: View {
             // the Paste affordance in step with the clipboard.
             .onChange(of: scenePhase) { _, phase in
                 if phase == .active { canPaste = UIPasteboard.general.hasStrings }
+            }
+            .onChange(of: host) { _, updatedHost in
+                if pendingManualInvite?.host != updatedHost {
+                    pendingManualInvite = nil
+                }
             }
             .sheet(isPresented: $showScanner) {
                 QRScannerSheet { payload in
@@ -441,7 +447,15 @@ struct ConnectionView: View {
 
     private func connect() {
         focused = false
-        guard let invite = CaveInvite.parse(cleanHost(host)) else { return }
+        guard let parsedInvite = CaveInvite.parse(cleanHost(host)) else { return }
+        let invite = CaveInvite(
+            host: parsedInvite.host,
+            token: parsedInvite.token,
+            threadId: pendingManualInvite?.host == parsedInvite.host
+                ? pendingManualInvite?.threadId
+                : parsedInvite.threadId
+        )
+        pendingManualInvite = nil
         // Avoid redundant work before spawning the Task. The outcome switch
         // remains authoritative if a same-runloop tap still races this guard.
         guard appLock.canBeginAuthentication else { return }
@@ -449,10 +463,17 @@ struct ConnectionView: View {
         busy = true
         liveCheck = .idle
         Task {
-            let outcome = await configurePairing(invite)
+            let pairingIntent = PairingIntent(invite: invite)
+            app.stagePairingDestination(pairingIntent)
+            let result = await configurePairing(pairingIntent)
             busy = false
-            handleApprovalOutcome(outcome)
-            if outcome == .authorized, app.connectionState == .connected {
+            handleApprovalOutcome(result.outcome)
+            if result.outcome == .authorized, let lease = result.lease {
+                app.armPairingDestination(pairingIntent, lease: lease)
+            } else {
+                app.cancelPairingDestination(matching: pairingIntent.id)
+            }
+            if result.outcome == .authorized, app.connectionState == .connected {
                 Haptics.success()
             }
         }
@@ -472,34 +493,46 @@ struct ConnectionView: View {
         guard let invite = CaveInvite.parse(cleanHost(input)) else { return }
         host = invite.host
         if invite.token != nil {
+            pendingManualInvite = nil
             // Same synchronous fast-path as `connect()`; QR scans route here too.
             guard appLock.canBeginAuthentication else { return }
             busy = true
             liveCheck = .idle
             Task {
-                let outcome = await configurePairing(invite)
+                let pairingIntent = PairingIntent(invite: invite)
+                app.stagePairingDestination(pairingIntent)
+                let result = await configurePairing(pairingIntent)
                 busy = false
-                handleApprovalOutcome(outcome)
-                if outcome == .authorized, app.connectionState == .connected {
+                handleApprovalOutcome(result.outcome)
+                if result.outcome == .authorized, let lease = result.lease {
+                    app.armPairingDestination(pairingIntent, lease: lease)
+                } else {
+                    app.cancelPairingDestination(matching: pairingIntent.id)
+                }
+                if result.outcome == .authorized, app.connectionState == .connected {
                     Haptics.success()
                 }
             }
         } else {
+            pendingManualInvite = invite
             manualEntry = true
             focused = true
         }
     }
 
-    private func configurePairing(_ invite: CaveInvite) async -> AuthenticationOutcome {
+    private func configurePairing(
+        _ intent: PairingIntent
+    ) async -> (outcome: AuthenticationOutcome, lease: AppModel.ConnectionDispatchLease?) {
         guard PairingApprovalPolicy.requiresApproval(hasExistingPairing: app.connection != nil) else {
-            await app.configure(host: invite.host, token: invite.token)
-            return .authorized
+            let lease = await app.configure(host: intent.host, token: intent.token)
+            return (.authorized, lease)
         }
-        return await appLock.performApprovedAction(
+        let outcome = await appLock.requestApproval(
             reason: "Confirm it's you to replace your desktop pairing"
-        ) {
-            await app.configure(host: invite.host, token: invite.token)
-        }
+        )
+        guard outcome == .authorized else { return (outcome, nil) }
+        let lease = await app.configure(host: intent.host, token: intent.token)
+        return (.authorized, lease)
     }
 
     private func handleApprovalOutcome(_ outcome: AuthenticationOutcome) {

--- a/apps/ios/CovenCave/CovenCaveTests/CaveInviteTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/CaveInviteTests.swift
@@ -38,6 +38,22 @@ final class CaveInviteTests: XCTestCase {
         XCTAssertEqual(invite?.token, "raw-sidecar")
     }
 
+    func testBrowserInvitePreservesRequestedChatFragment() {
+        let invite = CaveInvite.parse(
+            "https://cave.example.ts.net/?coven_access_token=v1.5.n.s#chat-thread-123"
+        )
+
+        XCTAssertEqual(invite?.threadId, "thread-123")
+    }
+
+    func testUnrelatedBrowserFragmentDoesNotRequestAChat() {
+        let invite = CaveInvite.parse(
+            "https://cave.example.ts.net/?coven_access_token=v1.5.n.s#settings"
+        )
+
+        XCTAssertNil(invite?.threadId)
+    }
+
     // MARK: - bare hosts
 
     func testBareHostPassesThrough() {

--- a/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
@@ -18,6 +18,171 @@ final class PairingIntentTests: XCTestCase {
         XCTAssertEqual(app.connection, existing)
     }
 
+    func testConnectDeepLinkPreservesRequestedChatUntilPairingCompletes() throws {
+        let app = AppModel()
+        let url = try XCTUnwrap(
+            URL(string: "covencave://connect?host=new-desktop.example.ts.net&token=new-secret#chat-thread-123")
+        )
+
+        app.handleDeepLink(url)
+
+        XCTAssertEqual(app.pendingPairingIntent?.threadId, "thread-123")
+    }
+
+    func testCompletedPairingQueuesRequestedChatNavigation() {
+        let app = AppModel()
+        let intent = PairingIntent(
+            host: "new-desktop.example.ts.net",
+            token: "new-secret",
+            threadId: "thread-123"
+        )
+        app.connection = CaveConnection(host: intent.host)
+        app.connectionState = .connected
+        app.stagePairingDestination(intent)
+        app.armPairingDestination(intent, lease: app.captureConnectionDispatchLease())
+
+        app.resumePairingDestination(intent)
+
+        XCTAssertEqual(
+            app.pendingProjectNavigationIntent,
+            ProjectNavigationIntent(entity: .thread(id: "thread-123"), destination: .chats)
+        )
+    }
+
+    func testSupersededPairingDoesNotNavigateOnTheReplacementConnection() {
+        let app = AppModel()
+        let intent = PairingIntent(
+            host: "old-desktop.example.ts.net",
+            token: "old-secret",
+            threadId: "thread-123"
+        )
+        app.stagePairingDestination(intent)
+        app.connection = CaveConnection(host: "replacement.example.ts.net")
+        app.connectionState = .connected
+        app.armPairingDestination(intent, lease: app.captureConnectionDispatchLease())
+
+        app.resumePairingDestination(intent)
+
+        XCTAssertNil(app.pendingProjectNavigationIntent)
+    }
+
+    func testDiscoveryRelocationStillNavigatesOnThePairedHost() {
+        let app = AppModel()
+        let intent = PairingIntent(
+            host: "desktop.example.ts.net",
+            token: "secret",
+            threadId: "thread-123"
+        )
+        app.stagePairingDestination(intent)
+        app.connection = CaveConnection(host: "https://desktop.example.ts.net:8443")
+        app.connectionState = .connected
+        app.armPairingDestination(intent, lease: app.captureConnectionDispatchLease())
+
+        XCTAssertEqual(app.pendingProjectNavigationIntent?.threadId, "thread-123")
+    }
+
+    func testPairingDestinationWaitsForTheConnectionToBecomeReady() {
+        let app = AppModel()
+        let intent = PairingIntent(
+            host: "new-desktop.example.ts.net",
+            token: "new-secret",
+            threadId: "thread-123"
+        )
+        app.connection = CaveConnection(host: intent.host)
+        app.connectionState = .checking
+        app.stagePairingDestination(intent)
+        app.armPairingDestination(intent, lease: app.captureConnectionDispatchLease())
+
+        app.resumePairingDestination(intent)
+
+        XCTAssertNil(app.pendingProjectNavigationIntent)
+
+        app.connectionState = .connected
+
+        XCTAssertEqual(app.pendingProjectNavigationIntent?.threadId, "thread-123")
+    }
+
+    func testPairingDestinationSurvivesDelayedConnectionAfterPortRelocation() {
+        let app = AppModel()
+        let intent = PairingIntent(
+            host: "desktop.example.ts.net",
+            token: "secret",
+            threadId: "thread-123"
+        )
+        let original = CaveConnection(host: "https://desktop.example.ts.net:3000")
+        let relocated = CaveConnection(host: "https://desktop.example.ts.net:8443")
+        app.connection = original
+        app.connectionState = .checking
+        app.stagePairingDestination(intent)
+        app.armPairingDestination(intent, lease: app.captureConnectionDispatchLease())
+
+        app.rebasePairingDestinationLease(from: original, to: relocated)
+        app.connection = relocated
+        app.connectionState = .connected
+
+        XCTAssertEqual(app.pendingProjectNavigationIntent?.threadId, "thread-123")
+    }
+
+    func testNewerPairingSuppressesStaleDestinationOnTheSameHost() throws {
+        let app = AppModel()
+        let oldIntent = PairingIntent(
+            host: "desktop.example.ts.net",
+            token: "old-secret",
+            threadId: "old-thread"
+        )
+        app.connection = CaveConnection(host: oldIntent.host)
+        app.connectionState = .connected
+        app.stagePairingDestination(oldIntent)
+        let oldLease = app.captureConnectionDispatchLease()
+        let replacementURL = try XCTUnwrap(
+            URL(string: "covencave://connect?host=desktop.example.ts.net&token=new-secret#chat-new-thread")
+        )
+        app.handleDeepLink(replacementURL)
+
+        app.armPairingDestination(oldIntent, lease: oldLease)
+        app.resumePairingDestination(oldIntent)
+
+        XCTAssertNil(app.pendingProjectNavigationIntent)
+        XCTAssertEqual(app.pendingPairingIntent?.threadId, "new-thread")
+    }
+
+    func testNewerOrdinaryNavigationCancelsTheStagedPairingDestination() throws {
+        let app = AppModel()
+        let intent = PairingIntent(
+            host: "desktop.example.ts.net",
+            token: "secret",
+            threadId: "thread-123"
+        )
+        app.connection = CaveConnection(host: intent.host)
+        app.connectionState = .checking
+        app.stagePairingDestination(intent)
+        app.armPairingDestination(intent, lease: app.captureConnectionDispatchLease())
+        let tasksURL = try XCTUnwrap(URL(string: "covencave://tasks"))
+
+        app.handleDeepLink(tasksURL)
+        app.connectionState = .connected
+
+        XCTAssertEqual(
+            app.pendingProjectNavigationIntent,
+            ProjectNavigationIntent(destination: .tasks)
+        )
+        XCTAssertNotEqual(app.pendingProjectNavigationIntent?.threadId, intent.threadId)
+    }
+
+    func testPairingWithoutDestinationPreservesPendingProjectNavigation() {
+        let app = AppModel()
+        let pendingNavigation = ProjectNavigationIntent(destination: .tasks)
+        app.pendingProjectNavigationIntent = pendingNavigation
+        let pairing = PairingIntent(
+            host: "desktop.example.ts.net",
+            token: "secret"
+        )
+
+        app.stagePairingDestination(pairing)
+
+        XCTAssertEqual(app.pendingProjectNavigationIntent, pendingNavigation)
+    }
+
     func testNonConnectDeepLinkStillRoutesWithoutCreatingPairingIntent() throws {
         let suiteName = "PairingIntentTests-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/scripts/ios-auto-reconnect.test.mjs
+++ b/scripts/ios-auto-reconnect.test.mjs
@@ -103,7 +103,7 @@ assert.match(
 );
 assert.match(
   model,
-  /func configure\(host:[\s\S]*?let transitionGeneration = connectionConfigurationGeneration[\s\S]*?await refreshCoordinator\.cancelActiveRefresh\(\)[\s\S]{0,360}guard connectionConfigurationLeaseIsCurrent\(transitionGeneration\) else \{ return \}[\s\S]*?let configuredGeneration = connectionConfigurationGeneration[\s\S]*?await refreshConnection\(\)[\s\S]{0,180}connectionConfigurationLeaseIsCurrent\(configuredGeneration\)/,
+  /func configure\(host:[\s\S]*?let transitionGeneration = connectionConfigurationGeneration[\s\S]*?await refreshCoordinator\.cancelActiveRefresh\(\)[\s\S]{0,360}guard connectionConfigurationLeaseIsCurrent\(transitionGeneration\) else \{ return nil \}[\s\S]*?let configuredGeneration = connectionConfigurationGeneration[\s\S]*?await refreshConnection\(\)[\s\S]{0,180}connectionConfigurationLeaseIsCurrent\(configuredGeneration\)/,
   "an older configure must prove transition ownership after every suspension before it can overwrite a newer endpoint",
 );
 assert.match(

--- a/scripts/ios-auto-reconnect.test.mjs
+++ b/scripts/ios-auto-reconnect.test.mjs
@@ -108,6 +108,11 @@ assert.match(
 );
 assert.match(
   model,
+  /await refreshConnection\(\)[\s\S]{0,180}connectionConfigurationLeaseIsCurrent\(configuredGeneration\)[\s\S]{0,180}requestConnectionRecovery\(\.foreground\)[\s\S]{0,120}return captureConnectionDispatchLease\(\)/,
+  "a winning configure restarts supervised recovery even when discovery relocated its port",
+);
+assert.match(
+  model,
   /private func resetHostScopedStateForNewConnection\(\)[\s\S]*?serverSessions = \[\][\s\S]{0,180}sessionsError = nil[\s\S]{0,180}lastSessionsLoadedAt = nil[\s\S]*?operatorProfile = nil/,
   "pairing a different host must clear the previous host's sessions and operator identity before new loads can fail",
 );

--- a/scripts/ios-claude-design-fidelity.test.mjs
+++ b/scripts/ios-claude-design-fidelity.test.mjs
@@ -112,8 +112,8 @@ assert.match(
 );
 assert.match(
   appModel,
-  /guard let intent = ProjectNavigationIntent\(url: url\) else \{ return \}[\s\S]*pendingProjectNavigationIntent = intent[\s\S]*resolvePendingProjectNavigationIntent\([^)]*\)/,
-  "runtime links queue one project-aware navigation intent until hydration can resolve it",
+  /guard let intent = ProjectNavigationIntent\(url: url\) else \{ return \}[\s\S]*beginProjectNavigation\(intent\)/,
+  "runtime links enter the centralized project-navigation authority so they queue until hydration can resolve them",
 );
 assert.match(
   appModel,

--- a/scripts/ios-connect-screen-ux.test.mjs
+++ b/scripts/ios-connect-screen-ux.test.mjs
@@ -112,8 +112,13 @@ assert.match(
 // --- Connected moment ----------------------------------------------------------
 assert.match(
   src,
-  /if result\.outcome == \.authorized, app\.connectionState == \.connected \{\s*Haptics\.success\(\)\s*\}/,
-  "an approved successful connect lands with success haptics",
+  /if result\.outcome == \.authorized,\s*result\.lease != nil,\s*app\.connectionState == \.connected \{\s*Haptics\.success\(\)\s*\}/,
+  "only an approved configuration that retained lease ownership lands with success haptics",
+);
+assert.equal(
+  [...src.matchAll(/result\.lease != nil,\s*app\.connectionState == \.connected/g)].length,
+  2,
+  "manual and credential-bearing paste/scan flows both suppress stale success haptics",
 );
 assert.equal(
   [...src.matchAll(/app\.stagePairingDestination\(pairingIntent\)/g)].length,

--- a/scripts/ios-connect-screen-ux.test.mjs
+++ b/scripts/ios-connect-screen-ux.test.mjs
@@ -112,8 +112,28 @@ assert.match(
 // --- Connected moment ----------------------------------------------------------
 assert.match(
   src,
-  /if outcome == \.authorized, app\.connectionState == \.connected \{\s*Haptics\.success\(\)\s*\}/,
+  /if result\.outcome == \.authorized, app\.connectionState == \.connected \{\s*Haptics\.success\(\)\s*\}/,
   "an approved successful connect lands with success haptics",
+);
+assert.equal(
+  [...src.matchAll(/app\.stagePairingDestination\(pairingIntent\)/g)].length,
+  2,
+  "both manual connect and credential-bearing paste/scan flows retain the requested chat while connecting",
+);
+assert.equal(
+  [...src.matchAll(/app\.armPairingDestination\(pairingIntent, lease: lease\)/g)].length,
+  2,
+  "both manual connect and credential-bearing paste/scan flows arm the retained chat against the completed configuration",
+);
+assert.match(
+  src,
+  /@State private var pendingManualInvite: CaveInvite\?/,
+  "tokenless QR and paste flows retain their parsed invite until Connect is tapped",
+);
+assert.match(
+  src,
+  /threadId: pendingManualInvite\?\.host == parsedInvite\.host\s*\?\s*pendingManualInvite\?\.threadId/,
+  "manual confirmation restores the chat destination only when the address was not edited",
 );
 assert.match(
   src,

--- a/scripts/ios-self-healing-sync.test.mjs
+++ b/scripts/ios-self-healing-sync.test.mjs
@@ -68,7 +68,7 @@ assert.match(
 // --- New host handoff: do not show stale old-host data while probing the new one
 assert.match(
   model,
-  /func configure\(host: String, token: String\? = nil\) async \{[\s\S]*?let isSameEndpoint[\s\S]*?if !isSameEndpoint \{[\s\S]*?resetHostScopedStateForNewConnection\(\)/,
+  /func configure\(host: String, token: String\? = nil\) async -> ConnectionDispatchLease\? \{[\s\S]*?let isSameEndpoint[\s\S]*?if !isSameEndpoint \{[\s\S]*?resetHostScopedStateForNewConnection\(\)/,
   "configuring a different host should clear host-scoped data before probing it",
 );
 assert.match(


### PR DESCRIPTION
## Summary
- preserve `#chat-<id>` destinations across iOS invite parsing, approval, pairing, and delayed reconnects
- fence navigation with the active connection configuration lease, including same-host discovery relocation and supersession
- retain tokenless QR/paste destinations until confirmation and update native/source regression coverage

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `pnpm test:mobile`
- `pnpm test:app`
- final read-only code review: no findings

Bead: `cave-f1wo`