### PR TITLE
feat: validate attached source URLs client-side in the evidence ledger (cave-k4kp)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -126,6 +126,7 @@ export const SUITES = {
     "src/lib/research-mission-client.test.ts",
     "src/lib/roving-list.test.ts",
     "src/lib/research-artifact-contract.test.ts",
+    "src/lib/research-source-url.test.ts",
     "src/lib/document-reader.test.ts",
     "src/lib/research-findings-doc.test.ts",
     "src/lib/role-surface-state.test.ts",

--- a/src/components/role-surfaces/research-evidence-ledger.test.ts
+++ b/src/components/role-surfaces/research-evidence-ledger.test.ts
@@ -34,6 +34,22 @@ test("sources triage at scale: filters, quiet attach, title-open affordance", ()
   assert.match(source, /<span className="sr-only">Status of \{source\.title\}<\/span>/);
 });
 
+test("attach source validates the URL scheme with an accessible inline error", () => {
+  // Only http(s) URLs may be submitted as web sources; the gate lives next to
+  // the empty-field guard so a bad scheme is refused before any action call.
+  assert.match(source, /isValidResearchSourceUrl/);
+  assert.match(source, /setUrlError\("Source URL must start with http:\/\/ or https:\/\/"\)/);
+  // The error is an inline field error: the input is marked invalid and points
+  // at the message via aria-describedby, and the message itself announces.
+  assert.match(source, /aria-invalid=\{urlError \? true : undefined\}/);
+  assert.match(source, /aria-describedby=\{urlError \? SOURCE_URL_ERROR_ID : undefined\}/);
+  assert.match(source, /role="alert"/);
+  assert.match(source, /SOURCE_URL_ERROR_ID = "research-source-url-error"/);
+  // Typing clears the error; a mission switch resets it with the other draft state.
+  assert.match(source, /if \(urlError\) setUrlError\(null\);/);
+  assert.match(source, /setUrlError\(null\);/);
+});
+
 test("artifact rejection is explicit and append-preserving", () => {
   assert.match(source, /reject-artifact/);
   assert.match(source, /Reject artifact/);
@@ -45,7 +61,7 @@ test("mission switches reset every piece of local ledger state", () => {
   // bleeds into the next mission's ledger.
   assert.match(
     source,
-    /missionIdRef\.current = mission\.id;\s*setTitle\(""\);\s*setUrl\(""\);\s*setRejection\(\{\}\);\s*setBusy\(false\);\s*setError\(null\);\s*setSourceFilter\("all"\);\s*\}, \[mission\.id\]\)/,
+    /missionIdRef\.current = mission\.id;\s*setTitle\(""\);\s*setUrl\(""\);\s*setRejection\(\{\}\);\s*setBusy\(false\);\s*setError\(null\);\s*setUrlError\(null\);\s*setSourceFilter\("all"\);\s*\}, \[mission\.id\]\)/,
   );
   // Panels remount per mission so uncontrolled disclosure state cannot ride
   // colliding artifact/source key shapes onto the wrong mission's rows.

--- a/src/components/role-surfaces/research-evidence-ledger.tsx
+++ b/src/components/role-surfaces/research-evidence-ledger.tsx
@@ -10,6 +10,7 @@ import {
   type ResearchMissionActionInput,
   type ResearchSourceRef,
 } from "@/lib/research-missions";
+import { isValidResearchSourceUrl } from "@/lib/research-source-url";
 import { relativeTime } from "@/lib/relative-time";
 import { ResearchArtifactActions } from "./research-artifact-actions";
 
@@ -47,6 +48,9 @@ const SOURCE_STATUSES: ResearchSourceRef["status"][] = [
 export const VERIFY_NOTE = "Verify next iteration";
 const LEGACY_VERIFY_NOTE = "Verify next pass";
 
+/** Inline error target for the Attach source URL field (aria-describedby). */
+const SOURCE_URL_ERROR_ID = "research-source-url-error";
+
 function hasVerificationRequest(note: string | undefined): boolean {
   return [VERIFY_NOTE, LEGACY_VERIFY_NOTE].some((marker) => (note ?? "").includes(marker));
 }
@@ -66,6 +70,7 @@ export function ResearchEvidenceLedger({
   const [rejection, setRejection] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [urlError, setUrlError] = useState<string | null>(null);
   const [sourceFilter, setSourceFilter] = useState<"all" | ResearchSourceRef["status"]>("all");
   // Tracks the mission currently on screen so an act that settles after the
   // user switched missions is discarded instead of planting its error/busy
@@ -83,6 +88,7 @@ export function ResearchEvidenceLedger({
     setRejection({});
     setBusy(false);
     setError(null);
+    setUrlError(null);
     setSourceFilter("all");
   }, [mission.id]);
 
@@ -137,6 +143,14 @@ export function ResearchEvidenceLedger({
   const attach = async (event: React.FormEvent) => {
     event.preventDefault();
     if (!title.trim() || !url.trim()) return;
+    // Only http(s) URLs may be recorded as web sources; a typo'd or hostile
+    // scheme (ftp:, file:, javascript:, …) is refused here so it never reaches
+    // an action round-trip (the server enforces the same gate).
+    if (!isValidResearchSourceUrl(url)) {
+      setUrlError("Source URL must start with http:// or https://");
+      return;
+    }
+    setUrlError(null);
     const ok = await act({
       action: "attach-source",
       source: {
@@ -242,10 +256,20 @@ export function ResearchEvidenceLedger({
             />
             <input
               value={url}
-              onChange={(event) => setUrl(event.target.value)}
+              onChange={(event) => {
+                setUrl(event.target.value);
+                if (urlError) setUrlError(null);
+              }}
               placeholder="https://…"
               aria-label="Source URL"
+              aria-invalid={urlError ? true : undefined}
+              aria-describedby={urlError ? SOURCE_URL_ERROR_ID : undefined}
             />
+            {urlError ? (
+              <p id={SOURCE_URL_ERROR_ID} role="alert" className="research-source-attach__error">
+                {urlError}
+              </p>
+            ) : null}
             <Button type="submit" size="xs" variant="ghost" disabled={busy || !title.trim() || !url.trim()}>
               Attach
             </Button>

--- a/src/lib/research-source-url.test.ts
+++ b/src/lib/research-source-url.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isValidResearchSourceUrl,
+  RESEARCH_SOURCE_URL_RE,
+} from "./research-source-url.ts";
+
+test("source URL regex admits http(s) URLs", () => {
+  for (const url of [
+    "https://example.com",
+    "https://example.com/path?q=1#frag",
+    "http://example.com",
+    "http://example.com:8080/a/b",
+    "https://example.com/path",
+    "https://example.com?query=1",
+    "https://example.com#hash",
+    "HTTPS://EXAMPLE.COM",
+    "http://127.0.0.1:3000/x",
+  ]) {
+    assert.equal(RESEARCH_SOURCE_URL_RE.test(url), true, url);
+  }
+});
+
+test("source URL regex rejects non-http(s) schemes and bare strings", () => {
+  for (const url of [
+    "ftp://example.com",
+    "file:///etc/passwd",
+    "javascript:alert(1)",
+    "mailto:user@example.com",
+    "data:text/plain,hi",
+    "example.com",
+    "www.example.com",
+    "example.com/path",
+    "https://",
+    "https:/example.com",
+    "//example.com",
+    "not a url",
+    "",
+  ]) {
+    assert.equal(RESEARCH_SOURCE_URL_RE.test(url), false, url);
+  }
+});
+
+test("isValidResearchSourceUrl trims and gates the same scheme", () => {
+  assert.equal(isValidResearchSourceUrl("  https://example.com  "), true);
+  assert.equal(isValidResearchSourceUrl("\thttps://example.com/x\n"), true);
+  assert.equal(isValidResearchSourceUrl("ftp://example.com"), false);
+  assert.equal(isValidResearchSourceUrl("https://"), false);
+  assert.equal(isValidResearchSourceUrl(""), false);
+  assert.equal(isValidResearchSourceUrl("   "), false);
+});

--- a/src/lib/research-source-url.ts
+++ b/src/lib/research-source-url.ts
@@ -1,0 +1,18 @@
+/**
+ * Client-side gate for the evidence ledger's Attach source form: only http(s)
+ * URLs may be submitted as web sources. Mirrors the server's normalizeWebUrl
+ * scheme check (research-artifact-contract.ts) so a typo'd or hostile scheme
+ * (ftp:, file:, javascript:, mailto:, data:, …) is refused before it ever
+ * reaches an action round-trip.
+ *
+ * The regex requires an explicit http:// or https:// scheme (case-insensitive,
+ * like the URL parser the server uses) followed by a host segment. A bare
+ * "example.com" without a scheme, or "https://" with nothing after the scheme,
+ * is rejected. Trailing whitespace is tolerated because the form trims input
+ * before it is stored.
+ */
+export const RESEARCH_SOURCE_URL_RE = /^https?:\/\/[^\s/?#]+(?:[/?#]|$)/i;
+
+export function isValidResearchSourceUrl(value: string): boolean {
+  return RESEARCH_SOURCE_URL_RE.test(value.trim());
+}

--- a/src/styles/globals/surface-role-workspaces.css
+++ b/src/styles/globals/surface-role-workspaces.css
@@ -1111,6 +1111,8 @@
 .research-artifact-reject input, .research-source-attach input { width: 100%; min-width: 0; padding: 5px 6px; font-size: 16px; color: var(--text-primary); border: 1px solid var(--input); border-radius: var(--radius-sm); background: var(--bg-base); }
 .research-artifact-reject input { margin: 6px 0; }
 .research-source-attach { display: grid; gap: 5px; margin-bottom: 8px; }
+.research-source-attach__error { margin: 0; font-size: 9.5px; color: var(--destructive, oklch(0.68 0.18 25)); }
+.research-source-attach input[aria-invalid="true"] { border-color: var(--destructive, oklch(0.68 0.18 25)); }
 .research-source-attach-disclosure { margin-bottom: 8px; font-size: 10px; color: var(--text-muted); }
 .research-source-attach-disclosure summary { width: fit-content; cursor: pointer; }
 .research-source-attach-disclosure[open] summary { margin-bottom: 7px; }


### PR DESCRIPTION
**Bead:** cave-k4kp (Research desk: validate attached source URLs client-side)

**Scope (P3):** add client-side validation on the evidence ledger Attach source form so only http(s) URL schemes submit, with an accessible inline error and source-regex test coverage. Follow-up from research-desk-polish.

**Changes**
- src/lib/research-source-url.ts (new): exported RESEARCH_SOURCE_URL_RE regex + isValidResearchSourceUrl gate mirroring the server's normalizeWebUrl scheme check.
- research-evidence-ledger.tsx: the Attach source handler now refuses non-http(s) URLs with an accessible inline error — the URL input gets aria-invalid + aria-describedby pointing at a role=alert message; the error clears on typing and on mission switch.
- surface-role-workspaces.css: inline error + invalid-input styles (existing --destructive token).
- Tests: src/lib/research-source-url.test.ts (new, registered in run-tests.mjs) exercises the regex (admits http/https incl. ports/IPs/case, rejects ftp/file/javascript/mailto/data/bare strings); research-evidence-ledger.test.ts gains a source-scan test for the accessible error wiring and the updated mission-switch reset.

**Tests run (worktree)**
- node scripts/check-tests-wired.mjs — all 1914 test files wired
- src/lib/research-source-url.test.ts — 3 pass
- research-evidence-ledger.test.ts — 7 pass
- related research suites (tab-desk, desk-view, missions, x-sources, tab-resources behavior) — all pass
- pnpm exec tsc --noEmit — clean
- eslint on changed files — clean
- design checks (tokenize-tsx, token-reference-scan, test-clocks, design-token-drift) — pass
