### PR TITLE
fix(daemon): supported-set daemon API gate with wanted-vs-got diagnostics (cave-0mrr7)

### DIFF
--- a/src/lib/daemon-startup-contract.test.ts
+++ b/src/lib/daemon-startup-contract.test.ts
@@ -4,6 +4,8 @@ import {
   assessDaemonStartupCompatibility,
   COVEN_DAEMON_API_VERSION,
   isSupportedDaemonApiVersion,
+  SUPPORTED_DAEMON_API_VERSIONS,
+  unsupportedDaemonApiDiagnostic,
 } from "./daemon-startup-contract.ts";
 
 const healthy = {
@@ -13,7 +15,37 @@ const healthy = {
   daemon: { pid: 1234 },
 };
 
+// --- supported-set gate (cave-0mrr7) ---
+
 assert.equal(isSupportedDaemonApiVersion(COVEN_DAEMON_API_VERSION), true);
+
+// The set is the single source of adoption truth: non-empty, pinned, and every
+// member round-trips through the guard it feeds.
+assert.ok(SUPPORTED_DAEMON_API_VERSIONS.size >= 1, "the supported set must never be empty");
+assert.ok(
+  SUPPORTED_DAEMON_API_VERSIONS.has(COVEN_DAEMON_API_VERSION),
+  "the pinned contract must be in the supported set",
+);
+for (const supported of SUPPORTED_DAEMON_API_VERSIONS) {
+  assert.equal(isSupportedDaemonApiVersion(supported), true, `${supported} must be adoptable`);
+}
+
+// Fail-closed: nothing outside the source-pinned set is adoptable — not a
+// newer contract, not a near miss, not a non-string.
+for (const apiVersion of [
+  "1",
+  "v1",
+  "coven.daemon.v2",
+  "coven.daemon.v0",
+  ` ${COVEN_DAEMON_API_VERSION} `,
+  "",
+  null,
+  1,
+  undefined,
+  {},
+]) {
+  assert.equal(isSupportedDaemonApiVersion(apiVersion), false, `${String(apiVersion)} must not be adoptable`);
+}
 
 assert.deepEqual(assessDaemonStartupCompatibility(healthy), {
   ok: true,
@@ -29,14 +61,45 @@ for (const ok of [undefined, false, null, 1, "true"]) {
   });
 }
 
-for (const apiVersion of ["1", "v1", "coven.daemon.v2", ` ${COVEN_DAEMON_API_VERSION} `, null, 1]) {
+// Every previously-refused API contract stays a refusal with the same code,
+// and the diagnostic now names the contract Cave wanted and the one it got.
+for (const apiVersion of ["1", "v1", "coven.daemon.v2", ` ${COVEN_DAEMON_API_VERSION} `, null, 1, undefined]) {
   assert.equal(isSupportedDaemonApiVersion(apiVersion), false);
-  assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, apiVersion }), {
-    ok: false,
-    code: "unsupported_api",
-    diagnostic: "The running Coven daemon uses an incompatible API. Update Coven, then restart the daemon.",
-  });
+  const result = assessDaemonStartupCompatibility({ ...healthy, apiVersion });
+  assert.equal(result.ok, false, `${String(apiVersion)} must stay a refusal`);
+  if (!result.ok) {
+    assert.equal(result.code, "unsupported_api", `${String(apiVersion)} must keep its refusal code`);
+    assert.ok(result.diagnostic.length > 0, "every refusal must stay actionable");
+    assert.match(result.diagnostic, /"coven\.daemon\.v1"/, "the diagnostic must name the contract Cave wanted");
+  }
 }
+
+// A well-formed but newer contract is refused AND tells the user the daemon is
+// ahead of this build, so the next step points at the client, not the daemon.
+{
+  const newer = assessDaemonStartupCompatibility({ ...healthy, apiVersion: "coven.daemon.v2" });
+  assert.equal(newer.ok, false);
+  if (!newer.ok) {
+    assert.match(newer.diagnostic, /"coven\.daemon\.v2"/, "the diagnostic must name the contract the daemon published");
+    assert.match(newer.diagnostic, /Update Cave/, "a newer daemon contract must point at the client");
+  }
+}
+
+// A missing apiVersion is named as such, and the advice stays actionable.
+{
+  const missing = assessDaemonStartupCompatibility({ ...healthy, apiVersion: undefined });
+  assert.equal(missing.ok, false);
+  if (!missing.ok) {
+    assert.match(missing.diagnostic, /no apiVersion field/, "a missing contract must be named as missing");
+    assert.match(missing.diagnostic, /Update Coven/, "the refusal must keep its next step");
+  }
+}
+
+// The diagnostic builder itself is stable and source-pinned.
+assert.match(unsupportedDaemonApiDiagnostic("coven.daemon.v2"), /"coven\.daemon\.v1"/);
+assert.match(unsupportedDaemonApiDiagnostic("coven.daemon.v2"), /"coven\.daemon\.v2"/);
+assert.match(unsupportedDaemonApiDiagnostic(undefined), /no apiVersion field/);
+assert.match(unsupportedDaemonApiDiagnostic(null), /null/);
 
 assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, covenVersion: "0.0.0" }), {
   ok: true,

--- a/src/lib/daemon-startup-contract.ts
+++ b/src/lib/daemon-startup-contract.ts
@@ -1,12 +1,77 @@
 import { exactSemver } from "./exact-semver.ts";
 
-/** The exact named daemon API contract Cave can safely adopt. */
+/** The daemon API contract this build requires — the "wanted" side of every compatibility diagnostic. */
 export const COVEN_DAEMON_API_VERSION = "coven.daemon.v1";
 
-export function isSupportedDaemonApiVersion(
-  value: unknown,
-): value is typeof COVEN_DAEMON_API_VERSION {
-  return value === COVEN_DAEMON_API_VERSION;
+/**
+ * The daemon API contracts this build of Cave can adopt. Pinned in source by
+ * hand: adding a contract here is the only way a daemon becomes adoptable, and
+ * each entry asserts that Cave's own daemon call surface has been verified
+ * against that contract.
+ *
+ * The gate is membership in this set, not a "minimum contract" comparison
+ * (accept any `coven.daemon.vN` with N >= 1). A newer contract may add, rename,
+ * or remove surface, so adopting one on the strength of a higher number would
+ * let an unverified daemon through — the exact failure this gate exists to
+ * prevent. An unknown-newer contract therefore stays a refusal until every
+ * daemon-backed surface gates on the capability it actually requires (see
+ * afs.ts and canonical-memory-client.ts); only then can it degrade to reduced
+ * function instead of refusing adoption. Until that lands, fail-closed is the
+ * only correct behaviour, and the diagnostic names both sides of the mismatch
+ * so the refusal stays actionable.
+ */
+export const SUPPORTED_DAEMON_API_VERSIONS: ReadonlySet<string> = new Set([
+  COVEN_DAEMON_API_VERSION,
+]);
+
+export function isSupportedDaemonApiVersion(value: unknown): value is string {
+  return typeof value === "string" && SUPPORTED_DAEMON_API_VERSIONS.has(value);
+}
+
+const DAEMON_CONTRACT_RE = /^coven\.daemon\.v(\d+)$/;
+
+/** The highest contract major this build has verified; used to classify newer contracts for diagnostics. */
+const MAX_SUPPORTED_DAEMON_API_MAJOR = [...SUPPORTED_DAEMON_API_VERSIONS].reduce(
+  (max, version) => {
+    const match = DAEMON_CONTRACT_RE.exec(version);
+    return match ? Math.max(max, Number(match[1])) : max;
+  },
+  0,
+);
+
+function isNewerDaemonContract(value: string): boolean {
+  const match = DAEMON_CONTRACT_RE.exec(value);
+  return match !== null && Number(match[1]) > MAX_SUPPORTED_DAEMON_API_MAJOR;
+}
+
+function describeGotApiContract(value: unknown): string {
+  if (value === undefined) return "no apiVersion field at all";
+  if (typeof value === "string") return JSON.stringify(value);
+  try {
+    const rendered = JSON.stringify(value);
+    return rendered === undefined ? String(value) : rendered;
+  } catch {
+    return String(value);
+  }
+}
+
+const NEWER_DAEMON_API_DIAGNOSTIC_ADVICE =
+  "This build of Cave predates that daemon contract. Update Cave, then try again.";
+
+const DAEMON_API_UPDATE_DIAGNOSTIC_ADVICE =
+  "Update Coven, then restart the daemon.";
+
+/**
+ * The `unsupported_api` diagnostic names both sides of the mismatch: the
+ * contract Cave requires and the contract (or absence) the daemon published.
+ * A well-formed but newer contract points the user at the client, since the
+ * daemon is ahead of this build; anything else points at the daemon.
+ */
+export function unsupportedDaemonApiDiagnostic(got: unknown): string {
+  const advice = typeof got === "string" && isNewerDaemonContract(got)
+    ? NEWER_DAEMON_API_DIAGNOSTIC_ADVICE
+    : DAEMON_API_UPDATE_DIAGNOSTIC_ADVICE;
+  return `Cave requires the Coven daemon API contract ${JSON.stringify(COVEN_DAEMON_API_VERSION)}, but the running daemon published ${describeGotApiContract(got)}. ${advice}`;
 }
 
 export type DaemonStartupHealth = {
@@ -29,7 +94,9 @@ export type DaemonStartupCompatibility =
  * only after the health document identifies a supported API and a valid
  * runtime version. The CLI package and daemon runtime have independent release
  * lines, so comparing their version strings would reject a healthy daemon
- * (for example CLI 0.2.5 with daemon runtime 0.0.0).
+ * (for example CLI 0.2.5 with daemon runtime 0.0.0). API compatibility is
+ * decided against SUPPORTED_DAEMON_API_VERSIONS; any other contract is refused
+ * with a diagnostic naming the wanted-versus-got contracts.
  */
 export function assessDaemonStartupCompatibility(
   health: DaemonStartupHealth | null | undefined,
@@ -48,7 +115,7 @@ export function assessDaemonStartupCompatibility(
     return {
       ok: false,
       code: "unsupported_api",
-      diagnostic: "The running Coven daemon uses an incompatible API. Update Coven, then restart the daemon.",
+      diagnostic: unsupportedDaemonApiDiagnostic(apiVersion),
     };
   }
 


### PR DESCRIPTION
## What\n\nImplements proposals 1 and 2 from bead cave-0mrr7 in `src/lib/daemon-startup-contract.ts`, keeping the daemon adoption gate fail-closed:\n\n1. **Supported-set gate** — `isSupportedDaemonApiVersion` no longer compares with exact equality against a single constant. Adoption is now membership in `SUPPORTED_DAEMON_API_VERSIONS`, a source-pinned `ReadonlySet` built from `COVEN_DAEMON_API_VERSION`. Every refusal the equality check produced is still a refusal: `coven.daemon.v2`, near-miss strings, and non-strings are all rejected with the same `unsupported_api` code. The set is deliberately a membership check rather than a minimum-contract comparison (accept any `coven.daemon.vN` with N >= 1): a newer contract may add/rename/remove surface, so adopting it on the strength of a higher number would admit an unverified daemon. Degrading an unknown-newer contract to reduced function is only safe once per-surface capability gating lands (proposal 3, afs.ts pattern); until then the conservative refusal is the only correct behaviour. The comment documents this so the intent is not lost.\n\n2. **Wanted-versus-got diagnostic** — the generic 'incompatible API' sentence is replaced by `unsupportedDaemonApiDiagnostic`, which names the contract Cave requires (`"coven.daemon.v1"`) and the contract (or absence) the daemon published. A well-formed but newer contract (e.g. `coven.daemon.v2`) also tells the user the daemon is ahead of this build and points the next step at the client ('Update Cave'), while malformed/missing contracts keep the original actionable 'Update Coven, then restart the daemon.' advice.\n\nNo codes, refusal paths, or adoption results change; only the diagnostic text and the internal shape of the check do.\n\n## Why\n\nThe exact-equality gate (`value === COVEN_DAEMON_API_VERSION`) had no notion of a supported set and surfaced one generic, undiagnostic sentence for every mismatch, so the day a daemon ships `coven.daemon.v2` every Cave build would refuse it without saying which contract was wanted or got. This PR is the smallest fail-closed step: the contract list becomes explicit and source-pinned, and the refusal names both sides so an operator knows what to update.\n\n## Verification\n\n- `node --experimental-strip-types src/lib/daemon-startup-contract.test.ts` — ok (extended: set invariants, fail-closed refusals keep `unsupported_api`, wanted-vs-got assertions incl. `coven.daemon.v2` and missing apiVersion, direct `unsupportedDaemonApiDiagnostic` checks).\n- `node --experimental-strip-types src/lib/daemon-endpoint-faults.test.ts` — 13/13 pass (incl. `unsupported_api` code pin for `apiVersion: "99"`).\n- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/daemon-start.test.ts` — 25/25 pass.\n- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs scripts/daemon-connectivity-faults.test.ts` — 6/6 pass.\n- `src/app/api/daemon/status/route.test.ts` — pass.\n- `node scripts/check-tests-wired.mjs` — '✓ all 1911 test files wired into CI' (no new test file added; existing file extended).\n- `npx tsc --noEmit` — clean.\n- Gates re-run in a detached worktree of the commit to exclude concurrent agents' in-flight files in this shared checkout: all green.\n\nChanged files: `src/lib/daemon-startup-contract.ts`, `src/lib/daemon-startup-contract.test.ts`.\n\nCloses the two smallest proposals of cave-0mrr7; capability-gated degradation (proposal 3) and the unknown-capability rule (proposal 4) remain separate follow-ups.