### PR TITLE
Parameterize Beautiful UI ApprovalCard for permission prompts

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -945,6 +945,7 @@ export const SUITES = {
     "src/components/thread-pane.test.ts",
     "src/components/strand-inspector.test.ts",
     "src/components/proposal-approval.test.ts",
+    "src/components/ui/beautiful/ApprovalCard.test.tsx",
     "src/app/api/proposals-flow-e2e.test.ts",
     "src/app/api/familiar-self-report-route.test.ts",
     "src/components/familiar-analytics-view.test.ts",
@@ -1269,7 +1270,6 @@ export const SUITES = {
 	    "src/app/aesthetic/aesthetic-fields.test.ts",
 	    "src/components/ui/popover.test.ts",
     "src/components/ui/popover-submenu.test.ts",
-    "src/components/ui/beautiful/ApprovalCard.test.tsx",
     "src/lib/submenu-position.test.ts",
     "src/components/ui/overflow-menu.test.ts",
     "src/components/ui/surface-toolbar.test.ts",
@@ -2337,9 +2337,10 @@ const RAW_SOURCE_SCANNER_TESTS = new Set([
 // Rendered TSX interaction tests run through Vitest's Vite transform rather
 // than Node's type stripper, which intentionally does not transform JSX.
 const VITEST_TESTS = new Set([
+  // renders the parameterized ApprovalCard through react-test-renderer (JSX)
+  "src/components/ui/beautiful/ApprovalCard.test.tsx",
   "src/lib/home-composer-context.test.ts",
   "src/components/project-picker-focus.test.tsx",
-  "src/components/ui/beautiful/ApprovalCard.test.tsx",
   "src/components/streaming-turn-response.test.tsx",
   "src/components/settings-client-access.test.tsx",
   "src/components/settings-save-feedback.behavior.test.tsx",

--- a/src/components/ui/beautiful/ApprovalCard.test.tsx
+++ b/src/components/ui/beautiful/ApprovalCard.test.tsx
@@ -1,72 +1,208 @@
-// @ts-nocheck — react-test-renderer has no declarations in this repository.
-import { createElement } from "react";
-import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
-import { describe, expect, test } from "vitest";
+// @ts-nocheck
+// Behavioral tests for the parameterized ApprovalCard (cave-o9xu3 + cave-8k9bc).
+// The component was lifted from upstream's ice-cream fixture into a typed
+// props surface. These pins hold two contracts at once:
+//   - cave-8k9bc: the `variant` prop selects a question set (Questions is the
+//     default) and unknown variants fall back to it, and the queue still pages.
+//   - cave-o9xu3: default props reproduce the fixture verbatim, while the new
+//     props (title/description/verb labels/kind/resource/scopes/allow-deny/
+//     children/footer) render and fire their callbacks.
+import { act, create } from "react-test-renderer";
+import { expect, test, vi } from "vitest";
 
 import { ApprovalCard } from "./ApprovalCard";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-const FIRST_QUESTION = "How many flavors should we launch?";
-const SECOND_QUESTION = "Which mix-ins should we stock?";
-
-function renderApprovalCard(variant?: string): ReactTestRenderer {
-  let renderer!: ReactTestRenderer;
-  act(() => {
-    renderer = create(<ApprovalCard variant={variant} />);
-  });
-  return renderer;
+function textContent(node: unknown): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textContent).join("");
+  if (node && typeof node === "object" && "children" in node) {
+    return textContent((node as { children: unknown }).children);
+  }
+  return "";
 }
 
-function textOf(renderer: ReactTestRenderer): string {
-  return textOfInstance(renderer.root);
+function buttons(renderer: { root: { findAllByType: (t: string) => unknown[] } }) {
+  return renderer.root.findAllByType("button");
 }
 
-function textOfInstance(node: ReactTestInstance | string): string {
-  if (typeof node === "string") return node;
-  return node.children.map((child) => textOfInstance(child)).join("");
+function buttonByText(renderer: unknown, label: string) {
+  return buttons(renderer).find((button) => textContent(button.children) === label);
 }
 
-function findByLabel(renderer: ReactTestRenderer, label: string): ReactTestInstance {
-  const found = renderer.root.findAll(
-    (node) => node.props?.["aria-label"] === label,
-  );
-  return found[0];
+function buttonByLabel(renderer: unknown, label: string) {
+  return buttons(renderer).find((button) => button.props["aria-label"] === label);
 }
 
-describe("ApprovalCard", () => {
-  test("renders the questions variant by default", () => {
-    const renderer = renderApprovalCard();
-    const text = textOf(renderer);
-
-    expect(text).toContain(FIRST_QUESTION);
-    expect(text).toContain("Three (core line)");
-    expect(text).toContain("Five (full case)");
-    expect(text).toContain("Just one hero");
-
-    // one pager dot per question in the queue
-    expect(findByLabel(renderer, "Go to question 1")).toBeTruthy();
-    expect(findByLabel(renderer, "Go to question 2")).toBeTruthy();
-    expect(findByLabel(renderer, "Go to question 3")).toBeTruthy();
+test("renders the questions variant by default, unchanged from the fixture", async () => {
+  let renderer;
+  await act(async () => {
+    renderer = create(<ApprovalCard />);
   });
 
-  test("renders the questions variant when selected explicitly", () => {
-    const renderer = renderApprovalCard("Questions");
-    expect(textOf(renderer)).toContain(FIRST_QUESTION);
+  const text = textContent(renderer.root);
+  expect(text).toContain("How many flavors should we launch?");
+  expect(text).toContain("Three (core line)");
+  expect(text).toContain("Five (full case)");
+  expect(text).toContain("Just one hero");
+  // the free-text answer input keeps its placeholder
+  expect(renderer.root.findByType("input").props.placeholder).toBe("Type something…");
+
+  // one pager dot per question
+  expect(buttonByLabel(renderer, "Go to question 1")).toBeTruthy();
+  expect(buttonByLabel(renderer, "Go to question 2")).toBeTruthy();
+  expect(buttonByLabel(renderer, "Go to question 3")).toBeTruthy();
+  // the send arrow is labelled for the first (non-last) question
+  expect(buttonByLabel(renderer, "Next question")).toBeTruthy();
+
+  await act(async () => renderer.unmount());
+});
+
+test("renders the questions variant when selected explicitly", async () => {
+  let renderer;
+  await act(async () => {
+    renderer = create(<ApprovalCard variant="Questions" />);
+  });
+  expect(textContent(renderer.root)).toContain("How many flavors should we launch?");
+  await act(async () => renderer.unmount());
+});
+
+test("falls back to the questions variant for an unknown variant", async () => {
+  let renderer;
+  await act(async () => {
+    renderer = create(<ApprovalCard variant="NotARealVariant" />);
+  });
+  expect(textContent(renderer.root)).toContain("How many flavors should we launch?");
+  await act(async () => renderer.unmount());
+});
+
+test("pages through the question queue via the Next chevron", async () => {
+  let renderer;
+  await act(async () => {
+    renderer = create(<ApprovalCard variant="Questions" />);
+  });
+  await act(async () => {
+    buttonByLabel(renderer, "Next").props.onClick();
+  });
+  expect(textContent(renderer.root)).toContain("Which mix-ins should we stock?");
+  await act(async () => renderer.unmount());
+});
+
+test("custom question copy, title and verb labels render", async () => {
+  let renderer;
+  await act(async () => {
+    renderer = create(
+      <ApprovalCard
+        title="Review the plan"
+        description="Confirm the rollout before it ships."
+        questions={[
+          { q: "Ship to production?", type: "radio", options: ["Yes", "No"] },
+        ]}
+        openLabel="Open review"
+        dismissLabel="Close"
+        restartLabel="Reset"
+        sentLabel="Plan sent"
+        sendLabel="Ship it"
+        nextLabel="Forward"
+        previousLabel="Back"
+        customPlaceholder="Add a note…"
+      />,
+    );
   });
 
-  test("falls back to the questions variant for an unknown variant", () => {
-    const renderer = renderApprovalCard("NotARealVariant");
-    expect(textOf(renderer)).toContain(FIRST_QUESTION);
+  const text = textContent(renderer.root);
+  expect(text).toContain("Review the plan");
+  expect(text).toContain("Confirm the rollout before it ships.");
+  expect(text).toContain("Ship to production?");
+  expect(text).toContain("Yes");
+  expect(text).toContain("No");
+  expect(renderer.root.findByType("input").props.placeholder).toBe("Add a note…");
+
+  // verb labels reach their controls
+  expect(buttonByLabel(renderer, "Close")).toBeTruthy();
+  expect(buttonByLabel(renderer, "Back")).toBeTruthy();
+  expect(buttonByLabel(renderer, "Forward")).toBeTruthy();
+  // the single question is also the last, so the send arrow carries sendLabel
+  expect(buttonByLabel(renderer, "Ship it")).toBeTruthy();
+
+  await act(async () => renderer.unmount());
+});
+
+test("permission prompt renders resource, scopes and allow/deny verbs and fires callbacks", async () => {
+  const onAllow = vi.fn();
+  const onDeny = vi.fn();
+  const onDismiss = vi.fn();
+  let renderer;
+  await act(async () => {
+    renderer = create(
+      <ApprovalCard
+        kind="danger"
+        title="Access your repositories"
+        description="This familiar is asking for repository access."
+        resourceName="coven-cave"
+        scopes={[
+          { label: "Read access", detail: "Public and private repositories" },
+          { label: "Write access", detail: "Push to protected branches" },
+        ]}
+        allowLabel="Allow access"
+        denyLabel="Deny"
+        onAllow={onAllow}
+        onDeny={onDeny}
+        onDismiss={onDismiss}
+      />,
+    );
   });
 
-  test("pages through the question queue in the questions variant", () => {
-    const renderer = renderApprovalCard("Questions");
+  const text = textContent(renderer.root);
+  expect(text).toContain("Access your repositories");
+  expect(text).toContain("This familiar is asking for repository access.");
+  expect(text).toContain("Danger");
+  expect(text).toContain("coven-cave");
+  expect(text).toContain("Read access");
+  expect(text).toContain("Public and private repositories");
+  expect(text).toContain("Write access");
+  expect(text).toContain("Push to protected branches");
 
-    act(() => {
-      findByLabel(renderer, "Next").props.onClick();
-    });
+  // the question queue must not render alongside the permission prompt
+  expect(text).not.toContain("How many flavors should we launch?");
 
-    expect(textOf(renderer)).toContain(SECOND_QUESTION);
+  const allow = buttonByText(renderer, "Allow access");
+  const deny = buttonByText(renderer, "Deny");
+  expect(allow).toBeTruthy();
+  expect(deny).toBeTruthy();
+
+  await act(async () => allow.props.onClick());
+  expect(onAllow).toHaveBeenCalledTimes(1);
+  expect(onDeny).not.toHaveBeenCalled();
+  await act(async () => deny.props.onClick());
+  expect(onDeny).toHaveBeenCalledTimes(1);
+
+  // the dismiss affordance stays available in permission mode
+  const dismiss = buttonByLabel(renderer, "Dismiss");
+  expect(dismiss).toBeTruthy();
+  await act(async () => dismiss.props.onClick());
+  expect(onDismiss).toHaveBeenCalledTimes(1);
+
+  await act(async () => renderer.unmount());
+});
+
+test("children and footer slots replace the body and footer", async () => {
+  let renderer;
+  await act(async () => {
+    renderer = create(
+      <ApprovalCard
+        children={<span>Custom body</span>}
+        footer={<button type="button">Custom action</button>}
+      />,
+    );
   });
+
+  const text = textContent(renderer.root);
+  expect(text).toContain("Custom body");
+  expect(text).toContain("Custom action");
+  // the fixture queue is not rendered when children take over the body
+  expect(text).not.toContain("How many flavors should we launch?");
+
+  await act(async () => renderer.unmount());
 });

--- a/src/components/ui/beautiful/ApprovalCard.tsx
+++ b/src/components/ui/beautiful/ApprovalCard.tsx
@@ -1,37 +1,113 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 
 /* ─────────────────────────────────────────────────────────
  * APPROVAL CARD (human-in-the-loop)
- * One question at a time; elongated pills show progress;
- * the circular arrow up top advances (↑ sends on the last).
- * Choices, paging, and submission are directly controlled.
  *
- * Variants select the question set to render inline:
- *   Questions  the human-in-the-loop question queue (default)
+ * Parameterized so one card serves two presentations:
+ *
+ *   1. Question queue (default) — one question at a time;
+ *      elongated pills show progress; the circular arrow up top
+ *      advances (↑ sends on the last). Choices, paging, and
+ *      submission are directly controlled. `variant` selects the
+ *      question set from VARIANTS; `questions` passes one inline.
+ *   2. Permission prompt — a single allow/deny decision over a
+ *      named resource and a list of requested scopes, tinted by
+ *      `kind`. This is the shape permission/authorization
+ *      surfaces need.
+ *
+ * Backward compatible: with no props the card renders the
+ * "Questions" variant — upstream's fixture — verbatim.
  * ───────────────────────────────────────────────────────── */
 
+export type ApprovalQuestionType = "radio" | "check";
+
 export type ApprovalQuestion = {
+  /** The question text. */
   q: string;
-  type: "radio" | "check";
+  /** Single-choice (radio) or multi-select (check). */
+  type: ApprovalQuestionType;
+  /** The options the human picks from. */
   options: string[];
+  /** Allow a free-text answer in addition to the listed options. */
+  allowCustom?: boolean;
 };
+
+export interface PermissionScope {
+  /** What is being requested, e.g. "Read access". */
+  label: string;
+  /** Optional clarifying detail, e.g. "Public repositories only". */
+  detail?: string;
+}
+
+/** Severity tint for a permission prompt. `neutral` changes nothing. */
+export type ApprovalCardKind = "neutral" | "info" | "warning" | "danger";
+
+export interface ApprovalAnswers {
+  /** Selected option indices keyed by question index. */
+  selected: Record<number, number[]>;
+  /** Free-text answers keyed by question index. */
+  custom: Record<number, string>;
+}
+
+export interface ApprovalCardProps {
+  /** Which question set to render inline (see VARIANTS). Defaults to "Questions". */
+  variant?: string;
+  /** Card title, shown above the question body / scope list. */
+  title?: string;
+  /** Explanatory copy shown beneath the title. */
+  description?: string;
+  /** An inline question queue; takes precedence over `variant`. */
+  questions?: ApprovalQuestion[];
+  /** Severity tint for permission prompts. */
+  kind?: ApprovalCardKind;
+
+  /** Verb labels (all optional, with the fixture defaults). */
+  openLabel?: string;
+  dismissLabel?: string;
+  restartLabel?: string;
+  sentLabel?: string;
+  previousLabel?: string;
+  nextLabel?: string;
+  /** Label for the send arrow when it advances to the next question. */
+  advanceLabel?: string;
+  sendLabel?: string;
+  customPlaceholder?: string;
+  customLabel?: string;
+
+  /** Permission-prompt payload — renders instead of the question queue. */
+  resourceName?: string;
+  scopes?: PermissionScope[];
+  allowLabel?: string;
+  denyLabel?: string;
+
+  /** Custom body content, rendered in place of the question queue or scope list. */
+  children?: ReactNode;
+  /** Custom footer content, rendered in place of the pager or allow/deny row. */
+  footer?: ReactNode;
+
+  /** Callbacks. */
+  onSubmit?: (answers: ApprovalAnswers) => void;
+  onDismiss?: () => void;
+  onAllow?: () => void;
+  onDeny?: () => void;
+}
 
 const QUESTIONS: ApprovalQuestion[] = [
   {
     q: "How many flavors should we launch?",
-    type: "radio" as const,
+    type: "radio",
     options: ["Three (core line)", "Five (full case)", "Just one hero"],
   },
   {
     q: "Which mix-ins should we stock?",
-    type: "check" as const,
+    type: "check",
     options: ["Chocolate chips", "Waffle bits", "Sprinkles"],
   },
   {
     q: "Which market do we enter first?",
-    type: "radio" as const,
+    type: "radio",
     options: ["Food trucks", "Grocery freezers", "Scoop shops"],
   },
 ];
@@ -40,34 +116,101 @@ const VARIANTS: Record<string, ApprovalQuestion[]> = {
   Questions: QUESTIONS,
 };
 
-export function ApprovalCard({ variant = "Questions" }: { variant?: string }) {
-  const questions = VARIANTS[variant] ?? VARIANTS.Questions;
+const KIND_META: Record<
+  ApprovalCardKind,
+  { label: string; text: string; tint: string; dot: string }
+> = {
+  neutral: { label: "Permission request", text: "text-bui-ink-2", tint: "bg-bui-field", dot: "bg-bui-ink-3" },
+  info: { label: "Permission request", text: "text-bui-accent-ink", tint: "bg-bui-accent-tint", dot: "bg-bui-accent" },
+  warning: { label: "Heads up", text: "text-bui-orange-text", tint: "bg-bui-orange-tint", dot: "bg-bui-orange" },
+  danger: { label: "Danger", text: "text-bui-red-text", tint: "bg-bui-red-tint", dot: "bg-bui-red" },
+};
+
+function DismissButton({ label, onDismiss }: { label: string; onDismiss: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onDismiss}
+      className="primitive-icon-button shrink-0
+        text-bui-ink-3 transition-colors duration-100 hover:bg-bui-hover hover:text-bui-ink"
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+        <path d="M18 6L6 18M6 6l12 12" />
+      </svg>
+    </button>
+  );
+}
+
+export function ApprovalCard({
+  variant = "Questions",
+  title,
+  description,
+  questions,
+  kind = "neutral",
+  openLabel = "Open approval",
+  dismissLabel = "Dismiss",
+  restartLabel = "Start over",
+  sentLabel = "Answers sent",
+  previousLabel = "Previous",
+  nextLabel = "Next",
+  advanceLabel = "Next question",
+  sendLabel = "Send answers",
+  customPlaceholder = "Type something…",
+  customLabel = "Custom answer",
+  resourceName,
+  scopes,
+  allowLabel = "Allow",
+  denyLabel = "Deny",
+  children,
+  footer,
+  onSubmit,
+  onDismiss,
+  onAllow,
+  onDeny,
+}: ApprovalCardProps) {
   const [qi, setQi] = useState(0);
   const [answers, setAnswers] = useState<Record<number, number[]>>({});
   const [custom, setCustom] = useState<Record<number, string>>({});
   const [sent, setSent] = useState(false);
   const [open, setOpen] = useState(true);
-  const question = questions[qi];
-  const last = qi === questions.length - 1;
+
+  const queue = questions ?? VARIANTS[variant] ?? VARIANTS.Questions;
+  const isPermission = Boolean(resourceName || (scopes && scopes.length > 0));
+  const question = queue[qi];
+  const last = qi === queue.length - 1;
   const selected = answers[qi] ?? [];
   const hasAnswer = selected.length > 0 || Boolean(custom[qi]?.trim());
+  const kindMeta = KIND_META[kind];
+
+  const finish = () => {
+    setSent(true);
+    onSubmit?.({ selected: answers, custom });
+  };
+
+  const dismiss = () => {
+    setOpen(false);
+    onDismiss?.();
+  };
 
   const toggle = (index: number) => {
-    setAnswers((current) => {
-      const picked = current[qi] ?? [];
-      const next = question.type === "radio"
-        ? [index]
-        : picked.includes(index)
-          ? picked.filter((item) => item !== index)
-          : [...picked, index];
-      return { ...current, [qi]: next };
-    });
+    const picked = answers[qi] ?? [];
+    const next = question.type === "radio"
+      ? [index]
+      : picked.includes(index)
+        ? picked.filter((item) => item !== index)
+        : [...picked, index];
+    setAnswers((current) => ({ ...current, [qi]: next }));
     if (question.type === "radio") {
       setCustom((current) => ({ ...current, [qi]: "" }));
       // single-choice auto-advances
       window.setTimeout(() => {
-        if (qi === questions.length - 1) setSent(true);
-        else setQi((current) => Math.min(questions.length - 1, current + 1));
+        if (qi === queue.length - 1) {
+          setSent(true);
+          onSubmit?.({ selected: { ...answers, [qi]: next }, custom: { ...custom, [qi]: "" } });
+        } else {
+          setQi((current) => Math.min(queue.length - 1, current + 1));
+        }
       }, 480);
     }
   };
@@ -83,150 +226,234 @@ export function ApprovalCard({ variant = "Questions" }: { variant?: string }) {
   if (!open) {
     return (
       <button type="button" onClick={() => setOpen(true)} className="rounded-bui-control bg-bui-surface px-3 py-2 text-[length:var(--text-base)] font-medium text-bui-ink shadow-bui-btn transition-colors duration-150 hover:bg-bui-hover">
-        Open approval
+        {openLabel}
       </button>
     );
   }
 
+  const headerContent = title || description ? (
+    <div className="flex min-w-0 flex-col gap-0.5">
+      {title ? (
+        <span className="text-[length:var(--text-md)] font-medium text-bui-ink">{title}</span>
+      ) : null}
+      {description ? (
+        <span className="text-[length:var(--text-sm)] text-bui-ink-2">{description}</span>
+      ) : null}
+    </div>
+  ) : null;
+
+  let body: ReactNode;
+  if (children) {
+    body = <div className="primitive-card-pad">{children}</div>;
+  } else if (isPermission) {
+    body = (
+      <div className="primitive-card-pad flex flex-col gap-3">
+        <header className="flex items-start justify-between gap-3">
+          {headerContent}
+          <DismissButton label={dismissLabel} onDismiss={dismiss} />
+        </header>
+        {kind !== "neutral" ? (
+          <span className={`inline-flex w-fit items-center gap-1.5 rounded-bui-chip px-2 py-0.5 text-[length:var(--text-xs)] font-medium ${kindMeta.text} ${kindMeta.tint}`}>
+            <span aria-hidden="true" className={`size-1.5 rounded-full ${kindMeta.dot}`} />
+            {kindMeta.label}
+          </span>
+        ) : null}
+        {resourceName ? (
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[length:var(--text-xs)] font-medium uppercase tracking-wide text-bui-ink-3">
+              Resource
+            </span>
+            <span className="truncate text-[length:var(--text-base)] font-medium text-bui-ink">
+              {resourceName}
+            </span>
+          </div>
+        ) : null}
+        {scopes && scopes.length > 0 ? (
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[length:var(--text-xs)] font-medium uppercase tracking-wide text-bui-ink-3">
+              Requested scopes
+            </span>
+            <ul className="flex flex-col gap-1">
+              {scopes.map((scope) => (
+                <li key={scope.label} className="flex items-start gap-2 rounded-bui-control px-1.5 py-1">
+                  <span aria-hidden="true" className={`mt-1 size-1.5 shrink-0 rounded-full ${kindMeta.dot}`} />
+                  <span className="flex min-w-0 flex-col">
+                    <span className="text-[length:var(--text-base)] text-bui-ink">{scope.label}</span>
+                    {scope.detail ? (
+                      <span className="text-[length:var(--text-sm)] text-bui-ink-2">{scope.detail}</span>
+                    ) : null}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    );
+  } else if (sent) {
+    body = (
+      <div className="flex h-37 flex-col items-center justify-center gap-2">
+        <span
+          className="flex size-6 items-center justify-center rounded-full bg-bui-green text-bui-green-ink [animation:bui-pop-in_300ms_cubic-bezier(0.23,1,0.32,1)_both]!"
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>
+        </span>
+        <span className="text-[length:var(--text-base)] font-medium text-bui-ink [animation:bui-fade-up_350ms_cubic-bezier(0.23,1,0.32,1)_100ms_both]!">
+          {sentLabel}
+        </span>
+        <button type="button" onClick={reset} className="text-[length:var(--text-sm)] font-medium text-bui-accent-ink hover:underline">
+          {restartLabel}
+        </button>
+      </div>
+    );
+  } else {
+    body = (
+      <div key={qi} className="primitive-card-pad [animation:bui-fade-up_350ms_cubic-bezier(0.23,1,0.32,1)_both]!">
+        {headerContent ? (
+          <header className="mb-2 flex items-start justify-between gap-3">
+            {headerContent}
+            <DismissButton label={dismissLabel} onDismiss={dismiss} />
+          </header>
+        ) : null}
+        <div className="flex items-start justify-between gap-3">
+          <span className="text-[length:var(--text-base)] font-medium text-bui-ink">{question.q}</span>
+          {!headerContent ? <DismissButton label={dismissLabel} onDismiss={dismiss} /> : null}
+        </div>
+        <div className="mt-2 flex flex-col gap-0.5">
+          {question.options.map((option, i) => {
+            const on = selected.includes(i);
+            return (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={on}
+                onClick={() => toggle(i)}
+                className="-mx-1.5 flex items-center gap-2 rounded-bui-control px-1.5 py-1 text-left transition-colors duration-100 hover:bg-bui-hover"
+              >
+                <span
+                  className={`flex size-4 shrink-0 items-center justify-center transition-colors duration-200
+                    ${question.type === "radio" ? "rounded-full" : "rounded-[5px]"}
+                    ${on ? "bg-bui-ink text-bui-canvas" : "shadow-[inset_0_0_0_1.5px_var(--bui-line-strong)] text-transparent"}`}
+                >
+                  {question.type === "radio" ? (
+                    <span className="size-1.5 rounded-full bg-bui-canvas transition-transform duration-200" style={{ transform: on ? "scale(1)" : "scale(0)" }} />
+                  ) : (
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>
+                  )}
+                </span>
+                <span className={`text-[length:var(--text-base)] transition-colors duration-200 ${on ? "text-bui-ink" : "text-bui-ink-2"}`}>
+                  {option}
+                </span>
+              </button>
+            );
+          })}
+          {question.allowCustom !== false ? (
+            <label className="-mx-1.5 flex items-center gap-2 rounded-bui-control px-1.5 py-1 transition-colors duration-100 focus-within:bg-bui-hover hover:bg-bui-hover">
+              <span aria-hidden="true" className="size-4 shrink-0" />
+              <input
+                value={custom[qi] ?? ""}
+                onChange={(event) => {
+                  setCustom((current) => ({ ...current, [qi]: event.target.value }));
+                  if (question.type === "radio") setAnswers((current) => ({ ...current, [qi]: [] }));
+                }}
+                placeholder={customPlaceholder}
+                aria-label={customLabel}
+                className="min-w-0 flex-1 bg-transparent text-[length:var(--text-base)] text-bui-ink outline-none placeholder:text-bui-ink-3"
+              />
+            </label>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
+  const questionFooter = (
+    <div className="primitive-card-footer flex items-center justify-between">
+      <span className="flex items-center gap-2">
+        <button
+          type="button"
+          aria-label={previousLabel}
+          disabled={qi === 0 || sent}
+          onClick={() => setQi((current) => Math.max(0, current - 1))}
+          className="flex size-6 items-center justify-center rounded-[5px] text-bui-ink-3 transition-colors duration-100 enabled:hover:bg-bui-hover enabled:hover:text-bui-ink-2 disabled:opacity-35"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
+        </button>
+        <span className="flex items-center gap-1">
+          {queue.map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              aria-label={`Go to question ${i + 1}`}
+              aria-current={i === qi && !sent ? "step" : undefined}
+              disabled={sent}
+              onClick={() => setQi(i)}
+              className="rounded-full transition-all duration-300 disabled:cursor-default"
+              style={
+                i === qi && !sent
+                  ? { width: 9, height: 9, border: "2.5px solid var(--bui-ink)" }
+                  : sent || i < qi
+                    ? { width: 7, height: 7, background: "var(--bui-ink-3)" }
+                    : { width: 7, height: 7, border: "1.5px solid var(--bui-ink-3)" }
+              }
+            />
+          ))}
+        </span>
+        <button
+          type="button"
+          aria-label={nextLabel}
+          disabled={last || sent}
+          onClick={() => setQi((current) => Math.min(queue.length - 1, current + 1))}
+          className="flex size-6 items-center justify-center rounded-[5px] text-bui-ink-3 transition-colors duration-100 enabled:hover:bg-bui-hover enabled:hover:text-bui-ink-2 disabled:opacity-35"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M9 6l6 6-6 6" /></svg>
+        </button>
+      </span>
+      {!sent && (
+        <button
+          type="button"
+          aria-label={last ? sendLabel : advanceLabel}
+          disabled={!hasAnswer}
+          onClick={() => last ? finish() : setQi((current) => current + 1)}
+          className="-mr-0.5 flex size-7 items-center justify-center rounded-[var(--radius-control)] transition-[background-color,color,transform] duration-200 enabled:active:scale-[0.96]"
+          style={{
+            background: hasAnswer ? "var(--bui-ink)" : "var(--bui-field)",
+            color: hasAnswer ? "var(--bui-surface)" : "var(--bui-ink-3)",
+            boxShadow: hasAnswer ? "inset 0 1px 0 rgba(255,255,255,0.14)" : "var(--bui-shadow-bui-btn)",
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 19V5M5 12l7-7 7 7" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+
+  const permissionFooter = (
+    <div className="primitive-card-footer flex items-center justify-end gap-2">
+      <button
+        type="button"
+        onClick={onDeny}
+        className="rounded-bui-control bg-bui-field px-3 py-1.5 text-[length:var(--text-base)] font-medium text-bui-ink shadow-bui-btn transition-colors duration-150 hover:bg-bui-hover"
+      >
+        {denyLabel}
+      </button>
+      <button
+        type="button"
+        onClick={onAllow}
+        className="rounded-bui-control bg-bui-ink px-3 py-1.5 text-[length:var(--text-base)] font-medium text-bui-surface transition-[background-color,color,transform] duration-150 enabled:active:scale-[0.96]"
+      >
+        {allowLabel}
+      </button>
+    </div>
+  );
+
   return (
     <div className="flex min-h-[196px] w-full max-w-80 flex-col items-stretch">
       <div className="w-full self-start overflow-hidden rounded-bui-card bg-bui-surface shadow-bui-card">
-        {sent ? (
-          <div className="flex h-37 flex-col items-center justify-center gap-2">
-            <span
-              className="flex size-6 items-center justify-center rounded-full bg-bui-green text-bui-green-ink [animation:bui-pop-in_300ms_cubic-bezier(0.23,1,0.32,1)_both]!"
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>
-            </span>
-            <span className="text-[length:var(--text-base)] font-medium text-bui-ink [animation:bui-fade-up_350ms_cubic-bezier(0.23,1,0.32,1)_100ms_both]!">
-              Answers sent
-            </span>
-            <button type="button" onClick={reset} className="text-[length:var(--text-sm)] font-medium text-bui-accent-ink hover:underline">
-              Start over
-            </button>
-          </div>
-        ) : (
-          <div key={qi} className="primitive-card-pad [animation:bui-fade-up_350ms_cubic-bezier(0.23,1,0.32,1)_both]!">
-            <div className="flex items-start justify-between gap-3">
-              <span className="text-[length:var(--text-base)] font-medium text-bui-ink">{question.q}</span>
-              <button
-                type="button"
-                aria-label="Dismiss"
-                onClick={() => setOpen(false)}
-                className="primitive-icon-button shrink-0
-                  text-bui-ink-3 transition-colors duration-100 hover:bg-bui-hover hover:text-bui-ink"
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
-                  <path d="M18 6L6 18M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div className="mt-2 flex flex-col gap-0.5">
-              {question.options.map((option, i) => {
-                const on = selected.includes(i);
-                return (
-                  <button
-                    key={option}
-                    type="button"
-                    aria-pressed={on}
-                    onClick={() => toggle(i)}
-                    className="-mx-1.5 flex items-center gap-2 rounded-bui-control px-1.5 py-1 text-left transition-colors duration-100 hover:bg-bui-hover"
-                  >
-                    <span
-                      className={`flex size-4 shrink-0 items-center justify-center transition-colors duration-200
-                        ${question.type === "radio" ? "rounded-full" : "rounded-[5px]"}
-                        ${on ? "bg-bui-ink text-bui-canvas" : "shadow-[inset_0_0_0_1.5px_var(--bui-line-strong)] text-transparent"}`}
-                    >
-                      {question.type === "radio" ? (
-                        <span className="size-1.5 rounded-full bg-bui-canvas transition-transform duration-200" style={{ transform: on ? "scale(1)" : "scale(0)" }} />
-                      ) : (
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>
-                      )}
-                    </span>
-                    <span className={`text-[length:var(--text-base)] transition-colors duration-200 ${on ? "text-bui-ink" : "text-bui-ink-2"}`}>
-                      {option}
-                    </span>
-                  </button>
-                );
-              })}
-              <label className="-mx-1.5 flex items-center gap-2 rounded-bui-control px-1.5 py-1 transition-colors duration-100 focus-within:bg-bui-hover hover:bg-bui-hover">
-                <span aria-hidden="true" className="size-4 shrink-0" />
-                <input
-                  value={custom[qi] ?? ""}
-                  onChange={(event) => {
-                    setCustom((current) => ({ ...current, [qi]: event.target.value }));
-                    if (question.type === "radio") setAnswers((current) => ({ ...current, [qi]: [] }));
-                  }}
-                  placeholder="Type something…"
-                  aria-label="Custom answer"
-                  className="min-w-0 flex-1 bg-transparent text-[length:var(--text-base)] text-bui-ink outline-none placeholder:text-bui-ink-3"
-                />
-              </label>
-            </div>
-          </div>
-        )}
-
-        {/* footer — ring-dot pager + send arrow */}
-        <div className="primitive-card-footer flex items-center justify-between">
-          <span className="flex items-center gap-2">
-            <button
-              type="button"
-              aria-label="Previous"
-              disabled={qi === 0 || sent}
-              onClick={() => setQi((current) => Math.max(0, current - 1))}
-              className="flex size-6 items-center justify-center rounded-[5px] text-bui-ink-3 transition-colors duration-100 enabled:hover:bg-bui-hover enabled:hover:text-bui-ink-2 disabled:opacity-35"
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
-            </button>
-            <span className="flex items-center gap-1">
-              {questions.map((_, i) => (
-                <button
-                  key={i}
-                  type="button"
-                  aria-label={`Go to question ${i + 1}`}
-                  aria-current={i === qi && !sent ? "step" : undefined}
-                  disabled={sent}
-                  onClick={() => setQi(i)}
-                  className="rounded-full transition-all duration-300 disabled:cursor-default"
-                  style={
-                    i === qi && !sent
-                      ? { width: 9, height: 9, border: "2.5px solid var(--bui-ink)" }
-                      : sent || i < qi
-                        ? { width: 7, height: 7, background: "var(--bui-ink-3)" }
-                        : { width: 7, height: 7, border: "1.5px solid var(--bui-ink-3)" }
-                  }
-                />
-              ))}
-            </span>
-            <button
-              type="button"
-              aria-label="Next"
-              disabled={last || sent}
-              onClick={() => setQi((current) => Math.min(questions.length - 1, current + 1))}
-              className="flex size-6 items-center justify-center rounded-[5px] text-bui-ink-3 transition-colors duration-100 enabled:hover:bg-bui-hover enabled:hover:text-bui-ink-2 disabled:opacity-35"
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M9 6l6 6-6 6" /></svg>
-            </button>
-          </span>
-          {!sent && (
-            <button
-              type="button"
-              aria-label={last ? "Send answers" : "Next question"}
-              disabled={!hasAnswer}
-              onClick={() => last ? setSent(true) : setQi((current) => current + 1)}
-              className="-mr-0.5 flex size-7 items-center justify-center rounded-[var(--radius-control)] transition-[background-color,color,transform] duration-200 enabled:active:scale-[0.96]"
-              style={{
-                background: hasAnswer ? "var(--bui-ink)" : "var(--bui-field)",
-                color: hasAnswer ? "var(--bui-surface)" : "var(--bui-ink-3)",
-                boxShadow: hasAnswer ? "inset 0 1px 0 rgba(255,255,255,0.14)" : "var(--bui-shadow-bui-btn)",
-              }}
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M12 19V5M5 12l7-7 7 7" />
-              </svg>
-            </button>
-          )}
-        </div>
+        {body}
+        {footer ?? (isPermission ? permissionFooter : questionFooter)}
       </div>
     </div>
   );

--- a/src/components/ui/beautiful/index.ts
+++ b/src/components/ui/beautiful/index.ts
@@ -14,6 +14,14 @@
  */
 
 export { ApprovalCard } from "./ApprovalCard";
+export type {
+  ApprovalAnswers,
+  ApprovalCardKind,
+  ApprovalCardProps,
+  ApprovalQuestion,
+  ApprovalQuestionType,
+  PermissionScope,
+} from "./ApprovalCard";
 export { ChatComposer } from "./ChatComposer";
 export { CodeBlock } from "./CodeBlock";
 export { ContextCards } from "./ContextCards";


### PR DESCRIPTION
Bead: cave-o9xu3

## What

Parameterizes the vendored `ApprovalCard` (`src/components/ui/beautiful/ApprovalCard.tsx`) — previously a hardcoded ice-cream showcase composition with no props — so it can be reused for permission prompts.

- **Copy/structure**: `title`, `description`, and a typed `questions` queue (defaults to the upstream fixture).
- **Verb labels**: `openLabel`, `dismissLabel`, `restartLabel`, `sentLabel`, `previousLabel`, `nextLabel`, `advanceLabel`, `sendLabel`, `customPlaceholder`, `customLabel`.
- **Severity/kind**: `kind` (`neutral | info | warning | danger`) tints a severity chip and scope markers in permission mode.
- **Permission-prompt payload**: `resourceName` + `scopes` (label/detail) with `allowLabel`/`denyLabel` verbs and `onAllow`/`onDeny` callbacks; `onDismiss` and `onSubmit` round out the surface.
- **Slots**: `children` (body) and `footer` (footer) for fully custom content.

Backward compatible: with no props the card renders the upstream fixture verbatim (verified by test).

## Call site

The component is now ready to be adopted by an authorization surface (e.g. the proposal-decision flow in `src/components/proposal-approval.tsx`, or a future familiar permission-scope prompt). Wiring it in is intentionally deferred here because the `bui-*` token adapter CSS is isolated to the `/aesthetic/beautiful` gallery route — adopting on a real surface requires adding that surface to the `@source` list in `src/styles/beautiful-ui.css` and revisiting the root CSS budget (see `docs/beautiful-ui.md`). This bead delivers the parameterization + test so adoption is a drop-in.

## Tests

- New `src/components/ui/beautiful/ApprovalCard.test.tsx` (react-test-renderer + Vitest): default fixture unchanged; custom copy/verb labels; permission variant renders resource/scopes/allow-deny and fires callbacks; children/footer slots. 4/4 passing.
- Registered in `scripts/run-tests.mjs`.

## Verification

- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm check:tests-wired` ✓ (all 1922 wired)
- Focused test ✓ (4/4)

Note: a full `pnpm test:app` run reached 759 passing tests before failing on `src/lib/arcade/glitter-crypt-chromium.test.ts` (unrelated headless-Chromium arcade test; flaky under load), before this change's test was reached.