### PR TITLE
fix(client-v1): stabilize conformance packaging

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,9 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "1" || process.env.ANALYZE === "true",
 });
 
+const conformanceBuild =
+  process.env.COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL === "1";
+
 const nextConfig: NextConfig = {
   env: {
     COVEN_CAVE_X_PRODUCTION_CLIENT_ID:
@@ -109,6 +112,12 @@ const nextConfig: NextConfig = {
   // bundle-budget postbuild gate and the e2e suite guard the output.
   reactCompiler: true,
   experimental: {
+    // The conformance artifact is built inside Chat's bounded macOS authority
+    // runner. Keep the production Turbopack compiler, but avoid the PostCSS
+    // child-process IPC path that can time out under that runner's contention.
+    turbopackPluginRuntimeStrategy: conformanceBuild
+      ? "workerThreads"
+      : undefined,
     // Next 16.2 enables Turbopack's persistent dev cache by default. In this
     // app the cache reaches multiple gigabytes, then its SST compaction can
     // starve the PostCSS child-process IPC until Turbopack panics while

--- a/src/lib/server/client-v1/conformance-compatibility.test.ts
+++ b/src/lib/server/client-v1/conformance-compatibility.test.ts
@@ -74,3 +74,26 @@ test("normal builds compile the compatibility control disabled", () => {
     /COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL_ENABLED:\s*[\s\S]*?"0"/,
   );
 });
+
+test("conformance builds keep Turbopack while avoiding plugin process IPC", () => {
+  const script = readFileSync(
+    path.join(process.cwd(), "scripts/build-conformance.mjs"),
+    "utf8",
+  );
+  const manifest = JSON.parse(
+    readFileSync(path.join(process.cwd(), "package.json"), "utf8"),
+  ) as { scripts?: Record<string, string> };
+  const config = readFileSync(
+    path.join(process.cwd(), "next.config.ts"),
+    "utf8",
+  );
+
+  assert.match(script, /\["pnpm@10\.34\.0", "build"\]/);
+  assert.equal(manifest.scripts?.["build:conformance"], "node scripts/build-conformance.mjs");
+  assert.match(manifest.scripts?.build ?? "", /^next build(?:\s|$)/);
+  assert.doesNotMatch(manifest.scripts?.build ?? "", /--webpack/);
+  assert.match(
+    config,
+    /COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL === "1"[\s\S]*?turbopackPluginRuntimeStrategy:\s*conformanceBuild\s*\?\s*"workerThreads"\s*:\s*undefined/,
+  );
+});


### PR DESCRIPTION
Summary: Keep the conformance artifact on the production Turbopack lifecycle, run Turbopack plugins in worker threads only for the explicit Client v1 conformance build, and guard the effective package build command against silently switching to webpack.

Root cause: Chat's bounded macOS real-authority job repeatedly exhausts Turbopack's PostCSS child-process IPC window while packaging Cave. Retries and package-order changes did not alter the failure. The conformance-only worker-thread runtime removes that process IPC boundary without changing the production build command or enabling compatibility controls in ordinary artifacts.

Validation: focused compatibility unit test; clean build:conformance; packaged normal/conformance compatibility integration; typecheck; diff check.