### PR TITLE
fix(usage): emit token usage and cost from the codex/opencode harness adapters (cave-0osmn)

### DIFF
--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -1160,6 +1160,18 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /case "usage": \{[\s\S]*?result = \{ \.\.\.result, usage: parseStreamJsonUsage\(event\.usage\) \};/,
+  "Codex turn.completed usage must be captured through parseStreamJsonUsage (cave-0osmn)",
+);
+
+assert.match(
+  chatRoute,
+  /onUsage: \(ev\) => \{[\s\S]*?usage: parseStreamJsonUsage\(ev\.usage\),[\s\S]*?costUsd: parseCostUsd\(ev\.totalCostUsd\),/,
+  "OpenCode step_finish usage/cost must be captured through the defensive validators (cave-0osmn)",
+);
+
+assert.match(
+  chatRoute,
   /binding\.harness !== "claude"[\s\S]*?ev\.type === "output"[\s\S]*?typeof ev\.text === "string"[\s\S]*?assistantFilter\.push\(cleaned\)[\s\S]*?kind: "assistant_chunk", text: filtered/,
   "Coven stream-json output events must pass through the Codex assistant filter instead of being discarded as handled JSON",
 );
@@ -1232,6 +1244,39 @@ assert.match(
     parseStreamJsonUsage({ input_tokens: 7, output_tokens: -3, cache_read_input_tokens: -1 }),
     { inputTokens: 7, outputTokens: 0 },
     "negative counters drop; partial blocks keep the valid fields",
+  );
+  // Codex `turn.completed` usage is flat snake_case with its own cache spellings.
+  assert.deepEqual(
+    parseStreamJsonUsage({
+      input_tokens: 24763,
+      cached_input_tokens: 24448,
+      cache_write_input_tokens: 128,
+      output_tokens: 122,
+    }),
+    {
+      inputTokens: 24763,
+      outputTokens: 122,
+      cacheReadTokens: 24448,
+      cacheCreationTokens: 128,
+    },
+    "Codex cached_input_tokens/cache_write_input_tokens map onto cache read/write",
+  );
+  // OpenCode `step_finish` tokens are camelCase with a nested cache object.
+  assert.deepEqual(
+    parseStreamJsonUsage({
+      total: 7077,
+      input: 205,
+      output: 3,
+      reasoning: 21,
+      cache: { write: 0, read: 6848 },
+    }),
+    {
+      inputTokens: 205,
+      outputTokens: 3,
+      cacheReadTokens: 6848,
+      cacheCreationTokens: 0,
+    },
+    "OpenCode camelCase counters and nested cache map onto the turn shape",
   );
 }
 

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -4096,6 +4096,16 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
             );
             if (ended) push({ kind: "tool_use", ...ended });
           },
+          onUsage: (ev) => {
+            // Terminal step_finish token counters (input/output/cache) plus
+            // cost, normalized by the shared defensive validators at the
+            // Cave boundary. A client that omits either leaves it un-emitted.
+            result = {
+              ...result,
+              usage: parseStreamJsonUsage(ev.usage),
+              costUsd: parseCostUsd(ev.totalCostUsd),
+            };
+          },
           onError: (ev) => {
             // This is an explicit error envelope, so retain its error state
             // even if its message does not match the generic stderr filter.
@@ -4220,6 +4230,12 @@ async function postChat(req: Request, dependencies: ChatSendRouteDependencies = 
             // stripped every payload from this event.
             result = { ...result, is_error: true };
             recordStdoutErrorTail("Codex reported a failure event", true);
+            return;
+          }
+          case "usage": {
+            // turn.completed token counters (input/output/cache). Codex reports
+            // no cost, so costUsd stays absent and the meter shows null for it.
+            result = { ...result, usage: parseStreamJsonUsage(event.usage) };
             return;
           }
           case "unknown": {

--- a/src/lib/codex-compatibility.test.ts
+++ b/src/lib/codex-compatibility.test.ts
@@ -145,6 +145,16 @@ const unknownTool = parseCodexStreamEvent({ type: "item.completed", item: { id: 
 assert.equal(unknownTool?.kind, "unknown", "known outer events with an unknown tool type fail closed too");
 assert.deepEqual(parseCodexStreamEvent({ type: "turn.failed", message: "never render" }, selected.schema), { kind: "failure" }, "terminal turn failures retain no payload");
 assert.deepEqual(parseCodexStreamEvent({ type: "error", message: "never render" }, selected.schema), { kind: "failure" }, "terminal error frames retain no payload");
+assert.deepEqual(
+  parseCodexStreamEvent({ type: "turn.completed", usage: { input_tokens: 24763, cached_input_tokens: 24448, cache_write_input_tokens: 128, output_tokens: 122 } }, selected.schema),
+  { kind: "usage", usage: { input_tokens: 24763, cached_input_tokens: 24448, cache_write_input_tokens: 128, output_tokens: 122 } },
+  "turn.completed forwards its raw usage object for the route to validate",
+);
+assert.deepEqual(
+  parseCodexStreamEvent({ type: "turn.completed", secret: "never render" }, selected.schema),
+  { kind: "usage", usage: undefined },
+  "a turn.completed frame without usage still exposes no payload",
+);
 
 const decoder = new CodexJsonlDecoder();
 const preambleJson = decoder.push('{"type":"error","message":"assistant JSON, not protocol"}\n{"type":"thread.started","thread_id":"example-thread"}\n{"type":"item.started","item":{"id":"example","type":"command_execution"}}\n', selected.schema);

--- a/src/lib/codex-compatibility.ts
+++ b/src/lib/codex-compatibility.ts
@@ -1070,6 +1070,9 @@ export type CodexStreamEvent =
   | { kind: "tool_end"; id: string; name: string; input?: unknown; output?: string; isError: boolean }
   /** Terminal Codex failure with no untrusted payload attached. */
   | { kind: "failure" }
+  /** `turn.completed` token usage. The raw `usage` object is passed through
+   *  untouched; the chat route validates it with parseStreamJsonUsage. */
+  | { kind: "usage"; usage: unknown }
   | { kind: "unknown"; fingerprint: string }
   | { kind: "ignored" };
 
@@ -1112,8 +1115,15 @@ export function parseCodexStreamEvent(value: unknown, schema: CodexEventSchema):
   if (event.type === "turn.failed" || event.type === "error") {
     return { kind: "failure" };
   }
-  if (event.type === "turn.started" || event.type === "turn.completed") {
+  if (event.type === "turn.started") {
     return { kind: "ignored" };
+  }
+  if (event.type === "turn.completed") {
+    // The terminal turn event carries token usage (`input_tokens`,
+    // `output_tokens`, `cached_input_tokens`, `cache_write_input_tokens`).
+    // Pass the raw object through so the route can validate it through the
+    // shared defensive parser; Codex reports no cost, so none is attached.
+    return { kind: "usage", usage: event.usage };
   }
   const item = record(event.item);
   if (!item) return { kind: "unknown", fingerprint: eventFingerprint(event) };

--- a/src/lib/opencode-stream.test.ts
+++ b/src/lib/opencode-stream.test.ts
@@ -32,6 +32,23 @@ assert.deepEqual(
   assert.deepEqual(toolIds, ["tool_live"], "terminal tool frames retain their upstream call id");
   assert.deepEqual(diagnostics, ["malformed-event"], "hostile frames reach the diagnostic path instead of assistant text");
 }
+{
+  let usage: unknown;
+  handleOpenCodeJsonLine(
+    JSON.stringify({
+      type: "step_finish",
+      sessionID: "ses_usage_dispatch",
+      part: { tokens: { input: 10, output: 2 }, cost: 0.001 },
+    }),
+    BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
+    { onUsage: (event) => { usage = event; } },
+  );
+  assert.deepEqual(
+    usage,
+    { kind: "usage", sessionId: "ses_usage_dispatch", usage: { input: 10, output: 2 }, totalCostUsd: 0.001 },
+    "step_finish usage dispatches through the onUsage handler",
+  );
+}
 assert.deepEqual(
   parseOpenCodeRunEvent(
     { type: "text", sessionID: "ses_123", text: "provider-controlled root field" },
@@ -71,6 +88,27 @@ assert.deepEqual(
   ),
   { kind: "ignore", sessionId: "ses_123" },
   "current OpenCode step-finish frames are lifecycle metadata, not compatibility failures",
+);
+assert.deepEqual(
+  parseOpenCodeRunEvent(
+    {
+      type: "step_finish",
+      sessionID: "ses_usage",
+      part: {
+        id: "step_1",
+        tokens: { total: 7077, input: 205, output: 3, reasoning: 21, cache: { write: 0, read: 6848 } },
+        cost: 0.000124095,
+      },
+    },
+    BUILTIN_OPENCODE_SCHEMA_BUNDLE.schemas[0],
+  ),
+  {
+    kind: "usage",
+    sessionId: "ses_usage",
+    usage: { total: 7077, input: 205, output: 3, reasoning: 21, cache: { write: 0, read: 6848 } },
+    totalCostUsd: 0.000124095,
+  },
+  "a step_finish frame carrying tokens and cost forwards the raw usage/cost for the route to validate",
 );
 assert.deepEqual(
   parseOpenCodeRunEvent(

--- a/src/lib/opencode-stream.ts
+++ b/src/lib/opencode-stream.ts
@@ -7,6 +7,10 @@ export type OpenCodeRunEvent =
   | { kind: "tool_progress"; sessionId?: string; id: string; output: unknown }
   | { kind: "tool_end"; sessionId?: string; id: string; output: unknown; isError: boolean }
   | { kind: "tool"; sessionId?: string; id: string; name: string; input: unknown; output: unknown; isError: boolean }
+  /** Terminal `step_finish` token usage and cost. Raw `tokens`/`cost` values
+   *  are passed through; the chat route validates them with
+   *  parseStreamJsonUsage / parseCostUsd. */
+  | { kind: "usage"; sessionId?: string; usage: unknown; totalCostUsd?: unknown }
   | { kind: "error"; sessionId?: string; message: string }
   | { kind: "other"; sessionId?: string; diagnostic?: "unknown-event" | "malformed-event" };
 
@@ -17,6 +21,7 @@ export type OpenCodeJsonLineHandlers = {
   onToolStart?: (event: Extract<OpenCodeRunEvent, { kind: "tool_start" }>) => void;
   onToolProgress?: (event: Extract<OpenCodeRunEvent, { kind: "tool_progress" }>) => void;
   onToolEnd?: (event: Extract<OpenCodeRunEvent, { kind: "tool_end" }>) => void;
+  onUsage?: (event: Extract<OpenCodeRunEvent, { kind: "usage" }>) => void;
   onError?: (event: Extract<OpenCodeRunEvent, { kind: "error" }>) => void;
   onOther?: (event: Extract<OpenCodeRunEvent, { kind: "other" }>, rawEvent: unknown) => void;
   onMalformedJson?: () => void;
@@ -147,6 +152,19 @@ export function parseOpenCodeRunEvent(value: unknown, schema?: OpenCodeEventSche
   const discriminator = schema?.shape?.discriminator ?? { envelope: "root" as const, field: "type" };
   const eventType = stringAt(envelope(event, [discriminator.envelope]), discriminator.field);
   if (!eventType) return { kind: "other", sessionId, diagnostic: "malformed-event" };
+  // OpenCode's terminal `step_finish` event carries token usage and cost on
+  // its payload (`part.tokens` / `part.cost`; observed CLI 1.18.x). Extract
+  // them through the same envelope used for text/tools so the chat route can
+  // validate them with parseStreamJsonUsage / parseCostUsd. A `step_finish`
+  // with no usage falls through to the ordinary lifecycle handling below.
+  if (eventType === "step_finish") {
+    const usageSource = part ?? event;
+    const tokens = valueAt(usageSource, ["tokens"]);
+    const cost = valueAt(usageSource, ["cost"]);
+    if (tokens !== undefined || cost !== undefined) {
+      return { kind: "usage", sessionId, usage: tokens, totalCostUsd: cost };
+    }
+  }
   if (eventTypes(schema, "ignored", ["step_start", "step_finish"]).includes(eventType)) {
     // Lifecycle/control frames are deliberately non-renderable. The selected
     // schema nevertheless authorizes their label, so retain its session token:
@@ -298,6 +316,7 @@ export function handleOpenCodeJsonLine(
       case "tool_start": handlers.onToolStart?.(event); return;
       case "tool_progress": handlers.onToolProgress?.(event); return;
       case "tool_end": handlers.onToolEnd?.(event); return;
+      case "usage": handlers.onUsage?.(event); return;
       case "error": handlers.onError?.(event); return;
       case "other": handlers.onOther?.(event, rawEvent); return;
     }

--- a/src/lib/usage-format.ts
+++ b/src/lib/usage-format.ts
@@ -19,23 +19,52 @@ function finiteNonNegative(value: unknown): number | undefined {
     : undefined;
 }
 
+/** First finite, non-negative number among several candidate fields, or
+ *  undefined when none qualifies. Accepts the several field-name spellings
+ *  the different harness CLIs emit for the same counter without guessing. */
+function firstFiniteNonNegative(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    const parsed = finiteNonNegative(value);
+    if (parsed !== undefined) return parsed;
+  }
+  return undefined;
+}
+
 /** Validated cost from an untrusted number-ish value. Zero is preserved
  *  (formatCost hides it at render time); negatives/NaN/non-numbers drop. */
 export function parseCostUsd(raw: unknown): number | undefined {
   return finiteNonNegative(raw);
 }
 
-/** Parse the `usage` object from a Claude Code stream-json `result` event.
+/** Parse the `usage` object from a harness stream-json/JSONL terminal event
+ *  and normalize it onto Cave's TurnUsage shape. Three wire conventions are
+ *  accepted, one per harness family:
+ *    • Claude / Grok: `input_tokens`, `output_tokens`, `cache_read_input_tokens`,
+ *      `cache_creation_input_tokens`
+ *    • Codex: `input_tokens`, `output_tokens`, `cached_input_tokens`,
+ *      `cache_write_input_tokens`
+ *    • OpenCode: camelCase `input`, `output`, nested `cache.read`, `cache.write`
  *  Fields are optional and defensively validated — a malformed or empty
  *  usage block yields undefined so callers omit it entirely. */
 export function parseStreamJsonUsage(raw: unknown): TurnUsage | undefined {
   if (!raw || typeof raw !== "object") return undefined;
   const u = raw as Record<string, unknown>;
-  const inputTokens = finiteNonNegative(u.input_tokens);
-  const outputTokens = finiteNonNegative(u.output_tokens);
+  const cache = u.cache && typeof u.cache === "object" && !Array.isArray(u.cache)
+    ? u.cache as Record<string, unknown>
+    : null;
+  const inputTokens = firstFiniteNonNegative(u.input_tokens, u.input);
+  const outputTokens = firstFiniteNonNegative(u.output_tokens, u.output);
   if (inputTokens === undefined && outputTokens === undefined) return undefined;
-  const cacheReadTokens = finiteNonNegative(u.cache_read_input_tokens);
-  const cacheCreationTokens = finiteNonNegative(u.cache_creation_input_tokens);
+  const cacheReadTokens = firstFiniteNonNegative(
+    u.cache_read_input_tokens,
+    u.cached_input_tokens,
+    cache?.read,
+  );
+  const cacheCreationTokens = firstFiniteNonNegative(
+    u.cache_creation_input_tokens,
+    u.cache_write_input_tokens,
+    cache?.write,
+  );
   return {
     inputTokens: inputTokens ?? 0,
     outputTokens: outputTokens ?? 0,


### PR DESCRIPTION
## Summary

Cave's usage/cost pipeline (`src/app/api/chat/send/route.ts` + `parseStreamJsonUsage`/`parseCostUsd`) is complete and working — it records `usage` and `costUsd` on the assistant turn from a harness's terminal stream event. The gap is that only the `claude` harness ever put those fields on the wire. This PR wires the two harnesses whose CLIs actually report token usage in the structured streams Cave consumes.

## Harnesses that now emit usage

- **codex** — the terminal `turn.completed` event carries `usage` (`input_tokens`, `output_tokens`, `cached_input_tokens`, `cache_write_input_tokens`; verified from `openai/codex` `codex-rs/exec/src/exec_events.rs`). `parseCodexStreamEvent` now returns a `usage` event and the route captures `parseStreamJsonUsage(event.usage)`. Codex reports no cost, so `costUsd` stays absent (the meter shows null for it).
- **opencode** — the terminal `step_finish` event carries `part.tokens` (`{total, input, output, reasoning, cache:{write, read}}`) and `part.cost` (USD; verified against a live OpenCode 1.18.23 `run --format json` capture). `parseOpenCodeRunEvent` now returns a `usage` event and the route captures `parseStreamJsonUsage(ev.usage)` + `parseCostUsd(ev.totalCostUsd)`.

## Harnesses that cannot emit usage (left un-emitted, not zero-filled)

- **copilot** (64% of turns) — verified against the repo's own conformance fixture (`src/lib/fixtures/copilot/1.0.70-tool-lifecycle.jsonl`) and the Copilot CLI changelog: the JSONL `result` event's `usage` object only carries `premiumRequests`, `totalApiDurationMs`, `sessionDurationMs` — no token counts. Token usage is exposed only via ACP prompt results, live `usage_update` notifications, and `--usage-output-file`, none of which are part of the `--output-format json --stream on` stream Cave consumes. Emitting zeros here would be a number nothing measured, so it is left un-emitted.
- **openclaw** — the bridge/gateway adapter has no usage in its event contract.
- **hermes** (3 turns) — the Responses API `response.completed` does carry a `usage` object, but this is out of scope for this PR (smallest population and a third, separate Responses-API shape).

## Changes

- `src/lib/usage-format.ts` — `parseStreamJsonUsage` now normalizes three wire conventions onto `TurnUsage`: Claude/Grok snake_case (`cache_read_input_tokens`/`cache_creation_input_tokens`), Codex snake_case (`cached_input_tokens`/`cache_write_input_tokens`), and OpenCode camelCase nested (`input`/`output`/`cache.read`/`cache.write`).
- `src/lib/codex-compatibility.ts` — `turn.completed` → `usage` event.
- `src/lib/opencode-stream.ts` — `step_finish` → `usage` event, plus `onUsage` dispatch.
- `src/app/api/chat/send/route.ts` — capture codex/opencode usage/cost through the shared defensive validators.

## Test evidence

- `node --experimental-strip-types --test src/lib/codex-compatibility.test.ts src/lib/opencode-stream.test.ts src/app/api/chat/send/harness-routing-tool-events.test.ts` — all pass.
- `pnpm typecheck` — clean.
- `git diff --check` — clean.
