### PR TITLE
Make project workspace restriction actionable

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -763,6 +763,7 @@ export const SUITES = {
     "src/lib/use-projects-normalize.test.ts",
     "src/lib/project-frecency.test.ts",
     "src/lib/project-root-normalizers.test.ts",
+    "src/lib/project-root-guidance.test.ts",
     "src/lib/project-root-migration.test.ts",
     "src/lib/project-display-name-spaces.test.ts",
     "src/lib/use-projects-scope-transition.test.ts",

--- a/src/components/canvas-github-import-modal.test.ts
+++ b/src/components/canvas-github-import-modal.test.ts
@@ -72,4 +72,18 @@ assert.doesNotMatch(
   "repository registration does not ask for a redundant project name",
 );
 
+// cave-cu0x: the import modal is a project-creation entry point too — its
+// "Local checkout" field explains the workspace rule before the pick, and a
+// containment rejection pairs the server error with the shared help.
+assert.match(
+  modal,
+  /\{PROJECT_ROOT_WORKSPACE_HELP\}/,
+  "the local-checkout hint explains the allowed-workspace rule before the pick",
+);
+assert.match(
+  modal,
+  /setError\(projectRootRejectionMessage\(projectErrorCode\(caught\), message\)\)/,
+  "containment rejections pair the server error with the shared workspace help",
+);
+
 console.log("canvas GitHub import modal contract: ok");

--- a/src/components/canvas-github-import-modal.tsx
+++ b/src/components/canvas-github-import-modal.tsx
@@ -19,6 +19,11 @@ import {
   parseGitHubFileUrl,
 } from "@/lib/github-repo-link";
 import { Icon } from "@/lib/icon";
+import { projectErrorCode } from "@/lib/project-errors";
+import {
+  PROJECT_ROOT_WORKSPACE_HELP,
+  projectRootRejectionMessage,
+} from "@/lib/project-root-guidance";
 import { isTauri } from "@/lib/tauri-platform";
 import { useProjects } from "@/lib/use-projects";
 
@@ -205,7 +210,7 @@ export function CanvasGitHubImportModal({
         caught instanceof Error
           ? caught.message
           : "Couldn’t load that GitHub file.";
-      setError(message);
+      setError(projectRootRejectionMessage(projectErrorCode(caught), message));
       announce(message, "assertive");
     } finally {
       setBusy(false);
@@ -411,6 +416,7 @@ export function CanvasGitHubImportModal({
                     Choose an existing checkout for {parsed.owner}/{parsed.repo}.
                     Canvas doesn’t clone repositories.
                   </small>
+                  <small>{PROJECT_ROOT_WORKSPACE_HELP}</small>
                 </label>
               ) : null}
             </section>

--- a/src/components/directory-picker-modal.tsx
+++ b/src/components/directory-picker-modal.tsx
@@ -139,6 +139,12 @@ export type DirectoryPickerModalProps = {
   onClose: () => void;
   /** Called with the absolute path of the chosen directory. */
   onSelect: (dir: string) => void;
+  /**
+   * Optional requirement guidance shown before the user picks a folder. Project
+   * callers pass the shared allowed-workspace help so the rule is explained
+   * proactively rather than only after a rejected pick.
+   */
+  helpText?: string;
 };
 
 /**
@@ -156,7 +162,7 @@ export type DirectoryPickerModalProps = {
  * or drive is always a mistake), matching isAllowedNewProjectRoot on the
  * server.
  */
-export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPickerModalProps) {
+export function DirectoryPickerModal({ open, onClose, onSelect, helpText }: DirectoryPickerModalProps) {
   const [home, setHome] = useState<string | null>(null);
   const [cwd, setCwd] = useState<string | null>(null);
   const [parent, setParent] = useState<string | null>(null);
@@ -508,6 +514,11 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
             <span className="text-[length:var(--text-sm)] text-[var(--text-muted)]">
               Pick where this project&apos;s chats will live.
             </span>
+            {helpText ? (
+              <span className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">
+                {helpText}
+              </span>
+            ) : null}
           </div>
           <Button
             ref={closeButtonRef}

--- a/src/components/directory-picker.test.ts
+++ b/src/components/directory-picker.test.ts
@@ -506,6 +506,17 @@ test("creating a dot folder reveals it instead of hiding what the user just made
   );
 });
 
+// cave-cu0x: the workspace rule must be explained BEFORE the user picks — not
+// discovered only after a rejected pick. The modal takes optional guidance and
+// renders it in the header, so project callers pass the shared help text.
+test("the modal surfaces optional allowed-workspace guidance before picking", () => {
+  const src = read("./directory-picker-modal.tsx");
+  assert.match(src, /helpText\?: string;/, "the modal accepts optional requirement guidance");
+  assert.match(src, /onSelect, helpText \}: DirectoryPickerModalProps/, "the guidance prop is destructured");
+  assert.match(src, /helpText \? \(/, "provided guidance renders below the subtitle");
+  assert.match(src, /\{helpText\}/, "the guidance text is rendered in the header");
+});
+
 test("the picker never reports a folder as empty while it is withholding dot folders", () => {
   const src = read("./directory-picker-modal.tsx");
   // "This folder is empty" beside a toggle reading "Hidden folders (3)" is a

--- a/src/components/first-project-gate.test.ts
+++ b/src/components/first-project-gate.test.ts
@@ -191,7 +191,7 @@ test("the gate keeps drafts through failures, blocks blank or busy submits, and 
   assert.match(src, /name: submitName/, "passes the stored-or-drafted name through addChatProject");
   assert.match(src, /const createdProjectName = lockedProject\?\.name \?\? submitName;/, "success uses the existing project name when granting access");
   assert.match(src, /clearPendingFirstProjectAccessSnapshot\(\);[\s\S]*onPendingGrantChange\(null\);/, "success clears persisted retry state only after the grant succeeds");
-  assert.match(src, /else \{\s*setSubmitError\(result\.error\);\s*\}/, "the gate preserves addChatProject's actionable creation failure");
+  assert.match(src, /else \{\s*setSubmitError\(projectRootRejectionMessage\(result\.code, result\.error\)\);\s*\}/, "the gate preserves addChatProject's actionable creation failure, appending workspace help on containment rejection");
   assert.match(src, /lockedProject \? "Granted" : "Created"/, "the live announcement distinguishes a grant from project creation");
   assert.match(src, /if \(submitting \|\| loadingProjects \|\| Boolean\(projectsError\)\) return;/, "the submit handler rejects busy or registry-blocked submits before any mutation");
   assert.match(src, /if \(!lockedProject && !submitName\) \{[\s\S]*setSubmitError\("Enter a project name\."\);/, "blank project names are blocked before the first registration");
@@ -220,6 +220,28 @@ test("the gate exposes the exact root field plus Browse and Create-or-retry acti
   assert.match(src, />\s*Browse\s*</, "the gate exposes a Browse action next to the root field");
   assert.match(src, /"Create"/, "the gate exposes a Create action for the first project");
   assert.match(src, /\{registeredProject \? "Retry access" : lockedProject \? "Grant access" : "Create"\}/, "the primary action distinguishes Create, Grant access, and Retry access");
+});
+
+// cave-cu0x: the first-project gate explains the workspace rule before the
+// pick (typed path, native dialog, or web browser) and pairs the server's
+// containment error with the shared help when a root is rejected.
+test("the gate explains the workspace rule proactively and on containment rejection", () => {
+  const src = read("./first-project-gate.tsx");
+  assert.match(
+    src,
+    /\{PROJECT_ROOT_WORKSPACE_HELP\}/,
+    "the root hint shows the shared workspace help before the pick",
+  );
+  assert.match(
+    src,
+    /helpText=\{PROJECT_ROOT_WORKSPACE_HELP\}/,
+    "the folder browser shows the shared workspace help before the pick",
+  );
+  assert.match(
+    src,
+    /projectRootRejectionMessage\(result\.code, result\.error\)/,
+    "containment rejections compose the server error with the shared workspace help",
+  );
 });
 
 console.log("first-project-gate.test.ts OK");

--- a/src/components/first-project-gate.tsx
+++ b/src/components/first-project-gate.tsx
@@ -13,6 +13,10 @@ import {
   writePendingFirstProjectAccessSnapshot,
   type PendingFirstProjectAccessSnapshot,
 } from "@/lib/first-project-gate-retry";
+import {
+  PROJECT_ROOT_WORKSPACE_HELP,
+  projectRootRejectionMessage,
+} from "@/lib/project-root-guidance";
 import { isTauri } from "@/lib/tauri-platform";
 
 function pathBasename(p: string): string {
@@ -191,7 +195,7 @@ export function FirstProjectGate({
         setSubmitError(null);
         announce(`${lockedProject ? "Granted" : "Created"} project ${createdProjectName}. Chat is ready.`);
       } else {
-        setSubmitError(result.error);
+        setSubmitError(projectRootRejectionMessage(result.code, result.error));
       }
     } catch (error) {
       setSubmitError(error instanceof Error ? error.message : "Could not create that project.");
@@ -361,6 +365,9 @@ export function FirstProjectGate({
                   <p id={rootHintId} className="text-[length:var(--text-sm)] text-[var(--text-muted)]">
                     Pick the repository root you want chat to run inside.
                   </p>
+                  <p className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">
+                    {PROJECT_ROOT_WORKSPACE_HELP}
+                  </p>
                 </div> : null}
 
                 <div className="flex items-center justify-end">
@@ -389,6 +396,7 @@ export function FirstProjectGate({
           setPickerOpen(false);
           applyPickedRoot(dir);
         }}
+        helpText={PROJECT_ROOT_WORKSPACE_HELP}
       />
     </>
   );

--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -411,4 +411,23 @@ assert.match(
   "onClick guard prevents open being set while disabled",
 );
 
+// cave-cu0x: the shared add flow explains the workspace rule before the pick
+// and, on a containment rejection, pairs the server's error with the help so
+// every picker that renders addFlow.addError shows the actionable guidance.
+assert.match(
+  src,
+  /projectRootRejectionMessage\(result\.code, result\.error\)/,
+  "containment rejections compose the server error with the shared workspace help",
+);
+assert.match(
+  src,
+  /helpText=\{PROJECT_ROOT_WORKSPACE_HELP\}/,
+  "the folder browser shows the shared workspace help before the pick",
+);
+assert.match(
+  src,
+  /PROJECT_ROOT_WORKSPACE_HELP,[\s\S]*?projectRootRejectionMessage,[\s\S]*?\} from "@\/lib\/project-root-guidance"/,
+  "the shared guidance constants are imported, never re-typed",
+);
+
 console.log("project-picker.test.ts OK");

--- a/src/components/project-picker.tsx
+++ b/src/components/project-picker.tsx
@@ -26,6 +26,10 @@ import {
   type CaveProject,
 } from "@/lib/cave-projects-types";
 import { projectAccessLabel } from "@/lib/project-access-levels";
+import {
+  PROJECT_ROOT_WORKSPACE_HELP,
+  projectRootRejectionMessage,
+} from "@/lib/project-root-guidance";
 import { isTauri } from "@/lib/tauri-platform";
 import { resolveProjectPickerSelection } from "@/lib/project-picker-selection";
 
@@ -81,7 +85,7 @@ export function useAddProjectFlow(args: {
     });
     setAdding(false);
     if (result.ok) args.onAdded(result.projectId);
-    else setAddError(result.error);
+    else setAddError(projectRootRejectionMessage(result.code, result.error));
   };
 
   const beginAddProject = () => {
@@ -109,6 +113,7 @@ export function useAddProjectFlow(args: {
         setPickerOpen(false);
         void registerRoot(dir);
       }}
+      helpText={PROJECT_ROOT_WORKSPACE_HELP}
     />
   );
 

--- a/src/components/project-setup-modal.test.ts
+++ b/src/components/project-setup-modal.test.ts
@@ -116,4 +116,13 @@ assert.match(
   "picking a suggestion routes through the shared fill rule",
 );
 
+// cave-cu0x: the setup modal's create failure surfaces the server's error
+// body, and for the containment code it appends the shared workspace help so
+// the in-place registration explains what IS allowed too.
+assert.match(
+  src,
+  /projectRootRejectionMessage\(\s*projectErrorCode\(error\),\s*error instanceof Error && error\.message\s*\?\s*error\.message/,
+  "containment rejections pair the server error with the shared workspace help (cave-cu0x)",
+);
+
 console.log("project-setup-modal.test.ts OK");

--- a/src/components/project-setup-modal.tsx
+++ b/src/components/project-setup-modal.tsx
@@ -20,6 +20,8 @@ import { Popover, PopoverBody } from "@/components/ui/popover";
 import type { ProjectAccessLevel } from "@/lib/project-access-levels";
 import { publishProjectAccessChanged } from "@/lib/project-access-events";
 import { emitProjectRegistryMutation } from "@/lib/project-registry-events";
+import { projectErrorCode } from "@/lib/project-errors";
+import { projectRootRejectionMessage } from "@/lib/project-root-guidance";
 import { PROJECT_SETUP_COLOR_CHOICES } from "@/lib/project-setup-offer";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
@@ -275,9 +277,12 @@ export function ProjectSetupModal({
         );
       } else {
         setError(
-          error instanceof Error && error.message
-            ? error.message
-            : "Couldn't reach the desktop — nothing was created. Retry?",
+          projectRootRejectionMessage(
+            projectErrorCode(error),
+            error instanceof Error && error.message
+              ? error.message
+              : "Couldn't reach the desktop — nothing was created. Retry?",
+          ),
         );
       }
     } finally {

--- a/src/lib/project-root-guidance.test.ts
+++ b/src/lib/project-root-guidance.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE,
+  PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR,
+  PROJECT_ROOT_WORKSPACE_HELP,
+  projectRootRejectionMessage,
+} from "./project-root-guidance.ts";
+
+// cave-cu0x: the shared constants are the single source of the workspace
+// requirement copy — the client must render these, never a parallel string.
+test("the shared guidance constants stay stable", () => {
+  assert.equal(
+    PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE,
+    "PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE",
+  );
+  assert.equal(
+    PROJECT_ROOT_WORKSPACE_HELP,
+    "Project folders can live anywhere on this computer — any folder works except your home folder itself or the top of a drive.",
+  );
+  assert.equal(
+    PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR,
+    "Choose a specific folder for this project — your home folder itself or the top of a drive can't be a project root.",
+  );
+});
+
+// The containment rejection must pair the server's error with the shared help
+// so the user sees both what was rejected and what IS allowed.
+test("the containment code composes the shared error with the workspace help", () => {
+  assert.equal(
+    projectRootRejectionMessage(
+      PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE,
+      PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR,
+    ),
+    `${PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR} ${PROJECT_ROOT_WORKSPACE_HELP}`,
+  );
+});
+
+// Non-containment failures (missing root, invalid GitHub link, local-only
+// rejections, …) must pass through untouched so their own guidance survives.
+test("non-containment errors pass through unchanged", () => {
+  assert.equal(
+    projectRootRejectionMessage("local_request_required", "Project registration must happen from the Cave desktop."),
+    "Project registration must happen from the Cave desktop.",
+  );
+  assert.equal(
+    projectRootRejectionMessage(undefined, "root does not exist"),
+    "root does not exist",
+  );
+});

--- a/src/lib/project-root-guidance.ts
+++ b/src/lib/project-root-guidance.ts
@@ -6,3 +6,20 @@ export const PROJECT_ROOT_WORKSPACE_HELP =
 
 export const PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_ERROR =
   "Choose a specific folder for this project — your home folder itself or the top of a drive can't be a project root.";
+
+/**
+ * Compose the inline guidance a project entry point shows when the server
+ * refuses a root. For the containment code this is the server's shared error
+ * plus the shared workspace help — what was rejected and what IS allowed, in
+ * one message. Any other code/error passes through unchanged, so no entry
+ * point has to know the boundary itself. Client guidance only: it never
+ * changes what the server accepts.
+ */
+export function projectRootRejectionMessage(
+  code: string | undefined,
+  error: string,
+): string {
+  return code === PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE
+    ? `${error} ${PROJECT_ROOT_WORKSPACE_HELP}`
+    : error;
+}


### PR DESCRIPTION
Bead: cave-cu0x — Make project workspace restriction actionable.

The server half already shipped: `src/lib/project-root-guidance.ts` exposes the shared containment code/help/error, and `POST /api/projects` + `PUT /api/projects/[id]` return them. This lands the client half.

## What changed
- **Proactive** explanation of the allowed-workspace requirement before a root is picked:
  - `DirectoryPickerModal` gains an optional `helpText` prop; project callers pass `PROJECT_ROOT_WORKSPACE_HELP`.
  - First-project gate root hint and the Canvas GitHub import "Local checkout" hint show the same shared help.
- **Inline** surfacing of the server's containment error paired with the shared help at every creation/import entry point via `projectRootRejectionMessage`:
  - `useAddProjectFlow` (project picker, composer, chat overflow, Projects view, Familiar Studio)
  - first-project gate
  - project setup modal
  - Canvas GitHub import modal

Client guidance only — the server boundary is unchanged.

## Tests
- `src/lib/project-root-guidance.test.ts` (new): pins the constants and the rejection-message composition.
- Extended source-contract tests: directory-picker, project-picker, first-project-gate, project-setup-modal, canvas-github-import-modal.
- Registered the new test in `scripts/run-tests.mjs`.

Verified locally: `pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` green; focused tests pass.