### PR TITLE
Decode a double-encoded coven so one bead cannot block every creation (cave-7bfpz)

### DIFF
--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -2213,4 +2213,62 @@ await withFixture({}, async (fixture) => {
   assert.equal(report.head, ref.oid);
 });
 
+// cave-7bfpz. A `coven` stored as a JSON STRING on some OTHER bead used to
+// refuse creation for every bead in the checkout.
+//
+// The mechanism: an unreadable coven yields no records, and a record is what
+// carries the branch and path that errors are scoped by (cave-g9byt). With
+// nothing to name, the error lands in `globalErrors` — explicitly the only
+// bucket allowed to abort an operation on someone else's unit — and every
+// `--bead` fails with "lifecycle inventory is incomplete". Observed 2026-08-27
+// on two closed, already-archived beads; it blocked all three live sessions
+// until their records were normalised by hand, which is the one repair the
+// worktree rules forbid.
+//
+// Decoding removes the unreadability rather than reclassifying the error.
+// Reclassifying would have meant ignoring a record that might claim your path;
+// a blob that genuinely cannot be read still fails closed, and still global.
+await withFixture(
+  {
+    issues: [
+      defaultIssue("cave-unit1"),
+      {
+        id: "cave-encoded",
+        status: "closed",
+        title: "Double-encoded record on an unrelated bead",
+        description: "",
+        notes: "",
+        external_ref: null,
+        // The real shape: an extra JSON.stringify around a valid record.
+        metadata: {
+          coven: JSON.stringify({
+            worktree: {
+              branch: "feat/cave-encoded-elsewhere",
+              path: "/nowhere/cave-encoded-elsewhere",
+              owner: "kitty",
+              purpose: "Double encoded fixture",
+              createdAt: "2026-08-01T00:00:00.000Z",
+              disposition: "archive",
+            },
+          }),
+        },
+      },
+    ],
+  },
+  async (fixture) => {
+    const created = runCreate(fixture, createArgs());
+    assert.doesNotMatch(
+      created.stderr,
+      /lifecycle inventory is incomplete/,
+      `a decodable coven on an unrelated bead must not abort creation: ${created.stderr}`,
+    );
+    assert.equal(created.status, 0, `create must succeed: ${created.stderr}`);
+    assert.equal(
+      refState(fixture.repo, "refs/heads/feat/cave-unit1-example") !== null,
+      true,
+      "and the requested branch really exists",
+    );
+  },
+);
+
 console.log("worktree-lifecycle-create.test.mjs: ok");

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -1832,21 +1832,40 @@ function parseStructuredMetadata(
   if (value.coven === undefined || value.coven === null) {
     return { records: [], errors: [] };
   }
-  if (!isRecord(value.coven)) {
+  // A DOUBLE-ENCODED blob is readable, so read it. Some writer stores
+  // `metadata.coven` with an extra JSON.stringify, and the value is then a
+  // string whose contents parse cleanly into the expected object.
+  //
+  // Why that matters far more than the tidiness of it: an unreadable coven
+  // produces no records, and a record is what carries the branch and path that
+  // cave-g9byt scopes errors by. With nothing to name, the error lands in
+  // `globalErrors` and aborts creation for EVERY bead in the checkout — the
+  // cave-l11sw outage, reached by a different road. Observed 2026-08-27: two
+  // closed, already-archived beads refused `--bead` for every live session
+  // until their records were normalised by hand.
+  //
+  // Decoding removes the outage at its source rather than reclassifying the
+  // error, which would have meant ignoring a record that might claim your path.
+  // A blob that genuinely cannot be read still fails closed and still global,
+  // because then nobody can say what it claims.
+  const covenRaw = value.coven;
+  const coven = isRecord(covenRaw) ? covenRaw : decodeDoubleEncodedCoven(covenRaw);
+  if (coven === null) {
     return {
       records: [],
       errors: [`Bead ${taskId} coven metadata: coven must be an object`],
     };
   }
+  const doubleEncoded = !isRecord(covenRaw);
 
   const records: StructuredMetadataRecord[] = [];
   const errors: string[] = [];
   const primaryPresent =
-    value.coven.worktree !== undefined && value.coven.worktree !== null;
+    coven.worktree !== undefined && coven.worktree !== null;
   if (primaryPresent) {
     const primary = parseStructuredRecord(
       taskId,
-      value.coven.worktree,
+      coven.worktree,
       "worktree",
       "primary",
       root,
@@ -1854,16 +1873,16 @@ function parseStructuredMetadata(
     records.push(primary);
   }
 
-  if (value.coven.worktrees !== undefined) {
-    if (!Array.isArray(value.coven.worktrees)) {
+  if (coven.worktrees !== undefined) {
+    if (!Array.isArray(coven.worktrees)) {
       errors.push(`Bead ${taskId} worktrees metadata: worktrees must be an array`);
     } else {
-      if (!primaryPresent && value.coven.worktrees.length > 0) {
+      if (!primaryPresent && coven.worktrees.length > 0) {
         errors.push(
           `Bead ${taskId} worktrees metadata: additional records require a primary worktree`,
         );
       }
-      value.coven.worktrees.forEach((record, index) => {
+      coven.worktrees.forEach((record, index) => {
         const parsed = parseStructuredRecord(
           taskId,
           record,
@@ -1876,7 +1895,31 @@ function parseStructuredMetadata(
     }
   }
 
+  // Deliberately NOT reported as an error on the decoded records. `record.errors`
+  // is not a warning channel: the orphan scan treats ANY record error as
+  // malformed and refuses the record as a clean candidate, so attaching a note
+  // here would silently change how a perfectly readable unit classifies —
+  // trading the outage for a subtler misclassification. Surfacing it properly
+  // needs a warnings channel this type does not have; the writer defect is
+  // tracked separately in cave-7bfpz.
+  void doubleEncoded;
+
   return { records, errors };
+}
+
+/**
+ * Decode a `coven` value that was stored as a JSON string, or null if it is not
+ * one. Only an object is accepted: a string encoding a scalar or an array is
+ * not the metadata shape, so it stays a hard error.
+ */
+function decodeDoubleEncodedCoven(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "string") return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 function fetchTasks(root: string): { tasks: BeadTask[]; error: string | null } {


### PR DESCRIPTION
Some writer stores `metadata.coven` with an extra `JSON.stringify`, leaving a string whose contents parse cleanly into the expected object.

Observed 2026-08-27 on `cave-bnay4` and `cave-16uo9` — both **closed**, both **already archived** — and it refused `beads:worktrees:create` for **every bead in the checkout**, across three live sessions, until the records were normalised by hand. That hand repair is the one the worktree rules forbid, which is what makes this worth fixing at the source.

## Why cave-g9byt didn't already cover it

An unreadable `coven` produces **no records** — and a *record* is what carries the branch and path that errors are scoped by. With nothing to name, the error lands in `globalErrors`, explicitly the only bucket allowed to abort an operation on someone else's unit, so it fails closed across the whole repository.

`cave-g9byt` scoped record-level errors; `cave-1x9pz` scoped four more kinds. Task-level **parse** errors are the case neither covered.

## The fix removes the unreadability, not the error

Reclassifying "coven must be an object" as non-global was the tempting move and it's wrong: it would mean ignoring a record that might claim your path, trading a loud outage for a silent collision. A blob nobody can read still fails closed, and still global. Decoding a *readable* one sidesteps the question entirely — it yields records, which the existing scoping already handles.

## Two things I backed out, deliberately

**A "this was double-encoded" note on `record.errors`,** so the writer defect stayed visible. The orphan scan treats *any* record error as malformed, so the note flipped a perfectly readable unit into a different lane — trading a loud outage for a quiet misclassification. `record.errors` is not a warning channel, and this change doesn't invent one.

**A first test asserting on the patrol's orphaned-metadata report.** It passed with the fix **disabled**, so it proved nothing — the blocking happens in `create`'s inventory gate, not the orphan scan. I removed it rather than keep it for the coverage count.

## Verification

The replacement test sits where the failure actually occurs. **Negative control:** with the decode disabled it fails with the exact production message —

```
lifecycle inventory is incomplete: Bead cave-encoded coven metadata: coven must be an object
```

— and passes with it restored. Full create suite green.

The existing unscoped fixture is untouched: its `coven` is the literal string `"malformed"`, which isn't valid JSON, so it still fails closed exactly as before.

## Still open

The **writer** that double-encodes is not identified here. Both affected beads were last updated the same day with three live sessions running, so it may recur — this change means it degrades to a per-unit problem instead of a checkout-wide outage.

Closes cave-7bfpz.
