### PR TITLE
feat: revive the client-v1 proxy bearer-presentation gate (cave-q5mwb)

### DIFF
--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -661,7 +661,10 @@ in over Tailscale Serve gets the 403 above rather than a mobile-auth prompt.
 `authenticated` rather than public. That classification is a **demotion**, not a
 promotion: `proxy()` skips the mobile-access gate and returns *before* the
 sidecar-token block, so on those paths the route's own bearer check is the only
-credential check in the request. See *When the authenticated routes land*.
+check that *verifies* the credential. The proxy still demands a well-formed
+`Authorization: Bearer` *presentation* first (cave-q5mwb) — presentation, not
+verification: a syntactically valid fake passes the proxy and is refused by the
+route's `requireScope`. See *When the authenticated routes land*.
 
 Eight of the thirteen routes re-check the stamp in the route itself, via
 `runtime.authenticator.isTrustedLoopback`, and answer `unauthorized` in the
@@ -1834,12 +1837,16 @@ adding a route here.
 `CLIENT_V1_AUTHENTICATED_PATHS` now holds exactly those five paths. **Matching
 it is a demotion, not a promotion**: `proxy()` computes the ingress kind before
 the mobile-access gate, skips that gate for any client-v1 match, and returns
-before the sidecar-token block ever runs — so for a listed path the *only*
-credential check left is the one the route performs on itself. That is a sound
-trade for a route that really calls `requireScope`, and a hole for a path that
-does not exist yet: a handler landing later would inherit an exemption it never
-opted into. The list previously named thirteen Phase 2 paths against zero
-handlers, which is why it was emptied before any of them existed.
+before the sidecar-token block ever runs. The proxy still requires a
+well-formed `Authorization: Bearer` *presentation* on a listed path
+(cave-q5mwb, revived from cave-d1sjz) — presentation only, so a 12-byte fake
+`Bearer AAAA` passes it and lands on the route's own `requireScope` — which
+means for a listed path the *only* check that verifies the credential is the
+one the route performs on itself. That is a sound trade for a route that really
+calls `requireScope`, and a hole for a path that does not exist yet: a handler
+landing later would inherit an exemption it never opted into. The list
+previously named thirteen Phase 2 paths against zero handlers, which is why it
+was emptied before any of them existed.
 
 **But absence is a decision too, and it costs something.** Both of the
 client-v1-only protections described under *Reaching the API at all* are gated

--- a/src/lib/server/client-v1/auth.test.ts
+++ b/src/lib/server/client-v1/auth.test.ts
@@ -29,6 +29,7 @@ import {
   isClientV1AdminPath,
   isClientV1Path,
   isRefusedClientV1Path,
+  presentsClientV1Bearer,
 } from "../../../proxy-helpers.ts";
 
 const ACTIVE_CREDENTIAL: ClientV1CredentialRecord = {
@@ -270,6 +271,16 @@ function contractPublicPaths(): string[] {
   );
   return paths.filter((path, index) => paths.indexOf(path) === index);
 }
+
+/**
+ * A syntactically well-formed presented credential for the proxy-level tests.
+ *
+ * Deliberately NOT a real credential: an issued bearer is
+ * randomBytes(32).toString("base64url"), and the proxy gate is presentation-
+ * only, so a fake that is well-formed must pass the proxy and be refused by
+ * the route's own requireScope. 43 characters mirrors the real length.
+ */
+const PRESENTED_BEARER = "a".repeat(43);
 
 test("client-v1 ingress allowlists only the reviewed public routes", () => {
   const publicRoutes = [
@@ -666,18 +677,29 @@ test("reviewed client-v1 routes use loopback ingress without exposing private ro
     for (const route of [
       "/api/client/v1/pairing/requests",
       "/api/client/v1/pairing/requests/request-1/exchange",
-      // The canonical reads pass the proxy with no sidecar token, which is
-      // exactly the demotion CLIENT_V1_AUTHENTICATED_PATHS buys and the reason
-      // each of these routes calls requireScope for itself (cave-jfa9y). What
-      // reaches the handler here is an unauthenticated request; the route
-      // tests assert it is refused there.
+    ]) {
+      const response = await proxy(proxyRequest(route, { headers }));
+      assert.equal(passedThrough(response), true, `${route} returned ${response.status}`);
+    }
+
+    // The canonical reads pass the proxy with no sidecar token and no bearer
+    // check on their own, which is exactly the demotion
+    // CLIENT_V1_AUTHENTICATED_PATHS buys and the reason each of these routes
+    // calls requireScope for itself (cave-jfa9y). The revived bearer gate
+    // (cave-q5mwb) makes a well-formed presented credential a condition of
+    // that pass-through — the bearer test below covers the refusals — so these
+    // present one. What reaches the handler is still an UNVERIFIED credential;
+    // the route tests assert the route refuses the fake for itself.
+    for (const route of [
       "/api/client/v1/familiars",
       "/api/client/v1/projects",
       "/api/client/v1/conversations",
       "/api/client/v1/conversations/conversation-1",
       "/api/client/v1/conversations/conversation-1/messages",
     ]) {
-      const response = await proxy(proxyRequest(route, { headers }));
+      const response = await proxy(proxyRequest(route, {
+        headers: { ...headers, authorization: `Bearer ${PRESENTED_BEARER}` },
+      }));
       assert.equal(passedThrough(response), true, `${route} returned ${response.status}`);
     }
 
@@ -697,6 +719,151 @@ test("reviewed client-v1 routes use loopback ingress without exposing private ro
     // outside Client v1's separately reviewed ingress and admin boundaries.
     const appResponse = await proxy(proxyRequest("/api/chat/conversation", { headers }));
     assert.equal(passedThrough(appResponse), true);
+  } finally {
+    restoreProxyEnv();
+  }
+});
+
+test("presentsClientV1Bearer accepts only well-formed RFC 6750 token68", () => {
+  // Well-formed presentations pass, whatever the case of the scheme.
+  assert.equal(presentsClientV1Bearer(`Bearer ${PRESENTED_BEARER}`), true);
+  assert.equal(presentsClientV1Bearer(`bearer ${PRESENTED_BEARER}`), true);
+  assert.equal(presentsClientV1Bearer(`BEARER ${PRESENTED_BEARER}`), true);
+  // A real minted bearer is 43 base64url characters (randomBytes(32)
+  // .toString("base64url")); the token68 alphabet and RFC 6750's tolerated
+  // trailing padding are accepted, and surrounding whitespace is trimmed.
+  assert.equal(presentsClientV1Bearer(`Bearer ${"A".repeat(43)}`), true);
+  assert.equal(presentsClientV1Bearer(`Bearer ${"A-Za-z0-9._~+/-".repeat(3)}a`), true);
+  assert.equal(presentsClientV1Bearer(`Bearer ${PRESENTED_BEARER}==`), true);
+  assert.equal(presentsClientV1Bearer(`Bearer  ${PRESENTED_BEARER}`), true);
+  assert.equal(presentsClientV1Bearer(`Bearer ${PRESENTED_BEARER} `), true);
+  assert.equal(presentsClientV1Bearer(`Bearer ${"a".repeat(4096)}`), true);
+
+  // Fail-closed: absent or empty header.
+  assert.equal(presentsClientV1Bearer(null), false);
+  assert.equal(presentsClientV1Bearer(""), false);
+
+  // A bare credential with no scheme, and a scheme with no space.
+  assert.equal(presentsClientV1Bearer(PRESENTED_BEARER), false);
+  assert.equal(presentsClientV1Bearer("Bearer"), false);
+
+  // A non-bearer scheme is refused (a Basic credential is not a bearer).
+  assert.equal(presentsClientV1Bearer(`Basic ${PRESENTED_BEARER}`), false);
+  assert.equal(presentsClientV1Bearer(`BearerToken ${PRESENTED_BEARER}`), false);
+
+  // Empty or whitespace-only credentials.
+  assert.equal(presentsClientV1Bearer("Bearer "), false);
+  assert.equal(presentsClientV1Bearer("Bearer   "), false);
+
+  // Whitespace inside the credential makes it two words.
+  assert.equal(presentsClientV1Bearer("Bearer two words"), false);
+
+  // Characters outside the token68 alphabet.
+  assert.equal(presentsClientV1Bearer(`Bearer ${PRESENTED_BEARER}!`), false);
+  assert.equal(presentsClientV1Bearer(`Bearer ${PRESENTED_BEARER}@`), false);
+  assert.equal(presentsClientV1Bearer(`Bearer ab\u0000cd`), false);
+
+  // A tab, vertical-tab, form-feed or NBSP as the ONLY separator fails: the
+  // gate requires the literal ASCII space RFC 6750's ABNF uses.
+  assert.equal(presentsClientV1Bearer(`Bearer\t${PRESENTED_BEARER}`), false);
+  assert.equal(presentsClientV1Bearer(`Bearer\u000B${PRESENTED_BEARER}`), false);
+  assert.equal(presentsClientV1Bearer(`Bearer\u000C${PRESENTED_BEARER}`), false);
+  assert.equal(presentsClientV1Bearer(`Bearer\u00A0${PRESENTED_BEARER}`), false);
+
+  // Duplicate Authorization headers join to "a, Bearer …" before the gate
+  // sees them, which fails the scheme check (cave-d1sjz review).
+  assert.equal(presentsClientV1Bearer(`a, Bearer ${PRESENTED_BEARER}`), false);
+
+  // The credential is attacker-controlled and reaches a regex, so its length
+  // is capped. An issued bearer is 43 characters; 4097 is the far side.
+  assert.equal(presentsClientV1Bearer(`Bearer ${"a".repeat(4097)}`), false);
+});
+
+test("client-v1 resource ingress refuses a request that presents no bearer", async () => {
+  try {
+    setProxyEnv({
+      COVEN_CAVE_ACCESS_TOKEN: "configured-mobile-secret",
+      COVEN_CAVE_AUTH_TOKEN: "configured-sidecar-secret",
+      COVEN_CAVE_LOCAL_PEER_SECRET: "loopback-secret",
+    });
+    const headers = {
+      [LOCAL_PEER_HEADER]: "loopback-secret",
+      origin: ORIGIN,
+      referer: `${ORIGIN}/`,
+    };
+
+    // The gate below only exists for RESOURCE ingress, and every assertion in
+    // this test would still pass if these paths stopped classifying that way:
+    // a path that classifies null falls through to the ordinary sidecar-token
+    // gate, whose refusal is byte-identical — same 401, same
+    // {ok:false,error:"unauthorized"} — so the whole test would go green while
+    // never reaching the code it is about. Measured, not hypothetical: emptying
+    // CLIENT_V1_AUTHENTICATED_PATHS turned three tests in this file red and
+    // left the bearer test green (cave-d1sjz). State the classification as a
+    // precondition so that stops being a silent pass (cave-q5mwb).
+    const resourceRoutes = [
+      "/api/client/v1/familiars",
+      "/api/client/v1/projects",
+      "/api/client/v1/conversations",
+      "/api/client/v1/conversations/conversation-1",
+      "/api/client/v1/conversations/conversation-1/messages",
+    ];
+    for (const route of resourceRoutes) {
+      assert.equal(clientV1IngressKind(route), "authenticated", route);
+    }
+
+    // Resource ingress skips the sidecar token, so without the bearer gate the
+    // only thing between a loopback process and the handler is the handler's
+    // own requireScope call.
+    for (const route of resourceRoutes) {
+      const response = await proxy(proxyRequest(route, { headers }));
+      assert.equal(passedThrough(response), false, route);
+      assert.equal(response.status, 401, route);
+      assert.deepEqual(await response.json(), { ok: false, error: "unauthorized" });
+    }
+
+    // Malformed presentations are refused the same way: a bare credential with
+    // no scheme, a non-bearer scheme, no credential, a credential with a space,
+    // a character outside token68, and a credential over the length cap.
+    for (const authorization of [
+      PRESENTED_BEARER,
+      `Basic ${PRESENTED_BEARER}`,
+      "Bearer",
+      "Bearer ",
+      "Bearer two words",
+      `Bearer ${PRESENTED_BEARER}!`,
+      // The credential is attacker-controlled and reaches a regex, so its
+      // length is capped. An issued bearer is 43 characters; 4097 is the far
+      // side of the cap.
+      `Bearer ${"a".repeat(4097)}`,
+    ]) {
+      const response = await proxy(proxyRequest("/api/client/v1/conversations", {
+        headers: { ...headers, authorization },
+      }));
+      assert.equal(response.status, 401, authorization);
+      assert.deepEqual(await response.json(), { ok: false, error: "unauthorized" });
+    }
+
+    // The gate is presentation-only: a WELL-FORMED credential — even the fake
+    // 12-byte "Bearer AAAA" — passes the proxy, and the route's own requireScope
+    // is what refuses it. Assert the pass-through so the proxy gate cannot
+    // silently start rejecting every resource request.
+    for (const route of resourceRoutes) {
+      const response = await proxy(proxyRequest(route, {
+        headers: { ...headers, authorization: `Bearer ${PRESENTED_BEARER}` },
+      }));
+      assert.equal(passedThrough(response), true, `${route} returned ${response.status}`);
+    }
+    const fakeTwelveByte = await proxy(proxyRequest("/api/client/v1/conversations", {
+      headers: { ...headers, authorization: "Bearer AAAA" },
+    }));
+    assert.equal(passedThrough(fakeTwelveByte), true, "presentation-only gate must admit a well-formed fake");
+
+    // The public set stays credential-free: pairing is how a client gets one.
+    for (const path of contractPublicPaths()) {
+      const response = await proxy(proxyRequest(path, { headers }));
+      assert.equal(passedThrough(response), true, `${path} returned ${response.status}`);
+    }
   } finally {
     restoreProxyEnv();
   }

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -311,6 +311,49 @@ export function isRefusedClientV1Path(pathname: string) {
   return pathname.includes("%");
 }
 
+/**
+ * The presented credential may be at most this many characters. An issued
+ * bearer is 43 base64url characters (randomBytes(32).toString("base64url"));
+ * the cap exists so an attacker-controlled header cannot push an unbounded
+ * value into the token68 regex below. It is deliberately looser than the
+ * route-level cap (read-guard MAX_BEARER_CHARACTERS) because this gate is
+ * presentation-only: the route still verifies the credential and applies its
+ * own bounds.
+ */
+const CLIENT_V1_BEARER_CHARACTERS = 4096;
+const CLIENT_V1_BEARER_CREDENTIAL = /^[A-Za-z0-9._~+/-]+=*$/;
+
+/**
+ * True when Authorization presents a syntactically well-formed bearer
+ * credential (RFC 6750 token68) for client-v1 resource ingress.
+ *
+ * Presented, not verified: deciding whether a credential is real means
+ * findByBearer, which reads the on-disk credential store, and this module is
+ * kept free of node builtins so the proxy's import graph stays
+ * client-bundlable (proxy-helpers.ts is reachable from a "use client"
+ * component via research-media-ticket.ts). Presentation is the half the proxy
+ * can enforce, and enforcing it is what keeps an anonymous loopback process
+ * off a resource route — the routes' requireScope calls are otherwise the only
+ * layer, and a route whose author forgets one has none at all (cave-q5mwb,
+ * revived from cave-d1sjz). The 12-byte fake "Bearer AAAA" satisfies this
+ * check and still lands on the route's own 401, so this gate never excuses
+ * requireScope.
+ *
+ * Fail-closed by construction: no header, a bare credential with no scheme,
+ * a non-"bearer" scheme, an empty credential, a credential over the cap, or a
+ * credential outside the token68 alphabet all return false.
+ */
+export function presentsClientV1Bearer(headerValue: string | null) {
+  if (!headerValue) return false;
+  const separator = headerValue.indexOf(" ");
+  if (separator <= 0) return false;
+  if (headerValue.slice(0, separator).toLowerCase() !== "bearer") return false;
+  const credential = headerValue.slice(separator + 1).trim();
+  return credential.length > 0
+    && credential.length <= CLIENT_V1_BEARER_CHARACTERS
+    && CLIENT_V1_BEARER_CREDENTIAL.test(credential);
+}
+
 export function clientV1IngressKind(pathname: string): ClientV1IngressKind | null {
   if (isRefusedClientV1Path(pathname)) return null;
   if (CLIENT_V1_PUBLIC_PATHS.some((pattern) => pattern.test(pathname))) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -28,7 +28,9 @@ import {
   TAILNET_PEER_HEADER,
   verifiedTailnetNode,
   requiresPasskeyPresence,
+  CLIENT_V1_PUBLIC_INGRESS,
   clientV1IngressKind,
+  presentsClientV1Bearer,
   isClientV1AdminPath,
   isClientV1Path,
   isRefusedClientV1Path,
@@ -521,6 +523,22 @@ export async function proxy(req: NextRequest) {
   if (clientV1Ingress) {
     if (!trustedLocalPeer || remoteIngress) {
       return jsonError(403, "forbidden peer: client v1 requires direct loopback");
+    }
+    // Resource ingress returns below without ever reaching the sidecar-token
+    // block, so a route reached this way is guarded by its own requireScope
+    // call and nothing else. Demanding a well-formed presented bearer here
+    // makes the paired credential a condition of arrival rather than a
+    // courtesy each handler pays separately, which is what the first author to
+    // forget one would otherwise cost (cave-q5mwb, revived from cave-d1sjz).
+    // Presentation, not verification: a 12-byte fake "Bearer AAAA" satisfies
+    // this check and still lands on the route's own 401, so requireScope stays
+    // mandatory. Public ingress is exempt by definition: pairing is how a
+    // client obtains the credential.
+    if (
+      clientV1Ingress !== CLIENT_V1_PUBLIC_INGRESS
+      && !presentsClientV1Bearer(req.headers.get("authorization"))
+    ) {
+      return jsonError(401, "unauthorized");
     }
     return nextWithInternalAuthMarkers(req, false);
   }


### PR DESCRIPTION
Bead: cave-q5mwb (P2). Revives the client-v1 proxy bearer-presentation gate removed in fix/cave-d1sjz (PR #4851) once CLIENT_V1_AUTHENTICATED_PATHS re-listed its five paths.

## Scope
- **src/proxy.ts**: client-v1 RESOURCE ingress (non-public) now requires a well-formed `Authorization: Bearer` token68 presentation before pass-through. Public ingress stays credential-free (pairing is how a client obtains a credential). Presentation-only: a 12-byte fake `Bearer AAAA` passes the proxy and is refused by the route's own requireScope.
- **src/proxy-helpers.ts**: `presentsClientV1Bearer` (RFC 6750 token68, 4096-char cap, case-insensitive scheme, credential trimmed). No node builtins — stays client-bundlable (proxy-helpers.ts is reachable from a "use client" component via research-media-ticket.ts).
- **docs/api/client-v1.md**: updated the ingress/auth layering description.
- **src/lib/server/client-v1/auth.test.ts**: new unit test for the header matrix and a proxy-level bearer test that **asserts `clientV1IngressKind(route) === "authenticated"` as a precondition** — the 401 is byte-identical to the ordinary sidecar-token 401, so without that assertion the test passes vacuously whenever the list empties (verified by mutation: emptying the list turns this test red).

## Carry-forward findings honored
1. Gate is presentation-only; requireScope stays mandatory.
2. Ingress classification asserted as precondition (fail-on-vacuity).
3. proxy-helpers.ts stays client-bundlable (no node:fs).
4. Paths are live today (five listed, all with handlers), so the gate is live, not latent.

## Tests run
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/client-v1/auth.test.ts (36 pass)
- src/app/api/api-contracts.test.ts (310 route contracts pass)
- src/app/api/client/v1/authenticated-route-refusal.test.ts (5 pass)
- src/middleware.test.ts, src/proxy-behavior.test.ts (pass)
- All five Phase 2 route suites (61 tests pass)
- pnpm exec tsc --noEmit (clean)
- node scripts/check-tests-wired.mjs (all 1913 test files wired)
