### PR TITLE
fix(chat): retry blank failed Copilot resumes

### DIFF
--- a/src/app/api/chat/send/chat-send-runtime.test.ts
+++ b/src/app/api/chat/send/chat-send-runtime.test.ts
@@ -3,7 +3,10 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { filterUsableLocalDirectories } from "./chat-send-runtime.ts";
+import {
+  filterUsableLocalDirectories,
+  shouldRetryBlankCopilotResume,
+} from "./chat-send-runtime.ts";
 
 test("stale project grants never reach local harness launch arguments", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "cave-chat-grants-"));
@@ -41,10 +44,64 @@ test("Chat derives effective grants from usable local directories", async () => 
   );
 });
 
-test("a silent stale Copilot resume retries with recent context", async () => {
+test("blank resumed Copilot attempts retry for silent zero and nonzero exits", () => {
+  const resumedBlankAttempt = {
+    hasCopilotStream: true,
+    resumeTarget: "copilot-session",
+    runtimeAccessRefreshNeeded: false,
+    inferenceRouteRefreshNeeded: false,
+    stopRequested: false,
+    launchFailed: false,
+    assistantText: "",
+    durationMs: undefined,
+    resultIsError: undefined,
+  };
+
+  assert.equal(shouldRetryBlankCopilotResume(resumedBlankAttempt), true);
+  assert.equal(
+    shouldRetryBlankCopilotResume({ ...resumedBlankAttempt, resultIsError: true }),
+    true,
+    "a blank resumed nonzero exit receives the same bounded fresh-session retry",
+  );
+});
+
+test("blank Copilot resume retry preserves every existing boundary", () => {
+  const resumedBlankAttempt = {
+    hasCopilotStream: true,
+    resumeTarget: "copilot-session",
+    runtimeAccessRefreshNeeded: false,
+    inferenceRouteRefreshNeeded: false,
+    stopRequested: false,
+    launchFailed: false,
+    assistantText: "",
+    durationMs: undefined,
+    resultIsError: true,
+  };
+  const excludedAttempts = [
+    { name: "non-Copilot route", input: { hasCopilotStream: false } },
+    { name: "fresh conversation", input: { resumeTarget: null } },
+    { name: "access refresh", input: { runtimeAccessRefreshNeeded: true } },
+    { name: "inference-route refresh", input: { inferenceRouteRefreshNeeded: true } },
+    { name: "stopped run", input: { stopRequested: true } },
+    { name: "launch failure", input: { launchFailed: true } },
+    { name: "assistant response", input: { assistantText: "visible answer" } },
+    { name: "result duration", input: { durationMs: 10 } },
+    { name: "explicit successful result", input: { resultIsError: false } },
+  ] as const;
+
+  for (const excluded of excludedAttempts) {
+    assert.equal(
+      shouldRetryBlankCopilotResume({ ...resumedBlankAttempt, ...excluded.input }),
+      false,
+      excluded.name,
+    );
+  }
+});
+
+test("Chat routes blank resumed Copilot attempts through the bounded retry predicate", async () => {
   const route = await readFile(new URL("./route.ts", import.meta.url), "utf8");
   assert.match(
     route,
-    /copilotStream[\s\S]*?resumeTarget[\s\S]*?!assistantText\.trim\(\)[\s\S]*?result\.duration_ms == null[\s\S]*?result\.is_error == null[\s\S]*?resumeFailed = true/,
+    /shouldRetryBlankCopilotResume\(\{[\s\S]*?hasCopilotStream: Boolean\(copilotStream\),[\s\S]*?resumeTarget,[\s\S]*?durationMs: result\.duration_ms,[\s\S]*?resultIsError: result\.is_error,[\s\S]*?resumeFailed = true/,
   );
 });

--- a/src/app/api/chat/send/chat-send-runtime.ts
+++ b/src/app/api/chat/send/chat-send-runtime.ts
@@ -26,6 +26,28 @@ export async function conversationCwd(sessionId?: string): Promise<string | unde
 
 type DaemonSessionRow = { id?: string; project_root?: string };
 
+export function shouldRetryBlankCopilotResume(input: {
+  hasCopilotStream: boolean;
+  resumeTarget: string | null;
+  runtimeAccessRefreshNeeded: boolean;
+  inferenceRouteRefreshNeeded: boolean;
+  stopRequested: boolean;
+  launchFailed: boolean;
+  assistantText: string;
+  durationMs?: number;
+  resultIsError?: boolean;
+}): boolean {
+  return input.hasCopilotStream &&
+    Boolean(input.resumeTarget) &&
+    !input.runtimeAccessRefreshNeeded &&
+    !input.inferenceRouteRefreshNeeded &&
+    !input.stopRequested &&
+    !input.launchFailed &&
+    !input.assistantText.trim() &&
+    input.durationMs == null &&
+    input.resultIsError !== false;
+}
+
 /**
  * Resume-cwd fallback for sessions the Cave conversation store has no local
  * runtime for — e.g. threads opened from Familiar analytics (`/#chat-<id>`)

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -313,6 +313,7 @@ import {
   daemonSessionCwd,
   filterUsableLocalDirectories,
   resolveFamiliarWorkspace,
+  shouldRetryBlankCopilotResume,
 } from "./chat-send-runtime";
 import { resolveOpenClawGatewayOutcome } from "./openclaw-gateway-outcome";
 
@@ -5332,21 +5333,22 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
         await runAttempt(args);
       }
 
-      // Copilot can silently close an expired native session with exit code 0:
-      // no result frame, no assistant text, and no "session not found" stderr.
-      // Treat that exact resumed-attempt shape as a stale session so the
-      // existing bounded context-replay retry can answer the user's turn.
-      if (
-        copilotStream &&
-        resumeTarget &&
-        !runtimeAccessRefreshNeeded &&
-        !inferenceRouteRefreshNeeded &&
-        !runHandle.stopRequested &&
-        !launchFailure &&
-        !assistantText.trim() &&
-        result.duration_ms == null &&
-        result.is_error == null
-      ) {
+      // Copilot can silently close an expired native session with no result
+      // frame or assistant text. This can surface as either exit code 0 or a
+      // nonzero process exit, so retry both blank resumed-attempt shapes while
+      // preserving explicit successful empty results and every fresh-session
+      // boundary above.
+      if (shouldRetryBlankCopilotResume({
+        hasCopilotStream: Boolean(copilotStream),
+        resumeTarget,
+        runtimeAccessRefreshNeeded,
+        inferenceRouteRefreshNeeded,
+        stopRequested: runHandle.stopRequested,
+        launchFailed: Boolean(launchFailure),
+        assistantText,
+        durationMs: result.duration_ms,
+        resultIsError: result.is_error,
+      })) {
         resumeFailed = true;
       }
 


### PR DESCRIPTION
## Summary
- retry blank resumed Copilot attempts when the native process exits nonzero
- preserve the existing one-shot context-replay boundaries and reject explicit successful empty results
- add focused predicate and route-wiring regression coverage

## Verification
- focused chat-send runtime test: 5/5 pass
- adjacent Copilot JSONL routing test: pass
- scoped ESLint for all three changed files: pass
- pnpm check:tests-wired: 1883 test files wired
- pnpm build: pass
- API suite: all 447 files passed across the initial 0..428 run and dependency-corrected 429..446 tail

## Existing baseline findings
- pnpm lint stops before source lint on seven untouched design-token findings
- pnpm test:app reproduces two failures in untouched src/lib/server/store-read-cache.test.ts
- host Node 24.15.0 is below the repository requested >=24.18.0 <25

Bead: cave-g7x06

Merge is intentionally withheld.