### PR TITLE
fix(docs): neutralize misleading plan-doc checkbox tracking header (cave-y5tx2)

### DIFF
--- a/docs/content-gen-flow-plan.md
+++ b/docs/content-gen-flow-plan.md
@@ -6,7 +6,7 @@
 > Research Desk surfaces; see their current specs before starting new work.
 
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add a new Flow template (`content-generation`) to `FLOW_TEMPLATES` that automates long-form content generation across blog, Twitter thread, and Discord surfaces from one research run, gated by a human approval after research synthesis.
 

--- a/docs/plans/2026-07-29-ios-new-chat-project-contract.md
+++ b/docs/plans/2026-07-29-ios-new-chat-project-contract.md
@@ -1,6 +1,6 @@
 # iOS New-Chat Project Contract Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make every native iOS first-turn chat carry a persisted, familiar-authorized project root and permanently guard the client/server contract with native and Linux-runnable tests.
 

--- a/docs/specs/2026-06-08-reader-visual-polish-plan.md
+++ b/docs/specs/2026-06-08-reader-visual-polish-plan.md
@@ -1,6 +1,6 @@
 # Reader Visual Polish Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Apply visual polish to the coven-cave library reader modal — swap body font to Lora, widen modal to 820px, and apply airy padding throughout.
 

--- a/docs/specs/2026-06-28-cave-native-eval-templates-plan.md
+++ b/docs/specs/2026-06-28-cave-native-eval-templates-plan.md
@@ -1,6 +1,6 @@
 # Cave-Native Eval Templates Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Refresh the Evals starter template catalog so it is directly applicable to Coven Cave familiar operations.
 

--- a/docs/specs/2026-06-28-eval-loop-control-plane-plan.md
+++ b/docs/specs/2026-06-28-eval-loop-control-plane-plan.md
@@ -1,6 +1,6 @@
 # Eval Loop Control Plane Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Build a daemon-owned eval-loop lock recovery API and a dedicated Cave Eval Loops surface that can run and unblock familiar eval loops safely.
 

--- a/docs/specs/2026-06-28-grouped-eval-stale-state-plan.md
+++ b/docs/specs/2026-06-28-grouped-eval-stale-state-plan.md
@@ -1,6 +1,6 @@
 # Grouped Eval Stale State Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add thread eval freshness verification, grouped manual queueing, richer per-thread eval details, and a review-first Thread Signals summary.
 

--- a/docs/specs/2026-06-28-response-confidence-events-plan.md
+++ b/docs/specs/2026-06-28-response-confidence-events-plan.md
@@ -1,6 +1,6 @@
 # Response Confidence Events Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add append-only per-response familiar confidence diagnostics and surface their rollups in Familiar Analytics and Eval Loops.
 

--- a/docs/specs/2026-06-28-unified-evals-analysis-plan.md
+++ b/docs/specs/2026-06-28-unified-evals-analysis-plan.md
@@ -1,6 +1,6 @@
 # Unified Evals Analysis Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Merge the split Eval Loops and Evals workspaces into one richer Evals analysis/control room.
 

--- a/docs/specs/2026-06-29-coven-channels-docs-alignment-plan.md
+++ b/docs/specs/2026-06-29-coven-channels-docs-alignment-plan.md
@@ -1,6 +1,6 @@
 # Coven Channels Docs Alignment Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Update Coven Cave internal and user-facing docs so Cave reflects the new OpenCoven-native `@opencoven/channels` Discord connector without treating OpenClaw as the channel owner.
 

--- a/docs/specs/2026-06-29-telegram-channel-migration-plan.md
+++ b/docs/specs/2026-06-29-telegram-channel-migration-plan.md
@@ -1,6 +1,6 @@
 # Telegram Channel Migration Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Move Telegram channel connection from OpenClaw-owned runtime behavior into OpenCoven-native channel infrastructure without breaking Val's existing Telegram direct-message workflow.
 

--- a/docs/specs/2026-06-30-codex-code-surface-plan.md
+++ b/docs/specs/2026-06-30-codex-code-surface-plan.md
@@ -1,6 +1,6 @@
 # Codex Code Surface Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Recreate the Code page (`mode === "code"`) to comprehensively emulate the OpenAI Codex cloud experience — a project→thread nav sidebar with Pinned + user footer, a single active conversation with "Worked for Xs"/code blocks/inline file-edit cards, and a Codex composer with permission + model chips.
 

--- a/docs/specs/2026-07-03-chat-sidebar-recency-grouping-plan.md
+++ b/docs/specs/2026-07-03-chat-sidebar-recency-grouping-plan.md
@@ -1,6 +1,6 @@
 # Chat Sidebar Recency View Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add an "Organize sidebar" menu to the chat sidebar that switches between the existing By-project view and a new default time-bucketed Recent-chats view, and drop the " ago" suffix from sidebar row times.
 

--- a/docs/specs/2026-07-03-ios-ipad-mac-onboarding-plan.md
+++ b/docs/specs/2026-07-03-ios-ipad-mac-onboarding-plan.md
@@ -1,6 +1,6 @@
 # iOS iPad/macOS Adaptivity + Seamless Onboarding Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Every screen of the native app lays out properly on iPad landscape and macOS ("Designed for iPad") windows, and pairing a device with a token-gated desktop is a paste/scan/tap affair with actionable errors and silent renewal.
 

--- a/docs/specs/2026-07-03-shell-left-panels-px-widths-plan.md
+++ b/docs/specs/2026-07-03-shell-left-panels-px-widths-plan.md
@@ -1,6 +1,6 @@
 # Shell Left Panels Pixel Widths — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Convert the app shell's left nav and list panels from percentage widths (which balloon on wide monitors) to pixel widths matching the declared `--shell-nav-width`/`--shell-list-width` intents, so the main content gets the reclaimed width.
 

--- a/docs/specs/2026-07-03-sidebar-version-line-plan.md
+++ b/docs/specs/2026-07-03-sidebar-version-line-plan.md
@@ -1,6 +1,6 @@
 # Sidebar version line — implementation plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Show `v{APP_VERSION}` as the bottommost, minimal-height element of the default left sidebar.
 

--- a/docs/specs/2026-07-03-unified-chat-code-workspace-plan.md
+++ b/docs/specs/2026-07-03-unified-chat-code-workspace-plan.md
@@ -1,6 +1,6 @@
 # Unified Chat + Code Workspace — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Collapse the separate Chat and Code surfaces into one chat-centered "morphing workspace" whose right **code rail** (Changes · Files · Terminal) smart-auto-reveals when code is in play and can be pinned/collapsed.
 

--- a/docs/specs/2026-07-03-unified-project-picker-plan.md
+++ b/docs/specs/2026-07-03-unified-project-picker-plan.md
@@ -1,6 +1,6 @@
 # Unified Project Picker Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** One shared project-selection UI and one shared add-project (register **and** grant) flow across chat, home, and the projects management surface; the code surface remembers its selected project.
 

--- a/docs/specs/2026-07-12-research-mission-desk-plan.md
+++ b/docs/specs/2026-07-12-research-mission-desk-plan.md
@@ -1,6 +1,6 @@
 # Research Mission Desk Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Turn the Research Desk into a mission-first research factory that launches real familiar work, publishes provenance-rich artifacts, and supports bounded autoresearch through linked Automations.
 

--- a/docs/specs/2026-07-21-ios-ultra-snappy-performance-plan.md
+++ b/docs/specs/2026-07-21-ios-ultra-snappy-performance-plan.md
@@ -1,6 +1,6 @@
 # iOS Ultra-Snappy Performance Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Measure and remove the highest-impact launch, network, media, persistence, and chat rendering bottlenecks in the native iOS app.
 

--- a/docs/specs/2026-07-22-chat-footer-split-context-chips-plan.md
+++ b/docs/specs/2026-07-22-chat-footer-split-context-chips-plan.md
@@ -1,6 +1,6 @@
 # Chat Footer Split Context Chips — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Replace the chat composer footer's combined "Project · Model · branch" pill with three separate chips (project · model · branch), shared with the home composer's existing split grammar.
 

--- a/docs/specs/2026-07-26-group-chat-mention-selection-plan.md
+++ b/docs/specs/2026-07-26-group-chat-mention-selection-plan.md
@@ -1,6 +1,6 @@
 # Group Chat Mentions Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make desktop group-chat mentions finish cleanly after picker selection, visibly identify tagged familiars, and teach coven familiars to address one another with exact `@Display Name` tags.
 

--- a/docs/specs/2026-07-26-ios-drawer-quiet-portal-plan.md
+++ b/docs/specs/2026-07-26-ios-drawer-quiet-portal-plan.md
@@ -4,7 +4,7 @@
 > Use [`../ios-current-direction.md`](../ios-current-direction.md) for current
 > priorities.
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Remove the native iOS bottom tab bar, make the Cave drawer the complete primary navigation surface, and replace the cold connection spinner with the approved Quiet Portal.
 

--- a/docs/specs/2026-07-29-research-studio-media-pipeline-implementation-plan.md
+++ b/docs/specs/2026-07-29-research-studio-media-pipeline-implementation-plan.md
@@ -1,6 +1,6 @@
 # Research Studio Media Pipeline Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Ship podcast, short-video, and long-video generations from Research Mission artifacts with reviewable drafts, explicit render configuration, persistent single-flight execution, cancellable child processes, secure seekable media, honest readiness, and requirement-level proof.
 

--- a/docs/superpowers/plans/2026-06-30-home-chat-code-command-center.md
+++ b/docs/superpowers/plans/2026-06-30-home-chat-code-command-center.md
@@ -1,6 +1,6 @@
 # Home Chat Code Command Center Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Build the shared command-control contract approved in `docs/superpowers/specs/2026-06-30-home-chat-code-command-center-design.md`, polish Home as the primary launch surface, and keep Chat, Code, and Quick Chat switching behavior consistent.
 

--- a/docs/superpowers/plans/2026-07-06-journal-to-familiar-studio.md
+++ b/docs/superpowers/plans/2026-07-06-journal-to-familiar-studio.md
@@ -1,6 +1,6 @@
 # Journal → Familiar Studio Tab; Canvas Surface → Feature Branch — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Move the Journal into a per-familiar tab in Settings → Familiars (Familiar Studio), redirect all old Journal entry points there, and retire the generated-canvas *surface* from `main` (preserved on `feature/journal-canvas-surface`). Backend (`/api/canvas`, `/api/journal`) and chat inline canvas artifacts stay.
 

--- a/docs/superpowers/plans/2026-07-06-user-profile.md
+++ b/docs/superpowers/plans/2026-07-06-user-profile.md
@@ -1,6 +1,6 @@
 # User Profile Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Server-side operator profile (name, pronouns, bio, timezone, links) plus a server-stored avatar image, editable in a new Settings → Profile section, consumed by chat surfaces and injected as operator context for familiars.
 

--- a/docs/superpowers/plans/2026-07-09-waste-free-half-splits.md
+++ b/docs/superpowers/plans/2026-07-09-waste-free-half-splits.md
@@ -1,6 +1,6 @@
 # Waste-Free Half Splits Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make every registered workspace page render in either half of the desktop detail area with pixel-exact, waste-free geometry, honest responsive behavior, and exhaustive rendered verification.
 

--- a/docs/superpowers/plans/2026-07-18-chat-collapsed-nav-siderail.md
+++ b/docs/superpowers/plans/2026-07-18-chat-collapsed-nav-siderail.md
@@ -1,6 +1,6 @@
 # Chat Collapsed Navigation and Persistent Siderail Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Open desktop Chat with the global navigation collapsed, keep a separate Chats siderail visible, and replace hover-only Chat actions with persistent overflow and context menus.
 

--- a/docs/superpowers/plans/2026-07-19-new-reminder-design.md
+++ b/docs/superpowers/plans/2026-07-19-new-reminder-design.md
@@ -1,6 +1,6 @@
 # New Reminder Modal Redesign Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Re-port the approved compact New Reminder modal redesign onto current `main` without carrying stale branch history or raw pixel typography.
 

--- a/docs/superpowers/plans/2026-07-20-chat-contextual-sidebar.md
+++ b/docs/superpowers/plans/2026-07-20-chat-contextual-sidebar.md
@@ -1,6 +1,6 @@
 # Chat Contextual Sidebar Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Replace Chat's separate list column with one contextual, collapsible primary left sidepanel on desktop and mobile.
 

--- a/docs/superpowers/plans/2026-07-21-canvas-fullscreen.md
+++ b/docs/superpowers/plans/2026-07-21-canvas-fullscreen.md
@@ -1,6 +1,6 @@
 # Canvas Editor Full Screen Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add an in-app Expand toggle and a native Full screen button to the Canvas sketch editor so a sketch can fill the editor body or the whole monitor.
 

--- a/docs/superpowers/plans/2026-07-23-blaze-backdrop.md
+++ b/docs/superpowers/plans/2026-07-23-blaze-backdrop.md
@@ -1,6 +1,6 @@
 # Blaze Animated Backdrop Style Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add "Blaze" (Canvas UI fire/sparks/smoke WebGL effect) as a second backdrop style alongside the image backdrop, selectable in Settings → Appearance → Backdrop, with colors derived from the live theme accent.
 

--- a/docs/superpowers/plans/2026-07-24-analytics-contract-review.md
+++ b/docs/superpowers/plans/2026-07-24-analytics-contract-review.md
@@ -1,6 +1,6 @@
 # Analytics Contract Review Button + Empty-Results Layout Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** On the Familiar Analytics page, stop empty-state cards from leaving blank holes in the two-column grid, and give failing Contract compliance reports a "Review and resolve" button that direct-launches a chat seeded with the rehabilitation brief.
 

--- a/docs/superpowers/plans/2026-07-24-project-setup-from-chat.md
+++ b/docs/superpowers/plans/2026-07-24-project-setup-from-chat.md
@@ -1,6 +1,6 @@
 # Project Setup From a Chat's Unregistered Folder — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** When a chat runs in an ad-hoc folder that maps to no registered Cave project, offer an in-place "Set up as project" flow (picker row + dismissible banner) that explains what registering entails and lets the human pick access for the chat's familiar and the familiar's access groups.
 

--- a/docs/superpowers/plans/2026-07-24-research-final-artifacts.md
+++ b/docs/superpowers/plans/2026-07-24-research-final-artifacts.md
@@ -1,6 +1,6 @@
 # Research Final Artifacts Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Research missions durably save all four final artifacts (primary deliverable, findings, source ledger, research log) — auto-published to the Grimoire Vault on completion, manually publishable when settled, and viewable/downloadable from the Desk and Library.
 

--- a/docs/superpowers/plans/2026-07-24-sidepanel-peel-reveal.md
+++ b/docs/superpowers/plans/2026-07-24-sidepanel-peel-reveal.md
@@ -1,6 +1,6 @@
 # Sidepanel Peel-Reveal Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** When the desktop nav is collapsed to its 56px rail, moving the cursor toward the left edge of the detail pane peels the page back (WebGL page-curl) revealing the sidebar beneath — on HTML-in-canvas browsers only; everywhere else stays byte-identical.
 

--- a/docs/superpowers/plans/2026-07-26-familiar-rooms-ui.md
+++ b/docs/superpowers/plans/2026-07-26-familiar-rooms-ui.md
@@ -1,6 +1,6 @@
 # Familiar Rooms UI Refinement Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Refine all eight familiar rooms into one clean, minimal, accessible interaction system without removing capabilities or rewriting room-specific workflows.
 

--- a/docs/superpowers/plans/2026-07-26-runtime-availability-followup.md
+++ b/docs/superpowers/plans/2026-07-26-runtime-availability-followup.md
@@ -1,6 +1,6 @@
 # Runtime Availability Forward-Fix Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Finish the merged runtime-availability contract so passive, credential-free, bounded launch validation precedes every local capability or model subprocess and all consumers preserve truthful diagnostics.
 

--- a/docs/superpowers/plans/2026-07-27-memories-sidebar-collapse.md
+++ b/docs/superpowers/plans/2026-07-27-memories-sidebar-collapse.md
@@ -1,6 +1,6 @@
 # Memories Sidebar Collapse Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make the Memories navigator a locally persisted, explicitly collapsible icon rail while preserving the expanded experience by default.
 

--- a/docs/superpowers/plans/2026-07-28-streamed-chat-activity.md
+++ b/docs/superpowers/plans/2026-07-28-streamed-chat-activity.md
@@ -1,6 +1,6 @@
 # Streamed Chat Activity Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use `executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `executing-plans` to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Stream inline reasoning and collapse adjacent repeated tool calls into an expandable, counted run without changing chat stream data.
 

--- a/docs/superpowers/plans/2026-07-29-chat-follow-up-intents.md
+++ b/docs/superpowers/plans/2026-07-29-chat-follow-up-intents.md
@@ -1,6 +1,6 @@
 # Chat Follow-up Intents Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make assistant-recommended chat follow-ups visibly and behaviorally distinct as editable replies, review-first tasks, or safe registered actions.
 

--- a/docs/superpowers/plans/2026-07-29-marketplace-owned-coming-soon.md
+++ b/docs/superpowers/plans/2026-07-29-marketplace-owned-coming-soon.md
@@ -1,6 +1,6 @@
 # User-owned Marketplace and curated Skills preview implementation plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make Marketplace show only installed or authored user inventory and add an honest, distinctive Coming Soon destination for the future OpenCoven-curated Skills catalog.
 

--- a/docs/superpowers/plans/2026-07-29-mobile-live-voice.md
+++ b/docs/superpowers/plans/2026-07-29-mobile-live-voice.md
@@ -1,6 +1,6 @@
 # Mobile live voice Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add a direct-chat iOS voice-call sheet with OpenAI Realtime full-duplex audio and an explicit Apple-native turn-taking mode, while retaining composer dictation.
 

--- a/docs/superpowers/plans/2026-07-29-opencoven-tools-full-width.md
+++ b/docs/superpowers/plans/2026-07-29-opencoven-tools-full-width.md
@@ -1,6 +1,6 @@
 # OpenCoven Tools Full-Width Settings Control Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Give the OpenCoven Tools control a full-width desktop row on Settings > About while keeping CovenCave compact and preserving the existing narrow layout.
 

--- a/docs/superpowers/plans/2026-07-29-tasks-multi-familiar-grouping.md
+++ b/docs/superpowers/plans/2026-07-29-tasks-multi-familiar-grouping.md
@@ -1,6 +1,6 @@
 # Tasks Multi-Familiar Grouping Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Show the Tasks page's Familiar grouping option only when the shell scope contains more than one selected familiar.
 

--- a/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
+++ b/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
@@ -1,6 +1,6 @@
 # Automatic Local Branch Retirement Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Build complete local branch/worktree lifecycle inventory, prevention policy, and a tested fail-closed local retirement engine while keeping production mutation disabled until every `cave-wqa0b` maintenance plane is enforced.
 

--- a/docs/superpowers/plans/2026-07-31-github-into-code-workshop.md
+++ b/docs/superpowers/plans/2026-07-31-github-into-code-workshop.md
@@ -1,6 +1,6 @@
 # GitHub into Code Workshop Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Remove the standalone GitHub workspace page while preserving its complete activity, notification, detail, settings, and action coverage inside the coding-role Code Workshop.
 

--- a/docs/superpowers/plans/2026-07-31-openclaw-tool-activity-cave-implementation.md
+++ b/docs/superpowers/plans/2026-07-31-openclaw-tool-activity-cave-implementation.md
@@ -1,6 +1,6 @@
 # OpenClaw Tool-Activity Cave Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add signed, refreshable OpenClaw tool-event compatibility and project validated Gateway tool lifecycle into Cave chat, persistence, and resume.
 

--- a/docs/superpowers/plans/2026-07-31-openclaw-tool-activity-registry-publisher.md
+++ b/docs/superpowers/plans/2026-07-31-openclaw-tool-activity-registry-publisher.md
@@ -1,6 +1,6 @@
 # OpenClaw Compatibility Registry Publisher Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Publish and deploy the signed OpenClaw compatibility profile from `OpenCoven/coven-runtimes`, then configure Cave's public release trust anchors.
 

--- a/docs/superpowers/plans/2026-07-31-v0.2.2-release-preparation.md
+++ b/docs/superpowers/plans/2026-07-31-v0.2.2-release-preparation.md
@@ -1,6 +1,6 @@
 # v0.2.2 Release Preparation Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Open a protected-branch release-stamp pull request for CovenCave v0.2.2 from approved cut `330fc19b2a7b998019dadb0ef0c2f170b866ff6d` (`origin/main` through PR #4113), without merging, tagging, or dispatching a release.
 

--- a/docs/superpowers/plans/2026-08-01-chat-detail-row.md
+++ b/docs/superpowers/plans/2026-08-01-chat-detail-row.md
@@ -1,6 +1,6 @@
 # Chat Detail Row Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Turn the existing Chat session context band into the supplied full-width instrument strip with interactive Done, Elapsed, and Context breakdowns.
 

--- a/docs/superpowers/plans/2026-08-01-compact-thread-signal-card.md
+++ b/docs/superpowers/plans/2026-08-01-compact-thread-signal-card.md
@@ -1,6 +1,6 @@
 # Compact Thread Signal Card Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make Thread Signal chat cards substantially denser, less rounded, and responsive to their own available width with one score column when constrained and three columns only when wide.
 

--- a/docs/superpowers/plans/2026-08-01-daemon-connection-request-noise.md
+++ b/docs/superpowers/plans/2026-08-01-daemon-connection-request-noise.md
@@ -1,6 +1,6 @@
 # Daemon Connection and Request-Noise Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Replace overlapping heavyweight daemon-status polling with a pure, coalesced connection heartbeat and a serial adaptive client supervisor, then remove the remaining verified full-status polling noise.
 

--- a/docs/superpowers/plans/2026-08-01-dev-app-origin-readiness-retry.md
+++ b/docs/superpowers/plans/2026-08-01-dev-app-origin-readiness-retry.md
@@ -1,6 +1,6 @@
 # Dev App Origin Readiness Retry Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Split the unrelated launcher readiness change out of PR #4184, then make its bounded retry loop resource-safe and deterministically tested in a separate PR.
 

--- a/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
+++ b/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
@@ -3,7 +3,7 @@
 > Historical implementation record. Superseded on 2026-08-25 by `cave-0pu26`;
 > the current mandatory retirement recency window is 15 minutes.
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Change only the branch/worktree retirement recency window from 24 hours to a mandatory 8 hours.
 

--- a/docs/superpowers/plans/2026-08-01-maintainer-authorized-branch-cleanup.md
+++ b/docs/superpowers/plans/2026-08-01-maintainer-authorized-branch-cleanup.md
@@ -1,6 +1,6 @@
 # Maintainer-Authorized Branch Cleanup Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add a bounded, explicit maintainer-authorized cleanup profile to Branch Curator while leaving unattended retirement and protected `main` controls fail-closed.
 

--- a/docs/superpowers/plans/2026-08-01-onboarding-readiness-fail-open.md
+++ b/docs/superpowers/plans/2026-08-01-onboarding-readiness-fail-open.md
@@ -1,6 +1,6 @@
 # Onboarding Readiness Fail-Open Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Let users continue through onboarding when readiness evidence is pending or unavailable, while preserving a hard stop for confirmed required setup failures.
 

--- a/docs/superpowers/plans/2026-08-01-reviewer-render-announcement.md
+++ b/docs/superpowers/plans/2026-08-01-reviewer-render-announcement.md
@@ -1,6 +1,6 @@
 # Reviewer Render Announcement Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Remove the React render-phase cross-component update when the reviewer queue bucket filter announces its new state.
 

--- a/docs/superpowers/plans/2026-08-03-chat-chrome-removals.md
+++ b/docs/superpowers/plans/2026-08-03-chat-chrome-removals.md
@@ -1,6 +1,6 @@
 # Redundant Chat Chrome Removals Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Remove the redundant solo-participant cluster from the web Chat header and the read-only Project band from started iOS chats without removing either platform's remaining group/project recovery paths.
 

--- a/docs/superpowers/plans/2026-08-03-ios-chat-familiars-first.md
+++ b/docs/superpowers/plans/2026-08-03-ios-chat-familiars-first.md
@@ -4,7 +4,7 @@
 > relevant, but current priorities are consolidated in
 > [`../../ios-current-direction.md`](../../ios-current-direction.md).
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make the iOS Chats home an iMessage-style list of familiars, open a familiar's chat in one tap, and move session selection into the config popover.
 

--- a/docs/superpowers/plans/2026-08-03-ios-familiar-new-chat.md
+++ b/docs/superpowers/plans/2026-08-03-ios-familiar-new-chat.md
@@ -1,6 +1,6 @@
 # iOS Familiar-Scoped New Chat Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Let iOS start a new conversation from an already-selected familiar without reopening the familiar roster, while preserving authorized project selection and adding an in-flow project-access repair path.
 

--- a/docs/superpowers/plans/2026-08-03-notification-dropdown-layering.md
+++ b/docs/superpowers/plans/2026-08-03-notification-dropdown-layering.md
@@ -1,6 +1,6 @@
 # Notification Dropdown Layering Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Keep the native-shell notification dropdown above workspace content only while it is open.
 

--- a/docs/superpowers/plans/2026-08-03-supervisor-safe-daemon-recovery.md
+++ b/docs/superpowers/plans/2026-08-03-supervisor-safe-daemon-recovery.md
@@ -1,6 +1,6 @@
 # Supervisor-safe Daemon Recovery Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Recover a local daemon without competing with an existing supervisor and without transiently presenting successful recovery as daemon instability.
 

--- a/docs/superpowers/plans/2026-08-04-accessible-solo-coven-promotion.md
+++ b/docs/superpowers/plans/2026-08-04-accessible-solo-coven-promotion.md
@@ -1,6 +1,6 @@
 # Accessible Solo-to-Coven Promotion Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Restore a keyboard- and screen-reader-accessible way to promote the current solo Chat into a coven without restoring the removed avatar, `Solo` label, or permanent add button.
 

--- a/docs/superpowers/plans/2026-08-04-adaptive-chat-context-controls.md
+++ b/docs/superpowers/plans/2026-08-04-adaptive-chat-context-controls.md
@@ -1,6 +1,6 @@
 # Adaptive Chat Context Controls Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Move project, worktree, branch, and model controls out of an active chat's composer and into its header while keeping the same controls in a footer below the new-chat composer.
 

--- a/docs/superpowers/plans/2026-08-04-administrative-cleanup-review.md
+++ b/docs/superpowers/plans/2026-08-04-administrative-cleanup-review.md
@@ -1,6 +1,6 @@
 # Administrative Cleanup Review Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add a local-only, exact-candidate review path for clean landed branches and worktrees blocked only by missing lifecycle metadata or non-closed Beads.
 

--- a/docs/superpowers/plans/2026-08-04-chat-sidebar-attention.md
+++ b/docs/superpowers/plans/2026-08-04-chat-sidebar-attention.md
@@ -1,6 +1,6 @@
 # Chat Sidebar Attention Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add canonical session-level attention states and make chats awaiting the human prominent, accessible, and age-aware in the Chat sidebar.
 

--- a/docs/superpowers/plans/2026-08-04-chat-sidebar-titles-reflections.md
+++ b/docs/superpowers/plans/2026-08-04-chat-sidebar-titles-reflections.md
@@ -1,6 +1,6 @@
 # Chat Sidebar, Titles, and Reflections Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make new chats appear in the sidebar as soon as their first reply is persisted, keep generated titles to short topic labels, and archive eligible reflected threads by default.
 

--- a/docs/superpowers/plans/2026-08-04-chat-spec-reader.md
+++ b/docs/superpowers/plans/2026-08-04-chat-spec-reader.md
@@ -1,6 +1,6 @@
 # In-chat Familiar Spec Reader Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Render familiar-authored Markdown specifications as inline chat cards that open into an accessible full-screen reader.
 

--- a/docs/superpowers/plans/2026-08-04-compact-assistant-tool-activity.md
+++ b/docs/superpowers/plans/2026-08-04-compact-assistant-tool-activity.md
@@ -1,6 +1,6 @@
 # Compact Assistant Tool Activity Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Replace tall per-turn tool activity with one compact, status-aware disclosure while keeping edit review cards visible and auto-expanding only repeated running-call groups.
 

--- a/docs/superpowers/plans/2026-08-05-adaptive-chat-follow-up-pills.md
+++ b/docs/superpowers/plans/2026-08-05-adaptive-chat-follow-up-pills.md
@@ -1,6 +1,6 @@
 # Adaptive Chat Follow-Up Pills Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Replace the current three-item chat follow-up strip with four compact, context-adaptive typed options, explicit recommendation styling, and a reviewed Save-link destination flow.
 

--- a/docs/superpowers/plans/2026-08-05-familiar-selector-above-tabs.md
+++ b/docs/superpowers/plans/2026-08-05-familiar-selector-above-tabs.md
@@ -1,6 +1,6 @@
 # Familiar Selector and Reference-Style Home Composer Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Move familiar context above the Home and Chat controls, and make the Home / New chat composer emulate the supplied reference while retaining its current capabilities.
 

--- a/docs/superpowers/plans/2026-08-05-managed-node-npm-timeout.md
+++ b/docs/superpowers/plans/2026-08-05-managed-node-npm-timeout.md
@@ -1,6 +1,6 @@
 # Managed Node npm Verification Timeout Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Give managed npm verification a Windows-safe cold-start deadline
 without slowing the Node executable probe.

--- a/docs/superpowers/plans/2026-08-05-session-exit-worktree-retirement.md
+++ b/docs/superpowers/plans/2026-08-05-session-exit-worktree-retirement.md
@@ -1,6 +1,6 @@
 # Session-Exit Worktree Retirement Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Retire clean local worktrees already merged into `main` when a Claude session ends.
 

--- a/docs/superpowers/plans/2026-08-05-sidecar-startup-recovery.md
+++ b/docs/superpowers/plans/2026-08-05-sidecar-startup-recovery.md
@@ -1,6 +1,6 @@
 # Sidecar Startup Recovery Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make packaged non-Windows desktop startup tolerate realistic cold starts, isolate each launch's readiness evidence, and reap the Node child before a fatal startup exit.
 

--- a/docs/superpowers/plans/2026-08-06-active-session-tick.md
+++ b/docs/superpowers/plans/2026-08-06-active-session-tick.md
@@ -1,6 +1,6 @@
 # Active Session Tick Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Show the selected chat row's accent rail without a duplicate status tick.
 

--- a/docs/superpowers/plans/2026-08-06-ios-claude-design-fidelity-closeout.md
+++ b/docs/superpowers/plans/2026-08-06-ios-claude-design-fidelity-closeout.md
@@ -4,7 +4,7 @@
 > [`../../ios-current-direction.md`](../../ios-current-direction.md) for the
 > active visual priorities and supersession rules.
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Close the remaining compatible gaps between the native SwiftUI app and the supplied Claude Design handoff without undoing the newer, approved familiars-first Chats IA or drawer navigation.
 

--- a/docs/superpowers/plans/2026-08-07-familiar-dashboard-contract.md
+++ b/docs/superpowers/plans/2026-08-07-familiar-dashboard-contract.md
@@ -1,6 +1,6 @@
 # Familiar Dashboard Contract Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Build phase 1 of Bead `cave-9rwd.1`: the shared, versioned `GET /api/familiars/{id}/dashboard?v=1` DTO, pure builders, reusable server loaders, route, and tests.
 

--- a/docs/superpowers/plans/2026-08-08-active-chat-siderail-highlight.md
+++ b/docs/superpowers/plans/2026-08-08-active-chat-siderail-highlight.md
@@ -1,6 +1,6 @@
 # Active Chat Siderail Highlight Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Highlight the full horizontal row of the active chat in every expanded Chats siderail view without reducing the session content width.
 

--- a/docs/superpowers/plans/2026-08-08-activity-lattice-readability.md
+++ b/docs/superpowers/plans/2026-08-08-activity-lattice-readability.md
@@ -1,6 +1,6 @@
 # Activity Lattice Readability Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Repair the familiar activity lattice so its density ramp survives outliers, its year cells remain square, its quarter caption does not overlap the chart, and its narrow container layout is browser-verified.
 

--- a/docs/superpowers/plans/2026-08-08-calm-streaming-chat.md
+++ b/docs/superpowers/plans/2026-08-08-calm-streaming-chat.md
@@ -1,6 +1,6 @@
 # Calm Streaming Chat Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make Main Chat and Quick Chat render live familiar replies as stable Markdown blocks with one current activity line, trustworthy result rows, explicit interrupted/failed states, and user-controlled stream following.
 

--- a/docs/superpowers/plans/2026-08-08-global-right-chat-panel.md
+++ b/docs/superpowers/plans/2026-08-08-global-right-chat-panel.md
@@ -1,6 +1,6 @@
 # Global Right Chat Panel Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add a persistent, resizable right-side Chat panel to every Cave workspace surface, with an independent chat on desktop and an accessible modal drawer on tablet/mobile.
 

--- a/docs/superpowers/plans/2026-08-08-orphaned-worktree-metadata-repair.md
+++ b/docs/superpowers/plans/2026-08-08-orphaned-worktree-metadata-repair.md
@@ -1,6 +1,6 @@
 # Orphaned Worktree Metadata Repair Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make lifecycle patrol discover and safely repair non-closed Beads whose structured worktree record points at a missing local branch and missing path.
 

--- a/docs/superpowers/plans/2026-08-09-beads-delivery-accounting.md
+++ b/docs/superpowers/plans/2026-08-09-beads-delivery-accounting.md
@@ -1,6 +1,6 @@
 # Beads Delivery Accounting Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Keep Beads canonical while adding complete desktop delivery accounting, explicit Board-to-Bead links, and read-only linked delivery state in native iOS.
 

--- a/docs/superpowers/plans/2026-08-09-derived-project-organization-grouping.md
+++ b/docs/superpowers/plans/2026-08-09-derived-project-organization-grouping.md
@@ -1,6 +1,6 @@
 # Derived Project Organization Grouping Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add a derived organization level above projects in the Chat rail and Projects hub without changing persisted project data.
 

--- a/docs/superpowers/plans/2026-08-09-ios-terminal-composer.md
+++ b/docs/superpowers/plans/2026-08-09-ios-terminal-composer.md
@@ -4,7 +4,7 @@
 > on 2026-08-18. Do not execute or resume this plan. See
 > [`../../ios-current-direction.md`](../../ios-current-direction.md).
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add an accessible native composer below the iOS terminal that safely sends shell input, exposes terminal slash commands, and hands drafts to native chat for review.
 

--- a/docs/superpowers/plans/2026-08-09-journal-retry-locator.md
+++ b/docs/superpowers/plans/2026-08-09-journal-retry-locator.md
@@ -1,6 +1,6 @@
 # Journal Retry Locator Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make the Journal error-state E2E assertion select the Journal-owned Retry action even when the shell exposes another Retry button.
 

--- a/docs/superpowers/plans/2026-08-09-ux-conformance-audit-closeout.md
+++ b/docs/superpowers/plans/2026-08-09-ux-conformance-audit-closeout.md
@@ -1,6 +1,6 @@
 # UX Conformance Audit Closeout Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Resolve `cave-ui5z` using reproducible design-gate evidence instead of recreating a missing heuristic percentage scorecard.
 

--- a/docs/superpowers/plans/2026-08-15-comms-operations-room.md
+++ b/docs/superpowers/plans/2026-08-15-comms-operations-room.md
@@ -1,6 +1,6 @@
 # Comms Operations Room Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Turn the existing Messenger role surface into Charm's durable, approval-gated communications cockpit for listening, shaping one message into channel-native variants, delivering through OpenCoven connectors, and learning what resonated.
 

--- a/docs/superpowers/plans/2026-08-15-hf-papers-ingest.md
+++ b/docs/superpowers/plans/2026-08-15-hf-papers-ingest.md
@@ -1,6 +1,6 @@
 # HF Paper Ingest with pdf.js Viewer — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Pasting `hf papers read 2401.12345` (or an HF papers / arXiv URL) into Research Desk resources saves one paper resource with real title, authors and abstract, and opening it renders the PDF inline with pdf.js.
 

--- a/docs/superpowers/plans/2026-08-15-research-protocol-unit-0.md
+++ b/docs/superpowers/plans/2026-08-15-research-protocol-unit-0.md
@@ -1,6 +1,6 @@
 # Research Protocol Unit 0 Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Implement the provider-neutral Research Run Protocol v1 as authoritative JSON Schemas, hand-written TypeScript parsers, canonical SHA-256 digests, shared fixtures, and a cross-environment conformance suite.
 

--- a/docs/superpowers/plans/2026-08-15-thread-signal-chat-overlay.md
+++ b/docs/superpowers/plans/2026-08-15-thread-signal-chat-overlay.md
@@ -1,6 +1,6 @@
 # Thread Signal Chat Overlay Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Render the complete Thread Signal card over chat content without adding it to transcript layout or scroll height.
 

--- a/docs/superpowers/plans/2026-08-16-externalized-research-desk-program.md
+++ b/docs/superpowers/plans/2026-08-16-externalized-research-desk-program.md
@@ -1,6 +1,6 @@
 # Externalized Research Desk Program Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Deliver the approved externalized Research Desk end to end through independently shippable protocol, local resource, Context Pack, discovery, gateway, executor, and optional hosted-cloud units.
 

--- a/docs/superpowers/plans/2026-08-17-release-candidate-ci.md
+++ b/docs/superpowers/plans/2026-08-17-release-candidate-ci.md
@@ -1,6 +1,6 @@
 # Signed Release-Candidate CI Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make pull-request CI one non-skippable Linux gate and require a successful, signed, exact-commit release candidate before any final release publication begins.
 

--- a/docs/superpowers/plans/2026-08-17-settings-vertical-scroll-ownership.md
+++ b/docs/superpowers/plans/2026-08-17-settings-vertical-scroll-ownership.md
@@ -1,6 +1,6 @@
 # Settings Vertical Scroll Ownership Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make the Settings content pane scroll vertically within its fixed viewport in standalone and embedded modes.
 

--- a/docs/superpowers/plans/2026-08-18-project-primary-hybrid-navigation-stage-1.md
+++ b/docs/superpowers/plans/2026-08-18-project-primary-hybrid-navigation-stage-1.md
@@ -1,6 +1,6 @@
 # Project-primary Hybrid Navigation Stage 1 Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add the project/crew/actor context contract, render the hybrid selector in the shared desktop rail, and migrate Home and new-chat launch to that shell-owned context without changing non-pilot surface filtering.
 

--- a/docs/superpowers/plans/2026-08-20-reliable-chat-file-ingestion.md
+++ b/docs/superpowers/plans/2026-08-20-reliable-chat-file-ingestion.md
@@ -1,6 +1,6 @@
 # Reliable Chat File Ingestion Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Preserve bounded HTML, JavaScript, archive, and other file payloads through Cave chat sends, transcript reloads, and retries, then materialize them as private files inside the local harness's granted runtime root.
 

--- a/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
+++ b/docs/superpowers/plans/2026-08-22-beads-dolt-sync-watchdog.md
@@ -1,6 +1,6 @@
 # Beads Dolt Sync Watchdog Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Replace Cave's unbounded `bd dolt pull && bd dolt push` shell chain with a cross-platform watchdog that bounds both phases, terminates the complete owned process tree, and documents an honest retry and remote-ref verification procedure.
 

--- a/docs/superpowers/plans/2026-08-24-canvas-github-import-modal.md
+++ b/docs/superpowers/plans/2026-08-24-canvas-github-import-modal.md
@@ -1,6 +1,6 @@
 # Canvas GitHub Import Modal Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Replace the dense Canvas GitHub importer with a progressive, truthful flow that asks for a file URL first, automatically connects a compatible Cave project, and requests a local checkout only when registration is necessary.
 

--- a/docs/superpowers/plans/2026-08-24-chat-list-grouping-latency.md
+++ b/docs/superpowers/plans/2026-08-24-chat-list-grouping-latency.md
@@ -1,6 +1,6 @@
 # Chat List Grouping Latency Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Remove the duplicate full project-grouping pass from the default large chat-list render and preserve a reproducible before/after benchmark.
 

--- a/docs/superpowers/plans/2026-08-25-client-v1-hpke-bound-authority.md
+++ b/docs/superpowers/plans/2026-08-25-client-v1-hpke-bound-authority.md
@@ -1,6 +1,6 @@
 # Client v1 HPKE-Bound Authority Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Add a compatibility-safe, SDK-consumable RFC 9180 `hpke-bound-v1` producer mechanism that atomically binds pairing-secret and bearer-bearing Client v1 requests and responses to one per-runtime Cave authority.
 

--- a/scripts/plan-doc-checkbox-hygiene.test.mjs
+++ b/scripts/plan-doc-checkbox-hygiene.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+// cave-y5tx2: plan/spec docs used to tell agentic workers that steps are tracked
+// with checkbox syntax ("Steps use checkbox (`- [ ]`) syntax for tracking.").
+// Roughly 86 of 97 plan docs shipped their work with zero boxes ticked, so an
+// agent following that instruction concluded shipped work was unstarted — the
+// confirmed instance is docs/specs/2026-07-21-ios-ultra-snappy-performance-plan.md
+// (0/38 ticked; tasks 1-6 merged a month earlier in PR #3623). The headers now
+// disclaim checkbox authority and point at code + merged PRs. These tests keep
+// the misleading claim out and the disclaimer in.
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// The areas that carry the agentic-workers header (docs/plans and top-level
+// docs/*.md like docs/content-gen-flow-plan.md are plan docs too).
+const PLAN_AREAS = ["docs/specs", "docs/superpowers/plans", "docs/plans"];
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else if (entry.name.endsWith(".md")) out.push(full);
+  }
+  return out;
+}
+
+function collectPlanDocs() {
+  const files = [];
+  for (const area of PLAN_AREAS) {
+    const dir = path.join(repoRoot, area);
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory() && entry.name.endsWith(".md")) files.push(path.join(area, entry.name));
+    }
+  }
+  for (const entry of readdirSync(path.join(repoRoot, "docs"))) {
+    if (entry.endsWith(".md") && entry !== "README.md") files.push(path.join("docs", entry));
+  }
+  return [...new Set(files)].sort();
+}
+
+const allDocs = walk(path.join(repoRoot, "docs")).map((f) => path.relative(repoRoot, f).split(path.sep).join("/"));
+const planDocs = collectPlanDocs();
+
+const textOf = (rel) => readFileSync(path.join(repoRoot, rel), "utf8");
+
+// The old header claim: "Steps use checkbox (`- [ ]`) syntax for tracking."
+const MISLEADING = /syntax for tracking/i;
+const HEADER = "For agentic workers";
+const CHECKBOX = /-\s*\[[ xX]\]/;
+// Every doc that keeps checkboxes next to the agentic-workers header must say
+// checkbox state is not authoritative. Two phrasings exist: the canonical one
+// (cave-y5tx2) and the earlier "tracked in Beads, not a second task tracker"
+// formulation used by docs/superpowers/plans/2026-07-09-ui-consistency-phase-0.md.
+const DISCLAIMER = /not evidence of completion|not a second task tracker/i;
+
+test("no docs/ markdown tells agentic workers checkbox syntax tracks progress (cave-y5tx2)", () => {
+  const offenders = allDocs.filter((f) => MISLEADING.test(textOf(f)));
+  assert.deepEqual(offenders, [],
+    "checkbox state is not evidence of completion — code and merged PRs are authoritative (cave-y5tx2)");
+});
+
+test("plan docs with checkboxes and the agentic-workers header carry the disclaimer (cave-y5tx2)", () => {
+  const offenders = planDocs.filter((f) => {
+    const text = textOf(f);
+    return CHECKBOX.test(text) && text.includes(HEADER) && !DISCLAIMER.test(text);
+  });
+  assert.deepEqual(offenders, [],
+    "a doc that keeps checkboxes next to the agentic-workers header must disclaim checkbox authority (cave-y5tx2)");
+});
+
+// The acceptance case: a doc whose work has PARTIALLY shipped must not read as
+// unstarted. The iOS ultra-snappy plan is 0/38 ticked while tasks 1-6 shipped
+// in PR #3623 — exactly the misdirection this guard exists to prevent.
+test("the partially-shipped iOS ultra-snappy plan cannot read as unstarted (cave-y5tx2)", () => {
+  const target = "docs/specs/2026-07-21-ios-ultra-snappy-performance-plan.md";
+  const text = textOf(target);
+  assert.ok(!MISLEADING.test(text), "must not claim checkbox tracking");
+  assert.ok(DISCLAIMER.test(text), "must disclaim checkbox authority");
+  assert.ok(CHECKBOX.test(text), "keeps its (now disclaimed) step checkboxes");
+});
+
+console.log(`plan-doc-checkbox-hygiene.test.mjs: ${allDocs.length} docs scanned, ${planDocs.length} plan docs, no misleading checkbox-tracking claims`);

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1272,6 +1272,7 @@ export const SUITES = {
     "src/components/dead-ui-removal.test.ts",
     "scripts/ui-consistency.test.mjs",
     "scripts/docs-index.test.mjs",
+    "scripts/plan-doc-checkbox-hygiene.test.mjs",
     "src/components/ui/select.test.ts",
     "src/components/ui/context-menu.test.ts",
     "src/components/ui/undo-toast.test.ts",


### PR DESCRIPTION
## What

Plan/spec docs under `docs/` carried an agentic-workers header instructing agents to implement the plan task-by-task with the claim *"Steps use checkbox (`- [ ]`) syntax for tracking."* Roughly 86 of 97 plan docs shipped their work with **zero boxes ticked**, so an agent following that instruction concluded shipped work was unstarted. The confirmed instance: `docs/specs/2026-07-21-ios-ultra-snappy-performance-plan.md` is 0/38 ticked while tasks 1–6 shipped a month earlier in merged PR #3623 (cave-y5tx2).

This PR applies the bead's Option 1 (cheapest fix, prevents the misdirection at the point of use):

- **All 101 docs** carrying the checkbox-tracking claim now read:

  > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**

- `docs/superpowers/plans/2026-07-09-ui-consistency-phase-0.md` already carried a neutralized form ("tracked in Beads … not a second task tracker") and is left as-is.
- Step checkboxes are kept (they remain a useful step outline); only the claim that they track progress is removed.

## Why

Checkbox state is not evidence of completion — code and merged PRs are. The old header made an unstarted-looking doc the default and gave an agent a confident *wrong* signal that agreed with its own progress tracking the whole way (silent, self-consistent failure). The acceptance case is the partially-shipped iOS ultra-snappy plan: an agent handed it now cannot conclude the shipped tasks are unstarted.

## Tests

New `scripts/plan-doc-checkbox-hygiene.test.mjs` pins the fix (registered in `scripts/run-tests.mjs`):

1. No `docs/` markdown may claim "checkbox … syntax for tracking".
2. Plan docs that keep checkboxes + the agentic-workers header must carry the disclaimer.
3. The partially-shipped iOS ultra-snappy plan (0/38 ticked, tasks shipped in #3623) must not read as unstarted.

## Verification

- `node scripts/plan-doc-checkbox-hygiene.test.mjs` → 3/3 pass
- `node scripts/check-tests-wired.mjs` → all 1912 test files wired into CI
- `npx tsc --noEmit` → clean
- `scripts/docs-index.test.mjs`, `scripts/beads-familiar-workflow.test.mjs`, `scripts/branch-curator-manual-cleanup-contract.test.mjs` (the tests that read these docs) → pass
- `git diff --stat`: 101 docs × 1-line header change + new test + 1-line registry entry