### PR TITLE
fix(a11y): make full-bleed right-chat drawer close reachable (cave-4snk9)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -205,6 +205,20 @@ export default defineConfig({
       grepInvert: PERSISTED_SCREEN_SCALE_TEST,
       use: { ...devices["iPhone 13"] },
     },
+    {
+      // Tablet-width project for the right Chat drawer's non-full-bleed case
+      // (cave-4snk9): pixel-5 (393px) and iphone-13 (390px) are the only
+      // mobile projects and both are full-bleed (≤480px), so no project
+      // exercised the right-chat backdrop at a width where the pointer path
+      // exists. iPad Mini is 768×1024 — the drawer is capped at 480px and
+      // the backdrop is genuinely reachable along the left edge. Scoped to
+      // right-chat-panel.spec.ts only: the rest of tests/mobile/ was written
+      // for phone widths and must keep running on the phone projects alone.
+      name: "tablet",
+      dependencies: ["preferences-iphone-13"],
+      testMatch: /right-chat-panel\.spec\.ts/,
+      use: { ...devices["iPad Mini"] },
+    },
   ],
   webServer: {
     command: `pnpm exec next dev -H 127.0.0.1 -p ${PORT}`,

--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -209,8 +209,21 @@ const MAX_CHUNK_BYTES = (Number(process.env.BUNDLE_MAX_CHUNK_KB) || 2400) * 1024
 // attempted here because this branch exists to un-red `main`, not to re-order
 // the cascade under several concurrent sessions. This is a ceiling for the
 // shell chrome that already landed, not a licence for the next surface.
+// RAISED home 940→945 (2026-08-28, cave-4snk9): the full-bleed right Chat
+// drawer's close strip — the drawer's own top dismiss bar, shown at ≤480px
+// where the drawer is width:100vw and covers the backdrop — is always-loaded
+// shell CSS in shell-responsive.css, the same class as the cave-ltl38.4
+// drawer rules that raised root. Measured on this branch: home 962,643 B
+// (940.08 KiB) against the 940 KiB ceiling, 83 B over — the strip adds ~1 KiB
+// and the set already sat at the boundary, exactly the cave-iktbc situation
+// (a 378-byte fix was enough to fail then). 945 leaves 4.9 KiB (0.52%), still
+// THIN by the 2% rule — the honest reading, and the warning stays visible.
+// The real reclaim remains the #3264 extraction candidates for home
+// (settings-familiars.css, calendar-agenda.css, surface-compact-calendar.css,
+// surface-role-workspaces.css), untouched here; this is a ceiling for this
+// feature's CSS, not a licence for the next one.
 const MAX_ROOT_CSS_BYTES = (Number(process.env.BUNDLE_MAX_ROOT_CSS_KB) || 640) * 1024;
-const MAX_HOME_CSS_BYTES = (Number(process.env.BUNDLE_MAX_HOME_CSS_KB) || 940) * 1024;
+const MAX_HOME_CSS_BYTES = (Number(process.env.BUNDLE_MAX_HOME_CSS_KB) || 945) * 1024;
 
 if (!existsSync(chunksDir)) {
   console.error(

--- a/src/components/mobile-drawer.tsx
+++ b/src/components/mobile-drawer.tsx
@@ -158,6 +158,23 @@ export function MobileDrawer({ open, onClose, rightChat }: MobileDrawerProps) {
           inert={open !== "right-chat"}
           tabIndex={-1}
         >
+          {/* Full-bleed close strip (cave-4snk9): on phones (≤480px) the
+              drawer is width:100vw and covers the backdrop button at every
+              pixel, so CSS hides the backdrop for this slot and THIS strip
+              owns dismissal instead. It is a child of the dialog — not a
+              sibling like the backdrop — so the focus trap reaches it: it is
+              the drawer's first focusable, and a Tab/Enter user can close
+              the drawer without ever touching the phantom backdrop. CSS
+              shows it only at ≤480px; at wider mobile widths the real,
+              exposed backdrop is the close surface and this strip stays
+              display:none. */}
+          <button
+            type="button"
+            className="focus-ring mobile-right-chat-drawer__close"
+            data-drawer-slot="right-chat"
+            aria-label="Close drawer"
+            onClick={onClose}
+          />
           {rightChat}
         </section>
       ) : null}

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -542,6 +542,18 @@ assert.match(
   "the backdrop renders only while any drawer is open, as a real <button>",
 );
 
+// Full-bleed close strip (cave-4snk9): on phones (≤480px) the drawer is
+// width:100vw and covers the backdrop at every pixel, so CSS hides the
+// backdrop for this slot and THIS button — the drawer's own first child,
+// inside the focus trap — is the close control pointer AND keyboard users
+// can reach. CSS (shell-responsive.css) shows it only at ≤480px; this pin
+// fixes its source shape and that it precedes the panel content.
+assert.match(
+  drawerSource,
+  /className="focus-ring mobile-right-chat-drawer__close"[\s\S]{0,120}aria-label="Close drawer"[\s\S]{0,60}onClick=\{onClose\}\s*\/>\s*\{rightChat\}/,
+  "the full-bleed close strip is the drawer's first child (inside the trap) and calls the same onClose the backdrop uses",
+);
+
 // Escape ownership: the legacy standalone listener must step aside for the
 // right Chat drawer, which owns Escape entirely through useFocusTrap's
 // onEscape — otherwise Escape would fire onClose twice for that slot.

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -276,6 +276,17 @@ assert.match(css, /\.mobile-right-chat-drawer\s*\{[^}]*right:\s*0;[^}]*width:\s*
 assert.match(css, /@media \(max-width: 480px\)[\s\S]*?\.mobile-right-chat-drawer\s*\{[^}]*width:\s*100vw;/, "narrow phones use the available width");
 assert.match(css, /prefers-reduced-motion: reduce[\s\S]*?\.mobile-right-chat-drawer[\s\S]*?animation:\s*none/, "drawer motion respects the global reduced-motion contract");
 
+// Full-bleed close strip (cave-4snk9): at ≤480px the drawer is width:100vw
+// and covers the backdrop at every pixel, so the backdrop is hidden for this
+// slot (a control no input modality can reach) and the drawer's own top
+// strip — absolute above the drawer's content, a child of the trapped
+// dialog — owns dismissal. The strip shows exactly when the drawer is
+// full-bleed; the exposed backdrop keeps owning dismissal everywhere else.
+assert.match(css, /\.mobile-right-chat-drawer__close\s*\{[^}]*position:\s*absolute;[^}]*z-index:\s*5;/, "the full-bleed close strip is an absolute bar above the drawer's own content");
+assert.match(css, /@media \(max-width: 480px\)[\s\S]*?\.mobile-right-chat-drawer__close\s*\{[^}]*display:\s*block;/, "the close strip shows exactly when the right Chat drawer is full-bleed");
+assert.match(css, /@media \(max-width: 480px\)[\s\S]*?\.mobile-drawer-backdrop\[data-drawer-slot="right-chat"\]\s*\{[^}]*display:\s*none;/, "the backdrop is hidden while the right Chat drawer is full-bleed — a control no input modality could reach (cave-4snk9)");
+assert.match(css, /@media \(max-width: 480px\)[\s\S]*?\.mobile-right-chat-drawer\s*\{[^}]*padding-top:\s*calc\(var\(--sai-top\) \+ var\(--touch-target\)\);/, "the full-bleed drawer pushes its content below the close strip so nothing interactive is covered");
+
 // The right companion panel (and its in-panel collapse bridge) was removed.
 assert.doesNotMatch(
   shell,

--- a/src/styles/globals/shell-responsive.css
+++ b/src/styles/globals/shell-responsive.css
@@ -1383,10 +1383,67 @@
   to { transform: translateX(0); }
 }
 
+/* Full-bleed close strip (cave-4snk9): the drawer's own top dismiss bar,
+   rendered by <MobileDrawer/> as the dialog's FIRST child so the focus trap
+   reaches it. At ≤480px the drawer is width:100vw and covers the backdrop
+   button at every pixel, so the backdrop is a control no input modality can
+   operate — the strip replaces it as the close affordance for that case
+   (pointer AND keyboard: it is the first focusable inside the trapped
+   dialog). A child of the drawer (not a portal sibling like the backdrop),
+   so it rides the slide-in animation with the panel and needs no z-index
+   fight: it paints above the drawer's own content via position + z-index
+   within the drawer's stacking context. display:none at wider widths, where
+   the real backdrop (exposed beside the capped drawer) owns dismissal. */
+.mobile-right-chat-drawer__close {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 5;
+  display: none;
+  height: var(--touch-target);
+  border: none;
+  border-bottom: 1px solid var(--border-hairline);
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  background: var(--bg-panel);
+  touch-action: manipulation;
+}
+/* A quiet grabber pill signals "pull/tap here to dismiss" without
+   competing with the drawer's own chrome. */
+.mobile-right-chat-drawer__close::after {
+  content: "";
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--text-muted);
+}
+
 @media (max-width: 480px) {
   .mobile-right-chat-drawer {
     width: 100vw;
     border-left: 0;
+    /* The close strip overlays the drawer's top var(--touch-target) band;
+       push the panel content below it so nothing interactive is covered. */
+    padding-top: calc(var(--sai-top) + var(--touch-target));
+  }
+  .mobile-right-chat-drawer__close {
+    display: block;
+  }
+  /* Full-bleed drawer: the backdrop is simultaneously invisible (the
+     opaque drawer covers it) and un-hittable, and the focus trap wraps
+     inside the drawer so Tab can never reach it either. Hiding it here
+     stops offering a control no input modality can operate — dismissal is
+     the strip's job at this width (cave-4snk9). Kept for nav/list and for
+     right-chat at wider mobile widths, where it is a real target. */
+  .mobile-drawer-backdrop[data-drawer-slot="right-chat"] {
+    display: none;
   }
 }
 

--- a/tests/right-chat-panel.spec.ts
+++ b/tests/right-chat-panel.spec.ts
@@ -210,48 +210,104 @@ test("mobile uses one focus-trapped right drawer and returns focus", async ({ pa
   // The drawer intentionally spans the full viewport width on narrow phones
   // (`.mobile-right-chat-drawer` under `@media (max-width: 480px)`), so on
   // Pixel 5 (393px) and iPhone 13 (390px) it covers the backdrop button at
-  // EVERY coordinate once its slide-in has settled — its own header is what
-  // sits at the top-left pixel.
+  // EVERY coordinate once its slide-in has settled. That made the backdrop a
+  // control no input modality could reach — invisible under the opaque
+  // drawer, un-hittable by pointer, and skipped by the focus trap's
+  // last→first wrap (cave-4snk9). Since then the backdrop is hidden for this
+  // slot and the drawer's own top close strip owns dismissal.
   //
-  // `force: true` does not rescue that, and believing it did is what kept
-  // this line flaky across three CI runs (cave-m1mgi). `force` only skips
-  // the actionability checks; Playwright still delivers a real mouse event
-  // at real viewport coordinates, so the click lands on whatever is topmost
-  // there, not on the located element. Whether that was the backdrop or the
-  // drawer depended on how far `mobile-right-chat-in` (translateX(100%) → 0
-  // over `--duration-base`, 180ms) had advanced at the instant the event was
-  // delivered: a fast round trip caught the drawer still off-screen and
-  // passed, a slow one hit the settled drawer and failed, which is why CI
-  // lost both the first attempt and the in-process retry but passed on a
-  // fresh job. Measured on this viewport with CDP CPU throttling, which is
-  // what a loaded runner looks like: 0/10 failures unthrottled, 7/10 at 2×,
-  // 10/10 at 4× and at 8×. The dispatch below was 0/40 across all four.
-  //
-  // So invoke the backdrop button's own click instead of aiming a pointer at
-  // a pixel this layout never exposes. The assertion below is unchanged —
-  // this is still "the backdrop's close handler dismisses the drawer" — it
-  // just no longer races an animation to ask the question.
+  // The strip is a GENUINE pointer target: `elementFromPoint` at its centre
+  // resolves to it, and a REAL click — no `force`, no `dispatchEvent` —
+  // closes the drawer. `force` would not be a valid escape hatch here
+  // anyway: it only skips Playwright's actionability checks while still
+  // delivering the mouse event at real viewport coordinates, so the click
+  // would land on whatever is actually topmost, not on the located element
+  // (the cave-m1mgi flake was exactly that race with the slide-in).
   await toggle.click();
   await expect(drawer).toBeVisible();
-  const backdrop = page.getByRole("button", { name: "Close drawer" });
+  const closeStrip = drawer.getByRole("button", { name: "Close drawer" });
+  await expect(page.locator(".mobile-drawer-backdrop")).toBeHidden();
+  await expect(closeStrip).toBeVisible();
+  const stripBox = await closeStrip.boundingBox();
+  if (!stripBox) throw new Error("Close strip did not render");
   await expect
-    .poll(
-      () =>
-        page.evaluate(
-          () => !!document.elementFromPoint(2, 2)?.closest("#shell-right-chat-drawer"),
-        ),
-      {
-        message:
-          "the full-width drawer should cover the backdrop at the top-left pixel; if it no longer does, a real pointer click on the backdrop is available again and should replace the dispatch below",
-      },
+    .poll(() =>
+      page.evaluate(
+        ([x, y]) =>
+          !!document.elementFromPoint(x, y)?.closest(".mobile-right-chat-drawer__close"),
+        [Math.round(stripBox.x + stripBox.width / 2), Math.round(stripBox.y + stripBox.height / 2)],
+      ),
     )
     .toBe(true);
-  await backdrop.dispatchEvent("click");
+  await closeStrip.click();
   await expect(drawer).toBeHidden();
-  await expect(backdrop).toHaveCount(0);
+  await expect(page.locator(".mobile-right-chat-drawer__close")).toBeHidden();
   await expect(toggle).toBeFocused();
 
   await toggle.click();
   await drawer.getByRole("button", { name: "Close Chat panel" }).click();
   await expect(drawer).toBeHidden();
+});
+
+test("full-bleed right drawer's close control is reachable by keyboard", async ({ page }, testInfo) => {
+  test.skip(!["pixel-5", "iphone-13"].includes(testInfo.project.name));
+  await boot(page);
+
+  const toggle = page.getByRole("button", { name: "Open Chat panel" });
+  await toggle.click();
+
+  const drawer = page.getByRole("dialog", { name: "Chat panel" });
+  await expect(drawer).toBeVisible();
+
+  // The close strip is the dialog's FIRST focusable, so the trap usually
+  // puts keyboard focus on it the moment the drawer opens. Don't depend on
+  // that landing: Tab through the trapped dialog — the trap wraps last→first,
+  // so a bounded loop visits every focusable, the close strip included — and
+  // prove we reached a real "Close drawer" control, not the phantom backdrop
+  // (which is display:none at this width and cannot be tabbed to at all).
+  for (let i = 0; i < 25; i += 1) {
+    const label = await page.evaluate(() => document.activeElement?.getAttribute("aria-label"));
+    if (label === "Close drawer") break;
+    await page.keyboard.press("Tab");
+  }
+  await expect
+    .poll(() => page.evaluate(() => document.activeElement?.getAttribute("aria-label")))
+    .toBe("Close drawer");
+
+  // Activate the focused close control with the keyboard; focus returns to
+  // the toggle that opened the drawer.
+  await page.keyboard.press("Enter");
+  await expect(drawer).toBeHidden();
+  await expect(toggle).toBeFocused();
+});
+
+test("tablet-width right drawer keeps a genuinely pointer-reachable backdrop", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "tablet");
+  await boot(page);
+
+  const toggle = page.getByRole("button", { name: "Open Chat panel" });
+  await toggle.click();
+
+  const drawer = page.getByRole("dialog", { name: "Chat panel" });
+  await expect(drawer).toBeVisible();
+
+  // At 768px the drawer is capped at min(100vw, 480px), so the backdrop is
+  // exposed along the viewport's left edge — a real pointer target that no
+  // phone project can exercise (pixel-5/iphone-13 are both full-bleed;
+  // cave-4snk9). The full-bleed close strip stays hidden here.
+  const backdrop = page.locator(".mobile-drawer-backdrop");
+  await expect(backdrop).toBeVisible();
+  await expect(page.locator(".mobile-right-chat-drawer__close")).toBeHidden();
+  await expect
+    .poll(() =>
+      page.evaluate(() => !!document.elementFromPoint(2, 2)?.closest(".mobile-drawer-backdrop")),
+    )
+    .toBe(true);
+
+  // A genuine pointer delivery: click at the exposed (2,2) corner — Playwright
+  // hit-tests the real mouse event there — and the drawer closes.
+  await backdrop.click({ position: { x: 2, y: 2 } });
+  await expect(drawer).toBeHidden();
+  await expect(backdrop).toHaveCount(0);
+  await expect(toggle).toBeFocused();
 });


### PR DESCRIPTION
Closes bead **cave-4snk9** — Mobile drawer backdrop is an unreachable control while the full-bleed right Chat drawer is open.

## Scope
P3 a11y bug: at ≤480px the right Chat drawer is width:100vw (z-index 200) and covers the backdrop (z-index 199) at every pixel — the backdrop was a control no input modality could reach (invisible, un-hittable by pointer, and skipped by the focus trap's last→first wrap). The bead also flagged a coverage gap: no Playwright project exercised the right-chat backdrop at a width where the pointer path exists.

## Fix
- **mobile-drawer.tsx** — render a close strip as the dialog's **first child** so it lives *inside* the focus trap (Tab-reachable) and rides the existing slide-in animation with the drawer.
- **shell-responsive.css** — at ≤480px show the strip (a 44px full-width top bar with a grabber pill), push the drawer content below it (padding-top calc) so nothing interactive is covered, and hide the phantom backdrop for this slot. The backdrop is kept for nav/list and for the >480px right-chat case, where it is a real target.
- **playwright.config.ts** — new `tablet` project (iPad Mini 768×1024) so the right-chat backdrop gets genuine pointer-delivery coverage.
- **tests/right-chat-panel.spec.ts** — replace the dispatchEvent workaround with a real pointer click on the close strip at phone widths (pixel-5/iphone-13); new keyboard Tab test proving the close control is reachable; new tablet test proving the backdrop is pointer-reachable at 768px.

## Tests run
- Unit: right-chat-panel.test.ts, shell-edge-rails.test.ts, shell-drawer-smoke.test.ts — pass
- pnpm exec tsc --noEmit — clean
- node scripts/check-tests-wired.mjs — all wired
- Local e2e (chromium): all three right-chat-panel tests pass (phone pointer, keyboard, tablet pointer) — WebKit/iPhone-13 project runs on CI