### PR TITLE
Retile the Settings About links grid so every track fills

### DIFF
--- a/src/components/settings-about.test.ts
+++ b/src/components/settings-about.test.ts
@@ -116,14 +116,41 @@ test("About follows the revised handoff artwork and full-width release rail", ()
   );
 });
 
-test("About podcast fills the default four-column row remainder", () => {
+test("About podcast closes the default three-column grid", () => {
+  // Four columns did not divide six cards: the three small links filled three
+  // of four and podcast's span-2 left two more tracks empty, so the section
+  // ended on a ragged column of holes. Dense flow could not fix it — podcast
+  // needs two adjacent tracks and only one was ever free.
   const defaultCss =
     css.split("@container settings-about (max-width: 55rem)")[0] ?? "";
 
   assert.match(
     defaultCss,
-    /\.settings-about-link-card--podcast\s*\{[^}]*grid-column:\s*span 2;/,
+    /\.settings-about-link-card--podcast\s*\{[\s\S]*?grid-column:\s*span 3;/,
   );
+  assert.match(
+    defaultCss,
+    /\.settings-about-link-card--grimoire\s*\{[\s\S]*?grid-column:\s*span 2;/,
+  );
+});
+
+test("About has exactly six link cards, which is what the grid is sized for", () => {
+  // The 3-column grid closes every row only because the count is 2+1, 1+1+1, 3.
+  // A seventh card would silently reopen the gap this layout exists to close,
+  // and the section header says "6 places" out loud.
+  for (const modifier of ["grimoire", "github", "podcast"]) {
+    assert.ok(
+      component.includes(`settings-about-link-card--${modifier}`),
+      `${modifier} card is declared inline`,
+    );
+  }
+  const smallLinks = /const SMALL_LINKS[^=]*=\s*\[([\s\S]*?)\n\];/.exec(component)?.[1] ?? "";
+  assert.equal(
+    (smallLinks.match(/label:/g) ?? []).length,
+    3,
+    "docs, X and discord come from SMALL_LINKS",
+  );
+  assert.match(component, /6 places/, "and the section header still says six");
 });
 
 test("About podcast shares the intermediate two-column row", () => {
@@ -143,7 +170,7 @@ test("About podcast shares the intermediate two-column row", () => {
 test("About CSS follows the token, focus, motion, and narrow-pane contracts", () => {
   assert.match(css, /\.settings-about\s*\{[\s\S]*container-type:\s*inline-size/);
   assert.match(css, /\.settings-about-control-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(2/);
-  assert.match(css, /\.settings-about-links-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(4/);
+  assert.match(css, /\.settings-about-links-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(3/);
   assert.match(css, /@container settings-about/);
   assert.match(css, /@media \(prefers-reduced-motion:\s*reduce\)/);
   assert.match(css, /var\(--accent-presence\)/);

--- a/src/styles/settings-about.css
+++ b/src/styles/settings-about.css
@@ -359,9 +359,18 @@
   min-width: 0;
 }
 
+/* Three columns, not four, because there are exactly SIX cards and four does
+   not divide them: Docs/X/Discord filled three of four and Podcast spanned two
+   of the remaining four, so the section ended on a ragged pair of holes down
+   the right-hand side. `grid-auto-flow: dense` cannot rescue that — Podcast
+   needs two adjacent tracks and only one was ever free.
+
+   At three, every row closes: Grimoire(2)+GitHub(1), then the three small
+   cards, then Podcast across the full width. The card count is asserted in
+   settings-about.test.ts so a seventh link cannot silently reopen the gap. */
 .settings-about-links-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   grid-auto-flow: dense;
   grid-auto-rows: minmax(8rem, auto);
   gap: var(--space-2);
@@ -432,7 +441,7 @@
 }
 
 .settings-about-link-card--grimoire {
-  grid-column: span 3;
+  grid-column: span 2;
   grid-row: span 2;
   min-height: 20rem;
   justify-content: flex-end;
@@ -619,7 +628,9 @@
 }
 
 .settings-about-link-card--podcast {
-  grid-column: span 2;
+  /* Full width: it is the last row, and a row card with a trailing action reads
+     better across the whole measure than stranded beside empty tracks. */
+  grid-column: span 3;
   min-height: 10rem;
   flex-direction: row;
   align-items: flex-end;


### PR DESCRIPTION
The About links grid was `repeat(4, minmax(0, 1fr))` holding exactly six cards whose spans cannot tile four columns:

| card | old span |
|---|---|
| Grimoire | 3 cols, 2 rows |
| GitHub | 1 col, 2 rows |
| Docs / X / Discord | 1 col each |
| Podcast | 2 cols |

Row three filled three of four tracks and the Podcast row filled two of four, leaving a ragged pair of holes down the right-hand side. `grid-auto-flow: dense` could not rescue it — Podcast needs two **adjacent** free tracks and only one was ever free.

**Three columns tile the same six cards exactly:** Grimoire(2)+GitHub(1), then Docs/X/Discord, then Podcast across the full width.

### Measured in the running app

At 1440px the grid now reports three 364.66px tracks with rows of `737+365`, `365+365+365`, and `1110` — every track filled, no gaps. Screenshot confirmed against the reported surface.

Both container-query breakpoints (`55rem` → 2 columns, `36rem` → 1 column) already collapsed coherently and are unchanged.

### The card count is now asserted

The tiling only works for six cards — a seventh silently reopens the same holes — so the count is pinned in `settings-about.test.ts`.

Both new guards were checked against a **negative control**: reverting the column count to 4 fails one test, and adding a seventh `SMALL_LINKS` entry fails the other. Neither guard is vacuous.

### Validation

`typecheck` · `lint` · `settings-about.test.ts` 12/12 · `design-token-drift` · `css-module-order` · `build` (bundle budget within)