### PR TITLE
fix(checker): resolve static imports in key space so Windows-style keys stop failing open (cave-0f8tk)

### DIFF
--- a/scripts/check-test-clock-consistency.mjs
+++ b/scripts/check-test-clock-consistency.mjs
@@ -132,6 +132,29 @@ function parse(file, text) {
  */
 const asKey = (file) => file.split(path.sep).join("/").replace(/\\/g, "/");
 
+/**
+ * Resolve a relative first-party import against a forward-slash key directory.
+ *
+ * Keys keep a Windows drive prefix (`C:/Users/…`) that `path.posix` treats as
+ * relative, so `path.posix.resolve` re-anchors the candidate to the process cwd
+ * and the lookup silently misses — the analyzer failed open on Windows
+ * (cave-0f8tk). Resolve `./` and `../` against the key's own directory instead,
+ * pinning the leading drive/root segment (`C:` or "") so `..` can never escape
+ * above the key's own root.
+ */
+const resolveKeySpecifier = (directory, specifier) => {
+  const segments = directory.split("/");
+  for (const part of specifier.split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      if (segments.length > 1) segments.pop();
+      continue;
+    }
+    segments.push(part);
+  }
+  return segments.join("/");
+};
+
 /** `new Date()` — the live clock, taken now. */
 function isLiveDateConstruction(node) {
   return ts.isNewExpression(node)
@@ -502,10 +525,11 @@ export function analyzeTestSource(file, text, registry, relativeTo = root) {
     if (!specifier.startsWith(".")) continue; // a package, not first-party
     const bindingsNode = statement.importClause?.namedBindings;
     if (!bindingsNode || !ts.isNamedImports(bindingsNode)) continue;
-    // Resolved in POSIX space against the already-normalized path. `path.resolve`
-    // is wrong here on Windows: given a POSIX-rooted path it prepends the current
-    // drive, so the candidate never equals the key the scanner stored.
-    const base = path.posix.resolve(path.posix.dirname(asKey(file)), specifier);
+    // Resolved in key space against the already-normalized path. The key keeps
+    // its Windows drive prefix, which path.posix treats as relative, so
+    // path.posix.resolve re-anchored the candidate to the cwd and the lookup
+    // missed — the analyzer failed open on Windows (cave-0f8tk).
+    const base = resolveKeySpecifier(path.posix.dirname(asKey(file)), specifier);
     // `./x-sources.ts`, `./x-sources`, `./x-sources/index.ts` all appear here.
     const candidates = [
       base,

--- a/scripts/check-test-clock-consistency.test.mjs
+++ b/scripts/check-test-clock-consistency.test.mjs
@@ -260,6 +260,38 @@ test("repair B — a frozen write read back through the same instant passes", ()
   );
 });
 
+test("a Windows-style key still resolves static first-party imports (cave-0f8tk)", () => {
+  // On Windows the scanner stores keys like C:/Users/…/cache.test.ts. The old
+  // path.posix.resolve treated that drive prefix as relative, re-anchored the
+  // candidate to the cwd, missed the registry key, and silently dropped the
+  // import — so this same bomb passed with zero findings (fail open).
+  const windowsRegistry = collectTtlBearingApis([
+    { file: "C:/Users/dev/repo/src/lib/cache.ts", text: PRODUCTION },
+    { file: "C:/Users/dev/repo/src/lib/other.ts", text: OTHER_MODULE },
+  ]);
+  const found = analyzeTestSource(
+    "C:/Users/dev/repo/src/lib/cache.test.ts",
+    `import { seedCache } from "./cache.ts";\n`
+      + wrap(`  await seedCache([post], new Date("${stillLive()}"));`),
+    windowsRegistry,
+    "C:/Users/dev/repo",
+  );
+  assert.equal(found.length, 1, "the frozen seed must still be flagged through a Windows-style key");
+  assert.equal(found[0].kind, "bomb");
+  assert.equal(found[0].file, "src/lib/cache.test.ts", "the finding names the normalized relative path");
+
+  // A live-clock repair through the same key shape must still pass — the fix
+  // must not turn Windows keys into blanket findings.
+  const clean = analyzeTestSource(
+    "C:/Users/dev/repo/src/lib/cache.test.ts",
+    `import { seedCache } from "./cache.ts";\n`
+      + wrap(`  await seedCache([post], new Date(Date.now() - 25 * 60 * 60 * 1000));`),
+    windowsRegistry,
+    "C:/Users/dev/repo",
+  );
+  assert.deepEqual(clean, [], "a live-clock repair through a Windows-style key stays clean");
+});
+
 test("a block that pins the expiry boundary deliberately passes", () => {
   // The disjunction. `x-sources.test.ts` seeds at `fetched` and reads one
   // millisecond past the TTL at `expiredAt`, asserting the entry is gone. That


### PR DESCRIPTION
## What

`scripts/check-test-clock-consistency.mjs` resolved static first-party imports with `path.posix.resolve(path.posix.dirname(asKey(file)), specifier)`. A Windows key keeps its drive prefix (`C:/Users/…/x.test.ts`), which `path.posix` treats as relative — so the candidate was re-anchored to the process cwd, the registry lookup missed, and the analyzer silently dropped the import: it **failed open** on every Windows checkout (`cave-0f8tk`).

Replaced with `resolveKeySpecifier`, a forward-slash `./`/`../` resolver that pins the leading drive/root segment, so `C:/…` keys and POSIX keys both resolve to the exact keys the scanner stored.

## Verification

- New regression test: a Windows-style key with a static import still flags a frozen seed as a bomb (previously: zero findings), and a live-clock repair through the same key shape stays clean.
- `node --test scripts/check-test-clock-consistency.test.mjs` → 24/24 on Linux.
- Native Windows run (temp dir, typescript 6.0.3): 24/24.
- Repo scan unchanged: `node scripts/check-test-clock-consistency.mjs` → `no frozen-write / live-read time bombs (76 TTL-bearing helpers registered)`.

## Bead

`cave-0f8tk` — check-test-clock-consistency fails open on Windows: path.posix.resolve drops static first-party imports.