### PR TITLE
fix(marketplace): regenerate the logo audit registry from the catalog

### DIFF
--- a/src/lib/marketplace-logo-registry.gen.json
+++ b/src/lib/marketplace-logo-registry.gen.json
@@ -6,9 +6,9 @@
     "license": "CC0-1.0",
     "package": "simple-icons"
   },
-  "catalogCount": 130,
+  "catalogCount": 129,
   "brandCount": 35,
-  "monogramCount": 95,
+  "monogramCount": 94,
   "entries": {
     "github": {
       "kind": "brand",
@@ -654,11 +654,6 @@
       "kind": "monogram",
       "title": "E2B Code Sandbox",
       "monogram": "ES"
-    },
-    "daytona": {
-      "kind": "monogram",
-      "title": "Daytona Sandboxes",
-      "monogram": "DS"
     },
     "browserbase": {
       "kind": "monogram",


### PR DESCRIPTION
8eb0c0c1b hand-added a daytona entry to the GENERATED registry without a matching catalog entry, so marketplace-logo.test.ts failed on every PR and took the app suite red repository-wide. Regenerated via pnpm marketplace:logos (129 entries; 35 brand, 94 monogram). When the catalog gains its daytona entry, regeneration re-adds the audit row.