### PR TITLE
fix(client-v1): accept canonical encoded HPKE paths

### DIFF
--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -169,12 +169,45 @@ operations require an empty body.
 ### Canonical route and binary AAD
 
 The canonical route mode is `rfc3986-sorted-query-v1`. Cave takes the actual
-request URL, refuses `%` or `\` in the pathname, decodes query names and values
-with `URLSearchParams`, then RFC 3986-encodes each component with uppercase hex,
-`%20` for spaces, and escaping for `!'()*`. Each name and value is encoded before sorting.
-The already-encoded ASCII pairs are sorted by encoded name and
-then encoded value using byte/code-unit order, joined with `=` and `&`, and
-never encoded a second time.
+request URL and validates the serialized `URL.pathname` segment by segment.
+Implementations MUST:
+
+1. Require a leading `/`. `/` is valid; otherwise empty segments, including a
+   trailing empty segment, are invalid.
+2. Split on literal `/` **before** decoding. An encoded slash such as `%2F`
+   therefore remains part of one segment and never becomes a separator.
+3. Percent-decode each segment exactly once as UTF-8. Malformed escapes and
+   invalid UTF-8 are invalid.
+4. Reject a decoded segment equal to `.` or `..`, containing `\`, or containing
+   `%` followed by two ASCII hexadecimal digits. The last rule excludes
+   nested/double-encoded escape spellings while permitting an ordinary literal
+   percent such as the `%25` in `100%25`.
+5. Re-encode the decoded segment from UTF-8, leaving only ASCII letters,
+   digits, `-._~`, and `!'()*` literal. Every other byte is `%HH` with uppercase
+   hexadecimal. The result MUST equal the original serialized segment byte for
+   byte. Thus `%2f`, `%63`, `%21`, and a raw `$` are invalid aliases, while
+   `%2F`, `%20`, `%23`, `%3F`, `%24`, `100%25`, and canonical uppercase UTF-8
+   escapes are valid.
+6. Preserve the validated serialized pathname exactly in the canonical route;
+   do not render it from the decoded value.
+
+This is the language-neutral equivalent of decoding one segment with
+`decodeURIComponent`, rejecting the values above, re-encoding it with
+`encodeURIComponent`, and comparing for exact equality. WHATWG URL parsing
+preserves percent-escape hex case and even a malformed `%` in `pathname`, so
+those spellings remain observable and rejectable. It normalizes literal
+backslashes and whole `.` / `..` segments, including percent-encoded dot
+segments, before `pathname` is observable; producers MUST therefore construct
+paths from canonical encoded segments rather than accept an arbitrary
+pre-parse request-target spelling. Both Cave and SDK consumers bind the
+serialized pathname they actually route.
+
+Query handling is unchanged: decode names and values with `URLSearchParams`,
+then RFC 3986-encode each component with uppercase hex, `%20` for spaces, and
+escaping for `!'()*`. Each name and value is encoded before sorting. The
+already-encoded ASCII pairs are sorted by encoded name and then encoded value
+using byte/code-unit order, joined with `=` and `&`, and never encoded a second
+time.
 
 AAD uses `u32be-length-prefixed-v1`, not JSON. Every variable field is a
 four-byte unsigned big-endian byte length followed by its bytes; `issuedAt` is
@@ -639,28 +672,31 @@ routes because `proxy.ts` gives that family its own hard direct-loopback gate
 than a check inside each handler.
 
 **The poll route did not always re-check, and that gap is what made
-`cave-f1xki` (#4854) exploitable.** `clientV1IngressKind` returns `null` for any
-pathname containing `%` or `\`, while Next still percent-decodes a *dynamic*
-segment before matching it — so a pairing id written with one percent-escaped
-character classified as *not* client-v1 ingress and reached the handler anyway,
-skipping both the direct-loopback branch above and the body rules below. A
-caller already holding the sidecar token or the mobile access credential could
-use that to read `GET /pairing/requests/:id` from **off the machine**, which the
-403 above otherwise forbids. Measured against a production build: the plain path
+`cave-f1xki` (#4854) exploitable.** The old classifier returned `null` for any
+pathname containing `%` or `\`, while Next still percent-decoded a *dynamic*
+segment before matching it. A pairing id written with one percent-escaped
+unreserved character therefore skipped both the direct-loopback branch above
+and the body rules below. A caller already holding the sidecar token or mobile
+access credential could use that to read `GET /pairing/requests/:id` from
+**off the machine**. Measured against a production build: the plain path
 answered `403 forbidden peer` and the percent-written one answered `200` with
 the pairing record.
 
-**Fixed by refusing such a target outright.** `proxy.ts` answers any request
-whose pathname is inside `/api/client/v1` and contains a `%` or a `\` with
+`proxy.ts` still answers a malformed or noncanonical conversation target,
+every backslash-bearing target, and every escaped pairing or admin target with
 
 ```
 400 {"ok":false,"error":"invalid client v1 path"}
 ```
 
-before anything is classified. Nothing a correct client sends is affected: every
-segment of this surface is a fixed literal or a UUID, and the pairing secret
-travels in a header — so no legitimate path needs an escape. Percent-encoding in
-the **query string** is untouched.
+before anything is classified. The narrow exception is a canonical
+percent-encoded segment on
+`/api/client/v1/conversations/:id` or
+`/api/client/v1/conversations/:id/messages`. Conversation IDs can contain `/`,
+`?`, `#`, spaces, and Unicode; those paths are validated with the normative
+algorithm above and classified as authenticated ingress without decoding an
+encoded separator. Pairing/admin IDs remain UUID-only. Percent-encoding in the
+**query string** is untouched.
 
 ⚠️ **In practice only the `%` half of that is a 400 you will ever see.** Measured
 over a real socket by
@@ -676,15 +712,14 @@ normalizing, and removing it would trade a live defence for tidier prose.
 
 The refusal is scoped by path prefix rather than by the ingress lists, so it
 covers the admin family and any dynamic-segmented route added later, including
-one nobody remembers to add to a list. Refusal was chosen over normalizing the
-pathname before classifying it because Next decodes a dynamic segment exactly
-once and does *not* treat a decoded `%2F` as a separator (both measured), so a
-normalizing fix would have to reproduce those rules exactly and keep reproducing
-them across Next versions — while decoding twice would open the `%252e` class
-instead. The poll route's own stamp check, added in the same change, is the
-second layer: no route that serves *user data* takes its locality from the proxy
-branch alone any more. `GET /health` still does, and deliberately — it answers
-the same compatibility envelope to everyone and carries nothing to leak.
+one nobody remembers to add to a list. The validator splits before decoding and
+compares a one-pass decode/re-encode, so `%2F` preserves one dynamic segment
+while `%252F` is refused rather than decoded twice. Non-conversation escaped
+targets remain refused instead of normalized. The poll route's own stamp check
+remains the second layer: no route that serves *user data* takes its locality
+from the proxy branch alone. `GET /health` still does, deliberately — it
+answers the same compatibility envelope to everyone and carries nothing to
+leak.
 
 ### Body and content-type rules on the public routes
 

--- a/docs/superpowers/plans/2026-08-25-client-v1-hpke-bound-authority.md
+++ b/docs/superpowers/plans/2026-08-25-client-v1-hpke-bound-authority.md
@@ -431,13 +431,24 @@ export const CLIENT_V1_HPKE_OPERATION_CREDENTIAL = Object.freeze({
 
 Build the route from the actual request URL, never from caller-supplied JSON:
 
-1. Use `URL.pathname` after the existing proxy refusal of `%` and `\`.
-2. Decode query names and values through `URLSearchParams`.
-3. Re-encode each name/value with RFC 3986 percent encoding: UTF-8, uppercase hex, spaces as `%20`, and `!'()*` percent-escaped.
-4. Sort pairs by encoded name, then encoded value, using ASCII byte order.
-5. Join pairs with `&` and name/value with `=`.
-6. Return `pathname` when no query exists, otherwise `pathname + "?" + query`.
-7. Reject a canonical route longer than 2048 UTF-8 bytes.
+> **2026-08-27 follow-up to #5044:** the original blanket `%` refusal below was
+> not compatible with canonical conversation IDs built with
+> `encodeURIComponent`. The normative implementation now lives in
+> `canonical-path.ts`; this section supersedes the original code sketch.
+
+1. Use the serialized `URL.pathname`.
+2. Require a leading slash and reject empty non-root segments.
+3. Split on literal `/` before decoding. Decode each segment exactly once as
+   UTF-8, reject malformed input, `.`, `..`, decoded `\`, and decoded `%HH`,
+   then re-encode with the exact `encodeURIComponent` literal set and uppercase
+   hex. The re-encoded segment must equal the original byte for byte. Preserve
+   the original validated pathname, including `%2F` within one segment.
+4. Decode query names and values through `URLSearchParams`.
+5. Re-encode each name/value with RFC 3986 percent encoding: UTF-8, uppercase hex, spaces as `%20`, and `!'()*` percent-escaped.
+6. Sort pairs by encoded name, then encoded value, using ASCII byte order.
+7. Join pairs with `&` and name/value with `=`.
+8. Return `pathname` when no query exists, otherwise `pathname + "?" + query`.
+9. Reject a canonical route longer than 2048 UTF-8 bytes.
 
 ```ts
 function rfc3986Component(value: string): string {
@@ -450,9 +461,7 @@ const asciiCompare = (left: string, right: string): number =>
   left < right ? -1 : left > right ? 1 : 0;
 
 export function canonicalClientV1Route(url: URL): string {
-  if (url.pathname.includes("%") || url.pathname.includes("\\")) {
-    throw new Error("Client v1 authority path is not canonical.");
-  }
+  const pathname = canonicalClientV1Pathname(url.pathname);
   const pairs = [...url.searchParams.entries()]
     .map(([name, value]) => [
       rfc3986Component(name),
@@ -464,7 +473,7 @@ export function canonicalClientV1Route(url: URL): string {
         : asciiCompare(leftName, rightName),
     );
   const query = pairs.map(([name, value]) => `${name}=${value}`).join("&");
-  const route = query ? `${url.pathname}?${query}` : url.pathname;
+  const route = query ? `${pathname}?${query}` : pathname;
   if (new TextEncoder().encode(route).byteLength > 2048) {
     throw new Error("Client v1 authority route is too long.");
   }

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -223,8 +223,9 @@ records the gap. Two stand today, both documentation-level — the gates
 themselves hold:
 
 1. **The backslash half of the escaped-target refusal is unreachable.**
-   `docs/api/client-v1.md` says a target inside `/api/client/v1` containing `%`
-   *or* `\` is answered `400 invalid client v1 path`. The `%` half holds. A `\`
+   `docs/api/client-v1.md` says malformed/noncanonical escapes, escaped
+   non-conversation targets, and backslash targets are answered
+   `400 invalid client v1 path`. The observable `%` cases hold. A `\`
    is normalised to `/` by Next in the request target and answered `308` to the
    normalised target before `proxy.ts` runs; that target is not a client-v1
    route and is refused `401`. Nothing is served and no handler is reached, so

--- a/scripts/client-v1-conformance.mjs
+++ b/scripts/client-v1-conformance.mjs
@@ -3091,7 +3091,7 @@ export const FINDINGS = [
   {
     id: "backslash-refusal-is-unreachable",
     where: "docs/api/client-v1.md — Reaching the API at all",
-    says: 'a request target inside /api/client/v1 containing "%" or "\\" is answered 400 {"ok":false,"error":"invalid client v1 path"}',
+    says: 'a malformed/noncanonical escaped target, backslash target, or escaped non-conversation target is answered 400 {"ok":false,"error":"invalid client v1 path"}',
     measured: 'the "%" half holds; a "\\" is normalised to "/" by Next and answered 308 to the normalised target before proxy.ts runs, and that target is then refused 401 by the ordinary gate',
     severity: "documentation",
     why: "no handler is reached and nothing is served, so the gate still holds; the doc describes an answer no client will observe",

--- a/src/app/api/client/v1/conversations/[id]/messages/route.test.ts
+++ b/src/app/api/client/v1/conversations/[id]/messages/route.test.ts
@@ -449,13 +449,13 @@ test("an unprojectable turn answers an envelope, not a Next error page", async (
   });
 });
 
-test("bound messages preserve an encoded slash, query punctuation, spaces, and Unicode", async () => {
+test("bound messages preserve encoded query punctuation, spaces, and Unicode", async () => {
   const root = await mkdtemp(scratchPrefix);
   try {
     await withClientV1HpkeRouteTestAuthority(
       { instanceId: INSTANCE_ID, now: BOUND_NOW, seed: 91 },
       async (authority) => {
-        const conversationId = "conversation/one?# with snow 雪";
+        const conversationId = "conversation one?# with snow 雪";
         const encodedPath =
           `/api/client/v1/conversations/${encodeURIComponent(conversationId)}/messages`;
         const boundConversation: ConversationFile = {

--- a/src/app/api/client/v1/conversations/[id]/messages/route.test.ts
+++ b/src/app/api/client/v1/conversations/[id]/messages/route.test.ts
@@ -449,12 +449,19 @@ test("an unprojectable turn answers an envelope, not a Next error page", async (
   });
 });
 
-test("bound messages encrypt results and reject downgrade or AAD drift before stores, budgets, and sources", async () => {
+test("bound messages preserve an encoded slash, query punctuation, spaces, and Unicode", async () => {
   const root = await mkdtemp(scratchPrefix);
   try {
     await withClientV1HpkeRouteTestAuthority(
       { instanceId: INSTANCE_ID, now: BOUND_NOW, seed: 91 },
       async (authority) => {
+        const conversationId = "conversation/one?# with snow 雪";
+        const encodedPath =
+          `/api/client/v1/conversations/${encodeURIComponent(conversationId)}/messages`;
+        const boundConversation: ConversationFile = {
+          ...BRANCHED,
+          sessionId: conversationId,
+        };
         const runtime = createClientV1Runtime({
           authority: authority.runtime,
           credentialRoot: root,
@@ -486,17 +493,17 @@ test("bound messages encrypt results and reject downgrade or AAD drift before st
           sources({
             loadConversation: async (id) => {
               sourceCalls += 1;
-              return id === "conversation-1" ? BRANCHED : null;
+              return id === conversationId ? boundConversation : null;
             },
           }),
         );
 
         const downgrade = await handler(
           request(
-            "conversation-1",
+            conversationId,
             { authorization: ["Bearer", issued.bearer].join(" ") },
           ),
-          context("conversation-1"),
+          context(conversationId),
         );
         assert.equal(downgrade.status, 426);
         assert.deepEqual({ findCalls, chargeCalls, sourceCalls }, {
@@ -510,7 +517,7 @@ test("bound messages encrypt results and reject downgrade or AAD drift before st
           instanceId: INSTANCE_ID,
           runtimeNonce: authority.runtimeNonce,
           operation: "messages.list",
-          url: "http://127.0.0.1:3020/api/client/v1/conversations/conversation-1/messages",
+          url: `http://127.0.0.1:3020${encodedPath}`,
           method: "GET",
           issuedAt: BOUND_NOW,
           requestNonce: new Uint8Array(32).fill(16),
@@ -520,7 +527,7 @@ test("bound messages encrypt results and reject downgrade or AAD drift before st
         headers.set(LOCAL_PEER_HEADER, STAMP);
         const valid = await handler(
           new Request(prepared.request, { headers }),
-          context("conversation-1"),
+          context(conversationId),
         );
         assert.equal(valid.status, 200);
         assert.equal(
@@ -535,6 +542,7 @@ test("bound messages encrypt results and reject downgrade or AAD drift before st
           }).data.messages.map(({ id }) => id),
           ["t1", "t3", "t4"],
         );
+        assert.equal(new URL(prepared.request.url).pathname, encodedPath);
         assert.deepEqual({ findCalls, chargeCalls, sourceCalls }, {
           findCalls: 1,
           chargeCalls: 1,
@@ -549,7 +557,7 @@ test("bound messages encrypt results and reject downgrade or AAD drift before st
         const beforeAadDrift = { findCalls, chargeCalls, sourceCalls };
         const wrongAad = await handler(
           new Request(prepared.request, { headers: aadHeaders }),
-          context("conversation-1"),
+          context(conversationId),
         );
         assert.equal(wrongAad.status, 400);
         assert.deepEqual(

--- a/src/app/api/client/v1/conversations/[id]/route.test.ts
+++ b/src/app/api/client/v1/conversations/[id]/route.test.ts
@@ -274,12 +274,24 @@ test("an unauthenticated probe cannot learn whether a conversation exists", asyn
   });
 });
 
-test("bound conversation detail encrypts the result and rejects downgrade or query drift before stores, budgets, and sources", async () => {
+test("bound conversation detail preserves an encoded slash, query punctuation, spaces, and Unicode", async () => {
   const root = await mkdtemp(scratchPrefix);
   try {
     await withClientV1HpkeRouteTestAuthority(
       { instanceId: INSTANCE_ID, now: BOUND_NOW, seed: 81 },
       async (authority) => {
+        const conversationId = "conversation/one?# with snow 雪";
+        const encodedPath =
+          `/api/client/v1/conversations/${encodeURIComponent(conversationId)}`;
+        const boundLedger: ConversationSummary[] = [
+          ...LEDGER,
+          {
+            sessionId: conversationId,
+            familiarId: "scribe",
+            createdAt: "2026-08-07T00:00:00.000Z",
+            updatedAt: "2026-08-08T00:00:00.000Z",
+          },
+        ];
         const runtime = createClientV1Runtime({
           authority: authority.runtime,
           credentialRoot: root,
@@ -311,17 +323,17 @@ test("bound conversation detail encrypts the result and rejects downgrade or que
           sources({
             listConversations: async () => {
               sourceCalls += 1;
-              return LEDGER;
+              return boundLedger;
             },
           }),
         );
 
         const downgrade = await handler(
           request(
-            "conversation-1",
+            conversationId,
             { authorization: ["Bearer", issued.bearer].join(" ") },
           ),
-          context("conversation-1"),
+          context(conversationId),
         );
         assert.equal(downgrade.status, 426);
         assert.deepEqual({ findCalls, chargeCalls, sourceCalls }, {
@@ -335,7 +347,7 @@ test("bound conversation detail encrypts the result and rejects downgrade or que
           instanceId: INSTANCE_ID,
           runtimeNonce: authority.runtimeNonce,
           operation: "conversations.read",
-          url: "http://127.0.0.1:3020/api/client/v1/conversations/conversation-1",
+          url: `http://127.0.0.1:3020${encodedPath}`,
           method: "GET",
           issuedAt: BOUND_NOW,
           requestNonce: new Uint8Array(32).fill(15),
@@ -345,7 +357,7 @@ test("bound conversation detail encrypts the result and rejects downgrade or que
         headers.set(LOCAL_PEER_HEADER, STAMP);
         const valid = await handler(
           new Request(prepared.request, { headers }),
-          context("conversation-1"),
+          context(conversationId),
         );
         assert.equal(valid.status, 200);
         assert.equal(
@@ -358,8 +370,9 @@ test("bound conversation detail encrypts the result and rejects downgrade or que
           (JSON.parse(new TextDecoder().decode(opened.body)) as {
             data: { conversation: { id: string } };
           }).data.conversation.id,
-          "conversation-1",
+          conversationId,
         );
+        assert.equal(new URL(prepared.request.url).pathname, encodedPath);
         assert.deepEqual({ findCalls, chargeCalls, sourceCalls }, {
           findCalls: 1,
           chargeCalls: 1,
@@ -369,10 +382,10 @@ test("bound conversation detail encrypts the result and rejects downgrade or que
         const beforeQueryDrift = { findCalls, chargeCalls, sourceCalls };
         const wrongQuery = await handler(
           new Request(
-            "http://127.0.0.1:3020/api/client/v1/conversations/conversation-1?limit=1",
+            `http://127.0.0.1:3020${encodedPath}?limit=1`,
             { headers },
           ),
-          context("conversation-1"),
+          context(conversationId),
         );
         assert.equal(wrongQuery.status, 400);
         assert.deepEqual(

--- a/src/app/api/client/v1/conversations/[id]/route.test.ts
+++ b/src/app/api/client/v1/conversations/[id]/route.test.ts
@@ -274,13 +274,13 @@ test("an unauthenticated probe cannot learn whether a conversation exists", asyn
   });
 });
 
-test("bound conversation detail preserves an encoded slash, query punctuation, spaces, and Unicode", async () => {
+test("bound conversation detail preserves encoded query punctuation, spaces, and Unicode", async () => {
   const root = await mkdtemp(scratchPrefix);
   try {
     await withClientV1HpkeRouteTestAuthority(
       { instanceId: INSTANCE_ID, now: BOUND_NOW, seed: 81 },
       async (authority) => {
-        const conversationId = "conversation/one?# with snow 雪";
+        const conversationId = "conversation one?# with snow 雪";
         const encodedPath =
           `/api/client/v1/conversations/${encodeURIComponent(conversationId)}`;
         const boundLedger: ConversationSummary[] = [

--- a/src/lib/server/client-v1/auth.test.ts
+++ b/src/lib/server/client-v1/auth.test.ts
@@ -478,6 +478,30 @@ test("client-v1 request-targets carrying an escape are refused, not classified",
   }
 });
 
+test("canonical encoded conversation ids remain authenticated ingress", () => {
+  for (const id of [
+    "conversation/one?#",
+    "conversation with spaces",
+    "会話-雪-☃️",
+  ]) {
+    for (const suffix of ["", "/messages"]) {
+      const pathname =
+        `/api/client/v1/conversations/${encodeURIComponent(id)}${suffix}`;
+      assert.equal(isClientV1Path(pathname), true, pathname);
+      assert.equal(isRefusedClientV1Path(pathname), false, pathname);
+      assert.equal(clientV1IngressKind(pathname), "authenticated", pathname);
+    }
+  }
+});
+
+test("raw URL path punctuation cannot alias its canonical encoded conversation id", () => {
+  for (const id of ["$value", "value:part", "value@host", "a+b=c&d"]) {
+    const pathname = `/api/client/v1/conversations/${id}`;
+    assert.equal(isRefusedClientV1Path(pathname), true, pathname);
+    assert.equal(clientV1IngressKind(pathname), null, pathname);
+  }
+});
+
 test("the client-v1 escape refusal is scoped to the client-v1 path prefix", () => {
   // An escape outside this surface is none of the refusal's business — every
   // other API family accepts encoded path segments, and widening the refusal to

--- a/src/lib/server/client-v1/authority-runtime.test.ts
+++ b/src/lib/server/client-v1/authority-runtime.test.ts
@@ -172,19 +172,20 @@ async function createBoundClient(input: {
   bootstrap: ClientV1AuthorityBootstrap;
   operation?: ClientV1Operation;
   authorization?: ClientV1HpkeAuthorization;
+  url?: string;
   issuedAt?: number;
   body?: Uint8Array;
   requestNonceByte?: number;
 }): Promise<ClientV1HpkeTestClient> {
   const operation = input.operation ?? "projects.list";
-  const { method, url } = operationRequestDetails(operation);
+  const details = operationRequestDetails(operation);
   return createClientV1HpkeTestClient({
     authority: publicAuthority(input.bootstrap),
     instanceId: TEST_INSTANCE_ID,
     runtimeNonce: base64UrlEncode(input.bootstrap.runtimeNonce),
     operation,
-    url,
-    method,
+    url: input.url ?? details.url,
+    method: details.method,
     ...(input.body === undefined ? {} : { body: input.body }),
     issuedAt: input.issuedAt ?? TEST_NOW,
     requestNonce: new Uint8Array(32).fill(input.requestNonceByte ?? 7),
@@ -385,6 +386,55 @@ test("advertise permits only an unmarked legacy fallback and enforce requires bi
     ),
   );
   assert.equal(invocations, 1);
+});
+
+test("enforce dispatches canonical encoded conversation paths without changing their bytes", async () => {
+  const bootstrap = await createBootstrap("enforce", 21);
+  const authority = withBootstrap(bootstrap, () =>
+    createClientV1AuthorityRuntimeFromGlobal({ now: () => TEST_NOW }));
+  const cases = [
+    {
+      id: "conversation/one?#",
+      operation: "conversations.read" as const,
+      suffix: "",
+    },
+    {
+      id: "conversation with spaces",
+      operation: "messages.list" as const,
+      suffix: "/messages",
+    },
+    {
+      id: "会話-雪-☃️",
+      operation: "conversations.read" as const,
+      suffix: "",
+    },
+  ];
+
+  for (const [index, item] of cases.entries()) {
+    const pathname =
+      `/api/client/v1/conversations/${encodeURIComponent(item.id)}${item.suffix}`;
+    const client = await createBoundClient({
+      bootstrap,
+      operation: item.operation,
+      url: `http://127.0.0.1:3020${pathname}`,
+      requestNonceByte: 70 + index,
+    });
+    let invocations = 0;
+    const response = await authority.handle({
+      operation: item.operation,
+      request: client.request,
+      invoke: async (authorizedRequest) => {
+        invocations += 1;
+        assert.equal(new URL(authorizedRequest.url).pathname, pathname);
+        return Response.json({ id: item.id });
+      },
+    });
+    assert.equal(invocations, 1, item.id);
+    assert.deepEqual(await openJson(client, response), {
+      status: 200,
+      body: { id: item.id },
+    });
+  }
 });
 
 test("present non-exact authority markers fail fixed before callbacks in advertise and enforce", async () => {

--- a/src/lib/server/client-v1/canonical-path.ts
+++ b/src/lib/server/client-v1/canonical-path.ts
@@ -1,0 +1,37 @@
+function invalidPath(): Error {
+  return new Error("Client v1 authority path is not canonical.");
+}
+
+export function canonicalClientV1Pathname(pathname: string): string {
+  if (
+    !pathname.startsWith("/")
+    || pathname.includes("\\")
+  ) {
+    throw invalidPath();
+  }
+  if (pathname === "/") return pathname;
+
+  const segments = pathname.slice(1).split("/");
+  if (segments.some((segment) => segment.length === 0)) {
+    throw invalidPath();
+  }
+
+  for (const segment of segments) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      throw invalidPath();
+    }
+    if (
+      decoded === "."
+      || decoded === ".."
+      || /%[0-9A-Fa-f]{2}/u.test(decoded)
+      || decoded.includes("\\")
+      || encodeURIComponent(decoded) !== segment
+    ) {
+      throw invalidPath();
+    }
+  }
+  return pathname;
+}

--- a/src/lib/server/client-v1/hpke-bound-v1.test.ts
+++ b/src/lib/server/client-v1/hpke-bound-v1.test.ts
@@ -16,6 +16,7 @@ import {
   type ClientV1HpkeAuthorization,
   type ClientV1HpkeBinding,
 } from "./authority-contract.ts";
+import { canonicalClientV1Pathname } from "./canonical-path.ts";
 import {
   CLIENT_V1_HPKE_REQUEST_INFO,
   CLIENT_V1_HPKE_RESPONSE_INFO,
@@ -313,7 +314,7 @@ test("canonicalizes query pairs by deterministic encoded wire order", () => {
       + "&z=plain",
   );
   assert.throws(
-    () => canonicalClientV1Route(new URL("http://127.0.0.1:3020/api/%25")),
+    () => canonicalClientV1Route(new URL("http://127.0.0.1:3020/api/%252F")),
     /path is not canonical/u,
   );
   assert.throws(
@@ -322,6 +323,110 @@ test("canonicalizes query pairs by deterministic encoded wire order", () => {
         new URL(`http://127.0.0.1:3020/${"a".repeat(2050)}`),
       ),
     /route is too long/u,
+  );
+});
+
+test("preserves canonical encoded pathname segments without decoding separators", () => {
+  const cases = [
+    {
+      id: "conversation/one?#",
+      pathname:
+        "/api/client/v1/conversations/conversation%2Fone%3F%23",
+    },
+    {
+      id: "conversation with spaces",
+      pathname:
+        "/api/client/v1/conversations/conversation%20with%20spaces",
+    },
+    {
+      id: "会話-雪-☃️",
+      pathname:
+        "/api/client/v1/conversations/"
+        + "%E4%BC%9A%E8%A9%B1-%E9%9B%AA-%E2%98%83%EF%B8%8F",
+    },
+    {
+      id: "$value!",
+      pathname: "/api/client/v1/conversations/%24value!",
+    },
+    {
+      id: "100% ready",
+      pathname: "/api/client/v1/conversations/100%25%20ready",
+    },
+  ] as const;
+
+  for (const { id, pathname } of cases) {
+    const url = new URL(
+      `http://127.0.0.1:3020/api/client/v1/conversations/${encodeURIComponent(id)}`,
+    );
+    assert.equal(url.pathname, pathname, id);
+    assert.equal(canonicalClientV1Route(url), pathname, id);
+  }
+});
+
+test("rejects malformed, noncanonical, nested, and backslash pathname escapes", () => {
+  for (const pathname of [
+    "/api/client/v1/conversations/conversation%2fone",
+    "/api/client/v1/conversations/conversation%3fone",
+    "/api/client/v1/conversations/%e4%bc%9a%e8%a9%b1",
+    "/api/client/v1/conversations/conversation%2Done",
+    "/api/client/v1/conversations/%21",
+    "/api/client/v1/conversations/$value",
+    "/api/client/v1/conversations/conversation%252Fone",
+    "/api/client/v1/conversations/conversation%255Cone",
+    "/api/client/v1/conversations/conversation%5Cone",
+    "/api/client/v1/conversations/conversation%",
+    "/api/client/v1/conversations/conversation%GG",
+    "/api/client/v1/conversations/%E9",
+  ]) {
+    assert.throws(
+      () =>
+        canonicalClientV1Route(
+          new URL(`http://127.0.0.1:3020${pathname}`),
+        ),
+      /path is not canonical/u,
+      pathname,
+    );
+  }
+});
+
+test("rejects raw dot segments and empty path aliases before routing", () => {
+  for (const pathname of [
+    "api/client/v1/projects",
+    "/api/client/v1/",
+    "/api//client/v1/projects",
+    "/api/client/v1/conversations/.",
+    "/api/client/v1/conversations/..",
+    "/api/client/v1/conversations/%2E",
+    "/api/client/v1/conversations/%2e%2E",
+  ]) {
+    assert.throws(
+      () => canonicalClientV1Pathname(pathname),
+      /path is not canonical/u,
+      pathname,
+    );
+  }
+});
+
+test("WHATWG preserves escape spelling but normalizes slash, backslash, and dot aliases", () => {
+  assert.equal(
+    new URL("http://127.0.0.1:3020/a/%2f/%2F/%c3%a9/%C3%A9").pathname,
+    "/a/%2f/%2F/%c3%a9/%C3%A9",
+  );
+  assert.equal(
+    new URL("http://127.0.0.1:3020/a\\b").pathname,
+    "/a/b",
+  );
+  assert.equal(
+    new URL("http://127.0.0.1:3020/a/%2E/b").pathname,
+    "/a/b",
+  );
+  assert.equal(
+    new URL("http://127.0.0.1:3020/a/%2e%2e/b").pathname,
+    "/b",
+  );
+  assert.equal(
+    new URL("http://127.0.0.1:3020/a/value%2Fpart/b").pathname,
+    "/a/value%2Fpart/b",
   );
 });
 

--- a/src/lib/server/client-v1/hpke-bound-v1.ts
+++ b/src/lib/server/client-v1/hpke-bound-v1.ts
@@ -20,6 +20,7 @@ import {
   type ClientV1HpkeBoundResponseEnvelope,
   type ClientV1HpkeBoundResponsePlaintext,
 } from "./authority-contract.ts";
+import { canonicalClientV1Pathname } from "./canonical-path.ts";
 
 const UTF8 = new TextEncoder();
 const UTF8_FATAL = new TextDecoder("utf-8", { fatal: true });
@@ -163,9 +164,7 @@ function asciiCompare(left: string, right: string): number {
 }
 
 export function canonicalClientV1Route(url: URL): string {
-  if (url.pathname.includes("%") || url.pathname.includes("\\")) {
-    throw new Error("Client v1 authority path is not canonical.");
-  }
+  const pathname = canonicalClientV1Pathname(url.pathname);
   const pairs = [...url.searchParams.entries()]
     .map(([name, value]) => [
       rfc3986Component(name),
@@ -177,7 +176,7 @@ export function canonicalClientV1Route(url: URL): string {
         : asciiCompare(leftName, rightName),
     );
   const query = pairs.map(([name, value]) => `${name}=${value}`).join("&");
-  const route = query ? `${url.pathname}?${query}` : url.pathname;
+  const route = query ? `${pathname}?${query}` : pathname;
   if (
     UTF8.encode(route).byteLength
     > CLIENT_V1_HPKE_LIMITS.canonicalRouteBytes

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -10,6 +10,7 @@
 // imports are type-only and therefore erased), so pulling it in here costs the
 // proxy no runtime dependency.
 import { CLIENT_V1_PUBLIC_ROUTES } from "./lib/server/client-v1/contract.ts";
+import { canonicalClientV1Pathname } from "./lib/server/client-v1/canonical-path.ts";
 
 export function timingSafeEqualString(a: string, b: string) {
   const encoder = new TextEncoder();
@@ -192,47 +193,6 @@ export function isClientV1Path(pathname: string) {
 }
 
 /**
- * True for a Client v1 request-target proxy() must refuse outright (cave-f1xki,
- * #4854).
- *
- * The defect: Next does not route a `%` in a static segment, but it DOES route
- * one in a dynamic segment — it percent-decodes the segment for `[id]` matching
- * while middleware still reads the raw `%` in `nextUrl.pathname`. So
- * `GET /api/client/v1/pairing/requests/<uuid with %34>` reached the handler
- * while classifying as *not* client-v1 ingress, which skipped the direct-
- * loopback gate AND the 411/413/64 KiB body rules, both of which hang off that
- * classification. Measured against a production build: the plain path answered
- * `403 forbidden peer` to a forwarded caller holding the sidecar token, and the
- * percent-written one answered `200` with the pairing record.
- *
- * Refusal rather than normalization, deliberately:
- *
- *   - Decoding is the thing that would have to be exactly right. Next decodes a
- *     segment ONCE (`%2534` arrives at the route as `%34`, measured) and does
- *     NOT treat a decoded `%2F` as a separator (`aaa%2Fbbb` routes as ONE `[id]`
- *     segment, measured). A classifier that decoded the whole pathname would
- *     split that into two segments and go on returning null — the same hole —
- *     and a classifier that decoded twice would open the `%252e` class instead.
- *     Refusing decodes nothing, so it stays correct without tracking Next's
- *     decoding rules across versions.
- *   - No legitimate client needs it. Every Client v1 path segment is either a
- *     fixed literal or a UUID (`parseClientV1PairingRequestId`), and the pairing
- *     secret travels in a header, so nothing a real client sends contains a `%`
- *     or a `\`.
- *   - It generalises. The check is scoped by PREFIX, not by the two ingress
- *     lists, so it covers admin and any future dynamic-segmented route the day
- *     that route lands — including one nobody remembers to add to a list. Fixing
- *     only the classifier would have left `/api/client/v1/admin/*` (which
- *     classifies null by design) and every unlisted path exactly as they were.
- *   - `\` earns the same treatment for the same reason: never legitimate, and
- *     leaving it to classify null was the other half of the same silent bail.
- */
-export function isRefusedClientV1Path(pathname: string) {
-  return isClientV1Path(pathname)
-    && (pathname.includes("%") || pathname.includes("\\"));
-}
-
-/**
  * True for the Client v1 administrative family — the credential list, the
  * pairing-approval queue, and the decisions taken on it.
  */
@@ -327,15 +287,32 @@ export const CLIENT_V1_AUTHENTICATED_PATHS: RegExp[] = [
   "/api/client/v1/conversations/:id/messages",
 ].map(clientV1PathPattern);
 
+/**
+ * True for a Client v1 request target proxy() must refuse outright.
+ *
+ * Pairing and admin IDs remain UUID-only. Conversation IDs may require one
+ * canonical encodeURIComponent-style pass, so only those authenticated route
+ * patterns accept validated escapes. Everything malformed, aliased, nested, or
+ * backslash-bearing still fails before ingress classification.
+ */
+export function isRefusedClientV1Path(pathname: string) {
+  if (!isClientV1Path(pathname)) return false;
+  if (pathname.includes("\\")) return true;
+  if (
+    CLIENT_V1_AUTHENTICATED_PATHS.some((pattern) => pattern.test(pathname))
+  ) {
+    try {
+      canonicalClientV1Pathname(pathname);
+      return false;
+    } catch {
+      return true;
+    }
+  }
+  return pathname.includes("%");
+}
+
 export function clientV1IngressKind(pathname: string): ClientV1IngressKind | null {
-  // Kept, and no longer load-bearing. proxy() refuses such a target through
-  // isRefusedClientV1Path before it ever asks for a classification, so this
-  // line is now the second of two layers rather than the only one. It stays
-  // because dropping it would make a classifier that someone calls from a new
-  // site silently PROMOTE an escaped path into the public set — `%2534` in an
-  // id already matches the `[^/]+` id pattern by raw bytes — which is the one
-  // direction a bail-out to null must never take.
-  if (pathname.includes("%") || pathname.includes("\\")) return null;
+  if (isRefusedClientV1Path(pathname)) return null;
   if (CLIENT_V1_PUBLIC_PATHS.some((pattern) => pattern.test(pathname))) {
     return CLIENT_V1_PUBLIC_INGRESS;
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -339,14 +339,10 @@ export async function proxy(req: NextRequest) {
     process.env.COVEN_CAVE_TAILNET_PEER_SECRET,
   );
   const tailnetPeerVerified = tailnetNodeId !== null;
-  // A Client v1 request-target carrying a percent-escape or a backslash is
-  // refused before anything is classified (cave-f1xki, #4854). It cannot be a
-  // real client — every segment of this surface is a fixed literal or a UUID —
-  // and leaving it to the classifier is exactly how it slipped the gate: the
-  // classifier answered null, so the direct-loopback branch and the
-  // 411/413/64 KiB body rules below, which both hang off a non-null answer,
-  // never ran. See isRefusedClientV1Path for why this refuses rather than
-  // normalizes.
+  // Reject noncanonical conversation path spellings and every escaped
+  // pairing/admin target before classification (cave-f1xki, #4854).
+  // Canonically encoded conversation IDs are the narrow exception; the helper
+  // validates them before the authenticated matcher can apply the gates below.
   if (isRefusedClientV1Path(req.nextUrl.pathname)) {
     return jsonError(400, "invalid client v1 path");
   }


### PR DESCRIPTION
## Summary

- replace the HPKE blanket `%` pathname rejection with strict one-pass segment validation
- preserve canonical encoded path bytes (including `%2F`) for routing and AAD while rejecting malformed, lowercase/noncanonical, nested, backslash, dot, and raw punctuation aliases
- admit only validated encoded conversation detail/message paths through Client v1 ingress; pairing/admin escape refusal remains fail-closed
- document the language-neutral JS/Rust algorithm without changing query canonicalization or the default authority mode

Follow-up to #5044 and #4996.

## Canonical pathname contract

Split the serialized pathname on literal `/` before decoding. Decode each segment exactly once as UTF-8, reject malformed input, `.`, `..`, backslash, and decoded `%HH`, then re-encode with the exact `encodeURIComponent` literal set and uppercase hex. Require byte-for-byte equality and bind the original validated pathname, so encoded `/` remains segment data rather than a separator.

## Validation

- strict RED/GREEN coverage for `conversation/one?#`, spaces, Unicode, literal percent, uppercase escapes, malformed/lowercase/noncanonical/nested escapes, backslash, dot, and empty-segment aliases
- 5 focused HPKE/runtime/ingress/conversation test files
- complete 40-file Client v1/API slice
- Client v1 doc/conformance/takeover contract tests
- typecheck, lint, test wiring, production build and budget checks
- real enforce-mode conversation detail/messages proof over a production server
- real authority takeover proof (all five assertions)
- contract/vector exporters `--check`

Full `test:api` was attempted but stopped before the Client v1 files on unrelated `scripts/worktree-guard.test.mjs` environment failures. The complete Client v1 slice passed independently.

## Artifacts

No fixture/vector bytes changed:

- contract: `1b78125dab5b77414efd2d34e13315f542b197715ed26c6521f588e299abe61d`
- HPKE vectors: `f806967291de12175277b6b24ac3c7bba912ae760fd8227fb21b1a4d5f5e6797`
