### PR TITLE
Thin the desktop menu-bar icon strip and even its spacing

### DIFF
--- a/src/components/acting-familiar-gate.test.ts
+++ b/src/components/acting-familiar-gate.test.ts
@@ -278,10 +278,18 @@ assert.match(
   /case "\/new":[\s\S]{0,80}startWorkspaceChat\(\)/,
   "the slash-command blank chat uses shell context",
 );
-assert.ok(
-  (workspaceSource.match(/onOpenQuickChat=\{startWorkspaceChat\}/g) ?? []).length === 2,
-  "both desktop and mobile quick-chat controls use shell context",
-);
+// One, not two, since cave-l9slw removed the desktop menu bar's New chat
+// trigger; the mobile top bar is the only chrome control left. The invariant is
+// unchanged and is what the count enforces: EVERY onOpenQuickChat handed to
+// chrome is startWorkspaceChat, so no control can route around the actor gate.
+{
+  const wired = (workspaceSource.match(/onOpenQuickChat=\{startWorkspaceChat\}/g) ?? []).length;
+  const total = (workspaceSource.match(/onOpenQuickChat=\{/g) ?? []).length;
+  assert.ok(
+    wired === 1 && total === wired,
+    `the surviving quick-chat control uses shell context and no other handler is wired (${wired} via startWorkspaceChat of ${total} total)`,
+  );
+}
 assert.doesNotMatch(
   workspaceSource,
   /startFamiliarChat\(activeId\)/,

--- a/src/components/board-enrich-steps.test.ts
+++ b/src/components/board-enrich-steps.test.ts
@@ -37,10 +37,14 @@ assert.match(
   "Desktop menu bar should accept the enrich action and progress state",
 );
 
+// The trailing "…next to Tasks" clause is gone with the Tasks button itself
+// (cave-l9slw). What this assertion was actually protecting — Enhance is
+// conditional, wired to onEnrichTasks, and DISABLED without a selected familiar
+// — is unchanged and is what remains pinned here.
 assert.match(
   menuBar,
-  /onEnrichTasks \? \([\s\S]*onClick=\{onEnrichTasks\}[\s\S]*disabled=\{enrichingTasks \|\| !activeFamiliarId\}[\s\S]*aria-label=\{enrichingTasks[\s\S]*\{enrichingTasks \? enrichLabel : "Enhance"\}[\s\S]*onClick=\{onViewTasks\}/,
-  "Desktop menu bar should place Enhance next to Tasks and disable it without a selected familiar",
+  /onEnrichTasks \? \([\s\S]*onClick=\{onEnrichTasks\}[\s\S]*disabled=\{enrichingTasks \|\| !activeFamiliarId\}[\s\S]*aria-label=\{enrichingTasks[\s\S]*\{enrichingTasks \? enrichLabel : "Enhance"\}/,
+  "Desktop menu bar should render Enhance and disable it without a selected familiar",
 );
 
 assert.match(

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -81,15 +81,21 @@ assert.doesNotMatch(
   /computePresence\(|<FamiliarAvatar/,
   "presence/avatar computation does not live in the menu bar",
 );
-assert.match(
+// cave-l9slw: New chat no longer opens this cluster. It was one of six ways to
+// start a chat on desktop, and the bar is for destinations that have no other
+// desktop home. Assert the removal is COMPLETE — a stale trigger attribute or
+// an unused ⌘J hint left behind is the failure mode worth catching.
+assert.doesNotMatch(
   source,
-  /data-quick-chat-trigger[\s\S]{0,180}onClick=\{onOpenQuickChat\}[\s\S]{0,180}aria-label=\{NEW_CHAT_LABEL\}/,
-  "the menu bar keeps a shell-owned New chat action",
+  /data-quick-chat-trigger|onOpenQuickChat|NEW_CHAT_LABEL/,
+  "the menu bar carries no New chat trigger, prop, or label",
 );
-assert.match(
+// Targets the derivation, not the string: the file's prose still names ⌘J when
+// explaining where New chat went, and that reference is the point.
+assert.doesNotMatch(
   source,
-  /const newChatShortcut = platformizeHint\("⌘J", keys\);[\s\S]*title=\{`\$\{NEW_CHAT_LABEL\} \(\$\{newChatShortcut\}\)`\}/,
-  "the menu bar platformizes the New chat shortcut hint",
+  /newChatShortcut|platformizeHint\("⌘J"/,
+  "the ⌘J hint derivation went with the button rather than lingering unused",
 );
 assert.match(
   source,
@@ -107,51 +113,43 @@ assert.match(
   "the menu bar exposes Settings through the existing shell handler",
 );
 
-// Right group — tasks. A Tasks button (board) and a Schedules button, each
-// with a live count badge that is hidden at zero.
-assert.match(
+// cave-l9slw: the right group is down to Enhance and Settings. Tasks went
+// because the sidebar navigation already carries it as a labelled destination
+// (id "board", ⌘3) — this was a second, icon-only route to the same board, and
+// its badge duplicated the sidebar row's badge from the same source.
+assert.doesNotMatch(
   source,
-  /className="menu-bar__task focus-ring"[\s\S]*onClick=\{onViewTasks\}/,
-  "the Tasks button jumps to the board",
+  /onViewTasks|taskCount|TASKS_LABEL|ph:kanban|workspacePageDefinition\("board"\)/,
+  "the menu bar carries no Tasks button, count, label, or registry lookup",
 );
-assert.match(
+// cave-l9slw: the Rituals button is gone from this bar. The surface it landed
+// on (workspace mode "inbox" — calendar + crons) is unchanged and still reached
+// from the home dashboard, the mobile bottom tabs, the ⌘K palette and the tray.
+// Assert the removal is complete, including the needs-you count it badged: a
+// prop still threaded in to feed a button that no longer exists is dead wiring.
+assert.doesNotMatch(
   source,
-  /workspacePageDefinition\("board"\)/,
-  "Tasks naming comes from the shared page registry",
+  /onViewSchedules|scheduleNeedsCount|RITUALS_LABEL|ph:calendar-check/,
+  "the menu bar carries no Rituals button, badge count, or label",
 );
-assert.match(
-  source,
-  /taskCount > 0 \? <span className="menu-bar__badge">\{fmtBadge\(taskCount\)\}<\/span> : null/,
-  "the Tasks badge shows the open-task count and hides at zero",
-);
-// The old "Inbox" button was dishonest: workspace mode "inbox" IS the
-// Schedules surface (calendar + crons) and no dedicated inbox surface exists
-// (inbox items live in the notification bell). The button now says what it
-// does: Schedules, calendar icon, schedule needs-you badge.
-assert.match(
-  source,
-  /onClick=\{onViewSchedules\}/,
-  "the Schedules button jumps to the Schedules surface",
-);
-assert.match(
-  source,
-  /aria-label=\{scheduleNeedsCount > 0 \? `View rituals — \$\{scheduleNeedsCount\} need attention` : "View rituals"\}/,
-  "the Rituals button is announced as rituals, not inbox",
-);
-assert.match(
-  source,
-  /<Icon name="ph:calendar-check"[\s\S]{0,160}<span className="menu-bar__task-label">\{RITUALS_LABEL\}<\/span>/,
-  "the Rituals button matches the sidebar's Rituals label + icon (label CSS-demoted in the seamless bar; aria-label carries the name)",
-);
+// Still true, and still worth pinning: whatever this bar does carry must not
+// claim to be an Inbox, because no inbox surface exists to land on (inbox
+// items live in the notification bell).
 assert.doesNotMatch(
   source,
   /"View inbox"|<span>Inbox<\/span>|ph:tray/,
   "no top-bar control claims to be an Inbox — there is no inbox surface to land on",
 );
-assert.match(
+// Both counter buttons are gone, so this cluster no longer counts anything.
+// `menu-bar__badge` survives as a class — the workspace-owned running-sessions
+// control still uses it — but nothing in THIS file may render one, and the
+// fmtBadge helper that capped them went rather than lingering without a caller.
+// Targets rendered markup and the declaration, not the words: the comment
+// above the cluster names fmtBadge while explaining why it went.
+assert.doesNotMatch(
   source,
-  /scheduleNeedsCount > 0 \? \(\s*<span className="menu-bar__badge">/,
-  "the Schedules badge matches the Tasks badge chrome (no alert tint) and hides at zero",
+  /className="menu-bar__badge"|function fmtBadge|fmtBadge\(/,
+  "the menu bar renders no count badge and keeps no orphaned badge formatter",
 );
 // The running-processes control is workspace-owned (it needs the sessions
 // state and chat navigation): the bar renders it as the `runningStatus` slot
@@ -240,20 +238,26 @@ assert.match(
 
 // Wiring in the workspace: the bar mounts in the Shell topBar slot with the
 // real scope/navigation handlers and live counts.
-assert.match(
+// Bounded to the element: workspace still hands taskCount/onViewTasks to OTHER
+// components (the status rail, the mobile top bar), so an unbounded search
+// would find those and this assertion would never fail.
+assert.doesNotMatch(
   workspace,
-  /onViewTasks=\{\(\) => setMode\("board"\)\}/,
-  "View tasks switches to the board surface",
+  /<FamiliarMenuBar(?:(?!\/>)[\s\S])*(?:taskCount|onViewTasks)/,
+  "workspace no longer feeds the desktop menu bar a task count or board handler",
 );
+// The count itself is untouched — the surfaces that still badge Tasks keep it.
 assert.match(
   workspace,
-  /onViewSchedules=\{\(\) => setMode\("inbox"\)\}/,
-  "View schedules switches to the Schedules surface (workspace mode id 'inbox')",
+  /taskCount=\{boardTaskCount\}/,
+  "the live board task count survives for the surfaces that still show it",
 );
+// scheduleNeedsCount is still DERIVED in workspace — the sidebar Schedules
+// badge consumes it — it is just no longer handed to this bar (cave-l9slw).
 assert.match(
   workspace,
-  /taskCount=\{boardTaskCount\}[\s\S]*scheduleNeedsCount=\{scheduleNeedsCount\}/,
-  "the bar is fed the live board task count and the schedule needs-you count (same source as the sidebar Schedules badge)",
+  /const scheduleNeedsCount = inboxNeedsYou\.length;/,
+  "the schedule needs-you count survives for the surfaces that still badge it",
 );
 assert.match(
   workspace,
@@ -306,21 +310,30 @@ assert.match(
   "menu bar shows on desktop (≥1024px)",
 );
 
-// Desktop quick-chat entry point: the bar carries the quick-chat trigger (the
-// mobile top bar's copy is hidden ≥1024px), tagged so the popover anchors under
-// it as a dropdown from this menubar.
-assert.match(
+// cave-l9slw: the desktop menu bar no longer carries a quick-chat trigger.
+assert.doesNotMatch(
   source,
-  /data-quick-chat-trigger[\s\S]{0,140}onClick=\{onOpenQuickChat\}[\s\S]{0,140}aria-label=\{NEW_CHAT_LABEL\}/,
-  "the desktop menu bar renders a New chat trigger wired to onOpenQuickChat",
+  /data-quick-chat-trigger/,
+  "no quick-chat trigger remains in the desktop menu bar",
 );
-// cave-xsq.6 + project-primary navigation: the quick-chat trigger enters the
-// shared shell launch path, which resolves project and acting-familiar authority
-// instead of opening a duplicate mini-chat popover or bypassing the actor gate.
+// cave-xsq.6 + project-primary navigation, unchanged in substance: whichever
+// surface owns a New chat trigger must enter the SHARED shell launch path,
+// which resolves project and acting-familiar authority, rather than opening a
+// duplicate mini-chat popover or bypassing the actor gate. The mobile top bar
+// is now the only chrome trigger, so it is the one that has to prove it.
+// Both patterns are bounded to a SINGLE element by refusing to cross the
+// self-closing `/>`. A plain lazy `[\s\S]*?` runs straight past the end of
+// <FamiliarMenuBar> into the <TopBar> that follows it, so the negative
+// assertion below would match TopBar's handler and never fail.
 assert.match(
   workspace,
-  /<FamiliarMenuBar[\s\S]*?onOpenQuickChat=\{startWorkspaceChat\}/,
-  "workspace wires the desktop menu bar's quick-chat trigger to the shell-owned launch path",
+  /<TopBar(?:(?!\/>)[\s\S])*onOpenQuickChat=\{startWorkspaceChat\}/,
+  "workspace wires the surviving chrome quick-chat trigger to the shell-owned launch path",
+);
+assert.doesNotMatch(
+  workspace,
+  /<FamiliarMenuBar(?:(?!\/>)[\s\S])*onOpenQuickChat/,
+  "workspace no longer hands the desktop menu bar a quick-chat handler",
 );
 assert.doesNotMatch(
   workspace,

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -16,44 +16,24 @@ type Props = {
   /** Notification bell, rendered by the workspace (it owns the inbox state)
    *  so this bar stays markup-thin. Joins the right-side status controls. */
   bell?: ReactNode;
-  /** Open task count (board cards not yet done) — drives the Tasks badge. */
-  taskCount: number;
-  /** Schedule items needing attention — drives the Schedules badge. */
-  scheduleNeedsCount: number;
   /** Open the shared context-aware search palette. */
   onOpenSearch: () => void;
   /** Shared top-search query, mirrored with the mobile top bar and palette. */
   searchQuery: string;
   /** Update shared top-search query. */
   onSearchQueryChange: (query: string) => void;
-  /** Jump to the task board. */
-  onViewTasks: () => void;
   /** Enrich active tasks for the selected familiar. */
   onEnrichTasks?: () => void;
   enrichingTasks?: boolean;
   enrichProgress?: { done: number; total: number } | null;
-  /** Jump to the Schedules surface (calendar + crons). */
-  onViewSchedules: () => void;
   /** Open Settings. */
   onOpenSettings: () => void;
-  /** Start a blank chat through the shell's acting-familiar gate. */
-  onOpenQuickChat: () => void;
 };
 
 const ENRICH_TASKS_TITLE =
   "Enhance assigned familiar tasks: update subtasks, dates, description, status, priority, links, issues, and chats";
 const SEARCH_LABEL = "Search Cave";
-const NEW_CHAT_LABEL = "New chat";
-const TASKS_LABEL = workspacePageDefinition("board")?.title ?? "Tasks";
-const RITUALS_LABEL = workspacePageDefinition("inbox")?.title ?? "Rituals";
 const SETTINGS_LABEL = workspacePageDefinition("settings")?.title ?? "Settings";
-
-function fmtBadge(n: number): string {
-  // Cap at 9+: two adjacent three-glyph "99+" pills read as duplicate noise
-  // in the corner — one glyph says "many" just as well, and the button's
-  // aria-label/tooltip still carries the exact count (cave-gf5l).
-  return n > 9 ? "9+" : String(n);
-}
 
 /**
  * A slim, always-visible desktop top menu bar with global search and
@@ -66,22 +46,16 @@ export function FamiliarMenuBar({
   activeFamiliarId,
   runningStatus,
   bell,
-  taskCount,
-  scheduleNeedsCount,
   onOpenSearch,
   searchQuery,
   onSearchQueryChange,
-  onViewTasks,
   onEnrichTasks,
   enrichingTasks,
   enrichProgress,
-  onViewSchedules,
   onOpenSettings,
-  onOpenQuickChat,
 }: Props) {
   const keys = useKeySymbols();
   const searchShortcut = platformizeHint("⌘K", keys);
-  const newChatShortcut = platformizeHint("⌘J", keys);
   const settingsShortcut = platformizeHint("⌘,", keys);
   const enrichLabel = enrichingTasks
     ? enrichProgress
@@ -120,18 +94,11 @@ export function FamiliarMenuBar({
         <kbd>{searchShortcut}</kbd>
       </form>
 
+      {/* No New chat trigger here (cave-l9slw). It opened the cluster while
+          ⌘J, the sidebar rail CTA, the chat project sidebar, the right-panel
+          dropdown and the mobile top bar all still offer it — this bar keeps
+          the destinations that have no other desktop home. */}
       <div className="menu-bar__group menu-bar__group--tasks">
-        <button
-          type="button"
-          data-quick-chat-trigger
-          className="menu-bar__task focus-ring"
-          onClick={onOpenQuickChat}
-          aria-label={NEW_CHAT_LABEL}
-          title={`${NEW_CHAT_LABEL} (${newChatShortcut})`}
-        >
-          <Icon name="ph:note-pencil" width={22} height={22} aria-hidden />
-          <span className="menu-bar__task-label">{NEW_CHAT_LABEL}</span>
-        </button>
         {onEnrichTasks ? (
           <button
             type="button"
@@ -149,34 +116,21 @@ export function FamiliarMenuBar({
             </span>
           </button>
         ) : null}
-        <button
-          type="button"
-          className="menu-bar__task focus-ring"
-          onClick={onViewTasks}
-          aria-label={taskCount > 0 ? `${TASKS_LABEL} — ${taskCount} open` : TASKS_LABEL}
-          title={taskCount > 0 ? `${TASKS_LABEL} — ${taskCount} open` : TASKS_LABEL}
-        >
-          <Icon name="ph:kanban" width={22} height={22} aria-hidden />
-          <span className="menu-bar__task-label">{TASKS_LABEL}</span>
-          {taskCount > 0 ? <span className="menu-bar__badge">{fmtBadge(taskCount)}</span> : null}
-        </button>
-        {/* This button lands on the Rituals surface (workspace mode "inbox"
-            is the Rituals view — calendar + crons), so it is labelled
-            Rituals and badged with the schedule needs-you count. There is no
-            dedicated Inbox surface; inbox items live in the notification bell. */}
-        <button
-          type="button"
-          className="menu-bar__task focus-ring"
-          onClick={onViewSchedules}
-          aria-label={scheduleNeedsCount > 0 ? `View rituals — ${scheduleNeedsCount} need attention` : "View rituals"}
-          title={scheduleNeedsCount > 0 ? `View rituals — ${scheduleNeedsCount} need attention` : "View rituals"}
-        >
-          <Icon name="ph:calendar-check" width={22} height={22} aria-hidden />
-          <span className="menu-bar__task-label">{RITUALS_LABEL}</span>
-          {scheduleNeedsCount > 0 ? (
-            <span className="menu-bar__badge">{fmtBadge(scheduleNeedsCount)}</span>
-          ) : null}
-        </button>
+        {/* No Tasks button here either (cave-l9slw). The sidebar navigation
+            already carries Tasks as a labelled destination, so this was a
+            second, icon-only route to the same board. Its open-task badge went
+            with it; the sidebar row still badges the same count from the same
+            source, so no signal was lost.
+
+            No Rituals button either. It landed on workspace mode "inbox" and
+            badged the schedule needs-you count; that surface is still reached
+            from the home dashboard cards, the mobile bottom tabs, the ⌘K
+            palette and the tray, and the needs-you count is still surfaced by
+            the dashboard and the bottom-tab badge.
+
+            With both badges gone this cluster no longer counts anything, which
+            is why fmtBadge went too rather than lingering as a helper with no
+            caller. */}
         <button
           type="button"
           className="menu-bar__task focus-ring"

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -36,11 +36,21 @@ const SEARCH_LABEL = "Search Cave";
 const SETTINGS_LABEL = workspacePageDefinition("settings")?.title ?? "Settings";
 
 /**
- * A slim, always-visible desktop top menu bar with global search and
- * task/schedule counters. It is the desktop counterpart to the mobile
- * `.top-bar` (which stays hidden ≥1024px); this bar is hidden below 1024px so
- * the two never both render. Familiar selection lives in the chat sidebar's
- * header switcher, not here.
+ * A slim, always-visible desktop top menu bar: centered global search, the
+ * Enhance action, Settings, and the workspace-owned status slots (running
+ * processes + notification bell).
+ *
+ * It carries NO counters. The Tasks and Rituals buttons and their badges were
+ * removed in cave-l9slw because the sidebar navigation already lists both as
+ * labelled destinations and badges the same counts from the same sources —
+ * this bar is for what has no other desktop home. New chat went with them
+ * (⌘J and four other entry points remain).
+ *
+ * It is the desktop counterpart to the mobile `.top-bar` (which stays hidden
+ * ≥1024px); this bar is hidden below 1024px so the two never both render.
+ * Note the mobile bar is NOT a mirror — it keeps its own New chat trigger and
+ * Tasks row, because those alternatives are not at hand on a phone. Familiar
+ * selection lives in the chat sidebar's header switcher, not here.
  */
 export function FamiliarMenuBar({
   activeFamiliarId,

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -43,23 +43,15 @@ assert.match(
   /Open Rituals/,
   "Notification bell routes users to the renamed Rituals surface",
 );
-// The desktop menu bar button that opens this surface (mode "inbox") says
-// Rituals — an "Inbox" label would be dishonest since the slim surface has
-// no inbox tab and inbox items live in the notification bell instead.
-assert.match(
-  menuBar,
-  /<Icon name="ph:calendar-check"[\s\S]{0,160}<span className="menu-bar__task-label">\{RITUALS_LABEL\}<\/span>/,
-  "Desktop menu bar names the surface Rituals with the calendar-check icon (label CSS-demoted in the seamless bar; aria-label carries the name)",
-);
+// The desktop menu bar dropped its Rituals button (cave-l9slw); the surface is
+// reached from the home dashboard, the mobile bottom tabs, the ⌘K palette, the
+// /rituals slash command below and the tray. What still matters here is the
+// naming rule that button used to carry: nothing may advertise an "Inbox"
+// surface, because none exists — inbox items live in the notification bell.
 assert.doesNotMatch(
   menuBar,
-  /<span>Inbox<\/span>|"View inbox"/,
-  "Desktop menu bar no longer advertises a nonexistent Inbox surface",
-);
-assert.match(
-  workspace,
-  /onViewSchedules=\{\(\) => setMode\("inbox"\)\}/,
-  "Menu-bar Rituals button routes to the Rituals surface (mode id 'inbox')",
+  /<span>Inbox<\/span>|"View inbox"|ph:tray/,
+  "Desktop menu bar does not advertise a nonexistent Inbox surface",
 );
 assert.match(
   slashCommands,

--- a/src/components/settings-shortcut.test.ts
+++ b/src/components/settings-shortcut.test.ts
@@ -42,10 +42,13 @@ assert.match(
   /platformizeHint\("⌘K", keys\)/,
   "FamiliarMenuBar platformizes the Search shortcut hint",
 );
-assert.match(
+// The desktop menu bar's New chat button was removed in cave-l9slw, so it no
+// longer renders a ⌘J hint to platformize. TopBar above still does — it keeps
+// its own New chat trigger — and ⌘J itself is unchanged as a global shortcut.
+assert.doesNotMatch(
   familiarMenuBar,
   /platformizeHint\("⌘J", keys\)/,
-  "FamiliarMenuBar platformizes the New chat shortcut hint",
+  "FamiliarMenuBar has no New chat hint left to platformize",
 );
 assert.match(
   familiarMenuBar,

--- a/src/components/top-bar-polish.test.ts
+++ b/src/components/top-bar-polish.test.ts
@@ -10,10 +10,13 @@ const topBar = readFileSync(new URL("./top-bar.tsx", import.meta.url), "utf8");
 // ── Badge caps at 9+ ─────────────────────────────────────────────────────────
 // Two adjacent three-glyph "99+" pills (Tasks + Schedules) read as duplicate
 // noise; one glyph says "many" and the exact count lives in the tooltip.
-assert.match(
+// The desktop menu bar no longer badges anything (cave-l9slw) — both counter
+// buttons moved to surfaces that carry a label — so there is no cap to assert
+// here. The rule below still binds the mobile top bar, which does badge.
+assert.doesNotMatch(
   menuBar,
-  /return n > 9 \? "9\+" : String\(n\);/,
-  "Desktop menu-bar badge caps at 9+",
+  /className="menu-bar__badge"|function fmtBadge/,
+  "Desktop menu bar renders no count badge",
 );
 assert.match(
   topBar,
@@ -28,16 +31,22 @@ assert.match(
 );
 
 // ── Counter buttons carry sighted tooltips, not just aria-labels ────────────
-assert.match(
+// Both of the desktop bar's counter buttons — Tasks and Rituals — were removed
+// in cave-l9slw, so this rule now has no subject on that surface. It is kept as
+// a NEGATIVE: if a counted destination ever returns to the bar it must arrive
+// with the tooltip, and this fails until the assertion above it is restored.
+assert.doesNotMatch(
   menuBar,
-  /aria-label=\{taskCount > 0 \? `\$\{TASKS_LABEL\} — \$\{taskCount\} open` : TASKS_LABEL\}\s*\n\s*title=\{taskCount > 0 \? `\$\{TASKS_LABEL\} — \$\{taskCount\} open` : TASKS_LABEL\}/,
-  "Tasks button exposes the exact count as a hover tooltip",
+  /taskCount|scheduleNeedsCount/,
+  "no counter button remains in the desktop menu bar to need a tooltip",
 );
-assert.match(
-  menuBar,
-  /aria-label=\{scheduleNeedsCount > 0 \? `View rituals — \$\{scheduleNeedsCount\} need attention` : "View rituals"\}\s*\n\s*title=\{scheduleNeedsCount > 0 \? `View rituals — \$\{scheduleNeedsCount\} need attention` : "View rituals"\}/,
-  "Rituals button exposes the exact count as a hover tooltip",
-);
+// The surviving icon-only controls still owe a sighted tooltip apiece.
+for (const label of ["ENRICH_TASKS_TITLE", "SETTINGS_LABEL"]) {
+  assert.ok(
+    new RegExp(`title=\\{[^}]*${label}`).test(menuBar),
+    `${label} control exposes a hover tooltip, not just an aria-label`,
+  );
+}
 
 // ── Brand string: user-visible chrome says "CovenCave" (the product name) ───
 for (const [file, label] of [

--- a/src/components/workspace-destination-consistency.test.ts
+++ b/src/components/workspace-destination-consistency.test.ts
@@ -96,30 +96,35 @@ assert.doesNotMatch(
   "CommandPalette does not silently filter out destinations when metadata is missing",
 );
 
-for (const [source, label] of [
-  [familiarMenuBar, "Desktop chrome"],
-  [topBar, "Mobile chrome"],
-]) {
-  assert.match(
-    source,
-    /workspacePageDefinition\("board"\)/,
-    `${label} derives the Tasks action from the shared page registry`,
-  );
-  assert.match(
-    source,
-    /workspacePageDefinition\("settings"\)/,
-    `${label} derives the Settings action from the shared page registry`,
-  );
+// Tasks is only asserted for mobile now: cave-l9slw removed the desktop menu
+// bar's Tasks button because the sidebar navigation already carries that
+// destination with a label. The rule is unchanged — a surface that DOES expose
+// a destination must name it from the shared registry, never a private array.
+for (const [source, label, destinations] of [
+  [familiarMenuBar, "Desktop chrome", ["settings"]],
+  [topBar, "Mobile chrome", ["board", "settings"]],
+] as const) {
+  for (const destination of destinations) {
+    assert.match(
+      source,
+      new RegExp(`workspacePageDefinition\\("${destination}"\\)`),
+      `${label} derives the ${destination} action from the shared page registry`,
+    );
+  }
   assert.doesNotMatch(
     source,
     /\[[\s\S]{0,240}id:\s*"(?:board|settings)"/,
     `${label} does not keep a private destination array for Tasks or Settings`,
   );
 }
-assert.match(
+// Desktop chrome deliberately stopped exposing New chat (cave-l9slw): the
+// menu bar is for destinations with no other desktop home, and New chat has
+// ⌘J, the sidebar rail CTA, the chat project sidebar and the right-panel
+// dropdown. Mobile keeps its trigger, where those alternatives are not at hand.
+assert.doesNotMatch(
   familiarMenuBar,
-  /aria-label=\{NEW_CHAT_LABEL\}/,
-  "Desktop chrome exposes a New chat action",
+  /NEW_CHAT_LABEL/,
+  "Desktop menu bar does not duplicate a New chat action",
 );
 assert.match(
   topBar,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -4782,21 +4782,16 @@ export function Workspace() {
                   onPrefsChanged={refreshPrefs}
                 />
               }
-              taskCount={boardTaskCount}
-              scheduleNeedsCount={scheduleNeedsCount}
               onOpenSearch={() => openPalette()}
               searchQuery={topSearchQuery}
               onSearchQueryChange={(query) => {
                 setTopSearchQuery(query);
                 openPalette();
               }}
-              onViewTasks={() => setMode("board")}
               onEnrichTasks={handleEnrichTasks}
               enrichingTasks={enrichingTasks}
               enrichProgress={enrichProgress}
-              onViewSchedules={() => setMode("inbox")}
               onOpenSettings={() => nextRouter.push("/settings")}
-              onOpenQuickChat={startWorkspaceChat}
             />
             <TopBar
               onOpenPalette={() => openPalette()}

--- a/src/styles/globals/desktop-chrome.css
+++ b/src/styles/globals/desktop-chrome.css
@@ -790,7 +790,12 @@ button:active > .edge-rail-chip {
   position: relative;
   align-items: center;
   justify-content: flex-end;
-  gap: var(--space-3);
+  /* --space-2, matching the gap INSIDE each __group. The right-hand icons read
+     as one continuous strip but are split across two flex children (--tasks
+     and --status), so a wider gap here put 12px between Settings and the bell
+     where every other pitch was 8px. Search is position: absolute and out of
+     flow, so this governs that one seam and nothing else (cave-l9slw). */
+  gap: var(--space-2);
   min-width: 0;
   width: 100%;
   padding: 5px var(--space-3);


### PR DESCRIPTION
Three buttons leave the top-right cluster, each because the destination already has a better-labelled home.

| removed | still reachable via |
|---|---|
| **New chat** | ⌘J, the sidebar rail CTA, the chat project sidebar, the right-panel dropdown, and the mobile top bar's own trigger |
| **Rituals** | the home dashboard cards, the mobile bottom tabs, the ⌘K palette, the tray handler |
| **Tasks** | the sidebar navigation, which carries it as a labelled destination (`id: "board"`, ⌘3) |

Mobile keeps its New chat trigger, where those desktop alternatives are not at hand — this is a desktop-menu-bar change only.

Both count badges went with their buttons, and the counts are still surfaced by the sidebar rows that badge them from the same sources. With nothing left to count, `fmtBadge` went too rather than lingering without a caller. Dead props were removed rather than left wired to nothing; `boardTaskCount` and `scheduleNeedsCount` are still derived in `workspace.tsx` for the surfaces that do use them.

### Spacing

The strip reads as one continuous run of 28px buttons but is built from **two** flex children of `.menu-bar`. Each `__group` sets `gap: var(--space-2)` while `.menu-bar` set `var(--space-3)`, so the seam between Settings and the notification bell was 12px where every other pitch was 8px.

Measured at 1440px before the change:

```
1180  1216  1252  1288  1324      1364        1400
└──── 36px pitch ────────┘   40px ┘   36px ───┘
 New   Enh  Tasks Rit   Set    bell      panel toggle
```

The centered search form is `position: absolute` and out of flow, so `.menu-bar`'s gap governs that one seam and nothing else.

### On the tests

They are re-pointed rather than deleted. Each keeps the property it was really protecting — the destination stays reachable, the handler enters the shell-owned launch path, a control that *is* exposed names itself from the shared page registry — and additionally asserts the removal is **complete**, so a half-removal or a dead prop still fails.

Two rewrites needed a second pass, both worth flagging for reviewers:

- A lazy `[\s\S]*?` bounded to `<FamiliarMenuBar>` runs straight past the element into the `<TopBar>` that follows it. The negative assertion matched TopBar's handler and **could never fail**. Both are now bounded by refusing to cross `/>`.
- The tempting generalisation *"every aria-label in the bar has a matching title"* is false on correct markup — the `<nav>` landmark carries an aria-label and must **not** carry a tooltip (5 labels, 4 titles).

### Coordination

`cave-fh9so` (unified sidebar) has in-flight uncommitted work removing the **Settings** button from this same cluster. Same direction, no disagreement — sequencing was agreed with the owner, and this lands first so that branch rebases onto the smaller cluster.

### Validation

`typecheck` · `lint` · `test:app` · the nine suites that pin this cluster (`familiar-menu-bar`, `rituals-tabs`, `top-bar-polish`, `workspace-destination-consistency`, `menu-bar-icon-size`, `acting-familiar-gate`, `board-enrich-steps`, `shell-chrome-revamp`, `mobile-shell-smoke`)