### PR TITLE
Define local Research Resource contracts

### DIFF
--- a/docs/superpowers/plans/2026-08-26-research-resource-contracts-and-flags.md
+++ b/docs/superpowers/plans/2026-08-26-research-resource-contracts-and-flags.md
@@ -1,0 +1,51 @@
+# Research Resource Contracts and Feature Flags Implementation Plan
+
+**Goal:** Define the Cave-owned Research Resource records and retrieval boundary needed by the local resource release, plus truthful rollout gates, without changing the portable Research Run Protocol.
+
+**Source:** `docs/superpowers/plans/2026-08-16-externalized-research-desk-program.md` §§3-7, 9, and 11 A1, building on the approved selector contract in `src/lib/research-protocol/context-pack.ts`.
+
+**Boundary:** This unit adds types, parsers, tests, and feature-flag getters only. It does not add stores, APIs, UI, backup behavior, ingestion workers, indexes, embeddings, migrations, or changes under `schemas/research/v1/` and `src/lib/research-protocol/`.
+
+## Contract decisions
+
+All persisted mutable records use `version: 1`, accept only canonical JSON values, preserve safe unknown additive fields, and validate their known fields before returning detached data. The deletion tombstone is the persisted-record exception: it is a strict allowlist so a title, URL, excerpt, local path, or future unreviewed field cannot enter authoritative backup state. Query responses and their hits are also strict allowlists because they are non-persisted disclosure boundaries; an additive path, URI, URL, credential, or object key must not pass through accidentally.
+
+The exact contracts are:
+
+- `ResourceManifestV1` and `ResourceSnapshotV1`: the exact fields and enums approved in umbrella §3.3. Snapshot selectors reuse `ContextSelectorV1` and `parseContextSelectorV1`; local resource types do not join the portable protocol dispatcher.
+- `ResourceIngestJobV1` and `ResourceEmbeddingTaskV1`: the exact fields and states approved in umbrella §4. A lease is present exactly for a claimed job. `paused_quota` is represented without changing `attempt`. Semantic state remains independent from lexical publication.
+- `ResourceTombstoneV1`: exactly `{ version: 1, resourceId, deletionRevision, deletedAt }`. No additive fields are accepted.
+- `ResearchLinksProjectionV1`: `{ version: 1, catalogRevision, projectedDigest, generatedAt }`. The digest is the complete generated `research-links.json` projection.
+- `ResearchLinksMigrationJournalV1`: `{ version: 1, catalogRevision, intendedProjectionDigest, startedAt }`. Its presence means projection verification/repair must finish before reads.
+- `ResourceQueryV1`: `{ version: 1, text, filters?, ranking, limit }`. `text` is non-empty. Filters are optional arrays `projectIds`, `familiarIds`, `kinds`, `sensitivities`, and `ingestStates`, plus `publishedFrom` (inclusive), `publishedBefore` (exclusive), and `contextPackId`. `ranking` is `exact | lexical | hybrid`; `limit` is an integer from 1 through 100. Empty filter arrays are rejected rather than ambiguously meaning either all or none.
+- `ResourceQueryResponseV1`: `{ version: 1, ranking, hits }`. Each `ResourceQueryHitV1` carries `resourceId`, `snapshotId`, `resourceRevision`, `normalizedBlobDigest`, the exact `selector`, `excerpt`, `excerptDigest`, and truthful `retrieval` evidence. Exact matching is boolean; lexical matching carries an optional positive rank only when matched; semantic state is `disabled | unavailable | ready`, may report a match only when ready, and carries an optional positive rank only when matched. The response, hit, and nested retrieval evidence are strict allowlists and deliberately have no path, URI, URL, provider credential, or remote object key.
+
+Digests are lowercase SHA-256. Timestamps are UTC RFC 3339. Revisions and deletion fences are non-negative safe integers; manifest revisions and snapshot resource revisions are positive. Page boundaries use one-based consecutive page numbers and ordered, non-overlapping half-open byte ranges within `normalizedBytes`. Snapshot validation cross-checks selectors against those bytes: a `text-span` ends within `normalizedBytes`, while a `pdf-page-span` requires the page table, names an existing page, and uses page-relative offsets no larger than that page's boundary length. Published date filters must form a non-empty half-open interval when both are present.
+
+## Feature-flag decisions
+
+`src/lib/feature-flags.ts` remains the only flag authority. New raw environment gates use the existing truthy grammar and default off:
+
+- `NEXT_PUBLIC_CAVE_RESEARCH_RESOURCES`
+- `NEXT_PUBLIC_CAVE_RESEARCH_LOCAL_INGESTION`
+- `NEXT_PUBLIC_CAVE_RESEARCH_SEMANTIC`
+- `NEXT_PUBLIC_CAVE_RESEARCH_CONTEXT_PACKS`
+- `NEXT_PUBLIC_CAVE_RESEARCH_TOPIC_DISCOVERY`
+- `NEXT_PUBLIC_CAVE_RESEARCH_HOSTED_RUNS`
+
+Effective gates are hierarchical: resources is the root; local ingestion requires resources; semantic requires local ingestion; Context Packs require resources; Topic Discovery requires Context Packs. `caveResearchHostedRuns()` keeps its required no-argument signature and returns false throughout A1, including when the public environment flag is true, because no Gate C0 server authority exists yet. A later C0 server-only integration must replace this fail-closed implementation only after it can prove the approved account, repository, bindings, and authentication policy; the client flag alone can never claim readiness.
+
+## Implementation
+
+1. Add `src/lib/research-resource-contracts.ts` with local types and hand-written parsers.
+2. Add focused valid, invalid, compatibility, privacy, and semantic-invariant coverage in `src/lib/research-resource-contracts.test.ts`.
+3. Add the six hierarchical getters to `src/lib/feature-flags.ts` and extend its test with default-off, truthy grammar, hierarchy, and hosted-readiness cases.
+4. Register the local contract test in the app test suite. Keep portable conformance wiring unchanged.
+
+## Verification
+
+Run the two focused tests, `pnpm test:app`, `pnpm test:conformance`, `pnpm typecheck`, `pnpm lint`, and `pnpm check:tests-wired`. Confirm the final diff contains no file under `schemas/research/v1/` or `src/lib/research-protocol/`.
+
+## Rollback
+
+All feature gates default off. Reverting this unit removes unused types and getters without migrating persisted data because no store or writer ships in A1. Later units must keep their read/migration paths compatible while their effective flag is off.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -820,6 +820,7 @@ export const SUITES = {
     "src/lib/agentic-recommendations.test.ts",
     "src/lib/use-agentic-recommendations.test.ts",
     "src/lib/feature-flags.test.ts",
+    "src/lib/research-resource-contracts.test.ts",
     "src/lib/research-recommendation-context.test.ts",
     "src/lib/research-topic-recommendations.test.ts",
     "src/lib/comux-projects.test.ts",

--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -1,7 +1,30 @@
 import assert from "node:assert/strict";
-import { caveAgenticRecommendations } from "./feature-flags.ts";
+import {
+  caveAgenticRecommendations,
+  caveResearchContextPacks,
+  caveResearchHostedRuns,
+  caveResearchLocalIngestion,
+  caveResearchResources,
+  caveResearchSemantic,
+  caveResearchTopicDiscovery,
+} from "./feature-flags.ts";
 
 const original = process.env.NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS;
+const researchFlagNames = [
+  "NEXT_PUBLIC_CAVE_RESEARCH_RESOURCES",
+  "NEXT_PUBLIC_CAVE_RESEARCH_LOCAL_INGESTION",
+  "NEXT_PUBLIC_CAVE_RESEARCH_SEMANTIC",
+  "NEXT_PUBLIC_CAVE_RESEARCH_CONTEXT_PACKS",
+  "NEXT_PUBLIC_CAVE_RESEARCH_TOPIC_DISCOVERY",
+  "NEXT_PUBLIC_CAVE_RESEARCH_HOSTED_RUNS",
+] as const;
+const originalResearchFlags = Object.fromEntries(
+  researchFlagNames.map((name) => [name, process.env[name]]),
+) as Record<(typeof researchFlagNames)[number], string | undefined>;
+
+function clearResearchFlags(): void {
+  for (const name of researchFlagNames) delete process.env[name];
+}
 
 try {
   delete process.env.NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS;
@@ -16,9 +39,65 @@ try {
     process.env.NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS = disabled;
     assert.equal(caveAgenticRecommendations(), false, `${disabled} does not enable agentic recommendations`);
   }
+
+  clearResearchFlags();
+  assert.equal(caveResearchResources(), false, "resources default off");
+  assert.equal(caveResearchLocalIngestion(), false, "local ingestion defaults off");
+  assert.equal(caveResearchSemantic(), false, "semantic defaults off");
+  assert.equal(caveResearchContextPacks(), false, "Context Packs default off");
+  assert.equal(caveResearchTopicDiscovery(), false, "Topic Discovery defaults off");
+  assert.equal(caveResearchHostedRuns(), false, "hosted runs default off");
+
+  for (const enabled of ["1", "true", "yes", "on", " ON "]) {
+    clearResearchFlags();
+    process.env.NEXT_PUBLIC_CAVE_RESEARCH_RESOURCES = enabled;
+    assert.equal(caveResearchResources(), true, `${enabled} enables Research Resources`);
+  }
+
+  for (const disabled of ["0", "false", "no", "off", "enabled", ""]) {
+    clearResearchFlags();
+    process.env.NEXT_PUBLIC_CAVE_RESEARCH_RESOURCES = disabled;
+    assert.equal(caveResearchResources(), false, `${disabled || "empty"} does not enable Research Resources`);
+  }
+
+  clearResearchFlags();
+  process.env.NEXT_PUBLIC_CAVE_RESEARCH_LOCAL_INGESTION = "1";
+  process.env.NEXT_PUBLIC_CAVE_RESEARCH_SEMANTIC = "1";
+  process.env.NEXT_PUBLIC_CAVE_RESEARCH_CONTEXT_PACKS = "1";
+  process.env.NEXT_PUBLIC_CAVE_RESEARCH_TOPIC_DISCOVERY = "1";
+  assert.equal(caveResearchLocalIngestion(), false, "ingestion requires resources");
+  assert.equal(caveResearchSemantic(), false, "semantic requires ingestion and resources");
+  assert.equal(caveResearchContextPacks(), false, "Context Packs require resources");
+  assert.equal(caveResearchTopicDiscovery(), false, "Topic Discovery requires Context Packs and resources");
+
+  process.env.NEXT_PUBLIC_CAVE_RESEARCH_RESOURCES = "1";
+  assert.equal(caveResearchLocalIngestion(), true);
+  assert.equal(caveResearchSemantic(), true);
+  assert.equal(caveResearchContextPacks(), true);
+  assert.equal(caveResearchTopicDiscovery(), true);
+
+  delete process.env.NEXT_PUBLIC_CAVE_RESEARCH_LOCAL_INGESTION;
+  assert.equal(caveResearchSemantic(), false, "semantic stays off when ingestion is off");
+  assert.equal(caveResearchContextPacks(), true, "Context Packs do not require ingestion");
+  assert.equal(caveResearchTopicDiscovery(), true, "Topic Discovery follows Context Packs");
+
+  delete process.env.NEXT_PUBLIC_CAVE_RESEARCH_CONTEXT_PACKS;
+  assert.equal(caveResearchTopicDiscovery(), false, "Topic Discovery stays off without Context Packs");
+
+  clearResearchFlags();
+  process.env.NEXT_PUBLIC_CAVE_RESEARCH_HOSTED_RUNS = "1";
+  assert.equal(caveResearchHostedRuns(), false, "public hosted intent cannot prove C0 readiness");
+
+  delete process.env.NEXT_PUBLIC_CAVE_RESEARCH_HOSTED_RUNS;
+  assert.equal(caveResearchHostedRuns(), false, "hosted runs remain off without a C0 server authority");
 } finally {
   if (original === undefined) delete process.env.NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS;
   else process.env.NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS = original;
+  for (const name of researchFlagNames) {
+    const value = originalResearchFlags[name];
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
 }
 
 console.log("feature-flags.test.ts: ok");

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -18,3 +18,42 @@ export function caveCrafts(): boolean {
 export function caveAgenticRecommendations(): boolean {
   return envFlag(process.env.NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS);
 }
+
+/** Root rollout gate for the Cave-owned local Research Resource catalog. */
+export function caveResearchResources(): boolean {
+  return envFlag(process.env.NEXT_PUBLIC_CAVE_RESEARCH_RESOURCES);
+}
+
+/** Local ingestion cannot run without the authoritative resource catalog. */
+export function caveResearchLocalIngestion(): boolean {
+  return caveResearchResources()
+    && envFlag(process.env.NEXT_PUBLIC_CAVE_RESEARCH_LOCAL_INGESTION);
+}
+
+/** Semantic retrieval is optional and never gates lexical resource search. */
+export function caveResearchSemantic(): boolean {
+  return caveResearchLocalIngestion()
+    && envFlag(process.env.NEXT_PUBLIC_CAVE_RESEARCH_SEMANTIC);
+}
+
+/** Context Packs depend on local resources, but not on semantic retrieval. */
+export function caveResearchContextPacks(): boolean {
+  return caveResearchResources()
+    && envFlag(process.env.NEXT_PUBLIC_CAVE_RESEARCH_CONTEXT_PACKS);
+}
+
+/** Topic Discovery cannot run until Context Packs are available. */
+export function caveResearchTopicDiscovery(): boolean {
+  return caveResearchContextPacks()
+    && envFlag(process.env.NEXT_PUBLIC_CAVE_RESEARCH_TOPIC_DISCOVERY);
+}
+
+/**
+ * Hosted runs fail closed until Gate C0 supplies a server-only authority that
+ * can prove cloud account, repository, bindings, and authentication-policy
+ * readiness. The public environment variable records rollout intent only and
+ * cannot enable this getter in A1.
+ */
+export function caveResearchHostedRuns(): boolean {
+  return false;
+}

--- a/src/lib/research-resource-contracts.test.ts
+++ b/src/lib/research-resource-contracts.test.ts
@@ -1,0 +1,360 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  parseResearchLinksMigrationJournalV1,
+  parseResearchLinksProjectionV1,
+  parseResourceEmbeddingTaskV1,
+  parseResourceIngestJobV1,
+  parseResourceManifestV1,
+  parseResourceQueryResponseV1,
+  parseResourceQueryV1,
+  parseResourceSnapshotV1,
+  parseResourceTombstoneV1,
+} from "./research-resource-contracts.ts";
+import { sha256Digest } from "./research-protocol/digest.ts";
+
+const DIGEST_A = "a".repeat(64);
+const DIGEST_B = "b".repeat(64);
+const CREATED_AT = "2026-08-26T12:00:00Z";
+const UPDATED_AT = "2026-08-26T12:01:00.100Z";
+
+function expectOk<T>(result: { ok: true; value: T } | { ok: false; error: { path: string; message: string } }): T {
+  if (!result.ok) assert.fail(`${result.error.path}: ${result.error.message}`);
+  return result.value;
+}
+
+function expectError(
+  result: { ok: true; value: unknown } | { ok: false; error: { path: string; code: string; message: string } },
+  path: string,
+  code?: string,
+): void {
+  if (result.ok) assert.fail("expected parse failure");
+  assert.equal(result.error.path, path);
+  if (code) assert.equal(result.error.code, code);
+}
+
+function manifest() {
+  return {
+    version: 1,
+    id: "resource_1",
+    revision: 3,
+    kind: "paper",
+    canonicalIdentity: "arxiv:2608.00001",
+    title: "A local-first research system",
+    sourceUri: "https://arxiv.org/abs/2608.00001",
+    sourceType: "arxiv",
+    category: "paper",
+    publishedAt: "2026-08-25T10:00:00Z",
+    legacySavedLink: {
+      id: "saved_1",
+      url: "https://arxiv.org/abs/2608.00001",
+      addedAt: "2026-08-26T10:00:00Z",
+      source: "desk",
+      futureLegacyField: true,
+    },
+    paper: {
+      arxivId: "2608.00001",
+      authors: ["Ada Lovelace"],
+      abstract: "Local evidence.",
+      publishedAt: "2026-08-25T10:00:00Z",
+      futurePaperField: "kept",
+    },
+    subject: { familiarId: "familiar_1", projectId: "project_1", futureSubjectField: 1 },
+    sensitivity: "private",
+    ingest: { desired: true, state: "ready", futureIngestField: [1, 2] },
+    currentSnapshotId: "snapshot_1",
+    createdAt: CREATED_AT,
+    updatedAt: UPDATED_AT,
+    futureManifestField: { preserved: true },
+  } as const;
+}
+
+test("manifest parses the approved compatibility fields and preserves safe additive data", () => {
+  const input = structuredClone(manifest());
+  const parsed = expectOk(parseResourceManifestV1(input));
+  assert.equal((parsed.futureManifestField as { preserved: boolean }).preserved, true);
+  assert.equal(parsed.legacySavedLink?.futureLegacyField, true);
+  assert.equal(parsed.paper?.futurePaperField, "kept");
+  assert.notStrictEqual(parsed, input);
+  assert.notStrictEqual(parsed.subject, input.subject);
+});
+
+test("manifest rejects invalid versions, unsafe revisions, and inconsistent ingest state", () => {
+  expectError(parseResourceManifestV1({ ...manifest(), version: 2 }), "$.version", "invalid_value");
+  expectError(parseResourceManifestV1({ ...manifest(), revision: 0 }), "$.revision", "invalid_value");
+  expectError(
+    parseResourceManifestV1({ ...manifest(), ingest: { desired: false, state: "queued" } }),
+    "$.ingest",
+    "semantic_conflict",
+  );
+  const { currentSnapshotId: _snapshot, ...withoutSnapshot } = manifest();
+  expectError(parseResourceManifestV1(withoutSnapshot), "$.currentSnapshotId", "semantic_conflict");
+  assert.equal(
+    expectOk(parseResourceManifestV1({ ...manifest(), ingest: { desired: true, state: "failed", lastFailureCode: "timeout" } })).ingest.lastFailureCode,
+    "timeout",
+    "lastFailureCode is independently optional",
+  );
+  assert.equal(
+    expectOk(parseResourceManifestV1({ ...manifest(), ingest: { desired: true, state: "failed", retryable: false } })).ingest.retryable,
+    false,
+    "retryable is independently optional",
+  );
+  expectError(
+    parseResourceManifestV1({ ...manifest(), updatedAt: "2026-08-26T11:59:59Z" }),
+    "$.updatedAt",
+    "semantic_conflict",
+  );
+});
+
+function snapshot() {
+  return {
+    version: 1,
+    id: "snapshot_1",
+    resourceId: "resource_1",
+    resourceRevision: 3,
+    rawBlobDigest: DIGEST_B,
+    normalizedBlobDigest: DIGEST_A,
+    normalizedMediaType: "text/plain; charset=utf-8",
+    normalizedBytes: 20,
+    sourceSelector: { type: "pdf-page-span", page: 1, start: 0, end: 10, futureSelectorField: true },
+    pageBoundaries: [
+      { page: 1, start: 0, end: 10, extractorReceipt: "v1" },
+      { page: 2, start: 10, end: 20 },
+    ],
+    fetchedAt: UPDATED_AT,
+    finalUrl: "https://example.test/paper.pdf",
+    etag: "etag-1",
+    lastModified: "Wed, 26 Aug 2026 12:01:00 GMT",
+    createdAt: UPDATED_AT,
+    futureSnapshotField: "kept",
+  } as const;
+}
+
+test("snapshot delegates exact selectors to A0 and validates deterministic page boundaries", () => {
+  const parsed = expectOk(parseResourceSnapshotV1(snapshot()));
+  assert.equal(parsed.sourceSelector.type, "pdf-page-span");
+  assert.equal(parsed.sourceSelector.futureSelectorField, true);
+  assert.equal(parsed.pageBoundaries?.[0]?.extractorReceipt, "v1");
+  assert.equal(parsed.futureSnapshotField, "kept");
+
+  expectError(
+    parseResourceSnapshotV1({ ...snapshot(), sourceSelector: { type: "text-span", start: 4, end: 4 } }),
+    "$.sourceSelector",
+    "semantic_conflict",
+  );
+  expectError(
+    parseResourceSnapshotV1({ ...snapshot(), pageBoundaries: [{ page: 1, start: 0, end: 12 }, { page: 2, start: 11, end: 20 }] }),
+    "$.pageBoundaries[1].start",
+    "semantic_conflict",
+  );
+  expectError(
+    parseResourceSnapshotV1({ ...snapshot(), pageBoundaries: [{ page: 2, start: 0, end: 10 }] }),
+    "$.pageBoundaries[0].page",
+    "semantic_conflict",
+  );
+  expectError(
+    parseResourceSnapshotV1({ ...snapshot(), sourceSelector: { type: "text-span", start: 0, end: 21 } }),
+    "$.sourceSelector.end",
+    "semantic_conflict",
+  );
+  const { pageBoundaries: _boundaries, ...withoutPageBoundaries } = snapshot();
+  expectError(
+    parseResourceSnapshotV1(withoutPageBoundaries),
+    "$.pageBoundaries",
+    "semantic_conflict",
+  );
+  expectError(
+    parseResourceSnapshotV1({ ...snapshot(), sourceSelector: { type: "pdf-page-span", page: 3, start: 0, end: 1 } }),
+    "$.sourceSelector.page",
+    "semantic_conflict",
+  );
+  expectError(
+    parseResourceSnapshotV1({ ...snapshot(), sourceSelector: { type: "pdf-page-span", page: 2, start: 0, end: 11 } }),
+    "$.sourceSelector.end",
+    "semantic_conflict",
+  );
+});
+
+function ingestJob() {
+  return {
+    version: 1,
+    id: "job_1",
+    resourceId: "resource_1",
+    resourceRevision: 3,
+    deletionRevision: 0,
+    status: "claimed",
+    stage: "extract",
+    attempt: 1,
+    availableAt: CREATED_AT,
+    lease: { owner: "worker_1", expiresAt: "2026-08-26T12:05:00Z", futureLeaseField: true },
+    createdAt: CREATED_AT,
+    updatedAt: UPDATED_AT,
+    futureJobField: true,
+  } as const;
+}
+
+test("ingest jobs preserve operational intent and enforce lease truth", () => {
+  const parsed = expectOk(parseResourceIngestJobV1(ingestJob()));
+  assert.equal(parsed.lease?.futureLeaseField, true);
+  assert.equal(parsed.futureJobField, true);
+
+  const { lease: _lease, ...withoutLease } = ingestJob();
+  expectError(parseResourceIngestJobV1(withoutLease), "$.lease", "semantic_conflict");
+  expectError(parseResourceIngestJobV1({ ...ingestJob(), status: "queued" }), "$.lease", "semantic_conflict");
+  expectError(parseResourceIngestJobV1({ ...ingestJob(), deletionRevision: -1 }), "$.deletionRevision", "invalid_value");
+});
+
+test("embedding tasks are versioned best-effort state with bounded numeric fields", () => {
+  const task = {
+    version: 1,
+    resourceId: "resource_1",
+    snapshotId: "snapshot_1",
+    lexicalRevision: 2,
+    providerId: "loopback",
+    modelId: "embedding-model",
+    dimensions: 768,
+    status: "unavailable",
+    updatedAt: UPDATED_AT,
+    providerReceipt: { local: true },
+  } as const;
+  const parsed = expectOk(parseResourceEmbeddingTaskV1(task));
+  assert.deepEqual(parsed.providerReceipt, { local: true });
+  expectError(parseResourceEmbeddingTaskV1({ ...task, dimensions: 0 }), "$.dimensions", "invalid_value");
+  expectError(parseResourceEmbeddingTaskV1({ ...task, status: "completed" }), "$.status", "invalid_value");
+});
+
+test("tombstones are a strict privacy allowlist", () => {
+  const tombstone = {
+    version: 1,
+    resourceId: "resource_1",
+    deletionRevision: 4,
+    deletedAt: UPDATED_AT,
+  } as const;
+  assert.deepEqual(expectOk(parseResourceTombstoneV1(tombstone)), tombstone);
+  expectError(parseResourceTombstoneV1({ ...tombstone, title: "private title" }), "$.title", "invalid_value");
+  expectError(parseResourceTombstoneV1({ ...tombstone, deletionRevision: 0 }), "$.deletionRevision", "invalid_value");
+});
+
+test("saved-link migration records carry verified projection revisions and preserve extensions", () => {
+  const projection = expectOk(parseResearchLinksProjectionV1({
+    version: 1,
+    catalogRevision: 8,
+    projectedDigest: DIGEST_A,
+    generatedAt: CREATED_AT,
+    writerVersion: "0.3",
+  }));
+  assert.equal(projection.writerVersion, "0.3");
+
+  const journal = expectOk(parseResearchLinksMigrationJournalV1({
+    version: 1,
+    catalogRevision: 9,
+    intendedProjectionDigest: DIGEST_B,
+    startedAt: UPDATED_AT,
+    repairAttempt: 2,
+  }));
+  assert.equal(journal.repairAttempt, 2);
+  expectError(parseResearchLinksProjectionV1({ ...projection, projectedDigest: DIGEST_A.toUpperCase() }), "$.projectedDigest", "invalid_value");
+});
+
+function query() {
+  return {
+    version: 1,
+    text: "local research",
+    filters: {
+      projectIds: ["project_1"],
+      familiarIds: ["familiar_1"],
+      kinds: ["paper", "saved-resource"],
+      sensitivities: ["private"],
+      ingestStates: ["ready"],
+      publishedFrom: "2026-08-01T00:00:00Z",
+      publishedBefore: "2026-09-01T00:00:00Z",
+      contextPackId: "pack_1",
+      futureFilter: true,
+    },
+    ranking: "hybrid",
+    limit: 25,
+    futureQueryField: "kept",
+  } as const;
+}
+
+test("query validates every approved pre-ranking filter and preserves request extensions", () => {
+  const parsed = expectOk(parseResourceQueryV1(query()));
+  assert.equal(parsed.filters?.futureFilter, true);
+  assert.equal(parsed.futureQueryField, "kept");
+  expectError(parseResourceQueryV1({ ...query(), text: "   " }), "$.text", "invalid_value");
+  expectError(parseResourceQueryV1({ ...query(), limit: 101 }), "$.limit", "invalid_value");
+  expectError(parseResourceQueryV1({ ...query(), filters: { ...query().filters, kinds: [] } }), "$.filters.kinds", "invalid_value");
+  expectError(
+    parseResourceQueryV1({ ...query(), filters: { ...query().filters, publishedFrom: "2026-09-01T00:00:00Z" } }),
+    "$.filters",
+    "semantic_conflict",
+  );
+  expectError(parseResourceQueryV1({ ...query(), filters: { ...query().filters, projectIds: ["project_1", "project_1"] } }), "$.filters.projectIds[1]", "invalid_value");
+});
+
+function queryResponse() {
+  return {
+    version: 1,
+    ranking: "hybrid",
+    hits: [{
+      resourceId: "resource_1",
+      snapshotId: "snapshot_1",
+      resourceRevision: 3,
+      normalizedBlobDigest: DIGEST_A,
+      selector: { type: "text-span", start: 0, end: 14 },
+      excerpt: "local research",
+      excerptDigest: sha256Digest("local research"),
+      retrieval: {
+        exact: true,
+        lexical: { matched: true, rank: 1 },
+        semantic: { state: "ready", matched: true, rank: 2 },
+      },
+    }],
+  } as const;
+}
+
+test("query response carries authoritative snapshot identity and truthful retrieval evidence", () => {
+  const parsed = expectOk(parseResourceQueryResponseV1(queryResponse()));
+  assert.equal(parsed.hits[0]?.resourceRevision, 3);
+  assert.equal(parsed.hits[0]?.retrieval.semantic.state, "ready");
+  expectError(
+    parseResourceQueryResponseV1({ ...queryResponse(), hits: [{ ...queryResponse().hits[0], retrieval: { ...queryResponse().hits[0].retrieval, semantic: { state: "unavailable", matched: true, rank: 1 } } }] }),
+    "$.hits[0].retrieval.semantic",
+    "semantic_conflict",
+  );
+  expectError(
+    parseResourceQueryResponseV1({ ...queryResponse(), hits: [{ ...queryResponse().hits[0], retrieval: { ...queryResponse().hits[0].retrieval, lexical: { matched: false, rank: 1 } } }] }),
+    "$.hits[0].retrieval.lexical",
+    "semantic_conflict",
+  );
+  expectError(
+    parseResourceQueryResponseV1({ ...queryResponse(), hits: [{ ...queryResponse().hits[0], localPath: "/private/research.txt" }] }),
+    "$.hits[0].localPath",
+    "invalid_value",
+  );
+  expectError(
+    parseResourceQueryResponseV1({ ...queryResponse(), hits: [{ ...queryResponse().hits[0], excerpt: "changed bytes" }] }),
+    "$.hits[0].excerptDigest",
+    "digest_mismatch",
+  );
+  expectError(
+    parseResourceQueryResponseV1({ ...queryResponse(), hits: [{ ...queryResponse().hits[0], selector: { ...queryResponse().hits[0].selector, sourceUri: "file:///private/research.txt" } }] }),
+    "$.hits[0].selector.sourceUri",
+    "invalid_value",
+  );
+  expectError(
+    parseResourceQueryResponseV1({ ...queryResponse(), hits: [queryResponse().hits[0], queryResponse().hits[0]] }),
+    "$.hits[1]",
+    "semantic_conflict",
+  );
+});
+
+test("all parsers reject non-canonical JSON containers before reading fields", () => {
+  const hidden = { ...manifest() };
+  Object.defineProperty(hidden, "secret", { value: "not enumerable", enumerable: false });
+  expectError(parseResourceManifestV1(hidden), "$", "invalid_value");
+
+  const sparse = { ...query(), filters: { projectIds: ["project_1", , "project_2"] } };
+  expectError(parseResourceQueryV1(sparse), "$", "invalid_value");
+});

--- a/src/lib/research-resource-contracts.ts
+++ b/src/lib/research-resource-contracts.ts
@@ -1,0 +1,811 @@
+import {
+  copyProtocolJsonValue,
+  compareUtcTimestamps,
+  fail,
+  isRecord,
+  isSha256,
+  isUtcTimestamp,
+  pass,
+  type ProtocolParseResult,
+  type UnknownFields,
+} from "./research-protocol/common.ts";
+import {
+  parseContextSelectorV1,
+  type ContextSelectorV1,
+} from "./research-protocol/context-pack.ts";
+import { sha256Digest } from "./research-protocol/digest.ts";
+
+export const RESOURCE_KINDS = [
+  "saved-resource",
+  "paper",
+  "attachment",
+  "mission-artifact",
+  "session",
+  "thread-self-report",
+  "local-file",
+] as const;
+
+export const RESOURCE_CATEGORIES = [
+  "github",
+  "docs",
+  "paper",
+  "video",
+  "social",
+  "article",
+  "other",
+] as const;
+
+export const RESOURCE_SENSITIVITIES = ["public", "private", "restricted"] as const;
+export const RESOURCE_INGEST_STATES = [
+  "metadata_only",
+  "queued",
+  "ingesting",
+  "ready",
+  "partial",
+  "failed",
+  "deleting",
+] as const;
+export const RESOURCE_INGEST_JOB_STATUSES = [
+  "queued",
+  "claimed",
+  "paused_quota",
+  "retry_wait",
+  "completed",
+  "failed",
+  "cancelled",
+] as const;
+export const RESOURCE_INGEST_JOB_STAGES = [
+  "fetch",
+  "snapshot",
+  "extract",
+  "publish_lexical",
+] as const;
+export const RESOURCE_EMBEDDING_STATUSES = [
+  "queued",
+  "building",
+  "ready",
+  "failed",
+  "unavailable",
+] as const;
+export const RESOURCE_QUERY_RANKINGS = ["exact", "lexical", "hybrid"] as const;
+export const RESOURCE_SEMANTIC_STATES = ["disabled", "unavailable", "ready"] as const;
+
+export type ResourceKindV1 = (typeof RESOURCE_KINDS)[number];
+export type ResourceCategoryV1 = (typeof RESOURCE_CATEGORIES)[number];
+export type ResourceSensitivityV1 = (typeof RESOURCE_SENSITIVITIES)[number];
+export type ResourceIngestStateV1 = (typeof RESOURCE_INGEST_STATES)[number];
+export type ResourceIngestJobStatusV1 = (typeof RESOURCE_INGEST_JOB_STATUSES)[number];
+export type ResourceIngestJobStageV1 = (typeof RESOURCE_INGEST_JOB_STAGES)[number];
+export type ResourceEmbeddingStatusV1 = (typeof RESOURCE_EMBEDDING_STATUSES)[number];
+export type ResourceQueryRankingV1 = (typeof RESOURCE_QUERY_RANKINGS)[number];
+export type ResourceSemanticStateV1 = (typeof RESOURCE_SEMANTIC_STATES)[number];
+
+export type ResourceManifestV1 = {
+  version: 1;
+  id: string;
+  revision: number;
+  kind: ResourceKindV1;
+  canonicalIdentity: string;
+  title: string;
+  sourceUri?: string;
+  sourceType: string;
+  category?: ResourceCategoryV1;
+  publishedAt?: string;
+  legacySavedLink?: {
+    id: string;
+    url: string;
+    addedAt: string;
+    source: "chat" | "desk";
+  } & UnknownFields;
+  paper?: {
+    arxivId: string;
+    authors: string[];
+    abstract?: string;
+    publishedAt?: string;
+  } & UnknownFields;
+  subject: {
+    familiarId?: string;
+    projectId?: string;
+  } & UnknownFields;
+  sensitivity: ResourceSensitivityV1;
+  ingest: {
+    desired: boolean;
+    state: ResourceIngestStateV1;
+    lastFailureCode?: string;
+    retryable?: boolean;
+  } & UnknownFields;
+  currentSnapshotId?: string;
+  createdAt: string;
+  updatedAt: string;
+} & UnknownFields;
+
+export type ResourcePageBoundaryV1 = {
+  page: number;
+  start: number;
+  end: number;
+} & UnknownFields;
+
+export type ResourceSnapshotV1 = {
+  version: 1;
+  id: string;
+  resourceId: string;
+  resourceRevision: number;
+  rawBlobDigest?: string;
+  normalizedBlobDigest: string;
+  normalizedMediaType: string;
+  normalizedBytes: number;
+  sourceSelector: ContextSelectorV1;
+  pageBoundaries?: ResourcePageBoundaryV1[];
+  fetchedAt?: string;
+  finalUrl?: string;
+  etag?: string;
+  lastModified?: string;
+  createdAt: string;
+} & UnknownFields;
+
+export type ResourceIngestJobV1 = {
+  version: 1;
+  id: string;
+  resourceId: string;
+  resourceRevision: number;
+  deletionRevision: number;
+  status: ResourceIngestJobStatusV1;
+  stage: ResourceIngestJobStageV1;
+  attempt: number;
+  availableAt: string;
+  lease?: {
+    owner: string;
+    expiresAt: string;
+  } & UnknownFields;
+  createdAt: string;
+  updatedAt: string;
+} & UnknownFields;
+
+export type ResourceEmbeddingTaskV1 = {
+  version: 1;
+  resourceId: string;
+  snapshotId: string;
+  lexicalRevision: number;
+  providerId: string;
+  modelId: string;
+  dimensions: number;
+  status: ResourceEmbeddingStatusV1;
+  updatedAt: string;
+} & UnknownFields;
+
+export type ResourceTombstoneV1 = {
+  version: 1;
+  resourceId: string;
+  deletionRevision: number;
+  deletedAt: string;
+};
+
+export type ResearchLinksProjectionV1 = {
+  version: 1;
+  catalogRevision: number;
+  projectedDigest: string;
+  generatedAt: string;
+} & UnknownFields;
+
+export type ResearchLinksMigrationJournalV1 = {
+  version: 1;
+  catalogRevision: number;
+  intendedProjectionDigest: string;
+  startedAt: string;
+} & UnknownFields;
+
+export type ResourceQueryFiltersV1 = {
+  projectIds?: string[];
+  familiarIds?: string[];
+  kinds?: ResourceKindV1[];
+  sensitivities?: ResourceSensitivityV1[];
+  ingestStates?: ResourceIngestStateV1[];
+  publishedFrom?: string;
+  publishedBefore?: string;
+  contextPackId?: string;
+} & UnknownFields;
+
+export type ResourceQueryV1 = {
+  version: 1;
+  text: string;
+  filters?: ResourceQueryFiltersV1;
+  ranking: ResourceQueryRankingV1;
+  limit: number;
+} & UnknownFields;
+
+export type ResourceQuerySelectorV1 =
+  | Pick<Extract<ContextSelectorV1, { type: "turn-range" }>, "type" | "start" | "end">
+  | Pick<Extract<ContextSelectorV1, { type: "json-pointer" }>, "type" | "pointer">
+  | Pick<Extract<ContextSelectorV1, { type: "text-span" }>, "type" | "start" | "end">
+  | Pick<Extract<ContextSelectorV1, { type: "markdown-section" }>, "type" | "headingPath">
+  | Pick<Extract<ContextSelectorV1, { type: "pdf-page-span" }>, "type" | "page" | "start" | "end">
+  | Pick<Extract<ContextSelectorV1, { type: "whole-resource" }>, "type">;
+
+export type ResourceQueryHitV1 = {
+  resourceId: string;
+  snapshotId: string;
+  resourceRevision: number;
+  normalizedBlobDigest: string;
+  selector: ResourceQuerySelectorV1;
+  excerpt: string;
+  excerptDigest: string;
+  retrieval: {
+    exact: boolean;
+    lexical: {
+      matched: boolean;
+      rank?: number;
+    };
+    semantic: {
+      state: ResourceSemanticStateV1;
+      matched: boolean;
+      rank?: number;
+    };
+  };
+};
+
+export type ResourceQueryResponseV1 = {
+  version: 1;
+  ranking: ResourceQueryRankingV1;
+  hits: ResourceQueryHitV1[];
+};
+
+function childPath(path: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${path}.${key}`
+    : `${path}[${JSON.stringify(key)}]`;
+}
+
+function indexPath(path: string, index: number): string {
+  return `${path}[${index}]`;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function rejectUnexpected(
+  record: Record<string, unknown>,
+  allowed: readonly string[],
+  path: string,
+  label: string,
+): ProtocolParseResult<void> {
+  const allowlist = new Set(allowed);
+  for (const key of Object.keys(record)) {
+    if (!allowlist.has(key)) {
+      return fail("invalid_value", childPath(path, key), `${label} does not allow additional fields`);
+    }
+  }
+  return pass(undefined);
+}
+
+function object(value: unknown, path: string): ProtocolParseResult<Record<string, unknown>> {
+  if (!isRecord(value)) return fail("invalid_type", path, "Expected an object");
+  return pass(value);
+}
+
+function required(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+): ProtocolParseResult<unknown> {
+  if (!hasOwn(record, key)) {
+    return fail("missing_field", childPath(path, key), `Missing required field ${key}`);
+  }
+  return pass(record[key]);
+}
+
+function versionOne(value: unknown, path: string): ProtocolParseResult<1> {
+  if (value !== 1) return fail("invalid_value", path, "version must equal 1");
+  return pass(1);
+}
+
+function stringValue(
+  value: unknown,
+  path: string,
+  label: string,
+  options: { nonEmpty?: boolean; identifier?: boolean } = {},
+): ProtocolParseResult<string> {
+  if (typeof value !== "string") return fail("invalid_type", path, `${label} must be a string`);
+  if (options.nonEmpty && value.trim().length === 0) {
+    return fail("invalid_value", path, `${label} must not be empty`);
+  }
+  if (options.identifier && value !== value.trim()) {
+    return fail("invalid_value", path, `${label} must not have surrounding whitespace`);
+  }
+  return pass(value);
+}
+
+function identifier(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  return stringValue(value, path, label, { nonEmpty: true, identifier: true });
+}
+
+function booleanValue(value: unknown, path: string, label: string): ProtocolParseResult<boolean> {
+  if (typeof value !== "boolean") return fail("invalid_type", path, `${label} must be a boolean`);
+  return pass(value);
+}
+
+function enumValue<const T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  path: string,
+  label: string,
+): ProtocolParseResult<T[number]> {
+  if (typeof value !== "string" || !allowed.includes(value as T[number])) {
+    return fail("invalid_value", path, `${label} must be one of ${allowed.join(", ")}`);
+  }
+  return pass(value as T[number]);
+}
+
+function integer(
+  value: unknown,
+  path: string,
+  label: string,
+  minimum = 0,
+): ProtocolParseResult<number> {
+  if (!Number.isSafeInteger(value) || (value as number) < minimum) {
+    return fail("invalid_value", path, `${label} must be a safe integer >= ${minimum}`);
+  }
+  return pass(value as number);
+}
+
+function utc(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (!isUtcTimestamp(value)) return fail("invalid_value", path, `${label} must be a UTC RFC 3339 timestamp`);
+  return pass(value);
+}
+
+function digest(value: unknown, path: string, label: string): ProtocolParseResult<string> {
+  if (!isSha256(value)) return fail("invalid_value", path, `${label} must be a lowercase SHA-256 digest`);
+  return pass(value);
+}
+
+function optional<T>(
+  record: Record<string, unknown>,
+  key: string,
+  path: string,
+  parser: (value: unknown, path: string) => ProtocolParseResult<T>,
+): ProtocolParseResult<T | undefined> {
+  if (!hasOwn(record, key)) return pass(undefined);
+  return parser(record[key], childPath(path, key));
+}
+
+function parseStringArray(
+  value: unknown,
+  path: string,
+  label: string,
+  { nonEmpty = false }: { nonEmpty?: boolean } = {},
+): ProtocolParseResult<string[]> {
+  if (!Array.isArray(value)) return fail("invalid_type", path, `${label} must be an array`);
+  if (nonEmpty && value.length === 0) return fail("invalid_value", path, `${label} must not be empty`);
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const [index, item] of value.entries()) {
+    const parsed = identifier(item, indexPath(path, index), `${label} item`);
+    if (!parsed.ok) return parsed;
+    if (seen.has(parsed.value)) return fail("invalid_value", indexPath(path, index), `${label} must not contain duplicates`);
+    seen.add(parsed.value);
+    result.push(parsed.value);
+  }
+  return pass(result);
+}
+
+function parseEnumArray<const T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  path: string,
+  label: string,
+): ProtocolParseResult<T[number][]> {
+  if (!Array.isArray(value)) return fail("invalid_type", path, `${label} must be an array`);
+  if (value.length === 0) return fail("invalid_value", path, `${label} must not be empty`);
+  const result: T[number][] = [];
+  const seen = new Set<string>();
+  for (const [index, item] of value.entries()) {
+    const parsed = enumValue(item, allowed, indexPath(path, index), `${label} item`);
+    if (!parsed.ok) return parsed;
+    if (seen.has(parsed.value)) return fail("invalid_value", indexPath(path, index), `${label} must not contain duplicates`);
+    seen.add(parsed.value);
+    result.push(parsed.value);
+  }
+  return pass(result);
+}
+
+function prepare(value: unknown, path: string): ProtocolParseResult<Record<string, unknown>> {
+  const copied = copyProtocolJsonValue(value, path);
+  if (!copied.ok) return copied;
+  return object(copied.value, path);
+}
+
+function parseLegacySavedLink(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<NonNullable<ResourceManifestV1["legacySavedLink"]>> {
+  const parsedObject = object(value, path);
+  if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const idField = required(raw, "id", path); if (!idField.ok) return idField;
+  const id = identifier(idField.value, childPath(path, "id"), "legacy saved-link id"); if (!id.ok) return id;
+  const urlField = required(raw, "url", path); if (!urlField.ok) return urlField;
+  const url = stringValue(urlField.value, childPath(path, "url"), "legacy saved-link URL", { nonEmpty: true }); if (!url.ok) return url;
+  const addedAtField = required(raw, "addedAt", path); if (!addedAtField.ok) return addedAtField;
+  const addedAt = utc(addedAtField.value, childPath(path, "addedAt"), "addedAt"); if (!addedAt.ok) return addedAt;
+  const sourceField = required(raw, "source", path); if (!sourceField.ok) return sourceField;
+  const source = enumValue(sourceField.value, ["chat", "desk"] as const, childPath(path, "source"), "source"); if (!source.ok) return source;
+  return pass({ ...raw, id: id.value, url: url.value, addedAt: addedAt.value, source: source.value });
+}
+
+function parsePaper(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<NonNullable<ResourceManifestV1["paper"]>> {
+  const parsedObject = object(value, path); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const arxivField = required(raw, "arxivId", path); if (!arxivField.ok) return arxivField;
+  const arxivId = identifier(arxivField.value, childPath(path, "arxivId"), "arXiv id"); if (!arxivId.ok) return arxivId;
+  const authorsField = required(raw, "authors", path); if (!authorsField.ok) return authorsField;
+  const authors = parseStringArray(authorsField.value, childPath(path, "authors"), "authors"); if (!authors.ok) return authors;
+  const abstract = optional(raw, "abstract", path, (item, itemPath) => stringValue(item, itemPath, "abstract")); if (!abstract.ok) return abstract;
+  const publishedAt = optional(raw, "publishedAt", path, (item, itemPath) => utc(item, itemPath, "publishedAt")); if (!publishedAt.ok) return publishedAt;
+  return pass({ ...raw, arxivId: arxivId.value, authors: authors.value, ...(abstract.value === undefined ? {} : { abstract: abstract.value }), ...(publishedAt.value === undefined ? {} : { publishedAt: publishedAt.value }) });
+}
+
+function parseSubject(value: unknown, path: string): ProtocolParseResult<ResourceManifestV1["subject"]> {
+  const parsedObject = object(value, path); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const familiarId = optional(raw, "familiarId", path, (item, itemPath) => identifier(item, itemPath, "familiarId")); if (!familiarId.ok) return familiarId;
+  const projectId = optional(raw, "projectId", path, (item, itemPath) => identifier(item, itemPath, "projectId")); if (!projectId.ok) return projectId;
+  return pass({ ...raw, ...(familiarId.value === undefined ? {} : { familiarId: familiarId.value }), ...(projectId.value === undefined ? {} : { projectId: projectId.value }) });
+}
+
+function parseIngest(value: unknown, path: string): ProtocolParseResult<ResourceManifestV1["ingest"]> {
+  const parsedObject = object(value, path); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const desiredField = required(raw, "desired", path); if (!desiredField.ok) return desiredField;
+  const desired = booleanValue(desiredField.value, childPath(path, "desired"), "desired"); if (!desired.ok) return desired;
+  const stateField = required(raw, "state", path); if (!stateField.ok) return stateField;
+  const state = enumValue(stateField.value, RESOURCE_INGEST_STATES, childPath(path, "state"), "ingest state"); if (!state.ok) return state;
+  if (!desired.value && ["queued", "ingesting"].includes(state.value)) {
+    return fail("semantic_conflict", path, "queued or ingesting state requires desired=true");
+  }
+  const lastFailureCode = optional(raw, "lastFailureCode", path, (item, itemPath) => identifier(item, itemPath, "lastFailureCode")); if (!lastFailureCode.ok) return lastFailureCode;
+  const retryable = optional(raw, "retryable", path, (item, itemPath) => booleanValue(item, itemPath, "retryable")); if (!retryable.ok) return retryable;
+  return pass({ ...raw, desired: desired.value, state: state.value, ...(lastFailureCode.value === undefined ? {} : { lastFailureCode: lastFailureCode.value }), ...(retryable.value === undefined ? {} : { retryable: retryable.value }) });
+}
+
+export function parseResourceManifestV1(value: unknown): ProtocolParseResult<ResourceManifestV1> {
+  const parsedObject = prepare(value, "$"); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const versionField = required(raw, "version", "$"); if (!versionField.ok) return versionField;
+  const version = versionOne(versionField.value, "$.version"); if (!version.ok) return version;
+  const idField = required(raw, "id", "$"); if (!idField.ok) return idField;
+  const id = identifier(idField.value, "$.id", "resource id"); if (!id.ok) return id;
+  const revisionField = required(raw, "revision", "$"); if (!revisionField.ok) return revisionField;
+  const revision = integer(revisionField.value, "$.revision", "revision", 1); if (!revision.ok) return revision;
+  const kindField = required(raw, "kind", "$"); if (!kindField.ok) return kindField;
+  const kind = enumValue(kindField.value, RESOURCE_KINDS, "$.kind", "resource kind"); if (!kind.ok) return kind;
+  const canonicalField = required(raw, "canonicalIdentity", "$"); if (!canonicalField.ok) return canonicalField;
+  const canonicalIdentity = stringValue(canonicalField.value, "$.canonicalIdentity", "canonicalIdentity", { nonEmpty: true }); if (!canonicalIdentity.ok) return canonicalIdentity;
+  const titleField = required(raw, "title", "$"); if (!titleField.ok) return titleField;
+  const title = stringValue(titleField.value, "$.title", "title", { nonEmpty: true }); if (!title.ok) return title;
+  const sourceTypeField = required(raw, "sourceType", "$"); if (!sourceTypeField.ok) return sourceTypeField;
+  const sourceType = identifier(sourceTypeField.value, "$.sourceType", "sourceType"); if (!sourceType.ok) return sourceType;
+  const sourceUri = optional(raw, "sourceUri", "$", (item, itemPath) => stringValue(item, itemPath, "sourceUri", { nonEmpty: true })); if (!sourceUri.ok) return sourceUri;
+  const category = optional(raw, "category", "$", (item, itemPath) => enumValue(item, RESOURCE_CATEGORIES, itemPath, "category")); if (!category.ok) return category;
+  const publishedAt = optional(raw, "publishedAt", "$", (item, itemPath) => utc(item, itemPath, "publishedAt")); if (!publishedAt.ok) return publishedAt;
+  const legacySavedLink = optional(raw, "legacySavedLink", "$", parseLegacySavedLink); if (!legacySavedLink.ok) return legacySavedLink;
+  const paper = optional(raw, "paper", "$", parsePaper); if (!paper.ok) return paper;
+  const subjectField = required(raw, "subject", "$"); if (!subjectField.ok) return subjectField;
+  const subject = parseSubject(subjectField.value, "$.subject"); if (!subject.ok) return subject;
+  const sensitivityField = required(raw, "sensitivity", "$"); if (!sensitivityField.ok) return sensitivityField;
+  const sensitivity = enumValue(sensitivityField.value, RESOURCE_SENSITIVITIES, "$.sensitivity", "sensitivity"); if (!sensitivity.ok) return sensitivity;
+  const ingestField = required(raw, "ingest", "$"); if (!ingestField.ok) return ingestField;
+  const ingest = parseIngest(ingestField.value, "$.ingest"); if (!ingest.ok) return ingest;
+  const currentSnapshotId = optional(raw, "currentSnapshotId", "$", (item, itemPath) => identifier(item, itemPath, "currentSnapshotId")); if (!currentSnapshotId.ok) return currentSnapshotId;
+  if (ingest.value.state === "ready" && currentSnapshotId.value === undefined) {
+    return fail("semantic_conflict", "$.currentSnapshotId", "ready resources require currentSnapshotId");
+  }
+  const createdField = required(raw, "createdAt", "$"); if (!createdField.ok) return createdField;
+  const createdAt = utc(createdField.value, "$.createdAt", "createdAt"); if (!createdAt.ok) return createdAt;
+  const updatedField = required(raw, "updatedAt", "$"); if (!updatedField.ok) return updatedField;
+  const updatedAt = utc(updatedField.value, "$.updatedAt", "updatedAt"); if (!updatedAt.ok) return updatedAt;
+  if (compareUtcTimestamps(updatedAt.value, createdAt.value) < 0) return fail("semantic_conflict", "$.updatedAt", "updatedAt must not precede createdAt");
+  return pass({ ...raw, version: 1, id: id.value, revision: revision.value, kind: kind.value, canonicalIdentity: canonicalIdentity.value, title: title.value, sourceType: sourceType.value, subject: subject.value, sensitivity: sensitivity.value, ingest: ingest.value, createdAt: createdAt.value, updatedAt: updatedAt.value, ...(sourceUri.value === undefined ? {} : { sourceUri: sourceUri.value }), ...(category.value === undefined ? {} : { category: category.value }), ...(publishedAt.value === undefined ? {} : { publishedAt: publishedAt.value }), ...(legacySavedLink.value === undefined ? {} : { legacySavedLink: legacySavedLink.value }), ...(paper.value === undefined ? {} : { paper: paper.value }), ...(currentSnapshotId.value === undefined ? {} : { currentSnapshotId: currentSnapshotId.value }) });
+}
+
+function parsePageBoundaries(value: unknown, path: string, normalizedBytes: number): ProtocolParseResult<ResourcePageBoundaryV1[]> {
+  if (!Array.isArray(value)) return fail("invalid_type", path, "pageBoundaries must be an array");
+  if (value.length === 0) return fail("invalid_value", path, "pageBoundaries must not be empty");
+  const boundaries: ResourcePageBoundaryV1[] = [];
+  let previousEnd = 0;
+  for (const [index, item] of value.entries()) {
+    const itemPath = indexPath(path, index);
+    const parsedObject = object(item, itemPath); if (!parsedObject.ok) return parsedObject;
+    const raw = parsedObject.value;
+    const pageField = required(raw, "page", itemPath); if (!pageField.ok) return pageField;
+    const page = integer(pageField.value, childPath(itemPath, "page"), "page", 1); if (!page.ok) return page;
+    if (page.value !== index + 1) return fail("semantic_conflict", childPath(itemPath, "page"), "pages must be consecutive and one-based");
+    const startField = required(raw, "start", itemPath); if (!startField.ok) return startField;
+    const start = integer(startField.value, childPath(itemPath, "start"), "start"); if (!start.ok) return start;
+    const endField = required(raw, "end", itemPath); if (!endField.ok) return endField;
+    const end = integer(endField.value, childPath(itemPath, "end"), "end"); if (!end.ok) return end;
+    if (start.value >= end.value) return fail("semantic_conflict", itemPath, "page boundary must be a non-empty half-open range");
+    if (start.value < previousEnd) return fail("semantic_conflict", childPath(itemPath, "start"), "page boundaries must not overlap or move backwards");
+    if (end.value > normalizedBytes) return fail("semantic_conflict", childPath(itemPath, "end"), "page boundary exceeds normalizedBytes");
+    previousEnd = end.value;
+    boundaries.push({ ...raw, page: page.value, start: start.value, end: end.value });
+  }
+  return pass(boundaries);
+}
+
+export function parseResourceSnapshotV1(value: unknown): ProtocolParseResult<ResourceSnapshotV1> {
+  const parsedObject = prepare(value, "$"); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const versionField = required(raw, "version", "$"); if (!versionField.ok) return versionField;
+  const version = versionOne(versionField.value, "$.version"); if (!version.ok) return version;
+  const idField = required(raw, "id", "$"); if (!idField.ok) return idField;
+  const id = identifier(idField.value, "$.id", "snapshot id"); if (!id.ok) return id;
+  const resourceIdField = required(raw, "resourceId", "$"); if (!resourceIdField.ok) return resourceIdField;
+  const resourceId = identifier(resourceIdField.value, "$.resourceId", "resourceId"); if (!resourceId.ok) return resourceId;
+  const revisionField = required(raw, "resourceRevision", "$"); if (!revisionField.ok) return revisionField;
+  const resourceRevision = integer(revisionField.value, "$.resourceRevision", "resourceRevision", 1); if (!resourceRevision.ok) return resourceRevision;
+  const rawBlobDigest = optional(raw, "rawBlobDigest", "$", (item, itemPath) => digest(item, itemPath, "rawBlobDigest")); if (!rawBlobDigest.ok) return rawBlobDigest;
+  const normalizedDigestField = required(raw, "normalizedBlobDigest", "$"); if (!normalizedDigestField.ok) return normalizedDigestField;
+  const normalizedBlobDigest = digest(normalizedDigestField.value, "$.normalizedBlobDigest", "normalizedBlobDigest"); if (!normalizedBlobDigest.ok) return normalizedBlobDigest;
+  const mediaField = required(raw, "normalizedMediaType", "$"); if (!mediaField.ok) return mediaField;
+  const normalizedMediaType = stringValue(mediaField.value, "$.normalizedMediaType", "normalizedMediaType", { nonEmpty: true }); if (!normalizedMediaType.ok) return normalizedMediaType;
+  const bytesField = required(raw, "normalizedBytes", "$"); if (!bytesField.ok) return bytesField;
+  const normalizedBytes = integer(bytesField.value, "$.normalizedBytes", "normalizedBytes"); if (!normalizedBytes.ok) return normalizedBytes;
+  const selectorField = required(raw, "sourceSelector", "$"); if (!selectorField.ok) return selectorField;
+  const sourceSelector = parseContextSelectorV1(selectorField.value, "$.sourceSelector"); if (!sourceSelector.ok) return sourceSelector;
+  const pageBoundaries = optional(raw, "pageBoundaries", "$", (item, itemPath) => parsePageBoundaries(item, itemPath, normalizedBytes.value)); if (!pageBoundaries.ok) return pageBoundaries;
+  if (sourceSelector.value.type === "text-span" && sourceSelector.value.end > normalizedBytes.value) {
+    return fail("semantic_conflict", "$.sourceSelector.end", "text-span exceeds normalizedBytes");
+  }
+  if (sourceSelector.value.type === "pdf-page-span") {
+    if (pageBoundaries.value === undefined) {
+      return fail("semantic_conflict", "$.pageBoundaries", "pdf-page-span requires pageBoundaries");
+    }
+    const pageBoundary = pageBoundaries.value.find(
+      (boundary) => boundary.page === sourceSelector.value.page,
+    );
+    if (!pageBoundary) {
+      return fail("semantic_conflict", "$.sourceSelector.page", "pdf-page-span references a page outside pageBoundaries");
+    }
+    const pageLength = pageBoundary.end - pageBoundary.start;
+    if (sourceSelector.value.end > pageLength) {
+      return fail("semantic_conflict", "$.sourceSelector.end", "pdf-page-span exceeds the selected page's normalized bytes");
+    }
+  }
+  const fetchedAt = optional(raw, "fetchedAt", "$", (item, itemPath) => utc(item, itemPath, "fetchedAt")); if (!fetchedAt.ok) return fetchedAt;
+  const finalUrl = optional(raw, "finalUrl", "$", (item, itemPath) => stringValue(item, itemPath, "finalUrl", { nonEmpty: true })); if (!finalUrl.ok) return finalUrl;
+  const etag = optional(raw, "etag", "$", (item, itemPath) => stringValue(item, itemPath, "etag")); if (!etag.ok) return etag;
+  const lastModified = optional(raw, "lastModified", "$", (item, itemPath) => stringValue(item, itemPath, "lastModified")); if (!lastModified.ok) return lastModified;
+  const createdField = required(raw, "createdAt", "$"); if (!createdField.ok) return createdField;
+  const createdAt = utc(createdField.value, "$.createdAt", "createdAt"); if (!createdAt.ok) return createdAt;
+  return pass({ ...raw, version: 1, id: id.value, resourceId: resourceId.value, resourceRevision: resourceRevision.value, normalizedBlobDigest: normalizedBlobDigest.value, normalizedMediaType: normalizedMediaType.value, normalizedBytes: normalizedBytes.value, sourceSelector: sourceSelector.value, createdAt: createdAt.value, ...(rawBlobDigest.value === undefined ? {} : { rawBlobDigest: rawBlobDigest.value }), ...(pageBoundaries.value === undefined ? {} : { pageBoundaries: pageBoundaries.value }), ...(fetchedAt.value === undefined ? {} : { fetchedAt: fetchedAt.value }), ...(finalUrl.value === undefined ? {} : { finalUrl: finalUrl.value }), ...(etag.value === undefined ? {} : { etag: etag.value }), ...(lastModified.value === undefined ? {} : { lastModified: lastModified.value }) });
+}
+
+export function parseResourceIngestJobV1(value: unknown): ProtocolParseResult<ResourceIngestJobV1> {
+  const parsedObject = prepare(value, "$"); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const versionField = required(raw, "version", "$"); if (!versionField.ok) return versionField;
+  const version = versionOne(versionField.value, "$.version"); if (!version.ok) return version;
+  const idField = required(raw, "id", "$"); if (!idField.ok) return idField;
+  const id = identifier(idField.value, "$.id", "job id"); if (!id.ok) return id;
+  const resourceIdField = required(raw, "resourceId", "$"); if (!resourceIdField.ok) return resourceIdField;
+  const resourceId = identifier(resourceIdField.value, "$.resourceId", "resourceId"); if (!resourceId.ok) return resourceId;
+  const resourceRevisionField = required(raw, "resourceRevision", "$"); if (!resourceRevisionField.ok) return resourceRevisionField;
+  const resourceRevision = integer(resourceRevisionField.value, "$.resourceRevision", "resourceRevision", 1); if (!resourceRevision.ok) return resourceRevision;
+  const deletionRevisionField = required(raw, "deletionRevision", "$"); if (!deletionRevisionField.ok) return deletionRevisionField;
+  const deletionRevision = integer(deletionRevisionField.value, "$.deletionRevision", "deletionRevision"); if (!deletionRevision.ok) return deletionRevision;
+  const statusField = required(raw, "status", "$"); if (!statusField.ok) return statusField;
+  const status = enumValue(statusField.value, RESOURCE_INGEST_JOB_STATUSES, "$.status", "job status"); if (!status.ok) return status;
+  const stageField = required(raw, "stage", "$"); if (!stageField.ok) return stageField;
+  const stage = enumValue(stageField.value, RESOURCE_INGEST_JOB_STAGES, "$.stage", "job stage"); if (!stage.ok) return stage;
+  const attemptField = required(raw, "attempt", "$"); if (!attemptField.ok) return attemptField;
+  const attempt = integer(attemptField.value, "$.attempt", "attempt"); if (!attempt.ok) return attempt;
+  const availableAtField = required(raw, "availableAt", "$"); if (!availableAtField.ok) return availableAtField;
+  const availableAt = utc(availableAtField.value, "$.availableAt", "availableAt"); if (!availableAt.ok) return availableAt;
+  const lease = optional(raw, "lease", "$", (item, itemPath) => {
+    const leaseObject = object(item, itemPath); if (!leaseObject.ok) return leaseObject;
+    const ownerField = required(leaseObject.value, "owner", itemPath); if (!ownerField.ok) return ownerField;
+    const owner = identifier(ownerField.value, childPath(itemPath, "owner"), "lease owner"); if (!owner.ok) return owner;
+    const expiresField = required(leaseObject.value, "expiresAt", itemPath); if (!expiresField.ok) return expiresField;
+    const expiresAt = utc(expiresField.value, childPath(itemPath, "expiresAt"), "lease expiresAt"); if (!expiresAt.ok) return expiresAt;
+    return pass({ ...leaseObject.value, owner: owner.value, expiresAt: expiresAt.value });
+  }); if (!lease.ok) return lease;
+  if ((status.value === "claimed") !== (lease.value !== undefined)) {
+    return fail("semantic_conflict", "$.lease", "lease must be present exactly when status is claimed");
+  }
+  const createdField = required(raw, "createdAt", "$"); if (!createdField.ok) return createdField;
+  const createdAt = utc(createdField.value, "$.createdAt", "createdAt"); if (!createdAt.ok) return createdAt;
+  const updatedField = required(raw, "updatedAt", "$"); if (!updatedField.ok) return updatedField;
+  const updatedAt = utc(updatedField.value, "$.updatedAt", "updatedAt"); if (!updatedAt.ok) return updatedAt;
+  if (compareUtcTimestamps(updatedAt.value, createdAt.value) < 0) return fail("semantic_conflict", "$.updatedAt", "updatedAt must not precede createdAt");
+  return pass({ ...raw, version: 1, id: id.value, resourceId: resourceId.value, resourceRevision: resourceRevision.value, deletionRevision: deletionRevision.value, status: status.value, stage: stage.value, attempt: attempt.value, availableAt: availableAt.value, createdAt: createdAt.value, updatedAt: updatedAt.value, ...(lease.value === undefined ? {} : { lease: lease.value }) });
+}
+
+export function parseResourceEmbeddingTaskV1(value: unknown): ProtocolParseResult<ResourceEmbeddingTaskV1> {
+  const parsedObject = prepare(value, "$"); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const versionField = required(raw, "version", "$"); if (!versionField.ok) return versionField;
+  const version = versionOne(versionField.value, "$.version"); if (!version.ok) return version;
+  const resourceIdField = required(raw, "resourceId", "$"); if (!resourceIdField.ok) return resourceIdField;
+  const resourceId = identifier(resourceIdField.value, "$.resourceId", "resourceId"); if (!resourceId.ok) return resourceId;
+  const snapshotIdField = required(raw, "snapshotId", "$"); if (!snapshotIdField.ok) return snapshotIdField;
+  const snapshotId = identifier(snapshotIdField.value, "$.snapshotId", "snapshotId"); if (!snapshotId.ok) return snapshotId;
+  const lexicalRevisionField = required(raw, "lexicalRevision", "$"); if (!lexicalRevisionField.ok) return lexicalRevisionField;
+  const lexicalRevision = integer(lexicalRevisionField.value, "$.lexicalRevision", "lexicalRevision", 1); if (!lexicalRevision.ok) return lexicalRevision;
+  const providerIdField = required(raw, "providerId", "$"); if (!providerIdField.ok) return providerIdField;
+  const providerId = identifier(providerIdField.value, "$.providerId", "providerId"); if (!providerId.ok) return providerId;
+  const modelIdField = required(raw, "modelId", "$"); if (!modelIdField.ok) return modelIdField;
+  const modelId = identifier(modelIdField.value, "$.modelId", "modelId"); if (!modelId.ok) return modelId;
+  const dimensionsField = required(raw, "dimensions", "$"); if (!dimensionsField.ok) return dimensionsField;
+  const dimensions = integer(dimensionsField.value, "$.dimensions", "dimensions", 1); if (!dimensions.ok) return dimensions;
+  const statusField = required(raw, "status", "$"); if (!statusField.ok) return statusField;
+  const status = enumValue(statusField.value, RESOURCE_EMBEDDING_STATUSES, "$.status", "embedding status"); if (!status.ok) return status;
+  const updatedField = required(raw, "updatedAt", "$"); if (!updatedField.ok) return updatedField;
+  const updatedAt = utc(updatedField.value, "$.updatedAt", "updatedAt"); if (!updatedAt.ok) return updatedAt;
+  return pass({ ...raw, version: 1, resourceId: resourceId.value, snapshotId: snapshotId.value, lexicalRevision: lexicalRevision.value, providerId: providerId.value, modelId: modelId.value, dimensions: dimensions.value, status: status.value, updatedAt: updatedAt.value });
+}
+
+export function parseResourceTombstoneV1(value: unknown): ProtocolParseResult<ResourceTombstoneV1> {
+  const parsedObject = prepare(value, "$"); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const strict = rejectUnexpected(raw, ["version", "resourceId", "deletionRevision", "deletedAt"], "$", "tombstone"); if (!strict.ok) return strict;
+  const versionField = required(raw, "version", "$"); if (!versionField.ok) return versionField;
+  const version = versionOne(versionField.value, "$.version"); if (!version.ok) return version;
+  const resourceIdField = required(raw, "resourceId", "$"); if (!resourceIdField.ok) return resourceIdField;
+  const resourceId = identifier(resourceIdField.value, "$.resourceId", "resourceId"); if (!resourceId.ok) return resourceId;
+  const revisionField = required(raw, "deletionRevision", "$"); if (!revisionField.ok) return revisionField;
+  const deletionRevision = integer(revisionField.value, "$.deletionRevision", "deletionRevision", 1); if (!deletionRevision.ok) return deletionRevision;
+  const deletedField = required(raw, "deletedAt", "$"); if (!deletedField.ok) return deletedField;
+  const deletedAt = utc(deletedField.value, "$.deletedAt", "deletedAt"); if (!deletedAt.ok) return deletedAt;
+  return pass({ version: 1, resourceId: resourceId.value, deletionRevision: deletionRevision.value, deletedAt: deletedAt.value });
+}
+
+function parseMigrationRecord<T extends ResearchLinksProjectionV1 | ResearchLinksMigrationJournalV1>(
+  value: unknown,
+  digestKey: "projectedDigest" | "intendedProjectionDigest",
+  timestampKey: "generatedAt" | "startedAt",
+): ProtocolParseResult<T> {
+  const parsedObject = prepare(value, "$"); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const versionField = required(raw, "version", "$"); if (!versionField.ok) return versionField;
+  const version = versionOne(versionField.value, "$.version"); if (!version.ok) return version;
+  const revisionField = required(raw, "catalogRevision", "$"); if (!revisionField.ok) return revisionField;
+  const catalogRevision = integer(revisionField.value, "$.catalogRevision", "catalogRevision"); if (!catalogRevision.ok) return catalogRevision;
+  const digestField = required(raw, digestKey, "$"); if (!digestField.ok) return digestField;
+  const parsedDigest = digest(digestField.value, childPath("$", digestKey), digestKey); if (!parsedDigest.ok) return parsedDigest;
+  const timestampField = required(raw, timestampKey, "$"); if (!timestampField.ok) return timestampField;
+  const timestamp = utc(timestampField.value, childPath("$", timestampKey), timestampKey); if (!timestamp.ok) return timestamp;
+  return pass({ ...raw, version: 1, catalogRevision: catalogRevision.value, [digestKey]: parsedDigest.value, [timestampKey]: timestamp.value } as T);
+}
+
+export function parseResearchLinksProjectionV1(value: unknown): ProtocolParseResult<ResearchLinksProjectionV1> {
+  return parseMigrationRecord<ResearchLinksProjectionV1>(value, "projectedDigest", "generatedAt");
+}
+
+export function parseResearchLinksMigrationJournalV1(value: unknown): ProtocolParseResult<ResearchLinksMigrationJournalV1> {
+  return parseMigrationRecord<ResearchLinksMigrationJournalV1>(value, "intendedProjectionDigest", "startedAt");
+}
+
+function parseQueryFilters(value: unknown, path: string): ProtocolParseResult<ResourceQueryFiltersV1> {
+  const parsedObject = object(value, path); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const projectIds = optional(raw, "projectIds", path, (item, itemPath) => parseStringArray(item, itemPath, "projectIds", { nonEmpty: true })); if (!projectIds.ok) return projectIds;
+  const familiarIds = optional(raw, "familiarIds", path, (item, itemPath) => parseStringArray(item, itemPath, "familiarIds", { nonEmpty: true })); if (!familiarIds.ok) return familiarIds;
+  const kinds = optional(raw, "kinds", path, (item, itemPath) => parseEnumArray(item, RESOURCE_KINDS, itemPath, "kinds")); if (!kinds.ok) return kinds;
+  const sensitivities = optional(raw, "sensitivities", path, (item, itemPath) => parseEnumArray(item, RESOURCE_SENSITIVITIES, itemPath, "sensitivities")); if (!sensitivities.ok) return sensitivities;
+  const ingestStates = optional(raw, "ingestStates", path, (item, itemPath) => parseEnumArray(item, RESOURCE_INGEST_STATES, itemPath, "ingestStates")); if (!ingestStates.ok) return ingestStates;
+  const publishedFrom = optional(raw, "publishedFrom", path, (item, itemPath) => utc(item, itemPath, "publishedFrom")); if (!publishedFrom.ok) return publishedFrom;
+  const publishedBefore = optional(raw, "publishedBefore", path, (item, itemPath) => utc(item, itemPath, "publishedBefore")); if (!publishedBefore.ok) return publishedBefore;
+  if (publishedFrom.value !== undefined && publishedBefore.value !== undefined && compareUtcTimestamps(publishedFrom.value, publishedBefore.value) >= 0) {
+    return fail("semantic_conflict", path, "publishedFrom must precede publishedBefore");
+  }
+  const contextPackId = optional(raw, "contextPackId", path, (item, itemPath) => identifier(item, itemPath, "contextPackId")); if (!contextPackId.ok) return contextPackId;
+  return pass({ ...raw, ...(projectIds.value === undefined ? {} : { projectIds: projectIds.value }), ...(familiarIds.value === undefined ? {} : { familiarIds: familiarIds.value }), ...(kinds.value === undefined ? {} : { kinds: kinds.value }), ...(sensitivities.value === undefined ? {} : { sensitivities: sensitivities.value }), ...(ingestStates.value === undefined ? {} : { ingestStates: ingestStates.value }), ...(publishedFrom.value === undefined ? {} : { publishedFrom: publishedFrom.value }), ...(publishedBefore.value === undefined ? {} : { publishedBefore: publishedBefore.value }), ...(contextPackId.value === undefined ? {} : { contextPackId: contextPackId.value }) });
+}
+
+export function parseResourceQueryV1(value: unknown): ProtocolParseResult<ResourceQueryV1> {
+  const parsedObject = prepare(value, "$"); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const versionField = required(raw, "version", "$"); if (!versionField.ok) return versionField;
+  const version = versionOne(versionField.value, "$.version"); if (!version.ok) return version;
+  const textField = required(raw, "text", "$"); if (!textField.ok) return textField;
+  const text = stringValue(textField.value, "$.text", "query text", { nonEmpty: true }); if (!text.ok) return text;
+  const filters = optional(raw, "filters", "$", parseQueryFilters); if (!filters.ok) return filters;
+  const rankingField = required(raw, "ranking", "$"); if (!rankingField.ok) return rankingField;
+  const ranking = enumValue(rankingField.value, RESOURCE_QUERY_RANKINGS, "$.ranking", "ranking"); if (!ranking.ok) return ranking;
+  const limitField = required(raw, "limit", "$"); if (!limitField.ok) return limitField;
+  const limit = integer(limitField.value, "$.limit", "limit", 1); if (!limit.ok) return limit;
+  if (limit.value > 100) return fail("invalid_value", "$.limit", "limit must be <= 100");
+  return pass({ ...raw, version: 1, text: text.value, ranking: ranking.value, limit: limit.value, ...(filters.value === undefined ? {} : { filters: filters.value }) });
+}
+
+function parseRankEvidence(value: unknown, path: string, label: string): ProtocolParseResult<{ matched: boolean; rank?: number }> {
+  const parsedObject = object(value, path); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const strict = rejectUnexpected(raw, ["matched", "rank"], path, `${label} retrieval evidence`); if (!strict.ok) return strict;
+  const matchedField = required(raw, "matched", path); if (!matchedField.ok) return matchedField;
+  const matched = booleanValue(matchedField.value, childPath(path, "matched"), `${label} matched`); if (!matched.ok) return matched;
+  const rank = optional(raw, "rank", path, (item, itemPath) => integer(item, itemPath, `${label} rank`, 1)); if (!rank.ok) return rank;
+  if (matched.value !== (rank.value !== undefined)) return fail("semantic_conflict", path, `${label} rank must be present exactly when matched`);
+  return pass({ ...raw, matched: matched.value, ...(rank.value === undefined ? {} : { rank: rank.value }) });
+}
+
+function parseQueryHit(value: unknown, path: string): ProtocolParseResult<ResourceQueryHitV1> {
+  const parsedObject = object(value, path); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const strict = rejectUnexpected(raw, ["resourceId", "snapshotId", "resourceRevision", "normalizedBlobDigest", "selector", "excerpt", "excerptDigest", "retrieval"], path, "query hit"); if (!strict.ok) return strict;
+  const resourceIdField = required(raw, "resourceId", path); if (!resourceIdField.ok) return resourceIdField;
+  const resourceId = identifier(resourceIdField.value, childPath(path, "resourceId"), "resourceId"); if (!resourceId.ok) return resourceId;
+  const snapshotIdField = required(raw, "snapshotId", path); if (!snapshotIdField.ok) return snapshotIdField;
+  const snapshotId = identifier(snapshotIdField.value, childPath(path, "snapshotId"), "snapshotId"); if (!snapshotId.ok) return snapshotId;
+  const revisionField = required(raw, "resourceRevision", path); if (!revisionField.ok) return revisionField;
+  const resourceRevision = integer(revisionField.value, childPath(path, "resourceRevision"), "resourceRevision", 1); if (!resourceRevision.ok) return resourceRevision;
+  const normalizedField = required(raw, "normalizedBlobDigest", path); if (!normalizedField.ok) return normalizedField;
+  const normalizedBlobDigest = digest(normalizedField.value, childPath(path, "normalizedBlobDigest"), "normalizedBlobDigest"); if (!normalizedBlobDigest.ok) return normalizedBlobDigest;
+  const selectorField = required(raw, "selector", path); if (!selectorField.ok) return selectorField;
+  const selector = parseContextSelectorV1(selectorField.value, childPath(path, "selector")); if (!selector.ok) return selector;
+  const selectorKeys = selector.value.type === "json-pointer"
+    ? ["type", "pointer"]
+    : selector.value.type === "markdown-section"
+      ? ["type", "headingPath"]
+      : selector.value.type === "whole-resource"
+        ? ["type"]
+        : selector.value.type === "pdf-page-span"
+          ? ["type", "page", "start", "end"]
+          : ["type", "start", "end"];
+  const strictSelector = rejectUnexpected(selector.value, selectorKeys, childPath(path, "selector"), "query-hit selector"); if (!strictSelector.ok) return strictSelector;
+  const excerptField = required(raw, "excerpt", path); if (!excerptField.ok) return excerptField;
+  const excerpt = stringValue(excerptField.value, childPath(path, "excerpt"), "excerpt"); if (!excerpt.ok) return excerpt;
+  const excerptDigestField = required(raw, "excerptDigest", path); if (!excerptDigestField.ok) return excerptDigestField;
+  const excerptDigest = digest(excerptDigestField.value, childPath(path, "excerptDigest"), "excerptDigest"); if (!excerptDigest.ok) return excerptDigest;
+  if (excerptDigest.value !== sha256Digest(excerpt.value)) {
+    return fail("digest_mismatch", childPath(path, "excerptDigest"), "excerptDigest does not match the exact excerpt bytes");
+  }
+  const retrievalField = required(raw, "retrieval", path); if (!retrievalField.ok) return retrievalField;
+  const retrievalObject = object(retrievalField.value, childPath(path, "retrieval")); if (!retrievalObject.ok) return retrievalObject;
+  const retrievalRaw = retrievalObject.value;
+  const strictRetrieval = rejectUnexpected(retrievalRaw, ["exact", "lexical", "semantic"], childPath(path, "retrieval"), "retrieval evidence"); if (!strictRetrieval.ok) return strictRetrieval;
+  const exactField = required(retrievalRaw, "exact", childPath(path, "retrieval")); if (!exactField.ok) return exactField;
+  const exact = booleanValue(exactField.value, childPath(childPath(path, "retrieval"), "exact"), "exact"); if (!exact.ok) return exact;
+  const lexicalField = required(retrievalRaw, "lexical", childPath(path, "retrieval")); if (!lexicalField.ok) return lexicalField;
+  const lexical = parseRankEvidence(lexicalField.value, childPath(childPath(path, "retrieval"), "lexical"), "lexical"); if (!lexical.ok) return lexical;
+  const semanticField = required(retrievalRaw, "semantic", childPath(path, "retrieval")); if (!semanticField.ok) return semanticField;
+  const semanticObject = object(semanticField.value, childPath(childPath(path, "retrieval"), "semantic")); if (!semanticObject.ok) return semanticObject;
+  const semanticRaw = semanticObject.value;
+  const strictSemantic = rejectUnexpected(semanticRaw, ["state", "matched", "rank"], childPath(childPath(path, "retrieval"), "semantic"), "semantic retrieval evidence"); if (!strictSemantic.ok) return strictSemantic;
+  const stateField = required(semanticRaw, "state", childPath(childPath(path, "retrieval"), "semantic")); if (!stateField.ok) return stateField;
+  const state = enumValue(stateField.value, RESOURCE_SEMANTIC_STATES, childPath(childPath(childPath(path, "retrieval"), "semantic"), "state"), "semantic state"); if (!state.ok) return state;
+  const matchedField = required(semanticRaw, "matched", childPath(childPath(path, "retrieval"), "semantic")); if (!matchedField.ok) return matchedField;
+  const matched = booleanValue(matchedField.value, childPath(childPath(childPath(path, "retrieval"), "semantic"), "matched"), "semantic matched"); if (!matched.ok) return matched;
+  const rank = optional(semanticRaw, "rank", childPath(childPath(path, "retrieval"), "semantic"), (item, itemPath) => integer(item, itemPath, "semantic rank", 1)); if (!rank.ok) return rank;
+  if (matched.value && state.value !== "ready") return fail("semantic_conflict", childPath(childPath(path, "retrieval"), "semantic"), "semantic matches require state=ready");
+  if (matched.value !== (rank.value !== undefined)) return fail("semantic_conflict", childPath(childPath(path, "retrieval"), "semantic"), "semantic rank must be present exactly when matched");
+  const semantic = { ...semanticRaw, state: state.value, matched: matched.value, ...(rank.value === undefined ? {} : { rank: rank.value }) };
+  const retrieval = { ...retrievalRaw, exact: exact.value, lexical: lexical.value, semantic };
+  return pass({ ...raw, resourceId: resourceId.value, snapshotId: snapshotId.value, resourceRevision: resourceRevision.value, normalizedBlobDigest: normalizedBlobDigest.value, selector: selector.value as ResourceQuerySelectorV1, excerpt: excerpt.value, excerptDigest: excerptDigest.value, retrieval });
+}
+
+export function parseResourceQueryResponseV1(value: unknown): ProtocolParseResult<ResourceQueryResponseV1> {
+  const parsedObject = prepare(value, "$"); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  const strict = rejectUnexpected(raw, ["version", "ranking", "hits"], "$", "query response"); if (!strict.ok) return strict;
+  const versionField = required(raw, "version", "$"); if (!versionField.ok) return versionField;
+  const version = versionOne(versionField.value, "$.version"); if (!version.ok) return version;
+  const rankingField = required(raw, "ranking", "$"); if (!rankingField.ok) return rankingField;
+  const ranking = enumValue(rankingField.value, RESOURCE_QUERY_RANKINGS, "$.ranking", "ranking"); if (!ranking.ok) return ranking;
+  const hitsField = required(raw, "hits", "$"); if (!hitsField.ok) return hitsField;
+  if (!Array.isArray(hitsField.value)) return fail("invalid_type", "$.hits", "hits must be an array");
+  if (hitsField.value.length > 100) return fail("invalid_value", "$.hits", "hits must contain at most 100 entries");
+  const hits: ResourceQueryHitV1[] = [];
+  const identities = new Set<string>();
+  for (const [index, item] of hitsField.value.entries()) {
+    const hit = parseQueryHit(item, indexPath("$.hits", index)); if (!hit.ok) return hit;
+    const identity = `${hit.value.resourceId}\u0000${hit.value.snapshotId}`;
+    if (identities.has(identity)) return fail("semantic_conflict", indexPath("$.hits", index), "response must not duplicate a resource/snapshot pair");
+    identities.add(identity);
+    hits.push(hit.value);
+  }
+  return pass({ ...raw, version: 1, ranking: ranking.value, hits });
+}


### PR DESCRIPTION
## Summary

- define Cave-owned Research Resource manifest, snapshot, ingest-job, embedding-task, tombstone, migration, and retrieval contracts
- add runtime parsers with canonical JSON detachment, selector/snapshot bounds, digest verification, deletion/privacy allowlists, and semantic invariants
- add hierarchical local rollout flags while keeping hosted Research fail-closed until a server-authoritative Gate C0 lands
- document the PR-sized A1 plan and wire focused tests without changing portable Research schemas

Bead: `cave-6sles.2`

## Verification

- `node --experimental-strip-types --test src/lib/research-resource-contracts.test.ts` — 10/10 passed
- `node --experimental-strip-types src/lib/feature-flags.test.ts` — passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm check:tests-wired` — all 1884 files wired
- direct portable Research Protocol suite — 447/447 passed
- independent implementation re-review — no findings

## Known baseline/host gates

- `pnpm test:app` reaches untouched `src/lib/server/store-read-cache.test.ts`, where the external-write and same-size-rewrite assertions also fail on the base checkout; tracked separately as `cave-35gnr`
- aggregate `pnpm test:conformance` is unavailable on this host because it has neither a Tailscale Serve URL nor a MagicDNS DNSName; the portable Research Protocol tests pass directly

## Boundary

No files under `schemas/research/v1/` or `src/lib/research-protocol/` changed. This PR adds no store, API, UI, backup, ingestion-worker, index, or embedding implementation.