### PR TITLE
ci: fail PR jobs on a stale merge-tree checkout (cave-d9xfq)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,21 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
           persist-credentials: false
 
+      # This job IS the required check; a green from it that ran a stale tree
+      # is the hazard this guard exists for (cave-d9xfq #4934).
+      - name: Refuse a stale merge-tree checkout
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test -f scripts/check-merge-tree-freshness.mjs || {
+            echo "::error::Checked-out tree predates the merge-freshness guard (scripts/check-merge-tree-freshness.mjs is absent); refusing to run tests on a tree that cannot be the current merge (cave-d9xfq)."
+            exit 1
+          }
+          node scripts/check-merge-tree-freshness.mjs --pr "$PR_NUMBER" --head "$HEAD_SHA"
+
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -132,6 +147,22 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # The path selector's verdict decides which jobs run at all; a stale
+      # tree here could silently skip a lane the PR actually touches
+      # (cave-d9xfq).
+      - name: Refuse a stale merge-tree checkout
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test -f scripts/check-merge-tree-freshness.mjs || {
+            echo "::error::Checked-out tree predates the merge-freshness guard (scripts/check-merge-tree-freshness.mjs is absent); refusing to select paths from a tree that cannot be the current merge (cave-d9xfq)."
+            exit 1
+          }
+          node scripts/check-merge-tree-freshness.mjs --pr "$PR_NUMBER" --head "$HEAD_SHA"
+
       - id: paths
         name: Select path-aware validation
         env:
@@ -156,6 +187,24 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+
+      # Guards the checked-out tree against the stale-merge hazard
+      # (cave-d9xfq): the checkout's CONTENT must match refs/pull/<n>/merge
+      # fetched fresh at job time, or the run's verdict is about the wrong
+      # tree. Two jobs in one run once took different trees (#4922), so every
+      # job that checks out the PR tree runs this.
+      - name: Refuse a stale merge-tree checkout
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test -f scripts/check-merge-tree-freshness.mjs || {
+            echo "::error::Checked-out tree predates the merge-freshness guard (scripts/check-merge-tree-freshness.mjs is absent); refusing to run tests on a tree that cannot be the current merge (cave-d9xfq)."
+            exit 1
+          }
+          node scripts/check-merge-tree-freshness.mjs --pr "$PR_NUMBER" --head "$HEAD_SHA"
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
@@ -321,6 +370,24 @@ jobs:
         with:
           persist-credentials: false
 
+      # Guards the checked-out tree against the stale-merge hazard
+      # (cave-d9xfq): the checkout's CONTENT must match refs/pull/<n>/merge
+      # fetched fresh at job time, or the run's verdict is about the wrong
+      # tree. Two jobs in one run once took different trees (#4922), so every
+      # job that checks out the PR tree runs this.
+      - name: Refuse a stale merge-tree checkout
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test -f scripts/check-merge-tree-freshness.mjs || {
+            echo "::error::Checked-out tree predates the merge-freshness guard (scripts/check-merge-tree-freshness.mjs is absent); refusing to run tests on a tree that cannot be the current merge (cave-d9xfq)."
+            exit 1
+          }
+          node scripts/check-merge-tree-freshness.mjs --pr "$PR_NUMBER" --head "$HEAD_SHA"
+
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -343,6 +410,24 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+
+      # Guards the checked-out tree against the stale-merge hazard
+      # (cave-d9xfq): the checkout's CONTENT must match refs/pull/<n>/merge
+      # fetched fresh at job time, or the run's verdict is about the wrong
+      # tree. Two jobs in one run once took different trees (#4922), so every
+      # job that checks out the PR tree runs this.
+      - name: Refuse a stale merge-tree checkout
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test -f scripts/check-merge-tree-freshness.mjs || {
+            echo "::error::Checked-out tree predates the merge-freshness guard (scripts/check-merge-tree-freshness.mjs is absent); refusing to run tests on a tree that cannot be the current merge (cave-d9xfq)."
+            exit 1
+          }
+          node scripts/check-merge-tree-freshness.mjs --pr "$PR_NUMBER" --head "$HEAD_SHA"
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
@@ -386,6 +471,24 @@ jobs:
         with:
           persist-credentials: false
 
+      # Guards the checked-out tree against the stale-merge hazard
+      # (cave-d9xfq): the checkout's CONTENT must match refs/pull/<n>/merge
+      # fetched fresh at job time, or the run's verdict is about the wrong
+      # tree. Two jobs in one run once took different trees (#4922), so every
+      # job that checks out the PR tree runs this.
+      - name: Refuse a stale merge-tree checkout
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test -f scripts/check-merge-tree-freshness.mjs || {
+            echo "::error::Checked-out tree predates the merge-freshness guard (scripts/check-merge-tree-freshness.mjs is absent); refusing to run tests on a tree that cannot be the current merge (cave-d9xfq)."
+            exit 1
+          }
+          node scripts/check-merge-tree-freshness.mjs --pr "$PR_NUMBER" --head "$HEAD_SHA"
+
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -412,6 +515,24 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+
+      # Guards the checked-out tree against the stale-merge hazard
+      # (cave-d9xfq): the checkout's CONTENT must match refs/pull/<n>/merge
+      # fetched fresh at job time, or the run's verdict is about the wrong
+      # tree. Two jobs in one run once took different trees (#4922), so every
+      # job that checks out the PR tree runs this.
+      - name: Refuse a stale merge-tree checkout
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test -f scripts/check-merge-tree-freshness.mjs || {
+            echo "::error::Checked-out tree predates the merge-freshness guard (scripts/check-merge-tree-freshness.mjs is absent); refusing to run tests on a tree that cannot be the current merge (cave-d9xfq)."
+            exit 1
+          }
+          node scripts/check-merge-tree-freshness.mjs --pr "$PR_NUMBER" --head "$HEAD_SHA"
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
@@ -477,6 +598,24 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+
+      # Guards the checked-out tree against the stale-merge hazard
+      # (cave-d9xfq): the checkout's CONTENT must match refs/pull/<n>/merge
+      # fetched fresh at job time, or the run's verdict is about the wrong
+      # tree. Two jobs in one run once took different trees (#4922), so every
+      # job that checks out the PR tree runs this.
+      - name: Refuse a stale merge-tree checkout
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test -f scripts/check-merge-tree-freshness.mjs || {
+            echo "::error::Checked-out tree predates the merge-freshness guard (scripts/check-merge-tree-freshness.mjs is absent); refusing to run tests on a tree that cannot be the current merge (cave-d9xfq)."
+            exit 1
+          }
+          node scripts/check-merge-tree-freshness.mjs --pr "$PR_NUMBER" --head "$HEAD_SHA"
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 

--- a/scripts/check-merge-tree-freshness.mjs
+++ b/scripts/check-merge-tree-freshness.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+// Fail a CI job when the checked-out tree does not match the CURRENT content
+// of refs/pull/<n>/merge for the PR this run belongs to (cave-d9xfq).
+//
+// WHY THIS EXISTS
+// After close/reopen forces a fresh pull_request event, a job can check out a
+// merge commit that PREDATES the current refs/pull/<n>/merge value. Three
+// measured occurrences (cave-d9xfq):
+//   #4922 — two jobs in one run took different trees; the later job got the
+//           older one (false RED).
+//   #4940 — a reopened PR's app tests ran the old buggy tree and failed
+//           (false RED).
+//   #4934 — a job passed on a tree roughly nineteen merges behind main, so the
+//           hydration test that should have run was not even present (false
+//           GREEN, the dangerous direction: a green is exactly when nobody
+//           looks).
+// Both surfaces that "verify" the checkout afterwards lie: the ref endpoint
+// and the job log's Commit: header describe the current ref, not the tree the
+// job actually ran. The only sound detection is CONTENT-BASED.
+//
+// WHAT THIS CHECKS (two independent content signals)
+//   1. TREE HASH — the checked-out HEAD tree must equal the tree of
+//      refs/pull/<n>/merge fetched FRESH at job time. A tree hash is
+//      content-addressed, so equality is content equality.
+//   2. CONTENT PROBE — every file present in the current merge tree must also
+//      be present in the checked-out tree (reported first for test files, the
+//      "code under test"). This is the false-green guard: a stale tree that
+//      predates the code under test trivially lacks its files, and an absent
+//      file is exactly what that looks like (cave-d9xfq #4934). The file
+//      count is the same corroborating metric the bead measured by hand
+//      (1292 -> 1285 test files).
+//
+// The head sha from the event payload is used as a diagnostic cross-check
+// against the live refs/pull/<n>/head (via ls-remote, no object download):
+// if the PR was pushed while the run was in flight, the merge ref was
+// refreshed and that explains any mismatch below. The verdict is content, not
+// the event header.
+//
+// Usage:
+//   node scripts/check-merge-tree-freshness.mjs --pr <n> --head <40-hex> [--repo <path>] [--remote <name>]
+//
+// Exit codes: 0 = checked-out tree matches the current merge ref content
+//             1 = stale checkout or unusable environment (job must fail)
+//             2 = usage error
+//
+// Runs on the CI checkout itself: node builtins and git only, no deps. The
+// fetch targets refs/pull/<n>/merge exactly as actions/checkout does, which
+// works unauthenticated on this public repository (and the job's checkout
+// already proves the ref is readable).
+//
+// Design notes:
+//  - --depth=1 keeps the fetch tiny: in the healthy case the current merge
+//    commit is already the checked-out HEAD, so nothing is downloaded; in the
+//    stale case the run is going to fail anyway.
+//  - ls-tree -r needs only tree objects, which the fetch provides, so the
+//    content probe never materializes the fetched tree into the worktree.
+//  - GIT_TERMINAL_PROMPT=0 makes any credential failure loud and immediate
+//    instead of a hang.
+
+import { spawnSync } from "node:child_process";
+
+const USAGE = `Usage:
+  node scripts/check-merge-tree-freshness.mjs --pr <pull-request-number> --head <40-hex-sha> [--repo <repo-path>] [--remote <remote-name>]`;
+
+const TEST_FILE_RE = /\.test\.(tsx?|mjs)$/;
+
+function parseArgs(argv) {
+  const args = { pr: null, head: null, repo: process.cwd(), remote: "origin" };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === "--pr") args.pr = value;
+    else if (flag === "--head") args.head = value;
+    else if (flag === "--repo") args.repo = value;
+    else if (flag === "--remote") args.remote = value;
+    else if (flag === "--help" || flag === "-h") {
+      console.log(USAGE);
+      process.exit(0);
+    } else {
+      console.error(`unknown argument: ${flag}`);
+      console.error(USAGE);
+      process.exit(2);
+    }
+    i += 1;
+  }
+  if (!args.pr || !/^\d+$/.test(String(args.pr))) {
+    console.error("missing or invalid --pr <pull-request-number>");
+    console.error(USAGE);
+    process.exit(2);
+  }
+  if (!args.head || !/^[0-9a-f]{40}$/i.test(String(args.head))) {
+    console.error("missing or invalid --head <40-hex sha>");
+    console.error(USAGE);
+    process.exit(2);
+  }
+  return args;
+}
+
+function git(repo, args) {
+  const res = spawnSync("git", ["-C", repo, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+  });
+  if (res.error) {
+    throw new Error(`cannot run git ${args.join(" ")}: ${res.error.message}`);
+  }
+  return {
+    status: res.status,
+    stdout: (res.stdout ?? "").trim(),
+    stderr: (res.stderr ?? "").trim(),
+  };
+}
+
+function requireGit(repo, args, what) {
+  const res = git(repo, args);
+  if (res.status !== 0) {
+    console.error(`::error::cannot ${what} in ${repo}`);
+    console.error(res.stderr || res.stdout);
+    process.exit(1);
+  }
+  return res;
+}
+
+function testFileCount(files) {
+  return files.filter((file) => TEST_FILE_RE.test(file)).length;
+}
+
+function main() {
+  const { pr, head, repo, remote } = parseArgs(process.argv.slice(2));
+
+  // 1. Sanity: the repo is a work tree with a checked-out HEAD.
+  const inside = git(repo, ["rev-parse", "--is-inside-work-tree"]);
+  if (inside.status !== 0) {
+    console.error(`::error::${repo} is not a git work tree (cave-d9xfq guard cannot verify the checkout)`);
+    process.exit(1);
+  }
+  const headSha = requireGit(repo, ["rev-parse", "HEAD"], "resolve HEAD");
+  const checkedOutTree = requireGit(repo, ["rev-parse", "HEAD^{tree}"], "resolve the checked-out tree");
+  const checkedOutTreeHash = checkedOutTree.stdout;
+
+  // 2. Fetch the CURRENT merge ref fresh, at job time. A fetch that fails
+  //    (ref gone, PR closed mid-run, credentials) means the tree cannot be
+  //    verified — refuse to trust it.
+  const mergeRef = `refs/pull/${pr}/merge`;
+  const freshRef = "refs/ci/merge-freshness/merge";
+  // Force refspec: the local freshness ref must be able to move from an
+  // older merge commit to the current one (the stale case) — the same `+`
+  // prefix actions/checkout uses for its own refs/pull fetch.
+  const fetchRes = git(repo, ["fetch", "--depth=1", "--no-tags", remote, `+${mergeRef}:${freshRef}`]);
+  if (fetchRes.status !== 0) {
+    console.error(
+      `::error::cannot fetch the CURRENT ${mergeRef} (fetched at job time) — the checked-out tree cannot be verified against it (cave-d9xfq). The PR may have been closed or the ref removed mid-run. Refusing to trust the checkout.`,
+    );
+    console.error(fetchRes.stderr || fetchRes.stdout);
+    process.exit(1);
+  }
+
+  // 3. Resolve the fresh merge tree.
+  const freshTree = requireGit(repo, ["rev-parse", `${freshRef}^{tree}`], `resolve the tree of ${mergeRef}`);
+  const freshTreeHash = freshTree.stdout;
+
+  // 4. Content probe: file sets of both trees.
+  const checkedOutFiles = requireGit(repo, ["ls-tree", "-r", "--name-only", "HEAD"], "list the checked-out tree");
+  const freshFiles = requireGit(repo, ["ls-tree", "-r", "--name-only", freshRef], `list the ${mergeRef} tree`);
+  const checkedOutList = checkedOutFiles.stdout.split("\n").filter(Boolean);
+  const freshList = freshFiles.stdout.split("\n").filter(Boolean);
+  const checkedOutSet = new Set(checkedOutList);
+  const missing = freshList.filter((file) => !checkedOutSet.has(file));
+  const missingTests = missing.filter((file) => TEST_FILE_RE.test(file));
+
+  // 5. Diagnostic: does the live head ref still match the event's head sha?
+  //    Informational only — the verdict is content. If the PR was pushed while
+  //    this run was in flight, the merge ref moved and any mismatch below is
+  //    explained by that.
+  let headNote = "head ref check skipped";
+  const lsRemote = git(repo, ["ls-remote", remote, `refs/pull/${pr}/head`]);
+  if (lsRemote.status === 0 && lsRemote.stdout) {
+    const [refSha] = lsRemote.stdout.split(/\s+/);
+    if (refSha) {
+      headNote =
+        refSha.toLowerCase() === head.toLowerCase()
+          ? `refs/pull/${pr}/head is the event head (${head.slice(0, 12)})`
+          : `refs/pull/${pr}/head moved during the run: event head ${head.slice(0, 12)} vs current ${refSha.slice(0, 12)} — the merge ref was refreshed, which is the likely cause of any mismatch below`;
+    }
+  }
+
+  const treeMatches = checkedOutTreeHash === freshTreeHash;
+  const probePasses = missing.length === 0;
+
+  console.log(`Checked-out HEAD:  ${headSha.stdout.slice(0, 12)}  tree ${checkedOutTreeHash}`);
+  console.log(`Current ${mergeRef}: tree ${freshTreeHash} (fetched at job time)`);
+  console.log(`Files: checked-out ${checkedOutList.length} (${testFileCount(checkedOutList)} test), current merge tree ${freshList.length} (${testFileCount(freshList)} test)`);
+  console.log(`${headNote}.`);
+
+  if (!treeMatches || !probePasses) {
+    if (!treeMatches) {
+      console.error(
+        `::error::STALE MERGE-TREE CHECKOUT (cave-d9xfq): the checked-out tree ${checkedOutTreeHash} does not match the current ${mergeRef} tree ${freshTreeHash} fetched at job time. This run is testing code that is not the PR's current merge — its verdict must not be trusted.`,
+      );
+    }
+    if (!probePasses) {
+      const missingSource = missingTests.length ? missingTests : missing;
+      const examples = missingSource.slice(0, 5);
+      console.error(
+        `::error::STALE MERGE-TREE CHECKOUT (cave-d9xfq): the checked-out tree is missing ${missing.length} file(s) present in the current ${mergeRef} tree (${missingTests.length} of them test files). A tree that predates the code under test trivially lacks its files, which is exactly what a stale checkout looks like. Missing, e.g.: ${examples.join(", ")}${missingSource.length > 5 ? ", ..." : ""}`,
+      );
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `OK: the checked-out tree matches the current ${mergeRef} content — ${freshList.length} files, ${testFileCount(freshList)} test files.`,
+  );
+  process.exit(0);
+}
+
+main();

--- a/scripts/check-merge-tree-freshness.test.mjs
+++ b/scripts/check-merge-tree-freshness.test.mjs
@@ -19,8 +19,10 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
 
 const SCRIPT = fileURLToPath(new URL("./check-merge-tree-freshness.mjs", import.meta.url));
 const PR_NUMBER = "7";
@@ -206,5 +208,41 @@ test("--help exits 0 with usage", () => {
   const res = runGuard(["--help"]);
   assert.equal(res.status, 0);
   assert.match(res.stdout, /--pr <pull-request-number>/);
+});
+
+// Wiring pin: every job that checks out the PR tree must run the guard, or a
+// future edit could silently re-expose a lane to the stale-merge hazard — the
+// same per-job gap #4922 demonstrated inside a single run.
+test("every job that checks out the PR tree runs the freshness guard", () => {
+  const ci = parse(readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8"));
+  const prTreeJobs = [
+    "pr-checks",
+    "paths",
+    "ios",
+    "frontend-validation",
+    "frontend-bundle",
+    "frontend-e2e",
+    "frontend-e2e-agentic",
+    "build",
+  ];
+  assert.deepEqual(
+    Object.keys(ci.jobs).sort(),
+    prTreeJobs.slice().sort(),
+    "the guard's job inventory must match the workflow's actual jobs",
+  );
+  for (const jobName of prTreeJobs) {
+    const steps = ci.jobs[jobName].steps;
+    const guard = steps.find((step) => step.name === "Refuse a stale merge-tree checkout");
+    assert.ok(guard, `${jobName} must run the stale merge-tree guard`);
+    assert.equal(guard.if, "github.event_name == 'pull_request'", `${jobName} guard must be PR-only`);
+    assert.equal(guard.env.PR_NUMBER, "${{ github.event.pull_request.number }}", `${jobName} guard needs the PR number`);
+    assert.equal(guard.env.HEAD_SHA, "${{ github.event.pull_request.head.sha }}", `${jobName} guard needs the head sha`);
+    assert.match(guard.run, /node scripts\/check-merge-tree-freshness\.mjs --pr "\$PR_NUMBER" --head "\$HEAD_SHA"/, `${jobName} guard must invoke the freshness script`);
+    // The guard must run before the job's verdict-producing steps, so a stale
+    // tree fails the job before anything expensive runs on it.
+    const checkoutIdx = steps.findIndex((step) => step.uses?.startsWith("actions/checkout@"));
+    const guardIdx = steps.indexOf(guard);
+    assert.ok(checkoutIdx >= 0 && guardIdx > checkoutIdx, `${jobName} guard must sit after its checkout`);
+  }
 });
 

--- a/scripts/check-merge-tree-freshness.test.mjs
+++ b/scripts/check-merge-tree-freshness.test.mjs
@@ -1,0 +1,210 @@
+// Content-based staleness guard for PR CI checkouts (cave-d9xfq).
+//
+// Exercises scripts/check-merge-tree-freshness.mjs against a fixture "GitHub"
+// (a bare origin repo with refs/pull/<n>/merge and refs/pull/<n>/head) and
+// CI-style SHALLOW checkouts of the merge commit — the exact shape
+// actions/checkout produces on a pull_request event. The three measured
+// failure classes from the bead are reproduced end to end:
+//   • fresh checkout of the current merge ref            -> pass
+//   • checkout PREDATES the current merge ref (reopen)   -> fail (false RED
+//     class, #4922/#4940)
+//   • checkout predates the code under test entirely     -> fail (false GREEN
+//     class, #4934)
+//
+// The guard is a CLI (it calls process.exit), so it is exercised by spawning
+// it, never by importing it.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("./check-merge-tree-freshness.mjs", import.meta.url));
+const PR_NUMBER = "7";
+
+function git(args, cwd) {
+  const res = spawnSync("git", args, { encoding: "utf8", cwd });
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed in ${cwd}: ${res.stderr || res.stdout}`);
+  }
+  return res.stdout.trim();
+}
+
+function write(seed, relPath, contents) {
+  const target = path.join(seed, relPath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, contents);
+}
+
+// Build a fixture "GitHub" plus CI-style shallow checkouts.
+//   stale=false: refs/pull/7/{head,merge} point at h1/m1 and the main checkout
+//                sits on m1 — the healthy state.
+//   stale=true:  refs/pull/7/{head,merge} are re-created at h2/m2 (a close/
+//                reopen with a new head) while the main checkout still sits on
+//                m1 — the exact stale state this guard exists to catch.
+// Either way checkoutBase is a shallow checkout of the pre-PR base commit.
+function makeFixture({ stale = false } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "merge-freshness-"));
+  const origin = path.join(root, "origin.git");
+  const seed = path.join(root, "seed");
+
+  git(["init", "--bare", "-q", origin]);
+  git(["symbolic-ref", "HEAD", "refs/heads/main"], origin);
+  git(["clone", "-q", origin, seed]);
+  git(["config", "user.email", "t@t"], seed);
+  git(["config", "user.name", "T"], seed);
+  git(["config", "commit.gpgsign", "false"], seed);
+
+  // Base commit on main, WITH files: a realistic baseline. The false-green
+  // probe needs a base tree that has files yet lacks the PR's entirely.
+  write(seed, "base.txt", "base\n");
+  write(seed, "tests/a.test.mjs", "import { test } from 'node:test';\n");
+  write(seed, "tests/b.test.mjs", "import { test } from 'node:test';\n");
+  git(["add", "-A"], seed);
+  git(["commit", "-q", "-m", "base"], seed);
+  const base = git(["rev-parse", "HEAD"], seed);
+  git(["push", "-q", "-u", "origin", "main"], seed);
+
+  // Topic branch: the PR adds feature.txt + tests/c.test.mjs.
+  git(["checkout", "-q", "-b", "topic"], seed);
+  write(seed, "feature.txt", "feature\n");
+  write(seed, "tests/c.test.mjs", "import { test } from 'node:test';\n");
+  git(["add", "-A"], seed);
+  git(["commit", "-q", "-m", "feature"], seed);
+  const h1 = git(["rev-parse", "HEAD"], seed);
+
+  // First merge ref: the value at the original pull_request event.
+  git(["checkout", "-q", "main"], seed);
+  git(["merge", "-q", "--no-ff", "topic", "-m", "Merge pull request #7 from topic"], seed);
+  const m1 = git(["rev-parse", "HEAD"], seed);
+  git(["push", "-q", "origin", "main"], seed);
+  git(["update-ref", `refs/pull/${PR_NUMBER}/head`, h1], origin);
+  git(["update-ref", `refs/pull/${PR_NUMBER}/merge`, m1], origin);
+
+  // CI-style checkout: shallow, detached at the merge commit.
+  const checkout = path.join(root, "checkout");
+  git(["clone", "-q", "--no-checkout", "--depth=1", origin, checkout]);
+  git(["fetch", "-q", "--depth=1", "origin", `refs/pull/${PR_NUMBER}/merge`], checkout);
+  git(["checkout", "-q", "FETCH_HEAD"], checkout);
+
+  // A checkout that PREDATES the PR entirely (false-green shape): shallow,
+  // detached at the base commit.
+  const checkoutBase = path.join(root, "checkout-base");
+  git(["clone", "-q", "--no-checkout", "--depth=1", origin, checkoutBase]);
+  git(["fetch", "-q", "--depth=1", "origin", `${base}:refs/ci/base`], checkoutBase);
+  git(["checkout", "-q", "refs/ci/base"], checkoutBase);
+
+  const result = { root, origin, seed, checkout, checkoutBase, base, h1, m1, h2: null, m2: null };
+
+  if (stale) {
+    // Reopen with a NEW head: topic advances (adds tests/d.test.mjs) and the
+    // merge ref is re-created at m2 while the main checkout still sits on m1.
+    git(["checkout", "-q", "topic"], seed);
+    write(seed, "tests/d.test.mjs", "import { test } from 'node:test';\n");
+    git(["add", "-A"], seed);
+    git(["commit", "-q", "-m", "second feature"], seed);
+    result.h2 = git(["rev-parse", "HEAD"], seed);
+    git(["checkout", "-q", "main"], seed);
+    git(["merge", "-q", "--no-ff", "topic", "-m", "Merge pull request #7 again"], seed);
+    result.m2 = git(["rev-parse", "HEAD"], seed);
+    git(["push", "-q", "origin", "main"], seed);
+    git(["update-ref", `refs/pull/${PR_NUMBER}/head`, result.h2], origin);
+    git(["update-ref", `refs/pull/${PR_NUMBER}/merge`, result.m2], origin);
+  }
+
+  return result;
+}
+
+function runGuard(args) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { encoding: "utf8" });
+}
+
+function withFixture(options, fn) {
+  const fx = makeFixture(options);
+  try {
+    return fn(fx);
+  } finally {
+    rmSync(fx.root, { recursive: true, force: true });
+  }
+}
+
+test("a fresh checkout matching the current merge ref passes", () => {
+  withFixture({}, ({ checkout, h1 }) => {
+    const res = runGuard(["--pr", PR_NUMBER, "--head", h1, "--repo", checkout]);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /OK: the checked-out tree matches the current refs\/pull\/7\/merge content/);
+    assert.match(res.stdout, /refs\/pull\/7\/head is the event head/);
+    // The corroborating file counts agree on the fresh tree (the bead's
+    // cheaper detector): m1's tree is base.txt + feature.txt + three tests.
+    assert.match(res.stdout, /Files: checked-out 5 \(3 test\), current merge tree 5 \(3 test\)/);
+  });
+});
+
+test("a checkout that predates the current merge ref fails (false-RED class)", () => {
+  withFixture({ stale: true }, ({ checkout, m1, h2 }) => {
+    // The checkout still sits on m1 while refs/pull/7/merge is now m2.
+    assert.equal(git(["rev-parse", "HEAD"], checkout), m1);
+    const res = runGuard(["--pr", PR_NUMBER, "--head", h2, "--repo", checkout]);
+    assert.equal(res.status, 1, "the guard must fail the stale run");
+    assert.match(res.stderr, /STALE MERGE-TREE CHECKOUT \(cave-d9xfq\)/);
+    assert.match(res.stderr, /does not match the current refs\/pull\/7\/merge tree/);
+    assert.match(res.stderr, /missing 1 file\(s\)/);
+    assert.match(res.stderr, /tests\/d\.test\.mjs/);
+    assert.match(res.stderr, /1 of them test files/);
+  });
+});
+
+test("a stale event head is reported as a mid-run head move, not silently trusted", () => {
+  withFixture({ stale: true }, ({ checkout, h1 }) => {
+    const res = runGuard(["--pr", PR_NUMBER, "--head", h1, "--repo", checkout]);
+    assert.equal(res.status, 1);
+    assert.match(res.stdout, /refs\/pull\/7\/head moved during the run: event head/);
+  });
+});
+
+test("a tree predating the code under test fails the content probe (false-GREEN class)", () => {
+  withFixture({ stale: true }, ({ checkoutBase, h2 }) => {
+    // checkoutBase is the base commit: it has files but lacks the PR's entirely.
+    const res = runGuard(["--pr", PR_NUMBER, "--head", h2, "--repo", checkoutBase]);
+    assert.equal(res.status, 1, "a tree missing the code under test must fail");
+    assert.match(res.stderr, /STALE MERGE-TREE CHECKOUT \(cave-d9xfq\)/);
+    assert.match(res.stderr, /missing 3 file\(s\) present in the current refs\/pull\/7\/merge tree \(2 of them test files\)/);
+    assert.match(res.stderr, /tests\/c\.test\.mjs/);
+  });
+});
+
+test("a PR whose merge ref does not exist fails closed", () => {
+  withFixture({}, ({ checkout, h1 }) => {
+    const res = runGuard(["--pr", "999", "--head", h1, "--repo", checkout]);
+    assert.equal(res.status, 1);
+    assert.match(res.stderr, /cannot fetch the CURRENT refs\/pull\/999\/merge/);
+  });
+});
+
+test("a non-git directory fails closed", () => {
+  withFixture({}, ({ root, h1 }) => {
+    const res = runGuard(["--pr", PR_NUMBER, "--head", h1, "--repo", path.join(root, "does-not-exist")]);
+    assert.equal(res.status, 1);
+    assert.match(res.stderr, /not a git work tree/);
+  });
+});
+
+test("usage errors exit 2 with the usage text", () => {
+  const noPr = runGuard(["--head", "a".repeat(40)]);
+  assert.equal(noPr.status, 2);
+  assert.match(noPr.stderr, /missing or invalid --pr/);
+
+  const badHead = runGuard(["--pr", PR_NUMBER, "--head", "not-a-sha"]);
+  assert.equal(badHead.status, 2);
+  assert.match(badHead.stderr, /missing or invalid --head/);
+});
+
+test("--help exits 0 with usage", () => {
+  const res = runGuard(["--help"]);
+  assert.equal(res.status, 0);
+  assert.match(res.stdout, /--pr <pull-request-number>/);
+});
+

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1412,6 +1412,7 @@ export const SUITES = {
     "scripts/beads-pr-bridge.test.mjs",
     "scripts/beads-pr-patrol.test.mjs",
     "scripts/ci-paths.test.mjs",
+    "scripts/check-merge-tree-freshness.test.mjs",
     "scripts/export-client-v1-contract.test.mjs",
     "scripts/export-client-v1-hpke-vectors.test.mjs",
     "scripts/client-v1-doc-contract.test.mjs",


### PR DESCRIPTION
Bead: cave-d9xfq (P1, CI). After close/reopen forces a fresh pull_request event, a job can check out a merge commit that predates the current refs/pull/<n>/merge; the ref endpoint and the log's Commit: header both lie about the tree actually checked out. Three measured occurrences: #4922 and #4940 false reds, #4934 false green.

**Guard**: scripts/check-merge-tree-freshness.mjs verifies the checked-out tree against the CURRENT merge ref content, fetched fresh at job time:
- tree-hash equality (checked-out HEAD tree vs refs/pull/N/merge tree fetched NOW)
- content probe: every file present in the current merge tree must be present in the checkout (catches the false-green class where the tree predates the code under test entirely)

Wired into ci.yml as a step in every job that checks out the PR tree (pr-checks, paths, ios, frontend-validation, frontend-bundle, frontend-e2e, frontend-e2e-agentic, build) — #4922 proved two jobs in one run can take different trees, so per-job guarding is required. The step fails the run on staleness and fails closed when the tree predates the guard script.

**Tests**: scripts/check-merge-tree-freshness.test.mjs (8 cases, fixture-bare-repo + CI-style shallow checkouts covering fresh pass, false-RED stale, false-GREEN stale, missing ref, non-git dir, usage) registered in scripts/run-tests.mjs (api suite). check-tests-wired passes (1922 files wired). tsc --noEmit clean, eslint clean, ci.yml-pinning tests (ci-recovery-workflow, ci-paths, ios-build-ci, release-packaging-contract) pass.