### PR TITLE
Patrol surfaces stale worktree locks distinctly from live ones (cave-eg1ag)

### DIFF
--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -141,6 +141,11 @@ type WorktreeEntry = {
   ref: string | null;
   branch: string | null;
   refError: string | null;
+  /**
+   * The worktree's lock reason from `git worktree list --porcelain -z`.
+   * `null` = not locked; `""` = locked with no reason recorded.
+   */
+  lockReason: string | null;
 };
 
 type LocalBranchRef = {
@@ -536,7 +541,15 @@ function parseWorktrees(raw: string): WorktreeEntry[] {
       const worktreeFields = fields.filter((field) => field.startsWith("worktree "));
       const headFields = fields.filter((field) => field.startsWith("HEAD "));
       const branchFields = fields.filter((field) => field.startsWith("branch "));
-      if (worktreeFields.length !== 1 || headFields.length !== 1 || branchFields.length > 1) {
+      const lockFields = fields.filter(
+        (field) => field === "locked" || field.startsWith("locked "),
+      );
+      if (
+        worktreeFields.length !== 1 ||
+        headFields.length !== 1 ||
+        branchFields.length > 1 ||
+        lockFields.length > 1
+      ) {
         throw new Error("malformed git worktree inventory");
       }
       const worktreePath = worktreeFields[0]!.slice("worktree ".length);
@@ -545,6 +558,9 @@ function parseWorktrees(raw: string): WorktreeEntry[] {
       if (normalizedWorktreePath === null || !OID.test(head)) {
         throw new Error("malformed git worktree inventory");
       }
+      const lockField = lockFields[0] ?? null;
+      const lockReason =
+        lockField === null ? null : lockField === "locked" ? "" : lockField.slice("locked ".length);
       const ref = branchFields[0]?.slice("branch ".length) ?? null;
       if (ref === null) {
         return {
@@ -554,6 +570,7 @@ function parseWorktrees(raw: string): WorktreeEntry[] {
           ref: null,
           branch: null,
           refError: null,
+          lockReason,
         };
       }
       const match = ref.match(/^refs\/heads\/(.+)$/);
@@ -564,6 +581,7 @@ function parseWorktrees(raw: string): WorktreeEntry[] {
           ref,
           branch: null,
           refError: `worktree ref is not a direct refs/heads ref: ${ref}`,
+          lockReason,
         };
       }
       return {
@@ -572,6 +590,7 @@ function parseWorktrees(raw: string): WorktreeEntry[] {
         ref,
         branch: match[1],
         refError: null,
+        lockReason,
       };
     });
 }
@@ -3338,6 +3357,7 @@ function collectInventory(
       ref: entry.ref,
       branch: entry.branch,
       head: entry.head,
+      lockReason: entry.lockReason,
       initialErrors: [
         entry.refError,
         entry.ref && !localRefByName.has(entry.ref)
@@ -3365,6 +3385,7 @@ function collectInventory(
         ref: localRef.ref,
         branch: localRef.branch,
         head: localRef.oid,
+        lockReason: null,
         initialErrors: [] as string[],
       })),
   ];
@@ -3613,6 +3634,7 @@ function collectInventory(
       ref: unit.ref,
       branch: unit.branch,
       head: unit.head,
+      lockReason: unit.lockReason,
       isPrimary: unit.path !== null && normalizePath(unit.path) === primaryPath,
       protectedBranch:
         unit.branch !== null &&

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -5896,6 +5896,57 @@ exit 0
       "a worktree registered mid-run is out of scope for this report",
     );
   }
+
+  // cave-eg1ag: the read-only patrol surfaces each locked unit's lock reason
+  // alongside its live cleanliness/retention verdict — so a lock contradicted
+  // by current state (clean + retained, yet held by "active … PR completion")
+  // is visible at a glance. It never releases a lock the hook did not write:
+  // it only names it. feat/old is clean/landed (retire-after-gate), feat/live
+  // is dirty (active); both get a foreign reason the hook cannot evaluate.
+  {
+    const foreignReason = "active cave-1c8zf PR completion";
+    git(["worktree", "lock", "--reason", foreignReason, old], repo);
+    git(["worktree", "lock", "--reason", foreignReason, live], repo);
+    try {
+      const lockedReport = JSON.parse(patrol(["--json"]));
+      const lockedOld = lockedReport.items.find((item) => item.branch === "feat/old");
+      const lockedLive = lockedReport.items.find((item) => item.branch === "feat/live");
+      assert.equal(
+        lockedOld.lane,
+        "retire-after-gate",
+        "a lock never changes the live cleanliness/retention verdict",
+      );
+      assert.equal(
+        lockedOld.lockReason,
+        foreignReason,
+        "a clean/retained locked unit carries its lock reason into the report",
+      );
+      assert.equal(
+        lockedLive.lane,
+        "active",
+        "a dirty unit stays active under a lock, exactly as when unlocked",
+      );
+      assert.equal(
+        lockedLive.lockReason,
+        foreignReason,
+        "a dirty locked unit carries its lock reason into the report",
+      );
+
+      const humanReport = patrol();
+      assert.match(
+        humanReport,
+        /worktree locked: active cave-1c8zf PR completion/,
+        "the human report names the lock reason verbatim",
+      );
+      // The stale-lock signal is the juxtaposition: the clean unit still says
+      // "clean landed work is at least 15 minutes old" while naming a lock that
+      // claims live work. Both facts appear for the same unit.
+      assert.match(humanReport, /clean landed work is at least 15 minutes old/);
+    } finally {
+      git(["worktree", "unlock", old], repo);
+      git(["worktree", "unlock", live], repo);
+    }
+  }
 } finally {
   if (existsSync(registeredDrift)) {
     git(["worktree", "remove", registeredDrift], repo);

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -1368,3 +1368,110 @@ console.log("worktree-lifecycle.test.ts: ok");
     "unknown recency is refused, never overridden — the clock cannot answer it",
   );
 }
+
+// ── cave-eg1ag: the patrol surfaces a lock reason alongside the live verdict ──
+// A lock is a point-in-time claim the classifier cannot evaluate, so it never
+// changes the lane. What changes is the report: it names the lock reason next
+// to the unit's cleanliness/retention verdict, so a lock contradicted by
+// current state (clean + retained, yet held by "active … PR completion") is
+// visible at a glance instead of forcing an operator to diff lock reasons
+// against merged PRs by hand.
+{
+  const budgets = {
+    worktrees: { count: 4, registered: 4, detached: 0, warning: 28, exceeded: false },
+    branches: { count: 4, warning: 38, exceeded: false },
+    exceptions: { active: 0, expired: 0 },
+  };
+  const foreignReason = "active cave-1c8zf PR completion";
+  const staleAutoLock =
+    "auto-locked 2026-08-14: 1 commit not on any remote — a removal would lose this";
+
+  // Clean + retained: the live verdict says "retire-after-gate", yet the lock
+  // reason claims live work. That contradiction is the stale-lock signal.
+  const lockedClean = classifyLifecycleUnit(
+    observation({
+      branch: "feat/clean",
+      ref: "refs/heads/feat/clean",
+      headOnDefaultBranch: true,
+      updatedAtMs: NOW - 2 * DAY,
+      lockReason: foreignReason,
+    }),
+    NOW,
+  );
+  assert.equal(lockedClean.lane, "retire-after-gate");
+  // The lock must not reclassify the unit: a stale lock is still, in git's
+  // eyes, a clean landed unit — that is what makes it visible as stale.
+  assert.ok(
+    lockedClean.reasons.join("\n").includes("clean landed work"),
+    "the lock does not disturb the live cleanliness/retention verdict",
+  );
+
+  // Dirty: the live verdict says "active", so the lock's risk may still hold.
+  const lockedDirty = classifyLifecycleUnit(
+    observation({
+      branch: "feat/dirty",
+      ref: "refs/heads/feat/dirty",
+      changes: ["? src/live.ts"],
+      lockReason: foreignReason,
+    }),
+    NOW,
+  );
+  assert.equal(lockedDirty.lane, "active");
+
+  // Hook-written auto-lock on clean/retained work: also surfaced, and the
+  // reason self-identifies as machine-generated.
+  const lockedAuto = classifyLifecycleUnit(
+    observation({
+      branch: "feat/auto",
+      ref: "refs/heads/feat/auto",
+      headOnDefaultBranch: true,
+      updatedAtMs: NOW - 2 * DAY,
+      lockReason: staleAutoLock,
+    }),
+    NOW,
+  );
+  assert.equal(lockedAuto.lane, "retire-after-gate");
+
+  const bareLock = classifyLifecycleUnit(
+    observation({
+      branch: "feat/bare",
+      ref: "refs/heads/feat/bare",
+      headOnDefaultBranch: true,
+      updatedAtMs: NOW - 2 * DAY,
+      lockReason: "",
+    }),
+    NOW,
+  );
+
+  const text = renderWorktreeLifecycleReport(
+    summarizeWorktreeLifecycle([lockedClean, lockedDirty, lockedAuto, bareLock], budgets),
+  );
+  assert.match(text, /worktree locked: active cave-1c8zf PR completion/);
+  assert.equal(
+    text.split("worktree locked: active cave-1c8zf PR completion").length - 1,
+    2,
+    "each locked unit names its own lock reason, not one shared echo",
+  );
+  assert.match(text, /worktree locked: auto-locked 2026-08-14/);
+  assert.match(text, /worktree locked: \(no reason recorded\)/);
+
+  // The lock line sits on the same unit as the verdict that contradicts it, so
+  // the juxtaposition is what a reader sees at a glance — not two detached
+  // facts. The clean unit's block must contain both the "clean landed work"
+  // reason and the foreign lock reason.
+  const cleanStart = text.indexOf("- feat/clean");
+  const cleanEnd = text.indexOf("\n\n", cleanStart);
+  const cleanBlock = text.slice(cleanStart, cleanEnd === -1 ? undefined : cleanEnd);
+  assert.match(cleanBlock, /worktree locked: active cave-1c8zf PR completion/);
+  assert.match(cleanBlock, /clean landed work is at least 15 minutes old/);
+
+  // An unlocked unit gains no lock line at all.
+  const unlocked = classifyLifecycleUnit(
+    observation({ headOnDefaultBranch: true, updatedAtMs: NOW - 2 * DAY }),
+    NOW,
+  );
+  const unlockedText = renderWorktreeLifecycleReport(
+    summarizeWorktreeLifecycle([unlocked], budgets),
+  );
+  assert.doesNotMatch(unlockedText, /worktree locked/);
+}

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -140,6 +140,23 @@ export type WorktreeLifecycleObservation = {
   metadataGlobalErrors: string[];
   remoteRef: WorktreeRemoteRef | null;
   sessionIds: string[];
+  /**
+   * The worktree's lock reason, exactly as `git worktree list --porcelain`
+   * reports it. `null` means the worktree is not locked; an empty string means
+   * it is locked with no reason recorded.
+   *
+   * Deliberately NOT a classification input. A lock is a point-in-time claim
+   * the classifier cannot evaluate — a foreign reason like "active cave-1c8zf
+   * PR completion" says nothing about dirtiness or retention — so it never
+   * changes the lane. It is surfaced in the report alongside the unit's live
+   * cleanliness/retention verdict, so a lock contradicted by current state is
+   * visible at a glance instead of forcing an operator to diff lock reasons
+   * against merged PRs by hand (cave-eg1ag).
+   *
+   * Optional so legacy callers that never populate it keep their old behaviour;
+   * absent reads as "not locked".
+   */
+  lockReason?: string | null;
 };
 
 type LegacyWorktreeObservation = Pick<
@@ -183,6 +200,9 @@ type WorktreeObservationCompatibilityFields = Partial<
     // Optional because only a platform with a directory-hold probe can answer
     // it; absent reads as "no such evidence", never as "proven free".
     | "directoryHeldOpen"
+    // Optional so legacy observations that predate lock surfacing still parse;
+    // absent reads as "not locked".
+    | "lockReason"
   >
 >;
 
@@ -948,6 +968,7 @@ function normalizeWorktreeObservation(
       metadataGlobalErrors: observation.metadataGlobalErrors ?? [],
       remoteRef: observation.remoteRef ?? null,
       sessionIds: observation.sessionIds ?? [],
+      lockReason: observation.lockReason ?? null,
     },
   };
 }
@@ -1148,6 +1169,16 @@ export function renderWorktreeLifecycleReport(
       const location = item.kind === "branch-only" || !item.path ? "" : ` @ ${item.path}`;
       const kind = item.kind === "branch-only" ? " [branch-only]" : "";
       lines.push(`- ${labelFor(item)}${kind}${location}`);
+      // cave-eg1ag: surface a locked unit's lock reason alongside its live
+      // verdict, so a stale lock contradicted by the verdict (clean + retained,
+      // yet held by "active … PR completion") is visible at a glance. Printed
+      // first so it reads as the unit's most salient caveat, before the reasons
+      // that describe what the tree actually is. Never a lane input.
+      if (item.lockReason != null) {
+        lines.push(
+          `  worktree locked: ${item.lockReason.length > 0 ? item.lockReason : "(no reason recorded)"}`,
+        );
+      }
       // Drop the copies of a checkout-level failure that were already stated
       // above. `reasons` keeps them — this is presentation, not classification,
       // and every consumer reading the item still sees the full list.


### PR DESCRIPTION
Bead: cave-eg1ag

## What

The lifecycle patrol reported a locked unit purely by its cleanliness/retention
lane, so a lock whose stated risk still held and a lock contradicted by current
state read identically. PR #4720 already released the auto-lock hook's *own*
locks at source; the uncovered case is a lock the hook did not write
(e.g. `active cave-1c8zf PR completion` still held after the bead closed).

Those foreign locks must never be auto-released — the reason is a claim the
hook cannot evaluate — but the patrol should **name** them so a human can clear
them, instead of leaving an operator to diff lock reasons against merged PRs by
hand.

## Change

- `scripts/worktree-lifecycle-inventory.ts` — `parseWorktrees` now captures each
  worktree's `locked <reason>` field from `git worktree list --porcelain -z`,
  and the inventory threads it onto the observation as `lockReason`
  (`null` = not locked, `""` = locked with no reason recorded).
- `src/lib/worktree-lifecycle.ts` — `WorktreeLifecycleObservation.lockReason`
  (optional, legacy-safe); the human report renders `worktree locked: <reason>`
  directly under each locked unit's header, alongside its live verdict. The lock
  is never a classification input, so a stale lock still shows as
  `cleanup-ready` — which is exactly what makes the contradiction visible at a
  glance.

The retirement apply path's release/non-release boundary is unchanged: a
hook-written auto-lock is still released once its risk is disproven, and a
foreign lock is still left in place and reported.

## Tests

- `src/lib/worktree-lifecycle.test.ts` — renderer: clean/retained + foreign lock
  (named, reason shown, verdict intact), dirty + lock (named, reason shown),
  hook auto-lock, bare lock (`(no reason recorded)`), and unlocked units (no
  lock line).
- `scripts/worktree-lifecycle-patrol.test.mjs` — end-to-end: locks the clean
  `feat/old` and dirty `feat/live` fixtures with a foreign reason and asserts
  the JSON report carries `lockReason` and the human report names it, without
  ever changing the lane or releasing the lock.

## Verification

- `pnpm typecheck` — green
- `pnpm lint` — green
- `pnpm check:tests-wired` — green (1921 files)
- `pnpm test:app` — green (1359 test files passed)