### PR TITLE
test(e2e): calendar rove spec respects the documented stay-put edge (UTC Saturdays)

### DIFF
--- a/tests/calendar-month-grid.spec.ts
+++ b/tests/calendar-month-grid.spec.ts
@@ -74,7 +74,13 @@ test.describe("calendar month grid keyboard model", () => {
     expect(await focusedCellIndex(page)).toBe(start + 1);
 
     await page.keyboard.press("ArrowDown");
-    expect(await focusedCellIndex(page)).toBe(start + 8);
+    // A ↓ row-step from the grid's last row would leave the grid entirely;
+    // the roving hook's documented behavior is to stay put at the edge
+    // (see use-roving-tabindex.ts) rather than slide into a different
+    // column. The anchor is today's cell, so this case occurs whenever the
+    // test runs on the last day of a calendar row (e.g. a Saturday in a
+    // Sunday-start grid). Every other row advances a full week.
+    expect(await focusedCellIndex(page)).toBe(start + 8 <= 41 ? start + 8 : start + 1);
 
     // The grid owns its arrows: the month must NOT have paged underneath.
     await expect(page.getByRole("grid")).toHaveAttribute("aria-label", monthLabel!);


### PR DESCRIPTION
## Summary

The month-grid roving hook stays put when a row-step would leave the grid (documented in `src/lib/use-roving-tabindex.ts`: "A row-step off the top/bottom edge stays put rather than clamping"), but `calendar-month-grid.spec.ts` always asserted `start + 8` after ArrowDown.

When the anchor (today's cell) is in the grid's last row — e.g. any Saturday in a Sunday-start grid, which is what UTC CI hits — ArrowRight moves into the final row and ArrowDown correctly stays put, making the old assertion (an index that does not exist) fail deterministically. Reproduced locally with `TZ=UTC`, passes with `TZ` unset.

## Fix

The spec now asserts the documented behavior: `start + 8` when a next row exists, the stay-put `start + 1` at the bottom edge. This is currently blocking E2E shard 1 for every PR that runs CI on a UTC Saturday.

## Verification

`TZ=UTC pnpm exec playwright test tests/calendar-month-grid.spec.ts --project=desktop` — 5 passed.