### PR TITLE
fix(codex): platform-guard the POSIX-only OAuth port probes (cave-drb8w)

### DIFF
--- a/src/lib/server/codex-oauth-port.test.ts
+++ b/src/lib/server/codex-oauth-port.test.ts
@@ -16,6 +16,7 @@
 //
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { createServer } from "node:net";
 import {
   CODEX_OAUTH_PORT,
@@ -109,6 +110,20 @@ test("pidHoldingPort returns null when no process holds the port", async () => {
   // observable result, which is the right behavior for the caller.
   const result = await pidHoldingPort(ephemeral);
   assert.equal(result, null);
+});
+
+test("the POSIX-only probes are platform-guarded (cave-drb8w)", () => {
+  const source = readFileSync(new URL("./codex-oauth-port.ts", import.meta.url), "utf8");
+  assert.match(
+    source,
+    /if \(process\.platform === "win32"\) return null;/,
+    "pidHoldingPort refuses the lsof probe explicitly on Windows",
+  );
+  assert.match(
+    source,
+    /if \(process\.platform === "win32"\) return "";/,
+    "describePid refuses the ps probe explicitly on Windows",
+  );
 });
 
 // ─── preflightCodexOAuthPort (port-free branch) ────────────────────────

--- a/src/lib/server/codex-oauth-port.ts
+++ b/src/lib/server/codex-oauth-port.ts
@@ -66,6 +66,11 @@ export async function portIsFree(port: number): Promise<boolean> {
  * processes hold it (refuses to disambiguate — safer to print instructions).
  */
 export async function pidHoldingPort(port: number): Promise<number | null> {
+  // lsof is a POSIX tool; on Windows the probe could only ENOENT and report
+  // "no holder" anyway. Skip it explicitly so the caller's HeldUnknown branch
+  // is a deliberate platform fact rather than a swallowed spawn failure
+  // (cave-drb8w).
+  if (process.platform === "win32") return null;
   let stdout: string;
   try {
     const result = await execFileAsync("lsof", ["-ti", `tcp:${port}`], {
@@ -99,6 +104,11 @@ export async function pidHoldingPort(port: number): Promise<number | null> {
  * Returns an empty string if the process is gone or ps is unavailable.
  */
 export async function describePid(pid: number): Promise<string> {
+  // ps is a POSIX tool; pidHoldingPort never returns a pid on Windows, so
+  // this probe is unreachable there — guard it explicitly anyway so the
+  // "unknown" result is deliberate rather than a swallowed spawn failure
+  // (cave-drb8w).
+  if (process.platform === "win32") return "";
   try {
     // `command=` (with the trailing =) suppresses the header so we get
     // just the argv line. Works on both macOS and Linux ps.


### PR DESCRIPTION
pidHoldingPort (lsof) and describePid (ps) ran on every platform; on Windows both ENOENT and the catch returned null/empty, so the OAuth port owner was silently never identified. Both probes are now guarded to non-win32 explicitly, making the caller's HeldUnknown branch a deliberate platform fact, with source pins in the test file. Existing suite green (9/9).