### PR TITLE
fix(ci): serialize main validation runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,12 @@ on:
 # dispatch. The required check can never report while that runs.
 #
 # So a dispatch never cancels: with cancel-in-progress false it QUEUES behind
-# the in-flight run for that head and starts only once the group frees. A push
-# still supersedes its predecessor, which is the behaviour this setting is for.
+# the in-flight run for that head and starts only once the group frees. Every
+# main push shares ci-main and cancels its predecessor, while pull requests and
+# their recovery dispatches continue to share their PR-scoped group.
 concurrency:
-  group: ci-pr-${{ github.event.pull_request.number || inputs.expected_pr_number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' && github.ref != 'refs/heads/main' }}
+  group: ci-${{ github.event_name == 'push' && 'main' || format('pr-{0}', github.event.pull_request.number || inputs.expected_pr_number || github.run_id) }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 permissions:
   contents: read

--- a/scripts/ci-recovery-workflow.test.mjs
+++ b/scripts/ci-recovery-workflow.test.mjs
@@ -175,20 +175,22 @@ assert.deepEqual(ciWorkflow.on.workflow_dispatch, {
 });
 assert.equal(
   ciWorkflow.concurrency.group,
-  "ci-pr-${{ github.event.pull_request.number || inputs.expected_pr_number || github.run_id }}",
-  "each pull request and its recovery dispatch must share one concurrency key",
+  "ci-${{ github.event_name == 'push' && 'main' || format('pr-{0}', github.event.pull_request.number || inputs.expected_pr_number || github.run_id) }}",
+  "main pushes must share one key while each pull request and its recovery dispatch share a PR-scoped key",
 );
-// Sharing the key is deliberate; CANCELLING across it is not. A dispatch
-// resolves to the same group as the run it is rescuing, so with a blanket
-// cancel-in-progress it kills that run and the required check never reports —
-// observed on #4618, where one head collected three cancelled runs and no
-// verdict, each cancellation feeding ci-recovery's `cancelled_latest_run`
-// wedge test and provoking the next dispatch (cave-f22tp). Excluded from
-// cancellation, a dispatch queues behind the in-flight run instead.
+// Main pushes share a constant key and cancel stale predecessors. Sharing the
+// PR key is also deliberate, but CANCELLING from a recovery dispatch is not: a
+// dispatch resolves to the same group as the run it is rescuing, so with a
+// blanket cancel-in-progress it kills that run and the required check never
+// reports — observed on #4618, where one head collected three cancelled runs
+// and no verdict, each cancellation feeding ci-recovery's
+// `cancelled_latest_run` wedge test and provoking the next dispatch
+// (cave-f22tp). Excluded from cancellation, a dispatch queues behind the
+// in-flight run instead.
 assert.equal(
   ciWorkflow.concurrency["cancel-in-progress"],
-  "${{ github.event_name != 'workflow_dispatch' && github.ref != 'refs/heads/main' }}",
-  "a recovery dispatch must never cancel the run it exists to rescue",
+  "${{ github.event_name != 'workflow_dispatch' }}",
+  "a main push must cancel its predecessor while a recovery dispatch never cancels the run it exists to rescue",
 );
 const expectedSubordinateJobGuards = {
   paths: "github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha",


### PR DESCRIPTION
## Summary

- serialize `main` push validation in one `ci-main` concurrency group
- cancel superseded `main` runs while preserving PR/recovery pairing
- pin the workflow contract so `main-health` cancellation semantics cannot drift again

## Why

Six merges landed within one minute, but every `main` push fell back to a unique `github.run_id` group and `cancel-in-progress` explicitly excluded `main`. That launched six full CI suites concurrently; repeated shard-3 runner shutdowns then left `main` red even though the merged product checks were green.

Fixes #5183.

Bead: `cave-wi81e`

## Verification

- `node scripts/ci-recovery-workflow.test.mjs`
- `node --test scripts/main-health.test.mjs` — 18/18 passed
- `node scripts/main-health-workflow.test.mjs`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` — 1,975 files wired
- `pnpm build` — production build, bundle budget, and standalone budget passed
- `git diff --check`

Host-limited broad-suite attempts were also made. `pnpm test:app` stopped after 64 passing files on the known Windows fake-`bd.cmd` `spawnSync EINVAL` fixture limitation. `pnpm test:api` stopped after three passing files because WSL `bash.exe` could not resolve `node`. Neither failure touched the scoped workflow contract; Linux PR CI is the authoritative broad gate.