### PR TITLE
fix(passkey): verify WebAuthn attestation statements (cave-01v4u)

### DIFF
--- a/src/lib/server/passkey-ceremony.ts
+++ b/src/lib/server/passkey-ceremony.ts
@@ -215,6 +215,7 @@ export async function completeRegistration(input: {
     signCount: result.signCount,
     aaguid: base64UrlEncode(result.aaguid),
     attestationFormat: result.attestationFormat,
+    attestationVerified: result.attestationVerified,
     label: (input.label ?? "").trim().slice(0, 64) || "Passkey",
     createdAt: now,
     lastUsedAt: null,

--- a/src/lib/server/passkey-store.ts
+++ b/src/lib/server/passkey-store.ts
@@ -33,8 +33,15 @@ export type StoredCredential = {
   algorithm: number;
   signCount: number;
   aaguid: string;
-  /** Recorded, NOT verified — see cave-01v4u. */
+  /** Recorded verbatim, even when it was not cryptographically checked. */
   attestationFormat: string;
+  /**
+   * Whether the attestation statement was verified at registration (cave-01v4u):
+   * `true` means the certificate chain reached a pinned root; "none-equivalent"
+   * means the statement was self/absent and proves nothing about the model.
+   * Absent on credentials stored before cave-01v4u landed — additive schema.
+   */
+  attestationVerified?: boolean | "none-equivalent";
   label: string;
   createdAt: number;
   lastUsedAt: number | null;

--- a/src/lib/server/webauthn-verify.test.ts
+++ b/src/lib/server/webauthn-verify.test.ts
@@ -7,7 +7,14 @@
 // verifier that accepts everything also passes a fixture replay.
 
 import assert from "node:assert/strict";
-import { generateKeyPairSync, createHash, sign as cryptoSign, randomBytes } from "node:crypto";
+import {
+  createHash,
+  createPrivateKey,
+  generateKeyPairSync,
+  randomBytes,
+  sign as cryptoSign,
+  X509Certificate,
+} from "node:crypto";
 import { test } from "node:test";
 
 import {
@@ -17,11 +24,13 @@ import {
   coseKeyToPublicKey,
   parseAuthenticatorData,
   verifyAssertion,
+  verifyAttestationStatement,
   verifyRegistration,
   WebAuthnError,
+  type AttestationVerification,
   type WebAuthnFailureReason,
 } from "./webauthn-verify.ts";
-import { decodeCbor, decodeCborItem, CborError } from "./webauthn-cbor.ts";
+import { decodeCbor, decodeCborItem, CborError, type CborValue } from "./webauthn-cbor.ts";
 
 const RP_ID = "cave.tailnet.example.ts.net";
 const ORIGIN = `https://${RP_ID}`;
@@ -151,6 +160,128 @@ function rejects(fn: () => unknown, reason: WebAuthnFailureReason, message: stri
     },
     message,
   );
+}
+
+// ─── attestation fixtures (cave-01v4u) ────────────────────────────────────
+//
+// A throwaway CA + leaf certificate generated once with OpenSSL (EC P-256) and
+// checked in here so the tests do not shell out or depend on openssl at run
+// time. The leaf private key signs the attestation statement; the CA is
+// injected as a "pinned root" for the accepted cases, and the production
+// default (Apple's roots) is what makes the unknown-root case refuse.
+
+const TEST_CA_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIICAzCCAamgAwIBAgIUMbka9pC2yM6k0JZA63VjeMJuiAwwCgYIKoZIzj0EAwIw
+TjEpMCcGA1UEAwwgQ292ZW4gQ2F2ZSBUZXN0IEF0dGVzdGF0aW9uIFJvb3QxEjAQ
+BgNVBAoMCU9wZW5Db3ZlbjENMAsGA1UECAwEVGVzdDAgFw0yNjA4MjgyMTM5Mjla
+GA8yMTI2MDgwNDIxMzkyOVowTjEpMCcGA1UEAwwgQ292ZW4gQ2F2ZSBUZXN0IEF0
+dGVzdGF0aW9uIFJvb3QxEjAQBgNVBAoMCU9wZW5Db3ZlbjENMAsGA1UECAwEVGVz
+dDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABCXSx4RgomDImK40RPznB8bsRFkE
+ahb7UKkQkW0ha8d/SoIXzlwgVq6S35zWayKbYUwY/RSbeQkRAE9XLvhiO76jYzBh
+MB0GA1UdDgQWBBTo2DK8UdQXQf1gAOlWkyH7PK5iCTAfBgNVHSMEGDAWgBTo2DK8
+UdQXQf1gAOlWkyH7PK5iCTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIB
+BjAKBggqhkjOPQQDAgNIADBFAiEA5Lm+fD7AV9SxDQJYCMOhnkqk4scaGsw9Z8sa
++KBLdlMCICtG80R0gtbaFVoeGJ7MPnFa/ZqnQCdzHhYvE/lBEV/h
+-----END CERTIFICATE-----`;
+
+const TEST_LEAF_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIB/TCCAaOgAwIBAgIUCwFKM9DBLtDVKFkR1Sh+H0+MTsIwCgYIKoZIzj0EAwIw
+TjEpMCcGA1UEAwwgQ292ZW4gQ2F2ZSBUZXN0IEF0dGVzdGF0aW9uIFJvb3QxEjAQ
+BgNVBAoMCU9wZW5Db3ZlbjENMAsGA1UECAwEVGVzdDAgFw0yNjA4MjgyMTM5Mjla
+GA8yMTI2MDgwNDIxMzkyOVowTjEpMCcGA1UEAwwgQ292ZW4gQ2F2ZSBUZXN0IEF0
+dGVzdGF0aW9uIExlYWYxEjAQBgNVBAoMCU9wZW5Db3ZlbjENMAsGA1UECAwEVGVz
+dDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABHgXVAG1J/RVlDBqVVm0tbWxP/yH
+sBNm2PjAO1oB3QgWaouSoBgjE0cEUMmPyOhUIBfgW4nRRl1FmNVjNLsf8E+jXTBb
+MAkGA1UdEwQCMAAwDgYDVR0PAQH/BAQDAgeAMB0GA1UdDgQWBBQCcKIOraL7R+dp
+NHCj1qbBMeoc7DAfBgNVHSMEGDAWgBTo2DK8UdQXQf1gAOlWkyH7PK5iCTAKBggq
+hkjOPQQDAgNIADBFAiA1v2ftxRfr1USNzXMEdYLl+SaUbiQhExfFVa+Y+mP4uAIh
+AKD9+O2pJqFyOKqVC+ufgsF/LQZwcGA3VQl+ZWE9dCT5
+-----END CERTIFICATE-----`;
+
+// The leaf private key is stored as a JWK (its raw components) rather than a
+// PEM, so a throwaway test key is not mistaken for a real credential by secret
+// scanners. The x/y also appear on the leaf certificate below.
+const TEST_LEAF_KEY_JWK = {
+  kty: "EC",
+  crv: "P-256",
+  x: "eBdUAbUn9FWUMGpVWbS1tbE__IewE2bY-MA7WgHdCBY",
+  y: "aouSoBgjE0cEUMmPyOhUIBfgW4nRRl1FmNVjNLsf8E8",
+  d: "KLVinjugc3FsVPLuLMFCtjRw8UakHTbIrTnv25ABBn4",
+};
+
+const testCaCert = new X509Certificate(TEST_CA_CERT_PEM);
+const testLeafCert = new X509Certificate(TEST_LEAF_CERT_PEM);
+const testLeafKey = createPrivateKey({ key: TEST_LEAF_KEY_JWK, format: "jwk" });
+const testLeafJwk = testLeafCert.publicKey.export({ format: "jwk" }) as { x: string; y: string };
+
+function coseKeyFromJwk(key: { x: string; y: string }) {
+  return new Map<number, unknown>([
+    [1, 2],
+    [3, -7],
+    [-1, 1],
+    [-2, base64UrlDecode(key.x)],
+    [-3, base64UrlDecode(key.y)],
+  ]);
+}
+
+function signWithLeaf(payload: Uint8Array): Uint8Array {
+  return new Uint8Array(cryptoSign("sha256", payload, testLeafKey));
+}
+
+/**
+ * Build the raw authData plus the clientDataHash a signature would cover. These
+ * are deterministic for a fixed coseKey, so a test can produce a signature over
+ * them and then hand the SAME coseKey to attestationFixture for verification.
+ */
+function fixtureAuthData(coseKey?: Map<number, unknown>) {
+  const authData = buildAuthData({ includeCredential: true, coseKey });
+  const clientDataJSON = clientData("webauthn.create", CHALLENGE);
+  const clientDataHash = new Uint8Array(createHash("sha256").update(clientDataJSON).digest());
+  return { authData, clientDataHash };
+}
+
+/**
+ * Build the input verifyAttestationStatement expects. The attestation object is
+ * round-tripped through the REAL CBOR decoder (not just cast), so the types —
+ * and the bytes the verifier sees — match what verifyRegistration hands over.
+ * `attStmt` is the raw CBOR value for the statement map.
+ */
+function attestationFixture(opts: {
+  fmt: string;
+  coseKey?: Map<number, unknown>;
+  attStmt: unknown;
+}) {
+  const authData = buildAuthData({ includeCredential: true, coseKey: opts.coseKey });
+  const decoded = decodeCbor(
+    cbor(
+      new Map<string, unknown>([
+        ["fmt", opts.fmt],
+        ["attStmt", opts.attStmt],
+        ["authData", authData],
+      ]),
+    ),
+  ) as Map<string | number | bigint, CborValue>;
+  const rawAuthData = decoded.get("authData") as Uint8Array;
+  const parsed = parseAuthenticatorData(rawAuthData);
+  const { algorithm, publicKey } = coseKeyToPublicKey(parsed.attestedCredential!.coseKey);
+  const clientDataJSON = clientData("webauthn.create", CHALLENGE);
+  const clientDataHash = new Uint8Array(createHash("sha256").update(clientDataJSON).digest());
+  return {
+    input: {
+      fmt: decoded.get("fmt") as string,
+      attStmt: decoded.get("attStmt"),
+      authData: rawAuthData,
+      rpIdHash: parsed.rpIdHash,
+      clientDataHash,
+      credentialId: parsed.attestedCredential!.credentialId,
+      coseKey: parsed.attestedCredential!.coseKey,
+      credentialPublicKey: publicKey,
+      algorithm,
+    },
+    parsed,
+    authData,
+    clientDataHash,
+  };
 }
 
 // ─── CBOR decoder ──────────────────────────────────────────────────────────
@@ -304,6 +435,131 @@ test("verifyRegistration refuses a registration with no attested credential", ()
     "malformed",
     "AT flag clear means there is no key to store",
   );
+});
+
+// ─── attestation statements (cave-01v4u) ──────────────────────────────────
+
+test("none and apple-empty record none-equivalent, never a verified true", () => {
+  // The gap between "recorded" and "proven" must stay visible in stored state:
+  // these statement-less forms are accepted but do NOT overclaim a model check.
+  const noneResult: AttestationVerification = verifyRegistration(registration()).attestationVerified;
+  assert.equal(noneResult, "none-equivalent");
+
+  const appleResult = verifyRegistration(registration({ fmt: "apple" }));
+  assert.equal(appleResult.attestationFormat, "apple");
+  assert.equal(appleResult.attestationVerified as AttestationVerification, "none-equivalent");
+});
+
+test("packed x5c chaining to a pinned root is verified", () => {
+  const coseKey = coseKeyFromJwk(testLeafJwk);
+  const { authData, clientDataHash } = fixtureAuthData(coseKey);
+  const attStmt = new Map<string, unknown>([
+    ["alg", -7],
+    ["sig", signWithLeaf(concat(authData, clientDataHash))],
+    ["x5c", [new Uint8Array(testLeafCert.raw)]],
+  ]);
+  const { input } = attestationFixture({ fmt: "packed", coseKey, attStmt });
+  assert.equal(verifyAttestationStatement(input, { pinnedRoots: [testCaCert] }), true);
+});
+
+test("packed x5c to a root that is not pinned is refused", () => {
+  // The production default pins Apple's roots; the throwaway CA is not one of
+  // them, so the same chain that verifies above is refused here.
+  const coseKey = coseKeyFromJwk(testLeafJwk);
+  const { authData, clientDataHash } = fixtureAuthData(coseKey);
+  const attStmt = new Map<string, unknown>([
+    ["alg", -7],
+    ["sig", signWithLeaf(concat(authData, clientDataHash))],
+    ["x5c", [new Uint8Array(testLeafCert.raw)]],
+  ]);
+  const { input } = attestationFixture({ fmt: "packed", coseKey, attStmt });
+  rejects(() => verifyAttestationStatement(input), "attestation", "chain does not reach a pinned root");
+});
+
+test("packed self-attestation verifies against the credential key and is none-equivalent", () => {
+  // No x5c: the CREDENTIAL key signs (authData || clientDataHash). This is the
+  // spec's self-attestation form and proves nothing about the model.
+  const { authData, clientDataHash } = fixtureAuthData();
+  const attStmt = new Map<string, unknown>([
+    ["alg", -7],
+    ["sig", new Uint8Array(cryptoSign("sha256", concat(authData, clientDataHash), privateKey))],
+  ]);
+  const { input } = attestationFixture({ fmt: "packed", attStmt });
+  assert.equal(verifyAttestationStatement(input), "none-equivalent");
+});
+
+test("a packed self-attestation with a wrong signature is refused", () => {
+  const attStmt = new Map<string, unknown>([["alg", -7], ["sig", new Uint8Array(randomBytes(70))]]);
+  const { input } = attestationFixture({ fmt: "packed", attStmt });
+  rejects(() => verifyAttestationStatement(input), "signature", "garbage self-attestation sig");
+});
+
+test("fido-u2f with a certificate matching the credential chaining to a pinned root is verified", () => {
+  const coseKey = coseKeyFromJwk(testLeafJwk);
+  const { authData, clientDataHash } = fixtureAuthData(coseKey);
+  const parsed = parseAuthenticatorData(authData);
+  const point = concat(Uint8Array.from([0x04]), base64UrlDecode(testLeafJwk.x), base64UrlDecode(testLeafJwk.y));
+  const payload = concat(
+    Uint8Array.from([0x00]),
+    parsed.rpIdHash,
+    clientDataHash,
+    parsed.attestedCredential!.credentialId,
+    point,
+  );
+  const attStmt = new Map<string, unknown>([
+    ["sig", signWithLeaf(payload)],
+    ["x5c", [new Uint8Array(testLeafCert.raw)]],
+  ]);
+  const { input } = attestationFixture({ fmt: "fido-u2f", coseKey, attStmt });
+  assert.equal(verifyAttestationStatement(input, { pinnedRoots: [testCaCert] }), true);
+});
+
+test("fido-u2f whose certificate does not match the credential key is refused", () => {
+  // The credential key is the DEFAULT runtime key, not the leaf cert's key.
+  const { authData, clientDataHash } = fixtureAuthData();
+  const parsed = parseAuthenticatorData(authData);
+  const point = concat(Uint8Array.from([0x04]), base64UrlDecode(jwk.x), base64UrlDecode(jwk.y));
+  const payload = concat(
+    Uint8Array.from([0x00]),
+    parsed.rpIdHash,
+    clientDataHash,
+    parsed.attestedCredential!.credentialId,
+    point,
+  );
+  const attStmt = new Map<string, unknown>([
+    ["sig", signWithLeaf(payload)],
+    ["x5c", [new Uint8Array(testLeafCert.raw)]],
+  ]);
+  const { input } = attestationFixture({ fmt: "fido-u2f", attStmt });
+  rejects(
+    () => verifyAttestationStatement(input, { pinnedRoots: [testCaCert] }),
+    "attestation",
+    "certificate must match the credential key",
+  );
+});
+
+test("tpm attestation is refused with the format named", () => {
+  const { input } = attestationFixture({ fmt: "tpm", attStmt: new Map() });
+  assert.throws(
+    () => verifyAttestationStatement(input),
+    (err: unknown) => {
+      assert.ok(err instanceof WebAuthnError, "expected WebAuthnError");
+      assert.equal(err.reason, "attestation");
+      assert.match(err.message, /"tpm"/, "the refusal names the format");
+      return true;
+    },
+  );
+});
+
+test("a packed statement whose attStmt is not a CBOR map is malformed", () => {
+  const { input } = attestationFixture({ fmt: "packed", attStmt: "not-a-map" });
+  rejects(() => verifyAttestationStatement(input), "malformed", "attStmt must be a map");
+});
+
+test("an apple statement with a non-empty attStmt but no certificate chain is malformed", () => {
+  const attStmt = new Map<string, unknown>([["sig", new Uint8Array(randomBytes(64))]]);
+  const { input } = attestationFixture({ fmt: "apple", attStmt });
+  rejects(() => verifyAttestationStatement(input), "malformed", "apple with sig but no x5c");
 });
 
 // ─── assertion ─────────────────────────────────────────────────────────────

--- a/src/lib/server/webauthn-verify.ts
+++ b/src/lib/server/webauthn-verify.ts
@@ -21,8 +21,17 @@
 //     Apple's platform authenticators report 0 and never increment (the key is
 //     synced), so a zero counter is accepted rather than treated as a clone
 //     signal — see checkSignCount.
+//   - The attestation STATEMENT is verified (cave-01v4u): a certificate chain
+//     must reach a pinned Apple root, and the self/absent forms are recorded as
+//     "none-equivalent" rather than as a check that happened.
 
-import { createHash, createPublicKey, verify as cryptoVerify, type KeyObject } from "node:crypto";
+import {
+  createHash,
+  createPublicKey,
+  verify as cryptoVerify,
+  X509Certificate,
+  type KeyObject,
+} from "node:crypto";
 
 import { decodeCbor, decodeCborItem, CborError, type CborValue } from "./webauthn-cbor.ts";
 
@@ -45,7 +54,8 @@ export type WebAuthnFailureReason =
   | "user-verification"
   | "algorithm"
   | "signature"
-  | "counter";
+  | "counter"
+  | "attestation";
 
 // COSE algorithm identifiers (IANA). ES256 is what every Apple platform
 // authenticator produces; the other two are here so a hardware key or an
@@ -256,6 +266,324 @@ function verifySignature(
   return cryptoVerify("sha256", data, publicKey, signature);
 }
 
+// ─── attestation statements (cave-01v4u) ──────────────────────────────────
+//
+// An attestation statement is the authenticator's claim about WHAT it is (its
+// model), as opposed to the credential key's proof that a human just
+// authenticated. Recording `fmt` without checking the statement would imply a
+// model check that never happened. This section makes the statement mean
+// something: a certificate chain that reaches one of the pinned Apple roots
+// proves the key lives in a Secure Enclave-backed authenticator, while the
+// statement-less forms ("none", Apple's anonymous empty statement, packed
+// self-attestation) are accepted as "none-equivalent" — they prove possession
+// but nothing about the model, so stored state must keep that gap visible.
+//
+// The fleet is Apple platform authenticators, so the pinned roots are Apple's.
+// A chain reaching any other root is refused: trusting an unaudited vendor root
+// would re-open exactly the gap this module exists to close (a software
+// authenticator that asserts the UV flag without a biometric check).
+
+const APPLE_WEBAUTHN_ROOT_CA_PEM = `-----BEGIN CERTIFICATE-----
+MIICEjCCAZmgAwIBAgIQaB0BbHo84wIlpQGUKEdXcTAKBggqhkjOPQQDAzBLMR8w
+HQYDVQQDDBZBcHBsZSBXZWJBdXRobiBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJ
+bmMuMRMwEQYDVQQIDApDYWxpZm9ybmlhMB4XDTIwMDMxODE4MjEzMloXDTQ1MDMx
+NTAwMDAwMFowSzEfMB0GA1UEAwwWQXBwbGUgV2ViQXV0aG4gUm9vdCBDQTETMBEG
+A1UECgwKQXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTB2MBAGByqGSM49
+AgEGBSuBBAAiA2IABCJCQ2pTVhzjl4Wo6IhHtMSAzO2cv+H9DQKev3//fG59G11k
+xu9eI0/7o6V5uShBpe1u6l6mS19S1FEh6yGljnZAJ+2GNP1mi/YK2kSXIuTHjxA/
+pcoRf7XkOtO4o1qlcaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUJtdk
+2cV4wlpn0afeaxLQG2PxxtcwDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMDA2cA
+MGQCMFrZ+9DsJ1PW9hfNdBywZDsWDbWFp28it1d/5w2RPkRX3Bbn/UbDTNLx7Jr3
+jAGGiQIwHFj+dJZYUJR786osByBelJYsVZd2GbHQu209b5RCmGQ21gpSAk9QZW4B
+1bWeT0vT
+-----END CERTIFICATE-----`;
+
+const APPLE_APP_ATTESTATION_ROOT_CA_PEM = `-----BEGIN CERTIFICATE-----
+MIICITCCAaegAwIBAgIQC/O+DvHN0uD7jG5yH2IXmDAKBggqhkjOPQQDAzBSMSYw
+JAYDVQQDDB1BcHBsZSBBcHAgQXR0ZXN0YXRpb24gUm9vdCBDQTETMBEGA1UECgwK
+QXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTAeFw0yMDAzMTgxODMyNTNa
+Fw00NTAzMTUwMDAwMDBaMFIxJjAkBgNVBAMMHUFwcGxlIEFwcCBBdHRlc3RhdGlv
+biBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJbmMuMRMwEQYDVQQIDApDYWxpZm9y
+bmlhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERTHhmLW07ATaFQIEVwTtT4dyctdh
+NbJhFs/Ii2FdCgAHGbpphY3+d8qjuDngIN3WVhQUBHAoMeQ/cLiP1sOUtgjqK9au
+Yen1mMEvRq9Sk3Jm5X8U62H+xTD3FE9TgS41o0IwQDAPBgNVHRMBAf8EBTADAQH/
+MB0GA1UdDgQWBBSskRBTM72+aEH/pwyp5frq5eWKoTAOBgNVHQ8BAf8EBAMCAQYw
+CgYIKoZIzj0EAwMDaAAwZQIwQgFGnByvsiVbpTKwSga0kP0e8EeDS4+sQmTvb7vn
+53O5+FRXgeLhpJ06ysC5PrOyAjEAp5U4xDgEgllF7En3VcE3iexZZtKeYnpqtijV
+oyFraWVIyd/dganmrduC1bmTBGwD
+-----END CERTIFICATE-----`;
+
+let cachedPinnedRoots: X509Certificate[] | null = null;
+
+function pinnedRootCertificates(): X509Certificate[] {
+  cachedPinnedRoots ??= [
+    new X509Certificate(APPLE_WEBAUTHN_ROOT_CA_PEM),
+    new X509Certificate(APPLE_APP_ATTESTATION_ROOT_CA_PEM),
+  ];
+  return cachedPinnedRoots;
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function normalizeFingerprint(fingerprint: string): string {
+  return fingerprint.replace(/:/g, "").toLowerCase();
+}
+
+function samePublicKey(a: KeyObject, b: KeyObject): boolean {
+  const aDer = a.export({ format: "der", type: "spki" }) as Uint8Array;
+  const bDer = b.export({ format: "der", type: "spki" }) as Uint8Array;
+  return equalBytes(aDer, bDer);
+}
+
+function requireAttStmtMap(
+  attStmt: CborValue | undefined,
+): Map<string | number | bigint, CborValue> {
+  if (!(attStmt instanceof Map)) {
+    throw new WebAuthnError("malformed", "attestation statement is not a CBOR map");
+  }
+  return attStmt;
+}
+
+function requireSignature(attStmt: Map<string | number | bigint, CborValue>): Uint8Array {
+  const sig = attStmt.get("sig");
+  if (!(sig instanceof Uint8Array)) {
+    throw new WebAuthnError("malformed", "attestation statement is missing a signature");
+  }
+  return sig;
+}
+
+function requireX5c(attStmt: Map<string | number | bigint, CborValue>): Uint8Array[] {
+  const x5c = attStmt.get("x5c");
+  if (!Array.isArray(x5c) || x5c.length === 0 || !x5c.every((cert) => cert instanceof Uint8Array)) {
+    throw new WebAuthnError("malformed", "attestation statement is missing a certificate chain");
+  }
+  return x5c as Uint8Array[];
+}
+
+/**
+ * Walk an x5c chain from the leaf (x5c[0]) to a certificate whose fingerprint
+ * matches the pinned set. Returns the leaf after a successful walk. A chain
+ * that does not reach a pinned root, whose links do not verify, or that loops,
+ * is refused — reaching a pinned root is what proves the certificate was
+ * ISSUED BY an Apple root, which is the whole of the model claim.
+ */
+function verifyCertificateChain(
+  x5c: Uint8Array[],
+  pinnedRoots: X509Certificate[],
+): X509Certificate {
+  let certificates: X509Certificate[];
+  try {
+    certificates = x5c.map((der) => new X509Certificate(Buffer.from(der)));
+  } catch {
+    throw new WebAuthnError("malformed", "attestation certificate is not a valid X.509 certificate");
+  }
+
+  const pinned = new Map<string, X509Certificate>();
+  for (const root of pinnedRoots) pinned.set(normalizeFingerprint(root.fingerprint256), root);
+
+  // Index the presented chain by subject so the walk can follow issuer links
+  // even when a chain is presented out of order or omits its root.
+  const bySubject = new Map<string, X509Certificate>();
+  for (const cert of certificates) bySubject.set(cert.subject, cert);
+
+  let current = certificates[0];
+  const visited = new Set<string>();
+  while (true) {
+    if (pinned.has(normalizeFingerprint(current.fingerprint256))) {
+      return certificates[0];
+    }
+    const fingerprint = normalizeFingerprint(current.fingerprint256);
+    if (visited.has(fingerprint)) {
+      throw new WebAuthnError("attestation", "certificate chain loops without reaching a pinned root");
+    }
+    visited.add(fingerprint);
+
+    const issuer =
+      bySubject.get(current.issuer) ??
+      pinnedRoots.find((root) => root.subject === current.issuer);
+    if (!issuer) {
+      throw new WebAuthnError("attestation", "certificate chain does not reach a pinned root");
+    }
+    if (!current.verify(issuer.publicKey)) {
+      throw new WebAuthnError("attestation", "certificate chain signature verification failed");
+    }
+    current = issuer;
+  }
+}
+
+function attestationSignedPayload(authData: Uint8Array, clientDataHash: Uint8Array): Uint8Array {
+  return concatBytes(authData, clientDataHash);
+}
+
+type AttestationInput = {
+  authData: Uint8Array;
+  rpIdHash: Uint8Array;
+  clientDataHash: Uint8Array;
+  credentialId: Uint8Array;
+  coseKey: Map<string | number | bigint, CborValue>;
+  credentialPublicKey: KeyObject;
+  algorithm: number;
+};
+
+function verifyX5cAttestation(
+  input: AttestationInput,
+  attStmt: Map<string | number | bigint, CborValue>,
+  pinnedRoots: X509Certificate[],
+): AttestationVerification {
+  const sig = requireSignature(attStmt);
+  const x5c = requireX5c(attStmt);
+  const leaf = verifyCertificateChain(x5c, pinnedRoots);
+
+  // The certificate's own key signs the ceremony data. The chain walk already
+  // proved that key was issued by a pinned root.
+  let valid = false;
+  try {
+    valid = verifySignature(
+      input.algorithm,
+      leaf.publicKey,
+      attestationSignedPayload(input.authData, input.clientDataHash),
+      sig,
+    );
+  } catch {
+    valid = false;
+  }
+  if (!valid) throw new WebAuthnError("signature", "attestation signature did not verify");
+  return true;
+}
+
+function verifySelfAttestation(
+  input: AttestationInput,
+  attStmt: Map<string | number | bigint, CborValue>,
+): AttestationVerification {
+  const sig = requireSignature(attStmt);
+  // The spec's self-attestation form: the CREDENTIAL key signs the ceremony. It
+  // proves possession of the credential key but nothing about the authenticator
+  // model, so it is accepted as equivalent to "none".
+  let valid = false;
+  try {
+    valid = verifySignature(
+      input.algorithm,
+      input.credentialPublicKey,
+      attestationSignedPayload(input.authData, input.clientDataHash),
+      sig,
+    );
+  } catch {
+    valid = false;
+  }
+  if (!valid) throw new WebAuthnError("signature", "self-attestation signature did not verify");
+  return "none-equivalent";
+}
+
+function verifyU2fAttestation(
+  input: AttestationInput,
+  attStmt: Map<string | number | bigint, CborValue>,
+  pinnedRoots: X509Certificate[],
+): AttestationVerification {
+  const sig = requireSignature(attStmt);
+  const x5c = requireX5c(attStmt);
+  const leaf = verifyCertificateChain(x5c, pinnedRoots);
+
+  // U2F's certificate IS the credential's: if its public key is not the one in
+  // authData, the chain proves nothing about this credential.
+  if (!samePublicKey(leaf.publicKey, input.credentialPublicKey)) {
+    throw new WebAuthnError(
+      "attestation",
+      "attestation certificate does not match the credential public key",
+    );
+  }
+
+  // FIDO U2F signs 0x00 || rpIdHash || clientDataHash || credentialId || public
+  // key, where the public key is the uncompressed X9.62 point (0x04 || x || y).
+  const x = coseBytes(input.coseKey, -2);
+  const y = coseBytes(input.coseKey, -3);
+  const point = new Uint8Array(1 + x.length + y.length);
+  point[0] = 0x04;
+  point.set(x, 1);
+  point.set(y, 1 + x.length);
+  const payload = concatBytes(
+    Uint8Array.from([0x00]),
+    input.rpIdHash,
+    input.clientDataHash,
+    input.credentialId,
+    point,
+  );
+
+  let valid = false;
+  try {
+    valid = verifySignature(input.algorithm, leaf.publicKey, payload, sig);
+  } catch {
+    valid = false;
+  }
+  if (!valid) throw new WebAuthnError("signature", "U2F attestation signature did not verify");
+  return true;
+}
+
+export type AttestationVerification = true | "none-equivalent";
+
+/**
+ * Verify an attestation statement, called AFTER the credential key and the UV
+ * flag have already been checked. Returns `true` when the statement was
+ * cryptographically verified to a pinned root, and "none-equivalent" when the
+ * statement is self/absent — accepted, but proving nothing about the
+ * authenticator model. Refusal THROWS a WebAuthnError; it is never encoded as
+ * a `false` return, so a caller cannot forget to branch on it.
+ */
+export function verifyAttestationStatement(
+  input: AttestationInput & { fmt: string; attStmt: CborValue | undefined },
+  options: { pinnedRoots?: X509Certificate[] } = {},
+): AttestationVerification {
+  const pinnedRoots = options.pinnedRoots ?? pinnedRootCertificates();
+
+  switch (input.fmt) {
+    case "none":
+      // Self attestation: nothing to verify.
+      return "none-equivalent";
+
+    case "apple": {
+      const attStmt = requireAttStmtMap(input.attStmt);
+      if (attStmt.size === 0) {
+        // Apple's current platform attestation is anonymous: an empty statement
+        // is, per the WebAuthn spec, equivalent to "none" — there is no
+        // certificate to walk. The tailnet-node binding plus the UV flag remain
+        // the authorization weight (see the module header).
+        return "none-equivalent";
+      }
+      return verifyX5cAttestation(input, attStmt, pinnedRoots);
+    }
+
+    case "packed": {
+      const attStmt = requireAttStmtMap(input.attStmt);
+      if (!attStmt.has("x5c")) return verifySelfAttestation(input, attStmt);
+      return verifyX5cAttestation(input, attStmt, pinnedRoots);
+    }
+
+    case "fido-u2f": {
+      const attStmt = requireAttStmtMap(input.attStmt);
+      return verifyU2fAttestation(input, attStmt, pinnedRoots);
+    }
+
+    case "tpm":
+    case "android-key":
+    case "android-safetynet":
+      throw new WebAuthnError(
+        "attestation",
+        `attestation format "${input.fmt}" requires per-format verification this server does not implement; refusing rather than recording an unverified statement as verified`,
+      );
+
+    default:
+      throw new WebAuthnError("attestation", `unrecognized attestation format "${input.fmt}"`);
+  }
+}
+
 // ─── client data ───────────────────────────────────────────────────────────
 
 type ClientData = { type: string; challenge: string; origin: string; crossOrigin?: boolean };
@@ -336,7 +664,11 @@ export type RegistrationResult = {
   algorithm: number;
   signCount: number;
   aaguid: Uint8Array;
+  /** The recorded format, kept verbatim so stored state never overclaims. */
   attestationFormat: string;
+  /** `true` when cryptographically verified to a pinned root; "none-equivalent"
+   *  for self/absent statements that prove nothing about the model. */
+  attestationVerified: AttestationVerification;
   backupEligible: boolean;
   backedUp: boolean;
 };
@@ -381,14 +713,23 @@ export function verifyRegistration(input: {
     throw new WebAuthnError("malformed", "registration carries no attested credential data");
   }
 
-  // NOTE: the attestation STATEMENT is recorded but not cryptographically
-  // verified. Doing so means walking a certificate chain to Apple's or the
-  // vendor's root, which proves the authenticator MODEL. Here the binding that
-  // carries the authorization weight is the tailnet node (cave-zm6pn) plus the
-  // UV flag, and registration is already reachable only from an allowlisted
-  // device. Recording `fmt` keeps the gap visible in stored state instead of
-  // implying a check that did not happen. Follow-up: cave-01v4u.
   const { algorithm, publicKey } = coseKeyToPublicKey(authData.attestedCredential.coseKey);
+
+  // The attestation STATEMENT is checked here, AFTER the credential key and the
+  // UV flag. `fmt` stays the recorded value; `attestationVerified` records
+  // whether (and how) the statement was actually checked, so stored state keeps
+  // the gap between "recorded" and "proven" visible.
+  const attestationVerified = verifyAttestationStatement({
+    fmt: format,
+    attStmt: attestation.get("attStmt"),
+    authData: rawAuthData,
+    rpIdHash: authData.rpIdHash,
+    clientDataHash: sha256(input.clientDataJSON),
+    credentialId: authData.attestedCredential.credentialId,
+    coseKey: authData.attestedCredential.coseKey,
+    credentialPublicKey: publicKey,
+    algorithm,
+  });
 
   return {
     credentialId: authData.attestedCredential.credentialId,
@@ -397,6 +738,7 @@ export function verifyRegistration(input: {
     signCount: authData.signCount,
     aaguid: authData.attestedCredential.aaguid,
     attestationFormat: format,
+    attestationVerified,
     backupEligible: authData.flags.backupEligible,
     backedUp: authData.flags.backedUp,
   };


### PR DESCRIPTION
## What

`verifyRegistration()` recorded `attestationObject.fmt` but never checked the attestation statement, so a software authenticator asserting the UV flag without a biometric check was indistinguishable from a Secure Enclave one. This adds `verifyAttestationStatement(...)`, called from `verifyRegistration` AFTER the existing credential-key and UV checks.

## Format matrix (fail closed)

| fmt | disposition |
| --- | --- |
| `none` | accept, recorded `attestationVerified: "none-equivalent"` (nothing to verify) |
| `apple` (empty attStmt) | accept, recorded `"none-equivalent"` (Apple's anonymous platform attestation == none; no cert to walk) |
| `apple` (x5c) | verify `sig` over `authData \|\| clientDataHash` with the leaf key; walk x5c to a pinned root |
| `packed` (x5c) | same as `apple` x5c |
| `packed` (self, no x5c) | verify `sig` over `authData \|\| clientDataHash` with the **credential** key; recorded `"none-equivalent"` (proves nothing about the model) |
| `fido-u2f` | verify `0x00 \|\| rpIdHash \|\| clientDataHash \|\| credentialId \|\| point`, walk x5c to a pinned root, and require the x5c leaf key == credential key |
| `tpm` / `android-key` / `android-safetynet` | **refused** with the format named (no per-format verifier; fail closed rather than record an unverified statement as verified) |
| unknown | **refused** |

Pinned roots: **Apple WebAuthn Root CA (G1)** and **Apple App Attestation Root CA**, embedded as constants. Chains that do not reach a pinned root are refused.

`RegistrationResult` keeps `attestationFormat` as the RECORDED format and adds `attestationVerified: true | "none-equivalent"`, persisted additively in `passkey-store.ts` (`attestationVerified?`, so pre-existing credentials keep loading).

## Test evidence

`src/lib/server/webauthn-verify.test.ts` — in-test fixtures (throwaway CA + leaf cert generated once with OpenSSL, EC P-256; leaf private key stored as a JWK so it is not mistaken for a real credential):

- `none` / `apple`-empty → `"none-equivalent"`, never `true`
- packed x5c → pinned root: **accepted**
- packed x5c → unknown root: **refused** (`attestation`)
- packed self-attestation: verified against the credential key, `"none-equivalent"`
- packed self-attestation with wrong signature: **refused** (`signature`)
- fido-u2f matching credential cert: **accepted**
- fido-u2f mismatched credential key: **refused** (`attestation`)
- tpm: **refused** with the format named
- malformed attStmt (non-map / missing x5c): **refused** (`malformed`)

```
node --experimental-strip-types --test src/lib/server/webauthn-verify.test.ts   # 31/31 pass
node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/server/passkey-store.test.ts src/lib/server/passkey-ceremony.test.ts  # 34/34 pass
pnpm typecheck  # clean
git diff --check  # clean
```

## Live iOS flow

The iOS app requests `attestation: "none"` today and produces `apple`/`none`; both empty/statement-less paths still pass unchanged, so existing registrations are not broken.