### PR TITLE
feat(passkey): verify WebAuthn attestation statements (cave-01v4u)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1789,6 +1789,8 @@ export const SUITES = {
     "src/lib/server/space-usage.test.ts",
     "src/lib/server/preferences-store.test.ts",
     "src/lib/server/webauthn-verify.test.ts",
+    "src/lib/server/webauthn-roots.test.ts",
+    "src/lib/server/webauthn-attestation-contract.test.ts",
     "src/lib/server/passkey-store.test.ts",
     "src/lib/server/passkey-ceremony.test.ts",
     "src/lib/passkey-presence.test.ts",

--- a/src/components/settings-phone.tsx
+++ b/src/components/settings-phone.tsx
@@ -599,6 +599,16 @@ function PasskeyCard() {
         // A cancelled Face ID prompt is not a failure worth shouting about;
         // everything else is something the operator has to see.
         if (err instanceof PasskeyError && err.kind === "cancelled") return;
+        // cave-01v4u: the server now refuses enrollments whose browser did not
+        // return device attestation (Chrome on macOS commonly returns "none"
+        // even under "direct"). Translate the raw reason into guidance instead
+        // of showing an opaque "attestation" string.
+        if (err instanceof PasskeyError && err.kind === "server" && err.message === "attestation") {
+          setError(
+            "This browser did not return device attestation. Enroll from Safari (iOS or macOS), or from the browser built into the device itself, so the Secure Enclave can be verified.",
+          );
+          return;
+        }
         setError(err instanceof Error ? err.message : "Passkey step failed");
       } finally {
         setBusy(null);

--- a/src/lib/passkey-client.test.ts
+++ b/src/lib/passkey-client.test.ts
@@ -112,6 +112,10 @@ test("registration asks for a platform authenticator with UV required", async ()
     [-7, -257],
     "only algorithms the server can verify are offered",
   );
+  // cave-01v4u: the client must request the attestation statement so the
+  // server can verify the authenticator model. Falling back to "none" would
+  // recreate the gap this closes.
+  assert.equal(options?.attestation, "direct");
 });
 
 test("registration posts the ceremony fields the server expects", async () => {

--- a/src/lib/passkey-client.ts
+++ b/src/lib/passkey-client.ts
@@ -123,7 +123,11 @@ export async function registerPasskey(
           userVerification: "required",
         },
         timeout: 60_000,
-        attestation: "none",
+        // cave-01v4u: request the attestation statement so the server can
+        // prove the authenticator MODEL (Secure Enclave) instead of trusting
+        // a client-asserted flag. Never fall back to "none" here — that would
+        // recreate the exact gap attestation verification closes.
+        attestation: "direct",
       },
     })) as PublicKeyCredential | null;
   } catch (err) {

--- a/src/lib/server/passkey-ceremony.test.ts
+++ b/src/lib/server/passkey-ceremony.test.ts
@@ -137,22 +137,30 @@ async function enroll(nodeId = NODE, flags = FLAG_UP | FLAG_UV) {
   const context = ceremonyContext(tailnetHeaders(nodeId), "https:")!;
   const { challenge } = await startCeremony("register", peer, context);
   const data = authData({ flags, withCredential: true });
+  // cave-01v4u: a remote registration must not use fmt "none". Self-attest
+  // with the fixture key so the happy path keeps exercising real signatures.
+  const attestationObject = packedSelfAttestationObject(challenge, data);
   return completeRegistration({
     peer,
     context,
     challenge,
     clientDataJSON: b64(clientData("webauthn.create", challenge)),
-    attestationObject: b64(
-      cbor(
-        new Map<string, unknown>([
-          ["fmt", "none"],
-          ["attStmt", new Map()],
-          ["authData", data],
-        ]),
-      ),
-    ),
+    attestationObject: b64(attestationObject),
     label: "Test iPhone",
   });
+}
+
+function packedSelfAttestationObject(challenge: string, data: Uint8Array): Uint8Array {
+  const cdj = clientData("webauthn.create", challenge);
+  const clientDataHash = new Uint8Array(createHash("sha256").update(cdj).digest());
+  const signature = new Uint8Array(cryptoSign("sha256", concat(data, clientDataHash), privateKey));
+  return cbor(
+    new Map<string, unknown>([
+      ["fmt", "packed"],
+      ["attStmt", new Map<string, unknown>([["alg", -7], ["sig", signature]])],
+      ["authData", data],
+    ]),
+  );
 }
 
 async function assertPresence(
@@ -216,6 +224,45 @@ test("ceremonyContext refuses a host that is not a plain host[:port]", () => {
   assert.equal(ceremonyContext(new Headers(), "https:"), null);
 });
 
+// ─── attestation policy (cave-01v4u) ────────────────────────────────────────
+
+async function noneEnrollment(headersForPeer: Headers, context: ReturnType<typeof ceremonyContext>) {
+  const peer = resolvePeerIdentity(headersForPeer)!;
+  const { challenge } = await startCeremony("register", peer, context!);
+  return completeRegistration({
+    peer,
+    context: context!,
+    challenge,
+    clientDataJSON: b64(clientData("webauthn.create", challenge)),
+    attestationObject: b64(
+      cbor(
+        new Map<string, unknown>([
+          ["fmt", "none"],
+          ["attStmt", new Map()],
+          ["authData", authData({ flags: FLAG_UP | FLAG_UV, withCredential: true })],
+        ]),
+      ),
+    ),
+    label: "Test",
+  });
+}
+
+test("a remote registration with fmt 'none' is refused", async () => {
+  const result = await noneEnrollment(tailnetHeaders(), ceremonyContext(tailnetHeaders(), "https:"));
+  assert.deepEqual(result, { ok: false, status: 400, error: "attestation" });
+});
+
+test("a local loopback registration may still use fmt 'none'", async () => {
+  const localHeaders = headers({ "x-coven-cave-local-peer": process.env.COVEN_CAVE_LOCAL_PEER_SECRET! });
+  const result = await noneEnrollment(localHeaders, ceremonyContext(localHeaders, "https:"));
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.credential.attestationTrustPath, "none");
+    assert.equal(result.credential.attestationVerified, false);
+    assert.equal(result.credential.attestationVerifiedAt, undefined);
+  }
+});
+
 // ─── the happy path ────────────────────────────────────────────────────────
 
 test("register then assert yields a presence token bound to the device", async () => {
@@ -223,6 +270,12 @@ test("register then assert yields a presence token bound to the device", async (
   assert.equal(registration.ok, true);
   assert.equal(registration.ok && registration.credential.credentialId, CREDENTIAL_ID_B64);
   assert.equal(registration.ok && registration.credential.tailnetNodeId, NODE);
+  assert.equal(
+    registration.ok && registration.credential.attestationTrustPath,
+    "packed-self",
+    "the self-attested fixture key records its model-unproven trust path",
+  );
+  assert.equal(registration.ok && registration.credential.attestationVerified, false);
 
   const assertion = await assertPresence();
   assert.equal(assertion.ok, true, assertion.ok ? "" : `failed: ${assertion.error}`);
@@ -374,13 +427,7 @@ test("a proven presence lets the same device enroll another credential", async (
     challenge,
     clientDataJSON: b64(clientData("webauthn.create", challenge)),
     attestationObject: b64(
-      cbor(
-        new Map<string, unknown>([
-          ["fmt", "none"],
-          ["attStmt", new Map()],
-          ["authData", authData({ withCredential: true })],
-        ]),
-      ),
+      packedSelfAttestationObject(challenge, authData({ withCredential: true })),
     ),
     presenceProven: true,
   });

--- a/src/lib/server/passkey-ceremony.ts
+++ b/src/lib/server/passkey-ceremony.ts
@@ -190,15 +190,22 @@ export async function completeRegistration(input: {
 
   let result;
   try {
-    result = verifyRegistration({
-      clientDataJSON: base64UrlDecode(input.clientDataJSON),
-      attestationObject: base64UrlDecode(input.attestationObject),
-      expectedChallenge: input.challenge,
-      // The challenge record's origin/rpId, NOT this request's. Otherwise a
-      // ceremony begun on one host could be completed against another.
-      expectedOrigin: record.origin,
-      expectedRpId: record.rpId,
-    });
+    result = verifyRegistration(
+      {
+        clientDataJSON: base64UrlDecode(input.clientDataJSON),
+        attestationObject: base64UrlDecode(input.attestationObject),
+        expectedChallenge: input.challenge,
+        // The challenge record's origin/rpId, NOT this request's. Otherwise a
+        // ceremony begun on one host could be completed against another.
+        expectedOrigin: record.origin,
+        expectedRpId: record.rpId,
+      },
+      // cave-01v4u: attestation "none" is refused for remote peers, but the
+      // local loopback peer may enroll without device attestation — loopback
+      // already equals "someone at this machine" (the same boundary as the
+      // local-ingress presence exemption).
+      { allowNone: input.peer.kind === "local" },
+    );
   } catch (err) {
     if (err instanceof WebAuthnError) return { ok: false, status: 400, error: err.reason };
     return { ok: false, status: 400, error: "malformed" };
@@ -215,6 +222,9 @@ export async function completeRegistration(input: {
     signCount: result.signCount,
     aaguid: base64UrlEncode(result.aaguid),
     attestationFormat: result.attestationFormat,
+    attestationVerified: result.attestation.verified,
+    attestationTrustPath: result.attestation.trustPath,
+    ...(result.attestation.verified ? { attestationVerifiedAt: now } : {}),
     label: (input.label ?? "").trim().slice(0, 64) || "Passkey",
     createdAt: now,
     lastUsedAt: null,

--- a/src/lib/server/passkey-store.test.ts
+++ b/src/lib/server/passkey-store.test.ts
@@ -43,11 +43,13 @@ function credential(overrides: Partial<Parameters<typeof saveCredential>[0]> = {
     signCount: 0,
     aaguid: "AAAAAAAAAAAAAAAAAAAAAA",
     attestationFormat: "none",
+    attestationVerified: false,
+    attestationTrustPath: "legacy",
     label: "iPhone",
     createdAt: 1_000,
     lastUsedAt: null,
     ...overrides,
-  };
+  } as const;
 }
 
 // ─── credentials ───────────────────────────────────────────────────────────
@@ -126,7 +128,7 @@ test("entries that do not look like credentials are dropped on read", async () =
 test("the store is written as JSON at the configured path", async () => {
   await saveCredential(credential());
   const parsed = JSON.parse(await readFile(passkeyStorePath(), "utf8"));
-  assert.equal(parsed.version, 1);
+  assert.equal(parsed.version, 2, "writes carry the attestation-aware store version");
   assert.equal(parsed.credentials[0].tailnetNodeId, NODE_A);
 });
 
@@ -204,4 +206,44 @@ test("outstanding challenges are bounded so an abandoned ceremony cannot grow th
     null,
     "the oldest challenge was evicted",
   );
+});
+
+// ─── attestation outcome fields (cave-01v4u) ────────────────────────────────
+
+test("a legacy credential without attestation outcome fields loads and stays assertable", async () => {
+  const legacy = credential() as unknown as Record<string, unknown>;
+  delete legacy.attestationVerified;
+  delete legacy.attestationTrustPath;
+  await writeFile(
+    passkeyStorePath(),
+    JSON.stringify({ version: 1, credentials: [legacy] }),
+  );
+  const found = await findCredential("Y3JlZC1vbmU", NODE_A);
+  assert.ok(found, "legacy rows are not dropped by the lenient reader");
+  assert.equal(found.attestationVerified, false);
+  assert.equal(found.attestationTrustPath, "legacy");
+  assert.equal(found.attestationVerifiedAt, undefined);
+});
+
+test("a credential stores its attestation outcome", async () => {
+  await saveCredential(
+    credential({
+      attestationFormat: "apple",
+      attestationVerified: true,
+      attestationTrustPath: "apple",
+      attestationVerifiedAt: 2_000,
+    }),
+  );
+  const found = await findCredential("Y3JlZC1vbmU", NODE_A);
+  assert.equal(found?.attestationVerified, true);
+  assert.equal(found?.attestationTrustPath, "apple");
+  assert.equal(found?.attestationVerifiedAt, 2_000);
+  const raw = JSON.parse(await readFile(passkeyStorePath(), "utf8")) as { version: number };
+  assert.equal(raw.version, 2, "new writes carry the attestation-aware store version");
+});
+
+test("a malformed attestation trust path normalizes to legacy rather than dropping the credential", async () => {
+  await saveCredential(credential({ attestationTrustPath: "bogus" as never }));
+  const found = await findCredential("Y3JlZC1vbmU", NODE_A);
+  assert.equal(found?.attestationTrustPath, "legacy");
 });

--- a/src/lib/server/passkey-store.ts
+++ b/src/lib/server/passkey-store.ts
@@ -22,6 +22,8 @@ import path from "node:path";
 import { caveHome } from "@/lib/coven-paths";
 import { writeJsonAtomic } from "@/lib/server/atomic-write";
 
+export type AttestationTrustPath = "apple" | "packed-basic" | "packed-self" | "none" | "legacy";
+
 export type StoredCredential = {
   /** base64url, as it appears on the wire and in allowCredentials. */
   credentialId: string;
@@ -33,14 +35,20 @@ export type StoredCredential = {
   algorithm: number;
   signCount: number;
   aaguid: string;
-  /** Recorded, NOT verified — see cave-01v4u. */
+  /** The attestation fmt string the authenticator reported. */
   attestationFormat: string;
+  /** True only when the authenticator MODEL was proven (cave-01v4u). */
+  attestationVerified: boolean;
+  /** How the attestation statement was (or was not) verified. */
+  attestationTrustPath: AttestationTrustPath;
+  /** Epoch ms when `attestationVerified` became true, if it ever did. */
+  attestationVerifiedAt?: number;
   label: string;
   createdAt: number;
   lastUsedAt: number | null;
 };
 
-type StoreFile = { version: 1; credentials: StoredCredential[] };
+type StoreFile = { version: 1 | 2; credentials: StoredCredential[] };
 
 export function passkeyStorePath(): string {
   const override = process.env.COVEN_CAVE_PASSKEY_STORE_PATH?.trim();
@@ -48,7 +56,7 @@ export function passkeyStorePath(): string {
 }
 
 function emptyStore(): StoreFile {
-  return { version: 1, credentials: [] };
+  return { version: 2, credentials: [] };
 }
 
 function isCredential(value: unknown): value is StoredCredential {
@@ -65,6 +73,25 @@ function isCredential(value: unknown): value is StoredCredential {
   );
 }
 
+const TRUST_PATHS = new Set<AttestationTrustPath>(["apple", "packed-basic", "packed-self", "none", "legacy"]);
+
+/**
+ * Credentials written before cave-01v4u carry no attestation outcome fields;
+ * their attestation statement was discarded at registration, so they can
+ * never be re-verified. Normalize them to an honest `legacy` trust path —
+ * assertions never read attestation fields, so existing credentials keep
+ * working exactly as before.
+ */
+function normalizeCredential(value: StoredCredential): StoredCredential {
+  const trustPath = TRUST_PATHS.has(value.attestationTrustPath) ? value.attestationTrustPath : "legacy";
+  return {
+    ...value,
+    attestationVerified: value.attestationVerified === true,
+    attestationTrustPath: trustPath,
+    ...(value.attestationVerifiedAt !== undefined ? { attestationVerifiedAt: value.attestationVerifiedAt } : {}),
+  };
+}
+
 async function readStore(): Promise<StoreFile> {
   let parsed: unknown;
   try {
@@ -77,8 +104,13 @@ async function readStore(): Promise<StoreFile> {
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return emptyStore();
   const record = parsed as Record<string, unknown>;
-  const credentials = Array.isArray(record.credentials) ? record.credentials.filter(isCredential) : [];
-  return { version: 1, credentials };
+  const credentials = Array.isArray(record.credentials)
+    ? record.credentials.filter(isCredential).map(normalizeCredential)
+    : [];
+  // Version 1 files are valid input forever: they just lack the attestation
+  // outcome fields, which normalization fills in as `legacy`.
+  const version = record.version === 1 || record.version === 2 ? record.version : 2;
+  return { version, credentials };
 }
 
 async function writeStore(store: StoreFile): Promise<void> {
@@ -120,7 +152,7 @@ export async function saveCredential(credential: StoredCredential): Promise<void
     (existing) => existing.credentialId !== credential.credentialId,
   );
   remaining.push(credential);
-  await writeStore({ version: 1, credentials: remaining });
+  await writeStore({ version: 2, credentials: remaining });
 }
 
 export async function recordCredentialUse(
@@ -150,7 +182,7 @@ export async function deleteCredential(credentialId: string): Promise<boolean> {
     (credential) => credential.credentialId !== credentialId,
   );
   if (remaining.length === store.credentials.length) return false;
-  await writeStore({ version: 1, credentials: remaining });
+  await writeStore({ version: 2, credentials: remaining });
   return true;
 }
 

--- a/src/lib/server/webauthn-attestation-contract.test.ts
+++ b/src/lib/server/webauthn-attestation-contract.test.ts
@@ -1,0 +1,28 @@
+// Source-contract pins for attestation conveyance (cave-01v4u).
+//
+// These pins read the source files that choose attestation conveyance and
+// enforce the literals: the client must request "direct" (never "none"), and
+// the verifier must refuse "none" for new remote registrations. A behavior
+// test could drift from the code that ships; these pins cannot.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+const root = process.cwd();
+
+test("the client requests attestation 'direct' and never 'none'", () => {
+  const source = readFileSync(path.join(root, "src/lib/passkey-client.ts"), "utf8");
+  assert.match(source, /attestation: "direct"/, "registration must request the attestation statement");
+  assert.doesNotMatch(source, /attestation: "none"/, "the client must never fall back to no attestation");
+});
+
+test("the verifier refuses fmt 'none' by default", () => {
+  const source = readFileSync(path.join(root, "src/lib/server/webauthn-verify.ts"), "utf8");
+  assert.match(
+    source,
+    /if \(input\.format === "none"\) \{[\s\S]*?if \(!input\.allowNone\) \{[\s\S]*?throw new WebAuthnError\([\s\S]*?"attestation"/,
+    "fmt 'none' must be a rejection branch unless the loopback policy allows it",
+  );
+});

--- a/src/lib/server/webauthn-attestation-fixtures.ts
+++ b/src/lib/server/webauthn-attestation-fixtures.ts
@@ -1,0 +1,99 @@
+// Generated throwaway attestation fixture chains for cave-01v4u tests.
+// NOT production material: these keys exist only to exercise the verifiers.
+// Regenerate with /tmp/attest-fixture/gen.sh (see the cave-01v4u PR notes);
+// do not reuse these keys anywhere else.
+import { X509Certificate } from "node:crypto";
+
+export const APPLE_FIXTURE_CHALLENGE = "fixture-challenge-0123456789";
+export const APPLE_FIXTURE_ORIGIN = "http://127.0.0.1:3080";
+export const APPLE_FIXTURE_RP_ID = "127.0.0.1";
+
+/** Deterministic clientDataJSON (hex) for the apple fixture ceremony. */
+export const APPLE_FIXTURE_CLIENT_DATA_JSON_HEX = "7b2274797065223a22776562617574686e2e637265617465222c226368616c6c656e6765223a22666978747572652d6368616c6c656e67652d30313233343536373839222c226f726967696e223a22687474703a2f2f3132372e302e302e313a33303830227d";
+/** Deterministic authenticator data (hex) including the COSE key whose
+ *  private counterpart is apple-leaf. */
+export const APPLE_FIXTURE_AUTH_DATA_HEX = "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a04500000000000000000000000000000000000000000010ababababababababababababababababa501020326200121582071ce70274e0495358b129b2938b39b519d6e42ab0ccc806c4fce59a6ff1534b2225820973cbfaf0881fa5919ec050287f5b1c002b37c93f348241f435cb8ddaeef7689";
+/** SHA256(authData || SHA256(clientDataJSON)) — committed in the leaf cert. */
+export const APPLE_FIXTURE_NONCE_HEX = "99c086968586bc85e9eaa68e25694a53e7434e3ae49f130fa408c09143da4d3b";
+
+const APPLE_LEAF_DER_B64 = (
+  "MIIB2jCCAYGgAwIBAgIUMQcyLCdr5gKx93LlTqnRHxGVX3gwCgYIKoZIzj0EAwIw" +
+  "JzElMCMGA1UEAwwcQ2F2ZSBUZXN0IEFwcGxlIEludGVybWVkaWF0ZTAeFw0yNjA4" +
+  "MjgyMTM1MjFaFw0zNjA4MjUyMTM1MjFaMB8xHTAbBgNVBAMMFENhdmUgVGVzdCBB" +
+  "cHBsZSBMZWFmMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcc5wJ04ElTWLEpsp" +
+  "OLObUZ1uQqsMzIBsT85Zpv8VNLKXPL+vCIH6WRnsBQKH9bHAArN8k/NIJB9DXLjd" +
+  "ru92iaOBkjCBjzAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIHgDAvBgkqhkiG" +
+  "92NkCAIEIgQgmcCGloWGvIXp6qaOJWlKU+dDTjrknxMPpAjAkUPaTTswHQYDVR0O" +
+  "BBYEFPmArQsTV7LyFlQiZLquTdhKwIl+MB8GA1UdIwQYMBaAFK1bEPGsncYablxG" +
+  "AwH4uR0Qz+9nMAoGCCqGSM49BAMCA0cAMEQCIBS9xNvw9L85q4qAepL0jVwY09nK" +
+  "6nJ56aCroggrcOpBAiALof/7YufxS2kCqdzPIbja4wkMKvLIIa03b+y9DJ7D5A=="
+);
+const APPLE_INTER_DER_B64 = (
+  "MIIBqzCCAVGgAwIBAgIUV7eNI79dai4qJ4P02hvBxXxFREcwCgYIKoZIzj0EAwIw" +
+  "HzEdMBsGA1UEAwwUQ2F2ZSBUZXN0IEFwcGxlIFJvb3QwHhcNMjYwODI4MjEzNTIx" +
+  "WhcNMzYwODI1MjEzNTIxWjAnMSUwIwYDVQQDDBxDYXZlIFRlc3QgQXBwbGUgSW50" +
+  "ZXJtZWRpYXRlMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7a5rpq7QWqgWLI9k" +
+  "wOJgCeoR5J1TWyUlyEGlc9Cm3sD/oo4HWK1rWFI5+2OJJG9AnHZtt9NU1fDrNt5w" +
+  "cqNZTKNjMGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0O" +
+  "BBYEFK1bEPGsncYablxGAwH4uR0Qz+9nMB8GA1UdIwQYMBaAFBajkii8NyGD7p9K" +
+  "ZeerELPjRXBsMAoGCCqGSM49BAMCA0gAMEUCIQDf84nesC4Z4YpyocSrZpuqC0lt" +
+  "N9dGg87Xk0qopbDKZgIgH3c9jSMx2Bgu0OtbpePwdVKCCXPPbZJyNhDaE2ht2vQ="
+);
+const APPLE_ROOT_DER_B64 = (
+  "MIIBozCCAUmgAwIBAgIUTGkblK54/QNzVcWAy9ypYgYXOQcwCgYIKoZIzj0EAwIw" +
+  "HzEdMBsGA1UEAwwUQ2F2ZSBUZXN0IEFwcGxlIFJvb3QwHhcNMjYwODI4MjEzNTIx" +
+  "WhcNMzYwODI1MjEzNTIxWjAfMR0wGwYDVQQDDBRDYXZlIFRlc3QgQXBwbGUgUm9v" +
+  "dDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAUk2BsKu6mpB+P1ajtZCSwDoze8" +
+  "Mrb5cvKL4Mgk3yG6UYwg018q1C8xh13XQElWiqCtONVuhoSouyY74cT941ijYzBh" +
+  "MB0GA1UdDgQWBBQWo5IovDchg+6fSmXnqxCz40VwbDAfBgNVHSMEGDAWgBQWo5Io" +
+  "vDchg+6fSmXnqxCz40VwbDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIB" +
+  "BjAKBggqhkjOPQQDAgNIADBFAiAsKn1sLDkB54FRsjaDPFcKkrA2cLwM4Sl6SuGH" +
+  "DXiOWQIhAM+nLqxzarQkdGtByY1abA3VffG5DQcUMpJ3KGyIsiH6"
+);
+const PACKED_LEAF_DER_B64 = (
+  "MIIBozCCAUigAwIBAgIUaFR1Ig2fS1sxvNpv8vjdeN2TAVMwCgYIKoZIzj0EAwIw" +
+  "IDEeMBwGA1UEAwwVQ2F2ZSBUZXN0IFBhY2tlZCBSb290MB4XDTI2MDgyODIxMzUy" +
+  "MVoXDTM2MDgyNTIxMzUyMVowIDEeMBwGA1UEAwwVQ2F2ZSBUZXN0IFBhY2tlZCBM" +
+  "ZWFmMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5QdYGi/wED1dO8EFk8bcuSlA" +
+  "CoSz2LLyVAGjdUxyDusqTiS+5Ns7ikuNDu9BCUsAM81Yr2JV8hsKKCEM9Dza+6Ng" +
+  "MF4wDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFORtexk0" +
+  "8uKpjBFRe4fmdzl3xpR+MB8GA1UdIwQYMBaAFE68J2vcITasW86w0WSllTOUwwMR" +
+  "MAoGCCqGSM49BAMCA0kAMEYCIQD5qLUDv59btt9aL/pL+5n6OAGpBvKjU+VTQbRf" +
+  "P6cqeQIhAIjrmObWcfcRoluJWDAyZyubHctRuGu7Ju0QPCoj3Fms"
+);
+const PACKED_ROOT_DER_B64 = (
+  "MIIBpTCCAUugAwIBAgIUSTnUXnRWOf9HcC7FJOHIQ8cDDwIwCgYIKoZIzj0EAwIw" +
+  "IDEeMBwGA1UEAwwVQ2F2ZSBUZXN0IFBhY2tlZCBSb290MB4XDTI2MDgyODIxMzUy" +
+  "MVoXDTM2MDgyNTIxMzUyMVowIDEeMBwGA1UEAwwVQ2F2ZSBUZXN0IFBhY2tlZCBS" +
+  "b290MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2hm9upsZeeF4i3q6eTRXJ93c" +
+  "cBMsnDBPlW6DjuIYlq1ZJ5yXPCc9HtlKca+hCqOI3tosPss6oVj1ERXv3VoNTaNj" +
+  "MGEwHQYDVR0OBBYEFE68J2vcITasW86w0WSllTOUwwMRMB8GA1UdIwQYMBaAFE68" +
+  "J2vcITasW86w0WSllTOUwwMRMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQD" +
+  "AgEGMAoGCCqGSM49BAMCA0gAMEUCIAwaSiBSO+akOU86nIB01H4HnKFDQbzjL1kr" +
+  "kEYU96R2AiEAhkiMOTGbVxeWoNkiJAXkARsnrlOZIJZalMWIzb2pmDs="
+);
+
+export const APPLE_FIXTURE = {
+  /** x5c = [credential cert, intermediate] — root excluded, per WebAuthn. */
+  x5c: [Buffer.from(APPLE_LEAF_DER_B64, "base64"), Buffer.from(APPLE_INTER_DER_B64, "base64")] as const,
+  root: Buffer.from(APPLE_ROOT_DER_B64, "base64"),
+  rootFingerprint256: "9b649d15499e9ccb4dcd1143544e61ccbb0db82dff9595b0c120514076996d64",
+};
+
+export const PACKED_FIXTURE = {
+  /** Attestation certificate for the packed-basic path (attestation key, not the credential key). */
+  leaf: Buffer.from(PACKED_LEAF_DER_B64, "base64"),
+  root: Buffer.from(PACKED_ROOT_DER_B64, "base64"),
+  rootFingerprint256: "805c08b678ab3ad931d10a19947f972ad08c9af193b0417a00a6683199d62281",
+  /** The packed attestation signing key (DER, base64). Test-only. */
+  leafPrivateKeyDerB64: (
+  "MHcCAQEEIAXOpCoW7JwfFmmcDKr6po/BoDZL+lhgcsiq7wUITPLGoAoGCCqGSM49" +
+  "AwEHoUQDQgAE5QdYGi/wED1dO8EFk8bcuSlACoSz2LLyVAGjdUxyDusqTiS+5Ns7" +
+  "ikuNDu9BCUsAM81Yr2JV8hsKKCEM9Dza+w=="
+),
+};
+
+/** A certificate chain ending in a root that is NOT pinned anywhere. */
+export function fixtureLeafCert(der: Buffer): X509Certificate {
+  return new X509Certificate(der);
+}

--- a/src/lib/server/webauthn-roots.test.ts
+++ b/src/lib/server/webauthn-roots.test.ts
@@ -1,0 +1,39 @@
+// Pinned-root integrity tests (cave-01v4u).
+//
+// These tests exist so a wrong, corrupted, or silently rotated root embed
+// fails CI instead of silently weakening attestation verification: the Apple
+// root must parse as a CA certificate, match Apple's published SHA-256
+// fingerprint, and the production packed root set must stay empty (fail
+// closed) until a specific vendor root is deliberately reviewed and pinned.
+
+import assert from "node:assert/strict";
+import { X509Certificate } from "node:crypto";
+import { test } from "node:test";
+
+import {
+  APPLE_WEB_AUTHN_ROOT_G1,
+  APPLE_WEB_AUTHN_ROOTS,
+  PACKED_WEB_AUTHN_ROOTS,
+} from "./webauthn-roots.ts";
+
+test("the embedded Apple WebAuthn root parses and matches Apple's published fingerprint", () => {
+  const cert = new X509Certificate(APPLE_WEB_AUTHN_ROOT_G1.der);
+  assert.equal(cert.subject, "CN=Apple WebAuthn Root CA\nO=Apple Inc.\nST=California");
+  assert.equal(cert.ca, true, "the pinned Apple root is a CA");
+  assert.equal(
+    cert.fingerprint256.replace(/:/g, "").toLowerCase(),
+    APPLE_WEB_AUTHN_ROOT_G1.fingerprint256,
+    "the embedded DER must hash to the fingerprint published by Apple",
+  );
+  assert.equal(
+    APPLE_WEB_AUTHN_ROOT_G1.fingerprint256,
+    "0915dd5c07a28db549d1f677bb5a75d4bfbe9561a773424327762e9e02f9bb29",
+    "the pinned fingerprint literal must be Apple's published value",
+  );
+});
+
+test("the production packed root set is empty until a vendor root is deliberately reviewed", () => {
+  assert.equal(PACKED_WEB_AUTHN_ROOTS.length, 0, "x5c packed attestation stays fail-closed by default");
+  assert.equal(APPLE_WEB_AUTHN_ROOTS.length, 1);
+  assert.equal(APPLE_WEB_AUTHN_ROOTS[0].id, APPLE_WEB_AUTHN_ROOT_G1.id);
+});

--- a/src/lib/server/webauthn-roots.ts
+++ b/src/lib/server/webauthn-roots.ts
@@ -1,0 +1,60 @@
+// Pinned WebAuthn attestation trust anchors (cave-01v4u).
+//
+// Attestation verification only ever trusts a certificate chain that ends at
+// one of the roots pinned HERE, by exact DER equality — never by self-signature
+// or by "the client sent it". A rotated or unknown root therefore fails closed:
+// new enrollments are refused, never silently accepted.
+//
+// The Apple WebAuthn Root CA (G1) is the dedicated trust anchor for Apple
+// Anonymous Attestation (fmt "apple"), distinct from Apple's general-purpose
+// roots. Distributed at:
+//   https://www.apple.com/certificateauthority/Apple_WebAuthn_Root_CA.pem
+// Fingerprint and DER are pinned by tests so a wrong or corrupted embed fails
+// CI instead of silently weakening verification.
+//
+// The `packed` root set is deliberately EMPTY: there is no universal WebAuthn
+// root for fmt "packed", and chaining to an arbitrary vendor root would prove
+// a vendor, not the Secure Enclave. Packed attestation with x5c is therefore
+// refused until a specific vendor root is deliberately reviewed and pinned
+// here as an additive entry.
+
+export type PinnedRoot = {
+  /** Stable identifier for diagnostics and future rotation. */
+  id: string;
+  /** DER-encoded X.509 certificate; exact equality is the trust anchor. */
+  der: Buffer;
+  /** SHA-256 fingerprint of `der`, lowercased hex, pinned by test. */
+  fingerprint256: string;
+};
+
+// DER (base64) of the Apple WebAuthn Root CA (G1) certificate, fetched from
+// Apple's certificate authority page. Do not hand-edit: regen with
+//   curl -sL https://www.apple.com/certificateauthority/Apple_WebAuthn_Root_CA.pem \
+//     | openssl x509 -outform DER | base64 -w0
+const APPLE_WEB_AUTHN_ROOT_G1_DER_B64 = (
+  "MIICEjCCAZmgAwIBAgIQaB0BbHo84wIlpQGUKEdXcTAKBggqhkjOPQQDAzBLMR8w" +
+  "HQYDVQQDDBZBcHBsZSBXZWJBdXRobiBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJ" +
+  "bmMuMRMwEQYDVQQIDApDYWxpZm9ybmlhMB4XDTIwMDMxODE4MjEzMloXDTQ1MDMx" +
+  "NTAwMDAwMFowSzEfMB0GA1UEAwwWQXBwbGUgV2ViQXV0aG4gUm9vdCBDQTETMBEG" +
+  "A1UECgwKQXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTB2MBAGByqGSM49" +
+  "AgEGBSuBBAAiA2IABCJCQ2pTVhzjl4Wo6IhHtMSAzO2cv+H9DQKev3//fG59G11k" +
+  "xu9eI0/7o6V5uShBpe1u6l6mS19S1FEh6yGljnZAJ+2GNP1mi/YK2kSXIuTHjxA/" +
+  "pcoRf7XkOtO4o1qlcaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUJtdk" +
+  "2cV4wlpn0afeaxLQG2PxxtcwDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMDA2cA" +
+  "MGQCMFrZ+9DsJ1PW9hfNdBywZDsWDbWFp28it1d/5w2RPkRX3Bbn/UbDTNLx7Jr3" +
+  "jAGGiQIwHFj+dJZYUJR786osByBelJYsVZd2GbHQu209b5RCmGQ21gpSAk9QZW4B" +
+  "1bWeT0vT"
+);
+
+export const APPLE_WEB_AUTHN_ROOT_G1: PinnedRoot = {
+  id: "apple-webauthn-root-g1",
+  der: Buffer.from(APPLE_WEB_AUTHN_ROOT_G1_DER_B64, "base64"),
+  fingerprint256: "0915dd5c07a28db549d1f677bb5a75d4bfbe9561a773424327762e9e02f9bb29",
+};
+
+/** Production trust anchors for Apple Anonymous Attestation. */
+export const APPLE_WEB_AUTHN_ROOTS: readonly PinnedRoot[] = [APPLE_WEB_AUTHN_ROOT_G1];
+
+/** Production trust anchors for fmt "packed" with x5c. Deliberately empty —
+ *  see the module header. */
+export const PACKED_WEB_AUTHN_ROOTS: readonly PinnedRoot[] = [];

--- a/src/lib/server/webauthn-verify.test.ts
+++ b/src/lib/server/webauthn-verify.test.ts
@@ -7,21 +7,41 @@
 // verifier that accepts everything also passes a fixture replay.
 
 import assert from "node:assert/strict";
-import { generateKeyPairSync, createHash, sign as cryptoSign, randomBytes } from "node:crypto";
+import {
+  generateKeyPairSync,
+  createHash,
+  createPrivateKey,
+  sign as cryptoSign,
+  randomBytes,
+  X509Certificate,
+} from "node:crypto";
 import { test } from "node:test";
 
 import {
+  appleNonceExtension,
   base64UrlEncode,
   base64UrlDecode,
   checkSignCount,
   coseKeyToPublicKey,
   parseAuthenticatorData,
+  validateChainToPinnedRoot,
   verifyAssertion,
   verifyRegistration,
   WebAuthnError,
   type WebAuthnFailureReason,
 } from "./webauthn-verify.ts";
+import type { PinnedRoot } from "./webauthn-roots.ts";
 import { decodeCbor, decodeCborItem, CborError } from "./webauthn-cbor.ts";
+import {
+  APPLE_FIXTURE,
+  APPLE_FIXTURE_AUTH_DATA_HEX,
+  APPLE_FIXTURE_CHALLENGE,
+  APPLE_FIXTURE_CLIENT_DATA_JSON_HEX,
+  APPLE_FIXTURE_NONCE_HEX,
+  APPLE_FIXTURE_ORIGIN,
+  APPLE_FIXTURE_RP_ID,
+  PACKED_FIXTURE,
+} from "./webauthn-attestation-fixtures.ts";
 
 const RP_ID = "cave.tailnet.example.ts.net";
 const ORIGIN = `https://${RP_ID}`;
@@ -248,11 +268,32 @@ function registration(overrides: { authData?: Uint8Array; clientDataJSON?: Uint8
 }
 
 test("verifyRegistration accepts a well-formed UV ceremony", () => {
-  const result = verifyRegistration(registration());
+  const result = verifyRegistration(registration(), { allowNone: true });
   assert.deepEqual(result.credentialId, CREDENTIAL_ID);
   assert.equal(result.algorithm, -7);
   assert.equal(result.attestationFormat, "none");
   assert.equal((result.publicKeyJwk as { x: string }).x, jwk.x);
+  assert.deepEqual(
+    result.attestation,
+    { format: "none", verified: false, trustPath: "none" },
+    "an allowed fmt 'none' registration records its model-unproven trust path honestly",
+  );
+});
+
+test("verifyRegistration refuses fmt 'none' without the loopback policy", () => {
+  rejects(
+    () => verifyRegistration(registration()),
+    "attestation",
+    "fmt 'none' must not enroll a new remote credential",
+  );
+});
+
+test("verifyRegistration refuses an unsupported attestation format", () => {
+  rejects(
+    () => verifyRegistration(registration({ fmt: "tpm" })),
+    "attestation",
+    "an unknown fmt is refused, never silently treated as none",
+  );
 });
 
 test("verifyRegistration refuses a ceremony with user verification off", () => {
@@ -303,6 +344,197 @@ test("verifyRegistration refuses a registration with no attested credential", ()
     () => verifyRegistration(registration({ authData: buildAuthData({ includeCredential: false }) })),
     "malformed",
     "AT flag clear means there is no key to store",
+  );
+});
+
+// ─── attestation statements (cave-01v4u) ────────────────────────────────────
+
+const APPLE_FIXTURE_ROOTS: readonly PinnedRoot[] = [{
+  id: "cave-test-apple-root",
+  der: APPLE_FIXTURE.root,
+  fingerprint256: APPLE_FIXTURE.rootFingerprint256,
+}];
+
+const PACKED_FIXTURE_ROOTS: readonly PinnedRoot[] = [{
+  id: "cave-test-packed-root",
+  der: PACKED_FIXTURE.root,
+  fingerprint256: PACKED_FIXTURE.rootFingerprint256,
+}];
+
+function appleRegistration() {
+  return {
+    clientDataJSON: new Uint8Array(Buffer.from(APPLE_FIXTURE_CLIENT_DATA_JSON_HEX, "hex")),
+    attestationObject: cbor(
+      new Map<string, unknown>([
+        ["fmt", "apple"],
+        [
+          "attStmt",
+          new Map<string, unknown>([
+            ["x5c", APPLE_FIXTURE.x5c.map((der) => new Uint8Array(der))],
+            ["nonce", new Uint8Array(Buffer.from(APPLE_FIXTURE_NONCE_HEX, "hex"))],
+          ]),
+        ],
+        ["authData", new Uint8Array(Buffer.from(APPLE_FIXTURE_AUTH_DATA_HEX, "hex"))],
+      ]),
+    ),
+    expectedChallenge: APPLE_FIXTURE_CHALLENGE,
+    expectedOrigin: APPLE_FIXTURE_ORIGIN,
+    expectedRpId: APPLE_FIXTURE_RP_ID,
+  };
+}
+
+test("apple attestation chains to a pinned root and verifies", () => {
+  const result = verifyRegistration(appleRegistration(), { allowNone: false, appleRoots: APPLE_FIXTURE_ROOTS });
+  assert.equal(result.attestationFormat, "apple");
+  assert.deepEqual(
+    result.attestation,
+    { format: "apple", verified: true, trustPath: "apple" },
+    "a chain to a pinned root proves the authenticator model",
+  );
+});
+
+test("apple attestation rejects a foreign root", () => {
+  const foreignRoots: readonly PinnedRoot[] = [{
+    id: "foreign-root",
+    der: PACKED_FIXTURE.root,
+    fingerprint256: PACKED_FIXTURE.rootFingerprint256,
+  }];
+  rejects(
+    () => verifyRegistration(appleRegistration(), { allowNone: false, appleRoots: foreignRoots }),
+    "attestation",
+    "a chain ending in an unpinned root must not verify",
+  );
+});
+
+test("apple attestation rejects a ceremony the nonce was not committed to", () => {
+  // Same type/challenge/origin but extra JSON bytes: SHA256(authData ||
+  // SHA256(clientDataJSON)) no longer matches the nonce inside the credential
+  // certificate, while every earlier check still passes.
+  const tampered = new TextEncoder().encode(
+    JSON.stringify({
+      type: "webauthn.create",
+      challenge: APPLE_FIXTURE_CHALLENGE,
+      origin: APPLE_FIXTURE_ORIGIN,
+      extra: "tampered",
+    }),
+  );
+  rejects(
+    () => verifyRegistration({ ...appleRegistration(), clientDataJSON: tampered }),
+    "attestation",
+    "the nonce binding must cover the exact ceremony bytes",
+  );
+});
+
+test("appleNonceExtension reads the fixture nonce and rejects certificates without it", () => {
+  const leaf = new X509Certificate(APPLE_FIXTURE.x5c[0]);
+  assert.equal(
+    Buffer.from(appleNonceExtension(leaf) ?? new Uint8Array()).toString("hex"),
+    APPLE_FIXTURE_NONCE_HEX,
+    "the DER walker extracts the 32-byte nonce from OID 1.2.840.113635.100.8.2",
+  );
+  const packedLeaf = new X509Certificate(PACKED_FIXTURE.leaf);
+  assert.equal(appleNonceExtension(packedLeaf), null, "a certificate without the extension yields null");
+  assert.equal(appleNonceExtension(new X509Certificate(PACKED_FIXTURE.root)), null);
+});
+
+test("validateChainToPinnedRoot rejects a chain whose top is not issued by a pinned root", () => {
+  const certs = [new X509Certificate(APPLE_FIXTURE.x5c[0]), new X509Certificate(APPLE_FIXTURE.x5c[1])];
+  assert.equal(
+    validateChainToPinnedRoot(certs, PACKED_FIXTURE_ROOTS),
+    false,
+    "the packed test root did not sign the apple chain",
+  );
+  assert.equal(validateChainToPinnedRoot(certs, APPLE_FIXTURE_ROOTS), true);
+});
+
+function packedSelfRegistration(overrides: { sig?: Uint8Array; alg?: number } = {}) {
+  const authData = buildAuthData({ includeCredential: true });
+  const clientDataJSON = clientData("webauthn.create", CHALLENGE);
+  const clientDataHash = new Uint8Array(createHash("sha256").update(clientDataJSON).digest());
+  const sig = overrides.sig ?? new Uint8Array(cryptoSign("sha256", concat(authData, clientDataHash), privateKey));
+  return {
+    clientDataJSON,
+    attestationObject: cbor(
+      new Map<string, unknown>([
+        ["fmt", "packed"],
+        ["attStmt", new Map<string, unknown>([["alg", overrides.alg ?? -7], ["sig", sig]])],
+        ["authData", authData],
+      ]),
+    ),
+    expectedChallenge: CHALLENGE,
+    expectedOrigin: ORIGIN,
+    expectedRpId: RP_ID,
+  };
+}
+
+test("packed self-attestation verifies but stays model-unproven", () => {
+  const result = verifyRegistration(packedSelfRegistration(), { allowNone: false });
+  assert.deepEqual(
+    result.attestation,
+    { format: "packed", verified: false, trustPath: "packed-self" },
+    "self-attestation proves the key holder, not the model",
+  );
+});
+
+test("packed self-attestation refuses a bad signature and a mismatched algorithm", () => {
+  rejects(
+    () => verifyRegistration(packedSelfRegistration({ sig: new Uint8Array(64) }), { allowNone: false }),
+    "signature",
+    "a wrong signature must not verify",
+  );
+  rejects(
+    () => verifyRegistration(packedSelfRegistration({ alg: -257 }), { allowNone: false }),
+    "attestation",
+    "a self-attestation must use the credential's own algorithm",
+  );
+});
+
+function packedBasicRegistration(roots: readonly PinnedRoot[]) {
+  const authData = new Uint8Array(Buffer.from(APPLE_FIXTURE_AUTH_DATA_HEX, "hex"));
+  const clientDataJSON = new Uint8Array(Buffer.from(APPLE_FIXTURE_CLIENT_DATA_JSON_HEX, "hex"));
+  const clientDataHash = new Uint8Array(createHash("sha256").update(clientDataJSON).digest());
+  const sig = new Uint8Array(
+    cryptoSign("sha256", concat(authData, clientDataHash), createPrivateKey(Buffer.from(PACKED_FIXTURE.leafPrivateKeyDerB64, "base64"))),
+  );
+  return {
+    clientDataJSON,
+    attestationObject: cbor(
+      new Map<string, unknown>([
+        ["fmt", "packed"],
+        [
+          "attStmt",
+          new Map<string, unknown>([
+            ["alg", -7],
+            ["sig", sig],
+            ["x5c", [new Uint8Array(PACKED_FIXTURE.leaf)]],
+          ]),
+        ],
+        ["authData", authData],
+      ]),
+    ),
+    expectedChallenge: APPLE_FIXTURE_CHALLENGE,
+    expectedOrigin: APPLE_FIXTURE_ORIGIN,
+    expectedRpId: APPLE_FIXTURE_RP_ID,
+    roots,
+  };
+}
+
+test("packed basic attestation verifies against a pinned packed root", () => {
+  const { roots, ...registration } = packedBasicRegistration(PACKED_FIXTURE_ROOTS);
+  const result = verifyRegistration(registration, { allowNone: false, packedRoots: roots });
+  assert.deepEqual(
+    result.attestation,
+    { format: "packed", verified: true, trustPath: "packed-basic" },
+    "a packed chain to a pinned root verifies",
+  );
+});
+
+test("packed basic attestation fails closed when no packed root is pinned", () => {
+  const { roots: _, ...registration } = packedBasicRegistration(PACKED_FIXTURE_ROOTS);
+  rejects(
+    () => verifyRegistration(registration, { allowNone: false, packedRoots: [] }),
+    "attestation",
+    "the production packed root set is empty, so x5c packed attestation is refused",
   );
 });
 

--- a/src/lib/server/webauthn-verify.test.ts
+++ b/src/lib/server/webauthn-verify.test.ts
@@ -494,7 +494,7 @@ function packedBasicRegistration(roots: readonly PinnedRoot[]) {
   const clientDataJSON = new Uint8Array(Buffer.from(APPLE_FIXTURE_CLIENT_DATA_JSON_HEX, "hex"));
   const clientDataHash = new Uint8Array(createHash("sha256").update(clientDataJSON).digest());
   const sig = new Uint8Array(
-    cryptoSign("sha256", concat(authData, clientDataHash), createPrivateKey(Buffer.from(PACKED_FIXTURE.leafPrivateKeyDerB64, "base64"))),
+    cryptoSign("sha256", concat(authData, clientDataHash), createPrivateKey({ key: Buffer.from(PACKED_FIXTURE.leafPrivateKeyDerB64, "base64"), format: "der", type: "sec1" })),
   );
   return {
     clientDataJSON,

--- a/src/lib/server/webauthn-verify.ts
+++ b/src/lib/server/webauthn-verify.ts
@@ -22,9 +22,16 @@
 //     synced), so a zero counter is accepted rather than treated as a clone
 //     signal — see checkSignCount.
 
-import { createHash, createPublicKey, verify as cryptoVerify, type KeyObject } from "node:crypto";
+import {
+  createHash,
+  createPublicKey,
+  verify as cryptoVerify,
+  X509Certificate,
+  type KeyObject,
+} from "node:crypto";
 
 import { decodeCbor, decodeCborItem, CborError, type CborValue } from "./webauthn-cbor.ts";
+import { APPLE_WEB_AUTHN_ROOTS, PACKED_WEB_AUTHN_ROOTS, type PinnedRoot } from "./webauthn-roots.ts";
 
 export class WebAuthnError extends Error {
   readonly reason: WebAuthnFailureReason;
@@ -45,7 +52,8 @@ export type WebAuthnFailureReason =
   | "user-verification"
   | "algorithm"
   | "signature"
-  | "counter";
+  | "counter"
+  | "attestation";
 
 // COSE algorithm identifiers (IANA). ES256 is what every Apple platform
 // authenticator produces; the other two are here so a hardware key or an
@@ -337,17 +345,44 @@ export type RegistrationResult = {
   signCount: number;
   aaguid: Uint8Array;
   attestationFormat: string;
+  /** The cryptographically-derived attestation outcome (cave-01v4u). */
+  attestation: AttestationOutcome;
   backupEligible: boolean;
   backedUp: boolean;
 };
 
-export function verifyRegistration(input: {
-  clientDataJSON: Uint8Array;
-  attestationObject: Uint8Array;
-  expectedChallenge: string;
-  expectedOrigin: string;
-  expectedRpId: string;
-}): RegistrationResult {
+export type AttestationTrustPath = "apple" | "packed-basic" | "packed-self" | "none" | "legacy";
+
+export type AttestationOutcome = {
+  format: string;
+  /** True only when the authenticator MODEL was proven (chain to a pinned root). */
+  verified: boolean;
+  trustPath: AttestationTrustPath;
+};
+
+export type RegistrationAttestationPolicy = {
+  /**
+   * When true, `fmt === "none"` is accepted and recorded as model-unproven
+   * (`trustPath: "none"`). The ceremony grants this only to the local loopback
+   * peer, where "someone at this machine" is already the trust boundary.
+   */
+  allowNone: boolean;
+  /** Test seam: override the Apple trust anchors (defaults to production roots). */
+  appleRoots?: readonly PinnedRoot[];
+  /** Test seam: override the packed trust anchors (defaults to production roots). */
+  packedRoots?: readonly PinnedRoot[];
+};
+
+export function verifyRegistration(
+  input: {
+    clientDataJSON: Uint8Array;
+    attestationObject: Uint8Array;
+    expectedChallenge: string;
+    expectedOrigin: string;
+    expectedRpId: string;
+  },
+  policy: RegistrationAttestationPolicy = { allowNone: false },
+): RegistrationResult {
   const clientData = parseClientData(input.clientDataJSON);
   checkClientData(clientData, {
     expectedType: "webauthn.create",
@@ -381,14 +416,20 @@ export function verifyRegistration(input: {
     throw new WebAuthnError("malformed", "registration carries no attested credential data");
   }
 
-  // NOTE: the attestation STATEMENT is recorded but not cryptographically
-  // verified. Doing so means walking a certificate chain to Apple's or the
-  // vendor's root, which proves the authenticator MODEL. Here the binding that
-  // carries the authorization weight is the tailnet node (cave-zm6pn) plus the
-  // UV flag, and registration is already reachable only from an allowlisted
-  // device. Recording `fmt` keeps the gap visible in stored state instead of
-  // implying a check that did not happen. Follow-up: cave-01v4u.
   const { algorithm, publicKey } = coseKeyToPublicKey(authData.attestedCredential.coseKey);
+  const clientDataHash = sha256(input.clientDataJSON);
+
+  const outcome = verifyAttestationStatement({
+    format,
+    attStmt: attestation.get("attStmt"),
+    authData: rawAuthData,
+    clientDataHash,
+    algorithm,
+    credentialPublicKey: publicKey,
+    allowNone: policy.allowNone,
+    appleRoots: policy.appleRoots ?? APPLE_WEB_AUTHN_ROOTS,
+    packedRoots: policy.packedRoots ?? PACKED_WEB_AUTHN_ROOTS,
+  });
 
   return {
     credentialId: authData.attestedCredential.credentialId,
@@ -397,9 +438,350 @@ export function verifyRegistration(input: {
     signCount: authData.signCount,
     aaguid: authData.attestedCredential.aaguid,
     attestationFormat: format,
+    attestation: outcome,
     backupEligible: authData.flags.backupEligible,
     backedUp: authData.flags.backedUp,
   };
+}
+
+// ─── attestation statement verification (cave-01v4u) ────────────────────────
+//
+// The attestation statement proves the authenticator MODEL: fmt "apple" chains
+// to the Apple WebAuthn Root CA (Secure Enclave), fmt "packed" either chains to
+// a pinned vendor root or self-attests (model unproven), and fmt "none" is
+// refused for new remote registrations. Verification is fully offline — no
+// OCSP/CRL/AIA — and every parse failure fails closed.
+
+// 1.2.840.113635.100.8.2 — Apple's anonymous-attestation nonce extension.
+const APPLE_ANONYMOUS_ATTESTATION_NONCE_OID = Uint8Array.from([
+  0x2a, 0x86, 0x48, 0x86, 0xf7, 0x63, 0x64, 0x08, 0x02,
+]);
+
+const MAX_X5C_CERTS = 5;
+const MAX_CERT_DER_BYTES = 16 * 1024;
+
+function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}
+
+/**
+ * Read one definite-length DER TLV at `offset`. Returns null on truncation or
+ * a non-definite (indefinite) length — this walker only ever reads certs we
+ * are about to trust, so anything it cannot parse exactly is refused.
+ */
+function readDerTlv(
+  bytes: Uint8Array,
+  offset: number,
+): { tag: number; headerEnd: number; contentEnd: number } | null {
+  if (offset >= bytes.length) return null;
+  const tag = bytes[offset];
+  let cursor = offset + 1;
+  if (cursor >= bytes.length) return null;
+  const first = bytes[cursor];
+  cursor += 1;
+  let length: number;
+  if (first < 0x80) {
+    length = first;
+  } else {
+    const lengthBytes = first & 0x7f;
+    if (lengthBytes === 0 || lengthBytes > 4 || cursor + lengthBytes > bytes.length) return null;
+    length = 0;
+    for (let i = 0; i < lengthBytes; i += 1) length = length * 256 + bytes[cursor + i];
+    cursor += lengthBytes;
+  }
+  if (cursor + length > bytes.length) return null;
+  return { tag, headerEnd: cursor, contentEnd: cursor + length };
+}
+
+/**
+ * Locate the Apple anonymous-attestation nonce (extension OID
+ * 1.2.840.113635.100.8.2) inside a credential certificate. X509Certificate does
+ * not expose arbitrary extensions, so this walks the DER itself: Certificate →
+ * tbsCertificate → [3] EXPLICIT extensions → extnValue OCTET STRING that wraps
+ * a second OCTET STRING holding the 32 nonce bytes. Returns null for anything
+ * it does not fully understand.
+ */
+export function appleNonceExtension(cert: X509Certificate): Uint8Array | null {
+  const der = cert.raw;
+  const certificate = readDerTlv(der, 0);
+  if (!certificate || certificate.tag !== 0x30) return null;
+  const tbs = readDerTlv(der, certificate.headerEnd);
+  if (!tbs || tbs.tag !== 0x30) return null;
+  const tbsContent = der.subarray(tbs.headerEnd, tbs.contentEnd);
+
+  // tbsCertificate fields in order: [0] version?, serial, signature, issuer,
+  // validity, subject, subjectPublicKeyInfo, [1]/[2] unique ids?, [3] extensions.
+  let offset = 0;
+  while (offset < tbsContent.length) {
+    const field = readDerTlv(tbsContent, offset);
+    if (!field) return null;
+    if (field.tag !== 0xa3) {
+      offset = field.contentEnd;
+      continue;
+    }
+    // [3] EXPLICIT extensions: content is a SEQUENCE OF Extension.
+    const extensions = readDerTlv(tbsContent, field.headerEnd);
+    if (!extensions || extensions.tag !== 0x30) return null;
+    const sequence = tbsContent.subarray(extensions.headerEnd, extensions.contentEnd);
+    let extensionOffset = 0;
+    while (extensionOffset < sequence.length) {
+      const extension = readDerTlv(sequence, extensionOffset);
+      if (!extension || extension.tag !== 0x30) return null;
+      const body = sequence.subarray(extension.headerEnd, extension.contentEnd);
+      const oid = readDerTlv(body, 0);
+      if (!oid || oid.tag !== 0x06) return null;
+      let bodyOffset = oid.contentEnd;
+      const maybeCritical = readDerTlv(body, bodyOffset);
+      if (maybeCritical && maybeCritical.tag === 0x01) bodyOffset = maybeCritical.contentEnd;
+      const value = readDerTlv(body, bodyOffset);
+      if (!value || value.tag !== 0x04) return null;
+      if (equalBytes(body.subarray(oid.headerEnd, oid.contentEnd), APPLE_ANONYMOUS_ATTESTATION_NONCE_OID)) {
+        // The extension value wraps the nonce bytes. Apple's real encoding is
+        // SEQUENCE { [1] EXPLICIT { OCTET STRING(32) } } (30 24 a1 22 04 20 …),
+        // so descend 0x30 → 0xa1 → 0x04 before reading the 32 bytes. A bare
+        // OCTET STRING and the tagless SEQUENCE { OCTET STRING(32) } variant
+        // (generated fixtures) are also accepted.
+        const outer = body.subarray(value.headerEnd, value.contentEnd);
+        let cursor = outer;
+        let inner = readDerTlv(cursor, 0);
+        if (inner && inner.tag === 0x30) {
+          cursor = cursor.subarray(inner.headerEnd, inner.contentEnd);
+          inner = readDerTlv(cursor, 0);
+          if (inner && inner.tag === 0xa1) {
+            cursor = cursor.subarray(inner.headerEnd, inner.contentEnd);
+            inner = readDerTlv(cursor, 0);
+          }
+        }
+        if (inner && inner.tag === 0x04) {
+          return cursor.subarray(inner.headerEnd, inner.contentEnd);
+        }
+        return null;
+      }
+      extensionOffset = extension.contentEnd;
+    }
+    return null;
+  }
+  return null;
+}
+
+function parseX5c(attStmt: Map<CborValue, CborValue>): X509Certificate[] {
+  const raw = attStmt.get("x5c");
+  if (!Array.isArray(raw) || raw.length === 0 || raw.length > MAX_X5C_CERTS) {
+    throw new WebAuthnError("attestation", "attestation x5c is missing or exceeds 5 certificates");
+  }
+  const certs: X509Certificate[] = [];
+  for (const entry of raw) {
+    if (!(entry instanceof Uint8Array) || entry.length === 0 || entry.length > MAX_CERT_DER_BYTES) {
+      throw new WebAuthnError("attestation", "attestation x5c contains an invalid certificate");
+    }
+    try {
+      certs.push(new X509Certificate(entry));
+    } catch {
+      throw new WebAuthnError("attestation", "attestation x5c contains an unparsable certificate");
+    }
+  }
+  return certs;
+}
+
+/**
+ * Validate `certs` (leaf first) against pinned roots. Per the WebAuthn spec,
+ * x5c runs "up to but not including" the root, so the chain's top certificate
+ * must be ISSUED BY one of the pinned roots — the roots themselves are trusted
+ * by exact equality, never by self-signature. All certificates must be inside
+ * their validity window, and every non-leaf must be a CA.
+ */
+export function validateChainToPinnedRoot(
+  certs: X509Certificate[],
+  roots: readonly PinnedRoot[],
+): boolean {
+  if (certs.length === 0 || roots.length === 0) return false;
+  const now = Date.now();
+  const inWindow = (cert: X509Certificate): boolean => {
+    const from = Date.parse(cert.validFrom);
+    const to = Date.parse(cert.validTo);
+    return Number.isFinite(from) && Number.isFinite(to) && now >= from && now <= to;
+  };
+  for (const cert of certs) {
+    if (!inWindow(cert)) return false;
+  }
+  for (let index = 0; index < certs.length - 1; index += 1) {
+    const child = certs[index];
+    const parent = certs[index + 1];
+    if (!parent.ca) return false;
+    if (!child.checkIssued(parent)) return false;
+    try {
+      if (!child.verify(parent.publicKey)) return false;
+    } catch {
+      return false;
+    }
+  }
+  const top = certs[certs.length - 1];
+  for (const root of roots) {
+    let parsed: X509Certificate;
+    try {
+      parsed = new X509Certificate(root.der);
+    } catch {
+      continue;
+    }
+    if (!inWindow(parsed)) continue;
+    if (!top.checkIssued(parsed)) continue;
+    try {
+      if (top.verify(parsed.publicKey)) return true;
+    } catch {
+      // keep looking at other pinned roots
+    }
+  }
+  return false;
+}
+
+function publicKeyJwkFieldsEqual(a: KeyObject, b: KeyObject): boolean {
+  const ja = a.export({ format: "jwk" }) as Record<string, unknown>;
+  const jb = b.export({ format: "jwk" }) as Record<string, unknown>;
+  if (ja.kty !== jb.kty) return false;
+  if (ja.kty === "EC" || ja.kty === "OKP") {
+    return ja.crv === jb.crv && ja.x === jb.x && ja.y === jb.y;
+  }
+  if (ja.kty === "RSA") {
+    return ja.n === jb.n && ja.e === jb.e;
+  }
+  return false;
+}
+
+export function verifyAppleAttestation(input: {
+  attStmt: Map<CborValue, CborValue>;
+  authData: Uint8Array;
+  clientDataHash: Uint8Array;
+  credentialPublicKey: KeyObject;
+  roots: readonly PinnedRoot[];
+}): AttestationOutcome {
+  const nonce = input.attStmt.get("nonce");
+  if (!(nonce instanceof Uint8Array) || nonce.length === 0) {
+    throw new WebAuthnError("attestation", "apple attestation is missing its nonce");
+  }
+  const certs = parseX5c(input.attStmt);
+  const leaf = certs[0];
+  if (!publicKeyJwkFieldsEqual(leaf.publicKey, input.credentialPublicKey)) {
+    throw new WebAuthnError("attestation", "attestation certificate does not match the credential public key");
+  }
+  // Apple commits SHA256(authData || clientDataHash) inside the credential
+  // certificate; the authenticator binds the certificate to this exact
+  // ceremony by signing it with the Secure Enclave key. The attStmt carries
+  // the same nonce on the wire; it must agree with the certificate extension.
+  const committed = appleNonceExtension(leaf);
+  if (!committed || committed.length !== 32 || !equalBytes(committed, nonce)) {
+    throw new WebAuthnError("attestation", "apple attestation nonce does not match the certificate extension");
+  }
+  const expected = sha256(concatBytes(input.authData, input.clientDataHash));
+  if (!equalBytes(committed, expected)) {
+    throw new WebAuthnError("attestation", "apple attestation nonce does not match authData || clientDataHash");
+  }
+  if (!validateChainToPinnedRoot(certs, input.roots)) {
+    throw new WebAuthnError("attestation", "apple attestation chain does not reach a pinned root");
+  }
+  return { format: "apple", verified: true, trustPath: "apple" };
+}
+
+export function verifyPackedAttestation(input: {
+  attStmt: Map<CborValue, CborValue>;
+  authData: Uint8Array;
+  clientDataHash: Uint8Array;
+  algorithm: number;
+  credentialPublicKey: KeyObject;
+  roots: readonly PinnedRoot[];
+}): AttestationOutcome {
+  const alg = input.attStmt.get("alg");
+  const sig = input.attStmt.get("sig");
+  if (typeof alg !== "number" || !SUPPORTED_ALGORITHMS.has(alg)) {
+    throw new WebAuthnError("attestation", "packed attestation declares an unsupported algorithm");
+  }
+  if (!(sig instanceof Uint8Array) || sig.length === 0) {
+    throw new WebAuthnError("attestation", "packed attestation is missing its signature");
+  }
+  const payload = concatBytes(input.authData, input.clientDataHash);
+
+  if (input.attStmt.get("x5c") !== undefined) {
+    // Basic attestation: the signature is made with the attestation key in
+    // x5c[0], and the chain must reach a pinned root. No universal WebAuthn
+    // root exists for packed, so the production root set is empty — fail
+    // closed until a specific vendor root is deliberately pinned.
+    const certs = parseX5c(input.attStmt);
+    let valid = false;
+    try {
+      valid = verifySignature(alg, certs[0].publicKey, payload, sig);
+    } catch {
+      valid = false;
+    }
+    if (!valid) throw new WebAuthnError("signature", "packed attestation signature did not verify");
+    if (!validateChainToPinnedRoot(certs, input.roots)) {
+      throw new WebAuthnError("attestation", "packed attestation chain does not reach a pinned root");
+    }
+    return { format: "packed", verified: true, trustPath: "packed-basic" };
+  }
+
+  // Self-attestation: signed with the credential key itself. This proves the
+  // key holder signed — not the model — so it is recorded honestly.
+  if (alg !== input.algorithm) {
+    throw new WebAuthnError("attestation", "packed self-attestation algorithm does not match the credential algorithm");
+  }
+  let valid = false;
+  try {
+    valid = verifySignature(alg, input.credentialPublicKey, payload, sig);
+  } catch {
+    valid = false;
+  }
+  if (!valid) throw new WebAuthnError("signature", "packed self-attestation signature did not verify");
+  return { format: "packed", verified: false, trustPath: "packed-self" };
+}
+
+function verifyAttestationStatement(input: {
+  format: string;
+  attStmt: CborValue | undefined;
+  authData: Uint8Array;
+  clientDataHash: Uint8Array;
+  algorithm: number;
+  credentialPublicKey: KeyObject;
+  allowNone: boolean;
+  appleRoots: readonly PinnedRoot[];
+  packedRoots: readonly PinnedRoot[];
+}): AttestationOutcome {
+  if (input.format === "apple") {
+    if (!(input.attStmt instanceof Map)) {
+      throw new WebAuthnError("attestation", "apple attestation statement is missing");
+    }
+    return verifyAppleAttestation({
+      attStmt: input.attStmt,
+      authData: input.authData,
+      clientDataHash: input.clientDataHash,
+      credentialPublicKey: input.credentialPublicKey,
+      roots: input.appleRoots,
+    });
+  }
+  if (input.format === "packed") {
+    if (!(input.attStmt instanceof Map)) {
+      throw new WebAuthnError("attestation", "packed attestation statement is missing");
+    }
+    return verifyPackedAttestation({
+      attStmt: input.attStmt,
+      authData: input.authData,
+      clientDataHash: input.clientDataHash,
+      algorithm: input.algorithm,
+      credentialPublicKey: input.credentialPublicKey,
+      roots: input.packedRoots,
+    });
+  }
+  if (input.format === "none") {
+    if (!input.allowNone) {
+      throw new WebAuthnError(
+        "attestation",
+        "fmt 'none' is not accepted for new credentials — enroll from a browser that returns device attestation",
+      );
+    }
+    return { format: "none", verified: false, trustPath: "none" };
+  }
+  throw new WebAuthnError("attestation", `unsupported attestation format '${input.format}'`);
 }
 
 // ─── assertion ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes **cave-01v4u**: the server recorded `attestationObject.fmt` but never checked the attestation statement, so a software authenticator could assert UV without any biometric backing. Registration now requests `attestation: "direct"` and the server cryptographically verifies the statement before enrolling.

## Verification

- **fmt "apple"** (Apple Anonymous Attestation): x5c chain validated to the pinned **Apple WebAuthn Root CA (G1)** (embedded DER, fingerprint-pinned by test), nonce `SHA256(authData || SHA256(clientDataJSON))` read from OID `1.2.840.113635.100.8.2` via a small hand-rolled DER walker (X509Certificate hides extensions), plus credential public-key match. Proves the Secure Enclave model.
- **fmt "packed"**: x5c chain to pinned packed roots (**empty by default — fail closed**, no universal packed root exists) or self-attestation, recorded honestly as model-unproven (`trustPath: "packed-self"`).
- **fmt "none"**: refused for remote (tailnet) peers; the local loopback peer may still enroll and is recorded `trustPath: "none"` (loopback already equals "someone at this machine" — same boundary as the presence local-ingress exemption). Unsupported formats (`tpm` etc.) are refused, never silently treated as none.
- **Storage**: additive `attestationVerified` / `attestationTrustPath` / `attestationVerifiedAt`; legacy rows normalize to `trustPath: "legacy"` and keep working (assertions never read attestation fields). Store version bumps to 2 on write, v1 files remain valid input forever.
- **Client/UX**: one-line `attestation: "direct"` flip + a human-readable enrollment-guidance message when a browser (e.g. Chrome on macOS) returns `none` anyway.

## Tests

- 32 webauthn-verify tests (incl. full apple-chain acceptance with an openssl-minted fixture chain, foreign-root/tampered-nonce/malformed rejections, packed self/basic paths)
- Roots integrity tests (embedded Apple root parses + published-fingerprint pin)
- Source-contract pins: client must request `direct` and never `none`; verifier rejects `none` by default
- Ceremony policy tests (remote "none" refused, loopback allowed, trust path persisted), store legacy-normalization tests
- `pnpm typecheck` / `pnpm lint` / `pnpm check:tests-wired` (1926 files) clean

## Notes

- Verification is fully offline (no OCSP/CRL/AIA) by design — see the header of `webauthn-roots.ts`.
- Cross-repo follow-up: the native (Swift) front end must also switch to `attestation: "direct"` so its enrollments keep working against the new policy.
