### PR TITLE
test(client-v1): add packaged compatibility controls

### DIFF
--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -804,13 +804,32 @@ because the whole body is public.
 - **`releaseVersion`** is the running Cave's package version. The fixture's
   `"0.0.0"` is a placeholder and never served.
 
+### Conformance-only compatibility controls
+
+Normal `pnpm build` artifacts compile this control disabled; setting a runtime
+environment variable cannot activate it. The explicit conformance build
+contract is:
+
+```bash
+pnpm build:conformance
+COVEN_CAVE_CLIENT_V1_COMPATIBILITY_PRESET=api-major pnpm start
+```
+
+The runtime selector is finite: `api-major` emits `apiVersion: "2.0"` while
+keeping `minimumClientVersion: "0.1.0"`, and `minimum-client` emits
+`apiVersion: "1.0"` with `minimumClientVersion: "999.0.0"`. An unset selector
+emits normal metadata; any other value returns HTTP 500 with the shared error
+envelope. These controls exist only to let the Phase 1 harness independently
+prove the SDK's API-major and minimum-client compatibility checks.
+
 The live inventory is **not** in `data`: `capabilities` and `operations` ride
 the envelope, here as on every other response. This is nonetheless the response
 a client reads them from, because it is the only one reachable before pairing —
 so it is the first place the declaration has to be true. See *Capability
 discovery*.
 
-**Errors:** none. The route has no failure branch of its own.
+**Errors:** normal builds have no failure branch of their own. An enabled
+conformance build returns `500 internal_error` when its selector is invalid.
 
 ### `POST /api/client/v1/pairing/requests`
 

--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -1476,8 +1476,10 @@ All four call `requireClientV1Admin`, which:
    [the conformance run](../workflows/client-v1-conformance.md) on 2026-08-22;
    a handler-level test cannot see it, because it never runs the proxy. The
    check in `requireClientV1Admin` is not redundant — it is what answers if the
-   admin family ever stops falling through — but it is the *second* refusal, and
-   the 503 for an unset token is the only one of its answers a caller observes.
+   admin family ever stops falling through — but it is the *second* refusal.
+   With no configured token, a verified direct-loopback development request
+   receives the proxy's per-boot marker and reaches the route; a missing marker
+   still receives the route-level 503.
 3. For **mutations only** (the decision POST and the credential DELETE),
    requires **at least one** of `Origin` and `Referer`, and requires every one
    that *is* present to be same-origin. A request carrying neither is refused;

--- a/docs/api/client-v1.md
+++ b/docs/api/client-v1.md
@@ -663,9 +663,13 @@ in over Tailscale Serve gets the 403 above rather than a mobile-auth prompt.
 promotion: `proxy()` skips the mobile-access gate and returns *before* the
 sidecar-token block, so on those paths the route's own bearer check is the only
 check that *verifies* the credential. The proxy still demands a well-formed
-`Authorization: Bearer` *presentation* first (cave-q5mwb) — presentation, not
-verification: a syntactically valid fake passes the proxy and is refused by the
-route's `requireScope`. See *When the authenticated routes land*.
+`Authorization: Bearer` presentation or the complete exact
+`hpke-bound-v1` header set first (cave-q5mwb) — presentation, not verification.
+A syntactically valid fake bearer passes the proxy and is refused by the route's
+`requireScope`; a complete bound presentation reaches the authority runtime,
+which validates and opens it before the route runs. A request presenting neither
+receives the proxy's bare `401 {"ok":false,"error":"unauthorized"}`. See *When
+the authenticated routes land*.
 
 Eight of the thirteen routes re-check the stamp in the route itself, via
 `runtime.authenticator.isTrustedLoopback`, and answer `unauthorized` in the

--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -94,9 +94,10 @@ tombstone surviving a store reload, and the revoked bearer being refused **by
 all five canonical reads** — `read-guard.ts` keeps the credential decision
 written out in each route module rather than delegated, so there are five copies
 of it and a single-route probe clears one; and
-every admin route answering `503` when `COVEN_CAVE_AUTH_TOKEN` is unset —
-together with the consequence that matters, which is that a pairing opened on a
-tokenless Cave can only ever answer `pairing_pending`.
+the tokenless non-bundled development path proving direct-loopback admin
+authorization over the real proxy: empty approval and credential lists, 404 for
+unknown decision/revocation ids, pairing creation, and an undecided exchange
+remaining `pairing_pending`.
 
 **Canonical reads (#4838)** — all five routes; empty first page, exact-multiple
 page, continuation, partial final page, and `hasMore` in both directions;

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,8 @@ const nextConfig: NextConfig = {
   env: {
     COVEN_CAVE_X_PRODUCTION_CLIENT_ID:
       process.env.COVEN_CAVE_X_PRODUCTION_CLIENT_ID?.trim() ?? "",
+    COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED:
+      process.env.COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL === "1" ? "1" : "0",
   },
   // The Next.js dev tools launcher renders in a portal at bottom-left by
   // default, which intercepts taps on Cave's mobile bottom tabs in local dev.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "protocol:tweet-thread:validator:check": "node scripts/build-tweet-thread-validator.mjs --check",
     "prebuild": "node scripts/generate-icon-subset.mjs && node scripts/generate-marketplace-logos.mjs && node scripts/generate-pwa-icons.mjs && node scripts/build-sandbox-runtime.mjs && node scripts/copy-pdf-worker.mjs",
     "build": "next build && pnpm build:server",
+    "build:conformance": "node scripts/build-conformance.mjs",
     "postbuild": "node scripts/bundle-budget.mjs && node scripts/standalone-budget.mjs",
     "test:bundle": "node scripts/bundle-budget.mjs",
     "bench:conversation-list": "node --experimental-strip-types scripts/conversation-list-benchmark.mjs",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "test:api": "node scripts/run-tests.mjs api",
     "test:api:http": "node scripts/api-http-smoke.mjs",
     "test:client-v1:conformance": "node scripts/client-v1-conformance.mjs",
+    "test:client-v1:compatibility-control": "node scripts/client-v1-compatibility-control.integration.test.mjs",
     "test:client-v1:authority-takeover": "node --experimental-strip-types scripts/client-v1-authority-takeover.mjs",
     "test:research-media:ffmpeg": "node --experimental-strip-types scripts/research-media-ffmpeg.integration.test.mjs",
     "test:mobile": "node scripts/run-tests.mjs mobile",

--- a/scripts/build-conformance.mjs
+++ b/scripts/build-conformance.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+
+const result = spawnSync("corepack", ["pnpm@10.34.0", "build"], {
+  env: {
+    ...process.env,
+    COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL: "1",
+  },
+  stdio: "inherit",
+});
+
+if (result.error) {
+  console.error(`build:conformance failed to start: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/client-v1-compatibility-control.integration.test.mjs
+++ b/scripts/client-v1-compatibility-control.integration.test.mjs
@@ -1,0 +1,325 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import {
+  link,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readlink,
+  readFile,
+  rm,
+  symlink,
+} from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const buildTimeoutMs = 10 * 60_000;
+const startupTimeoutMs = 45_000;
+const requestTimeoutMs = 3_000;
+const shutdownTimeoutMs = 8_000;
+const maxOutputBytes = 32_000;
+const healthPath = "/api/client/v1/health";
+const successMetadata = {
+  apiVersion: "1.0",
+  minimumClientVersion: "0.1.0",
+};
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function isRunning(child) {
+  return child.exitCode === null && child.signalCode === null;
+}
+
+async function stopChild(child) {
+  if (!child || !isRunning(child)) return;
+  await new Promise((resolve) => {
+    let finished = false;
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(forceTimer);
+      resolve();
+    };
+    const forceTimer = setTimeout(() => {
+      if (isRunning(child)) child.kill("SIGKILL");
+    }, shutdownTimeoutMs);
+    child.once("exit", finish);
+    child.kill("SIGTERM");
+  });
+}
+
+function collectOutput(child) {
+  let output = "";
+  const append = (chunk) => {
+    if (output.length >= maxOutputBytes) return;
+    output += chunk.toString("utf8").slice(0, maxOutputBytes - output.length);
+  };
+  child.stdout?.on("data", append);
+  child.stderr?.on("data", append);
+  return () => output;
+}
+
+async function runBuild(label, args, env) {
+  const child = spawn("corepack", ["pnpm@10.34.0", ...args], {
+    cwd: repositoryRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const output = collectOutput(child);
+
+  await new Promise((resolve, reject) => {
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      void stopChild(child);
+    }, buildTimeoutMs);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(new Error(`${label} failed to start: ${error.message}`, { cause: error }));
+    });
+    child.once("close", (code, signal) => {
+      clearTimeout(timer);
+      if (timedOut) {
+        reject(new Error(`${label} timed out after ${buildTimeoutMs} ms`));
+      } else if (code !== 0) {
+        reject(new Error(`${label} exited with ${code ?? signal}\n${output().slice(-4_000)}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+async function snapshotEntry(source, destination, excluded = new Set()) {
+  const info = await lstat(source);
+  if (info.isSymbolicLink()) {
+    await symlink(await readlink(source), destination);
+    return;
+  }
+  if (info.isDirectory()) {
+    await mkdir(destination);
+    for (const entry of await readdir(source, { withFileTypes: true })) {
+      if (excluded.has(entry.name)) continue;
+      await snapshotEntry(
+        path.join(source, entry.name),
+        path.join(destination, entry.name),
+      );
+    }
+    return;
+  }
+  await link(source, destination);
+}
+
+async function snapshotBuild(destination) {
+  await mkdir(destination, { recursive: true });
+  await mkdir(path.join(destination, "app"));
+  await snapshotEntry(
+    path.join(repositoryRoot, ".next", "standalone", ".next"),
+    path.join(destination, ".next"),
+  );
+  await snapshotEntry(
+    path.join(repositoryRoot, ".next", "static"),
+    path.join(destination, ".next", "static"),
+  );
+  await snapshotEntry(
+    path.join(repositoryRoot, "server.mjs"),
+    path.join(destination, "server.mjs"),
+  );
+}
+
+async function freePort() {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  const port = address.port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+function isolatedEnvironment(root, port, selector) {
+  const env = {};
+  for (const [name, value] of Object.entries(process.env)) {
+    if (
+      name === "HOME"
+      || name === "USERPROFILE"
+      || name === "HOMEDRIVE"
+      || name === "HOMEPATH"
+      || name.startsWith("COVEN_")
+      || /(?:TOKEN|SECRET|PASSWORD|PRIVATE|API_KEY|CREDENTIAL)/i.test(name)
+    ) {
+      continue;
+    }
+    env[name] = value;
+  }
+  env.HOME = path.join(root, "home");
+  env.USERPROFILE = env.HOME;
+  env.TMPDIR = path.join(root, "tmp");
+  env.TMP = env.TMPDIR;
+  env.TEMP = env.TMPDIR;
+  env.XDG_CONFIG_HOME = path.join(root, "config");
+  env.XDG_CACHE_HOME = path.join(root, "cache");
+  env.NODE_ENV = "production";
+  env.COVEN_HOME = path.join(root, "coven");
+  env.COVEN_CAVE_HOME = path.join(root, "coven", "cave");
+  env.COVEN_CAVE_HEAP_MONITOR = "0";
+  env.COVEN_CAVE_CLIENT_V1_AUTHORITY_MODE = "off";
+  if (port !== undefined) env.COVEN_CAVE_PORT = String(port);
+  if (selector !== undefined) {
+    env.COVEN_CAVE_CLIENT_V1_COMPATIBILITY_PRESET = selector;
+  }
+  return env;
+}
+
+async function requestHealth(origin) {
+  const response = await fetch(`${origin}${healthPath}`, {
+    signal: AbortSignal.timeout(requestTimeoutMs),
+  });
+  let body;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new Error(`health response was not JSON: ${error.message}`, { cause: error });
+  }
+  return { response, body };
+}
+
+async function launchArtifact(artifact, root, selector) {
+  const port = await freePort();
+  const buildManifest = JSON.parse(
+    await readFile(path.join(repositoryRoot, ".next", "required-server-files.json"), "utf8"),
+  );
+  const child = spawn(process.execPath, [path.join(artifact, "server.mjs")], {
+    cwd: artifact,
+    env: {
+      ...isolatedEnvironment(root, port, selector),
+      __NEXT_PRIVATE_STANDALONE_CONFIG: JSON.stringify(buildManifest.config),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const output = collectOutput(child);
+  const origin = `http://127.0.0.1:${port}`;
+  const deadline = Date.now() + startupTimeoutMs;
+  while (Date.now() < deadline) {
+    if (!isRunning(child)) {
+      throw new Error(`packaged server exited before readiness\n${output().slice(-4_000)}`);
+    }
+    try {
+      const result = await requestHealth(origin);
+      return { child, origin, port, result };
+    } catch {
+      await sleep(250);
+    }
+  }
+  await stopChild(child);
+  throw new Error(`packaged server did not answer within ${startupTimeoutMs} ms\n${output().slice(-4_000)}`);
+}
+
+async function stopArtifact(server) {
+  await stopChild(server.child);
+  const deadline = Date.now() + shutdownTimeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`${server.origin}/`, { signal: AbortSignal.timeout(500) });
+    } catch {
+      return;
+    }
+    await sleep(100);
+  }
+  throw new Error(`packaged server port ${server.port} remained open after cleanup`);
+}
+
+function assertNormalHealth(body) {
+  assert.equal(body.apiVersion, successMetadata.apiVersion);
+  assert.equal(body.minimumClientVersion, successMetadata.minimumClientVersion);
+  assert.equal(body.error, undefined);
+}
+
+function assertConformanceHealth(body, apiVersion, minimumClientVersion) {
+  assert.equal(body.apiVersion, apiVersion);
+  assert.equal(body.minimumClientVersion, minimumClientVersion);
+  assert.equal(body.error, undefined);
+}
+
+function assertSafeError(response, body) {
+  assert.equal(response.status, 500);
+  assert.deepEqual(Object.keys(body).sort(), [
+    "apiVersion",
+    "capabilities",
+    "error",
+    "minimumClientVersion",
+    "operations",
+  ]);
+  assert.equal(body.apiVersion, successMetadata.apiVersion);
+  assert.equal(body.minimumClientVersion, successMetadata.minimumClientVersion);
+  assert.ok(Array.isArray(body.capabilities) && body.capabilities.length > 0);
+  assert.ok(Array.isArray(body.operations) && body.operations.length > 0);
+  assert.deepEqual(body.error, {
+    code: "internal_error",
+    details: { reason: "invalid_conformance_preset" },
+    message: "Client v1 compatibility preset is invalid.",
+    retryable: false,
+  });
+}
+
+test("builds and launches normal and conformance packaged Client v1 artifacts", async () => {
+  const scratchParent = path.join(repositoryRoot, ".tmp");
+  await mkdir(scratchParent, { recursive: true });
+  const root = await mkdtemp(path.join(scratchParent, "client-v1-compatibility-control-"));
+  const normalArtifact = path.join(root, "artifacts", "normal");
+  const conformanceArtifact = path.join(root, "artifacts", "conformance");
+  await mkdir(path.join(root, "home"), { recursive: true });
+  await mkdir(path.join(root, "tmp"), { recursive: true });
+  await mkdir(path.join(root, "config"), { recursive: true });
+  await mkdir(path.join(root, "cache"), { recursive: true });
+  await mkdir(path.join(root, "coven", "cave"), { recursive: true });
+
+  try {
+    await runBuild("normal build", ["build"], isolatedEnvironment(root));
+    await snapshotBuild(normalArtifact);
+
+    let server;
+    try {
+      server = await launchArtifact(normalArtifact, root, "api-major");
+      assert.equal(server.result.response.status, 200);
+      assertNormalHealth(server.result.body);
+    } finally {
+      if (server) await stopArtifact(server);
+    }
+
+    await runBuild("conformance build", ["build:conformance"], isolatedEnvironment(root));
+    await snapshotBuild(conformanceArtifact);
+
+    for (const [selector, apiVersion, minimumClientVersion] of [
+      ["api-major", "2.0", "0.1.0"],
+      ["minimum-client", "1.0", "999.0.0"],
+    ]) {
+      server = null;
+      try {
+        server = await launchArtifact(conformanceArtifact, root, selector);
+        assert.equal(server.result.response.status, 200);
+        assertConformanceHealth(server.result.body, apiVersion, minimumClientVersion);
+      } finally {
+        if (server) await stopArtifact(server);
+      }
+    }
+
+    server = null;
+    try {
+      server = await launchArtifact(conformanceArtifact, root, "invalid-selector");
+      assertSafeError(server.result.response, server.result.body);
+    } finally {
+      if (server) await stopArtifact(server);
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/client-v1-compatibility-control.integration.test.mjs
+++ b/scripts/client-v1-compatibility-control.integration.test.mjs
@@ -270,6 +270,23 @@ function assertSafeError(response, body) {
   });
 }
 
+async function removeTestBuildOutputs(root) {
+  const removals = await Promise.allSettled([
+    rm(root, { recursive: true, force: true }),
+    rm(path.join(repositoryRoot, ".next"), { recursive: true, force: true }),
+    rm(path.join(repositoryRoot, "server.mjs"), { force: true }),
+  ]);
+  const failures = removals
+    .filter((result) => result.status === "rejected")
+    .map((result) => result.reason);
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      "compatibility-control test build cleanup failed",
+    );
+  }
+}
+
 test("builds and launches normal and conformance packaged Client v1 artifacts", async () => {
   const scratchParent = path.join(repositoryRoot, ".tmp");
   await mkdir(scratchParent, { recursive: true });
@@ -320,6 +337,7 @@ test("builds and launches normal and conformance packaged Client v1 artifacts", 
       if (server) await stopArtifact(server);
     }
   } finally {
-    await rm(root, { recursive: true, force: true });
+    // Never leave the conformance-enabled build in the canonical package path.
+    await removeTestBuildOutputs(root);
   }
 });

--- a/scripts/client-v1-compatibility-control.integration.test.mjs
+++ b/scripts/client-v1-compatibility-control.integration.test.mjs
@@ -274,7 +274,6 @@ async function removeTestBuildOutputs(root) {
   const removals = await Promise.allSettled([
     rm(root, { recursive: true, force: true }),
     rm(path.join(repositoryRoot, ".next"), { recursive: true, force: true }),
-    rm(path.join(repositoryRoot, "server.mjs"), { force: true }),
   ]);
   const failures = removals
     .filter((result) => result.status === "rejected")

--- a/scripts/client-v1-conformance.mjs
+++ b/scripts/client-v1-conformance.mjs
@@ -67,7 +67,14 @@ import { once } from "node:events";
 import { connect as netConnect, createServer as createNetServer } from "node:net";
 import { randomUUID } from "node:crypto";
 import http from "node:http";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -602,7 +609,13 @@ export const RECORD_SHAPES = {
  * reaches the wire as written), and it refuses some header spellings outright.
  */
 export function requestOnce(origin, options) {
-  const { method = "GET", path: target, headers = {}, body } = options;
+  const {
+    method = "GET",
+    path: target,
+    headers = {},
+    body,
+    timeoutMs,
+  } = options;
   const url = new URL(origin);
   return new Promise((resolve, reject) => {
     const outgoing = { ...headers };
@@ -633,6 +646,11 @@ export function requestOnce(origin, options) {
       },
     );
     request.on("error", reject);
+    if (timeoutMs !== undefined) {
+      request.setTimeout(timeoutMs, () => {
+        request.destroy(new Error("request timed out"));
+      });
+    }
     if (body !== undefined) request.write(body);
     request.end();
   });
@@ -710,6 +728,10 @@ export async function freePort() {
   return port;
 }
 
+export async function createConformanceFixtureRoot(parent = tmpdir()) {
+  return realpath(await mkdtemp(path.join(parent, "cave-client-v1-conformance-")));
+}
+
 /**
  * A loopback stand-in for the Coven daemon's familiar roster.
  *
@@ -784,6 +806,7 @@ export async function startCave(input) {
   child.stderr.resume();
 
   const origin = `http://127.0.0.1:${port}`;
+  const discoveryPath = path.join(input.caveHomeDir, "client-v1-discovery.json");
   const deadline = Date.now() + 120_000;
   let exited = false;
   child.once("exit", () => {
@@ -796,8 +819,24 @@ export async function startCave(input) {
       break;
     }
     try {
-      const response = await requestOnce(origin, { path: `${CLIENT_V1_PREFIX}/health` });
-      if (response.status === 200) return { child, origin, port };
+      const response = await requestOnce(origin, {
+        path: `${CLIENT_V1_PREFIX}/health`,
+        timeoutMs: Math.min(1_000, Math.max(1, deadline - Date.now())),
+      });
+      let discovery = null;
+      try {
+        discovery = JSON.parse(await readFile(discoveryPath, "utf8"));
+      } catch {
+        // The listen callback may not have published the discovery record yet.
+      }
+      const readinessFailure = caveReadinessFailure({
+        healthStatus: response.status,
+        discovery,
+        expectedPid: child.pid,
+        origin,
+      });
+      if (readinessFailure === null) return { child, origin, port };
+      failure = readinessFailure;
     } catch {
       // Not listening yet.
     }
@@ -805,6 +844,25 @@ export async function startCave(input) {
   }
   await stopCave({ child }, port).catch(() => {});
   throw new Error(failure);
+}
+
+export function caveReadinessFailure({
+  healthStatus,
+  discovery,
+  expectedPid,
+  origin,
+}) {
+  if (healthStatus !== 200) return "Cave health is not ready.";
+  if (!discovery || typeof discovery !== "object" || Array.isArray(discovery)) {
+    return "Client v1 discovery record is not published.";
+  }
+  if (discovery.endpoint !== origin) {
+    return "Client v1 discovery endpoint does not match the listening Cave.";
+  }
+  if (discovery.pid !== expectedPid) {
+    return "Client v1 discovery pid does not match the launched Cave.";
+  }
+  return null;
 }
 
 /**
@@ -1231,13 +1289,45 @@ async function walk(client, target, bearer, collection, limit) {
 // ── legs ─────────────────────────────────────────────────────────────────────
 
 /**
- * Phase A: a Cave with no `COVEN_CAVE_AUTH_TOKEN`.
+ * Phase A: a non-bundled Cave with no `COVEN_CAVE_AUTH_TOKEN`.
  *
- * This is the state a plain `pnpm dev` is in, and the doc's stated consequence
- * is stronger than "the admin routes 503": a client can open a pairing request
- * and can *never* get it approved. That whole sequence is asserted here,
- * because the 503 alone reads like an inconvenience rather than a dead end.
+ * This is the state a plain `pnpm dev` is in. The listener and proxy prove a
+ * direct-loopback peer and stamp a per-boot secret marker, so the Settings UI
+ * can list and mutate the local approval stores without a packaged sidecar
+ * token. Caller-supplied markers remain stripped and cannot activate this path.
  */
+export function tokenlessAdminProbeExpectation(method, target) {
+  if (method === "GET" && target === "/admin/pairing-requests") {
+    return { status: 200, kind: "success", collection: "pairingRequests" };
+  }
+  if (method === "GET" && target === "/admin/credentials") {
+    return { status: 200, kind: "success", collection: "credentials" };
+  }
+  if (
+    method === "POST"
+    && /^\/admin\/pairing-requests\/[0-9a-f-]{36}\/decision$/u.test(target)
+  ) {
+    return {
+      status: 404,
+      kind: "error",
+      code: "not_found",
+      retryable: false,
+    };
+  }
+  if (
+    method === "DELETE"
+    && /^\/admin\/credentials\/[0-9a-f-]{36}$/u.test(target)
+  ) {
+    return {
+      status: 404,
+      kind: "error",
+      code: "not_found",
+      retryable: false,
+    };
+  }
+  throw new Error(`unsupported tokenless admin probe: ${method} ${target}`);
+}
+
 async function runUnconfiguredAdminLeg(client, recorder) {
   const probes = [
     ["GET", "/admin/pairing-requests", undefined],
@@ -1247,9 +1337,24 @@ async function runUnconfiguredAdminLeg(client, recorder) {
   ];
   for (const [method, target, body] of probes) {
     const response = await client.admin(method, target, "any-token-at-all", body === undefined ? {} : { body });
+    const expected = tokenlessAdminProbeExpectation(method, target);
     const failures = [];
-    if (response.status !== 503) failures.push(`${method} ${target} answered ${response.status}, expected 503`);
-    failures.push(...checkEnvelope(response.json, { kind: "error", code: "service_unavailable", retryable: false }));
+    if (response.status !== expected.status) {
+      failures.push(`${method} ${target} answered ${response.status}, expected ${expected.status}`);
+    }
+    if (expected.kind === "success") {
+      failures.push(...checkEnvelope(response.json, { kind: "success" }));
+      const collection = response.json?.data?.[expected.collection];
+      if (!Array.isArray(collection) || collection.length !== 0) {
+        failures.push(`${expected.collection} was not an empty array`);
+      }
+    } else {
+      failures.push(...checkEnvelope(response.json, {
+        kind: "error",
+        code: expected.code,
+        retryable: expected.retryable,
+      }));
+    }
     recorder.expect(`admin.unconfigured${target.replace(/\/[0-9a-f-]{36}/, "/:id")}.${method}`, failures);
   }
 
@@ -1272,7 +1377,7 @@ async function runUnconfiguredAdminLeg(client, recorder) {
     recorder.expect(
       "admin.unconfigured.exchange-stays-pending",
       failures,
-      "the documented dead end: no approval route, so the exchange can only ever answer pairing_pending",
+      "an undecided tokenless-development pairing remains pending",
     );
   } else {
     recorder.skip("admin.unconfigured.exchange-stays-pending", "no pairing request was opened to exchange");
@@ -2998,7 +3103,7 @@ async function main(argv) {
   }
   const manifest = JSON.parse(await readFile(path.join(repositoryRoot, "package.json"), "utf8"));
 
-  const fixtureRoot = await mkdtemp(path.join(tmpdir(), "cave-client-v1-conformance-"));
+  const fixtureRoot = await createConformanceFixtureRoot();
   const covenHomeDir = path.join(fixtureRoot, "coven");
   const caveHomeDir = path.join(covenHomeDir, "cave");
   const adminToken = `conformance-${randomUUID()}`;

--- a/scripts/client-v1-conformance.mjs
+++ b/scripts/client-v1-conformance.mjs
@@ -2043,7 +2043,14 @@ async function runAuthFailureLeg(client, recorder, bearer, writeOnlyBearer) {
   const noBearer = await client.read("/conversations", null);
   const noBearerFailures = [];
   if (noBearer.status !== 401) noBearerFailures.push(`answered ${noBearer.status}, expected 401`);
-  noBearerFailures.push(...checkEnvelope(noBearer.json, { kind: "error", code: "unauthorized" }));
+  if (
+    JSON.stringify(noBearer.json)
+      !== JSON.stringify({ ok: false, error: "unauthorized" })
+  ) {
+    noBearerFailures.push(
+      `body was ${JSON.stringify(noBearer.text.slice(0, 160))}, expected the proxy refusal {"ok":false,"error":"unauthorized"}`,
+    );
+  }
   recorder.expect("reads.no-bearer", noBearerFailures);
 
   const garbage = await client.read("/conversations", "not-a-real-bearer");

--- a/scripts/client-v1-conformance.test.mjs
+++ b/scripts/client-v1-conformance.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { EventEmitter } from "node:events";
+import { EventEmitter, once } from "node:events";
+import { realpath, rm } from "node:fs/promises";
+import { createServer } from "node:http";
 import test from "node:test";
 
 import {
@@ -21,6 +23,8 @@ import {
   checkRecordShape,
   checkRecordValues,
   buildCaveEnvironment,
+  caveReadinessFailure,
+  createConformanceFixtureRoot,
   createRecorder,
   expectedAssertionIds,
   expectedBranchedMessages,
@@ -31,9 +35,11 @@ import {
   parseConformanceArgs,
   parseRawResponse,
   recordAuthorityTakeoverResult,
+  requestOnce,
   renderConformanceRecord,
   stopCave,
   summarizeConformance,
+  tokenlessAdminProbeExpectation,
 } from "./client-v1-conformance.mjs";
 
 // The conformance run itself needs a release build, a spare port and a couple
@@ -189,6 +195,118 @@ test("stopCave subscribes before terminating a live child and does not force-kil
   await stopCave({ child }, 1);
 
   assert.deepEqual(events, ["subscribe", "SIGTERM"]);
+});
+
+test("tokenless loopback admin probes follow the reviewed development contract", () => {
+  assert.deepEqual(
+    tokenlessAdminProbeExpectation("GET", "/admin/pairing-requests"),
+    { status: 200, kind: "success", collection: "pairingRequests" },
+  );
+  assert.deepEqual(
+    tokenlessAdminProbeExpectation("GET", "/admin/credentials"),
+    { status: 200, kind: "success", collection: "credentials" },
+  );
+  assert.deepEqual(
+    tokenlessAdminProbeExpectation(
+      "POST",
+      "/admin/pairing-requests/00000000-0000-4000-8000-000000000000/decision",
+    ),
+    { status: 404, kind: "error", code: "not_found", retryable: false },
+  );
+  assert.deepEqual(
+    tokenlessAdminProbeExpectation(
+      "DELETE",
+      "/admin/credentials/00000000-0000-4000-8000-000000000000",
+    ),
+    { status: 404, kind: "error", code: "not_found", retryable: false },
+  );
+  assert.throws(
+    () => tokenlessAdminProbeExpectation("PATCH", "/admin/credentials"),
+    /unsupported tokenless admin probe/u,
+  );
+});
+
+test("Cave readiness requires the matching discovery record after health answers", () => {
+  const origin = "http://127.0.0.1:4310";
+  const expectedPid = 4310;
+  assert.equal(
+    caveReadinessFailure({
+      healthStatus: 200,
+      discovery: null,
+      expectedPid,
+      origin,
+    }),
+    "Client v1 discovery record is not published.",
+  );
+  assert.equal(
+    caveReadinessFailure({
+      healthStatus: 200,
+      discovery: {
+        endpoint: "http://127.0.0.1:4311",
+        pid: expectedPid,
+      },
+      expectedPid,
+      origin,
+    }),
+    "Client v1 discovery endpoint does not match the listening Cave.",
+  );
+  assert.equal(
+    caveReadinessFailure({
+      healthStatus: 503,
+      discovery: { endpoint: origin, pid: expectedPid },
+      expectedPid,
+      origin,
+    }),
+    "Cave health is not ready.",
+  );
+  assert.equal(
+    caveReadinessFailure({
+      healthStatus: 200,
+      discovery: { endpoint: origin, pid: expectedPid + 1 },
+      expectedPid,
+      origin,
+    }),
+    "Client v1 discovery pid does not match the launched Cave.",
+  );
+  assert.equal(
+    caveReadinessFailure({
+      healthStatus: 200,
+      discovery: { endpoint: origin, pid: expectedPid },
+      expectedPid,
+      origin,
+    }),
+    null,
+  );
+});
+
+test("bounded readiness requests reject a stalled HTTP response", async () => {
+  const server = createServer(() => {});
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  try {
+    await assert.rejects(
+      requestOnce(`http://127.0.0.1:${address.port}`, {
+        path: "/api/client/v1/health",
+        timeoutMs: 50,
+      }),
+      /request timed out/u,
+    );
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve, reject) =>
+      server.close((error) => error ? reject(error) : resolve()),
+    );
+  }
+});
+
+test("the conformance fixture root is canonical before Cave validates it", async () => {
+  const root = await createConformanceFixtureRoot();
+  try {
+    assert.equal(root, await realpath(root));
+  } finally {
+    await rm(root, { recursive: true });
+  }
 });
 
 // ── the envelope ─────────────────────────────────────────────────────────────

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1509,6 +1509,7 @@ export const SUITES = {
     "src/lib/server/client-v1/path-ownership.test.ts",
     "src/lib/server/client-v1/status.test.ts",
     "src/lib/server/client-v1/runtime.test.ts",
+    "src/lib/server/client-v1/conformance-compatibility.test.ts",
     "src/app/api/client/v1/health/route.test.ts",
     "src/app/api/client/v1/pairing/requests/route.test.ts",
     "src/app/api/client/v1/pairing/requests/[id]/route.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1985,6 +1985,7 @@ export const SUITES = {
   // Keep this separate from the broader app/api/mobile suites.
   conformance: [
     "scripts/cross-environment.test.ts",
+    "scripts/client-v1-compatibility-control.integration.test.mjs",
     "scripts/research-protocol-conformance.test.ts",
     "scripts/research-protocol-scenario-conformance.test.ts",
     "src/lib/research-protocol/common.test.ts",

--- a/src/app/api/client/v1/health/route.test.ts
+++ b/src/app/api/client/v1/health/route.test.ts
@@ -13,6 +13,10 @@ import {
 } from "@/lib/server/client-v1/contract";
 import { clientV1Operation } from "@/lib/server/client-v1/operations";
 import { APP_VERSION } from "@/lib/app-version";
+import {
+  CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED,
+  CLIENT_V1_COMPATIBILITY_PRESET_ENV,
+} from "@/lib/server/client-v1/conformance-compatibility";
 
 import { GET } from "./route.ts";
 
@@ -82,6 +86,95 @@ test("reports the running release rather than the fixture placeholder", async ()
     assert.equal(envelope.data.releaseVersion, APP_VERSION);
   });
 });
+
+test(
+  "keeps production metadata unchanged when only the runtime selector is present",
+  { skip: CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED },
+  async () => {
+    await withTemporaryCaveHome(async () => {
+      const previousPreset = process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV];
+      process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV] = "api-major";
+      try {
+        const envelope = await (await GET()).json();
+        assert.equal(envelope.apiVersion, CLIENT_V1_API_VERSION);
+        assert.equal(envelope.minimumClientVersion, CLIENT_V1_MIN_CLIENT_VERSION);
+      } finally {
+        if (previousPreset === undefined) {
+          delete process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV];
+        } else {
+          process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV] = previousPreset;
+        }
+      }
+    });
+  },
+);
+
+test(
+  "the enabled conformance build emits the API-major preset through the real route",
+  { skip: !CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED },
+  async () => {
+    await withTemporaryCaveHome(async () => {
+      const previousPreset = process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV];
+      process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV] = "api-major";
+      try {
+        const envelope = await (await GET()).json();
+        assert.equal(envelope.apiVersion, "2.0");
+        assert.equal(envelope.minimumClientVersion, CLIENT_V1_MIN_CLIENT_VERSION);
+      } finally {
+        if (previousPreset === undefined) {
+          delete process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV];
+        } else {
+          process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV] = previousPreset;
+        }
+      }
+    });
+  },
+);
+
+test(
+  "the enabled conformance build emits the minimum-client preset independently",
+  { skip: !CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED },
+  async () => {
+    await withTemporaryCaveHome(async () => {
+      const previousPreset = process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV];
+      process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV] = "minimum-client";
+      try {
+        const envelope = await (await GET()).json();
+        assert.equal(envelope.apiVersion, CLIENT_V1_API_VERSION);
+        assert.equal(envelope.minimumClientVersion, "999.0.0");
+      } finally {
+        if (previousPreset === undefined) {
+          delete process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV];
+        } else {
+          process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV] = previousPreset;
+        }
+      }
+    });
+  },
+);
+
+test(
+  "the enabled conformance build rejects an invalid preset",
+  { skip: !CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED },
+  async () => {
+    await withTemporaryCaveHome(async () => {
+      const previousPreset = process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV];
+      process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV] = "not-a-preset";
+      try {
+        const response = await GET();
+        const envelope = await response.json();
+        assert.equal(response.status, 500);
+        assert.equal(envelope.error.code, "internal_error");
+      } finally {
+        if (previousPreset === undefined) {
+          delete process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV];
+        } else {
+          process.env[CLIENT_V1_COMPATIBILITY_PRESET_ENV] = previousPreset;
+        }
+      }
+    });
+  },
+);
 
 test("answers without leaking paths, configuration, or user data", async () => {
   await withTemporaryCaveHome(async () => {

--- a/src/app/api/client/v1/health/route.ts
+++ b/src/app/api/client/v1/health/route.ts
@@ -21,15 +21,32 @@ import {
 import { clientV1InstanceId } from "@/lib/server/client-v1/instance-id";
 import {
   clientV1ErrorResponse,
+  clientV1Success,
   clientV1SuccessResponse,
 } from "@/lib/server/client-v1/responses";
 import {
   CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED,
+  type ClientV1Compatibility,
   resolveClientV1Compatibility,
 } from "@/lib/server/client-v1/conformance-compatibility";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+function clientV1HealthResponse(
+  health: ClientV1Health,
+  compatibility: ClientV1Compatibility,
+): Response {
+  const envelope = clientV1Success(health);
+  if (compatibility.kind !== "override") {
+    return Response.json(envelope);
+  }
+  return Response.json({
+    ...envelope,
+    apiVersion: compatibility.apiVersion,
+    minimumClientVersion: compatibility.minimumClientVersion,
+  });
+}
 
 export async function GET() {
   const compatibility = resolveClientV1Compatibility(
@@ -52,8 +69,8 @@ export async function GET() {
   // apiVersion, minimumClientVersion, and capabilities ride the shared
   // envelope rather than being repeated in `data` — one source, so a client
   // can never read two different answers out of the same response.
-  return clientV1SuccessResponse(
-    health,
-    compatibility.kind === "override" ? { compatibility } : undefined,
-  );
+  if (compatibility.kind === "default" || compatibility.kind === "disabled") {
+    return clientV1SuccessResponse(health);
+  }
+  return clientV1HealthResponse(health, compatibility);
 }

--- a/src/app/api/client/v1/health/route.ts
+++ b/src/app/api/client/v1/health/route.ts
@@ -19,12 +19,31 @@ import {
   type ClientV1Health,
 } from "@/lib/server/client-v1/contract";
 import { clientV1InstanceId } from "@/lib/server/client-v1/instance-id";
-import { clientV1SuccessResponse } from "@/lib/server/client-v1/responses";
+import {
+  clientV1ErrorResponse,
+  clientV1SuccessResponse,
+} from "@/lib/server/client-v1/responses";
+import {
+  CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED,
+  resolveClientV1Compatibility,
+} from "@/lib/server/client-v1/conformance-compatibility";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET() {
+  const compatibility = resolveClientV1Compatibility(
+    process.env,
+    CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED,
+  );
+  if (compatibility.kind === "invalid") {
+    return clientV1ErrorResponse(
+      "internal_error",
+      "Client v1 compatibility preset is invalid.",
+      { details: { reason: "invalid_conformance_preset" } },
+    );
+  }
+
   const health: ClientV1Health = {
     instanceId: clientV1InstanceId(),
     pairingRequired: CLIENT_V1_PAIRING_REQUIRED,
@@ -33,5 +52,8 @@ export async function GET() {
   // apiVersion, minimumClientVersion, and capabilities ride the shared
   // envelope rather than being repeated in `data` — one source, so a client
   // can never read two different answers out of the same response.
-  return clientV1SuccessResponse(health);
+  return clientV1SuccessResponse(
+    health,
+    compatibility.kind === "override" ? { compatibility } : undefined,
+  );
 }

--- a/src/lib/server/client-v1/auth.test.ts
+++ b/src/lib/server/client-v1/auth.test.ts
@@ -5,6 +5,10 @@ import test from "node:test";
 import { NextRequest } from "next/server";
 
 import {
+  CLIENT_V1_HPKE_HEADERS,
+  CLIENT_V1_HPKE_MECHANISM,
+} from "./authority-contract.ts";
+import {
   createClientV1Authenticator,
   type ClientV1AuthResult,
 } from "./auth.ts";
@@ -30,6 +34,7 @@ import {
   isClientV1Path,
   isRefusedClientV1Path,
   presentsClientV1Bearer,
+  presentsClientV1BoundAuthority,
 } from "../../../proxy-helpers.ts";
 
 const ACTIVE_CREDENTIAL: ClientV1CredentialRecord = {
@@ -779,6 +784,37 @@ test("presentsClientV1Bearer accepts only well-formed RFC 6750 token68", () => {
   assert.equal(presentsClientV1Bearer(`Bearer ${"a".repeat(4097)}`), false);
 });
 
+test("presentsClientV1BoundAuthority requires the exact complete HPKE presentation", () => {
+  const headers = new Headers(
+    Object.fromEntries(
+      Object.values(CLIENT_V1_HPKE_HEADERS).map((name) => [
+        name,
+        name === CLIENT_V1_HPKE_HEADERS.mechanism
+          ? CLIENT_V1_HPKE_MECHANISM
+          : "present",
+      ]),
+    ),
+  );
+  assert.equal(presentsClientV1BoundAuthority(headers), true);
+
+  for (const name of Object.values(CLIENT_V1_HPKE_HEADERS)) {
+    const incomplete = new Headers(headers);
+    incomplete.delete(name);
+    assert.equal(
+      presentsClientV1BoundAuthority(incomplete),
+      false,
+      `missing ${name}`,
+    );
+  }
+
+  const wrongMechanism = new Headers(headers);
+  wrongMechanism.set(
+    CLIENT_V1_HPKE_HEADERS.mechanism,
+    "hpke-bound-v2",
+  );
+  assert.equal(presentsClientV1BoundAuthority(wrongMechanism), false);
+});
+
 test("client-v1 resource ingress refuses a request that presents no bearer", async () => {
   try {
     setProxyEnv({
@@ -858,6 +894,35 @@ test("client-v1 resource ingress refuses a request that presents no bearer", asy
       headers: { ...headers, authorization: "Bearer AAAA" },
     }));
     assert.equal(passedThrough(fakeTwelveByte), true, "presentation-only gate must admit a well-formed fake");
+
+    const boundHeaders = Object.fromEntries(
+      Object.values(CLIENT_V1_HPKE_HEADERS).map((name) => [
+        name,
+        name === CLIENT_V1_HPKE_HEADERS.mechanism
+          ? CLIENT_V1_HPKE_MECHANISM
+          : "present",
+      ]),
+    );
+    const bound = await proxy(proxyRequest("/api/client/v1/projects", {
+      headers: { ...headers, ...boundHeaders },
+    }));
+    assert.equal(
+      passedThrough(bound),
+      true,
+      "a complete HPKE-bound presentation must reach the authority runtime",
+    );
+    for (const missing of Object.values(CLIENT_V1_HPKE_HEADERS)) {
+      const incomplete = { ...boundHeaders };
+      delete incomplete[missing];
+      const response = await proxy(proxyRequest("/api/client/v1/projects", {
+        headers: { ...headers, ...incomplete },
+      }));
+      assert.equal(response.status, 401, `missing ${missing}`);
+      assert.deepEqual(await response.json(), {
+        ok: false,
+        error: "unauthorized",
+      });
+    }
 
     // The public set stays credential-free: pairing is how a client gets one.
     for (const path of contractPublicPaths()) {

--- a/src/lib/server/client-v1/conformance-compatibility.test.ts
+++ b/src/lib/server/client-v1/conformance-compatibility.test.ts
@@ -11,9 +11,8 @@ import {
   CLIENT_V1_COMPATIBILITY_PRESET_ENV,
   resolveClientV1Compatibility,
 } from "./conformance-compatibility.ts";
-import { clientV1SuccessResponse } from "./responses.ts";
 
-test("emits an incompatible API major from the closed conformance preset", async () => {
+test("resolves the finite API-major conformance preset", () => {
   const compatibility = resolveClientV1Compatibility(
     { [CLIENT_V1_COMPATIBILITY_PRESET_ENV]: "api-major" },
     true,
@@ -23,18 +22,9 @@ test("emits an incompatible API major from the closed conformance preset", async
     apiVersion: "2.0",
     minimumClientVersion: CLIENT_V1_MIN_CLIENT_VERSION,
   });
-
-  const response = clientV1SuccessResponse(
-    { probe: "compatibility" },
-    { compatibility },
-  );
-  const envelope = await response.json();
-  assert.equal(envelope.apiVersion, "2.0");
-  assert.equal(envelope.minimumClientVersion, CLIENT_V1_MIN_CLIENT_VERSION);
-  assert.equal(envelope.data.probe, "compatibility");
 });
 
-test("emits an incompatible minimum client version independently", async () => {
+test("resolves the finite minimum-client conformance preset", () => {
   const compatibility = resolveClientV1Compatibility(
     { [CLIENT_V1_COMPATIBILITY_PRESET_ENV]: "minimum-client" },
     true,
@@ -44,14 +34,6 @@ test("emits an incompatible minimum client version independently", async () => {
     apiVersion: CLIENT_V1_API_VERSION,
     minimumClientVersion: "999.0.0",
   });
-
-  const response = clientV1SuccessResponse(
-    { probe: "compatibility" },
-    { compatibility },
-  );
-  const envelope = await response.json();
-  assert.equal(envelope.apiVersion, CLIENT_V1_API_VERSION);
-  assert.equal(envelope.minimumClientVersion, "999.0.0");
 });
 
 test("invalid selectors fail closed in the enabled conformance build", () => {

--- a/src/lib/server/client-v1/conformance-compatibility.test.ts
+++ b/src/lib/server/client-v1/conformance-compatibility.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  CLIENT_V1_API_VERSION,
+  CLIENT_V1_MIN_CLIENT_VERSION,
+} from "./contract.ts";
+import {
+  CLIENT_V1_COMPATIBILITY_PRESET_ENV,
+  resolveClientV1Compatibility,
+} from "./conformance-compatibility.ts";
+import { clientV1SuccessResponse } from "./responses.ts";
+
+test("emits an incompatible API major from the closed conformance preset", async () => {
+  const compatibility = resolveClientV1Compatibility(
+    { [CLIENT_V1_COMPATIBILITY_PRESET_ENV]: "api-major" },
+    true,
+  );
+  assert.deepEqual(compatibility, {
+    kind: "override",
+    apiVersion: "2.0",
+    minimumClientVersion: CLIENT_V1_MIN_CLIENT_VERSION,
+  });
+
+  const response = clientV1SuccessResponse(
+    { probe: "compatibility" },
+    { compatibility },
+  );
+  const envelope = await response.json();
+  assert.equal(envelope.apiVersion, "2.0");
+  assert.equal(envelope.minimumClientVersion, CLIENT_V1_MIN_CLIENT_VERSION);
+  assert.equal(envelope.data.probe, "compatibility");
+});
+
+test("emits an incompatible minimum client version independently", async () => {
+  const compatibility = resolveClientV1Compatibility(
+    { [CLIENT_V1_COMPATIBILITY_PRESET_ENV]: "minimum-client" },
+    true,
+  );
+  assert.deepEqual(compatibility, {
+    kind: "override",
+    apiVersion: CLIENT_V1_API_VERSION,
+    minimumClientVersion: "999.0.0",
+  });
+
+  const response = clientV1SuccessResponse(
+    { probe: "compatibility" },
+    { compatibility },
+  );
+  const envelope = await response.json();
+  assert.equal(envelope.apiVersion, CLIENT_V1_API_VERSION);
+  assert.equal(envelope.minimumClientVersion, "999.0.0");
+});
+
+test("invalid selectors fail closed in the enabled conformance build", () => {
+  assert.deepEqual(
+    resolveClientV1Compatibility(
+      { [CLIENT_V1_COMPATIBILITY_PRESET_ENV]: "arbitrary-json" },
+      true,
+    ),
+    { kind: "invalid" },
+  );
+});
+
+test("the disabled build gate ignores the runtime selector", () => {
+  assert.deepEqual(
+    resolveClientV1Compatibility(
+      { [CLIENT_V1_COMPATIBILITY_PRESET_ENV]: "api-major" },
+      false,
+    ),
+    { kind: "disabled" },
+  );
+});
+
+test("normal builds compile the compatibility control disabled", () => {
+  const config = readFileSync(
+    path.join(process.cwd(), "next.config.ts"),
+    "utf8",
+  );
+  assert.match(
+    config,
+    /COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED/,
+  );
+  assert.match(
+    config,
+    /process\.env\.COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL === "1"/,
+  );
+  assert.match(
+    config,
+    /COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED:\s*[\s\S]*?"0"/,
+  );
+});

--- a/src/lib/server/client-v1/conformance-compatibility.ts
+++ b/src/lib/server/client-v1/conformance-compatibility.ts
@@ -1,0 +1,62 @@
+import {
+  CLIENT_V1_API_VERSION,
+  CLIENT_V1_MIN_CLIENT_VERSION,
+} from "./contract.ts";
+
+/**
+ * Next injects this value from the build environment. A normal `pnpm build`
+ * writes "0", so a runtime selector cannot activate this control in a
+ * production artifact.
+ */
+export const CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED =
+  process.env.COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED === "1";
+
+export const CLIENT_V1_COMPATIBILITY_PRESET_ENV =
+  "COVEN_CAVE_CLIENT_V1_COMPATIBILITY_PRESET";
+
+export type ClientV1CompatibilityOverride = {
+  kind: "override";
+  apiVersion: string;
+  minimumClientVersion: string;
+};
+
+export type ClientV1Compatibility =
+  | { kind: "disabled" }
+  | { kind: "default" }
+  | ClientV1CompatibilityOverride
+  | { kind: "invalid" };
+
+const PRESETS = Object.freeze({
+  "api-major": Object.freeze({
+    apiVersion: "2.0",
+    minimumClientVersion: CLIENT_V1_MIN_CLIENT_VERSION,
+  }),
+  "minimum-client": Object.freeze({
+    apiVersion: CLIENT_V1_API_VERSION,
+    minimumClientVersion: "999.0.0",
+  }),
+});
+
+type ClientV1CompatibilityPreset = keyof typeof PRESETS;
+
+function isPreset(value: string): value is ClientV1CompatibilityPreset {
+  return Object.prototype.hasOwnProperty.call(PRESETS, value);
+}
+
+export function resolveClientV1Compatibility(
+  env: Record<string, string | undefined> = process.env,
+  enabled = CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED,
+): ClientV1Compatibility {
+  if (!enabled) return { kind: "disabled" };
+
+  const raw = env[CLIENT_V1_COMPATIBILITY_PRESET_ENV];
+  if (raw === undefined || raw.trim() === "") return { kind: "default" };
+
+  const preset = raw.trim();
+  if (!isPreset(preset)) return { kind: "invalid" };
+
+  return {
+    kind: "override",
+    ...PRESETS[preset],
+  };
+}

--- a/src/lib/server/client-v1/responses.ts
+++ b/src/lib/server/client-v1/responses.ts
@@ -28,7 +28,6 @@ import {
   type ClientV1SuccessEnvelope,
 } from "./contract.ts";
 import type { ClientV1RateLimitResult } from "./rate-limit.ts";
-import type { ClientV1CompatibilityOverride } from "./conformance-compatibility.ts";
 
 export type ClientV1EnvelopeOptions = {
   capabilities?: readonly ClientV1Capability[];
@@ -40,7 +39,6 @@ export type ClientV1EnvelopeOptions = {
 };
 
 export type ClientV1SuccessResponseOptions = ClientV1EnvelopeOptions & {
-  compatibility?: ClientV1CompatibilityOverride;
   headers?: HeadersInit;
   status?: number;
 };
@@ -204,19 +202,9 @@ export function clientV1SuccessResponse<TData extends ClientV1Record>(
   data: TData,
   options: ClientV1SuccessResponseOptions = {},
 ): Response {
-  const { compatibility, headers, status = 200, ...envelopeOptions } = options;
+  const { headers, status = 200, ...envelopeOptions } = options;
   assertSuccessStatus(status);
-  const envelope = clientV1Success(data, envelopeOptions);
-  return Response.json(
-    compatibility
-      ? {
-          ...envelope,
-          apiVersion: compatibility.apiVersion,
-          minimumClientVersion: compatibility.minimumClientVersion,
-        }
-      : envelope,
-    { headers, status },
-  );
+  return Response.json(clientV1Success(data, envelopeOptions), { headers, status });
 }
 
 export function clientV1ErrorResponse(

--- a/src/lib/server/client-v1/responses.ts
+++ b/src/lib/server/client-v1/responses.ts
@@ -28,6 +28,7 @@ import {
   type ClientV1SuccessEnvelope,
 } from "./contract.ts";
 import type { ClientV1RateLimitResult } from "./rate-limit.ts";
+import type { ClientV1CompatibilityOverride } from "./conformance-compatibility.ts";
 
 export type ClientV1EnvelopeOptions = {
   capabilities?: readonly ClientV1Capability[];
@@ -39,6 +40,7 @@ export type ClientV1EnvelopeOptions = {
 };
 
 export type ClientV1SuccessResponseOptions = ClientV1EnvelopeOptions & {
+  compatibility?: ClientV1CompatibilityOverride;
   headers?: HeadersInit;
   status?: number;
 };
@@ -202,9 +204,19 @@ export function clientV1SuccessResponse<TData extends ClientV1Record>(
   data: TData,
   options: ClientV1SuccessResponseOptions = {},
 ): Response {
-  const { headers, status = 200, ...envelopeOptions } = options;
+  const { compatibility, headers, status = 200, ...envelopeOptions } = options;
   assertSuccessStatus(status);
-  return Response.json(clientV1Success(data, envelopeOptions), { headers, status });
+  const envelope = clientV1Success(data, envelopeOptions);
+  return Response.json(
+    compatibility
+      ? {
+          ...envelope,
+          apiVersion: compatibility.apiVersion,
+          minimumClientVersion: compatibility.minimumClientVersion,
+        }
+      : envelope,
+    { headers, status },
+  );
 }
 
 export function clientV1ErrorResponse(

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -11,6 +11,10 @@
 // proxy no runtime dependency.
 import { CLIENT_V1_PUBLIC_ROUTES } from "./lib/server/client-v1/contract.ts";
 import { canonicalClientV1Pathname } from "./lib/server/client-v1/canonical-path.ts";
+import {
+  CLIENT_V1_HPKE_HEADERS,
+  CLIENT_V1_HPKE_MECHANISM,
+} from "./lib/server/client-v1/authority-contract.ts";
 
 export function timingSafeEqualString(a: string, b: string) {
   const encoder = new TextEncoder();
@@ -352,6 +356,28 @@ export function presentsClientV1Bearer(headerValue: string | null) {
   return credential.length > 0
     && credential.length <= CLIENT_V1_BEARER_CHARACTERS
     && CLIENT_V1_BEARER_CREDENTIAL.test(credential);
+}
+
+/**
+ * True when the request presents the complete reviewed HPKE-bound header set.
+ *
+ * Like presentsClientV1Bearer, this checks presentation only. The authority
+ * runtime validates every value, opens the ciphertext, and rejects malformed,
+ * stale, replayed, or incorrectly keyed requests before the route runs.
+ */
+export function presentsClientV1BoundAuthority(
+  headers: Pick<Headers, "get">,
+) {
+  if (
+    headers.get(CLIENT_V1_HPKE_HEADERS.mechanism)
+      !== CLIENT_V1_HPKE_MECHANISM
+  ) {
+    return false;
+  }
+  return Object.values(CLIENT_V1_HPKE_HEADERS).every((name) => {
+    const value = headers.get(name);
+    return value !== null && value.length > 0;
+  });
 }
 
 export function clientV1IngressKind(pathname: string): ClientV1IngressKind | null {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -31,6 +31,7 @@ import {
   CLIENT_V1_PUBLIC_INGRESS,
   clientV1IngressKind,
   presentsClientV1Bearer,
+  presentsClientV1BoundAuthority,
   isClientV1AdminPath,
   isClientV1Path,
   isRefusedClientV1Path,
@@ -537,6 +538,7 @@ export async function proxy(req: NextRequest) {
     if (
       clientV1Ingress !== CLIENT_V1_PUBLIC_INGRESS
       && !presentsClientV1Bearer(req.headers.get("authorization"))
+      && !presentsClientV1BoundAuthority(req.headers)
     ) {
       return jsonError(401, "unauthorized");
     }


### PR DESCRIPTION
## Summary
- add build-time-gated Client v1 compatibility presets for API-major and minimum-client rejection
- package controls only through `pnpm build:conformance`; normal production builds bake them off
- preserve exact proxy/authority behavior for HPKE-bound requests and current tokenless loopback administration
- harden the full authority harness so failures cannot be hidden or misattributed

## Invocation contract
- `COVEN_CAVE_CLIENT_V1_COMPATIBILITY_PRESET=api-major node server.mjs` advertises API `2.0`
- `COVEN_CAVE_CLIENT_V1_COMPATIBILITY_PRESET=minimum-client node server.mjs` advertises minimum client `999.0.0`
- unset preserves normal metadata; unknown selectors fail closed with a safe HTTP 500 envelope

## Validation
- full authority matrix: 110 passed, 0 failed, 0 skipped
- Client v1 auth/proxy tests: 37 passed
- conformance unit tests: 66 passed
- `corepack pnpm build:conformance`
- `corepack pnpm lint`
- `corepack pnpm typecheck`
- `node scripts/check-tests-wired.mjs` (1,961 files wired)
- independent review: no significant findings

This producer control is consumed by OpenCoven/chat#30 using the exact packed SDK health operation over fresh isolated Cave processes.