### PR TITLE
Release v0.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,54 @@ breaking config changes; patch releases stay additive.
 ### Changes
 - Correct the port-claim occupant docs and harden the two contracts that pin them (#4980)
 
+## [0.3.11] - 2026-08-25
+
+> Makes iOS pairing land on the requested chat reliably, adds richer Familiar
+> insight, and sharpens everyday Chat, Research, Rituals, and Calendar flows.
+
+Patch release on top of v0.3.10. Native iOS now preserves invite destinations
+through approval, pairing, discovery relocation, and delayed reconnects, while
+Familiar profiles gain a comprehensive overview and truthful analytics.
+Shared surfaces add calendar-backed cron visibility, live run feedback,
+stronger research recommendations, compact chat chrome, and hardened release
+and recovery gates.
+
+### Changes
+- Refuse to report a worktree creation whose unit is not present (#5036)
+- Route paired iOS invites to requested chats (#5035)
+- Project cron runs into Day, Week and Month calendar views (cave-aa10e) (#5034)
+- Show the run you just started (#5031)
+- Scale Research resources and ground topic suggestions (#5032)
+- Tell the cron detail pane when the cron next runs (#5029)
+- Compact Chat workspace chrome (#5028)
+- Put the crons on the calendar (#5027)
+- Show the cron dialog what it will actually do (#5026)
+- Make the first magnification step a nudge, not a jump (#5025)
+- Keep Research runnable without Codex launch policy (#5024)
+- Require the signed OpenClaw release contract (#5015)
+- Make project identity host and worktree aware (#5017)
+- Use dropdowns for podcast voices (#5023)
+- Let an operator discharge the retirement cooldown, on the record (#5022)
+- Say what the last run did, and stay legible while hovered (#5020)
+- Match Research Desk to familiar model defaults (#5021)
+- Rebuild the Rituals Crons tab from the design handoff (#5019)
+- Modernize branded destination cards (#5018)
+- iOS: add truthful Familiar analytics digest (#5004)
+- Refine chat continuation controls (#5013)
+- fix(gate): report a coven spawn that never ran as a timeout, not a bad version (#5014)
+- Reconcile X publish surface with its design spec (cave-uajyn) (#4988)
+- perf(chat): share large-list project grouping (#5012)
+- fix(ci): skip desktop publishing for iOS releases (#5011)
+- fix(rituals): compress calendar chrome (#4998)
+- fix(ios): restore deterministic XCTest gate (#5010)
+- iOS: build Familiar Overview command center (#5005)
+- ci: shard final release E2E validation (#5009)
+- Refine the command palette into a sleek search surface (#4995)
+- fix: make Client v1 fixture cursors canonical
+- ci: isolate PR and release E2E servers (#5008)
+- feat(ios): build comprehensive Familiar profile (#5003)
+- feat(projects): finish AI-generated project icons
+
 ## [0.3.10] - 2026-08-24
 
 > Modernizes native iOS chat and project controls, adds familiar avatar

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.3.10"
+    MARKETING_VERSION: "0.3.11"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026082404"
+    CURRENT_PROJECT_VERSION: "2026082523"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "aes-gcm",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.10"
+version = "0.3.11"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- stamp Coven Cave v0.3.11 across web, Tauri, Rust, and native iOS manifests
- advance the TestFlight build to `2026082523`
- finalize release notes for iOS invite routing, Familiar insights, and workflow polish since v0.3.10

## Validation
- `pnpm release:preview --version 0.3.11`
- `pnpm release:prepare --version 0.3.11`
- `pnpm release:verify --version 0.3.11`
- `git diff --check`
- read-only release stamp review: no findings

Bead: `cave-go8rk`