### PR TITLE
feat(chat): restore organization level in group-by-project mode (cave-1vpy)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -627,6 +627,7 @@ export const SUITES = {
     "src/lib/chat-list-grouping.test.ts",
     "src/components/chat-list-collapse.test.ts",
     "src/components/chat-list-render-optimization.test.ts",
+    "src/components/chat-list-organization.test.ts",
     "src/components/chat-router-hide-archived.test.ts",
     "src/components/chat-router-switching.test.ts",
     "src/components/chat-router-removal-race.test.tsx",

--- a/src/components/chat-list-organization.test.ts
+++ b/src/components/chat-list-organization.test.ts
@@ -1,0 +1,67 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+// Source-contract pins for the organization level in the chat list's
+// "Group by project" mode (cave-1vpy). The live chat surface was redesigned
+// away from the org-grouped rail (#5099), so the derived-organization
+// grouping now renders in the list: org headers above project folders, with
+// the "(no project)" bucket last via the shared chatProjectOrganizationGroups
+// sort. These pins keep the wiring visible to the suite.
+
+const src = readFileSync(new URL("./chat-list.tsx", import.meta.url), "utf8");
+
+test("chat-list imports the organization grouping helper", () => {
+  assert.match(
+    src,
+    /import \{\s*\n\s*NO_PROJECT_ORGANIZATION,\s*\n\s*chatProjectOrganizationGroups,\s*\n\} from "@\/lib\/project-organizations"/,
+    "chat-list should import chatProjectOrganizationGroups and NO_PROJECT_ORGANIZATION from the shared org module",
+  );
+});
+
+test("chat-list makes project groups org-major in Group by project mode", () => {
+  assert.match(
+    src,
+    /if \(groupBy === "project"\) \{\s*\n\s*ordered = chatProjectOrganizationGroups\(ordered\)\.flatMap\(\(orgGroup\) => orgGroup\.items\);/,
+    "Group by project should reorder the project folders under their derived organization (org-major, no-project last)",
+  );
+  assert.match(
+    src,
+    /organizationProjectCounts\s*=\s*useMemo\([\s\S]{0,200}?if \(groupBy !== "project"\) return null;/,
+    "the org project counts should only be derived in Group by project mode",
+  );
+});
+
+test("chat-list renders one organization header per org, above the project folders", () => {
+  assert.match(
+    src,
+    /const showOrganizationHeader =\s*\n\s*groupBy === "project"\s*\n\s*&& \(groupIndex === 0 \|\| organization\.key !== displayGroups\[groupIndex - 1\]\.organization\.key\);/,
+    "an organization header should render only when the org key changes (once per org in the org-major list)",
+  );
+  assert.match(
+    src,
+    /<li className="chat-list-org-header" aria-label=\{organization\.label\}>/,
+    "the org header should be an accessible li labelled with the org name",
+  );
+  assert.match(
+    src,
+    /\{organizationProjectCounts\?\.get\(organization\.key\) \?\? 0\}/,
+    "the org header should show its project count",
+  );
+});
+
+test("chat-list keeps the flat and date views free of org headers", () => {
+  assert.match(
+    src,
+    /showOrganizationHeader \? \(\s*\n\s*<li className="chat-list-org-header"/,
+    "org headers are conditional on showOrganizationHeader",
+  );
+  assert.doesNotMatch(
+    src,
+    /chat-list-org-header[^\n]*\{\s*\n/,
+    "org headers should never render unconditionally",
+  );
+});
+
+console.log("chat-list-organization.test.ts: ok");

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -34,11 +34,16 @@ import { useDateTimePrefs, formatDate, type DateTimePrefs } from "@/lib/datetime
 import {
   createChatProjectIndex,
   filterVisibleChatSessions,
+  type ChatProjectGroup,
 } from "@/lib/chat-projects";
 import {
   deriveChatListProjectGroups,
   withoutArchivedChatSessions,
 } from "@/lib/chat-list-grouping";
+import {
+  NO_PROJECT_ORGANIZATION,
+  chatProjectOrganizationGroups,
+} from "@/lib/project-organizations";
 import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { useProjects } from "@/lib/use-projects";
 import {
@@ -485,21 +490,43 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
         projectRoot: null,
         runtimeHost: null,
         projectName: null,
+        organization: NO_PROJECT_ORGANIZATION,
+        projectColor: null,
         sessions: rows,
         defaultFamiliarId: latest?.familiarId ?? scopedFamiliarId,
         updatedAt: latest ? (latest.updated_at || latest.created_at) : null,
       }];
     }
-    if (sessionOrder.length === 0) return sortPinnedFirst(scopedGroups, pinnedIds);
-    let changed = false;
-    const next = scopedGroups.map((group) => {
-      const ordered = applyManualOrder(group.sessions, sessionOrder);
-      if (ordered === group.sessions) return group;
-      changed = true;
-      return { ...group, sessions: ordered };
-    });
-    return changed ? next : scopedGroups;
+    let ordered: ChatProjectGroup[] = sessionOrder.length === 0
+      ? sortPinnedFirst(scopedGroups, pinnedIds)
+      : scopedGroups;
+    if (sessionOrder.length > 0) {
+      let changed = false;
+      const next = scopedGroups.map((group) => {
+        const manuallyOrdered = applyManualOrder(group.sessions, sessionOrder);
+        if (manuallyOrdered === group.sessions) return group;
+        changed = true;
+        return { ...group, sessions: manuallyOrdered };
+      });
+      ordered = changed ? next : scopedGroups;
+    }
+    // "Group by project" nests the project folders under their derived
+    // organization (cave-1vpy): org-major order with the "(no project)"
+    // bucket last. The flat "none"/"date" views keep their own headers.
+    if (groupBy === "project") {
+      ordered = chatProjectOrganizationGroups(ordered).flatMap((orgGroup) => orgGroup.items);
+    }
+    return ordered;
   }, [effectiveSelection, groupBy, scopedGroups, sessionOrder, sessionSort, pinnedIds, scopedFamiliarId]);
+  // Project count per organization for the "Group by project" org headers.
+  const organizationProjectCounts = useMemo(() => {
+    if (groupBy !== "project") return null;
+    const counts = new Map<string, number>();
+    for (const group of displayGroups) {
+      counts.set(group.organization.key, (counts.get(group.organization.key) ?? 0) + 1);
+    }
+    return counts;
+  }, [groupBy, displayGroups]);
   // Calendar-day sections for the "Group by date" mode: header metadata keyed
   // by the first row index of each local day (Today / Yesterday / formatted).
   const daySectionsByIndex = useMemo(() => {
@@ -1297,7 +1324,14 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
           >
             <SortableContext items={displayIds} strategy={verticalListSortingStrategy}>
           <ul className="divide-y divide-[var(--border-hairline)]">
-            {displayGroups.map(({ projectRoot, runtimeHost, projectName, sessions: rows }) => {
+            {displayGroups.map(({ projectRoot, runtimeHost, projectName, sessions: rows, organization }, groupIndex) => {
+              // Organization disclosure header — the second grouping level above
+              // project folders in "Group by project" mode (cave-1vpy). The
+              // list is org-major there, so the header renders once per org
+              // (and the "(no project)" bucket stays last, see the org sort).
+              const showOrganizationHeader =
+                groupBy === "project"
+                && (groupIndex === 0 || organization.key !== displayGroups[groupIndex - 1].organization.key);
               // Flat "All sessions" view (the phone surface): split the list into a
               // counted PINNED section and a counted SESSIONS section, mirroring
               // the desktop rail. firstPinnedIdx/firstRestIdx place each header
@@ -1308,7 +1342,19 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
               const firstPinnedIdx = pinnedFlags.indexOf(true);
               const firstRestIdx = pinnedFlags.indexOf(false);
               return (
-              <li key={selectionKey(null, projectRoot, runtimeHost)}>
+              <Fragment key={selectionKey(null, projectRoot, runtimeHost)}>
+                {showOrganizationHeader ? (
+                  <li className="chat-list-org-header" aria-label={organization.label}>
+                    <span className="truncate text-[length:var(--text-2xs)] font-bold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
+                      {organization.label}
+                    </span>
+                    <span className="shrink-0 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+                      {organizationProjectCounts?.get(organization.key) ?? 0}
+                    </span>
+                    <span aria-hidden className="h-px min-w-0 flex-1 bg-gradient-to-r from-[var(--border-hairline)] to-transparent" />
+                  </li>
+                ) : null}
+              <li>
                 {/* Project group header — uppercase label + count + fading rule
                     (rendered for every group in the "Group by project" mode,
                     including the no-project bucket). */}
@@ -1809,6 +1855,7 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                   })}
                 </ul>
               </li>
+              </Fragment>
               );
             })}
           </ul>

--- a/src/lib/chat-list-grouping.test.ts
+++ b/src/lib/chat-list-grouping.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { NO_CHAT_ATTENTION } from "./chat-attention.ts";
-import { createChatProjectIndex, type CaveProject } from "./chat-projects.ts";
+import { createChatProjectIndex, type CaveProject, type ChatProjectGroup } from "./chat-projects.ts";
 import {
   deriveChatListProjectGroups,
   withoutArchivedChatSessions,
 } from "./chat-list-grouping.ts";
+import { chatProjectOrganizationGroups } from "./project-organizations.ts";
 import type { SessionRow } from "./types.ts";
 
 const projects: CaveProject[] = [
@@ -91,4 +92,45 @@ test("archive filtering preserves identity or copies once from the first archive
   const archived = { ...current[1], archived_at: "2026-08-24T01:00:00.000Z" };
   const filtered = withoutArchivedChatSessions([current[0], archived, session("three", "/work/two")]);
   assert.deepEqual(filtered.map((row) => row.id), ["one", "three"]);
+});
+
+// cave-1vpy: the chat list's "Group by project" mode nests project folders
+// under their derived organization. The list derives org groups from the
+// ordered project groups and flattens them back to project groups (org-major
+// order), so the org sort — recency with the "(no project)" bucket last —
+// must survive that derive+flatten round-trip unchanged.
+test("org-major derive + flatten keeps the no-project bucket last (cave-1vpy)", () => {
+  const group = (projectId: string | null, root: string | null, updatedAt: string): ChatProjectGroup => ({
+    projectId,
+    projectRoot: root,
+    runtimeHost: null,
+    projectName: projectId ? "Project " + projectId : null,
+    organization: root
+      ? { key: "opencoven", label: "OpenCoven", source: "github" }
+      : { key: "__no-project-organization__", label: "No organization", source: "none" },
+    projectColor: null,
+    sessions: [session("s", root ?? "")],
+    defaultFamiliarId: "nova",
+    updatedAt,
+  });
+  const ordered = [
+    group("c", "/work/coven-cave", "2026-08-24T00:00:00.000Z"),
+    group(null, null, "2026-08-25T00:00:00.000Z"),
+    group("a", "/work/alpha", "2026-08-23T00:00:00.000Z"),
+  ];
+  const orgGroups = chatProjectOrganizationGroups(ordered);
+  assert.deepEqual(
+    orgGroups.map((g) => [g.organization.label, g.items.map((i) => i.projectId)]),
+    [
+      ["OpenCoven", ["c", "a"]],
+      ["No organization", [null]],
+    ],
+    "projects regroup under their org with the no-org bucket last",
+  );
+  const flattened = orgGroups.flatMap((orgGroup) => orgGroup.items);
+  assert.deepEqual(
+    flattened.map((g) => g.projectId),
+    ["c", "a", null],
+    "the list's flatten keeps org-major order with the no-project bucket last",
+  );
 });


### PR DESCRIPTION
Bead: cave-1vpy (project grouping primitives — orgs / tags / second-level grouping).

Scope: the bead's derived-organization grouping was implemented and merged earlier (commit 4965ed615) for the Projects hub Grid, but the chat-surface redesign (#5099) replaced the org-grouped rail with a recency/attention list, leaving the org level absent from the live chat list. This PR restores the second grouping level in the current chat surface: the ChatList "Group by project" mode now nests project folders under their derived organization (GitHub owner or parent-directory leaf), with the "(no project)" bucket last via the shared chatProjectOrganizationGroups sort.

Changes:
- src/components/chat-list.tsx: org-major ordering for group-by-project; org disclosure headers (label + project count) above project folders; flat/date views unchanged.
- src/components/chat-list-organization.test.ts (new): source-contract pins for the org wiring.
- src/lib/chat-list-grouping.test.ts: pure test that derive+flatten keeps the no-project bucket last.
- scripts/run-tests.mjs: new test registered.

Tests run: project-organizations (7), chat-projects, chat-project-selection, chat-list-grouping (5), chat-list-organization (4), chat-list-collapse, chat-list-panel, chat-list-coarse-actions, chat-list-mobile-rail-port, chat-list-render-optimization, chat-session-grouping (13), board-grouping, group-chat-projects (3), projects-view (26), access-page (19); pnpm exec tsc --noEmit clean; targeted ESLint clean; node scripts/check-tests-wired.mjs OK (all 1922 wired).

Note: chat-list-delete / chat-list-mobile-command-center failures are pre-existing CSS token-drift (design-token-drift baseline, verified identical on main via stash).
