### PR TITLE
Keep Cave runtime alive until the last main window closes (cave-4hhna)

### DIFF
--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -413,8 +413,8 @@ test("Windows native close remains authoritative when the WebView is unresponsiv
 
   assert.match(
     launcher,
-    /#\[cfg\(target_os = "windows"\)\][\s\S]*WindowEvent::CloseRequested[\s\S]*window\.label\(\) == PRIMARY_MAIN_WINDOW_LABEL[\s\S]*shutdown_owned_processes\(window\.app_handle\(\)\)[\s\S]*window\.app_handle\(\)\.exit\(0\)/,
-    "the Windows title-bar close must exit natively without waiting for a wedged JS close listener",
+    /#\[cfg\(target_os = "windows"\)\][\s\S]*WindowEvent::CloseRequested[\s\S]*window\.label\(\) == PRIMARY_MAIN_WINDOW_LABEL[\s\S]*live_main_window_count\(\) <= 1[\s\S]*shutdown_owned_processes\(window\.app_handle\(\)\)[\s\S]*window\.app_handle\(\)\.exit\(0\)/,
+    "the Windows title-bar close must exit natively without waiting for a wedged JS close listener, but only when the primary is the last live main window",
   );
   assert.match(
     launcher,
@@ -882,8 +882,8 @@ test("macOS tray exposes quick chat as a separate floating window", async () => 
   );
   assert.match(
     launcher,
-    /if window\.label\(\) == PRIMARY_MAIN_WINDOW_LABEL[\s\S]*try_state::<SidecarState>/,
-    "closing the quick chat window must not stop the desktop sidecar",
+    /if main_webview_windows\(window\.app_handle\(\)\)\.is_empty\(\)[\s\S]*try_state::<SidecarState>/,
+    "the desktop sidecar must be stopped only once no live main window remains (quick chat is not a main window)",
   );
 });
 

--- a/src-tauri/src/main_window.rs
+++ b/src-tauri/src/main_window.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use tauri::{AppHandle, Manager, WebviewWindow};
@@ -35,6 +36,22 @@ struct MainWindowRegistryInner {
 
 #[derive(Default)]
 pub(super) struct MainWindowRegistry(Mutex<MainWindowRegistryInner>);
+
+/// Process-wide count of live main windows (registered and not yet destroyed).
+///
+/// Mirrors `MainWindowRegistryInner::labels` but is a lock-free atomic so the
+/// Windows native-close subclass — which must not lock, log, allocate, spawn,
+/// or enter Tauri — can decide whether closing the primary main window should
+/// tear down the whole Cave runtime or just that one window. The registry
+/// keeps the count in step with `labels` on every desktop platform.
+static LIVE_MAIN_WINDOW_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Lock-free count of live main windows, safe to read from the Win32
+/// window-proc subclass that cannot touch the registry's `Mutex`.
+#[cfg(target_os = "windows")]
+pub(super) fn live_main_window_count() -> usize {
+    LIVE_MAIN_WINDOW_COUNT.load(Ordering::SeqCst)
+}
 
 pub(super) fn is_main_window_label(label: &str) -> bool {
     if label == PRIMARY_MAIN_WINDOW_LABEL {
@@ -75,6 +92,7 @@ impl MainWindowRegistry {
             ));
         }
         if inner.labels.insert(label.to_string()) {
+            LIVE_MAIN_WINDOW_COUNT.fetch_add(1, Ordering::SeqCst);
             inner.next_generation = inner
                 .next_generation
                 .checked_add(1)
@@ -109,7 +127,9 @@ impl MainWindowRegistry {
 
     pub(super) fn remove(&self, label: &str) -> Option<u64> {
         if let Ok(mut inner) = self.0.lock() {
-            inner.labels.remove(label);
+            if inner.labels.remove(label) {
+                LIVE_MAIN_WINDOW_COUNT.fetch_sub(1, Ordering::SeqCst);
+            }
             let generation = inner.generations.remove(label);
             if generation.is_some() {
                 inner.retired_labels.insert(label.to_string());
@@ -292,5 +312,27 @@ mod tests {
         assert!(error.contains("cannot be reused"));
         assert_eq!(registry.generation("main-2"), None);
         assert!(first_generation > 0);
+    }
+
+    #[test]
+    fn closing_a_non_last_main_window_keeps_the_rest_registered() {
+        let registry = MainWindowRegistry::default();
+        registry.register("main").expect("register primary");
+        registry.register("main-2").expect("register secondary");
+
+        // Closing the primary window while a secondary remains open must not
+        // retire the secondary: the Cave runtime still has a window to serve.
+        registry.remove("main");
+        assert!(
+            registry.is_registered("main-2"),
+            "the still-open secondary window must survive the primary closing"
+        );
+        assert!(!registry.is_registered("main"));
+
+        // Closing the final window empties the registry — the signal the
+        // destruction teardown uses to stop the sidecar and supervisor.
+        registry.remove("main-2");
+        assert!(!registry.is_registered("main"));
+        assert!(!registry.is_registered("main-2"));
     }
 }

--- a/src-tauri/src/platform_lifecycle.rs
+++ b/src-tauri/src/platform_lifecycle.rs
@@ -363,13 +363,21 @@ unsafe extern "system" fn windows_main_close_subclass(
     reference_data: usize,
 ) -> LRESULT {
     if is_windows_main_close_message(message, wparam) {
-        if !signal_windows_main_close(reference_data as HANDLE) {
-            terminate_current_process_now();
+        // Closing the primary main window force-quits only when it is the last
+        // live main window. With secondary main windows still open, pass the
+        // message through so Tauri closes just this window and the Cave
+        // runtime keeps serving the rest. `live_main_window_count` is a
+        // lock-free atomic: this callback must not lock, log, allocate, spawn,
+        // or enter Tauri.
+        if crate::main_window::live_main_window_count() <= 1 {
+            if !signal_windows_main_close(reference_data as HANDLE) {
+                terminate_current_process_now();
+            }
+            // Consume the native close here so neither a JavaScript listener nor a
+            // nested WRY message pump can defer it. The pre-spawned cleanup waiter
+            // owns graceful app.exit; the hard waiter owns the deadline.
+            return 0;
         }
-        // Consume the native close here so neither a JavaScript listener nor a
-        // nested WRY message pump can defer it. The pre-spawned cleanup waiter
-        // owns graceful app.exit; the hard waiter owns the deadline.
-        return 0;
     }
 
     if message == WM_NCDESTROY {

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -889,9 +889,15 @@ pub fn run() {
             if matches!(event, tauri::WindowEvent::CloseRequested { .. })
                 && window.label() == PRIMARY_MAIN_WINDOW_LABEL
             {
-                shutdown_owned_processes(window.app_handle());
-                window.app_handle().exit(0);
-                return;
+                // Closing the primary main window quits only when it is the
+                // last live main window. With secondary main windows still
+                // open, let this window close on its own so the sidecar and
+                // supervisor keep serving the windows that remain.
+                if live_main_window_count() <= 1 {
+                    shutdown_owned_processes(window.app_handle());
+                    window.app_handle().exit(0);
+                    return;
+                }
             }
 
             if let tauri::WindowEvent::Destroyed = event {
@@ -903,7 +909,12 @@ pub fn run() {
                     pty::retire_window_sessions(window.label(), generation);
                     browser::retire_window_resources(window.app_handle(), window.label());
                 }
-                if window.label() == PRIMARY_MAIN_WINDOW_LABEL {
+                // Tear down the Cave runtime only once no live main window
+                // remains. Closing the primary (or any secondary) window while
+                // another main window is still open must leave the sidecar and
+                // supervisor running for the windows that remain; the final
+                // close stops them and hands off to the background daemon.
+                if main_webview_windows(window.app_handle()).is_empty() {
                     // Before the stop, never after: the supervisor polls every
                     // couple of seconds, and a flag set afterwards races it
                     // into respawning the sidecar we are deliberately killing.


### PR DESCRIPTION
Bead: cave-4hhna — "Keep Cave runtime alive until the last main window closes".

## Problem

The desktop shell stops its companion processes (the sidecar Node runtime and its supervisor) when the **primary** main window is destroyed, keyed on `window.label() == PRIMARY_MAIN_WINDOW_LABEL`. With the multi-window identity work from #4956 in place, a primary window close while a secondary `main-*` window is still open tears the runtime out from under the surviving windows — and on Windows, closing the primary force-quits the whole process regardless of remaining windows.

## Change

- **`src-tauri/src/main_window.rs`** — add a lock-free `LIVE_MAIN_WINDOW_COUNT` atomic maintained in step with the registry (`register`/`remove`), plus a `live_main_window_count()` reader safe to call from the Win32 close subclass (which must not lock, log, allocate, spawn, or enter Tauri). Added a unit test covering the "closing a non-last main window keeps the rest registered" contract.
- **`src-tauri/src/tauri_setup.rs`** — the `WindowEvent::Destroyed` teardown (stop supervisor, stop sidecar, hand off to the background daemon) now runs only once `main_webview_windows(app).is_empty()` — i.e. after the **final** live main window closes. The Windows `CloseRequested` quit is gated on `live_main_window_count() <= 1`.
- **`src-tauri/src/platform_lifecycle.rs`** — the raw main-HWND close subclass passes `WM_CLOSE`/`SC_CLOSE` through to Tauri when secondary main windows remain, so closing the primary closes just that window instead of force-quitting the process.
- **`src-tauri/release-runtime.test.mjs`** — updated the two pinned contracts to assert the last-window gating.

## Verification

- `cargo check` in `src-tauri`: green.
- `cargo test --lib`: 231 passed, 0 failed (includes the new `main_window` test).
- `node --test src-tauri/release-runtime.test.mjs`: 25 passed.
- `node --test src-tauri/permissions/desktop-permissions.test.mjs`: 18 passed.

## Manual verification (not exercised by CI)

The Windows native-close subclass and the multi-window close path are `#[cfg(target_os = "windows")]` and are not compiled on the Linux CI runner (see the note in `platform_lifecycle.rs`). On a Windows build:

1. Launch the app and open a secondary main window (`main-*`).
2. Click the title-bar × on the primary window → the primary closes, the secondary stays up, and the sidecar/supervisor keep serving it (tray → Quick Chat still resolves the ready sidecar).
3. Close the final remaining main window → the sidecar and supervisor are stopped and handed off to the background daemon, then the process exits cleanly.