### PR TITLE
fix(scope): roll up per-root read/write access level in the permissions UI (cave-fydri)

### DIFF
--- a/src/components/access-groups-section.test.ts
+++ b/src/components/access-groups-section.test.ts
@@ -88,4 +88,24 @@ assert.match(
 );
 assert.match(section, /role="checkbox"/, "member chips are accessible checkboxes");
 
+// ── Per-root read/write rollup in the group header (cave-fydri) ─────────────
+// Each group's base-project grants roll up into a read vs write line beside
+// the member/project counts, so a collapsed group still answers "read-only or
+// mixed?" at a glance.
+assert.match(
+  section,
+  /rollupAccessLevels\(/,
+  "the group header rolls its base-project grants into read vs write counts",
+);
+assert.match(
+  section,
+  /grant\.access === "read" \? "read" : "write"/,
+  "legacy level-less group grants count as write, matching the row badges",
+);
+assert.match(
+  section,
+  /· \$\{accessRollupLabel\(grantRollup\)\}/,
+  "the header appends the read/write rollup line",
+);
+
 console.log("access-groups-section.test.ts: ok");

--- a/src/components/access-groups-section.tsx
+++ b/src/components/access-groups-section.tsx
@@ -9,7 +9,9 @@ import { SettingsGroup } from "@/components/ui/settings-group";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import {
   accessLevelMeta,
+  accessRollupLabel,
   isSupreme,
+  rollupAccessLevels,
   type ConsoleAccessGroup,
   type ConsoleProject,
 } from "@/lib/permissions-console";
@@ -211,6 +213,12 @@ export function AccessGroupsSection({ familiars }: { familiars: ResolvedFamiliar
         {groups.map((group) => {
           const open = expanded === group.id;
           const groupBusy = busy.has(group.id);
+          // The group's own base-project grants, rolled up into read vs write
+          // (legacy level-less grants mean write). Shown in the header so a
+          // collapsed group still answers "read-only or mixed?" at a glance.
+          const grantRollup = rollupAccessLevels(
+            group.projectGrants.map((grant) => (grant.access === "read" ? "read" : "write")),
+          );
           return (
             <div key={group.id}>
               <button
@@ -231,6 +239,9 @@ export function AccessGroupsSection({ familiars }: { familiars: ResolvedFamiliar
                       {group.projectGrants.length === 1
                         ? "1 project"
                         : `${group.projectGrants.length} projects`}
+                      {group.projectGrants.length > 0
+                        ? ` · ${accessRollupLabel(grantRollup)}`
+                        : ""}
                     </span>
                   </span>
                 </span>

--- a/src/components/familiar-studio-projects-tab.test.ts
+++ b/src/components/familiar-studio-projects-tab.test.ts
@@ -171,3 +171,23 @@ assert.match(
   /grantChangeOriginLabel\(e\)/,
   "each line says where the change came from",
 );
+
+// ── Per-root read/write rollup (cave-fydri) ─────────────────────────────────
+// The grant-matrix header rolls the familiar's effective per-root levels up
+// into a read vs write line (same levels the chat runtime-scope preamble
+// annotates), so read vs write is visible at a glance.
+assert.match(
+  tab,
+  /rollupAccessLevels\(/,
+  "the tab rolls per-root levels into read vs write counts",
+);
+assert.match(
+  tab,
+  /\$\{accessibleCount\} of \$\{projects\.length\} accessible · \$\{accessRollupLabel\(accessRollup\)\}/,
+  "the matrix header shows the read/write rollup next to the accessible count",
+);
+assert.match(
+  tab,
+  /effectiveByProject\.get\(project\.id\)\?\.level \?\? null/,
+  "the rollup uses the EFFECTIVE level (direct + group union-max), matching the preamble",
+);

--- a/src/components/familiar-studio-projects-tab.tsx
+++ b/src/components/familiar-studio-projects-tab.tsx
@@ -16,6 +16,7 @@ import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { useUserProfile, userDisplayName } from "@/lib/user-profile";
 import {
   accessLevelMeta,
+  accessRollupLabel,
   auditDecisionMeta,
   auditReasonLabel,
   grantChangeMeta,
@@ -28,6 +29,7 @@ import {
   isSupreme,
   nameResolver,
   proposalStatusMeta,
+  rollupAccessLevels,
   splitProposals,
   surfaceLabel,
   type ConsoleAccessGroup,
@@ -296,10 +298,6 @@ export function FamiliarStudioProjectsTab({ familiar, variant = "full" }: Props)
   const projectName = useMemo(() => nameResolver(projects, (p) => p.name), [projects]);
 
   const supreme = isSupreme(familiar.id, supremeFamiliarId);
-  const grantedCount = useMemo(
-    () => projects.reduce((n, p) => (granted.has(grantKey(familiar.id, p.id)) ? n + 1 : n), 0),
-    [projects, granted, familiar.id],
-  );
 
   // Effective access = union-max of the direct grant + this familiar's access
   // groups, resolved with the SAME helper the server enforces with.
@@ -312,6 +310,22 @@ export function FamiliarStudioProjectsTab({ familiar, variant = "full" }: Props)
     });
     return new Map(rows.map((row) => [row.project.id, row.effective]));
   }, [projects, grantMeta, accessGroups, familiar.id]);
+
+  // Per-root read vs write, rolled up over every project the familiar can
+  // access (direct or through a group) at its EFFECTIVE level — the same
+  // levels the chat runtime-scope preamble annotates from
+  // listAccessibleProjects, so the header says what the preamble says.
+  const accessibleCount = useMemo(
+    () => projects.reduce((n, p) => (effectiveByProject.get(p.id)?.level ? n + 1 : n), 0),
+    [projects, effectiveByProject],
+  );
+  const accessRollup = useMemo(
+    () =>
+      rollupAccessLevels(
+        projects.map((project) => effectiveByProject.get(project.id)?.level ?? null),
+      ),
+    [projects, effectiveByProject],
+  );
   const memberGroups = useMemo(
     () => groupsForFamiliar(accessGroups, familiar.id),
     [accessGroups, familiar.id],
@@ -424,7 +438,11 @@ export function FamiliarStudioProjectsTab({ familiar, variant = "full" }: Props)
       ) : (
         <SettingsGroup
           label="Project access"
-          description={`${grantedCount} of ${projects.length} granted`}
+          description={
+            accessibleCount > 0
+              ? `${accessibleCount} of ${projects.length} accessible · ${accessRollupLabel(accessRollup)}`
+              : `${accessibleCount} of ${projects.length} accessible`
+          }
         >
           <div className="flex justify-end border-b border-[var(--border-hairline)] px-4 py-2">
             <Button variant="secondary" size="sm" leadingIcon="ph:plus-bold" onClick={addFlow.beginAddProject}>

--- a/src/lib/permissions-console.test.ts
+++ b/src/lib/permissions-console.test.ts
@@ -5,6 +5,7 @@ import {
   grantChangeOriginLabel,
   grantLevelLabel,
   accessLevelMeta,
+  accessRollupLabel,
   accessSummary,
   auditDecisionMeta,
   auditReasonLabel,
@@ -19,6 +20,7 @@ import {
   nameResolver,
   pendingProposalCount,
   proposalStatusMeta,
+  rollupAccessLevels,
   sortFamiliars,
   splitProposals,
   surfaceLabel,
@@ -230,6 +232,31 @@ assert.equal(
 assert.equal(
   grantChangeOriginLabel({ actor: "system", kind: "project-removed" }),
   "project removed from the registry",
+);
+
+// ── Per-root read/write rollup (cave-fydri) ────────────────────────────────
+// The UI rolls the SAME effective per-root levels the chat runtime-scope
+// preamble annotates into a compact read vs write summary, so a human looking
+// at a familiar's (or group's) grants sees read vs write without reading the
+// preamble.
+assert.deepEqual(
+  rollupAccessLevels(["read", "write", "write", null, undefined]),
+  { read: 1, write: 2 },
+  "counts read vs write and skips non-grants",
+);
+assert.deepEqual(rollupAccessLevels([]), { read: 0, write: 0 }, "empty rollup is zeros");
+assert.deepEqual(rollupAccessLevels(["write"]), { read: 0, write: 1 });
+assert.equal(accessRollupLabel({ read: 1, write: 2 }), "1 read-only · 2 read + write");
+assert.equal(
+  accessRollupLabel({ read: 3, write: 0 }),
+  "3 read-only",
+  "zero-count levels are dropped so a fully read-only set reads plainly",
+);
+assert.equal(accessRollupLabel({ read: 0, write: 2 }), "2 read + write");
+assert.equal(
+  accessRollupLabel({ read: 0, write: 0 }),
+  "no access",
+  "an empty rollup reads as no access",
 );
 
 console.log("permissions-console grant-change assertions: ok");

--- a/src/lib/permissions-console.ts
+++ b/src/lib/permissions-console.ts
@@ -413,3 +413,45 @@ export function groupsForFamiliar(
     .filter((group) => group.memberFamiliarIds.includes(familiarId))
     .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
 }
+/**
+ * A familiar's (or access group's) granted roots, split by read vs write. The
+ * two counts are what the UI rollup lines render — the at-a-glance answer to
+ * "can this familiar write anywhere?" that the chat runtime-scope preamble
+ * spells out root by root.
+ */
+export type AccessRollup = { read: number; write: number };
+
+/**
+ * Roll up per-root access levels into read vs write counts. Levels are the
+ * EFFECTIVE levels (union-max of direct + group grants) — the same levels the
+ * chat runtime-scope preamble annotates from listAccessibleProjects — so the
+ * UI and the preamble tell the same story. Non-grants (null/undefined) are
+ * skipped: the rollup counts the access a familiar holds, not the whole
+ * registry.
+ */
+export function rollupAccessLevels(
+  levels: Iterable<ProjectAccessLevel | null | undefined>,
+): AccessRollup {
+  let read = 0;
+  let write = 0;
+  for (const level of levels) {
+    if (level === "read") read += 1;
+    else if (level === "write") write += 1;
+  }
+  return { read, write };
+}
+
+/**
+ * At-a-glance summary of a rollup, in the preamble's own vocabulary:
+ * "3 read-only · 2 read + write". Zero-count levels are dropped so a fully
+ * read-only familiar reads as "3 read-only" rather than "3 read-only · 0 read
+ * + write"; an empty rollup reads as "no access".
+ */
+export function accessRollupLabel(rollup: AccessRollup): string {
+  const parts: string[] = [];
+  if (rollup.read > 0) parts.push(`${rollup.read} read-only`);
+  if (rollup.write > 0) parts.push(`${rollup.write} read + write`);
+  if (parts.length === 0) return "no access";
+  return parts.join(" · ");
+}
+


### PR DESCRIPTION
## What

Follow-up to PR #4474 (cave-0tkwx): that PR annotated each granted project root in the chat runtime-scope preamble with `(read-only)` / `(read + write)`. This rolls that **same per-root level** up into the permissions UI, so read vs write is visible at a glance without reading the preamble.

## Why

The bead (cave-fydri) asked for a per-root read/write rollup across the permissions UI. Investigation of all five candidate surfaces (per bead):

| Surface | Verdict |
| --- | --- |
| `src/lib/permissions-console.ts` | Touched — hosts the shared pure rollup helpers (the Settings/Permissions console's logic module) |
| `src/components/familiar-studio-projects-tab.tsx` | Touched — matrix header now shows `K of N accessible · N read-only · M read + write` |
| `src/components/access-groups-section.tsx` | Touched — each collapsed group header appends its base grants' rollup (`2 read-only · 3 read + write`) |
| `src/components/projects-view.tsx` | No change needed — already rolls up per level (proportional ledger bar, by-level tree view, collapsed-section mix chips) |
| `src/components/project-setup-modal.tsx` | No change needed — it is an access *chooser* for a brand-new project, with no existing per-root grant list to roll up |

## Changes

- **permissions-console.ts**: new `rollupAccessLevels()` (counts read vs write, skips non-grants) and `accessRollupLabel()` (`"3 read-only · 2 read + write"`, zero-count levels dropped, `"no access"` when empty) — shared by every surface, using the **effective** levels (direct + group union-max) that `listAccessibleProjects` annotates in the preamble, so the UI and the preamble tell the same story.
- **familiar-studio-projects-tab.tsx**: `grantedCount` (direct toggles only) replaced by `accessibleCount` + `accessRollup` over effective levels; the Project access header reads e.g. `3 of 5 accessible · 1 read-only · 2 read + write`.
- **access-groups-section.tsx**: group header summary (previously `2 members · 3 projects`) now appends `· 1 read-only · 2 read + write` when the group has grants.

## Verification

- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test` on the three affected suites: **3/3 pass** (permissions-console.test.ts unit tests for the helpers; component assertions added to familiar-studio-projects-tab.test.ts and access-groups-section.test.ts).
- `node scripts/check-tests-wired.mjs`: ✓ all 1913 test files wired (no new test files — existing ones extended).
- `npx tsc --noEmit` in the worktree: clean (exit 0).
