### PR TITLE
Build Research resource snapshot store

### DIFF
--- a/docs/superpowers/plans/2026-08-27-research-resource-snapshot-blob-store.md
+++ b/docs/superpowers/plans/2026-08-27-research-resource-snapshot-blob-store.md
@@ -1,0 +1,330 @@
+# Research Resource Snapshot and Blob Store Implementation Plan
+
+**Goal:** Add the Cave-owned store that publishes immutable Research Resource
+snapshots over a dedicated content-addressed blob store, verifies every byte at
+the trust boundary, and garbage-collects a blob only after proving that no live
+snapshot references it.
+
+**Source:**
+`docs/superpowers/plans/2026-08-16-externalized-research-desk-program.md`
+§§2, 3.1-3.4, 5, 11 A2, and 13, building on
+`src/lib/research-resource-contracts.ts` from A1.
+
+**Boundary:** A2 owns the resource CAS, immutable snapshot persistence,
+normalization receipt contract, verified reads, and snapshot-to-blob reference
+accounting. It does not add manifests, list/detail APIs, legacy saved-link
+migration, fetchers, extractors, jobs, indexes, embeddings, Context Packs,
+backup integration, UI, or changes to the portable Research Run Protocol.
+Those remain A3 and later work.
+
+## Storage layout and ownership
+
+The store is rooted at `<caveHome>/research-resources/` and A2 creates only:
+
+```text
+research-resources/
+  snapshots/<snapshot-id>.json
+  blobs/sha256/<first-two-hex>/<digest>
+  locks/intents/<intent-id>.lock
+```
+
+The resource CAS is physically and logically separate from
+`research-context-packs/`. A later Context Pack build must copy selected bytes
+into the pack-owned CAS; it must never retain a resource-CAS path or depend on a
+resource snapshot remaining present.
+
+Production code derives the root from `caveHome()`. Tests inject a root through
+a store factory/options object; there is no new production environment override
+that can redirect authoritative data.
+
+Every directory is owner-only (`0700`) and every file is owner-only (`0600`).
+On POSIX, an existing path must be owned by the current uid and already have the
+exact private mode; broader permission bits are refused rather than repaired
+through a race-prone pathname chmod. Foreign-owned paths are refused. On
+Windows, the existing exclusive-path ownership/DACL guard is used for the store
+root and the created subtree. No permission policy makes a symlink, junction,
+foreign-owned path, or unclassifiable entry acceptable.
+
+## Contract decisions
+
+### The immutable snapshot is the normalization receipt
+
+A2 does not create a second receipt file that could disagree with its snapshot.
+Instead it adds this required, typed field to `ResourceSnapshotV1`:
+
+```ts
+type ResourceNormalizationReceiptV1 = {
+  extractorId: string;
+  extractorVersion: string;
+};
+
+type ResourceSnapshotV1 = {
+  // A1 fields remain unchanged.
+  normalizationReceipt: ResourceNormalizationReceiptV1;
+};
+```
+
+Both receipt strings are non-empty, trimmed identifiers. The containing
+snapshot already records the raw digest when one exists, normalized digest,
+normalized media type, exact byte count, selector, page-boundary table, source
+fetch metadata, and creation time. Keeping extractor identity/version beside
+those results makes the immutable snapshot the complete durable normalization
+receipt without duplicating integrity fields. A2 updates the parser and focused
+contract fixtures so the receipt is validated rather than passing through as an
+unknown additive object. No persisted A1 snapshot exists because A1 shipped no
+store or writer, so making the receipt required does not require a migration.
+
+Snapshot ids are path segments and therefore have a stricter store grammar than
+the general A1 identifier helper: ASCII alphanumeric first, followed by at most
+127 ASCII alphanumeric, `_`, or `-` characters. Windows device names are
+refused case-insensitively. A caller value is never joined to a filesystem path
+until this grammar passes. Digests keep the existing exact lowercase 64-hex
+grammar; the first two digest characters select the shard.
+
+### Immutability and idempotence
+
+Snapshot JSON is serialized with the existing RFC 8785-compatible canonical
+JSON helper. A snapshot id is write-once:
+
+- publishing an absent id atomically creates it;
+- replaying the same canonical snapshot succeeds as an idempotent no-op; and
+- replaying the id with any different canonical content returns an immutable
+  conflict and changes nothing.
+
+Blobs are keyed by SHA-256 over their exact bytes. Publishing an existing digest
+verifies the existing regular file through a stable, no-follow handle. Matching
+bytes are deduplicated; a digest mismatch or unsafe entry is corruption, not an
+instruction to overwrite the path.
+
+The hard safety ceiling for either one raw or normalized blob is 512 MiB. The
+store rejects a larger byte array before creating a temporary file. A2 does not
+invent a user-visible total storage quota or provider quota: ingest quota and
+`paused_quota` policy belong to A5. Reference scans are nevertheless bounded to
+100,000 snapshot entries and fail closed on an unexpected, unreadable, or
+unclassifiable entry rather than reporting a partial proof as complete.
+
+## Store API
+
+Add `src/lib/server/research-resource-store.ts` with these server-only seams:
+
+```ts
+type PublishResourceSnapshotInput = {
+  snapshot: ResourceSnapshotV1;
+  normalizedBlob: Uint8Array;
+  rawBlob?: Uint8Array;
+};
+
+type VerifiedResourceSnapshot = {
+  snapshot: ResourceSnapshotV1;
+  normalizedBlob: Uint8Array;
+  rawBlob?: Uint8Array;
+};
+
+createResearchResourceStore(options?: { root?: string }): ResearchResourceStore;
+
+ResearchResourceStore.publishSnapshot(
+  input: PublishResourceSnapshotInput,
+): Promise<{ created: boolean; snapshot: ResourceSnapshotV1 }>;
+
+ResearchResourceStore.readSnapshot(
+  snapshotId: string,
+): Promise<VerifiedResourceSnapshot>;
+
+ResearchResourceStore.deleteSnapshot(
+  snapshotId: string,
+): Promise<{ deleted: boolean; removedBlobDigests: string[] }>;
+```
+
+`publishSnapshot` is the only public blob-write seam. It validates and detaches
+the snapshot, hashes both supplied byte arrays, requires the normalized hash and
+byte length to equal `normalizedBlobDigest` and `normalizedBytes`, and requires
+`rawBlob` presence to match `rawBlobDigest` presence and value. It publishes
+each unique blob first and makes the snapshot visible last, all under the store
+mutation lock. If raw and normalized bytes have the same digest they occupy one
+CAS file and count as one snapshot reference.
+
+`readSnapshot` never returns unverified content. It safely opens and parses the
+snapshot record, then opens each referenced CAS path with the same no-follow and
+identity checks, reads within the hard cap, recomputes SHA-256, and checks the
+normalized byte count before returning detached bytes. Missing, malformed,
+oversized, unsafe, or digest-mismatched content is a typed integrity error.
+
+The module may keep narrower helpers private for layout validation, immutable
+publication, safe open/read, and reference scanning. It must not export a raw
+path, unchecked `readFile`, unchecked blob put, or recursive removal primitive.
+
+## Filesystem and CAS invariants
+
+The store root is private to the Cave OS account. A malicious process already
+running as that same account is outside A2's enforceable boundary: Node exposes
+no `openat`/`linkat`/`unlinkat` API that can bind a namespace mutation to an
+already-validated directory handle. A2 rejects pre-existing traversal,
+symlink/junction, hard-link, ownership, mode, and identity violations and
+rechecks paths around operations, but it does not claim to prevent a hostile
+same-user process from swapping a parent in the final pathname-syscall window.
+Closing that residual race would require a native directory-relative helper and
+is not represented as a guarantee in this JavaScript store.
+
+Every operation establishes and rechecks the following invariants:
+
+1. The root, `snapshots`, `blobs`, `sha256`, shard, and lock directories are real
+   directories, not symlinks or junctions, and their `realpath` remains inside
+   the canonical root.
+2. Directory identity (`dev` and `ino`) is captured after validation and checked
+   again around opens and namespace operations. Detected parent swaps are
+   integrity failures; the documented same-user final-syscall race remains.
+3. POSIX reads add `O_NOFOLLOW`; every platform also compares `lstat` before
+   open, handle `stat`, and `lstat` after open, verifies a regular file, and
+   checks final `realpath` containment. Windows junction/reparse substitutions
+   therefore cannot be admitted solely because `O_NOFOLLOW` is unavailable.
+4. Published files have exactly one link after the temporary publication link
+   is removed. Reads and deletes refuse a final file with an unexpected hard
+   link count so a CAS path cannot alias mutable bytes outside the store.
+5. Temporary files are unique, created with exclusive/no-follow flags and mode
+   `0600`, checked against the opened handle identity, written completely, and
+   file-synced before publication.
+6. Immutable publication is no-clobber. After syncing the temporary file, an
+   atomic hard link into the final name wins only when that name is absent; an
+   `EEXIST` contender verifies the winner. Ordinary replacing `rename` is not
+   used for immutable blobs or snapshots.
+7. The containing directory is synced where the host supports directory fsync.
+   Unsupported-operation errors are tolerated only after the file handle sync
+   and atomic namespace operation succeeded; permission errors always fail.
+8. A temporary file is removed on every failure. Unexpected non-temporary
+   entries are never swept. The store does not follow links during cleanup.
+9. Blob identity is always derived from computed bytes. A caller-supplied digest
+   is an assertion to verify, never a filename authority by itself.
+10. A resource blob is never read from, written to, referenced by, or collected
+    through the Context Pack root.
+
+The generic `writeFileAtomic` helper is intentionally not used here: it is a
+last-writer-wins replacement helper, does not set the required file mode, and
+does not fsync the file or directory. The safe directory/handle identity pattern
+in `research-media-store.ts`, the canonical JSON and SHA-256 helpers in
+`research-protocol/digest.ts`, and the FIFO cross-process intent lock are the
+starting primitives, tightened for immutable no-clobber publication.
+
+## Deletion and reference accounting
+
+All snapshot publication and deletion uses one cross-process store mutation
+lock. The lock directory is validated with the same path rules and intent files
+remain unique `0600` records. A live lock is never reclaimed by age alone.
+
+Deletion is proof-driven and ordered:
+
+1. Acquire the mutation lock and validate the entire store layout.
+2. Enumerate snapshot entries without following links. Every non-temporary
+   entry must be a safe `<snapshot-id>.json` regular file whose parsed `id`
+   matches its filename. Parse every record before mutating anything.
+3. Build a map from each unique raw/normalized digest to the set of remaining
+   snapshot ids. Duplicate raw/normalized fields inside one snapshot contribute
+   one reference, not two.
+4. If the requested id is absent, return `deleted: false` without mutation. If
+   any live record is malformed, unreadable, unsafe, or changes identity during
+   the scan, fail closed: absence of a complete reference graph is not proof of
+   zero references.
+5. Unlink the requested snapshot record first and sync `snapshots/`. A crash at
+   this point can leave an orphan blob but cannot leave a visible snapshot that
+   points to a blob A2 removed.
+6. Consider only the unique digests formerly referenced by that snapshot.
+   Remove a candidate only when its remaining reference set is empty and its
+   exact CAS entry is a contained, single-link regular file. Never recurse.
+7. Return the sorted digests actually removed. Failure after snapshot unlink is
+   recoverable orphan residue; it is never repaired by restoring the deleted
+   snapshot or guessing at references.
+
+This A2 operation deletes one immutable snapshot record. Resource deletion,
+tombstone fencing, manifest-last ordering, and startup resumption remain A3/A5
+orchestration. Those callers must use this proof-preserving operation rather
+than unlinking CAS paths themselves.
+
+## Focused test matrix
+
+Add `src/lib/server/research-resource-store.test.ts` and extend
+`src/lib/research-resource-contracts.test.ts`. Automated A2 coverage includes:
+
+- a raw and normalized blob round trip with exact digests, media type, byte
+  count, receipt, selector, and owner-only modes;
+- raw and normalized bytes sharing one digest and one physical CAS entry;
+- concurrent publication of the same bytes deduplicating without a partial
+  file, and concurrent different content for one snapshot id producing exactly
+  one winner and one immutable conflict;
+- idempotent replay of byte-identical canonical snapshot JSON, including
+  different input object key order;
+- mismatched raw digest, normalized digest, normalized byte count, missing raw
+  bytes, and unexpected raw bytes rejected before snapshot visibility;
+- untrimmed, traversal, slash, backslash, overlong, Unicode, and Windows device
+  snapshot ids rejected before path construction;
+- symlinked roots, snapshot directories, final snapshot records, and final blobs
+  refused on POSIX;
+- a hard-linked final blob or snapshot refused on read and deletion;
+- a corrupted existing CAS winner causing a typed integrity error rather than
+  replacement, quarantine, or silent deduplication;
+- malformed, missing, or digest-mismatched referenced blobs causing
+  `readSnapshot` to fail without returning metadata or partial bytes;
+- deletion of one of two snapshots sharing a blob preserving the blob, followed
+  by deletion of the last reference removing it;
+- raw and normalized duplicate digest counted once during deletion;
+- a malformed sibling snapshot making reference accounting fail closed before
+  any unlink, and POSIX broader-mode refusal without pathname repair; and
+- parser coverage for a valid receipt, missing receipt, empty/untrimmed
+  extractor fields, unknown receipt fields, and detached returned data.
+
+The 512 MiB ceiling is a direct pre-I/O guard but is not exercised by allocating
+a half-gigabyte test fixture. Windows DACL/junction behavior is covered by the
+shared ownership guard's platform suite; POSIX link tests skip on Windows where
+unprivileged link creation is not reliable. A future native directory-relative
+filesystem seam must add deterministic parent-swap and unlink-failure injection
+tests before claiming protection against hostile same-user namespace races.
+
+## Implementation sequence
+
+1. Extend the A1 snapshot type/parser and its fixtures with the required strict
+   normalization receipt.
+2. Add the server-only store with typed errors, safe id/digest paths, exclusive
+   ownership enforcement, stable directory/open-handle checks, canonical JSON,
+   verified hashing, and immutable no-clobber publication.
+3. Add snapshot-first deletion and complete reference accounting under the
+   cross-process mutation lock.
+4. Add the focused adversarial test suite and register it with the app test
+   runner. Keep portable conformance wiring unchanged.
+
+Expected implementation paths are:
+
+- `src/lib/research-resource-contracts.ts`
+- `src/lib/research-resource-contracts.test.ts`
+- `src/lib/server/research-resource-store.ts`
+- `src/lib/server/research-resource-store.test.ts`
+- `scripts/run-tests.mjs`
+
+No file under `schemas/research/v1/`, `src/lib/research-protocol/`, the Context
+Pack store, or a UI surface belongs in A2.
+
+## Verification
+
+Run the focused contract and store tests first, followed by:
+
+```bash
+pnpm test:app
+pnpm test:conformance
+pnpm typecheck
+pnpm lint
+pnpm check:tests-wired
+git diff --check
+```
+
+The review must also confirm that the exact diff contains no portable protocol,
+Context Pack, API, manifest, migration, index, job, embedding, backup, or UI
+change; every snapshot read returns digest-verified bytes; snapshot publication
+is blob-first; and deletion is snapshot-first with a complete fail-closed
+reference proof.
+
+## Rollback
+
+Research Resource feature flags remain default-off. Before any A3 manifest can
+point at these snapshots, reverting A2 removes an unreachable store and contract
+field with no migration. After A3, rollback must preserve the
+`research-resources/` directory as opaque authoritative data; an older build may
+ignore it but must not delete or rewrite it. No rollback path may merge the
+resource CAS into the Context Pack CAS or discard a snapshot merely because its
+blob cannot be verified.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -454,6 +454,7 @@ export const SUITES = {
     "src/lib/server/research-mission-lock.test.ts",
     "src/lib/server/research-generations.test.ts",
     "src/lib/server/research-media-store.test.ts",
+    "src/lib/server/research-resource-store.test.ts",
     "src/lib/research-media-ticket.test.ts",
     "src/lib/server/chat-attachment-store.test.ts",
     "src/lib/server/research-podcast-pipeline.test.ts",

--- a/src/lib/research-resource-contracts.test.ts
+++ b/src/lib/research-resource-contracts.test.ts
@@ -117,6 +117,7 @@ function snapshot() {
     normalizedBlobDigest: DIGEST_A,
     normalizedMediaType: "text/plain; charset=utf-8",
     normalizedBytes: 20,
+    normalizationReceipt: { extractorId: "pdf-text", extractorVersion: "1.4.0" },
     sourceSelector: { type: "pdf-page-span", page: 1, start: 0, end: 10, futureSelectorField: true },
     pageBoundaries: [
       { page: 1, start: 0, end: 10, extractorReceipt: "v1" },
@@ -132,8 +133,16 @@ function snapshot() {
 }
 
 test("snapshot delegates exact selectors to A0 and validates deterministic page boundaries", () => {
-  const parsed = expectOk(parseResourceSnapshotV1(snapshot()));
+  const input = structuredClone(snapshot());
+  const parsed = expectOk(parseResourceSnapshotV1(input));
   assert.equal(parsed.sourceSelector.type, "pdf-page-span");
+  assert.deepEqual(parsed.normalizationReceipt, {
+    extractorId: "pdf-text",
+    extractorVersion: "1.4.0",
+  });
+  (input.normalizationReceipt as { extractorVersion: string }).extractorVersion =
+    "changed-after-parse";
+  assert.equal(parsed.normalizationReceipt.extractorVersion, "1.4.0");
   assert.equal(parsed.sourceSelector.futureSelectorField, true);
   assert.equal(parsed.pageBoundaries?.[0]?.extractorReceipt, "v1");
   assert.equal(parsed.futureSnapshotField, "kept");
@@ -173,6 +182,50 @@ test("snapshot delegates exact selectors to A0 and validates deterministic page 
     parseResourceSnapshotV1({ ...snapshot(), sourceSelector: { type: "pdf-page-span", page: 2, start: 0, end: 11 } }),
     "$.sourceSelector.end",
     "semantic_conflict",
+  );
+  const { normalizationReceipt: _receipt, ...withoutReceipt } = snapshot();
+  expectError(
+    parseResourceSnapshotV1(withoutReceipt),
+    "$.normalizationReceipt",
+    "missing_field",
+  );
+  expectError(
+    parseResourceSnapshotV1({
+      ...snapshot(),
+      normalizationReceipt: { extractorId: " pdf-text", extractorVersion: "1.4.0" },
+    }),
+    "$.normalizationReceipt.extractorId",
+    "invalid_value",
+  );
+  for (const [field, value] of [
+    ["extractorId", ""],
+    ["extractorId", "pdf-text "],
+    ["extractorVersion", ""],
+    ["extractorVersion", " 1.4.0"],
+  ] as const) {
+    expectError(
+      parseResourceSnapshotV1({
+        ...snapshot(),
+        normalizationReceipt: {
+          extractorId: field === "extractorId" ? value : "pdf-text",
+          extractorVersion: field === "extractorVersion" ? value : "1.4.0",
+        },
+      }),
+      `$.normalizationReceipt.${field}`,
+      "invalid_value",
+    );
+  }
+  expectError(
+    parseResourceSnapshotV1({
+      ...snapshot(),
+      normalizationReceipt: {
+        extractorId: "pdf-text",
+        extractorVersion: "1.4.0",
+        localBinaryPath: "/tmp/extractor",
+      },
+    }),
+    "$.normalizationReceipt.localBinaryPath",
+    "invalid_value",
   );
 });
 

--- a/src/lib/research-resource-contracts.ts
+++ b/src/lib/research-resource-contracts.ts
@@ -125,6 +125,11 @@ export type ResourcePageBoundaryV1 = {
   end: number;
 } & UnknownFields;
 
+export type ResourceNormalizationReceiptV1 = {
+  extractorId: string;
+  extractorVersion: string;
+};
+
 export type ResourceSnapshotV1 = {
   version: 1;
   id: string;
@@ -134,6 +139,7 @@ export type ResourceSnapshotV1 = {
   normalizedBlobDigest: string;
   normalizedMediaType: string;
   normalizedBytes: number;
+  normalizationReceipt: ResourceNormalizationReceiptV1;
   sourceSelector: ContextSelectorV1;
   pageBoundaries?: ResourcePageBoundaryV1[];
   fetchedAt?: string;
@@ -535,6 +541,24 @@ function parsePageBoundaries(value: unknown, path: string, normalizedBytes: numb
   return pass(boundaries);
 }
 
+function parseNormalizationReceipt(
+  value: unknown,
+  path: string,
+): ProtocolParseResult<ResourceNormalizationReceiptV1> {
+  const parsedObject = object(value, path); if (!parsedObject.ok) return parsedObject;
+  const raw = parsedObject.value;
+  for (const key of Object.keys(raw)) {
+    if (key !== "extractorId" && key !== "extractorVersion") {
+      return fail("invalid_value", childPath(path, key), `Unknown normalization receipt field ${key}`);
+    }
+  }
+  const extractorIdField = required(raw, "extractorId", path); if (!extractorIdField.ok) return extractorIdField;
+  const extractorId = identifier(extractorIdField.value, childPath(path, "extractorId"), "extractorId"); if (!extractorId.ok) return extractorId;
+  const extractorVersionField = required(raw, "extractorVersion", path); if (!extractorVersionField.ok) return extractorVersionField;
+  const extractorVersion = identifier(extractorVersionField.value, childPath(path, "extractorVersion"), "extractorVersion"); if (!extractorVersion.ok) return extractorVersion;
+  return pass({ extractorId: extractorId.value, extractorVersion: extractorVersion.value });
+}
+
 export function parseResourceSnapshotV1(value: unknown): ProtocolParseResult<ResourceSnapshotV1> {
   const parsedObject = prepare(value, "$"); if (!parsedObject.ok) return parsedObject;
   const raw = parsedObject.value;
@@ -553,6 +577,8 @@ export function parseResourceSnapshotV1(value: unknown): ProtocolParseResult<Res
   const normalizedMediaType = stringValue(mediaField.value, "$.normalizedMediaType", "normalizedMediaType", { nonEmpty: true }); if (!normalizedMediaType.ok) return normalizedMediaType;
   const bytesField = required(raw, "normalizedBytes", "$"); if (!bytesField.ok) return bytesField;
   const normalizedBytes = integer(bytesField.value, "$.normalizedBytes", "normalizedBytes"); if (!normalizedBytes.ok) return normalizedBytes;
+  const receiptField = required(raw, "normalizationReceipt", "$"); if (!receiptField.ok) return receiptField;
+  const normalizationReceipt = parseNormalizationReceipt(receiptField.value, "$.normalizationReceipt"); if (!normalizationReceipt.ok) return normalizationReceipt;
   const selectorField = required(raw, "sourceSelector", "$"); if (!selectorField.ok) return selectorField;
   const sourceSelector = parseContextSelectorV1(selectorField.value, "$.sourceSelector"); if (!sourceSelector.ok) return sourceSelector;
   const pageBoundaries = optional(raw, "pageBoundaries", "$", (item, itemPath) => parsePageBoundaries(item, itemPath, normalizedBytes.value)); if (!pageBoundaries.ok) return pageBoundaries;
@@ -580,7 +606,7 @@ export function parseResourceSnapshotV1(value: unknown): ProtocolParseResult<Res
   const lastModified = optional(raw, "lastModified", "$", (item, itemPath) => stringValue(item, itemPath, "lastModified")); if (!lastModified.ok) return lastModified;
   const createdField = required(raw, "createdAt", "$"); if (!createdField.ok) return createdField;
   const createdAt = utc(createdField.value, "$.createdAt", "createdAt"); if (!createdAt.ok) return createdAt;
-  return pass({ ...raw, version: 1, id: id.value, resourceId: resourceId.value, resourceRevision: resourceRevision.value, normalizedBlobDigest: normalizedBlobDigest.value, normalizedMediaType: normalizedMediaType.value, normalizedBytes: normalizedBytes.value, sourceSelector: sourceSelector.value, createdAt: createdAt.value, ...(rawBlobDigest.value === undefined ? {} : { rawBlobDigest: rawBlobDigest.value }), ...(pageBoundaries.value === undefined ? {} : { pageBoundaries: pageBoundaries.value }), ...(fetchedAt.value === undefined ? {} : { fetchedAt: fetchedAt.value }), ...(finalUrl.value === undefined ? {} : { finalUrl: finalUrl.value }), ...(etag.value === undefined ? {} : { etag: etag.value }), ...(lastModified.value === undefined ? {} : { lastModified: lastModified.value }) });
+  return pass({ ...raw, version: 1, id: id.value, resourceId: resourceId.value, resourceRevision: resourceRevision.value, normalizedBlobDigest: normalizedBlobDigest.value, normalizedMediaType: normalizedMediaType.value, normalizedBytes: normalizedBytes.value, normalizationReceipt: normalizationReceipt.value, sourceSelector: sourceSelector.value, createdAt: createdAt.value, ...(rawBlobDigest.value === undefined ? {} : { rawBlobDigest: rawBlobDigest.value }), ...(pageBoundaries.value === undefined ? {} : { pageBoundaries: pageBoundaries.value }), ...(fetchedAt.value === undefined ? {} : { fetchedAt: fetchedAt.value }), ...(finalUrl.value === undefined ? {} : { finalUrl: finalUrl.value }), ...(etag.value === undefined ? {} : { etag: etag.value }), ...(lastModified.value === undefined ? {} : { lastModified: lastModified.value }) });
 }
 
 export function parseResourceIngestJobV1(value: unknown): ProtocolParseResult<ResourceIngestJobV1> {

--- a/src/lib/server/research-resource-store.test.ts
+++ b/src/lib/server/research-resource-store.test.ts
@@ -1,0 +1,553 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  link,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { ResourceSnapshotV1 } from "../research-resource-contracts.ts";
+import {
+  createResearchResourceStore,
+  ResearchResourceStoreError,
+} from "./research-resource-store.ts";
+
+function digest(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function snapshot(input: {
+  id: string;
+  normalizedBlob: Uint8Array;
+  rawBlob?: Uint8Array;
+  resourceId?: string;
+  resourceRevision?: number;
+}): ResourceSnapshotV1 {
+  return {
+    version: 1,
+    id: input.id,
+    resourceId: input.resourceId ?? "resource_1",
+    resourceRevision: input.resourceRevision ?? 1,
+    ...(input.rawBlob === undefined ? {} : { rawBlobDigest: digest(input.rawBlob) }),
+    normalizedBlobDigest: digest(input.normalizedBlob),
+    normalizedMediaType: "text/plain; charset=utf-8",
+    normalizedBytes: input.normalizedBlob.byteLength,
+    normalizationReceipt: {
+      extractorId: "plain-text",
+      extractorVersion: "1.0.0",
+    },
+    sourceSelector: { type: "whole-resource" },
+    createdAt: "2026-08-27T04:00:00Z",
+  };
+}
+
+async function fixture(
+  operation: (input: { root: string; outside: string }) => Promise<void>,
+): Promise<void> {
+  const parent = await mkdtemp(path.join(tmpdir(), "cave-resource-store-test-"));
+  const root = path.join(parent, "store");
+  const outside = path.join(parent, "outside");
+  await mkdir(outside, { mode: 0o700 });
+  try {
+    await operation({ root, outside });
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+}
+
+function hasStoreCode(code: ResearchResourceStoreError["code"]): (error: unknown) => boolean {
+  return (error: unknown) =>
+    error instanceof ResearchResourceStoreError && error.code === code;
+}
+
+function blobPath(root: string, sha256: string): string {
+  return path.join(root, "blobs", "sha256", sha256.slice(0, 2), sha256);
+}
+
+test("publishes and verifies an immutable snapshot with private storage modes", async () => {
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("normalized research text\n", "utf8");
+    const rawBlob = Buffer.from("RAW research text\r\n", "utf8");
+    const record = snapshot({ id: "snapshot_publish", normalizedBlob, rawBlob });
+    const store = createResearchResourceStore({ root });
+
+    const published = await store.publishSnapshot({
+      snapshot: record,
+      normalizedBlob,
+      rawBlob,
+    });
+    assert.equal(published.created, true);
+    assert.deepEqual(published.snapshot, record);
+
+    const verified = await store.readSnapshot(record.id);
+    assert.deepEqual(verified.snapshot, record);
+    assert.deepEqual(verified.normalizedBlob, new Uint8Array(normalizedBlob));
+    assert.deepEqual(verified.rawBlob, new Uint8Array(rawBlob));
+
+    if (process.platform !== "win32") {
+      for (const directory of [
+        root,
+        path.join(root, "snapshots"),
+        path.join(root, "blobs"),
+        path.join(root, "blobs", "sha256"),
+        path.dirname(blobPath(root, record.normalizedBlobDigest)),
+      ]) {
+        assert.equal((await lstat(directory)).mode & 0o777, 0o700, `${directory} is private`);
+      }
+      for (const file of [
+        path.join(root, "snapshots", `${record.id}.json`),
+        blobPath(root, record.normalizedBlobDigest),
+        blobPath(root, record.rawBlobDigest!),
+      ]) {
+        assert.equal((await lstat(file)).mode & 0o777, 0o600, `${file} is private`);
+      }
+    }
+  });
+});
+
+test("identical publication is idempotent and changed replay is an immutable conflict", async () => {
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("stable bytes", "utf8");
+    const record = snapshot({ id: "snapshot_replay", normalizedBlob });
+    const store = createResearchResourceStore({ root });
+
+    assert.equal((await store.publishSnapshot({ snapshot: record, normalizedBlob })).created, true);
+    const reordered: ResourceSnapshotV1 = {
+      createdAt: record.createdAt,
+      sourceSelector: record.sourceSelector,
+      normalizationReceipt: record.normalizationReceipt,
+      normalizedBytes: record.normalizedBytes,
+      normalizedMediaType: record.normalizedMediaType,
+      normalizedBlobDigest: record.normalizedBlobDigest,
+      resourceRevision: record.resourceRevision,
+      resourceId: record.resourceId,
+      id: record.id,
+      version: record.version,
+    };
+    assert.equal((await store.publishSnapshot({ snapshot: reordered, normalizedBlob })).created, false);
+
+    const changed = { ...record, resourceRevision: record.resourceRevision + 1 };
+    await assert.rejects(
+      () => store.publishSnapshot({ snapshot: changed, normalizedBlob }),
+      hasStoreCode("immutable-conflict"),
+    );
+    assert.equal((await store.readSnapshot(record.id)).snapshot.resourceRevision, 1);
+  });
+});
+
+test("rejects normalized digest and length mismatches plus inconsistent raw receipts", async () => {
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("normalized", "utf8");
+    const rawBlob = Buffer.from("raw", "utf8");
+    const store = createResearchResourceStore({ root });
+
+    const wrongLength = {
+      ...snapshot({ id: "wrong_length", normalizedBlob }),
+      normalizedBytes: normalizedBlob.byteLength + 1,
+    };
+    await assert.rejects(
+      () => store.publishSnapshot({ snapshot: wrongLength, normalizedBlob }),
+      hasStoreCode("digest-mismatch"),
+    );
+
+    const wrongDigest = {
+      ...snapshot({ id: "wrong_digest", normalizedBlob }),
+      normalizedBlobDigest: digest(Buffer.from("different", "utf8")),
+    };
+    await assert.rejects(
+      () => store.publishSnapshot({ snapshot: wrongDigest, normalizedBlob }),
+      hasStoreCode("digest-mismatch"),
+    );
+
+    const expectsRaw = snapshot({ id: "missing_raw", normalizedBlob, rawBlob });
+    await assert.rejects(
+      () => store.publishSnapshot({ snapshot: expectsRaw, normalizedBlob }),
+      hasStoreCode("invalid-snapshot"),
+    );
+
+    const rejectsUnexpectedRaw = snapshot({ id: "unexpected_raw", normalizedBlob });
+    await assert.rejects(
+      () => store.publishSnapshot({
+        snapshot: rejectsUnexpectedRaw,
+        normalizedBlob,
+        rawBlob,
+      }),
+      hasStoreCode("invalid-snapshot"),
+    );
+
+    await assert.rejects(
+      () => store.publishSnapshot({
+        snapshot: expectsRaw,
+        normalizedBlob,
+        rawBlob: Buffer.from("not raw", "utf8"),
+      }),
+      hasStoreCode("digest-mismatch"),
+    );
+  });
+});
+
+test("rejects unsafe snapshot ids on publish, read, and delete", async () => {
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("safe content", "utf8");
+    const store = createResearchResourceStore({ root });
+
+    for (const id of [
+      "../escape",
+      "nested/name",
+      "nested\\name",
+      "CON",
+      "café",
+      `a${"b".repeat(128)}`,
+    ]) {
+      await assert.rejects(
+        () => store.publishSnapshot({ snapshot: snapshot({ id, normalizedBlob }), normalizedBlob }),
+        hasStoreCode("invalid-id"),
+      );
+      await assert.rejects(() => store.readSnapshot(id), hasStoreCode("invalid-id"));
+      await assert.rejects(() => store.deleteSnapshot(id), hasStoreCode("invalid-id"));
+    }
+    for (const id of [" leading", "trailing "]) {
+      await assert.rejects(
+        () => store.publishSnapshot({ snapshot: snapshot({ id, normalizedBlob }), normalizedBlob }),
+        hasStoreCode("invalid-snapshot"),
+      );
+      await assert.rejects(() => store.readSnapshot(id), hasStoreCode("invalid-id"));
+      await assert.rejects(() => store.deleteSnapshot(id), hasStoreCode("invalid-id"));
+    }
+  });
+});
+
+test("refuses broader existing POSIX permissions instead of repairing pathname races", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("POSIX mode bits do not apply on Windows");
+    return;
+  }
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("private bytes", "utf8");
+    const record = snapshot({ id: "snapshot_private", normalizedBlob });
+    const store = createResearchResourceStore({ root });
+    await store.publishSnapshot({ snapshot: record, normalizedBlob });
+
+    await chmod(root, 0o755);
+    await assert.rejects(() => store.readSnapshot(record.id), hasStoreCode("unsafe-path"));
+    assert.equal((await lstat(root)).mode & 0o777, 0o755);
+  });
+});
+
+test("deletion retains shared blobs until the final immutable reference is removed", async () => {
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("shared normalized bytes", "utf8");
+    const rawOne = Buffer.from("raw one", "utf8");
+    const rawTwo = Buffer.from("raw two", "utf8");
+    const first = snapshot({ id: "snapshot_first", normalizedBlob, rawBlob: rawOne });
+    const second = snapshot({
+      id: "snapshot_second",
+      normalizedBlob,
+      rawBlob: rawTwo,
+      resourceRevision: 2,
+    });
+    const store = createResearchResourceStore({ root });
+    await store.publishSnapshot({ snapshot: first, normalizedBlob, rawBlob: rawOne });
+    await store.publishSnapshot({ snapshot: second, normalizedBlob, rawBlob: rawTwo });
+
+    const firstDeletion = await store.deleteSnapshot(first.id);
+    assert.equal(firstDeletion.deleted, true);
+    assert.deepEqual(firstDeletion.removedBlobDigests, [first.rawBlobDigest]);
+    assert.deepEqual((await store.readSnapshot(second.id)).normalizedBlob, new Uint8Array(normalizedBlob));
+    await assert.rejects(() => lstat(blobPath(root, first.rawBlobDigest!)), { code: "ENOENT" });
+    assert.equal((await lstat(blobPath(root, first.normalizedBlobDigest))).isFile(), true);
+
+    const secondDeletion = await store.deleteSnapshot(second.id);
+    assert.equal(secondDeletion.deleted, true);
+    assert.deepEqual(
+      secondDeletion.removedBlobDigests,
+      [second.normalizedBlobDigest, second.rawBlobDigest].sort(),
+    );
+    assert.deepEqual(await store.deleteSnapshot(second.id), {
+      deleted: false,
+      removedBlobDigests: [],
+    });
+  });
+});
+
+test("raw and normalized bytes with one digest use and collect one CAS entry", async () => {
+  await fixture(async ({ root }) => {
+    const bytes = Buffer.from("identical raw and normalized bytes", "utf8");
+    const record = snapshot({ id: "snapshot_one_digest", normalizedBlob: bytes, rawBlob: bytes });
+    const store = createResearchResourceStore({ root });
+
+    await store.publishSnapshot({ snapshot: record, normalizedBlob: bytes, rawBlob: bytes });
+    assert.equal(record.rawBlobDigest, record.normalizedBlobDigest);
+    assert.equal((await lstat(blobPath(root, record.normalizedBlobDigest))).isFile(), true);
+
+    assert.deepEqual(await store.deleteSnapshot(record.id), {
+      deleted: true,
+      removedBlobDigests: [record.normalizedBlobDigest],
+    });
+    await assert.rejects(() => lstat(blobPath(root, record.normalizedBlobDigest)), {
+      code: "ENOENT",
+    });
+  });
+});
+
+test("verified reads reject blob corruption instead of returning untrusted bytes", async () => {
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("original bytes", "utf8");
+    const record = snapshot({ id: "snapshot_corrupt", normalizedBlob });
+    const store = createResearchResourceStore({ root });
+    await store.publishSnapshot({ snapshot: record, normalizedBlob });
+
+    await writeFile(blobPath(root, record.normalizedBlobDigest), Buffer.from("tampered bytes", "utf8"));
+    if (process.platform !== "win32") {
+      await chmod(blobPath(root, record.normalizedBlobDigest), 0o600);
+    }
+    await assert.rejects(
+      () => store.readSnapshot(record.id),
+      hasStoreCode("digest-mismatch"),
+    );
+  });
+});
+
+test("publication refuses a corrupted existing CAS winner and missing blobs fail reads", async () => {
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("winner bytes", "utf8");
+    const record = snapshot({ id: "snapshot_winner", normalizedBlob });
+    const store = createResearchResourceStore({ root });
+    await store.publishSnapshot({ snapshot: record, normalizedBlob });
+
+    await writeFile(blobPath(root, record.normalizedBlobDigest), Buffer.from("corrupt", "utf8"));
+    if (process.platform !== "win32") {
+      await chmod(blobPath(root, record.normalizedBlobDigest), 0o600);
+    }
+    await assert.rejects(
+      () => store.publishSnapshot({ snapshot: record, normalizedBlob }),
+      hasStoreCode("corrupt"),
+    );
+
+    await unlink(blobPath(root, record.normalizedBlobDigest));
+    await assert.rejects(() => store.readSnapshot(record.id), hasStoreCode("missing"));
+  });
+});
+
+test("a malformed sibling snapshot blocks deletion reference accounting", async () => {
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("target bytes", "utf8");
+    const siblingBlob = Buffer.from("sibling bytes", "utf8");
+    const target = snapshot({ id: "snapshot_target", normalizedBlob });
+    const sibling = snapshot({ id: "snapshot_sibling", normalizedBlob: siblingBlob });
+    const store = createResearchResourceStore({ root });
+    await store.publishSnapshot({ snapshot: target, normalizedBlob });
+    await store.publishSnapshot({ snapshot: sibling, normalizedBlob: siblingBlob });
+
+    const siblingPath = path.join(root, "snapshots", `${sibling.id}.json`);
+    await writeFile(siblingPath, "{not-json", { mode: 0o600 });
+    await assert.rejects(
+      () => store.deleteSnapshot(target.id),
+      hasStoreCode("corrupt"),
+    );
+    assert.deepEqual((await store.readSnapshot(target.id)).normalizedBlob, new Uint8Array(normalizedBlob));
+  });
+});
+
+test("refuses symlinked snapshot and blob entries", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("creating symlinks is not reliably available to unprivileged Windows tests");
+    return;
+  }
+  await fixture(async ({ root, outside }) => {
+    const normalizedBlob = Buffer.from("symlink target bytes", "utf8");
+    const record = snapshot({ id: "snapshot_symlink", normalizedBlob });
+    const store = createResearchResourceStore({ root });
+    await store.publishSnapshot({ snapshot: record, normalizedBlob });
+
+    const externalRecord = path.join(outside, "external-record.json");
+    await writeFile(externalRecord, JSON.stringify(record), { mode: 0o600 });
+    const recordPath = path.join(root, "snapshots", `${record.id}.json`);
+    const canonicalRecord = await readFile(recordPath);
+    await unlink(recordPath);
+    await symlink(externalRecord, recordPath);
+    await assert.rejects(() => store.readSnapshot(record.id), hasStoreCode("symlink"));
+
+    await unlink(recordPath);
+    await writeFile(recordPath, canonicalRecord, { mode: 0o600 });
+    const externalBlob = path.join(outside, "external-blob");
+    await writeFile(externalBlob, normalizedBlob, { mode: 0o600 });
+    const storedBlob = blobPath(root, record.normalizedBlobDigest);
+    await unlink(storedBlob);
+    await symlink(externalBlob, storedBlob);
+    await assert.rejects(() => store.readSnapshot(record.id), hasStoreCode("symlink"));
+  });
+});
+
+test("refuses an in-root symlinked blob shard on reads and deletion", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("creating symlinks is not reliably available to unprivileged Windows tests");
+    return;
+  }
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("shard link bytes", "utf8");
+    const record = snapshot({ id: "snapshot_shard_link", normalizedBlob });
+    const store = createResearchResourceStore({ root });
+    await store.publishSnapshot({ snapshot: record, normalizedBlob });
+
+    const shard = path.dirname(blobPath(root, record.normalizedBlobDigest));
+    const movedShard = `${shard}-moved`;
+    await rename(shard, movedShard);
+    await symlink(movedShard, shard);
+
+    await assert.rejects(() => store.readSnapshot(record.id), hasStoreCode("symlink"));
+    await assert.rejects(() => store.deleteSnapshot(record.id), hasStoreCode("symlink"));
+    assert.equal(
+      (await lstat(path.join(root, "snapshots", `${record.id}.json`))).isFile(),
+      true,
+    );
+    assert.equal((await lstat(path.join(movedShard, record.normalizedBlobDigest))).isFile(), true);
+  });
+});
+
+test("refuses multiply-linked snapshot and blob files", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("hard-link permission and volume behavior varies on Windows CI");
+    return;
+  }
+  await fixture(async ({ root, outside }) => {
+    const normalizedBlob = Buffer.from("hard-linked bytes", "utf8");
+    const record = snapshot({ id: "snapshot_hardlink", normalizedBlob });
+    const store = createResearchResourceStore({ root });
+    await store.publishSnapshot({ snapshot: record, normalizedBlob });
+
+    const recordPath = path.join(root, "snapshots", `${record.id}.json`);
+    const recordLink = path.join(outside, "record-link.json");
+    await link(recordPath, recordLink);
+    await assert.rejects(() => store.readSnapshot(record.id), hasStoreCode("unsafe-path"));
+    await unlink(recordLink);
+
+    const storedBlob = blobPath(root, record.normalizedBlobDigest);
+    const blobLink = path.join(outside, "blob-link");
+    await link(storedBlob, blobLink);
+    await assert.rejects(() => store.readSnapshot(record.id), hasStoreCode("unsafe-path"));
+    await assert.rejects(() => store.deleteSnapshot(record.id), hasStoreCode("unsafe-path"));
+    assert.equal(
+      (await lstat(path.join(root, "snapshots", `${record.id}.json`))).isFile(),
+      true,
+    );
+  });
+});
+
+test("copies caller-owned bytes before asynchronous publication", async () => {
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("caller-owned immutable bytes", "utf8");
+    const original = Buffer.from(normalizedBlob);
+    const record = snapshot({ id: "snapshot_caller_mutation", normalizedBlob });
+    const store = createResearchResourceStore({ root });
+
+    const publication = store.publishSnapshot({ snapshot: record, normalizedBlob });
+    normalizedBlob.fill(0x78);
+    await publication;
+
+    assert.deepEqual((await store.readSnapshot(record.id)).normalizedBlob, new Uint8Array(original));
+  });
+});
+
+test("concurrent identical publication creates exactly one immutable record", async () => {
+  await fixture(async ({ root }) => {
+    const normalizedBlob = Buffer.from("concurrent normalized bytes", "utf8");
+    const rawBlob = Buffer.from("concurrent raw bytes", "utf8");
+    const record = snapshot({ id: "snapshot_concurrent", normalizedBlob, rawBlob });
+    const store = createResearchResourceStore({ root });
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        store.publishSnapshot({
+          snapshot: structuredClone(record),
+          normalizedBlob,
+          rawBlob,
+        }),
+      ),
+    );
+    assert.equal(results.filter((result) => result.created).length, 1);
+    assert.equal(results.filter((result) => !result.created).length, 7);
+    assert.deepEqual((await store.readSnapshot(record.id)).snapshot, record);
+
+    const snapshotBytes = await readFile(
+      path.join(root, "snapshots", `${record.id}.json`),
+      "utf8",
+    );
+    assert.equal(JSON.parse(snapshotBytes).id, record.id);
+    for (const directory of [
+      path.join(root, "snapshots"),
+      path.dirname(blobPath(root, record.normalizedBlobDigest)),
+      path.dirname(blobPath(root, record.rawBlobDigest!)),
+    ]) {
+      assert.deepEqual(
+        (await readdir(directory)).filter((name) => name.startsWith(".tmp-")),
+        [],
+      );
+    }
+  });
+});
+
+test("concurrent different snapshots for one id produce one winner and one conflict", async () => {
+  await fixture(async ({ root }) => {
+    const firstBytes = Buffer.from("first contender", "utf8");
+    const secondBytes = Buffer.from("second contender", "utf8");
+    const first = snapshot({ id: "snapshot_race", normalizedBlob: firstBytes });
+    const second = snapshot({
+      id: "snapshot_race",
+      normalizedBlob: secondBytes,
+      resourceRevision: 2,
+    });
+    const store = createResearchResourceStore({ root });
+
+    const settled = await Promise.allSettled([
+      store.publishSnapshot({ snapshot: first, normalizedBlob: firstBytes }),
+      store.publishSnapshot({ snapshot: second, normalizedBlob: secondBytes }),
+    ]);
+    assert.equal(settled.filter((result) => result.status === "fulfilled").length, 1);
+    const rejected = settled.find((result) => result.status === "rejected");
+    assert.ok(rejected?.status === "rejected");
+    assert.equal(hasStoreCode("immutable-conflict")(rejected.reason), true);
+
+    const winner = await store.readSnapshot("snapshot_race");
+    assert.ok(winner.snapshot.resourceRevision === 1 || winner.snapshot.resourceRevision === 2);
+  });
+});
+
+test("refuses symlinked roots and intermediate snapshot directories", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("creating symlinks is not reliably available to unprivileged Windows tests");
+    return;
+  }
+  await fixture(async ({ root, outside }) => {
+    await symlink(outside, root);
+    const bytes = Buffer.from("root link", "utf8");
+    const linkedRootStore = createResearchResourceStore({ root });
+    await assert.rejects(
+      () => linkedRootStore.publishSnapshot({
+        snapshot: snapshot({ id: "snapshot_root_link", normalizedBlob: bytes }),
+        normalizedBlob: bytes,
+      }),
+      hasStoreCode("symlink"),
+    );
+    await unlink(root);
+
+    const store = createResearchResourceStore({ root });
+    const record = snapshot({ id: "snapshot_directory_link", normalizedBlob: bytes });
+    await store.publishSnapshot({ snapshot: record, normalizedBlob: bytes });
+    await rm(path.join(root, "snapshots"), { recursive: true });
+    await symlink(outside, path.join(root, "snapshots"));
+    await assert.rejects(() => store.readSnapshot(record.id), hasStoreCode("symlink"));
+  });
+});

--- a/src/lib/server/research-resource-store.ts
+++ b/src/lib/server/research-resource-store.ts
@@ -1,0 +1,747 @@
+import { constants } from "node:fs";
+import {
+  link,
+  lstat,
+  mkdir,
+  open,
+  opendir,
+  realpath,
+  rm,
+  unlink,
+  type FileHandle,
+} from "node:fs/promises";
+import path from "node:path";
+import { randomBytes } from "node:crypto";
+
+import {
+  parseResourceSnapshotV1,
+  type ResourceSnapshotV1,
+} from "../research-resource-contracts.ts";
+import { canonicalJson, sha256Digest } from "../research-protocol/digest.ts";
+import { caveHome } from "../coven-paths.ts";
+import { assertExclusivePathOwnership } from "./client-v1/path-ownership.ts";
+import { acquireProcessIntentLock } from "./process-intent-lock.ts";
+
+export const MAX_RESEARCH_RESOURCE_BLOB_BYTES = 512 * 1024 * 1024;
+const MAX_SNAPSHOT_RECORD_BYTES = 1024 * 1024;
+const MAX_SNAPSHOT_RECORDS = 100_000;
+const DIRECTORY_MODE = 0o700;
+const FILE_MODE = 0o600;
+const SAFE_STORE_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+const WINDOWS_DEVICE_IDS = /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i;
+
+export type PublishResourceSnapshotInput = {
+  snapshot: ResourceSnapshotV1;
+  normalizedBlob: Uint8Array;
+  rawBlob?: Uint8Array;
+};
+
+export type VerifiedResourceSnapshot = {
+  snapshot: ResourceSnapshotV1;
+  normalizedBlob: Uint8Array;
+  rawBlob?: Uint8Array;
+};
+
+export type ResearchResourceStore = {
+  publishSnapshot(
+    input: PublishResourceSnapshotInput,
+  ): Promise<{ created: boolean; snapshot: ResourceSnapshotV1 }>;
+  readSnapshot(snapshotId: string): Promise<VerifiedResourceSnapshot>;
+  deleteSnapshot(
+    snapshotId: string,
+  ): Promise<{ deleted: boolean; removedBlobDigests: string[] }>;
+};
+
+export class ResearchResourceStoreError extends Error {
+  readonly code:
+    | "invalid-id"
+    | "invalid-snapshot"
+    | "digest-mismatch"
+    | "immutable-conflict"
+    | "missing"
+    | "too-large"
+    | "symlink"
+    | "unsafe-path"
+    | "corrupt";
+
+  constructor(
+    code: ResearchResourceStoreError["code"],
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "ResearchResourceStoreError";
+    this.code = code;
+  }
+}
+
+async function assertSafeOwnership(
+  candidate: string,
+  metadata: Parameters<typeof assertExclusivePathOwnership>[1],
+  label: string,
+): Promise<void> {
+  try {
+    await assertExclusivePathOwnership(candidate, metadata, label);
+  } catch (error) {
+    if (error instanceof ResearchResourceStoreError) throw error;
+    throw new ResearchResourceStoreError(
+      "unsafe-path",
+      `${label} ownership is unsafe`,
+      { cause: error },
+    );
+  }
+}
+
+type PathIdentity = {
+  path: string;
+  dev: number | bigint;
+  ino: number | bigint;
+};
+
+type StoreLayout = {
+  root: PathIdentity;
+  rootRealPath: string;
+  snapshots: PathIdentity;
+  blobs: PathIdentity;
+  sha256: PathIdentity;
+  locks: PathIdentity;
+  intents: PathIdentity;
+};
+
+function pathIdentity(
+  candidate: string,
+  metadata: { dev: number | bigint; ino: number | bigint },
+): PathIdentity {
+  return { path: candidate, dev: metadata.dev, ino: metadata.ino };
+}
+
+function sameIdentity(
+  left: Pick<PathIdentity, "dev" | "ino">,
+  right: Pick<PathIdentity, "dev" | "ino">,
+): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function isContained(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" ||
+    (relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
+}
+
+function assertSnapshotId(value: string): void {
+  if (!SAFE_STORE_ID.test(value) || WINDOWS_DEVICE_IDS.test(value)) {
+    throw new ResearchResourceStoreError(
+      "invalid-id",
+      "snapshot id is not a safe cross-platform store path segment",
+    );
+  }
+}
+
+function assertBlobSize(bytes: Uint8Array, label: string): void {
+  if (bytes.byteLength > MAX_RESEARCH_RESOURCE_BLOB_BYTES) {
+    throw new ResearchResourceStoreError(
+      "too-large",
+      `${label} exceeds the 512 MiB Research Resource blob limit`,
+    );
+  }
+}
+
+function assertPrivateMode(mode: number, expected: number, label: string): void {
+  if (process.platform === "win32") return;
+  if ((mode & 0o777) !== expected) {
+    throw new ResearchResourceStoreError(
+      "unsafe-path",
+      `${label} permissions must be ${expected.toString(8)}`,
+    );
+  }
+}
+
+async function pathMetadata(candidate: string, missingMessage: string) {
+  try {
+    return await lstat(candidate);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new ResearchResourceStoreError("missing", missingMessage);
+    }
+    throw error;
+  }
+}
+
+async function ensureRealDirectory(
+  candidate: string,
+  rootRealPath: string | null,
+  label: string,
+): Promise<PathIdentity> {
+  let created = false;
+  try {
+    await mkdir(candidate, { mode: DIRECTORY_MODE });
+    created = true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  }
+  const before = await pathMetadata(candidate, `${label} directory is missing`);
+  if (before.isSymbolicLink()) {
+    throw new ResearchResourceStoreError("symlink", `${label} directory is a symlink`);
+  }
+  if (!before.isDirectory()) {
+    throw new ResearchResourceStoreError("unsafe-path", `${label} path is not a directory`);
+  }
+  await assertSafeOwnership(candidate, before, `Research Resource ${label} directory`);
+  const resolved = await realpath(candidate);
+  if (rootRealPath !== null && !isContained(rootRealPath, resolved)) {
+    throw new ResearchResourceStoreError("symlink", `${label} directory escapes the store root`);
+  }
+  const after = await lstat(candidate);
+  if (!sameIdentity(before, after)) {
+    throw new ResearchResourceStoreError("symlink", `${label} directory identity changed`);
+  }
+  assertPrivateMode(after.mode, DIRECTORY_MODE, `${label} directory`);
+  if (created) await syncDirectory(path.dirname(candidate));
+  return pathIdentity(candidate, after);
+}
+
+async function assertStableDirectory(entry: PathIdentity, label: string): Promise<void> {
+  const current = await pathMetadata(entry.path, `${label} directory is missing`);
+  if (current.isSymbolicLink() || !current.isDirectory() || !sameIdentity(entry, current)) {
+    throw new ResearchResourceStoreError("symlink", `${label} directory identity changed`);
+  }
+  await assertSafeOwnership(entry.path, current, `Research Resource ${label} directory`);
+  assertPrivateMode(current.mode, DIRECTORY_MODE, `${label} directory`);
+}
+
+function noFollowFlag(): number {
+  return process.platform === "win32" || typeof constants.O_NOFOLLOW !== "number"
+    ? 0
+    : constants.O_NOFOLLOW;
+}
+
+function readFlags(): number {
+  return constants.O_RDONLY | noFollowFlag();
+}
+
+function exclusiveWriteFlags(): number {
+  return constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | noFollowFlag();
+}
+
+async function syncDirectory(directory: string): Promise<void> {
+  let handle: FileHandle | null = null;
+  try {
+    handle = await open(directory, constants.O_RDONLY);
+    await handle.sync();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code ?? "";
+    if (!new Set(["EINVAL", "EISDIR", "ENOTSUP"]).has(code)) throw error;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+async function readSafeFile(input: {
+  target: string;
+  rootRealPath: string;
+  label: string;
+  maxBytes: number;
+}): Promise<Uint8Array> {
+  const before = await pathMetadata(input.target, `${input.label} is missing`);
+  if (before.isSymbolicLink()) {
+    throw new ResearchResourceStoreError("symlink", `${input.label} is a symlink`);
+  }
+  if (!before.isFile()) {
+    throw new ResearchResourceStoreError("unsafe-path", `${input.label} is not a regular file`);
+  }
+  if (before.nlink !== 1) {
+    throw new ResearchResourceStoreError("unsafe-path", `${input.label} must have exactly one link`);
+  }
+  if (before.size > input.maxBytes) {
+    throw new ResearchResourceStoreError("too-large", `${input.label} exceeds its size limit`);
+  }
+  await assertSafeOwnership(input.target, before, `Research Resource ${input.label}`);
+  assertPrivateMode(before.mode, FILE_MODE, input.label);
+  let handle: FileHandle;
+  try {
+    handle = await open(input.target, readFlags());
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+      throw new ResearchResourceStoreError("symlink", `${input.label} is a symlink`);
+    }
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new ResearchResourceStoreError("missing", `${input.label} is missing`);
+    }
+    throw error;
+  }
+  try {
+    const opened = await handle.stat();
+    const after = await pathMetadata(input.target, `${input.label} is missing`);
+    if (
+      !opened.isFile() ||
+      opened.nlink !== 1 ||
+      opened.size > input.maxBytes ||
+      after.isSymbolicLink() ||
+      !after.isFile() ||
+      !sameIdentity(before, opened) ||
+      !sameIdentity(opened, after)
+    ) {
+      throw new ResearchResourceStoreError(
+        "symlink",
+        `${input.label} identity changed while opening`,
+      );
+    }
+    const resolved = await realpath(input.target);
+    if (!isContained(input.rootRealPath, resolved)) {
+      throw new ResearchResourceStoreError("symlink", `${input.label} escapes the store root`);
+    }
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const chunk = Buffer.allocUnsafe(Math.min(64 * 1024, input.maxBytes - total + 1));
+      const { bytesRead } = await handle.read(chunk, 0, chunk.byteLength, null);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > input.maxBytes) {
+        throw new ResearchResourceStoreError(
+          "too-large",
+          `${input.label} exceeds its size limit`,
+        );
+      }
+      chunks.push(chunk.subarray(0, bytesRead));
+    }
+    return new Uint8Array(Buffer.concat(chunks, total));
+  } finally {
+    await handle.close();
+  }
+}
+
+async function writeAll(handle: FileHandle, bytes: Uint8Array): Promise<void> {
+  let offset = 0;
+  while (offset < bytes.byteLength) {
+    const { bytesWritten } = await handle.write(bytes, offset, bytes.byteLength - offset, null);
+    if (bytesWritten <= 0) throw new Error("Research Resource write made no progress");
+    offset += bytesWritten;
+  }
+}
+
+async function publishNoReplace(input: {
+  layout: StoreLayout;
+  directory: PathIdentity;
+  target: string;
+  bytes: Uint8Array;
+  label: string;
+  maxBytes: number;
+  existingMismatchCode: "corrupt" | "immutable-conflict";
+}): Promise<"created" | "existing"> {
+  await assertStableLayout(input.layout);
+  await assertStableDirectory(input.directory, input.label);
+  const temporary = path.join(
+    input.directory.path,
+    `.tmp-${process.pid}-${randomBytes(12).toString("hex")}`,
+  );
+  let handle: FileHandle | null = null;
+  let result: "created" | "existing" = "created";
+  let openedIdentity: Awaited<ReturnType<FileHandle["stat"]>> | null = null;
+  try {
+    handle = await open(temporary, exclusiveWriteFlags(), FILE_MODE);
+    openedIdentity = await handle.stat();
+    const temporaryInfo = await lstat(temporary);
+    if (!openedIdentity.isFile() || !sameIdentity(openedIdentity, temporaryInfo)) {
+      throw new ResearchResourceStoreError("symlink", `${input.label} temporary identity changed`);
+    }
+    await writeAll(handle, input.bytes);
+    await handle.sync();
+    await handle.close();
+    handle = null;
+    await assertStableLayout(input.layout);
+    const closedTemporary = await lstat(temporary);
+    if (!sameIdentity(openedIdentity, closedTemporary)) {
+      throw new ResearchResourceStoreError("symlink", `${input.label} temporary identity changed`);
+    }
+    try {
+      await link(temporary, input.target);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      const existing = await readSafeFile({
+        target: input.target,
+        rootRealPath: input.layout.rootRealPath,
+        label: input.label,
+        maxBytes: input.maxBytes,
+      });
+      if (!Buffer.from(existing).equals(Buffer.from(input.bytes))) {
+        throw new ResearchResourceStoreError(
+          input.existingMismatchCode,
+          `${input.label} already exists with different bytes`,
+        );
+      }
+      result = "existing";
+    }
+  } finally {
+    await handle?.close().catch(() => {});
+    await rm(temporary, { force: true });
+  }
+  if (result === "created") {
+    const published = await pathMetadata(input.target, `${input.label} is missing`);
+    if (!openedIdentity || !sameIdentity(openedIdentity, published) || published.nlink !== 1) {
+      throw new ResearchResourceStoreError("unsafe-path", `${input.label} publication is unsafe`);
+    }
+    await assertSafeOwnership(input.target, published, `Research Resource ${input.label}`);
+    assertPrivateMode(published.mode, FILE_MODE, input.label);
+    await syncDirectory(input.directory.path);
+  }
+  return result;
+}
+
+function parseSnapshot(value: unknown): ResourceSnapshotV1 {
+  const parsed = parseResourceSnapshotV1(value);
+  if (!parsed.ok) {
+    throw new ResearchResourceStoreError(
+      "invalid-snapshot",
+      `${parsed.error.path}: ${parsed.error.message}`,
+    );
+  }
+  assertSnapshotId(parsed.value.id);
+  return parsed.value;
+}
+
+function parseJson(bytes: Uint8Array, label: string): unknown {
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch {
+    throw new ResearchResourceStoreError("corrupt", `${label} is not valid UTF-8 JSON`);
+  }
+}
+
+function snapshotFile(layout: StoreLayout, snapshotId: string): string {
+  assertSnapshotId(snapshotId);
+  return path.join(layout.snapshots.path, `${snapshotId}.json`);
+}
+
+async function assertStableLayout(layout: StoreLayout): Promise<void> {
+  await assertStableDirectory(layout.root, "store root");
+  await assertStableDirectory(layout.snapshots, "snapshots");
+  await assertStableDirectory(layout.blobs, "blobs");
+  await assertStableDirectory(layout.sha256, "sha256 blobs");
+  await assertStableDirectory(layout.locks, "locks");
+  await assertStableDirectory(layout.intents, "lock intents");
+  if ((await realpath(layout.root.path)) !== layout.rootRealPath) {
+    throw new ResearchResourceStoreError("symlink", "store root identity changed");
+  }
+}
+
+async function ensureLayout(root: string): Promise<StoreLayout> {
+  await mkdir(root, { recursive: true, mode: DIRECTORY_MODE });
+  const rootIdentity = await ensureRealDirectory(root, null, "store root");
+  const rootRealPath = await realpath(root);
+  const snapshots = await ensureRealDirectory(path.join(root, "snapshots"), rootRealPath, "snapshots");
+  const blobs = await ensureRealDirectory(path.join(root, "blobs"), rootRealPath, "blobs");
+  const sha256 = await ensureRealDirectory(path.join(root, "blobs", "sha256"), rootRealPath, "sha256 blobs");
+  const locks = await ensureRealDirectory(path.join(root, "locks"), rootRealPath, "locks");
+  const intents = await ensureRealDirectory(path.join(root, "locks", "intents"), rootRealPath, "lock intents");
+  return { root: rootIdentity, rootRealPath, snapshots, blobs, sha256, locks, intents };
+}
+
+async function ensureShard(layout: StoreLayout, digest: string): Promise<PathIdentity> {
+  if (!/^[a-f0-9]{64}$/.test(digest)) {
+    throw new ResearchResourceStoreError("invalid-snapshot", "blob digest is not lowercase SHA-256");
+  }
+  await assertStableLayout(layout);
+  return ensureRealDirectory(
+    path.join(layout.sha256.path, digest.slice(0, 2)),
+    layout.rootRealPath,
+    `blob shard ${digest.slice(0, 2)}`,
+  );
+}
+
+async function existingShard(layout: StoreLayout, digest: string): Promise<PathIdentity> {
+  if (!/^[a-f0-9]{64}$/.test(digest)) {
+    throw new ResearchResourceStoreError("invalid-snapshot", "blob digest is not lowercase SHA-256");
+  }
+  await assertStableLayout(layout);
+  const shardPath = path.join(layout.sha256.path, digest.slice(0, 2));
+  const metadata = await pathMetadata(shardPath, `blob shard ${digest.slice(0, 2)} is missing`);
+  if (metadata.isSymbolicLink()) {
+    throw new ResearchResourceStoreError("symlink", `blob shard ${digest.slice(0, 2)} is a symlink`);
+  }
+  if (!metadata.isDirectory()) {
+    throw new ResearchResourceStoreError("unsafe-path", `blob shard ${digest.slice(0, 2)} is not a directory`);
+  }
+  await assertSafeOwnership(
+    shardPath,
+    metadata,
+    `Research Resource blob shard ${digest.slice(0, 2)} directory`,
+  );
+  const resolved = await realpath(shardPath);
+  if (!isContained(layout.rootRealPath, resolved)) {
+    throw new ResearchResourceStoreError("symlink", `blob shard ${digest.slice(0, 2)} escapes the store root`);
+  }
+  const after = await lstat(shardPath);
+  if (!sameIdentity(metadata, after)) {
+    throw new ResearchResourceStoreError("symlink", `blob shard ${digest.slice(0, 2)} identity changed`);
+  }
+  assertPrivateMode(after.mode, DIRECTORY_MODE, `blob shard ${digest.slice(0, 2)} directory`);
+  return pathIdentity(shardPath, after);
+}
+
+async function publishBlob(layout: StoreLayout, digest: string, bytes: Uint8Array): Promise<void> {
+  assertBlobSize(bytes, "blob");
+  if (sha256Digest(bytes) !== digest) {
+    throw new ResearchResourceStoreError("digest-mismatch", "blob bytes do not match their digest");
+  }
+  const shard = await ensureShard(layout, digest);
+  await publishNoReplace({
+    layout,
+    directory: shard,
+    target: path.join(shard.path, digest),
+    bytes,
+    label: `blob ${digest}`,
+    maxBytes: MAX_RESEARCH_RESOURCE_BLOB_BYTES,
+    existingMismatchCode: "corrupt",
+  });
+}
+
+async function readBlob(layout: StoreLayout, digest: string): Promise<Uint8Array> {
+  const shard = await existingShard(layout, digest);
+  const bytes = await readSafeFile({
+    target: path.join(shard.path, digest),
+    rootRealPath: layout.rootRealPath,
+    label: `blob ${digest}`,
+    maxBytes: MAX_RESEARCH_RESOURCE_BLOB_BYTES,
+  });
+  if (sha256Digest(bytes) !== digest) {
+    throw new ResearchResourceStoreError("digest-mismatch", `blob ${digest} is corrupt`);
+  }
+  await assertStableDirectory(shard, `blob shard ${digest.slice(0, 2)}`);
+  return bytes;
+}
+
+async function readSnapshotRecord(
+  layout: StoreLayout,
+  snapshotId: string,
+  missingAsNull: boolean,
+): Promise<ResourceSnapshotV1 | null> {
+  try {
+    const bytes = await readSafeFile({
+      target: snapshotFile(layout, snapshotId),
+      rootRealPath: layout.rootRealPath,
+      label: `snapshot ${snapshotId}`,
+      maxBytes: MAX_SNAPSHOT_RECORD_BYTES,
+    });
+    const snapshot = parseSnapshot(parseJson(bytes, `snapshot ${snapshotId}`));
+    if (snapshot.id !== snapshotId) {
+      throw new ResearchResourceStoreError("corrupt", "snapshot filename and id do not match");
+    }
+    const canonicalBytes = new TextEncoder().encode(`${canonicalJson(snapshot)}\n`);
+    if (!Buffer.from(bytes).equals(Buffer.from(canonicalBytes))) {
+      throw new ResearchResourceStoreError(
+        "corrupt",
+        `snapshot ${snapshotId} is not canonical immutable JSON`,
+      );
+    }
+    return snapshot;
+  } catch (error) {
+    if (
+      missingAsNull &&
+      error instanceof ResearchResourceStoreError &&
+      error.code === "missing"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function scanSnapshots(layout: StoreLayout): Promise<Map<string, ResourceSnapshotV1>> {
+  await assertStableLayout(layout);
+  const records = new Map<string, ResourceSnapshotV1>();
+  const names: string[] = [];
+  for await (const entry of await opendir(layout.snapshots.path)) {
+    if (names.length >= MAX_SNAPSHOT_RECORDS) {
+      throw new ResearchResourceStoreError(
+        "too-large",
+        `snapshot store exceeds the ${MAX_SNAPSHOT_RECORDS} record scan limit`,
+      );
+    }
+    names.push(entry.name);
+  }
+  for (const name of names.sort()) {
+    if (name.startsWith(".tmp-")) continue;
+    if (!name.endsWith(".json")) {
+      throw new ResearchResourceStoreError("corrupt", `unexpected snapshot entry ${name}`);
+    }
+    const id = name.slice(0, -".json".length);
+    if (!SAFE_STORE_ID.test(id) || WINDOWS_DEVICE_IDS.test(id)) {
+      throw new ResearchResourceStoreError("corrupt", `unsafe snapshot entry ${name}`);
+    }
+    const snapshot = await readSnapshotRecord(layout, id, false);
+    if (!snapshot) throw new ResearchResourceStoreError("corrupt", `snapshot ${id} vanished`);
+    records.set(id, snapshot);
+  }
+  await assertStableDirectory(layout.snapshots, "snapshots");
+  return records;
+}
+
+function referenceCounts(records: Map<string, ResourceSnapshotV1>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const snapshot of records.values()) {
+    const digests = new Set(
+      [snapshot.normalizedBlobDigest, snapshot.rawBlobDigest].filter(Boolean) as string[],
+    );
+    for (const digest of digests) counts.set(digest, (counts.get(digest) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export function createResearchResourceStore(
+  options: { root?: string } = {},
+): ResearchResourceStore {
+  if (options.root !== undefined && !path.isAbsolute(options.root)) {
+    throw new ResearchResourceStoreError("unsafe-path", "Research Resource store root must be absolute");
+  }
+  const root = path.resolve(
+    options.root ?? path.join(/* turbopackIgnore: true */ caveHome(), "research-resources"),
+  );
+
+  const withMutationLock = async <T>(operation: (layout: StoreLayout) => Promise<T>): Promise<T> => {
+    const layout = await ensureLayout(root);
+    const release = await acquireProcessIntentLock({
+      intentsDirectory: layout.intents.path,
+      label: "Research Resource store",
+    });
+    try {
+      await assertStableLayout(layout);
+      return await operation(layout);
+    } finally {
+      await release();
+    }
+  };
+
+  return {
+    async publishSnapshot(input) {
+      const normalizedBlob = new Uint8Array(input.normalizedBlob);
+      const rawBlob = input.rawBlob === undefined ? undefined : new Uint8Array(input.rawBlob);
+      assertBlobSize(normalizedBlob, "normalized blob");
+      if (rawBlob !== undefined) assertBlobSize(rawBlob, "raw blob");
+      const snapshot = parseSnapshot(input.snapshot);
+      if (normalizedBlob.byteLength !== snapshot.normalizedBytes) {
+        throw new ResearchResourceStoreError(
+          "digest-mismatch",
+          "normalized byte length does not match the snapshot",
+        );
+      }
+      if (sha256Digest(normalizedBlob) !== snapshot.normalizedBlobDigest) {
+        throw new ResearchResourceStoreError(
+          "digest-mismatch",
+          "normalized bytes do not match the snapshot digest",
+        );
+      }
+      if ((snapshot.rawBlobDigest === undefined) !== (rawBlob === undefined)) {
+        throw new ResearchResourceStoreError(
+          "invalid-snapshot",
+          "raw blob must be present exactly when rawBlobDigest is present",
+        );
+      }
+      if (
+        snapshot.rawBlobDigest !== undefined &&
+        rawBlob !== undefined &&
+        sha256Digest(rawBlob) !== snapshot.rawBlobDigest
+      ) {
+        throw new ResearchResourceStoreError(
+          "digest-mismatch",
+          "raw bytes do not match the snapshot digest",
+        );
+      }
+      const recordBytes = new TextEncoder().encode(`${canonicalJson(snapshot)}\n`);
+      if (recordBytes.byteLength > MAX_SNAPSHOT_RECORD_BYTES) {
+        throw new ResearchResourceStoreError("too-large", "snapshot record exceeds 1 MiB");
+      }
+
+      return withMutationLock(async (layout) => {
+        const existing = await readSnapshotRecord(layout, snapshot.id, true);
+        if (existing && canonicalJson(existing) !== canonicalJson(snapshot)) {
+          throw new ResearchResourceStoreError(
+            "immutable-conflict",
+            `snapshot ${snapshot.id} already exists with different content`,
+          );
+        }
+        await publishBlob(layout, snapshot.normalizedBlobDigest, normalizedBlob);
+        if (snapshot.rawBlobDigest !== undefined && rawBlob !== undefined) {
+          await publishBlob(layout, snapshot.rawBlobDigest, rawBlob);
+        }
+        const result = await publishNoReplace({
+          layout,
+          directory: layout.snapshots,
+          target: snapshotFile(layout, snapshot.id),
+          bytes: recordBytes,
+          label: `snapshot ${snapshot.id}`,
+          maxBytes: MAX_SNAPSHOT_RECORD_BYTES,
+          existingMismatchCode: "immutable-conflict",
+        });
+        return { created: result === "created", snapshot };
+      });
+    },
+
+    async readSnapshot(snapshotId) {
+      assertSnapshotId(snapshotId);
+      const layout = await ensureLayout(root);
+      await assertStableLayout(layout);
+      const snapshot = await readSnapshotRecord(layout, snapshotId, false);
+      if (!snapshot) throw new ResearchResourceStoreError("missing", `snapshot ${snapshotId} is missing`);
+      const normalizedBlob = await readBlob(layout, snapshot.normalizedBlobDigest);
+      if (normalizedBlob.byteLength !== snapshot.normalizedBytes) {
+        throw new ResearchResourceStoreError(
+          "digest-mismatch",
+          `snapshot ${snapshotId} normalized byte length is corrupt`,
+        );
+      }
+      const rawBlob = snapshot.rawBlobDigest
+        ? await readBlob(layout, snapshot.rawBlobDigest)
+        : undefined;
+      return {
+        snapshot,
+        normalizedBlob,
+        ...(rawBlob === undefined ? {} : { rawBlob }),
+      };
+    },
+
+    async deleteSnapshot(snapshotId) {
+      assertSnapshotId(snapshotId);
+      return withMutationLock(async (layout) => {
+        const records = await scanSnapshots(layout);
+        const target = records.get(snapshotId);
+        if (!target) return { deleted: false, removedBlobDigests: [] };
+        const counts = referenceCounts(records);
+        const current = await readSnapshotRecord(layout, snapshotId, false);
+        if (!current || canonicalJson(current) !== canonicalJson(target)) {
+          throw new ResearchResourceStoreError(
+            "corrupt",
+            `snapshot ${snapshotId} changed during deletion accounting`,
+          );
+        }
+        const candidates = new Set(
+          [target.normalizedBlobDigest, target.rawBlobDigest].filter(Boolean) as string[],
+        );
+        const deletionCandidates: Array<{ digest: string; shard: PathIdentity }> = [];
+        for (const digest of [...candidates].sort()) {
+          if ((counts.get(digest) ?? 0) !== 1) continue;
+          const shard = await existingShard(layout, digest);
+          await readBlob(layout, digest);
+          deletionCandidates.push({ digest, shard });
+        }
+        await assertStableDirectory(layout.snapshots, "snapshots");
+        await unlink(snapshotFile(layout, snapshotId));
+        await syncDirectory(layout.snapshots.path);
+
+        const removedBlobDigests: string[] = [];
+        for (const { digest, shard } of deletionCandidates) {
+          await assertStableDirectory(shard, `blob shard ${digest.slice(0, 2)}`);
+          const targetPath = path.join(shard.path, digest);
+          await unlink(targetPath);
+          await syncDirectory(path.dirname(targetPath));
+          removedBlobDigests.push(digest);
+        }
+        return { deleted: true, removedBlobDigests };
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- define strict normalization receipts for immutable Resource snapshots
- add a private, content-addressed blob store with verified reads, no-clobber publication, and reference-aware deletion
- harden filesystem ownership, permissions, symlink, hard-link, digest, concurrency, and durability boundaries
- document the A2 implementation plan and wire the adversarial store suite into CI

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` (1,887 files wired)
- `pnpm test:app` (1,333 files passed)
- `pnpm test:api` (447 files passed)
- focused Resource store tests (17/17)
- focused Resource contract tests (10/10)
- `git diff --check`

Bead: `cave-6sles.3`