### PR TITLE
fix(mobile): verify the persisted access secret on the two read paths (cave-8pd39)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1917,6 +1917,7 @@ export const SUITES = {
     "scripts/ios-surface-load-discipline.test.mjs",
     "scripts/mobile-tailscale.test.mjs",
     "src/components/mobile-handoff.test.ts",
+    "src/app/api/mobile-handoff/route.test.ts",
     "src/components/shell-drawer-smoke.test.ts",
     "src/components/mobile-drawer-inert-focus-order.test.tsx",
     "src/components/mobile-drawer-nav-list-focus.test.tsx",

--- a/server.mjs
+++ b/server.mjs
@@ -66,7 +66,18 @@ function persistedMobileAccessSecretFile() {
 }
 if (process.env.COVEN_CAVE_BUNDLE !== "1" && process.env.COVEN_CAVE_E2E !== "1" && !process.env.COVEN_CAVE_ACCESS_TOKEN?.trim()) {
   try {
-    const persisted = readFileSync(persistedMobileAccessSecretFile(), "utf8").trim();
+    const file = persistedMobileAccessSecretFile();
+    const stats = lstatSync(file);
+    if (stats.isSymbolicLink()) throw new Error("the persisted mobile access secret must not be a symbolic link");
+    if (typeof process.getuid === "function") {
+      if (stats.uid !== process.getuid()) throw new Error("the persisted mobile access secret must be owned by the current user");
+      if ((stats.mode & 18) !== 0) throw new Error("the persisted mobile access secret must not be writable by group or others");
+    } else {
+      console.warn(
+        "[cave] boot re-arm reads the persisted mobile access secret without an ownership check on " + process.platform + "; the pairing route re-verifies it with the async guard (cave-8pd39)."
+      );
+    }
+    const persisted = readFileSync(file, "utf8").trim();
     if (persisted) process.env.COVEN_CAVE_ACCESS_TOKEN = persisted;
   } catch {
   }

--- a/server.ts
+++ b/server.ts
@@ -115,10 +115,30 @@ if (
   !process.env.COVEN_CAVE_ACCESS_TOKEN?.trim()
 ) {
   try {
-    const persisted = readFileSync(persistedMobileAccessSecretFile(), "utf8").trim();
+    const file = persistedMobileAccessSecretFile();
+    const stats = lstatSync(file);
+    // The boot re-arm reads a plaintext credential with no ownership check in
+    // the versions before this guard, and this server cannot import the async
+    // guard (it runs unbundled). Verify synchronously on POSIX: the file must
+    // not be a symlink, must be owned by the current user, and must not be
+    // writable by group or others. Windows cannot answer synchronously, so the
+    // pairing route re-verifies the armed value with the async DACL guard
+    // before trusting it (cave-8pd39); here the read proceeds and is announced.
+    if (stats.isSymbolicLink()) throw new Error("the persisted mobile access secret must not be a symbolic link");
+    if (typeof process.getuid === "function") {
+      if (stats.uid !== process.getuid()) throw new Error("the persisted mobile access secret must be owned by the current user");
+      if ((stats.mode & 0o022) !== 0) throw new Error("the persisted mobile access secret must not be writable by group or others");
+    } else {
+      console.warn(
+        "[cave] boot re-arm reads the persisted mobile access secret without an ownership check on "
+        + process.platform + "; the pairing route re-verifies it with the async guard (cave-8pd39).",
+      );
+    }
+    const persisted = readFileSync(file, "utf8").trim();
     if (persisted) process.env.COVEN_CAVE_ACCESS_TOKEN = persisted;
   } catch {
-    // No provisioned secret — stay tokenless, exactly as before.
+    // No provisioned (or unverifiable) secret — stay tokenless, exactly as
+    // before. A refusal here never crashes boot.
   }
 }
 

--- a/src/app/api/mobile-handoff/route.test.ts
+++ b/src/app/api/mobile-handoff/route.test.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+// Source pins for the mobile-handoff route's access-secret guards.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const route = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
+
+assert.match(
+  route,
+  /verifyArmedMobileAccessSecret/,
+  "the env-armed secret is re-verified against the persisted file",
+);
+assert.match(
+  route,
+  /assertExclusivePathOwnership\(file, stats, "The persisted mobile access secret"\)/,
+  "the armed value is verified with the async ownership guard (one cached probe per process)",
+);
+assert.match(
+  route,
+  /if \(stats\.isSymbolicLink\(\)\) return false;/,
+  "a symlinked persisted secret refuses the gate",
+);
+assert.match(
+  route,
+  /if \(existing\) \{\s*\n\s*if \(!\(await verifyArmedMobileAccessSecret\(\)\)\) return null;/,
+  "a refused persisted file returns null instead of trusting the armed value (cave-8pd39)",
+);
+
+console.log("mobile-handoff route.test.ts OK");

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -6,9 +6,12 @@ import {
   safeProcessErrorMessage,
   terminateProcessTree,
 } from "@/lib/process-execution";
+import { lstatSync } from "node:fs";
+import { assertExclusivePathOwnership } from "@/lib/server/client-v1/path-ownership";
 import { readMobileLastSeen } from "@/lib/server/mobile-paired";
 import {
   armMobileAccessSecret,
+  mobileAccessSecretFile,
   provisionMobileAccessSecret,
   retireMobileAccessSecret,
 } from "@/lib/server/mobile-access-provision";
@@ -258,9 +261,40 @@ function mobileAccessUnavailableResponse() {
  * cookie so the freshly armed gate never locks out the session that turned
  * pairing on.
  */
+/**
+ * Verify the persisted secret behind an env-armed gate.
+ *
+ * The boot re-arm in server.ts reads the plaintext token with no ownership
+ * check (a sync reader that cannot run the Windows DACL probe — cave-8pd39),
+ * so the armed value must be verified against the file it came from before
+ * the pairing gate trusts it. The guard's success cache keeps this to one
+ * probe per process; a substituted or loosened file refuses the gate.
+ */
+async function verifyArmedMobileAccessSecret(): Promise<boolean> {
+  const file = mobileAccessSecretFile();
+  let stats;
+  try {
+    stats = lstatSync(file);
+  } catch {
+    // No persisted file: the armed value came from the environment, not from
+    // the boot re-arm — nothing on disk to verify.
+    return true;
+  }
+  if (stats.isSymbolicLink()) return false;
+  try {
+    await assertExclusivePathOwnership(file, stats, "The persisted mobile access secret");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function resolveMobileAccessSecret(): Promise<{ secret: string; provisioned: boolean } | null> {
   const existing = mobileAccessSecret();
-  if (existing) return { secret: existing, provisioned: false };
+  if (existing) {
+    if (!(await verifyArmedMobileAccessSecret())) return null;
+    return { secret: existing, provisioned: false };
+  }
   // Async since cave-fawvh: provisioning now restricts the state directory and
   // the token file to this user before handing back a plaintext secret, and on
   // Windows that means reading a DACL out of a subprocess.

--- a/src/lib/server/client-v1/path-ownership.test.ts
+++ b/src/lib/server/client-v1/path-ownership.test.ts
@@ -7,6 +7,7 @@ import test, { type TestContext } from "node:test";
 
 import {
   assertClientV1PathOwnership,
+  assertExclusivePathOwnershipSync,
   parseClientV1WindowsAclReport,
   probeWindowsAcl,
   resetClientV1PathOwnershipCache,
@@ -78,6 +79,47 @@ test("compares uid where the platform has one", async () => {
       getuid: () => 1000,
     }),
     /Client v1 credential store root must be owned by the current user\./,
+  );
+});
+
+test("the sync guard answers POSIX ownership completely (cave-8pd39)", () => {
+  assert.doesNotThrow(() =>
+    assertExclusivePathOwnershipSync(uniquePath(), { uid: 1000, mode: 0o600 }, "sync subject", {
+      getuid: () => 1000,
+    }),
+  );
+
+  assert.throws(
+    () => assertExclusivePathOwnershipSync(uniquePath(), { uid: 1001, mode: 0o600 }, "sync subject", {
+      getuid: () => 1000,
+    }),
+    /sync subject must be owned by the current user\./,
+  );
+
+  assert.throws(
+    () => assertExclusivePathOwnershipSync(uniquePath(), { uid: 1000, mode: 0o622 }, "sync subject", {
+      getuid: () => 1000,
+    }),
+    /must not be writable by group or others \(mode 622\)/,
+  );
+
+  assert.throws(
+    () => assertExclusivePathOwnershipSync(uniquePath(), {
+      uid: 1000,
+      mode: 0o600,
+      isSymbolicLink: true,
+    }, "sync subject", { getuid: () => 1000 }),
+    /must not be a symbolic link/,
+  );
+});
+
+test("the sync guard refuses a platform it cannot answer synchronously (cave-8pd39)", () => {
+  assert.throws(
+    () => assertExclusivePathOwnershipSync(uniquePath(), { uid: 0, mode: 0o666 }, "sync subject", {
+      platform: "win32",
+      getuid: null,
+    }),
+    /cannot be verified synchronously on win32/,
   );
 });
 

--- a/src/lib/server/client-v1/path-ownership.ts
+++ b/src/lib/server/client-v1/path-ownership.ts
@@ -529,3 +529,47 @@ export async function assertExclusivePathOwnership(
 
   verifiedWindowsPaths.set(path, report);
 }
+
+/**
+ * Synchronous ownership check for boot-time readers that cannot await the
+ * Windows DACL probe (cave-8pd39).
+ *
+ * POSIX answers completely: the owner uid must be the current user, the group
+ * and other write bits must be clear, and the path must not be a symlink
+ * (metadata must therefore come from lstat, never stat). Windows cannot
+ * answer synchronously — chmod is a no-op there and the DACL needs a
+ * subprocess probe — so the Windows branch REFUSES; a caller that cannot take
+ * the async path must treat the refusal as "unreadable" and stay tokenless
+ * rather than trust silently.
+ */
+export function assertExclusivePathOwnershipSync(
+  path: string,
+  metadata: { uid: number | bigint; mode?: number; isSymbolicLink?: boolean },
+  subject: string,
+  options: ClientV1PathOwnershipOptions = {},
+): void {
+  const platform = options.platform ?? process.platform;
+  const getuid = options.getuid === undefined ? process.getuid : options.getuid;
+
+  if (metadata.isSymbolicLink) {
+    throw new Error(`${subject} must not be a symbolic link.`);
+  }
+
+  if (typeof getuid === "function") {
+    if (metadata.uid !== getuid()) {
+      throw new Error(`${subject} must be owned by the current user.`);
+    }
+    if (metadata.mode !== undefined && (metadata.mode & 0o022) !== 0) {
+      throw new Error(
+        `${subject} must not be writable by group or others `
+        + `(mode ${(metadata.mode & 0o7777).toString(8)}).`,
+      );
+    }
+    return;
+  }
+
+  throw new Error(
+    `${subject} ownership cannot be verified synchronously on ${platform}: `
+    + `${path} is refused. Use the async guard where the platform probe can run.`,
+  );
+}

--- a/src/lib/server/mobile-access-provision.ts
+++ b/src/lib/server/mobile-access-provision.ts
@@ -31,6 +31,7 @@ import path from "node:path";
 import { CAVE_PORTS, CAVE_PORT_ENV, parsePort } from "../../../scripts/ports.mjs";
 import {
   assertExclusivePathOwnership,
+  assertExclusivePathOwnershipSync,
   type ClientV1PathOwnershipOptions,
 } from "./client-v1/path-ownership.ts";
 
@@ -80,7 +81,18 @@ export function loadPersistedMobileAccessSecret(
   env: Record<string, string | undefined> = process.env,
 ): string | null {
   try {
-    const secret = readFileSync(mobileAccessSecretFile(env), "utf8").trim();
+    const file = mobileAccessSecretFile(env);
+    // This reader is sync and cannot run the Windows DACL probe, so it uses
+    // the sync guard: POSIX verifies owner/mode/symlink, and a platform that
+    // cannot answer synchronously refuses — the secret is treated as
+    // unreadable rather than trusted silently (cave-8pd39).
+    const stats = lstatSync(file);
+    assertExclusivePathOwnershipSync(
+      file,
+      { uid: stats.uid, mode: stats.mode, isSymbolicLink: stats.isSymbolicLink() },
+      "The persisted mobile access secret",
+    );
+    const secret = readFileSync(file, "utf8").trim();
     return secret.length > 0 ? secret : null;
   } catch {
     return null;


### PR DESCRIPTION
## What

The provision path guards the mobile access secret (`cave-fawvh`), but two readers still trusted the plaintext file blindly — `loadPersistedMobileAccessSecret` and the `server.ts` boot re-arm. A foreign principal who can write that file could substitute the gate secret and neither reader would notice (`cave-8pd39`).

## Change

- New `assertExclusivePathOwnershipSync` in `path-ownership.ts`: POSIX verifies owner uid, clear group/other write bits, and no symlink (metadata from `lstat`); a platform that cannot answer synchronously refuses.
- `loadPersistedMobileAccessSecret` runs the sync guard and treats a refusal as unreadable.
- The `server.ts` boot re-arm (unbundled, cannot import TS) performs the same POSIX checks inline; on platforms without uid semantics it announces the unverified read, and the pairing route re-verifies before trusting.
- `resolveMobileAccessSecret` now re-verifies the env-armed secret against the persisted file with the async DACL guard (one cached probe per process) — the contained option the bead's own review comment proposes — so a substituted file refuses the pairing gate even when the env was already armed.

## Verification

- `path-ownership.test.ts` + `mobile-access-provision.test.ts` 32/32 (1 skipped), `mobile-handoff.test.ts` + provision 14/14, new route source pins pass, `check:tests-wired` clean, `tsc --noEmit` clean.

## Bead

`cave-8pd39` — The mobile access token is verified on the provision path only, not on the two read paths.