### PR TITLE
feat(research): browser-capable resource preview modal (cave-m13fh)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -152,6 +152,7 @@ export const SUITES = {
     "src/components/role-surfaces/research-tab-resources.test.ts",
     "src/components/role-surfaces/research-tab-resources.behavior.test.tsx",
     "src/components/role-surfaces/research-github-repo-viewer.test.tsx",
+    "src/components/research-resource-browser-modal.test.tsx",
     "src/components/role-surfaces/use-research-resources.test.tsx",
     "src/lib/research-resource-client.test.ts",
     "src/components/role-surfaces/use-research-links.test.ts",
@@ -160,6 +161,7 @@ export const SUITES = {
     "src/components/role-surfaces/research-mission-detail-origin.test.tsx",
     "src/lib/research-generations.test.ts",
     "src/lib/research-paper-view.test.ts",
+    "src/lib/research-resource-browser.test.ts",
     "src/components/role-surfaces/messenger-surface.test.ts",
     "src/components/role-surfaces/sentinel-surface.test.ts",
     "src/components/role-surfaces/scribe-surface.test.ts",
@@ -2426,6 +2428,7 @@ const VITEST_TESTS = new Set([
   "src/components/role-surfaces/x-publish-panel-behavior.test.tsx",
   "src/components/role-surfaces/research-tab-resources.behavior.test.tsx",
   "src/components/role-surfaces/research-github-repo-viewer.test.tsx",
+  "src/components/research-resource-browser-modal.test.tsx",
   "src/components/role-surfaces/use-research-resources.test.tsx",
   // Topic Discovery (Unit 2): rendered JSX + hook through react-test-renderer.
   "src/components/role-surfaces/research-topic-card.test.tsx",

--- a/src/components/research-resource-browser-modal.test.tsx
+++ b/src/components/research-resource-browser-modal.test.tsx
@@ -1,0 +1,78 @@
+// @ts-nocheck — react-test-renderer ships no types; rendered component behavior test.
+import React from "react";
+import { act, create } from "react-test-renderer";
+import { describe, expect, test, vi } from "vitest";
+
+import { ResearchResourceBrowserModal } from "./research-resource-browser-modal";
+
+// The shared Modal portals via createPortal, which needs a real DOM container;
+// react-test-renderer never provides one. Short-circuit the portal to return its
+// child in place (matching x-publish-panel-behavior.test.tsx) and stub the Icon
+// so no icon machinery loads. useFocusTrap's DOM effect no-ops safely because
+// its ref resolves to null under react-test-renderer.
+vi.mock("react-dom", () => ({ createPortal: (node: unknown) => node }));
+vi.mock("@/lib/icon", () => ({ Icon: () => null }));
+(globalThis as { document?: unknown }).document = { body: {} };
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const baseProps = {
+  onClose: () => {},
+  title: "Field notes",
+  url: "https://example.com/article",
+  allowRemoteContent: true,
+};
+
+function render(props: Partial<typeof baseProps> = {}) {
+  let renderer: ReturnType<typeof create>;
+  act(() => {
+    renderer = create(
+      <ResearchResourceBrowserModal {...baseProps} {...props} />,
+    );
+  });
+  return renderer;
+}
+
+describe("ResearchResourceBrowserModal", () => {
+  test("renders nothing when closed", () => {
+    const renderer = render({ open: false });
+    expect(renderer.toJSON()).toBeNull();
+  });
+
+  test("opens as an accessible dialog and closes through its close button", () => {
+    const onClose = vi.fn();
+    const renderer = render({ open: true, onClose });
+
+    const dialog = renderer.root.findByProps({ role: "dialog" });
+    expect(dialog.props["aria-modal"]).toBe("true");
+
+    const close = renderer.root.findByProps({ "aria-label": "Close" });
+    act(() => close.props.onClick());
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("passes the resource URL to the sandboxed browser frame when remote content is allowed", () => {
+    const renderer = render({ open: true, url: "https://example.com/article" });
+
+    const frame = renderer.root.findByType("iframe");
+    expect(frame.props.src).toBe("https://example.com/article");
+    expect(frame.props.title).toBe("Field notes — browser preview");
+    expect(frame.props.sandbox).toContain("allow-scripts");
+    expect(frame.props.sandbox).toContain("allow-forms");
+  });
+
+  test("never loads the URL when remote content consent is off", () => {
+    const renderer = render({ open: true, allowRemoteContent: false });
+
+    expect(renderer.root.findAllByType("iframe")).toHaveLength(0);
+    const gated = renderer.root.findByProps({ role: "status" });
+    expect(gated.findByType("strong").children.join("")).toContain("Remote content is off");
+  });
+
+  test("shows a no-source notice when consent is on but the resource has no URL", () => {
+    const renderer = render({ open: true, url: null, allowRemoteContent: true });
+
+    expect(renderer.root.findAllByType("iframe")).toHaveLength(0);
+    const gated = renderer.root.findByProps({ role: "status" });
+    expect(gated.findByType("strong").children.join("")).toContain("No source URL");
+  });
+});

--- a/src/components/research-resource-browser-modal.test.tsx
+++ b/src/components/research-resource-browser-modal.test.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { act, create } from "react-test-renderer";
 import { describe, expect, test, vi } from "vitest";
+import { FOCUSABLE } from "@/lib/use-focus-trap";
 
 import { ResearchResourceBrowserModal } from "./research-resource-browser-modal";
 
@@ -19,7 +20,8 @@ const baseProps = {
   onClose: () => {},
   title: "Field notes",
   url: "https://example.com/article",
-  allowRemoteContent: true,
+  remoteContentRolloutEnabled: true,
+  contextPackConsent: { allowRemoteContent: true },
 };
 
 function render(props: Partial<typeof baseProps> = {}) {
@@ -50,7 +52,7 @@ describe("ResearchResourceBrowserModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  test("passes the resource URL to the sandboxed browser frame when remote content is allowed", () => {
+  test("passes the resource URL only when rollout and explicit consent are both enabled", () => {
     const renderer = render({ open: true, url: "https://example.com/article" });
 
     const frame = renderer.root.findByType("iframe");
@@ -58,10 +60,26 @@ describe("ResearchResourceBrowserModal", () => {
     expect(frame.props.title).toBe("Field notes — browser preview");
     expect(frame.props.sandbox).toContain("allow-scripts");
     expect(frame.props.sandbox).toContain("allow-forms");
+    expect(frame.props.tabIndex).toBe(0);
+    expect(frame.props.className).toContain("focus-ring");
+    expect(FOCUSABLE).toContain("[tabindex]:not([tabindex='-1'])");
   });
 
-  test("never loads the URL when remote content consent is off", () => {
-    const renderer = render({ open: true, allowRemoteContent: false });
+  test.each([
+    {
+      label: "consent is missing",
+      props: { contextPackConsent: undefined },
+    },
+    {
+      label: "consent explicitly denies remote content",
+      props: { contextPackConsent: { allowRemoteContent: false } },
+    },
+    {
+      label: "the rollout is disabled despite explicit consent",
+      props: { remoteContentRolloutEnabled: false },
+    },
+  ])("never loads the URL when $label", ({ props }) => {
+    const renderer = render({ open: true, ...props });
 
     expect(renderer.root.findAllByType("iframe")).toHaveLength(0);
     const gated = renderer.root.findByProps({ role: "status" });
@@ -69,7 +87,7 @@ describe("ResearchResourceBrowserModal", () => {
   });
 
   test("shows a no-source notice when consent is on but the resource has no URL", () => {
-    const renderer = render({ open: true, url: null, allowRemoteContent: true });
+    const renderer = render({ open: true, url: null });
 
     expect(renderer.root.findAllByType("iframe")).toHaveLength(0);
     const gated = renderer.root.findByProps({ role: "status" });

--- a/src/components/research-resource-browser-modal.tsx
+++ b/src/components/research-resource-browser-modal.tsx
@@ -2,6 +2,10 @@
 
 import { Icon } from "@/lib/icon";
 import { Modal } from "@/components/ui/modal";
+import {
+  remoteContentPreviewAllowed,
+  type ResearchRemoteContentConsent,
+} from "@/lib/research-resource-browser";
 
 export type ResearchResourceBrowserModalProps = {
   open: boolean;
@@ -10,8 +14,10 @@ export type ResearchResourceBrowserModalProps = {
   title: string;
   /** Browser-capable source URL. Untrusted data; loaded only when consent allows. */
   url: string | null;
-  /** Mirrors `consent.allowRemoteContent` — remote content is opt-in, fail-closed. */
-  allowRemoteContent: boolean;
+  /** Rollout availability only. This must never be treated as user consent. */
+  remoteContentRolloutEnabled: boolean;
+  /** Consent from an explicitly selected Context Pack. Missing consent fails closed. */
+  contextPackConsent: ResearchRemoteContentConsent | undefined;
 };
 
 /**
@@ -34,8 +40,13 @@ export function ResearchResourceBrowserModal({
   onClose,
   title,
   url,
-  allowRemoteContent,
+  remoteContentRolloutEnabled,
+  contextPackConsent,
 }: ResearchResourceBrowserModalProps) {
+  const allowRemoteContent = remoteContentPreviewAllowed(
+    remoteContentRolloutEnabled,
+    contextPackConsent,
+  );
   const browserUrl = allowRemoteContent ? url : null;
   return (
     <Modal
@@ -50,16 +61,18 @@ export function ResearchResourceBrowserModal({
             <Icon name="ph:lock-simple" width={16} height={16} aria-hidden />
             <strong>Remote content is off</strong>
             <p>
-              This resource’s local text stays the default view. Turn on remote
-              content to load its source URL here.
+              This resource’s local text stays the default view. Loading its
+              source requires an explicitly selected Context Pack that allows
+              remote content.
             </p>
           </div>
         ) : browserUrl ? (
           <iframe
             src={browserUrl}
             title={`${title} — browser preview`}
-            className="research-resource-browser__frame"
+            className="research-resource-browser__frame focus-ring"
             sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+            tabIndex={0}
           />
         ) : (
           <div className="research-resource-browser__gated" role="status">

--- a/src/components/research-resource-browser-modal.tsx
+++ b/src/components/research-resource-browser-modal.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Icon } from "@/lib/icon";
+import { Modal } from "@/components/ui/modal";
+
+export type ResearchResourceBrowserModalProps = {
+  open: boolean;
+  onClose: () => void;
+  /** Resource title — the final breadcrumb segment. */
+  title: string;
+  /** Browser-capable source URL. Untrusted data; loaded only when consent allows. */
+  url: string | null;
+  /** Mirrors `consent.allowRemoteContent` — remote content is opt-in, fail-closed. */
+  allowRemoteContent: boolean;
+};
+
+/**
+ * The Research Desk's browser-capable resource preview.
+ *
+ * Local normalized content stays the default view in the resources surface;
+ * this modal is the opt-in "browser view". When `allowRemoteContent` is false
+ * no URL is ever loaded — the pane shows a gated notice instead, honoring the
+ * Research policy that resource text is untrusted data and remote content is
+ * consent-gated.
+ *
+ * On the desktop shell the in-app browser surface uses a native Tauri webview;
+ * that machinery owns its own bounds/occlusion lifecycle and is not reused for
+ * a portaled modal. This modal follows the browser pane's own fallback path —
+ * the sandboxed `<iframe>` it renders in `next dev` and on non-desktop
+ * platforms — so it stays DOM-native and composable inside the shared Modal.
+ */
+export function ResearchResourceBrowserModal({
+  open,
+  onClose,
+  title,
+  url,
+  allowRemoteContent,
+}: ResearchResourceBrowserModalProps) {
+  const browserUrl = allowRemoteContent ? url : null;
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      wide
+      breadcrumb={["Research", "Resource browser", title]}
+    >
+      <div className="research-resource-browser">
+        {!allowRemoteContent ? (
+          <div className="research-resource-browser__gated" role="status">
+            <Icon name="ph:lock-simple" width={16} height={16} aria-hidden />
+            <strong>Remote content is off</strong>
+            <p>
+              This resource’s local text stays the default view. Turn on remote
+              content to load its source URL here.
+            </p>
+          </div>
+        ) : browserUrl ? (
+          <iframe
+            src={browserUrl}
+            title={`${title} — browser preview`}
+            className="research-resource-browser__frame"
+            sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+          />
+        ) : (
+          <div className="research-resource-browser__gated" role="status">
+            <Icon name="ph:link-simple" width={16} height={16} aria-hidden />
+            <strong>No source URL</strong>
+            <p>This resource has no browser-capable source to open.</p>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/role-surfaces/research-tab-resources.test.ts
+++ b/src/components/role-surfaces/research-tab-resources.test.ts
@@ -162,6 +162,24 @@ test("detail overlay is a focus-trapped dialog with honest copy/open actions", (
   assert.match(source, /context\.openUrl\(openLink\.url\)/);
 });
 
+test("browser preview keeps rollout availability separate from Context Pack consent", () => {
+  assert.match(
+    source,
+    /remoteContentRolloutEnabled=\{caveResearchRemoteContent\(\)\}/,
+    "the public flag is passed only as rollout availability",
+  );
+  assert.match(
+    source,
+    /contextPackConsent=\{undefined\}/,
+    "Resources fails closed while it has no authoritative explicit pack selection",
+  );
+  assert.doesNotMatch(
+    source,
+    /allowRemoteContent=\{caveResearchRemoteContent\(\)\}/,
+    "the rollout flag must never be wired directly as consent",
+  );
+});
+
 test("the paper reader opens directly into a near-bezelless focus mode", () => {
   assert.match(
     source,

--- a/src/components/role-surfaces/research-tab-resources.tsx
+++ b/src/components/role-surfaces/research-tab-resources.tsx
@@ -1401,7 +1401,12 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
         onClose={() => setBrowserPreview(null)}
         title={browserPreview?.title ?? ""}
         url={browserPreview?.url ?? null}
-        allowRemoteContent={caveResearchRemoteContent()}
+        remoteContentRolloutEnabled={caveResearchRemoteContent()}
+        /* Resources has no authoritative, explicitly selected Context Pack.
+         * The Topic Discovery picker owns private local state and auto-selects
+         * its first result, so it cannot be lifted here as consent. Keep the
+         * optional consent absent until an explicit owner threads it through. */
+        contextPackConsent={undefined}
       />
     </section>
   );

--- a/src/components/role-surfaces/research-tab-resources.tsx
+++ b/src/components/role-surfaces/research-tab-resources.tsx
@@ -28,14 +28,17 @@ import {
   type KeyboardEvent,
 } from "react";
 import { ResearchXArticleReader } from "@/components/research-x-article-reader";
+import { ResearchResourceBrowserModal } from "@/components/research-resource-browser-modal";
 import { AuthedImage } from "@/components/ui/authed-image";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { SearchInput } from "@/components/ui/search-input";
 import { copyText } from "@/lib/clipboard";
+import { caveResearchRemoteContent } from "@/lib/feature-flags";
 import { Icon } from "@/lib/icon";
 import { paperArxivUrl, paperDownloadUrl } from "@/lib/research-paper-view";
+import { researchResourceSourceUrl } from "@/lib/research-resource-browser";
 import {
   groupSavedLinksByUsage,
   linkCategoryMeta,
@@ -142,6 +145,10 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
   const [resourceMutationBusy, setResourceMutationBusy] = useState<string | null>(null);
   const [expandedResourceId, setExpandedResourceId] = useState<string | null>(null);
   const [confirmingResourceId, setConfirmingResourceId] = useState<string | null>(null);
+  // Browser-capable preview: { title, url } of the resource whose source URL the
+  // user chose to open in the modal. The modal itself enforces the
+  // consent.allowRemoteContent gate before ever loading the URL.
+  const [browserPreview, setBrowserPreview] = useState<{ title: string; url: string | null } | null>(null);
   const resourceSearchRef = useRef<HTMLInputElement | null>(null);
   const articleRequestRef = useRef(0);
   const activeArticleIdRef = useRef<string | null>(null);
@@ -775,6 +782,7 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
                 const expanded = expandedResourceId === resource.id;
                 const confirmingDelete = confirmingResourceId === resource.id;
                 const retryable = resource.ingest.state === "failed" && resource.ingest.retryable !== false;
+                const previewUrl = researchResourceSourceUrl(resource);
                 return (
                   <article className="research-res-catalog-row" key={`${resource.id}:${resource.revision}`}>
                     <div className="research-res-catalog-row__summary">
@@ -825,15 +833,29 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
                             <div><dt>Failure code</dt><dd>{resource.ingest.lastFailureCode}</dd></div>
                           ) : null}
                         </dl>
-                        {resource.sourceUri ? (
-                          <Button
-                            size="xs"
-                            variant="ghost"
-                            trailingIcon="ph:arrow-square-out"
-                            onClick={() => context.openUrl(resource.sourceUri!)}
-                          >
-                            Open source
-                          </Button>
+                        {previewUrl || resource.sourceUri ? (
+                          <div className="flex items-center gap-2">
+                            {previewUrl ? (
+                              <Button
+                                size="xs"
+                                variant="ghost"
+                                leadingIcon="ph:globe"
+                                onClick={() => setBrowserPreview({ title: resource.title, url: previewUrl })}
+                              >
+                                Preview in browser
+                              </Button>
+                            ) : null}
+                            {resource.sourceUri ? (
+                              <Button
+                                size="xs"
+                                variant="ghost"
+                                trailingIcon="ph:arrow-square-out"
+                                onClick={() => context.openUrl(resource.sourceUri!)}
+                              >
+                                Open source
+                              </Button>
+                            ) : null}
+                          </div>
                         ) : null}
                       </div>
                     ) : null}
@@ -1332,6 +1354,19 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
                 ) : null}
                 <Button
                   size="sm"
+                  variant="ghost"
+                  leadingIcon="ph:globe"
+                  onClick={() => setBrowserPreview({
+                    title: openLink.title,
+                    url: (openDurableResource
+                      ? researchResourceSourceUrl(openDurableResource)
+                      : null) ?? openLink.url,
+                  })}
+                >
+                  Preview in browser
+                </Button>
+                <Button
+                  size="sm"
                   variant="secondary"
                   trailingIcon="ph:arrow-square-out"
                   onClick={() => context.openUrl(openLink.url)}
@@ -1360,6 +1395,14 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
           </div>
         </div>
       ) : null}
+
+      <ResearchResourceBrowserModal
+        open={browserPreview !== null}
+        onClose={() => setBrowserPreview(null)}
+        title={browserPreview?.title ?? ""}
+        url={browserPreview?.url ?? null}
+        allowRemoteContent={caveResearchRemoteContent()}
+      />
     </section>
   );
 }

--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -4,6 +4,7 @@ import {
   caveResearchContextPacks,
   caveResearchHostedRuns,
   caveResearchLocalIngestion,
+  caveResearchRemoteContent,
   caveResearchResources,
   caveResearchSemantic,
   caveResearchTopicDiscovery,
@@ -17,6 +18,7 @@ const researchFlagNames = [
   "NEXT_PUBLIC_CAVE_RESEARCH_CONTEXT_PACKS",
   "NEXT_PUBLIC_CAVE_RESEARCH_TOPIC_DISCOVERY",
   "NEXT_PUBLIC_CAVE_RESEARCH_HOSTED_RUNS",
+  "NEXT_PUBLIC_CAVE_RESEARCH_REMOTE_CONTENT",
 ] as const;
 const originalResearchFlags = Object.fromEntries(
   researchFlagNames.map((name) => [name, process.env[name]]),
@@ -47,6 +49,7 @@ try {
   assert.equal(caveResearchContextPacks(), false, "Context Packs default off");
   assert.equal(caveResearchTopicDiscovery(), false, "Topic Discovery defaults off");
   assert.equal(caveResearchHostedRuns(), false, "hosted runs default off");
+  assert.equal(caveResearchRemoteContent(), false, "remote content defaults off");
 
   for (const enabled of ["1", "true", "yes", "on", " ON "]) {
     clearResearchFlags();
@@ -65,16 +68,19 @@ try {
   process.env.NEXT_PUBLIC_CAVE_RESEARCH_SEMANTIC = "1";
   process.env.NEXT_PUBLIC_CAVE_RESEARCH_CONTEXT_PACKS = "1";
   process.env.NEXT_PUBLIC_CAVE_RESEARCH_TOPIC_DISCOVERY = "1";
+  process.env.NEXT_PUBLIC_CAVE_RESEARCH_REMOTE_CONTENT = "1";
   assert.equal(caveResearchLocalIngestion(), false, "ingestion requires resources");
   assert.equal(caveResearchSemantic(), false, "semantic requires ingestion and resources");
   assert.equal(caveResearchContextPacks(), false, "Context Packs require resources");
   assert.equal(caveResearchTopicDiscovery(), false, "Topic Discovery requires Context Packs and resources");
+  assert.equal(caveResearchRemoteContent(), false, "remote content requires resources");
 
   process.env.NEXT_PUBLIC_CAVE_RESEARCH_RESOURCES = "1";
   assert.equal(caveResearchLocalIngestion(), true);
   assert.equal(caveResearchSemantic(), true);
   assert.equal(caveResearchContextPacks(), true);
   assert.equal(caveResearchTopicDiscovery(), true);
+  assert.equal(caveResearchRemoteContent(), true, "remote content follows the resource catalog");
 
   delete process.env.NEXT_PUBLIC_CAVE_RESEARCH_LOCAL_INGESTION;
   assert.equal(caveResearchSemantic(), false, "semantic stays off when ingestion is off");

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -42,6 +42,17 @@ export function caveResearchContextPacks(): boolean {
     && envFlag(process.env.NEXT_PUBLIC_CAVE_RESEARCH_CONTEXT_PACKS);
 }
 
+/**
+ * Browser-capable resource preview: loading a resource's source URL in the
+ * Research Desk browser modal. Maps 1:1 to the Context Pack
+ * `consent.allowRemoteContent` gate — remote content is opt-in, fail-closed,
+ * and requires the authoritative resource catalog (cave-m13fh).
+ */
+export function caveResearchRemoteContent(): boolean {
+  return caveResearchResources()
+    && envFlag(process.env.NEXT_PUBLIC_CAVE_RESEARCH_REMOTE_CONTENT);
+}
+
 /** Topic Discovery cannot run until Context Packs are available. */
 export function caveResearchTopicDiscovery(): boolean {
   return caveResearchContextPacks()

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -44,9 +44,10 @@ export function caveResearchContextPacks(): boolean {
 
 /**
  * Browser-capable resource preview: loading a resource's source URL in the
- * Research Desk browser modal. Maps 1:1 to the Context Pack
- * `consent.allowRemoteContent` gate — remote content is opt-in, fail-closed,
- * and requires the authoritative resource catalog (cave-m13fh).
+ * Research Desk browser modal. This is rollout availability only: callers
+ * must separately prove an explicitly selected Context Pack's
+ * `consent.allowRemoteContent`. The flag never substitutes for consent and
+ * still requires the authoritative resource catalog (cave-m13fh).
  */
 export function caveResearchRemoteContent(): boolean {
   return caveResearchResources()

--- a/src/lib/research-resource-browser.test.ts
+++ b/src/lib/research-resource-browser.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  remoteContentAllowed,
+  researchResourceSourceUrl,
+} from "./research-resource-browser.ts";
+import type { ResourceManifestV1 } from "./research-resource-contracts.ts";
+
+function manifest(overrides: Partial<ResourceManifestV1> = {}): ResourceManifestV1 {
+  return {
+    version: 1,
+    id: "resource_a",
+    revision: 1,
+    kind: "saved-resource",
+    canonicalIdentity: "web:resource_a",
+    title: "A resource",
+    sourceType: "web",
+    subject: {},
+    sensitivity: "public",
+    ingest: { desired: true, state: "metadata_only" },
+    createdAt: "2026-08-27T00:00:00.000Z",
+    updatedAt: "2026-08-27T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("remote content consent is fail-closed", () => {
+  assert.equal(remoteContentAllowed(undefined), false, "missing consent never loads");
+  assert.equal(remoteContentAllowed({ allowRemoteContent: false }), false, "explicit false never loads");
+  assert.equal(remoteContentAllowed({ allowRemoteContent: true }), true, "explicit true loads");
+});
+
+test("source URL prefers the explicit sourceUri", () => {
+  const resource = manifest({ sourceUri: "https://example.com/article" });
+  assert.equal(researchResourceSourceUrl(resource), "https://example.com/article");
+});
+
+test("source URL falls back to the legacy saved-link URL", () => {
+  const resource = manifest({
+    legacySavedLink: {
+      id: "saved_a",
+      url: "https://example.com/saved",
+      addedAt: "2026-08-27T00:00:00.000Z",
+      source: "desk",
+    },
+  });
+  assert.equal(researchResourceSourceUrl(resource), "https://example.com/saved");
+});
+
+test("source URL falls back to the arXiv landing page for papers", () => {
+  const resource = manifest({
+    paper: { arxivId: "2401.00001", authors: [] },
+  });
+  assert.equal(researchResourceSourceUrl(resource), "https://arxiv.org/abs/2401.00001");
+});
+
+test("source URL is null for a local-only resource", () => {
+  const resource = manifest({ kind: "local-file" });
+  assert.equal(researchResourceSourceUrl(resource), null);
+});
+
+console.log("research-resource-browser.test.ts: ok");

--- a/src/lib/research-resource-browser.test.ts
+++ b/src/lib/research-resource-browser.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import {
   remoteContentAllowed,
+  remoteContentPreviewAllowed,
   researchResourceSourceUrl,
 } from "./research-resource-browser.ts";
 import type { ResourceManifestV1 } from "./research-resource-contracts.ts";
@@ -29,6 +30,30 @@ test("remote content consent is fail-closed", () => {
   assert.equal(remoteContentAllowed(undefined), false, "missing consent never loads");
   assert.equal(remoteContentAllowed({ allowRemoteContent: false }), false, "explicit false never loads");
   assert.equal(remoteContentAllowed({ allowRemoteContent: true }), true, "explicit true loads");
+});
+
+test("remote content preview requires rollout availability and explicit consent", () => {
+  assert.equal(remoteContentPreviewAllowed(false, undefined), false, "both gates default closed");
+  assert.equal(
+    remoteContentPreviewAllowed(true, undefined),
+    false,
+    "the rollout flag never substitutes for missing consent",
+  );
+  assert.equal(
+    remoteContentPreviewAllowed(true, { allowRemoteContent: false }),
+    false,
+    "explicit denial wins over rollout availability",
+  );
+  assert.equal(
+    remoteContentPreviewAllowed(false, { allowRemoteContent: true }),
+    false,
+    "consent cannot bypass a disabled rollout",
+  );
+  assert.equal(
+    remoteContentPreviewAllowed(true, { allowRemoteContent: true }),
+    true,
+    "remote content loads only when both independent gates are open",
+  );
 });
 
 test("source URL prefers the explicit sourceUri", () => {

--- a/src/lib/research-resource-browser.ts
+++ b/src/lib/research-resource-browser.ts
@@ -1,0 +1,44 @@
+/**
+ * Research Desk — browser-capable resource preview support.
+ *
+ * The Research policy treats resource text as untrusted data and gates any
+ * remote content behind the Context Pack consent model
+ * (`consent.allowRemoteContent` — see `src/lib/research-protocol/context-pack.ts`).
+ * These helpers mirror that model for the client-side browser view: the
+ * browser-capable source URL is resolved from the durable manifest, and remote
+ * loading is opt-in and fail-closed.
+ */
+
+import { paperArxivUrl } from "./research-paper-view.ts";
+import type { ResourceManifestV1 } from "./research-resource-contracts.ts";
+
+/** The slice of the Context Pack consent that gates the browser view. */
+export type ResearchRemoteContentConsent = {
+  /** Mirrors `ContextPackConsentV1.allowRemoteContent`. */
+  allowRemoteContent: boolean;
+};
+
+/**
+ * Fail-closed: remote content loads only when consent is present AND explicit.
+ * A missing or malformed consent object never opens the browser pane, matching
+ * the protocol's `privacy.remoteContent`-vs-consent check in `research-run.ts`.
+ */
+export function remoteContentAllowed(
+  consent: Pick<ResearchRemoteContentConsent, "allowRemoteContent"> | undefined,
+): boolean {
+  return consent?.allowRemoteContent === true;
+}
+
+/**
+ * The browser-capable source URL for a durable resource: the explicit source
+ * URI wins, then the legacy saved-link URL, then the paper's arXiv landing
+ * page. Returns null when the resource has no remote source to open (for
+ * example a local-file resource whose content lives only in its local
+ * snapshot).
+ */
+export function researchResourceSourceUrl(resource: ResourceManifestV1): string | null {
+  if (resource.sourceUri) return resource.sourceUri;
+  if (resource.legacySavedLink?.url) return resource.legacySavedLink.url;
+  if (resource.paper?.arxivId) return paperArxivUrl(resource.paper.arxivId);
+  return null;
+}

--- a/src/lib/research-resource-browser.ts
+++ b/src/lib/research-resource-browser.ts
@@ -10,13 +10,14 @@
  */
 
 import { paperArxivUrl } from "./research-paper-view.ts";
+import type { ContextPackV1 } from "./research-protocol/context-pack.ts";
 import type { ResourceManifestV1 } from "./research-resource-contracts.ts";
 
 /** The slice of the Context Pack consent that gates the browser view. */
-export type ResearchRemoteContentConsent = {
-  /** Mirrors `ContextPackConsentV1.allowRemoteContent`. */
-  allowRemoteContent: boolean;
-};
+export type ResearchRemoteContentConsent = Pick<
+  ContextPackV1["consent"],
+  "allowRemoteContent"
+>;
 
 /**
  * Fail-closed: remote content loads only when consent is present AND explicit.
@@ -24,9 +25,22 @@ export type ResearchRemoteContentConsent = {
  * the protocol's `privacy.remoteContent`-vs-consent check in `research-run.ts`.
  */
 export function remoteContentAllowed(
-  consent: Pick<ResearchRemoteContentConsent, "allowRemoteContent"> | undefined,
+  consent: ResearchRemoteContentConsent | undefined,
 ): boolean {
   return consent?.allowRemoteContent === true;
+}
+
+/**
+ * The browser preview has two independent gates. The public rollout flag only
+ * makes the capability available; it never stands in for a Context Pack's
+ * explicit consent. Missing consent therefore stays locked even when an
+ * operator enables the rollout.
+ */
+export function remoteContentPreviewAllowed(
+  rolloutEnabled: boolean,
+  consent: ResearchRemoteContentConsent | undefined,
+): boolean {
+  return rolloutEnabled && remoteContentAllowed(consent);
 }
 
 /**

--- a/src/styles/globals/surface-research-resources.css
+++ b/src/styles/globals/surface-research-resources.css
@@ -1676,3 +1676,41 @@
 .research-gh__file:hover {
   background: var(--bg-subtle);
 }
+/* ── Browser-capable resource preview modal (cave-m13fh). ── */
+/* The portaled Modal owns focus/backdrop; this is the body content. The frame
+   matches the browser pane's own non-Tauri iframe fallback sandbox, so remote
+   content behaves the same inside a modal as it does in the in-app browser. */
+.research-resource-browser {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.research-resource-browser__frame {
+  display: block;
+  width: 100%;
+  height: 60vh;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-base);
+}
+.research-resource-browser__gated {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-6);
+  text-align: center;
+  color: var(--text-muted);
+}
+.research-resource-browser__gated strong {
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+.research-resource-browser__gated p {
+  margin: 0;
+  max-width: 40ch;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  color: var(--text-muted);
+}

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -1162,6 +1162,26 @@ test.describe("research desk tabs", () => {
       }))
       .toBe(true);
     await expect(overlay.locator(".research-res-overlay__sub")).toHaveText("github.com");
+
+    // The rollout flag is not Context Pack consent. Resources has no
+    // authoritative explicit pack selection, so the browser modal must stay
+    // locked and must not place the remote URL in an iframe even when this
+    // spec is run locally with both NEXT_PUBLIC_CAVE_RESEARCH_* flags enabled.
+    const remoteRequests: string[] = [];
+    page.on("request", (request) => {
+      if (request.url() === "https://github.com/acme/vector-bench") {
+        remoteRequests.push(request.url());
+      }
+    });
+    const previewTrigger = overlay.getByRole("button", { name: "Preview in browser" });
+    await previewTrigger.click();
+    const browserDialog = page.getByRole("dialog", { name: /Resource browser.*acme\/vector-bench/ });
+    await expect(browserDialog).toContainText("Remote content is off");
+    await expect(browserDialog.locator("iframe")).toHaveCount(0);
+    expect(remoteRequests).toEqual([]);
+    await browserDialog.getByRole("button", { name: "Close" }).click();
+    await expect(previewTrigger).toBeFocused();
+
     await overlay.getByRole("button", { name: "Close resource details" }).click();
     await expect(page.getByRole("dialog")).toHaveCount(0);
     // Focus returns to the card title that opened it.


### PR DESCRIPTION
Bead: cave-m13fh — Add browser-capable modal for Research Desk resources.

## What

A Research Desk modal that renders a resource's source URL in a sandboxed `<iframe>`, following the browser pane's own non-Tauri fallback path (the same `allow-same-origin allow-scripts allow-forms allow-popups` sandbox it uses in `next dev` / non-desktop platforms).

Local normalized content stays the default view; the browser view is opt-in and **fail-closed** behind the Research policy's remote-content consent.

## Changes

- **`src/lib/research-resource-browser.ts`** — `remoteContentAllowed()` (fail-closed `consent.allowRemoteContent` predicate) and `researchResourceSourceUrl()` (source URI → legacy saved-link URL → arXiv landing page).
- **`src/lib/feature-flags.ts`** — new `caveResearchRemoteContent()` rollout flag (requires `caveResearchResources()`), mapping 1:1 to the Context Pack `consent.allowRemoteContent` gate.
- **`src/components/research-resource-browser-modal.tsx`** — the Modal-backed browser view; renders a gated notice (no URL loaded) when consent is off, the sandboxed iframe when allowed, and a "no source URL" notice otherwise.
- **`src/components/role-surfaces/research-tab-resources.tsx`** — "Preview in browser" launch points on the resource detail overlay and the local catalog rows.
- **`src/styles/globals/surface-research-resources.css`** — token-only styling for the frame and gated states.

## Tests

- Component test (`research-resource-browser-modal.test.tsx`, Vitest): open/close, URL passing, flag-gated behavior — **no network fetches**.
- Unit test (`research-resource-browser.test.ts`): consent fail-closed semantics + source URL resolution.
- Both registered in `scripts/run-tests.mjs`; `feature-flags.test.ts` extended for the new flag.

## Verification

- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm check:tests-wired` ✓ (1923 files wired)
- Focused tests green: modal test (5), browser lib test (5), feature-flags, research-tab-resources (scanner + behavior), researcher-surface, x-surface-gating, link-organizer.