### PR TITLE
fix(security): refuse symlinked mobile token paths and probe the realpath (cave-8p0hn)

### DIFF
--- a/src/lib/server/mobile-access-provision.test.ts
+++ b/src/lib/server/mobile-access-provision.test.ts
@@ -2,7 +2,18 @@
 // provisions the pairing secret in dev instead of dead-ending on
 // "run `pnpm mobile:tailscale`".
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, statSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test, type TestContext } from "node:test";
@@ -27,6 +38,15 @@ function devEnv(overrides: Record<string, string | undefined> = {}): Record<stri
     PORT: "3000",
     ...overrides,
   };
+}
+
+/** Symlink creation is a privilege on some platforms; skip rather than fail. */
+function isUnsupportedSymlinkError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ENOSYS"
+    || code === "ENOTSUP"
+    || code === "EOPNOTSUPP"
+    || (process.platform === "win32" && (code === "EPERM" || code === "EACCES"));
 }
 
 // ── Windows seams (cave-fawvh) ───────────────────────────────────────────────
@@ -172,9 +192,11 @@ test("restricts the state directory and the token file on Windows, where chmod d
   assert.ok(secret, "an exclusive Windows path still provisions");
 
   const file = mobileAccessSecretFile(env);
+  // The guard probes the realpath'd target (cave-8p0hn): on macOS the mkdtemp
+  // path under /var resolves to /private/var, so the pinned paths resolve too.
   assert.deepEqual(
     probed,
-    [path.dirname(file), file],
+    [realpathSync(path.dirname(file)), realpathSync(file)],
     "the directory is restricted BEFORE the secret is written into it, then the file is verified",
   );
 
@@ -188,7 +210,7 @@ test("restricts the state directory and the token file on Windows, where chmod d
     await provisionMobileAccessSecret(env, { ownership: windowsOwnership(again) }),
     secret,
   );
-  assert.deepEqual(again, [path.dirname(file), file]);
+  assert.deepEqual(again, [realpathSync(path.dirname(file)), realpathSync(file)]);
 });
 
 test("a token file that cannot be restricted is never left on disk", async () => {
@@ -209,7 +231,7 @@ test("a token file that cannot be restricted is never left on disk", async () =>
     null,
     "a state directory another principal can write must not receive a plaintext secret",
   );
-  assert.deepEqual(sharedProbes, [path.dirname(mobileAccessSecretFile(shared))]);
+  assert.deepEqual(sharedProbes, [realpathSync(path.dirname(mobileAccessSecretFile(shared)))]);
   assert.equal(existsSync(mobileAccessSecretFile(shared)), false);
 
   // And when only the file itself fails the check, the secret written a moment
@@ -220,8 +242,12 @@ test("a token file that cannot be restricted is never left on disk", async () =>
     await provisionMobileAccessSecret(late, {
       warn: () => {},
       ownership: windowsOwnership([], async (target) => {
-        if (target === lateFile) throw new Error("spawn powershell.exe ENOENT");
-        return exclusiveReport();
+        // The directory probe passes; only the token file's probe fails, so
+        // the secret written a moment earlier must be removed. The probed
+        // paths are the realpath'd ones (cave-8p0hn), and the file does not
+        // exist until the mint writes it, so the comparison resolves the dir.
+        if (target === realpathSync(path.dirname(lateFile))) return exclusiveReport();
+        throw new Error("spawn powershell.exe ENOENT");
       }),
     }),
     null,
@@ -231,6 +257,71 @@ test("a token file that cannot be restricted is never left on disk", async () =>
     false,
     "a plaintext secret must not survive on a path whose ACL could not be verified",
   );
+});
+
+test("a symlinked state directory is refused before anything is written into it", async (t: TestContext) => {
+  // mkdirSync(recursive) and writeFileSync FOLLOW a reparse point, so a
+  // symlinked state dir would land the plaintext secret in a directory whose
+  // DACL was never the one verified — and lstat of the link itself reports
+  // the current user, so the ownership guard would pass it (cave-8p0hn).
+  const env = devEnv();
+  const stateDir = path.dirname(mobileAccessSecretFile(env));
+  const target = mkdtempSync(path.join(tmpdir(), "cave-mobile-dir-target-"));
+  let linked = false;
+  try {
+    symlinkSync(target, stateDir, process.platform === "win32" ? "junction" : "dir");
+    linked = true;
+  } catch (error) {
+    if (isUnsupportedSymlinkError(error)) {
+      t.skip(`directory symlinks are unsupported on this platform (${(error as NodeJS.ErrnoException).code})`);
+      return;
+    }
+    throw error;
+  }
+  try {
+    assert.equal(
+      await provisionMobileAccessSecret(env, { warn: () => {} }),
+      null,
+      "a symlinked state directory must not receive a plaintext secret",
+    );
+    assert.deepEqual(readdirSync(target), [], "nothing was written through the link");
+  } finally {
+    if (linked) rmSync(stateDir, { force: true });
+    rmSync(target, { recursive: true, force: true });
+  }
+});
+
+test("a symlinked token file is refused instead of followed", async (t: TestContext) => {
+  // The minted secret would be written THROUGH the link to its target, so the
+  // file guard must refuse the reparse point rather than verify the link's own
+  // (trivially current-user) metadata and hand the secret back (cave-8p0hn).
+  const env = devEnv();
+  const file = mobileAccessSecretFile(env);
+  mkdirSync(path.dirname(file), { recursive: true });
+  const targetDir = mkdtempSync(path.join(tmpdir(), "cave-mobile-file-target-"));
+  const target = path.join(targetDir, "access-token");
+  writeFileSync(target, "decoy\n", "utf8");
+  let linked = false;
+  try {
+    symlinkSync(target, file, "file");
+    linked = true;
+  } catch (error) {
+    if (isUnsupportedSymlinkError(error)) {
+      t.skip(`file symlinks are unsupported on this platform (${(error as NodeJS.ErrnoException).code})`);
+      return;
+    }
+    throw error;
+  }
+  try {
+    assert.equal(
+      await provisionMobileAccessSecret(env, { warn: () => {} }),
+      null,
+      "a symlinked token file must not be trusted",
+    );
+  } finally {
+    if (linked) rmSync(file, { force: true });
+    rmSync(targetDir, { recursive: true, force: true });
+  }
 });
 
 test("a refusal to restrict the token path is announced, not swallowed", async () => {

--- a/src/lib/server/mobile-access-provision.ts
+++ b/src/lib/server/mobile-access-provision.ts
@@ -23,6 +23,7 @@ import {
   lstatSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   writeFileSync,
   rmSync,
 } from "node:fs";
@@ -120,6 +121,13 @@ export interface MobileAccessProvisionOptions {
  * file holds the pairing secret in plaintext, so the same defect is worse
  * here. The POSIX modes above stay (they are real on POSIX); this adds the
  * DACL the platform actually enforces, using the guard #4852 already built.
+ *
+ * Since cave-8p0hn it also refuses a symlink and inspects the real path — the
+ * same two moves the sibling credential store makes. A reparse point here
+ * would be FOLLOWED by mkdirSync(recursive) and writeFileSync into a directory
+ * whose DACL was never the one verified, and the ownership answer is only
+ * about the path the guard actually inspected: on macOS mkdtempSync(tmpdir())
+ * hands back /var/… that resolves to /private/var/….
  */
 async function restrictToCurrentUser(
   target: string,
@@ -127,7 +135,24 @@ async function restrictToCurrentUser(
   env: Record<string, string | undefined>,
   options: MobileAccessProvisionOptions,
 ): Promise<void> {
-  await assertExclusivePathOwnership(target, lstatSync(target), subject, {
+  // lstat the path as handed BEFORE realpath resolves it: a symlink here must
+  // be refused, not followed, and realpath would resolve the link away so the
+  // guard would then describe a path the secret does not actually live at.
+  const handed = lstatSync(target);
+  if (handed.isSymbolicLink()) {
+    throw new Error(`${subject} must not be a symlink: ${target}.`);
+  }
+  // The ownership answer is only about the path the guard inspected, so it
+  // must inspect the target reads and writes actually land on — and keep the
+  // symlink refusal for the race that swaps one in between the two calls
+  // (same realpath-then-lstat move as credential-store.ts
+  // `initializeCredentialStoreLocation`).
+  const physical = realpathSync(target);
+  const metadata = lstatSync(physical);
+  if (metadata.isSymbolicLink()) {
+    throw new Error(`${subject} must not be a symlink: ${target}.`);
+  }
+  await assertExclusivePathOwnership(physical, metadata, subject, {
     // The waiver is read from the same environment this module was handed, so
     // a test can drive it and a caller cannot accidentally consult a different
     // one than the rest of the module.


### PR DESCRIPTION
## What

`restrictToCurrentUser()` in `src/lib/server/mobile-access-provision.ts` asserted ownership with `assertExclusivePathOwnership(target, lstatSync(target), ...)` — no `realpath`, no is-a-symlink check. It now mirrors the sibling credential-store call site:

- **Refuse a reparse point**: the path as handed is `lstat`'d first; a symlink throws (`<subject> must not be a symlink`) instead of being followed. `mkdirSync(recursive)` and `writeFileSync` resolve links, so a symlinked state dir or token file would land the plaintext pairing secret in a directory whose DACL was never the one verified — and `lstat` of the link itself reports the current user, so the old guard passed it.
- **Probe the realpath**: the guard now inspects `realpathSync(target)` (re-`lstat`'d) — the target reads/writes actually land on — because the ownership answer is only about the path the guard inspected. On macOS, `mkdtempSync(tmpdir())` hands back `/var/…` that resolves to `/private/var/…`, which is exactly why the test's exact-path pins had to be updated.

## Why

Found by the independent review of PR #4864 (cave-fawvh): the ownership answer was about the path the guard inspected, but the guard inspected the reparse point while the writes followed it. The prerequisite is write access to the parent, so not a privilege escalation from nothing — but it is the exact gap the client-v1 copy of the same guard closes, and this file holds the secret in plaintext rather than a SHA-256 hash.

## Verification

- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/server/mobile-access-provision.test.ts` — 15/15 pass, including two new regression tests: *a symlinked state directory is refused before anything is written into it* and *a symlinked token file is refused instead of followed* (both would have passed the old guard and minted/returned a secret).
- Sibling suites `credential-store.test.ts` + `path-ownership.test.ts` — 39 pass / 1 platform skip.
- `node scripts/check-tests-wired.mjs` — clean.
- `npx tsc --noEmit` — clean.