### PR TITLE
fix(desktop): prevent Windows startup 404 after sidecar handoff

### DIFF
--- a/src-tauri/src/sidecar_startup.rs
+++ b/src-tauri/src/sidecar_startup.rs
@@ -716,7 +716,17 @@ fn navigate_sidecar_window(window: &tauri::WebviewWindow, url: Url) -> Result<()
 }
 
 #[cfg(desktop)]
+const SIDECAR_STARTUP_PAGE_PATH: &str = "/startup.html";
+
+#[cfg(desktop)]
 pub(super) fn refreshed_sidecar_window_url(startup_url: &Url, current_url: &Url) -> Url {
+    // The packaged Windows shell starts on a bundled splash page. It is not a
+    // sidecar route, so carrying it into the ready URL turns the first launch
+    // into a request for /startup.html on Next rather than the app root.
+    if current_url.path() == SIDECAR_STARTUP_PAGE_PATH {
+        return startup_url.clone();
+    }
+
     let presentation_query: Vec<_> = current_url
         .query_pairs()
         .filter(|(key, _)| key != "covenCaveToken" && key != "coven_access_token")
@@ -729,6 +739,26 @@ pub(super) fn refreshed_sidecar_window_url(startup_url: &Url, current_url: &Url)
         refreshed.query_pairs_mut().append_pair(&key, &value);
     }
     refreshed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn startup_splash_is_replaced_by_the_sidecar_root() {
+        let startup = Url::parse(
+            "http://127.0.0.1:43123/?covenCaveToken=new-sidecar&coven_access_token=new-mobile",
+        )
+        .unwrap();
+        let current = Url::parse("tauri://localhost/startup.html").unwrap();
+
+        assert_eq!(
+            refreshed_sidecar_window_url(&startup, &current),
+            startup,
+            "the native splash path must not be copied to the authenticated sidecar URL"
+        );
+    }
 }
 
 #[cfg(desktop)]


### PR DESCRIPTION
## Summary

- Keep the packaged Windows startup handoff on the authenticated sidecar root.
- Preserve route and presentation state for already-running windows.
- Add a regression test for the bundled startup splash path.

## Root cause

Version 0.3.11 introduced the multi-window handoff that applied the route-preserving URL helper to the main window. On first Windows launch, the current native URL was tauri://localhost/startup.html, so the ready sidecar URL changed from / to /startup.html. Next has no /startup.html route and returned the observed 404.

## Validation

- cargo test --manifest-path src-tauri/Cargo.toml --locked --lib startup_splash_is_replaced_by_the_sidecar_root — pass
- cargo test --manifest-path src-tauri/Cargo.toml --locked --lib recovery_rotates_auxiliary_window_auth_without_losing_presentation_state — pass
- node --test src-tauri/release-runtime.test.mjs — 25/25 pass
- Full Rust library suite — 228 pass, with two unrelated existing failures: offline_cache::tests::abandoned_foreign_instances_are_reclaimed_and_live_ones_are_not and reliability_metrics::tests::records_are_private_on_unix
- cargo fmt --check reports pre-existing formatting drift in unrelated files; no formatter changes are included

Bead: cave-pqfdn