### PR TITLE
Prepare Coven Cave 0.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,37 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.3.12] - 2026-08-27
+
+> Streamlines iOS navigation, adds packaged mobile recovery, and strengthens
+> local Research, authenticated clients, and everyday workspace reliability.
+
+Patch release on top of v0.3.11. Native iOS now keeps Chats and Tasks focused
+as primary destinations while grouping project and familiar context beneath
+them. Cave also gains packaged mobile transport recovery, local Research
+resource contracts, stronger authenticated-client authority, and a collection
+of focused Chat, Code, Calendar, and maintenance fixes.
+
 ### Changes
+- Simplify the iOS navigation drawer (#5058)
+- Plan the simplified Canvas GitHub import modal (#5057)
+- Clarify Beads skill trigger boundary (#5030)
+- Stop GitHubActionPopover positioning itself inside a Popover (#5047)
+- Define local Research resource contracts (#5054)
+- Retry blank failed Copilot resumes (#5052)
+- Add packaged Cave mobile transport recovery
+- Define the Cave mobile recovery contract
+- Match OpenClaw profiles to real Gateway discovery (#5050)
+- Remove stale hydration test helper (#5049)
+- Portal the Code Desk action popovers so the drawer cannot clip them (cave-cadp4) (#5046)
+- Bind authenticated client requests to Cave authority (#5044)
+- Say which calendar cells are short when a projection is truncated (cave-fdcd4) (#5043)
+- Scope --allow-cooldown-override to named units (#5041)
+- Add a focus-first Research PDF reader (#5039)
+- Credit worktree-retention tags by OID rather than only local tag name (#5040)
+- Adopt the shared surface toolbar
+- Keep X hydration cache fixtures fresh (cave-290os)
+- Restore focused sidebar contracts
 - Correct the port-claim occupant docs and harden the two contracts that pin them (#4980)
 
 ## [0.3.11] - 2026-08-25

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.3.11"
+    MARKETING_VERSION: "0.3.12"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026082523"
+    CURRENT_PROJECT_VERSION: "2026082710"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "aes-gcm",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.11"
+version = "0.3.12"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- stamp desktop and native iOS version surfaces to `0.3.12`
- advance the iOS build number for App Store Connect
- curate the changelog for the release delta since `v0.3.11`

## Verification
- `pnpm release:verify --version 0.3.12`
- `node --test scripts/stamp-release.test.mjs`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `pnpm test:mobile`
- `pnpm mobile:ios:xcodegen`
- iPhone 16 Pro simulator build

After merge: cut signed `v0.3.12-rc.1`, require the exact-commit Release candidate workflow, then promote the same commit with signed `v0.3.12` for TestFlight.

Bead: `cave-wgngo`