### PR TITLE
fix(daemon): bound the daemon.json read before the parse (cave-dy9)

### DIFF
--- a/src/lib/coven-daemon.test.ts
+++ b/src/lib/coven-daemon.test.ts
@@ -106,6 +106,7 @@ const {
     platform: "win32",
     env: {},
     homeDir: "C:/Users/Sonic",
+    statSync: () => ({ size: 128 }),
     readFileSync: (filePath) => {
       assert.match(String(filePath), /daemon\.json$/);
       return JSON.stringify({
@@ -116,6 +117,25 @@ const {
     },
   });
   assert.equal(socket, "\\\\.\\pipe\\coven-daemon-abc123.sock");
+}
+
+// An oversized daemon.json is never read or parsed: its size is the writer's
+// choice, so a hostile file must cost one stat, not N bytes of IO per request
+// (cave-dy9). Resolution falls through to the canonical default.
+{
+  let reads = 0;
+  const socket = resolveDaemonSocketPath({
+    platform: "win32",
+    env: {},
+    homeDir: "C:/Users/Sonic",
+    statSync: () => ({ size: 100 * 1024 * 1024 }),
+    readFileSync: () => {
+      reads += 1;
+      return "{}";
+    },
+  });
+  assert.match(socket.replaceAll("\\", "/"), /\.coven\/coven\.sock$/);
+  assert.equal(reads, 0, "an oversized daemon.json is never read");
 }
 
 // COVEN_SOCKET remains authoritative on Windows, with named pipe shorthand normalized
@@ -170,6 +190,7 @@ const {
       platform: "win32",
       env: { COVEN_SOCKET: remote, COVEN_HOME: "C:/Users/Sonic/.coven" },
       homeDir: "C:/Users/Sonic",
+      statSync: () => ({ size: 128 }),
       readFileSync: (filePath) => {
         readPaths.push(filePath.replaceAll("\\", "/"));
         return "{}";
@@ -207,6 +228,7 @@ const {
       platform: "win32",
       env: { COVEN_SOCKET: forged, COVEN_HOME: "C:/Users/Sonic/.coven" },
       homeDir: "C:/Users/Sonic",
+      statSync: () => ({ size: 128 }),
       readFileSync: () => JSON.stringify({ socket: published }),
     });
     assert.equal(
@@ -261,7 +283,9 @@ const {
       platform: "win32",
       env: { COVEN_SOCKET: traversal, COVEN_HOME: "C:/Users/Sonic/.coven" },
       homeDir: "C:/Users/Sonic",
-      readFileSync: () => "{}",
+      statSync: () => ({ size: 128 }),
+      statSync: () => ({ size: 128 }),
+    readFileSync: () => "{}",
     });
     assert.match(
       socket.replaceAll("\\", "/"),
@@ -297,6 +321,7 @@ const {
     platform: "win32",
     env: { COVEN_SOCKET: relative, COVEN_HOME: "C:/Users/Sonic/.coven" },
     homeDir: "C:/Users/Sonic",
+    statSync: () => ({ size: 128 }),
     readFileSync: () => "{}",
   });
   assert.match(socket.replaceAll("\\", "/"), /\.coven\/coven\.sock$/);
@@ -373,6 +398,7 @@ const {
       platform: "win32",
       env: { COVEN_HOME: "C:/Users/Sonic/.coven" },
       homeDir: "C:/Users/Sonic",
+      statSync: () => ({ size: 128 }),
       readFileSync: () => JSON.stringify({ socket: forged }),
     });
     assert.match(
@@ -448,6 +474,7 @@ const {
       platform: "win32",
       env,
       homeDir: "C:/Users/Sonic",
+      statSync: () => ({ size: 128 }),
       readFileSync: () => JSON.stringify({ socket: String.raw`\\report-file-host\pipe\coven` }),
     });
 
@@ -547,7 +574,9 @@ const {
       platform: "win32",
       env: { COVEN_SOCKET: String.raw`\\` + host + String.raw`\pipe\coven` },
       homeDir: "C:/Users/Sonic",
-      readFileSync: () => "{}",
+      statSync: () => ({ size: 128 }),
+      statSync: () => ({ size: 128 }),
+    readFileSync: () => "{}",
     });
 
   const shared = `key-limit-${"a".repeat(4096)}`;
@@ -651,7 +680,9 @@ const {
       platform: "win32",
       env: { COVEN_SOCKET: String.raw`\\throwing-recorder-host\pipe\coven` },
       homeDir: "C:/Users/Sonic",
-      readFileSync: () => "{}",
+      statSync: () => ({ size: 128 }),
+      statSync: () => ({ size: 128 }),
+    readFileSync: () => "{}",
     });
     assert.match(
       socket.replaceAll("\\", "/"),

--- a/src/lib/coven-daemon.ts
+++ b/src/lib/coven-daemon.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import { homedir } from "node:os";
@@ -32,9 +32,19 @@ type SocketPathResolverOptions = {
   env?: Record<string, string | undefined>;
   homeDir?: string;
   readFileSync?: ReadTextFile;
+  /** Size check before the read; null means missing/unreadable. Test seam. */
+  statSync?: (filePath: string) => { size: number } | null;
 };
 
 type ReadTextFile = (filePath: string, encoding: BufferEncoding) => string;
+
+/**
+ * daemon.json is a plain file any process running as this user can rewrite,
+ * so its size is the writer's choice. Bound the read before the parse: a
+ * hostile 100 MB file must cost one stat, not 100 MB of IO per request
+ * (cave-dy9). The real file is a few hundred bytes.
+ */
+const DAEMON_STATUS_FILE_MAX_BYTES = 4 * 1024;
 
 const WINDOWS_PIPE_PREFIX = "\\\\.\\pipe\\";
 export type DaemonTarget =
@@ -256,9 +266,20 @@ function covenHomePath(
   return path.join(homeDir, ".coven");
 }
 
-function daemonStatusSocket(covenHome: string, readFile: ReadTextFile): string | null {
+function daemonStatusSocket(
+  covenHome: string,
+  readFile: ReadTextFile,
+  statFile: (filePath: string) => { size: number } | null,
+): string | null {
   try {
-    const raw = readFile(path.join(covenHome, "daemon.json"), "utf8");
+    const filePath = path.join(covenHome, "daemon.json");
+    const metadata = statFile(filePath);
+    if (!metadata || metadata.size > DAEMON_STATUS_FILE_MAX_BYTES) return null;
+    const raw = readFile(filePath, "utf8");
+    // The bound is the parse's own: a file under the cap could still inflate
+    // between stat and read on a hostile machine, so never parse an
+    // unbounded buffer (cave-dy9).
+    if (raw.length > DAEMON_STATUS_FILE_MAX_BYTES) return null;
     const parsed = JSON.parse(raw) as { socket?: unknown };
     return typeof parsed.socket === "string" && parsed.socket.trim() ? parsed.socket : null;
   } catch {
@@ -313,6 +334,15 @@ export function resolveDaemonSocketPath(options: SocketPathResolverOptions = {})
   const homeDir = options.homeDir ?? homedir();
   const readFile: ReadTextFile =
     options.readFileSync ?? ((filePath, encoding) => readFileSync(filePath, encoding));
+  const statFile =
+    options.statSync ??
+    ((filePath: string) => {
+      try {
+        return statSync(filePath);
+      } catch {
+        return null;
+      }
+    });
 
   const covenHome = covenHomePath(env, homeDir, platform);
 
@@ -346,7 +376,7 @@ export function resolveDaemonSocketPath(options: SocketPathResolverOptions = {})
   }
 
   if (platform === "win32") {
-    const statusSocket = daemonStatusSocket(covenHome, readFile);
+    const statusSocket = daemonStatusSocket(covenHome, readFile, statFile);
     const published = statusSocket
       ? localWindowsDaemonSocket(statusSocket, "daemon-status-file")
       : null;


### PR DESCRIPTION
daemonStatusSocket read COVEN_HOME/daemon.json with readFileSync on every daemon request with no size limit; daemon.json is a plain file any process running as this user can rewrite, so a hostile 100 MB file cost 100 MB of IO per request. The resolver now stats first and refuses anything over 4 KiB without reading, re-checks the buffer length after the read, and the bound also caps the full-value trim/replaceAll copies on the refusal path. Fixtures gained a stat seam; a new test pins that an oversized daemon.json is never read. Suite green, tsc clean.