### PR TITLE
fix(client-v1): raise conformance build heap

### DIFF
--- a/scripts/build-conformance.mjs
+++ b/scripts/build-conformance.mjs
@@ -6,6 +6,9 @@ const result = spawnSync("corepack", ["pnpm@10.34.0", "build"], {
   env: {
     ...process.env,
     COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL: "1",
+    // The worker-thread plugin runtime shares one V8 heap. The bounded macOS
+    // authority runner needs an explicit ceiling above Node's default 4 GiB.
+    NODE_OPTIONS: "--max-old-space-size=6144",
   },
   stdio: "inherit",
 });

--- a/src/lib/server/client-v1/conformance-compatibility.test.ts
+++ b/src/lib/server/client-v1/conformance-compatibility.test.ts
@@ -89,6 +89,7 @@ test("conformance builds keep Turbopack while avoiding plugin process IPC", () =
   );
 
   assert.match(script, /\["pnpm@10\.34\.0", "build"\]/);
+  assert.match(script, /NODE_OPTIONS:\s*"--max-old-space-size=6144"/);
   assert.equal(manifest.scripts?.["build:conformance"], "node scripts/build-conformance.mjs");
   assert.match(manifest.scripts?.build ?? "", /^next build(?:\s|$)/);
   assert.doesNotMatch(manifest.scripts?.build ?? "", /--webpack/);


### PR DESCRIPTION
Summary: Give only the explicit Client v1 conformance package a 6 GiB V8 heap. Ordinary production builds remain unchanged. This follows Cave #5181: worker-thread plugins removed the known PostCSS process IPC boundary, and Chat's fixed-vocabulary macOS diagnostic then identified the remaining failure as V8 heap exhaustion.

Validation: focused compatibility unit test; clean build:conformance; packaged normal/conformance compatibility integration; typecheck; diff check; independent code review with no significant findings.