### PR TITLE
Add a focus-first Research PDF reader

### DIFF
--- a/src/components/research-paper-viewer.tsx
+++ b/src/components/research-paper-viewer.tsx
@@ -42,6 +42,7 @@ import type {
   RenderTask,
   TextLayer,
 } from "pdfjs-dist";
+import "@/styles/research-paper-focus-reader.css";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/lib/icon";
 import {

--- a/src/components/research-paper-viewer.tsx
+++ b/src/components/research-paper-viewer.tsx
@@ -42,7 +42,6 @@ import type {
   RenderTask,
   TextLayer,
 } from "pdfjs-dist";
-import "@/styles/research-paper-focus-reader.css";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/lib/icon";
 import {

--- a/src/components/role-surfaces/research-tab-resources.test.ts
+++ b/src/components/role-surfaces/research-tab-resources.test.ts
@@ -129,6 +129,11 @@ test("detail overlay is a focus-trapped dialog with honest copy/open actions", (
 });
 
 test("the paper reader opens directly into a near-bezelless focus mode", () => {
+  assert.match(
+    source,
+    /import "@\/styles\/research-paper-focus-reader\.css"/,
+    "reader chrome loads with the Resources surface, before the lazy PDF chunk mounts",
+  );
   assert.match(source, /const \[readerExpanded, setReaderExpanded\] = useState\(false\)/);
   assert.match(
     source,

--- a/src/components/role-surfaces/research-tab-resources.test.ts
+++ b/src/components/role-surfaces/research-tab-resources.test.ts
@@ -135,6 +135,12 @@ test("the paper reader opens directly into a near-bezelless focus mode", () => {
     "reader chrome loads with the Resources surface, before the lazy PDF chunk mounts",
   );
   assert.match(source, /const \[readerExpanded, setReaderExpanded\] = useState\(false\)/);
+  assert.match(source, /const readerFocusControlRef = useRef<HTMLButtonElement>\(null\)/);
+  assert.match(
+    source,
+    /if \(reading && readerExpanded\) readerFocusControlRef\.current\?\.focus\(\)/,
+    "focus moves from the removed Read button to a surviving reader control",
+  );
   assert.match(
     source,
     /if \(readerExpanded\) \{\s*setReaderExpanded\(false\);\s*return;\s*\}\s*closeOverlay\(\)/,
@@ -163,6 +169,10 @@ test("the paper reader opens directly into a near-bezelless focus mode", () => {
     readerStyles,
     /\.research-res-overlay__dialog\[data-reader\] \.research-paper-view__stage[\s\S]*max-height: none/,
   );
+  assert.match(readerStyles, /var\(--sai-top\)/);
+  assert.match(readerStyles, /var\(--sai-right\)/);
+  assert.match(readerStyles, /var\(--sai-bottom\)/);
+  assert.match(readerStyles, /var\(--sai-left\)/);
 });
 
 test("resources expose a labeled multiline batch intake with truthful preview", () => {

--- a/src/components/role-surfaces/research-tab-resources.test.ts
+++ b/src/components/role-surfaces/research-tab-resources.test.ts
@@ -9,6 +9,10 @@ const styles = readFileSync(
   new URL("../../styles/globals/surface-research-resources.css", import.meta.url),
   "utf8",
 );
+const readerStyles = readFileSync(
+  new URL("../../styles/research-paper-focus-reader.css", import.meta.url),
+  "utf8",
+);
 const researchLinksHook = readFileSync(new URL("./use-research-links.ts", import.meta.url), "utf8");
 const xArticles = readFileSync(new URL("../../lib/x-articles.ts", import.meta.url), "utf8");
 const readerUrl = new URL("../research-x-article-reader.tsx", import.meta.url);
@@ -124,17 +128,36 @@ test("detail overlay is a focus-trapped dialog with honest copy/open actions", (
   assert.match(source, /context\.openUrl\(openLink\.url\)/);
 });
 
-test("the paper reader expands in place and Escape collapses before closing", () => {
+test("the paper reader opens directly into a near-bezelless focus mode", () => {
   assert.match(source, /const \[readerExpanded, setReaderExpanded\] = useState\(false\)/);
   assert.match(
     source,
     /if \(readerExpanded\) \{\s*setReaderExpanded\(false\);\s*return;\s*\}\s*closeOverlay\(\)/,
   );
+  assert.match(
+    source,
+    /onClick=\{\(\) => \{\s*setReading\(true\);\s*setReaderExpanded\(true\);\s*\}\}/,
+    "Read enters focus mode without requiring a second expansion click",
+  );
+  assert.match(source, /data-reader=\{reading && readerExpanded \|\| undefined\}/);
   assert.match(source, /data-expanded=\{readerExpanded \|\| undefined\}/);
-  assert.match(source, /aria-label=\{readerExpanded \? "Collapse paper reader" : "Expand paper reader"\}/);
+  assert.match(source, /aria-label=\{readerExpanded \? "Exit focus reader" : "Enter focus reader"\}/);
   assert.match(source, /name=\{readerExpanded \? "ph:corners-in" : "ph:corners-out"\}/);
-  assert.match(styles, /\.research-res-overlay__dialog\[data-expanded\]/);
-  assert.match(styles, /\.research-res-overlay__dialog\[data-expanded\] \.research-paper-view__stage/);
+  assert.match(source, /aria-label="Download PDF"/);
+  assert.match(readerStyles, /\.research-res-overlay\[data-reader\]/);
+  assert.match(readerStyles, /\.research-res-overlay__dialog\[data-reader\]/);
+  assert.match(
+    readerStyles,
+    /\.research-res-overlay__dialog\[data-reader\] \.research-res-overlay__source[\s\S]*display: none/,
+  );
+  assert.match(
+    readerStyles,
+    /\.research-res-overlay__dialog\[data-reader\] \.research-res-overlay__actions[\s\S]*display: none/,
+  );
+  assert.match(
+    readerStyles,
+    /\.research-res-overlay__dialog\[data-reader\] \.research-paper-view__stage[\s\S]*max-height: none/,
+  );
 });
 
 test("resources expose a labeled multiline batch intake with truthful preview", () => {

--- a/src/components/role-surfaces/research-tab-resources.tsx
+++ b/src/components/role-surfaces/research-tab-resources.tsx
@@ -16,6 +16,7 @@
  */
 
 import dynamic from "next/dynamic";
+import "@/styles/research-paper-focus-reader.css";
 import {
   useCallback,
   useEffect,

--- a/src/components/role-surfaces/research-tab-resources.tsx
+++ b/src/components/role-surfaces/research-tab-resources.tsx
@@ -130,6 +130,7 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
   const activeArticleIdRef = useRef<string | null>(null);
   const articleReaderRef = useRef<HTMLElement | null>(null);
   const pendingArticleFocusRef = useRef(false);
+  const readerFocusControlRef = useRef<HTMLButtonElement>(null);
   const selectedMission = research.selected;
   const act = research.act;
   const intake = useMemo(() => summarizeLinkIntake(draft, links), [draft, links]);
@@ -363,6 +364,10 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
     closeOverlay();
   }, [closeOverlay, readerExpanded]);
   useFocusTrap(Boolean(openLink), dialogRef, { onEscape: handleOverlayEscape });
+
+  useEffect(() => {
+    if (reading && readerExpanded) readerFocusControlRef.current?.focus();
+  }, [reading, readerExpanded]);
 
   // A fresh overlay never inherits the previous one's confirm/copied/reading
   // state — closing the overlay or opening a different resource both land
@@ -802,6 +807,7 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
                       </button>
                     ) : null}
                     <button
+                      ref={readerFocusControlRef}
                       type="button"
                       className="research-res-overlay__close focus-ring"
                       onClick={() => setReaderExpanded((current) => !current)}

--- a/src/components/role-surfaces/research-tab-resources.tsx
+++ b/src/components/role-surfaces/research-tab-resources.tsx
@@ -736,7 +736,11 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
       ) : null}
 
       {openLink ? (
-        <div className="research-res-overlay" onClick={closeOverlay}>
+        <div
+          className="research-res-overlay"
+          data-reader={reading && readerExpanded || undefined}
+          onClick={closeOverlay}
+        >
           <div
             ref={dialogRef}
             role="dialog"
@@ -744,6 +748,7 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
             aria-labelledby="research-res-overlay-title"
             className="research-res-overlay__dialog"
             data-expanded={readerExpanded || undefined}
+            data-reader={reading && readerExpanded || undefined}
             tabIndex={-1}
             onClick={(event) => event.stopPropagation()}
           >
@@ -783,27 +788,40 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
               </div>
               <div className="research-res-overlay__head-actions">
                 {openPaperId && reading ? (
-                  <button
-                    type="button"
-                    className="research-res-overlay__close focus-ring"
-                    onClick={() => setReaderExpanded((current) => !current)}
-                    aria-label={readerExpanded ? "Collapse paper reader" : "Expand paper reader"}
-                    aria-pressed={readerExpanded}
-                    title={readerExpanded ? "Collapse paper reader" : "Expand paper reader"}
-                  >
-                    <Icon
-                      name={readerExpanded ? "ph:corners-in" : "ph:corners-out"}
-                      width={13}
-                      height={13}
-                      aria-hidden
-                    />
-                  </button>
+                  <>
+                    {readerExpanded ? (
+                      <button
+                        type="button"
+                        className="research-res-overlay__close focus-ring"
+                        onClick={() => context.openUrl(paperDownloadUrl(openPaperId))}
+                        aria-label="Download PDF"
+                        title="Download PDF"
+                      >
+                        <Icon name="ph:download-simple" width={13} height={13} aria-hidden />
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      className="research-res-overlay__close focus-ring"
+                      onClick={() => setReaderExpanded((current) => !current)}
+                      aria-label={readerExpanded ? "Exit focus reader" : "Enter focus reader"}
+                      aria-pressed={readerExpanded}
+                      title={readerExpanded ? "Exit focus reader" : "Enter focus reader"}
+                    >
+                      <Icon
+                        name={readerExpanded ? "ph:corners-in" : "ph:corners-out"}
+                        width={13}
+                        height={13}
+                        aria-hidden
+                      />
+                    </button>
+                  </>
                 ) : null}
                 <button
                   type="button"
                   className="research-res-overlay__close focus-ring"
                   onClick={closeOverlay}
-                  aria-label="Close resource details"
+                  aria-label={reading ? "Close paper reader" : "Close resource details"}
                 >
                   <Icon name="ph:x" width={13} height={13} aria-hidden />
                 </button>
@@ -905,7 +923,10 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
                       size="sm"
                       variant="secondary"
                       leadingIcon="ph:book-open"
-                      onClick={() => setReading(true)}
+                      onClick={() => {
+                        setReading(true);
+                        setReaderExpanded(true);
+                      }}
                     >
                       Read
                     </Button>

--- a/src/lib/use-focus-trap.test.ts
+++ b/src/lib/use-focus-trap.test.ts
@@ -32,6 +32,11 @@ assert.match(
   /querySelectorAll<HTMLElement>\(FOCUSABLE\)/,
   "re-queries focusables on each Tab event",
 );
+assert.match(
+  source,
+  /\.filter\(\s*\(el\) => !el\.hasAttribute\("disabled"\) && el\.getClientRects\(\)\.length > 0,\s*\)/,
+  "excludes controls hidden by an active dialog mode from the Tab cycle",
+);
 
 // Exports the shared FOCUSABLE selector for consumers who want to use it directly.
 assert.match(source, /export const FOCUSABLE\s*=/, "exports FOCUSABLE selector constant");

--- a/src/lib/use-focus-trap.test.ts
+++ b/src/lib/use-focus-trap.test.ts
@@ -34,7 +34,7 @@ assert.match(
 );
 assert.match(
   source,
-  /\.filter\(\s*\(el\) => !el\.hasAttribute\("disabled"\) && el\.getClientRects\(\)\.length > 0,\s*\)/,
+  /typeof el\.getClientRects !== "function" \|\| el\.getClientRects\(\)\.length > 0/,
   "excludes controls hidden by an active dialog mode from the Tab cycle",
 );
 

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -165,7 +165,9 @@ export function useFocusTrap(
       if (e.key === "Tab" && container) {
         const focusables = Array.from(
           container.querySelectorAll<HTMLElement>(FOCUSABLE),
-        ).filter((el) => !el.hasAttribute("disabled"));
+        ).filter(
+          (el) => !el.hasAttribute("disabled") && el.getClientRects().length > 0,
+        );
         if (focusables.length === 0) {
           e.preventDefault();
           return;

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -166,7 +166,9 @@ export function useFocusTrap(
         const focusables = Array.from(
           container.querySelectorAll<HTMLElement>(FOCUSABLE),
         ).filter(
-          (el) => !el.hasAttribute("disabled") && el.getClientRects().length > 0,
+          (el) =>
+            !el.hasAttribute("disabled") &&
+            (typeof el.getClientRects !== "function" || el.getClientRects().length > 0),
         );
         if (focusables.length === 0) {
           e.preventDefault();

--- a/src/styles/research-paper-focus-reader.css
+++ b/src/styles/research-paper-focus-reader.css
@@ -18,7 +18,11 @@
   z-index: 4;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
+  padding:
+    calc(var(--space-2) + var(--sai-top))
+    calc(var(--space-3) + var(--sai-right))
+    var(--space-2)
+    calc(var(--space-3) + var(--sai-left));
   background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
   backdrop-filter: blur(var(--space-3));
 }
@@ -85,7 +89,11 @@
   min-height: 0;
   max-height: none;
   overflow: auto;
-  padding: var(--space-10) var(--space-4) var(--space-6);
+  padding:
+    var(--space-10)
+    calc(var(--space-4) + var(--sai-right))
+    calc(var(--space-6) + var(--sai-bottom))
+    calc(var(--space-4) + var(--sai-left));
   background: var(--bg-base);
   border: none;
   border-radius: 0;
@@ -106,7 +114,8 @@
   }
 
   .research-res-overlay__dialog[data-reader] .research-paper-view__stage {
-    padding-inline: var(--space-2);
+    padding-right: calc(var(--space-2) + var(--sai-right));
+    padding-left: calc(var(--space-2) + var(--sai-left));
   }
 }
 

--- a/src/styles/research-paper-focus-reader.css
+++ b/src/styles/research-paper-focus-reader.css
@@ -1,0 +1,117 @@
+.research-res-overlay[data-reader] {
+  padding: 0;
+  background: var(--bg-base);
+}
+
+.research-res-overlay__dialog[data-reader] {
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  max-height: none;
+  overflow: hidden;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.research-res-overlay__dialog[data-reader] .research-res-overlay__head {
+  z-index: 4;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
+  backdrop-filter: blur(var(--space-3));
+}
+
+.research-res-overlay__dialog[data-reader] .research-res-overlay__glyph,
+.research-res-overlay__dialog[data-reader] .research-res-overlay__meta,
+.research-res-overlay__dialog[data-reader] .research-res-overlay__sub,
+.research-res-overlay__dialog[data-reader] .research-res-overlay__source,
+.research-res-overlay__dialog[data-reader] .research-res-overlay__actions,
+.research-res-overlay__dialog[data-reader] .research-paper-view__byline,
+.research-res-overlay__dialog[data-reader] .research-paper-view__abstract,
+.research-res-overlay__dialog[data-reader] .research-res-overlay__stats,
+.research-res-overlay__dialog[data-reader] .research-res-overlay__runs {
+  display: none;
+}
+
+.research-res-overlay__dialog[data-reader] .research-res-overlay__heading {
+  display: block;
+}
+
+.research-res-overlay__dialog[data-reader] .research-res-overlay__heading h3 {
+  overflow: hidden;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: var(--leading-tight);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.research-res-overlay__dialog[data-reader] .research-res-overlay__body {
+  flex: 1;
+  min-height: 0;
+  gap: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
+.research-res-overlay__dialog[data-reader] .research-paper-view {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  height: 100%;
+  gap: 0;
+  background: var(--bg-base);
+}
+
+.research-res-overlay__dialog[data-reader] .research-paper-view__toolbar {
+  position: absolute;
+  z-index: 3;
+  top: var(--space-2);
+  left: 50%;
+  flex-wrap: nowrap;
+  padding: var(--space-1) var(--space-2);
+  background: color-mix(in oklch, var(--bg-elevated) 92%, transparent);
+  border-color: var(--border-strong);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-popover);
+  backdrop-filter: blur(var(--space-3));
+  transform: translateX(-50%);
+}
+
+.research-res-overlay__dialog[data-reader] .research-paper-view__stage {
+  flex: 1;
+  min-height: 0;
+  max-height: none;
+  overflow: auto;
+  padding: var(--space-10) var(--space-4) var(--space-6);
+  background: var(--bg-base);
+  border: none;
+  border-radius: 0;
+  scrollbar-gutter: stable both-edges;
+}
+
+.research-res-overlay__dialog[data-reader] .research-paper-view__canvas {
+  border-radius: 0;
+  box-shadow: var(--shadow-popover);
+}
+
+@media (max-width: 560px) {
+  .research-res-overlay__dialog[data-reader] .research-paper-view__toolbar {
+    right: var(--space-2);
+    left: var(--space-2);
+    justify-content: center;
+    transform: none;
+  }
+
+  .research-res-overlay__dialog[data-reader] .research-paper-view__stage {
+    padding-inline: var(--space-2);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .research-res-overlay__dialog[data-reader] .research-paper-view__toolbar {
+    transition: none;
+  }
+}

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -1186,7 +1186,12 @@ test.describe("research desk tabs", () => {
     await expect(dialog.getByRole("button", { name: "Exit focus reader" })).toBeVisible();
     await expect(dialog.locator(".research-res-overlay__source")).toBeHidden();
     await expect(dialog.locator(".research-res-overlay__actions")).toBeHidden();
-    await expect(dialog.locator(".research-paper-view__stage")).toHaveCSS("max-height", "none");
+    const stage = dialog.locator(".research-paper-view__stage");
+    await expect(stage).toHaveCSS("max-height", "none");
+    await expect(stage).toHaveAttribute("data-status", "ready", { timeout: 15_000 });
+    await expect
+      .poll(() => dialog.locator(".research-paper-view__canvas").evaluate((canvas) => canvas.width))
+      .toBeGreaterThan(100);
 
     const viewport = page.viewportSize();
     const box = await dialog.boundingBox();

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -280,6 +280,12 @@ type MockSavedLink = {
   title: string;
   addedAt: string;
   source: "chat" | "desk";
+  paper?: {
+    arxivId: string;
+    authors: string[];
+    abstract: string;
+    publishedAt: string;
+  };
   xArticle?: MockXArticle;
 };
 
@@ -325,7 +331,20 @@ const ORDINARY_RESOURCE_LINK: MockSavedLink = {
 const LINKS: MockSavedLink[] = [
   { id: "l-gh", url: "https://github.com/acme/vector-bench", category: "github", title: "acme/vector-bench", addedAt: iso(60), source: "chat" },
   { id: "l-docs", url: "https://docs.qdrant.tech/guide", category: "docs", title: "Qdrant guide", addedAt: iso(120), source: "chat" },
-  { id: "l-paper", url: "https://arxiv.org/abs/2401.01234", category: "paper", title: "Efficient ANN search", addedAt: iso(90), source: "desk" },
+  {
+    id: "l-paper",
+    url: "https://arxiv.org/abs/2401.01234",
+    category: "paper",
+    title: "Efficient ANN search",
+    addedAt: iso(90),
+    source: "desk",
+    paper: {
+      arxivId: "2401.01234",
+      authors: ["A. Researcher", "B. Builder"],
+      abstract: "A compact fixture paper for the Research Desk reader.",
+      publishedAt: "2024-01-03T00:00:00.000Z",
+    },
+  },
 ];
 
 const AGENTIC_CONTEXT_FINGERPRINT = "ctx-v1-1234567890abcdef1234567890abcdef";
@@ -1142,6 +1161,48 @@ test.describe("research desk tabs", () => {
     await overlay.getByRole("button", { name: "Close resource details" }).click();
     await expect(page.getByRole("dialog")).toHaveCount(0);
     // Focus returns to the card title that opened it.
+    await expect(opener).toBeFocused();
+  });
+
+  test("Resources opens papers edge-to-edge and Escape exits focus before closing", async ({ page }) => {
+    await page.route("**/api/research/papers/pdf?id=2401.01234", async (route) => {
+      await route.fulfill({
+        path: "tests/fixtures/sample-paper.pdf",
+        contentType: "application/pdf",
+      });
+    });
+    await openResearchDesk(page);
+    await deskTab(page, /^Resources/).click();
+
+    const opener = page.getByRole("button", {
+      name: /Efficient ANN search — open details/,
+    });
+    await opener.click();
+    const dialog = page.getByRole("dialog", { name: "Efficient ANN search" });
+    await dialog.getByRole("button", { name: "Read", exact: true }).click();
+
+    await expect(dialog).toHaveAttribute("data-reader", "true");
+    await expect(dialog.getByRole("button", { name: "Download PDF" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Exit focus reader" })).toBeVisible();
+    await expect(dialog.locator(".research-res-overlay__source")).toBeHidden();
+    await expect(dialog.locator(".research-res-overlay__actions")).toBeHidden();
+    await expect(dialog.locator(".research-paper-view__stage")).toHaveCSS("max-height", "none");
+
+    const viewport = page.viewportSize();
+    const box = await dialog.boundingBox();
+    expect(viewport).not.toBeNull();
+    expect(box).not.toBeNull();
+    expect(box!.x).toBeLessThanOrEqual(1);
+    expect(box!.y).toBeLessThanOrEqual(1);
+    expect(box!.width).toBeGreaterThanOrEqual(viewport!.width - 1);
+    expect(box!.height).toBeGreaterThanOrEqual(viewport!.height - 1);
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).not.toHaveAttribute("data-reader", "true");
+    await expect(dialog.locator(".research-res-overlay__source")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toHaveCount(0);
     await expect(opener).toBeFocused();
   });
 

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -1183,15 +1183,25 @@ test.describe("research desk tabs", () => {
 
     await expect(dialog).toHaveAttribute("data-reader", "true");
     await expect(dialog.getByRole("button", { name: "Download PDF" })).toBeVisible();
-    await expect(dialog.getByRole("button", { name: "Exit focus reader" })).toBeVisible();
+    const exitFocus = dialog.getByRole("button", { name: "Exit focus reader" });
+    await expect(exitFocus).toBeVisible();
+    await expect(exitFocus).toBeFocused();
     await expect(dialog.locator(".research-res-overlay__source")).toBeHidden();
     await expect(dialog.locator(".research-res-overlay__actions")).toBeHidden();
     const stage = dialog.locator(".research-paper-view__stage");
     await expect(stage).toHaveCSS("max-height", "none");
     await expect(stage).toHaveAttribute("data-status", "ready", { timeout: 15_000 });
     await expect
-      .poll(() => dialog.locator(".research-paper-view__canvas").evaluate((canvas) => canvas.width))
+      .poll(() => dialog.locator(".research-paper-view__canvas").evaluate(
+        (canvas) => (canvas as HTMLCanvasElement).width,
+      ))
       .toBeGreaterThan(100);
+    for (let index = 0; index < 8; index += 1) {
+      await page.keyboard.press("Tab");
+      await expect
+        .poll(() => dialog.evaluate((node) => node.contains(document.activeElement)))
+        .toBe(true);
+    }
 
     const viewport = page.viewportSize();
     const box = await dialog.boundingBox();


### PR DESCRIPTION
## Summary
- open Research papers directly into a near-bezelless, full-viewport focus reader
- reduce chrome to compact page, zoom, download, exit-focus, and close controls while preserving selectable PDF text
- preserve two-stage Escape, visible-only focus trapping, explicit focus transfer, responsive safe-area insets, and reduced-motion behavior
- add source contracts and daemon-less Playwright coverage for rendered PDF, focus containment, viewport sizing, and focus return

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` (1,328 files)
- `pnpm test:api` (441 files)
- `pnpm check:tests-wired`
- `pnpm build`
- focused Research Desk Playwright scenario
- production-style visual capture reviewed

Bead: `cave-kxz5e`