### PR TITLE
fix(client-v1): repair Windows discovery ownership

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -233,6 +233,7 @@ if (-not (Test-Exclusive $state)) {
   $removed = @($state.aces | Where-Object { $trusted -notcontains $_.sid } |
     ForEach-Object { $_.sid } | Select-Object -Unique)
   $acl = $item.GetAccessControl('Access')
+  $acl.SetOwner($me)
   $acl.SetAccessRuleProtection($true, $false)
   foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRule($rule) }
   $inheritance = if ($item.PSIsContainer) { 'ContainerInherit, ObjectInherit' } else { 'None' }

--- a/server.ts
+++ b/server.ts
@@ -393,6 +393,7 @@ if (-not (Test-Exclusive $state)) {
   $removed = @($state.aces | Where-Object { $trusted -notcontains $_.sid } |
     ForEach-Object { $_.sid } | Select-Object -Unique)
   $acl = $item.GetAccessControl('Access')
+  $acl.SetOwner($me)
   $acl.SetAccessRuleProtection($true, $false)
   foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRule($rule) }
   $inheritance = if ($item.PSIsContainer) { 'ContainerInherit, ObjectInherit' } else { 'None' }

--- a/src/lib/server/client-v1/discovery.test.ts
+++ b/src/lib/server/client-v1/discovery.test.ts
@@ -599,6 +599,11 @@ test("the standalone server enforces ownership on Windows with this module's scr
       `${what} must stay identical to the module server.mjs cannot import`,
     );
   }
+  assert.match(
+    region(moduleSource, "path-ownership.ts", /const WINDOWS_ACL_SCRIPT = `([\s\S]*?)`;/),
+    /\$acl\.SetOwner\(\$me\)/,
+    "the Windows ACL repair must take ownership instead of leaving an Administrators-owned path unusable",
+  );
   assert.equal(
     Number(region(moduleSource, "path-ownership.ts", /timeout:\s*([\d_]+),/).replaceAll("_", "")),
     60_000,

--- a/src/lib/server/client-v1/path-ownership.test.ts
+++ b/src/lib/server/client-v1/path-ownership.test.ts
@@ -264,6 +264,18 @@ test("the real probe restricts and verifies a real path on Windows", async (t: T
       );
     }
 
+    execFileSync("icacls.exe", [planted, "/setowner", `*${ADMINISTRATORS_SID}`], {
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    const ownerRepaired = await probeWindowsAcl(planted);
+    assert.equal(ownerRepaired.repaired, true, "a foreign owner must trigger ACL repair");
+    assert.equal(
+      ownerRepaired.owner,
+      ownerRepaired.self,
+      "repair must take ownership instead of leaving an Administrators-owned path unusable",
+    );
+
     // Whatever the machine's profile policy inherits, this is what the guard
     // exists to catch: hand an untrusted principal write access and the next
     // probe must both see it and take it away.

--- a/src/lib/server/client-v1/path-ownership.ts
+++ b/src/lib/server/client-v1/path-ownership.ts
@@ -198,13 +198,13 @@ export interface ClientV1PathOwnershipOptions {
  *
  * Node reports `uid: 0` for every path on win32 and `chmod` there sets nothing
  * but the read-only bit, so neither half of the POSIX contract this module
- * enforces has a native equivalent. `GetAccessControl("Access")` writes only
- * the DACL section — `Set-Acl`, which also carries owner and audit sections,
- * fails with `PrivilegeNotHeldException` (SeSecurityPrivilege) against an
- * already-protected path.
+ * enforces has a native equivalent. The repair takes ownership as the current
+ * SID, then writes only the owner and DACL sections; `Set-Acl`, which also
+ * carries the audit section, fails with `PrivilegeNotHeldException`
+ * (SeSecurityPrivilege) against an already-protected path.
  *
- * Ownership is verified, never taken: a path owned by somebody else is a
- * finding to report, not a race to win.
+ * The resulting owner and DACL are re-read below. A repair that cannot make
+ * both exclusive remains a finding and is refused rather than trusted.
  */
 const WINDOWS_ACL_SCRIPT = `
 $ErrorActionPreference = 'Stop'

--- a/src/lib/server/client-v1/path-ownership.ts
+++ b/src/lib/server/client-v1/path-ownership.ts
@@ -248,6 +248,7 @@ if (-not (Test-Exclusive $state)) {
   $removed = @($state.aces | Where-Object { $trusted -notcontains $_.sid } |
     ForEach-Object { $_.sid } | Select-Object -Unique)
   $acl = $item.GetAccessControl('Access')
+  $acl.SetOwner($me)
   $acl.SetAccessRuleProtection($true, $false)
   foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRule($rule) }
   $inheritance = if ($item.PSIsContainer) { 'ContainerInherit, ObjectInherit' } else { 'None' }


### PR DESCRIPTION
## Summary

- take ownership as the current Windows SID when repairing a non-exclusive Client v1 discovery path
- preserve the existing protected DACL and trusted-principal rewrite in the same transaction
- cover an Administrators-owned path in the real Windows probe and pin the standalone copy

## Root cause

`v0.3.12-rc.2` progressed past the earlier cold PowerShell timeout, then correctly refused the packaged discovery directory because elevated Node created it with Administrators as owner. The repair rewrote access rules but did not change that foreign owner, leaving the path permanently unusable.

## Evidence

- source regression failed before implementation and passes after it
- focused discovery and path-ownership tests pass
- lint, typecheck, test wiring, full app tests, and full API tests pass

## Release context

`v0.3.12-rc.2` remains immutable and will not be promoted. A passing merge will be validated as a new signed candidate.