### PR TITLE
fix(mobile): self-heal Tailscale Serve drift

### DIFF
--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -41,25 +41,24 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
 
 {
   assert.equal(
-    shouldAllowMagicDnsFallback({
-      serveOk: false,
-      statusOk: false,
-    }),
+    shouldAllowMagicDnsFallback({ serveOk: false, statusOk: false }),
     false,
-    "a failed Serve mutation, including macOS CLIError 3, needs a matching route in status before a handoff can succeed",
+    "a failed Serve mutation with no status proof stays fail-closed",
   );
   assert.equal(
-    shouldAllowMagicDnsFallback({
-      serveOk: true,
-      statusOk: false,
-    }),
+    shouldAllowMagicDnsFallback({ serveOk: false, statusOk: true }),
+    false,
+    "a readable status does not by itself authorize MagicDNS fallback after mutation failure",
+  );
+  assert.equal(
+    shouldAllowMagicDnsFallback({ serveOk: true, statusOk: false }),
     true,
-    "a successful Serve mutation may use MagicDNS when its follow-up status read is unavailable",
+    "an acknowledged Serve mutation may use MagicDNS when status is unavailable",
   );
   assert.equal(
     shouldAllowMagicDnsFallback({ serveOk: true, statusOk: true }),
-    false,
-    "a readable Serve status remains authoritative",
+    true,
+    "status-schema drift must not veto an acknowledged Serve mutation",
   );
 }
 
@@ -228,7 +227,7 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
       ok: false,
       reason: "tailscale serve route not found for http://127.0.0.1:3000",
     },
-    "a readable empty Serve status must not promote a bare MagicDNS name to a live route",
+    "a readable empty Serve status must not promote a bare MagicDNS name unless mutation evidence allows it",
   );
   const linuxMismatchedServeStatus = {
     Web: {
@@ -248,7 +247,37 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
       ok: false,
       reason: "tailscale serve route not found for http://127.0.0.1:3000",
     },
-    "a Linux Serve status for another loopback backend must not promote MagicDNS to a live route",
+    "a stale Serve status for another loopback backend must not promote MagicDNS without mutation evidence",
+  );
+  assert.deepEqual(
+    tailnetDiscoveryProof({
+      selfStatus: self,
+      serveStatus: linuxMismatchedServeStatus,
+      backendUrl: "http://127.0.0.1:3000",
+      allowMagicDnsFallback: true,
+    }),
+    {
+      ok: true,
+      host: "cave.tailnet.example.ts.net",
+      serveUrl,
+      source: "magicdns-self-status",
+    },
+    "after an acknowledged reclaim mutation, stale status-schema data cannot veto the recovered route",
+  );
+  assert.deepEqual(
+    tailnetDiscoveryProof({
+      selfStatus: self,
+      serveStatus: { FutureSchema: { routes: [] } },
+      backendUrl: "http://127.0.0.1:3000",
+      allowMagicDnsFallback: true,
+    }),
+    {
+      ok: true,
+      host: "cave.tailnet.example.ts.net",
+      serveUrl,
+      source: "magicdns-self-status",
+    },
+    "an unknown future Serve status schema cannot veto an acknowledged successful mutation",
   );
   assert.deepEqual(
     nativeAppDiscoveryProof({

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -14,11 +14,13 @@ export function shouldAllowMagicDnsFallback({
   serveOk: boolean;
   statusOk: boolean;
 }) {
-  // A successful `serve` mutation proves the requested backend was published,
-  // even when a follow-up status read is unavailable. A failed mutation,
-  // including macOS CLIError 3, needs a matching route in status before it can
-  // be used; a MagicDNS name only identifies the machine, not a Serve route.
-  return serveOk && !statusOk;
+  // An acknowledged `serve --bg <backend>` mutation is authoritative evidence
+  // that Tailscale accepted the requested route. A follow-up status read is
+  // corroboration only: its schema/parser may drift independently and must not
+  // veto a successful mutation. When mutation fails, callers still require a
+  // matching parsed route before they may claim the backend is published.
+  void statusOk;
+  return serveOk;
 }
 
 export function serveRouteFailure({


### PR DESCRIPTION
## Summary

Implements the mobile recovery contract captured in #5051 after the reproduced packaged Cave/iOS incident.

### What changes

- Treats a successful `tailscale serve --bg <expected-backend>` mutation as authoritative recovery evidence.
- Keeps `tailscale serve status --json` as corroboration rather than allowing parser/schema drift to veto an acknowledged mutation.
- Preserves fail-closed behavior when the Serve mutation itself fails.
- Adds regression coverage for the exact incident topology:
  - mutation succeeds + status unavailable;
  - mutation succeeds + status readable but unknown schema;
  - mutation succeeds + stale status still points at another worktree;
  - mutation fails + readable status does not authorize MagicDNS fallback;
  - matching parsed Serve status remains preferred when available.

## Why

A real packaged Cave session was healthy on `127.0.0.1:3020`, but the stable Tailscale Serve route had drifted to a development server. Reclaiming Serve manually succeeded and `tailscale serve status` visibly showed the correct backend, yet Cave 0.3.9 still returned `tailscale serve route not found` because its status interpretation vetoed the successful mutation. The existing mobile credential worked immediately once transport was repaired.

The recovery contract now requires transport repair and pairing authorization to remain separate, and requires successful Serve mutation to survive status-schema drift.

## Security properties preserved

- Tailnet membership is not authorization.
- No credential is minted merely because transport is healthy.
- Stale target processes are never killed.
- Failed Serve mutations still require independently observed matching route evidence.
- Existing credential validation remains the final authority after transport recovery.

## Related

- Fixes #5051
- Contract: `docs/contracts/mobile-recovery-contract.md`
- Operator fallback: `scripts/mobile-recovery.sh`

## Validation

Expected CI coverage includes the existing mobile handoff suite plus the new regression matrix in `src/lib/mobile-handoff.test.ts`.