### PR TITLE
fix(ios): give refused and partial group message deletes a recovery path (cave-7nrp9)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -806,6 +806,11 @@ final class ChatThread: Identifiable, Hashable {
             return
         }
         messages.remove(at: index)
+        // A re-sync's absent-for-session proof dies with the message it was
+        // about, and so does a partial-delete report's retry record when the
+        // note itself is the message being removed.
+        absentForSession.removeValue(forKey: messageId)
+        pendingPartialDeleteRetry.removeValue(forKey: messageId)
         updatedAt = Date()
         onChange()
 
@@ -829,6 +834,17 @@ final class ChatThread: Identifiable, Hashable {
     /// The tail of this thread's serialized server deletes. Nothing renders
     /// it, so it stays out of observation. See `deleteMessage`.
     @ObservationIgnored private var pendingServerDelete: Task<Void, Never>?
+
+    /// Sessions this thread's last re-sync PROVED never received a message — a
+    /// fan-out that reached some familiars and not others. Keyed by message
+    /// id; the delete path skips these sessions instead of letting one of them
+    /// refuse the whole delete on its behalf. In-memory only: a snapshot never
+    /// stores it, and `reload` recomputes it from the server.
+    @ObservationIgnored private var absentForSession: [String: Set<String>] = [:]
+
+    /// Partial-delete reports that still have a surviving copy, keyed by the
+    /// report note's message id so the view can offer a retry on that note.
+    @ObservationIgnored private var pendingPartialDeleteRetry: [String: PartialDeleteRetryState] = [:]
 
     /// Where a message lives on the server, when it lives there at all — one
     /// entry per session that can be holding a copy of it.
@@ -1003,7 +1019,10 @@ final class ChatThread: Identifiable, Hashable {
                 return
             }
         }
-        var failures: [(familiarId: String, reason: String)] = []
+        // A leg carries the session and the NAMED turn it still holds: the
+        // retry re-deletes by name, so a drifted transcript cannot refuse it
+        // a second time.
+        var failures: [(familiarId: String, sessionId: String, turnId: String, reason: String)] = []
         for deletion in deletions {
             do {
                 try await client.deleteConversationTurn(sessionId: deletion.sessionId,
@@ -1011,7 +1030,8 @@ final class ChatThread: Identifiable, Hashable {
             } catch {
                 // Keep going: every session that still answers is one fewer
                 // surviving copy, and the report below wants the whole list.
-                failures.append((deletion.familiarId, error.localizedDescription))
+                failures.append((deletion.familiarId, deletion.sessionId, deletion.turnId,
+                                 error.localizedDescription))
             }
         }
         guard let firstFailure = failures.first else { return }
@@ -1023,7 +1043,7 @@ final class ChatThread: Identifiable, Hashable {
             rollBack(message, to: index, reason: firstFailure.reason, onChange: onChange)
             return
         }
-        reportPartialDelete(failures, familiarNames: familiarNames, onChange: onChange)
+        reportPartialDelete(failures, at: index, familiarNames: familiarNames, onChange: onChange)
     }
 
     /// What one session says about where this message is, if anywhere.
@@ -1039,6 +1059,18 @@ final class ChatThread: Identifiable, Hashable {
     /// Name this message's turn inside one session, without deleting anything.
     private func resolveTurn(in session: ServerDeleteTarget.Session,
                              client: CaveClient) async -> ServerTurnResolution {
+        // A re-sync can PROVE this session never received the message — a
+        // fan-out that reached three of four familiars. The matcher's answer
+        // for that session is `ambiguous` (its transcript disagrees at the
+        // message's position), and refusing the whole delete on its behalf
+        // would keep the message alive in the sessions that DO hold it. The
+        // proof is a server transcript that cleanly skipped the message, so it
+        // is the same evidence as a transcript that simply ends before it: the
+        // local removal is already the whole delete for this session.
+        if let absent = absentForSession[session.message.id],
+           absent.contains(session.familiarId) {
+            return .absent
+        }
         if let known = session.message.serverTurnId, !known.isEmpty { return .named(known) }
         // A message composed in this session has no server-assigned id yet,
         // and nothing in the send path hands one back. Reading the
@@ -1077,17 +1109,15 @@ final class ChatThread: Identifiable, Hashable {
             // silent local-only delete, which is the bug this whole path
             // exists to end, not a success.
             //
-            // "Refresh and try again" is real advice in a DIRECT chat and only
-            // there: pull-to-refresh calls `reload`, the transcript comes back
-            // from the server with a `serverTurnId` on every message, and the
-            // next swipe deletes by name without the matcher at all. `reload`
-            // opens with `guard !isGroup`, so a group has no such route — the
-            // gesture is a no-op and the sentence would be sending someone to
-            // pull at a list that cannot change. Say what is true instead.
-            return .unresolved(
-                isGroup
-                    ? "the desktop's copy of this chat has changed and a group chat can't be refreshed to catch up"
-                    : "the desktop's copy of this chat has changed; refresh and try again")
+            // "Refresh and try again" is real advice in a DIRECT chat and a
+            // GROUP chat alike now: pull-to-refresh calls `reload`, which
+            // re-syncs a group from every session's transcript — dropping
+            // local bubbles no session holds, restoring turns this phone never
+            // showed, and re-acquiring the server turn ids that let the next
+            // swipe delete by name. That is exactly the repair a drifted
+            // session needs; the alternative — refusing forever with nothing
+            // the user can do — is the standing cost this bead exists to end.
+            return .unresolved("the desktop's copy of this chat has changed; refresh and try again")
         }
     }
 
@@ -1104,25 +1134,126 @@ final class ChatThread: Identifiable, Hashable {
     /// swipe's prefix walk finds them disagreeing, refuses as `ambiguous`, and
     /// the copies that DID survive can never be deleted at all. Keeping the
     /// removal is the description that is true of most sessions and leaves the
-    /// user somewhere to go.
+    /// user somewhere to go — and this report is that somewhere: it sits where
+    /// the deleted message was rather than at the end of a long transcript,
+    /// names each surviving chat with ITS OWN reason, and remembers the named
+    /// turns so the view's retry button on this very note can re-delete them
+    /// by name.
     ///
     /// The one thing never done here is nothing. An unreported partial delete
     /// is the silent local-only delete this whole path exists to end, just with
     /// fewer sessions holding the evidence.
-    private func reportPartialDelete(_ failures: [(familiarId: String, reason: String)],
-                                     familiarNames: [String: String],
-                                     onChange: @escaping () -> Void) {
-        let names = failures.map { familiarNames[$0.familiarId] ?? $0.familiarId }
-        let reason = failures[0].reason
-        // Most `localizedDescription`s already end in a full stop, and
-        // "… status 404.." is a shabby thing to read back to someone.
-        let detail = reason.hasSuffix(".") ? String(reason.dropLast()) : reason
-        appendSystem(
-            "That message was deleted, but it is still in this chat with "
-                + "\(names.joined(separator: ", ")) — \(detail).",
-            isError: true)
+    private func reportPartialDelete(
+        _ failures: [(familiarId: String, sessionId: String, turnId: String, reason: String)],
+        at index: Int,
+        familiarNames: [String: String],
+        onChange: @escaping () -> Void
+    ) {
+        let noteId = insertSystem(
+            Self.partialDeleteSentence(
+                failures.map { (familiarId: $0.familiarId, reason: $0.reason) },
+                familiarNames: familiarNames),
+            at: index, isError: true)
+        pendingPartialDeleteRetry[noteId] = PartialDeleteRetryState(
+            noteId: noteId,
+            legs: failures.map {
+                (familiarId: $0.familiarId, sessionId: $0.sessionId,
+                 turnId: $0.turnId, reason: $0.reason)
+            })
         updatedAt = Date()
         onChange()
+    }
+
+    /// One failed leg of a partial group delete, kept so the user can retry it.
+    /// The turn was already NAMED by the resolve phase before the first
+    /// attempt, so a retry re-deletes by name — no matching, and no refusal a
+    /// drifted transcript can re-provoke.
+    private struct PartialDeleteRetryState {
+        /// The system note that reported the partial delete; removed when the
+        /// last surviving copy finally lands.
+        var noteId: String
+        /// The sessions the delete did not reach, with the named turn each
+        /// still holds. Each leg keeps its OWN failure reason — a desktop that
+        /// went away and a desktop that refused are different facts about
+        /// different chats.
+        var legs: [(familiarId: String, sessionId: String, turnId: String, reason: String)]
+    }
+
+    /// Whether a system note is a partial-delete report with a surviving copy
+    /// that can still be deleted — the view offers a retry button when true.
+    func canRetryPartialDelete(noteId: String) -> Bool {
+        pendingPartialDeleteRetry[noteId] != nil
+    }
+
+    /// Re-attempt the deletes a partial group delete failed to land. Each
+    /// surviving session's turn was named before the first attempt, so this
+    /// re-deletes by name. Serialized behind the same per-thread delete chain,
+    /// so a retry never lands inside another delete's conversation read.
+    func retryPartialDelete(noteId: String, client: CaveClient?,
+                            familiarNames: [String: String],
+                            onChange: @escaping () -> Void) {
+        guard pendingPartialDeleteRetry[noteId] != nil else { return }
+        guard let client else { return }
+        let previous = pendingServerDelete
+        pendingServerDelete = Task { [weak self] in
+            _ = await previous?.value
+            await self?.retryPartialDeleteLegs(noteId: noteId, client: client,
+                                               familiarNames: familiarNames,
+                                               onChange: onChange)
+        }
+    }
+
+    private func retryPartialDeleteLegs(noteId: String, client: CaveClient,
+                                        familiarNames: [String: String],
+                                        onChange: @escaping () -> Void) async {
+        guard var state = pendingPartialDeleteRetry[noteId] else { return }
+        var stillFailing: [(familiarId: String, sessionId: String, turnId: String, reason: String)] = []
+        for leg in state.legs {
+            do {
+                try await client.deleteConversationTurn(sessionId: leg.sessionId,
+                                                        turnId: leg.turnId)
+            } catch {
+                stillFailing.append(leg)
+            }
+        }
+        if stillFailing.isEmpty {
+            // Every surviving copy is really gone now — the warning note's
+            // job is done, so it goes with the record.
+            pendingPartialDeleteRetry[noteId] = nil
+            messages.removeAll { $0.id == noteId }
+        } else {
+            state.legs = stillFailing
+            pendingPartialDeleteRetry[noteId] = state
+            updateText(
+                noteId,
+                Self.partialDeleteSentence(
+                    stillFailing.map { (familiarId: $0.familiarId, reason: $0.reason) },
+                    familiarNames: familiarNames),
+                isError: true)
+        }
+        updatedAt = Date()
+        onChange()
+    }
+
+    /// The sentence that names which chats still hold a partially-deleted
+    /// message and, for EACH one, why its copy survived. A chat and its reason
+    /// are independent facts — one desktop refused, another went away — so
+    /// reading every survivor's reason off the first failure is a lie whenever
+    /// they differ.
+    nonisolated static func partialDeleteSentence(
+        _ failures: [(familiarId: String, reason: String)],
+        familiarNames: [String: String]
+    ) -> String {
+        let detail = failures.map { failure -> String in
+            let name = familiarNames[failure.familiarId] ?? failure.familiarId
+            // Most `localizedDescription`s already end in a full stop, and
+            // "… status 404.." is a shabby thing to read back to someone.
+            let reason = failure.reason.hasSuffix(".")
+                ? String(failure.reason.dropLast())
+                : failure.reason
+            return "\(name) — \(reason)"
+        }.joined(separator: "; ")
+        return "That message was deleted, but it is still in this chat with \(detail)."
     }
 
     /// What the server's transcript says about a message it never named.
@@ -1295,6 +1426,18 @@ final class ChatThread: Identifiable, Hashable {
         return message.id
     }
 
+    /// Insert an inline system note at a specific position — a delete report
+    /// sits where the deleted message was, so the swipe and its outcome are
+    /// the same place in the transcript rather than the far end of it.
+    /// Returns the note's id.
+    @discardableResult
+    func insertSystem(_ text: String, at index: Int, isError: Bool = false) -> String {
+        let message = DisplayMessage(role: .system, familiarId: nil, text: text, isError: isError)
+        messages.insert(message, at: min(max(index, 0), messages.count))
+        updatedAt = Date()
+        return message.id
+    }
+
     /// Replace the text of a previously-appended message (by id).
     func updateText(_ messageId: String, _ text: String, isError: Bool = false) {
         mutate(messageId) { $0.text = text; if isError { $0.isError = true } }
@@ -1304,24 +1447,219 @@ final class ChatThread: Identifiable, Hashable {
     /// Remove every message, keeping the thread (mirrors web `/clear`).
     func clearMessages() {
         messages.removeAll()
+        absentForSession.removeAll()
+        pendingPartialDeleteRetry.removeAll()
         updatedAt = Date()
     }
 
     /// Re-fetch this thread's conversation from the server and replace the local
     /// messages — backs pull-to-refresh, so a chat advanced on another device
-    /// catches up. Direct threads only: a group is N independent sessions with no
-    /// shared turn ordering to merge. Skipped while streaming (and when there's no
-    /// server session yet) so an in-flight reply is never clobbered.
-    /// Re-sync a direct chat from the server. No-ops for groups / streaming /
-    /// unsent threads; THROWS on a real fetch failure so the caller (pull to
-    /// refresh) can surface it instead of failing silently.
+    /// catches up. A group is N independent sessions with no shared turn
+    /// ordering, so it re-syncs every session and reconciles the merged view
+    /// from their transcripts (see `reconciledGroupTranscript`) instead of
+    /// replacing it wholesale — the recovery gesture a drifted group delete
+    /// was missing. Skipped while streaming (and when there's no server session
+    /// yet) so an in-flight reply is never clobbered. THROWS on a real fetch
+    /// failure so the caller (pull to refresh) can surface it instead of
+    /// failing silently.
     func reload(client: CaveClient) async throws {
-        guard !isGroup, !isStreaming,
-              let familiarId = familiarIds.first,
+        guard !isStreaming else { return }
+        if isGroup {
+            try await reloadGroup(client: client)
+            return
+        }
+        guard let familiarId = familiarIds.first,
               let sessionId = sessionIds[familiarId] else { return }
         guard let convo = try await client.conversation(sessionId: sessionId) else { return }
         messages = DisplayMessage.restoredTranscript(from: convo.turns, familiarId: familiarId)
         updatedAt = Date()
+    }
+
+    /// Re-sync a GROUP thread from the server: fetch every session's transcript
+    /// and reconcile the merged view against them. A session that cannot be
+    /// reached is skipped, not fatal — re-syncing the sessions that DO answer
+    /// is still progress, and if none answer the reload is a no-op (the old
+    /// `guard !isGroup` behaviour, reached honestly).
+    private func reloadGroup(client: CaveClient) async throws {
+        var transcripts: [(familiarId: String, turns: [ChatTurn])] = []
+        for familiarId in familiarIds {
+            guard let sessionId = sessionIds[familiarId], !sessionId.isEmpty else { continue }
+            guard let convo = try? await client.conversation(sessionId: sessionId) else { continue }
+            transcripts.append((familiarId: familiarId, turns: convo.turns))
+        }
+        guard !transcripts.isEmpty else { return }
+        let reconciled = Self.reconciledGroupTranscript(current: messages,
+                                                        transcripts: transcripts)
+        messages = reconciled.messages
+        let keptIds = Set(messages.map(\.id))
+        absentForSession = reconciled.absentForSession.filter { keptIds.contains($0.key) }
+        updatedAt = Date()
+    }
+
+    /// Rebuild this thread's merged group transcript from each session's
+    /// server truth, and record which sessions provably never received which
+    /// messages.
+    ///
+    /// A group is N independent server sessions presented as one merged list,
+    /// and the merged list is the only transcript the phone keeps — so when a
+    /// session's server copy drifts from it (a reply cancelled before it
+    /// landed, a retried bubble the server re-appended, a fan-out that reached
+    /// some familiars and not others), the phone cannot see the truth until it
+    /// asks. This is that ask: each session's transcript is walked against
+    /// THIS thread's projection for that session — the same per-session view
+    /// the delete matcher uses — and the merged list is reconciled three ways:
+    ///
+    ///  - a local message a server turn agrees with adopts that turn's id, so
+    ///    a later delete names it instead of guessing;
+    ///  - a server turn the local list never showed (a retry's re-appended
+    ///    prompt+reply pair, a reply that landed while this device was away)
+    ///    is restored in place, so the session's transcript stops disagreeing
+    ///    at that position;
+    ///  - a local message EVERY session it projects into cleanly skipped never
+    ///    reached the server — a phantom everywhere — and is dropped rather
+    ///    than left to shift every later ordinal and refuse every later
+    ///    delete in the thread.
+    ///
+    /// The third outcome is recorded per session too: a message some sessions
+    /// hold and one provably does not (the fan-out that reached three of
+    /// four) keeps its place in the merged list, and the delete path learns
+    /// which session to skip instead of refusing the whole delete on its
+    /// behalf. A session whose walk could not say (neither side lined up) is
+    /// left unreconciled — nothing is dropped or adopted on its say-so, since
+    /// guessing is how a delete removes a stranger's turn.
+    ///
+    /// Pure over its inputs, so the delete recovery is testable without a
+    /// desktop.
+    nonisolated static func reconciledGroupTranscript(
+        current: [DisplayMessage],
+        transcripts: [(familiarId: String, turns: [ChatTurn])]
+    ) -> (messages: [DisplayMessage], absentForSession: [String: Set<String>]) {
+        var adoptions: [String: String] = [:]
+        var matchedBy: [String: Set<String>] = [:]
+        var absentFrom: [String: Set<String>] = [:]
+        var projectedInto: [String: Set<String>] = [:]
+        var insertions: [(anchorId: String?, familiarId: String, turn: ChatTurn)] = []
+
+        for transcript in transcripts {
+            let projection: [(id: String, message: DisplayMessage)] = current.compactMap { message in
+                guard let projected = sessionTurn(message, in: transcript.familiarId, isGroup: true) else {
+                    return nil
+                }
+                return (message.id, projected)
+            }
+            for (id, _) in projection {
+                projectedInto[id, default: []].insert(transcript.familiarId)
+            }
+
+            var p = 0
+            var t = 0
+            var lastMatchedId: String? = nil
+            var clean = true
+            while p < projection.count, t < transcript.turns.count {
+                let local = projection[p]
+                if Self.turn(transcript.turns[t], is: local.message) {
+                    adoptions[local.id] = transcript.turns[t].id
+                    matchedBy[local.id, default: []].insert(transcript.familiarId)
+                    lastMatchedId = local.id
+                    p += 1
+                    t += 1
+                    continue
+                }
+                // The server may hold turns the local list never showed (a
+                // retry re-appends its prompt+reply pair; a reply can land
+                // while this device is away). Look a little way ahead for the
+                // local message before declaring either side extra — the bound
+                // keeps a repeated short turn ("ok") from pulling the walk
+                // onto a stranger's copy of it.
+                var skipped = 0
+                var found = false
+                while skipped < 3, t + skipped + 1 < transcript.turns.count {
+                    skipped += 1
+                    if Self.turn(transcript.turns[t + skipped], is: local.message) {
+                        found = true
+                        break
+                    }
+                }
+                if found {
+                    for k in 0..<skipped {
+                        insertions.append((anchorId: lastMatchedId,
+                                           familiarId: transcript.familiarId,
+                                           turn: transcript.turns[t + k]))
+                    }
+                    adoptions[local.id] = transcript.turns[t + skipped].id
+                    matchedBy[local.id, default: []].insert(transcript.familiarId)
+                    lastMatchedId = local.id
+                    p += 1
+                    t += skipped + 1
+                    continue
+                }
+                // Otherwise the local message may be one this session never
+                // received — a phantom here — if the NEXT local message lines
+                // up with the current server turn.
+                if p + 1 < projection.count,
+                   Self.turn(transcript.turns[t], is: projection[p + 1].message) {
+                    absentFrom[local.id, default: []].insert(transcript.familiarId)
+                    p += 1
+                    continue
+                }
+                // Neither side lines up: the walk cannot say what happened.
+                // Stop and leave the rest of this session unreconciled.
+                clean = false
+                break
+            }
+            if clean {
+                // The walk ran off one end of the transcript. Local messages
+                // past the end were never received by this session; server
+                // turns past the end were never shown locally.
+                for i in p..<projection.count {
+                    absentFrom[projection[i].id, default: []].insert(transcript.familiarId)
+                }
+                for k in t..<transcript.turns.count {
+                    insertions.append((anchorId: lastMatchedId,
+                                       familiarId: transcript.familiarId,
+                                       turn: transcript.turns[k]))
+                }
+            }
+        }
+
+        var rebuilt: [DisplayMessage] = []
+        rebuilt += insertions
+            .filter { $0.anchorId == nil }
+            .map { DisplayMessage.restored(from: $0.turn, familiarId: $0.familiarId) }
+        for message in current {
+            let projected = projectedInto[message.id] ?? []
+            if projected.isEmpty {
+                // Not in any session's projection — a queued send, inline
+                // slash output, or an unattributed group reply. The server
+                // never held it; the local copy is the whole truth.
+                rebuilt.append(message)
+            } else if let matched = matchedBy[message.id], !matched.isEmpty {
+                // At least one session's transcript holds it. Adopt the turn
+                // id the walk matched — the last session to walk wins, and the
+                // id is inert for fanned-out user turns anyway (sessionTurn
+                // strips it before it could name a stranger's session).
+                var kept = message
+                if let id = adoptions[message.id] {
+                    kept.serverTurnId = id
+                }
+                rebuilt.append(kept)
+            } else if absentFrom[message.id, default: []] == projected {
+                // Every session it projects into cleanly proved it never
+                // received it — a phantom everywhere. Dropping it is the
+                // repair: kept, it shifts every later ordinal and refuses
+                // every later delete in the thread.
+                continue
+            } else {
+                // At least one session's walk could not say (it bailed before
+                // this message). Guessing is how a delete removes a stranger's
+                // turn — keep it and let the delete path refuse honestly.
+                rebuilt.append(message)
+            }
+            rebuilt += insertions
+                .filter { $0.anchorId == message.id }
+                .map { DisplayMessage.restored(from: $0.turn, familiarId: $0.familiarId) }
+        }
+        return (rebuilt, absentFrom)
     }
 
     private var replayingQueued = false

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -899,52 +899,11 @@ struct ChatView: View {
                     // interleaved with messages), so separator placement isn't
                     // recomputed — and no `enumerated()` array is allocated —
                     // on every body evaluation.
+                    // Each row renders through transcriptRow(_:) — extracted
+                    // so the compiler type-checks one row at a time instead of
+                    // the whole scroll view builder (cave-7nrp9).
                     ForEach(thread.transcriptRows) { row in
-                        switch row {
-                        case .day(_, let date):
-                            DaySeparator(date: date)
-                                // Track which day sections have scrolled past
-                                // the top edge: the transform runs per frame
-                                // but the action (a state write) only fires on
-                                // the Bool transition, keeping the hot scroll
-                                // path allocation-free.
-                                .onGeometryChange(for: Bool.self) { proxy in
-                                    proxy.frame(in: .scrollView).maxY < 0
-                                } action: { above in
-                                    if above { daysAboveTop.insert(date) }
-                                    else { daysAboveTop.remove(date) }
-                                }
-                        case .message(let message):
-                            if message.id == unreadDividerId {
-                                UnreadDividerView()
-                                    .id("unread-divider")
-                            }
-                            MessageBubble(message: message,
-                                          isGroup: thread.isGroup,
-                                          familiar: message.familiarId.flatMap(app.familiar),
-                                          isLast: message.id == thread.messages.last?.id,
-                                          onDelete: { deleteMessage(message) },
-                                          onSuggestion: { sendSuggestion($0) },
-                                          onOpenReader: { openReader(text: $0, familiar: message.familiarId.flatMap(app.familiar)) },
-                                          onForward: { beginForward($0) },
-                                          onRetry: canRetry(message) ? { retryAssistant(message) } : nil,
-                                          onReply: { beginReply($0) },
-                                          operatorName: app.operatorDisplayName,
-                                          operatorAvatarURL: app.operatorAvatarURL)
-                            .equatable()
-                            .id(message.id)
-                            // New bubbles settle in with a soft rise-and-fade
-                            // (native Messages behaviour) instead of popping;
-                            // queued-offline sends enter subdued (opacity
-                            // only) so they read as parked, not sent;
-                            // deletions fade out. Driven by the count-keyed
-                            // animation below; Reduce Motion turns it off.
-                            .transition(.asymmetric(
-                                insertion: message.isQueued
-                                    ? .opacity
-                                    : .opacity.combined(with: .scale(scale: 0.97, anchor: .bottom)),
-                                removal: .opacity))
-                        }
+                        transcriptRow(row)
                     }
                     Color.clear.frame(height: 1).id("bottom")
                 }
@@ -1062,6 +1021,74 @@ struct ChatView: View {
                     proxy.scrollTo("bottom", anchor: .bottom)
                 }
             }
+        }
+    }
+
+    /// Render one transcript row — a day divider or a message bubble. Extracted
+    /// from the scroll view builder so the compiler type-checks one row at a
+    /// time: the whole expression previously exceeded the type-checker budget
+    /// (cave-7nrp9).
+    @ViewBuilder
+    private func transcriptRow(_ row: TranscriptRow) -> some View {
+        switch row {
+        case .day(_, let date):
+            DaySeparator(date: date)
+                // Track which day sections have scrolled past
+                // the top edge: the transform runs per frame
+                // but the action (a state write) only fires on
+                // the Bool transition, keeping the hot scroll
+                // path allocation-free.
+                .onGeometryChange(for: Bool.self) { proxy in
+                    proxy.frame(in: .scrollView).maxY < 0
+                } action: { above in
+                    if above { daysAboveTop.insert(date) }
+                    else { daysAboveTop.remove(date) }
+                }
+        case .message(let message):
+            if message.id == unreadDividerId {
+                UnreadDividerView()
+                    .id("unread-divider")
+            }
+            // Hoisted into named bindings so the compiler can type-check
+            // the bubble call in steps instead of one oversized expression
+            // (cave-7nrp9: it previously exceeded the type-checker budget).
+            let bubbleFamiliar = message.familiarId.flatMap(app.familiar)
+            let bubbleOpenReader: ((String) -> Void)? = {
+                openReader(text: $0, familiar: bubbleFamiliar)
+            }
+            let bubbleRetry: (() -> Void)? = canRetry(message)
+                ? { retryAssistant(message) }
+                : nil
+            let bubbleRetryDelete: (() -> Void)? =
+                thread.canRetryPartialDelete(noteId: message.id)
+                    ? { retryPartialDelete(noteId: message.id) }
+                    : nil
+            MessageBubble(message: message,
+                          isGroup: thread.isGroup,
+                          familiar: bubbleFamiliar,
+                          isLast: message.id == thread.messages.last?.id,
+                          onDelete: { deleteMessage(message) },
+                          onSuggestion: { sendSuggestion($0) },
+                          onOpenReader: bubbleOpenReader,
+                          onForward: { beginForward($0) },
+                          onRetry: bubbleRetry,
+                          onReply: { beginReply($0) },
+                          onRetryDelete: bubbleRetryDelete,
+                          operatorName: app.operatorDisplayName,
+                          operatorAvatarURL: app.operatorAvatarURL)
+                .equatable()
+                .id(message.id)
+                // New bubbles settle in with a soft rise-and-fade
+                // (native Messages behaviour) instead of popping;
+                // queued-offline sends enter subdued (opacity
+                // only) so they read as parked, not sent;
+                // deletions fade out. Driven by the count-keyed
+                // animation below; Reduce Motion turns it off.
+                .transition(.asymmetric(
+                    insertion: message.isQueued
+                        ? .opacity
+                        : .opacity.combined(with: .scale(scale: 0.97, anchor: .bottom)),
+                    removal: .opacity))
         }
     }
 
@@ -2178,13 +2205,27 @@ struct ChatView: View {
         // `uniquingKeysWith:` rather than `uniqueKeysWithValues:` — the latter
         // traps on a repeated key, and a duplicated familiar id in a thread
         // must not turn a swipe into a crash.
-        let familiarNames = Dictionary(
+        thread.deleteMessage(message.id, client: app.client,
+                             familiarNames: deleteFamiliarNames()) { app.touch(thread) }
+    }
+
+    /// The display names the partial-delete report (and its retry) read back
+    /// to a person, keyed by familiar id. See `deleteMessage`.
+    private func deleteFamiliarNames() -> [String: String] {
+        Dictionary(
             thread.familiarIds.compactMap { id in
                 app.familiar(id).map { (id, $0.displayName) }
             },
             uniquingKeysWith: { first, _ in first })
-        thread.deleteMessage(message.id, client: app.client,
-                             familiarNames: familiarNames) { app.touch(thread) }
+    }
+
+    /// Retry a partial group delete from the note that reported it: the thread
+    /// re-deletes the surviving copies by the turn names the first attempt
+    /// already resolved, so a drifted transcript cannot refuse it again.
+    private func retryPartialDelete(noteId: String) {
+        guard let client = app.client else { return }
+        thread.retryPartialDelete(noteId: noteId, client: client,
+                                  familiarNames: deleteFamiliarNames()) { app.touch(thread) }
     }
 
     private func openReader(text: String, familiar: Familiar?) {

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -15,6 +15,9 @@ struct MessageBubble: View {
     /// Quote this message into the composer — swipe the bubble right, or use the
     /// long-press menu. nil hides the action.
     var onReply: ((DisplayMessage) -> Void)? = nil
+    /// Retry the delete a partial-delete report note is warning about; nil
+    /// hides the action.
+    var onRetryDelete: (() -> Void)? = nil
     /// The human operator's display name, shown above their own bubbles in
     /// group threads (mirrors the familiar name row). Defaults to "You" so a
     /// missing profile reads exactly as before.
@@ -175,16 +178,32 @@ struct MessageBubble: View {
     /// Inline slash-command output — a subtle monospaced card so it reads as
     /// system feedback rather than a familiar's reply.
     private var systemNote: some View {
-        HStack(alignment: .top, spacing: 8) {
-            Image(systemName: message.isError ? "exclamationmark.triangle.fill" : "terminal.fill")
-                .font(.caption)
-                .foregroundStyle(message.isError ? Color.red : Color.secondary)
-                .padding(.top, 2)
-            Text(message.text.isEmpty ? " " : message.text)
-                .font(.callout.monospaced())
-                .foregroundStyle(message.isError ? Color.red : Color.secondary)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: message.isError ? "exclamationmark.triangle.fill" : "terminal.fill")
+                    .font(.caption)
+                    .foregroundStyle(message.isError ? Color.red : Color.secondary)
+                    .padding(.top, 2)
+                Text(message.text.isEmpty ? " " : message.text)
+                    .font(.callout.monospaced())
+                    .foregroundStyle(message.isError ? Color.red : Color.secondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            // A partial-delete report carries its own recovery: the retry
+            // re-deletes the surviving copies by the turn names the first
+            // attempt already resolved, so a drifted transcript cannot refuse
+            // it a second time.
+            if let onRetryDelete {
+                Button(action: onRetryDelete) {
+                    Label("Retry delete", systemImage: "arrow.clockwise")
+                        .font(.caption.weight(.semibold))
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(.red)
+                .accessibilityLabel("Retry deleting the copy that survived")
+            }
         }
         .padding(.horizontal, 14).padding(.vertical, 10)
         .glassFill(.raised, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
@@ -736,6 +755,7 @@ extension MessageBubble: Equatable {
             && lhs.chrome == rhs.chrome
             && (lhs.onRetry == nil) == (rhs.onRetry == nil)
             && (lhs.onReply == nil) == (rhs.onReply == nil)
+            && (lhs.onRetryDelete == nil) == (rhs.onRetryDelete == nil)
             && (lhs.onOpenReader == nil) == (rhs.onOpenReader == nil)
             && (lhs.onForward == nil) == (rhs.onForward == nil)
     }

--- a/apps/ios/CovenCave/CovenCaveTests/GroupDeleteRecoveryTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/GroupDeleteRecoveryTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+@testable import CovenCave
+
+@MainActor
+final class GroupDeleteRecoveryTests: XCTestCase {
+    // MARK: - Group re-sync (the refusal's recovery gesture)
+
+    func testReconcileDropsPhantomBubbleNoSessionHolds() throws {
+        // A reply cancelled before it landed leaves a local bubble no server
+        // transcript holds. Every later ordinal is then one too high; the
+        // re-sync must drop the phantom and adopt the ids it can name.
+        let user = DisplayMessage(role: .user, familiarId: nil, text: "hello")
+        let phantom = DisplayMessage(role: .assistant, familiarId: "nyx", text: "cancelled draft")
+        let reply = DisplayMessage(role: .assistant, familiarId: "nyx", text: "hi there")
+
+        let result = ChatThread.reconciledGroupTranscript(
+            current: [user, phantom, reply],
+            transcripts: [
+                (familiarId: "nyx", turns: try decodeTurns("""
+                [
+                  {"id":"u1","role":"user","text":"hello"},
+                  {"id":"a1","role":"assistant","text":"hi there"}
+                ]
+                """)),
+            ]
+        )
+
+        XCTAssertEqual(result.messages.map(\.id), [user.id, reply.id])
+        XCTAssertEqual(result.messages[0].serverTurnId, "u1")
+        XCTAssertEqual(result.messages[1].serverTurnId, "a1")
+        XCTAssertEqual(result.absentForSession[phantom.id]?.contains("nyx"), true)
+        XCTAssertEqual(result.absentForSession[phantom.id]?.count, 1)
+    }
+
+    func testReconcileKeepsFanOutMessageAndRecordsTheMissedSession() throws {
+        // A prompt fanned out to four familiars but reached only three; the
+        // fourth session's transcript cleanly skipped it. The merged list keeps
+        // the prompt (three sessions hold it) and records which session
+        // provably lacks it, so a delete skips that session instead of letting
+        // it refuse the whole delete.
+        let prompt = DisplayMessage(role: .user, familiarId: nil, text: "hello all")
+        let nyxReply = DisplayMessage(role: .assistant, familiarId: "nyx", text: "hi")
+        let miloReply = DisplayMessage(role: .assistant, familiarId: "milo", text: "yo")
+        let sageReply = DisplayMessage(role: .assistant, familiarId: "sage", text: "hey")
+        let tessReply = DisplayMessage(role: .assistant, familiarId: "tess", text: "sup")
+
+        let result = ChatThread.reconciledGroupTranscript(
+            current: [prompt, nyxReply, miloReply, sageReply, tessReply],
+            transcripts: [
+                (familiarId: "nyx", turns: try decodeTurns("""
+                [
+                  {"id":"u1","role":"user","text":"hello all"},
+                  {"id":"a1","role":"assistant","text":"hi"}
+                ]
+                """)),
+                (familiarId: "milo", turns: try decodeTurns("""
+                [
+                  {"id":"u2","role":"user","text":"hello all"},
+                  {"id":"a2","role":"assistant","text":"yo"}
+                ]
+                """)),
+                (familiarId: "sage", turns: try decodeTurns("""
+                [
+                  {"id":"u3","role":"user","text":"hello all"},
+                  {"id":"a3","role":"assistant","text":"hey"}
+                ]
+                """)),
+                (familiarId: "tess", turns: try decodeTurns("""
+                [
+                  {"id":"a4","role":"assistant","text":"sup"}
+                ]
+                """)),
+            ]
+        )
+
+        XCTAssertEqual(result.messages.map(\.id),
+                       [prompt.id, nyxReply.id, miloReply.id, sageReply.id, tessReply.id])
+        XCTAssertEqual(result.absentForSession[prompt.id]?.contains("tess"), true)
+        XCTAssertEqual(result.absentForSession[prompt.id]?.count, 1)
+        XCTAssertNil(result.absentForSession[nyxReply.id])
+    }
+
+    func testReconcileRestoresServerTurnsTheLocalListNeverShowed() throws {
+        // A retried reply re-appends its prompt+reply pair on the server while
+        // the local bubble was re-streamed in place, so the server holds turns
+        // the local list never showed. The re-sync restores them so the
+        // session's transcript stops disagreeing at that position.
+        let user = DisplayMessage(role: .user, familiarId: nil, text: "hello")
+        let retried = DisplayMessage(role: .assistant, familiarId: "nyx", text: "first attempt")
+        let next = DisplayMessage(role: .user, familiarId: nil, text: "continue")
+
+        let result = ChatThread.reconciledGroupTranscript(
+            current: [user, retried, next],
+            transcripts: [
+                (familiarId: "nyx", turns: try decodeTurns("""
+                [
+                  {"id":"u1","role":"user","text":"hello"},
+                  {"id":"a1","role":"assistant","text":"first attempt"},
+                  {"id":"u2","role":"user","text":"hello"},
+                  {"id":"a2","role":"assistant","text":"second attempt"},
+                  {"id":"u3","role":"user","text":"continue"}
+                ]
+                """)),
+            ]
+        )
+
+        XCTAssertEqual(result.messages.count, 5)
+        XCTAssertEqual(result.messages.map(\.serverTurnId), ["u1", "a1", "u2", "a2", "u3"])
+        XCTAssertEqual(result.messages[3].familiarId, "nyx")
+    }
+
+    func testReconcileKeepsMessageWhenTheWalkCannotSay() throws {
+        // When neither side lines up the walk bails: nothing is dropped or
+        // adopted on a guess, because guessing is how a delete removes a
+        // stranger's turn. The already-matched prefix keeps its ids.
+        let user = DisplayMessage(role: .user, familiarId: nil, text: "hello")
+        let reply = DisplayMessage(role: .assistant, familiarId: "nyx", text: "hi there")
+
+        let result = ChatThread.reconciledGroupTranscript(
+            current: [user, reply],
+            transcripts: [
+                (familiarId: "nyx", turns: try decodeTurns("""
+                [
+                  {"id":"u1","role":"user","text":"hello"},
+                  {"id":"x1","role":"assistant","text":"diff one"},
+                  {"id":"x2","role":"assistant","text":"diff two"},
+                  {"id":"x3","role":"assistant","text":"diff three"},
+                  {"id":"x4","role":"assistant","text":"diff four"},
+                  {"id":"a1","role":"assistant","text":"hi there"}
+                ]
+                """)),
+            ]
+        )
+
+        XCTAssertEqual(result.messages.map(\.id), [user.id, reply.id])
+        XCTAssertEqual(result.messages[0].serverTurnId, "u1")
+        XCTAssertNil(result.messages[1].serverTurnId)
+        XCTAssertNil(result.absentForSession[reply.id])
+    }
+
+    // MARK: - The partial-delete report sentence
+
+    func testPartialDeleteSentenceUsesEachChatsOwnReason() {
+        let sentence = ChatThread.partialDeleteSentence(
+            [
+                (familiarId: "nyx", reason: "the desktop went away."),
+                (familiarId: "milo", reason: "the desktop refused (status 403)"),
+            ],
+            familiarNames: ["nyx": "Nyx", "milo": "Milo"]
+        )
+
+        XCTAssertEqual(
+            sentence,
+            "That message was deleted, but it is still in this chat with "
+                + "Nyx — the desktop went away; Milo — the desktop refused (status 403)."
+        )
+    }
+
+    func testPartialDeleteSentenceFallsBackToFamiliarIdWithoutDisplayName() {
+        let sentence = ChatThread.partialDeleteSentence(
+            [(familiarId: "nyx", reason: "refused")],
+            familiarNames: [:]
+        )
+
+        XCTAssertEqual(
+            sentence,
+            "That message was deleted, but it is still in this chat with nyx — refused."
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func decodeTurns(_ json: String) throws -> [ChatTurn] {
+        try JSONDecoder().decode([ChatTurn].self, from: Data(json.utf8))
+    }
+}

--- a/scripts/ios-message-delete-persistence.test.mjs
+++ b/scripts/ios-message-delete-persistence.test.mjs
@@ -26,6 +26,7 @@ const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
 const thread = await read("apps/ios/CovenCave/CovenCave/State/ChatThread.swift");
 const client = await read("apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift");
 const view = await read("apps/ios/CovenCave/CovenCave/Views/ChatView.swift");
+const bubble = await read("apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift");
 
 /** Extract a brace-balanced block starting at `marker` (which ends at its `{`). */
 function blockAfter(src, marker) {
@@ -156,7 +157,7 @@ assert.match(
 );
 assert.match(
   body,
-  /messages\.remove\(at: index\)\n\s*updatedAt = Date\(\)\n\s*onChange\(\)/,
+  /messages\.remove\(at: index\)\n(\s*\/\/.*\n)*\s*absentForSession\.removeValue\(forKey: messageId\)\n\s*pendingPartialDeleteRetry\.removeValue\(forKey: messageId\)\n\s*updatedAt = Date\(\)\n\s*onChange\(\)/,
   "the removal must be optimistic — a delete that waits on the tailnet reads as a broken swipe",
 );
 assert.match(
@@ -360,8 +361,9 @@ assert.doesNotMatch(
 );
 assert.match(
   deleteLoop,
-  /failures\.append\(\(deletion\.familiarId, error\.localizedDescription\)\)/,
-  "a refusal must be recorded against the familiar whose chat still holds the message",
+  /failures\.append\(\(deletion\.familiarId, deletion\.sessionId, deletion\.turnId,\s*\n\s*error\.localizedDescription\)\)/,
+  "a refusal must record the session and the NAMED turn it still holds, not just the " +
+    "familiar — the retry re-deletes by name without touching the matcher again",
 );
 
 // Total failure and partial failure are different states and must stay so.
@@ -373,8 +375,9 @@ assert.match(
 );
 assert.match(
   persist,
-  /reportPartialDelete\(failures, familiarNames: familiarNames, onChange: onChange\)/,
-  "a delete that landed in some sessions and not others must be reported, not swallowed",
+  /reportPartialDelete\(failures, at: index, familiarNames: familiarNames, onChange: onChange\)/,
+  "a delete that landed in some sessions and not others must be reported, not swallowed — " +
+    "and the note needs the deleted message's index to sit near it",
 );
 assert.ok(
   persist.indexOf("if failures.count == deletions.count") < persist.indexOf("reportPartialDelete"),
@@ -434,37 +437,40 @@ assert.match(
 );
 assert.match(
   resolve,
-  /case \.ambiguous:[\s\S]*?return \.unresolved\(\s*\n?\s*isGroup/,
+  /case \.ambiguous:[\s\S]*?return \.unresolved\(/,
   "a transcript that DISAGREES says nothing about where this message is — keeping the " +
     "removal there is a silent local-only delete, which is the bug being fixed",
 );
-// "Refresh and try again" is only advice a DIRECT chat can act on. `reload`
-// opens with `guard !isGroup`, so pull-to-refresh is a no-op for a group and
-// the transcript can never re-acquire the server turn ids that would let the
-// retry skip the matcher. Telling a group's user to refresh is sending them to
-// pull at a list that cannot change.
+// "Refresh and try again" is advice a DIRECT chat and a GROUP chat can both
+// act on now: `reload` re-syncs a group from every session's transcript
+// (re-acquiring the server turn ids that let the retry skip the matcher, and
+// repairing the very drift that caused the refusal), so the refusal no longer
+// has to hide that the gesture is a no-op.
 assert.match(
   resolve,
-  /\?\s*"the desktop's copy of this chat has changed and a group chat can't be refreshed to catch up"\s*\n\s*:\s*"the desktop's copy of this chat has changed; refresh and try again"\)/,
-  "only a direct chat may be told to refresh — `reload` refuses groups, so that advice " +
-    "cannot work there and the refusal must say something true instead",
+  /return \.unresolved\("the desktop's copy of this chat has changed; refresh and try again"\)/,
+  "the refusal must tell the user to refresh — `reload` now re-syncs a group, so the " +
+    "advice is true there too",
+);
+assert.doesNotMatch(
+  resolve,
+  /can't be refreshed|can\'t be refreshed/,
+  "the group-specific 'can't be refreshed' refusal is gone with the gap it papered over — " +
+    "refresh IS the recovery gesture the refusal was missing",
 );
 assert.match(
   thread,
-  /func reload\(client: CaveClient\) async throws \{\s*\n\s*guard !isGroup/,
-  "the assertion above is only worth anything while `reload` really does refuse groups — " +
-    "if that changes, the refusal copy should change with it",
+  /func reload\(client: CaveClient\) async throws \{\s*\n\s*guard !isStreaming else \{ return \}\s*\n\s*if isGroup \{/,
+  "reload must no longer refuse groups — the group re-sync is the recovery gesture, and " +
+    "the guard that made the old copy true is what changed",
 );
 
 // -- A partial group delete is stated, never undone and never hidden --------
-const partial = blockAfter(
-  thread,
-  "private func reportPartialDelete(_ failures: [(familiarId: String, reason: String)],",
-);
+const partial = blockAfter(thread, "private func reportPartialDelete(");
 assert.ok(partial, "reportPartialDelete must exist");
 assert.doesNotMatch(
   partial,
-  /messages\.insert/,
+  /messages\.insert\(message/,
   "a partial delete must NOT put the message back. The turn really is gone from at least one " +
     "session and the route has no undelete, so re-inserting asserts copies the server has " +
     "already destroyed — and those sessions' transcripts have moved, so the next swipe is " +
@@ -472,21 +478,55 @@ assert.doesNotMatch(
 );
 assert.match(
   partial,
-  /appendSystem\([\s\S]*?isError: true\)/,
-  "an unreported partial delete is the silent local-only delete this bead exists to end, " +
-    "just with fewer sessions holding the evidence",
+  /insertSystem\(\s*\n\s*Self\.partialDeleteSentence\(/,
+  "the note must be placed at the deleted message's position, not appended at the transcript " +
+    "end — a report at the far end never connects to the swipe that produced it, and it is " +
+    "the only record the partial delete leaves",
 );
 assert.match(
   partial,
-  /familiarNames\[\$0\.familiarId\] \?\? \$0\.familiarId/,
-  "the report must name the chats the message survived in, by display name where the view " +
-    "knows one and by familiar id when it does not",
+  /at: index, isError: true\)/,
+  "the report needs the deleted message's index to sit near it — the message was removed, so " +
+    "the note takes its place",
+);
+assert.match(
+  partial,
+  /pendingPartialDeleteRetry\[noteId\] = PartialDeleteRetryState\(/,
+  "the report must remember the surviving sessions by the NAMED turn each still holds — the " +
+    "retry the note offers re-deletes by name, so a drifted transcript cannot refuse it again",
+);
+assert.doesNotMatch(
+  partial,
+  /failures\[0\]/,
+  "the report must not read every listed chat's reason off the first failure — each chat and " +
+    "its reason are independent facts, and one desktop refusing while another went away is " +
+    "exactly the case that needs both reasons",
 );
 assert.match(
   partial,
   /onChange\(\)/,
   "the note is the ONLY record a partial delete leaves — unpersisted it is gone at the next " +
     "launch, which is the silent local-only delete again with an extra step",
+);
+
+const sentence = blockAfter(thread, "nonisolated static func partialDeleteSentence(");
+assert.ok(sentence, "partialDeleteSentence must exist");
+assert.match(
+  sentence,
+  /familiarNames\[failure\.familiarId\] \?\? failure\.familiarId/,
+  "the report must name each surviving chat by display name where the view knows one and by " +
+    "familiar id when it does not",
+);
+assert.match(
+  sentence,
+  /failure\.reason\.hasSuffix\("\."\)\s*\n\s*\? String\(failure\.reason\.dropLast\(\)\)\s*\n\s*: failure\.reason/,
+  "each chat's OWN reason must be trimmed of its trailing full stop — not a shared first " +
+    "failure's, since the chats can have failed for different reasons",
+);
+assert.doesNotMatch(
+  sentence,
+  /failures\[0\]/,
+  "the sentence must not read every survivor's reason off the first failure",
 );
 
 const matcher = blockAfter(thread, "nonisolated private static func turnMatch(for message: DisplayMessage,");
@@ -553,10 +593,110 @@ assert.match(
   "a failed delete must be visible; a silent local-only delete is the bug being fixed",
 );
 
+// -- The group re-sync (the refusal's recovery gesture) ----------------------
+const reconcile = blockAfter(
+  thread,
+  "nonisolated static func reconciledGroupTranscript(",
+);
+assert.ok(reconcile, "reconciledGroupTranscript must exist");
+assert.match(
+  reconcile,
+  /for transcript in transcripts \{\s*\n\s*let projection: \[\(id: String, message: DisplayMessage\)\] = current\.compactMap/,
+  "every session's transcript must be walked against THIS thread's projection for that " +
+    "session — the same per-session view the delete matcher uses",
+);
+assert.match(
+  reconcile,
+  /if let id = adoptions\[message\.id\] \{\s*\n\s*kept\.serverTurnId = id/,
+  "a local message a server turn agrees with must adopt that turn's id — that is what lets " +
+    "the next swipe delete by name instead of guessing",
+);
+assert.match(
+  reconcile,
+  /absentFrom\[message\.id, default: \[\]\] == projected/,
+  "a local message EVERY session it projects into cleanly skipped never reached the server — " +
+    "a phantom everywhere — and must be dropped rather than left to shift every later ordinal",
+);
+assert.match(
+  reconcile,
+  /insertions\.append\(\(anchorId: lastMatchedId,/,
+  "a server turn the local list never showed (a retry's re-appended pair) must be restored in " +
+    "place, anchored after the last matched message",
+);
+assert.match(
+  reconcile,
+  /absentFrom\[local\.id, default: \[\]\]\.insert\(transcript\.familiarId\)/,
+  "the walk must record, per session, the local messages that session provably never received — " +
+    "the fan-out that reached three of four must not be allowed to refuse the whole delete",
+);
+assert.match(
+  reconcile,
+  /return \(rebuilt, absentFrom\)/,
+  "the reconciliation must hand back the rebuilt transcript AND the absent-for-session proof",
+);
+assert.match(
+  thread,
+  /guard let convo = try\? await client\.conversation\(sessionId: sessionId\) else \{ continue \}/,
+  "one unreachable session must not abort the whole group re-sync — re-syncing the sessions " +
+    "that DO answer is still progress",
+);
+assert.match(
+  thread,
+  /if let absent = absentForSession\[session\.message\.id\],\s*\n\s*absent\.contains\(session\.familiarId\) \{\s*\n\s*return \.absent/,
+  "the delete path must skip a session a re-sync PROVED never received the message — the " +
+    "matcher's `ambiguous` on its behalf would keep the message alive in the sessions that DO " +
+    "hold it",
+);
+
+// -- The partial delete can be retried -------------------------------------
+assert.match(
+  thread,
+  /func canRetryPartialDelete\(noteId: String\) -> Bool \{\s*\n\s*pendingPartialDeleteRetry\[noteId\] != nil/,
+  "the view must be able to ask whether a note still has a retryable survivor, so it can " +
+    "offer the button on exactly the note that reported the partial delete",
+);
+const retryPartial = blockAfter(thread, "func retryPartialDelete(noteId: String, client: CaveClient?,");
+assert.ok(retryPartial, "retryPartialDelete must exist");
+assert.match(
+  retryPartial,
+  /pendingServerDelete = Task \{ \[weak self\] in[\s\S]*?await self\?\.retryPartialDeleteLegs\(/,
+  "the retry must run behind the same per-thread delete chain, so it never lands inside " +
+    "another delete's conversation read",
+);
+const retryLegs = blockAfter(thread, "private func retryPartialDeleteLegs(noteId: String, client: CaveClient,");
+assert.ok(retryLegs, "retryPartialDeleteLegs must exist");
+assert.match(
+  retryLegs,
+  /deleteConversationTurn\(sessionId: leg\.sessionId,\s*\n\s*turnId: leg\.turnId\)/,
+  "the retry must re-delete by the turn id resolved before the first attempt — no matching, " +
+    "so a drifted transcript cannot refuse it a second time",
+);
+assert.match(
+  retryLegs,
+  /messages\.removeAll \{ \$0\.id == noteId \}/,
+  "when the last surviving copy finally lands, the warning note's job is done and it must go — " +
+    "a stale 'still in this chat with …' note would be a lie",
+);
+assert.match(
+  retryLegs,
+  /updateText\(\s*\n\s*noteId,/,
+  "a retry that still fails must rewrite the note with the surviving chats that remain, not " +
+    "append a second one",
+);
+
+const insertSystem = blockAfter(thread, "func insertSystem(_ text: String, at index: Int, isError: Bool = false) -> String {");
+assert.ok(insertSystem, "insertSystem must exist");
+assert.match(
+  insertSystem,
+  /messages\.insert\(message, at: min\(max\(index, 0\), messages\.count\)\)/,
+  "a note placed near a message must clamp to the transcript — the list can have moved while " +
+    "the delete was in flight",
+);
+
 // -- The view hands the client (and the familiar names) through --------------
 assert.match(
   view,
-  /thread\.deleteMessage\(message\.id, client: app\.client,\s*\n\s*familiarNames: familiarNames\) \{ app\.touch\(thread\) \}/,
+  /thread\.deleteMessage\(message\.id, client: app\.client,\s*\n\s*familiarNames: deleteFamiliarNames\(\)\) \{ app\.touch\(thread\) \}/,
   "the swipe action must go through the server-backed path, not the old local splice",
 );
 assert.match(
@@ -564,6 +704,33 @@ assert.match(
   /uniquingKeysWith: \{ first, _ in first \}\)/,
   "`uniqueKeysWithValues:` traps on a repeated key — a duplicated familiar id in a thread must " +
     "not turn a swipe into a crash",
+);
+assert.match(
+  view,
+  /let bubbleRetryDelete: \(\(\) -> Void\)\? =\s*\n\s*thread\.canRetryPartialDelete\(noteId: message\.id\)/,
+  "the view must offer the retry on the note that reported the partial delete — the note " +
+    "carries the only record of the surviving copies",
+);
+assert.match(
+  view,
+  /onRetryDelete: bubbleRetryDelete,/,
+  "the hoisted retry binding must still be handed to the bubble as its retry action",
+);
+assert.match(
+  view,
+  /thread\.retryPartialDelete\(noteId: noteId, client: client,/,
+  "the view must route the retry back through the thread's server-backed path with the client",
+);
+assert.match(
+  bubble,
+  /var onRetryDelete: \(\(\) -> Void\)\? = nil/,
+  "the bubble must expose the retry action so the report note can carry a button",
+);
+assert.match(
+  bubble,
+  /if let onRetryDelete \{[\s\S]*?Label\("Retry delete", systemImage: "arrow\.clockwise"\)/,
+  "the report note must render a visible retry button — a recovery the user cannot see is no " +
+    "recovery at all",
 );
 
 console.log("ios-message-delete-persistence: ok");

--- a/scripts/ios-message-reader.test.mjs
+++ b/scripts/ios-message-reader.test.mjs
@@ -42,7 +42,7 @@ assert.match(
 
 assert.match(
   chatView,
-  /onOpenReader: \{ openReader\(text: \$0, familiar: message\.familiarId\.flatMap\(app\.familiar\)\) \}/,
+  /let bubbleFamiliar = message\.familiarId\.flatMap\(app\.familiar\)\s*\n\s*let bubbleOpenReader: \(\(String\) -> Void\)\? = \{\s*\n\s*openReader\(text: \$0, familiar: bubbleFamiliar\)/,
   "ChatView should wire assistant messages into the reader presenter",
 );
 


### PR DESCRIPTION
## What

Three linked recovery gaps from the adversarial review of PR #4857 (merged 3f4f47a8f), all specific to GROUP threads because `reload` guarded on `!isGroup` and a group never re-synced from the server — so one familiar's drifted session (a cancelled reply, a retry, a fan-out that reached 3 of 4) refused EVERY delete in the thread permanently, with no gesture that could repair it.

**1. The group refusal now has a recovery gesture.** `reload` no longer refuses groups. It re-syncs every session's transcript and reconciles the merged view (`reconciledGroupTranscript`):
- a local message a server turn agrees with adopts that turn's id, so the next swipe deletes by name;
- a server turn the local list never showed (a retry's re-appended prompt+reply pair) is restored in place;
- a local bubble NO session's transcript holds (a cancelled reply) is a phantom everywhere and is dropped;
- a message some sessions hold and one provably does not (the fan-out that reached 3 of 4) keeps its place, and the delete path learns which session to skip (`absentForSession`, consulted by `resolveTurn`) instead of refusing the whole delete on its behalf.

The `.ambiguous` refusal copy is unified to "refresh and try again" — true for groups now.

**2. The partial-delete note sits near the message and tells each chat's own story.** `reportPartialDelete` inserts the note at the deleted message's position (`insertSystem`) instead of appending at the transcript end, and the sentence names each surviving chat with ITS OWN failure reason (`partialDeleteSentence`) instead of reading every survivor's reason off `failures[0]`.

**3. The surviving desktop copy can be retried.** The report remembers the surviving sessions by the NAMED turns the resolve phase already produced; the note carries a **Retry delete** button (`MessageBubble.onRetryDelete`, `ChatView.retryPartialDelete`) that re-deletes by name — no matching, so a drifted transcript cannot refuse it a second time — and removes the note once the last copy lands. Rolling back was NOT chosen: the review proved it is a false affordance after a partial delete.

## Why

A refused or partial group delete previously left the user with nothing to do: the local bubble was gone (partial case), the surviving desktop copy was undeletable from iOS forever, and a drifted session refused every later delete in the thread with no repair (refused case).

## Verification

- `scripts/ios-message-delete-persistence.test.mjs` extended with the new family of source pins; every new/adjusted pin verified to FAIL against the regression (pre-fix sources) and pass with the fix.
- All 73 `scripts/ios-*.test.mjs` pass; `node scripts/check-tests-wired.mjs` green; `npx tsc --noEmit` clean.
- New native `GroupDeleteRecoveryTests` (XCTest, follows the repo's pure-logic test pattern) covers the reconciliation outcomes and the per-familiar sentence; compiled on macOS CI via the existing `CovenCaveTests` target.
