### PR TITLE
fix(lifecycle): tolerate WSL clock regression

### DIFF
--- a/scripts/local-maintenance-gate.mjs
+++ b/scripts/local-maintenance-gate.mjs
@@ -108,12 +108,13 @@ const MUTATION_LOCK_POLL_MS = 10;
 const MUTATION_LOCK_WAIT_MS = 1_000;
 const GATE_CLEANUP_TIMEOUT_MS = 5_000;
 // WSL can step CLOCK_REALTIME backwards while synchronizing with the host. The
-// lifecycle-create baseline measured repeated 1.32s corrections; treating each
-// one as tampering aborted owned lifecycle transactions, including compensation
-// paths. This tolerance is deliberately small relative to the two-minute
-// writer lease: larger/future-dated records still fail closed, and tolerated
+// lifecycle-create baseline measured repeated 1.32s corrections, and the WSL
+// host has since produced a measured 2.936s correction. Treating either as
+// tampering aborts owned lifecycle transactions, including compensation paths.
+// Five seconds remains deliberately small relative to the two-minute writer
+// lease: materially future-dated records still fail closed, and tolerated
 // corrections never move a persisted heartbeat backwards.
-const MAX_TRANSIENT_CLOCK_REGRESSION_MS = 2_000;
+const MAX_TRANSIENT_CLOCK_REGRESSION_MS = 5_000;
 
 /** Synchronous sleep without CPU spin (callers are sync CLI/hook processes). */
 function sleepSync(ms) {

--- a/scripts/local-maintenance-gate.test.mjs
+++ b/scripts/local-maintenance-gate.test.mjs
@@ -648,6 +648,38 @@ test("owner capability holds through postconditions and dies on tampering, expir
   rmSync(repo, { recursive: true, force: true });
 });
 
+test("a bounded WSL-sized clock correction remains live but a material future timestamp fails closed", (t) => {
+  const fixedNow = Date.now();
+  t.mock.method(Date, "now", () => fixedNow);
+  const repo = makeRepo();
+  const root = maintenanceGateRoot(repo);
+  const acquired = acquireMaintenanceGate({ ownerId: "clock-boundary", repoDir: repo, ttlMs: 60_000 });
+  assert.equal(acquired.ok, true);
+  const gateFile = path.join(root, "gate.json");
+  const original = JSON.parse(readFileSync(gateFile, "utf8"));
+  const correctionMs = 3_500;
+  const acceptedFutureHeartbeat = new Date(Date.now() + correctionMs).toISOString();
+  writeJsonAtomic(gateFile, { ...original, heartbeatAt: acceptedFutureHeartbeat });
+  assert.equal(
+    heartbeatMaintenanceGate(acquired.handle).ok,
+    true,
+    "the observed WSL-sized correction keeps the current owner live",
+  );
+  const accepted = JSON.parse(readFileSync(gateFile, "utf8"));
+  assert.ok(
+    Date.parse(accepted.heartbeatAt) >= Date.parse(acceptedFutureHeartbeat),
+    "a tolerated correction never moves the heartbeat backwards",
+  );
+  // Leave margin for filesystem work between sampling the clock and verifying
+  // the record: this proves a material future timestamp still fails closed
+  // without making the boundary assertion depend on scheduler latency.
+  const rejectedFutureHeartbeat = new Date(Date.now() + 7_000).toISOString();
+  writeJsonAtomic(gateFile, { ...accepted, heartbeatAt: rejectedFutureHeartbeat });
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).reason, "clock-regressed");
+  assert.equal(heartbeatMaintenanceGate(acquired.handle).reason, "heartbeat-regressed");
+  rmSync(repo, { recursive: true, force: true });
+});
+
 test("a fenced owner cannot overwrite a successful stale takeover", async () => {
   const repo = makeRepo();
   const root = maintenanceGateRoot(repo);
@@ -1092,7 +1124,7 @@ test("concurrent multi-process acquisition: exactly one winner", async () => {
   rmSync(repo, { recursive: true, force: true });
 });
 
-test("writer lease heartbeat keeps a long-running mutation live", async () => {
+test("writer lease heartbeat keeps a long-running mutation live", async (t) => {
   const gate = await import("./local-maintenance-gate.mjs");
   assert.equal(typeof gate.heartbeatWriterIntent, "function", "writer leases need a token-fenced heartbeat");
 
@@ -1102,7 +1134,9 @@ test("writer lease heartbeat keeps a long-running mutation live", async () => {
   assert.equal(gate.heartbeatWriterIntent(intent.lease).ok, true);
   const intentFile = intentFileForLease(intent.lease);
   const heartbeated = JSON.parse(readFileSync(intentFile, "utf8"));
-  const boundedFutureHeartbeat = new Date(Date.now() + 500).toISOString();
+  const fixedNow = Date.now();
+  t.mock.method(Date, "now", () => fixedNow);
+  const boundedFutureHeartbeat = new Date(Date.now() + 3_500).toISOString();
   writeFileSync(
     intentFile,
     JSON.stringify({

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -297,7 +297,7 @@ esac
   executable(
     path.join(bin, "coven"),
     `#!/usr/bin/env node
-const { readFileSync, writeFileSync } = require("node:fs");
+const { readFileSync, renameSync, writeFileSync } = require("node:fs");
 const path = require("node:path");
 const stateFile = path.join(__dirname, "..", "state", "coven-maintenance.json");
 const state = (() => {
@@ -373,6 +373,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -464,6 +465,16 @@ function snapshotIntents(state) {
     : [];
   state.intentSnapshots.push(intents);
 }
+function advanceLocalGateHeartbeat(state) {
+  if (process.env.CAVE_TEST_ADVANCE_LOCAL_GATE_HEARTBEAT_ONCE !== "1" || state.localClockStep) return;
+  const gatePath = path.join(state.repo, ".git", "coven-maintenance-gate", "gate.json");
+  const gate = JSON.parse(readFileSync(gatePath, "utf8"));
+  const heartbeatAt = new Date(Date.now() + 3_500).toISOString();
+  const temporary = gatePath + ".fixture-clock-step-" + process.pid;
+  writeFileSync(temporary, JSON.stringify({ ...gate, heartbeatAt }));
+  renameSync(temporary, gatePath);
+  state.localClockStep = { heartbeatAt };
+}
 function sabotageRelease(state) {
   if (!state.config.releaseSabotage) return;
   const covenState = path.join(path.dirname(state.repo), "state", "coven-maintenance.json");
@@ -489,6 +500,7 @@ if (command === "show") {
     state.counts.show += 1;
     const issue = exactIssue(state, id);
     if (!issue) return { missing: true };
+    advanceLocalGateHeartbeat(state);
     if (state.config.mutateAtShow === state.counts.show) mutateIssue(state, issue);
     return {
       fail: state.config.showAlwaysFail ||
@@ -1133,6 +1145,26 @@ await withFixture({}, async (fixture) => {
     readJson(fixture.stateFile).counts.show,
     4,
     "successful persistence must be verified with an exact Bead reread",
+  );
+});
+
+await withFixture({}, async (fixture) => {
+  const result = runCreate(
+    fixture,
+    createArgs({ branch: "feat/cave-unit1-wsl-clock-step" }),
+    { CAVE_TEST_ADVANCE_LOCAL_GATE_HEARTBEAT_ONCE: "1" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const state = readJson(fixture.stateFile);
+  assert.match(
+    state.localClockStep?.heartbeatAt ?? "",
+    /^\d{4}-\d{2}-\d{2}T/,
+    "fixture advances the real local gate heartbeat after acquisition and before heartbeatBoth",
+  );
+  const covenFence = readJson(fixture.covenStateFile);
+  assert.ok(
+    covenFence.events.includes("heartbeat"),
+    "lifecycle-create heartbeats the stepped local fence rather than bypassing it",
   );
 });
 


### PR DESCRIPTION
## Summary
- tolerate bounded WSL CLOCK_REALTIME corrections up to five seconds in the local maintenance gate
- retain monotonic heartbeats and fail-closed handling for material future timestamps
- add deterministic local-gate and lifecycle-create regression coverage

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test:app (1344 files)
- pnpm test:api (447 files)
- pnpm check:tests-wired
- node scripts/local-maintenance-gate.test.mjs (32/32)
- node scripts/worktree-lifecycle-create.test.mjs
- git diff --check

Tracks Bead cave-xdrwo.