### PR TITLE
docs: tombstone the content-gen-flow spec and plan (cave-a6zmc)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,7 +104,7 @@ Active initiatives. Parts have shipped; parts have not. Each states which.
 
 Point-in-time records. Read for intent, not for current behavior.
 
-- [`content-gen-flow-spec.md`](content-gen-flow-spec.md) and [`content-gen-flow-plan.md`](content-gen-flow-plan.md) — ⚠️ both target `FLOW_TEMPLATES` in `src/lib/flow/flow-templates.ts`, which no longer exists; the symbol appears nowhere in the tree (removed in #3902)
+- [`content-gen-flow-spec.md`](content-gen-flow-spec.md) and [`content-gen-flow-plan.md`](content-gen-flow-plan.md) — ⚠️ tombstoned 2026-08-28 (cave-a6zmc): both target `FLOW_TEMPLATES` in `src/lib/flow/flow-templates.ts`, which no longer exists; the symbol appears nowhere in the tree (removed in #3902). Content generation continues in the Research Desk surfaces.
 - [`ios-native-rebuild.md`](ios-native-rebuild.md) — the multi-phase rebuild plan; its tokenless tailnet-trust model was replaced by pair-once mobile access tokens (#3310)
 - [`ios-connection-cloud-plan.md`](ios-connection-cloud-plan.md) — draft planning anchor for onboarding, constant connection, and cloud persistence
 - [`nav-history-tracking.md`](nav-history-tracking.md) — the read-only inventory (PR #4407)

--- a/docs/content-gen-flow-plan.md
+++ b/docs/content-gen-flow-plan.md
@@ -1,5 +1,11 @@
 # Content Generation Flow Template — Implementation Plan
 
+> **Superseded (tombstoned 2026-08-28, cave-a6zmc).** This plan builds on
+> `FLOW_TEMPLATES` in `src/lib/flow/flow-templates.ts`, which was removed in
+> #3902. Do not implement this plan. Content generation continues in the
+> Research Desk surfaces; see their current specs before starting new work.
+
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a new Flow template (`content-generation`) to `FLOW_TEMPLATES` that automates long-form content generation across blog, Twitter thread, and Discord surfaces from one research run, gated by a human approval after research synthesis.

--- a/docs/content-gen-flow-spec.md
+++ b/docs/content-gen-flow-spec.md
@@ -1,8 +1,15 @@
 # Content Generation Flow — Design Spec
 
-**Status:** Resolved — ready for implementation plan
+**Status:** Superseded (tombstoned 2026-08-28, cave-a6zmc)
 **Owner:** Val
 **Date:** 2026-06-28
+
+> **Tombstone.** The host subsystem this design targets — `FLOW_TEMPLATES` in
+> `src/lib/flow/flow-templates.ts` — was removed in #3902, so this design can
+> never be implemented as written. Long-form content generation now lives in
+> the Research Desk surfaces (blog direction controls, podcast rendering, X
+> publishing) under their own reviewed contracts. Keep this document only for
+> citation and history; do not build from it.
 **Surface:** `src/lib/flow/flow-templates.ts` — adds a new template to the existing Flow subsystem
 **Refs:** Builds on patterns from `deep-research` (research pipeline), `pr-review` (per-branch fan-out), `flow-required-inputs` design (#1983/#1994/#1997/#1998)
 


### PR DESCRIPTION
## Summary

Decision recorded for cave-a6zmc: **tombstone**, not revive.

Both documents target `FLOW_TEMPLATES` in `src/lib/flow/flow-templates.ts`, removed in #3902 — they can never be implemented as written. Long-form content generation now lives in the Research Desk surfaces (blog direction controls, podcast rendering, X publishing) under their own reviewed contracts.

- Mark both docs **Superseded** with the tombstone reason.
- Update `docs/README.md` entry accordingly.
- Keep the files on main for citation; do not build from them.