### PR TITLE
fix(ci): PR checks suites report independently instead of short-circuiting (cave-t8p1a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,14 +79,31 @@ jobs:
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm check:tests-wired
-      - run: pnpm test:app
-      - run: pnpm test:api
-      - run: pnpm test:mobile
+      # Each suite must report its own result even when an earlier step failed:
+      # a test:app failure used to silently skip test:api and test:mobile, so a
+      # skipped suite and a passed one looked identical (cave-t8p1a).
+      # success() || failure() runs the suites unless the job was cancelled or
+      # the environment never came up, and each failure still fails the job.
+      - id: app-suite
+        name: Frontend app tests
+        if: success() || failure()
+        run: pnpm test:app
+      - id: api-suite
+        name: Frontend API tests
+        if: success() || failure()
+        run: pnpm test:api
+      - id: mobile-suite
+        name: Mobile tests
+        if: success() || failure()
+        run: pnpm test:mobile
 
       - name: Summarize PR check duration
         if: always()
         env:
           START_EPOCH: ${{ steps.clock.outputs.epoch }}
+          APP_OUTCOME: ${{ steps.app-suite.outcome }}
+          API_OUTCOME: ${{ steps.api-suite.outcome }}
+          MOBILE_OUTCOME: ${{ steps.mobile-suite.outcome }}
         run: |
           end_epoch=$(date +%s)
           duration=$((end_epoch - START_EPOCH))
@@ -95,6 +112,7 @@ jobs:
             echo
             echo "- Duration: ${duration}s"
             echo "- Commit: $GITHUB_SHA"
+            echo "- Suites: app=$APP_OUTCOME api=$API_OUTCOME mobile=$MOBILE_OUTCOME"
           } >> "$GITHUB_STEP_SUMMARY"
 
   paths:

--- a/scripts/ci-paths.test.mjs
+++ b/scripts/ci-paths.test.mjs
@@ -50,6 +50,27 @@ test("protocol changes run conformance in normal Linux pull-request CI", () => {
   );
 });
 
+test("PR checks cannot silently skip suites after an earlier failure (cave-t8p1a)", () => {
+  const workflow = readFileSync(
+    new URL("../.github/workflows/ci.yml", import.meta.url),
+    "utf8",
+  );
+  const prChecks = workflow.match(/^  pr-checks:\n[\s\S]*?(?=^  [a-z][a-z-]+:\n)/m)?.[0];
+  assert.ok(prChecks, "CI must retain the PR checks job");
+  for (const suite of ["app-suite", "api-suite", "mobile-suite"]) {
+    assert.match(
+      prChecks,
+      new RegExp(`^      - id: ${suite}\n        name: [^\n]+\n        if: success\\(\\) \\|\\| failure\\(\\)\n        run: `, "m"),
+      `${suite} must run unless the job was cancelled, so an earlier failure cannot skip it`,
+    );
+  }
+  assert.match(
+    prChecks,
+    /- Suites: app=\$APP_OUTCOME api=\$API_OUTCOME mobile=\$MOBILE_OUTCOME/,
+    "the summary must name each suite outcome so a skipped suite is distinguishable from a passed one",
+  );
+});
+
 test("Rust-only changes avoid frontend and E2E work", () => {
   assert.deepEqual(classifyCiPaths(["src-tauri/src/main.rs"]), {
     frontend: false,


### PR DESCRIPTION
A failure in pnpm test:app silently skipped test:api and test:mobile inside PR checks, so API-contract and mobile coverage vanished repository-wide for as long as the app suite stayed red — and a skipped suite looked identical to a passed one in the job summary.

Each suite step now carries if: success() || failure(), so an earlier failure cannot skip a later suite (each failure still fails the job), and the summary names every suite outcome (app/api/mobile) so a truncated run is visibly distinguishable from a passed one. Source pins added in ci-paths.test.mjs (11/11 green).