### PR TITLE
Add questions variant to the inline approve marker (ApprovalCard)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1268,6 +1268,7 @@ export const SUITES = {
 	    "src/app/aesthetic/aesthetic-fields.test.ts",
 	    "src/components/ui/popover.test.ts",
     "src/components/ui/popover-submenu.test.ts",
+    "src/components/ui/beautiful/ApprovalCard.test.tsx",
     "src/lib/submenu-position.test.ts",
     "src/components/ui/overflow-menu.test.ts",
     "src/components/ui/surface-toolbar.test.ts",
@@ -2334,6 +2335,7 @@ const RAW_SOURCE_SCANNER_TESTS = new Set([
 const VITEST_TESTS = new Set([
   "src/lib/home-composer-context.test.ts",
   "src/components/project-picker-focus.test.tsx",
+  "src/components/ui/beautiful/ApprovalCard.test.tsx",
   "src/components/streaming-turn-response.test.tsx",
   "src/components/settings-client-access.test.tsx",
   "src/components/settings-save-feedback.behavior.test.tsx",

--- a/src/app/aesthetic/beautiful/page.tsx
+++ b/src/app/aesthetic/beautiful/page.tsx
@@ -82,8 +82,8 @@ const ENTRIES: Entry[] = [
   {
     id: "approval-card",
     name: "Approval card",
-    note: "A permission/approval prompt with a question queue.",
-    render: () => <ApprovalCard />,
+    note: "A permission/approval prompt with a question queue. Questions variant.",
+    render: () => <ApprovalCard variant="Questions" />,
   },
   {
     id: "tool-chips",

--- a/src/components/ui/beautiful/ApprovalCard.test.tsx
+++ b/src/components/ui/beautiful/ApprovalCard.test.tsx
@@ -1,0 +1,72 @@
+// @ts-nocheck — react-test-renderer has no declarations in this repository.
+import { createElement } from "react";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { describe, expect, test } from "vitest";
+
+import { ApprovalCard } from "./ApprovalCard";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const FIRST_QUESTION = "How many flavors should we launch?";
+const SECOND_QUESTION = "Which mix-ins should we stock?";
+
+function renderApprovalCard(variant?: string): ReactTestRenderer {
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(<ApprovalCard variant={variant} />);
+  });
+  return renderer;
+}
+
+function textOf(renderer: ReactTestRenderer): string {
+  return textOfInstance(renderer.root);
+}
+
+function textOfInstance(node: ReactTestInstance | string): string {
+  if (typeof node === "string") return node;
+  return node.children.map((child) => textOfInstance(child)).join("");
+}
+
+function findByLabel(renderer: ReactTestRenderer, label: string): ReactTestInstance {
+  const found = renderer.root.findAll(
+    (node) => node.props?.["aria-label"] === label,
+  );
+  return found[0];
+}
+
+describe("ApprovalCard", () => {
+  test("renders the questions variant by default", () => {
+    const renderer = renderApprovalCard();
+    const text = textOf(renderer);
+
+    expect(text).toContain(FIRST_QUESTION);
+    expect(text).toContain("Three (core line)");
+    expect(text).toContain("Five (full case)");
+    expect(text).toContain("Just one hero");
+
+    // one pager dot per question in the queue
+    expect(findByLabel(renderer, "Go to question 1")).toBeTruthy();
+    expect(findByLabel(renderer, "Go to question 2")).toBeTruthy();
+    expect(findByLabel(renderer, "Go to question 3")).toBeTruthy();
+  });
+
+  test("renders the questions variant when selected explicitly", () => {
+    const renderer = renderApprovalCard("Questions");
+    expect(textOf(renderer)).toContain(FIRST_QUESTION);
+  });
+
+  test("falls back to the questions variant for an unknown variant", () => {
+    const renderer = renderApprovalCard("NotARealVariant");
+    expect(textOf(renderer)).toContain(FIRST_QUESTION);
+  });
+
+  test("pages through the question queue in the questions variant", () => {
+    const renderer = renderApprovalCard("Questions");
+
+    act(() => {
+      findByLabel(renderer, "Next").props.onClick();
+    });
+
+    expect(textOf(renderer)).toContain(SECOND_QUESTION);
+  });
+});

--- a/src/components/ui/beautiful/ApprovalCard.tsx
+++ b/src/components/ui/beautiful/ApprovalCard.tsx
@@ -7,9 +7,18 @@ import { useState } from "react";
  * One question at a time; elongated pills show progress;
  * the circular arrow up top advances (↑ sends on the last).
  * Choices, paging, and submission are directly controlled.
+ *
+ * Variants select the question set to render inline:
+ *   Questions  the human-in-the-loop question queue (default)
  * ───────────────────────────────────────────────────────── */
 
-const QUESTIONS = [
+export type ApprovalQuestion = {
+  q: string;
+  type: "radio" | "check";
+  options: string[];
+};
+
+const QUESTIONS: ApprovalQuestion[] = [
   {
     q: "How many flavors should we launch?",
     type: "radio" as const,
@@ -27,14 +36,19 @@ const QUESTIONS = [
   },
 ];
 
-export function ApprovalCard() {
+const VARIANTS: Record<string, ApprovalQuestion[]> = {
+  Questions: QUESTIONS,
+};
+
+export function ApprovalCard({ variant = "Questions" }: { variant?: string }) {
+  const questions = VARIANTS[variant] ?? VARIANTS.Questions;
   const [qi, setQi] = useState(0);
   const [answers, setAnswers] = useState<Record<number, number[]>>({});
   const [custom, setCustom] = useState<Record<number, string>>({});
   const [sent, setSent] = useState(false);
   const [open, setOpen] = useState(true);
-  const question = QUESTIONS[qi];
-  const last = qi === QUESTIONS.length - 1;
+  const question = questions[qi];
+  const last = qi === questions.length - 1;
   const selected = answers[qi] ?? [];
   const hasAnswer = selected.length > 0 || Boolean(custom[qi]?.trim());
 
@@ -52,8 +66,8 @@ export function ApprovalCard() {
       setCustom((current) => ({ ...current, [qi]: "" }));
       // single-choice auto-advances
       window.setTimeout(() => {
-        if (qi === QUESTIONS.length - 1) setSent(true);
-        else setQi((current) => Math.min(QUESTIONS.length - 1, current + 1));
+        if (qi === questions.length - 1) setSent(true);
+        else setQi((current) => Math.min(questions.length - 1, current + 1));
       }, 480);
     }
   };
@@ -165,7 +179,7 @@ export function ApprovalCard() {
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
             </button>
             <span className="flex items-center gap-1">
-              {QUESTIONS.map((_, i) => (
+              {questions.map((_, i) => (
                 <button
                   key={i}
                   type="button"
@@ -188,7 +202,7 @@ export function ApprovalCard() {
               type="button"
               aria-label="Next"
               disabled={last || sent}
-              onClick={() => setQi((current) => Math.min(QUESTIONS.length - 1, current + 1))}
+              onClick={() => setQi((current) => Math.min(questions.length - 1, current + 1))}
               className="flex size-6 items-center justify-center rounded-[5px] text-bui-ink-3 transition-colors duration-100 enabled:hover:bg-bui-hover enabled:hover:text-bui-ink-2 disabled:opacity-35"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M9 6l6 6-6 6" /></svg>


### PR DESCRIPTION
Bead: cave-8k9bc — "Inline approve marker: questions variant".

## What

Adds a `variant` prop to the vendored `ApprovalCard` (the human-in-the-loop approval affordance in `src/components/ui/beautiful/`), following the existing variant pattern used by `ThinkingState` / `TaskRows` / `LoadingState` / `PromptBar`.

- New `Questions` variant renders the question queue inline (the existing behavior, now selected explicitly). It is the default, so `<ApprovalCard />` is unchanged.
- Lifts the question fixture into an exported `ApprovalQuestion` type and a `VARIANTS` lookup, with graceful fallback to `Questions` for unknown variants (same contract as the sibling components).
- The `/aesthetic/beautiful` gallery now renders the variant explicitly.

## Why

The bead asks for a "questions" variant of the inline approve marker. This parameterizes the approval card's question set through a `variant` string so a surface can request the question-queue rendering inline, and keeps the door open for further variants without refactoring unrelated code.

## Tests

- Added `src/components/ui/beautiful/ApprovalCard.test.tsx` (4 cases: default variant, explicit `Questions`, unknown-variant fallback, paging through the queue) and wired it into `scripts/run-tests.mjs` (`app` suite + `VITEST_TESTS`).

## Verification

- `pnpm test:app` — 1360 test files passed
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm check:tests-wired` — all 1922 test files wired

No `.github/workflows` changes.