### PR TITLE
fix(test): normalize pausable-poll keys so Windows checkouts see allowlisted files (cave-oc7dh)

### DIFF
--- a/src/lib/pausable-poll-discipline.test.ts
+++ b/src/lib/pausable-poll-discipline.test.ts
@@ -67,7 +67,10 @@ for (const file of walk(SRC)) {
   const firstLines = source.slice(0, 200);
   if (!firstLines.includes('"use client"')) continue;
 
-  const rel = path.relative(SRC, file);
+  // RAW_INTERVAL_ALLOWLIST keys are forward-slash paths; path.relative
+  // yields platform separators, so a Windows checkout would report every
+  // allowlisted file as an offender (cave-oc7dh). Normalize before lookup.
+  const rel = path.relative(SRC, file).split(path.sep).join("/");
   let index = 0;
   let unguardedHere = 0;
   while ((index = source.indexOf("setInterval(", index)) !== -1) {


### PR DESCRIPTION
## What

`src/lib/pausable-poll-discipline.test.ts` keyed its allowlist lookup on `path.relative(SRC, file)`, which yields backslash separators on Windows while every `RAW_INTERVAL_ALLOWLIST` key is forward-slash. On any Windows checkout the test therefore reported all 17 allowlisted ticker files as offenders, so the report was noise there instead of a guard (`cave-oc7dh`).

The key is now normalized with `.split(path.sep).join("/")` before both the allowlist lookup and the guarded-list reporting — the same pattern `child-spawn-window.test.ts` already uses.

## Verification

- WSL: `node src/lib/pausable-poll-discipline.test.ts` → `ok (12 guarded interval(s), 17 allowlisted ticker/scoped file(s))`.
- Native Windows checkout (same repo at C:\Users\timot\Documents\projects\coven\coven-cave): identical pass; previously the same file reported 15+ offenders there.

## Bead

`cave-oc7dh` — pausable-poll-discipline test is inert on Windows (path.relative separator).