### PR TITLE
Scope --allow-cooldown-override to named units (cave-qamzg)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -565,15 +565,38 @@ one risk it covers — somebody else still sitting in that directory — is the 
 thing no amount of git evidence can answer. It was 8h (#4215), 3h since #4991,
 and 15m since `cave-0pu26`.
 
-If you know the unit is idle, say so explicitly (`cave-jinkd`):
+If you know the unit is idle, say so explicitly — and say WHICH unit
+(`cave-jinkd`, scoped in `cave-qamzg`):
 
 ```bash
-pnpm beads:worktrees:apply --allow-unenforced-planes --allow-cooldown-override
+pnpm beads:worktrees:apply --allow-unenforced-planes \
+  --allow-cooldown-override --only <path|branch|ref|head>
 ```
 
-The patrol prints that exact line for you whenever cooldown is the only thing
-left, so you never have to look it up — the same affordance the create gate
-gives for its budget exception.
+`--only` is **required** with the override and repeatable. It must name a unit
+that exists, and name exactly one — an ambiguous or unknown value is refused
+rather than resolved, because a scope that quietly covered a neighbour would
+defeat the point of having one.
+
+**Why it is required.** The flag began as an all-or-nothing lever over the
+whole cooldown lane, and the very first real use showed why that is unsafe
+here: the patrol's hint listed two cooldown units and the second belonged to
+**another live session** (`cave-iizwt`, PR #5021, landed mid-session). Running
+the unscoped override would have retired that session's worktree alongside the
+operator's own — the class of incident `scripts/worktree-autolock.mjs` exists
+to prevent. The override went unused and three units were hand-retired instead,
+which is what a lever nobody dares pull is worth.
+
+The patrol still prints the admissible line for you whenever cooldown is the
+only thing left — with an `--only` line per unit — the same affordance the
+create gate gives for its budget exception. It deliberately does **not** hand
+you a prefilled command covering every unit it lists: take the `--only` lines
+for units that are yours, and leave the rest alone.
+
+Note `--only` scopes the **override and nothing else**. Every other unit still
+retires on the gate's own evidence, which needs no assertion from you; passing
+`--only` without the override is refused rather than silently ignored, so it
+cannot be mistaken for a way to narrow the whole apply.
 
 **What the flag can and cannot do.** `cooldownIsTheOnlyBlocker` answers
 admission by re-running the real classifier one cooldown into the future and

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -55,6 +55,13 @@ type Options = {
    * job has nobody to make that assertion.
    */
   allowCooldownOverride: boolean;
+  /**
+   * Units the operator is asserting are idle, for --allow-cooldown-override.
+   *
+   * Required with that flag and meaningless without it. Matches a worktree
+   * path, a branch, a ref, or a head OID.
+   */
+  cooldownOverrideOnly: string[];
 };
 
 type PatrolInventory = ReturnType<typeof collectWorktreeLifecycleInventory>;
@@ -165,6 +172,7 @@ export function parseArgs(argv: string[]): Options {
     maxRetire: parseMaxRetire(undefined),
     allowUnenforcedPlanes: false,
     allowCooldownOverride: false,
+    cooldownOverrideOnly: [],
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -189,6 +197,16 @@ export function parseArgs(argv: string[]): Options {
       case "--allow-cooldown-override":
         options.allowCooldownOverride = true;
         break;
+      case "--only": {
+        const value = argv[++index];
+        if (value === undefined || value.trim().length === 0) {
+          throw new Error(
+            "--only requires a worktree path, branch, ref, or head OID",
+          );
+        }
+        options.cooldownOverrideOnly.push(value.trim());
+        break;
+      }
       case "--max-retire": {
         const value = argv[++index];
         if (value === undefined) {
@@ -616,7 +634,10 @@ function renderCooldownOverrideHint(
   const waiting = items.filter((item) => cooldownIsTheOnlyBlocker(item, nowMs));
   if (waiting.length === 0) return null;
   const names = waiting
-    .map((item) => `  - ${formatItemIdentity(item)}`)
+    .map((item) => {
+      const scope = item.path ?? item.branch ?? item.ref ?? item.head;
+      return `  - ${formatItemIdentity(item)}\n      --only ${scope}`;
+    })
     .sort(compareText);
   return [
     `${waiting.length} unit(s) are retirable except for the cooldown:`,
@@ -624,9 +645,18 @@ function renderCooldownOverrideHint(
     "",
     "The cooldown is the 'let a concurrent session notice' window — the work is",
     "already proven landed, clean and retained. If you know nobody is working in",
-    "them, discharge it explicitly:",
+    "them, discharge it explicitly, naming the units you know are idle:",
     "",
-    `  pnpm beads:worktrees:apply --allow-unenforced-planes --allow-cooldown-override`,
+    "  pnpm beads:worktrees:apply --allow-unenforced-planes \\",
+    "    --allow-cooldown-override --only <path|branch>",
+    "",
+    // Deliberately NOT a prefilled command containing every unit above. This
+    // list routinely includes other live sessions' worktrees — the first real
+    // use of the override found exactly that (cave-qamzg) — and a ready-made
+    // line covering all of them is how someone retires a colleague's work with
+    // one paste. Copy the --only lines you can vouch for, and no others.
+    "Take only the --only lines for units that are YOURS. Others in this list",
+    "may belong to a live session that has not finished with them.",
     "",
     applying
       ? "Every overridden retirement is recorded as such in the attempt log."
@@ -763,6 +793,7 @@ export function runRetirementApply(
             operations,
             maxRetire: String(gitLimit),
             allowCooldownOverride: options.allowCooldownOverride,
+            cooldownOverrideOnly: options.cooldownOverrideOnly,
             nowMs: options.nowMs,
           })
         : {
@@ -900,7 +931,96 @@ export function runRetirementApply(
   };
 }
 
-export function main(argv = process.argv.slice(2)): number {
+export /**
+ * Which unit a single `--only` value names, if exactly one.
+ *
+ * Matching is exact on the identities a unit actually has — path, ref, branch,
+ * head — plus the worktree's directory name, which is what an operator reads
+ * off the patrol's own output. Deliberately NOT a substring or prefix match:
+ * this decides which unit an idleness assertion covers, and a value that
+ * quietly widened to a neighbour would recreate the very bug the scope exists
+ * to close.
+ */
+function unitsNamedBy(value: string, items: readonly PatrolItem[]): PatrolItem[] {
+  return items.filter((item) => {
+    if (item.path === value || item.ref === value || item.branch === value) return true;
+    if (item.head === value) return true;
+    if (item.path !== null && item.path.split("/").pop() === value) return true;
+    return false;
+  });
+}
+
+/**
+ * Refuse an invocation whose cooldown override is not scoped to named units.
+ *
+ * `--allow-cooldown-override` began as an all-or-nothing lever over the whole
+ * cooldown lane, and that is unsafe on a shared checkout: the first real use
+ * found the patrol's hint listing two cooldown units, the second belonging to
+ * ANOTHER live session (cave-iizwt, PR #5021, landed mid-session). Applying it
+ * would have retired that session's worktree alongside the operator's own —
+ * the class of incident worktree-autolock.mjs exists to prevent. The override
+ * went unused and three units were hand-retired instead, which is what a lever
+ * nobody dares pull is worth.
+ *
+ * The flag's whole basis is an operator ASSERTING that a unit is idle, and an
+ * assertion has to be about something specific. So the scope is required, each
+ * value must name a unit that exists, and it must name exactly one.
+ *
+ * Returns the refusal lines, or [] to proceed.
+ */
+function cooldownOverrideScopeRefusal(
+  options: Options,
+  items: readonly PatrolItem[],
+): string[] {
+  const P = "worktree-lifecycle-patrol:";
+  if (!options.allowCooldownOverride) {
+    if (options.cooldownOverrideOnly.length === 0) return [];
+    // Refused rather than ignored: silently accepting a scope that governs
+    // nothing invites the reading that --only narrows the whole apply.
+    return [
+      `${P} --only is meaningless without --allow-cooldown-override.`,
+      "  --only scopes the cooldown override and nothing else; every other unit",
+      "  is retired on the gate's own evidence, which needs no assertion from you.",
+    ];
+  }
+  if (options.cooldownOverrideOnly.length === 0) {
+    const waiting = items.filter((item) => cooldownIsTheOnlyBlocker(item, options.nowMs));
+    return [
+      `${P} --allow-cooldown-override requires --only <path|branch|ref|head>.`,
+      "  The flag asserts that a unit is IDLE, and that assertion has to name",
+      "  something. Applied to the whole lane it also retires units belonging to",
+      "  other live sessions, which is how a colleague loses a worktree mid-edit.",
+      ...(waiting.length > 0
+        ? [
+            "  Units currently held only by cooldown — name the ones that are YOURS:",
+            ...waiting.map(
+              (item) => `    --only ${item.path ?? item.branch ?? item.ref ?? item.head}`,
+            ),
+          ]
+        : ["  Nothing is currently held only by cooldown."]),
+    ];
+  }
+  const refusal: string[] = [];
+  for (const value of options.cooldownOverrideOnly) {
+    const matches = unitsNamedBy(value, items);
+    if (matches.length === 0) {
+      refusal.push(
+        `${P} --only ${value} names no unit in this checkout.`,
+        "  A typo here would assert idleness about something that does not exist.",
+      );
+    } else if (matches.length > 1) {
+      refusal.push(
+        `${P} --only ${value} is ambiguous — it names ${matches.length} units:`,
+        ...matches.map((item) => `    ${item.path ?? item.ref ?? item.branch ?? item.head}`),
+        "  Name one unambiguously; a scope that covers a unit you did not mean is",
+        "  the failure this flag is scoped to avoid.",
+      );
+    }
+  }
+  return refusal;
+}
+
+function main(argv = process.argv.slice(2)): number {
   const options = parseArgs(argv);
   const inventory = collectWorktreeLifecycleInventory({
     repo: options.repo!,
@@ -910,6 +1030,11 @@ export function main(argv = process.argv.slice(2)): number {
   const summary = summarizeInventory(inventory);
 
   if (options.apply) {
+    const scopeRefusal = cooldownOverrideScopeRefusal(options, inventory.items);
+    if (scopeRefusal.length > 0) {
+      for (const line of scopeRefusal) console.error(line);
+      return 2;
+    }
     const capabilities = repositoryMaintenanceCapabilities();
     const admission = assessMaintenancePlaneAdmission({
       capabilities: capabilities as unknown as MaintenancePlaneCapabilities,

--- a/scripts/worktree-lifecycle-retirement.test.mjs
+++ b/scripts/worktree-lifecycle-retirement.test.mjs
@@ -20,6 +20,7 @@ import {
 } from "./maintenance-gate.mjs";
 import { refreshCovenBin } from "../src/lib/coven-bin.ts";
 import { collectWorktreeLifecycleInventory } from "./worktree-lifecycle-inventory.ts";
+import { cooldownIsTheOnlyBlocker } from "../src/lib/worktree-lifecycle.ts";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const moduleUrl = pathToFileURL(
@@ -2229,6 +2230,119 @@ test("removeWorktree leaves a foreign lock in place and reports it actionably", 
   } finally {
     cleanupFixture(fixture.fixtureRoot);
   }
+});
+
+// ── cave-qamzg: the cooldown override is scoped to NAMED units ───────────────
+// --allow-cooldown-override began as an all-or-nothing lever over the whole
+// cooldown lane. The first real use found the patrol's hint listing two
+// cooldown units, the second belonging to ANOTHER live session (cave-iizwt,
+// PR #5021, landed mid-session). Applying it would have retired that session's
+// worktree alongside the operator's own. The flag's basis is an operator
+// asserting a unit is IDLE, and an assertion has to be about something
+// specific — so the assertion now names its units.
+function cooldownItem(name, nowMs) {
+  const head = name.padEnd(40, "0");
+  return makeItem({
+    branch: `fix/${name}`,
+    ref: `refs/heads/fix/${name}`,
+    path: `/owned/${name}`,
+    head,
+    lane: "cooldown",
+    updatedAtMs: nowMs - 1_000,
+    mergedPr: { number: 1, mergedAtMs: nowMs - 1_000, headOid: head },
+    headOnDefaultBranch: true,
+    metadata: {
+      path: `/owned/${name}`,
+      branch: `fix/${name}`,
+      owner: "kitty",
+      purpose: "fixture",
+      createdAt: new Date(nowMs - 5_000).toISOString(),
+      disposition: "active",
+    },
+  });
+}
+
+test("the cooldown override admits only units the scope names", () => {
+  const nowMs = 1_000_000_000_000;
+  const mine = cooldownItem("mine", nowMs);
+  const theirs = cooldownItem("theirs", nowMs);
+  // Precondition: both really are held by cooldown alone, so the test is about
+  // the scope rather than about one of them being ineligible anyway.
+  assert.equal(cooldownIsTheOnlyBlocker(mine, nowMs), true);
+  assert.equal(cooldownIsTheOnlyBlocker(theirs, nowMs), true);
+
+  const { operations } = makeOperations();
+  const report = retireLifecycleUnits({
+    items: [mine, theirs],
+    gateHandle: { generation: 7, token: "gate" },
+    operations,
+    allowCooldownOverride: true,
+    cooldownOverrideOnly: ["/owned/mine"],
+    nowMs,
+  });
+
+  assert.deepEqual(
+    report.attempts.map((attempt) => attempt.ref),
+    ["refs/heads/fix/mine"],
+    "the other session's unit is not touched",
+  );
+});
+
+test("an empty scope admits nothing, even with the override set", () => {
+  // The patrol refuses this invocation up front. If some other caller forgets
+  // the scope, the override must admit NOTHING rather than everything — the
+  // safe direction, and the opposite of what an empty allowlist usually means.
+  const nowMs = 1_000_000_000_000;
+  const item = cooldownItem("mine", nowMs);
+  const { operations } = makeOperations();
+  const report = retireLifecycleUnits({
+    items: [item],
+    gateHandle: { generation: 7, token: "gate" },
+    operations,
+    allowCooldownOverride: true,
+    cooldownOverrideOnly: [],
+    nowMs,
+  });
+  assert.deepEqual(report.attempts, [], "no unit is admitted by an empty scope");
+});
+
+test("the scope matches a branch, a ref, or the worktree directory name", () => {
+  const nowMs = 1_000_000_000_000;
+  for (const value of ["fix/mine", "refs/heads/fix/mine", "mine"]) {
+    const { operations } = makeOperations();
+    const report = retireLifecycleUnits({
+      items: [cooldownItem("mine", nowMs)],
+      gateHandle: { generation: 7, token: "gate" },
+      operations,
+      allowCooldownOverride: true,
+      cooldownOverrideOnly: [value],
+      nowMs,
+    });
+    assert.equal(report.attempts.length, 1, `--only ${value} names the unit`);
+  }
+});
+
+test("the scope never widens eligibility past the cooldown lane", () => {
+  // Naming a unit is an assertion about idleness, not a waiver of the gate.
+  // A dirty unit stays refused however precisely it is named.
+  const nowMs = 1_000_000_000_000;
+  const dirty = makeItem({
+    branch: "fix/dirty",
+    ref: "refs/heads/fix/dirty",
+    path: "/owned/dirty",
+    lane: "active",
+    changes: ["M src/thing.ts"],
+  });
+  const { operations } = makeOperations();
+  const report = retireLifecycleUnits({
+    items: [dirty],
+    gateHandle: { generation: 7, token: "gate" },
+    operations,
+    allowCooldownOverride: true,
+    cooldownOverrideOnly: ["/owned/dirty", "fix/dirty"],
+    nowMs,
+  });
+  assert.deepEqual(report.attempts, [], "naming a unit does not waive the gate");
 });
 
 let failures = 0;

--- a/scripts/worktree-lifecycle-retirement.ts
+++ b/scripts/worktree-lifecycle-retirement.ts
@@ -147,12 +147,33 @@ export function parseMaxRetire(value: string | undefined): number {
   throw new Error("--max-retire must be an integer from 1 through 10");
 }
 
+/**
+ * Whether an operator's `--only` scope names this unit.
+ *
+ * Exact identities only, mirroring unitsNamedBy() in
+ * worktree-lifecycle-patrol.ts. An empty scope names nothing: the patrol
+ * refuses that invocation up front, and if some other caller forgets the flag
+ * the override must admit nothing rather than everything.
+ */
+function namedByScope(item: WorktreeLifecycleItem, scope: readonly string[]): boolean {
+  if (scope.length === 0) return false;
+  return scope.some(
+    (value) =>
+      item.path === value ||
+      item.ref === value ||
+      item.branch === value ||
+      item.head === value ||
+      (item.path !== null && item.path.split("/").pop() === value),
+  );
+}
+
 export function retireLifecycleUnits({
   items,
   gateHandle,
   operations,
   maxRetire,
   allowCooldownOverride = false,
+  cooldownOverrideOnly = [],
   nowMs = Date.now(),
 }: {
   items: WorktreeLifecycleItem[];
@@ -162,6 +183,15 @@ export function retireLifecycleUnits({
   /** Operator assertion that the cooldown units are idle — see the flag's
    *  documentation in worktree-lifecycle-patrol.ts. Never set by the sweep. */
   allowCooldownOverride?: boolean;
+  /**
+   * The units that assertion covers, from `--only`. The override admits NOTHING
+   * outside this list: an assertion about your own worktree is not an assertion
+   * about whatever else happens to share the cooldown lane, which on a shared
+   * checkout is routinely another live session's work (cave-qamzg). The patrol
+   * refuses an override with an empty scope, so an empty list here admits
+   * nothing rather than everything — the safe direction if a caller forgets.
+   */
+  cooldownOverrideOnly?: string[];
   nowMs?: number;
 }): RetirementReport {
   const report: RetirementReport = {
@@ -185,6 +215,7 @@ export function retireLifecycleUnits({
     .filter((item) => {
       if (item.lane === "retire-after-gate") return true;
       if (!allowCooldownOverride) return false;
+      if (!namedByScope(item, cooldownOverrideOnly)) return false;
       if (!cooldownIsTheOnlyBlocker(item, nowMs)) return false;
       overridden.add(overriddenKey(item));
       return true;


### PR DESCRIPTION
`--allow-cooldown-override` (cave-jinkd, #5022) was an all-or-nothing lever over the **whole cooldown lane**. That is unsafe on a shared checkout, and its very first real use showed why.

Retiring three of my own units, the patrol's hint listed **two** cooldown units — and the second was `cave-iizwt-research-default-model`, **another live session's worktree** from PR #5021, which landed mid-session. Running `--apply --allow-cooldown-override` would have retired theirs alongside mine. That is precisely the class of incident `scripts/worktree-autolock.mjs` exists to prevent (two live worktrees destroyed by GitHub Desktop, 2026-08-03).

So the override went unused and the three units were hand-retired via the archive-tag route. **A lever nobody dares pull is worth nothing** — this makes it safe enough to use.

## The fix

The flag's entire basis is an operator *asserting* that a unit is idle, and an assertion has to be about something specific.

`--only <path|branch|ref|head>` is now **required** with the override, and repeatable. Each value must name a unit that exists, and name **exactly one** — an unknown or ambiguous value is refused rather than resolved, since a scope that quietly widened to a neighbour would defeat the point of having a scope.

## Three deliberate choices

**An empty scope admits nothing, not everything.** The patrol refuses that invocation up front, but if another caller ever forgets the flag, the override must fail safe. That's the opposite of how an empty allowlist usually reads, so it's pinned by its own test.

**`--only` scopes the override and nothing else.** Every other unit still retires on the gate's own evidence, which needs no assertion from anyone. Passing `--only` *without* the override is refused rather than silently ignored, so it can't be misread as a way to narrow the whole apply.

**The hint does not hand over a prefilled command.** It prints an `--only` line per unit and says to take only the ones that are yours. A ready-made line covering every unit it lists is exactly how someone retires a colleague's worktree with one paste — the same bug, relocated into the help text.

## Verification

**Negative control:** with the scope filter disabled the suite exits **1** on *"the cooldown override admits only units the scope names"* and *"an empty scope admits nothing, even with the override set"*.

To be precise about the other two new tests: they pin adjacent properties — identity matching across path/branch/ref/dirname, and that naming a unit never waives the gate for a dirty one — and pass either way. Two of the four are genuine regression guards on the new behaviour.

`scripts/worktree-sweep.sh` still never passes the flag; a cron job has nobody to assert idleness, which is the whole basis of it.

`CLAUDE.md` is updated — it documented a command that is now refused.

Closes cave-qamzg.