### PR TITLE
feat(familiars): wire growth hints to their verbs (cave-mo4q)

### DIFF
--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -142,6 +142,20 @@ assert.ok(
   "Thread Signal should render after the transcript tail rather than inside the conversation log",
 );
 
+// cave-mo4q: a completed Reflect offers "Open daily note" — the card's action
+// pre-arms the Familiars surface preferences (same registry the detail panel
+// reads), dismisses the card, and switches the shell to the Familiars surface.
+assert.match(
+  source,
+  /const openFamiliarDailyNote = useCallback\(\(familiarId: string\) => \{[\s\S]*setThreadSignalReport\(null\);\s*setFamiliarsSelectedId\(familiarId\);\s*setFamiliarsViewMode\("detail"\);\s*setFamiliarsDetailTab\("daily-notes"\);\s*window\.dispatchEvent\(new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode: "agents" \} \}\)\);/,
+  "Open daily note pre-arms familiars.selectedId/detail/daily-notes and navigates to the Familiars surface",
+);
+assert.match(
+  source,
+  /onOpenDailyNote=\{openFamiliarDailyNote\}/,
+  "The ThreadSignalCard receives the daily-note action",
+);
+
 assert.match(
   source,
   /onOpenUrl\?: \(url: string\) => void/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -120,6 +120,8 @@ import { stampFirstReplyOnce } from "@/lib/first-run-stamps";
 import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/chat-reply";
 import { canonicalize, formatHelp, splitSlashCommandPrompt } from "@/lib/slash-commands";
 import { Icon } from "@/lib/icon";
+import { useSurfacePreference } from "@/lib/surface-preferences";
+import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 import {
   CHAT_VIEW_HANDOFF_SCOPE,
   claimInitialPromptHandoff,
@@ -2038,6 +2040,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const [reflectError, setReflectError] = useState<string | null>(null);
   const [threadSignalReport, setThreadSignalReport] = useState<ThreadSelfReport | null>(null);
   const [busy, setBusy] = useState(false);
+  // "Open daily note" from the completed Reflect: pre-arm the Familiars
+  // surface preferences (same registry the detail panel reads), then switch
+  // modes — the roster mounts already on the familiar's Daily Notes tab.
+  const [, setFamiliarsSelectedId] = useSurfacePreference(surfacePreferenceSpecs.familiars.selectedId);
+  const [, setFamiliarsViewMode] = useSurfacePreference(surfacePreferenceSpecs.familiars.viewMode);
+  const [, setFamiliarsDetailTab] = useSurfacePreference(surfacePreferenceSpecs.familiars.detailTab);
+  const openFamiliarDailyNote = useCallback((familiarId: string) => {
+    setThreadSignalReport(null);
+    setFamiliarsSelectedId(familiarId);
+    setFamiliarsViewMode("detail");
+    setFamiliarsDetailTab("daily-notes");
+    window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "agents" } }));
+  }, [setFamiliarsDetailTab, setFamiliarsSelectedId, setFamiliarsViewMode]);
   const flowBackedSession = useMemo(() => isFlowBackedSession(session ?? null), [session]);
   const reflectTranscript = useMemo(() => buildReflectTranscript(turns), [turns]);
   const autoSelfReportSessionsRef = useRef<Set<string>>(new Set());
@@ -8287,6 +8302,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           <ThreadSignalCard
             report={threadSignalReport}
             onDismiss={() => setThreadSignalReport(null)}
+            onOpenDailyNote={openFamiliarDailyNote}
             onViewFull={() => {
               const params = new URLSearchParams({ sessionId: threadSignalReport.sessionId });
               window.location.href = `/dashboard/familiars/${encodeURIComponent(threadSignalReport.familiarId)}/analytics?${params.toString()}`;

--- a/src/components/familiar-roster-card.test.ts
+++ b/src/components/familiar-roster-card.test.ts
@@ -18,10 +18,33 @@ assert.match(
 assert.match(card, /familiar\.display_name/, "Card shows display name");
 assert.match(card, /familiar\.role \|\| familiar\.harness \|\| familiar\.id/, "Card shows role / harness / id fallback chain");
 
+// Growth health replaces the duplicated online/offline presence dot: the
+// roster card now shows healthLabel with the status-dot + word pattern
+// (design language §3 — color is never the only channel) (cave-mo4q).
 assert.match(
   card,
-  /daemonRunning \? "online" : "offline"/,
-  "Status row shows online/offline tied to daemonRunning",
+  /healthLabel,/, 
+  "Card accepts the growth healthLabel (destructured prop)",
+);
+assert.match(
+  source,
+  /healthLabel: "active" \| "steady" \| "quiet" \| "stalled"/,
+  "The card prop type names the four growth health states",
+);
+assert.match(
+  card,
+  /familiars-view__health-dot familiars-view__health-dot--\$\{healthLabel\}/,
+  "Card renders the growth-health dot",
+);
+assert.match(
+  card,
+  /\{healthLabel\}/,
+  "Card shows the health word beside the dot",
+);
+assert.doesNotMatch(
+  card,
+  /daemonRunning|"online" \? "offline"/,
+  "The duplicated online/offline presence dot is gone",
 );
 
 assert.match(

--- a/src/components/familiar-summoning-circle.test.ts
+++ b/src/components/familiar-summoning-circle.test.ts
@@ -271,6 +271,43 @@ assert.doesNotMatch(
   "vitality stays honest — no invented XP mechanics",
 );
 
+// ── Enhancement rite: vitality hints wire to their verbs (cave-mo4q) ─────────
+assert.match(
+  source,
+  /action: "chat"/,
+  "conversation hints carry a Start chat verb",
+);
+assert.match(
+  source,
+  /action: "daily-notes"/,
+  "the no-memories hint carries an Open daily notes verb",
+);
+assert.match(
+  source,
+  /vitality\.action === "chat" && onStartChat \?[\s\S]*Start chat/,
+  "the rite renders a Start chat action when the hint asks for one",
+);
+assert.match(
+  source,
+  /vitality\.action === "daily-notes" && onOpenDailyNotes \?[\s\S]*Open daily notes/,
+  "the rite renders an Open daily notes action when the hint asks for one",
+);
+assert.match(
+  source,
+  /vitalityFor\(familiar, memoryCount\)/,
+  "the rite feeds the known memory count into vitality",
+);
+assert.match(
+  source,
+  /No memories yet — open daily notes to seed its mind\./,
+  "the no-memory vitality hint points at the daily notes verb",
+);
+assert.match(
+  source,
+  /role="group"/,
+  "the vitality strip stays a labelled group so the hint action stays reachable to AT",
+);
+
 // ── A11y: trap, announcer, roles ─────────────────────────────────────────────
 assert.match(source, /useFocusTrap\(true, dialogRef, \{ onEscape: handleClose \}\)/, "the circle traps focus and closes on Escape");
 assert.match(source, /useAnnouncer\(\)/, "the circle announces through the shared live region");

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -94,6 +94,11 @@ type Props = {
   daemonRunning?: boolean;
   /** When provided, the success stage offers to begin the first conversation. */
   onStartChat?: (id: string) => void;
+  /** When provided, the Enhancement Rite's memory hint opens the familiar's daily notes. */
+  onOpenDailyNotes?: (id: string) => void;
+  /** Known memory-entry count for the enhanced familiar (null = unknown). Feeds
+   *  the rite's "no memories yet" hint — an existing growth signal, wired here. */
+  memoryCount?: number | null;
 };
 
 export function FamiliarSummoningCircle({
@@ -106,6 +111,8 @@ export function FamiliarSummoningCircle({
   onEnhanced,
   daemonRunning,
   onStartChat,
+  onOpenDailyNotes,
+  memoryCount = null,
 }: Props) {
   if (!open) return null;
   return (
@@ -118,6 +125,8 @@ export function FamiliarSummoningCircle({
       onEnhanced={onEnhanced}
       daemonRunning={daemonRunning}
       onStartChat={onStartChat}
+      onOpenDailyNotes={onOpenDailyNotes}
+      memoryCount={memoryCount}
     />
   );
 }
@@ -132,6 +141,8 @@ function SummoningCircleOverlay({
   onEnhanced,
   daemonRunning,
   onStartChat,
+  onOpenDailyNotes,
+  memoryCount,
 }: Omit<Props, "open">) {
   const { announce } = useAnnouncer();
   const dialogRef = useRef<HTMLDivElement | null>(null);
@@ -161,6 +172,9 @@ function SummoningCircleOverlay({
             setSubmitting={setSubmitting}
             announce={announce}
             onEnhanced={onEnhanced}
+            onStartChat={onStartChat}
+            onOpenDailyNotes={onOpenDailyNotes}
+            memoryCount={memoryCount}
             onClose={handleClose}
           />
         ) : (
@@ -1495,25 +1509,40 @@ function SummonSuccess({
 
 // ─── The enhancement rite (alteration) ───────────────────────────────────────
 
+type VitalityAction = "chat" | "daily-notes" | null;
+
 type Vitality = {
   label: "Blazing" | "Warm" | "Quiet" | "Dormant";
   embers: 1 | 2 | 3 | 4;
   hint: string;
+  /** Verb this hint points at — an existing callback. Null when the familiar is healthy. */
+  action: VitalityAction;
 };
 
 /** Honest vitality from roster fields — live signals, nothing invented. */
-export function vitalityFor(familiar: ResolvedFamiliar): Vitality {
+export function vitalityFor(familiar: ResolvedFamiliar, memoryCount?: number | null): Vitality {
   if ((familiar.active_sessions ?? 0) > 0) {
-    return { label: "Blazing", embers: 4, hint: "Working right now." };
+    return { label: "Blazing", embers: 4, hint: "Working right now.", action: null };
+  }
+  // Known-empty memory outranks recency: seeding the mind (daily notes) is the
+  // one verb that helps before any conversation can (cave-mo4q).
+  if (memoryCount === 0) {
+    return {
+      label: "Quiet",
+      embers: 2,
+      hint: "No memories yet — open daily notes to seed its mind.",
+      action: "daily-notes",
+    };
   }
   const lastSeen = familiar.last_seen ? Date.parse(familiar.last_seen) : NaN;
   const days = Number.isFinite(lastSeen) ? (Date.now() - lastSeen) / 86_400_000 : Infinity;
-  if (days <= 7) return { label: "Warm", embers: 3, hint: "Active this week." };
-  if (days <= 21) return { label: "Quiet", embers: 2, hint: "A conversation would rekindle it." };
+  if (days <= 7) return { label: "Warm", embers: 3, hint: "Active this week.", action: null };
+  if (days <= 21) return { label: "Quiet", embers: 2, hint: "A conversation would rekindle it.", action: "chat" };
   return {
     label: "Dormant",
     embers: 1,
     hint: "It has been still a long while — begin a conversation to wake it.",
+    action: "chat",
   };
 }
 
@@ -1523,6 +1552,9 @@ function EnhancementRite({
   setSubmitting,
   announce,
   onEnhanced,
+  onStartChat,
+  onOpenDailyNotes,
+  memoryCount,
   onClose,
 }: {
   familiar: ResolvedFamiliar;
@@ -1530,6 +1562,9 @@ function EnhancementRite({
   setSubmitting: (v: boolean) => void;
   announce: (msg: string, tone?: "polite" | "assertive") => void;
   onEnhanced?: (id: string) => void;
+  onStartChat?: (id: string) => void;
+  onOpenDailyNotes?: (id: string) => void;
+  memoryCount?: number | null;
   onClose: () => void;
 }) {
   const [name, setName] = useState(familiar.display_name);
@@ -1543,7 +1578,7 @@ function EnhancementRite({
   const [empowered, setEmpowered] = useState(false);
   const fileRef = useRef<HTMLInputElement | null>(null);
 
-  const vitality = useMemo(() => vitalityFor(familiar), [familiar]);
+  const vitality = useMemo(() => vitalityFor(familiar, memoryCount), [familiar, memoryCount]);
 
   const identityDirty =
     name.trim() !== familiar.display_name ||
@@ -1638,7 +1673,11 @@ function EnhancementRite({
             flare={empowered}
             center={centerNode}
           />
-          <p className="summoning-vitality" role="img" aria-label={`Vitality: ${vitality.label}. ${vitality.hint}`}>
+          <div
+            className="summoning-vitality"
+            role="group"
+            aria-label={`Vitality: ${vitality.label}. ${vitality.hint}`}
+          >
             <span aria-hidden className="summoning-vitality__embers">
               {Array.from({ length: 4 }, (_, i) => (
                 <Icon
@@ -1651,7 +1690,26 @@ function EnhancementRite({
             </span>
             <span className="summoning-vitality__label">{vitality.label}</span>
             <span className="summoning-vitality__hint">{vitality.hint}</span>
-          </p>
+            {vitality.action === "chat" && onStartChat ? (
+              <Button
+                size="xs"
+                variant="secondary"
+                leadingIcon="ph:chat-circle-dots"
+                onClick={() => onStartChat(familiar.id)}
+              >
+                Start chat
+              </Button>
+            ) : vitality.action === "daily-notes" && onOpenDailyNotes ? (
+              <Button
+                size="xs"
+                variant="secondary"
+                leadingIcon="ph:book-open"
+                onClick={() => onOpenDailyNotes(familiar.id)}
+              >
+                Open daily notes
+              </Button>
+            ) : null}
+          </div>
         </div>
 
         <div className="summoning-panel">

--- a/src/components/familiars-view-sections.tsx
+++ b/src/components/familiars-view-sections.tsx
@@ -84,7 +84,9 @@ type MemoryStatus = "loading" | "error" | "ready";
 type AgentRosterCardProps = {
   familiar: ResolvedFamiliar;
   stats: FamiliarCardStats;
-  daemonRunning: boolean;
+  /** Growth health (active/steady/quiet/stalled) — the status-dot + word
+   *  pattern (design language §3) replacing the duplicated online/offline dot. */
+  healthLabel: "active" | "steady" | "quiet" | "stalled";
   responseNeeded: boolean;
   memoryStatus: MemoryStatus;
   onSelect: () => void;
@@ -93,7 +95,7 @@ type AgentRosterCardProps = {
 export function FamiliarRosterCard({
   familiar,
   stats,
-  daemonRunning,
+  healthLabel,
   responseNeeded,
   memoryStatus,
   onSelect,
@@ -148,10 +150,10 @@ export function FamiliarRosterCard({
           </span>
           <span className="familiars-view__microlabel inline-flex shrink-0 items-center gap-1.5 self-start">
             <span
-              className={`inline-flex h-1.5 w-1.5 rounded-full ${daemonRunning ? "bg-[var(--accent-presence)] familiars-view__status-dot--live" : "bg-[var(--text-muted)]"}`}
+              className={`familiars-view__health-dot familiars-view__health-dot--${healthLabel}`}
               aria-hidden="true"
             />
-            {daemonRunning ? "online" : "offline"}
+            {healthLabel}
           </span>
         </span>
 

--- a/src/components/familiars-view.test.ts
+++ b/src/components/familiars-view.test.ts
@@ -216,6 +216,43 @@ assert.match(
   "the roster does not expose a fallback-derived renown score in its tooltip",
 );
 
+// cave-mo4q: roster cards derive the growth healthLabel from the SAME stats
+// the card renders (retro state is the dashboard's — null here) and pass it
+// to the card as the status-dot + word pattern.
+assert.match(
+  source,
+  /const healthByFamiliar = useMemo\(\(\) => \{[\s\S]*deriveGrowthReport\(\{ familiar, stats: cardStats, retroState: null \}\)\.healthLabel,[\s\S]*\}, \[familiars, stats\]\);/,
+  "Roster health labels derive from deriveGrowthReport over the rendered stats",
+);
+assert.match(
+  source,
+  /healthLabel=\{healthByFamiliar\.get\(familiar\.id\) \?\? "steady"\}/,
+  "Each roster card receives its derived health label",
+);
+
+// cave-mo4q: the Enhancement Rite's "open daily notes" hint lands on the
+// familiar's Daily Notes tab — same preference registry the panel reads.
+assert.match(
+  source,
+  /const \[, setDetailTab\] = useSurfacePreference\(surfacePreferenceSpecs\.familiars\.detailTab\);/,
+  "FamiliarsView shares the detail-tab preference registry with the detail panel",
+);
+assert.match(
+  source,
+  /const openDailyNotes = useCallback\(\(id: string\) => \{[\s\S]*setEnhanceTarget\(null\);\s*setSelectedFamiliarId\(id\);\s*setViewMode\("detail"\);\s*setDetailTab\("daily-notes"\);/,
+  "Open daily notes closes the rite and opens the familiar's Daily Notes tab",
+);
+assert.match(
+  source,
+  /onOpenDailyNotes=\{openDailyNotes\}/,
+  "The summoning circle receives the daily-notes wiring",
+);
+assert.match(
+  source,
+  /memoryCount=\{[\s\S]*stats\.get\(enhanceTarget\.id\)\?\.memoryAvailability === "ready"[\s\S]*memoryCount \?\? null/,
+  "The rite learns the known memory count (null when memory is unavailable)",
+);
+
 assert.match(
   source,
   /viewMode === "detail" && selectedFamiliar/,

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -31,6 +31,10 @@ import {
 } from "@/lib/summon-events";
 import { useSurfacePreference } from "@/lib/surface-preferences";
 import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
+import {
+  deriveGrowthReport,
+  type FamiliarGrowthReport as GrowthReportModel,
+} from "@/lib/familiar-growth-signals";
 import { readSurfaceResource } from "@/lib/surface-warmup-registry";
 import {
   emptyStats,
@@ -141,6 +145,9 @@ export function FamiliarsView({
   const [previewFamiliar, setPreviewFamiliar] = useState<ResolvedFamiliar | null>(null);
   const [selectedFamiliarId, setSelectedFamiliarId] = useSurfacePreference(surfacePreferenceSpecs.familiars.selectedId);
   const [viewMode, setViewMode] = useSurfacePreference(surfacePreferenceSpecs.familiars.viewMode);
+  // Detail-tab setter shares the SAME registry as the detail panel (cave-mo4q):
+  // the rite's "open daily notes" hint lands on the Daily Notes tab in one move.
+  const [, setDetailTab] = useSurfacePreference(surfacePreferenceSpecs.familiars.detailTab);
   const rejectedPendingSelectionRef =
     useRef<PendingCanonicalMemorySelection | null>(null);
   const memoryRequestGateRef = useRef<ReturnType<
@@ -370,6 +377,22 @@ export function FamiliarsView({
   );
   const resolvedFamiliars = useResolvedFamiliars(familiars, { includeArchived: true });
 
+  // Growth health per familiar, derived from the SAME stats the roster already
+  // renders (retro state is null here — the dashboard owns retro runs). The
+  // roster card shows this as the status-dot + word pattern (cave-mo4q).
+  const healthByFamiliar = useMemo(() => {
+    const map = new Map<string, GrowthReportModel["healthLabel"]>();
+    for (const familiar of familiars) {
+      const cardStats = stats.get(familiar.id);
+      if (!cardStats) continue;
+      map.set(
+        familiar.id,
+        deriveGrowthReport({ familiar, stats: cardStats, retroState: null }).healthLabel,
+      );
+    }
+    return map;
+  }, [familiars, stats]);
+
   const visibleFamiliars = useMemo(
     () => resolvedFamiliars.filter((f) => familiarMatches(f, query)),
     [resolvedFamiliars, query],
@@ -441,6 +464,16 @@ export function FamiliarsView({
     setSelectedFamiliarId(id);
     setViewMode("detail");
   }, []);
+
+  // The Enhancement Rite's memory hint lands here: close the rite, open the
+  // familiar's detail panel on the Daily Notes tab (cave-mo4q).
+  const openDailyNotes = useCallback((id: string) => {
+    setCreateOpen(false);
+    setEnhanceTarget(null);
+    setSelectedFamiliarId(id);
+    setViewMode("detail");
+    setDetailTab("daily-notes");
+  }, [setDetailTab, setSelectedFamiliarId, setViewMode]);
 
   const backToRoster = useCallback(() => {
     setViewMode("roster");
@@ -618,7 +651,7 @@ export function FamiliarsView({
                     stats.get(familiar.id) ??
                     emptyStats(canonicalMemoryAvailability)
                   }
-                  daemonRunning={daemonRunning}
+                  healthLabel={healthByFamiliar.get(familiar.id) ?? "steady"}
                   responseNeeded={responseNeeded.has(familiar.id)}
                   memoryStatus={
                     canonicalMemoryAvailability === "ready"
@@ -665,6 +698,14 @@ export function FamiliarsView({
         onEnhanced={(id) => onFamiliarCreated?.(id)}
         daemonRunning={daemonRunning}
         onStartChat={onStartChat}
+        onOpenDailyNotes={openDailyNotes}
+        memoryCount={
+          enhanceTarget
+            ? stats.get(enhanceTarget.id)?.memoryAvailability === "ready"
+              ? stats.get(enhanceTarget.id)?.memoryCount ?? null
+              : null
+            : null
+        }
       />
     </div>
   );

--- a/src/components/thread-signal-card.test.ts
+++ b/src/components/thread-signal-card.test.ts
@@ -86,6 +86,15 @@ describe("thread-signal-card module wiring", () => {
     assert.match(source, /launch\(\s*openCriticals,/);
   });
 
+  it("announces where the completed Reflect landed and offers the daily note", () => {
+    // cave-mo4q: the card announces the persisted destination (growth analytics)
+    // and carries an Open daily note action wired to the report's familiar.
+    assert.match(source, /Reflection saved to \$\{name\}'s growth analytics/);
+    assert.match(source, /onOpenDailyNote\?: \(familiarId: string\) => void/);
+    assert.match(source, /onClick=\{\(\) => onOpenDailyNote\(report\.familiarId\)\}/);
+    assert.match(source, /Open daily note/);
+  });
+
   it("defers the dismissal upward so Undo can restore the card", () => {
     assert.match(source, /const \[dismissed, setDismissed\] = useState\(false\)/);
     assert.match(source, /setTimeout\(\(\) => onDismissRef\.current\(\), DISMISS_UNDO_MS\)/);
@@ -114,7 +123,7 @@ describe("thread-signal-card module wiring", () => {
 
   it("keeps every interactive element keyboard-reachable and announced", () => {
     assert.match(source, /useAnnouncer\(\)/);
-    assert.match(source, /announce\(`Thread Signal available for \$\{name\}\.`\)/);
+    assert.match(source, /announce\(`Reflection saved to \$\{name\}'s growth analytics/);
     assert.match(source, /className="tsc-row-btn focus-ring-inset"/);
     assert.match(source, /tsc-tile focus-ring/);
     assert.match(source, /aria-expanded=\{open\}/);

--- a/src/components/thread-signal-card.tsx
+++ b/src/components/thread-signal-card.tsx
@@ -24,6 +24,9 @@ type ThreadSignalCardProps = {
   report: ThreadSelfReport;
   onViewFull: () => void;
   onDismiss: () => void;
+  /** Open the familiar's daily note — where a completed Reflect can continue
+   *  in prose (cave-mo4q). Absent when the host surface cannot navigate. */
+  onOpenDailyNote?: (familiarId: string) => void;
 };
 
 /** Undo window before a dismissal is committed upward, matching use-undo-delete. */
@@ -46,7 +49,7 @@ function weakestTileId(tiles: ThreadSignalScoreTile[]): string | null {
   return [...scored].sort((a, b) => a.percent - b.percent)[0]?.id ?? null;
 }
 
-export function ThreadSignalCard({ report, onViewFull, onDismiss }: ThreadSignalCardProps) {
+export function ThreadSignalCard({ report, onViewFull, onDismiss, onOpenDailyNote }: ThreadSignalCardProps) {
   const { announce } = useAnnouncer();
   const tiles = useMemo(() => buildThreadSignalScoreTiles(report), [report]);
   const rows = useMemo(() => buildThreadSignalRows(report), [report]);
@@ -91,7 +94,10 @@ export function ThreadSignalCard({ report, onViewFull, onDismiss }: ThreadSignal
     return () => clearTimeout(timer);
   }, [dismissed]);
   useEffect(() => {
-    announce(`Thread Signal available for ${name}.`);
+    // A completed Reflect announces where it landed: the self-report is
+    // persisted to the familiar's growth analytics, with the daily note one
+    // action away (cave-mo4q).
+    announce(`Reflection saved to ${name}'s growth analytics. Open the daily note to continue it.`);
   }, [announce, name, report.id]);
 
   const selected = tiles.find((tile) => tile.id === selectedTile) ?? null;
@@ -349,6 +355,16 @@ export function ThreadSignalCard({ report, onViewFull, onDismiss }: ThreadSignal
         <Button size="sm" variant="ghost" trailingIcon="ph:arrow-square-out" onClick={onViewFull}>
           Analytics
         </Button>
+        {onOpenDailyNote ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            leadingIcon="ph:book-open"
+            onClick={() => onOpenDailyNote(report.familiarId)}
+          >
+            Open daily note
+          </Button>
+        ) : null}
         <span className="tsc-foot-spacer" />
         {criticals.length === 0 ? null : openCriticals.length > 0 ? (
           <Button

--- a/src/styles/globals/shell-responsive.css
+++ b/src/styles/globals/shell-responsive.css
@@ -185,19 +185,30 @@
   color: var(--color-warning);
 }
 
-/* Live-presence dot pulses gently; static under reduced motion. */
-.familiars-view__status-dot--live {
-  box-shadow: 0 0 6px color-mix(in srgb, var(--accent-presence) 70%, transparent);
-  animation: familiars-status-pulse 2.4s ease-in-out infinite;
+/* Growth-health dot — the status-dot + word pattern (design language §3):
+   a 6px dot colored by semantic token, always paired with its label text so
+   color is never the only channel. Replaces the online/offline presence dot:
+   growth health (active/steady/quiet/stalled) is the live state that matters
+   on the roster (cave-mo4q). */
+.familiars-view__health-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: var(--radius-pill);
+  background: var(--text-muted);
 }
-@keyframes familiars-status-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.55; }
+.familiars-view__health-dot--active {
+  background: var(--color-success);
+  box-shadow: 0 0 0 4px color-mix(in oklch, var(--color-success) 16%, transparent);
 }
-@media (prefers-reduced-motion: reduce) {
-  .familiars-view__status-dot--live {
-    animation: none;
-  }
+.familiars-view__health-dot--steady {
+  background: var(--color-info);
+}
+.familiars-view__health-dot--quiet {
+  background: var(--color-warning);
+}
+.familiars-view__health-dot--stalled {
+  background: var(--color-danger);
 }
 
 /* ────────────────────────────────────────────────


### PR DESCRIPTION
Bead: cave-mo4q · Golden path 6: grow a familiar — every growth hint one click from its remedy (P3, pure wiring).

Scope:
1. Enhancement Rite vitality hints wire to their verbs — conversation hints (Quiet/Dormant) render **Start chat**; the known-empty-memory hint renders **Open daily notes** (lands on the familiar's Daily Notes tab via the shared detail-tab preference registry).
2. Roster cards show the growth  as the status-dot + word pattern (design language §3), replacing the duplicated online/offline dot; health derives from the same stats the card renders via .
3. A completed Reflect announces where it landed (growth analytics) and the ThreadSignalCard gains an **Open daily note** action that pre-arms the Familiars surface preferences and navigates there.

Frontend only (Next.js client components + one stylesheet). No API/contract changes, no server.ts edits.

Tests run locally (worktree):
- src/components/familiar-summoning-circle.test.ts ✓
- src/components/familiar-roster-card.test.ts ✓
- src/components/familiars-view.test.ts ✓
- src/components/chat-view.test.ts ✓
- src/components/thread-signal-card.test.ts ✓
- src/lib/familiar-growth-signals.test.ts ✓
- src/components/familiar-growth-view.test.ts ✓
- node scripts/check-tests-wired.mjs ✓ (no new test files)
- pnpm exec tsc --noEmit ✓

Note:  tests importing CSS (familiars-view-memory-ownership, workspace-canonical-memory-lazy-familiar) fail on this local WSL runner with ERR_UNKNOWN_FILE_EXTENSION for .css on clean main too — pre-existing local runner limitation, unrelated to this diff.