### PR TITLE
fix(x-publish): surface stranded drafts with a retire action (cave-ag9ep)

### DIFF
--- a/src/components/role-surfaces/x-publish-panel-behavior.test.tsx
+++ b/src/components/role-surfaces/x-publish-panel-behavior.test.tsx
@@ -624,3 +624,73 @@ test("an expired publish exposes a fresh-review action inside the modal", async 
   await act(async () => button(renderer, "Review again").props.onClick());
   expect(button(renderer, "Publish to X").props.disabled).toBe(false);
 });
+
+// ── Stranded drafts (cave-ag9ep) ────────────────────────────────────────────
+// A draft is the record "Review this wording" itself mints, and the published
+// list cannot name it. These tests pin the surface that can: drafts are listed
+// with their wording, and one click retires a draft through the resolve the
+// uncertain records already use — outcome "abandoned" takes no network.
+
+test("a stranded draft is listed with its wording and a retire action", async () => {
+  handler = (url, init) =>
+    init?.method === "POST"
+      ? { body: { ok: true, publication: { ...DRAFT, status: "abandoned" } } }
+      : { body: { ok: true, publications: [DRAFT] } };
+  const renderer = await render();
+
+  expect(panelText(renderer)).toContain("ship it");
+  expect(button(renderer, "Retire")).toBeTruthy();
+  // A draft is not an attempt that may have posted, so it does NOT hold the
+  // composer — the room must stay usable while a draft waits to be retired.
+  expect(textarea(renderer).props.disabled).toBe(false);
+});
+
+test("retiring a draft resolves it to abandoned with no post id", async () => {
+  let stored: Array<Record<string, unknown>> = [DRAFT];
+  handler = (url, init) => {
+    if (init?.method !== "POST") return { body: { ok: true, publications: stored } };
+    stored = [{ ...DRAFT, status: "abandoned" }];
+    return { body: { ok: true, publication: stored[0] } };
+  };
+  const renderer = await render();
+
+  await act(async () => button(renderer, "Retire").props.onClick());
+  const resolve = requests.find((request) => request.body?.action === "resolve");
+  expect(resolve?.body).toMatchObject({
+    familiarId: "nyx",
+    publicationId: DRAFT.id,
+    outcome: "abandoned",
+  });
+  // A draft was never dispatched, so nothing is sent that would name a post.
+  expect(resolve?.body).not.toHaveProperty("postId");
+  // Retired: the draft leaves the list once the reload lands.
+  expect(button(renderer, "Retire")).toBeUndefined();
+  expect(panelText(renderer)).not.toContain("ship it");
+});
+
+test("a draft is never rendered among sent posts", async () => {
+  const published = {
+    ...DRAFT,
+    id: "99999999-9999-4999-8999-999999999999",
+    text: "actually posted",
+    status: "published",
+    postId: "1234567890123456789",
+    canonicalUrl: "https://x.com/nyx/status/1234567890123456789",
+    publishedAt: "2026-08-02T10:00:00.000Z",
+  };
+  handler = (url, init) =>
+    init?.method === "POST"
+      ? { body: { ok: true, publication: { ...DRAFT, status: "abandoned" } } }
+      : { body: { ok: true, publications: [DRAFT, published] } };
+  const renderer = await render();
+
+  // Both lists are present and each row carries its own wording; the draft
+  // must not be mistaken for a post that went out.
+  const lists = renderer.root.findAll((node) => node.type === "ul");
+  expect(lists).toHaveLength(2);
+  expect(panelText(renderer)).toContain("ship it");
+  expect(panelText(renderer)).toContain("actually posted");
+  expect(button(renderer, "Retire")).toBeTruthy();
+  // Only the sent row carries the post id.
+  expect(panelText(renderer)).toContain("1234567890123456789");
+});

--- a/src/components/role-surfaces/x-publish-panel.tsx
+++ b/src/components/role-surfaces/x-publish-panel.tsx
@@ -45,6 +45,7 @@ import { Icon } from "@/lib/icon";
 import { useLatestAsyncData } from "@/lib/use-role-surfaces";
 import {
   composerGate,
+  draftPublications,
   publishedPublications,
   unresolvedSummary,
   weightedPostLength,
@@ -152,6 +153,7 @@ export function XPublishPanel({ familiarId }: { familiarId: string }) {
     [text, confirmation, publications],
   );
   const published = useMemo(() => publishedPublications(publications), [publications]);
+  const drafts = useMemo(() => draftPublications(publications), [publications]);
   const weighted = weightedPostLength(text);
 
   /**
@@ -285,6 +287,23 @@ export function XPublishPanel({ familiarId }: { familiarId: string }) {
       announce(outcome === "published" ? "Recorded as posted." : "Recorded as not posted.");
     }),
     [announce, familiarId, postIdDrafts, run],
+  );
+
+  // Retire a stranded draft. This is the same resolve the uncertain records
+  // use, with the outcome that means "never sending this": the server accepts
+  // it for a `draft` and it takes no network. A draft has no post id — nothing
+  // was ever dispatched — so the resolve-form guards above do not apply.
+  const retire = useCallback(
+    (publicationId: string) => run(async () => {
+      await postPublishAction({
+        action: "resolve",
+        familiarId,
+        publicationId,
+        outcome: "abandoned",
+      });
+      announce("Draft retired.");
+    }),
+    [announce, familiarId, run],
   );
 
   /**
@@ -545,7 +564,7 @@ export function XPublishPanel({ familiarId }: { familiarId: string }) {
       )}
 
       {published.length > 0 && (
-        <ul className="role-surface-list">
+        <ul className="role-surface-list" aria-label="Sent posts">
           {published.map((publication) => (
             <li key={publication.id} className="role-surface-list-row">
               <span className="role-surface-memory-excerpt">{publication.text}</span>
@@ -564,6 +583,29 @@ export function XPublishPanel({ familiarId }: { familiarId: string }) {
             </li>
           ))}
         </ul>
+      )}
+
+      {drafts.length > 0 && (
+        <>
+          <p className="role-surface-hint">
+            Saved but never sent. Retire a draft when it is no longer wanted.
+          </p>
+          <ul className="role-surface-list" aria-label="Saved drafts">
+            {drafts.map((publication) => (
+              <li key={publication.id} className="role-surface-list-row">
+                <span className="role-surface-memory-excerpt">{publication.text}</span>
+                <button
+                  type="button"
+                  className="role-surface-chip focus-ring"
+                  disabled={busy}
+                  onClick={() => void retire(publication.id)}
+                >
+                  Retire
+                </button>
+              </li>
+            ))}
+          </ul>
+        </>
       )}
     </section>
   );

--- a/src/lib/x-publish-composer.test.ts
+++ b/src/lib/x-publish-composer.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   composerGate,
+  draftPublications,
   publishedPublications,
   unresolvedPublications,
   unresolvedSummary,
@@ -142,6 +143,21 @@ test("unresolved and published partitions are exactly the two statuses they name
     publishedPublications(all).map((p) => p.id),
     ["e", "c"],
     "sent posts read newest first",
+  );
+});
+
+test("the draft partition is saved-but-never-sent, newest touched first", () => {
+  const all = [
+    record({ id: "a", status: "draft", updatedAt: "2026-08-01T00:00:00.000Z" }),
+    record({ id: "b", status: "uncertain" }),
+    record({ id: "c", status: "published" }),
+    record({ id: "d", status: "abandoned" }),
+    record({ id: "e", status: "draft", updatedAt: "2026-08-03T00:00:00.000Z" }),
+  ];
+  assert.deepEqual(
+    draftPublications(all).map((p) => p.id),
+    ["e", "a"],
+    "drafts read newest touched first, like sent posts read newest sent first",
   );
 });
 

--- a/src/lib/x-publish-composer.ts
+++ b/src/lib/x-publish-composer.ts
@@ -80,6 +80,23 @@ export function publishedPublications(
     .sort((a, b) => (b.publishedAt ?? b.updatedAt).localeCompare(a.publishedAt ?? a.updatedAt));
 }
 
+/**
+ * Drafts that never went out, newest first, for the room's stranded-draft
+ * list. A draft is a record the composer itself made — "Review this wording"
+ * mints one on every confirmation — so a person who walked away without
+ * publishing has no way to know it is there from the published list, and
+ * nothing in the room can retire it. This is the list that makes both
+ * possible; `resolve` with outcome "abandoned" does the retiring and takes
+ * no network.
+ */
+export function draftPublications(
+  publications: readonly XPublicationRecord[],
+): XPublicationRecord[] {
+  return publications
+    .filter((publication) => publication.status === "draft")
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
 /** The confirmation the server minted, bound to the exact text it was for. */
 export type XComposerConfirmation = {
   publicationId: string;


### PR DESCRIPTION
## What\n\nXPublishPanel's 'Review this wording' mints a durable 'draft' record, but the panel only ever listed 'published' records (and held on 'uncertain'), so a draft left behind when someone walked away before publishing was invisible in the room that made it — and there was no in-app way to retire it short of hand-editing the JSON under COVEN_X_PUBLICATIONS_DIR.\n\nThis adds the smallest faithful surface: drafts are listed (newest touched first) alongside sent posts, each with a Retire action. Retire reuses the resolve path the uncertain records already use — outcome 'abandoned', which the server (src/lib/server/x-publications.ts) accepts for a 'draft' and which takes no network.\n\n## Why\n\nStranded drafts accumulate to MAX_PUBLICATIONS_PER_FAMILIAR (500), at which point upsertXPublicationDraft throws 'This familiar has too many stored X posts' for NEW drafts and the composer stops working for that familiar — a hard failure with no in-app path back.\n\n## Changes\n\n- src/lib/x-publish-composer.ts: new draftPublications() partition (draft-only, newest first) beside publishedPublications().\n- src/components/role-surfaces/x-publish-panel.tsx: list drafts with a Retire button; retiring resolves to 'abandoned' (no post id — nothing was ever dispatched) and reloads.\n- src/lib/x-publish-composer.test.ts: partition test for draftPublications().\n- src/components/role-surfaces/x-publish-panel-behavior.test.tsx: three tests — a stranded draft is listed with a retire action and does not hold the composer; retiring sends resolve/abandoned with no postId and clears the row; drafts are never rendered among sent posts.\n\n## Verification\n\n- node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/x-publish-composer.test.ts: 13/13 pass\n- npx vitest run src/components/role-surfaces/x-publish-panel-behavior.test.tsx: 21/21 pass\n- node scripts/check-tests-wired.mjs: all 1911 test files wired\n- npx tsc --noEmit: clean\n- eslint on changed files: clean\n\n## Scope\n\nNo server.ts / workflow changes. Bead left OPEN, PR not merged.