### PR TITLE
fix(inbox): surface agent inbox item when a session finishes unwatched (cave-fgey)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -295,6 +295,8 @@ export const SUITES = {
     "src/lib/cave-inbox-create.test.ts",
     "src/lib/cave-inbox-prefs.test.ts",
     "src/lib/cave-inbox-bulk.test.ts",
+    "src/lib/session-finished-inbox.test.ts",
+    "src/lib/session-finished-inbox-emit.test.ts",
     "src/lib/project-permissions.test.ts",
     "src/lib/project-grant-audit.test.ts",
     "src/lib/project-access-levels.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -2059,6 +2059,10 @@ const ALIAS_LOADER = new Set([
   // the picker imports the module under test, which resolves
   // "@/lib/code-surface" for the shared session-visibility rule.
   "src/lib/code-session-picker.test.ts",
+  // the session-finished emit test loads session-finished-inbox-emit.ts,
+  // which resolves "@/lib/cave-inbox", "@/lib/cave-config" and friends as
+  // runtime values; the suite cannot load without the alias resolver.
+  "src/lib/session-finished-inbox-emit.test.ts",
   // the prompt-brief + quick-saves tests type their fixtures against
   // "@/lib/research-missions" and "@/lib/link-organizer"
   "src/lib/research-prompt-brief.test.ts",

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -308,6 +308,7 @@ import {
   validateModelControlValues,
   type ModelControlValues,
 } from "@/lib/model-control-capabilities";
+import { emitSessionFinishedItem } from "@/lib/session-finished-inbox-emit";
 import { chatSse, startChatSseHeartbeat } from "./chat-send-sse";
 import {
   daemonSessionCwd,
@@ -5960,6 +5961,25 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
         ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
         responseMetadata,
       });
+      // Session-finished inbox item (cave-fgey): when the turn completed while
+      // the user wasn't watching this chat, surface one 'agent' inbox item
+      // ("<familiar> finished: <session title>") so finished long-running work
+      // is not silent outside Recent Activity. "Watching" is the same signal
+      // the detach cap already uses: the initiating request is still attached
+      // (fetch open) and no detached-run re-attach is pending — a transport
+      // drop arms detachKillTimer, a re-attach clears it, and a deliberate
+      // Stop never arms it. Long turns notify even when watched. Best-effort:
+      // never fails the turn; deduped per session.
+      if (finalSessionId) {
+        await emitSessionFinishedItem({
+          familiarId: body.familiarId,
+          familiarName:
+            config.familiars[body.familiarId]?.display_name?.trim() || body.familiarId,
+          sessionId: finalSessionId,
+          watchedByUser: detachKillTimer == null,
+          durationMs: result.duration_ms,
+        });
+      }
       // Best-effort temp cleanup: the harness child process has already
       // exited (including any resume retry), so nothing can still be reading
       // the saved images. Failures just leave files in tmpdir.

--- a/src/lib/session-finished-inbox-emit.test.ts
+++ b/src/lib/session-finished-inbox-emit.test.ts
@@ -1,0 +1,128 @@
+// Behavioral test for the session-finished inbox emit (cave-fgey): one
+// "agent" item per finished session when the user wasn't watching. Runs
+// against a throwaway COVEN_HOME/COVEN_CAVE_HOME so the real inbox is never
+// touched.
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+
+const tmpHome = mkdtempSync(path.join(os.tmpdir(), "cave-fgey-emit-"));
+// The store gate (withCaveHomeReconciledStore) scans covenHome() for legacy
+// cave-*.json entries, so both env vars must move before import.
+process.env.COVEN_HOME = path.join(tmpHome, ".coven");
+process.env.COVEN_CAVE_HOME = path.join(tmpHome, "cave");
+
+// Import AFTER the env override — INBOX_PATH / STATE_PATH resolve at module load.
+const { emitSessionFinishedItem } = await import("./session-finished-inbox-emit.ts");
+const { dismissItem, loadInbox } = await import("./cave-inbox.ts");
+const { setSessionTitle } = await import("./cave-config.ts");
+
+after(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("emitSessionFinishedItem", () => {
+  it("creates a fired agent item when the user is not watching", async () => {
+    const item = await emitSessionFinishedItem({
+      familiarId: "fam-a",
+      familiarName: "Nyx",
+      sessionId: "s-1",
+      watchedByUser: false,
+      durationMs: 30_000,
+    });
+    assert.ok(item, "item was created");
+    assert.equal(item.kind, "agent");
+    assert.equal(item.title, "Nyx finished: New chat");
+    assert.equal(item.status, "fired", "agent items fire immediately");
+    assert.equal(item.sessionId, "s-1");
+    assert.deepEqual(item.link, { kind: "session", ref: "s-1" });
+    const { items } = await loadInbox();
+    assert.equal(items.length, 1);
+  });
+
+  it("stays silent while the user is watching a short turn", async () => {
+    const item = await emitSessionFinishedItem({
+      familiarId: "fam-a",
+      familiarName: "Nyx",
+      sessionId: "s-2",
+      watchedByUser: true,
+      durationMs: 30_000,
+    });
+    assert.equal(item, null);
+    const { items } = await loadInbox();
+    assert.equal(items.length, 1, "nothing was added");
+  });
+
+  it("notifies a long turn even when the user is watching", async () => {
+    const item = await emitSessionFinishedItem({
+      familiarId: "fam-a",
+      familiarName: "Nyx",
+      sessionId: "s-3",
+      watchedByUser: true,
+      durationMs: 10 * 60_000,
+    });
+    assert.ok(item, "long turn surfaced");
+    const { items } = await loadInbox();
+    assert.equal(items.length, 2);
+  });
+
+  it("uses the cave-state session title when present", async () => {
+    await setSessionTitle("s-4", "Fix the search bar");
+    const item = await emitSessionFinishedItem({
+      familiarId: "fam-a",
+      familiarName: "Nyx",
+      sessionId: "s-4",
+      watchedByUser: false,
+      durationMs: 30_000,
+    });
+    assert.ok(item, "item was created");
+    assert.equal(item.title, "Nyx finished: Fix the search bar");
+  });
+
+  it("dedups per session while an item is unresolved", async () => {
+    const first = await emitSessionFinishedItem({
+      familiarId: "fam-a",
+      familiarName: "Nyx",
+      sessionId: "s-5",
+      watchedByUser: false,
+      durationMs: 30_000,
+    });
+    assert.ok(first);
+    const second = await emitSessionFinishedItem({
+      familiarId: "fam-a",
+      familiarName: "Nyx",
+      sessionId: "s-5",
+      watchedByUser: false,
+      durationMs: 30_000,
+    });
+    assert.equal(second, null, "duplicate suppressed for the same session");
+  });
+
+  it("surfaces a fresh item after the previous one was dismissed", async () => {
+    const { items: beforeItems } = await loadInbox();
+    const prior = beforeItems.find((it) => it.sessionId === "s-5");
+    assert.ok(prior);
+    await dismissItem(prior.id);
+    const again = await emitSessionFinishedItem({
+      familiarId: "fam-a",
+      familiarName: "Nyx",
+      sessionId: "s-5",
+      watchedByUser: false,
+      durationMs: 30_000,
+    });
+    assert.ok(again, "a new completion surfaces after dismissal");
+  });
+
+  it("is a no-op without a session id or on unknown failures", async () => {
+    const none = await emitSessionFinishedItem({
+      familiarId: "fam-a",
+      familiarName: "Nyx",
+      sessionId: "",
+      watchedByUser: false,
+      durationMs: 30_000,
+    });
+    assert.equal(none, null);
+  });
+});

--- a/src/lib/session-finished-inbox-emit.ts
+++ b/src/lib/session-finished-inbox-emit.ts
@@ -1,0 +1,64 @@
+import { createItem, loadInbox, type InboxItem } from "@/lib/cave-inbox";
+import { defaultChatTitleForSession } from "@/lib/cave-chat-titles";
+import { loadState } from "@/lib/cave-config";
+import { broadcastCreated } from "@/lib/inbox-scheduler";
+import {
+  hasUnresolvedSessionFinishedItem,
+  sessionFinishedItem,
+  shouldNotifySessionFinished,
+} from "@/lib/session-finished-inbox";
+
+/**
+ * Server-side IO wiring for the session-finished inbox item (cave-fgey). Pure
+ * decision logic lives in session-finished-inbox.ts; this module reads/writes
+ * the inbox + cave state and broadcasts to the inbox SSE stream. Best-effort:
+ * a failure here must never break the caller's primary operation (the chat
+ * turn completing), so this always resolves instead of throwing.
+ */
+
+/**
+ * Emit one 'agent' inbox item for a just-finished session when the user
+ * wasn't watching that chat (or the turn ran long), deduped per session.
+ * Returns the created item, or null when nothing was emitted.
+ */
+export async function emitSessionFinishedItem(input: {
+  familiarId: string;
+  /** Display name at completion time; falls back to familiarId in the title. */
+  familiarName: string;
+  sessionId: string;
+  /** True when the user is watching this chat right now (request attached). */
+  watchedByUser: boolean;
+  /** Turn duration in ms; null when unknown. */
+  durationMs: number | null | undefined;
+}): Promise<InboxItem | null> {
+  try {
+    if (!input.sessionId) return null;
+    if (
+      !shouldNotifySessionFinished({
+        watchedByUser: input.watchedByUser,
+        durationMs: input.durationMs,
+      })
+    ) {
+      return null;
+    }
+    const [{ items }, state] = await Promise.all([loadInbox(), loadState()]);
+    if (hasUnresolvedSessionFinishedItem(items, input.sessionId)) return null;
+    // The cave-state title is authoritative (auto-rename and manual renames
+    // both write sessionTitles); fall back to the neutral default.
+    const sessionTitle =
+      state.sessionTitles?.[input.sessionId]?.trim() ||
+      defaultChatTitleForSession(input.sessionId);
+    const item = await createItem(
+      sessionFinishedItem({
+        familiarId: input.familiarId,
+        familiarName: input.familiarName,
+        sessionTitle,
+        sessionId: input.sessionId,
+      }),
+    );
+    broadcastCreated(item);
+    return item;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/session-finished-inbox.test.ts
+++ b/src/lib/session-finished-inbox.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  hasUnresolvedSessionFinishedItem,
+  isSessionFinishedItem,
+  SESSION_FINISHED_AUTO,
+  SESSION_FINISHED_NOTIFY_MIN_MS,
+  sessionFinishedItem,
+  shouldNotifySessionFinished,
+} from "./session-finished-inbox.ts";
+import type { InboxItem } from "./cave-inbox.ts";
+
+const base: InboxItem = {
+  id: "i1",
+  kind: "agent",
+  title: "x",
+  status: "fired",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  fireAt: null,
+  firedAt: "2026-01-01T00:00:00.000Z",
+  snoozeUntil: null,
+  recurrence: { type: "none" },
+  source: "agent",
+  familiarId: "fam-a",
+  sessionId: "s-1",
+  link: { kind: "session", ref: "s-1" },
+  media: null,
+  auto: null,
+  readAt: null,
+  muted: null,
+};
+
+describe("sessionFinishedItem", () => {
+  it("builds the exact <familiar> finished: <session title> agent item", () => {
+    const input = sessionFinishedItem({
+      familiarId: "fam-a",
+      familiarName: "Nyx",
+      sessionTitle: "Fix the search bar",
+      sessionId: "s-1",
+    });
+    assert.equal(input.kind, "agent");
+    assert.equal(input.title, "Nyx finished: Fix the search bar");
+    assert.equal(input.source, "agent");
+    assert.equal(input.familiarId, "fam-a");
+    assert.equal(input.sessionId, "s-1");
+    assert.deepEqual(input.link, { kind: "session", ref: "s-1" });
+    assert.equal(input.auto, SESSION_FINISHED_AUTO);
+  });
+});
+
+describe("shouldNotifySessionFinished", () => {
+  it("stays silent when the user is watching and the turn was short", () => {
+    assert.equal(
+      shouldNotifySessionFinished({ watchedByUser: true, durationMs: 30_000 }),
+      false,
+    );
+  });
+  it("notifies when the user is not watching, even for a short turn", () => {
+    assert.equal(
+      shouldNotifySessionFinished({ watchedByUser: false, durationMs: 30_000 }),
+      true,
+    );
+  });
+  it("notifies long turns even when the user is watching", () => {
+    assert.equal(
+      shouldNotifySessionFinished({
+        watchedByUser: true,
+        durationMs: SESSION_FINISHED_NOTIFY_MIN_MS + 1,
+      }),
+      true,
+    );
+  });
+  it("notifies when the user is not watching and the turn was long", () => {
+    assert.equal(
+      shouldNotifySessionFinished({
+        watchedByUser: false,
+        durationMs: SESSION_FINISHED_NOTIFY_MIN_MS + 1,
+      }),
+      true,
+    );
+  });
+  it("treats an unknown duration as watched-only", () => {
+    assert.equal(shouldNotifySessionFinished({ watchedByUser: true, durationMs: null }), false);
+    assert.equal(shouldNotifySessionFinished({ watchedByUser: false, durationMs: null }), true);
+    assert.equal(shouldNotifySessionFinished({ watchedByUser: true, durationMs: undefined }), false);
+  });
+});
+
+describe("isSessionFinishedItem / hasUnresolvedSessionFinishedItem", () => {
+  it("recognizes items by the auto discriminator and session id", () => {
+    const mine: InboxItem = { ...base, auto: SESSION_FINISHED_AUTO } as InboxItem;
+    assert.equal(isSessionFinishedItem(mine, "s-1"), true);
+    assert.equal(isSessionFinishedItem(mine, "s-2"), false);
+    assert.equal(isSessionFinishedItem(mine), true);
+    const other: InboxItem = { ...base, auto: "archive-nudge" } as InboxItem;
+    assert.equal(isSessionFinishedItem(other, "s-1"), false);
+  });
+  it("matches on the session link ref when sessionId differs", () => {
+    const linked: InboxItem = {
+      ...base,
+      sessionId: null,
+      link: { kind: "session", ref: "s-9" },
+      auto: SESSION_FINISHED_AUTO,
+    } as InboxItem;
+    assert.equal(isSessionFinishedItem(linked, "s-9"), true);
+  });
+  it("an unresolved item dedups its session; resolved ones do not", () => {
+    const fired: InboxItem = { ...base, status: "fired", auto: SESSION_FINISHED_AUTO } as InboxItem;
+    assert.equal(hasUnresolvedSessionFinishedItem([fired], "s-1"), true);
+    const pending: InboxItem = { ...base, status: "pending", auto: SESSION_FINISHED_AUTO } as InboxItem;
+    assert.equal(hasUnresolvedSessionFinishedItem([pending], "s-1"), true);
+    const done: InboxItem = { ...base, status: "done", auto: SESSION_FINISHED_AUTO } as InboxItem;
+    assert.equal(hasUnresolvedSessionFinishedItem([done], "s-1"), false);
+    const dismissed: InboxItem = { ...base, status: "dismissed", auto: SESSION_FINISHED_AUTO } as InboxItem;
+    assert.equal(hasUnresolvedSessionFinishedItem([dismissed], "s-1"), false);
+    assert.equal(hasUnresolvedSessionFinishedItem([], "s-1"), false);
+  });
+});

--- a/src/lib/session-finished-inbox.ts
+++ b/src/lib/session-finished-inbox.ts
@@ -1,0 +1,92 @@
+import type { InboxItem, NewItemInput } from "@/lib/cave-inbox";
+
+/**
+ * Session-finished notification (cave-fgey): when a familiar's session
+ * completes while the user isn't watching that chat, land one 'agent' inbox
+ * item ("<familiar> finished: <session title>") linking back to the chat, so
+ * finished long-running work is not silent outside Recent Activity. The item
+ * fires immediately (kind 'agent', no fireAt) and rides the existing
+ * "Needs you" strip / bell badge for free.
+ *
+ * `auto` on the inbox item is the durable discriminator: it marks the item as
+ * machine-generated so producers can dedup and resolve their own items without
+ * brittle title matching (same convention as task-archive-nudge.ts). Human/user
+ * reminders never set it.
+ */
+export const SESSION_FINISHED_AUTO = "session-finished";
+
+/**
+ * A turn that ran longer than this is treated as "the user has wandered",
+ * even when their tab is still open on the chat. Default 3 minutes, floored
+ * at 1 minute, overridable via COVEN_CAVE_SESSION_FINISHED_MIN_MS — same
+ * env-shape as the chat detach cap (CHAT_DETACH_MAX_MS).
+ */
+export const SESSION_FINISHED_NOTIFY_MIN_MS = Math.max(
+  60_000,
+  Number(process.env.COVEN_CAVE_SESSION_FINISHED_MIN_MS ?? 3 * 60_000) || 3 * 60_000,
+);
+
+/**
+ * Whether a finished turn should surface an inbox item. The user is watching
+ * the chat AND the turn was short → silent; otherwise notify. `durationMs`
+ * null/undefined (unknown duration) falls back to the watched flag alone.
+ */
+export function shouldNotifySessionFinished(opts: {
+  watchedByUser: boolean;
+  durationMs: number | null | undefined;
+}): boolean {
+  if (opts.durationMs != null && opts.durationMs > SESSION_FINISHED_NOTIFY_MIN_MS) {
+    return true;
+  }
+  return !opts.watchedByUser;
+}
+
+/**
+ * Build the inbox payload for a finished session. Pure — no IO, never dedups;
+ * callers gate creation with {@link hasUnresolvedSessionFinishedItem}.
+ */
+export function sessionFinishedItem(input: {
+  familiarId: string;
+  familiarName: string;
+  sessionTitle: string;
+  sessionId: string;
+}): NewItemInput {
+  return {
+    kind: "agent",
+    title: `${input.familiarName} finished: ${input.sessionTitle}`,
+    source: "agent",
+    familiarId: input.familiarId,
+    sessionId: input.sessionId,
+    link: { kind: "session", ref: input.sessionId },
+    auto: SESSION_FINISHED_AUTO,
+  };
+}
+
+/** Statuses that mean the item no longer demands the user's attention. */
+const RESOLVED: ReadonlyArray<InboxItem["status"]> = ["done", "dismissed"];
+
+/**
+ * True when `item` is a session-finished item. When `sessionId` is supplied,
+ * also requires the item to target that session (matched on either the item's
+ * `sessionId` or its session link ref).
+ */
+export function isSessionFinishedItem(item: InboxItem, sessionId?: string): boolean {
+  if (item.auto !== SESSION_FINISHED_AUTO) return false;
+  if (sessionId == null) return true;
+  return item.sessionId === sessionId || item.link?.ref === sessionId;
+}
+
+/**
+ * Whether an unresolved session-finished item already exists for `sessionId`.
+ * "Deduped per session": one outstanding item per session — a second
+ * completion for the same chat does not stack while the user hasn't acted,
+ * but a fresh notification can surface after the previous one was handled.
+ */
+export function hasUnresolvedSessionFinishedItem(
+  items: InboxItem[],
+  sessionId: string,
+): boolean {
+  return items.some(
+    (item) => isSessionFinishedItem(item, sessionId) && !RESOLVED.includes(item.status),
+  );
+}


### PR DESCRIPTION
## What

Implements golden-path rider cave-fgey: when a familiar's session finishes (kind: 'done') while the user isn't watching that chat, create one 'agent' inbox item — '<familiar> finished: <session title>' linking #chat-<id> — deduped per session. The item fires immediately (kind 'agent', no fireAt) and rides the existing "Needs you" strip / bell badge for free.

## Why

/api/chat/send/route.ts wrote the {kind:'done'} stream event but never touched cave-inbox — a familiar finishing long-running work was silent unless the user was staring at Recent Activity. The plumbing (POST /api/inbox accepting kind:'agent') already existed; this is the conservative hook.

## How

- src/lib/session-finished-inbox.ts (new, pure): shouldNotifySessionFinished (notify when !watchedByUser || durationMs > SESSION_FINISHED_NOTIFY_MIN_MS, default 3 min, env-overridable COVEN_CAVE_SESSION_FINISHED_MIN_MS), the item builder, and the per-session dedup predicate (auto: 'session-finished' discriminator, following the task-archive-nudge convention — one outstanding item per session; a fresh notification can surface after the previous one was dismissed).
- src/lib/session-finished-inbox-emit.ts (new, IO): best-effort emit — loadInbox + loadState, dedup check, createItem, broadcastCreated. Resolves null on any failure; never throws into the turn.
- src/app/api/chat/send/route.ts: at the terminal 'done' push, when finalSessionId exists, call emitSessionFinishedItem. watchedByUser reuses the route's existing detach-cap signal: the initiating request is still attached and no re-attach is pending (detachKillTimer == null). A transport drop arms the timer (→ notify); a re-attach clears it (→ silent unless long); a deliberate Stop never arms it (→ silent). Long turns notify even when watched.

## Verification

- New tests (16): session-finished-inbox.test.ts (decision matrix, builder shape, dedup predicates) and session-finished-inbox-emit.test.ts (fires fired agent item, silent while watched+short, long-turn notify, cave-state title used, per-session dedup, re-surface after dismiss) — all pass against a throwaway COVEN_HOME.
- Related suites still green: cave-inbox-create, cave-inbox-bulk, route-body-validation, first-turn-stub.
- node scripts/check-tests-wired.mjs: ✓ all 1915 test files wired (new tests registered in scripts/run-tests.mjs).
- npx tsc --noEmit: clean (exit 0).
