### PR TITLE
fix(guard): fail closed when the live-cwd probe cannot run on Windows (cave-1wus5)

### DIFF
--- a/scripts/worktree-guard.mjs
+++ b/scripts/worktree-guard.mjs
@@ -574,6 +574,15 @@ function strictLiveProcesses(target) {
     process.env.WT_GUARD_TEST_MODE === "1" && process.env.WT_GUARD_TEST_LSOF_BIN
       ? process.env.WT_GUARD_TEST_LSOF_BIN
       : "lsof";
+  // Windows has no lsof, so the live-cwd-holder probe cannot answer there and
+  // the strict removal path must fail closed instead of silently skipping the
+  // liveness check (cave-1wus5). A test-mode override still runs: it models a
+  // supplied probe, never the missing POSIX tool.
+  if (process.platform === "win32" && testLsof === "lsof") {
+    throw new Error(
+      "live-worktree detection needs lsof, which Windows does not provide; strict removal is refused (fail closed)",
+    );
+  }
   const probe = spawnSync(testLsof, ["-d", "cwd", "-F", "pcn"], {
     cwd: path.parse(process.cwd()).root || path.sep,
     encoding: "utf8",

--- a/scripts/worktree-guard.test.mjs
+++ b/scripts/worktree-guard.test.mjs
@@ -23,8 +23,13 @@ import {
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const script = path.join(root, "scripts", "worktree-guard.mjs");
-const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
 const isWin = process.platform === "win32";
+// `which` does not exist on native Windows; `where` is its equivalent
+// (cave-1wus5). Take only the first match so multiple `where` hits cannot
+// smuggle a newline into the git path.
+const realGit = execFileSync(isWin ? "where" : "which", ["git"], { encoding: "utf8" })
+  .trim()
+  .split(/\r?\n/, 1)[0];
 const BYPASS = "WT_GUARD_BYPASS=1";
 const STRICT_GIT_ENV_KEYS = [
   "GIT_DIR",
@@ -50,6 +55,26 @@ const STRICT_GIT_ENV_KEYS = [
   "GIT_NOGLOB_PATHSPECS",
   "GIT_ICASE_PATHSPECS",
 ];
+
+await test("the POSIX-only live-cwd probe fails closed on Windows (cave-1wus5)", () => {
+  const source = readFileSync(script, "utf8");
+  assert.match(
+    source,
+    /process\.platform === "win32" && testLsof === "lsof"/,
+    "a Windows run without a test-mode probe must refuse before spawning lsof",
+  );
+  assert.match(
+    source,
+    /live-worktree detection needs lsof, which Windows does not provide/,
+    "the refusal names the missing tool instead of degrading silently",
+  );
+  const suite = readFileSync(new URL("./worktree-guard.test.mjs", import.meta.url), "utf8");
+  assert.match(
+    suite,
+    /isWin \? "where" : "which"/,
+    "the suite resolves git with where on Windows and which on POSIX",
+  );
+});
 
 await test("strict Git network probes have release-safe bounded timeouts", () => {
   assert.equal(STRICT_GIT_LOCAL_TIMEOUT_MS, 10_000);


### PR DESCRIPTION
strictLiveProcesses spawned lsof unguarded inside the blocking PreToolUse hook; on Windows the probe cannot answer, so the strict removal path now refuses explicitly with a message naming lsof instead of degrading silently. A WT_GUARD_TEST_LSOF_BIN override still runs (it models a supplied probe).

The test suite resolved git with 'which', which native Windows lacks; it now uses 'where' there and takes only the first match. Before this the suite died at module load on Windows (1/1 fail); it now loads and runs (the strict-mode tests still require POSIX tooling). Source pins added. Linux suite 14/14.