### PR TITLE
fix(shell): single writer for navOpen aria-expanded, harden sidebar-hidden-push spec (cave-az3ha)

### DIFF
--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -105,8 +105,17 @@ assert.match(
 );
 assert.match(
   shell,
-  /const toggleNavPanel = \(\) => \{[\s\S]*?panel\.expand\(\); setNavOpen\(true\)[\s\S]*?panel\.collapse\(\); setNavOpen\(false\)/,
+  /const toggleNavPanel = \(\) => \{[\s\S]*?panel\.expand\(\);[\s\S]*?panel\.collapse\(\);/,
   "nav toggle collapses and expands the nav panel",
+);
+// The toggle must NOT write navOpen optimistically: the nav Panel's onResize
+// callback derives it from the measured width (the single writer), so an
+// optimistic setNavOpen next to the panel call races the resize frames and
+// leaves the toggle disagreeing with the settled panel (cave-az3ha).
+assert.doesNotMatch(
+  shell.match(/const toggleNavPanel = \(\) => \{[\s\S]{0,400}?\n  \};/)?.[0] ?? "",
+  /setNavOpen\(/,
+  "the nav toggle drives the Panel only - the Panel onResize callback is the single navOpen writer",
 );
 // The old collapsed-only left edge rail and full-height corner floats are gone.
 assert.doesNotMatch(
@@ -246,8 +255,13 @@ assert.match(
 );
 assert.match(
   shell,
-  /const toggleDesktopNav = \(\) => \{[\s\S]*?panel\.isCollapsed\(\)[\s\S]*?panel\.expand\(\);[\s\S]*?setNavOpen\(true\);[\s\S]*?panel\.collapse\(\);[\s\S]*?setNavOpen\(false\);[\s\S]*?matchesPanelShortcut\(e, panelShortcuts\.toggleLeftPanel\)[\s\S]*?else toggleDesktopNav\(\)/,
-  "left panel shortcut toggles the resolved panel and synchronizes its visible state",
+  /const toggleDesktopNav = \(\) => \{[\s\S]*?panel\.isCollapsed\(\)[\s\S]*?panel\.expand\(\);[\s\S]*?panel\.collapse\(\);[\s\S]*?matchesPanelShortcut\(e, panelShortcuts\.toggleLeftPanel\)[\s\S]*?else toggleDesktopNav\(\)/,
+  "left panel shortcut toggles the resolved panel and defers navOpen to the measured-width callback",
+);
+assert.doesNotMatch(
+  shell.match(/const toggleDesktopNav = \(\) => \{[\s\S]{0,240}?\n    \};/)?.[0] ?? "",
+  /setNavOpen\(/,
+  "the shortcut toggle also defers navOpen to the Panel onResize callback",
 );
 assert.doesNotMatch(
   shell,

--- a/src/components/shell-nav-memory.test.ts
+++ b/src/components/shell-nav-memory.test.ts
@@ -491,7 +491,7 @@ assert.match(
 );
 assert.match(
   destinationLayoutEffect,
-  /const rememberedNavOpen =\s*navPolicy === "remembered" \? seedNavOpenPref\(false\) : null;[\s\S]*?const commitDestinationLayout = \(\) => \{[\s\S]*?group\.setLayout\(destinationLayout\);[\s\S]*?if \(rememberedNavOpen !== null\) \{\s*railAutoCollapsedNavRef\.current = false;\s*userOverrodeNavRef\.current = false;\s*applyPanelOpenState\(navRef\.current, rememberedNavOpen\);\s*setNavOpen\(rememberedNavOpen\);\s*minimizedGroupsRef\.current\.add\(groupId\);\s*markShellMinimizeApplied\(groupId\);\s*\}\s*\};/,
+  /const rememberedNavOpen =\s*navPolicy === "remembered" \? seedNavOpenPref\(false\) : null;[\s\S]*?const commitDestinationLayout = \(\) => \{[\s\S]*?group\.setLayout\(destinationLayout\);[\s\S]*?if \(rememberedNavOpen !== null\) \{\s*railAutoCollapsedNavRef\.current = false;\s*userOverrodeNavRef\.current = false;\s*applyPanelOpenState\(navRef\.current, rememberedNavOpen\);\s*minimizedGroupsRef\.current\.add\(groupId\);\s*markShellMinimizeApplied\(groupId\);\s*\}\s*\};/,
   "normal destination restoration applies the remembered state before paint while retaining the expanded layout",
 );
 assert.match(
@@ -571,7 +571,6 @@ assert.equal(
           chatContextualGroupRef.current !== groupId
         ) {
           chatContextualGroupRef.current = groupId;
-          setNavOpen(true);
         }
         previousNavPolicyRef.current = navPolicy;
         return;
@@ -593,7 +592,6 @@ assert.equal(
         navPrefArmedGroupRef.current = null;
         visitCollapsedGroupRef.current = groupId;
         navRef.current?.collapse();
-        setNavOpen(false);
       }
       previousNavPolicyRef.current = navPolicy;
     }, [mounted, groupId, isMobile, navPolicy]);

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -507,7 +507,6 @@ function ShellInner({
         rightChatAutoCollapsedNavRef.current = true;
         rightChatNavOverrideRef.current = false;
         navRef.current?.collapse();
-        setNavOpen(false);
       }
       applyPreferredRightChatWidth();
       rightChatRef.current?.expand();
@@ -533,7 +532,6 @@ function ShellInner({
       rightChatNavOverrideRef.current = false;
       if (restoreNav) {
         navRef.current?.expand();
-        setNavOpen(true);
       }
     }
     setRightChatOpen(false);
@@ -553,12 +551,10 @@ function ShellInner({
       openNav: () => {
         if (isMobile) { setMobileDrawer("nav"); return; }
         navRef.current?.expand();
-        setNavOpen(true);
       },
       closeNav: () => {
         if (isMobile) { setMobileDrawer((c) => (c === "nav" ? null : c)); return; }
         navRef.current?.collapse();
-        setNavOpen(false);
       },
       dismissNavMobile: () => {
         if (isMobile) setMobileDrawer((c) => (c === "nav" ? null : c));
@@ -567,8 +563,8 @@ function ShellInner({
         if (isMobile) { toggleDrawer("nav"); return; }
         const panel = navRef.current;
         if (!panel) return;
-        if (panel.isCollapsed()) { panel.expand(); setNavOpen(true); }
-        else { panel.collapse(); setNavOpen(false); }
+        if (panel.isCollapsed()) panel.expand();
+        else panel.collapse();
       },
       openList: () => {
         if (isMobile) { setMobileDrawer("list"); return; }
@@ -836,7 +832,6 @@ function ShellInner({
         railAutoCollapsedNavRef.current = false;
         userOverrodeNavRef.current = false;
         applyPanelOpenState(navRef.current, rememberedNavOpen);
-        setNavOpen(rememberedNavOpen);
         minimizedGroupsRef.current.add(groupId);
         markShellMinimizeApplied(groupId);
       }
@@ -894,7 +889,6 @@ function ShellInner({
         chatContextualGroupRef.current !== groupId
       ) {
         chatContextualGroupRef.current = groupId;
-        setNavOpen(true);
       }
       previousNavPolicyRef.current = navPolicy;
       return;
@@ -916,7 +910,6 @@ function ShellInner({
       navPrefArmedGroupRef.current = null;
       visitCollapsedGroupRef.current = groupId;
       navRef.current?.collapse();
-      setNavOpen(false);
     }
     previousNavPolicyRef.current = navPolicy;
   }, [mounted, groupId, isMobile, navPolicy]);
@@ -935,10 +928,8 @@ function ShellInner({
     if (panel && !railAutoCollapsedNavRef.current) {
       if (pref && panel.isCollapsed()) {
         panel.expand();
-        setNavOpen(true);
       } else if (!pref && !panel.isCollapsed()) {
         panel.collapse();
-        setNavOpen(false);
       }
     }
     navPrefArmedGroupRef.current = groupId;
@@ -980,10 +971,8 @@ function ShellInner({
 
       if (panel.isCollapsed()) {
         panel.expand();
-        setNavOpen(true);
       } else {
         panel.collapse();
-        setNavOpen(false);
       }
     };
     const handler = (e: KeyboardEvent) => {
@@ -1260,6 +1249,13 @@ function ShellInner({
           const width = size.inPixels ?? 0;
           if (Number.isFinite(width)) setNavChromeWidth(width);
           const open = width > NAV_OPEN_THRESHOLD_PX;
+          // THE single writer of navOpen (cave-az3ha): imperative handlers
+          // drive the Panel itself (expand/collapse) and this measured-width
+          // callback converges aria-expanded from the panel's real state.
+          // Optimistic setNavOpen calls next to panel calls raced with these
+          // resize frames once the open threshold narrowed to 1px — an
+          // intermediate frame could land after the optimistic write and
+          // leave the toggle disagreeing with the settled panel.
           setNavOpen(open);
           // Persist user-driven changes only: the group must be armed (boot /
           // group-swap layout churn is programmatic) and the code rail must
@@ -1377,8 +1373,11 @@ function ShellInner({
   const toggleNavPanel = () => {
     const panel = navRef.current;
     if (!panel) return;
-    if (panel.isCollapsed()) { panel.expand(); setNavOpen(true); }
-    else { panel.collapse(); setNavOpen(false); }
+    // No optimistic setNavOpen here: navOpen is derived from the panel's
+    // measured width by the Panel onResize callback, so the toggle drives
+    // the Panel and the callback converges the aria state (cave-az3ha).
+    if (panel.isCollapsed()) panel.expand();
+    else panel.collapse();
   };
   const navToggle = (
     <button

--- a/tests/sidebar-hidden-push.spec.ts
+++ b/tests/sidebar-hidden-push.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
 async function seedClosedSidebar(page: Page) {
   await page.addInitScript(() => {
@@ -6,6 +6,29 @@ async function seedClosedSidebar(page: Page) {
     window.localStorage.setItem("cave:shell:nav-open", "0");
     window.localStorage.setItem("cave:shell:nav-open:source", "user");
   });
+}
+
+// Await the SETTLED panel state rather than the toggle transition:
+// aria-expanded is derived from the panel's measured width via the nav
+// Panel's onResize callback, so it converges a frame after the width does.
+// Polling the PAIR (aria state AND width) passes only once the panel has
+// stopped moving and the toggle agrees with it, which is the state a real
+// user perceives.
+async function expectNavSettled(
+  toggle: Locator,
+  navPanel: Locator,
+  expected: "open" | "closed",
+) {
+  await expect
+    .poll(async () => {
+      const expanded = await toggle.getAttribute("aria-expanded");
+      const width =
+        (await navPanel.boundingBox())?.width ?? (expected === "open" ? 0 : 1);
+      return expected === "open"
+        ? expanded === "true" && width >= 220
+        : expanded === "false" && width <= 1;
+    })
+    .toBe(true);
 }
 
 async function dispatchTouchSwipe(
@@ -51,7 +74,7 @@ test("closing navigation removes the rail and opening pushes the main panel", as
   expect(closedNav?.width ?? 1).toBeLessThanOrEqual(1);
 
   await toggle.click();
-  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await expectNavSettled(toggle, navPanel, "open");
   await expect(page.locator(".shell-nav")).toHaveAttribute("aria-hidden", "false");
 
   const openNav = await navPanel.boundingBox();
@@ -60,8 +83,7 @@ test("closing navigation removes the rail and opening pushes the main panel", as
   expect((openDetail?.x ?? 0) - (closedDetail?.x ?? 0)).toBeGreaterThanOrEqual(200);
 
   await toggle.click();
-  await expect(toggle).toHaveAttribute("aria-expanded", "false");
-  await expect.poll(async () => (await navPanel.boundingBox())?.width ?? 1).toBeLessThanOrEqual(1);
+  await expectNavSettled(toggle, navPanel, "closed");
 });
 
 test("the fully closed sidebar remains closed after reload", async ({ page }) => {


### PR DESCRIPTION
## Bead
`cave-az3ha` — sidebar-hidden-push spec is flaky on main: two writers race on `aria-expanded` after the nav threshold narrowed to 1px (P1).

## Scope
- **Implementation (shell.tsx):** make the nav `Panel` `onResize` callback the **single writer** of `navOpen` (derived from the measured panel width, `width > NAV_OPEN_THRESHOLD_PX` — the 1px threshold is preserved). Every imperative handler (top-bar toggle, ⌘B shortcut, `ShellHandle` `openNav`/`closeNav`/`toggleNav`, right-chat auto-collapse/restore, visit-collapsed, remembered restore, chat-contextual handoff) now only drives the `Panel` itself (`expand`/`collapse`) and lets the measured-width callback converge `aria-expanded`. No optimistic `setNavOpen` calls remain next to panel calls — the race (an intermediate resize frame landing after the optimistic write) cannot happen.
- **Spec hardening (tests/sidebar-hidden-push.spec.ts):** await the **settled pair** (aria-expanded AND panel width together) via a poll helper instead of asserting the transition.
- **Source-pinning guards updated** to pin the single-writer contract, including `doesNotMatch` guards that fail if a toggle handler ever writes `navOpen` optimistically again.

## Files changed
- `src/components/shell.tsx`
- `tests/sidebar-hidden-push.spec.ts`
- `src/components/shell-edge-rails.test.ts` (pin updated)
- `src/components/shell-nav-memory.test.ts` (pin updated)

## Tests run
- `tests/sidebar-hidden-push.spec.ts` (desktop project): **21 consecutive executions green** (7 consecutive runs of the race test across two repeat rounds), zero flakes, zero retries.
- `shell-edge-rails.test.ts`, `shell-nav-memory.test.ts` and related shell unit tests (mobile-shell-smoke, shell-first-paint, shell-drawer-smoke, misc-aria-fixes, shell-left-panels-fit, analytics-page-shell, sidepanel-nav-peek, nav-rail-coupling, mobile-handoff, role-surface-shell, drag-to-split, home-composer-centering): pass.
- `pnpm exec tsc --noEmit`: clean. ESLint on changed files: clean.
- `node scripts/check-tests-wired.mjs`: all wired.

## Pre-existing, not caused by this diff
- `a11y-audit-fixes.test.ts` board-CSS assertions fail identically on a pristine `origin/main` checkout (design-token/CSS drift).
- The known `discovery.test.ts` chmod and marketplace-logo flakes are untouched.