### PR TITLE
fix(x): make the X cache purge best-effort on disconnect (cave-fspmd)

### DIFF
--- a/src/app/api/x/account-routes.test.ts
+++ b/src/app/api/x/account-routes.test.ts
@@ -37,6 +37,22 @@ assert.match(connection, /xCredentialService\.disconnect\(\)/);
 // to remove it (cave-1tu16). Durable identities, notes, mission links and
 // receipts live elsewhere and stay.
 assert.match(connection, /purgeXSourceCache\(\)/);
+// The purge is best-effort: it must sit inside a try/catch and disconnect must
+// sit OUTSIDE that block, so a purge failure (e.g. a cross-process cache-lock
+// timeout) can never skip the token drop — a user who asks to disconnect is
+// always disconnected, and the failure is surfaced separately (cave-fspmd).
+// Behavioural proof lives in connection-route-behavior.test.ts; this pin stops
+// a later edit reverting to purge-then-throw.
+assert.match(connection, /try\s*\{[\s\S]*?purgeXSourceCache\(\)[\s\S]*?\}\s*catch/);
+// The brace-excluding class keeps this honest: the try block has no nested
+// braces, so a match would have to be exactly purge and disconnect sharing one
+// block — the trailing \} cannot drift onto the response object.
+assert.doesNotMatch(
+  connection,
+  /try\s*\{[^{}]*purgeXSourceCache\(\)[^{}]*xCredentialService\.disconnect\(\)[^{}]*\}/,
+  "disconnect must not live inside the purge's try block — a purge failure must not skip it",
+);
+assert.match(connection, /purgeFailed/);
 
 // Both callers reject the response unless these three are booleans, so they
 // are the contract rather than an implementation detail.

--- a/src/app/api/x/connection-route-behavior.test.ts
+++ b/src/app/api/x/connection-route-behavior.test.ts
@@ -143,15 +143,18 @@ test("DELETE purges normalized post content and keeps the saved identity", async
   assert.deepEqual(sources[0]!.tags, ["research"]);
 });
 
-// DELETE purges BEFORE dropping the bundle, and the route comment calls that
-// ordering load-bearing: a purge failure must abort the disconnect rather than
-// strand post bodies behind a disconnected account. Until this test the
-// ordering was unenforced — swapping the two statements left every other
-// assertion in this file, and both source pins next door, green.
+// DELETE runs the purge best-effort and ALWAYS drops the bundle: the cache
+// holds public post text, the bundle holds OAuth access and refresh tokens, so
+// a purge failure — most plausibly a 15s cross-process cache-lock timeout —
+// must never leave the tokens stored. A user who asks to disconnect is always
+// disconnected, and the purge error is surfaced separately (purgeFailed +
+// purgeError in the response) instead of failing the request (cave-fspmd).
+// Until this test the purge ran first and its failure aborted the disconnect,
+// leaving the OAuth tokens stored.
 //
 // A regular file where the cache directory belongs is the cross-platform way to
 // make the purge fail; an unprivileged Windows process cannot create a symlink.
-test("a failed cache purge aborts the disconnect rather than dropping the bundle", async () => {
+test("a failed cache purge still drops the bundle and reports the purge failure", async () => {
   await rm(cacheDir, { recursive: true, force: true });
   await writeFile(cacheDir, "not a directory", "utf8");
   xCredentialService.replaceBundle({
@@ -163,15 +166,20 @@ test("a failed cache purge aborts the disconnect rather than dropping the bundle
   });
   assert.equal(xCredentialService.getConnectionStatus().connected, true);
 
-  await assert.rejects(
-    () => DELETE(localRequest("DELETE")),
-    /real directory/,
-    "a cache root that is not a real directory must fail the disconnect loudly",
+  const response = await DELETE(localRequest("DELETE"));
+  assert.equal(response.status, 200, "a purge failure must not fail the disconnect");
+  const body = await response.json() as Record<string, unknown>;
+  assert.equal(body.ok, true);
+  assert.equal(body.purgeFailed, true, "the purge failure must be surfaced in the response");
+  assert.equal(
+    typeof body.purgeError,
+    "string",
+    "the purge error message must be surfaced in the response",
   );
   assert.equal(
     xCredentialService.getConnectionStatus().connected,
-    true,
-    "the bundle must survive a failed purge — the purge runs BEFORE disconnect",
+    false,
+    "the bundle must be dropped even when the purge fails",
   );
 
   await rm(cacheDir, { force: true });

--- a/src/app/api/x/connection/route.ts
+++ b/src/app/api/x/connection/route.ts
@@ -66,9 +66,15 @@ export async function DELETE(req: Request) {
   // Disconnecting clears stored credentials AND the normalized post cache.
   // The cache is the only place a post BODY is ever persisted; leaving it
   // behind meant post text, author id and handle outlived the disconnect that
-  // is supposed to remove them (cave-1tu16). Purge before dropping the bundle
-  // so a failure leaves the account connected rather than leaving orphaned
-  // content behind a disconnected account.
+  // is supposed to remove them (cave-1tu16).
+  //
+  // The purge is best-effort and must never abort the disconnect (cave-fspmd):
+  // the cache holds public post text while the bundle holds OAuth access and
+  // refresh tokens, so a purge failure — most plausibly a 15s cross-process
+  // cache-lock timeout — must not leave the tokens stored. A user who asks to
+  // disconnect is always disconnected; the purge error is surfaced separately
+  // (logged, and reported as purgeFailed in the response) instead of failing
+  // the request.
   //
   // Durable source identities, user notes, mission links and publish receipts
   // live in x-sources/ and x-publications/ and are deliberately untouched.
@@ -77,7 +83,25 @@ export async function DELETE(req: Request) {
   // keyed by flowId and only the owner of that flow may end it — DELETE
   // /api/x/oauth/start is the documented path for that, and guessing here
   // would let one caller abort another's flow.
-  await purgeXSourceCache();
+  let purgeError: unknown = null;
+  try {
+    await purgeXSourceCache();
+  } catch (error) {
+    purgeError = error;
+    console.error(
+      "api/x/connection: cache purge failed; the X account was still disconnected",
+      error,
+    );
+  }
   xCredentialService.disconnect();
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({
+    ok: true,
+    ...(purgeError !== null
+      ? {
+          purgeFailed: true,
+          purgeError:
+            purgeError instanceof Error ? purgeError.message : String(purgeError),
+        }
+      : {}),
+  });
 }


### PR DESCRIPTION
## What

DELETE /api/x/connection currently awaits purgeXSourceCache() before xCredentialService.disconnect(), so a purge failure (e.g. a 15s cross-process cache-lock timeout) aborts the disconnect and leaves the OAuth access/refresh tokens stored. That inverts sensitivity: the cache holds public post text, the bundle holds OAuth tokens.

The purge is now best-effort: it runs inside a try/catch, the credential bundle is ALWAYS dropped, and the purge error is surfaced separately — logged, and reported as `purgeFailed` + `purgeError` in the 200 response — so a user who asks to disconnect is always disconnected (cave-fspmd).

## Why

Fixes cave-fspmd: a failed X cache purge must never leave the OAuth tokens stored.

## Verification

- Inverted the review-added behavior test: a cache root that is not a real directory now still drops the bundle, returns 200, and reports the purge failure (purgeFailed/purgeError present).
- Extended the source-pin test (account-routes.test.ts): purge must sit inside try/catch and disconnect must sit outside it; the response must surface purgeFailed.
- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/app/api/x/connection-route-behavior.test.ts src/app/api/x/account-routes.test.ts` → 5/5 pass.
- Sibling X route tests (sources/publish/research) → 12/12 pass.
- `node scripts/check-tests-wired.mjs` → all 1911 test files wired.
- `npx tsc --noEmit` → clean.
