### PR TITLE
Portal the Code Desk action popovers so the drawer cannot clip them (cave-cadp4)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -679,6 +679,7 @@ export const SUITES = {
     "src/components/notification-bell-glyph-size.test.ts",
     "src/components/surface-error-states.test.ts",
     "src/components/glass-overlay-chrome.test.ts",
+    "src/components/github-action-popover-portal.test.ts",
     "src/components/surface-loading-states.test.ts",
     "src/components/loading-discipline.test.ts",
     "src/components/chat-header-row.test.ts",

--- a/src/components/github-action-popover-portal.test.ts
+++ b/src/components/github-action-popover-portal.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const view = readFileSync(path.join(root, "src/components/github-view.tsx"), "utf8");
+const listCss = readFileSync(path.join(root, "src/styles/board/github-list.css"), "utf8");
+const detailCss = readFileSync(path.join(root, "src/styles/board/github-detail.css"), "utf8");
+
+// cave-cadp4. Clicking Start in the "what to do next" drawer opened a panel
+// that rendered as an unreadable clipped sliver. The panel was fine; its
+// POSITIONING CONTEXT was not — `.gh-action-popover` was absolutely positioned
+// and opened downward out of `.gh-next-body`, a short scroll container.
+//
+// These are source-text guards rather than a rendered check on purpose: the
+// Code Desk is role-gated behind a familiar with the coding room, so it cannot
+// be driven headlessly here. What can be pinned is the structural property that
+// made the bug possible, so it cannot come back by someone re-adding
+// positioning or hand-rolling another panel.
+describe("Code Desk action popovers stay portalled (cave-cadp4)", () => {
+  it("keeps the drawer body a scroll container — the reason portalling matters", () => {
+    // If this stops being true the guard below is merely tidy rather than
+    // load-bearing, and whoever changes it should know that.
+    const body = /\.gh-next-body\s*\{[^}]*\}/.exec(detailCss)?.[0] ?? "";
+    assert.match(body, /overflow-y\s*:\s*auto/, ".gh-next-body still scrolls");
+  });
+
+  it("never positions the action popover itself", () => {
+    const rule = /\.gh-action-popover\s*\{[^}]*\}/.exec(listCss)?.[0] ?? "";
+    assert.ok(rule.length > 0, ".gh-action-popover rule exists");
+    assert.doesNotMatch(
+      rule,
+      /position\s*:\s*absolute/,
+      "position belongs to the shared Popover, which portals out of the clipping ancestor",
+    );
+    assert.doesNotMatch(rule, /\btop\s*:/, "no anchor offset — Popover computes placement");
+  });
+
+  it("renders every action panel through the shared Popover", () => {
+    // Four panels: Start's card picker and wide popover, Task's popover, and
+    // Merge's familiar picker. Counting them stops a fifth being hand-rolled
+    // back into an absolute div.
+    const panels = view.match(/className="gh-action-popover[^"]*"/g) ?? [];
+    const containers = panels.filter((c) => !/-(title|list|item|item-title|item-familiar)/.test(c));
+    assert.equal(containers.length, 4, "four action panels");
+    for (const cls of containers) {
+      const at = view.indexOf(cls);
+      const before = view.slice(Math.max(0, at - 400), at);
+      assert.match(
+        before,
+        /<Popover\b/,
+        `panel ${cls} is a Popover child, not a positioned div`,
+      );
+    }
+  });
+
+  it("leaves dismissal to the Popover rather than re-adding document listeners", () => {
+    // Two hand-rolled outside-click/Escape effects were removed with the
+    // migration; Popover owns dismissal for all four panels now.
+    assert.doesNotMatch(
+      view,
+      /Close the (multi-card|familiar) picker on outside click/,
+      "no hand-rolled picker dismissal remains",
+    );
+  });
+});

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -43,7 +43,7 @@ import { useArmedConfirm } from "@/lib/use-armed-confirm";
 import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
 import { OverflowMenu } from "@/components/ui/overflow-menu";
-import { PopoverItem, PopoverLabel, PopoverSeparator } from "@/components/ui/popover";
+import { Popover, PopoverItem, PopoverLabel, PopoverSeparator } from "@/components/ui/popover";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { StandardSelect } from "@/components/ui/select";
 import { arrayContentEqual } from "@/lib/array-content-equal";
@@ -395,27 +395,14 @@ function OpenChatAction({
   const [pickerOpen, setPickerOpen] = useState(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const pickerRef = useRef<HTMLDivElement>(null);
-
-  // Close the multi-card picker on outside click / Escape
-  useEffect(() => {
-    if (!pickerOpen) return;
-    function onDoc(e: MouseEvent) {
-      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
-        setPickerOpen(false);
-      }
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") setPickerOpen(false);
-    }
-    const id = window.setTimeout(() => document.addEventListener("mousedown", onDoc), 30);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      window.clearTimeout(id);
-      document.removeEventListener("mousedown", onDoc);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [pickerOpen]);
+  // Anchors the portalled panels. They are rendered through Popover rather than
+  // positioned inside this wrapper: the buttons sit in `.gh-next-body`, which
+  // is `overflow-y:auto; overflow-x:hidden` inside a drawer capped at
+  // `max-height:min(66%,340px)`, so an absolutely-positioned panel opening
+  // downward from a low anchor was clipped on BOTH axes and rendered as an
+  // unreadable sliver (cave-cadp4). Popover portals out of every clipping
+  // ancestor and flips above the anchor when there is no room below.
+  const anchorRef = useRef<HTMLDivElement>(null);
 
   async function openChatForCard(cardId: string) {
     const target = cards.find((c) => c.id === cardId);
@@ -465,7 +452,7 @@ function OpenChatAction({
   const title = linkedCards.length === 0 ? "Start chat" : "Open chat";
 
   return (
-    <div className="gh-action-wrap">
+    <div className="gh-action-wrap" ref={anchorRef}>
       <Button
         size="xs"
         variant="secondary"
@@ -479,8 +466,16 @@ function OpenChatAction({
 
       {error && <span className="gh-action-error" role="img" aria-label={`Error: ${error}`} title={error}>!</span>}
 
-      {pickerOpen && linkedCards.length > 1 && (
-        <div ref={pickerRef} className="gh-action-popover" onClick={(e) => e.stopPropagation()}>
+      <Popover
+        open={pickerOpen && linkedCards.length > 1}
+        onOpenChange={setPickerOpen}
+        anchorRef={anchorRef}
+        placement="bottom-end"
+        minWidth={220}
+        ariaLabel="Open chat for"
+        className="gh-action-popover"
+      >
+        <div onClick={(e) => e.stopPropagation()}>
           <p className="gh-action-popover-title">Open chat for…</p>
           <ul className="gh-action-popover-list">
             {linkedCards.map((c) => {
@@ -512,10 +507,19 @@ function OpenChatAction({
             })}
           </ul>
         </div>
-      )}
+      </Popover>
 
-      {popoverOpen && (
-        <div className="gh-action-popover gh-action-popover--wide" onClick={(e) => e.stopPropagation()}>
+      <Popover
+        open={popoverOpen}
+        onOpenChange={setPopoverOpen}
+        anchorRef={anchorRef}
+        placement="bottom-end"
+        minWidth={280}
+        scrollStrategy="content"
+        ariaLabel="Start chat"
+        className="gh-action-popover gh-action-popover--wide"
+      >
+        <div onClick={(e) => e.stopPropagation()}>
           <GitHubActionPopover
             mode="chat"
             item={item}
@@ -526,7 +530,7 @@ function OpenChatAction({
             onClose={() => setPopoverOpen(false)}
           />
         </div>
-      )}
+      </Popover>
     </div>
   );
 }
@@ -550,26 +554,9 @@ function SafeMergeAction({
   const { announce } = useAnnouncer();
   const [error, setError] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
-  const pickerRef = useRef<HTMLDivElement>(null);
-
-  // Close the familiar picker on outside click / Escape (same posture as
-  // OpenChatAction's card picker).
-  useEffect(() => {
-    if (!pickerOpen) return;
-    function onDoc(ev: MouseEvent) {
-      if (pickerRef.current && !pickerRef.current.contains(ev.target as Node)) setPickerOpen(false);
-    }
-    function onKey(ev: KeyboardEvent) {
-      if (ev.key === "Escape") setPickerOpen(false);
-    }
-    const id = window.setTimeout(() => document.addEventListener("mousedown", onDoc), 30);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      window.clearTimeout(id);
-      document.removeEventListener("mousedown", onDoc);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [pickerOpen]);
+  // Same posture as OpenChatAction: Popover owns anchoring and dismissal, and
+  // portals the panel out of the drawer's scroll container (cave-cadp4).
+  const anchorRef = useRef<HTMLDivElement>(null);
 
   if (item.kind !== "pr" && item.kind !== "review_request") return null;
 
@@ -649,7 +636,7 @@ function SafeMergeAction({
   }
 
   return (
-    <div className="gh-action-wrap">
+    <div className="gh-action-wrap" ref={anchorRef}>
       <Button
         size="xs"
         variant="secondary"
@@ -663,8 +650,16 @@ function SafeMergeAction({
       </Button>
       {error && <span className="gh-action-error" role="img" aria-label={`Error: ${error}`} title={error}>!</span>}
 
-      {pickerOpen && (
-        <div ref={pickerRef} className="gh-action-popover" onClick={(e) => e.stopPropagation()}>
+      <Popover
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        anchorRef={anchorRef}
+        placement="bottom-end"
+        minWidth={220}
+        ariaLabel="Merge with"
+        className="gh-action-popover"
+      >
+        <div onClick={(e) => e.stopPropagation()}>
           <p className="gh-action-popover-title">Merge with…</p>
           {familiars.length === 0 ? (
             // An empty roster and a failed load are different claims: one says
@@ -689,7 +684,7 @@ function SafeMergeAction({
             </ul>
           )}
         </div>
-      )}
+      </Popover>
     </div>
   );
 }
@@ -712,6 +707,8 @@ function AddToBoardAction({
   onAfterLink: () => void;
 }) {
   const [mode, setMode] = useState<PopoverMode | null>(null);
+  // Portalled for the same reason as the sibling actions (cave-cadp4).
+  const anchorRef = useRef<HTMLDivElement>(null);
 
   function open(m: PopoverMode, e: React.MouseEvent) {
     e.stopPropagation();
@@ -722,7 +719,7 @@ function AddToBoardAction({
   }
 
   return (
-    <div className="gh-action-wrap">
+    <div className="gh-action-wrap" ref={anchorRef}>
       <Button
         size="xs"
         variant="secondary"
@@ -732,9 +729,18 @@ function AddToBoardAction({
       >
         Task
       </Button>
-      {mode && (
-        <div className="gh-action-popover gh-action-popover--wide" onClick={(e) => e.stopPropagation()}>
-          <GitHubActionPopover
+      <Popover
+        open={mode !== null}
+        onOpenChange={(next) => { if (!next) close(); }}
+        anchorRef={anchorRef}
+        placement="bottom-end"
+        minWidth={280}
+        scrollStrategy="content"
+        ariaLabel="Add to task"
+        className="gh-action-popover gh-action-popover--wide"
+      >
+        <div onClick={(e) => e.stopPropagation()}>
+          {mode ? <GitHubActionPopover
             mode={mode}
             item={item}
             familiars={familiars}
@@ -743,9 +749,9 @@ function AddToBoardAction({
             cardsFailed={cardsFailed}
             onClose={close}
             onComplete={onAfterLink}
-          />
+          /> : null}
         </div>
-      )}
+      </Popover>
     </div>
   );
 }

--- a/src/styles/board/github-list.css
+++ b/src/styles/board/github-list.css
@@ -248,9 +248,19 @@
    on screen. */
 .gh-row.is-selected .gh-actions.reveal-on-hover,
 .gh-actions.reveal-on-hover:has(.gh-action-error) { opacity:1; }
-.gh-action-wrap { position:relative; display:inline-flex; }
+/* No positioning context: the only absolutely-positioned child was the action
+   popover, which the shared Popover now portals. Leaving `position:relative`
+   here — and the `position:static` override that used to fight it — would
+   preserve scaffolding for a layout that no longer exists. cave-cadp4. */
+.gh-action-wrap { display:inline-flex; }
 .gh-action-error { display:inline-flex; align-items:center; justify-content:center; width:14px; height:14px; margin-left:4px; border-radius:50%; background:var(--color-danger); color:var(--color-danger-foreground); font-size:10px; font-weight:700; }
-.gh-action-popover { position:absolute; top:calc(100% + 4px); right:0; z-index:60; min-width:220px; padding:8px; border:1px solid var(--border-hairline); border-radius:10px; background:var(--glass-elevated); backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); box-shadow:0 12px 30px rgba(0,0,0,.18); }
+/* Skin only. Position, stacking and dismissal belong to the shared Popover,
+   which portals this panel to the top layer — these used to be
+   `position:absolute; top:calc(100% + 4px)`, which opened DOWNWARD out of
+   `.gh-next-body` (`overflow-y:auto; overflow-x:hidden`, inside a drawer capped
+   at `max-height:min(66%,340px)`) and was clipped on both axes into an
+   unreadable sliver. cave-cadp4. */
+.gh-action-popover { min-width:220px; padding:8px; border:1px solid var(--border-hairline); border-radius:10px; background:var(--glass-elevated); backdrop-filter:blur(var(--glass-blur)) saturate(var(--glass-saturate)); box-shadow:0 12px 30px rgba(0,0,0,.18); }
 .gh-action-popover--wide { padding:0; min-width:280px; background:transparent; border:none; box-shadow:none; backdrop-filter:none; }
 .gh-action-popover-title { padding:0 4px 6px; font-size:11px; color:var(--text-muted); }
 .gh-action-popover-list { list-style:none; margin:0; padding:0; max-height:220px; overflow-y:auto; }
@@ -262,7 +272,6 @@
 /* Detail-panel actions sit at the panel's LEFT edge, so a right-anchored popover
    extends into the scroll container's unreachable left overflow and gets clipped.
    Anchor to the actions row itself (wrap goes static) and open from the left. */
-.gh-glass-actions .gh-action-wrap { position:static; }
 
 .gh-glass-panel {
   position:relative;


### PR DESCRIPTION
Clicking **Start** in the "what to do next" drawer opened a panel that rendered as an unreadable clipped sliver overlapping the drawer, its content truncated mid-word.

## The panel was fine — its positioning context wasn't

- `.gh-action-popover` was `position:absolute; top:calc(100% + 4px); right:0` — it opens **downward** from the button.
- Those buttons live in `.gh-next-body`, which is `overflow-y:auto; overflow-x:hidden`, inside `.gh-next` capped at `max-height:min(66%,340px)`.

A downward-opening absolute panel anchored near the bottom of a short scroll container is clipped on both axes, and its 220px min-width against a narrow drawer made the horizontal clipping visible too.

## The repo already had the answer

`ui/popover.tsx` exports a `Popover` that portals to the top layer, auto-flips against the **visual** viewport when the anchor sits low, and clamps to screen. `github-view.tsx` imported only `PopoverItem`/`PopoverLabel`/`PopoverSeparator` and hand-rolled the containers — which is exactly how the clipping survived.

All **four** panels move onto it — Start's card picker and its wide popover, Task's popover, and Merge's familiar picker — so one fix covers every action instead of four copies drifting apart. Two hand-rolled outside-click/Escape effects go with them, since `Popover` owns dismissal.

The CSS becomes skin-only. `.gh-action-wrap`'s `position:relative` and the `.gh-glass-actions .gh-action-wrap { position:static }` override that used to fight it are both removed — I scanned every `.gh-action*` rule in both sheets and the popover was the only absolutely-positioned child, so keeping them would preserve scaffolding for a layout that no longer exists.

## Verification — and its limit

**I could not drive this surface headlessly.** The Code Desk is role-gated behind a familiar holding the coding room; two probe attempts reached the "choose a familiar before entering a room" gate instead of the drawer. I'm not claiming a visual confirmation I didn't get.

Instead the structural property that made the bug possible is pinned by four assertions: the drawer body is still a scroll container (so the guard stays load-bearing rather than merely tidy), `.gh-action-popover` carries no `position`/`top` of its own, all four panels are `Popover` children rather than positioned divs, and no hand-rolled dismissal creeps back.

**Negative control:** restoring the old `position:absolute; top:calc(100% + 4px)` fails the positioning assertion and passes again when removed.

**Pre-existing, not touched here:** `popover.test.ts` and `glass-overlay-chrome.test.ts` both fail identically on the primary checkout at a commit without this change — each asserts on `globals.css` content unrelated to this fix.

Closes cave-cadp4.