### PR TITLE
feat(chat): emit per-turn token usage from codex, opencode, and hermes (cave-0osmn)

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -4096,6 +4096,16 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
             );
             if (ended) push({ kind: "tool_use", ...ended });
           },
+          onResult: (ev) => {
+            // OpenCode's terminal `step_finish` carries token usage and a USD
+            // cost. Both are optional and already validated by the parser; a
+            // turn without them still completes but carries no meter/cost.
+            result = {
+              ...result,
+              ...(ev.usage ? { usage: ev.usage } : {}),
+              ...(ev.costUsd !== undefined ? { costUsd: ev.costUsd } : {}),
+            };
+          },
           onError: (ev) => {
             // This is an explicit error envelope, so retain its error state
             // even if its message does not match the generic stderr filter.
@@ -4213,6 +4223,13 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
             if (started) push({ kind: "tool_use", ...started });
             const ended = toolTracker.envelopeToolResult(event.id, event.output, event.isError);
             if (ended) push({ kind: "tool_use", ...ended });
+            return;
+          }
+          case "completed": {
+            // Codex's terminal `turn.completed` carries token usage (no cost).
+            // It is optional and already validated by the parser; a turn
+            // without it still completes but carries no meter.
+            if (event.usage) result = { ...result, usage: event.usage };
             return;
           }
           case "failure": {
@@ -4717,6 +4734,10 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
                   if (!sessionId) announceSession(event.id);
                 }
                 result = { ...result, is_error: event.isError };
+                // Hermes's Responses-compatible `response.completed` reports
+                // token usage (no cost). Optional and already validated by the
+                // parser; a turn without it still completes with no meter.
+                if (event.usage) result = { ...result, usage: event.usage };
                 if (event.isError) recordStdoutErrorTail("Hermes API stream failed", true);
                 if (event.isError && previousResponseId && event.invalidPreviousResponseId) resumeFailed = true;
                 return true;

--- a/src/lib/codex-compatibility.test.ts
+++ b/src/lib/codex-compatibility.test.ts
@@ -145,6 +145,37 @@ const unknownTool = parseCodexStreamEvent({ type: "item.completed", item: { id: 
 assert.equal(unknownTool?.kind, "unknown", "known outer events with an unknown tool type fail closed too");
 assert.deepEqual(parseCodexStreamEvent({ type: "turn.failed", message: "never render" }, selected.schema), { kind: "failure" }, "terminal turn failures retain no payload");
 assert.deepEqual(parseCodexStreamEvent({ type: "error", message: "never render" }, selected.schema), { kind: "failure" }, "terminal error frames retain no payload");
+assert.deepEqual(
+  parseCodexStreamEvent(
+    { type: "turn.completed", usage: { input_tokens: 100, output_tokens: 50, cached_input_tokens: 10 } },
+    selected.schema,
+  ),
+  { kind: "completed", usage: { inputTokens: 100, outputTokens: 50, cacheReadTokens: 10 } },
+  "a successful turn maps Codex's snake_case usage onto Cave's TurnUsage (cache read, no cache-creation/cost)",
+);
+assert.deepEqual(
+  parseCodexStreamEvent(
+    { type: "turn.completed", usage: { input_tokens: 80, output_tokens: 40 } },
+    selected.schema,
+  ),
+  { kind: "completed", usage: { inputTokens: 80, outputTokens: 40 } },
+  "cached_input_tokens is optional and omitted when the CLI does not report it",
+);
+assert.deepEqual(
+  parseCodexStreamEvent({ type: "turn.completed", secret: "never render" }, selected.schema),
+  { kind: "completed" },
+  "a turn.completed frame without a usage block completes with no meter (no fabricated zero)",
+);
+assert.equal(
+  parseCodexStreamEvent({ type: "turn.completed", usage: { input_tokens: "many", output_tokens: "lots" } }, selected.schema)?.kind,
+  "completed",
+  "a malformed usage block drops the usage but never fails the turn or leaks its values",
+);
+assert.doesNotMatch(
+  JSON.stringify(parseCodexStreamEvent({ type: "turn.completed", usage: { input_tokens: "secret", output_tokens: -5 } }, selected.schema)),
+  /secret/,
+  "usage payloads never leak into event diagnostics",
+);
 
 const decoder = new CodexJsonlDecoder();
 const preambleJson = decoder.push('{"type":"error","message":"assistant JSON, not protocol"}\n{"type":"thread.started","thread_id":"example-thread"}\n{"type":"item.started","item":{"id":"example","type":"command_execution"}}\n', selected.schema);

--- a/src/lib/codex-compatibility.test.ts
+++ b/src/lib/codex-compatibility.test.ts
@@ -147,11 +147,11 @@ assert.deepEqual(parseCodexStreamEvent({ type: "turn.failed", message: "never re
 assert.deepEqual(parseCodexStreamEvent({ type: "error", message: "never render" }, selected.schema), { kind: "failure" }, "terminal error frames retain no payload");
 assert.deepEqual(
   parseCodexStreamEvent(
-    { type: "turn.completed", usage: { input_tokens: 100, output_tokens: 50, cached_input_tokens: 10 } },
+    { type: "turn.completed", usage: { input_tokens: 100, output_tokens: 50, cached_input_tokens: 10, cache_write_input_tokens: 4 } },
     selected.schema,
   ),
-  { kind: "completed", usage: { inputTokens: 100, outputTokens: 50, cacheReadTokens: 10 } },
-  "a successful turn maps Codex's snake_case usage onto Cave's TurnUsage (cache read, no cache-creation/cost)",
+  { kind: "completed", usage: { inputTokens: 100, outputTokens: 50, cacheReadTokens: 10, cacheCreationTokens: 4 } },
+  "a successful turn maps Codex's snake_case usage onto Cave's TurnUsage (cached-input → cache read, cache-write-input → cache creation)",
 );
 assert.deepEqual(
   parseCodexStreamEvent(
@@ -159,7 +159,7 @@ assert.deepEqual(
     selected.schema,
   ),
   { kind: "completed", usage: { inputTokens: 80, outputTokens: 40 } },
-  "cached_input_tokens is optional and omitted when the CLI does not report it",
+  "cached_input_tokens and cache_write_input_tokens are optional and omitted when the CLI does not report them",
 );
 assert.deepEqual(
   parseCodexStreamEvent({ type: "turn.completed", secret: "never render" }, selected.schema),

--- a/src/lib/codex-compatibility.ts
+++ b/src/lib/codex-compatibility.ts
@@ -14,6 +14,7 @@ import { mkdir, open, readFile, rename, stat, unlink, writeFile } from "node:fs/
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import type { TurnUsage } from "./usage-format.ts";
 
 const execFileAsync = promisify(execFile);
 const MAX_SCHEMA_DOCUMENT_BYTES = 1_048_576;
@@ -1068,6 +1069,9 @@ export type CodexStreamEvent =
   | { kind: "session"; sessionId: string }
   | { kind: "tool_start"; id: string; name: string; input?: unknown }
   | { kind: "tool_end"; id: string; name: string; input?: unknown; output?: string; isError: boolean }
+  /** Terminal Codex success (`turn.completed`), carrying token usage when the
+   * CLI reported it. Codex does not report a per-turn cost, so none is emitted. */
+  | { kind: "completed"; usage?: TurnUsage }
   /** Terminal Codex failure with no untrusted payload attached. */
   | { kind: "failure" }
   | { kind: "unknown"; fingerprint: string }
@@ -1100,6 +1104,29 @@ function eventFingerprint(value: Record<string, unknown>): string {
   return createHash("sha256").update(shape).digest("hex").slice(0, 12);
 }
 
+function finiteNonNegativeTokens(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/** Codex `turn.completed.usage` reports token counts as snake_case
+ * (`input_tokens`, `output_tokens`, `cached_input_tokens`). Map the fields
+ * Cave persists onto a `TurnUsage`; Codex has no cache-creation or cost
+ * counter, and a malformed/absent usage block yields undefined so the turn
+ * carries no meter rather than a fabricated zero. */
+function parseCodexUsage(raw: unknown): TurnUsage | undefined {
+  const usage = record(raw);
+  if (!usage) return undefined;
+  const inputTokens = finiteNonNegativeTokens(usage.input_tokens);
+  const outputTokens = finiteNonNegativeTokens(usage.output_tokens);
+  if (inputTokens === undefined && outputTokens === undefined) return undefined;
+  const cacheReadTokens = finiteNonNegativeTokens(usage.cached_input_tokens);
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+  };
+}
+
 export function parseCodexStreamEvent(value: unknown, schema: CodexEventSchema): CodexStreamEvent | null {
   const event = record(value);
   if (!event || typeof event.type !== "string") return null;
@@ -1112,8 +1139,15 @@ export function parseCodexStreamEvent(value: unknown, schema: CodexEventSchema):
   if (event.type === "turn.failed" || event.type === "error") {
     return { kind: "failure" };
   }
-  if (event.type === "turn.started" || event.type === "turn.completed") {
+  if (event.type === "turn.started") {
     return { kind: "ignored" };
+  }
+  if (event.type === "turn.completed") {
+    // A successful Codex turn reports its token usage here. The usage block is
+    // optional and defensively validated: a turn without it still completes,
+    // but carries no meter (Codex emits no cost, so costUsd is never set).
+    const usage = parseCodexUsage(event.usage);
+    return usage ? { kind: "completed", usage } : { kind: "completed" };
   }
   const item = record(event.item);
   if (!item) return { kind: "unknown", fingerprint: eventFingerprint(event) };

--- a/src/lib/codex-compatibility.ts
+++ b/src/lib/codex-compatibility.ts
@@ -1109,10 +1109,11 @@ function finiteNonNegativeTokens(value: unknown): number | undefined {
 }
 
 /** Codex `turn.completed.usage` reports token counts as snake_case
- * (`input_tokens`, `output_tokens`, `cached_input_tokens`). Map the fields
- * Cave persists onto a `TurnUsage`; Codex has no cache-creation or cost
- * counter, and a malformed/absent usage block yields undefined so the turn
- * carries no meter rather than a fabricated zero. */
+ * (`input_tokens`, `output_tokens`, `cached_input_tokens`,
+ * `cache_write_input_tokens`). Map the fields Cave persists onto a `TurnUsage`
+ * (cached-input → cache read, cache-write-input → cache creation); Codex has no
+ * per-turn cost counter, and a malformed/absent usage block yields undefined
+ * so the turn carries no meter rather than a fabricated zero. */
 function parseCodexUsage(raw: unknown): TurnUsage | undefined {
   const usage = record(raw);
   if (!usage) return undefined;
@@ -1120,10 +1121,12 @@ function parseCodexUsage(raw: unknown): TurnUsage | undefined {
   const outputTokens = finiteNonNegativeTokens(usage.output_tokens);
   if (inputTokens === undefined && outputTokens === undefined) return undefined;
   const cacheReadTokens = finiteNonNegativeTokens(usage.cached_input_tokens);
+  const cacheCreationTokens = finiteNonNegativeTokens(usage.cache_write_input_tokens);
   return {
     inputTokens: inputTokens ?? 0,
     outputTokens: outputTokens ?? 0,
     ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+    ...(cacheCreationTokens !== undefined ? { cacheCreationTokens } : {}),
   };
 }
 

--- a/src/lib/copilot-stream.test.ts
+++ b/src/lib/copilot-stream.test.ts
@@ -520,6 +520,18 @@ assert.deepEqual(resultEv, {
   isError: false,
   durationMs: 9980,
 });
+// The Copilot CLI's terminal `result.usage` carries only
+// `{ premiumRequests, totalApiDurationMs, sessionDurationMs }` — no token
+// counts. Per-turn token data exists only as per-message `outputTokens` (a
+// partial, output-only signal) and as session-wide `session.shutdown`
+// aggregates that cannot be attributed to one turn. So the result event
+// deliberately emits NO usage: Cave shows no meter rather than a fabricated
+// zero or a misleading partial count.
+assert.equal(
+  Object.hasOwn(resultEv ?? {}, "usage"),
+  false,
+  "copilot result frames never fabricate a usage block from their token-less usage payload",
+);
 assert.deepEqual(
   parseCopilotChatEvent({ type: "result", exitCode: 1 }),
   { kind: "result", sessionId: undefined, isError: true, durationMs: undefined },

--- a/src/lib/copilot-stream.ts
+++ b/src/lib/copilot-stream.ts
@@ -24,6 +24,11 @@
 //   {"type":"tool.execution_complete","data":{"toolCallId","success",
 //       "result":{"content"}}}
 //   {"type":"result","sessionId","exitCode","usage":{"sessionDurationMs",…}}
+// The `result.usage` object reports premium-request billing counters
+// (`premiumRequests`, `totalApiDurationMs`, `sessionDurationMs`) only — no
+// per-turn token counts or cost — so Cave deliberately renders no token/cost
+// meter for Copilot turns (a 0-token meter would claim a number nothing
+// measured).
 // plus session.* / assistant.turn_* / *_delta noise events that the chat
 // ignores. The final `result` frame is top-level (no `data` envelope).
 

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -50,6 +50,30 @@ test("Hermes Responses events normalise text, calls, output, session, and comple
     { kind: "done", isError: false, id: "resp-terminal" },
   );
   assert.deepEqual(
+    parseHermesResponsesEvent("response.completed", {
+      response: {
+        id: "resp-usage",
+        usage: { input_tokens: 1200, output_tokens: 340, input_tokens_details: { cached_tokens: 800 } },
+      },
+    }),
+    { kind: "done", isError: false, id: "resp-usage", usage: { inputTokens: 1200, outputTokens: 340, cacheReadTokens: 800 } },
+    "a completed response maps OpenAI-style usage (cached tokens → cache read) onto the done event",
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.completed", {
+      response: { id: "resp-usage-no-cache", usage: { input_tokens: 100, output_tokens: 50 } },
+    }),
+    { kind: "done", isError: false, id: "resp-usage-no-cache", usage: { inputTokens: 100, outputTokens: 50 } },
+    "cached tokens are optional and omitted when the provider does not report them",
+  );
+  assert.doesNotMatch(
+    JSON.stringify(parseHermesResponsesEvent("response.completed", {
+      response: { id: "resp-malformed", usage: { input_tokens: "secret-leak", output_tokens: -5 } },
+    })),
+    /secret-leak/,
+    "Hermes usage payloads never leak into parsed events",
+  );
+  assert.deepEqual(
     parseHermesResponsesEvent("response.failed", { response: { id: "resp-failed", error: { message: "invalid model" } } }),
     { kind: "done", isError: true, id: "resp-failed", message: "invalid model" },
   );

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -9,13 +9,15 @@
 // incomplete data.  The normalised events are fed to ToolCallTracker by the
 // chat route, retaining Cave's stable-id, persistence, and resume semantics.
 
+import type { TurnUsage } from "./usage-format.ts";
+
 export type HermesResponsesEvent =
   | { kind: "text"; text: string }
   | { kind: "tool_start"; id: string; name: string; input?: unknown; itemId?: string }
   | { kind: "tool_input"; id?: string; itemId?: string; input: string; isFinal: boolean }
   | { kind: "tool_end"; id: string; output?: unknown; isError: boolean }
   | { kind: "session"; id: string }
-  | { kind: "done"; isError: boolean; id?: string; message?: string; invalidPreviousResponseId?: boolean }
+  | { kind: "done"; isError: boolean; id?: string; message?: string; usage?: TurnUsage; invalidPreviousResponseId?: boolean }
   | { kind: "error"; message: string; invalidPreviousResponseId?: boolean }
   | { kind: "ignore" };
 
@@ -108,6 +110,30 @@ export function isHermesResponsesEventName(eventName: string): boolean {
     "response.completed", "response.failed", "response.incomplete", "hermes.tool.progress",
     "hermes.tool.completed", "error",
   ]).has(eventName);
+}
+
+function finiteNonNegativeTokens(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/** Hermes's Responses-compatible `response.completed` reports `response.usage`
+ * as `{ input_tokens, output_tokens, input_tokens_details: { cached_tokens } }`.
+ * Map those onto Cave's `TurnUsage` (cached tokens → cache read); Hermes has no
+ * cache-creation or cost counter in this stream, and an absent/malformed block
+ * yields undefined so the turn shows no meter instead of a fabricated zero. */
+function parseHermesUsage(raw: unknown): TurnUsage | undefined {
+  const usage = record(raw);
+  if (!usage) return undefined;
+  const inputTokens = finiteNonNegativeTokens(usage.input_tokens);
+  const outputTokens = finiteNonNegativeTokens(usage.output_tokens);
+  if (inputTokens === undefined && outputTokens === undefined) return undefined;
+  const details = record(usage.input_tokens_details);
+  const cacheReadTokens = finiteNonNegativeTokens(details?.cached_tokens);
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+  };
 }
 
 /** Parse one complete SSE frame. Unknown/future frame types are safely ignored. */
@@ -209,7 +235,8 @@ export function parseHermesResponsesEvent(eventName: string, payload: unknown): 
 
   if (type === "response.completed") {
     const id = responseId(value);
-    return { kind: "done", isError: false, ...(id ? { id } : {}) };
+    const usage = parseHermesUsage(record(value.response)?.usage ?? value.usage);
+    return { kind: "done", isError: false, ...(id ? { id } : {}), ...(usage ? { usage } : {}) };
   }
   if (type === "response.failed" || type === "response.incomplete") {
     const response = record(value.response);

--- a/src/lib/opencode-stream.test.ts
+++ b/src/lib/opencode-stream.test.ts
@@ -74,6 +74,47 @@ assert.deepEqual(
 );
 assert.deepEqual(
   parseOpenCodeRunEvent(
+    {
+      type: "step_finish",
+      sessionID: "ses_123",
+      part: { reason: "stop", cost: 0.001, tokens: { input: 671, output: 8, reasoning: 0, cache: { read: 21415, write: 0 } } },
+    },
+    BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
+  ),
+  {
+    kind: "result",
+    sessionId: "ses_123",
+    usage: { inputTokens: 671, outputTokens: 8, cacheReadTokens: 21415, cacheCreationTokens: 0 },
+    costUsd: 0.001,
+  },
+  "a terminal step-finish maps OpenCode's tokens (cache write → cache creation) and USD cost onto the result event",
+);
+assert.deepEqual(
+  parseOpenCodeRunEvent(
+    { type: "step_finish", sessionID: "ses_123", part: { reason: "tool-calls", cost: 0, tokens: { input: 21772, output: 110, cache: { read: 0, write: 0 } } } },
+    BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
+  ),
+  { kind: "ignore", sessionId: "ses_123" },
+  "an intermediate tool-calls step is not the terminal outcome and its per-step counters are not surfaced",
+);
+assert.deepEqual(
+  parseOpenCodeRunEvent(
+    { type: "step_finish", sessionID: "ses_123", part: { reason: "stop", tokens: { input: "many", output: "lots" } } },
+    BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
+  ),
+  { kind: "ignore", sessionId: "ses_123" },
+  "a malformed token block yields no usage (no fabricated zero) and falls back to lifecycle handling",
+);
+assert.doesNotMatch(
+  JSON.stringify(parseOpenCodeRunEvent(
+    { type: "step_finish", sessionID: "ses_123", part: { reason: "stop", tokens: { input: "secret", output: -5 } } },
+    BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
+  )),
+  /secret/,
+  "OpenCode usage payloads never leak into parsed events",
+);
+assert.deepEqual(
+  parseOpenCodeRunEvent(
     { type: "reasoning", sessionID: "ses_123", part: { text: "private chain of thought" } },
     BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
   ),

--- a/src/lib/opencode-stream.ts
+++ b/src/lib/opencode-stream.ts
@@ -1,4 +1,5 @@
 import type { OpenCodeEnvelopePath, OpenCodeEventSchema } from "@/lib/opencode-compatibility";
+import { parseCostUsd, type TurnUsage } from "./usage-format.ts";
 
 export type OpenCodeRunEvent =
   | { kind: "ignore"; sessionId?: string }
@@ -8,6 +9,7 @@ export type OpenCodeRunEvent =
   | { kind: "tool_end"; sessionId?: string; id: string; output: unknown; isError: boolean }
   | { kind: "tool"; sessionId?: string; id: string; name: string; input: unknown; output: unknown; isError: boolean }
   | { kind: "error"; sessionId?: string; message: string }
+  | { kind: "result"; sessionId?: string; usage?: TurnUsage; costUsd?: number }
   | { kind: "other"; sessionId?: string; diagnostic?: "unknown-event" | "malformed-event" };
 
 export type OpenCodeJsonLineHandlers = {
@@ -18,6 +20,7 @@ export type OpenCodeJsonLineHandlers = {
   onToolProgress?: (event: Extract<OpenCodeRunEvent, { kind: "tool_progress" }>) => void;
   onToolEnd?: (event: Extract<OpenCodeRunEvent, { kind: "tool_end" }>) => void;
   onError?: (event: Extract<OpenCodeRunEvent, { kind: "error" }>) => void;
+  onResult?: (event: Extract<OpenCodeRunEvent, { kind: "result" }>) => void;
   onOther?: (event: Extract<OpenCodeRunEvent, { kind: "other" }>, rawEvent: unknown) => void;
   onMalformedJson?: () => void;
 };
@@ -133,6 +136,32 @@ function hasToolErrorPayload(value: unknown): boolean {
     && (typeof value !== "string" || value.trim().length > 0);
 }
 
+function finiteNonNegativeTokens(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+/** OpenCode's terminal `step_finish` reports `part.tokens` as
+ * `{ input, output, reasoning, cache: { read, write } }` plus a USD `cost`.
+ * Map the counters Cave persists onto a `TurnUsage` (cache write → cache
+ * creation); a missing/empty block yields undefined so the turn shows no meter
+ * instead of a fabricated zero. */
+function parseOpenCodeUsage(raw: unknown): TurnUsage | undefined {
+  const tokens = record(raw);
+  if (!tokens) return undefined;
+  const inputTokens = finiteNonNegativeTokens(tokens.input);
+  const outputTokens = finiteNonNegativeTokens(tokens.output);
+  if (inputTokens === undefined && outputTokens === undefined) return undefined;
+  const cache = record(tokens.cache);
+  const cacheReadTokens = finiteNonNegativeTokens(cache?.read);
+  const cacheCreationTokens = finiteNonNegativeTokens(cache?.write);
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+    ...(cacheCreationTokens !== undefined ? { cacheCreationTokens } : {}),
+  };
+}
+
 /** Decode OpenCode's `run --format json` envelope without trusting its fields. */
 export function parseOpenCodeRunEvent(value: unknown, schema?: OpenCodeEventSchema): OpenCodeRunEvent {
   const event = record(value);
@@ -147,6 +176,27 @@ export function parseOpenCodeRunEvent(value: unknown, schema?: OpenCodeEventSche
   const discriminator = schema?.shape?.discriminator ?? { envelope: "root" as const, field: "type" };
   const eventType = stringAt(envelope(event, [discriminator.envelope]), discriminator.field);
   if (!eventType) return { kind: "other", sessionId, diagnostic: "malformed-event" };
+  // OpenCode's terminal `step_finish` (reason "stop" or absent) carries the
+  // turn's token usage and USD cost on its `part`. This is the usage/cost
+  // terminal event, handled before the ignored-lifecycle branch below. A
+  // `reason: "tool-calls"` step is an intermediate tool-loop step, not the
+  // turn's terminal outcome, so its per-step counters are not surfaced.
+  if (eventType === "step_finish") {
+    const reason = stringAt(part, "reason");
+    const terminal = reason === undefined || reason === "stop";
+    if (terminal) {
+      const usage = parseOpenCodeUsage(valueAt(part, ["tokens"]));
+      const costUsd = parseCostUsd(valueAt(part, ["cost"]));
+      if (usage || costUsd !== undefined) {
+        return {
+          kind: "result",
+          ...(sessionId ? { sessionId } : {}),
+          ...(usage ? { usage } : {}),
+          ...(costUsd !== undefined ? { costUsd } : {}),
+        };
+      }
+    }
+  }
   if (eventTypes(schema, "ignored", ["step_start", "step_finish"]).includes(eventType)) {
     // Lifecycle/control frames are deliberately non-renderable. The selected
     // schema nevertheless authorizes their label, so retain its session token:
@@ -299,6 +349,7 @@ export function handleOpenCodeJsonLine(
       case "tool_progress": handlers.onToolProgress?.(event); return;
       case "tool_end": handlers.onToolEnd?.(event); return;
       case "error": handlers.onError?.(event); return;
+      case "result": handlers.onResult?.(event); return;
       case "other": handlers.onOther?.(event, rawEvent); return;
     }
   } catch {


### PR DESCRIPTION
## Summary

Closes **cave-0osmn**: only 3 of 7755 recorded turns carried a usage meter — the pipeline works, but only the claude harness put usage on the wire. This PR makes the three harnesses that DO report tokens feed Cave's existing result.usage / costUsd path.

## Per harness

- **codex** (326 convos): `turn.completed` carries `usage: {input_tokens, cached_input_tokens, cache_write_input_tokens, output_tokens, reasoning_output_tokens}` (pinned from openai/codex codex-rs exec_events.rs). Now parsed into a `completed` event with a defensively-mapped TurnUsage (cached-input → cache read). Codex emits no cost, so no costUsd.
- **opencode** (27): terminal `step_finish` (reason `stop`/absent) carries `part.tokens` + USD `part.cost` (verified USD from sst/opencode session.ts getUsage — per-million pricing, not cents). New `result` event + `onResult` handler.
- **hermes** (3): `response.completed` carries Responses-API `usage` (input/output + cached_tokens). Tokens-only meter; no cost on that wire.
- **copilot** (1213): result.usage carries only premium-request counters (`premiumRequests`/durations) — no tokens, no cost. Pinned via test + comment: Copilot turns deliberately keep **no meter** rather than a fabricated 0-token meter.
- **openclaw**: no usage on the wire; unchanged (existing comment already names it).

## Verification

- 4 parser suites + 4 harness-routing route-contract suites green
- `pnpm typecheck` clean, `pnpm lint` clean, `pnpm check:tests-wired` 1921 files wired
- No new routes (api-contracts registry unchanged)

Follow-up (separate repo): relay codex usage through the `coven run` stream-json fallback in the Coven daemon.