### PR TITLE
Reduce worktree retirement cooldown to 15 minutes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -554,15 +554,16 @@ closed** on absent data. `=== false` would be the bug — it would treat a
 missing or malformed entry as "not disabled, therefore fine" and waive the
 exclusion silently. Don't tidy it in that direction.
 
-### The three-hour cooldown, and how to discharge it deliberately
+### The 15-minute cooldown, and how to discharge it deliberately
 
 A just-merged unit classifies `cooldown` — *"landed work remains inside the
-mandatory 3-hour cooldown"* — and the patrol will not retire it. Read what that
+mandatory 15-minute cooldown"* — and the patrol will not retire it. Read what that
 gate is before reaching past it: by the time it applies, the unit is **already**
 proven landed, clean, non-divergent and retained on a remote ref. It is not a
 correctness check. It is a *"let a concurrent session notice"* window, and the
 one risk it covers — somebody else still sitting in that directory — is the one
-thing no amount of git evidence can answer. It was 8h (#4215), 3h since #4991.
+thing no amount of git evidence can answer. It was 8h (#4215), 3h since #4991,
+and 15m since `cave-0pu26`.
 
 If you know the unit is idle, say so explicitly (`cave-jinkd`):
 

--- a/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
+++ b/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
@@ -1,7 +1,7 @@
 # Eight-Hour Worktree Retirement Implementation Plan
 
 > Historical implementation record. Superseded on 2026-08-24 by `cave-vwt75`;
-> the current mandatory retirement recency window is 3 hours.
+> the current mandatory retirement recency window is 15 minutes.
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 

--- a/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
+++ b/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
@@ -1,6 +1,6 @@
 # Eight-Hour Worktree Retirement Implementation Plan
 
-> Historical implementation record. Superseded on 2026-08-24 by `cave-vwt75`;
+> Historical implementation record. Superseded on 2026-08-25 by `cave-0pu26`;
 > the current mandatory retirement recency window is 15 minutes.
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
+++ b/docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
@@ -6,7 +6,8 @@
 **Depends on:** `cave-wqa0b`
 
 > Recency amendment: `cave-vwt75` reduced the mandatory retirement cooldown
-> from 8 hours to 3 hours on 2026-08-24. All other safety gates in this design
+> from 8 hours to 3 hours on 2026-08-24; `cave-0pu26` reduced it to 15 minutes
+> on 2026-08-25. All other safety gates in this design
 > remain unchanged.
 
 ## Goal
@@ -193,7 +194,7 @@ maintenance transaction:
    request, or active workflow owns the path, branch, or exact OID.
 6. Every liveness query is complete and schema-valid.
 7. The latest commit, branch reflog, worktree HEAD reflog, and exact merge are
-   outside the mandatory 3-hour cooldown.
+   outside the mandatory 15-minute cooldown.
 8. The exact local OID is on the freshly fetched default branch or exactly
    matches the recorded head of a pull request merged into that default branch.
 9. Structured lifecycle metadata exists and no unexpired exception or recovery

--- a/docs/superpowers/specs/2026-08-01-eight-hour-worktree-retirement-design.md
+++ b/docs/superpowers/specs/2026-08-01-eight-hour-worktree-retirement-design.md
@@ -1,6 +1,6 @@
 # Eight-Hour Worktree Retirement Design
 
-> Historical policy record. Superseded on 2026-08-24 by `cave-vwt75`, which
+> Historical policy record. Superseded on 2026-08-25 by `cave-0pu26`, which
 > reduces the mandatory retirement recency window to 15 minutes while preserving
 > the maintenance gate and deletion proof.
 

--- a/docs/superpowers/specs/2026-08-01-eight-hour-worktree-retirement-design.md
+++ b/docs/superpowers/specs/2026-08-01-eight-hour-worktree-retirement-design.md
@@ -1,7 +1,7 @@
 # Eight-Hour Worktree Retirement Design
 
 > Historical policy record. Superseded on 2026-08-24 by `cave-vwt75`, which
-> reduces the mandatory retirement recency window to 3 hours while preserving
+> reduces the mandatory retirement recency window to 15 minutes while preserving
 > the maintenance gate and deletion proof.
 
 ## Goal

--- a/docs/workflows/beads-familiars.md
+++ b/docs/workflows/beads-familiars.md
@@ -169,7 +169,7 @@ lanes are:
 
 - `active` — local changes or a live owner still needs the worktree.
 - `recovery` — detached, WIP, backup, or unlanded work still protects data.
-- `cooldown` — landed work is inside the mandatory 3-hour recency window.
+- `cooldown` — landed work is inside the mandatory 15-minute recency window.
 - `retire-after-gate` — old, clean, landed work is cleanup-ready. Automatic
   retirement still requires the full repository-wide maintenance gate; explicit
   maintainer authorization in the current task may instead activate Branch

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1266,7 +1266,7 @@ process.exit(2);
   git(["reset", "-q", "--hard", "HEAD"], recentReflog, {
     env: {
       ...process.env,
-      GIT_COMMITTER_DATE: "2026-08-10T21:00:00Z",
+      GIT_COMMITTER_DATE: "2026-08-10T21:50:00Z",
     },
   });
   const recentReflogHead = git(["rev-parse", "HEAD"], recentReflog).trim();
@@ -1325,8 +1325,8 @@ process.exit(2);
   git(["merge", "-q", "--no-ff", "feat/manual-recent", "-m", "land manual work today"], repo, {
     env: {
       ...process.env,
-      GIT_AUTHOR_DATE: "2026-08-10T21:30:00Z",
-      GIT_COMMITTER_DATE: "2026-08-10T21:30:00Z",
+      GIT_AUTHOR_DATE: "2026-08-10T21:50:00Z",
+      GIT_COMMITTER_DATE: "2026-08-10T21:50:00Z",
     },
   });
 
@@ -1353,8 +1353,8 @@ process.exit(2);
     {
       env: {
         ...process.env,
-        GIT_AUTHOR_DATE: "2026-08-10T21:30:00Z",
-        GIT_COMMITTER_DATE: "2026-08-10T21:30:00Z",
+        GIT_AUTHOR_DATE: "2026-08-10T21:50:00Z",
+        GIT_COMMITTER_DATE: "2026-08-10T21:50:00Z",
       },
     },
   );
@@ -1384,8 +1384,8 @@ process.exit(2);
   git(["commit", "-q", "-m", "later default work"], repo, {
     env: {
       ...process.env,
-      GIT_AUTHOR_DATE: "2026-08-10T21:45:00Z",
-      GIT_COMMITTER_DATE: "2026-08-10T21:45:00Z",
+      GIT_AUTHOR_DATE: "2026-08-10T21:50:00Z",
+      GIT_COMMITTER_DATE: "2026-08-10T21:50:00Z",
     },
   });
   git(["push", "-q", "origin", "main"], repo);
@@ -2203,7 +2203,7 @@ if [ "$1" = "api" ] &&
         elif [ "\${LIFECYCLE_OUTBOUND_OPEN:-0}" = "1" ]; then
           printf '%s\\n' '[[{"number":142,"html_url":"https://github.com/ArchiveOrg/archive/pull/142","state":"closed","draft":false,"merged_at":null,"head":{"ref":"archived-name","sha":"${oldHead}","repo":{"full_name":"ForkOwner/fork"}},"base":{"ref":"archive","repo":{"full_name":"ArchiveOrg/archive"}}}],[{"number":99,"html_url":"https://github.com/OtherOrg/other-repo/pull/99","state":"open","draft":false,"merged_at":null,"head":{"ref":"different-head-name","sha":"${oldHead}","repo":{"full_name":"ForkOwner/fork"}},"base":{"ref":"main","repo":{"full_name":"OtherOrg/other-repo"}}}]]'
         elif [ "\${LIFECYCLE_EXACT_MERGED_DIFFERENT_HEAD:-0}" = "1" ]; then
-          printf '%s\\n' '[[{"number":98,"html_url":"https://github.com/OpenCoven/coven-cave/pull/98","state":"closed","draft":false,"merged_at":"2026-08-10T21:30:00Z","head":{"ref":"different-merged-head","sha":"${oldHead}","repo":{"full_name":"ForkOwner/fork"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
+          printf '%s\\n' '[[{"number":98,"html_url":"https://github.com/OpenCoven/coven-cave/pull/98","state":"closed","draft":false,"merged_at":"2026-08-10T21:50:00Z","head":{"ref":"different-merged-head","sha":"${oldHead}","repo":{"full_name":"ForkOwner/fork"}},"base":{"ref":"main","repo":{"full_name":"OpenCoven/coven-cave"}}}]]'
         elif [ "\${LIFECYCLE_CLOSED_UNMERGED:-0}" = "1" ] ||
              [ "\${LIFECYCLE_CLOSED_DRAFT:-0}" = "1" ]; then
           DRAFT=false
@@ -2217,12 +2217,12 @@ if [ "$1" = "api" ] &&
           printf '[[{"number":42,"html_url":"https://github.com/OpenCoven/coven-cave/pull/42","state":"closed","draft":false,"merged_at":"2026-07-21T12:00:00Z","head":{"ref":"feat/old","sha":"${oldHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"%s","repo":{"full_name":"OpenCoven/coven-cave"}}}]]\\n' "$BASE_REF"
         fi
       elif [ "$OID_ARG" = "${recentMergeHead}" ]; then
-        printf '[[{"number":43,"html_url":"https://github.com/OpenCoven/coven-cave/pull/43","state":"closed","draft":false,"merged_at":"2026-08-10T21:00:00Z","head":{"ref":"feat/recent-merge","sha":"${recentMergeHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"%s","repo":{"full_name":"OpenCoven/coven-cave"}}}]]\\n' "$BASE_REF"
+        printf '[[{"number":43,"html_url":"https://github.com/OpenCoven/coven-cave/pull/43","state":"closed","draft":false,"merged_at":"2026-08-10T21:50:00Z","head":{"ref":"feat/recent-merge","sha":"${recentMergeHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"%s","repo":{"full_name":"OpenCoven/coven-cave"}}}]]\\n' "$BASE_REF"
       elif [ "$OID_ARG" = "${recentReflogHead}" ]; then
         printf '[[{"number":44,"html_url":"https://github.com/OpenCoven/coven-cave/pull/44","state":"closed","draft":false,"merged_at":"2026-07-21T12:00:00Z","head":{"ref":"feat/recent-reflog","sha":"${recentReflogHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"%s","repo":{"full_name":"OpenCoven/coven-cave"}}}]]\\n' "$BASE_REF"
       elif [ "$OID_ARG" = "${fastForwardHead}" ] &&
            [ "\${LIFECYCLE_FAST_FORWARD_MERGED_PR:-0}" = "1" ]; then
-        printf '[[{"number":45,"html_url":"https://github.com/OpenCoven/coven-cave/pull/45","state":"closed","draft":false,"merged_at":"2026-08-10T21:30:00Z","head":{"ref":"feat/fast-forward","sha":"${fastForwardHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"%s","repo":{"full_name":"OpenCoven/coven-cave"}}}]]\\n' "$BASE_REF"
+        printf '[[{"number":45,"html_url":"https://github.com/OpenCoven/coven-cave/pull/45","state":"closed","draft":false,"merged_at":"2026-08-10T21:50:00Z","head":{"ref":"feat/fast-forward","sha":"${fastForwardHead}","repo":{"full_name":"OpenCoven/coven-cave"}},"base":{"ref":"%s","repo":{"full_name":"OpenCoven/coven-cave"}}}]]\\n' "$BASE_REF"
       else
         printf '%s\\n' '[[]]'
       fi
@@ -2340,7 +2340,7 @@ if [ "$1" = "api" ] &&
       elif [ "\${LIFECYCLE_OUTBOUND_OPEN:-0}" = "1" ]; then
         printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":2,"nodes":[{"number":142,"url":"https://github.com/ArchiveOrg/archive/pull/142","state":"CLOSED","isDraft":false,"mergedAt":null,"headRefName":"archived-name","headRefOid":"${oldHead}","headRepository":{"nameWithOwner":"ForkOwner/fork"},"baseRefName":"archive","baseRepository":{"nameWithOwner":"ArchiveOrg/archive"}}],"pageInfo":{"hasNextPage":true,"endCursor":"assoc-1"}}}}}},{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":2,"nodes":[{"number":99,"url":"https://github.com/OtherOrg/other-repo/pull/99","state":"OPEN","isDraft":false,"mergedAt":null,"headRefName":"different-head-name","headRefOid":"${oldHead}","headRepository":{"nameWithOwner":"ForkOwner/fork"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OtherOrg/other-repo"}}],"pageInfo":{"hasNextPage":false,"endCursor":"assoc-2"}}}}}}]'
       elif [ "\${LIFECYCLE_EXACT_MERGED_DIFFERENT_HEAD:-0}" = "1" ]; then
-        printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":98,"url":"https://github.com/OpenCoven/coven-cave/pull/98","state":"MERGED","isDraft":false,"mergedAt":"2026-08-10T21:30:00Z","headRefName":"different-merged-head","headRefOid":"${oldHead}","headRepository":{"nameWithOwner":"ForkOwner/fork"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"merged-different"}}}}}}]'
+        printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":98,"url":"https://github.com/OpenCoven/coven-cave/pull/98","state":"MERGED","isDraft":false,"mergedAt":"2026-08-10T21:50:00Z","headRefName":"different-merged-head","headRefOid":"${oldHead}","headRepository":{"nameWithOwner":"ForkOwner/fork"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"merged-different"}}}}}}]'
       elif [ "\${LIFECYCLE_CLOSED_UNMERGED:-0}" = "1" ]; then
         printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":97,"url":"https://github.com/OpenCoven/coven-cave/pull/97","state":"CLOSED","isDraft":false,"mergedAt":null,"headRefName":"feat/old","headRefOid":"${oldHead}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"closed"}}}}}}]'
       elif [ "\${LIFECYCLE_CLOSED_DRAFT:-0}" = "1" ]; then
@@ -2352,12 +2352,12 @@ if [ "$1" = "api" ] &&
         printf '[{"data":{"repository":{"nameWithOwner":"%s","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":42,"url":"https://github.com/OpenCoven/coven-cave/pull/42","state":"MERGED","isDraft":false,"mergedAt":"2026-07-21T12:00:00Z","headRefName":"feat/old","headRefOid":"${oldHead}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"%s","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"old"}}}}}}]\\n' "$REPOSITORY" "$BASE_REF"
       fi
     elif [ "$OID_ARG" = "${recentMergeHead}" ]; then
-      printf '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":43,"url":"https://github.com/OpenCoven/coven-cave/pull/43","state":"MERGED","isDraft":false,"mergedAt":"2026-08-10T21:00:00Z","headRefName":"feat/recent-merge","headRefOid":"${recentMergeHead}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"%s","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"recent"}}}}}}]\\n' "$BASE_REF"
+      printf '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":43,"url":"https://github.com/OpenCoven/coven-cave/pull/43","state":"MERGED","isDraft":false,"mergedAt":"2026-08-10T21:50:00Z","headRefName":"feat/recent-merge","headRefOid":"${recentMergeHead}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"%s","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"recent"}}}}}}]\\n' "$BASE_REF"
     elif [ "$OID_ARG" = "${recentReflogHead}" ]; then
       printf '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":44,"url":"https://github.com/OpenCoven/coven-cave/pull/44","state":"MERGED","isDraft":false,"mergedAt":"2026-07-21T12:00:00Z","headRefName":"feat/recent-reflog","headRefOid":"${recentReflogHead}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"%s","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"reflog"}}}}}}]\\n' "$BASE_REF"
     elif [ "$OID_ARG" = "${fastForwardHead}" ] &&
          [ "\${LIFECYCLE_FAST_FORWARD_MERGED_PR:-0}" = "1" ]; then
-      printf '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":45,"url":"https://github.com/OpenCoven/coven-cave/pull/45","state":"MERGED","isDraft":false,"mergedAt":"2026-08-10T21:30:00Z","headRefName":"feat/fast-forward","headRefOid":"${fastForwardHead}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"%s","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"fast-forward"}}}}}}]\\n' "$BASE_REF"
+      printf '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":45,"url":"https://github.com/OpenCoven/coven-cave/pull/45","state":"MERGED","isDraft":false,"mergedAt":"2026-08-10T21:50:00Z","headRefName":"feat/fast-forward","headRefOid":"${fastForwardHead}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"%s","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"fast-forward"}}}}}}]\\n' "$BASE_REF"
     else
       printf '[{"data":{"repository":{"nameWithOwner":"%s","object":{"associatedPullRequests":{"totalCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]\\n' "$REPOSITORY"
     fi
@@ -3019,15 +3019,15 @@ exit 0
     "cooldown",
     "a fresh direct default-branch landing supplies cooldown evidence without a matching PR",
   );
-  assert.equal(directLanding.updatedAtMs, Date.parse("2026-08-10T21:30:00Z"));
+  assert.equal(directLanding.updatedAtMs, Date.parse("2026-08-10T21:50:00Z"));
   assert.equal(directLanding.mergedPr, null);
   const postLandingCooldown = JSON.parse(
-    patrol(["--json", "--now", "2026-08-11T00:30:00Z"]),
+    patrol(["--json", "--now", "2026-08-10T22:05:00Z"]),
   ).items.find((item) => item.branch === "feat/direct-landing");
   assert.equal(
     postLandingCooldown.lane,
     "retire-after-gate",
-    "the stable direct landing becomes eligible after 3 hours",
+    "the stable direct landing becomes eligible after 15 minutes",
   );
   assert.deepEqual(report.budgets, {
     // cave-oenag: 8 registered, one of them detached, so 7 are assessed.
@@ -3190,7 +3190,7 @@ exit 0
     const fastForward = byBranch.get("feat/fast-forward");
     assert.notEqual(fastForward.head, defaultHead);
     assert.equal(fastForward.lane, "cooldown");
-    assert.equal(fastForward.updatedAtMs, Date.parse("2026-08-10T21:45:00Z"));
+    assert.equal(fastForward.updatedAtMs, Date.parse("2026-08-10T21:50:00Z"));
     assert.equal(byBranch.get("main").lane, "protected");
   });
 
@@ -3203,12 +3203,12 @@ exit 0
     );
     assert.equal(mergedFastForward.head, fastForwardHead);
     assert.equal(mergedFastForward.lane, "cooldown");
-    assert.equal(mergedFastForward.updatedAtMs, Date.parse("2026-08-10T21:45:00Z"));
+    assert.equal(mergedFastForward.updatedAtMs, Date.parse("2026-08-10T21:50:00Z"));
     assert.equal(mergedFastForward.mergedPr.number, 45);
 
     const eligibleFastForward = JSON.parse(
       patrol(
-        ["--json", "--now", "2026-08-11T21:45:01Z"],
+        ["--json", "--now", "2026-08-10T22:05:01Z"],
         { LIFECYCLE_FAST_FORWARD_MERGED_PR: "1" },
       ),
     ).items.find((item) => item.branch === "feat/fast-forward");

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -22,8 +22,8 @@ const DAY = 24 * 60 * 60 * 1000;
 
 assert.equal(
   RETIREMENT_COOLDOWN_MS,
-  3 * HOUR,
-  "retirement cooldown remains the mandatory three-hour window",
+  15 * 60 * 1000,
+  "retirement cooldown remains the mandatory 15-minute window",
 );
 
 {
@@ -410,7 +410,7 @@ function legacyObservation(overrides = {}) {
     NOW,
   );
   assert.equal(item.lane, "cooldown");
-  assert.match(item.reasons.join("\n"), /3-hour cooldown/);
+  assert.match(item.reasons.join("\n"), /15-minute cooldown/);
 }
 
 {
@@ -423,7 +423,7 @@ function legacyObservation(overrides = {}) {
     NOW,
   );
   assert.equal(item.lane, "retire-after-gate", "old exact merged heads become owner-actionable");
-  assert.match(item.reasons.join("\n"), /at least 3 hours old/);
+  assert.match(item.reasons.join("\n"), /at least 15 minutes old/);
   assert.match(item.reasons.join("\n"), /maintenance gate/);
 }
 

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -786,7 +786,7 @@ function classifyLifecycleUnitInternal(
   // exception granted to escape a full budget went on to hold the budget full,
   // forcing the next session to request another one.
   //
-  // Retirement stays gated by the 3-hour cooldown, the repository-wide
+  // Retirement stays gated by the 15-minute cooldown, the repository-wide
   // maintenance gate, and the deletion proof below, so dropping the exception
   // here reclassifies landed work without authorizing any new deletion.
 

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -343,14 +343,15 @@ function headMismatchReason(pr: WorktreeMergedPrRef): string {
  * non-divergent and retained — so this is not a correctness check. It is a
  * "let a concurrent session notice" window: the one risk left is that someone
  * else is still sitting in the directory, and no amount of git evidence can
- * answer that. 8h originally (#4215), 3h since #4991 (`cave-vwt75`).
+ * answer that. 8h originally (#4215), 3h since #4991 (`cave-vwt75`), and
+ * 15m since `cave-0pu26`.
  *
  * An operator who KNOWS the unit is idle can discharge the wait explicitly
  * with `--allow-cooldown-override` — see {@link cooldownIsTheOnlyBlocker}.
  * The scheduled sweep never passes it, because a cron job has nobody to make
  * that assertion.
  */
-export const RETIREMENT_COOLDOWN_MS = 3 * 60 * 60 * 1000;
+export const RETIREMENT_COOLDOWN_MS = 15 * 60 * 1000;
 /** Branch namespaces whose content is a snapshot to preserve, never retire.
  *
  *  `wip/` is a NAMESPACE here, not a token anywhere in the name. The previous
@@ -806,13 +807,13 @@ function classifyLifecycleUnitInternal(
   const ageMs = nowMs - observation.updatedAtMs;
   if (ageMs < RETIREMENT_COOLDOWN_MS) {
     return withReasons(observation, "cooldown", [
-      "landed work remains inside the mandatory 3-hour cooldown",
+      "landed work remains inside the mandatory 15-minute cooldown",
       ...reviewAfterReasons(observation.metadata, nowMs),
     ]);
   }
 
   return withReasons(observation, "retire-after-gate", [
-    "clean landed work is at least 3 hours old",
+    "clean landed work is at least 15 minutes old",
     "removal still requires the repository-wide maintenance gate and final deletion proof",
     ...reviewAfterReasons(observation.metadata, nowMs),
   ]);
@@ -855,12 +856,12 @@ function classifyLifecycleUnitWithoutMetadata(
   const ageMs = nowMs - observation.updatedAtMs;
   if (ageMs < RETIREMENT_COOLDOWN_MS) {
     return withReasons(observation, "cooldown", [
-      "landed work remains inside the mandatory 3-hour cooldown",
+      "landed work remains inside the mandatory 15-minute cooldown",
     ]);
   }
 
   return withReasons(observation, "retire-after-gate", [
-    "clean landed work is at least 3 hours old",
+    "clean landed work is at least 15 minutes old",
     "removal still requires the repository-wide maintenance gate and final deletion proof",
   ]);
 }


### PR DESCRIPTION
## Summary
- reduce the merged-worktree observation window from three hours to 15 minutes
- preserve clean, landed, retained, liveness, maintenance-gate, and explicit-override safeguards
- pin the exact boundary in classifier and patrol tests and align current workflow documentation

## Verification
- `node --experimental-strip-types src/lib/worktree-lifecycle.test.ts`
- `node scripts/worktree-lifecycle-patrol.test.mjs`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `pnpm build`

Bead: `cave-0pu26`