### PR TITLE
perf(copilot): memoize bundled plugin startup dirs across turns (cave-wks6)

### DIFF
--- a/src/lib/server/bundled-copilot-plugins.test.ts
+++ b/src/lib/server/bundled-copilot-plugins.test.ts
@@ -3,7 +3,10 @@ import { mkdir, mkdtemp, realpath, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { resolveBundledCopilotPluginDirs } from "./bundled-copilot-plugins.ts";
+import {
+  clearBundledCopilotPluginDirsCache,
+  resolveBundledCopilotPluginDirs,
+} from "./bundled-copilot-plugins.ts";
 
 async function writePlugin(root: string, id: string, extra: Record<string, unknown> = {}) {
   const dir = path.join(root, id);
@@ -60,5 +63,28 @@ test("missing plugin roots degrade to no plugins", async () => {
   assert.deepEqual(
     await resolveBundledCopilotPluginDirs([], { pluginsRoot: "/definitely/missing/cave-plugins" }),
     [],
+  );
+});
+
+test("memoizes the resolved startup plugin dirs until explicitly cleared", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "cave-bundled-plugins-cache-"));
+  // First resolution on an empty root records the (empty) result.
+  assert.deepEqual(
+    await resolveBundledCopilotPluginDirs(["coven-memory"], { pluginsRoot: root }),
+    [],
+  );
+  // A plugin that appears after the first resolution must not be picked up by
+  // a later call: the cached startup context is reused rather than re-scanned,
+  // so per-turn chat spawns skip repeated realpath/stat/readFile work.
+  const dir = await writePlugin(root, "coven-memory");
+  assert.deepEqual(
+    await resolveBundledCopilotPluginDirs(["coven-memory"], { pluginsRoot: root }),
+    [],
+  );
+  // Clearing the process-local cache forces the next call to re-scan the root.
+  clearBundledCopilotPluginDirsCache();
+  assert.deepEqual(
+    await resolveBundledCopilotPluginDirs(["coven-memory"], { pluginsRoot: root }),
+    [await realpath(dir)],
   );
 });

--- a/src/lib/server/bundled-copilot-plugins.ts
+++ b/src/lib/server/bundled-copilot-plugins.ts
@@ -30,14 +30,21 @@ function isSkillOnlyManifest(value: unknown, expectedName: string): boolean {
  * Resolve app-bundled, skill-only Copilot plugins without trusting a familiar
  * workspace's writable plugin manifest. Invalid or missing bundles are omitted
  * so chat remains available without silently loading hooks, agents, or MCPs.
+ *
+ * The result is memoized per process because the bundled plugins are part of
+ * the packaged app and immutable for a process lifetime (they change only on
+ * app update/restart, which reloads this module). The chat send route calls
+ * this on every Copilot turn to assemble the `--plugin-dir` startup args, so
+ * without the cache each turn repeats realpath/stat/readFile work for startup
+ * context that cannot have changed.
  */
-export async function resolveBundledCopilotPluginDirs(
-  pluginIds: readonly string[] = ["coven-memory"],
-  options: BundledPluginOptions = {},
+async function resolveUncached(
+  pluginIds: readonly string[],
+  requestedRoot: string,
 ): Promise<string[]> {
   let root: string;
   try {
-    root = await realpath(options.pluginsRoot ?? marketplacePluginsRoot());
+    root = await realpath(requestedRoot);
     if (!(await stat(root)).isDirectory()) return [];
   } catch {
     return [];
@@ -57,4 +64,24 @@ export async function resolveBundledCopilotPluginDirs(
     }
   }
   return resolved;
+}
+
+const resolvedCache = new Map<string, string[]>();
+
+/** Test seam: reset the process-local bundled plugin resolution cache. */
+export function clearBundledCopilotPluginDirsCache(): void {
+  resolvedCache.clear();
+}
+
+export async function resolveBundledCopilotPluginDirs(
+  pluginIds: readonly string[] = ["coven-memory"],
+  options: BundledPluginOptions = {},
+): Promise<string[]> {
+  const requestedRoot = options.pluginsRoot ?? marketplacePluginsRoot();
+  const cacheKey = `${requestedRoot}\u0000${pluginIds.join("\u0000")}`;
+  const cached = resolvedCache.get(cacheKey);
+  if (cached) return [...cached];
+  const resolved = await resolveUncached(pluginIds, requestedRoot);
+  resolvedCache.set(cacheKey, resolved);
+  return [...resolved];
 }


### PR DESCRIPTION
Bead: cave-wks6 — "Streamline Copilot CLI startup context and integrations"

## Finding

The Copilot CLI startup-context assembly is already largely minimal and well-factored:

- A single `buildCopilotStreamArgs()` assembles the deterministic argv for both chat and flow spawns, and is extensively pinned by tests.
- The spawn environment is computed once per turn via `resolveCopilotRuntimeLaunch()` and reused at spawn (`localRuntimePlan.env`), so it is not re-derived per turn.
- Capability probes (5 min TTL) and model inventory (60 s TTL) are already cached.

One genuine per-turn re-computation of startup context remained: the chat send route resolves the app-bundled, skill-only Copilot plugin directories on every Copilot turn to emit the repeatable `--plugin-dir` startup args. `resolveBundledCopilotPluginDirs()` performed uncached `realpath`/`stat`/`readFile` work each turn even though bundled plugins are immutable for a process lifetime.

## Change

- `src/lib/server/bundled-copilot-plugins.ts`: memoize `resolveBundledCopilotPluginDirs()` per process (keyed on the plugins root + requested plugin ids), and expose `clearBundledCopilotPluginDirsCache()` as a test seam.
- `src/lib/server/bundled-copilot-plugins.test.ts`: regression test proving the cached startup context is reused (not re-scanned) until explicitly cleared.

No behavior users rely on changes: the resolved `--plugin-dir` argv is byte-identical; only the repeated filesystem scan is removed.

## Tests

- Focused: `bundled-copilot-plugins.test.ts` (4 pass), `copilot-stream.test.ts`, `flow-copilot-session.test.ts` (35 pass / 2 skipped), `harness-routing-copilot-jsonl.test.ts` — all green.
- Gates: `pnpm typecheck` ✓, `pnpm lint` ✓, `pnpm check:tests-wired` ✓ (1921 wired).
- `pnpm test:app` reached 759 passing tests before an unrelated, pre-existing flaky Chromium game-loop test (`src/lib/arcade/glitter-crypt-chromium.test.ts`) failed on a timing assertion; that test passes when re-run directly.