### PR TITLE
Refuse to report a worktree creation whose unit is not present (cave-6go4e)

### DIFF
--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -539,6 +539,20 @@ if (command === "update") {
       spawnSync(realGit, ["-C", intended.path, "checkout", "--detach", state.alternateOid], { stdio: "ignore" });
       return { status: 25, error: "fixture persistence failed after changing worktree identity" };
     }
+    if (mode === "vanish-unit-then-succeed") {
+      // cave-6go4e's shape: the metadata write SUCCEEDS and is persisted, and
+      // the unit is gone by the time anything looks. Removing it any earlier is
+      // caught by the created-OID capture instead, which is why this sits here
+      // rather than in the git stub.
+      const intended = incoming.coven?.worktrees?.at(-1) ?? incoming.coven?.worktree;
+      spawnSync(realGit, ["-C", state.repo, "worktree", "remove", "--force", intended.path], { stdio: "ignore" });
+      spawnSync(realGit, ["-C", state.repo, "branch", "-D", intended.branch], { stdio: "ignore" });
+      rmSync(intended.path, { recursive: true, force: true });
+      // Persist exactly as the ordinary success path does -- the record really
+      // does land, which is what makes the phantom dangerous.
+      issue.metadata = { ...(issue.metadata ?? {}), ...incoming };
+      return { status: 0, output: issue };
+    }
     if (mode === "fail-unverifiable") {
       state.config.showAlwaysFail = true;
       return { status: 26, error: "fixture persistence unverifiable" };
@@ -2139,5 +2153,64 @@ await withFixture(
     );
   },
 );
+
+// cave-6go4e. Observed in the wild on cave-aa10e: this command exited 0 and
+// printed a full created report -- path, branch, head, and a metadata record it
+// had already written to the bead -- for a worktree that did not exist, was not
+// registered, and whose branch did not resolve. Nothing in the hook logs or
+// GitHub Desktop's log touched it, and a rerun minutes later succeeded, so the
+// cause is intermittent and is NOT diagnosed here. What is fixed is that the
+// command can no longer CLAIM it: a false report sends the caller to a
+// directory that is not there and leaves the bead claiming a unit nothing can
+// retire, which is the cave-l11sw shape whose only repair is hand-editing a
+// lifecycle record.
+await withFixture({}, async (fixture) => {
+  const target = path.join(fixture.repo, ".worktrees", "cave-unit1-example");
+  updateFixture(fixture, (state) => {
+    state.config.updateMode = "vanish-unit-then-succeed";
+  });
+  const result = runCreate(fixture, createArgs());
+
+  assert.notEqual(result.status, 0, "a phantom creation must not exit 0");
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(
+    parsed.error,
+    "creation reported success but the unit is not present",
+  );
+  assert.ok(
+    Array.isArray(parsed.missing) && parsed.missing.length > 0,
+    "the refusal names what is missing",
+  );
+  assert.equal(parsed.claimed.path, target, "and echoes what it claimed");
+  assert.match(
+    result.stderr,
+    /--unset-metadata coven/,
+    "the refusal prints the repair for the record it may have left behind",
+  );
+});
+
+// The invariant that was violated, and that nothing asserted: sixteen existing
+// checks read `status === 0` and not one of them looked at whether the worktree
+// was there.
+await withFixture({}, async (fixture) => {
+  const branch = "feat/cave-unit1-example";
+  const fullRef = `refs/heads/${branch}`;
+  const target = path.join(fixture.repo, ".worktrees", "cave-unit1-example");
+
+  const result = runCreate(fixture, createArgs());
+  assert.equal(result.status, 0, `create must succeed: ${result.stderr}`);
+
+  const entry = pathEntry(target);
+  assert.ok(entry?.exists && entry.kind === "directory", "the directory is there");
+  assert.ok(registeredAt(fixture.repo, target), "git registers the worktree");
+  const ref = refState(fixture.repo, fullRef);
+  assert.ok(ref, "the branch resolves");
+
+  // ...and the report describes THAT unit rather than some other one.
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.path, target);
+  assert.equal(report.fullRef, fullRef);
+  assert.equal(report.head, ref.oid);
+});
 
 console.log("worktree-lifecycle-create.test.mjs: ok");

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -1193,6 +1193,101 @@ function assessLocalRefusalPreflight(
   };
 }
 
+/**
+ * The root `execute` resolved, so the CLI boundary can re-probe the unit after
+ * the fences are released — see {@link phantomCreationOutcome}.
+ */
+let resolvedRoot: string | null = null;
+
+/**
+ * What is missing from a unit this run claims to have created.
+ *
+ * Empty means the report is true: the directory is there, git registers it, and
+ * the branch resolves to the head that was reported.
+ */
+function missingCreatedArtifacts(
+  root: string,
+  report: CreatedReport,
+): string[] {
+  const state = probePartialState(root, report.path, report.fullRef);
+  const missing: string[] = [];
+  if (!state.pathEntry.exists) {
+    missing.push(`the worktree directory is ${state.pathEntry.kind}`);
+  } else if (state.pathEntry.kind !== "directory") {
+    missing.push(`the worktree path is a ${state.pathEntry.kind}, not a directory`);
+  }
+  if (state.registrations.length === 0) {
+    missing.push("git does not register a worktree at that path");
+  }
+  if (state.ref === null) {
+    missing.push(`${report.fullRef} does not resolve`);
+  } else if (OID.test(report.head) && state.ref.oid !== report.head) {
+    missing.push(
+      `${report.fullRef} is ${state.ref.oid}, not the reported ${report.head}`,
+    );
+  }
+  // A probe that could not read is NOT proof of absence, so it is reported as
+  // its own uncertainty rather than folded into the missing list.
+  return missing.length > 0
+    ? missing
+    : state.probeErrors.length > 0
+      ? [`the unit could not be verified: ${state.probeErrors.join("; ")}`]
+      : [];
+}
+
+/**
+ * Refuse to report a creation that is not there.
+ *
+ * Observed 2026-08-25 on cave-aa10e: this command exited 0 and printed a full
+ * created report — path, branch, head, and a complete metadata record it had
+ * already written to the bead — for a worktree that did not exist, was not
+ * registered, and whose branch did not resolve. Nothing in the hook logs or in
+ * GitHub Desktop's log touched it, and a second run minutes later succeeded, so
+ * the cause is intermittent and is NOT diagnosed here.
+ *
+ * That is exactly why this exists. The report is the only thing a caller reads,
+ * and a false one is worse than a failure: it sends them to a directory that is
+ * not there, and it leaves the bead claiming a unit nothing can retire — the
+ * cave-l11sw shape, whose repair is hand-editing a lifecycle record, the one
+ * thing the worktree rules forbid. Making the state loud where it is observed
+ * costs one probe and removes the silent case whatever the cause turns out to
+ * be.
+ *
+ * It deliberately does NOT repair or roll back. Compensation is a separate,
+ * fenced path with its own preconditions, and by here the fences are released,
+ * so removing anything would be an unfenced mutation racing whatever else the
+ * checkout is doing.
+ */
+function phantomCreationOutcome(
+  report: CreatedReport,
+  missing: string[],
+): Outcome {
+  return {
+    status: 1,
+    // No created report: printing one is the defect this guards.
+    stdout: JSON.stringify({
+      error: "creation reported success but the unit is not present",
+      missing,
+      claimed: {
+        path: report.path,
+        fullRef: report.fullRef,
+        head: report.head,
+        beadId: report.beadId,
+      },
+    }),
+    stderr: [
+      "worktree-lifecycle-create: creation reported success but the unit is not present:",
+      ...missing.map((item) => `  - ${item}`),
+      `  claimed path: ${report.path}`,
+      `  claimed ref:  ${report.fullRef} @ ${report.head}`,
+      "  The bead may now carry a worktree record for a unit that is not there.",
+      `  Clear it on your OWN bead before retrying, and use a different branch name:`,
+      `    bd update ${report.beadId} --unset-metadata coven`,
+    ],
+    createdReport: null,
+  };
+}
+
 function probePartialState(
   root: string,
   worktreePath: string,
@@ -1718,6 +1813,7 @@ function execute(
   leases: MaintenanceFence[],
 ): Outcome {
   const root = realpathSync(path.resolve(options.root));
+  resolvedRoot = root;
   const { fullRef, worktreePath } = validateBranchAndPath(root, options.branch);
   assertRefAndPathAbsent(root, fullRef, worktreePath);
 
@@ -2290,6 +2386,18 @@ function main(): never {
       outcome.stdout = JSON.stringify(outcome.createdReport);
     }
   }
+  // Last stop before the report reaches a caller, and after the fences are
+  // released, so this observes the state they will actually find.
+  if (outcome.createdReport !== null) {
+    const missing =
+      resolvedRoot === null
+        ? ["the resolved repository root is unknown, so the unit cannot be verified"]
+        : missingCreatedArtifacts(resolvedRoot, outcome.createdReport);
+    if (missing.length > 0) {
+      outcome = phantomCreationOutcome(outcome.createdReport, missing);
+    }
+  }
+
   return render(outcome);
 }
 


### PR DESCRIPTION
## What was observed

On `cave-aa10e`, `pnpm beads:worktrees:create` **exited 0 and printed a full created report** — path, branch, head, and a complete metadata record it had already written to the bead — for a worktree that did not exist, was not registered, and whose branch did not resolve.

## What this PR does and does not claim

**It does not fix the cause.** The cause is undiagnosed and intermittent: a rerun minutes later succeeded with the same inputs, no hook logged anything, and GitHub Desktop's log shows nothing in that window. I tried to reproduce it directly and could not.

Two plausible explanations were ruled out by reading the code:
- a **timed-out** add cannot report success — `ok` is `status === 0 && !result.error`, and a timeout sets `result.error`;
- a **completed compensation** exits 1 with `createdReport: null`.

**What is fixed is that the command can no longer make the claim.** The report is the only thing a caller reads, and a false one is worse than a plain failure: it sends them to a directory that isn't there, and it leaves the bead claiming a unit nothing can retire — the `cave-l11sw` shape, whose repair is hand-editing a lifecycle record, the one thing the worktree rules forbid.

So the CLI boundary re-probes before rendering — after the fences are released, so it observes the state the caller will actually find:

- the directory is present and is a directory
- git registers a worktree at that path
- the ref resolves, to the head that was reported

On any miss it exits 1, names exactly what is missing, echoes what was claimed, and prints the `bd update <id> --unset-metadata coven` repair for the record it may have left behind.

It **deliberately does not repair or roll back**. Compensation is a separate fenced path with its own preconditions, and by this point the fences are released — removing anything here would be an unfenced mutation racing whatever else the checkout is doing. A probe that cannot read is reported as its own uncertainty rather than folded into "missing", because an unreadable probe is not proof of absence.

## Two corrections to my own bug report

Both were wrong on inspection, and both are stated in the commit so the next reader doesn't inherit them:

1. I wrote that the metadata write precedes `git worktree add`. **It doesn't** — the add is first.
2. I wrote that the missing branch reflog proved the branch was never created. **It doesn't follow** — compensation deletes refs with `update-ref --no-deref -d`, which leaves no reflog either, so absence looks identical to a rollback.

## Tests

A new `vanish-unit-then-succeed` update mode persists the metadata *exactly as the success path does* and then removes the unit — the observed shape. It sits at the metadata step deliberately: injecting any earlier is caught by the existing created-OID capture instead, which I confirmed by trying it there first.

**Verified as a negative control:** with the postcondition disabled, the new test fails with `status: 0` — the original bug — and passes with it restored. Full existing suite green.

It also pins the invariant that was never asserted: **sixteen existing checks read `status === 0` and not one looked at whether the worktree was there.**

Closes cave-6go4e.