### PR TITLE
fix(worktrees): surface stale locks beside live patrol verdicts (cave-eg1ag)

### DIFF
--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -23,6 +23,8 @@ import {
   createGitRetirementOperations,
   parseMaxRetire,
   retireLifecycleUnits,
+  readWorktreeLocks,
+  isAutoLockReason,
 } from "./worktree-lifecycle-retirement.ts";
 import {
   createMetadataRepairOperations,
@@ -625,16 +627,26 @@ function formatMetadataRepairBlock(
   return `- ${blocked.beadId} ${blocked.location}: ${blocked.reason}`;
 }
 
+type WorktreeLockReport =
+  | { ok: true; locks: Map<string, string> }
+  | { ok: false; reason: string };
+
 function renderPatrolReport(
   summary: PatrolSummary,
   inventory: PatrolInventory,
   nowMs: number = Date.now(),
+  lockReport?: WorktreeLockReport,
 ): string {
   // Annotate the budget line so expired-orphaned exceptions are not invisible
   // (cave-4oor6). Inventory still counts only unit-matched exceptions; the
   // third term is residue on beads whose worktrees are already gone.
   const expiredOrphaned = listExpiredOrphanedExceptions(inventory, nowMs);
-  let lifecycleReport = renderWorktreeLifecycleReport(summary, { includeFooter: false });
+  let lifecycleReport = renderWorktreeLifecycleReport(summary, {
+    includeFooter: false,
+    ...(lockReport?.ok === true
+      ? { lockReasons: lockReport.locks, isAutoLockReason }
+      : {}),
+  });
   if (expiredOrphaned.length > 0) {
     lifecycleReport = lifecycleReport.replace(
       /^(Managed exceptions: \d+ active \| \d+ expired)$/m,
@@ -642,6 +654,28 @@ function renderPatrolReport(
     );
   }
   const lines = [lifecycleReport];
+  if (lockReport) {
+    // Distinct surface for the lock census: each lock reason sits beside the
+    // unit's own verdict up in the lanes, and this section collects the
+    // stale-lock callouts where a human is the only actor that can clear a
+    // foreign lock (cave-eg1ag).
+    const lockedPaths = [...(lockReport.ok ? lockReport.locks.keys() : [])];
+    pushSection(
+      lines,
+      "Locked worktrees",
+      lockedPaths.length === 0
+        ? []
+        : lockedPaths
+            .sort()
+            .map(
+              (lockPath) =>
+                `- ${lockPath}: "${lockReport.locks.get(lockPath) || "(no reason recorded)"}"`,
+            ),
+    );
+    if (!lockReport.ok) {
+      lines.push("", `Lock census unavailable: ${lockReport.reason}`);
+    }
+  }
   pushSection(
     lines,
     "Expired, orphaned managed-creation exceptions (grants nothing; drop under --apply when gated)",
@@ -1131,6 +1165,21 @@ function main(argv = process.argv.slice(2)): number {
     nowMs: options.nowMs,
   });
   const summary = summarizeInventory(inventory);
+  // Lock census is a local, sub-second read; failing it must not fail the
+  // patrol, only mark the lock surface unavailable (cave-eg1ag).
+  const lockReport: WorktreeLockReport = readWorktreeLocks(options.root);
+  const jsonLockExtras =
+    lockReport.ok === true
+      ? {
+          worktreeLocks: [...lockReport.locks.entries()]
+            .sort(([left], [right]) => left.localeCompare(right))
+            .map(([path, reason]) => ({
+              path,
+              reason,
+              isAutoLock: reason.length > 0 && isAutoLockReason(reason),
+            })),
+        }
+      : { worktreeLocksUnavailable: lockReport.reason };
 
   if (options.apply) {
     const scopeRefusal = cooldownOverrideScopeRefusal(options, inventory.items);
@@ -1198,6 +1247,7 @@ function main(argv = process.argv.slice(2)): number {
             ...(warning ? { warning } : {}),
             inventoryPhase: postInventory ? "post-apply" : "pre-apply-fallback",
             ...(postInventoryError ? { postInventoryError } : {}),
+            ...jsonLockExtras,
             metadataRepair,
             exceptionDrop,
             retirement,
@@ -1216,8 +1266,8 @@ function main(argv = process.argv.slice(2)): number {
 
   console.log(
     options.json
-      ? renderJsonReport(options, inventory, summary)
-      : renderPatrolReport(summary, inventory, options.nowMs),
+      ? renderJsonReport(options, inventory, summary, jsonLockExtras)
+      : renderPatrolReport(summary, inventory, options.nowMs, lockReport),
   );
   return 0;
 }

--- a/scripts/worktree-lifecycle-retirement.ts
+++ b/scripts/worktree-lifecycle-retirement.ts
@@ -1141,7 +1141,7 @@ const AUTOLOCK_REASON_PREFIX = "auto-locked";
  * unit's admin directory for us, which reading `.git/worktrees/<id>/locked`
  * by hand would not. A bare `locked` line means locked without a reason.
  */
-function readWorktreeLocks(root: string): OperationFailure | { ok: true; locks: Map<string, string> } {
+export function readWorktreeLocks(root: string): OperationFailure | { ok: true; locks: Map<string, string> } {
   const listed = git(
     root,
     ["worktree", "list", "--porcelain"],
@@ -1179,7 +1179,7 @@ function readWorktreeLocks(root: string): OperationFailure | { ok: true; locks: 
  * quote strip: porcelain C-quotes a reason containing anything unusual, and the
  * hook's reason always does (an em dash).
  */
-function isAutoLockReason(reason: string): boolean {
+export function isAutoLockReason(reason: string): boolean {
   return reason.trim().replace(/^"/, "").startsWith(AUTOLOCK_REASON_PREFIX);
 }
 

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -970,6 +970,84 @@ function legacyObservation(overrides = {}) {
   );
 }
 
+// cave-eg1ag: a lock reason is printed BESIDE the unit's live verdict. A lock
+// on a unit the classifier has already proven clean + retained is contradicted
+// by current state, and the report must say so distinctly — foreign locks need
+// a human, the hook's own auto-locks self-heal or resolve under --apply.
+{
+  const budgets = {
+    worktrees: { count: 3, registered: 3, detached: 0, warning: 28, exceeded: false },
+    branches: { count: 3, warning: 38, exceeded: false },
+    exceptions: { active: 0, expired: 0 },
+  };
+  const foreignLocked = {
+    ...observation({
+      branch: "fix/cave-1c8zf-compact-tool-rollup-pr",
+      path: "/repo/.worktrees/cave-1c8zf",
+    }),
+    lane: "retire-after-gate",
+    reasons: [],
+  };
+  const autoLocked = {
+    ...observation({ branch: "feat/auto", path: "/repo/.worktrees/auto" }),
+    lane: "cooldown",
+    reasons: [],
+  };
+  const activeLocked = {
+    ...observation({ branch: "feat/live", path: "/repo/.worktrees/live" }),
+    lane: "active",
+    reasons: [],
+  };
+  const summary = summarizeWorktreeLifecycle(
+    [foreignLocked, autoLocked, activeLocked],
+    budgets,
+  );
+  const lockReasons = new Map([
+    ["/repo/.worktrees/cave-1c8zf", "active cave-1c8zf PR completion"],
+    ["/repo/.worktrees/auto", 'auto-locked — head on no remote ref'],
+    ["/repo/.worktrees/live", "active cave-other PR completion"],
+  ]);
+  const text = renderWorktreeLifecycleReport(summary, {
+    includeFooter: false,
+    lockReasons,
+    isAutoLockReason: (reason) => reason.trim().replace(/^"/, "").startsWith("auto-locked"),
+  });
+  assert.match(
+    text,
+    /lock: "active cave-1c8zf PR completion"/,
+    "every locked unit carries its lock reason beside its verdict",
+  );
+  assert.match(
+    text,
+    /STALE FOREIGN LOCK — the live verdict \(clean \+ retained\) contradicts its stated risk; confirm with its owner, then: git worktree unlock \/repo\/\.worktrees\/cave-1c8zf/,
+    "a foreign lock on a proven clean+retained unit is called out as stale, with the exact unlock command",
+  );
+  assert.match(
+    text,
+    /stale auto-lock — the live verdict \(clean \+ retained\) contradicts its stated risk/,
+    "the hook's own lock on a proven clean+retained unit is called out as stale and self-resolving",
+  );
+  assert.doesNotMatch(
+    text,
+    /STALE FOREIGN LOCK[\s\S]*feat\/auto/,
+    "an auto-lock never renders as a foreign lock",
+  );
+  assert.match(
+    text,
+    /lock: "active cave-other PR completion"/,
+    "a lock on a live unit still renders its reason",
+  );
+  const activeSection = text.split("feat/live")[1].split("feat/auto")[0];
+  assert.doesNotMatch(
+    activeSection,
+    /stale|STALE/,
+    "a lock whose stated risk may still hold gets no stale marker — only the live verdict can contradict it",
+  );
+
+  const without = renderWorktreeLifecycleReport(summary, { includeFooter: false });
+  assert.doesNotMatch(without, /lock:/, "omitting the lock census renders no lock lines");
+}
+
 // cave-we34s: a checkout-level probe failure is stated once, not once per unit.
 // It still fails every unit closed; what changes is that the report can no
 // longer be misread as N independent problems.

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -216,6 +216,20 @@ export type WorktreeLifecycleSummary = {
 
 export type WorktreeLifecycleRenderOptions = {
   includeFooter?: boolean;
+  /**
+   * Lock reasons by absolute worktree path, as read from
+   * `git worktree list --porcelain`. Informational only: a lock never changes
+   * a lane, but naming it beside the unit's live verdict is what makes a lock
+   * whose stated risk no longer holds visible at a glance (cave-eg1ag).
+   */
+  lockReasons?: ReadonlyMap<string, string>;
+  /**
+   * Which lock reasons are the auto-lock hook's own (prefix-matched, the same
+   * way the retirement pipeline decides what it may release). Only used to
+   * phrase the distinct stale-lock line correctly: the hook's own locks
+   * self-heal or are resolved under --apply, foreign locks need a human.
+   */
+  isAutoLockReason?: (reason: string) => boolean;
 };
 
 // These thresholds serve two surfaces with deliberately different arithmetic.
@@ -1105,7 +1119,7 @@ export function renderWorktreeLifecycleReport(
   summary: WorktreeLifecycleSummary,
   options: WorktreeLifecycleRenderOptions = {},
 ): string {
-  const { includeFooter = true } = options;
+  const { includeFooter = true, lockReasons, isAutoLockReason } = options;
   const { counts } = summary;
   const { detached, registered } = summary.budgets.worktrees;
   // Say so when the assessed number is smaller than the registered one, so the
@@ -1181,6 +1195,30 @@ export function renderWorktreeLifecycleReport(
       // claiming it. Printed so the reader can still find the conversation.
       if (item.mentionTaskIds.length > 0) {
         lines.push(`  mentions (not blocking): ${item.mentionTaskIds.join(", ")}`);
+      }
+      // A lock is also informational, never a lane input — but it must be
+      // printed BESIDE the live verdict, because that pairing is the whole
+      // signal (cave-eg1ag). A lock whose stated risk still matches the unit's
+      // state reads as one plain line; a lock contradicted by a live verdict
+      // of clean + retained gets the distinct stale-lock lines, so an operator
+      // no longer has to diff lock reasons against merged PRs by hand.
+      if (item.path !== null && lockReasons?.has(item.path)) {
+        const lockReason = lockReasons.get(item.path) ?? "";
+        const quoted = lockReason.length > 0 ? `"${lockReason}"` : "(no reason recorded)";
+        lines.push(`  lock: ${quoted}`);
+        const provenCleanAndRetained =
+          item.lane === "retire-after-gate" || item.lane === "cooldown";
+        if (provenCleanAndRetained) {
+          const isAuto =
+            isAutoLockReason !== undefined &&
+            lockReason.length > 0 &&
+            isAutoLockReason(lockReason);
+          lines.push(
+            isAuto
+              ? `  stale auto-lock — the live verdict (clean + retained) contradicts its stated risk; the hook re-evaluates and releases its own locks, or --apply resolves it under the maintenance gate`
+              : `  STALE FOREIGN LOCK — the live verdict (clean + retained) contradicts its stated risk; confirm with its owner, then: git worktree unlock ${item.path}`,
+          );
+        }
       }
       for (const change of item.changes) lines.push(`  change: ${change}`);
       for (const ignoredPath of item.nonDisposableIgnoredPaths) {


### PR DESCRIPTION
## cave-eg1ag: Patrol should surface stale worktree locks distinctly from live ones

Part (a) of cave-a245b. PR #4720 already fixes the machine-generated case at
source — the auto-lock hook releases its own locks once the tree is clean and
the head is retained. What remains uncovered is a lock the hook did NOT write,
e.g. `active cave-1c8zf PR completion` on `fix/cave-1c8zf-compact-tool-rollup-pr`,
held after PR #4685 merged. Those are never auto-released (the reason is a claim
the tool cannot evaluate), but the patrol should NAME them so a human can clear
them — instead of diffing lock reasons against merged PRs by hand.

### What changed

- **`renderWorktreeLifecycleReport`** (src/lib/worktree-lifecycle.ts): optional
  `lockReasons` map + `isAutoLockReason` predicate. Every locked unit prints its
  lock reason beside its live verdict (`  lock: "…"`). When the unit's lane
  already proves clean + retained (`retire-after-gate` or `cooldown`), the lock's
  stated risk is contradicted by current state and gets a distinct callout:
  - foreign lock → `STALE FOREIGN LOCK — … confirm with its owner, then: git worktree unlock <path>`
  - hook's own lock → `stale auto-lock — … the hook re-evaluates and releases its own locks, or --apply resolves it`
  A lock never changes a lane; this is presentation over the same classification.
- **Patrol** (scripts/worktree-lifecycle-patrol.ts): reads the lock census once
  per run from `git worktree list --porcelain`, adds a `Locked worktrees (N)`
  section to the read-only report, and emits `worktreeLocks` (path/reason/isAutoLock)
  in `--json`. A failed census prints `Lock census unavailable: …` and does not
  fail the patrol.
- **Retirement script**: `readWorktreeLocks` / `isAutoLockReason` exported so the
  patrol shares the exact reason-prefix contract with the auto-lock hook
  (the existing `worktree-lifecycle-retirement.test.mjs` cross-file assertion
  continues to guard drift).

### Verification

- `src/lib/worktree-lifecycle.test.ts`: new renderer contract block — foreign
  stale lock callout with exact unlock command, auto-lock callout, live-unit lock
  with no stale marker, and no lock lines when the census is absent.
- `scripts/worktree-lifecycle-patrol.test.mjs`: pass (patrol suite).
- `pnpm typecheck`: clean.
- `git diff --check`: clean.

No lane inputs or retirement behavior changed; the apply path's foreign-lock
safety boundary (reported, never released) is untouched.