### PR TITLE
feat(group-chat): add shared conversation topic and goal (cave-o1za)

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -507,6 +507,35 @@ test("Group surface follows the design handoff: SurfaceRail covens + details dra
   assert.doesNotMatch(view, /replying…/, "the ambiguous typing line is replaced by the stepper");
 });
 
+test("Group chat shows a shared, editable topic and goal (cave-o1za)", () => {
+  // The brief lives on the local group model and commits on blur through the
+  // same saveGroups path as every other group mutation, with the same no-op
+  // guard so an untouched blur neither persists nor reorders the rail.
+  assert.match(view, /setGroupTopicGoal\(group, patch, nowIso\(\)\)/, "topic/goal commits route through the pure helper");
+  assert.match(view, /announce\("Conversation brief saved\."\)/, "a topic/goal commit is announced");
+  // Two always-visible, labelled fields in the surface (not the inspector).
+  assert.match(view, /className="coven-tab__brief"/, "the shared brief strip renders in the group surface");
+  assert.match(view, /placeholder="Add a shared topic…"/, "topic field uses an intent-forward placeholder");
+  assert.match(view, /placeholder="Add a shared goal…"/, "goal field uses an intent-forward placeholder");
+  assert.match(view, /aria-label="Shared conversation topic"/, "topic field keeps a durable accessible name");
+  assert.match(view, /aria-label="Shared conversation goal"/, "goal field keeps a durable accessible name");
+  assert.match(view, /key=\{`\$\{activeGroup\.id\}:topic`\}/, "topic field re-seeds when the coven changes");
+  assert.match(view, /key=\{`\$\{activeGroup\.id\}:goal`\}/, "goal field re-seeds when the coven changes");
+  // The brief is relayed to every participant through every prompt builder
+  // (broadcast round-robin + roundtable, delegation child, retry round-robin +
+  // roundtable = five call sites).
+  assert.equal(
+    view.match(/topic: group\.topic,/g)?.length,
+    5,
+    "every prompt builder relays the shared topic",
+  );
+  assert.equal(
+    view.match(/goal: group\.goal,/g)?.length,
+    5,
+    "every prompt builder relays the shared goal",
+  );
+});
+
 test("Group chat is a world-class chat surface (a11y + resilience)", () => {
   // Smart autoscroll (cave-o8si): intent-based release via the shared hook —
   // scrolling up detaches, only the true bottom re-attaches. No position

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -65,6 +65,7 @@ import {
   mentionSuggestionAuthor,
   setGroupResponseMode,
   setGroupDetails,
+  setGroupTopicGoal,
   setGroupParticipantIncluded,
   moveGroupParticipant,
   includedGroupParticipants,
@@ -612,6 +613,22 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
     [persistGroups, announce],
   );
 
+  // Shared brief (topic / goal): always-visible in the header, committed on
+  // blur through the same saveGroups path. setGroupTopicGoal returns the
+  // identical object on a no-op commit, so an untouched blur neither persists
+  // nor reorders the rail.
+  const commitTopicGoal = useCallback(
+    (patch: { topic?: string; goal?: string }) => {
+      const group = activeGroupRef.current;
+      if (!group) return;
+      const next = setGroupTopicGoal(group, patch, nowIso());
+      if (next === group) return;
+      persistGroups(upsertGroup(groupsRef.current, next));
+      announce("Conversation brief saved.");
+    },
+    [persistGroups, announce],
+  );
+
   const changeResponseMode = useCallback(
     (responseMode: CovenResponseMode) => {
       const group = activeGroupRef.current;
@@ -985,6 +1002,8 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                 receivingFamiliarId: reply.familiarId,
                 userText: text,
                 targeted,
+                topic: group.topic,
+                goal: group.goal,
                 familiarNames: mentionable,
                 transcript: [...priorTurns, userTurn, ...settledBefore].map((turn) =>
                   turn.role === "assistant"
@@ -997,6 +1016,8 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                 receivingFamiliarId: reply.familiarId,
                 userText: text,
                 targeted,
+                topic: group.topic,
+                goal: group.goal,
               });
           return streamOne(group, reply, prompt, projectRoot, scopeId, controller.signal);
         },
@@ -1098,6 +1119,8 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                 receivingFamiliarId: targetId,
                 userText: `Delegated by @${delegatedBy}:\n${delegation.task}`,
                 targeted: true,
+                topic: group.topic,
+                goal: group.goal,
               }),
               projectRoot,
               scopeId,
@@ -1234,6 +1257,8 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
               receivingFamiliarId: fresh.familiarId,
               userText: retryText,
               targeted: Boolean(userTurn.targetFamiliarIds && userTurn.targetFamiliarIds.length > 0),
+              topic: group.topic,
+              goal: group.goal,
               familiarNames: group.familiarIds.map((id) => ({
                 id,
                 name: byId.get(id)?.display_name ?? id,
@@ -1249,6 +1274,8 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
               receivingFamiliarId: fresh.familiarId,
               userText: retryText,
               targeted: Boolean(userTurn.targetFamiliarIds && userTurn.targetFamiliarIds.length > 0),
+              topic: group.topic,
+              goal: group.goal,
             }),
         selectedGroupProject.root,
         scopeId,
@@ -1757,6 +1784,35 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                 <Icon name="ph:sidebar-simple" width={14} height={14} aria-hidden />
               </button>
             </header>
+
+            {/* Shared brief: topic + goal stay visible in the surface (not the
+                inspector) because every member of the conversation reads them. */}
+            <div className="coven-tab__brief">
+              <label className="coven-tab__brief-field">
+                <span className="coven-tab__brief-label">Topic</span>
+                <input
+                  key={`${activeGroup.id}:topic`}
+                  type="text"
+                  defaultValue={activeGroup.topic ?? ""}
+                  placeholder="Add a shared topic…"
+                  aria-label="Shared conversation topic"
+                  className="coven-tab__brief-input focus-ring-inset"
+                  onBlur={(event) => commitTopicGoal({ topic: event.target.value })}
+                />
+              </label>
+              <label className="coven-tab__brief-field">
+                <span className="coven-tab__brief-label">Goal</span>
+                <input
+                  key={`${activeGroup.id}:goal`}
+                  type="text"
+                  defaultValue={activeGroup.goal ?? ""}
+                  placeholder="Add a shared goal…"
+                  aria-label="Shared conversation goal"
+                  className="coven-tab__brief-input focus-ring-inset"
+                  onBlur={(event) => commitTopicGoal({ goal: event.target.value })}
+                />
+              </label>
+            </div>
 
             {/* Transcript + details inspector */}
             <div className="coven-tab__body">

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -16,6 +16,7 @@ import {
   moveGroupParticipant,
   setGroupResponseMode,
   setGroupDetails,
+  setGroupTopicGoal,
   orderRoundRobinFamiliarIds,
   parseMentions,
   extractCovenDelegations,
@@ -23,6 +24,7 @@ import {
   resolveGroupMessageTargets,
   mentionSuggestionAuthor,
   renderCovenRoster,
+  renderCovenBrief,
   renderCovenRoundtablePrompt,
   renderCovenRoundRobinPrompt,
   renderCovenContext,
@@ -369,6 +371,90 @@ test("group details round-trip through save/load; legacy groups without them sti
     if (previous) Object.defineProperty(globalThis, "localStorage", previous);
     else delete (globalThis as { localStorage?: unknown }).localStorage;
   }
+});
+
+// --- shared brief (topic / goal) -------------------------------------------
+
+test("setGroupTopicGoal: sets topic/goal and bumps updatedAt; no-op returns the same object", () => {
+  const g = makeGroup("X", ["a"], "2026-06-24T00:00:00.000Z", "g1");
+  const withTopic = setGroupTopicGoal(g, { topic: "Q3 roadmap" }, "2026-06-24T01:00:00.000Z");
+  assert.equal(withTopic.topic, "Q3 roadmap");
+  assert.equal(withTopic.goal, undefined);
+  assert.equal(withTopic.updatedAt, "2026-06-24T01:00:00.000Z");
+  const withBoth = setGroupTopicGoal(withTopic, { goal: "Ship two features" }, "2026-06-24T02:00:00.000Z");
+  assert.equal(withBoth.topic, "Q3 roadmap");
+  assert.equal(withBoth.goal, "Ship two features");
+  // A no-change commit (blur without edits) returns the identical object so
+  // callers can skip the persist/reorder entirely.
+  assert.equal(setGroupTopicGoal(withBoth, { topic: "Q3 roadmap" }, "2026-06-24T03:00:00.000Z"), withBoth);
+  assert.equal(setGroupTopicGoal(withBoth, {}, "2026-06-24T03:00:00.000Z"), withBoth);
+});
+
+test("topic/goal round-trip through save/load; legacy groups without them still load", () => {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+    },
+  });
+  try {
+    const briefed = setGroupTopicGoal(
+      makeGroup("Echo & Sage", ["echo", "sage"], "2026-06-24T00:00:00.000Z", "g1"),
+      { topic: "Q3 roadmap", goal: "Pick the two features to ship" },
+      "2026-06-24T01:00:00.000Z",
+    );
+    const legacy = {
+      // A pre-brief stored group (no topic/goal keys at all).
+      id: "legacy",
+      name: "Legacy coven",
+      familiarIds: ["a"],
+      sessions: {},
+      createdAt: "t1",
+      updatedAt: "t2",
+    };
+    const garbage = {
+      // Non-string topic/goal garbage must be dropped, not crash the header.
+      id: "garbage",
+      name: "Odd coven",
+      familiarIds: ["a"],
+      sessions: {},
+      topic: 42,
+      goal: { nested: true },
+      createdAt: "t1",
+      updatedAt: "t1",
+    };
+    saveGroups([briefed, legacy as never, garbage as never]);
+    const loaded = loadGroups();
+    const byId = new Map(loaded.map((g) => [g.id, g]));
+    assert.equal(byId.get("g1")?.topic, "Q3 roadmap");
+    assert.equal(byId.get("g1")?.goal, "Pick the two features to ship");
+    assert.equal(byId.get("legacy")?.topic, undefined);
+    assert.equal(byId.get("legacy")?.goal, undefined);
+    assert.equal(byId.get("garbage")?.topic, undefined);
+    assert.equal(byId.get("garbage")?.goal, undefined);
+  } finally {
+    if (previous) Object.defineProperty(globalThis, "localStorage", previous);
+    else delete (globalThis as { localStorage?: unknown }).localStorage;
+  }
+});
+
+test("renderCovenBrief: empty without topic or goal", () => {
+  assert.equal(renderCovenBrief(undefined, undefined), "");
+  assert.equal(renderCovenBrief("  ", ""), "");
+});
+
+test("renderCovenBrief: lists topic and goal inside a coven_brief block", () => {
+  const out = renderCovenBrief("Q3 roadmap", "Ship two features");
+  assert.match(out, /<coven_brief>[\s\S]*<\/coven_brief>/);
+  assert.match(out, /Topic: Q3 roadmap/);
+  assert.match(out, /Goal: Ship two features/);
+  assert.match(out, /keep your reply relevant/i);
+  // A single field omits the other rather than rendering a dangling label.
+  assert.match(renderCovenBrief("Q3 roadmap"), /Topic: Q3 roadmap/);
+  assert.doesNotMatch(renderCovenBrief("Q3 roadmap"), /Goal:/);
 });
 
 // --- @mentions -------------------------------------------------------------
@@ -832,6 +918,45 @@ test("renderCovenRoundRobinPrompt: later recipients see settled peers and stay t
   assert.doesNotMatch(out, /Charm said:/);
   assert.doesNotMatch(out, /independent first-pass/);
   assert.match(out, /<coven:delegation target="familiar-id">/);
+});
+
+test("renderCovenRoundtablePrompt: relays the shared brief to every participant", () => {
+  const out = renderCovenRoundtablePrompt({
+    participants: COVEN,
+    receivingFamiliarId: "nova",
+    userText: "What should we do?",
+    targeted: false,
+    topic: "Q3 roadmap",
+    goal: "Ship two features",
+  });
+  assert.match(out, /<coven_brief>/);
+  assert.match(out, /Topic: Q3 roadmap/);
+  assert.match(out, /Goal: Ship two features/);
+  assert.match(out, /What should we do\?$/);
+  // Without a brief the roundtable prompt stays byte-identical (no empty block).
+  const bare = renderCovenRoundtablePrompt({
+    participants: COVEN,
+    receivingFamiliarId: "nova",
+    userText: "What should we do?",
+    targeted: false,
+  });
+  assert.doesNotMatch(bare, /<coven_brief>/);
+});
+
+test("renderCovenRoundRobinPrompt: relays the shared brief to later recipients", () => {
+  const out = renderCovenRoundRobinPrompt({
+    participants: COVEN,
+    receivingFamiliarId: "charm",
+    userText: "What should we do?",
+    targeted: false,
+    familiarNames: NAMES,
+    transcript: [],
+    topic: "Q3 roadmap",
+    goal: "Ship two features",
+  });
+  assert.match(out, /<coven_brief>/);
+  assert.match(out, /Topic: Q3 roadmap/);
+  assert.match(out, /Goal: Ship two features/);
 });
 
 function deferred<T>() {

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -49,6 +49,16 @@ export type CovenGroup = {
   subject?: string;
   /** Optional short running summary of the conversation (details drawer). */
   summary?: string;
+  /**
+   * Shared conversation topic, always visible in the group header and relayed
+   * to every participant so the whole coven knows what is being discussed.
+   */
+  topic?: string;
+  /**
+   * Shared conversation goal — what the group is trying to achieve together.
+   * Always visible in the group header and relayed to every participant.
+   */
+  goal?: string;
   createdAt: string;
   updatedAt: string;
 };
@@ -738,6 +748,22 @@ export function setGroupDetails(
   return { ...group, subject, summary, updatedAt: now };
 }
 
+/**
+ * Update the shared conversation topic and goal shown in the group header.
+ * Returns the SAME object when nothing changed so callers can skip a persist
+ * (and the updatedAt-driven rail reorder) on a no-op blur commit.
+ */
+export function setGroupTopicGoal(
+  group: CovenGroup,
+  patch: { topic?: string; goal?: string },
+  now: string,
+): CovenGroup {
+  const topic = patch.topic !== undefined ? patch.topic : group.topic;
+  const goal = patch.goal !== undefined ? patch.goal : group.goal;
+  if (topic === group.topic && goal === group.goal) return group;
+  return { ...group, topic, goal, updatedAt: now };
+}
+
 /** Filter recipients without changing the user-selected Coven order. */
 export function orderRoundRobinFamiliarIds(
   familiarIds: string[],
@@ -808,7 +834,35 @@ export type CovenRoundtablePromptArgs = {
   receivingFamiliarId: string;
   userText: string;
   targeted: boolean;
+  /** Shared conversation topic, relayed to every participant when set. */
+  topic?: string;
+  /** Shared conversation goal, relayed to every participant when set. */
+  goal?: string;
 };
+
+/**
+ * Render the shared conversation brief (topic + goal) every participant sees.
+ *
+ * Pairs with {@link renderCovenRoster}: the roster says *who* is present, this
+ * says *what* the group is discussing and *why*. Third-person and
+ * framework-free; returns "" when neither field is set so sends without a
+ * brief are byte-identical to before.
+ */
+export function renderCovenBrief(topic?: string, goal?: string): string {
+  const parts: string[] = [];
+  const t = topic?.trim();
+  const g = goal?.trim();
+  if (t) parts.push(`Topic: ${t}`);
+  if (g) parts.push(`Goal: ${g}`);
+  if (parts.length === 0) return "";
+  return [
+    "<coven_brief>",
+    "Shared context for this conversation:",
+    ...parts,
+    "Keep your reply relevant to this shared context.",
+    "</coven_brief>",
+  ].join("\n");
+}
 
 const COVEN_DELEGATION_PROMPT_LINES = [
   "Do not merely suggest that the human ask another familiar to do something.",
@@ -829,6 +883,7 @@ const COVEN_DELEGATION_PROMPT_LINES = [
  */
 export function renderCovenRoundtablePrompt(args: CovenRoundtablePromptArgs): string {
   const roster = renderCovenRoster(args.participants, args.receivingFamiliarId);
+  const brief = renderCovenBrief(args.topic, args.goal);
   const mode = [
     "<coven_roundtable>",
     args.targeted
@@ -839,7 +894,7 @@ export function renderCovenRoundtablePrompt(args: CovenRoundtablePromptArgs): st
     ...COVEN_DELEGATION_PROMPT_LINES,
     "</coven_roundtable>",
   ].join("\n");
-  return [roster, mode, args.userText.trim()].filter(Boolean).join("\n\n");
+  return [roster, brief, mode, args.userText.trim()].filter(Boolean).join("\n\n");
 }
 
 export type CovenRoundRobinPromptArgs = CovenRoundtablePromptArgs & {
@@ -850,6 +905,7 @@ export type CovenRoundRobinPromptArgs = CovenRoundtablePromptArgs & {
 /** Build one sequential reply prompt with settled peer context. */
 export function renderCovenRoundRobinPrompt(args: CovenRoundRobinPromptArgs): string {
   const roster = renderCovenRoster(args.participants, args.receivingFamiliarId);
+  const brief = renderCovenBrief(args.topic, args.goal);
   const context = renderCovenContext(args.transcript, args.receivingFamiliarId, args.familiarNames);
   const mode = [
     "<coven_round_robin>",
@@ -862,7 +918,7 @@ export function renderCovenRoundRobinPrompt(args: CovenRoundRobinPromptArgs): st
     ...COVEN_DELEGATION_PROMPT_LINES,
     "</coven_round_robin>",
   ].join("\n");
-  return [roster, mode, context, args.userText.trim()].filter(Boolean).join("\n\n");
+  return [roster, brief, mode, context, args.userText.trim()].filter(Boolean).join("\n\n");
 }
 
 export type CovenReplyRunner = (
@@ -1122,6 +1178,9 @@ function normalizeCovenGroup(group: CovenGroup): CovenGroup {
     // the details drawer.
     subject: typeof group.subject === "string" ? group.subject : undefined,
     summary: typeof group.summary === "string" ? group.summary : undefined,
+    // Shared topic/goal follow the same later-addition rules as details.
+    topic: typeof group.topic === "string" ? group.topic : undefined,
+    goal: typeof group.goal === "string" ? group.goal : undefined,
     projectId:
       typeof group.projectId === "string" && group.projectId.trim()
         ? group.projectId.trim()

--- a/src/styles/coven-tab.css
+++ b/src/styles/coven-tab.css
@@ -192,6 +192,52 @@
   color: var(--text-muted);
 }
 
+/* ── Shared brief (topic + goal) ─────────────────────────────────────────── */
+
+.coven-tab__brief {
+  display: flex;
+  flex: none;
+  align-items: flex-end;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-5);
+  border-bottom: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 45%, transparent);
+}
+
+.coven-tab__brief-field {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.coven-tab__brief-label {
+  font-size: var(--text-2xs);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.coven-tab__brief-input {
+  width: 100%;
+  min-height: 32px;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-raised) 70%, transparent);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: var(--text-base);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.coven-tab__brief-input::placeholder {
+  color: var(--text-muted);
+}
+
 /* ── Details strip ───────────────────────────────────────────────────────── */
 
 .coven-tab__details-toggle {
@@ -1969,6 +2015,11 @@ textarea.coven-inspector__input {
 
   .coven-inspector {
     display: none;
+  }
+
+  .coven-tab__brief {
+    flex-direction: column;
+    align-items: stretch;
   }
 }
 


### PR DESCRIPTION
Bead: cave-o1za — "Group chat: add a shared conversation topic and goal"

## What

Adds a shared conversation **topic** and **goal** to the group chat ("coven") surface:

- **Model** (`src/lib/group-chat.ts`): two new optional fields on `CovenGroup` (`topic`, `goal`), a `setGroupTopicGoal` reducer (no-op returns the same object), and a `renderCovenBrief` prompt helper.
- **Surface** (`src/components/group-chat-view.tsx`): an always-visible "Topic" / "Goal" strip in the group header, committed on blur through the existing `saveGroups` path with an announcer call.
- **Shared with every member** (`src/lib/group-chat.ts`): the brief is relayed to each participant via the roundtable and round-robin prompt builders, mirroring the existing `renderCovenRoster` "who is present" context.
- **Styles** (`src/styles/coven-tab.css`): token-only `.coven-tab__brief` strip; stacks on narrow panes.

## Storage / protocol note

The daemon/Coven CLI has no server-side group-session primitive — covens are a local Cave concept persisted in `localStorage` (see `loadGroups`/`saveGroups`). `topic` and `goal` follow the exact same local pattern as the existing `subject`/`summary`/`responseMode`/`excludedFamiliarIds` group flags, so the wire protocol is untouched and solo chats are unaffected. Legacy groups without these keys load cleanly (`normalizeCovenGroup` drops non-string garbage).

## Tests

- `src/lib/group-chat.test.ts`: `setGroupTopicGoal` semantics + no-op, topic/goal save/load round-trip (legacy + garbage), `renderCovenBrief` empty/partial/full, and brief relay through both prompt builders.
- `src/components/group-chat-view.test.ts`: source-pin test for the brief strip, blur commit wiring, accessible labels/placeholders, and relay through all five prompt call sites.

## Verification

- `pnpm test:app` — 1359 test files pass
- `pnpm typecheck` — clean
- `pnpm lint` — clean (incl. design-token gates)
- `pnpm check:tests-wired` — clean