### PR TITLE
fix(client-v1): stabilize packaged discovery validation

### DIFF
--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -26,6 +26,12 @@ const [
 const baseConfig = JSON.parse(baseConfigSource);
 const windowsConfig = JSON.parse(windowsConfigSource);
 
+assert.match(
+  smokeSource,
+  /const covenHome = await realpath\(\s*await mkdtemp\(/,
+  "the packaged smoke must give COVEN_HOME its physical path on symlinked temp roots",
+);
+
 function sourceSection(source, startMarker, endMarker, label) {
   const startIndex = source.indexOf(startMarker);
   const endIndex = source.indexOf(endMarker);

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import { access, chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, realpath, readdir, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -384,7 +384,9 @@ async function main() {
     `packaged native modules must load from the sidecar runtime: ${nativeModules.stderr || nativeModules.error}`,
   );
 
-  const covenHome = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-smoke-"));
+  const covenHome = await realpath(
+    await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-smoke-")),
+  );
   const daemonMarker = path.join(covenHome, "daemon-timeout-child.pid");
   const hangingDaemon = await writeHangingDaemonFixture(covenHome, daemonMarker);
   const avatarDir = path.join(covenHome, "workspaces", "familiars", "smoke", "avatars");

--- a/server.mjs
+++ b/server.mjs
@@ -292,7 +292,7 @@ function assertStandaloneWindowsExclusive(path, label) {
         env: probeEnv,
         encoding: "utf8",
         windowsHide: true,
-        timeout: 15e3,
+        timeout: 6e4,
         maxBuffer: 1024 * 1024
       }
     ));

--- a/server.ts
+++ b/server.ts
@@ -472,7 +472,7 @@ function assertStandaloneWindowsExclusive(path: string, label: string): void {
         env: probeEnv,
         encoding: "utf8",
         windowsHide: true,
-        timeout: 15_000,
+        timeout: 60_000,
         maxBuffer: 1024 * 1024,
       },
     ));

--- a/src/lib/server/client-v1/discovery.test.ts
+++ b/src/lib/server/client-v1/discovery.test.ts
@@ -573,6 +573,7 @@ test("the standalone server enforces ownership on Windows with this module's scr
     ["the inlined ACL script", /const WINDOWS_ACL_SCRIPT = `([\s\S]*?)`;/],
     ["the trusted SYSTEM SID", /const WINDOWS_SYSTEM_SID = "([^"]+)";/],
     ["the trusted Administrators SID", /const WINDOWS_ADMINISTRATORS_SID = "([^"]+)";/],
+    ["the ACL subprocess timeout", /timeout:\s*([\d_]+),/],
     ["the trusted-principal set", /const trusted = new Set\(\[[^\]]*\]\);/],
     [
       "the exclusivity findings",
@@ -598,6 +599,11 @@ test("the standalone server enforces ownership on Windows with this module's scr
       `${what} must stay identical to the module server.mjs cannot import`,
     );
   }
+  assert.equal(
+    Number(region(moduleSource, "path-ownership.ts", /timeout:\s*([\d_]+),/).replaceAll("_", "")),
+    60_000,
+    "the Windows ACL probe must tolerate a cold PowerShell start on hosted release runners",
+  );
   assert.match(
     source,
     /if \(findings\.length > 0\) \{\s*throw new Error\(/,

--- a/src/lib/server/client-v1/path-ownership.ts
+++ b/src/lib/server/client-v1/path-ownership.ts
@@ -370,7 +370,7 @@ export const probeWindowsAcl: ClientV1WindowsAclProbe = async (path) => {
       env: windowsProbeEnv(path),
       encoding: "utf8",
       windowsHide: true,
-      timeout: 15_000,
+      timeout: 60_000,
       maxBuffer: 1024 * 1024,
     },
   );


### PR DESCRIPTION
## Summary

- canonicalize the sidecar smoke COVEN_HOME so macOS system temp aliases satisfy the intentional physical-root guard
- allow the Windows ownership probe 60 seconds for cold PowerShell startup in both source and standalone server copies
- pin both cross-platform contracts with regression coverage

## Evidence

- reproduced both new assertions red against `v0.3.12-rc.1`
- rebuilt and passed the packaged sidecar runtime smoke on macOS
- passed focused discovery and ownership tests, lint, and typecheck

## Release context

Replaces the platform-blocked `v0.3.12-rc.1`; that immutable candidate tag will not be moved or reused. A passing merge will be validated as `v0.3.12-rc.2` before final promotion.