### PR TITLE
test: stabilize semantic cleanup and Grimoire E2E

### DIFF
--- a/src/lib/server/research-resource-semantic.test.ts
+++ b/src/lib/server/research-resource-semantic.test.ts
@@ -44,7 +44,14 @@ async function fixture(
   try { await operation(input); } finally {
     input.lexical.close();
     input.semanticIndex.close();
-    await rm(input.root, { recursive: true, force: true });
+    // Multi-process lock cleanup may finish asynchronously after the child exits.
+    // Give recursive removal bounded retries without hiding persistent fixture leaks.
+    await rm(input.root, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 100,
+    });
   }
 }
 

--- a/tests/grimoire-autosave.spec.ts
+++ b/tests/grimoire-autosave.spec.ts
@@ -60,6 +60,21 @@ const MEMORY_ENTRY = {
 
 const JOURNAL_DAY = "2026-07-01";
 
+const EMPTY_RUNNING_ACTIVITY = {
+  ok: true,
+  generatedAt: "2026-07-01T00:00:00.000Z",
+  total: 0,
+  items: [],
+  sources: {
+    sessions: { ok: true, count: 0 },
+    board: { ok: true, count: 0 },
+    automations: { ok: true, count: 0 },
+    flows: { ok: true, count: 0 },
+    workflows: { ok: true, count: 0 },
+  },
+  unavailable: [],
+} as const;
+
 async function gotoGrimoire(page: Page, readyTimeout = 60_000) {
   await page.addInitScript(() => {
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
@@ -67,6 +82,10 @@ async function gotoGrimoire(page: Page, readyTimeout = 60_000) {
     // through the same updateRaw → debounce → save pipeline as VISUAL mode,
     // without Milkdown's cold-compile flake.
     window.localStorage.setItem("cave:md-editor:mode", "markdown");
+  });
+  await page.route(/\/api\/running-activity(?:\?.*)?$/, (route) => {
+    expect(route.request().method()).toBe("GET");
+    return route.fulfill({ json: EMPTY_RUNNING_ACTIVITY });
   });
   await page.route("**/api/familiars**", (route) =>
     route.fulfill({ json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", status: "active" }] } }),


### PR DESCRIPTION
## Summary

- retry semantic fixture-root removal when asynchronous intent cleanup briefly leaves the directory non-empty
- bound recursive removal to ten 100 ms retries so persistent fixture leaks still fail
- complete the Grimoire E2E daemon-less mock envelope for `GET /api/running-activity`
- leave production cleanup, running-activity, and timeout behavior unchanged

## Why

Main CI run `33275969875` exposed a transient `ENOTEMPTY` teardown race after the eight-child semantic reconciliation test had passed its functional assertions. The lock can finish unlink work just after a child exits, while Node recursive removal otherwise performs no retries.

Fresh CI on this PR then consistently reached `tests/grimoire-autosave.spec.ts` after a web-server reset and timed out waiting for `.grimoire-view`. The always-mounted running-activity popover added a daemon-backed request that this fixture's otherwise complete API mocks did not intercept. The repair installs a schema-valid empty response before navigation, preventing five daemon fan-outs without weakening assertions or raising timeouts.

Addresses the recurring failure observed in #5186. Main-health already closed that tracker after a separate green rerun, so this PR deliberately does not auto-close it.

Beads: `cave-0zgch`, `cave-ljf4m`

## Verification

- full `tests/grimoire-autosave.spec.ts` desktop file: 10/10 passed
- failing Grimoire sequence repeated three times: 10/10 passed including dependencies
- exact CI E2E shard 3/8 with one worker: 51/51 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` — all 1,975 test files wired
- `pnpm build` — production build and budgets passed
- semantic cleanup is covered by fresh Ubuntu PR CI; the focused Windows runner reaches the repository's known directory-`fsync` `EPERM` host boundary first
- `pnpm test:app` — 64 files passed before the known Windows fake-`bd.cmd` `spawnSync EINVAL` boundary
- `pnpm test:api` — 3 files passed before WSL Bash could not resolve `node` (`status 127`)