### PR TITLE
fix(cave-lzl2e): guard the browser preview pane sliver fix

### DIFF
--- a/src/components/drag-to-split.test.ts
+++ b/src/components/drag-to-split.test.ts
@@ -141,6 +141,22 @@ test("split panes use their container instead of generic overflow floors", () =>
   assert.match(host, /<div className="split-host__pane-body">\{primary\}<\/div>/, "legacy primary content uses the pane body class");
 });
 
+test("the browser preview pane fills its split panel instead of collapsing to a sliver (cave-lzl2e)", () => {
+  // A flex (non-grid) tile-panel laid its pane out on the row axis with no flex
+  // basis, so a narrow surface (the browser preview pane, whose toolbar is only
+  // ~120px wide) shrink-to-fit to a ~123px sliver beside dead space. The pane
+  // must claim the whole panel so the grid/flex paths cannot regress it.
+  const css = readFileSync(
+    new URL("../styles/globals/surface-chat-overlays.css", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    css,
+    /\.split-host__tile-panel > \.split-host__pane \{[\s\S]*?flex: 1 1 auto;[\s\S]*?width: 100%;/,
+    "tile panels fill their pane so the browser preview cannot collapse to a sliver",
+  );
+});
+
 test("surfaces size their grids by PANE, not viewport (cave-hivd)", () => {
   // In a split tile, a wide window must not force wide-viewport column counts.
   const roster = readFileSync(new URL("./familiars-view.tsx", import.meta.url), "utf8");


### PR DESCRIPTION
Bead: cave-lzl2e — Ship browser preview pane sliver fix to a release build

## What the sliver was

Opening a chat local preview "beside chat" mounts the Browser pane as a
`chat-preview-browser` split tile. The flex (non-grid) split panel laid its
tile out on the row axis with no flex basis, so a narrow surface — the browser
preview pane, whose toolbar is only ~120px wide — shrink-to-fit to a ~123px
sliver beside dead space instead of filling its half of the split.

## The fix

The CSS fix already landed on `main` (commit `387e9b1b5`,
"Reuse board resource and fix split pane sizing") and shipped in v0.3.12:

```css
.split-host__tile-panel > .split-host__pane {
  flex: 1 1 auto;
  width: 100%;
}
```

Its only regression guard has been the heavy Playwright e2e
(`tests/chat-local-preview.spec.ts`), which asserts the pane width but only runs
in the e2e project. This PR adds a fast unit-level source-text guard in
`src/components/drag-to-split.test.ts` pinning that rule, so the sliver fix
cannot silently regress in an ordinary CI pass.

## Files changed

- `src/components/drag-to-split.test.ts` — new source-text guard asserting the
  `.split-host__tile-panel > .split-host__pane` fill rule (flex basis + width).

## Test summary

- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/drag-to-split.test.ts` — 11 pass, 0 fail
- `pnpm test:app` — 1361 test files pass
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm check:tests-wired` — 1925 test files wired
