### PR TITLE
fix(settings): show installed Coven version on Windows

### DIFF
--- a/src/lib/coven-version.test.ts
+++ b/src/lib/coven-version.test.ts
@@ -1,11 +1,16 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 
-const { displayCovenVersion, exactSemver, firstSemver } = await import("./coven-version.ts");
+const { covenVersionFromOutput, displayCovenVersion, exactSemver, firstSemver } = await import("./coven-version.ts");
 
 assert.equal(firstSemver("coven 0.0.39\n"), "0.0.39");
 assert.equal(firstSemver("v1.2.3-beta.1"), "1.2.3-beta.1");
 assert.equal(firstSemver("no version here"), null);
+assert.equal(
+  covenVersionFromOutput("coven 0.4.1\n", "warning: dependency 0.2.5 is deprecated\n"),
+  "0.4.1",
+  "CLI stdout must win when stderr mentions another version",
+);
 
 assert.equal(exactSemver("v1.2.3-beta.1+build.7"), "1.2.3-beta.1+build.7");
 assert.equal(exactSemver(" 0.0.54 "), "0.0.54");
@@ -26,8 +31,32 @@ for (const unsafeVersion of [
 
 assert.equal(
   displayCovenVersion({ daemonVersion: "0.0.40", installedVersion: "0.0.39" }),
-  "0.0.40",
-  "non-placeholder daemon health versions should win",
+  "0.0.39",
+  "the verified installed CLI version should win over a stale local daemon",
+);
+
+assert.equal(
+  displayCovenVersion({ daemonVersion: "0.2.5", installedVersion: "0.4.1" }),
+  "0.4.1",
+  "Windows Settings must show the installed Coven version after a CLI update",
+);
+
+assert.equal(
+  displayCovenVersion({ daemonVersion: "0.4.1", installedVersion: null }),
+  "0.4.1",
+  "a daemon version remains the fallback when installed discovery is unavailable",
+);
+
+assert.equal(
+  displayCovenVersion({ daemonVersion: "0.4.1", installedVersion: "0.0.0" }),
+  "0.4.1",
+  "an installed placeholder must not hide a valid daemon version",
+);
+
+assert.equal(
+  displayCovenVersion({ daemonVersion: "0.0.0", installedVersion: "0.0.0" }),
+  undefined,
+  "placeholder versions must not be displayed",
 );
 
 assert.equal(

--- a/src/lib/coven-version.ts
+++ b/src/lib/coven-version.ts
@@ -12,6 +12,11 @@ export function firstSemver(text: string): string | null {
   return match?.[1] ?? null;
 }
 
+/** Prefer the CLI's stdout when stderr contains an unrelated version string. */
+export function covenVersionFromOutput(stdout: string, stderr: string): string | null {
+  return firstSemver(stdout) ?? firstSemver(stderr);
+}
+
 export function displayCovenVersion({
   daemonVersion,
   installedVersion,
@@ -19,9 +24,17 @@ export function displayCovenVersion({
   daemonVersion?: string;
   installedVersion: string | null;
 }): string | undefined {
+  // On a local desktop, the daemon can be an older process left running
+  // across a Coven CLI update. Settings describes the installed CLI the user
+  // will launch next, so prefer that verified version whenever discovery found
+  // one. Hub responses have no installedVersion and continue to display the
+  // version reported by the remote daemon.
+  const installed = exactSemver(installedVersion);
+  if (installed && installed !== "0.0.0") return installed;
+
   const daemon = exactSemver(daemonVersion);
   if (daemon && daemon !== "0.0.0") return daemon;
-  return exactSemver(installedVersion) ?? undefined;
+  return undefined;
 }
 
 export async function installedCovenVersion(): Promise<string | null> {
@@ -32,7 +45,7 @@ export async function installedCovenVersion(): Promise<string | null> {
       env: covenWrapperSpawnEnv(),
       timeout: 2500,
     });
-    return firstSemver(`${stdout}\n${stderr}`);
+    return covenVersionFromOutput(stdout, stderr);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- prefer the verified installed Coven CLI version for local desktop Settings
- keep the daemon version as the fallback for hub status and unavailable CLI discovery
- prefer CLI stdout over unrelated stderr version text and reject `0.0.0` placeholders

Fixes #5188
Bead: cave-qbigx

## Verification
- `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/lib/coven-version.test.ts`
- `pnpm exec eslint src/lib/coven-version.ts src/lib/coven-version.test.ts --max-warnings=0`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:tests-wired`
