### PR TITLE
Say which calendar cells are short when a projection is truncated (cave-fdcd4)

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1,9 +1,16 @@
 "use client";
 
 import "@/styles/calendar.css";
+/**
+ * How much of a projection is trustworthy per day. Passed alongside the runs so
+ * a cell can say its count is a floor rather than a total (cave-fdcd4).
+ */
+type ProjectionCompleteness = Pick<CronProjection, "truncated" | "completeThroughMs">;
+
 import {
   RUN_DENSITY_MAX_LEVEL,
   clusterLabel,
+  dayProjectionIsPartial,
   clusterRunsByMinute,
   runCountLabel,
   runCountOn,
@@ -297,9 +304,11 @@ const MAX_ALLDAY_VISIBLE = 3;
 function RunDensityStrip({
   columns,
   onOpenDay,
+  projectionCompleteness,
 }: {
   columns: { date: Date; runs: readonly ProjectedCronRun[] }[];
   onOpenDay?: (day: Date) => void;
+  projectionCompleteness?: ProjectionCompleteness;
 }) {
   // Nothing projected anywhere in the week — draw no band at all rather than a
   // row of empty axes, which would read as "measured zero" instead of "off".
@@ -318,7 +327,10 @@ function RunDensityStrip({
         {columns.map((col, i) => {
           const bands = runDensityBands(col.runs, col.date);
           const count = runCountOn(col.runs, col.date);
-          const label = runCountLabel(count, "ritual runs");
+          const partial = projectionCompleteness
+            ? dayProjectionIsPartial(projectionCompleteness, col.date)
+            : false;
+          const label = runCountLabel(count, "ritual runs", partial);
           if (!label) return <div key={i} className="flex-1 min-w-[80px] p-1" />;
           const Cell = onOpenDay ? "button" : "div";
           return (
@@ -328,7 +340,9 @@ function RunDensityStrip({
                   ? {
                       type: "button" as const,
                       onClick: () => onOpenDay(col.date),
-                      "aria-label": `${label} on ${fmtDateHeading(col.date)} — open day`,
+                      "aria-label": partial
+                        ? `at least ${count} ritual runs on ${fmtDateHeading(col.date)}, projection truncated — open day`
+                        : `${label} on ${fmtDateHeading(col.date)} — open day`,
                     }
                   : {})}
                 className={`cal-run-density ${onOpenDay ? "cal-run-density--action focus-ring" : ""}`}
@@ -967,6 +981,7 @@ function WeekView({
   items,
   deadlines,
   projectedRuns,
+  projectionCompleteness,
   anchor,
   onAddEntry,
   onOpenItem,
@@ -978,6 +993,8 @@ function WeekView({
   deadlines?: CalendarDeadline[];
   /** Cron occurrences projected onto this week — see calendar-cron-projection. */
   projectedRuns?: readonly ProjectedCronRun[];
+  /** Whether those runs are complete for a given day — see cave-fdcd4. */
+  projectionCompleteness?: ProjectionCompleteness;
   anchor: Date;
   onAddEntry?: (defaults?: { fireAt?: string; title?: string; whenText?: string }) => void;
   onOpenItem?: (item: InboxItem) => void;
@@ -1089,7 +1106,11 @@ function WeekView({
       {/* Cron density — a forecast band, above the grid so it does not scroll
           away from the columns it describes. Self-guards: renders nothing when
           the week has no projected runs. */}
-      <RunDensityStrip columns={densityColumns} onOpenDay={onOpenDay} />
+      <RunDensityStrip
+        columns={densityColumns}
+        onOpenDay={onOpenDay}
+        projectionCompleteness={projectionCompleteness}
+      />
       <div className="relative flex flex-1 overflow-hidden">
         <TimeGrid columns={columns} onOpenItem={onOpenItem} onAddEntry={onAddEntry} onReschedule={onReschedule} />
       </div>
@@ -1103,6 +1124,7 @@ function MonthView({
   items,
   deadlines,
   projectedRuns,
+  projectionCompleteness,
   anchor,
   onOpenItem,
   onDayClick,
@@ -1113,6 +1135,8 @@ function MonthView({
   deadlines?: CalendarDeadline[];
   /** Cron occurrences projected onto this grid — see calendar-cron-projection. */
   projectedRuns?: readonly ProjectedCronRun[];
+  /** Whether those runs are complete for a given day — see cave-fdcd4. */
+  projectionCompleteness?: ProjectionCompleteness;
   anchor: Date;
   onOpenItem?: (item: InboxItem) => void;
   onDayClick?: (day: Date) => void;
@@ -1320,10 +1344,20 @@ function MonthView({
                         because none of these have happened yet. */}
                     {(() => {
                       const runs = runCountOn(projectedRuns ?? [], day);
-                      const label = runCountLabel(runs);
+                      const partial = projectionCompleteness
+                        ? dayProjectionIsPartial(projectionCompleteness, day)
+                        : false;
+                      const label = runCountLabel(runs, "runs", partial);
                       if (!label) return null;
                       return (
-                        <span className="cal-month-runs" title={`${label} projected`}>
+                        <span
+                          className="cal-month-runs"
+                          title={
+                            partial
+                              ? `at least ${runs} projected — the projection hit its cap, so this day may hold more`
+                              : `${label} projected`
+                          }
+                        >
                           <Icon name="ph:clock" width={10} height={10} aria-hidden />
                           <span>{label}</span>
                           <span
@@ -1754,7 +1788,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
   // surface lying about itself. Widen this only alongside a renderer.
   const projection: CronProjection = useMemo(() => {
     if (!showRuns || !PROJECTING_VIEWS.has(effectiveView) || cronAutomations.length === 0) {
-      return { runs: [], projectedCount: 0, truncated: false };
+      return { runs: [], projectedCount: 0, truncated: false, completeThroughMs: 0 };
     }
     const start =
       effectiveView === "month" ? startOfWeek(startOfMonth(anchor))
@@ -2072,6 +2106,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
           <WeekView
             items={scopedItems}
             projectedRuns={projection.runs}
+            projectionCompleteness={projection}
             deadlines={scopedDeadlines}
             anchor={anchor}
             onAddEntry={onAddEntry}
@@ -2085,6 +2120,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
           <MonthView
             items={scopedItems}
             projectedRuns={projection.runs}
+            projectionCompleteness={projection}
             deadlines={scopedDeadlines}
             anchor={anchor}
             onOpenItem={(item) => setSelectedItem(item)}

--- a/src/lib/calendar-cron-projection.test.ts
+++ b/src/lib/calendar-cron-projection.test.ts
@@ -119,7 +119,7 @@ describe("projectionSummary", () => {
 
   it("renders nothing rather than a '0 active crons' line", () => {
     // An absence does not need a sentence drawing attention to it.
-    assert.equal(projectionSummary({ runs: [], projectedCount: 0, truncated: false }), null);
+    assert.equal(projectionSummary({ runs: [], projectedCount: 0, truncated: false, completeThroughMs: 0 }), null);
   });
 });
 
@@ -132,7 +132,7 @@ describe("projectionSummary", () => {
 // asserts the model's half of that contract: no runs means no sentence.
 describe("projection chrome contract", () => {
   it("says nothing when there is nothing drawn", () => {
-    assert.equal(projectionSummary({ runs: [], projectedCount: 0, truncated: false }), null);
+    assert.equal(projectionSummary({ runs: [], projectedCount: 0, truncated: false, completeThroughMs: 0 }), null);
   });
 });
 
@@ -163,5 +163,63 @@ describe("window boundaries", () => {
   it("still includes an occurrence at the very start of the window", () => {
     const runs = projectCronRuns(daily, dayStart, nextMidnight - 1).runs;
     assert.equal(new Date(runs[0].atIso).getTime(), dayStart);
+  });
+});
+
+describe("completeThroughMs", () => {
+  // `truncated` says the frame is short; this says WHERE, which is what a
+  // per-day cell needs to know whether its own number is a total or a floor.
+  const start = new Date(2026, 7, 24, 0, 0, 0).getTime();
+  const shortEnd = new Date(2026, 7, 31, 0, 0, 0).getTime();
+  // Long enough that a daily cron runs past CRON_PROJECTION_PER_CRON_CAP.
+  const longEnd = new Date(2030, 0, 1).getTime();
+
+  it("is the window end when nothing was dropped", () => {
+    const projection = projectCronRuns([cron("c1", DAILY_9)], start, shortEnd);
+    assert.equal(projection.truncated, false);
+    assert.equal(projection.completeThroughMs, shortEnd, "all of it is trustworthy");
+  });
+
+  it("stops at the last occurrence a per-cron cap allowed", () => {
+    const projection = projectCronRuns([cron("c1", DAILY_9)], start, longEnd);
+    assert.equal(projection.truncated, true);
+    const last = new Date(projection.runs[projection.runs.length - 1].atIso).getTime();
+    assert.equal(projection.completeThroughMs, last, "complete up to its final surviving fire");
+    assert.ok(projection.completeThroughMs < longEnd, "and that is well short of the window");
+  });
+
+  it("declares NOTHING complete when the overall cap stopped the walk early", () => {
+    // Six daily crons over this window exhaust CRON_PROJECTION_CAP before the
+    // last is reached. Crons the loop never visits are absent from the WHOLE
+    // window, not just its tail, so no day in it is trustworthy — reporting
+    // "complete through the last instant we happened to reach" would be the
+    // comfortable lie.
+    const many = Array.from({ length: 6 }, (_, i) => cron(`c${i}`, DAILY_9));
+    const projection = projectCronRuns(many, start, longEnd);
+    assert.equal(projection.truncated, true);
+    assert.ok(
+      projection.completeThroughMs < start,
+      `nothing in the window is complete (got ${projection.completeThroughMs}, start ${start})`,
+    );
+  });
+
+  it("takes the EARLIEST cut-off when several crons are capped", () => {
+    // One cron running out early must not be masked by another that survived
+    // further into the window.
+    const early = cron("early", "RRULE:FREQ=DAILY;BYHOUR=1;BYMINUTE=0");
+    const late = cron("late", "RRULE:FREQ=DAILY;BYHOUR=23;BYMINUTE=0");
+    const projection = projectCronRuns([early, late], start, longEnd);
+    assert.equal(projection.truncated, true);
+    const lastOf = (id) =>
+      Math.max(
+        ...projection.runs
+          .filter((run) => run.automationId === id)
+          .map((run) => new Date(run.atIso).getTime()),
+      );
+    assert.equal(
+      projection.completeThroughMs,
+      Math.min(lastOf("early"), lastOf("late")),
+      "the earliest exhaustion bounds the whole window",
+    );
   });
 });

--- a/src/lib/calendar-cron-projection.test.ts
+++ b/src/lib/calendar-cron-projection.test.ts
@@ -210,7 +210,7 @@ describe("completeThroughMs", () => {
     const late = cron("late", "RRULE:FREQ=DAILY;BYHOUR=23;BYMINUTE=0");
     const projection = projectCronRuns([early, late], start, longEnd);
     assert.equal(projection.truncated, true);
-    const lastOf = (id) =>
+    const lastOf = (id: string) =>
       Math.max(
         ...projection.runs
           .filter((run) => run.automationId === id)

--- a/src/lib/calendar-cron-projection.ts
+++ b/src/lib/calendar-cron-projection.ts
@@ -24,6 +24,20 @@ export type ProjectedCronRun = {
 
 export type CronProjection = {
   runs: ProjectedCronRun[];
+  /**
+   * The instant through which this projection is COMPLETE.
+   *
+   * Everything at or before it is fully enumerated; anything after it may be
+   * missing occurrences the caps dropped. Equal to the window end when nothing
+   * was truncated, and to `startMs - 1` when the overall cap stopped the walk
+   * before every cron had been visited — those crons contribute nothing
+   * ANYWHERE, so no part of the window is complete.
+   *
+   * `truncated` says the frame is short; this says WHERE, which is what a
+   * per-day surface needs. A month cell showing "2 runs" is otherwise
+   * indistinguishable from one that would have shown nine (cave-fdcd4).
+   */
+  completeThroughMs: number;
   /** Active crons that contributed at least one run to this window. */
   projectedCount: number;
   /**
@@ -85,11 +99,15 @@ export function projectCronRuns(
   startMs: number,
   endMs: number,
 ): CronProjection {
-  if (!(endMs > startMs)) return { runs: [], projectedCount: 0, truncated: false };
+  if (!(endMs > startMs)) {
+    return { runs: [], projectedCount: 0, truncated: false, completeThroughMs: endMs };
+  }
 
   const runs: ProjectedCronRun[] = [];
   const contributors = new Set<string>();
   let truncated = false;
+  // Complete until something says otherwise.
+  let completeThroughMs = endMs;
 
   for (const auto of automations) {
     if (auto.status !== "ACTIVE") continue;
@@ -100,6 +118,11 @@ export function projectCronRuns(
     const remaining = CRON_PROJECTION_CAP - runs.length;
     if (remaining <= 0) {
       truncated = true;
+      // This cron and every one after it was never walked, so they are absent
+      // from the WHOLE window rather than from its tail. Nothing here is
+      // complete, and saying "complete through the last instant we happened to
+      // reach" would be the more comfortable lie.
+      completeThroughMs = startMs - 1;
       break;
     }
     const { times, hitCap } = walkWindow(
@@ -108,7 +131,15 @@ export function projectCronRuns(
       endMs,
       Math.min(CRON_PROJECTION_PER_CRON_CAP, remaining),
     );
-    if (hitCap) truncated = true;
+    if (hitCap) {
+      truncated = true;
+      // This cron stopped early — at its own 120 ceiling, or because the
+      // remaining overall budget was smaller. Either way its occurrences are
+      // known up to its last one and unknown after it, so the window is
+      // complete only as far as the EARLIEST such cut-off.
+      const last = times.length > 0 ? new Date(times[times.length - 1]!).getTime() : startMs - 1;
+      if (Number.isFinite(last)) completeThroughMs = Math.min(completeThroughMs, last);
+    }
     for (const atIso of times) {
       runs.push({ automationId: auto.id, name: auto.name, atIso });
       contributors.add(auto.id);
@@ -116,7 +147,7 @@ export function projectCronRuns(
   }
 
   runs.sort((a, b) => a.atIso.localeCompare(b.atIso) || a.name.localeCompare(b.name));
-  return { runs, projectedCount: contributors.size, truncated };
+  return { runs, projectedCount: contributors.size, truncated, completeThroughMs };
 }
 
 /** Group projected runs by local calendar day (`YYYY-MM-DD`), which is the key

--- a/src/lib/calendar-run-density.test.ts
+++ b/src/lib/calendar-run-density.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import type { ProjectedCronRun } from "./calendar-cron-projection.ts";
 import {
   RUN_DENSITY_BANDS,
+  dayProjectionIsPartial,
   RUN_DENSITY_MAX_LEVEL,
   clusterLabel,
   clusterRunsByMinute,
@@ -154,5 +155,62 @@ describe("clusterLabel", () => {
       DAY,
     )[0];
     assert.equal(clusterLabel(c), "Daily brief +2");
+  });
+});
+
+describe("dayProjectionIsPartial", () => {
+  const day = new Date(2026, 7, 25);
+  const dayEnd = new Date(2026, 7, 26).getTime() - 1;
+
+  it("is false whenever nothing was truncated, whatever the instant says", () => {
+    assert.equal(
+      dayProjectionIsPartial({ truncated: false, completeThroughMs: 0 }, day),
+      false,
+      "a complete projection is complete even at completeThroughMs 0",
+    );
+  });
+
+  it("marks a day that lies entirely past the cut-off", () => {
+    const cutoff = new Date(2026, 7, 24, 12).getTime();
+    assert.equal(dayProjectionIsPartial({ truncated: true, completeThroughMs: cutoff }, day), true);
+  });
+
+  it("leaves a day that ends before the cut-off alone", () => {
+    const cutoff = new Date(2026, 7, 26, 12).getTime();
+    assert.equal(dayProjectionIsPartial({ truncated: true, completeThroughMs: cutoff }, day), false);
+  });
+
+  it("marks the day CONTAINING the cut-off — the rest of it is unknown", () => {
+    const cutoff = new Date(2026, 7, 25, 9).getTime();
+    assert.equal(dayProjectionIsPartial({ truncated: true, completeThroughMs: cutoff }, day), true);
+  });
+
+  it("treats the last millisecond of the day as still complete", () => {
+    // The boundary matters: completeThroughMs IS complete, so a cut-off at the
+    // final instant of the day leaves nothing unknown inside it.
+    assert.equal(dayProjectionIsPartial({ truncated: true, completeThroughMs: dayEnd }, day), false);
+    assert.equal(
+      dayProjectionIsPartial({ truncated: true, completeThroughMs: dayEnd - 1 }, day),
+      true,
+    );
+  });
+});
+
+describe("runCountLabel partial marking", () => {
+  it("marks a floor rather than presenting a total", () => {
+    assert.equal(runCountLabel(2, "runs", true), "2+ runs");
+    assert.equal(runCountLabel(2, "runs", false), "2 runs");
+  });
+
+  it("keeps the plural noun when one run is only a floor", () => {
+    // "1+ run" reads as a total of one; the count is at least one and the
+    // plural is what carries that.
+    assert.equal(runCountLabel(1, "runs", true), "1+ runs");
+    assert.equal(runCountLabel(1, "runs", false), "1 run");
+  });
+
+  it("still shows nothing at zero, partial or not", () => {
+    // "0+ runs" is noise on a day the reader has no reason to look at.
+    assert.equal(runCountLabel(0, "runs", true), null);
   });
 });

--- a/src/lib/calendar-run-density.ts
+++ b/src/lib/calendar-run-density.ts
@@ -13,7 +13,7 @@
 // load is". A finer bucket would render sub-pixel bands at the width a week
 // column actually gets; a coarser one stops distinguishing morning from night.
 
-import type { ProjectedCronRun } from "./calendar-cron-projection.ts";
+import type { CronProjection, ProjectedCronRun } from "./calendar-cron-projection.ts";
 
 /** Hours covered by one band. 24 / 4 = the six bands the frame draws. */
 export const RUN_DENSITY_BAND_HOURS = 4;
@@ -114,15 +114,41 @@ export function runCountOn(runs: readonly ProjectedCronRun[], day: Date): number
 }
 
 /**
+ * Whether `day` falls past the point where the projection is still complete.
+ *
+ * A partial day's count is a FLOOR, not a total: the caps dropped occurrences
+ * it would otherwise hold. Callers say so with a "+" rather than presenting the
+ * number as final — a cell reading "2 runs" where the answer is nine tells the
+ * reader the month is quieter than it is, which the projection module's own
+ * comment calls the same class of lie as a status that cannot be known.
+ *
+ * Compares against the END of the local day: a day containing the cut-off is
+ * itself partial, because everything after that instant is unknown.
+ */
+export function dayProjectionIsPartial(
+  projection: Pick<CronProjection, "truncated" | "completeThroughMs">,
+  day: Date,
+): boolean {
+  if (!projection.truncated) return false;
+  const dayEndMs =
+    new Date(day.getFullYear(), day.getMonth(), day.getDate() + 1).getTime() - 1;
+  return dayEndMs > projection.completeThroughMs;
+}
+
+/**
  * The caption under a density strip, or under a month cell's glyph.
  *
  * Returns null at zero rather than "0 runs": a day with no projected runs
  * should draw no chrome at all, and returning a string would tempt a caller
  * into rendering an empty affordance.
  */
-export function runCountLabel(count: number, noun = "runs"): string | null {
+export function runCountLabel(count: number, noun = "runs", partial = false): string | null {
+  // A partial day with zero KNOWN runs still has nothing to show: "0+ runs" is
+  // noise on a day the reader has no reason to look at, and every other cell in
+  // a truncated window already carries the "+".
   if (count <= 0) return null;
-  return `${count} ${count === 1 ? noun.replace(/s$/, "") : noun}`;
+  const word = count === 1 && !partial ? noun.replace(/s$/, "") : noun;
+  return `${count}${partial ? "+" : ""} ${word}`;
 }
 
 export type RunCluster = {


### PR DESCRIPTION
`projectionSummary()` already reports truncation at the **frame** level — the footer becomes *"… · showing the first N"*. Nothing said it per **cell**. A month cell reading "2 runs" was indistinguishable from one that would have read nine, and an empty cell from a genuinely quiet day.

## Why the obvious fix would have been wrong

Two mechanisms drop different things, and marking "everything after the last projected instant" only handles the first:

- The **per-cron cap (120)** walks chronologically, so it drops a cron's *latest* occurrences — every day after its cut-off undercounts by that cron.
- The **overall cap (400)** is spent cron-by-cron in list order and `break`s when exhausted, so crons never visited are absent from the **whole window**, not just its tail.

There's a third wrinkle: the per-cron walk is bounded by `Math.min(PER_CRON_CAP, remaining)`, so `hitCap` conflates both limits. Either way that cron is known up to its last occurrence and unknown after it.

## One quantity that answers both

`CronProjection` now carries **`completeThroughMs`** — the instant through which the projection is complete:

| situation | value |
|---|---|
| nothing dropped | the window end |
| tails lost to caps | the **earliest** capped cron's final occurrence |
| overall cap stopped the walk | `startMs - 1` — nothing is complete |

That last row is the one worth arguing about: reporting "complete through the last instant we happened to reach" would be the comfortable lie, when in fact crons the loop never visited are missing from every day in the window.

Month cells and Week density strips read it via `dayProjectionIsPartial()` and render **"2+ runs"** instead of "2 runs", with a title and `aria-label` saying the cap was hit. A partial day with zero *known* runs still shows nothing — "0+ runs" is noise on a day the reader has no reason to look at.

The boundary is deliberate: `completeThroughMs` **is** complete, so a day is partial only when its final millisecond lies past it. The day *containing* the cut-off is partial; a day ending exactly on it is not. Both directions are pinned.

## Verification

**Negative control:** with the narrowing removed, all three `completeThroughMs` tests fail. 27 density tests and 18 projection tests pass. Lint clean; the drift ratchet is unchanged, since the "+" is text rather than styling.

One correction to the bead: my first attempt at these tests used `FREQ=MINUTELY` without the `RRULE:` prefix, which the parser skips entirely — so `truncated` came back false and the tests failed for the wrong reason. They now use the same daily-rule-over-a-long-window mechanism the existing cap test uses.

Closes cave-fdcd4.