### PR TITLE
feat(chat): emit token usage from harness adapters (cave-0osmn)

### DIFF
--- a/src/app/api/chat/send/harness-routing-codex-direct.test.ts
+++ b/src/app/api/chat/send/harness-routing-codex-direct.test.ts
@@ -231,11 +231,21 @@ try {
   const done = events.findLast((event) => event.kind === "done");
   assert.ok(done, "the direct stream completes");
   assert.ok(!done.isError, "a completed fixture turn is not an error");
+  assert.deepEqual(
+    done.usage,
+    { inputTokens: 10200, outputTokens: 2150, cacheReadTokens: 5000, cacheCreationTokens: 1200 },
+    "the done event carries turn.completed token usage on the stream-json contract (cave-0osmn)",
+  );
 
   const conversation = await loadConversation(done.sessionId);
   const assistantTurn = conversation?.turns.at(-1);
   assert.equal(assistantTurn?.role, "assistant");
   assert.equal(assistantTurn?.text, "Fixture assistant response.");
+  assert.deepEqual(
+    assistantTurn?.usage,
+    { inputTokens: 10200, outputTokens: 2150, cacheReadTokens: 5000, cacheCreationTokens: 1200 },
+    "turn.completed usage persists on the saved assistant turn (cave-0osmn)",
+  );
   assert.equal(conversation?.harnessSessionId, "thread-current", "the native thread id persists for resume");
   const persistedTools = assistantTurn?.tools ?? [];
   assert.deepEqual(

--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -341,6 +341,21 @@ assert.match(
   /if \(copilotStream\) \{[\s\S]*?handleCopilotLine\(line, isJson \|\| line\.trimStart\(\)\.startsWith\("\{"\)\);[\s\S]*?return;/,
   "Complete and truncated Copilot JSONL frames route through the redacted protocol handler, never the AssistantFilter",
 );
+assert.match(
+  chatRoute,
+  /let copilotUsage: \{[\s\S]*?cache_creation_input_tokens\?: number;[\s\S]*?\} \| undefined;[\s\S]*?const accumulateCopilotUsage = \(raw: \{[\s\S]*?\}\) => \{[\s\S]*?input_tokens: \(copilotUsage\?\.input_tokens \?\? 0\) \+ raw\.input_tokens,/,
+  "Copilot turns accumulate per-message token usage across the stream (cave-0osmn)",
+);
+assert.match(
+  chatRoute,
+  /if \(ev\.usage && !copilotUsageMessageIds\.has\(ev\.messageId\)\) \{[\s\S]*?accumulateCopilotUsage\(ev\.usage\);/,
+  "Copilot assistant.message frames feed the turn usage accumulator, deduped per message id (cave-0osmn)",
+);
+assert.match(
+  chatRoute,
+  /\.\.\.\(copilotUsage \? \{ usage: parseStreamJsonUsage\(copilotUsage\) \} : \{\}\),/,
+  "Copilot accumulated usage reaches the terminal result through the shared defensive parser (cave-0osmn)",
+);
 
 assert.match(
   chatRoute,

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -1157,6 +1157,16 @@ assert.match(
   /if \(ev\.type === "result"\) \{[\s\S]*?usage: parseStreamJsonUsage\(ev\.usage\),[\s\S]*?costUsd: parseCostUsd\(ev\.total_cost_usd\),/,
   "The result-event parse must capture usage and total_cost_usd through the defensive validators (CHAT-D12-02)",
 );
+assert.match(
+  chatRoute,
+  /case "completed": \{[\s\S]*?\.\.\.\(event\.usage \? \{ usage: parseStreamJsonUsage\(event\.usage\) \} : \{\}\),/,
+  "Codex turn.completed must merge its usage through the shared defensive parser (cave-0osmn)",
+);
+assert.match(
+  chatRoute,
+  /case "done":[\s\S]*?is_error: event\.isError,[\s\S]*?\.\.\.\(event\.usage \? \{ usage: parseStreamJsonUsage\(event\.usage\) \} : \{\}\),/,
+  "Hermes Responses terminal events must merge their usage through the shared defensive parser (cave-0osmn)",
+);
 
 assert.match(
   chatRoute,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -4037,11 +4037,6 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
       };
 
       const handleOpenCodeLine = (line: string) => {
-        // Token usage (cave-0osmn): OpenCode's `run --format json` stream
-        // exposes only text/tool/step/error parts; per-message token and
-        // cost counters live in message metadata that the CLI does not emit
-        // on this transport, so no usage is forwarded and the meter stays
-        // absent rather than inventing a number nothing measured.
         // Current OpenCode can write a human-oriented permission control
         // notice to stdout. Only structured mode has framing sufficient to
         // recognize it without risking a valid assistant-text loss.
@@ -4136,6 +4131,16 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
               ev.isError,
             );
             if (ended) push({ kind: "tool_use", ...ended });
+          },
+          onResult: (ev) => {
+            // OpenCode's terminal `step_finish` carries token usage and a USD
+            // cost. Both are optional and already validated by the parser; a
+            // turn without them still completes but carries no meter/cost.
+            result = {
+              ...result,
+              ...(ev.usage ? { usage: ev.usage } : {}),
+              ...(ev.costUsd !== undefined ? { costUsd: ev.costUsd } : {}),
+            };
           },
           onError: (ev) => {
             // This is an explicit error envelope, so retain its error state

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -3350,6 +3350,37 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
         usage?: TurnUsage;
         costUsd?: number;
       } = {};
+      // Copilot reports per-message token usage on assistant.message frames;
+      // its terminal result frame only carries duration metrics. Accumulate
+      // the turn's usage here and merge it into the persisted/done result
+      // through the shared defensive parser (CHAT-D12-02 / cave-0osmn).
+      let copilotUsage: {
+        input_tokens: number;
+        output_tokens: number;
+        cache_read_input_tokens?: number;
+        cache_creation_input_tokens?: number;
+      } | undefined;
+      // The CLI can re-emit a full message frame for the same id (e.g. a
+      // correction); its usage block would then be counted twice. Count each
+      // message id once, first-wins.
+      const copilotUsageMessageIds = new Set<string>();
+      const accumulateCopilotUsage = (raw: {
+        input_tokens: number;
+        output_tokens: number;
+        cache_read_input_tokens?: number;
+        cache_creation_input_tokens?: number;
+      }) => {
+        copilotUsage = {
+          input_tokens: (copilotUsage?.input_tokens ?? 0) + raw.input_tokens,
+          output_tokens: (copilotUsage?.output_tokens ?? 0) + raw.output_tokens,
+          ...(raw.cache_read_input_tokens !== undefined || copilotUsage?.cache_read_input_tokens !== undefined
+            ? { cache_read_input_tokens: (copilotUsage?.cache_read_input_tokens ?? 0) + (raw.cache_read_input_tokens ?? 0) }
+            : {}),
+          ...(raw.cache_creation_input_tokens !== undefined || copilotUsage?.cache_creation_input_tokens !== undefined
+            ? { cache_creation_input_tokens: (copilotUsage?.cache_creation_input_tokens ?? 0) + (raw.cache_creation_input_tokens ?? 0) }
+            : {}),
+        };
+      };
       // Launch-integrity flag (#3856): set when the pre-spawn availability
       // gate or the post-spawn error handler proves the harness never
       // actually ran. Downstream it suppresses the empty-output diagnostic
@@ -3785,6 +3816,10 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
                   if (toolEv) push({ kind: "tool_use", ...toolEv });
                   settlePendingCopilotToolCompletion(req.toolCallId);
                 }
+                if (ev.usage && !copilotUsageMessageIds.has(ev.messageId)) {
+                  copilotUsageMessageIds.add(ev.messageId);
+                  accumulateCopilotUsage(ev.usage);
+                }
                 break;
               }
               case "tool_start": {
@@ -3819,6 +3854,7 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
                 result = {
                   duration_ms: ev.durationMs,
                   is_error: ev.isError,
+                  ...(copilotUsage ? { usage: parseStreamJsonUsage(copilotUsage) } : {}),
                 };
                 break;
               }
@@ -4001,6 +4037,11 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
       };
 
       const handleOpenCodeLine = (line: string) => {
+        // Token usage (cave-0osmn): OpenCode's `run --format json` stream
+        // exposes only text/tool/step/error parts; per-message token and
+        // cost counters live in message metadata that the CLI does not emit
+        // on this transport, so no usage is forwarded and the meter stays
+        // absent rather than inventing a number nothing measured.
         // Current OpenCode can write a human-oriented permission control
         // notice to stdout. Only structured mode has framing sufficient to
         // recognize it without risking a valid assistant-text loss.
@@ -4213,6 +4254,16 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
             if (started) push({ kind: "tool_use", ...started });
             const ended = toolTracker.envelopeToolResult(event.id, event.output, event.isError);
             if (ended) push({ kind: "tool_use", ...ended });
+            return;
+          }
+          case "completed": {
+            // Terminal Codex success (`turn.completed`) carries whole-turn
+            // token usage (CHAT-D12-02 / cave-0osmn). The stream's final
+            // failure state, if one arrives later, stays authoritative.
+            result = {
+              ...result,
+              ...(event.usage ? { usage: parseStreamJsonUsage(event.usage) } : {}),
+            };
             return;
           }
           case "failure": {
@@ -4716,7 +4767,14 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
                   hermesResponseId = event.id;
                   if (!sessionId) announceSession(event.id);
                 }
-                result = { ...result, is_error: event.isError };
+                // The Responses terminal can carry whole-turn token usage
+                // (CHAT-D12-02 / cave-0osmn); merge it through the shared
+                // defensive parser so it persists and reaches the done event.
+                result = {
+                  ...result,
+                  is_error: event.isError,
+                  ...(event.usage ? { usage: parseStreamJsonUsage(event.usage) } : {}),
+                };
                 if (event.isError) recordStdoutErrorTail("Hermes API stream failed", true);
                 if (event.isError && previousResponseId && event.invalidPreviousResponseId) resumeFailed = true;
                 return true;
@@ -5379,6 +5437,8 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
         jsonBuf = "";
         stdoutDecoder = new StringDecoder("utf8");
         result = {};
+        copilotUsage = undefined;
+        copilotUsageMessageIds.clear();
         resetToolTrackerForRetry();
         openCodeModelRejected = false;
         copilotText.reset();
@@ -5439,6 +5499,8 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
         jsonBuf = "";
         stdoutDecoder = new StringDecoder("utf8");
         result = {};
+        copilotUsage = undefined;
+        copilotUsageMessageIds.clear();
         resetToolTrackerForRetry();
         openCodeModelRejected = false;
         copilotText.reset();

--- a/src/lib/codex-compatibility.test.ts
+++ b/src/lib/codex-compatibility.test.ts
@@ -145,6 +145,48 @@ const unknownTool = parseCodexStreamEvent({ type: "item.completed", item: { id: 
 assert.equal(unknownTool?.kind, "unknown", "known outer events with an unknown tool type fail closed too");
 assert.deepEqual(parseCodexStreamEvent({ type: "turn.failed", message: "never render" }, selected.schema), { kind: "failure" }, "terminal turn failures retain no payload");
 assert.deepEqual(parseCodexStreamEvent({ type: "error", message: "never render" }, selected.schema), { kind: "failure" }, "terminal error frames retain no payload");
+assert.deepEqual(
+  parseCodexStreamEvent({ type: "turn.completed" }, selected.schema),
+  { kind: "completed" },
+  "a turn.completed without usage confirms terminal success without inventing a meter",
+);
+assert.deepEqual(
+  parseCodexStreamEvent({
+    type: "turn.completed",
+    usage: {
+      input_tokens: 10200,
+      cached_input_tokens: 5000,
+      cache_write_input_tokens: 1200,
+      output_tokens: 2150,
+      reasoning_output_tokens: 300,
+    },
+  }, selected.schema),
+  {
+    kind: "completed",
+    usage: {
+      input_tokens: 10200,
+      output_tokens: 2150,
+      cache_read_input_tokens: 5000,
+      cache_creation_input_tokens: 1200,
+    },
+  },
+  "turn.completed usage maps Codex counters onto the stream-json wire contract (cave-0osmn)",
+);
+assert.deepEqual(
+  parseCodexStreamEvent({ type: "turn.completed", usage: { input_tokens: 7, output_tokens: -3, cached_input_tokens: -1 } }, selected.schema),
+  { kind: "completed", usage: { input_tokens: 7, output_tokens: 0 } },
+  "negative counters drop; partial blocks keep the valid fields",
+);
+assert.deepEqual(
+  parseCodexStreamEvent({ type: "turn.completed", usage: { input_tokens: "12", output_tokens: NaN } }, selected.schema),
+  { kind: "completed" },
+  "malformed turn usage fails closed rather than fabricating a meter",
+);
+assert.deepEqual(
+  parseCodexStreamEvent({ type: "turn.completed", secret: "never render" }, selected.schema),
+  { kind: "completed" },
+  "turn.completed payloads never leak into the usage block",
+);
 
 const decoder = new CodexJsonlDecoder();
 const preambleJson = decoder.push('{"type":"error","message":"assistant JSON, not protocol"}\n{"type":"thread.started","thread_id":"example-thread"}\n{"type":"item.started","item":{"id":"example","type":"command_execution"}}\n', selected.schema);
@@ -258,7 +300,7 @@ await assert.rejects(
   "a registry which lies about Content-Length is still bounded while streaming",
 );
 
-for (const [version, expectedEvents] of [["0.144.2", 3], ["0.145.0", 6]] as const) {
+for (const [version, expectedEvents] of [["0.144.2", 3], ["0.145.0", 7]] as const) {
   const fixtureSchema = resolveCodexSchema({ version, capabilities: { jsonEvents: true, resume: true } });
   assert.ok(fixtureSchema.ok, `${version} fixture selects a compatible schema`);
   if (!fixtureSchema.ok) continue;
@@ -271,6 +313,17 @@ for (const [version, expectedEvents] of [["0.144.2", 3], ["0.145.0", 6]] as cons
       fixtureEvents.events.some((event) => event.kind === "tool_end" && event.isError),
       true,
       "the observed 0.145 completed-item failure fixture settles its tool as an error",
+    );
+    const completed = fixtureEvents.events.find((event) => event.kind === "completed");
+    assert.deepEqual(
+      completed?.usage,
+      {
+        input_tokens: 10200,
+        output_tokens: 2150,
+        cache_read_input_tokens: 5000,
+        cache_creation_input_tokens: 1200,
+      },
+      "the 0.145 fixture terminal turn.completed carries normalised usage (cave-0osmn)",
     );
   }
 }

--- a/src/lib/codex-compatibility.ts
+++ b/src/lib/codex-compatibility.ts
@@ -1063,11 +1063,26 @@ export function peekCachedCodexRuntime(
   return cached.report;
 }
 
+/**
+ * Codex turn token usage normalised onto the stream-json wire contract
+ * (CHAT-D12-02): `cached_input_tokens` maps to cache reads and
+ * `cache_write_input_tokens` to cache writes so Cave's shared
+ * `parseStreamJsonUsage` can consume the terminal event unchanged.
+ */
+export type CodexTurnUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+};
+
 export type CodexStreamEvent =
   | { kind: "text"; text: string }
   | { kind: "session"; sessionId: string }
   | { kind: "tool_start"; id: string; name: string; input?: unknown }
   | { kind: "tool_end"; id: string; name: string; input?: unknown; output?: string; isError: boolean }
+  /** Terminal Codex success (`turn.completed`) with optional token usage. */
+  | { kind: "completed"; usage?: CodexTurnUsage }
   /** Terminal Codex failure with no untrusted payload attached. */
   | { kind: "failure" }
   | { kind: "unknown"; fingerprint: string }
@@ -1100,6 +1115,26 @@ function eventFingerprint(value: Record<string, unknown>): string {
   return createHash("sha256").update(shape).digest("hex").slice(0, 12);
 }
 
+function finiteNonNegative(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function codexTurnUsage(value: Record<string, unknown>): CodexTurnUsage | undefined {
+  const raw = record(value.usage);
+  if (!raw) return undefined;
+  const inputTokens = finiteNonNegative(raw.input_tokens);
+  const outputTokens = finiteNonNegative(raw.output_tokens);
+  if (inputTokens === undefined && outputTokens === undefined) return undefined;
+  const cacheRead = finiteNonNegative(raw.cached_input_tokens);
+  const cacheWrite = finiteNonNegative(raw.cache_write_input_tokens);
+  return {
+    input_tokens: inputTokens ?? 0,
+    output_tokens: outputTokens ?? 0,
+    ...(cacheRead !== undefined ? { cache_read_input_tokens: cacheRead } : {}),
+    ...(cacheWrite !== undefined ? { cache_creation_input_tokens: cacheWrite } : {}),
+  };
+}
+
 export function parseCodexStreamEvent(value: unknown, schema: CodexEventSchema): CodexStreamEvent | null {
   const event = record(value);
   if (!event || typeof event.type !== "string") return null;
@@ -1112,8 +1147,17 @@ export function parseCodexStreamEvent(value: unknown, schema: CodexEventSchema):
   if (event.type === "turn.failed" || event.type === "error") {
     return { kind: "failure" };
   }
-  if (event.type === "turn.started" || event.type === "turn.completed") {
+  if (event.type === "turn.started") {
     return { kind: "ignored" };
+  }
+  if (event.type === "turn.completed") {
+    // The Codex CLI reports whole-turn token usage on its terminal success
+    // event (`codex exec --json`), normalised onto the stream-json contract
+    // so Cave's shared defensive parser can persist and render it unchanged
+    // (CHAT-D12-02 / cave-0osmn). A declared-but-malformed usage block is
+    // protocol drift, not permission to reinterpret the frame.
+    const usage = codexTurnUsage(event);
+    return usage ? { kind: "completed", usage } : { kind: "completed" };
   }
   const item = record(event.item);
   if (!item) return { kind: "unknown", fingerprint: eventFingerprint(event) };

--- a/src/lib/copilot-stream.test.ts
+++ b/src/lib/copilot-stream.test.ts
@@ -513,6 +513,67 @@ assert.deepEqual(
   "the parser preserves the schema-declared frame identity for replay suppression",
 );
 
+// ── assistant.message token usage (cave-0osmn) ───────────────────────────────
+// Copilot reports OpenAI-style counters on message frames when its runtime
+// has them; Cave normalises them onto the stream-json wire contract so the
+// route can sum a turn's messages through the shared defensive parser.
+
+assert.deepEqual(
+  parseCopilotChatEvent({
+    type: "assistant.message",
+    data: {
+      messageId: "m-usage",
+      content: "done",
+      toolRequests: [],
+      usage: {
+        prompt_tokens: 10200,
+        completion_tokens: 2150,
+        cache_read_input_tokens: 5000,
+        cache_creation_input_tokens: 1200,
+      },
+    },
+  }),
+  {
+    kind: "message",
+    messageId: "m-usage",
+    content: "done",
+    toolRequests: [],
+    model: undefined,
+    usage: {
+      input_tokens: 10200,
+      output_tokens: 2150,
+      cache_read_input_tokens: 5000,
+      cache_creation_input_tokens: 1200,
+    },
+  },
+  "a message frame with OpenAI-style usage maps onto the stream-json wire contract",
+);
+assert.deepEqual(
+  parseCopilotChatEvent({
+    type: "assistant.message",
+    data: { messageId: "m-min", content: "hi", toolRequests: [], usage: { prompt_tokens: 12, completion_tokens: 34 } },
+  }),
+  {
+    kind: "message",
+    messageId: "m-min",
+    content: "hi",
+    toolRequests: [],
+    model: undefined,
+    usage: { input_tokens: 12, output_tokens: 34 },
+  },
+  "cache counters stay optional when Copilot omits them",
+);
+const noUsageMessage = parseCopilotChatEvent({
+  type: "assistant.message",
+  data: { messageId: "m-nousage", content: "hi", toolRequests: [] },
+});
+assert.equal(noUsageMessage?.kind === "message" ? noUsageMessage.usage : undefined, undefined, "messages without a usage block stay usage-free");
+const badUsageMessage = parseCopilotChatEvent({
+  type: "assistant.message",
+  data: { messageId: "m-bad", content: "hi", toolRequests: [], usage: { prompt_tokens: "12k", completion_tokens: NaN } },
+});
+assert.equal(badUsageMessage?.kind === "message" ? badUsageMessage.usage : undefined, undefined, "malformed usage counters fail closed rather than inventing a meter");
+
 const resultEv = parseCopilotChatEvent(JSON.parse(FIXTURE[14]));
 assert.deepEqual(resultEv, {
   kind: "result",

--- a/src/lib/copilot-stream.ts
+++ b/src/lib/copilot-stream.ts
@@ -566,6 +566,21 @@ export type CopilotToolRequest = {
   input?: unknown;
 };
 
+/**
+ * Copilot per-message token usage normalised onto the stream-json wire
+ * contract (CHAT-D12-02): Copilot reports OpenAI-style counters
+ * (`prompt_tokens`/`completion_tokens`/`cache_read_input_tokens`/
+ * `cache_creation_input_tokens`) on `assistant.message` frames; Cave maps
+ * them to the shared contract so the route can sum a turn's messages and
+ * persist the total through `parseStreamJsonUsage` unchanged.
+ */
+export type CopilotStreamUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+};
+
 export type CopilotChatEvent =
   | { kind: "text_delta"; messageId: string; text: string; frameId?: string; model?: string }
   | {
@@ -576,6 +591,8 @@ export type CopilotChatEvent =
       /** The message content is usable, but one or more declared tool calls were not. */
       malformedToolRequests?: boolean;
       model?: string;
+      /** Token usage this assistant message's model call reported, when the CLI emits it. */
+      usage?: CopilotStreamUsage;
     }
   | {
       kind: "tool_start";
@@ -608,6 +625,29 @@ function field(source: Record<string, unknown> | null, aliases: string[]): unkno
 function textField(source: Record<string, unknown> | null, aliases: string[]): string | undefined {
   const value = field(source, aliases);
   return typeof value === "string" && value ? value : undefined;
+}
+
+function finiteNonNegative(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function copilotMessageUsage(data: Record<string, unknown> | null, protocol: RuntimeEventProtocolSchema): CopilotStreamUsage | undefined {
+  const raw = record(field(data, protocol.fields.usage));
+  if (!raw) return undefined;
+  // Copilot reports OpenAI-style counters on assistant.message frames; a
+  // declared-but-malformed block is protocol drift, not permission to
+  // reinterpret the message as usage-free.
+  const inputTokens = finiteNonNegative(raw.prompt_tokens);
+  const outputTokens = finiteNonNegative(raw.completion_tokens);
+  if (inputTokens === undefined && outputTokens === undefined) return undefined;
+  const cacheRead = finiteNonNegative(raw.cache_read_input_tokens);
+  const cacheWrite = finiteNonNegative(raw.cache_creation_input_tokens);
+  return {
+    input_tokens: inputTokens ?? 0,
+    output_tokens: outputTokens ?? 0,
+    ...(cacheRead !== undefined ? { cache_read_input_tokens: cacheRead } : {}),
+    ...(cacheWrite !== undefined ? { cache_creation_input_tokens: cacheWrite } : {}),
+  };
 }
 
 function typeIs(type: string, aliases: string[]): boolean {
@@ -706,6 +746,7 @@ export function parseCopilotChatEvent(
           });
         }
       }
+      const usage = copilotMessageUsage(data, protocol);
       return {
         kind: "message",
         messageId,
@@ -713,6 +754,7 @@ export function parseCopilotChatEvent(
         toolRequests,
         ...(malformedToolRequests ? { malformedToolRequests: true } : {}),
         model: asModel(field(data, protocol.fields.model)),
+        ...(usage ? { usage } : {}),
       };
   }
   if (typeIs(type, protocol.eventTypes.toolStart)) {

--- a/src/lib/fixtures/codex/0.145.0-tool-lifecycle.jsonl
+++ b/src/lib/fixtures/codex/0.145.0-tool-lifecycle.jsonl
@@ -4,3 +4,4 @@
 {"type":"item.completed","item":{"id":"call-current","type":"command_execution","command":"git status --short","aggregated_output":""}}
 {"type":"item.started","item":{"id":"call-failed","type":"mcp_tool_call","server":"example","tool":"lookup","arguments":{"query":"sanitized fixture"}}}
 {"type":"item.completed","item":{"id":"call-failed","type":"mcp_tool_call","server":"example","tool":"lookup","status":"failed","error":{"message":"fixture failure"}}}
+{"type":"turn.completed","usage":{"input_tokens":10200,"cached_input_tokens":5000,"cache_write_input_tokens":1200,"output_tokens":2150,"reasoning_output_tokens":300}}

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -49,6 +49,36 @@ test("Hermes Responses events normalise text, calls, output, session, and comple
     parseHermesResponsesEvent("response.completed", { response: { id: "resp-terminal" } }),
     { kind: "done", isError: false, id: "resp-terminal" },
   );
+  // Terminal usage (cave-0osmn): OpenAI-compatible Responses usage maps onto
+  // the stream-json wire contract so the route persists and renders it.
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.completed", {
+      response: {
+        id: "resp-usage",
+        usage: {
+          input_tokens: 10200,
+          input_tokens_details: { cached_tokens: 5000 },
+          output_tokens: 2150,
+          total_tokens: 12350,
+        },
+      },
+    }),
+    {
+      kind: "done",
+      isError: false,
+      id: "resp-usage",
+      usage: { input_tokens: 10200, output_tokens: 2150, cache_read_input_tokens: 5000 },
+    },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.completed", {
+      response: { id: "resp-min", usage: { input_tokens: 12, output_tokens: 34 } },
+    }),
+    { kind: "done", isError: false, id: "resp-min", usage: { input_tokens: 12, output_tokens: 34 } },
+    "cache counters stay optional when the server omits them",
+  );
+  const malformedUsageDone = parseHermesResponsesEvent("response.completed", { response: { id: "resp-nousage", usage: { input_tokens: "12", output_tokens: NaN } } });
+  assert.equal(malformedUsageDone.kind === "done" ? malformedUsageDone.usage : undefined, undefined, "malformed usage fails closed rather than inventing a meter");
   assert.deepEqual(
     parseHermesResponsesEvent("response.failed", { response: { id: "resp-failed", error: { message: "invalid model" } } }),
     { kind: "done", isError: true, id: "resp-failed", message: "invalid model" },

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -9,13 +9,26 @@
 // incomplete data.  The normalised events are fed to ToolCallTracker by the
 // chat route, retaining Cave's stable-id, persistence, and resume semantics.
 
+/**
+ * Hermes Responses terminal token usage normalised onto the stream-json
+ * wire contract (CHAT-D12-02): the OpenAI-compatible Responses API reports
+ * `input_tokens`/`output_tokens` with `input_tokens_details.cached_tokens`;
+ * Cave maps the cached count onto cache reads so its shared
+ * `parseStreamJsonUsage` can persist and render it unchanged.
+ */
+export type HermesStreamUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+};
+
 export type HermesResponsesEvent =
   | { kind: "text"; text: string }
   | { kind: "tool_start"; id: string; name: string; input?: unknown; itemId?: string }
   | { kind: "tool_input"; id?: string; itemId?: string; input: string; isFinal: boolean }
   | { kind: "tool_end"; id: string; output?: unknown; isError: boolean }
   | { kind: "session"; id: string }
-  | { kind: "done"; isError: boolean; id?: string; message?: string; invalidPreviousResponseId?: boolean }
+  | { kind: "done"; isError: boolean; id?: string; message?: string; invalidPreviousResponseId?: boolean; usage?: HermesStreamUsage }
   | { kind: "error"; message: string; invalidPreviousResponseId?: boolean }
   | { kind: "ignore" };
 
@@ -82,6 +95,28 @@ function toolFailed(value: RecordValue, item: RecordValue | null): boolean {
   return hasError(value.error) || hasError(item?.error) ||
     failedStatuses.has(string(value.status) ?? "") ||
     failedStatuses.has(string(item?.status) ?? "");
+}
+
+function finiteNonNegative(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/** Responses `usage` block → stream-json wire contract (CHAT-D12-02). */
+function responsesUsage(value: RecordValue | null): HermesStreamUsage | undefined {
+  const response = record(value?.response) ?? value;
+  const raw = record(response?.usage) ?? record(value?.usage);
+  if (!raw) return undefined;
+  const inputTokens = finiteNonNegative(raw.input_tokens);
+  const outputTokens = finiteNonNegative(raw.output_tokens);
+  if (inputTokens === undefined && outputTokens === undefined) return undefined;
+  // OpenAI Responses nests cache hits under input_tokens_details.cached_tokens.
+  const details = record(raw.input_tokens_details);
+  const cacheRead = finiteNonNegative(details?.cached_tokens) ?? finiteNonNegative(raw.cached_input_tokens);
+  return {
+    input_tokens: inputTokens ?? 0,
+    output_tokens: outputTokens ?? 0,
+    ...(cacheRead !== undefined ? { cache_read_input_tokens: cacheRead } : {}),
+  };
 }
 
 /** A fresh retry is safe only when the API explicitly rejects the stored
@@ -209,18 +244,26 @@ export function parseHermesResponsesEvent(eventName: string, payload: unknown): 
 
   if (type === "response.completed") {
     const id = responseId(value);
-    return { kind: "done", isError: false, ...(id ? { id } : {}) };
+    const usage = responsesUsage(value);
+    return {
+      kind: "done",
+      isError: false,
+      ...(id ? { id } : {}),
+      ...(usage ? { usage } : {}),
+    };
   }
   if (type === "response.failed" || type === "response.incomplete") {
     const response = record(value.response);
     const error = record(response?.error) ?? record(value.error);
     const message = string(error?.message) ?? string(value.message);
     const id = responseId(value);
+    const usage = responsesUsage(value);
     return {
       kind: "done",
       isError: true,
       ...(id ? { id } : {}),
       ...(message ? { message } : {}),
+      ...(usage ? { usage } : {}),
       ...(isHermesInvalidPreviousResponseIdError(value) ? { invalidPreviousResponseId: true } : {}),
     };
   }

--- a/src/lib/opencode-stream.test.ts
+++ b/src/lib/opencode-stream.test.ts
@@ -74,6 +74,47 @@ assert.deepEqual(
 );
 assert.deepEqual(
   parseOpenCodeRunEvent(
+    {
+      type: "step_finish",
+      sessionID: "ses_123",
+      part: { reason: "stop", cost: 0.001, tokens: { input: 671, output: 8, reasoning: 0, cache: { read: 21415, write: 0 } } },
+    },
+    BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
+  ),
+  {
+    kind: "result",
+    sessionId: "ses_123",
+    usage: { inputTokens: 671, outputTokens: 8, cacheReadTokens: 21415, cacheCreationTokens: 0 },
+    costUsd: 0.001,
+  },
+  "a terminal step-finish maps OpenCode's tokens (cache write → cache creation) and USD cost onto the result event",
+);
+assert.deepEqual(
+  parseOpenCodeRunEvent(
+    { type: "step_finish", sessionID: "ses_123", part: { reason: "tool-calls", cost: 0, tokens: { input: 21772, output: 110, cache: { read: 0, write: 0 } } } },
+    BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
+  ),
+  { kind: "ignore", sessionId: "ses_123" },
+  "an intermediate tool-calls step is not the terminal outcome and its per-step counters are not surfaced",
+);
+assert.deepEqual(
+  parseOpenCodeRunEvent(
+    { type: "step_finish", sessionID: "ses_123", part: { reason: "stop", tokens: { input: "many", output: "lots" } } },
+    BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
+  ),
+  { kind: "ignore", sessionId: "ses_123" },
+  "a malformed token block yields no usage (no fabricated zero) and falls back to lifecycle handling",
+);
+assert.doesNotMatch(
+  JSON.stringify(parseOpenCodeRunEvent(
+    { type: "step_finish", sessionID: "ses_123", part: { reason: "stop", tokens: { input: "secret", output: -5 } } },
+    BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
+  )),
+  /secret/,
+  "OpenCode usage payloads never leak into parsed events",
+);
+assert.deepEqual(
+  parseOpenCodeRunEvent(
     { type: "reasoning", sessionID: "ses_123", part: { text: "private chain of thought" } },
     BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
   ),

--- a/src/lib/opencode-stream.ts
+++ b/src/lib/opencode-stream.ts
@@ -1,4 +1,5 @@
 import type { OpenCodeEnvelopePath, OpenCodeEventSchema } from "@/lib/opencode-compatibility";
+import { parseCostUsd, type TurnUsage } from "./usage-format.ts";
 
 export type OpenCodeRunEvent =
   | { kind: "ignore"; sessionId?: string }
@@ -8,6 +9,7 @@ export type OpenCodeRunEvent =
   | { kind: "tool_end"; sessionId?: string; id: string; output: unknown; isError: boolean }
   | { kind: "tool"; sessionId?: string; id: string; name: string; input: unknown; output: unknown; isError: boolean }
   | { kind: "error"; sessionId?: string; message: string }
+  | { kind: "result"; sessionId?: string; usage?: TurnUsage; costUsd?: number }
   | { kind: "other"; sessionId?: string; diagnostic?: "unknown-event" | "malformed-event" };
 
 export type OpenCodeJsonLineHandlers = {
@@ -18,6 +20,7 @@ export type OpenCodeJsonLineHandlers = {
   onToolProgress?: (event: Extract<OpenCodeRunEvent, { kind: "tool_progress" }>) => void;
   onToolEnd?: (event: Extract<OpenCodeRunEvent, { kind: "tool_end" }>) => void;
   onError?: (event: Extract<OpenCodeRunEvent, { kind: "error" }>) => void;
+  onResult?: (event: Extract<OpenCodeRunEvent, { kind: "result" }>) => void;
   onOther?: (event: Extract<OpenCodeRunEvent, { kind: "other" }>, rawEvent: unknown) => void;
   onMalformedJson?: () => void;
 };
@@ -133,6 +136,32 @@ function hasToolErrorPayload(value: unknown): boolean {
     && (typeof value !== "string" || value.trim().length > 0);
 }
 
+function finiteNonNegativeTokens(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/** OpenCode's terminal `step_finish` reports `part.tokens` as
+ * `{ input, output, reasoning, cache: { read, write } }` plus a USD `cost`.
+ * Map the counters Cave persists onto a `TurnUsage` (cache write → cache
+ * creation); a missing/empty block yields undefined so the turn shows no meter
+ * instead of a fabricated zero. */
+function parseOpenCodeUsage(raw: unknown): TurnUsage | undefined {
+  const tokens = record(raw);
+  if (!tokens) return undefined;
+  const inputTokens = finiteNonNegativeTokens(tokens.input);
+  const outputTokens = finiteNonNegativeTokens(tokens.output);
+  if (inputTokens === undefined && outputTokens === undefined) return undefined;
+  const cache = record(tokens.cache);
+  const cacheReadTokens = finiteNonNegativeTokens(cache?.read);
+  const cacheCreationTokens = finiteNonNegativeTokens(cache?.write);
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+    ...(cacheCreationTokens !== undefined ? { cacheCreationTokens } : {}),
+  };
+}
+
 /** Decode OpenCode's `run --format json` envelope without trusting its fields. */
 export function parseOpenCodeRunEvent(value: unknown, schema?: OpenCodeEventSchema): OpenCodeRunEvent {
   const event = record(value);
@@ -147,6 +176,27 @@ export function parseOpenCodeRunEvent(value: unknown, schema?: OpenCodeEventSche
   const discriminator = schema?.shape?.discriminator ?? { envelope: "root" as const, field: "type" };
   const eventType = stringAt(envelope(event, [discriminator.envelope]), discriminator.field);
   if (!eventType) return { kind: "other", sessionId, diagnostic: "malformed-event" };
+  // OpenCode's terminal `step_finish` (reason "stop" or absent) carries the
+  // turn's token usage and USD cost on its `part`. This is the usage/cost
+  // terminal event, handled before the ignored-lifecycle branch below. A
+  // `reason: "tool-calls"` step is an intermediate tool-loop step, not the
+  // turn's terminal outcome, so its per-step counters are not surfaced.
+  if (eventType === "step_finish") {
+    const reason = stringAt(part, "reason");
+    const terminal = reason === undefined || reason === "stop";
+    if (terminal) {
+      const usage = parseOpenCodeUsage(valueAt(part, ["tokens"]));
+      const costUsd = parseCostUsd(valueAt(part, ["cost"]));
+      if (usage || costUsd !== undefined) {
+        return {
+          kind: "result",
+          ...(sessionId ? { sessionId } : {}),
+          ...(usage ? { usage } : {}),
+          ...(costUsd !== undefined ? { costUsd } : {}),
+        };
+      }
+    }
+  }
   if (eventTypes(schema, "ignored", ["step_start", "step_finish"]).includes(eventType)) {
     // Lifecycle/control frames are deliberately non-renderable. The selected
     // schema nevertheless authorizes their label, so retain its session token:
@@ -299,6 +349,7 @@ export function handleOpenCodeJsonLine(
       case "tool_progress": handlers.onToolProgress?.(event); return;
       case "tool_end": handlers.onToolEnd?.(event); return;
       case "error": handlers.onError?.(event); return;
+      case "result": handlers.onResult?.(event); return;
       case "other": handlers.onOther?.(event, rawEvent); return;
     }
   } catch {


### PR DESCRIPTION
Bead: cave-0osmn (P2 bug) — Cave records token usage for 3 of 7755 turns because only the claude harness emitted usage on its stream-json terminal event.

Scope: make the harness adapters emit token usage into the existing (complete, working) usage/cost pipeline wherever the upstream CLI reports it. No pipeline changes; only emission points + tests.

## WHAT CHANGED
- **Copilot** (1213 convs, priority 1): Copilot reports OpenAI-style per-message counters (`prompt_tokens`/`completion_tokens`/`cache_read_input_tokens`/`cache_creation_input_tokens`) on `assistant.message` frames. The route now accumulates per-message usage across the turn (deduped per message id, reset per attempt) and merges the total into the terminal result — the result frame's own `usage` carries only duration metrics.
- **Codex** (326 convs, priority 2): `codex exec --json` emits `turn.completed` with whole-turn `usage` (input_tokens / cached_input_tokens / cache_write_input_tokens / output_tokens). Cave previously parsed `turn.completed` as ignored. Now it normalises the counters onto the stream-json wire contract and merges them into the terminal result.
- **OpenCode** (27 convs, priority 3): the terminal `step_finish` part carries tokens (`input`/`output`/`cache.read`/`cache.write`) and a USD `cost`. The schema ignored the frame; it now parses the terminal step (reason `stop`/absent) into a result event wired through the route's `onResult` handler into the existing usage/costUsd persistence path.
- **Hermes** (3 convs, priority 5): the OpenAI-compatible Responses terminal (`response.completed`/`failed`/`incomplete`) carries `usage` (incl. `input_tokens_details.cached_tokens`); the parser normalises it onto the wire contract and the route merges it into the done result.
- **OpenClaw** (7 convs): the bridge reports no usage (existing expectation — the meter comment already anticipates it).

## FILES
- `src/lib/copilot-stream.ts` (+ tests)
- `src/lib/codex-compatibility.ts` (+ tests)
- `src/lib/opencode-stream.ts` (+ tests)
- `src/lib/hermes-responses-stream.ts` (+ tests)
- `src/app/api/chat/send/route.ts` (emission points)
- `src/lib/fixtures/codex/0.145.0-tool-lifecycle.jsonl` (fixture now carries a terminal turn.completed)
- `harness-routing-*` wiring tests extended

## TESTS RUN
- `pnpm exec tsc --noEmit`: clean
- `src/lib/copilot-stream.test.ts`, `src/lib/codex-compatibility.test.ts`, `src/lib/opencode-stream.test.ts`, `src/lib/hermes-responses-stream.test.ts`
- `src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts`, `harness-routing-tool-events.test.ts`, `harness-routing-codex-direct.test.ts` (end-to-end: done event + persisted turn carry usage), `harness-routing-opencode.test.ts`, plus the chat/send route + harness-routing suite
- `node scripts/check-tests-wired.mjs`: all 1921 test files wired