### PR TITLE
Prevent Dashboard navigation from reloading the document

### DIFF
--- a/src/components/sidebar-footer.test.ts
+++ b/src/components/sidebar-footer.test.ts
@@ -13,7 +13,9 @@ const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf
 
 // The shared component owns the whole footer.
 assert.match(footer, /export function SidebarFooter\(\{[\s\S]*onOpenSettings,[\s\S]*activeDestination/, "SidebarFooter accepts the active standalone destination");
-assert.match(footer, /href="\/dashboard"/, "footer links to the Dashboard route");
+assert.match(footer, /import Link from "next\/link"/, "footer uses Next client navigation");
+assert.match(footer, /<Link[\s\S]*?href="\/dashboard"/, "footer links to the Dashboard route through Next");
+assert.doesNotMatch(footer, /<a[\s\S]*?href="\/dashboard"/, "footer does not hard-navigate to Dashboard");
 assert.match(footer, /onClick=\{onOpenSettings\}[\s\S]*?aria-label="Settings"/, "footer Settings button calls onOpenSettings");
 assert.match(footer, /aria-current=\{activeDestination === "dashboard" \? "page" : undefined\}/, "footer exposes the active Dashboard route");
 assert.match(footer, /aria-current=\{activeDestination === "settings" \? "page" : undefined\}/, "footer exposes the active Settings route");
@@ -25,10 +27,10 @@ assert.match(
 assert.match(footer, /className="sidebar-version"[\s\S]*?v\{APP_VERSION\}/, "footer shows the app version line");
 // The version line is the shortest path to what it's about: Settings → About
 // carries the version, updates and project links, and the settings shell
-// honours the `#about` section hash. It's a real link to the standalone route
-// (same idiom as the Dashboard link above), not an onOpenSettings caller —
-// which also keeps middle-click / open-in-new-window working.
-assert.match(footer, /href="\/settings#about"/, "the version line deep-links to Settings → About");
+// honours the `#about` section hash. It uses the same client-side link idiom as
+// Dashboard, not an onOpenSettings caller — and still keeps middle-click /
+// open-in-new-window working because Next Link renders an anchor.
+assert.match(footer, /<Link[\s\S]*?href="\/settings#about"/, "the version line deep-links to Settings → About through Next");
 assert.match(
   footer,
   /className="sidebar-version"[\s\S]{0,240}?aria-label=\{`CovenCave v\$\{APP_VERSION\} — open About in Settings`\}/,

--- a/src/components/sidebar-footer.tsx
+++ b/src/components/sidebar-footer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Icon, CAVE_ICON_SIZE } from "@/lib/icon";
 import { APP_VERSION } from "@/lib/app-version";
 
@@ -27,8 +28,8 @@ export function SidebarFooter({
       {/* Bottom: Dashboard + Settings */}
       <div className="sidebar-foot">
         {/* Dashboard is a standalone Next route (/dashboard), not a workspace
-            mode — navigate with a real link rather than onModeChange. */}
-        <a
+            mode — preserve that route while using Next client navigation. */}
+        <Link
           className={`sidebar-foot-btn${activeDestination === "dashboard" ? " sidebar-foot-btn--active" : ""}`}
           href="/dashboard"
           aria-label="Dashboard"
@@ -39,7 +40,7 @@ export function SidebarFooter({
             <Icon name="ph:squares-four" width={CAVE_ICON_SIZE.sidePanelNav} height={CAVE_ICON_SIZE.sidePanelNav} className="sidebar-foot-icon" />
           </span>
           <span className="sidebar-foot-label">Dashboard</span>
-        </a>
+        </Link>
         <button
           type="button"
           className={`sidebar-foot-btn${activeDestination === "settings" ? " sidebar-foot-btn--active" : ""}`}
@@ -59,17 +60,17 @@ export function SidebarFooter({
           shortest path to what it's about. "Which version am I on, and is
           there a newer one?" is answered in Settings → About (version,
           updates, project links), so the line links there instead of being
-          the one dead label in the footer. A real <a> to the standalone
+          the one dead label in the footer. A client-side link to the standalone
           /settings route, matching the Dashboard link above; the #about hash
           is the section deep-link the settings shell already honours. */}
-      <a
+      <Link
         className="sidebar-version"
         href="/settings#about"
         title={`CovenCave v${APP_VERSION} — version, updates and project links`}
         aria-label={`CovenCave v${APP_VERSION} — open About in Settings`}
       >
         v{APP_VERSION}
-      </a>
+      </Link>
     </>
   );
 }

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -523,7 +523,7 @@ assert.match(
 // minimal-height muted line, still the bottommost element.
 assert.match(
   footer,
-  /className="sidebar-version"[\s\S]{0,280}?v\{APP_VERSION\}[\s\S]{0,40}?<\/a>/,
+  /className="sidebar-version"[\s\S]{0,280}?v\{APP_VERSION\}[\s\S]{0,40}?<\/Link>/,
   "the version line is the bottommost element of the shared footer",
 );
 // The shared footer is the bottommost element of the nav in BOTH states. The

--- a/tests/sidebar-footer.spec.ts
+++ b/tests/sidebar-footer.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Request } from "@playwright/test";
 
 test("open sidebar places Dashboard directly above Settings", async ({ page }) => {
   await page.addInitScript(() => {
@@ -21,4 +21,41 @@ test("open sidebar places Dashboard directly above Settings", async ({ page }) =
   expect(dashboardBox).not.toBeNull();
   expect(settingsBox).not.toBeNull();
   expect(dashboardBox!.y).toBeLessThan(settingsBox!.y);
+});
+
+test("Dashboard uses client navigation from Home and Chat without reloading the document", async ({ page }) => {
+  test.setTimeout(180_000);
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:shell:nav-open", "1");
+    (window as Window & { __caveDocumentMarker?: string }).__caveDocumentMarker = crypto.randomUUID();
+  });
+
+  for (const startPath of ["/?demo=1", "/?mode=chat&demo=1"]) {
+    await page.goto(startPath, { waitUntil: "domcontentloaded", timeout: 120_000 });
+    await page.getByRole("searchbox").first().waitFor({ state: "visible", timeout: 60_000 });
+    const dashboard = page.locator(".sidebar-foot").getByRole("link", { name: "Dashboard", exact: true });
+    await expect(dashboard).toBeVisible({ timeout: 60_000 });
+
+    const marker = await page.evaluate(() => (window as Window & { __caveDocumentMarker?: string }).__caveDocumentMarker);
+    const documentRequests: string[] = [];
+    const onRequest = (request: Request) => {
+      if (request.resourceType() === "document") documentRequests.push(request.url());
+    };
+    page.on("request", onRequest);
+
+    try {
+      await dashboard.click();
+      await expect(page).toHaveURL(/\/dashboard\/?$/, { timeout: 120_000 });
+      await expect(page.locator(".dr-page")).toBeVisible({ timeout: 60_000 });
+
+      expect(documentRequests).toEqual([]);
+      expect(
+        await page.evaluate(() => (window as Window & { __caveDocumentMarker?: string }).__caveDocumentMarker),
+      ).toBe(marker);
+    } finally {
+      page.off("request", onRequest);
+    }
+  }
 });


### PR DESCRIPTION
## Summary

- Route the shared footer's `/dashboard` and `/settings#about` destinations through Next `Link`, preserving normal anchor semantics while avoiding same-origin document reloads.
- Add source guards and a browser regression covering Dashboard navigation from both Home and Chat, including zero document requests and document-marker preservation.
- Bead: cave-i8qs7

## Verification

- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm check:tests-wired` — passed
- `pnpm build` — passed
- Focused footer/shell source guards — passed
- Direct Chromium replay from Home and Chat — passed; both ended at `/dashboard` with zero document requests
- Targeted Playwright regression — passed on retry after a cold-start dev-server timeout
- `pnpm test:app` — existing unrelated timing failure in `scripts/canonical-memory-smoke-lifecycle.test.mjs` (SIGHUP cleanup measured ~2.68s vs 2.5s)
- `pnpm test:api` — existing unrelated WSL permission failure in `src/lib/server/client-v1/discovery.test.ts` (511 vs 448)

Not merged.