### PR TITLE
Stop GitHubActionPopover positioning itself inside a Popover (cave-7dktt)

### DIFF
--- a/src/components/github-action-popover-portal.test.ts
+++ b/src/components/github-action-popover-portal.test.ts
@@ -56,6 +56,42 @@ describe("Code Desk action popovers stay portalled (cave-cadp4)", () => {
     }
   });
 
+  it("never lets a Popover child position ITSELF (cave-7dktt)", () => {
+    // The clipping fix alone was not enough, and this guard is the reason to
+    // say so. GitHubActionPopover renders its root `absolute right-0 top-full`,
+    // which is out of flow — so the Popover wrapper measured ZERO height, its
+    // auto-flip saw room below that did not exist, and the dialog ran off the
+    // bottom of the viewport (measured: dialog bottom 1004 in a 900px view).
+    //
+    // A panel that is unclipped but off-screen is no better than a clipped one,
+    // and the assertions above all passed while that was true — they check
+    // clipping, which stayed fixed. So check placement ownership too.
+    const actionPopover = readFileSync(
+      path.join(root, "src/components/github-action-popover.tsx"),
+      "utf8",
+    );
+    assert.match(
+      actionPopover,
+      /positioned\s*=\s*true/,
+      "GitHubActionPopover takes a `positioned` prop, defaulting to its standalone behaviour",
+    );
+    assert.match(
+      actionPopover,
+      /positioned \? "absolute right-0 top-full/,
+      "and drops its own absolute placement when it is false",
+    );
+    // Every use inside a Popover must hand placement over.
+    const uses = view.split("<GitHubActionPopover").slice(1);
+    assert.equal(uses.length, 2, "two GitHubActionPopover call sites");
+    for (const use of uses) {
+      assert.match(
+        use.slice(0, 200),
+        /positioned=\{false\}/,
+        "a GitHubActionPopover inside a Popover must not position itself",
+      );
+    }
+  });
+
   it("leaves dismissal to the Popover rather than re-adding document listeners", () => {
     // Two hand-rolled outside-click/Escape effects were removed with the
     // migration; Popover owns dismissal for all four panels now.

--- a/src/components/github-action-popover.tsx
+++ b/src/components/github-action-popover.tsx
@@ -19,6 +19,17 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 export type PopoverMode = "board" | "chat" | "assign";
 
 type Props = {
+  /**
+   * Whether this dialog places ITSELF (`absolute right-0 top-full`).
+   *
+   * False when a Popover owns placement. It matters more than it looks: an
+   * absolutely-positioned child is out of flow, so the Popover's wrapper
+   * measures ZERO height, its auto-flip decides there is room below, and the
+   * dialog runs off the bottom of the viewport — measured at bottom 1004 in a
+   * 900px viewport before this existed (cave-cadp4).
+   */
+  positioned?: boolean;
+
   mode: PopoverMode;
   item: GitHubItem;
   familiars: Familiar[];
@@ -326,6 +337,7 @@ export function GitHubActionPopover({
   cardsFailed = false,
   onClose,
   onComplete,
+  positioned = true,
 }: Props) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -371,7 +383,7 @@ export function GitHubActionPopover({
       aria-modal="true"
       aria-label={TITLES[mode]}
       tabIndex={-1}
-      className="absolute right-0 top-full z-50 mt-1 w-64 rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] p-3 shadow-xl"
+      className={`${positioned ? "absolute right-0 top-full z-50 mt-1 " : ""}w-64 rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] p-3 shadow-xl`}
       onClick={(e) => e.stopPropagation()}
     >
       {/* Header */}

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -521,6 +521,7 @@ function OpenChatAction({
       >
         <div onClick={(e) => e.stopPropagation()}>
           <GitHubActionPopover
+            positioned={false}
             mode="chat"
             item={item}
             familiars={familiars}
@@ -741,6 +742,7 @@ function AddToBoardAction({
       >
         <div onClick={(e) => e.stopPropagation()}>
           {mode ? <GitHubActionPopover
+            positioned={false}
             mode={mode}
             item={item}
             familiars={familiars}


### PR DESCRIPTION
Follow-up to #5046, and a correction to it. **That fix was incomplete, and only driving the surface with a real GitHub token showed why.**

#5046 stopped the drawer clipping these panels by portalling them, and that part held — measured `insideScrollingDrawer: false`, `clippingAncestor: null`. But it left the two **wide** variants (Start with no linked cards, and Task) mispositioned.

## An out-of-flow child defeats auto-flip

`GitHubActionPopover` renders its own root as `absolute right-0 top-full`. An absolutely positioned child is **out of flow**, so:

1. the `Popover` wrapper measured **zero height**;
2. its auto-flip compared that against the space below, concluded there was room;
3. it never flipped, and the dialog offset `top-full` from a zero-height box.

**Measured on the merged head:** wrapper `280×0` at top 673, and the real dialog `256×353` spanning top 651 → **bottom 1004 in a 900px viewport** — 104px off the bottom.

That trades a clipped panel for an off-screen one, which is no better.

## The fix

A `positioned` prop, default `true`, so the component's standalone behaviour is unchanged. The two call sites inside a `Popover` pass `false`, the dialog lays out in flow, the wrapper gets real height, and the flip logic can finally see it.

## Verified in the browser

After the fix: wrapper `280×353`, dialog `256×353` spanning top 320 → **bottom 673, `onScreen: true`** — and it now **flips upward** instead of running off the bottom.

The panel renders in full: issue reference, "Start a chat with…", the familiar list, and the Open chat button — where the original report showed a ~120px sliver truncated mid-word.

## The guard is extended, because it passed through this

Every assertion added in #5046 **passed while the dialog was off-screen**, because they check whether the panel is *clipped* — which stayed fixed. A panel that is unclipped but off-screen is no better, so placement ownership is now checked too.

**Negative control:** removing `positioned={false}` from the call sites fails the new assertion; restoring it passes. Lint clean, typecheck clean.

Closes cave-7dktt.