### PR TITLE
worktree-guard: credit a remote tag by OID, not only by a local tag name (cave-bgxx4)

### DIFF
--- a/scripts/worktree-guard.mjs
+++ b/scripts/worktree-guard.mjs
@@ -973,12 +973,21 @@ function tagsOnRemote(cwd, remote) {
   }
   const cached = perRemote.get(remote);
   if (cached) return cached;
-  const found = new Set();
+  const found = { names: new Set(), oids: new Set() };
   perRemote.set(remote, found);
   try {
     for (const line of git(["ls-remote", "--tags", remote], cwd).split("\n")) {
-      const m = /refs\/tags\/(.+?)(?:\^\{\})?$/.exec(line.trim());
-      if (m) found.add(m[1]);
+      const trimmed = line.trim();
+      const m = /refs\/tags\/(.+?)(?:\^\{\})?$/.exec(trimmed);
+      if (m) found.names.add(m[1]);
+      // Both ref forms are collected. An annotated tag advertises the tag
+      // OBJECT at `refs/tags/x` and its commit at `refs/tags/x^{}`; a
+      // lightweight tag advertises the commit directly. Taking both means the
+      // peeled commit is always present, and a tag-object id can never collide
+      // with a commit id. Same parse as remoteTagCommits() in
+      // worktree-retention-push.mjs, which had to answer this first.
+      const oid = trimmed.slice(0, 40);
+      if (/^[0-9a-f]{40}$/.test(oid)) found.oids.add(oid);
     }
   } catch {
     /* this remote is unreachable — credit nothing from it */
@@ -1002,17 +1011,34 @@ function retainedOnRemote(oid, cwd) {
       .map((s) => s.trim())
       .filter(Boolean);
   } catch {
-    return "";
+    // A failed LOCAL enumeration is not evidence of absence, and the remote
+    // probe below is independent of it — so keep going with no local names
+    // rather than discarding proof this machine can still fetch.
+    tags = [];
   }
-  if (!tags.length) return "";
+  // NOT `if (!tags.length) return ""`. That early return is what made this
+  // helper contradict its own criterion: "retained" counts a tag pushed to a
+  // remote, but the only tags considered were ones this machine happens to have
+  // locally — and `worktree-retention-push.mjs` pushes `<sha>:refs/tags/<tag>`
+  // WITHOUT creating a local tag. So the retention this repository writes
+  // automatically was invisible here, and retiring a merged unit blocked with
+  // "exists on NO remote ref" while the tag sat on origin at exactly that SHA.
+  // Observed three times in one session on cave-kmrd3 (#5025) and again on
+  // cave-cgfx2; each was worked around with `git fetch origin --tags`, which
+  // treated a real defect as an operator chore. A tag pushed by another session,
+  // by CI, or from another machine was never visible either.
+  //
   // Every remote is probed — an archive tag pushed to a second remote is just as
   // durable as one on origin, and capping the scan would reintroduce exactly the
   // false block this helper exists to remove. Ordered scan with an early return
   // keeps the ordinary single-remote case at one ls-remote.
   for (const remote of remoteNames(cwd)) {
     const pushed = tagsOnRemote(cwd, remote);
-    const hit = tags.find((t) => pushed.has(t));
+    const hit = tags.find((t) => pushed.names.has(t));
     if (hit) return `remote tag ${hit} on ${remote}`;
+    // The local tag list is a convenience, not the evidence. ls-remote already
+    // advertises the OID, so ask it directly.
+    if (pushed.oids.has(oid)) return `a remote tag on ${remote}`;
   }
   return "";
 }

--- a/scripts/worktree-guard.test.mjs
+++ b/scripts/worktree-guard.test.mjs
@@ -431,6 +431,50 @@ if (!isWin) {
   );
 }
 
+// ── 3e. A tag pushed WITHOUT a local tag is still retention (cave-bgxx4) ─────
+// 3d creates the tag locally and then pushes it, so a local name always
+// existed. `worktree-retention-push.mjs` does not work that way: it pushes
+// `<sha>:refs/tags/<tag>` and creates NO local tag. So the retention this
+// repository writes automatically was exactly the case the guard could not see
+// — `for-each-ref refs/tags` found nothing, the helper returned early, and the
+// ls-remote evidence was never consulted.
+//
+// The cost was a reflex: retiring a merged unit blocked with "exists on NO
+// remote ref" while the tag sat on origin at that SHA, three times in one
+// session (cave-kmrd3 / #5025, then cave-cgfx2). Each was cleared with
+// `git fetch origin --tags`, which quietly reframes a guard defect as an
+// operator chore — and a guard that cries wolf is how WT_GUARD_BYPASS becomes
+// muscle memory.
+{
+  const { dir, wt } = repoWithWorktree({ push: false });
+  const tip = sh("git", ["-C", wt, "rev-parse", "HEAD"], dir).trim();
+
+  // No local tag anywhere — exactly what the retention hook leaves behind.
+  let res = runHook(`git worktree remove ${wt}`, dir);
+  assert.equal(res.status, 2, "unretained work is still blocked");
+
+  // Push the commit straight to a tag ref, creating nothing locally.
+  sh("git", ["-C", wt, "push", "-q", "origin", `${tip}:refs/tags/retention/feature-x-${tip.slice(0, 9)}`], dir);
+  assert.equal(
+    sh("git", ["-C", wt, "tag", "-l"], dir).trim(),
+    "",
+    "precondition: the fixture really has no local tag",
+  );
+
+  res = runHook(`git worktree remove ${wt}`, dir);
+  assert.equal(
+    res.status,
+    0,
+    `a tag pushed with no local counterpart IS retention — guard said: ${JSON.stringify(res.stderr)}`,
+  );
+  res = runHook(`git branch -D feature-x`, wt);
+  assert.equal(
+    res.status,
+    0,
+    `branch -D allowed too — guard said: ${JSON.stringify(res.stderr)}`,
+  );
+}
+
 // ── 3d-ii. Unverifiable retention must read as NO retention ──────────────────
 // The tag probe needs the network (git keeps no remote-tracking ref for tags).
 // If that lookup fails, the guard must block: "cannot verify" is not "verified",


### PR DESCRIPTION
Retiring a merged worktree blocked with:

```
`…/.worktrees/x` HEAD (16c59606) exists on NO remote ref — removing it orphans unpushed commits.
```

…while the retention tag was sitting on `origin` at exactly that SHA. Three times in one session on `cave-kmrd3` (#5025), then again on `cave-cgfx2`.

## The contradiction

`retainedOnRemote()` did not implement its own documented criterion. "Retained" counts *a tag pushed to a remote* — but the only tags it ever considered came from `for-each-ref refs/tags`, i.e. **this machine's local tags**. `ls-remote` was used merely to confirm that those *names* also existed on the remote. So when no local tag named the commit:

```js
if (!tags.length) return "";   // ← returns before any remote is asked
```

That is exactly the retention this repository writes **automatically**: `worktree-retention-push.mjs` pushes `<sha>:refs/tags/<tag>` and creates no local tag at all. A tag pushed by another session, by CI, or from another machine was invisible for the same reason.

## The fix

`ls-remote` already advertises the OID, so ask it directly rather than using it only to cross-check locally-known names.

Both ref forms are collected — an annotated tag advertises the tag *object* at `refs/tags/x` and its *commit* at `refs/tags/x^{}`, a lightweight tag advertises the commit directly. Taking both means the peeled commit is always present, and a tag-object id can never collide with a commit id. That is the same parse `remoteTagCommits()` in `worktree-retention-push.mjs` already had to work out — the sibling hook solved this; the guard hadn't.

**Two properties preserved deliberately:**

- **Still fails closed.** An unreachable remote credits nothing and the guard blocks. Every other probe in that file fails open, but those decide whether to *warn*; this one decides whether deletion is safe, and "cannot verify" must never read as "verified."
- **A local-only tag is still not retention.** It dies with the machine, which is the whole point of the distinction that section 3d pins.

One related repair: a failed *local* enumeration no longer early-returns either. It isn't evidence of absence, and the remote probe is independent of it.

## Why it matters beyond the inconvenience

The workaround was `git fetch origin --tags`, which quietly reframes a guard defect as an operator chore. A guard that cries wolf on provably-preserved work is how `WT_GUARD_BYPASS` becomes muscle memory — the same dynamic section 3d already records, where a sweep bypassed the guard six times to delete work it had itself archived. No bypass was used to reach this fix.

## Verification

New section **3e** covers what 3d could not: a tag pushed with **no local counterpart**, asserting the fixture genuinely has no local tag before testing.

**Negative control:** with the OID credit disabled, the suite exits **1** on precisely the real-world message; with it restored, **0**. Full guard suite 13/13.

Closes cave-bgxx4.