### PR TITLE
Redesign the Research Reader around Evidence Edge

### DIFF
--- a/docs/superpowers/plans/2026-08-29-research-reader-evidence-edge.md
+++ b/docs/superpowers/plans/2026-08-29-research-reader-evidence-edge.md
@@ -1,0 +1,1048 @@
+# Research Reader Evidence Edge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the Research Reader as a reading-first Apple/OpenAI hybrid with explicit evidence integrity, faithful document structure, claim-aligned provenance, and an on-demand evidence inspector.
+
+**Architecture:** Keep `parseFindingsDoc` as the document authority, add a separate pure integrity model, and make Research Reader opt into new shared-reader capabilities without changing Memories behavior. Render every reference-bearing block as a structural content-plus-provenance row, then synchronize those anchors with one unified inspector containing every real ledger source.
+
+**Tech Stack:** Next.js 16.3, React 19, TypeScript 6, CSS container queries and semantic tokens, Node test runner, React server rendering tests, Playwright.
+
+---
+
+## File map
+
+### Create
+
+- `src/lib/research-findings-integrity.ts` — strict bracketed-reference scanner and lifecycle-independent evidence integrity summary.
+- `src/lib/research-findings-integrity.test.ts` — integrity precedence, false-positive, candidate, conflict, and unavailable-ledger coverage.
+- `src/components/role-surfaces/research-evidence-inspector.tsx` — unified source cards for every ledger entry.
+- `src/components/role-surfaces/research-provenance-edge.tsx` — claim-aligned source clusters with roving keyboard focus.
+- `src/components/role-surfaces/research-evidence-components.test.ts` — server-rendered inspector and provenance semantics.
+
+### Modify
+
+- `src/lib/research-findings-doc.ts` — stable block/item/row IDs, ordered lists, quotations, and block-level support targets.
+- `src/lib/research-findings-doc.test.ts` — parser and support-target tests.
+- `src/components/document-reader.tsx` — optional mission context, non-collapsible sections, active-section callback, and target scrolling.
+- `src/components/document-reader-view.test.ts` — shared-reader opt-in behavior without changing existing defaults.
+- `src/components/role-surfaces/research-reader.tsx` — reading-first chrome, integrity state, Evidence Edge composition, hidden-by-default panels, and synchronization.
+- `src/components/role-surfaces/research-reader-shared.test.ts` — static architecture assertions for the new components and defaults.
+- `src/styles/research-reader.css` — component-scoped reader plane, provenance grid, inspector, responsive sheets, contrast, and motion.
+- `tests/research-reader.spec.ts` — end-to-end default hierarchy, source synchronization, missing-ledger integrity, keyboard, and responsive behavior.
+
+## Task 1: Evidence integrity model
+
+**Files:**
+- Create: `src/lib/research-findings-integrity.ts`
+- Create: `src/lib/research-findings-integrity.test.ts`
+
+- [ ] **Step 1: Write the failing integrity tests**
+
+Create `src/lib/research-findings-integrity.test.ts` with cases for bracketed
+source groups, ordinary bare text, empty ledgers, partially missing ledgers,
+conflicts, candidates, verified sources, and no-reference documents:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ResearchSourceRef } from "./research-missions.ts";
+import {
+  deriveResearchFindingsIntegrity,
+  scanBracketedSourceIds,
+} from "./research-findings-integrity.ts";
+
+const source = (
+  id: string,
+  status: ResearchSourceRef["status"],
+): ResearchSourceRef => ({
+  id,
+  title: `${id} title`,
+  sourceType: "web",
+  status,
+});
+
+test("scanner accepts explicit bracketed source groups only", () => {
+  assert.deepEqual(
+    scanBracketedSourceIds("See [S1], [S4, S5], and [R2]."),
+    ["S1", "S4", "S5", "R2"],
+  );
+  assert.deepEqual(
+    scanBracketedSourceIds("model S1 and S3 bucket are prose"),
+    [],
+  );
+});
+
+test("empty ledger with bracketed sources is unavailable", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "Claim [S1]. Conflict C2.",
+    [],
+  );
+  assert.equal(integrity.ledger, "empty");
+  assert.deepEqual(integrity.unresolvedIds, ["S1"]);
+  assert.deepEqual(integrity.conflictIds, ["C2"]);
+  assert.deepEqual(integrity.summary, {
+    kind: "unavailable",
+    label: "Sources unavailable — references can't be verified",
+  });
+});
+
+test("unresolved references outrank conflicts and candidates", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "Claim [S1] [S9]. Conflict C1.",
+    [source("S1", "candidate")],
+  );
+  assert.deepEqual(integrity.unresolvedIds, ["S9"]);
+  assert.equal(integrity.summary.kind, "unresolved");
+});
+
+test("candidate entries remain distinct from verified sources", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "Claim [S1] [S2].",
+    [source("S1", "used"), source("S2", "candidate")],
+  );
+  assert.deepEqual(integrity.counts, {
+    used: 1,
+    candidate: 1,
+    conflicting: 0,
+    rejected: 0,
+  });
+  assert.deepEqual(integrity.summary, {
+    kind: "candidate",
+    label: "1 source awaits review",
+  });
+});
+
+test("documents without citations report no references", () => {
+  const integrity = deriveResearchFindingsIntegrity("Plain prose.", []);
+  assert.equal(integrity.summary.kind, "none");
+});
+```
+
+- [ ] **Step 2: Run the integrity test and verify failure**
+
+Run:
+
+```bash
+node --test src/lib/research-findings-integrity.test.ts
+```
+
+Expected: failure because `research-findings-integrity.ts` does not exist.
+
+- [ ] **Step 3: Implement the pure integrity model**
+
+Create `src/lib/research-findings-integrity.ts` with this public contract:
+
+```ts
+import type { ResearchSourceRef } from "./research-missions.ts";
+
+export type ResearchIntegritySummaryKind =
+  | "unavailable"
+  | "unresolved"
+  | "conflicting"
+  | "candidate"
+  | "verified"
+  | "none";
+
+export type ResearchFindingsIntegrity = {
+  ledger: "available" | "empty";
+  referencedIds: string[];
+  unresolvedIds: string[];
+  conflictIds: string[];
+  counts: Record<ResearchSourceRef["status"], number>;
+  summary: {
+    kind: ResearchIntegritySummaryKind;
+    label: string;
+  };
+};
+
+const BRACKETED_SOURCE_GROUP_RE =
+  /\[((?:[SR]\d+\s*)(?:,\s*[SR]\d+\s*)*)\]/g;
+const SOURCE_ID_RE = /[SR]\d+/g;
+const CONFLICT_ID_RE = /\bC\d+\b/g;
+
+export function scanBracketedSourceIds(markdown: string): string[] {
+  const ids: string[] = [];
+  for (
+    let match = BRACKETED_SOURCE_GROUP_RE.exec(markdown);
+    match;
+    match = BRACKETED_SOURCE_GROUP_RE.exec(markdown)
+  ) {
+    for (const id of match[1].match(SOURCE_ID_RE) ?? []) {
+      if (!ids.includes(id)) ids.push(id);
+    }
+  }
+  return ids;
+}
+
+export function deriveResearchFindingsIntegrity(
+  markdown: string,
+  sources: ResearchSourceRef[],
+): ResearchFindingsIntegrity {
+  // Count ledger statuses, compare explicit bracketed IDs with real rows, keep
+  // C# conflict markers independent, then apply the precedence from the spec.
+}
+```
+
+Implement singular/plural labels exactly:
+
+- `Sources unavailable — references can't be verified`
+- `1 reference is unresolved` / `N references are unresolved`
+- `1 conflict remains` / `N conflicts remain`
+- `1 source awaits review` / `N sources await review`
+- `1 source verified` / `N sources verified`
+- `This report does not cite sources`
+
+- [ ] **Step 4: Run the integrity tests**
+
+Run:
+
+```bash
+node --test src/lib/research-findings-integrity.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit the integrity model**
+
+```bash
+git add src/lib/research-findings-integrity.ts src/lib/research-findings-integrity.test.ts
+git commit -m "feat(research): model findings evidence integrity (cave-6gcw8)"
+```
+
+## Task 2: Structured findings blocks and support targets
+
+**Files:**
+- Modify: `src/lib/research-findings-doc.ts`
+- Modify: `src/lib/research-findings-doc.test.ts`
+
+- [ ] **Step 1: Add failing parser tests**
+
+Extend `src/lib/research-findings-doc.test.ts` with:
+
+```ts
+test("ordered lists and quotations retain block identity", () => {
+  const doc = parseFindingsDoc(`# Findings
+
+## Evidence
+
+1. First claim [S1]
+2. Second claim S14
+
+> Signed does not mean verified [S6].
+`, SOURCES);
+  const evidence = doc.sections[0];
+  assert.equal(evidence.blocks[0].kind, "ol");
+  assert.equal(evidence.blocks[1].kind, "quote");
+  assert.ok(evidence.blocks[0].id.startsWith("s-evidence-block-"));
+  assert.deepEqual(evidence.blocks[0].refIds, ["S1", "S14"]);
+  assert.deepEqual(evidence.blocks[1].refIds, ["S6"]);
+});
+
+test("list items and table rows expose their own reference ids", () => {
+  const doc = parseFindingsDoc(FINDINGS, SOURCES);
+  const questions = doc.sections.find(
+    (section) => section.heading === "Open questions",
+  );
+  const list = questions?.blocks.find((block) => block.kind === "ul");
+  assert.ok(list?.kind === "ul");
+  assert.deepEqual(list.items[0].refIds, ["C1"]);
+
+  const results = doc.sections.find(
+    (section) => section.heading === "Key results",
+  );
+  const table = results?.blocks.find((block) => block.kind === "table");
+  assert.ok(table?.kind === "table");
+  assert.deepEqual(table.rows[0].refIds, ["S14"]);
+});
+
+test("support targets include overview, lede, list items, and table rows", () => {
+  const doc = parseFindingsDoc(`# Findings
+
+> Question [S1]
+
+Overview [S1].
+
+## Results
+
+- Claim [S1]
+`, SOURCES);
+  assert.deepEqual(
+    targetsSupportingRef(doc, "S1").map((target) => target.label),
+    ["Research question", "Overview", "Results · item 1"],
+  );
+});
+```
+
+Update imports to replace `sectionsSupportingRef` with
+`targetsSupportingRef`.
+
+- [ ] **Step 2: Run the parser tests and verify failure**
+
+Run:
+
+```bash
+node --test src/lib/research-findings-doc.test.ts
+```
+
+Expected: failures because blocks do not have IDs/ref IDs, ordered lists and
+quotes are flattened, and `targetsSupportingRef` is undefined.
+
+- [ ] **Step 3: Extend the findings types**
+
+Change the public shapes in `src/lib/research-findings-doc.ts`:
+
+```ts
+export type FindingsListItem = {
+  id: string;
+  spans: FindingsSpan[];
+  refIds: string[];
+};
+
+export type FindingsTableRow = {
+  id: string;
+  cells: FindingsSpan[][];
+  refIds: string[];
+};
+
+type FindingsBlockBase = {
+  id: string;
+  refIds: string[];
+};
+
+export type FindingsBlock =
+  | (FindingsBlockBase & { kind: "p"; spans: FindingsSpan[] })
+  | (FindingsBlockBase & {
+      kind: "ul" | "ol";
+      items: FindingsListItem[];
+    })
+  | (FindingsBlockBase & {
+      kind: "quote";
+      spans: FindingsSpan[];
+    })
+  | (FindingsBlockBase & {
+      kind: "table";
+      header: FindingsSpan[][];
+      rows: FindingsTableRow[];
+    })
+  | (FindingsBlockBase & {
+      kind: "code";
+      language: string;
+      code: string;
+    });
+
+export type FindingsSupportTarget = {
+  id: string;
+  label: string;
+  sectionId: string | null;
+};
+```
+
+- [ ] **Step 4: Implement stable parsing**
+
+Update `parseBlocks` to accept an ID prefix:
+
+```ts
+function parseBlocks(
+  lines: string[],
+  resolver: RefResolver,
+  idPrefix: string,
+): FindingsBlock[]
+```
+
+Use a local monotonic block index. Create IDs such as
+`${idPrefix}-block-${blockIndex + 1}`, item IDs such as
+`${blockId}-item-${itemIndex + 1}`, and table-row IDs such as
+`${blockId}-row-${rowIndex + 1}`.
+
+Add:
+
+```ts
+const ORDERED_LIST_RE = /^\s*\d+[.)]\s+(.+)$/;
+const QUOTE_RE = /^\s*>\s?(.*)$/;
+```
+
+Consecutive ordered items form one `ol`. Consecutive quote lines form one
+`quote` whose spans join with a space. Code blocks always use `refIds: []`.
+
+The preamble uses prefix `s-overview`; each named group uses its section slug.
+When the first preamble block is a quote, move its spans to `doc.lede` and
+retain its stable target identity as `doc.ledeId = "research-question"`.
+
+- [ ] **Step 5: Replace section-only supports**
+
+Add `ledeId: string | null` to `FindingsDoc` and implement:
+
+```ts
+export function targetsSupportingRef(
+  doc: FindingsDoc,
+  id: string,
+): FindingsSupportTarget[] {
+  const targets: FindingsSupportTarget[] = [];
+  if (doc.lede && doc.refIds.includes(id)) {
+    // Check the lede spans directly before adding Research question.
+  }
+  // Add paragraph/quote blocks, individual list items, and individual table
+  // rows. Use the section heading, "Overview", "item N", and "row N" labels.
+  return targets;
+}
+```
+
+Do not emit both a parent block and its child list/table targets for the same
+reference.
+
+- [ ] **Step 6: Run parser tests**
+
+Run:
+
+```bash
+node --test src/lib/research-findings-doc.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit structured findings**
+
+```bash
+git add src/lib/research-findings-doc.ts src/lib/research-findings-doc.test.ts
+git commit -m "feat(research): preserve findings claim structure (cave-6gcw8)"
+```
+
+## Task 3: Shared DocumentReader opt-ins
+
+**Files:**
+- Modify: `src/components/document-reader.tsx`
+- Modify: `src/components/document-reader-view.test.ts`
+
+- [ ] **Step 1: Write failing shared-reader tests**
+
+Extend `src/components/document-reader-view.test.ts`:
+
+```ts
+test("sections can render as headings without disclosure buttons", () => {
+  const document = documentWith(["First section", "Second section"]);
+  const markup = renderToStaticMarkup(
+    createElement(DocumentReader<Block, Block>, {
+      document,
+      navigation: "compact",
+      collapsibleSections: false,
+      renderLede: (lede) =>
+        createElement(MarkdownReaderBlock, {
+          block: lede,
+          blockKey: "lede",
+        }),
+      renderBlock: (block, key) =>
+        createElement(MarkdownReaderBlock, {
+          block,
+          blockKey: key,
+        }),
+    }),
+  );
+  assert.match(markup, /<h2[^>]*>First section<\/h2>/);
+  assert.doesNotMatch(markup, /aria-expanded=/);
+});
+
+test("context renders between title and lede", () => {
+  const document = documentWith(["Section"]);
+  const markup = renderToStaticMarkup(
+    createElement(DocumentReader<Block, Block>, {
+      document,
+      navigation: "compact",
+      context: createElement("p", null, "Mission intent"),
+      renderLede: (lede) =>
+        createElement(MarkdownReaderBlock, {
+          block: lede,
+          blockKey: "lede",
+        }),
+      renderBlock: (block, key) =>
+        createElement(MarkdownReaderBlock, {
+          block,
+          blockKey: key,
+        }),
+    }),
+  );
+  assert.match(
+    markup,
+    /document-reader__title[\s\S]*document-reader__context[\s\S]*document-reader__lede/,
+  );
+});
+```
+
+Add an active-section callback assertion using the source-level static test if
+the current server-render harness cannot trigger scroll.
+
+- [ ] **Step 2: Run the shared-reader tests and verify failure**
+
+Run:
+
+```bash
+pnpm exec vitest run src/components/document-reader-view.test.ts
+```
+
+Expected: failure because `collapsibleSections`, `context`, and target scrolling
+are not supported.
+
+- [ ] **Step 3: Add opt-in props without changing defaults**
+
+Extend `DocumentReaderProps`:
+
+```ts
+context?: ReactNode;
+collapsibleSections?: boolean;
+onActiveSectionChange?: (section: { id: string; heading: string } | null) => void;
+```
+
+Default `collapsibleSections = true`. Render `context` after the title and before
+the lede. When non-collapsible, render the heading text directly and always
+render the section body.
+
+Extend `DocumentReaderApi`:
+
+```ts
+export type DocumentReaderApi = {
+  scrollToSection: (id: string) => void;
+  scrollToTarget: (id: string, focus?: boolean) => void;
+};
+```
+
+`scrollToTarget` queries `[data-document-target="${CSS.escape(id)}"]`, scrolls
+with reduced-motion awareness, and focuses the target on the next animation
+frame when requested.
+
+Call `onActiveSectionChange` whenever scroll-spy changes the active section and
+after document reset.
+
+- [ ] **Step 4: Add context styling**
+
+In `src/styles/document-reader.css`, add only shared semantic structure:
+
+```css
+.document-reader__context {
+  margin: calc(-1 * var(--space-2)) 0 var(--space-4);
+  color: var(--text-secondary);
+  font-size: calc(var(--text-lg) * var(--reader-text-scale));
+  line-height: var(--cave-reading-leading, 1.6);
+}
+```
+
+Do not add Evidence Edge or Research-specific panel rules to this global sheet.
+
+- [ ] **Step 5: Run shared reader tests**
+
+Run:
+
+```bash
+pnpm exec vitest run \
+  src/components/document-reader-view.test.ts \
+  src/components/document-reader-text-size.test.ts
+```
+
+Expected: all tests pass and existing rail/compact behavior remains unchanged.
+
+- [ ] **Step 6: Commit shared opt-ins**
+
+```bash
+git add src/components/document-reader.tsx src/components/document-reader-view.test.ts src/styles/document-reader.css
+git commit -m "feat(reader): add composed document opt-ins (cave-6gcw8)"
+```
+
+## Task 4: Provenance Edge and unified evidence inspector
+
+**Files:**
+- Create: `src/components/role-surfaces/research-provenance-edge.tsx`
+- Create: `src/components/role-surfaces/research-evidence-inspector.tsx`
+- Create: `src/components/role-surfaces/research-evidence-components.test.ts`
+
+- [ ] **Step 1: Write failing component tests**
+
+Create `research-evidence-components.test.ts` using `createElement`,
+`react-dom/server`, and Vitest:
+
+```ts
+import assert from "node:assert/strict";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { test } from "vitest";
+import { ResearchProvenanceEdge } from "./research-provenance-edge.tsx";
+import { ResearchEvidenceInspector } from "./research-evidence-inspector.tsx";
+
+test("provenance edge exposes one labelled control per source", () => {
+  const html = renderToStaticMarkup(
+    createElement(ResearchProvenanceEdge, {
+      ids: ["S1", "C1"],
+      selectedId: null,
+      toneForId: (id) => id === "C1" ? "warn" : "accent",
+      onPreview: () => {},
+      onSelect: () => {},
+    }),
+  );
+  assert.match(html, /aria-label="Open evidence S1"/);
+  assert.match(html, /aria-label="Open conflict C1"/);
+});
+
+test("inspector renders candidate and sparse sources as full cards", () => {
+  const html = renderToStaticMarkup(
+    createElement(ResearchEvidenceInspector, {
+      sources: [
+        {
+          id: "S2",
+          title: "Sparse source",
+          sourceType: "web",
+          status: "candidate",
+        },
+      ],
+      integrityLabel: "1 source awaits review",
+      selectedId: "S2",
+      openIds: new Set(["S2"]),
+      targetsBySource: new Map(),
+      onToggle: () => {},
+      onOpenUrl: () => {},
+      onCite: () => {},
+      onSupport: () => {},
+      onClose: () => {},
+    }),
+  );
+  assert.match(html, /Sparse source/);
+  assert.match(html, /Candidate/);
+});
+```
+
+- [ ] **Step 2: Run the component tests and verify failure**
+
+Run:
+
+```bash
+pnpm exec vitest run src/components/role-surfaces/research-evidence-components.test.ts
+```
+
+Expected: failure because both components are missing.
+
+- [ ] **Step 3: Implement `ResearchProvenanceEdge`**
+
+Public props:
+
+```ts
+type ResearchProvenanceEdgeProps = {
+  ids: string[];
+  selectedId: string | null;
+  toneForId: (id: string) => "accent" | "warn" | "muted" | "unresolved";
+  onPreview: (id: string | null, element?: HTMLElement) => void;
+  onSelect: (id: string) => void;
+};
+```
+
+Render nothing for an empty ID list. Otherwise render a labelled group with one
+button per ID. Use roving `tabIndex`, ArrowUp/ArrowLeft and
+ArrowDown/ArrowRight, Home, and End. Arrow keys move focus and call `onPreview`;
+click or Enter calls `onSelect`. `C#` buttons use conflict copy and warning
+tone; all other IDs use evidence copy and their status tone supplied later by
+the reader.
+
+- [ ] **Step 4: Implement `ResearchEvidenceInspector`**
+
+Move source-card rendering out of `research-reader.tsx`. Render every source in
+mission order grouped by status priority:
+
+1. used
+2. candidate
+3. conflicting
+4. rejected
+
+Keep real source fields and actions only. Props carry selected ID, open IDs,
+support targets, and callbacks. The inspector header includes its source count,
+the primary integrity label, and a close button with visible focus.
+
+- [ ] **Step 5: Run component tests**
+
+Run:
+
+```bash
+pnpm exec vitest run src/components/role-surfaces/research-evidence-components.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit evidence components**
+
+```bash
+git add \
+  src/components/role-surfaces/research-provenance-edge.tsx \
+  src/components/role-surfaces/research-evidence-inspector.tsx \
+  src/components/role-surfaces/research-evidence-components.test.ts
+git commit -m "feat(research): add Evidence Edge components (cave-6gcw8)"
+```
+
+## Task 5: Recompose Research Reader
+
+**Files:**
+- Modify: `src/components/role-surfaces/research-reader.tsx`
+- Modify: `src/components/role-surfaces/research-reader-shared.test.ts`
+
+- [ ] **Step 1: Update static architecture assertions**
+
+Replace assertions tied to expanded permanent rail behavior with:
+
+```ts
+assert.match(
+  source,
+  /useState\(false\)[\s\S]*?setTocOn/,
+  "contents are hidden by default",
+);
+assert.match(
+  source,
+  /useState\(false\)[\s\S]*?setInspectorOn/,
+  "the full evidence inspector is hidden by default",
+);
+assert.match(source, /deriveResearchFindingsIntegrity/);
+assert.match(source, /<ResearchProvenanceEdge/);
+assert.match(source, /<ResearchEvidenceInspector/);
+assert.match(source, /collapsibleSections=\{false\}/);
+assert.match(source, /context=\{/);
+```
+
+Retain the existing assertions that Mermaid uses `MarkdownBlock`, secondary
+actions use `OverflowMenu`, and medium/narrow inspector layouts exist.
+
+- [ ] **Step 2: Run the static test and verify failure**
+
+Run:
+
+```bash
+node src/components/role-surfaces/research-reader-shared.test.ts
+```
+
+Expected: failure against the old expanded reader and embedded evidence cards.
+
+- [ ] **Step 3: Replace expanded mode with reading-first state**
+
+In `ResearchReader`:
+
+```ts
+const [tocOn, setTocOn] = useState(false);
+const [inspectorOn, setInspectorOn] = useState(false);
+const [selectedSourceId, setSelectedSourceId] = useState<string | null>(null);
+const [activeSection, setActiveSection] =
+  useState<{ id: string; heading: string } | null>(null);
+```
+
+Remove `expanded`, the expand/collapse button, and the progress-only-in-expanded
+condition. Keep the reader as one large native panel with a centered document
+plane.
+
+Derive integrity:
+
+```ts
+const integrity = useMemo(
+  () => deriveResearchFindingsIntegrity(markdown ?? "", mission.sources),
+  [markdown, mission.sources],
+);
+```
+
+Display lifecycle and integrity separately in the top chrome. The compact title
+uses `doc.title ?? artifact.title`; the current section appears after it when
+available.
+
+- [ ] **Step 4: Render structured block rows**
+
+Render each block with `data-document-target={block.id}` and a sibling
+`ResearchProvenanceEdge`.
+
+Required shapes:
+
+```tsx
+<div className="rr-block-row" data-document-target={block.id} tabIndex={-1}>
+  <p>{renderSpans(block.spans, key)}</p>
+  <ResearchProvenanceEdge ids={block.refIds} ... />
+</div>
+```
+
+For list blocks, each `<li>` is its own `.rr-list-row` with its item ID and
+source edge. For tables, add an Evidence header cell and one provenance cell per
+row. Quote blocks render `<blockquote>`.
+
+Inline `.rr-sref` buttons remain in the spans for compact layouts. CSS hides
+them when the provenance edge is visible and hides edge controls when inline
+references are active.
+
+- [ ] **Step 5: Synchronize sources and support targets**
+
+Selecting an inline or edge reference:
+
+1. sets `selectedSourceId`
+2. opens the inspector
+3. opens the matching card
+4. announces `Opened evidence S1.` or `Opened conflict C1.`
+
+Inspector `Supports` uses `DocumentReaderApi.scrollToTarget(target.id, true)`.
+Hover/focus preview does not announce.
+
+- [ ] **Step 6: Use the shared reader opt-ins**
+
+Compose:
+
+```tsx
+<DocumentReader
+  document={doc}
+  navigation={tocOn ? "rail" : "compact"}
+  kicker={titleCase(artifact.kind)}
+  context={mission.intent ? (
+    <p title={mission.intent}>{mission.intent}</p>
+  ) : null}
+  collapsibleSections={false}
+  apiRef={documentReaderApiRef}
+  onActiveSectionChange={setActiveSection}
+  renderLede={(lede) => renderSpans(lede, "lede")}
+  renderBlock={renderBlock}
+/>
+```
+
+Top-bar Contents toggles `tocOn`. Evidence toggles `inspectorOn`. On medium
+widths the existing container-query behavior overlays panels instead of
+squeezing the measure.
+
+- [ ] **Step 7: Run targeted component tests**
+
+Run:
+
+```bash
+node --test \
+  src/lib/research-findings-doc.test.ts \
+  src/lib/research-findings-integrity.test.ts
+pnpm exec vitest run \
+  src/components/document-reader-view.test.ts \
+  src/components/document-reader-text-size.test.ts \
+  src/components/role-surfaces/research-evidence-components.test.ts
+node src/components/role-surfaces/research-reader-shared.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit reader composition**
+
+```bash
+git add \
+  src/components/role-surfaces/research-reader.tsx \
+  src/components/role-surfaces/research-reader-shared.test.ts
+git commit -m "feat(research): compose reading-first findings reader (cave-6gcw8)"
+```
+
+## Task 6: Apply the Evidence Edge visual system
+
+**Files:**
+- Modify: `src/styles/research-reader.css`
+
+- [ ] **Step 1: Replace modal and grid styling**
+
+Use only existing semantic tokens. Key rules:
+
+```css
+.research-reader-overlay {
+  padding: var(--space-4);
+  background: var(--backdrop-scrim);
+}
+
+.research-reader {
+  width: min(96rem, 100%);
+  max-height: calc(100dvh - var(--space-8));
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-popover);
+}
+
+.research-reader__grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.research-reader[data-inspector="true"] .research-reader__grid {
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, var(--rail-w, 22rem));
+}
+```
+
+Use `--shadow-popover`, the existing shadow token defined in
+`foundations.css`; do not introduce a parallel shadow token.
+
+- [ ] **Step 2: Create the report plane**
+
+Style the Research Reader instance of `DocumentReader` so:
+
+- shell background uses `--bg-panel`
+- scroll area uses `--bg-base`
+- report column uses `--bg-raised`, hairline border, panel radius, and generous
+  tokenized padding
+- primary prose uses `--text-primary`
+- secondary metadata uses `--text-secondary` or `--text-muted`
+- body measure remains the reading preference value
+- no raw color, raw spacing, or raw text-size literals are introduced
+
+- [ ] **Step 3: Style structural provenance**
+
+Add:
+
+```css
+.rr-block-row,
+.rr-list-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--space-10);
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.rr-provenance {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-1);
+}
+
+.rr-provenance__button {
+  min-width: var(--space-7);
+  min-height: var(--space-7);
+  border: 1px solid color-mix(
+    in oklch,
+    var(--research-accent) 38%,
+    var(--border-hairline)
+  );
+  border-radius: var(--radius-pill);
+  background: var(--research-accent-soft);
+  color: var(--research-accent);
+}
+```
+
+Selected, conflict, rejected, and unresolved treatments follow the semantic
+tint recipe. Table evidence cells remain compact and sticky to the row.
+
+- [ ] **Step 4: Style the on-demand inspector and contents**
+
+The inspector uses `--bg-elevated`, a strong separating border, and no nested
+card shadows. At medium width it overlays from the right; at narrow width it
+fills the reader body. The contents rail retains shared behavior but receives
+Research-specific elevated material and stronger selected-state contrast.
+
+- [ ] **Step 5: Define the responsive representation switch**
+
+At the wide breakpoint, show `.rr-provenance` and hide `.rr-inline-ref`.
+At compact width, hide `.rr-provenance` and show `.rr-inline-ref`. Hidden
+controls use `display: none`, ensuring only one representation is focusable.
+
+Reduced motion disables all reader transitions.
+
+- [ ] **Step 6: Run design gates**
+
+Run:
+
+```bash
+node scripts/design-system/token-reference-scan.mjs --check
+pnpm codemod:design:check
+node src/components/role-surfaces/research-reader-shared.test.ts
+```
+
+Expected: no undefined tokens, no codemod drift, and static reader assertions
+pass.
+
+- [ ] **Step 7: Commit visual styling**
+
+```bash
+git add src/styles/research-reader.css
+git commit -m "style(research): apply Evidence Edge reader system (cave-6gcw8)"
+```
+
+## Task 7: End-to-end behavior and final verification
+
+**Files:**
+- Modify: `tests/research-reader.spec.ts`
+
+- [ ] **Step 1: Update the default-state test**
+
+Assert:
+
+```ts
+await expect(reader).toHaveAttribute("data-toc", "false");
+await expect(reader).toHaveAttribute("data-inspector", "false");
+await expect(reader.locator(".document-reader__title")).toBeVisible();
+await expect(reader.locator(".rr-provenance")).toBeVisible();
+await expect(reader.locator(".rr-evidence-inspector")).toBeHidden();
+```
+
+Click the S14 provenance anchor and assert the inspector opens, the S14 card is
+selected/open, and its support link scrolls to a target with
+`data-document-target`.
+
+- [ ] **Step 2: Add a missing-ledger test**
+
+Parameterize `openReader` to accept mission and markdown overrides. Open a
+mission with `sources: []` and findings containing `Claim [S1].` Assert:
+
+```ts
+await expect(reader.locator(".rr-integrity")).toHaveText(
+  "Sources unavailable — references can't be verified",
+);
+await expect(reader.locator(".rr-status")).toContainText("Published");
+```
+
+This proves lifecycle and integrity render independently.
+
+- [ ] **Step 3: Add keyboard and responsive tests**
+
+Cover:
+
+- Enter on a provenance anchor opens the inspector.
+- `Supports` returns focus to the claim target.
+- Escape closes the inspector before the reader.
+- At 400px, provenance margin is hidden and inline source controls are visible.
+- Contents remains one action away and preserves positive prose gutters.
+
+- [ ] **Step 4: Run targeted Playwright**
+
+Run:
+
+```bash
+pnpm exec playwright test tests/research-reader.spec.ts --project=chromium
+```
+
+Expected: all Research Reader scenarios pass.
+
+- [ ] **Step 5: Run the focused application checks**
+
+Run:
+
+```bash
+node --test \
+  src/lib/research-findings-doc.test.ts \
+  src/lib/research-findings-integrity.test.ts
+pnpm exec vitest run \
+  src/components/document-reader-view.test.ts \
+  src/components/document-reader-text-size.test.ts \
+  src/components/role-surfaces/research-evidence-components.test.ts
+node src/components/role-surfaces/research-reader-shared.test.ts
+pnpm lint
+pnpm typecheck
+```
+
+Expected: all tests, lint, token checks, codemod checks, and type checking pass.
+
+- [ ] **Step 6: Verify the native visual result**
+
+Use the repository's `run-cave-app` skill to build the production web surface,
+open Research Desk, load a completed mission, and capture:
+
+- default reading state
+- Evidence Edge with inspector open
+- contents open
+- narrow reader
+- missing-ledger integrity state
+
+Compare against the acceptance criteria in
+`docs/superpowers/specs/2026-08-28-research-reader-evidence-edge-design.md`.
+
+- [ ] **Step 7: Commit end-to-end coverage**
+
+```bash
+git add tests/research-reader.spec.ts
+git commit -m "test(research): cover Evidence Edge reader flows (cave-6gcw8)"
+```
+
+- [ ] **Step 8: Record completion evidence**
+
+Append the exact commands and results to `cave-6gcw8`. Keep the bead
+`in_progress` until the implementation branch is reviewed and merged.

--- a/docs/superpowers/plans/2026-08-29-research-reader-evidence-edge.md
+++ b/docs/superpowers/plans/2026-08-29-research-reader-evidence-edge.md
@@ -146,7 +146,7 @@ export type ResearchIntegritySummaryKind =
   | "none";
 
 export type ResearchFindingsIntegrity = {
-  ledger: "available" | "empty";
+  ledger: "available" | "empty" | "failed";
   referencedIds: string[];
   unresolvedIds: string[];
   conflictIds: string[];
@@ -165,6 +165,7 @@ export function scanBracketedSourceIds(markdown: string): string[] {
 export function deriveResearchFindingsIntegrity(
   markdown: string,
   sources: ResearchSourceRef[],
+  options?: { ledger?: "available" | "empty" | "failed" },
 ): ResearchFindingsIntegrity {
   // Reuse parseFindingsDoc (or its exact ref-recognition rules) against the
   // sanitized Markdown to collect actual ledger-backed source ids such as

--- a/docs/superpowers/plans/2026-08-29-research-reader-evidence-edge.md
+++ b/docs/superpowers/plans/2026-08-29-research-reader-evidence-edge.md
@@ -142,6 +142,7 @@ export type ResearchIntegritySummaryKind =
   | "conflicting"
   | "candidate"
   | "verified"
+  | "rejected"
   | "none";
 
 export type ResearchFindingsIntegrity = {
@@ -156,31 +157,20 @@ export type ResearchFindingsIntegrity = {
   };
 };
 
-const BRACKETED_SOURCE_GROUP_RE =
-  /\[((?:[SR]\d+\s*)(?:,\s*[SR]\d+\s*)*)\]/g;
-const SOURCE_ID_RE = /[SR]\d+/g;
-const CONFLICT_ID_RE = /\bC\d+\b/g;
-
 export function scanBracketedSourceIds(markdown: string): string[] {
-  const ids: string[] = [];
-  for (
-    let match = BRACKETED_SOURCE_GROUP_RE.exec(markdown);
-    match;
-    match = BRACKETED_SOURCE_GROUP_RE.exec(markdown)
-  ) {
-    for (const id of match[1].match(SOURCE_ID_RE) ?? []) {
-      if (!ids.includes(id)) ids.push(id);
-    }
-  }
-  return ids;
+  // Preprocess Markdown first so fenced code, inline code, image alt text,
+  // link destinations, and bare URLs never fabricate evidence states.
 }
 
 export function deriveResearchFindingsIntegrity(
   markdown: string,
   sources: ResearchSourceRef[],
 ): ResearchFindingsIntegrity {
-  // Count ledger statuses, compare explicit bracketed IDs with real rows, keep
-  // C# conflict markers independent, then apply the precedence from the spec.
+  // Reuse parseFindingsDoc (or its exact ref-recognition rules) against the
+  // sanitized Markdown to collect actual ledger-backed source ids such as
+  // manual-1, supplement that with strict bracketed S#/R# detection for
+  // missing rows, keep C# conflict markers independent, preserve first-seen
+  // order, then apply the precedence from the spec.
 }
 ```
 
@@ -191,7 +181,21 @@ Implement singular/plural labels exactly:
 - `1 conflict remains` / `N conflicts remain`
 - `1 source awaits review` / `N sources await review`
 - `1 source verified` / `N sources verified`
+- `1 rejected source cited` / `N rejected sources cited`
 - `This report does not cite sources`
+
+Primary-summary precedence must be:
+
+1. unavailable
+2. unresolved
+3. conflicting
+4. candidate
+5. verified
+6. rejected
+7. none
+
+The `none` summary is valid only when the sanitized document contains no
+source or conflict tokens at all.
 
 - [ ] **Step 4: Run the integrity tests**
 

--- a/docs/superpowers/plans/2026-08-29-research-reader-evidence-edge.md
+++ b/docs/superpowers/plans/2026-08-29-research-reader-evidence-edge.md
@@ -1,6 +1,6 @@
 # Research Reader Evidence Edge Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Rebuild the Research Reader as a reading-first Apple/OpenAI hybrid with explicit evidence integrity, faithful document structure, claim-aligned provenance, and an on-demand evidence inspector.
 

--- a/docs/superpowers/specs/2026-08-28-research-reader-evidence-edge-design.md
+++ b/docs/superpowers/specs/2026-08-28-research-reader-evidence-edge-design.md
@@ -357,12 +357,14 @@ enum:
 - Reference presence: whether the document cites any source or conflict token.
 
 The current parser's "recognize only real ledger IDs" rule remains the safe path
-for normal inline tokenization. A separate integrity scanner recognizes only
-explicit bracketed source forms such as `[S1]`, `[S4, S5]`, or `[R1]` in every
-document, then compares them with the available ledger. It does not classify
-bare strings such as `model S1` or `S3 bucket` as citations. Unmatched detected
-IDs drive unresolved and unavailable states; they do not receive a verified
-source card.
+for normal inline tokenization. Integrity scanning first removes fenced code,
+inline code, image alt text, link destinations, and bare URLs so raw Markdown
+syntax cannot fabricate evidence states. It then reuses the findings parser's
+real-ledger ID recognition for actual citations and supplements that with
+strict bracketed source forms such as `[S1]`, `[S4, S5]`, or `[R1]` so missing
+ledger rows still surface honestly. It does not classify bare strings such as
+`model S1` or `S3 bucket` as citations. Unmatched detected IDs drive
+unresolved and unavailable states; they do not receive a verified source card.
 
 The chrome presents one primary integrity summary with deterministic
 precedence, while the inspector exposes all counts:
@@ -373,7 +375,8 @@ precedence, while the inspector exposes all counts:
 3. Conflict markers or conflicting ledger entries: `N conflicts remain`.
 4. One or more candidate entries: `N sources await review`.
 5. Used sources with no higher-priority issue: `N sources verified`.
-6. No source or conflict tokens: `This report does not cite sources`.
+6. Rejected sources with no higher-priority issue: `N rejected sources cited`.
+7. No source or conflict tokens: `This report does not cite sources`.
 
 A published artifact may carry any integrity facts. The chrome must not turn
 publication into evidence approval.
@@ -383,6 +386,7 @@ Example integrity copy:
 - `3 conflicts remain`
 - `2 references are unresolved`
 - `Sources unavailable — references can't be verified`
+- `1 rejected source cited`
 - `This report does not cite sources`
 
 Unknown IDs remain visible with an unresolved treatment. They never inherit the

--- a/docs/superpowers/specs/2026-08-28-research-reader-evidence-edge-design.md
+++ b/docs/superpowers/specs/2026-08-28-research-reader-evidence-edge-design.md
@@ -328,6 +328,9 @@ parser delta is explicit:
 - Add stable block IDs and block-level reference IDs.
 - Add per-item reference IDs for ordered and unordered lists.
 - Add per-row reference IDs for tables.
+- Treat ATX title and section heading text as navigation only, not as
+  provenance-bearing claims; heading-only source or conflict tokens do not
+  contribute to evidence integrity.
 - Keep code content opaque; fenced code does not produce source anchors.
 
 `Supports` relationships target stable blocks, including heading-less overview

--- a/docs/superpowers/specs/2026-08-28-research-reader-evidence-edge-design.md
+++ b/docs/superpowers/specs/2026-08-28-research-reader-evidence-edge-design.md
@@ -1,0 +1,577 @@
+# Research Reader Evidence Edge Design
+
+**Date:** 2026-08-28 · **Bead:** `cave-6gcw8` · **Status:** approved design, implementation pending
+
+The Research Reader already turns findings markdown into a structured document
+with source references, an evidence rail, reading preferences, and accessible
+navigation. The current presentation does not make those capabilities feel like
+a composed research artifact. It reads as a developer console wrapped around
+long prose: metadata and chrome dominate, the document has no distinct reading
+plane, and provenance occupies permanent space without feeling trustworthy.
+
+This design makes the report the primary object. It combines Apple-style native
+spatial behavior with OpenAI-style editorial hierarchy and evidence
+transparency. Its signature is the **Evidence Edge**: a slim provenance margin
+whose source anchors align with the claims they support and open a native
+evidence inspector.
+
+## Goal
+
+Make a completed findings report feel authored, calm, and credible while
+keeping every source, conflict, and rejected reference available for immediate
+verification.
+
+The first glance must land on the report title and argument, not the app chrome,
+contents rail, or metadata.
+
+## Current-state critique
+
+The review used the supplied screenshots of mission
+`research-00b591f3-2e35-4d2e-8c7e-ee89ab1c6d68` and the shipped implementation
+in:
+
+- `src/components/role-surfaces/research-reader.tsx`
+- `src/components/document-reader.tsx`
+- `src/styles/research-reader.css`
+- `src/styles/document-reader.css`
+- `src/lib/research-findings-doc.ts`
+
+### 1. The surface reads as operational chrome, not a report
+
+The top row compresses lifecycle, artifact kind, version, mode, pass count,
+source count, freshness, and several icon actions into one thin line. Its
+typography and density resemble a log header. The reader then opens onto an
+edge-to-edge graphite field, so the report never becomes a visually distinct
+object.
+
+### 2. Navigation competes with reading
+
+The permanent contents rail consumes a large left column even when the reader
+is following the document linearly. Long labels wrap into dense blocks, while
+small timeline dots carry too much responsibility for position and selection.
+Inactive entries are dim enough to resemble disabled content.
+
+### 3. The text hierarchy is too quiet
+
+The title and section headings have some hierarchy, but body copy remains small,
+low-contrast, and wide. Long evidence paragraphs become gray walls. The reader
+uses the same restrained tone for contextual metadata and the argument itself,
+so the document lacks a clear foreground.
+
+### 4. Source mechanics are visible but not credible
+
+The report contains bracketed `S#` references while the navigation footer says
+`0 sources · 0 used`. Because the current tokenizer learns valid source IDs from
+the ledger, those `S#` references remain plain text while bare `C#` conflict
+tokens can still receive a styled treatment. The result promises traceability
+without providing it. Publication lifecycle and evidence integrity are
+presented as if they were one healthy state. A green **Published** label cannot
+compensate for an unavailable source ledger.
+
+### 5. Markdown structure is visually flattened
+
+Numbered evidence, quotations, status statements, and implementation notes can
+collapse into long paragraphs. Every section heading also behaves like an
+accordion, which adds interface weight to ordinary reading and makes chapters
+feel like settings disclosures.
+
+### 6. Controls are cryptic at screenshot scale
+
+Several toolbar actions are unlabeled, visually slight, and close to the window
+edge. The interaction model is capable, but it does not communicate the native,
+confident affordance expected from a focused macOS reader.
+
+## Design principles
+
+1. **The document is the stage.** Chrome explains and controls the report; it
+   never competes with it.
+2. **Reading is the default.** Contents and evidence are available on demand,
+   not permanently imposed.
+3. **Provenance stays attached to claims.** A source belongs beside the sentence,
+   list item, or table row it supports.
+4. **Lifecycle and integrity are separate truths.** A report can be published
+   while its sources are missing, unresolved, or conflicting.
+5. **One memorable device.** The Evidence Edge carries the identity of the
+   surface. Everything around it remains quiet.
+6. **No invented synthesis.** Counts, statuses, summaries, and source
+   relationships must be derived from real mission and artifact data.
+
+## Alternatives considered
+
+### A. Reading Sheet
+
+A centered document with navigation and evidence moved entirely into popovers.
+This is the most Apple-like and calmest option, but it hides provenance too
+aggressively for a research product.
+
+### B. Evidence Edge — selected
+
+A composed document with a narrow claim-aligned provenance margin and a
+revealable evidence inspector. It keeps reading dominant while making evidence
+more meaningful than a generic sidebar.
+
+### C. Research Canvas
+
+A modular dashboard of conclusions, source coverage, open questions, and status.
+It improves scanning but weakens long-form comprehension and encourages
+invented summary metrics. It is better suited to a mission overview than a
+findings reader.
+
+## Information architecture
+
+The reader has four spatial layers:
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Published · Findings      Report title / current section      Aa  ☷  × │
+├───────────────┬───────────────────────────────────────┬─────────────────┤
+│ Contents      │                                       │ Evidence        │
+│ on demand     │     authored report plane             │ inspector       │
+│               │                                       │ on demand       │
+│ Current       │     title, abstract, sections,        │ selected source │
+│ chapter       │     lists, tables, code, callouts     │ claim, status,  │
+│ highlighted   │                                  S4 ● │ supports, open  │
+│               │                                  C1 ● │ and cite        │
+└───────────────┴───────────────────────────────────────┴─────────────────┘
+```
+
+Only the report plane and the slim Evidence Edge are present by default.
+Contents and the full evidence inspector are independently revealable.
+
+### Opening state
+
+The document opens at a focused reading measure with:
+
+1. Artifact-kind kicker, normally `Findings`.
+2. Parsed document title, falling back to the artifact title.
+3. Mission intent, when present, with visual line clamping but no rewriting or
+   synthesized shortening.
+4. Parsed lede only when the findings document supplies the explicit leading
+   blockquote that `parseFindingsDoc` recognizes.
+5. The first section.
+
+The complete artifact metadata remains available through the document identity
+control. It is not repeated as a toolbar sentence. When neither mission intent
+nor a parsed lede exists, the first body block follows the title directly.
+
+### Scrolled state
+
+After the title leaves the viewport, the chrome shows:
+
+- Lifecycle: `Published`, `Working draft`, or `Rejected`.
+- Short report title.
+- Current section.
+- Reading preferences.
+- Contents toggle.
+- Evidence toggle.
+- Overflow actions.
+- Close.
+
+The header remains one line. Secondary details such as version, mode, passes,
+source count, and update time live in the identity disclosure.
+
+## Visual system
+
+The visual plan uses these reference colors:
+
+| Name | Reference | Semantic token | Role |
+| --- | --- | --- | --- |
+| Graphite shell | `#191A1F` | `--bg-panel` | Window and reader surroundings |
+| Reader paper | `#24252B` | `--bg-raised` | Primary document plane |
+| Raised inspector | `#2A2B31` | `--bg-elevated` | Contents and evidence disclosures |
+| Frost ink | `#F3F1F5` | `--text-primary` | Titles and primary prose |
+| Quiet text | `#B3B0B9` | `--text-secondary` | Secondary copy and metadata |
+| Presence lavender | `#9386D0` | `--accent-presence` | Active provenance and selected state |
+
+These values describe the intended relationships, not implementation literals.
+Implementation must use the Cave semantic tokens and the existing theme model
+so every palette and mode remains valid.
+
+### Material
+
+- The shell uses the panel/base surface relationship defined by the active
+  theme.
+- The report plane uses the raised surface token with a hairline edge.
+- Contents and inspector use the elevated token step.
+- Translucency is reserved for the sticky chrome and temporary overlays.
+- The document plane does not use decorative blur, glow, or gradients.
+- Shadows establish separation only when a panel overlays content.
+
+This applies Apple-like material restraint without turning the surface into a
+stack of frosted cards.
+
+### Typography
+
+Use the existing Cave type system:
+
+- **EB Garamond:** report title, lede, and occasional source quotation.
+- **Inter:** body prose, headings, navigation, and controls.
+- **JetBrains Mono:** source IDs, lifecycle metadata, dates, and compact status.
+
+Target relationships use the existing type ladder and reader scale:
+
+| Role | Token relationship |
+| --- | --- |
+| Report title | `--text-display × --reader-text-scale`, tight leading, restrained serif |
+| Lede / mission intent | `--text-lg × --reader-text-scale`, secondary tone |
+| Section heading | `--text-xl × --reader-text-scale`, strong sans |
+| Body | `--text-lg × --reader-text-scale`, relaxed reading leading |
+| Metadata | `--text-2xs` through `--text-xs`, mono only where the value is machine-like |
+
+The body measure is 66–72 characters for the default reading width. Existing
+reader size, width, weight, leading, tracking, alignment, and hyphenation
+preferences remain supported.
+
+### Structural emphasis
+
+- A short lavender rule may mark the current section heading.
+- Source anchors use compact circular or pill geometry from the Cave shape
+  vocabulary.
+- Verified, conflicting, rejected, and unresolved references use semantic
+  state tokens plus text labels or icons; color is never the only channel.
+- Section collapse is not shown by default. Collapsing becomes a contents or
+  navigation action rather than a caret on every heading.
+
+## Signature interaction: Evidence Edge
+
+The Evidence Edge is a narrow column between the report and the optional
+inspector.
+
+### Placement
+
+Every rendered reference-bearing block exposes zero or more reference anchors:
+
+- Paragraph: one cluster aligned to the first cited line.
+- List item: one cluster aligned to that item.
+- Table row: one cluster aligned to the row.
+- Quotation: one cluster aligned to the quotation.
+
+References that support the same block form one compact cluster. The reader
+does not duplicate every inline `S#` token in the margin; the inline text may
+retain a quieter reference marker for copying and exported output.
+
+Alignment is structural, not measured. Each rendered block and its source
+cluster are sibling cells in one CSS grid row: document content in the measure
+column, provenance in the edge column. No `ResizeObserver` or absolute-position
+recalculation is used. Reading preference changes, font loading, resize, and
+panel reflow therefore preserve alignment through normal layout.
+
+Wide tables and code blocks remain horizontally contained inside the document
+cell and stop before the edge column. They may expand within the document's
+wide measure, but never underneath provenance controls.
+
+### Interaction
+
+- Hover or focus previews source ID, title, status, publisher/type, and date.
+- Click or Enter opens the matching source in the evidence inspector.
+- Selecting an inspector card highlights its claim anchors in the document.
+- `Supports` links move to the cited block and restore focus.
+- Conflicts and unresolved references remain visible and explain their state.
+- The selected source, claim, and inspector card share one synchronized state.
+- Roving focus changes highlight only. Selection is committed and announced on
+  click or Enter, preventing announcement spam while arrowing through anchors.
+
+### Reflow
+
+On wide desktop windows, opening the evidence inspector reflows the surrounding
+grid while preserving the document's reading measure and centered alignment.
+On narrower windows, it overlays from the right. On compact windows, it becomes
+a full-height sheet. The contents sidebar follows the same native split-view
+logic from the left.
+
+## Component boundaries
+
+The redesign should preserve the existing parser and evidence behavior while
+separating presentation into focused units.
+
+### `ResearchReader`
+
+Owns modal lifecycle, top-level layout state, focus trapping, Escape behavior,
+copy/export/publish actions, and synchronization between the document,
+provenance margin, and evidence inspector.
+
+### `ReaderChrome`
+
+Owns the lifecycle label, compact document identity, current-section label,
+reading controls, panel toggles, overflow menu, and close action. It does not
+own report parsing or evidence data.
+
+### `DocumentReader`
+
+Continues to own reading preferences, scroll progress, section navigation, and
+the semantic document column. Research Reader adds a new `panel` navigation
+mode for a revealable contents panel; the existing `rail`, `compact`, and
+`none` modes remain unchanged for Memories and other consumers.
+
+### `ProvenanceMargin`
+
+Receives block-level anchors and selected/hovered source IDs. It renders source
+clusters, manages roving keyboard focus, and requests inspector selection. It
+does not interpret ledger status. Each cluster is a DOM sibling immediately
+after its content block and is placed visually by the structural grid.
+
+### `EvidenceInspector`
+
+Reuses the current source-card fields and actions: status, claim, note,
+confidence, supporting blocks, open source, and copy citation. Every ledger
+entry receives an inspector card; today's `miniSources` are promoted to the
+same card shape with only the fields that exist. It owns no document scrolling
+beyond emitting a `supports` target.
+
+### Findings model
+
+`parseFindingsDoc` remains the source of semantic document structure. The
+parser delta is explicit:
+
+- Add ordered-list blocks rather than flattening numbered evidence into prose.
+- Add quotation blocks rather than stripping `>` into ordinary paragraphs.
+- Add stable block IDs and block-level reference IDs.
+- Add per-item reference IDs for ordered and unordered lists.
+- Add per-row reference IDs for tables.
+- Keep code content opaque; fenced code does not produce source anchors.
+
+`Supports` relationships target stable blocks, including heading-less overview
+blocks and the parsed lede, rather than filtering only to named sections.
+
+## Data and integrity states
+
+Publication lifecycle and evidence integrity are independent.
+
+### Lifecycle
+
+- `Published`
+- `Working draft`
+- `Rejected`
+
+### Evidence integrity
+
+Integrity is a set of independent derived facts, not one mutually exclusive
+enum:
+
+- Ledger availability: `available`, `empty`, or `failed`.
+- Resolved source counts by ledger status: `used`, `candidate`, `conflicting`,
+  and `rejected`.
+- Unresolved source IDs: bracketed source references with no ledger entry.
+- Conflict markers: `C#` tokens, which are tracked separately and never counted
+  as missing source records.
+- Reference presence: whether the document cites any source or conflict token.
+
+The current parser's "recognize only real ledger IDs" rule remains the safe path
+for normal inline tokenization. A separate integrity scanner recognizes only
+explicit bracketed source forms such as `[S1]`, `[S4, S5]`, or `[R1]` in every
+document, then compares them with the available ledger. It does not classify
+bare strings such as `model S1` or `S3 bucket` as citations. Unmatched detected
+IDs drive unresolved and unavailable states; they do not receive a verified
+source card.
+
+The chrome presents one primary integrity summary with deterministic
+precedence, while the inspector exposes all counts:
+
+1. Ledger failed, or ledger empty with detected source IDs:
+   `Sources unavailable`.
+2. Unresolved source IDs: `N references are unresolved`.
+3. Conflict markers or conflicting ledger entries: `N conflicts remain`.
+4. One or more candidate entries: `N sources await review`.
+5. Used sources with no higher-priority issue: `N sources verified`.
+6. No source or conflict tokens: `This report does not cite sources`.
+
+A published artifact may carry any integrity facts. The chrome must not turn
+publication into evidence approval.
+
+Example integrity copy:
+
+- `3 conflicts remain`
+- `2 references are unresolved`
+- `Sources unavailable — references can't be verified`
+- `This report does not cite sources`
+
+Unknown IDs remain visible with an unresolved treatment. They never inherit the
+verified accent by default.
+
+## Document semantics
+
+The reader should preserve the author's structure instead of rendering every
+passage as generic prose.
+
+- Numbered evidence remains an ordered list.
+- Bullets remain a list.
+- Blockquotes become quotation blocks.
+- Tables remain tables with focus mode for wide content.
+- Code and Mermaid retain the existing rich renderer.
+- Headings remain headings and do not become disclosure controls by default.
+
+This may require extending the deliberately small line-based parser. Unknown
+constructs must continue to degrade honestly to prose rather than being
+invented into a richer shape.
+
+## Interaction details
+
+### Keyboard
+
+- `Escape` closes the most recently opened layer first. A focused table dialog
+  therefore closes before the panel beneath it; when contents and evidence are
+  both open, the one opened most recently closes first. The reader closes only
+  when no nested layer remains.
+- Contents and provenance anchors use roving focus with arrow-key navigation.
+- Opening and closing a panel returns focus to its trigger.
+- Source `Supports` actions move focus to the target claim after scrolling.
+- Every icon-only control has an accessible name and visible tooltip.
+- On wide layouts, the margin anchor is the only interactive and announced
+  representation of a reference; its inline marker is visual/export text and
+  is hidden from assistive technology. On compact layouts, the margin is hidden
+  and the inline marker becomes the single interactive, announced
+  representation. Both are never focusable at the same time.
+
+### Motion
+
+Use one coordinated reflow for panel changes at the existing base or slow
+duration. Evidence highlights may fade at the fast duration. No ambient or
+decorative animation is added. Reduced motion makes panel changes immediate and
+scrolls without smooth behavior.
+
+### Touch and pointer
+
+Toolbar controls meet the existing Cave control target. The Evidence Edge
+provides a larger invisible hit area than its visible anchor. Hover previews
+never contain actions; click or tap opens the inspector.
+
+## Responsive behavior
+
+| Width | Behavior |
+| --- | --- |
+| Wide | Centered report, Evidence Edge, optional left contents and right inspector |
+| Medium | Report remains centered; one side panel may reflow while the other overlays |
+| Narrow | Single report column; contents and evidence open as full-height sheets |
+| Mobile | Compact sticky chrome; no persistent margin; references appear as inline anchors that open the evidence sheet |
+
+The report retains positive side gutters at every width and never touches the
+viewport edge.
+
+## Loading, empty, and failure behavior
+
+- Initial document loading uses the shared reader skeleton with title and prose
+  shapes.
+- A missing unwritten artifact uses `EmptyState` and names the next action.
+- A file-read failure uses `ErrorState` with retry.
+- A ledger failure does not hide the report. It presents the report with a
+  `Sources unavailable` integrity state and a retry action in the evidence
+  panel.
+- An external source that cannot open remains visible; the action reports the
+  specific failure.
+- Copy, export, and publish keep their current explicit announcements.
+
+No error is silently converted into an empty source list.
+
+## Accessibility
+
+- Primary prose and navigation meet contrast requirements in every theme and
+  mode.
+- Focus uses the shared solid focus ring.
+- Panel open/close and committed source selection changes are announced once.
+- The Evidence Edge has an accessible landmark and source count.
+- Source state is communicated with label and icon in addition to color.
+- The inspector remains inside the reader's focus trap.
+- Reading preferences continue to affect the report without breaking the
+  structural block-and-anchor grid.
+- The design supports reduced motion, text zoom, narrow windows, and keyboard
+  navigation without losing access to provenance.
+
+## Testing
+
+### Model tests
+
+- Parse ordered lists, blockquotes, tables, code, and block-level source IDs.
+- Derive ledger availability, per-status counts, unresolved bracketed IDs,
+  conflict markers, and primary-summary precedence.
+- Distinguish bracketed missing source IDs from ordinary bare text such as
+  `model S1`.
+- Group multiple references attached to one block without duplication.
+- Preserve unknown syntax as honest prose.
+
+### Component tests
+
+- Lifecycle and integrity render independently.
+- Selecting a margin anchor opens the matching real source.
+- Inspector selection highlights every supporting block.
+- `Supports` includes heading-less overview and lede blocks and returns focus
+  to the claim.
+- Contents and inspector restore focus to their triggers.
+- Escape closes layers in the required order.
+- Section headings are expanded by default and retain heading semantics.
+
+### End-to-end tests
+
+- Default opening state emphasizes the title and hides the full side panels.
+- Wide, medium, narrow, and mobile layouts preserve readable gutters and
+  measure.
+- A report containing `S1` with an empty ledger shows `Sources unavailable`
+  rather than a verified state.
+- Reading preference changes preserve usable provenance alignment.
+- Automated token and contrast checks cover every theme and mode; visual
+  snapshots cover Coven dark/light plus representative alternate palettes.
+- Reduced-motion mode removes smooth panel and scroll transitions.
+
+### Visual review
+
+Use the native Tauri shell for the final desktop pass. Review:
+
+- Long titles and long contents labels.
+- Dense evidence paragraphs.
+- Several references on one claim.
+- One selected source across multiple supporting claims.
+- Conflicting, rejected, and unresolved sources.
+- Empty and failed ledgers.
+- Open contents and evidence panels at the same time.
+
+## Acceptance criteria
+
+1. At first glance, the report title and argument dominate the screen.
+2. The default body measure remains within 66–72 characters at the default
+   reading size.
+3. The full contents and evidence panels are hidden by default and remain
+   reachable in one action.
+4. Source anchors align with the blocks they support and open real ledger
+   records.
+5. Publication and evidence integrity never collapse into one status.
+6. Findings containing references with no ledger show an explicit integrity
+   failure.
+7. Section headings are not disclosure controls in the default reading state.
+8. All icon-only controls have names, tooltips, visible focus, and adequate hit
+   targets.
+9. Desktop panel reflow preserves the document's reading measure.
+10. Narrow layouts retain positive prose gutters and full access to contents,
+    evidence, preferences, and close.
+11. The surface survives every Cave theme and mode through semantic tokens.
+12. No metric, summary, source relationship, or status is invented.
+
+## Non-goals
+
+- Redesigning the Research Desk mission list, prompt builder, or artifact rail.
+- Adding report collaboration, comments, approvals, or version comparison.
+- Generating executive summaries not present in the artifact.
+- Replacing the shared Cave theme, typography, icon, popover, or modal systems.
+- Turning the findings reader into a mission analytics dashboard.
+- Changing the behavior or layout of Memories readers that share
+  `DocumentReader`.
+- Redesigning the adjacent paper-focus reader used by Research Resources.
+
+## Implementation sequence
+
+The implementation plan should stage the work as several independently
+shippable pull requests:
+
+1. Integrity model: separate lifecycle from evidence facts and add the strict
+   bracketed-reference scanner.
+2. Parser model: add ordered lists, quotations, stable block IDs, and
+   block/item/row reference identity.
+3. Inspector: promote every real ledger source into the unified evidence card
+   without changing source actions.
+4. Evidence Edge: add the structural block-and-anchor grid and synchronized
+   source selection.
+5. Chrome and navigation: add Research Reader's `panel` mode and compose the
+   reading-first toolbar without changing other `DocumentReader` consumers.
+6. Visual and responsive layer: implement in the component-imported
+   `src/styles/research-reader.css`; do not add Evidence Edge styles to the
+   global CSS facade.
+7. Verification: add targeted model, component, end-to-end, token/contrast,
+   representative visual, and native-shell checks.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -138,6 +138,7 @@ export const SUITES = {
     "src/components/role-surfaces/familiar-room-interactions.test.tsx",
     "src/components/role-surfaces/researcher-surface.test.ts",
     "src/components/role-surfaces/research-reader-shared.test.ts",
+    "src/components/role-surfaces/research-evidence-components.test.ts",
     "src/components/role-surfaces/research-evidence-ledger.test.ts",
     "src/components/role-surfaces/research-artifact-actions.test.ts",
     "src/components/role-surfaces/research-tab-prompt.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -2100,6 +2100,9 @@ const ALIAS_LOADER = new Set([
   "src/app/api/research/links/route.test.ts",
   // the github-repo route resolves "@/lib/server/..." and "@/lib/github-token".
   "src/app/api/research/github-repo/route.test.ts",
+  // the mission-file route resolves the validated store and shared source
+  // parser through "@/lib/..." runtime imports.
+  "src/app/api/research/missions/[id]/files/[key]/route.test.ts",
   // beads-delivery-source.ts imports "@/lib/beads-delivery",
   // "@/lib/server/beads-cli" and "@/lib/server/beads-workspace" as runtime
   // values, so the resolver has to be loaded or the file throws

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -129,6 +129,7 @@ export const SUITES = {
     "src/lib/research-source-url.test.ts",
     "src/lib/document-reader.test.ts",
     "src/lib/research-findings-doc.test.ts",
+    "src/lib/research-findings-integrity.test.ts",
     "src/lib/role-surface-state.test.ts",
     "src/components/role-surface-host-state.test.ts",
     "src/components/role-surface-shell.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -2442,6 +2442,7 @@ const VITEST_TESTS = new Set([
   "src/components/role-surfaces/research-tab-resources.behavior.test.tsx",
   "src/components/role-surfaces/research-github-repo-viewer.test.tsx",
   "src/components/role-surfaces/use-research-resources.test.tsx",
+  "src/components/role-surfaces/research-evidence-components.test.ts",
   // Topic Discovery (Unit 2): rendered JSX + hook through react-test-renderer.
   "src/components/role-surfaces/research-topic-card.test.tsx",
   "src/components/role-surfaces/use-research-topic-discovery.test.tsx",

--- a/src/app/api/research/missions/[id]/files/[key]/route.test.ts
+++ b/src/app/api/research/missions/[id]/files/[key]/route.test.ts
@@ -178,6 +178,102 @@ test("valid ledgers keep mission order before unmatched file-only additions", as
   });
 });
 
+test("ambiguous source identities fail closed without exposing source content", async () => {
+  const cases: Array<{
+    name: string;
+    missionSources: ResearchMission["sources"];
+    fileSources: ResearchMission["sources"];
+  }> = [
+    {
+      name: "URL merge would duplicate the mission id",
+      missionSources: [{
+        ...SOURCE,
+        id: "manual-current",
+        title: "sensitive mission title",
+      }],
+      fileSources: [
+        {
+          ...SOURCE,
+          id: "runner-stale",
+          title: "sensitive stale title",
+        },
+        {
+          ...SOURCE,
+          id: "manual-current",
+          title: "sensitive duplicate title",
+          url: "https://example.com/other",
+        },
+      ],
+    },
+    {
+      name: "file rows duplicate an id",
+      missionSources: [],
+      fileSources: [
+        {
+          ...SOURCE,
+          id: "duplicate-file-id",
+          title: "sensitive duplicate one",
+          url: "https://example.com/first",
+        },
+        {
+          ...SOURCE,
+          id: "duplicate-file-id",
+          title: "sensitive duplicate two",
+          url: "https://example.com/second",
+        },
+      ],
+    },
+    {
+      name: "one mission row bridges distinct URL and path rows",
+      missionSources: [{
+        ...SOURCE,
+        id: "mission-bridge",
+        title: "sensitive bridge title",
+        localPath: "/workspace/sensitive.pdf",
+      }],
+      fileSources: [
+        {
+          ...SOURCE,
+          id: "url-row",
+          title: "sensitive URL title",
+        },
+        {
+          ...SOURCE,
+          id: "path-row",
+          title: "sensitive path title",
+          url: undefined,
+          localPath: "/workspace/sensitive.pdf",
+          sourceType: "file",
+        },
+      ],
+    },
+  ];
+
+  for (const current of cases) {
+    const { GET } = createResearchMissionFileRouteHandlers({
+      loadMission: async () => mission(current.missionSources),
+      readFile: async (_id, relativePath) =>
+        relativePath === "findings.md"
+          ? "# Findings"
+          : JSON.stringify(current.fileSources),
+      workspacePath: () => "/workspace/mission-1",
+    });
+
+    const response = await GET(localRequest(), context());
+    const body = await response.json();
+    assert.deepEqual(
+      body.file.sourceLedger,
+      { state: "failed", sources: [] },
+      current.name,
+    );
+    assert.doesNotMatch(
+      JSON.stringify(body),
+      /sensitive|ambiguous|duplicate-file-id|workspace\/sensitive/,
+      current.name,
+    );
+  }
+});
+
 test("a legacy missing ledger fails closed without exposing stale mission sources", async () => {
   const { GET } = createResearchMissionFileRouteHandlers({
     loadMission: async () => mission(),

--- a/src/app/api/research/missions/[id]/files/[key]/route.test.ts
+++ b/src/app/api/research/missions/[id]/files/[key]/route.test.ts
@@ -12,7 +12,7 @@ const SOURCE = {
   status: "used",
 } as const;
 
-function mission(): ResearchMission {
+function mission(sources: ResearchMission["sources"] = [{ ...SOURCE }]): ResearchMission {
   return {
     version: 1,
     id: "mission-1",
@@ -43,7 +43,7 @@ function mission(): ResearchMission {
       state: "working",
       updatedAt: "2026-08-29T01:00:00.000Z",
     }],
-    sources: [{ ...SOURCE }],
+    sources,
   };
 }
 
@@ -81,7 +81,7 @@ test("artifact response carries the independently validated current source ledge
   });
 });
 
-test("a valid empty source ledger is distinct from a failed source ledger", async () => {
+test("a valid empty source ledger preserves a mission-only manual attachment", async () => {
   const { GET } = createResearchMissionFileRouteHandlers({
     loadMission: async () => mission(),
     readFile: async (_id, relativePath) =>
@@ -91,22 +91,139 @@ test("a valid empty source ledger is distinct from a failed source ledger", asyn
 
   const response = await GET(localRequest(), context());
   const body = await response.json();
-  assert.deepEqual(body.file.sourceLedger, { state: "empty", sources: [] });
+  assert.deepEqual(body.file.sourceLedger, {
+    state: "available",
+    sources: [SOURCE],
+  });
 });
 
-test("missing, unreadable, and malformed ledgers fail closed without stale sources or raw errors", async () => {
-  const cases = [
-    async () => {
+test("persisted mission edits win over stale file fields without losing file or provider fields", async () => {
+  const persisted = {
+    ...SOURCE,
+    id: "manual-current",
+    title: "Current user title",
+    publisher: "Mission publisher",
+    note: "Current user note",
+    status: "used" as const,
+    provider: "x" as const,
+    externalId: "post-1",
+    availability: "available" as const,
+  };
+  const staleFileSource = {
+    id: "runner-stale",
+    title: "Stale runner title",
+    url: SOURCE.url,
+    publishedAt: "2026-08-01",
+    sourceType: "journal",
+    note: "Stale runner note",
+    status: "candidate",
+  };
+  const { GET } = createResearchMissionFileRouteHandlers({
+    loadMission: async () => mission([persisted]),
+    readFile: async (_id, relativePath) =>
+      relativePath === "findings.md"
+        ? "# Findings"
+        : JSON.stringify([staleFileSource]),
+    workspacePath: () => "/workspace/mission-1",
+  });
+
+  const response = await GET(localRequest(), context());
+  const body = await response.json();
+  assert.deepEqual(body.file.sourceLedger, {
+    state: "available",
+    sources: [{
+      ...staleFileSource,
+      ...persisted,
+      publishedAt: "2026-08-01",
+    }],
+  });
+});
+
+test("valid ledgers keep mission order before unmatched file-only additions", async () => {
+  const missionSources = [
+    { ...SOURCE, id: "mission-first", title: "Mission first" },
+    {
+      id: "mission-second",
+      title: "Mission second",
+      localPath: "/workspace/manual.pdf",
+      sourceType: "file",
+      status: "candidate" as const,
+    },
+  ];
+  const fileOnly = {
+    id: "file-only",
+    title: "Runner addition",
+    url: "https://example.com/file-only",
+    sourceType: "web",
+    status: "candidate",
+  };
+  const { GET } = createResearchMissionFileRouteHandlers({
+    loadMission: async () => mission(missionSources),
+    readFile: async (_id, relativePath) =>
+      relativePath === "findings.md"
+        ? "# Findings"
+        : JSON.stringify([
+          { ...missionSources[1], title: "Stale second" },
+          fileOnly,
+          { ...missionSources[0], title: "Stale first" },
+        ]),
+    workspacePath: () => "/workspace/mission-1",
+  });
+
+  const response = await GET(localRequest(), context());
+  const body = await response.json();
+  assert.deepEqual(body.file.sourceLedger, {
+    state: "available",
+    sources: [...missionSources, fileOnly],
+  });
+});
+
+test("a legacy missing ledger fails closed without exposing stale mission sources", async () => {
+  const { GET } = createResearchMissionFileRouteHandlers({
+    loadMission: async () => mission(),
+    readFile: async (_id, relativePath) => {
+      if (relativePath === "findings.md") return "# Findings";
       const error = new Error("missing sources.json") as NodeJS.ErrnoException;
       error.code = "ENOENT";
       throw error;
     },
+    workspacePath: () => "/workspace/mission-1",
+  });
+
+  const response = await GET(localRequest(), context());
+  const body = await response.json();
+  assert.deepEqual(body.file.sourceLedger, {
+    state: "failed",
+    sources: [],
+  });
+  assert.doesNotMatch(JSON.stringify(body), /Primary source/);
+});
+
+test("a malformed ledger fails closed without exposing stale mission sources or raw errors", async () => {
+  const { GET } = createResearchMissionFileRouteHandlers({
+    loadMission: async () => mission(),
+    readFile: async (_id, relativePath) =>
+      relativePath === "findings.md" ? "# Findings" : "{not-json",
+    workspacePath: () => "/workspace/mission-1",
+  });
+
+  const response = await GET(localRequest(), context());
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.deepEqual(body.file.sourceLedger, {
+    state: "failed",
+    sources: [],
+  });
+  assert.doesNotMatch(JSON.stringify(body), /malformed|Primary source/);
+});
+
+test("unreadable and structurally invalid ledgers also fail closed", async () => {
+  const cases = [
     async () => {
       const error = new Error("permission denied: /secret/path") as NodeJS.ErrnoException;
       error.code = "EACCES";
       throw error;
     },
-    async () => "{not-json",
     async () => JSON.stringify([{
       id: "invalid-source",
       title: "Missing URL or local path",
@@ -124,12 +241,14 @@ test("missing, unreadable, and malformed ledgers fail closed without stale sourc
     });
 
     const response = await GET(localRequest(), context());
-    assert.equal(response.status, 200);
     const body = await response.json();
     assert.deepEqual(body.file.sourceLedger, {
       state: "failed",
       sources: [],
     });
-    assert.doesNotMatch(JSON.stringify(body), /permission denied|secret\/path/);
+    assert.doesNotMatch(
+      JSON.stringify(body),
+      /permission denied|secret\/path|Primary source/,
+    );
   }
 });

--- a/src/app/api/research/missions/[id]/files/[key]/route.test.ts
+++ b/src/app/api/research/missions/[id]/files/[key]/route.test.ts
@@ -1,25 +1,135 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
 
-const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
+import type { ResearchMission } from "@/lib/research-missions";
+import { createResearchMissionFileRouteHandlers } from "./route.ts";
 
-test("research mission file route is dynamic, node-only, and local-only", () => {
-  assert.match(source, /export const dynamic = "force-dynamic"/);
-  assert.match(source, /export const runtime = "nodejs"/);
-  assert.match(source, /rejectNonLocalRequest/);
+const SOURCE = {
+  id: "manual-primary",
+  title: "Primary source",
+  url: "https://example.com/source",
+  sourceType: "web",
+  status: "used",
+} as const;
+
+function mission(): ResearchMission {
+  return {
+    version: 1,
+    id: "mission-1",
+    familiarId: "sage",
+    title: "Mission",
+    intent: "Investigate the evidence",
+    mode: "brief",
+    modeSource: "user",
+    deliverable: "Findings",
+    constraints: [],
+    bounds: {
+      wallClockMinutes: 30,
+      maxIterations: 3,
+      sourceTarget: 5,
+      checkpointEvery: 1,
+      stopWhenCostUnavailable: true,
+    },
+    status: "completed",
+    createdAt: "2026-08-29T00:00:00.000Z",
+    updatedAt: "2026-08-29T01:00:00.000Z",
+    iterations: [{ number: 1, status: "completed" }],
+    artifacts: [{
+      key: "findings",
+      kind: "findings",
+      title: "Findings",
+      relativePath: "findings.md",
+      iteration: 1,
+      state: "working",
+      updatedAt: "2026-08-29T01:00:00.000Z",
+    }],
+    sources: [{ ...SOURCE }],
+  };
+}
+
+function localRequest(): Request {
+  return new Request(
+    "http://localhost:3000/api/research/missions/mission-1/files/findings",
+    { headers: { host: "localhost" } },
+  );
+}
+
+function context() {
+  return { params: Promise.resolve({ id: "mission-1", key: "findings" }) };
+}
+
+test("artifact response carries the independently validated current source ledger", async () => {
+  const reads: string[] = [];
+  const { GET } = createResearchMissionFileRouteHandlers({
+    loadMission: async () => mission(),
+    readFile: async (_id, relativePath) => {
+      reads.push(relativePath);
+      if (relativePath === "findings.md") return "# Findings";
+      if (relativePath === "sources.json") return JSON.stringify([SOURCE]);
+      throw new Error(`unexpected path ${relativePath}`);
+    },
+    workspacePath: () => "/workspace/mission-1",
+  });
+
+  const response = await GET(localRequest(), context());
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.deepEqual(reads, ["findings.md", "sources.json"]);
+  assert.deepEqual(body.file.sourceLedger, {
+    state: "available",
+    sources: [SOURCE],
+  });
 });
 
-test("route validates the mission id and resolves the artifact by key", () => {
-  assert.match(source, /"path not allowed"/);
-  assert.match(source, /"research mission not found"/);
-  assert.match(source, /"research artifact not found"/);
-  assert.match(source, /isValidResearchMissionId/);
+test("a valid empty source ledger is distinct from a failed source ledger", async () => {
+  const { GET } = createResearchMissionFileRouteHandlers({
+    loadMission: async () => mission(),
+    readFile: async (_id, relativePath) =>
+      relativePath === "findings.md" ? "# Findings" : "[]",
+    workspacePath: () => "/workspace/mission-1",
+  });
+
+  const response = await GET(localRequest(), context());
+  const body = await response.json();
+  assert.deepEqual(body.file.sourceLedger, { state: "empty", sources: [] });
 });
 
-test("route reads through the validated store reader and tolerates missing files", () => {
-  assert.match(source, /readValidatedMissionFile/);
-  assert.match(source, /ENOENT/);
-  assert.match(source, /content: string \| null/);
-  assert.match(source, /workspacePath/);
+test("missing, unreadable, and malformed ledgers fail closed without stale sources or raw errors", async () => {
+  const cases = [
+    async () => {
+      const error = new Error("missing sources.json") as NodeJS.ErrnoException;
+      error.code = "ENOENT";
+      throw error;
+    },
+    async () => {
+      const error = new Error("permission denied: /secret/path") as NodeJS.ErrnoException;
+      error.code = "EACCES";
+      throw error;
+    },
+    async () => "{not-json",
+    async () => JSON.stringify([{
+      id: "invalid-source",
+      title: "Missing URL or local path",
+      sourceType: "web",
+      status: "used",
+    }]),
+  ];
+
+  for (const readLedger of cases) {
+    const { GET } = createResearchMissionFileRouteHandlers({
+      loadMission: async () => mission(),
+      readFile: async (_id, relativePath) =>
+        relativePath === "findings.md" ? "# Findings" : readLedger(),
+      workspacePath: () => "/workspace/mission-1",
+    });
+
+    const response = await GET(localRequest(), context());
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.deepEqual(body.file.sourceLedger, {
+      state: "failed",
+      sources: [],
+    });
+    assert.doesNotMatch(JSON.stringify(body), /permission denied|secret\/path/);
+  }
 });

--- a/src/app/api/research/missions/[id]/files/[key]/route.test.ts
+++ b/src/app/api/research/missions/[id]/files/[key]/route.test.ts
@@ -178,33 +178,91 @@ test("valid ledgers keep mission order before unmatched file-only additions", as
   });
 });
 
+test("versioned source ids sharing a URL remain available and distinct", async () => {
+  const versions = [
+    {
+      ...SOURCE,
+      id: "content-v1",
+      title: "Version one",
+      localPath: "/workspace/report-v1.md",
+    },
+    {
+      ...SOURCE,
+      id: "content-v2",
+      title: "Version two",
+      localPath: "/workspace/report-v2.md",
+    },
+  ];
+  const { GET } = createResearchMissionFileRouteHandlers({
+    loadMission: async () => mission([]),
+    readFile: async (_id, relativePath) =>
+      relativePath === "findings.md"
+        ? "# Findings"
+        : JSON.stringify(versions),
+    workspacePath: () => "/workspace/mission-1",
+  });
+
+  const response = await GET(localRequest(), context());
+  const body = await response.json();
+  assert.deepEqual(body.file.sourceLedger, {
+    state: "available",
+    sources: versions,
+  });
+});
+
+test("exact-id reconciliation wins over a competing shared-URL bridge", async () => {
+  const current = {
+    ...SOURCE,
+    id: "manual-current",
+    title: "Current mission title",
+  };
+  const fileSources = [
+    {
+      ...SOURCE,
+      id: "runner-stale",
+      title: "Stale URL title",
+    },
+    {
+      ...SOURCE,
+      id: "manual-current",
+      title: "Stale exact-id title",
+      url: "https://example.com/other",
+      publisher: "File publisher",
+    },
+  ];
+  const { GET } = createResearchMissionFileRouteHandlers({
+    loadMission: async () => mission([current]),
+    readFile: async (_id, relativePath) =>
+      relativePath === "findings.md"
+        ? "# Findings"
+        : JSON.stringify(fileSources),
+    workspacePath: () => "/workspace/mission-1",
+  });
+
+  const response = await GET(localRequest(), context());
+  const body = await response.json();
+  assert.deepEqual(body.file.sourceLedger, {
+    state: "available",
+    sources: [
+      {
+        ...fileSources[1],
+        ...current,
+      },
+      fileSources[0],
+    ],
+  });
+  assert.equal(
+    new Set(body.file.sourceLedger.sources.map((source: { id: string }) => source.id)).size,
+    body.file.sourceLedger.sources.length,
+  );
+});
+
 test("ambiguous source identities fail closed without exposing source content", async () => {
   const cases: Array<{
     name: string;
     missionSources: ResearchMission["sources"];
     fileSources: ResearchMission["sources"];
   }> = [
-    {
-      name: "URL merge would duplicate the mission id",
-      missionSources: [{
-        ...SOURCE,
-        id: "manual-current",
-        title: "sensitive mission title",
-      }],
-      fileSources: [
-        {
-          ...SOURCE,
-          id: "runner-stale",
-          title: "sensitive stale title",
-        },
-        {
-          ...SOURCE,
-          id: "manual-current",
-          title: "sensitive duplicate title",
-          url: "https://example.com/other",
-        },
-      ],
-    },
     {
       name: "file rows duplicate an id",
       missionSources: [],

--- a/src/app/api/research/missions/[id]/files/[key]/route.ts
+++ b/src/app/api/research/missions/[id]/files/[key]/route.ts
@@ -1,7 +1,13 @@
 import path from "node:path";
 import { NextResponse } from "next/server";
-import { parseResearchSourcesFile } from "@/lib/research-artifact-contract";
-import type { ResearchSourceLedgerSnapshot } from "@/lib/research-missions";
+import {
+  parseResearchSourcesFile,
+  reconcileResearchSourcesForRead,
+} from "@/lib/research-artifact-contract";
+import type {
+  ResearchSourceLedgerSnapshot,
+  ResearchSourceRef,
+} from "@/lib/research-missions";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 import {
   isValidResearchMissionId,
@@ -21,11 +27,15 @@ type ResearchMissionFileRouteDependencies = {
 
 async function readSourceLedgerSnapshot(
   missionId: string,
+  missionSources: ResearchSourceRef[],
   readFile: typeof readValidatedMissionFile,
 ): Promise<ResearchSourceLedgerSnapshot> {
   try {
     const raw = await readFile(missionId, "sources.json");
-    const sources = parseResearchSourcesFile(raw);
+    const sources = reconcileResearchSourcesForRead(
+      parseResearchSourcesFile(raw),
+      missionSources,
+    );
     return sources.length > 0
       ? { state: "available", sources }
       : { state: "empty", sources: [] };
@@ -71,7 +81,11 @@ export function createResearchMissionFileRouteHandlers(
           );
         }
       }
-      const sourceLedger = await readSourceLedgerSnapshot(id, readFile);
+      const sourceLedger = await readSourceLedgerSnapshot(
+        id,
+        mission.sources,
+        readFile,
+      );
       return NextResponse.json({
         ok: true,
         file: {

--- a/src/app/api/research/missions/[id]/files/[key]/route.ts
+++ b/src/app/api/research/missions/[id]/files/[key]/route.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
 import { NextResponse } from "next/server";
+import { parseResearchSourcesFile } from "@/lib/research-artifact-contract";
+import type { ResearchSourceLedgerSnapshot } from "@/lib/research-missions";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 import {
   isValidResearchMissionId,
@@ -11,46 +13,82 @@ import {
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET(
-  req: Request,
-  context: { params: Promise<{ id: string; key: string }> },
-) {
-  const forbidden = rejectNonLocalRequest(req);
-  if (forbidden) return forbidden;
-  const { id, key } = await context.params;
-  if (!isValidResearchMissionId(id)) {
-    return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
-  }
-  const mission = await loadResearchMission(id);
-  if (!mission) {
-    return NextResponse.json({ ok: false, error: "research mission not found" }, { status: 404 });
-  }
-  const artifact = mission.artifacts.find((item) => item.key === key);
-  if (!artifact) {
-    return NextResponse.json({ ok: false, error: "research artifact not found" }, { status: 404 });
-  }
-  let content: string | null = null;
+type ResearchMissionFileRouteDependencies = {
+  loadMission?: typeof loadResearchMission;
+  readFile?: typeof readValidatedMissionFile;
+  workspacePath?: typeof researchMissionWorkspacePath;
+};
+
+async function readSourceLedgerSnapshot(
+  missionId: string,
+  readFile: typeof readValidatedMissionFile,
+): Promise<ResearchSourceLedgerSnapshot> {
   try {
-    content = await readValidatedMissionFile(id, artifact.relativePath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      return NextResponse.json(
-        { ok: false, error: (error as Error).message },
-        { status: 500 },
-      );
-    }
+    const raw = await readFile(missionId, "sources.json");
+    const sources = parseResearchSourcesFile(raw);
+    return sources.length > 0
+      ? { state: "available", sources }
+      : { state: "empty", sources: [] };
+  } catch {
+    return { state: "failed", sources: [] };
   }
-  return NextResponse.json({
-    ok: true,
-    file: {
-      key: artifact.key,
-      kind: artifact.kind,
-      title: artifact.title,
-      fileName: path.posix.basename(artifact.relativePath),
-      relativePath: artifact.relativePath,
-      content,
-      workspacePath: researchMissionWorkspacePath(id),
-      updatedAt: artifact.updatedAt,
-    },
-  });
 }
+
+export function createResearchMissionFileRouteHandlers(
+  dependencies: ResearchMissionFileRouteDependencies = {},
+) {
+  const loadMission = dependencies.loadMission ?? loadResearchMission;
+  const readFile = dependencies.readFile ?? readValidatedMissionFile;
+  const workspacePath = dependencies.workspacePath ?? researchMissionWorkspacePath;
+
+  return {
+    async GET(
+      req: Request,
+      context: { params: Promise<{ id: string; key: string }> },
+    ) {
+      const forbidden = rejectNonLocalRequest(req);
+      if (forbidden) return forbidden;
+      const { id, key } = await context.params;
+      if (!isValidResearchMissionId(id)) {
+        return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+      }
+      const mission = await loadMission(id);
+      if (!mission) {
+        return NextResponse.json({ ok: false, error: "research mission not found" }, { status: 404 });
+      }
+      const artifact = mission.artifacts.find((item) => item.key === key);
+      if (!artifact) {
+        return NextResponse.json({ ok: false, error: "research artifact not found" }, { status: 404 });
+      }
+      let content: string | null = null;
+      try {
+        content = await readFile(id, artifact.relativePath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          return NextResponse.json(
+            { ok: false, error: (error as Error).message },
+            { status: 500 },
+          );
+        }
+      }
+      const sourceLedger = await readSourceLedgerSnapshot(id, readFile);
+      return NextResponse.json({
+        ok: true,
+        file: {
+          key: artifact.key,
+          kind: artifact.kind,
+          title: artifact.title,
+          fileName: path.posix.basename(artifact.relativePath),
+          relativePath: artifact.relativePath,
+          content,
+          workspacePath: workspacePath(id),
+          updatedAt: artifact.updatedAt,
+          sourceLedger,
+        },
+      });
+    },
+  };
+}
+
+const handlers = createResearchMissionFileRouteHandlers();
+export const GET = handlers.GET;

--- a/src/components/document-reader-view.test.ts
+++ b/src/components/document-reader-view.test.ts
@@ -27,11 +27,16 @@ function documentWith(headings: string[]): DocumentReaderDocument<Block, Block> 
 function render(
   document: DocumentReaderDocument<Block, Block>,
   navigation: "compact" | "rail" | "none",
+  options: {
+    context?: ReturnType<typeof createElement>;
+    collapsibleSections?: boolean;
+  } = {},
 ): string {
   return renderToStaticMarkup(
     createElement(DocumentReader<Block, Block>, {
       document,
       navigation,
+      ...options,
       renderLede: (lede) =>
         createElement(MarkdownReaderBlock, {
           block: lede,
@@ -72,6 +77,48 @@ test("expanded navigation renders a persistent contents rail and collapsible sec
   assert.match(markup, /Body 1\./);
 });
 
+test("non-collapsible sections render direct headings and keep their bodies visible", () => {
+  const markup = render(
+    documentWith(["First section", "Second section"]),
+    "none",
+    { collapsibleSections: false },
+  );
+
+  assert.match(
+    markup,
+    /<h2 class="document-reader__heading" data-document-section="section-1" id="section-1">First section<\/h2>/,
+  );
+  assert.doesNotMatch(markup, /document-reader__section-toggle/);
+  assert.doesNotMatch(markup, /<h2[^>]*aria-expanded=/);
+  assert.match(markup, /Body 1\./);
+  assert.match(markup, /Body 2\./);
+});
+
+test("context renders between the document title and lede", () => {
+  const markup = render(documentWith(["First section"]), "none", {
+    context: createElement("p", null, "Shared context"),
+  });
+  const css = readFileSync(
+    new URL("../styles/document-reader.css", import.meta.url),
+    "utf8",
+  );
+  const titleIndex = markup.indexOf("Shared document");
+  const contextIndex = markup.indexOf("Shared context");
+  const ledeIndex = markup.indexOf("A concise introduction.");
+
+  assert.ok(titleIndex >= 0);
+  assert.ok(contextIndex > titleIndex);
+  assert.ok(ledeIndex > contextIndex);
+  assert.match(
+    markup,
+    /<div class="document-reader__context"><p>Shared context<\/p><\/div>/,
+  );
+  assert.match(
+    css,
+    /\.document-reader__context\s*\{\s*margin:\s*calc\(-1 \* var\(--space-2\)\) 0 var\(--space-4\);\s*color:\s*var\(--text-secondary\);\s*font-size:\s*calc\(var\(--text-lg\) \* var\(--reader-text-scale\)\);\s*line-height:\s*var\(--cave-reading-leading,\s*1\.6\);\s*\}/,
+  );
+});
+
 test("the shared reader uses the popover scaffold, roving outline keys, and reduced-motion-aware scrolling", () => {
   const source = readFileSync(
     new URL("./document-reader.tsx", import.meta.url),
@@ -90,6 +137,50 @@ test("the shared reader uses the popover scaffold, roving outline keys, and redu
   assert.match(source, /End/);
   assert.match(source, /prefers-reduced-motion: reduce/);
   assert.match(source, /className="[^"]*focus-ring/);
+});
+
+test("the shared reader reports active-section changes and exposes target scrolling", () => {
+  const source = readFileSync(
+    new URL("./document-reader.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    source,
+    /onActiveSectionChange\?: \(section: \{ id: string; heading: string \} \| null\) => void/,
+  );
+  assert.match(
+    source,
+    /onActiveSectionChangeRef\.current\?\.\(activeSectionForId\(id\)\)/,
+    "active-section changes should notify the current callback",
+  );
+  assert.match(
+    source,
+    /if \(current\) activateSection\(current\);/,
+    "the scroll spy should route section changes through the notifying helper",
+  );
+  assert.match(
+    source,
+    /setActiveSection\(resetActiveSection\);[\s\S]*?onActiveSectionChangeRef\.current\?\.\(activeSectionForId\(resetActiveSection\)\)/,
+    "document resets should notify even when the first section id is unchanged",
+  );
+  assert.match(
+    source,
+    /scrollToTarget: \(id: string, focus\?: boolean\) => void/,
+  );
+  assert.match(
+    source,
+    /`\[data-document-target="\$\{CSS\.escape\(id\)\}"\]`/,
+  );
+  assert.match(source, /prefers-reduced-motion: reduce/);
+  assert.match(
+    source,
+    /if \(focus\) \{[\s\S]*?window\.requestAnimationFrame\(\(\) => target\.focus\(\)\);[\s\S]*?\}/,
+  );
+  assert.match(
+    source,
+    /apiRef\.current = \{ scrollToSection, scrollToTarget \}/,
+  );
 });
 
 test("the shared reader falls back to the global accent outside Research", () => {

--- a/src/components/document-reader.tsx
+++ b/src/components/document-reader.tsx
@@ -437,6 +437,7 @@ export function DocumentReader<TBlock, TLede = TBlock>({
               ref={preferencesTriggerRef}
               type="button"
               className="document-reader__preferences-trigger focus-ring"
+              title="Reading preferences"
               aria-label="Reading preferences"
               aria-haspopup="dialog"
               aria-expanded={preferencesOpen}

--- a/src/components/document-reader.tsx
+++ b/src/components/document-reader.tsx
@@ -113,17 +113,21 @@ export type DocumentReaderDocument<TBlock, TLede = TBlock> = {
 
 export type DocumentReaderApi = {
   scrollToSection: (id: string) => void;
+  scrollToTarget: (id: string, focus?: boolean) => void;
 };
 
 type DocumentReaderProps<TBlock, TLede> = {
   document: DocumentReaderDocument<TBlock, TLede>;
   navigation?: "compact" | "rail" | "none";
   kicker?: ReactNode;
+  context?: ReactNode;
+  collapsibleSections?: boolean;
   empty?: ReactNode;
   tocMeta?: ReactNode;
   className?: string;
   apiRef?: MutableRefObject<DocumentReaderApi | null>;
   onScrollProgress?: (progress: number) => void;
+  onActiveSectionChange?: (section: { id: string; heading: string } | null) => void;
   renderLede: (lede: TLede) => ReactNode;
   renderBlock: (block: TBlock, key: string) => ReactNode;
 };
@@ -140,11 +144,14 @@ export function DocumentReader<TBlock, TLede = TBlock>({
   document,
   navigation = "none",
   kicker,
+  context,
+  collapsibleSections = true,
   empty,
   tocMeta,
   className,
   apiRef,
   onScrollProgress,
+  onActiveSectionChange,
   renderLede,
   renderBlock,
 }: DocumentReaderProps<TBlock, TLede>) {
@@ -157,6 +164,9 @@ export function DocumentReader<TBlock, TLede = TBlock>({
   const [activeSection, setActiveSection] = useState<string | null>(
     document.sections.find((section) => section.heading)?.id ?? null,
   );
+  const activeSectionRef = useRef(activeSection);
+  const onActiveSectionChangeRef = useRef(onActiveSectionChange);
+  onActiveSectionChangeRef.current = onActiveSectionChange;
   const [openSections, setOpenSections] = useState<Set<string>>(
     () => new Set(document.sections.map((section) => section.id)),
   );
@@ -189,17 +199,35 @@ export function DocumentReader<TBlock, TLede = TBlock>({
     [document.sections],
   );
 
-  useEffect(() => {
-    setOpenSections(new Set(document.sections.map((section) => section.id)));
-    setActiveSection(namedSections[0]?.id ?? null);
-  }, [document.sections, namedSections]);
+  const activeSectionForId = useCallback(
+    (id: string | null) => {
+      const section = namedSections.find((candidate) => candidate.id === id);
+      return section ? { id: section.id, heading: section.heading } : null;
+    },
+    [namedSections],
+  );
 
-  const scrollToSection = useCallback((id: string) => {
+  const activateSection = useCallback(
+    (id: string | null) => {
+      if (activeSectionRef.current === id) return;
+      activeSectionRef.current = id;
+      setActiveSection(id);
+      onActiveSectionChangeRef.current?.(activeSectionForId(id));
+    },
+    [activeSectionForId],
+  );
+
+  useEffect(() => {
+    const resetActiveSection = namedSections[0]?.id ?? null;
+    setOpenSections(new Set(document.sections.map((section) => section.id)));
+    activeSectionRef.current = resetActiveSection;
+    setActiveSection(resetActiveSection);
+    onActiveSectionChangeRef.current?.(activeSectionForId(resetActiveSection));
+  }, [activeSectionForId, document.sections, namedSections]);
+
+  const scrollToElement = useCallback((target: HTMLElement) => {
     const scroller = scrollerRef.current;
-    const target = scroller?.querySelector<HTMLElement>(
-      `[data-document-section="${CSS.escape(id)}"]`,
-    );
-    if (!scroller || !target) return;
+    if (!scroller) return;
     const top =
       target.getBoundingClientRect().top -
       scroller.getBoundingClientRect().top +
@@ -210,17 +238,38 @@ export function DocumentReader<TBlock, TLede = TBlock>({
       ? "auto"
       : "smooth";
     scroller.scrollTo({ top, behavior });
-    setActiveSection(id);
-    setContentsOpen(false);
   }, []);
+
+  const scrollToSection = useCallback((id: string) => {
+    const scroller = scrollerRef.current;
+    const target = scroller?.querySelector<HTMLElement>(
+      `[data-document-section="${CSS.escape(id)}"]`,
+    );
+    if (!target) return;
+    scrollToElement(target);
+    activateSection(id);
+    setContentsOpen(false);
+  }, [activateSection, scrollToElement]);
+
+  const scrollToTarget = useCallback((id: string, focus?: boolean) => {
+    const scroller = scrollerRef.current;
+    const target = scroller?.querySelector<HTMLElement>(
+      `[data-document-target="${CSS.escape(id)}"]`,
+    );
+    if (!target) return;
+    scrollToElement(target);
+    if (focus) {
+      window.requestAnimationFrame(() => target.focus());
+    }
+  }, [scrollToElement]);
 
   useEffect(() => {
     if (!apiRef) return;
-    apiRef.current = { scrollToSection };
+    apiRef.current = { scrollToSection, scrollToTarget };
     return () => {
       apiRef.current = null;
     };
-  }, [apiRef, scrollToSection]);
+  }, [apiRef, scrollToSection, scrollToTarget]);
 
   const onScroll = () => {
     const scroller = scrollerRef.current;
@@ -239,7 +288,7 @@ export function DocumentReader<TBlock, TLede = TBlock>({
         current = section.id;
       }
     }
-    if (current) setActiveSection(current);
+    if (current) activateSection(current);
   };
 
   const toggleSection = (id: string) => {
@@ -333,6 +382,7 @@ export function DocumentReader<TBlock, TLede = TBlock>({
 
   const hasBody =
     document.title !== null ||
+    (context !== null && context !== undefined) ||
     document.lede !== null ||
     document.sections.length > 0;
 
@@ -489,6 +539,9 @@ export function DocumentReader<TBlock, TLede = TBlock>({
               {document.title ? (
                 <h1 className="document-reader__title">{document.title}</h1>
               ) : null}
+              {context !== null && context !== undefined ? (
+                <div className="document-reader__context">{context}</div>
+              ) : null}
               {document.lede ? (
                 <div className="document-reader__lede rr-lede">
                   {renderLede(document.lede)}
@@ -523,23 +576,27 @@ export function DocumentReader<TBlock, TLede = TBlock>({
                         "data-document-section": section.id,
                         id: section.id,
                       },
-                      <button
-                        type="button"
-                        className="document-reader__section-toggle rr-h2-btn focus-ring"
-                        data-open={open}
-                        aria-expanded={open}
-                        onClick={() => toggleSection(section.id)}
-                      >
-                        <span>{section.heading}</span>
-                        <Icon
-                          name="ph:caret-down"
-                          width={13}
-                          className="document-reader__section-caret rr-sec-caret"
-                          aria-hidden
-                        />
-                      </button>,
+                      collapsibleSections ? (
+                        <button
+                          type="button"
+                          className="document-reader__section-toggle rr-h2-btn focus-ring"
+                          data-open={open}
+                          aria-expanded={open}
+                          onClick={() => toggleSection(section.id)}
+                        >
+                          <span>{section.heading}</span>
+                          <Icon
+                            name="ph:caret-down"
+                            width={13}
+                            className="document-reader__section-caret rr-sec-caret"
+                            aria-hidden
+                          />
+                        </button>
+                      ) : (
+                        section.heading
+                      ),
                     )}
-                    {open ? (
+                    {!collapsibleSections || open ? (
                       <div className="document-reader__section-body rr-doc__section-body">
                         {section.blocks.map((block, index) =>
                           <Fragment key={`${section.id}:block:${index}`}>

--- a/src/components/document-reader.tsx
+++ b/src/components/document-reader.tsx
@@ -124,6 +124,7 @@ type DocumentReaderProps<TBlock, TLede> = {
   collapsibleSections?: boolean;
   empty?: ReactNode;
   tocMeta?: ReactNode;
+  contentsId?: string;
   className?: string;
   apiRef?: MutableRefObject<DocumentReaderApi | null>;
   onScrollProgress?: (progress: number) => void;
@@ -148,6 +149,7 @@ export function DocumentReader<TBlock, TLede = TBlock>({
   collapsibleSections = true,
   empty,
   tocMeta,
+  contentsId,
   className,
   apiRef,
   onScrollProgress,
@@ -402,6 +404,7 @@ export function DocumentReader<TBlock, TLede = TBlock>({
       <div className="document-reader__layout">
       {navigation === "rail" && namedSections.length > 0 ? (
         <nav
+          id={contentsId}
           className="document-reader__toc rr-col rr-toc"
           aria-label="Contents"
         >

--- a/src/components/role-surfaces/research-artifact-actions.test.ts
+++ b/src/components/role-surfaces/research-artifact-actions.test.ts
@@ -28,3 +28,12 @@ test("download builds a Blob and revokes the object URL", () => {
 test("exports the workspace-path fetcher for the desk summary", () => {
   assert.match(source, /export async function fetchResearchWorkspacePath/);
 });
+
+test("reader receives the file-backed source ledger and can refresh it", () => {
+  assert.match(source, /sourceLedger=\{readerFile\.sourceLedger\}/);
+  assert.match(source, /onRetrySources=\{retryReaderSources\}/);
+  assert.match(
+    source,
+    /setReaderFile\(file\)[\s\S]*?return file\.sourceLedger/,
+  );
+});

--- a/src/components/role-surfaces/research-artifact-actions.tsx
+++ b/src/components/role-surfaces/research-artifact-actions.tsx
@@ -7,7 +7,12 @@ import { Icon } from "@/lib/icon";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { openGrimoireDoc } from "@/lib/grimoire-link";
 import { getResearchMissionFile, type ResearchMissionFile } from "@/lib/research-mission-client";
-import type { ResearchArtifactKind, ResearchArtifactRef, ResearchMission } from "@/lib/research-missions";
+import type {
+  ResearchArtifactKind,
+  ResearchArtifactRef,
+  ResearchMission,
+  ResearchSourceLedgerSnapshot,
+} from "@/lib/research-missions";
 
 // The typeset reader is interaction-only and carries its own stylesheet; lazy
 // so its JS+CSS stay out of the researcher route's first-load bundle.
@@ -81,6 +86,14 @@ export function ResearchArtifactActions({ mission, artifact, busy, onPublish }: 
       setPending(false);
     }
   };
+
+  const retryReaderSources =
+    async (): Promise<ResearchSourceLedgerSnapshot> => {
+      const file = await loadFile();
+      if (!file) return { state: "failed", sources: [] };
+      setReaderFile(file);
+      return file.sourceLedger;
+    };
 
   const view = async () => {
     if (pending) return;
@@ -186,12 +199,14 @@ export function ResearchArtifactActions({ mission, artifact, busy, onPublish }: 
           <pre className="research-artifact-viewer__content">{viewing.content}</pre>
         )}
       </Modal>
-      {readerOpen ? (
+      {readerOpen && readerFile ? (
         <ResearchReader
           mission={mission}
           artifact={artifact}
-          markdown={readerFile?.content ?? null}
+          markdown={readerFile.content}
+          sourceLedger={readerFile.sourceLedger}
           onClose={() => setReaderOpen(false)}
+          onRetrySources={retryReaderSources}
           onPublish={onPublish ? () => onPublish(artifact.key) : undefined}
         />
       ) : null}

--- a/src/components/role-surfaces/research-evidence-components.test.ts
+++ b/src/components/role-surfaces/research-evidence-components.test.ts
@@ -1,7 +1,9 @@
+// @ts-nocheck — react-test-renderer ships no types; this is a rendered component behavior test.
 import assert from "node:assert/strict";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, test } from "vitest";
+import { act, create } from "react-test-renderer";
+import { describe, expect, test, vi } from "vitest";
 import type { FindingsSupportTarget } from "@/lib/research-findings-doc";
 import type { ResearchSourceRef } from "@/lib/research-missions";
 import { ResearchEvidenceInspector } from "./research-evidence-inspector";
@@ -9,6 +11,8 @@ import {
   ResearchProvenanceEdge,
   type ResearchProvenanceTone,
 } from "./research-provenance-edge";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const callbacks = {
   onToggle: () => {},
@@ -37,6 +41,56 @@ function buttonTag(html: string, label: string): string {
 }
 
 describe("ResearchProvenanceEdge", () => {
+  test("keeps preview active until both hover and focus leave", async () => {
+    const onPreview = vi.fn();
+    let renderer;
+    await act(async () => {
+      renderer = create(
+        createElement(ResearchProvenanceEdge, {
+          ids: ["S1"],
+          selectedId: null,
+          toneForId: (): ResearchProvenanceTone => "accent",
+          onPreview,
+          onSelect: () => {},
+        }),
+      );
+    });
+    const button = renderer.root.findByType("button");
+    const element = {
+      closest: () => ({ querySelectorAll: () => [element] }),
+      tabIndex: 0,
+    };
+
+    button.props.onFocus({ currentTarget: element });
+    button.props.onMouseEnter({ currentTarget: element });
+    button.props.onMouseLeave({ currentTarget: element });
+    button.props.onBlur({ currentTarget: element });
+
+    expect(onPreview.mock.calls.map(([id]) => id)).toEqual([
+      "S1",
+      "S1",
+      "S1",
+      null,
+    ]);
+    expect(onPreview).toHaveBeenNthCalledWith(3, "S1", element);
+
+    onPreview.mockClear();
+    button.props.onMouseEnter({ currentTarget: element });
+    button.props.onFocus({ currentTarget: element });
+    button.props.onBlur({ currentTarget: element });
+    button.props.onMouseLeave({ currentTarget: element });
+
+    expect(onPreview.mock.calls.map(([id]) => id)).toEqual([
+      "S1",
+      "S1",
+      "S1",
+      null,
+    ]);
+    expect(onPreview).toHaveBeenNthCalledWith(3, "S1", element);
+
+    await act(async () => renderer.unmount());
+  });
+
   test("labels evidence and conflict controls and renders nothing without IDs", () => {
     const html = renderToStaticMarkup(
       createElement(ResearchProvenanceEdge, {

--- a/src/components/role-surfaces/research-evidence-components.test.ts
+++ b/src/components/role-surfaces/research-evidence-components.test.ts
@@ -4,7 +4,10 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { act, create } from "react-test-renderer";
 import { describe, expect, test, vi } from "vitest";
-import type { FindingsSupportTarget } from "@/lib/research-findings-doc";
+import {
+  parseInline,
+  type FindingsSupportTarget,
+} from "@/lib/research-findings-doc";
 import type { ResearchSourceRef } from "@/lib/research-missions";
 import { ResearchEvidenceInspector } from "./research-evidence-inspector";
 import {
@@ -15,6 +18,7 @@ import {
   compactResearchSourceId,
   ResearchSourceIdLabel,
 } from "./research-source-id-label";
+import { ResearchFindingsInlineSpans } from "./research-reader";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -470,5 +474,41 @@ describe("ResearchEvidenceInspector", () => {
       /class="research-source-id-label test-source-label"/,
     );
     assert.doesNotMatch(html, new RegExp(`>${id}</span>`));
+  });
+});
+
+describe("ResearchFindingsInlineSpans", () => {
+  test("renders mixed link labels as linked prose plus selectable evidence refs", () => {
+    const sources = [
+      source("S1", "used"),
+      source("S14", "candidate"),
+    ];
+    const html = renderToStaticMarkup(
+      createElement(ResearchFindingsInlineSpans, {
+        spans: parseInline(
+          "[S1](../sources.json), [evidence S14](https://example.com/report), and [paper](https://example.com/plain).",
+          sources,
+        ),
+        keyPrefix: "linked-citations",
+        sourceById: new Map(sources.map((item) => [item.id, item])),
+        hoverKey: null,
+        selectedSourceId: null,
+        onRefPreview: () => {},
+        onClearPreview: () => {},
+        onRefClick: () => {},
+      }),
+    );
+
+    assert.match(html, /<button[^>]*aria-label="Open evidence S1"/);
+    assert.match(html, /<button[^>]*aria-label="Open evidence S14"/);
+    assert.match(
+      html,
+      /<a href="https:\/\/example\.com\/report"[^>]*>evidence <\/a>/,
+    );
+    assert.match(
+      html,
+      /<a href="https:\/\/example\.com\/plain"[^>]*>paper<\/a>/,
+    );
+    assert.doesNotMatch(html, /<a[^>]*>S(?:1|14)<\/a>/);
   });
 });

--- a/src/components/role-surfaces/research-evidence-components.test.ts
+++ b/src/components/role-surfaces/research-evidence-components.test.ts
@@ -114,7 +114,7 @@ describe("ResearchProvenanceEdge", () => {
     await act(async () => renderer.unmount());
   });
 
-  test("labels evidence and conflict controls and renders nothing without IDs", () => {
+  test("exposes a labeled provenance landmark without changing its controls", () => {
     const html = renderToStaticMarkup(
       createElement(ResearchProvenanceEdge, {
         ids: ["S1", "C1"],
@@ -126,7 +126,11 @@ describe("ResearchProvenanceEdge", () => {
       }),
     );
 
-    assert.match(html, /role="group"/);
+    assert.match(
+      html,
+      /<div[^>]*class="research-provenance-edge"[^>]*role="region"[^>]*aria-label="Evidence references · 2"/,
+    );
+    assert.doesNotMatch(html, /role="group"/);
     assert.match(html, /aria-label="Open evidence S1"/);
     assert.match(html, /aria-label="Open conflict C1"/);
     assert.match(
@@ -151,6 +155,40 @@ describe("ResearchProvenanceEdge", () => {
       ),
       "",
     );
+  });
+
+  test("keeps arrow-key roving focus inside the provenance region", async () => {
+    let renderer;
+    await act(async () => {
+      renderer = create(
+        createElement(ResearchProvenanceEdge, {
+          ids: ["S1", "S2"],
+          selectedId: null,
+          toneForId: (): ResearchProvenanceTone => "accent",
+          onPreview: () => {},
+          onSelect: () => {},
+        }),
+      );
+    });
+    const buttons = renderer.root.findAllByType("button");
+    const focused: string[] = [];
+    const elements = buttons.map((button, index) => ({
+      focus: () => focused.push(button.props["data-research-provenance-id"]),
+      tabIndex: index === 0 ? 0 : -1,
+    }));
+    const region = { querySelectorAll: () => elements };
+
+    buttons[0].props.onKeyDown({
+      key: "ArrowRight",
+      currentTarget: {
+        closest: (selector: string) =>
+          selector === ".research-provenance-edge" ? region : null,
+      },
+      preventDefault: () => {},
+    });
+
+    expect(focused).toEqual(["S2"]);
+    await act(async () => renderer.unmount());
   });
 
   test("labels unresolved source controls truthfully without inventing evidence", () => {

--- a/src/components/role-surfaces/research-evidence-components.test.ts
+++ b/src/components/role-surfaces/research-evidence-components.test.ts
@@ -129,6 +129,15 @@ describe("ResearchProvenanceEdge", () => {
     assert.match(html, /role="group"/);
     assert.match(html, /aria-label="Open evidence S1"/);
     assert.match(html, /aria-label="Open conflict C1"/);
+    assert.match(
+      buttonTag(html, "Open evidence S1"),
+      /research-provenance-edge__item/,
+    );
+    assert.match(
+      html,
+      /<button[^>]*aria-label="Open evidence S1"[^>]*>[\s\S]*?<span class="research-provenance-edge__anchor">S1<\/span>[\s\S]*?<\/button>/,
+      "the focusable hit target wraps a smaller painted provenance anchor",
+    );
     assert.match(buttonTag(html, "Open conflict C1"), /data-tone="warn"/);
     assert.equal(
       renderToStaticMarkup(

--- a/src/components/role-surfaces/research-evidence-components.test.ts
+++ b/src/components/role-surfaces/research-evidence-components.test.ts
@@ -114,6 +114,44 @@ describe("ResearchProvenanceEdge", () => {
     await act(async () => renderer.unmount());
   });
 
+  test("committing a selection clears hover and focus preview state", async () => {
+    const onPreview = vi.fn();
+    const onSelect = vi.fn();
+    let renderer;
+    await act(async () => {
+      renderer = create(
+        createElement(ResearchProvenanceEdge, {
+          ids: ["S1"],
+          selectedId: null,
+          toneForId: (): ResearchProvenanceTone => "accent",
+          onPreview,
+          onSelect,
+        }),
+      );
+    });
+    const button = renderer.root.findByType("button");
+    const element = {
+      closest: () => ({ querySelectorAll: () => [element] }),
+      tabIndex: 0,
+    };
+
+    button.props.onFocus({ currentTarget: element });
+    button.props.onMouseEnter({ currentTarget: element });
+    button.props.onClick({ currentTarget: element });
+    button.props.onMouseLeave({ currentTarget: element });
+    button.props.onBlur({ currentTarget: element });
+
+    expect(onSelect).toHaveBeenCalledWith("S1", element);
+    expect(onPreview.mock.calls.map(([id]) => id)).toEqual([
+      "S1",
+      "S1",
+      null,
+      null,
+      null,
+    ]);
+    await act(async () => renderer.unmount());
+  });
+
   test("exposes a labeled provenance landmark without changing its controls", () => {
     const html = renderToStaticMarkup(
       createElement(ResearchProvenanceEdge, {

--- a/src/components/role-surfaces/research-evidence-components.test.ts
+++ b/src/components/role-surfaces/research-evidence-components.test.ts
@@ -153,6 +153,22 @@ describe("ResearchProvenanceEdge", () => {
     );
   });
 
+  test("labels unresolved source controls truthfully without inventing evidence", () => {
+    const html = renderToStaticMarkup(
+      createElement(ResearchProvenanceEdge, {
+        ids: ["S99"],
+        selectedId: null,
+        toneForId: (): ResearchProvenanceTone => "unresolved",
+        onPreview: () => {},
+        onSelect: () => {},
+      }),
+    );
+
+    assert.match(html, /aria-label="Missing source S99"/);
+    assert.match(buttonTag(html, "Missing source S99"), /data-tone="unresolved"/);
+    assert.doesNotMatch(html, /Open evidence S99/);
+  });
+
   test("uses the selected control as the roving tab stop", () => {
     const html = renderToStaticMarkup(
       createElement(ResearchProvenanceEdge, {

--- a/src/components/role-surfaces/research-evidence-components.test.ts
+++ b/src/components/role-surfaces/research-evidence-components.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, test } from "vitest";
+import type { FindingsSupportTarget } from "@/lib/research-findings-doc";
+import type { ResearchSourceRef } from "@/lib/research-missions";
+import { ResearchEvidenceInspector } from "./research-evidence-inspector";
+import {
+  ResearchProvenanceEdge,
+  type ResearchProvenanceTone,
+} from "./research-provenance-edge";
+
+const callbacks = {
+  onToggle: () => {},
+  onOpenUrl: () => {},
+  onCite: () => {},
+  onSupport: () => {},
+  onClose: () => {},
+};
+
+function source(
+  id: string,
+  status: ResearchSourceRef["status"],
+  title = `${id} source`,
+): ResearchSourceRef {
+  return {
+    id,
+    title,
+    sourceType: "web",
+    status,
+  };
+}
+
+function buttonTag(html: string, label: string): string {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return html.match(new RegExp(`<button[^>]*aria-label="${escaped}"[^>]*>`))?.[0] ?? "";
+}
+
+describe("ResearchProvenanceEdge", () => {
+  test("labels evidence and conflict controls and renders nothing without IDs", () => {
+    const html = renderToStaticMarkup(
+      createElement(ResearchProvenanceEdge, {
+        ids: ["S1", "C1"],
+        selectedId: null,
+        toneForId: (id): ResearchProvenanceTone =>
+          id === "C1" ? "muted" : "accent",
+        onPreview: () => {},
+        onSelect: () => {},
+      }),
+    );
+
+    assert.match(html, /role="group"/);
+    assert.match(html, /aria-label="Open evidence S1"/);
+    assert.match(html, /aria-label="Open conflict C1"/);
+    assert.match(buttonTag(html, "Open conflict C1"), /data-tone="warn"/);
+    assert.equal(
+      renderToStaticMarkup(
+        createElement(ResearchProvenanceEdge, {
+          ids: [],
+          selectedId: null,
+          toneForId: (): ResearchProvenanceTone => "accent",
+          onPreview: () => {},
+          onSelect: () => {},
+        }),
+      ),
+      "",
+    );
+  });
+
+  test("uses the selected control as the roving tab stop", () => {
+    const html = renderToStaticMarkup(
+      createElement(ResearchProvenanceEdge, {
+        ids: ["S1", "S2", "C1"],
+        selectedId: "S2",
+        toneForId: (): ResearchProvenanceTone => "accent",
+        onPreview: () => {},
+        onSelect: () => {},
+      }),
+    );
+
+    assert.match(buttonTag(html, "Open evidence S1"), /tabindex="-1"/);
+    assert.match(buttonTag(html, "Open evidence S2"), /tabindex="0"/);
+    assert.match(buttonTag(html, "Open evidence S2"), /aria-current="true"/);
+    assert.match(buttonTag(html, "Open conflict C1"), /tabindex="-1"/);
+  });
+});
+
+describe("ResearchEvidenceInspector", () => {
+  test("renders a sparse candidate source as a full card", () => {
+    const html = renderToStaticMarkup(
+      createElement(ResearchEvidenceInspector, {
+        sources: [source("S2", "candidate", "Sparse source")],
+        integrityLabel: "1 source awaits review",
+        selectedId: "S2",
+        openIds: new Set(["S2"]),
+        targetsBySource: new Map<string, FindingsSupportTarget[]>(),
+        ...callbacks,
+      }),
+    );
+
+    assert.match(html, /<article[^>]*research-evidence-card/);
+    assert.match(html, /Sparse source/);
+    assert.match(html, /Candidate/);
+    assert.match(html, />Type</);
+    assert.match(html, />web</);
+  });
+
+  test("groups every status by priority and preserves mission order within groups", () => {
+    const sources = [
+      source("S6", "rejected", "Rejected first in mission"),
+      source("S2", "used", "Used first"),
+      source("S4", "candidate", "Candidate first"),
+      source("S1", "used", "Used second"),
+      source("C1", "conflicting", "Conflict"),
+      source("S5", "candidate", "Candidate second"),
+    ];
+    const html = renderToStaticMarkup(
+      createElement(ResearchEvidenceInspector, {
+        sources,
+        integrityLabel: "1 conflict remains",
+        selectedId: null,
+        openIds: new Set<string>(),
+        targetsBySource: new Map<string, FindingsSupportTarget[]>(),
+        ...callbacks,
+      }),
+    );
+
+    const orderedTitles = [
+      "Used first",
+      "Used second",
+      "Candidate first",
+      "Candidate second",
+      "Conflict",
+      "Rejected first in mission",
+    ];
+    let previousIndex = -1;
+    for (const title of orderedTitles) {
+      const index = html.indexOf(title);
+      assert.ok(index > previousIndex, `${title} should follow the preceding priority item`);
+      previousIndex = index;
+    }
+  });
+
+  test("shows source count, integrity, and an accessible close control", () => {
+    const html = renderToStaticMarkup(
+      createElement(ResearchEvidenceInspector, {
+        sources: [source("S1", "used"), source("S2", "candidate")],
+        integrityLabel: "1 source awaits review",
+        selectedId: null,
+        openIds: new Set<string>(),
+        targetsBySource: new Map<string, FindingsSupportTarget[]>(),
+        ...callbacks,
+      }),
+    );
+
+    assert.match(html, /2 sources/);
+    assert.match(html, /1 source awaits review/);
+    assert.match(html, /aria-label="Close evidence inspector"/);
+    assert.match(buttonTag(html, "Close evidence inspector"), /focus-ring/);
+  });
+
+  test("renders only real support targets and the existing source actions", () => {
+    const richSource: ResearchSourceRef = {
+      id: "S1",
+      title: "Primary source",
+      sourceType: "journal",
+      status: "used",
+      url: "https://example.com/report",
+      publisher: "Example Journal",
+      publishedAt: "2026-08-01",
+      claim: "Observed result",
+      note: "Primary evidence",
+      confidence: 0.82,
+    };
+    const target: FindingsSupportTarget = {
+      id: "findings-overview-block-1",
+      label: "Overview",
+      sectionId: "overview",
+    };
+    const html = renderToStaticMarkup(
+      createElement(ResearchEvidenceInspector, {
+        sources: [richSource, source("S2", "candidate", "No linked evidence")],
+        integrityLabel: "1 source verified",
+        selectedId: "S1",
+        openIds: new Set(["S1", "S2"]),
+        targetsBySource: new Map([["S1", [target]]]),
+        ...callbacks,
+      }),
+    );
+
+    assert.match(html, /Observed result/);
+    assert.match(html, /Example Journal/);
+    assert.match(html, /2026-08-01/);
+    assert.match(html, /Primary evidence/);
+    assert.match(html, /82%/);
+    assert.match(html, />Overview</);
+    assert.equal((html.match(/>Open source</g) ?? []).length, 2);
+    assert.equal((html.match(/>Cite</g) ?? []).length, 2);
+    assert.equal((html.match(/rr-sd-supportlink/g) ?? []).length, 1);
+    assert.doesNotMatch(html, /Accept source|Reject source|Generated summary/);
+  });
+});

--- a/src/components/role-surfaces/research-evidence-components.test.ts
+++ b/src/components/role-surfaces/research-evidence-components.test.ts
@@ -142,6 +142,15 @@ describe("ResearchProvenanceEdge", () => {
       /<button[^>]*aria-label="Open evidence S1"[^>]*>[\s\S]*?<span class="research-provenance-edge__anchor">S1<\/span>[\s\S]*?<\/button>/,
       "the focusable hit target wraps a smaller painted provenance anchor",
     );
+    assert.match(
+      buttonTag(html, "Open evidence S1"),
+      /data-research-reference-id="S1"/,
+      "every margin representation exposes the stable reference id used for responsive focus restoration",
+    );
+    assert.match(
+      buttonTag(html, "Open evidence S1"),
+      /data-research-reference-representation="edge"/,
+    );
     assert.match(buttonTag(html, "Open conflict C1"), /data-tone="warn"/);
     assert.equal(
       renderToStaticMarkup(

--- a/src/components/role-surfaces/research-evidence-components.test.ts
+++ b/src/components/role-surfaces/research-evidence-components.test.ts
@@ -478,6 +478,58 @@ describe("ResearchEvidenceInspector", () => {
 });
 
 describe("ResearchFindingsInlineSpans", () => {
+  test("keeps authored refs as aria-hidden visual text beside the sole interactive inline control", () => {
+    const longId = `manual-${"source-".repeat(14)}primary`;
+    const sources = [
+      source("S1", "used"),
+      source("C1", "conflicting"),
+      source("R1", "rejected"),
+      source(longId, "used"),
+    ];
+    const html = renderToStaticMarkup(
+      createElement(ResearchFindingsInlineSpans, {
+        spans: parseInline(
+          `S1 contradicts C1; R1 is rejected; [S99] is missing; ${longId} remains.`,
+          sources,
+        ),
+        keyPrefix: "authored-refs",
+        sourceById: new Map(sources.map((item) => [item.id, item])),
+        hoverKey: null,
+        selectedSourceId: null,
+        onRefPreview: () => {},
+        onClearPreview: () => {},
+        onRefClick: () => {},
+      }),
+    );
+
+    for (const [id, tone] of [
+      ["S1", "accent"],
+      ["C1", "warn"],
+      ["R1", "muted"],
+      ["S99", "unresolved"],
+      [longId, "accent"],
+    ] as const) {
+      assert.equal(
+        html.match(new RegExp(`data-research-reference-id="${id}"`, "g"))
+          ?.length,
+        1,
+        `${id} has one interactive representation`,
+      );
+      assert.match(
+        html,
+        new RegExp(
+          `<span[^>]*class="rr-wide-ref rr-wide-ref--${tone}"[^>]*aria-hidden="true"[^>]*>[\\s\\S]*?data-research-source-id-label="${id}"`,
+        ),
+        `${id} has a noninteractive wide visual token`,
+      );
+    }
+    assert.match(html, new RegExp(`title="${longId}"`));
+    assert.doesNotMatch(
+      html,
+      /<button[^>]*rr-wide-ref|<span[^>]*rr-wide-ref[^>]*(?:tabindex|role)=/,
+    );
+  });
+
   test("renders mixed link labels as linked prose plus selectable evidence refs", () => {
     const sources = [
       source("S1", "used"),

--- a/src/components/role-surfaces/research-evidence-components.test.ts
+++ b/src/components/role-surfaces/research-evidence-components.test.ts
@@ -41,6 +41,29 @@ function buttonTag(html: string, label: string): string {
 }
 
 describe("ResearchProvenanceEdge", () => {
+  test("passes the invoking control through evidence selection", async () => {
+    const onSelect = vi.fn();
+    let renderer;
+    await act(async () => {
+      renderer = create(
+        createElement(ResearchProvenanceEdge, {
+          ids: ["S1"],
+          selectedId: null,
+          toneForId: (): ResearchProvenanceTone => "accent",
+          onPreview: () => {},
+          onSelect,
+        }),
+      );
+    });
+    const button = renderer.root.findByType("button");
+    const element = { focus: vi.fn() };
+
+    button.props.onClick({ currentTarget: element });
+
+    expect(onSelect).toHaveBeenCalledWith("S1", element);
+    await act(async () => renderer.unmount());
+  });
+
   test("keeps preview active until both hover and focus leave", async () => {
     const onPreview = vi.fn();
     let renderer;

--- a/src/components/role-surfaces/research-evidence-components.test.ts
+++ b/src/components/role-surfaces/research-evidence-components.test.ts
@@ -11,6 +11,10 @@ import {
   ResearchProvenanceEdge,
   type ResearchProvenanceTone,
 } from "./research-provenance-edge";
+import {
+  compactResearchSourceId,
+  ResearchSourceIdLabel,
+} from "./research-source-id-label";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -20,6 +24,9 @@ const callbacks = {
   onCite: () => {},
   onSupport: () => {},
   onClose: () => {},
+  onRetrySources: () => {},
+  ledgerState: "available" as const,
+  retryingSources: false,
 };
 
 function source(
@@ -177,7 +184,7 @@ describe("ResearchProvenanceEdge", () => {
     );
     assert.match(
       html,
-      /<button[^>]*aria-label="Open evidence S1"[^>]*>[\s\S]*?<span class="research-provenance-edge__anchor">S1<\/span>[\s\S]*?<\/button>/,
+      /<button[^>]*aria-label="Open evidence S1"[^>]*>[\s\S]*?<span[^>]*class="[^"]*research-provenance-edge__anchor[^"]*"[^>]*>[\s\S]*?S1[\s\S]*?<\/span>[\s\S]*?<\/button>/,
       "the focusable hit target wraps a smaller painted provenance anchor",
     );
     assert.match(
@@ -269,6 +276,33 @@ describe("ResearchProvenanceEdge", () => {
     assert.match(buttonTag(html, "Open evidence S2"), /tabindex="0"/);
     assert.match(buttonTag(html, "Open evidence S2"), /aria-current="true"/);
     assert.match(buttonTag(html, "Open conflict C1"), /tabindex="-1"/);
+  });
+
+  test("compacts long visual ids while retaining the complete accessible identity", () => {
+    const id = `manual-${"source-".repeat(14)}primary`;
+    const html = renderToStaticMarkup(
+      createElement(ResearchProvenanceEdge, {
+        ids: [id],
+        selectedId: null,
+        toneForId: (): ResearchProvenanceTone => "accent",
+        onPreview: () => {},
+        onSelect: () => {},
+      }),
+    );
+
+    assert.equal(compactResearchSourceId("S123"), "S123");
+    assert.equal(compactResearchSourceId("R4"), "R4");
+    assert.equal(compactResearchSourceId("C27"), "C27");
+    assert.notEqual(compactResearchSourceId(id), id);
+    assert.match(html, new RegExp(`aria-label="Open evidence ${id}"`));
+    assert.match(html, new RegExp(`title="${id}"`));
+    assert.match(html, new RegExp(`data-research-source-id-label="${id}"`));
+    assert.doesNotMatch(
+      html,
+      new RegExp(
+        `<span[^>]*class="[^"]*research-provenance-edge__anchor[^"]*"[^>]*>${id}</span>`,
+      ),
+    );
   });
 });
 
@@ -385,5 +419,56 @@ describe("ResearchEvidenceInspector", () => {
     assert.equal((html.match(/>Cite</g) ?? []).length, 2);
     assert.equal((html.match(/rr-sd-supportlink/g) ?? []).length, 1);
     assert.doesNotMatch(html, /Accept source|Reject source|Generated summary/);
+  });
+
+  test("failed ledgers render a retry treatment without stale source cards", async () => {
+    const onRetrySources = vi.fn();
+    let renderer;
+    await act(async () => {
+      renderer = create(
+        createElement(ResearchEvidenceInspector, {
+          ...callbacks,
+          sources: [],
+          ledgerState: "failed",
+          retryingSources: false,
+          integrityLabel: "Sources unavailable — references can't be verified",
+          selectedId: null,
+          openIds: new Set<string>(),
+          targetsBySource: new Map<string, FindingsSupportTarget[]>(),
+          onRetrySources,
+        }),
+      );
+    });
+
+    expect(renderer.root.findAllByProps({ "data-source-id": "S1" })).toHaveLength(0);
+    expect(
+      renderer.root.find(
+        (node) =>
+          typeof node.props.className === "string" &&
+          node.props.className.includes("research-evidence-inspector__failure"),
+      ),
+    ).toBeTruthy();
+    const retry = renderer.root.findByProps({ children: "Retry sources" });
+    retry.props.onClick();
+    expect(onRetrySources).toHaveBeenCalledTimes(1);
+    await act(async () => renderer.unmount());
+  });
+
+  test("source id label preserves full tooltip and data identity", () => {
+    const id = `manual-${"x".repeat(96)}`;
+    const html = renderToStaticMarkup(
+      createElement(ResearchSourceIdLabel, {
+        id,
+        className: "test-source-label",
+      }),
+    );
+
+    assert.match(html, new RegExp(`title="${id}"`));
+    assert.match(html, /aria-hidden="true"/);
+    assert.match(
+      html,
+      /class="research-source-id-label test-source-label"/,
+    );
+    assert.doesNotMatch(html, new RegExp(`>${id}</span>`));
   });
 });

--- a/src/components/role-surfaces/research-evidence-inspector.tsx
+++ b/src/components/role-surfaces/research-evidence-inspector.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { Icon } from "@/lib/icon";
+import type { FindingsSupportTarget } from "@/lib/research-findings-doc";
+import type { ResearchSourceRef } from "@/lib/research-missions";
+
+export type ResearchEvidenceInspectorProps = {
+  sources: ResearchSourceRef[];
+  integrityLabel: string;
+  selectedId: string | null;
+  openIds: ReadonlySet<string>;
+  targetsBySource: ReadonlyMap<string, readonly FindingsSupportTarget[]>;
+  onToggle: (id: string) => void;
+  onOpenUrl: (url: string) => void;
+  onCite: (source: ResearchSourceRef) => void;
+  onSupport: (target: FindingsSupportTarget) => void;
+  onClose: () => void;
+};
+
+type SourceStatusView = {
+  groupLabel: string;
+  label: string;
+  tone: "ok" | "warn" | "muted";
+  refTone: "accent" | "warn" | "muted";
+};
+
+const STATUS_PRIORITY: ResearchSourceRef["status"][] = [
+  "used",
+  "candidate",
+  "conflicting",
+  "rejected",
+];
+
+const STATUS_VIEW: Record<ResearchSourceRef["status"], SourceStatusView> = {
+  used: {
+    groupLabel: "Used",
+    label: "Verified",
+    tone: "ok",
+    refTone: "accent",
+  },
+  candidate: {
+    groupLabel: "Candidate",
+    label: "Candidate",
+    tone: "muted",
+    refTone: "accent",
+  },
+  conflicting: {
+    groupLabel: "Conflicting",
+    label: "Conflicts",
+    tone: "warn",
+    refTone: "warn",
+  },
+  rejected: {
+    groupLabel: "Rejected",
+    label: "Rejected",
+    tone: "muted",
+    refTone: "muted",
+  },
+};
+
+function sourceMeta(source: ResearchSourceRef): string {
+  const parts = [source.publisher || source.sourceType];
+  if (source.publishedAt) parts.push(source.publishedAt);
+  if (source.url) parts.push("fetched");
+  else if (source.localPath) parts.push("local");
+  return parts.filter(Boolean).join(" · ");
+}
+
+function sourceVariant(source: ResearchSourceRef): string {
+  if (source.status === "conflicting") return " rr-src--warn";
+  if (source.status === "rejected") return " rr-src--rejected";
+  return "";
+}
+
+export function ResearchEvidenceInspector({
+  sources,
+  integrityLabel,
+  selectedId,
+  openIds,
+  targetsBySource,
+  onToggle,
+  onOpenUrl,
+  onCite,
+  onSupport,
+  onClose,
+}: ResearchEvidenceInspectorProps) {
+  const sourceCountLabel = `${sources.length} source${sources.length === 1 ? "" : "s"}`;
+
+  return (
+    <aside
+      className="research-evidence-inspector"
+      aria-label="Evidence inspector"
+      data-selected-source={selectedId ?? undefined}
+    >
+      <header className="research-evidence-inspector__header">
+        <div className="research-evidence-inspector__heading">
+          <h2>Evidence</h2>
+          <span className="research-evidence-inspector__count">
+            {sourceCountLabel}
+          </span>
+        </div>
+        <p className="research-evidence-inspector__integrity">
+          {integrityLabel}
+        </p>
+        <button
+          className="research-evidence-inspector__close focus-ring"
+          type="button"
+          aria-label="Close evidence inspector"
+          onClick={onClose}
+        >
+          <Icon name="ph:x" width={13} height={13} aria-hidden />
+        </button>
+      </header>
+
+      <div className="research-evidence-inspector__list">
+        {STATUS_PRIORITY.map((status) => {
+          const statusSources = sources.filter(
+            (source) => source.status === status,
+          );
+          if (statusSources.length === 0) return null;
+
+          const view = STATUS_VIEW[status];
+          const headingId = `research-evidence-group-${status}`;
+          return (
+            <section
+              key={status}
+              className={`research-evidence-inspector__group research-evidence-inspector__group--${status}`}
+              aria-labelledby={headingId}
+              data-source-status={status}
+            >
+              <h3
+                id={headingId}
+                className="research-evidence-inspector__group-label"
+              >
+                {view.groupLabel}
+              </h3>
+              {statusSources.map((source) => {
+                const open = openIds.has(source.id);
+                const selected = selectedId === source.id;
+                const targets = targetsBySource.get(source.id) ?? [];
+                const detailId = `research-evidence-source-${source.id}`;
+                const refToneClass =
+                  view.refTone === "warn"
+                    ? " rr-sref--warn"
+                    : view.refTone === "muted"
+                      ? " rr-sref--muted"
+                      : "";
+
+                return (
+                  <article
+                    key={source.id}
+                    className={`research-evidence-card rr-src${sourceVariant(source)}${selected ? " is-selected is-match" : ""}`}
+                    aria-current={selected ? "true" : undefined}
+                    data-open={open ? "true" : "false"}
+                    data-selected={selected ? "true" : "false"}
+                    data-source-id={source.id}
+                    data-source-status={source.status}
+                  >
+                    <button
+                      className="research-evidence-card__toggle rr-src__toggle focus-ring"
+                      type="button"
+                      aria-expanded={open}
+                      aria-controls={detailId}
+                      onClick={() => onToggle(source.id)}
+                    >
+                      <span className="rr-src__head">
+                        <span className={`rr-sref${refToneClass}`}>
+                          {source.id}
+                        </span>
+                        <span
+                          className={`rr-srcstat rr-srcstat--${view.tone}`}
+                        >
+                          <i className="rr-srcstat__dot" aria-hidden />
+                          {view.label}
+                        </span>
+                        <Icon
+                          name="ph:caret-down"
+                          width={13}
+                          height={13}
+                          className="rr-srccaret"
+                          aria-hidden
+                        />
+                      </span>
+                      <span className="rr-src__title">{source.title}</span>
+                      <span className="rr-src__meta">
+                        {sourceMeta(source)}
+                      </span>
+                    </button>
+
+                    <div
+                      id={detailId}
+                      className="research-evidence-card__detail rr-srcdetail"
+                      hidden={!open}
+                    >
+                      {source.claim ? (
+                        <div className="rr-sd-quote">“{source.claim}”</div>
+                      ) : null}
+                      {source.publisher || source.publishedAt ? (
+                        <div className="rr-sd-row">
+                          <span className="rr-sd-k">Source</span>
+                          <span className="rr-sd-v">
+                            {[source.publisher, source.publishedAt]
+                              .filter(Boolean)
+                              .join(" · ")}
+                          </span>
+                        </div>
+                      ) : null}
+                      <div className="rr-sd-row">
+                        <span className="rr-sd-k">Type</span>
+                        <span className="rr-sd-v">{source.sourceType}</span>
+                      </div>
+                      {source.note ? (
+                        <div className="rr-sd-row">
+                          <span className="rr-sd-k">
+                            {source.status === "rejected" ? "Rejected" : "Note"}
+                          </span>
+                          <span className="rr-sd-v">{source.note}</span>
+                        </div>
+                      ) : null}
+                      {source.confidence !== undefined ? (
+                        <div className="rr-sd-row">
+                          <span className="rr-sd-k">Confidence</span>
+                          <span className="rr-sd-v">
+                            {Math.round(source.confidence * 100)}%
+                          </span>
+                        </div>
+                      ) : null}
+                      {targets.length > 0 ? (
+                        <div className="rr-sd-supports">
+                          <span className="rr-sd-supports__label">
+                            Supports
+                          </span>
+                          {targets.map((target) => (
+                            <button
+                              key={target.id}
+                              className="rr-sd-supportlink focus-ring"
+                              type="button"
+                              onClick={() => onSupport(target)}
+                            >
+                              {target.label}
+                            </button>
+                          ))}
+                        </div>
+                      ) : null}
+                      <div className="rr-sd-actions">
+                        <button
+                          className="rr-sd-btn rr-sd-btn--accent focus-ring"
+                          type="button"
+                          disabled={!source.url}
+                          onClick={() => {
+                            if (source.url) onOpenUrl(source.url);
+                          }}
+                        >
+                          <Icon
+                            name="ph:arrow-square-out"
+                            width={13}
+                            height={13}
+                            aria-hidden
+                          />
+                          Open source
+                        </button>
+                        <button
+                          className="rr-sd-btn focus-ring"
+                          type="button"
+                          onClick={() => onCite(source)}
+                        >
+                          <Icon
+                            name="ph:copy"
+                            width={13}
+                            height={13}
+                            aria-hidden
+                          />
+                          Cite
+                        </button>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </section>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/role-surfaces/research-evidence-inspector.tsx
+++ b/src/components/role-surfaces/research-evidence-inspector.tsx
@@ -20,7 +20,7 @@ export type ResearchEvidenceInspectorProps = {
 type SourceStatusView = {
   groupLabel: string;
   label: string;
-  tone: "ok" | "warn" | "muted";
+  tone: "ok" | "warn" | "muted" | "rejected";
   refTone: "accent" | "warn" | "muted";
 };
 
@@ -53,7 +53,7 @@ const STATUS_VIEW: Record<ResearchSourceRef["status"], SourceStatusView> = {
   rejected: {
     groupLabel: "Rejected",
     label: "Rejected",
-    tone: "muted",
+    tone: "rejected",
     refTone: "muted",
   },
 };
@@ -105,6 +105,7 @@ export function ResearchEvidenceInspector({
         <button
           className="research-evidence-inspector__close focus-ring"
           type="button"
+          title="Close evidence inspector"
           aria-label="Close evidence inspector"
           onClick={onClose}
         >

--- a/src/components/role-surfaces/research-evidence-inspector.tsx
+++ b/src/components/role-surfaces/research-evidence-inspector.tsx
@@ -1,11 +1,19 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
+import { ErrorState } from "@/components/ui/error-state";
 import { Icon } from "@/lib/icon";
 import type { FindingsSupportTarget } from "@/lib/research-findings-doc";
-import type { ResearchSourceRef } from "@/lib/research-missions";
+import type {
+  ResearchSourceLedgerSnapshot,
+  ResearchSourceRef,
+} from "@/lib/research-missions";
+import { ResearchSourceIdLabel } from "./research-source-id-label";
 
 export type ResearchEvidenceInspectorProps = {
   sources: ResearchSourceRef[];
+  ledgerState: ResearchSourceLedgerSnapshot["state"];
+  retryingSources: boolean;
   integrityLabel: string;
   selectedId: string | null;
   openIds: ReadonlySet<string>;
@@ -15,6 +23,7 @@ export type ResearchEvidenceInspectorProps = {
   onCite: (source: ResearchSourceRef) => void;
   onSupport: (target: FindingsSupportTarget) => void;
   onClose: () => void;
+  onRetrySources: () => void;
 };
 
 type SourceStatusView = {
@@ -74,6 +83,8 @@ function sourceVariant(source: ResearchSourceRef): string {
 
 export function ResearchEvidenceInspector({
   sources,
+  ledgerState,
+  retryingSources,
   integrityLabel,
   selectedId,
   openIds,
@@ -83,8 +94,12 @@ export function ResearchEvidenceInspector({
   onCite,
   onSupport,
   onClose,
+  onRetrySources,
 }: ResearchEvidenceInspectorProps) {
-  const sourceCountLabel = `${sources.length} source${sources.length === 1 ? "" : "s"}`;
+  const sourceCountLabel =
+    ledgerState === "failed"
+      ? "Unavailable"
+      : `${sources.length} source${sources.length === 1 ? "" : "s"}`;
 
   return (
     <aside
@@ -114,7 +129,24 @@ export function ResearchEvidenceInspector({
       </header>
 
       <div className="research-evidence-inspector__list">
-        {STATUS_PRIORITY.map((status) => {
+        {ledgerState === "failed" ? (
+          <ErrorState
+            compact
+            className="research-evidence-inspector__failure"
+            headline="Sources unavailable"
+            subtitle="The source ledger could not be read. The report remains available, but its citations cannot be verified."
+            actions={
+              <Button
+                size="sm"
+                leadingIcon="ph:arrow-clockwise"
+                loading={retryingSources}
+                onClick={onRetrySources}
+              >
+                Retry sources
+              </Button>
+            }
+          />
+        ) : STATUS_PRIORITY.map((status) => {
           const statusSources = sources.filter(
             (source) => source.status === status,
           );
@@ -162,12 +194,14 @@ export function ResearchEvidenceInspector({
                       type="button"
                       aria-expanded={open}
                       aria-controls={detailId}
+                      aria-label={`${open ? "Collapse" : "Expand"} evidence ${source.id}: ${source.title}`}
                       onClick={() => onToggle(source.id)}
                     >
                       <span className="rr-src__head">
-                        <span className={`rr-sref${refToneClass}`}>
-                          {source.id}
-                        </span>
+                        <ResearchSourceIdLabel
+                          id={source.id}
+                          className={`rr-sref${refToneClass}`}
+                        />
                         <span
                           className={`rr-srcstat rr-srcstat--${view.tone}`}
                         >

--- a/src/components/role-surfaces/research-provenance-edge.tsx
+++ b/src/components/role-surfaces/research-provenance-edge.tsx
@@ -137,7 +137,12 @@ export function ResearchProvenanceEdge({
               onPreview(hovered?.id ?? null, hovered?.element);
             }}
             onKeyDown={(event) => moveFocus(event, index)}
-            onClick={(event) => onSelect(id, event.currentTarget)}
+            onClick={(event) => {
+              hoveredPreview.current = null;
+              focusedPreview.current = null;
+              onPreview(null);
+              onSelect(id, event.currentTarget);
+            }}
           >
             <span className="research-provenance-edge__anchor">{id}</span>
           </button>

--- a/src/components/role-surfaces/research-provenance-edge.tsx
+++ b/src/components/role-surfaces/research-provenance-edge.tsx
@@ -95,6 +95,8 @@ export function ResearchProvenanceEdge({
             aria-label={accessibleLabel}
             aria-current={selected ? "true" : undefined}
             data-research-provenance-id={id}
+            data-research-reference-id={id}
+            data-research-reference-representation="edge"
             data-selected={selected ? "true" : "false"}
             data-tone={tone}
             tabIndex={id === tabStopId ? 0 : -1}

--- a/src/components/role-surfaces/research-provenance-edge.tsx
+++ b/src/components/role-surfaces/research-provenance-edge.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { KeyboardEvent } from "react";
+
+export type ResearchProvenanceTone =
+  | "accent"
+  | "warn"
+  | "muted"
+  | "unresolved";
+
+export type ResearchProvenanceEdgeProps = {
+  ids: string[];
+  selectedId: string | null;
+  toneForId: (id: string) => ResearchProvenanceTone;
+  onPreview: (id: string | null, element?: HTMLElement) => void;
+  onSelect: (id: string) => void;
+};
+
+const CONFLICT_ID_RE = /^C\d+$/;
+const NAVIGATION_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "Home",
+  "End",
+]);
+
+export function ResearchProvenanceEdge({
+  ids,
+  selectedId,
+  toneForId,
+  onPreview,
+  onSelect,
+}: ResearchProvenanceEdgeProps) {
+  if (ids.length === 0) return null;
+
+  const tabStopId = ids.includes(selectedId ?? "") ? selectedId : ids[0];
+
+  const moveFocus = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    currentIndex: number,
+  ) => {
+    if (!NAVIGATION_KEYS.has(event.key)) return;
+
+    event.preventDefault();
+    const nextIndex =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? ids.length - 1
+          : event.key === "ArrowUp" || event.key === "ArrowLeft"
+            ? (currentIndex - 1 + ids.length) % ids.length
+            : (currentIndex + 1) % ids.length;
+    const nextId = ids[nextIndex];
+    const buttons = event.currentTarget
+      .closest('[role="group"]')
+      ?.querySelectorAll<HTMLButtonElement>(
+        "[data-research-provenance-id]",
+      );
+    const nextButton = buttons?.[nextIndex];
+    if (!nextId || !nextButton) return;
+
+    nextButton.focus();
+  };
+
+  return (
+    <div
+      className="research-provenance-edge"
+      role="group"
+      aria-label={`Evidence references · ${ids.length}`}
+    >
+      {ids.map((id, index) => {
+        const conflict = CONFLICT_ID_RE.test(id);
+        const selected = selectedId === id;
+        const tone = conflict ? "warn" : toneForId(id);
+
+        return (
+          <button
+            key={`${id}-${index}`}
+            className={`research-provenance-edge__item research-provenance-edge__item--${tone} focus-ring${selected ? " is-selected" : ""}`}
+            type="button"
+            aria-label={`${conflict ? "Open conflict" : "Open evidence"} ${id}`}
+            aria-current={selected ? "true" : undefined}
+            data-research-provenance-id={id}
+            data-selected={selected ? "true" : "false"}
+            data-tone={tone}
+            tabIndex={id === tabStopId ? 0 : -1}
+            onMouseEnter={(event) => onPreview(id, event.currentTarget)}
+            onMouseLeave={() => onPreview(null)}
+            onFocus={(event) => {
+              const buttons = event.currentTarget
+                .closest('[role="group"]')
+                ?.querySelectorAll<HTMLButtonElement>(
+                  "[data-research-provenance-id]",
+                );
+              buttons?.forEach((button) => {
+                button.tabIndex = button === event.currentTarget ? 0 : -1;
+              });
+              onPreview(id, event.currentTarget);
+            }}
+            onBlur={() => onPreview(null)}
+            onKeyDown={(event) => moveFocus(event, index)}
+            onClick={() => onSelect(id)}
+          >
+            {id}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/role-surfaces/research-provenance-edge.tsx
+++ b/src/components/role-surfaces/research-provenance-edge.tsx
@@ -133,7 +133,7 @@ export function ResearchProvenanceEdge({
             onKeyDown={(event) => moveFocus(event, index)}
             onClick={(event) => onSelect(id, event.currentTarget)}
           >
-            {id}
+            <span className="research-provenance-edge__anchor">{id}</span>
           </button>
         );
       })}

--- a/src/components/role-surfaces/research-provenance-edge.tsx
+++ b/src/components/role-surfaces/research-provenance-edge.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { KeyboardEvent } from "react";
+import { useRef, type KeyboardEvent } from "react";
 
 export type ResearchProvenanceTone =
   | "accent"
@@ -26,6 +26,11 @@ const NAVIGATION_KEYS = new Set([
   "End",
 ]);
 
+type PreviewInteraction = {
+  id: string;
+  element: HTMLElement;
+};
+
 export function ResearchProvenanceEdge({
   ids,
   selectedId,
@@ -33,6 +38,9 @@ export function ResearchProvenanceEdge({
   onPreview,
   onSelect,
 }: ResearchProvenanceEdgeProps) {
+  const hoveredPreview = useRef<PreviewInteraction | null>(null);
+  const focusedPreview = useRef<PreviewInteraction | null>(null);
+
   if (ids.length === 0) return null;
 
   const tabStopId = ids.includes(selectedId ?? "") ? selectedId : ids[0];
@@ -86,9 +94,25 @@ export function ResearchProvenanceEdge({
             data-selected={selected ? "true" : "false"}
             data-tone={tone}
             tabIndex={id === tabStopId ? 0 : -1}
-            onMouseEnter={(event) => onPreview(id, event.currentTarget)}
-            onMouseLeave={() => onPreview(null)}
+            onMouseEnter={(event) => {
+              hoveredPreview.current = {
+                id,
+                element: event.currentTarget,
+              };
+              onPreview(id, event.currentTarget);
+            }}
+            onMouseLeave={(event) => {
+              if (hoveredPreview.current?.element === event.currentTarget) {
+                hoveredPreview.current = null;
+              }
+              const focused = focusedPreview.current;
+              onPreview(focused?.id ?? null, focused?.element);
+            }}
             onFocus={(event) => {
+              focusedPreview.current = {
+                id,
+                element: event.currentTarget,
+              };
               const buttons = event.currentTarget
                 .closest('[role="group"]')
                 ?.querySelectorAll<HTMLButtonElement>(
@@ -99,7 +123,13 @@ export function ResearchProvenanceEdge({
               });
               onPreview(id, event.currentTarget);
             }}
-            onBlur={() => onPreview(null)}
+            onBlur={(event) => {
+              if (focusedPreview.current?.element === event.currentTarget) {
+                focusedPreview.current = null;
+              }
+              const hovered = hoveredPreview.current;
+              onPreview(hovered?.id ?? null, hovered?.element);
+            }}
             onKeyDown={(event) => moveFocus(event, index)}
             onClick={() => onSelect(id)}
           >

--- a/src/components/role-surfaces/research-provenance-edge.tsx
+++ b/src/components/role-surfaces/research-provenance-edge.tsx
@@ -82,13 +82,17 @@ export function ResearchProvenanceEdge({
         const conflict = CONFLICT_ID_RE.test(id);
         const selected = selectedId === id;
         const tone = conflict ? "warn" : toneForId(id);
+        const accessibleLabel =
+          tone === "unresolved"
+            ? `Missing source ${id}`
+            : `${conflict ? "Open conflict" : "Open evidence"} ${id}`;
 
         return (
           <button
             key={`${id}-${index}`}
             className={`research-provenance-edge__item research-provenance-edge__item--${tone} focus-ring${selected ? " is-selected" : ""}`}
             type="button"
-            aria-label={`${conflict ? "Open conflict" : "Open evidence"} ${id}`}
+            aria-label={accessibleLabel}
             aria-current={selected ? "true" : undefined}
             data-research-provenance-id={id}
             data-selected={selected ? "true" : "false"}

--- a/src/components/role-surfaces/research-provenance-edge.tsx
+++ b/src/components/role-surfaces/research-provenance-edge.tsx
@@ -13,7 +13,7 @@ export type ResearchProvenanceEdgeProps = {
   selectedId: string | null;
   toneForId: (id: string) => ResearchProvenanceTone;
   onPreview: (id: string | null, element?: HTMLElement) => void;
-  onSelect: (id: string) => void;
+  onSelect: (id: string, invoker: HTMLButtonElement) => void;
 };
 
 const CONFLICT_ID_RE = /^C\d+$/;
@@ -131,7 +131,7 @@ export function ResearchProvenanceEdge({
               onPreview(hovered?.id ?? null, hovered?.element);
             }}
             onKeyDown={(event) => moveFocus(event, index)}
-            onClick={() => onSelect(id)}
+            onClick={(event) => onSelect(id, event.currentTarget)}
           >
             {id}
           </button>

--- a/src/components/role-surfaces/research-provenance-edge.tsx
+++ b/src/components/role-surfaces/research-provenance-edge.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, type KeyboardEvent } from "react";
+import { ResearchSourceIdLabel } from "./research-source-id-label";
 
 export type ResearchProvenanceTone =
   | "accent"
@@ -144,7 +145,10 @@ export function ResearchProvenanceEdge({
               onSelect(id, event.currentTarget);
             }}
           >
-            <span className="research-provenance-edge__anchor">{id}</span>
+            <ResearchSourceIdLabel
+              id={id}
+              className="research-provenance-edge__anchor"
+            />
           </button>
         );
       })}

--- a/src/components/role-surfaces/research-provenance-edge.tsx
+++ b/src/components/role-surfaces/research-provenance-edge.tsx
@@ -62,7 +62,7 @@ export function ResearchProvenanceEdge({
             : (currentIndex + 1) % ids.length;
     const nextId = ids[nextIndex];
     const buttons = event.currentTarget
-      .closest('[role="group"]')
+      .closest(".research-provenance-edge")
       ?.querySelectorAll<HTMLButtonElement>(
         "[data-research-provenance-id]",
       );
@@ -75,7 +75,7 @@ export function ResearchProvenanceEdge({
   return (
     <div
       className="research-provenance-edge"
-      role="group"
+      role="region"
       aria-label={`Evidence references · ${ids.length}`}
     >
       {ids.map((id, index) => {
@@ -118,7 +118,7 @@ export function ResearchProvenanceEdge({
                 element: event.currentTarget,
               };
               const buttons = event.currentTarget
-                .closest('[role="group"]')
+                .closest(".research-provenance-edge")
                 ?.querySelectorAll<HTMLButtonElement>(
                   "[data-research-provenance-id]",
                 );

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -72,6 +72,41 @@ assert.match(
 );
 assert.match(
   source,
+  /new ResizeObserver\(/,
+  "responsive inspector behavior measures the reader container",
+);
+assert.match(
+  source,
+  /const INSPECTOR_OVERLAY_MAX_REM = 62/,
+  "the overlay threshold follows the root rem size used by the container query",
+);
+assert.match(
+  source,
+  /getComputedStyle\(document\.documentElement\)\.fontSize[\s\S]*?INSPECTOR_OVERLAY_MAX_REM \* rootFontSize/,
+  "the overlay threshold converts rem against the live root font size",
+);
+assert.match(
+  source,
+  /documentPane\.inert = inspectorOn && inspectorOverlaysDocument/,
+  "the covered document and contents become inert only in overlay mode",
+);
+assert.match(
+  source,
+  /inspectorFocusReturnRef\.current = invoker/,
+  "the inspector remembers the exact control that invoked it",
+);
+assert.match(
+  source,
+  /selectedSourceId[\s\S]*?research-evidence-card__toggle[\s\S]*?research-evidence-inspector__close[\s\S]*?focus\(\)/,
+  "opening an overlay inspector moves focus to its selected card or close control",
+);
+assert.match(
+  source,
+  /const closeInspector = useCallback\([\s\S]*?\{ restoreFocus = true \}[\s\S]*?inspectorFocusReturnRef\.current[\s\S]*?invoker\?\.focus\(\)/,
+  "ordinary inspector dismissal restores focus to its invoker",
+);
+assert.match(
+  source,
   /const \[selectedSourceId, setSelectedSourceId\] = useState<string \| null>\(null\)/,
   "no evidence source is selected by default",
 );
@@ -136,7 +171,10 @@ assert.match(
   /collapsibleSections=\{false\}/,
   "Research sections retain heading semantics instead of becoming disclosures",
 );
-assert.match(source, /<aside className="rr-col rr-rail"/);
+assert.match(
+  source,
+  /<aside[\s\S]*?ref=\{inspectorRef\}[\s\S]*?className="rr-col rr-rail"/,
+);
 assert.match(source, /onRefClick/);
 assert.match(source, /onPublish/);
 assert.match(source, /<OverflowMenu/, "secondary Research actions live in the shared overflow menu");
@@ -172,7 +210,7 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /onSupport=\{\(target\) => \{\s*setInspectorOn\(false\);\s*requestAnimationFrame\(\(\) =>\s*documentReaderApiRef\.current\?\.scrollToTarget\(target\.id, true\)\s*\);\s*\}\}/,
+  /onSupport=\{\(target\) => \{\s*closeInspector\(\{ restoreFocus: false \}\);\s*requestAnimationFrame\(\(\) =>\s*documentReaderApiRef\.current\?\.scrollToTarget\(target\.id, true\)\s*\);\s*\}\}/,
   "Supports closes the responsive inspector before focusing the cited content",
 );
 

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -206,6 +206,11 @@ assert.match(
 );
 assert.match(
   source,
+  /className="rr-btn rr-btn--accent focus-ring"[\s\S]*?title="Publish"[\s\S]*?onClick=\{onPublish\}/,
+  "the narrow icon-only Publish control exposes a native tooltip matching its name",
+);
+assert.match(
+  source,
   /className="rr-krfocus focus-ring"[\s\S]*?title="Focus table"[\s\S]*?aria-label="Focus table"/,
   "the table focus control exposes a native tooltip matching its accessible name",
 );
@@ -373,6 +378,53 @@ assert.match(
   css,
   /@media \(hover: none\) and \(pointer: coarse\)[\s\S]*?rr-head__actions > \.ui-icon-btn[\s\S]*?min-height:\s*var\(--touch-target\)/,
   "the overflow trigger reaches the touch target on coarse pointers",
+);
+const coarsePointerRules = css.slice(
+  css.indexOf("@media (hover: none) and (pointer: coarse)"),
+  css.indexOf("@media (prefers-reduced-motion: reduce)"),
+);
+const coarsePointerHeightTargets = coarsePointerRules.slice(
+  0,
+  coarsePointerRules.indexOf("}") + 1,
+);
+const coarsePointerHeightEnd = coarsePointerHeightTargets.length;
+for (const selector of [
+  ".research-reader .document-reader__toc-link",
+  ".research-reader .rr-toclink",
+  ".research-reader .document-reader__preferences-trigger",
+  ".research-reader .document-reader__size-step",
+  ".research-reader .document-reader__preference-option",
+  ".research-reader .document-reader__reset",
+]) {
+  assert.match(
+    coarsePointerHeightTargets,
+    new RegExp(selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    `${selector} reaches the touch target height on coarse pointers`,
+  );
+}
+assert.match(
+  coarsePointerHeightTargets,
+  /min-height:\s*var\(--touch-target\)/,
+  "the coarse-pointer height target group uses the shared touch token",
+);
+const coarsePointerWidthTargets = coarsePointerRules.slice(
+  coarsePointerHeightEnd,
+  coarsePointerRules.indexOf("}", coarsePointerHeightEnd) + 1,
+);
+for (const selector of [
+  ".research-reader .document-reader__preferences-trigger",
+  ".research-reader .document-reader__size-step",
+]) {
+  assert.match(
+    coarsePointerWidthTargets,
+    new RegExp(selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    `${selector} reaches the touch target width on coarse pointers`,
+  );
+}
+assert.match(
+  coarsePointerWidthTargets,
+  /min-width:\s*var\(--touch-target\)/,
+  "the coarse-pointer square target group uses the shared touch token",
 );
 assert.match(
   css,

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -21,7 +21,7 @@ assert.match(
 );
 assert.match(
   source,
-  /<DocumentReader[\s\S]*?document=\{doc\}/,
+  /<DocumentReader[\s\S]*?document=\{readerDocument\}/,
   "the source-aware findings model must flow through DocumentReader",
 );
 assert.match(
@@ -33,6 +33,11 @@ assert.match(
   source,
   /deriveResearchFindingsIntegrity/,
   "Research Reader derives evidence integrity from the findings and ledger",
+);
+assert.match(
+  source,
+  /sourceLedger\.sources[\s\S]*?ledger:\s*sourceLedger\.state/,
+  "Research Reader derives evidence truth from the current file-ledger snapshot",
 );
 assert.match(
   source,
@@ -77,6 +82,16 @@ assert.match(
   source,
   /const \[inspectorOn, setInspectorOn\] = useState\(false\)/,
   "the evidence inspector is hidden by default",
+);
+assert.match(
+  source,
+  /const hasNamedSections = doc\.sections\.some[\s\S]*?\{hasNamedSections \? \([\s\S]*?contentsToggleRef/,
+  "headingless reports omit the dead top-level Contents control",
+);
+assert.match(
+  source,
+  /document=\{readerDocument\}/,
+  "DocumentReader receives the artifact-title fallback document",
 );
 assert.match(
   source,
@@ -202,6 +217,11 @@ assert.match(
   source,
   /const onRefClick[\s\S]*?openPanel\("evidence"\)/,
   "inline and margin evidence selection promote Evidence in panel opening order",
+);
+assert.match(
+  source,
+  /closest\("\.rr-kroverlay-card"\)[\s\S]*?closeTable\(\{ restoreFocus: false \}\)[\s\S]*?focusSelectedInspector/,
+  "focused-table evidence closes the table without restoring its invoker before focusing Evidence",
 );
 assert.match(
   source,

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -5,6 +5,14 @@ const source = await readFile(
   new URL("./research-reader.tsx", import.meta.url),
   "utf8",
 );
+const inspectorSource = await readFile(
+  new URL("./research-evidence-inspector.tsx", import.meta.url),
+  "utf8",
+);
+const documentReaderSource = await readFile(
+  new URL("../document-reader.tsx", import.meta.url),
+  "utf8",
+);
 
 assert.match(
   source,
@@ -198,6 +206,36 @@ assert.match(
 );
 assert.match(
   source,
+  /className="rr-krfocus focus-ring"[\s\S]*?title="Focus table"[\s\S]*?aria-label="Focus table"/,
+  "the table focus control exposes a native tooltip matching its accessible name",
+);
+assert.match(
+  source,
+  /title="Close focused table"[\s\S]*?aria-label="Close focused table"/,
+  "the focused-table close control exposes a native tooltip matching its accessible name",
+);
+assert.match(
+  inspectorSource,
+  /title="Close evidence inspector"[\s\S]*?aria-label="Close evidence inspector"/,
+  "the evidence inspector close control exposes a native tooltip matching its accessible name",
+);
+assert.match(
+  inspectorSource,
+  /candidate:\s*\{[\s\S]*?tone:\s*"muted"[\s\S]*?refTone:\s*"accent"/,
+  "candidate evidence keeps its neutral status and accent reference tone",
+);
+assert.match(
+  inspectorSource,
+  /rejected:\s*\{[\s\S]*?tone:\s*"rejected"[\s\S]*?refTone:\s*"muted"/,
+  "rejected evidence has a dedicated danger status without conflating candidate evidence",
+);
+assert.match(
+  documentReaderSource,
+  /title="Reading preferences"[\s\S]*?aria-label="Reading preferences"/,
+  "the shared reading-preferences trigger has matching visible and accessible names",
+);
+assert.match(
+  source,
   /context=\{[\s\S]*?<p title=\{mission\.intent\}>\{mission\.intent\}<\/p>[\s\S]*?\}/,
   "mission intent is passed through as authored context with its full title",
 );
@@ -260,6 +298,49 @@ assert.match(
 // direction overflowed the 268px rail by 1964px with cards clipped; column
 // direction overflows by 0 and every card renders at the full 268px.
 const css = await readFile(new URL("../../styles/research-reader.css", import.meta.url), "utf8");
+assert.match(
+  css,
+  /--research-evidence-edge-reserve:\s*calc\(\s*var\(--space-10\) \+ var\(--space-3\)\s*\)/,
+  "wide Research readers reserve the evidence edge outside the prose measure",
+);
+assert.match(
+  css,
+  /\.research-reader \.rr-doc__column[\s\S]*?var\(--document-reader-prose-measure\) \+[\s\S]*?var\(--research-evidence-edge-reserve\)/,
+  "the paper adds the provenance reserve to the reading preference measure",
+);
+assert.match(
+  css,
+  /@container document-reader \(max-width: 52rem\)[\s\S]*?--research-evidence-edge-reserve:\s*0/,
+  "compact readers remove the hidden evidence-edge reserve",
+);
+for (const rejectedSelector of [
+  ".research-provenance-edge__item--muted",
+  ".rr-sref--muted",
+  ".rr-src--rejected",
+  ".rr-src--rejected.is-selected",
+  ".rr-srcmini--rejected",
+]) {
+  const start = css.indexOf(rejectedSelector);
+  assert.notEqual(start, -1, `${rejectedSelector} exists`);
+  const rule = css.slice(start, css.indexOf("}", start) + 1);
+  assert.match(
+    rule,
+    /var\(--color-danger\)/,
+    `${rejectedSelector} derives its tint from the danger semantic`,
+  );
+}
+const mutedStatus = css.match(/^\.rr-srcstat--muted \{([^}]*)\}/m);
+assert.ok(mutedStatus, "the candidate status tone still exists");
+assert.doesNotMatch(
+  mutedStatus[1],
+  /--color-danger/,
+  "candidate status text does not inherit the rejected danger semantic",
+);
+assert.match(
+  css,
+  /@media \(hover: none\) and \(pointer: coarse\)[\s\S]*?\.rr-inline-ref[\s\S]*?\.rr-krfocus[\s\S]*?document-reader__preferences-trigger[\s\S]*?min-height:\s*var\(--touch-target\)[\s\S]*?\.rr-inline-ref[\s\S]*?\.rr-krfocus[\s\S]*?\.rr-btn--accent[\s\S]*?document-reader__preferences-trigger[\s\S]*?min-width:\s*var\(--touch-target\)/,
+  "coarse-pointer Research controls meet the touch target in both dimensions",
+);
 for (const duplicatedBaseSelector of [
   ".rr-doc h1",
   ".rr-doc h2",

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -398,8 +398,13 @@ assert.match(
 );
 assert.match(
   source,
+  /className=\{`rr-wide-ref rr-wide-ref--\$\{span\.tone\}`\}[\s\S]*?aria-hidden="true"[\s\S]*?<ResearchSourceIdLabel id=\{span\.id\}/,
+  "wide findings retain a separate noninteractive visual reference token",
+);
+assert.match(
+  source,
   /span\.kind === "ref-gap"[\s\S]*?className="rr-inline-ref-gap"/,
-  "parser-owned reference gaps render independently from prose and chips",
+  "parser-owned reference gaps render independently from prose and both reference representations",
 );
 assert.match(
   source,
@@ -505,8 +510,55 @@ assert.match(
   /@container document-reader \(max-width: 65rem\)[\s\S]*?--research-evidence-edge-reserve:\s*0/,
   "compact readers remove the hidden evidence-edge reserve",
 );
+const wideInlineReferenceRule = css.match(/^\.rr-wide-ref \{([^}]*)\}/m);
+assert.ok(wideInlineReferenceRule, "wide visual reference tokens have a dedicated rule");
+assert.match(
+  wideInlineReferenceRule[1],
+  /display:\s*inline-flex/,
+  "authored reference tokens remain visible in wide prose",
+);
+assert.match(
+  wideInlineReferenceRule[1],
+  /font:[^;]*var\(--font-mono\)/,
+  "wide visual reference tokens use restrained source typography",
+);
+assert.match(
+  wideInlineReferenceRule[1],
+  /color:\s*var\(--research-accent\)/,
+  "verified wide references keep the evidence accent",
+);
+assert.doesNotMatch(
+  wideInlineReferenceRule[1],
+  /(?:border|background):/,
+  "wide visual references remain typography rather than a second chip",
+);
+for (const [selector, token] of [
+  [".rr-wide-ref--warn", "--color-warning"],
+  [".rr-wide-ref--muted", "--color-danger"],
+  [".rr-wide-ref--unresolved", "--color-danger"],
+] as const) {
+  const escapedSelector = selector.replace(".", "\\.");
+  const rule = css.match(new RegExp(`^${escapedSelector} \\{([^}]*)\\}`, "m"));
+  assert.ok(rule, `${selector} has a semantic tone rule`);
+  assert.match(
+    rule[1],
+    new RegExp(`var\\(${token}\\)`),
+    `${selector} uses ${token}`,
+  );
+}
+assert.match(
+  css,
+  /@container document-reader \(max-width: 65rem\)[\s\S]*?\.rr-wide-ref\s*\{[\s\S]*?display:\s*none[\s\S]*?\}[\s\S]*?\.rr-inline-ref\s*\{[\s\S]*?display:\s*inline-flex/,
+  "compact readers swap the aria-hidden visual token for the interactive inline ref",
+);
+assert.match(
+  css,
+  /^\.rr-inline-ref-gap \{[\s\S]*?display:\s*inline/m,
+  "authored whitespace remains present beside refs in both layouts",
+);
 for (const rejectedSelector of [
   ".research-provenance-edge__item--muted",
+  ".rr-wide-ref--muted",
   ".rr-sref--muted",
   ".rr-src--rejected",
   ".rr-src--rejected.is-selected",

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -41,6 +41,20 @@ assert.match(
   /block\.kind === "code"[\s\S]*?<MarkdownBlock/,
   "fenced blocks use the shared Markdown renderer so Mermaid diagrams render",
 );
+const codeBranch = source.slice(
+  source.indexOf('if (block.kind === "code")'),
+  source.indexOf('if (block.kind === "table")'),
+);
+assert.match(
+  codeBranch,
+  /<MarkdownBlock/,
+  "code blocks render through the shared Markdown renderer",
+);
+assert.doesNotMatch(
+  codeBranch,
+  /data-document-target|rr-block-row|tabIndex|renderEdge|ResearchProvenanceEdge/,
+  "code blocks stay opaque instead of becoming provenance or focus targets",
+);
 assert.match(
   source,
   /block\.code\.match\(\/`\+\/g\)[\s\S]*?Math\.max\(3, longestBacktickRun \+ 1\)/,

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -90,6 +90,31 @@ assert.match(
 );
 assert.match(
   source,
+  /const RAIL_MIN_REM = 18/,
+  "the resizable inspector minimum matches the CSS 18rem track minimum",
+);
+assert.match(
+  source,
+  /const RAIL_INITIAL_REM = 18\.75[\s\S]*?useState\(RAIL_INITIAL_REM\)/,
+  "the rem-based rail preserves the previous 300px default at the canonical root size",
+);
+assert.match(
+  source,
+  /const COLLAPSE_AT_REM = 15/,
+  "pointer collapse keeps a rem-scaled buffer below the inspector minimum",
+);
+assert.match(
+  source,
+  /widthPx \/ rootFontSize[\s\S]*?Math\.max\(RAIL_MIN_REM,[\s\S]*?Math\.min\(RAIL_MAX_REM, widthRem\)/,
+  "pointer resizing clamps in live root-rem units",
+);
+assert.match(
+  source,
+  /setProperty\("--rail-w", `\$\{railWidth\}rem`\)/,
+  "the rail handle and CSS track share the same rem-based width",
+);
+assert.match(
+  source,
   /getComputedStyle\(document\.documentElement\)\.fontSize[\s\S]*?INSPECTOR_OVERLAY_MAX_REM \* rootFontSize/,
   "the overlay threshold converts rem against the live root font size",
 );
@@ -313,6 +338,35 @@ assert.match(
   /\.research-reader \.rr-doc__column[\s\S]*?var\(--document-reader-prose-measure\) \+[\s\S]*?var\(--research-evidence-edge-reserve\)/,
   "the paper adds the provenance reserve to the reading preference measure",
 );
+const codeBlockRule = css.match(
+  /^\.research-reader \.rr-codeblock \{([^}]*)\}/m,
+);
+assert.ok(codeBlockRule, "Research code blocks have a surface-specific width");
+assert.match(
+  codeBlockRule[1],
+  /width:\s*calc\(\s*100% - var\(--research-evidence-edge-reserve\)\s*\)/,
+  "opaque code and Mermaid stop before the provenance reserve",
+);
+assert.match(
+  codeBlockRule[1],
+  /max-width:\s*calc\(\s*100% - var\(--research-evidence-edge-reserve\)\s*\)/,
+  "opaque code and Mermaid remain contained within the prose/report lane",
+);
+assert.match(
+  codeBlockRule[1],
+  /margin-inline:\s*0/,
+  "Research code blocks do not inherit shared wide-block centering",
+);
+assert.match(
+  codeBlockRule[1],
+  /transform:\s*none/,
+  "Research code blocks do not translate under the provenance reserve",
+);
+assert.match(
+  css,
+  /\.rr-codeblock \.cave-md > \.cm-mermaid-diagram/,
+  "Mermaid uses the same reserve-excluding opaque block wrapper",
+);
 assert.match(
   css,
   /@container document-reader \(max-width: 52rem\)[\s\S]*?--research-evidence-edge-reserve:\s*0/,
@@ -334,6 +388,18 @@ for (const rejectedSelector of [
     `${rejectedSelector} derives its tint from the danger semantic`,
   );
 }
+const unresolvedAnchorInteraction = css.match(
+  /\.research-provenance-edge__item--unresolved:hover[\s\S]*?\{([^}]*)\}/,
+);
+assert.ok(
+  unresolvedAnchorInteraction,
+  "unresolved anchors retain a dedicated hover/selected state",
+);
+assert.match(
+  unresolvedAnchorInteraction[1],
+  /var\(--color-danger\)/,
+  "unresolved anchor interaction paint retains its semantic danger tint",
+);
 const mutedStatus = css.match(/^\.rr-srcstat--muted \{([^}]*)\}/m);
 assert.ok(mutedStatus, "the candidate status tone still exists");
 assert.doesNotMatch(
@@ -345,6 +411,39 @@ assert.match(
   css,
   /@media \(hover: none\) and \(pointer: coarse\)[\s\S]*?\.rr-inline-ref[\s\S]*?\.rr-krfocus[\s\S]*?document-reader__preferences-trigger[\s\S]*?min-height:\s*var\(--touch-target\)[\s\S]*?\.rr-inline-ref[\s\S]*?\.rr-krfocus[\s\S]*?\.rr-btn--accent[\s\S]*?document-reader__preferences-trigger[\s\S]*?min-width:\s*var\(--touch-target\)/,
   "coarse-pointer Research controls meet the touch target in both dimensions",
+);
+const provenanceButtonRule = css.match(
+  /^\.research-provenance-edge__item \{([^}]*)\}/m,
+);
+const provenanceAnchorRule = css.match(
+  /^\.research-provenance-edge__anchor \{([^}]*)\}/m,
+);
+assert.ok(provenanceButtonRule, "the provenance hit-target rule exists");
+assert.ok(provenanceAnchorRule, "the painted provenance anchor rule exists");
+assert.match(
+  provenanceButtonRule[1],
+  /min-width:\s*var\(--space-8\)/,
+  "the provenance button owns the token-sized hit width",
+);
+assert.match(
+  provenanceButtonRule[1],
+  /min-height:\s*var\(--space-8\)/,
+  "the provenance button owns the token-sized hit height",
+);
+assert.match(
+  provenanceButtonRule[1],
+  /background:\s*transparent/,
+  "the larger provenance button stays visually invisible",
+);
+assert.match(
+  provenanceAnchorRule[1],
+  /min-width:\s*var\(--space-6\)/,
+  "the painted anchor is narrower than its button hit target",
+);
+assert.match(
+  provenanceAnchorRule[1],
+  /min-height:\s*var\(--space-6\)/,
+  "the painted anchor is shorter than its button hit target",
 );
 for (const duplicatedBaseSelector of [
   ".rr-doc h1",

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -23,6 +23,21 @@ assert.match(
 );
 assert.match(
   source,
+  /deriveResearchFindingsIntegrity/,
+  "Research Reader derives evidence integrity from the findings and ledger",
+);
+assert.match(
+  source,
+  /<ResearchProvenanceEdge/,
+  "claim-aligned evidence controls use the shared provenance edge",
+);
+assert.match(
+  source,
+  /<ResearchEvidenceInspector/,
+  "all source cards render through the shared evidence inspector",
+);
+assert.match(
+  source,
   /block\.kind === "code"[\s\S]*?<MarkdownBlock/,
   "fenced blocks use the shared Markdown renderer so Mermaid diagrams render",
 );
@@ -33,8 +48,38 @@ assert.match(
 );
 assert.match(
   source,
-  /navigation=\{expanded && tocOn \? "rail" : "compact"\}/,
-  "Research uses the shared compact outline until the wide rail is available",
+  /const \[tocOn, setTocOn\] = useState\(false\)/,
+  "Contents is hidden by default",
+);
+assert.match(
+  source,
+  /const \[inspectorOn, setInspectorOn\] = useState\(false\)/,
+  "the evidence inspector is hidden by default",
+);
+assert.match(
+  source,
+  /const \[selectedSourceId, setSelectedSourceId\] = useState<string \| null>\(null\)/,
+  "no evidence source is selected by default",
+);
+assert.match(
+  source,
+  /const \[activeSection, setActiveSection\] = useState<\{ id: string; heading: string \} \| null>\(null\)/,
+  "the compact chrome waits for the shared reader's active section",
+);
+assert.match(
+  source,
+  /navigation=\{tocOn \? "rail" : "compact"\}/,
+  "Research opts into the shared contents rail independently",
+);
+assert.match(
+  source,
+  /context=\{[\s\S]*?<p title=\{mission\.intent\}>\{mission\.intent\}<\/p>[\s\S]*?\}/,
+  "mission intent is passed through as authored context with its full title",
+);
+assert.match(
+  source,
+  /collapsibleSections=\{false\}/,
+  "Research sections retain heading semantics instead of becoming disclosures",
 );
 assert.match(source, /<aside className="rr-col rr-rail"/);
 assert.match(source, /onRefClick/);
@@ -42,8 +87,33 @@ assert.match(source, /onPublish/);
 assert.match(source, /<OverflowMenu/, "secondary Research actions live in the shared overflow menu");
 assert.match(
   source,
-  /if \(!expanded\) \{\s*setExpanded\(true\);\s*setTocOn\(true\);\s*return;\s*\}\s*setTocOn\(\(value\) => !value\)/,
-  "Contents explicitly enables expansion and the outline when collapsed, then toggles only while expanded",
+  /data-document-target=\{block\.id\}[\s\S]*?renderEdge\(block\.refIds\)/,
+  "simple findings blocks expose stable claim targets beside provenance controls",
+);
+assert.match(
+  source,
+  /className="rr-list-row"[\s\S]*?data-document-target=\{item\.id\}[\s\S]*?renderEdge\(item\.refIds\)/,
+  "each list item owns its focus target and provenance edge",
+);
+assert.match(
+  source,
+  /<th[^>]*scope="col"[^>]*>Evidence<\/th>/,
+  "tables reserve an Evidence column for row provenance",
+);
+assert.match(
+  source,
+  /data-document-target=\{targetable \? row\.id : undefined\}[\s\S]*?renderEdge\(row\.refIds\)/,
+  "table rows are focusable evidence targets with their own provenance edge",
+);
+assert.match(
+  source,
+  /className=\{`rr-sref rr-inline-ref/,
+  "inline references retain their compact representation hook",
+);
+assert.doesNotMatch(
+  source,
+  /const \[expanded, setExpanded\]/,
+  "the old expanded reader mode is removed",
 );
 
 // ── "More sources" scrolls with the rail, never sideways (cave-l2hkx) ───────

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -90,6 +90,11 @@ assert.match(
 );
 assert.match(
   source,
+  /const CONTENTS_SHEET_MAX_REM = 65/,
+  "the Contents sheet threshold includes the 13rem rail beside the intended 52rem document",
+);
+assert.match(
+  source,
   /const RAIL_MIN_REM = 18/,
   "the resizable inspector minimum matches the CSS 18rem track minimum",
 );
@@ -126,7 +131,7 @@ assert.match(
 assert.match(
   source,
   /measureContents\(documentPane\.clientWidth\)[\s\S]*?contentRect\.width[\s\S]*?documentPane\.clientWidth/,
-  "Contents JS follows the DocumentReader container instead of assuming the outer width",
+  "Contents JS measures the outer DocumentReader width against the rail-inclusive threshold",
 );
 assert.match(
   source,
@@ -155,8 +160,18 @@ assert.match(
 );
 assert.match(
   source,
-  /const closeInspector = useCallback\([\s\S]*?\{ restoreFocus = true \}[\s\S]*?inspectorFocusReturnRef\.current[\s\S]*?invoker\?\.focus\(\)/,
-  "ordinary inspector dismissal restores focus to its invoker",
+  /const closeInspector = useCallback\([\s\S]*?\{ restoreFocus = true \}[\s\S]*?focusInspectorReturnTarget/,
+  "ordinary inspector dismissal validates and restores a reachable focus target",
+);
+assert.match(
+  source,
+  /isValidFocusReturnTarget[\s\S]*?isConnected[\s\S]*?closest\("\[inert\]"\)[\s\S]*?getClientRects\(\)\.length[\s\S]*?tabIndex/,
+  "focus restoration rejects detached, inert, hidden, and unfocusable invokers",
+);
+assert.match(
+  source,
+  /inspectorFocusReturnIdRef[\s\S]*?data-research-reference-id[\s\S]*?evidenceToggleRef/,
+  "a hidden invoker falls back to the visible representation of the same reference, then the toolbar toggle",
 );
 assert.match(
   source,
@@ -175,7 +190,7 @@ assert.match(
 );
 assert.match(
   source,
-  /const latestOpenPanel = \(\): ReaderPanel \| null =>[\s\S]*?panelOrderRef\.current[\s\S]*?panelOpenRef\.current\[panel\]/,
+  /const latestOpenPanel = useCallback\(\(\): ReaderPanel \| null =>[\s\S]*?panelOrderRef\.current[\s\S]*?panelOpenRef\.current\[panel\]/,
   "Escape resolves the latest still-open panel from current refs",
 );
 assert.match(
@@ -187,6 +202,16 @@ assert.match(
   source,
   /const onRefClick[\s\S]*?openPanel\("evidence"\)/,
   "inline and margin evidence selection promote Evidence in panel opening order",
+);
+assert.match(
+  source,
+  /const openPanel = useCallback\([\s\S]*?inspectorOverlayRef\.current[\s\S]*?suspendPanel\(otherPanel\)[\s\S]*?panelOpenRef\.current\[panel\] = true/,
+  "opening either panel in Evidence overlay mode synchronously suspends the inaccessible peer first",
+);
+assert.match(
+  source,
+  /const measureInspector[\s\S]*?inspectorOverlayRef\.current = overlays[\s\S]*?overlays &&[\s\S]*?panelOpenRef\.current\.contents[\s\S]*?panelOpenRef\.current\.evidence[\s\S]*?latestOpenPanel\(\)[\s\S]*?suspendPanel/,
+  "the resize measurement synchronously preserves only the latest panel before overlay state renders",
 );
 assert.match(
   source,
@@ -328,8 +353,8 @@ assert.match(
 );
 assert.match(
   source,
-  /<th[^>]*scope="col"[^>]*>Evidence<\/th>/,
-  "tables reserve an Evidence column for row provenance",
+  /<th[^>]*className="rr-table__evidence"[^>]*scope="col"[^>]*>[\s\S]*?rr-table__evidence-heading[\s\S]*?Evidence[\s\S]*?renderEdge\(table\.headerRefIds\)/,
+  "table header references move into the visible Evidence heading cell on wide layouts",
 );
 assert.match(
   source,
@@ -340,6 +365,11 @@ assert.match(
   source,
   /className=\{`rr-sref rr-inline-ref/,
   "inline references retain their compact representation hook",
+);
+assert.match(
+  source,
+  /data-research-reference-id=\{span\.id\}[\s\S]*?data-research-reference-representation="inline"/,
+  "inline references expose the same stable id as their margin representation",
 );
 assert.match(
   source,
@@ -437,7 +467,7 @@ assert.match(
 );
 assert.match(
   css,
-  /@container document-reader \(max-width: 52rem\)[\s\S]*?--research-evidence-edge-reserve:\s*0/,
+  /@container document-reader \(max-width: 65rem\)[\s\S]*?--research-evidence-edge-reserve:\s*0/,
   "compact readers remove the hidden evidence-edge reserve",
 );
 for (const rejectedSelector of [
@@ -554,7 +584,7 @@ assert.match(
 );
 assert.match(
   css,
-  /@container document-reader \(max-width: 52rem\)[\s\S]*?document-reader__toc[\s\S]*?position:\s*absolute[\s\S]*?display:\s*block/,
+  /@container document-reader \(max-width: 65rem\)[\s\S]*?document-reader__layout[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\)[\s\S]*?document-reader__toc[\s\S]*?position:\s*absolute[\s\S]*?display:\s*block/,
   "the dedicated Contents toggle reveals the real navigation as a compact sheet",
 );
 assert.match(

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -229,6 +229,11 @@ const onRefClickBranch = source.slice(
 );
 assert.match(
   onRefClickBranch,
+  /clearPreview\(\)[\s\S]*?const source = sourceById\.get\(id\)/,
+  "committed reference selection replaces any transient preview",
+);
+assert.match(
+  onRefClickBranch,
   /const source = sourceById\.get\(id\)/,
   "evidence selection verifies that the ledger contains a real source row",
 );
@@ -363,8 +368,18 @@ assert.match(
 );
 assert.match(
   source,
+  /redundantRefColumnIndexes\.includes\(index\)[\s\S]*?rr-table__redundant-reference/,
+  "parser-identified redundant reference columns receive a responsive rendering hook",
+);
+assert.match(
+  source,
   /className=\{`rr-sref rr-inline-ref/,
   "inline references retain their compact representation hook",
+);
+assert.match(
+  source,
+  /span\.kind === "ref-gap"[\s\S]*?className="rr-inline-ref-gap"/,
+  "parser-owned reference gaps render independently from prose and chips",
 );
 assert.match(
   source,

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -77,7 +77,7 @@ assert.match(
 );
 assert.match(
   source,
-  /const INSPECTOR_OVERLAY_MAX_REM = 62/,
+  /const INSPECTOR_OVERLAY_MAX_REM = 80/,
   "the overlay threshold follows the root rem size used by the container query",
 );
 assert.match(
@@ -87,8 +87,28 @@ assert.match(
 );
 assert.match(
   source,
+  /measureInspector\(reader\.clientWidth\)[\s\S]*?contentRect\.width[\s\S]*?reader\.clientWidth/,
+  "inspector JS measures the same content box used by its container query",
+);
+assert.match(
+  source,
+  /measureContents\(documentPane\.clientWidth\)[\s\S]*?contentRect\.width[\s\S]*?documentPane\.clientWidth/,
+  "Contents JS follows the DocumentReader container instead of assuming the outer width",
+);
+assert.match(
+  source,
   /documentPane\.inert = inspectorOn && inspectorOverlaysDocument/,
   "the covered document and contents become inert only in overlay mode",
+);
+assert.match(
+  source,
+  /documentScroll\.inert = tocOn && contentsOverlaysDocument/,
+  "the covered report becomes inert while the responsive Contents sheet is open",
+);
+assert.match(
+  source,
+  /document-reader__toc-link\[data-active="true"\][\s\S]*?contents\?\.focus\(\)/,
+  "opening the responsive Contents sheet moves focus into its real navigation",
 );
 assert.match(
   source,
@@ -160,6 +180,21 @@ assert.match(
   source,
   /navigation=\{tocOn \? "rail" : "compact"\}/,
   "Research opts into the shared contents rail independently",
+);
+assert.match(
+  source,
+  /aria-controls="research-reader-contents"/,
+  "the dedicated chrome toggle identifies the Contents panel it controls",
+);
+assert.match(
+  source,
+  /contentsId="research-reader-contents"/,
+  "the real Contents navigation receives the dedicated toggle's controlled id",
+);
+assert.match(
+  source,
+  /<OverflowMenu[\s\S]*?ariaLabel="More research reader actions"[\s\S]*?size="md"/,
+  "the overflow trigger uses the same Cave chrome size as adjacent controls",
 );
 assert.match(
   source,
@@ -240,8 +275,23 @@ for (const duplicatedBaseSelector of [
 }
 assert.match(
   css,
-  /@container research-reader \(max-width: 62rem\)[\s\S]*?\.rr-rail/,
+  /@container research-reader \(max-width: 80rem\)[\s\S]*?\.rr-rail/,
   "the evidence dock overlays instead of squeezing medium readers",
+);
+assert.match(
+  css,
+  /@container document-reader \(max-width: 52rem\)[\s\S]*?document-reader__toc[\s\S]*?position:\s*absolute[\s\S]*?display:\s*block/,
+  "the dedicated Contents toggle reveals the real navigation as a compact sheet",
+);
+assert.match(
+  css,
+  /\.research-reader \.document-reader__compact-nav\s*\{\s*display:\s*none/,
+  "Research hides the shared redundant compact Contents trigger",
+);
+assert.match(
+  css,
+  /@media \(hover: none\) and \(pointer: coarse\)[\s\S]*?rr-head__actions > \.ui-icon-btn[\s\S]*?min-height:\s*var\(--touch-target\)/,
+  "the overflow trigger reaches the touch target on coarse pointers",
 );
 assert.match(
   css,

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -306,6 +306,16 @@ assert.match(
   /className=\{`rr-sref rr-inline-ref/,
   "inline references retain their compact representation hook",
 );
+assert.match(
+  source,
+  /span\.tone === "unresolved"[\s\S]*?" rr-sref--unresolved"/,
+  "missing source spans map exhaustively to the unresolved compact style",
+);
+assert.match(
+  source,
+  /sourceById\.has\(span\.id\)[\s\S]*?"Open evidence"[\s\S]*?Missing source/,
+  "inline missing-source controls expose truthful accessible names",
+);
 assert.doesNotMatch(
   source,
   /const \[expanded, setExpanded\]/,
@@ -328,6 +338,29 @@ assert.match(
 // direction overflowed the 268px rail by 1964px with cards clipped; column
 // direction overflows by 0 and every card renders at the full 268px.
 const css = await readFile(new URL("../../styles/research-reader.css", import.meta.url), "utf8");
+const readerOverlayRule = css.match(
+  /^\.research-reader-overlay \{([^}]*)\}/m,
+);
+assert.ok(readerOverlayRule, "the Research Reader overlay rule exists");
+assert.match(
+  readerOverlayRule[1],
+  /z-index:\s*350/,
+  "Research Reader uses the shared modal layer above mobile navigation",
+);
+const tipRule = css.match(/^\.rr-tip \{([^}]*)\}/m);
+const tableOverlayRule = css.match(/^\.rr-kroverlay \{([^}]*)\}/m);
+assert.ok(tipRule, "the evidence tooltip layer exists");
+assert.ok(tableOverlayRule, "the focused table overlay layer exists");
+assert.match(
+  tipRule[1],
+  /z-index:\s*360/,
+  "evidence previews stay above the reader and below portaled popovers",
+);
+assert.match(
+  tableOverlayRule[1],
+  /z-index:\s*360/,
+  "focused tables stay above the reader and below portaled popovers",
+);
 assert.match(
   css,
   /--research-evidence-edge-reserve:\s*calc\(\s*var\(--space-10\) \+ var\(--space-3\)\s*\)/,
@@ -391,6 +424,13 @@ for (const rejectedSelector of [
 const unresolvedAnchorInteraction = css.match(
   /\.research-provenance-edge__item--unresolved:hover[\s\S]*?\{([^}]*)\}/,
 );
+const unresolvedInlineRule = css.match(/^\.rr-sref--unresolved \{([^}]*)\}/m);
+assert.ok(unresolvedInlineRule, "missing inline refs have a dedicated state");
+assert.match(
+  unresolvedInlineRule[1],
+  /var\(--color-danger\)/,
+  "missing inline refs derive their state from the danger semantic",
+);
 assert.ok(
   unresolvedAnchorInteraction,
   "unresolved anchors retain a dedicated hover/selected state",
@@ -444,6 +484,20 @@ assert.match(
   provenanceAnchorRule[1],
   /min-height:\s*var\(--space-6\)/,
   "the painted anchor is shorter than its button hit target",
+);
+const listMarkerRule = css.match(
+  /\.research-reader \.document-reader__column ol > \.rr-list-row::before,[\s\S]*?\.research-reader \.document-reader__column ul > \.rr-list-row::before \{([^}]*)\}/,
+);
+assert.ok(listMarkerRule, "the custom list marker rule exists");
+assert.match(
+  listMarkerRule[1],
+  /white-space:\s*nowrap/,
+  "multi-digit custom ordered markers never wrap or split",
+);
+assert.match(
+  listMarkerRule[1],
+  /inline-size:\s*max-content/,
+  "custom markers retain intrinsic non-wrapping containment",
 );
 for (const duplicatedBaseSelector of [
   ".rr-doc h1",

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -160,6 +160,41 @@ assert.match(
 );
 assert.match(
   source,
+  /useFocusTrap\(!focusTable, readerRef, \{ onEscape: closeFocusOrReader \}\)/,
+  "the reader focus trap suspends while the portaled table dialog is open",
+);
+assert.match(
+  source,
+  /useFocusTrap\(Boolean\(focusTable\), focusedTableRef, \{[\s\S]*?onEscape: closeTable[\s\S]*?\}\)/,
+  "the focused table owns a dedicated focus trap and Escape dismissal",
+);
+assert.match(
+  source,
+  /const panelOrderRef = useRef<ReaderPanel\[\]>\(\[\]\)/,
+  "Contents and Evidence keep a synchronous opening-order stack",
+);
+assert.match(
+  source,
+  /const latestOpenPanel = \(\): ReaderPanel \| null =>[\s\S]*?panelOrderRef\.current[\s\S]*?panelOpenRef\.current\[panel\]/,
+  "Escape resolves the latest still-open panel from current refs",
+);
+assert.match(
+  source,
+  /const closeFocusOrReader = \(\) => \{[\s\S]*?latestOpenPanel\(\)[\s\S]*?closeContents\(\)[\s\S]*?closeInspector\(\)[\s\S]*?onClose\(\)/,
+  "Escape closes the latest panel before the remaining panel and reader",
+);
+assert.match(
+  source,
+  /const onRefClick[\s\S]*?openPanel\("evidence"\)/,
+  "inline and margin evidence selection promote Evidence in panel opening order",
+);
+assert.match(
+  source,
+  /onSupport=\{\(target\) => \{[\s\S]*?closeInspector\(\{ restoreFocus: false \}\)/,
+  "Supports removes Evidence from the open-panel stack before focusing content",
+);
+assert.match(
+  source,
   /const \[selectedSourceId, setSelectedSourceId\] = useState<string \| null>\(null\)/,
   "no evidence source is selected by default",
 );
@@ -201,7 +236,7 @@ assert.doesNotMatch(
 );
 assert.match(
   onRefClickBranch,
-  /setSelectedSourceId\(id\)[\s\S]*?setInspectorOn\(true\)[\s\S]*?setOpenIds\([\s\S]*?Opened conflict" : "Opened evidence"/,
+  /setSelectedSourceId\(id\)[\s\S]*?openPanel\("evidence"\)[\s\S]*?setOpenIds\([\s\S]*?Opened conflict" : "Opened evidence"/,
   "real source selections retain the existing selected, open, and announced behavior",
 );
 assert.match(

--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -75,6 +75,47 @@ assert.match(
   /const \[selectedSourceId, setSelectedSourceId\] = useState<string \| null>\(null\)/,
   "no evidence source is selected by default",
 );
+const onRefClickBranch = source.slice(
+  source.indexOf("const onRefClick"),
+  source.indexOf("const clearPreview"),
+);
+assert.match(
+  onRefClickBranch,
+  /const source = sourceById\.get\(id\)/,
+  "evidence selection verifies that the ledger contains a real source row",
+);
+const missingRecordGuard = onRefClickBranch.match(
+  /if \(!source\) \{([\s\S]*?)\n\s*\}/,
+);
+assert.ok(
+  missingRecordGuard,
+  "missing source rows have an explicit selection guard",
+);
+assert.ok(
+  onRefClickBranch.indexOf("if (!source)") <
+    onRefClickBranch.indexOf("setSelectedSourceId(id)"),
+  "the missing-record guard runs before any inspector selection mutation",
+);
+assert.match(
+  missingRecordGuard[1],
+  /announce\(\s*`\$\{CONFLICT_ID_RE\.test\(id\) \? "Conflict" : "Evidence"\} \$\{id\} has no source record\.`,?\s*\)/,
+  "missing conflict and evidence references announce that no source record exists",
+);
+assert.match(
+  missingRecordGuard[1],
+  /return;/,
+  "missing source rows stop before any inspector selection state changes",
+);
+assert.doesNotMatch(
+  missingRecordGuard[1],
+  /setSelectedSourceId|setInspectorOn|setOpenIds/,
+  "missing source rows never select, open, or synthesize an inspector card",
+);
+assert.match(
+  onRefClickBranch,
+  /setSelectedSourceId\(id\)[\s\S]*?setInspectorOn\(true\)[\s\S]*?setOpenIds\([\s\S]*?Opened conflict" : "Opened evidence"/,
+  "real source selections retain the existing selected, open, and announced behavior",
+);
 assert.match(
   source,
   /const \[activeSection, setActiveSection\] = useState<\{ id: string; heading: string \} \| null>\(null\)/,
@@ -128,6 +169,11 @@ assert.doesNotMatch(
   source,
   /const \[expanded, setExpanded\]/,
   "the old expanded reader mode is removed",
+);
+assert.match(
+  source,
+  /onSupport=\{\(target\) => \{\s*setInspectorOn\(false\);\s*requestAnimationFrame\(\(\) =>\s*documentReaderApiRef\.current\?\.scrollToTarget\(target\.id, true\)\s*\);\s*\}\}/,
+  "Supports closes the responsive inspector before focusing the cited content",
 );
 
 // ── "More sources" scrolls with the rail, never sideways (cave-l2hkx) ───────

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -495,19 +495,24 @@ export function ResearchReader({
       const key = `${keyPrefix}-${index}`;
       if (span.kind === "ref") {
         const toneClass =
-          span.tone === "warn"
-            ? " rr-sref--warn"
-            : span.tone === "muted"
-              ? " rr-sref--muted"
-              : "";
+          span.tone === "unresolved"
+            ? " rr-sref--unresolved"
+            : span.tone === "warn"
+              ? " rr-sref--warn"
+              : span.tone === "muted"
+                ? " rr-sref--muted"
+                : "";
         const matched =
           hoverKey === span.id || selectedSourceId === span.id;
+        const accessibleLabel = sourceById.has(span.id)
+          ? `${CONFLICT_ID_RE.test(span.id) ? "Open conflict" : "Open evidence"} ${span.id}`
+          : `Missing source ${span.id}`;
         return (
           <button
             key={key}
             type="button"
             className={`rr-sref rr-inline-ref${toneClass}${matched ? " is-match" : ""}`}
-            aria-label={`${CONFLICT_ID_RE.test(span.id) ? "Open conflict" : "Open evidence"} ${span.id}`}
+            aria-label={accessibleLabel}
             onMouseEnter={(event) =>
               onRefPreview(span.id, event.currentTarget)
             }

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -42,6 +43,7 @@ import "@/styles/research-reader.css";
 const RAIL_MIN = 240;
 const RAIL_MAX = 520;
 const COLLAPSE_AT = 200;
+const INSPECTOR_OVERLAY_MAX_REM = 62;
 const CONFIDENCE_RE = /^(high|medium|low)$/i;
 const CONFLICT_ID_RE = /^C\d+$/;
 
@@ -122,6 +124,8 @@ export function ResearchReader({
   const focusedTableRef = useRef<HTMLDivElement | null>(null);
   const contentsToggleRef = useRef<HTMLButtonElement | null>(null);
   const evidenceToggleRef = useRef<HTMLButtonElement | null>(null);
+  const inspectorRef = useRef<HTMLElement | null>(null);
+  const inspectorFocusReturnRef = useRef<HTMLElement | null>(null);
   const draggingRail = useRef(false);
 
   const doc = useMemo(
@@ -149,6 +153,8 @@ export function ResearchReader({
 
   const [tocOn, setTocOn] = useState(false);
   const [inspectorOn, setInspectorOn] = useState(false);
+  const [inspectorOverlaysDocument, setInspectorOverlaysDocument] =
+    useState(false);
   const [selectedSourceId, setSelectedSourceId] = useState<string | null>(null);
   const [activeSection, setActiveSection] = useState<{ id: string; heading: string } | null>(null);
   const [openIds, setOpenIds] = useState<Set<string>>(() => new Set());
@@ -163,14 +169,28 @@ export function ResearchReader({
     requestAnimationFrame(() => tableFocusReturnRef.current?.focus());
   };
 
+  const closeInspector = useCallback(
+    (
+      { restoreFocus = true }: { restoreFocus?: boolean } = {},
+    ) => {
+      setInspectorOn(false);
+      if (!restoreFocus) return;
+      const invoker =
+        inspectorFocusReturnRef.current ?? evidenceToggleRef.current;
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => invoker?.focus());
+      });
+    },
+    [],
+  );
+
   const closeFocusOrReader = () => {
     if (focusTable) {
       closeTable();
       return;
     }
     if (inspectorOn) {
-      setInspectorOn(false);
-      requestAnimationFrame(() => evidenceToggleRef.current?.focus());
+      closeInspector();
       return;
     }
     if (tocOn) {
@@ -182,6 +202,56 @@ export function ResearchReader({
   };
 
   useFocusTrap(true, readerRef, { onEscape: closeFocusOrReader });
+
+  useEffect(() => {
+    const reader = readerRef.current;
+    if (!reader) return;
+
+    const measure = (width: number) => {
+      const rootFontSize =
+        Number.parseFloat(getComputedStyle(document.documentElement).fontSize) ||
+        16;
+      setInspectorOverlaysDocument(
+        width <= INSPECTOR_OVERLAY_MAX_REM * rootFontSize,
+      );
+    };
+    measure(reader.getBoundingClientRect().width);
+
+    const observer = new ResizeObserver((entries) => {
+      measure(entries[0]?.contentRect.width ?? reader.getBoundingClientRect().width);
+    });
+    observer.observe(reader);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const documentPane =
+      readerRef.current?.querySelector<HTMLElement>(".document-reader");
+    if (!documentPane) return;
+    const previousInert = documentPane.inert;
+    documentPane.inert = inspectorOn && inspectorOverlaysDocument;
+    return () => {
+      documentPane.inert = previousInert;
+    };
+  }, [inspectorOn, inspectorOverlaysDocument]);
+
+  useEffect(() => {
+    if (!inspectorOn || !inspectorOverlaysDocument) return;
+    const frame = requestAnimationFrame(() => {
+      const inspector = inspectorRef.current;
+      const target =
+        (selectedSourceId
+          ? inspector?.querySelector<HTMLElement>(
+              '[data-selected="true"] .research-evidence-card__toggle',
+            )
+          : null) ??
+        inspector?.querySelector<HTMLElement>(
+          ".research-evidence-inspector__close",
+        );
+      target?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [inspectorOn, inspectorOverlaysDocument, selectedSourceId]);
 
   useEffect(() => {
     readerRef.current?.style.setProperty("--rail-w", `${railWidth}px`);
@@ -210,7 +280,7 @@ export function ResearchReader({
       if (!draggingRail.current || !readerRef.current) return;
       const rect = readerRef.current.getBoundingClientRect();
       if (rect.right - event.clientX - 1 < COLLAPSE_AT) {
-        setInspectorOn(false);
+        closeInspector();
       }
       draggingRail.current = false;
       readerRef.current
@@ -225,7 +295,7 @@ export function ResearchReader({
       document.removeEventListener("pointermove", move);
       document.removeEventListener("pointerup", up);
     };
-  }, []);
+  }, [closeInspector]);
 
   const passes = mission.iterations.length;
   const rel = relativeTime(artifact.updatedAt);
@@ -295,7 +365,7 @@ export function ResearchReader({
     });
   };
 
-  const onRefClick = (id: string) => {
+  const onRefClick = (id: string, invoker: HTMLElement) => {
     const source = sourceById.get(id);
     if (!source) {
       announce(
@@ -304,6 +374,7 @@ export function ResearchReader({
       return;
     }
 
+    inspectorFocusReturnRef.current = invoker;
     setSelectedSourceId(id);
     setInspectorOn(true);
     setOpenIds((previous) => new Set(previous).add(id));
@@ -390,7 +461,7 @@ export function ResearchReader({
             onMouseLeave={clearPreview}
             onFocus={(event) => onRefPreview(span.id, event.currentTarget)}
             onBlur={clearPreview}
-            onClick={() => onRefClick(span.id)}
+            onClick={(event) => onRefClick(span.id, event.currentTarget)}
           >
             {span.id}
           </button>
@@ -587,6 +658,7 @@ export function ResearchReader({
           aria-label={`${artifact.title} — research reader`}
           data-toc={tocOn}
           data-rail={inspectorOn}
+          data-inspector={inspectorOn}
           data-copied={copied}
           tabIndex={-1}
           onClick={(event) => event.stopPropagation()}
@@ -657,7 +729,14 @@ export function ResearchReader({
                 aria-pressed={inspectorOn}
                 title={inspectorOn ? "Hide evidence" : "Show evidence"}
                 aria-label={inspectorOn ? "Hide evidence" : "Show evidence"}
-                onClick={() => setInspectorOn((value) => !value)}
+                onClick={(event) => {
+                  if (inspectorOn) {
+                    closeInspector();
+                    return;
+                  }
+                  inspectorFocusReturnRef.current = event.currentTarget;
+                  setInspectorOn(true);
+                }}
               >
                 <svg
                   width={15}
@@ -744,7 +823,11 @@ export function ResearchReader({
               <div className="rr-railgrip" />
             </div>
 
-            <aside className="rr-col rr-rail" aria-label="Evidence">
+            <aside
+              ref={inspectorRef}
+              className="rr-col rr-rail"
+              aria-label="Evidence"
+            >
               <ResearchEvidenceInspector
                 sources={mission.sources}
                 integrityLabel={integrity.summary.label}
@@ -755,17 +838,12 @@ export function ResearchReader({
                 onOpenUrl={openUrl}
                 onCite={(source) => void cite(source)}
                 onSupport={(target) => {
-                  setInspectorOn(false);
+                  closeInspector({ restoreFocus: false });
                   requestAnimationFrame(() =>
                     documentReaderApiRef.current?.scrollToTarget(target.id, true)
                   );
                 }}
-                onClose={() => {
-                  setInspectorOn(false);
-                  requestAnimationFrame(() =>
-                    evidenceToggleRef.current?.focus(),
-                  );
-                }}
+                onClose={closeInspector}
               />
             </aside>
           </div>

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -43,7 +43,9 @@ import "@/styles/research-reader.css";
 const RAIL_MIN = 240;
 const RAIL_MAX = 520;
 const COLLAPSE_AT = 200;
-const INSPECTOR_OVERLAY_MAX_REM = 62;
+const CONTENTS_SHEET_MAX_REM = 52;
+// Keep this equal to the research-reader container query in research-reader.css.
+const INSPECTOR_OVERLAY_MAX_REM = 80;
 const CONFIDENCE_RE = /^(high|medium|low)$/i;
 const CONFLICT_ID_RE = /^C\d+$/;
 
@@ -155,6 +157,8 @@ export function ResearchReader({
   const [inspectorOn, setInspectorOn] = useState(false);
   const [inspectorOverlaysDocument, setInspectorOverlaysDocument] =
     useState(false);
+  const [contentsOverlaysDocument, setContentsOverlaysDocument] =
+    useState(false);
   const [selectedSourceId, setSelectedSourceId] = useState<string | null>(null);
   const [activeSection, setActiveSection] = useState<{ id: string; heading: string } | null>(null);
   const [openIds, setOpenIds] = useState<Set<string>>(() => new Set());
@@ -205,23 +209,39 @@ export function ResearchReader({
 
   useEffect(() => {
     const reader = readerRef.current;
-    if (!reader) return;
-
-    const measure = (width: number) => {
-      const rootFontSize =
-        Number.parseFloat(getComputedStyle(document.documentElement).fontSize) ||
-        16;
+    const documentPane =
+      reader?.querySelector<HTMLElement>(".document-reader");
+    if (!reader || !documentPane) return;
+    const rootFontSize =
+      Number.parseFloat(getComputedStyle(document.documentElement).fontSize) ||
+      16;
+    const measureInspector = (width: number) => {
       setInspectorOverlaysDocument(
         width <= INSPECTOR_OVERLAY_MAX_REM * rootFontSize,
       );
     };
-    measure(reader.getBoundingClientRect().width);
+    const measureContents = (width: number) => {
+      setContentsOverlaysDocument(
+        width <= CONTENTS_SHEET_MAX_REM * rootFontSize,
+      );
+    };
+    measureInspector(reader.clientWidth);
+    measureContents(documentPane.clientWidth);
 
-    const observer = new ResizeObserver((entries) => {
-      measure(entries[0]?.contentRect.width ?? reader.getBoundingClientRect().width);
+    const readerObserver = new ResizeObserver((entries) => {
+      measureInspector(entries[0]?.contentRect.width ?? reader.clientWidth);
     });
-    observer.observe(reader);
-    return () => observer.disconnect();
+    const documentObserver = new ResizeObserver((entries) => {
+      measureContents(
+        entries[0]?.contentRect.width ?? documentPane.clientWidth,
+      );
+    });
+    readerObserver.observe(reader);
+    documentObserver.observe(documentPane);
+    return () => {
+      readerObserver.disconnect();
+      documentObserver.disconnect();
+    };
   }, []);
 
   useEffect(() => {
@@ -234,6 +254,29 @@ export function ResearchReader({
       documentPane.inert = previousInert;
     };
   }, [inspectorOn, inspectorOverlaysDocument]);
+
+  useEffect(() => {
+    const documentScroll =
+      readerRef.current?.querySelector<HTMLElement>(".document-reader__scroll");
+    if (!documentScroll) return;
+    const previousInert = documentScroll.inert;
+    documentScroll.inert = tocOn && contentsOverlaysDocument;
+    return () => {
+      documentScroll.inert = previousInert;
+    };
+  }, [contentsOverlaysDocument, tocOn]);
+
+  useEffect(() => {
+    if (!tocOn || !contentsOverlaysDocument) return;
+    if (readerRef.current?.dataset.inspector === "true") return;
+    const frame = requestAnimationFrame(() => {
+      const contents = readerRef.current?.querySelector<HTMLElement>(
+        '.document-reader__toc-link[data-active="true"], .document-reader__toc-link',
+      );
+      contents?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [contentsOverlaysDocument, tocOn]);
 
   useEffect(() => {
     if (!inspectorOn || !inspectorOverlaysDocument) return;
@@ -672,12 +715,14 @@ export function ResearchReader({
               className={`rr-status${published && !rejected ? "" : " rr-status--muted"}`}
             >
               <i className="rr-status__dot" aria-hidden />
-              {lifecycleLabel}
+              <span className="rr-status__label">{lifecycleLabel}</span>
             </span>
             <span
               className={`rr-integrity rr-integrity--${integrity.summary.kind}`}
             >
-              {integrity.summary.label}
+              <span className="rr-integrity__label">
+                {integrity.summary.label}
+              </span>
             </span>
             <span className="rr-meta" title={metaLine}>
               {chromeTitle}
@@ -706,6 +751,7 @@ export function ResearchReader({
                 ref={contentsToggleRef}
                 className="rr-iconbtn focus-ring"
                 type="button"
+                aria-controls="research-reader-contents"
                 aria-pressed={tocOn}
                 title={tocOn ? "Hide contents" : "Show contents"}
                 aria-label={tocOn ? "Hide contents" : "Show contents"}
@@ -750,7 +796,10 @@ export function ResearchReader({
                   <path d="M15 4v16" />
                 </svg>
               </button>
-              <OverflowMenu ariaLabel="More research reader actions">
+              <OverflowMenu
+                ariaLabel="More research reader actions"
+                size="md"
+              >
                 <PopoverItem onSelect={() => void copy()} disabled={!markdown}>
                   {copied ? "Copied findings" : "Copy findings"}
                 </PopoverItem>
@@ -781,6 +830,7 @@ export function ResearchReader({
             <DocumentReader
               document={doc}
               navigation={tocOn ? "rail" : "compact"}
+              contentsId="research-reader-contents"
               kicker={titleCase(artifact.kind)}
               context={
                 hasDocumentContent ? (

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -72,6 +72,8 @@ type EvidenceTip = {
   top: number;
 };
 
+type ReaderPanel = "contents" | "evidence";
+
 function titleCase(value: string): string {
   return value ? value.charAt(0).toUpperCase() + value.slice(1) : value;
 }
@@ -129,6 +131,11 @@ export function ResearchReader({
   const evidenceToggleRef = useRef<HTMLButtonElement | null>(null);
   const inspectorRef = useRef<HTMLElement | null>(null);
   const inspectorFocusReturnRef = useRef<HTMLElement | null>(null);
+  const panelOrderRef = useRef<ReaderPanel[]>([]);
+  const panelOpenRef = useRef<Record<ReaderPanel, boolean>>({
+    contents: false,
+    evidence: false,
+  });
   const draggingRail = useRef(false);
 
   const doc = useMemo(
@@ -169,15 +176,46 @@ export function ResearchReader({
   const [focusTable, setFocusTable] = useState<Extract<FindingsBlock, { kind: "table" }> | null>(null);
   const [tip, setTip] = useState<EvidenceTip | null>(null);
 
-  const closeTable = () => {
+  const openPanel = useCallback((panel: ReaderPanel) => {
+    panelOpenRef.current[panel] = true;
+    panelOrderRef.current = [
+      ...panelOrderRef.current.filter((candidate) => candidate !== panel),
+      panel,
+    ];
+    if (panel === "contents") setTocOn(true);
+    else setInspectorOn(true);
+  }, []);
+
+  const removePanelFromOrder = useCallback((panel: ReaderPanel) => {
+    panelOpenRef.current[panel] = false;
+    panelOrderRef.current = panelOrderRef.current.filter(
+      (candidate) => candidate !== panel,
+    );
+  }, []);
+
+  const closeTable = useCallback(() => {
     setFocusTable(null);
     requestAnimationFrame(() => tableFocusReturnRef.current?.focus());
-  };
+  }, []);
+
+  const closeContents = useCallback(
+    (
+      { restoreFocus = true }: { restoreFocus?: boolean } = {},
+    ) => {
+      removePanelFromOrder("contents");
+      setTocOn(false);
+      if (restoreFocus) {
+        requestAnimationFrame(() => contentsToggleRef.current?.focus());
+      }
+    },
+    [removePanelFromOrder],
+  );
 
   const closeInspector = useCallback(
     (
       { restoreFocus = true }: { restoreFocus?: boolean } = {},
     ) => {
+      removePanelFromOrder("evidence");
       setInspectorOn(false);
       if (!restoreFocus) return;
       const invoker =
@@ -186,27 +224,36 @@ export function ResearchReader({
         requestAnimationFrame(() => invoker?.focus());
       });
     },
-    [],
+    [removePanelFromOrder],
   );
 
+  const latestOpenPanel = (): ReaderPanel | null => {
+    for (let index = panelOrderRef.current.length - 1; index >= 0; index -= 1) {
+      const panel = panelOrderRef.current[index];
+      if (panelOpenRef.current[panel]) return panel;
+    }
+    if (panelOpenRef.current.contents) return "contents";
+    if (panelOpenRef.current.evidence) return "evidence";
+    return null;
+  };
+
   const closeFocusOrReader = () => {
-    if (focusTable) {
-      closeTable();
+    const panel = latestOpenPanel();
+    if (panel === "contents") {
+      closeContents();
       return;
     }
-    if (inspectorOn) {
+    if (panel === "evidence") {
       closeInspector();
-      return;
-    }
-    if (tocOn) {
-      setTocOn(false);
-      requestAnimationFrame(() => contentsToggleRef.current?.focus());
       return;
     }
     onClose();
   };
 
-  useFocusTrap(true, readerRef, { onEscape: closeFocusOrReader });
+  useFocusTrap(!focusTable, readerRef, { onEscape: closeFocusOrReader });
+  useFocusTrap(Boolean(focusTable), focusedTableRef, {
+    onEscape: closeTable,
+  });
 
   useEffect(() => {
     const reader = readerRef.current;
@@ -307,10 +354,6 @@ export function ResearchReader({
       tipRef.current.style.top = `${tip.top}px`;
     }
   }, [tip]);
-
-  useEffect(() => {
-    if (focusTable) focusedTableRef.current?.focus();
-  }, [focusTable]);
 
   useEffect(() => {
     const move = (event: PointerEvent) => {
@@ -429,7 +472,7 @@ export function ResearchReader({
 
     inspectorFocusReturnRef.current = invoker;
     setSelectedSourceId(id);
-    setInspectorOn(true);
+    openPanel("evidence");
     setOpenIds((previous) => new Set(previous).add(id));
     announce(
       `${CONFLICT_ID_RE.test(id) ? "Opened conflict" : "Opened evidence"} ${id}.`,
@@ -772,7 +815,13 @@ export function ResearchReader({
                 aria-pressed={tocOn}
                 title={tocOn ? "Hide contents" : "Show contents"}
                 aria-label={tocOn ? "Hide contents" : "Show contents"}
-                onClick={() => setTocOn((value) => !value)}
+                onClick={() => {
+                  if (panelOpenRef.current.contents) {
+                    closeContents({ restoreFocus: false });
+                    return;
+                  }
+                  openPanel("contents");
+                }}
               >
                 <svg
                   width={15}
@@ -798,7 +847,7 @@ export function ResearchReader({
                     return;
                   }
                   inspectorFocusReturnRef.current = event.currentTarget;
-                  setInspectorOn(true);
+                  openPanel("evidence");
                 }}
               >
                 <svg

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -66,7 +66,7 @@ type EvidenceTip = {
   title: string;
   meta: string;
   label: string;
-  tone: "ok" | "warn" | "muted";
+  tone: "ok" | "warn" | "muted" | "rejected";
   left: number;
   top: number;
 };
@@ -97,7 +97,7 @@ function statusView(status: ResearchSourceRef["status"]): {
 } {
   if (status === "used") return { label: "Verified", tone: "ok" };
   if (status === "conflicting") return { label: "Conflicts", tone: "warn" };
-  if (status === "rejected") return { label: "Rejected", tone: "muted" };
+  if (status === "rejected") return { label: "Rejected", tone: "rejected" };
   return { label: "Candidate", tone: "muted" };
 }
 
@@ -648,6 +648,7 @@ export function ResearchReader({
         <button
           className="rr-krfocus focus-ring"
           type="button"
+          title="Focus table"
           onClick={(event) => {
             tableFocusReturnRef.current = event.currentTarget;
             setFocusTable(block);
@@ -948,7 +949,8 @@ export function ResearchReader({
               <button
                 className="rr-iconbtn focus-ring"
                 type="button"
-                aria-label="Close"
+                title="Close focused table"
+                aria-label="Close focused table"
                 onClick={closeTable}
               >
                 <svg

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -1,51 +1,49 @@
 "use client";
 
-/**
- * Research Reader — typeset findings deliverable viewer.
- *
- * Recreates the Claude Design handoff "Research Reader.dc.html": a rich reader
- * that replaces the raw-markdown <pre> dump for a mission's Findings (and the
- * other prose deliverables). The document body is the mission's real
- * findings.md, typeset into a serif title, an italic lede, collapsible sections
- * with an accent tick, a Key Results table (with a focus overlay), and inline
- * S#/C# source-ref chips. The evidence rail is built from the mission's real
- * ledger sources — hovering a chip and its card cross-highlight, and a card's
- * "Supports" links are derived from the sections that actually cite it.
- *
- * Everything is derived from real data; nothing is invented. When the findings
- * file has not been written yet the reader shows an honest empty state.
- */
-
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { createPortal } from "react-dom";
-import { useAnnouncer } from "@/components/ui/live-region";
-import { OverflowMenu } from "@/components/ui/overflow-menu";
-import { PopoverItem, PopoverSeparator } from "@/components/ui/popover";
 import {
   DocumentReader,
   type DocumentReaderApi,
 } from "@/components/document-reader";
 import { MarkdownBlock } from "@/components/message-bubble";
-import { useFocusTrap } from "@/lib/use-focus-trap";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { OverflowMenu } from "@/components/ui/overflow-menu";
+import { PopoverItem } from "@/components/ui/popover";
 import { copyText } from "@/lib/clipboard";
 import { relativeTime } from "@/lib/relative-time";
 import {
   parseFindingsDoc,
-  sectionsSupportingRef,
+  targetsSupportingRef,
   type FindingsBlock,
   type FindingsSpan,
-  type FindingsRefTone,
+  type FindingsSupportTarget,
 } from "@/lib/research-findings-doc";
+import { deriveResearchFindingsIntegrity } from "@/lib/research-findings-integrity";
 import type {
   ResearchArtifactRef,
   ResearchMission,
   ResearchSourceRef,
 } from "@/lib/research-missions";
+import { useFocusTrap } from "@/lib/use-focus-trap";
+import { ResearchEvidenceInspector } from "./research-evidence-inspector";
+import {
+  ResearchProvenanceEdge,
+  type ResearchProvenanceTone,
+} from "./research-provenance-edge";
 import "@/styles/research-reader.css";
 
 const RAIL_MIN = 240;
 const RAIL_MAX = 520;
-const COLLAPSE_AT = 200; // drag narrower than this releases into collapsed
+const COLLAPSE_AT = 200;
+const CONFIDENCE_RE = /^(high|medium|low)$/i;
+const CONFLICT_ID_RE = /^C\d+$/;
 
 type ResearchReaderProps = {
   mission: ResearchMission;
@@ -59,37 +57,15 @@ type ResearchReaderProps = {
   onPublish?: () => void;
 };
 
-// ── inline icons (verbatim from the design) ────────────────────────────────
-const CaretDown = ({ size = 13 }: { size?: number }) => (
-  <svg className="rr-sec-caret" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="m6 9 6 6 6-6" /></svg>
-);
-
-// ── source card view model ──────────────────────────────────────────────────
-type CardModel = {
-  source: ResearchSourceRef;
-  variant: string;
-  refTone: FindingsRefTone;
-  statusLabel: string;
-  statusTone: "ok" | "warn" | "muted";
+type EvidenceTip = {
+  id: string;
+  title: string;
   meta: string;
-  supports: Array<{ id: string; heading: string }>;
-  citeCount: number;
+  label: string;
+  tone: "ok" | "warn" | "muted";
+  left: number;
+  top: number;
 };
-
-function statusView(status: ResearchSourceRef["status"]): { label: string; tone: "ok" | "warn" | "muted"; refTone: FindingsRefTone } {
-  if (status === "used") return { label: "Verified", tone: "ok", refTone: "accent" };
-  if (status === "conflicting") return { label: "Conflicts", tone: "warn", refTone: "warn" };
-  if (status === "rejected") return { label: "Rejected", tone: "muted", refTone: "muted" };
-  return { label: "Candidate", tone: "muted", refTone: "accent" };
-}
-
-function sourceMeta(source: ResearchSourceRef): string {
-  const parts = [source.publisher || source.sourceType];
-  if (source.publishedAt) parts.push(source.publishedAt);
-  if (source.url) parts.push("fetched");
-  else if (source.localPath) parts.push("local");
-  return parts.filter(Boolean).join(" · ");
-}
 
 function titleCase(value: string): string {
   return value ? value.charAt(0).toUpperCase() + value.slice(1) : value;
@@ -103,9 +79,40 @@ function citationText(source: ResearchSourceRef): string {
   return bits.join(" · ");
 }
 
-const CONFIDENCE_RE = /^(high|medium|low)$/i;
+function sourceMeta(source: ResearchSourceRef): string {
+  const parts = [source.publisher || source.sourceType];
+  if (source.publishedAt) parts.push(source.publishedAt);
+  if (source.url) parts.push("fetched");
+  else if (source.localPath) parts.push("local");
+  return parts.filter(Boolean).join(" · ");
+}
 
-export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl, onPublish }: ResearchReaderProps) {
+function statusView(status: ResearchSourceRef["status"]): {
+  label: string;
+  tone: EvidenceTip["tone"];
+} {
+  if (status === "used") return { label: "Verified", tone: "ok" };
+  if (status === "conflicting") return { label: "Conflicts", tone: "warn" };
+  if (status === "rejected") return { label: "Rejected", tone: "muted" };
+  return { label: "Candidate", tone: "muted" };
+}
+
+function refIdsForSpans(spans: FindingsSpan[]): string[] {
+  const ids: string[] = [];
+  for (const span of spans) {
+    if (span.kind === "ref" && !ids.includes(span.id)) ids.push(span.id);
+  }
+  return ids;
+}
+
+export function ResearchReader({
+  mission,
+  artifact,
+  markdown,
+  onClose,
+  onOpenUrl,
+  onPublish,
+}: ResearchReaderProps) {
   const { announce } = useAnnouncer();
   const readerRef = useRef<HTMLDivElement | null>(null);
   const documentReaderApiRef = useRef<DocumentReaderApi | null>(null);
@@ -113,34 +120,69 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
   const tipRef = useRef<HTMLDivElement | null>(null);
   const tableFocusReturnRef = useRef<HTMLButtonElement | null>(null);
   const focusedTableRef = useRef<HTMLDivElement | null>(null);
+  const contentsToggleRef = useRef<HTMLButtonElement | null>(null);
+  const evidenceToggleRef = useRef<HTMLButtonElement | null>(null);
+  const draggingRail = useRef(false);
 
   const doc = useMemo(
     () => parseFindingsDoc(markdown ?? "", mission.sources),
     [markdown, mission.sources],
   );
+  const integrity = useMemo(
+    () => deriveResearchFindingsIntegrity(markdown ?? "", mission.sources),
+    [markdown, mission.sources],
+  );
+  const sourceById = useMemo(
+    () => new Map(mission.sources.map((source) => [source.id, source])),
+    [mission.sources],
+  );
+  const targetsBySource = useMemo(
+    () =>
+      new Map<string, FindingsSupportTarget[]>(
+        mission.sources.map((source) => [
+          source.id,
+          targetsSupportingRef(doc, source.id),
+        ]),
+      ),
+    [doc, mission.sources],
+  );
 
-  const [expanded, setExpanded] = useState(false);
-  const [tocOn, setTocOn] = useState(true);
-  const [railOn, setRailOn] = useState(true);
+  const [tocOn, setTocOn] = useState(false);
+  const [inspectorOn, setInspectorOn] = useState(false);
+  const [selectedSourceId, setSelectedSourceId] = useState<string | null>(null);
+  const [activeSection, setActiveSection] = useState<{ id: string; heading: string } | null>(null);
+  const [openIds, setOpenIds] = useState<Set<string>>(() => new Set());
   const [railWidth, setRailWidth] = useState(300);
   const [copied, setCopied] = useState(false);
-  const [openCards, setOpenCards] = useState<Set<string>>(() => new Set());
   const [hoverKey, setHoverKey] = useState<string | null>(null);
   const [focusTable, setFocusTable] = useState<Extract<FindingsBlock, { kind: "table" }> | null>(null);
-  const [tip, setTip] = useState<{ id: string; title: string; meta: string; label: string; tone: "ok" | "warn" | "muted"; left: number; top: number } | null>(null);
+  const [tip, setTip] = useState<EvidenceTip | null>(null);
 
   const closeTable = () => {
     setFocusTable(null);
     requestAnimationFrame(() => tableFocusReturnRef.current?.focus());
   };
+
   const closeFocusOrReader = () => {
-    if (focusTable) closeTable();
-    else onClose();
+    if (focusTable) {
+      closeTable();
+      return;
+    }
+    if (inspectorOn) {
+      setInspectorOn(false);
+      requestAnimationFrame(() => evidenceToggleRef.current?.focus());
+      return;
+    }
+    if (tocOn) {
+      setTocOn(false);
+      requestAnimationFrame(() => contentsToggleRef.current?.focus());
+      return;
+    }
+    onClose();
   };
+
   useFocusTrap(true, readerRef, { onEscape: closeFocusOrReader });
 
-  // Reader data-attrs and the resizable rail width are set imperatively so the
-  // panel carries no static inline style.
   useEffect(() => {
     readerRef.current?.style.setProperty("--rail-w", `${railWidth}px`);
   }, [railWidth]);
@@ -156,54 +198,35 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
     if (focusTable) focusedTableRef.current?.focus();
   }, [focusTable]);
 
-  // ── evidence rail model ──────────────────────────────────────────────────
-  const { fullCards, miniSources, usedCount } = useMemo(() => {
-    const cards: CardModel[] = [];
-    const mini: ResearchSourceRef[] = [];
-    let used = 0;
-    for (const source of mission.sources) {
-      if (source.status === "used") used += 1;
-      const view = statusView(source.status);
-      const supports = sectionsSupportingRef(doc, source.id);
-      const isFull =
-        source.status === "conflicting" ||
-        source.status === "rejected" ||
-        Boolean(source.claim) ||
-        Boolean(source.note);
-      if (!isFull) {
-        mini.push(source);
-        continue;
+  useEffect(() => {
+    const move = (event: PointerEvent) => {
+      if (!draggingRail.current || !readerRef.current) return;
+      const rect = readerRef.current.getBoundingClientRect();
+      let width = rect.right - event.clientX - 1;
+      if (width < COLLAPSE_AT) width = RAIL_MIN;
+      setRailWidth(Math.max(RAIL_MIN, Math.min(RAIL_MAX, width)));
+    };
+    const up = (event: PointerEvent) => {
+      if (!draggingRail.current || !readerRef.current) return;
+      const rect = readerRef.current.getBoundingClientRect();
+      if (rect.right - event.clientX - 1 < COLLAPSE_AT) {
+        setInspectorOn(false);
       }
-      cards.push({
-        source,
-        variant: "",
-        refTone: view.refTone,
-        statusLabel: view.label,
-        statusTone: view.tone,
-        meta: sourceMeta(source),
-        supports,
-        citeCount: supports.length,
-      });
-    }
-    // Order: most-cited verified source first (accent), conflicts next,
-    // rejected last — the design's visual priority, from real citation counts.
-    const rank = (card: CardModel) => (card.source.status === "rejected" ? 2 : card.source.status === "conflicting" ? 1 : 0);
-    cards.sort((a, b) => rank(a) - rank(b) || b.citeCount - a.citeCount);
-    const topCited = cards.find((card) => rank(card) === 0 && card.citeCount > 0);
-    for (const card of cards) {
-      card.variant =
-        card.source.status === "rejected"
-          ? "rr-src--rejected"
-          : card.source.status === "conflicting"
-            ? "rr-src--warn"
-            : card === topCited
-              ? "rr-src--accent"
-              : "";
-    }
-    return { fullCards: cards, miniSources: mini, usedCount: used };
-  }, [mission.sources, doc]);
+      draggingRail.current = false;
+      readerRef.current
+        .querySelector(".rr-railhandle")
+        ?.removeAttribute("data-drag");
+      document.body.style.userSelect = "";
+    };
 
-  // ── header meta ──────────────────────────────────────────────────────────
+    document.addEventListener("pointermove", move);
+    document.addEventListener("pointerup", up);
+    return () => {
+      document.removeEventListener("pointermove", move);
+      document.removeEventListener("pointerup", up);
+    };
+  }, []);
+
   const passes = mission.iterations.length;
   const rel = relativeTime(artifact.updatedAt);
   const metaLine = [
@@ -216,13 +239,25 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
   ]
     .filter(Boolean)
     .join(" · ");
-
-  const published = Boolean(artifact.knowledgeId) || artifact.state === "published";
+  const published =
+    Boolean(artifact.knowledgeId) || artifact.state === "published";
   const rejected = artifact.state === "rejected";
-  const statusLabel = rejected ? "Rejected" : published ? "Published" : "Working draft";
-  const showPublish = Boolean(onPublish) && artifact.state === "working" && !artifact.knowledgeId;
+  const lifecycleLabel = rejected
+    ? "Rejected"
+    : published
+      ? "Published"
+      : "Working draft";
+  const showPublish =
+    Boolean(onPublish) &&
+    artifact.state === "working" &&
+    !artifact.knowledgeId;
+  const compactTitle = doc.title ?? artifact.title;
+  const chromeTitle = activeSection?.heading
+    ? `${compactTitle} · ${activeSection.heading}`
+    : compactTitle;
+  const hasDocumentContent =
+    doc.title !== null || doc.lede !== null || doc.sections.length > 0;
 
-  // ── actions ──────────────────────────────────────────────────────────────
   const copy = async () => {
     if (!markdown) return;
     const ok = await copyText(markdown);
@@ -234,113 +269,119 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
     announce("Findings copied as markdown.");
     window.setTimeout(() => setCopied(false), 1400);
   };
+
   const exportPdf = () => {
     if (typeof window !== "undefined") window.print();
   };
+
   const openUrl = (url: string | undefined) => {
     if (!url) return;
     if (onOpenUrl) onOpenUrl(url);
     else window.open(url, "_blank", "noopener,noreferrer");
   };
+
   const cite = async (source: ResearchSourceRef) => {
     const ok = await copyText(citationText(source));
     announce(ok ? "Citation copied." : "Citation could not be copied.");
   };
-  const toggleContents = () => {
-    if (!expanded) {
-      setExpanded(true);
-      setTocOn(true);
-      return;
-    }
-    setTocOn((value) => !value);
-  };
 
-  const toggleCard = (id: string) =>
-    setOpenCards((prev) => {
-      const next = new Set(prev);
+  const toggleSource = (id: string) => {
+    setSelectedSourceId(id);
+    setOpenIds((previous) => {
+      const next = new Set(previous);
       if (next.has(id)) next.delete(id);
       else next.add(id);
       return next;
     });
-
-  const scrollToSection = (id: string) => {
-    documentReaderApiRef.current?.scrollToSection(id);
   };
 
-  // Chip click opens the matching evidence card (and reveals the rail).
   const onRefClick = (id: string) => {
-    if (mission.sources.some((source) => source.id === id)) {
-      if (!railOn) setRailOn(true);
-      setOpenCards((prev) => new Set(prev).add(id));
-    }
+    setSelectedSourceId(id);
+    setInspectorOn(true);
+    setOpenIds((previous) => new Set(previous).add(id));
+    announce(
+      `${CONFLICT_ID_RE.test(id) ? "Opened conflict" : "Opened evidence"} ${id}.`,
+    );
   };
-  const onRefEnter = (event: { currentTarget: Element }, id: string) => {
+
+  const clearPreview = () => {
+    setHoverKey(null);
+    setTip(null);
+  };
+
+  const onRefPreview = (id: string | null, element?: HTMLElement) => {
+    if (!id || !element) {
+      clearPreview();
+      return;
+    }
+
     setHoverKey(id);
-    const source = mission.sources.find((item) => item.id === id);
-    const view = source ? statusView(source.status) : { label: "Conflict", tone: "warn" as const, refTone: "warn" as const };
-    const rect = event.currentTarget.getBoundingClientRect();
+    const source = sourceById.get(id);
+    const view = source
+      ? statusView(source.status)
+      : CONFLICT_ID_RE.test(id)
+        ? { label: "Conflict", tone: "warn" as const }
+        : { label: "Unresolved", tone: "warn" as const };
+    const rect = element.getBoundingClientRect();
     setTip({
       id,
-      title: source?.title ?? "Open conflict",
-      meta: source ? sourceMeta(source) : "flagged for the next pass",
+      title:
+        source?.title ??
+        (CONFLICT_ID_RE.test(id) ? "Open conflict" : "Unresolved reference"),
+      meta: source ? sourceMeta(source) : "No matching ledger record",
       label: view.label,
       tone: view.tone,
       left: Math.max(8, Math.min(rect.left, window.innerWidth - 272)),
       top: rect.top - 8,
     });
   };
-  const clearHover = () => {
-    setHoverKey(null);
-    setTip(null);
+
+  const toneForId = (id: string): ResearchProvenanceTone => {
+    if (CONFLICT_ID_RE.test(id)) return "warn";
+    if (integrity.unresolvedIds.includes(id)) return "unresolved";
+    const source = sourceById.get(id);
+    if (source?.status === "conflicting") return "warn";
+    if (source?.status === "rejected") return "muted";
+    return source ? "accent" : "unresolved";
   };
 
-  // ── rail resize (pointer drag on the handle) ─────────────────────────────
-  const draggingRail = useRef(false);
-  const onHandleDown = (event: React.PointerEvent) => {
-    draggingRail.current = true;
-    (event.currentTarget as HTMLElement).setAttribute("data-drag", "true");
-    document.body.style.userSelect = "none";
-    event.preventDefault();
-  };
-  useEffect(() => {
-    const move = (event: PointerEvent) => {
-      if (!draggingRail.current || !readerRef.current) return;
-      const rect = readerRef.current.getBoundingClientRect();
-      let w = rect.right - event.clientX - 1;
-      if (w < COLLAPSE_AT) w = RAIL_MIN; // preview only; release decides collapse
-      setRailWidth(Math.max(RAIL_MIN, Math.min(RAIL_MAX, w)));
-    };
-    const up = (event: PointerEvent) => {
-      if (!draggingRail.current || !readerRef.current) return;
-      const rect = readerRef.current.getBoundingClientRect();
-      if (rect.right - event.clientX - 1 < COLLAPSE_AT) setRailOn(false);
-      draggingRail.current = false;
-      readerRef.current.querySelector(".rr-railhandle")?.removeAttribute("data-drag");
-      document.body.style.userSelect = "";
-    };
-    document.addEventListener("pointermove", move);
-    document.addEventListener("pointerup", up);
-    return () => {
-      document.removeEventListener("pointermove", move);
-      document.removeEventListener("pointerup", up);
-    };
-  }, []);
+  const renderEdge = (ids: string[]) => (
+    <ResearchProvenanceEdge
+      ids={ids}
+      selectedId={selectedSourceId}
+      toneForId={toneForId}
+      onPreview={onRefPreview}
+      onSelect={onRefClick}
+    />
+  );
 
-  // ── span / block rendering ───────────────────────────────────────────────
-  const renderSpans = (spans: FindingsSpan[], keyPrefix: string): ReactNode[] =>
-    spans.map((span, i) => {
-      const key = `${keyPrefix}-${i}`;
+  const renderSpans = (
+    spans: FindingsSpan[],
+    keyPrefix: string,
+  ): ReactNode[] =>
+    spans.map((span, index) => {
+      const key = `${keyPrefix}-${index}`;
       if (span.kind === "ref") {
-        const toneClass = span.tone === "warn" ? " rr-sref--warn" : span.tone === "muted" ? " rr-sref--muted" : "";
+        const toneClass =
+          span.tone === "warn"
+            ? " rr-sref--warn"
+            : span.tone === "muted"
+              ? " rr-sref--muted"
+              : "";
+        const matched =
+          hoverKey === span.id || selectedSourceId === span.id;
         return (
           <button
             key={key}
             type="button"
-            className={`rr-sref${toneClass}${hoverKey === span.id ? " is-match" : ""}`}
-            onMouseEnter={(event) => onRefEnter(event, span.id)}
-            onMouseLeave={clearHover}
-            onFocus={(event) => onRefEnter(event, span.id)}
-            onBlur={clearHover}
+            className={`rr-sref rr-inline-ref${toneClass}${matched ? " is-match" : ""}`}
+            aria-label={`${CONFLICT_ID_RE.test(span.id) ? "Open conflict" : "Open evidence"} ${span.id}`}
+            onMouseEnter={(event) =>
+              onRefPreview(span.id, event.currentTarget)
+            }
+            onMouseLeave={clearPreview}
+            onFocus={(event) => onRefPreview(span.id, event.currentTarget)}
+            onBlur={clearPreview}
             onClick={() => onRefClick(span.id)}
           >
             {span.id}
@@ -359,37 +400,111 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
       return <span key={key}>{span.text}</span>;
     });
 
+  const renderLede = (lede: FindingsSpan[]): ReactNode => (
+    <div
+      className="rr-block-row"
+      data-document-target={doc.ledeId ?? undefined}
+      tabIndex={doc.ledeId ? -1 : undefined}
+    >
+      <div>{renderSpans(lede, "lede")}</div>
+      {renderEdge(refIdsForSpans(lede))}
+    </div>
+  );
+
   const renderCell = (cell: FindingsSpan[], key: string): ReactNode => {
-    if (cell.length === 1 && cell[0].kind === "text" && CONFIDENCE_RE.test(cell[0].text.trim())) {
+    if (
+      cell.length === 1 &&
+      cell[0].kind === "text" &&
+      CONFIDENCE_RE.test(cell[0].text.trim())
+    ) {
       const level = cell[0].text.trim().toLowerCase();
-      const tone = level === "high" ? "rr-cf--high" : level === "medium" ? "rr-cf--med" : "rr-cf--low";
+      const tone =
+        level === "high"
+          ? "rr-cf--high"
+          : level === "medium"
+            ? "rr-cf--med"
+            : "rr-cf--low";
       return <span className={`rr-cf ${tone}`}>{cell[0].text.trim()}</span>;
     }
     return renderSpans(cell, key);
   };
 
-  const renderTable = (table: Extract<FindingsBlock, { kind: "table" }>): ReactNode => (
+  const renderTable = (
+    table: Extract<FindingsBlock, { kind: "table" }>,
+    targetable = true,
+  ): ReactNode => (
     <table className="rr-table">
       <thead>
-        <tr>{table.header.map((cell, i) => <th key={i} scope="col">{renderSpans(cell, `th-${i}`)}</th>)}</tr>
+        <tr>
+          {table.header.map((cell, index) => (
+            <th key={`header-${index}`} scope="col">
+              {renderSpans(cell, `th-${index}`)}
+            </th>
+          ))}
+          <th className="rr-table__evidence" scope="col">Evidence</th>
+        </tr>
       </thead>
       <tbody>
-        {table.rows.map((row, r) => (
-          <tr key={r}>{row.map((cell, c) => <td key={c}>{renderCell(cell, `td-${r}-${c}`)}</td>)}</tr>
+        {table.rows.map((row) => (
+          <tr
+            key={row.id}
+            data-document-target={targetable ? row.id : undefined}
+            tabIndex={targetable ? -1 : undefined}
+          >
+            {row.cells.map((cell, index) => (
+              <td key={`${row.id}:cell:${index}`}>
+                {renderCell(cell, `${row.id}:cell:${index}`)}
+              </td>
+            ))}
+            <td className="rr-table__evidence">
+              {renderEdge(row.refIds)}
+            </td>
+          </tr>
         ))}
       </tbody>
     </table>
   );
 
   const renderBlock = (block: FindingsBlock, key: string): ReactNode => {
-    if (block.kind === "p") return <p key={key}>{renderSpans(block.spans, key)}</p>;
-    if (block.kind === "ul") {
+    if (block.kind === "p" || block.kind === "quote") {
+      const content =
+        block.kind === "quote" ? (
+          <blockquote>{renderSpans(block.spans, key)}</blockquote>
+        ) : (
+          <p>{renderSpans(block.spans, key)}</p>
+        );
       return (
-        <ul key={key}>
-          {block.items.map((item, i) => <li key={i}>{renderSpans(item, `${key}-li-${i}`)}</li>)}
-        </ul>
+        <div
+          key={key}
+          className="rr-block-row"
+          data-document-target={block.id}
+          tabIndex={-1}
+        >
+          {content}
+          {renderEdge(block.refIds)}
+        </div>
       );
     }
+
+    if (block.kind === "ul" || block.kind === "ol") {
+      const List = block.kind;
+      return (
+        <List key={key}>
+          {block.items.map((item) => (
+            <li
+              key={item.id}
+              className="rr-list-row"
+              data-document-target={item.id}
+              tabIndex={-1}
+            >
+              <span>{renderSpans(item.spans, `${key}:${item.id}`)}</span>
+              {renderEdge(item.refIds)}
+            </li>
+          ))}
+        </List>
+      );
+    }
+
     if (block.kind === "code") {
       const longestBacktickRun = Math.max(
         0,
@@ -397,15 +512,24 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
       );
       const fence = "`".repeat(Math.max(3, longestBacktickRun + 1));
       return (
-        <div className="rr-codeblock document-reader__wide-block" key={key}>
-          <MarkdownBlock
-            text={`${fence}${block.language}\n${block.code}\n${fence}`}
-            onOpenUrl={openUrl}
-          />
+        <div
+          key={key}
+          className="rr-block-row"
+          data-document-target={block.id}
+          tabIndex={-1}
+        >
+          <div className="rr-codeblock document-reader__wide-block">
+            <MarkdownBlock
+              text={`${fence}${block.language}\n${block.code}\n${fence}`}
+              onOpenUrl={openUrl}
+            />
+          </div>
+          {renderEdge([])}
         </div>
       );
     }
-    return (
+
+    if (block.kind === "table") return (
       <div className="rr-krblock document-reader__wide-block" key={key}>
         <button
           className="rr-krfocus focus-ring"
@@ -416,7 +540,16 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
           }}
           aria-label="Focus table"
         >
-          <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><path d="M15 3h6v6m0-6-7 7M9 21H3v-6m0 6 7-7" /></svg>
+          <svg
+            width={13}
+            height={13}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.8}
+          >
+            <path d="M15 3h6v6m0-6-7 7M9 21H3v-6m0 6 7-7" />
+          </svg>
         </button>
         <div
           className="rr-krframe focus-ring"
@@ -428,160 +561,139 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
         </div>
       </div>
     );
+
+    return null;
   };
 
-  const renderCard = (card: CardModel): ReactNode => {
-    const { source } = card;
-    const open = openCards.has(source.id);
-    const refTone = card.refTone === "warn" ? " rr-sref--warn" : card.refTone === "muted" ? " rr-sref--muted" : "";
-    return (
-      <div
-        key={source.id}
-        className={`rr-src ${card.variant}${hoverKey === source.id ? " is-match" : ""}`}
-        data-open={open}
-        onMouseEnter={() => setHoverKey(source.id)}
-        onMouseLeave={() => setHoverKey(null)}
-      >
-        <button className="rr-src__toggle focus-ring" type="button" aria-expanded={open} onClick={() => toggleCard(source.id)}>
-          <div className="rr-src__head">
-            <span className={`rr-sref${refTone}`}>{source.id}</span>
-            <span className={`rr-srcstat rr-srcstat--${card.statusTone}`}>
-              <i className="rr-srcstat__dot" aria-hidden />
-              {card.statusLabel}
-            </span>
-            <CaretDown />
-          </div>
-          <div className="rr-src__title">{source.title}</div>
-          <div className="rr-src__meta">{card.meta}</div>
-        </button>
-        {open ? (
-          <div className="rr-srcdetail">
-            {source.claim ? <div className="rr-sd-quote">“{source.claim}”</div> : null}
-            {source.publisher || source.publishedAt ? (
-              <div className="rr-sd-row">
-                <span className="rr-sd-k">Source</span>
-                <span className="rr-sd-v">{[source.publisher, source.publishedAt].filter(Boolean).join(" · ")}</span>
-              </div>
-            ) : null}
-            <div className="rr-sd-row">
-              <span className="rr-sd-k">Type</span>
-              <span className="rr-sd-v">{source.sourceType}</span>
-            </div>
-            {source.note ? (
-              <div className="rr-sd-row">
-                <span className="rr-sd-k">{source.status === "rejected" ? "Rejected" : "Note"}</span>
-                <span className="rr-sd-v">{source.note}</span>
-              </div>
-            ) : null}
-            {source.confidence !== undefined ? (
-              <div className="rr-sd-row">
-                <span className="rr-sd-k">Confidence</span>
-                <span className="rr-sd-v">{Math.round(source.confidence * 100)}%</span>
-              </div>
-            ) : null}
-            {card.supports.length ? (
-              <div className="rr-sd-supports">
-                <span className="rr-sd-supports__label">Supports</span>
-                {card.supports.map((section) => (
-                  <button key={section.id} type="button" className="rr-sd-supportlink focus-ring" onClick={() => scrollToSection(section.id)}>
-                    {section.heading}
-                  </button>
-                ))}
-              </div>
-            ) : null}
-            <div className="rr-sd-actions">
-              <button className="rr-sd-btn rr-sd-btn--accent" type="button" disabled={!source.url} onClick={() => openUrl(source.url)}>
-                <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><path d="M7 17 17 7M7 7h10v10" /></svg>
-                Open source
-              </button>
-              <button className="rr-sd-btn" type="button" onClick={() => cite(source)}>
-                <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><rect x="9" y="9" width="11" height="11" rx="2" /><path d="M5 15V5a2 2 0 0 1 2-2h10" /></svg>
-                Cite
-              </button>
-            </div>
-          </div>
-        ) : null}
-      </div>
-    );
+  const onHandleDown = (event: React.PointerEvent) => {
+    draggingRail.current = true;
+    event.currentTarget.setAttribute("data-drag", "true");
+    document.body.style.userSelect = "none";
+    event.preventDefault();
   };
 
   return createPortal(
     <>
-      <div className="research-reader-overlay" role="presentation" onClick={onClose}>
+      <div
+        className="research-reader-overlay"
+        role="presentation"
+        onClick={onClose}
+      >
         <div
           ref={readerRef}
           className="research-reader focus-ring"
           role="dialog"
           aria-modal="true"
           aria-label={`${artifact.title} — research reader`}
-          data-expanded={expanded}
           data-toc={tocOn}
-          data-rail={railOn}
+          data-rail={inspectorOn}
           data-copied={copied}
           tabIndex={-1}
           onClick={(event) => event.stopPropagation()}
         >
-          <div className="rr-pbar"><div className="rr-pbar__fill" ref={pbarRef} /></div>
+          <div className="rr-pbar">
+            <div className="rr-pbar__fill" ref={pbarRef} />
+          </div>
 
           <div className="rr-head">
-            <span className={`rr-status${published && !rejected ? "" : " rr-status--muted"}`}>
+            <span
+              className={`rr-status${published && !rejected ? "" : " rr-status--muted"}`}
+            >
               <i className="rr-status__dot" aria-hidden />
-              {statusLabel}
+              {lifecycleLabel}
             </span>
-            <span className="rr-meta">{metaLine}</span>
+            <span
+              className={`rr-integrity rr-integrity--${integrity.summary.kind}`}
+            >
+              {integrity.summary.label}
+            </span>
+            <span className="rr-meta" title={metaLine}>
+              {chromeTitle}
+            </span>
             <div className="rr-head__actions">
               {showPublish ? (
-                <button className="rr-btn rr-btn--accent focus-ring" type="button" onClick={onPublish}>
-                  <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Z" /></svg>
+                <button
+                  className="rr-btn rr-btn--accent focus-ring"
+                  type="button"
+                  onClick={onPublish}
+                >
+                  <svg
+                    width={14}
+                    height={14}
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={1.8}
+                  >
+                    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2Z" />
+                  </svg>
                   Publish
                 </button>
               ) : null}
               <button
+                ref={contentsToggleRef}
                 className="rr-iconbtn focus-ring"
                 type="button"
-                aria-pressed={railOn}
-                title="Toggle evidence"
-                aria-label="Toggle evidence"
-                onClick={() => setRailOn((v) => !v)}
+                aria-pressed={tocOn}
+                title={tocOn ? "Hide contents" : "Show contents"}
+                aria-label={tocOn ? "Hide contents" : "Show contents"}
+                onClick={() => setTocOn((value) => !value)}
               >
-                <svg width={15} height={15} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M15 4v16" /></svg>
-              </button>
-              {!showPublish ? (
-                <button
-                  className="rr-iconbtn focus-ring"
-                  type="button"
-                  title={expanded ? "Collapse" : "Expand"}
-                  aria-label={expanded ? "Collapse" : "Expand"}
-                  onClick={() => setExpanded((v) => !v)}
+                <svg
+                  width={15}
+                  height={15}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.8}
                 >
-                  {expanded ? (
-                    <svg width={15} height={15} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><path d="M9 9 4 4m0 0v4m0-4h4m6 5 5-5m0 0v4m0-4h-4M9 15l-5 5m0 0v-4m0 4h4m6-5 5 5m0 0v-4m0 4h-4" /></svg>
-                  ) : (
-                    <svg width={15} height={15} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><path d="M15 3h6v6m0-6-7 7M9 21H3v-6m0 6 7-7" /></svg>
-                  )}
-                </button>
-              ) : null}
+                  <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" />
+                </svg>
+              </button>
+              <button
+                ref={evidenceToggleRef}
+                className="rr-iconbtn focus-ring"
+                type="button"
+                aria-pressed={inspectorOn}
+                title={inspectorOn ? "Hide evidence" : "Show evidence"}
+                aria-label={inspectorOn ? "Hide evidence" : "Show evidence"}
+                onClick={() => setInspectorOn((value) => !value)}
+              >
+                <svg
+                  width={15}
+                  height={15}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.8}
+                >
+                  <rect x="3" y="4" width="18" height="16" rx="2" />
+                  <path d="M15 4v16" />
+                </svg>
+              </button>
               <OverflowMenu ariaLabel="More research reader actions">
                 <PopoverItem onSelect={() => void copy()} disabled={!markdown}>
                   {copied ? "Copied findings" : "Copy findings"}
                 </PopoverItem>
                 <PopoverItem onSelect={exportPdf}>Export PDF</PopoverItem>
-                <PopoverSeparator />
-                <PopoverItem
-                  checked={expanded && tocOn}
-                  checkedRole="checkbox"
-                  onSelect={toggleContents}
-                >
-                  Contents
-                </PopoverItem>
-                {showPublish ? (
-                  <PopoverItem onSelect={() => setExpanded((value) => !value)}>
-                    {expanded ? "Collapse reader" : "Expand reader"}
-                  </PopoverItem>
-                ) : null}
               </OverflowMenu>
-              <button className="rr-iconbtn focus-ring" type="button" title="Close" aria-label="Close" onClick={onClose}>
-                <svg width={15} height={15} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9}><path d="M6 6l12 12M18 6 6 18" /></svg>
+              <button
+                className="rr-iconbtn focus-ring"
+                type="button"
+                title="Close"
+                aria-label="Close"
+                onClick={onClose}
+              >
+                <svg
+                  width={15}
+                  height={15}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.9}
+                >
+                  <path d="M6 6l12 12M18 6 6 18" />
+                </svg>
               </button>
             </div>
           </div>
@@ -589,9 +701,16 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
           <div className="research-reader__grid">
             <DocumentReader
               document={doc}
-              navigation={expanded && tocOn ? "rail" : "compact"}
+              navigation={tocOn ? "rail" : "compact"}
               kicker={titleCase(artifact.kind)}
+              context={
+                hasDocumentContent ? (
+                  <p title={mission.intent}>{mission.intent}</p>
+                ) : undefined
+              }
+              collapsibleSections={false}
               apiRef={documentReaderApiRef}
+              onActiveSectionChange={setActiveSection}
               onScrollProgress={(progress) => {
                 if (pbarRef.current) {
                   pbarRef.current.style.width = `${progress * 100}%`;
@@ -599,69 +718,70 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
               }}
               tocMeta={
                 <>
-                <span>{mission.sources.length} sources · {usedCount} used</span>
-                <span>{passes} pass{passes === 1 ? "" : "es"} · {mission.mode}</span>
+                  <span>
+                    {mission.sources.length} sources · {integrity.counts.used} used
+                  </span>
+                  <span>
+                    {passes} pass{passes === 1 ? "" : "es"} · {mission.mode}
+                  </span>
                 </>
               }
               empty={
                 <div className="rr-empty">
-                  This {artifact.title.toLowerCase()} deliverable has not been written yet.
+                  This {artifact.title.toLowerCase()} deliverable has not been
+                  written yet.
                 </div>
               }
-              renderLede={(lede) => renderSpans(lede, "lede")}
+              renderLede={renderLede}
               renderBlock={renderBlock}
             />
 
-            <div className="rr-railhandle" onPointerDown={onHandleDown} aria-hidden>
+            <div
+              className="rr-railhandle"
+              onPointerDown={onHandleDown}
+              aria-hidden
+            >
               <div className="rr-railgrip" />
             </div>
 
             <aside className="rr-col rr-rail" aria-label="Evidence">
-              <button className="rr-railhead focus-ring" type="button" title="Collapse evidence" onClick={() => setRailOn(false)}>
-                <span className="rr-railhead__label">Evidence · {usedCount} used</span>
-              </button>
-              <div className="rr-rail__list">
-                {fullCards.length === 0 && miniSources.length === 0 ? (
-                  <p className="rr-src__meta">No sources in the ledger yet.</p>
-                ) : null}
-                {fullCards.map(renderCard)}
-                {miniSources.length ? (
-                  <div className="rr-more">
-                    <div className="rr-more__label">More sources · {miniSources.length}</div>
-                    <div className="rr-srcscroll">
-                      {miniSources.map((source) => {
-                        const view = statusView(source.status);
-                        const toneClass = view.refTone === "warn" ? " rr-sref--warn" : view.refTone === "muted" ? " rr-sref--muted" : "";
-                        return (
-                          <button
-                            key={source.id}
-                            type="button"
-                            className={`rr-srcmini${source.status === "rejected" ? " rr-srcmini--rejected" : ""}`}
-                            onMouseEnter={() => setHoverKey(source.id)}
-                            onMouseLeave={() => setHoverKey(null)}
-                            onClick={() => openUrl(source.url)}
-                          >
-                            <span className={`rr-sref${toneClass}`}>{source.id}</span>
-                            <div className="rr-srcmini__title">{source.title}</div>
-                            <div className="rr-srcmini__meta">{sourceMeta(source)}</div>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                ) : null}
-              </div>
+              <ResearchEvidenceInspector
+                sources={mission.sources}
+                integrityLabel={integrity.summary.label}
+                selectedId={selectedSourceId}
+                openIds={openIds}
+                targetsBySource={targetsBySource}
+                onToggle={toggleSource}
+                onOpenUrl={openUrl}
+                onCite={(source) => void cite(source)}
+                onSupport={(target) =>
+                  documentReaderApiRef.current?.scrollToTarget(target.id, true)
+                }
+                onClose={() => {
+                  setInspectorOn(false);
+                  requestAnimationFrame(() =>
+                    evidenceToggleRef.current?.focus(),
+                  );
+                }}
+              />
             </aside>
           </div>
         </div>
       </div>
 
-      <div className="rr-tip" ref={tipRef} data-show={tip ? "true" : "false"} aria-hidden>
+      <div
+        className="rr-tip"
+        ref={tipRef}
+        data-show={tip ? "true" : "false"}
+        aria-hidden
+      >
         {tip ? (
           <>
             <div className="rr-tip__head">
               <span className="rr-tip__id">{tip.id}</span>
-              <span className={`rr-tip__status rr-srcstat--${tip.tone}`}>
+              <span
+                className={`rr-tip__status rr-srcstat--${tip.tone}`}
+              >
                 <i className="rr-srcstat__dot" aria-hidden />
                 {tip.label}
               </span>
@@ -673,18 +793,46 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
       </div>
 
       {focusTable ? (
-        <div className="rr-kroverlay" role="presentation" onClick={closeTable}>
-          <div ref={focusedTableRef} className="rr-kroverlay-card" role="dialog" aria-modal="true" tabIndex={-1} aria-label="Key results" onClick={(event) => event.stopPropagation()}>
+        <div
+          className="rr-kroverlay"
+          role="presentation"
+          onClick={closeTable}
+        >
+          <div
+            ref={focusedTableRef}
+            className="rr-kroverlay-card"
+            role="dialog"
+            aria-modal="true"
+            tabIndex={-1}
+            aria-label="Key results"
+            onClick={(event) => event.stopPropagation()}
+          >
             <div className="rr-kroverlay__head">
               <div>
                 <div className="rr-kroverlay__title">Key results</div>
-                <div className="rr-kroverlay__sub">{focusTable.rows.length} findings · reference table</div>
+                <div className="rr-kroverlay__sub">
+                  {focusTable.rows.length} findings · reference table
+                </div>
               </div>
-              <button className="rr-iconbtn focus-ring" type="button" aria-label="Close" onClick={closeTable}>
-                <svg width={16} height={16} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9}><path d="M6 6l12 12M18 6 6 18" /></svg>
+              <button
+                className="rr-iconbtn focus-ring"
+                type="button"
+                aria-label="Close"
+                onClick={closeTable}
+              >
+                <svg
+                  width={16}
+                  height={16}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.9}
+                >
+                  <path d="M6 6l12 12M18 6 6 18" />
+                </svg>
               </button>
             </div>
-            {renderTable(focusTable)}
+            {renderTable(focusTable, false)}
           </div>
         </div>
       ) : null}

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -553,6 +553,7 @@ export function ResearchReader({
   };
 
   const onRefClick = (id: string, invoker: HTMLElement) => {
+    clearPreview();
     const source = sourceById.get(id);
     if (!source) {
       announce(
@@ -628,6 +629,13 @@ export function ResearchReader({
   ): ReactNode[] =>
     spans.map((span, index) => {
       const key = `${keyPrefix}-${index}`;
+      if (span.kind === "ref-gap") {
+        return (
+          <span key={key} className="rr-inline-ref-gap">
+            {span.text}
+          </span>
+        );
+      }
       if (span.kind === "ref") {
         const toneClass =
           span.tone === "unresolved"
@@ -711,7 +719,15 @@ export function ResearchReader({
       <thead>
         <tr>
           {table.header.map((cell, index) => (
-            <th key={`header-${index}`} scope="col">
+            <th
+              key={`header-${index}`}
+              className={
+                table.redundantRefColumnIndexes.includes(index)
+                  ? "rr-table__redundant-reference"
+                  : undefined
+              }
+              scope="col"
+            >
               {renderSpans(cell, `th-${index}`)}
             </th>
           ))}
@@ -731,7 +747,14 @@ export function ResearchReader({
             tabIndex={targetable ? -1 : undefined}
           >
             {row.cells.map((cell, index) => (
-              <td key={`${row.id}:cell:${index}`}>
+              <td
+                key={`${row.id}:cell:${index}`}
+                className={
+                  table.redundantRefColumnIndexes.includes(index)
+                    ? "rr-table__redundant-reference"
+                    : undefined
+                }
+              >
                 {renderCell(cell, `${row.id}:cell:${index}`)}
               </td>
             ))}

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -296,6 +296,14 @@ export function ResearchReader({
   };
 
   const onRefClick = (id: string) => {
+    const source = sourceById.get(id);
+    if (!source) {
+      announce(
+        `${CONFLICT_ID_RE.test(id) ? "Conflict" : "Evidence"} ${id} has no source record.`,
+      );
+      return;
+    }
+
     setSelectedSourceId(id);
     setInspectorOn(true);
     setOpenIds((previous) => new Set(previous).add(id));
@@ -746,9 +754,12 @@ export function ResearchReader({
                 onToggle={toggleSource}
                 onOpenUrl={openUrl}
                 onCite={(source) => void cite(source)}
-                onSupport={(target) =>
-                  documentReaderApiRef.current?.scrollToTarget(target.id, true)
-                }
+                onSupport={(target) => {
+                  setInspectorOn(false);
+                  requestAnimationFrame(() =>
+                    documentReaderApiRef.current?.scrollToTarget(target.id, true)
+                  );
+                }}
                 onClose={() => {
                   setInspectorOn(false);
                   requestAnimationFrame(() =>

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -44,7 +44,7 @@ const RAIL_MIN_REM = 18;
 const RAIL_INITIAL_REM = 18.75;
 const RAIL_MAX_REM = 32.5;
 const COLLAPSE_AT_REM = 15;
-const CONTENTS_SHEET_MAX_REM = 52;
+const CONTENTS_SHEET_MAX_REM = 65;
 // Keep this equal to the research-reader container query in research-reader.css.
 const INSPECTOR_OVERLAY_MAX_REM = 80;
 const CONFIDENCE_RE = /^(high|medium|low)$/i;
@@ -112,6 +112,24 @@ function refIdsForSpans(spans: FindingsSpan[]): string[] {
   return ids;
 }
 
+function isValidFocusReturnTarget(
+  element: HTMLElement | null,
+): element is HTMLElement {
+  if (!element?.isConnected || element.closest("[inert]")) return false;
+  if (element.closest('[aria-hidden="true"]')) return false;
+  if (element instanceof HTMLButtonElement && element.disabled) return false;
+  const style = getComputedStyle(element);
+  if (
+    style.display === "none" ||
+    style.visibility === "hidden" ||
+    style.visibility === "collapse" ||
+    element.getClientRects().length === 0
+  ) {
+    return false;
+  }
+  return element.tabIndex >= 0;
+}
+
 export function ResearchReader({
   mission,
   artifact,
@@ -131,6 +149,8 @@ export function ResearchReader({
   const evidenceToggleRef = useRef<HTMLButtonElement | null>(null);
   const inspectorRef = useRef<HTMLElement | null>(null);
   const inspectorFocusReturnRef = useRef<HTMLElement | null>(null);
+  const inspectorFocusReturnIdRef = useRef<string | null>(null);
+  const inspectorOverlayRef = useRef(false);
   const panelOrderRef = useRef<ReaderPanel[]>([]);
   const panelOpenRef = useRef<Record<ReaderPanel, boolean>>({
     contents: false,
@@ -176,22 +196,42 @@ export function ResearchReader({
   const [focusTable, setFocusTable] = useState<Extract<FindingsBlock, { kind: "table" }> | null>(null);
   const [tip, setTip] = useState<EvidenceTip | null>(null);
 
-  const openPanel = useCallback((panel: ReaderPanel) => {
-    panelOpenRef.current[panel] = true;
-    panelOrderRef.current = [
-      ...panelOrderRef.current.filter((candidate) => candidate !== panel),
-      panel,
-    ];
-    if (panel === "contents") setTocOn(true);
-    else setInspectorOn(true);
-  }, []);
-
   const removePanelFromOrder = useCallback((panel: ReaderPanel) => {
     panelOpenRef.current[panel] = false;
     panelOrderRef.current = panelOrderRef.current.filter(
       (candidate) => candidate !== panel,
     );
   }, []);
+
+  const suspendPanel = useCallback(
+    (panel: ReaderPanel) => {
+      removePanelFromOrder(panel);
+      if (panel === "contents") setTocOn(false);
+      else setInspectorOn(false);
+    },
+    [removePanelFromOrder],
+  );
+
+  const openPanel = useCallback(
+    (panel: ReaderPanel) => {
+      const otherPanel: ReaderPanel =
+        panel === "contents" ? "evidence" : "contents";
+      if (
+        inspectorOverlayRef.current &&
+        panelOpenRef.current[otherPanel]
+      ) {
+        suspendPanel(otherPanel);
+      }
+      panelOpenRef.current[panel] = true;
+      panelOrderRef.current = [
+        ...panelOrderRef.current.filter((candidate) => candidate !== panel),
+        panel,
+      ];
+      if (panel === "contents") setTocOn(true);
+      else setInspectorOn(true);
+    },
+    [suspendPanel],
+  );
 
   const closeTable = useCallback(() => {
     setFocusTable(null);
@@ -202,32 +242,57 @@ export function ResearchReader({
     (
       { restoreFocus = true }: { restoreFocus?: boolean } = {},
     ) => {
-      removePanelFromOrder("contents");
-      setTocOn(false);
+      suspendPanel("contents");
       if (restoreFocus) {
         requestAnimationFrame(() => contentsToggleRef.current?.focus());
       }
     },
-    [removePanelFromOrder],
+    [suspendPanel],
   );
+
+  const focusInspectorReturnTarget = useCallback(() => {
+    const invoker = inspectorFocusReturnRef.current;
+    if (isValidFocusReturnTarget(invoker)) {
+      invoker.focus();
+      return;
+    }
+
+    const referenceId = inspectorFocusReturnIdRef.current;
+    if (referenceId) {
+      const representations =
+        readerRef.current?.querySelectorAll<HTMLElement>(
+          "[data-research-reference-id]",
+        ) ?? [];
+      for (const representation of representations) {
+        if (
+          representation.dataset.researchReferenceId === referenceId &&
+          isValidFocusReturnTarget(representation)
+        ) {
+          representation.focus();
+          return;
+        }
+      }
+    }
+
+    if (isValidFocusReturnTarget(evidenceToggleRef.current)) {
+      evidenceToggleRef.current.focus();
+    }
+  }, []);
 
   const closeInspector = useCallback(
     (
       { restoreFocus = true }: { restoreFocus?: boolean } = {},
     ) => {
-      removePanelFromOrder("evidence");
-      setInspectorOn(false);
+      suspendPanel("evidence");
       if (!restoreFocus) return;
-      const invoker =
-        inspectorFocusReturnRef.current ?? evidenceToggleRef.current;
       requestAnimationFrame(() => {
-        requestAnimationFrame(() => invoker?.focus());
+        requestAnimationFrame(focusInspectorReturnTarget);
       });
     },
-    [removePanelFromOrder],
+    [focusInspectorReturnTarget, suspendPanel],
   );
 
-  const latestOpenPanel = (): ReaderPanel | null => {
+  const latestOpenPanel = useCallback((): ReaderPanel | null => {
     for (let index = panelOrderRef.current.length - 1; index >= 0; index -= 1) {
       const panel = panelOrderRef.current[index];
       if (panelOpenRef.current[panel]) return panel;
@@ -235,7 +300,7 @@ export function ResearchReader({
     if (panelOpenRef.current.contents) return "contents";
     if (panelOpenRef.current.evidence) return "evidence";
     return null;
-  };
+  }, []);
 
   const closeFocusOrReader = () => {
     const panel = latestOpenPanel();
@@ -264,9 +329,18 @@ export function ResearchReader({
       Number.parseFloat(getComputedStyle(document.documentElement).fontSize) ||
       16;
     const measureInspector = (width: number) => {
-      setInspectorOverlaysDocument(
-        width <= INSPECTOR_OVERLAY_MAX_REM * rootFontSize,
-      );
+      const overlays = width <= INSPECTOR_OVERLAY_MAX_REM * rootFontSize;
+      inspectorOverlayRef.current = overlays;
+      if (
+        overlays &&
+        panelOpenRef.current.contents &&
+        panelOpenRef.current.evidence
+      ) {
+        const panelToSuspend =
+          latestOpenPanel() === "contents" ? "evidence" : "contents";
+        suspendPanel(panelToSuspend);
+      }
+      setInspectorOverlaysDocument(overlays);
     };
     const measureContents = (width: number) => {
       setContentsOverlaysDocument(
@@ -290,7 +364,7 @@ export function ResearchReader({
       readerObserver.disconnect();
       documentObserver.disconnect();
     };
-  }, []);
+  }, [latestOpenPanel, suspendPanel]);
 
   useEffect(() => {
     const documentPane =
@@ -315,8 +389,14 @@ export function ResearchReader({
   }, [contentsOverlaysDocument, tocOn]);
 
   useEffect(() => {
-    if (!tocOn || !contentsOverlaysDocument) return;
-    if (readerRef.current?.dataset.inspector === "true") return;
+    if (
+      !tocOn ||
+      (!contentsOverlaysDocument && !inspectorOverlaysDocument) ||
+      !panelOpenRef.current.contents ||
+      panelOpenRef.current.evidence
+    ) {
+      return;
+    }
     const frame = requestAnimationFrame(() => {
       const contents = readerRef.current?.querySelector<HTMLElement>(
         '.document-reader__toc-link[data-active="true"], .document-reader__toc-link',
@@ -324,10 +404,21 @@ export function ResearchReader({
       contents?.focus();
     });
     return () => cancelAnimationFrame(frame);
-  }, [contentsOverlaysDocument, tocOn]);
+  }, [
+    contentsOverlaysDocument,
+    inspectorOn,
+    inspectorOverlaysDocument,
+    tocOn,
+  ]);
 
   useEffect(() => {
-    if (!inspectorOn || !inspectorOverlaysDocument) return;
+    if (
+      !inspectorOn ||
+      !inspectorOverlaysDocument ||
+      !panelOpenRef.current.evidence
+    ) {
+      return;
+    }
     const frame = requestAnimationFrame(() => {
       const inspector = inspectorRef.current;
       const target =
@@ -471,6 +562,7 @@ export function ResearchReader({
     }
 
     inspectorFocusReturnRef.current = invoker;
+    inspectorFocusReturnIdRef.current = id;
     setSelectedSourceId(id);
     openPanel("evidence");
     setOpenIds((previous) => new Set(previous).add(id));
@@ -556,6 +648,8 @@ export function ResearchReader({
             type="button"
             className={`rr-sref rr-inline-ref${toneClass}${matched ? " is-match" : ""}`}
             aria-label={accessibleLabel}
+            data-research-reference-id={span.id}
+            data-research-reference-representation="inline"
             onMouseEnter={(event) =>
               onRefPreview(span.id, event.currentTarget)
             }
@@ -621,7 +715,12 @@ export function ResearchReader({
               {renderSpans(cell, `th-${index}`)}
             </th>
           ))}
-          <th className="rr-table__evidence" scope="col">Evidence</th>
+          <th className="rr-table__evidence" scope="col">
+            <span className="rr-table__evidence-heading">
+              <span>Evidence</span>
+              {renderEdge(table.headerRefIds)}
+            </span>
+          </th>
         </tr>
       </thead>
       <tbody>
@@ -847,6 +946,7 @@ export function ResearchReader({
                     return;
                   }
                   inspectorFocusReturnRef.current = event.currentTarget;
+                  inspectorFocusReturnIdRef.current = null;
                   openPanel("evidence");
                 }}
               >

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Fragment,
   useCallback,
   useEffect,
   useMemo,
@@ -180,23 +181,30 @@ export function ResearchFindingsInlineSpans({
         ? `${CONFLICT_ID_RE.test(span.id) ? "Open conflict" : "Open evidence"} ${span.id}`
         : `Missing source ${span.id}`;
       return (
-        <button
-          key={key}
-          type="button"
-          className={`rr-sref rr-inline-ref${toneClass}${matched ? " is-match" : ""}`}
-          aria-label={accessibleLabel}
-          data-research-reference-id={span.id}
-          data-research-reference-representation="inline"
-          onMouseEnter={(event) =>
-            onRefPreview(span.id, event.currentTarget)
-          }
-          onMouseLeave={onClearPreview}
-          onFocus={(event) => onRefPreview(span.id, event.currentTarget)}
-          onBlur={onClearPreview}
-          onClick={(event) => onRefClick(span.id, event.currentTarget)}
-        >
-          <ResearchSourceIdLabel id={span.id} />
-        </button>
+        <Fragment key={key}>
+          <span
+            className={`rr-wide-ref rr-wide-ref--${span.tone}`}
+            aria-hidden="true"
+          >
+            <ResearchSourceIdLabel id={span.id} />
+          </span>
+          <button
+            type="button"
+            className={`rr-sref rr-inline-ref${toneClass}${matched ? " is-match" : ""}`}
+            aria-label={accessibleLabel}
+            data-research-reference-id={span.id}
+            data-research-reference-representation="inline"
+            onMouseEnter={(event) =>
+              onRefPreview(span.id, event.currentTarget)
+            }
+            onMouseLeave={onClearPreview}
+            onFocus={(event) => onRefPreview(span.id, event.currentTarget)}
+            onBlur={onClearPreview}
+            onClick={(event) => onRefClick(span.id, event.currentTarget)}
+          >
+            <ResearchSourceIdLabel id={span.id} />
+          </button>
+        </Fragment>
       );
     }
     if (span.kind === "link") {

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -30,6 +30,7 @@ import { deriveResearchFindingsIntegrity } from "@/lib/research-findings-integri
 import type {
   ResearchArtifactRef,
   ResearchMission,
+  ResearchSourceLedgerSnapshot,
   ResearchSourceRef,
 } from "@/lib/research-missions";
 import { useFocusTrap } from "@/lib/use-focus-trap";
@@ -38,6 +39,7 @@ import {
   ResearchProvenanceEdge,
   type ResearchProvenanceTone,
 } from "./research-provenance-edge";
+import { ResearchSourceIdLabel } from "./research-source-id-label";
 import "@/styles/research-reader.css";
 
 const RAIL_MIN_REM = 18;
@@ -49,13 +51,16 @@ const CONTENTS_SHEET_MAX_REM = 65;
 const INSPECTOR_OVERLAY_MAX_REM = 80;
 const CONFIDENCE_RE = /^(high|medium|low)$/i;
 const CONFLICT_ID_RE = /^C\d+$/;
+const EMPTY_SOURCES: ResearchSourceRef[] = [];
 
 type ResearchReaderProps = {
   mission: ResearchMission;
   artifact: ResearchArtifactRef;
   /** findings.md content; null when the file has not been written yet. */
   markdown: string | null;
+  sourceLedger: ResearchSourceLedgerSnapshot;
   onClose: () => void;
+  onRetrySources: () => Promise<ResearchSourceLedgerSnapshot>;
   onOpenUrl?: (url: string) => void;
   /** Publish this artifact to the Grimoire (offered only for a working,
    *  unpublished copy on a settled mission). */
@@ -134,7 +139,9 @@ export function ResearchReader({
   mission,
   artifact,
   markdown,
+  sourceLedger,
   onClose,
+  onRetrySources,
   onOpenUrl,
   onPublish,
 }: ResearchReaderProps) {
@@ -156,29 +163,47 @@ export function ResearchReader({
     contents: false,
     evidence: false,
   });
+  const tableRestoreFocusRef = useRef(true);
   const draggingRail = useRef(false);
+  const sources =
+    sourceLedger.state === "available"
+      ? sourceLedger.sources
+      : EMPTY_SOURCES;
 
   const doc = useMemo(
-    () => parseFindingsDoc(markdown ?? "", mission.sources),
-    [markdown, mission.sources],
+    () => parseFindingsDoc(markdown ?? "", sources),
+    [markdown, sources],
   );
+  const hasDocumentContent =
+    doc.title !== null || doc.lede !== null || doc.sections.length > 0;
+  const readerDocument = useMemo(
+    () => ({
+      ...doc,
+      title: doc.title ?? (hasDocumentContent ? artifact.title : null),
+    }),
+    [artifact.title, doc, hasDocumentContent],
+  );
+  const hasNamedSections = doc.sections.some((section) => section.heading);
   const integrity = useMemo(
-    () => deriveResearchFindingsIntegrity(markdown ?? "", mission.sources),
-    [markdown, mission.sources],
+    () =>
+      deriveResearchFindingsIntegrity(markdown ?? "", sources, {
+        ledger: sourceLedger.state,
+      }),
+    [markdown, sourceLedger.state, sources],
   );
   const sourceById = useMemo(
-    () => new Map(mission.sources.map((source) => [source.id, source])),
-    [mission.sources],
+    () => new Map(sources.map((source) => [source.id, source])),
+    [sources],
   );
   const targetsBySource = useMemo(
     () =>
       new Map<string, FindingsSupportTarget[]>(
-        mission.sources.map((source) => [
+        sources.map((source) => [
           source.id,
           targetsSupportingRef(doc, source.id),
         ]),
       ),
-    [doc, mission.sources],
+    [doc, sources],
   );
 
   const [tocOn, setTocOn] = useState(false);
@@ -195,6 +220,7 @@ export function ResearchReader({
   const [hoverKey, setHoverKey] = useState<string | null>(null);
   const [focusTable, setFocusTable] = useState<Extract<FindingsBlock, { kind: "table" }> | null>(null);
   const [tip, setTip] = useState<EvidenceTip | null>(null);
+  const [retryingSources, setRetryingSources] = useState(false);
 
   const removePanelFromOrder = useCallback((panel: ReaderPanel) => {
     panelOpenRef.current[panel] = false;
@@ -233,9 +259,16 @@ export function ResearchReader({
     [suspendPanel],
   );
 
-  const closeTable = useCallback(() => {
+  const closeTable = useCallback(({
+    restoreFocus = true,
+  }: {
+    restoreFocus?: boolean;
+  } = {}) => {
+    tableRestoreFocusRef.current = restoreFocus;
     setFocusTable(null);
-    requestAnimationFrame(() => tableFocusReturnRef.current?.focus());
+    if (restoreFocus) {
+      requestAnimationFrame(() => tableFocusReturnRef.current?.focus());
+    }
   }, []);
 
   const closeContents = useCallback(
@@ -292,6 +325,18 @@ export function ResearchReader({
     [focusInspectorReturnTarget, suspendPanel],
   );
 
+  const focusSelectedInspector = useCallback((id: string) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        inspectorRef.current
+          ?.querySelector<HTMLElement>(
+            `[data-source-id="${CSS.escape(id)}"] .research-evidence-card__toggle`,
+          )
+          ?.focus();
+      });
+    });
+  }, []);
+
   const latestOpenPanel = useCallback((): ReaderPanel | null => {
     for (let index = panelOrderRef.current.length - 1; index >= 0; index -= 1) {
       const panel = panelOrderRef.current[index];
@@ -318,7 +363,25 @@ export function ResearchReader({
   useFocusTrap(!focusTable, readerRef, { onEscape: closeFocusOrReader });
   useFocusTrap(Boolean(focusTable), focusedTableRef, {
     onEscape: closeTable,
+    restoreFocus: () => tableRestoreFocusRef.current,
   });
+
+  useEffect(() => {
+    if (hasNamedSections || !panelOpenRef.current.contents) return;
+    suspendPanel("contents");
+  }, [hasNamedSections, suspendPanel]);
+
+  useEffect(() => {
+    setSelectedSourceId((current) =>
+      current && sourceById.has(current) ? current : null,
+    );
+    setOpenIds((current) => {
+      const next = new Set(
+        [...current].filter((id) => sourceById.has(id)),
+      );
+      return next.size === current.size ? current : next;
+    });
+  }, [sourceById]);
 
   useEffect(() => {
     const reader = readerRef.current;
@@ -491,7 +554,9 @@ export function ResearchReader({
     `v${artifact.iteration}`,
     mission.mode,
     passes > 0 ? `${passes} pass${passes === 1 ? "" : "es"}` : null,
-    `${mission.sources.length} source${mission.sources.length === 1 ? "" : "s"}`,
+    sourceLedger.state === "failed"
+      ? "sources unavailable"
+      : `${sources.length} source${sources.length === 1 ? "" : "s"}`,
     rel ? `updated ${rel}` : null,
   ]
     .filter(Boolean)
@@ -508,13 +573,10 @@ export function ResearchReader({
     Boolean(onPublish) &&
     artifact.state === "working" &&
     !artifact.knowledgeId;
-  const compactTitle = doc.title ?? artifact.title;
+  const compactTitle = readerDocument.title ?? artifact.title;
   const chromeTitle = activeSection?.heading
     ? `${compactTitle} · ${activeSection.heading}`
     : compactTitle;
-  const hasDocumentContent =
-    doc.title !== null || doc.lede !== null || doc.sections.length > 0;
-
   const copy = async () => {
     if (!markdown) return;
     const ok = await copyText(markdown);
@@ -552,6 +614,21 @@ export function ResearchReader({
     });
   };
 
+  const retrySources = async () => {
+    if (retryingSources) return;
+    setRetryingSources(true);
+    try {
+      const next = await onRetrySources();
+      announce(
+        next.state === "failed"
+          ? "Evidence sources are still unavailable."
+          : "Evidence sources reloaded.",
+      );
+    } finally {
+      setRetryingSources(false);
+    }
+  };
+
   const onRefClick = (id: string, invoker: HTMLElement) => {
     clearPreview();
     const source = sourceById.get(id);
@@ -562,11 +639,18 @@ export function ResearchReader({
       return;
     }
 
-    inspectorFocusReturnRef.current = invoker;
+    const fromFocusedTable = Boolean(invoker.closest(".rr-kroverlay-card"));
+    if (fromFocusedTable) {
+      closeTable({ restoreFocus: false });
+      inspectorFocusReturnRef.current = tableFocusReturnRef.current;
+    } else {
+      inspectorFocusReturnRef.current = invoker;
+    }
     inspectorFocusReturnIdRef.current = id;
     setSelectedSourceId(id);
     openPanel("evidence");
     setOpenIds((previous) => new Set(previous).add(id));
+    if (fromFocusedTable) focusSelectedInspector(id);
     announce(
       `${CONFLICT_ID_RE.test(id) ? "Opened conflict" : "Opened evidence"} ${id}.`,
     );
@@ -666,7 +750,7 @@ export function ResearchReader({
             onBlur={clearPreview}
             onClick={(event) => onRefClick(span.id, event.currentTarget)}
           >
-            {span.id}
+            <ResearchSourceIdLabel id={span.id} />
           </button>
         );
       }
@@ -831,6 +915,7 @@ export function ResearchReader({
           title="Focus table"
           onClick={(event) => {
             tableFocusReturnRef.current = event.currentTarget;
+            tableRestoreFocusRef.current = true;
             setFocusTable(block);
           }}
           aria-label="Focus table"
@@ -929,33 +1014,35 @@ export function ResearchReader({
                   Publish
                 </button>
               ) : null}
-              <button
-                ref={contentsToggleRef}
-                className="rr-iconbtn focus-ring"
-                type="button"
-                aria-controls="research-reader-contents"
-                aria-pressed={tocOn}
-                title={tocOn ? "Hide contents" : "Show contents"}
-                aria-label={tocOn ? "Hide contents" : "Show contents"}
-                onClick={() => {
-                  if (panelOpenRef.current.contents) {
-                    closeContents({ restoreFocus: false });
-                    return;
-                  }
-                  openPanel("contents");
-                }}
-              >
-                <svg
-                  width={15}
-                  height={15}
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={1.8}
+              {hasNamedSections ? (
+                <button
+                  ref={contentsToggleRef}
+                  className="rr-iconbtn focus-ring"
+                  type="button"
+                  aria-controls="research-reader-contents"
+                  aria-pressed={tocOn}
+                  title={tocOn ? "Hide contents" : "Show contents"}
+                  aria-label={tocOn ? "Hide contents" : "Show contents"}
+                  onClick={() => {
+                    if (panelOpenRef.current.contents) {
+                      closeContents({ restoreFocus: false });
+                      return;
+                    }
+                    openPanel("contents");
+                  }}
                 >
-                  <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" />
-                </svg>
-              </button>
+                  <svg
+                    width={15}
+                    height={15}
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={1.8}
+                  >
+                    <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" />
+                  </svg>
+                </button>
+              ) : null}
               <button
                 ref={evidenceToggleRef}
                 className="rr-iconbtn focus-ring"
@@ -1017,7 +1104,7 @@ export function ResearchReader({
 
           <div className="research-reader__grid">
             <DocumentReader
-              document={doc}
+              document={readerDocument}
               navigation={tocOn ? "rail" : "compact"}
               contentsId="research-reader-contents"
               kicker={titleCase(artifact.kind)}
@@ -1037,7 +1124,9 @@ export function ResearchReader({
               tocMeta={
                 <>
                   <span>
-                    {mission.sources.length} sources · {integrity.counts.used} used
+                    {sourceLedger.state === "failed"
+                      ? "Sources unavailable"
+                      : `${sources.length} sources · ${integrity.counts.used} used`}
                   </span>
                   <span>
                     {passes} pass{passes === 1 ? "" : "es"} · {mission.mode}
@@ -1068,7 +1157,9 @@ export function ResearchReader({
               aria-label="Evidence"
             >
               <ResearchEvidenceInspector
-                sources={mission.sources}
+                sources={sources}
+                ledgerState={sourceLedger.state}
+                retryingSources={retryingSources}
                 integrityLabel={integrity.summary.label}
                 selectedId={selectedSourceId}
                 openIds={openIds}
@@ -1083,6 +1174,7 @@ export function ResearchReader({
                   );
                 }}
                 onClose={closeInspector}
+                onRetrySources={() => void retrySources()}
               />
             </aside>
           </div>
@@ -1098,7 +1190,10 @@ export function ResearchReader({
         {tip ? (
           <>
             <div className="rr-tip__head">
-              <span className="rr-tip__id">{tip.id}</span>
+              <ResearchSourceIdLabel
+                id={tip.id}
+                className="rr-tip__id"
+              />
               <span
                 className={`rr-tip__status rr-srcstat--${tip.tone}`}
               >
@@ -1116,7 +1211,7 @@ export function ResearchReader({
         <div
           className="rr-kroverlay"
           role="presentation"
-          onClick={closeTable}
+          onClick={() => closeTable()}
         >
           <div
             ref={focusedTableRef}
@@ -1139,7 +1234,7 @@ export function ResearchReader({
                 type="button"
                 title="Close focused table"
                 aria-label="Close focused table"
-                onClick={closeTable}
+                onClick={() => closeTable()}
               >
                 <svg
                   width={16}

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -512,19 +512,11 @@ export function ResearchReader({
       );
       const fence = "`".repeat(Math.max(3, longestBacktickRun + 1));
       return (
-        <div
-          key={key}
-          className="rr-block-row"
-          data-document-target={block.id}
-          tabIndex={-1}
-        >
-          <div className="rr-codeblock document-reader__wide-block">
-            <MarkdownBlock
-              text={`${fence}${block.language}\n${block.code}\n${fence}`}
-              onOpenUrl={openUrl}
-            />
-          </div>
-          {renderEdge([])}
+        <div key={key} className="rr-codeblock document-reader__wide-block">
+          <MarkdownBlock
+            text={`${fence}${block.language}\n${block.code}\n${fence}`}
+            onOpenUrl={openUrl}
+          />
         </div>
       );
     }

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -40,9 +40,10 @@ import {
 } from "./research-provenance-edge";
 import "@/styles/research-reader.css";
 
-const RAIL_MIN = 240;
-const RAIL_MAX = 520;
-const COLLAPSE_AT = 200;
+const RAIL_MIN_REM = 18;
+const RAIL_INITIAL_REM = 18.75;
+const RAIL_MAX_REM = 32.5;
+const COLLAPSE_AT_REM = 15;
 const CONTENTS_SHEET_MAX_REM = 52;
 // Keep this equal to the research-reader container query in research-reader.css.
 const INSPECTOR_OVERLAY_MAX_REM = 80;
@@ -162,7 +163,7 @@ export function ResearchReader({
   const [selectedSourceId, setSelectedSourceId] = useState<string | null>(null);
   const [activeSection, setActiveSection] = useState<{ id: string; heading: string } | null>(null);
   const [openIds, setOpenIds] = useState<Set<string>>(() => new Set());
-  const [railWidth, setRailWidth] = useState(300);
+  const [railWidth, setRailWidth] = useState(RAIL_INITIAL_REM);
   const [copied, setCopied] = useState(false);
   const [hoverKey, setHoverKey] = useState<string | null>(null);
   const [focusTable, setFocusTable] = useState<Extract<FindingsBlock, { kind: "table" }> | null>(null);
@@ -297,7 +298,7 @@ export function ResearchReader({
   }, [inspectorOn, inspectorOverlaysDocument, selectedSourceId]);
 
   useEffect(() => {
-    readerRef.current?.style.setProperty("--rail-w", `${railWidth}px`);
+    readerRef.current?.style.setProperty("--rail-w", `${railWidth}rem`);
   }, [railWidth]);
 
   useEffect(() => {
@@ -315,14 +316,23 @@ export function ResearchReader({
     const move = (event: PointerEvent) => {
       if (!draggingRail.current || !readerRef.current) return;
       const rect = readerRef.current.getBoundingClientRect();
-      let width = rect.right - event.clientX - 1;
-      if (width < COLLAPSE_AT) width = RAIL_MIN;
-      setRailWidth(Math.max(RAIL_MIN, Math.min(RAIL_MAX, width)));
+      const rootFontSize =
+        Number.parseFloat(getComputedStyle(document.documentElement).fontSize) ||
+        16;
+      const widthPx = rect.right - event.clientX - 1;
+      let widthRem = widthPx / rootFontSize;
+      if (widthRem < COLLAPSE_AT_REM) widthRem = RAIL_MIN_REM;
+      setRailWidth(
+        Math.max(RAIL_MIN_REM, Math.min(RAIL_MAX_REM, widthRem)),
+      );
     };
     const up = (event: PointerEvent) => {
       if (!draggingRail.current || !readerRef.current) return;
       const rect = readerRef.current.getBoundingClientRect();
-      if (rect.right - event.clientX - 1 < COLLAPSE_AT) {
+      const rootFontSize =
+        Number.parseFloat(getComputedStyle(document.documentElement).fontSize) ||
+        16;
+      if ((rect.right - event.clientX - 1) / rootFontSize < COLLAPSE_AT_REM) {
         closeInspector();
       }
       draggingRail.current = false;

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -135,6 +135,83 @@ function isValidFocusReturnTarget(
   return element.tabIndex >= 0;
 }
 
+type ResearchFindingsInlineSpansProps = {
+  spans: FindingsSpan[];
+  keyPrefix: string;
+  sourceById: ReadonlyMap<string, ResearchSourceRef>;
+  hoverKey: string | null;
+  selectedSourceId: string | null;
+  onRefPreview: (id: string, target: HTMLElement) => void;
+  onClearPreview: () => void;
+  onRefClick: (id: string, target: HTMLElement) => void;
+};
+
+export function ResearchFindingsInlineSpans({
+  spans,
+  keyPrefix,
+  sourceById,
+  hoverKey,
+  selectedSourceId,
+  onRefPreview,
+  onClearPreview,
+  onRefClick,
+}: ResearchFindingsInlineSpansProps) {
+  return spans.map((span, index) => {
+    const key = `${keyPrefix}-${index}`;
+    if (span.kind === "ref-gap") {
+      return (
+        <span key={key} className="rr-inline-ref-gap">
+          {span.text}
+        </span>
+      );
+    }
+    if (span.kind === "ref") {
+      const toneClass =
+        span.tone === "unresolved"
+          ? " rr-sref--unresolved"
+          : span.tone === "warn"
+            ? " rr-sref--warn"
+            : span.tone === "muted"
+              ? " rr-sref--muted"
+              : "";
+      const matched =
+        hoverKey === span.id || selectedSourceId === span.id;
+      const accessibleLabel = sourceById.has(span.id)
+        ? `${CONFLICT_ID_RE.test(span.id) ? "Open conflict" : "Open evidence"} ${span.id}`
+        : `Missing source ${span.id}`;
+      return (
+        <button
+          key={key}
+          type="button"
+          className={`rr-sref rr-inline-ref${toneClass}${matched ? " is-match" : ""}`}
+          aria-label={accessibleLabel}
+          data-research-reference-id={span.id}
+          data-research-reference-representation="inline"
+          onMouseEnter={(event) =>
+            onRefPreview(span.id, event.currentTarget)
+          }
+          onMouseLeave={onClearPreview}
+          onFocus={(event) => onRefPreview(span.id, event.currentTarget)}
+          onBlur={onClearPreview}
+          onClick={(event) => onRefClick(span.id, event.currentTarget)}
+        >
+          <ResearchSourceIdLabel id={span.id} />
+        </button>
+      );
+    }
+    if (span.kind === "link") {
+      return (
+        <a key={key} href={span.href} target="_blank" rel="noreferrer">
+          {span.text}
+        </a>
+      );
+    }
+    if (span.bold) return <b key={key}>{span.text}</b>;
+    if (span.italic) return <em key={key}>{span.text}</em>;
+    return <span key={key}>{span.text}</span>;
+  });
+}
+
 export function ResearchReader({
   mission,
   artifact,
@@ -710,61 +787,18 @@ export function ResearchReader({
   const renderSpans = (
     spans: FindingsSpan[],
     keyPrefix: string,
-  ): ReactNode[] =>
-    spans.map((span, index) => {
-      const key = `${keyPrefix}-${index}`;
-      if (span.kind === "ref-gap") {
-        return (
-          <span key={key} className="rr-inline-ref-gap">
-            {span.text}
-          </span>
-        );
-      }
-      if (span.kind === "ref") {
-        const toneClass =
-          span.tone === "unresolved"
-            ? " rr-sref--unresolved"
-            : span.tone === "warn"
-              ? " rr-sref--warn"
-              : span.tone === "muted"
-                ? " rr-sref--muted"
-                : "";
-        const matched =
-          hoverKey === span.id || selectedSourceId === span.id;
-        const accessibleLabel = sourceById.has(span.id)
-          ? `${CONFLICT_ID_RE.test(span.id) ? "Open conflict" : "Open evidence"} ${span.id}`
-          : `Missing source ${span.id}`;
-        return (
-          <button
-            key={key}
-            type="button"
-            className={`rr-sref rr-inline-ref${toneClass}${matched ? " is-match" : ""}`}
-            aria-label={accessibleLabel}
-            data-research-reference-id={span.id}
-            data-research-reference-representation="inline"
-            onMouseEnter={(event) =>
-              onRefPreview(span.id, event.currentTarget)
-            }
-            onMouseLeave={clearPreview}
-            onFocus={(event) => onRefPreview(span.id, event.currentTarget)}
-            onBlur={clearPreview}
-            onClick={(event) => onRefClick(span.id, event.currentTarget)}
-          >
-            <ResearchSourceIdLabel id={span.id} />
-          </button>
-        );
-      }
-      if (span.kind === "link") {
-        return (
-          <a key={key} href={span.href} target="_blank" rel="noreferrer">
-            {span.text}
-          </a>
-        );
-      }
-      if (span.bold) return <b key={key}>{span.text}</b>;
-      if (span.italic) return <em key={key}>{span.text}</em>;
-      return <span key={key}>{span.text}</span>;
-    });
+  ): ReactNode => (
+    <ResearchFindingsInlineSpans
+      spans={spans}
+      keyPrefix={keyPrefix}
+      sourceById={sourceById}
+      hoverKey={hoverKey}
+      selectedSourceId={selectedSourceId}
+      onRefPreview={onRefPreview}
+      onClearPreview={clearPreview}
+      onRefClick={onRefClick}
+    />
+  );
 
   const renderLede = (lede: FindingsSpan[]): ReactNode => (
     <div

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -733,6 +733,7 @@ export function ResearchReader({
                 <button
                   className="rr-btn rr-btn--accent focus-ring"
                   type="button"
+                  title="Publish"
                   onClick={onPublish}
                 >
                   <svg

--- a/src/components/role-surfaces/research-source-id-label.tsx
+++ b/src/components/role-surfaces/research-source-id-label.tsx
@@ -1,0 +1,30 @@
+type ResearchSourceIdLabelProps = {
+  id: string;
+  className?: string;
+};
+
+const COMPACT_SOURCE_ID_LENGTH = 5;
+
+export function compactResearchSourceId(id: string): string {
+  if (id.length <= COMPACT_SOURCE_ID_LENGTH) return id;
+  return `${id.slice(0, 2)}…${id.slice(-2)}`;
+}
+
+export function ResearchSourceIdLabel({
+  id,
+  className,
+}: ResearchSourceIdLabelProps) {
+  const classes = ["research-source-id-label", className ?? ""]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <span
+      className={classes}
+      title={id}
+      data-research-source-id-label={id}
+      aria-hidden
+    >
+      {compactResearchSourceId(id)}
+    </span>
+  );
+}

--- a/src/components/ui/overflow-menu.test.ts
+++ b/src/components/ui/overflow-menu.test.ts
@@ -7,6 +7,11 @@ const src = readFileSync(new URL("./overflow-menu.tsx", import.meta.url), "utf8"
 // The trigger must be a real menu button: aria-haspopup="menu" + aria-expanded
 // reflecting open state, with an accessible name required at the type level.
 assert.match(src, /ariaLabel: string/, "OverflowMenu requires an accessible name");
+assert.match(
+  src,
+  /aria-label=\{ariaLabel\}[\s\S]*?title=\{ariaLabel\}/,
+  "the icon-only trigger exposes a native title matching its accessible name",
+);
 assert.match(src, /aria-haspopup="menu"/, "trigger declares the menu popup");
 assert.match(src, /aria-expanded=\{open\}/, "trigger reflects open state");
 

--- a/src/components/ui/overflow-menu.tsx
+++ b/src/components/ui/overflow-menu.tsx
@@ -130,6 +130,7 @@ export function OverflowMenu({
         size={size}
         className={["focus-ring", className ?? ""].filter(Boolean).join(" ")}
         aria-label={ariaLabel}
+        title={ariaLabel}
         aria-haspopup="menu"
         aria-expanded={open}
         // `active` drives the pressed visual; aria-expanded is the correct

--- a/src/lib/research-artifact-contract.test.ts
+++ b/src/lib/research-artifact-contract.test.ts
@@ -165,6 +165,85 @@ test("read reconciliation keeps mission order and fields before unmatched file s
   );
 });
 
+test("read reconciliation rejects a URL match that would duplicate a mission source id", () => {
+  assert.throws(
+    () => reconcileResearchSourcesForRead([
+      {
+        id: "runner-stale",
+        title: "Stale URL match",
+        url: "https://example.com/shared",
+        sourceType: "web",
+        status: "candidate",
+      },
+      {
+        id: "manual-current",
+        title: "File row already using the current id",
+        url: "https://example.com/other",
+        sourceType: "web",
+        status: "candidate",
+      },
+    ], [{
+      id: "manual-current",
+      title: "Current mission source",
+      url: "https://example.com/shared",
+      sourceType: "web",
+      status: "used",
+    }]),
+    /Research source identities are ambiguous/,
+  );
+});
+
+test("read reconciliation rejects duplicate file source ids", () => {
+  assert.throws(
+    () => reconcileResearchSourcesForRead([
+      {
+        id: "duplicate-id",
+        title: "First file source",
+        url: "https://example.com/first",
+        sourceType: "web",
+        status: "candidate",
+      },
+      {
+        id: "duplicate-id",
+        title: "Second file source",
+        url: "https://example.com/second",
+        sourceType: "web",
+        status: "candidate",
+      },
+    ], []),
+    /Research source identities are ambiguous/,
+  );
+});
+
+test("read reconciliation rejects URL and path matches to different file rows", () => {
+  assert.throws(
+    () => reconcileResearchSourcesForRead([
+      {
+        id: "url-row",
+        title: "URL row",
+        url: "https://example.com/shared",
+        sourceType: "web",
+        status: "candidate",
+      },
+      {
+        id: "path-row",
+        title: "Path row",
+        localPath: "/workspace/shared.pdf",
+        sourceType: "file",
+        status: "candidate",
+      },
+    ], [{
+      id: "mission-row",
+      title: "Mission bridge",
+      url: "https://example.com/shared",
+      localPath: "/workspace/shared.pdf",
+      sourceType: "web",
+      status: "used",
+    }]),
+    /Research source identities are ambiguous/,
+  );
+});
+
 test("presentation artifacts accept Markdown or self-contained HTML only", () => {
   assert.equal(
     normalizeResearchArtifact({ kind: "presentation", path: "artifacts/slides.md" }).ok,

--- a/src/lib/research-artifact-contract.test.ts
+++ b/src/lib/research-artifact-contract.test.ts
@@ -165,32 +165,115 @@ test("read reconciliation keeps mission order and fields before unmatched file s
   );
 });
 
-test("read reconciliation rejects a URL match that would duplicate a mission source id", () => {
-  assert.throws(
-    () => reconcileResearchSourcesForRead([
+test("read reconciliation preserves distinct version ids that share a URL", () => {
+  const versions = [
+    {
+      id: "content-v1",
+      title: "Version one",
+      url: "https://example.com/report",
+      localPath: "/workspace/report-v1.md",
+      sourceType: "web",
+      status: "used" as const,
+    },
+    {
+      id: "content-v2",
+      title: "Version two",
+      url: "https://example.com/report",
+      localPath: "/workspace/report-v2.md",
+      sourceType: "web",
+      status: "candidate" as const,
+    },
+  ];
+
+  assert.deepEqual(reconcileResearchSourcesForRead(versions, []), versions);
+});
+
+test("read reconciliation gives exact ids priority over shared URL bridges", () => {
+  const missionSources = [
+    {
+      id: "content-v2",
+      title: "Current version title",
+      url: "https://example.com/report",
+      localPath: "/workspace/report-v2.md",
+      sourceType: "web",
+      status: "used" as const,
+    },
+  ];
+  const fileSources = [
+    {
+      id: "content-v1",
+      title: "Version one",
+      url: "https://example.com/report",
+      localPath: "/workspace/report-v1.md",
+      sourceType: "web",
+      status: "candidate" as const,
+    },
+    {
+      id: "content-v2",
+      title: "Stale version title",
+      url: "https://example.com/report",
+      localPath: "/workspace/stale-v2.md",
+      publisher: "File publisher",
+      sourceType: "journal",
+      status: "candidate" as const,
+    },
+  ];
+
+  assert.deepEqual(
+    reconcileResearchSourcesForRead(fileSources, missionSources),
+    [
       {
-        id: "runner-stale",
-        title: "Stale URL match",
-        url: "https://example.com/shared",
-        sourceType: "web",
-        status: "candidate",
+        ...fileSources[1],
+        ...missionSources[0],
       },
-      {
-        id: "manual-current",
-        title: "File row already using the current id",
-        url: "https://example.com/other",
-        sourceType: "web",
-        status: "candidate",
-      },
-    ], [{
+      fileSources[0],
+    ],
+  );
+});
+
+test("read reconciliation resolves the prior id-overwrite append collision without duplicate ids", () => {
+  const reconciled = reconcileResearchSourcesForRead([
+    {
+      id: "runner-stale",
+      title: "Stale URL match",
+      url: "https://example.com/shared",
+      sourceType: "web",
+      status: "candidate",
+    },
+    {
+      id: "manual-current",
+      title: "File row already using the current id",
+      url: "https://example.com/other",
+      publisher: "File publisher",
+      sourceType: "journal",
+      status: "candidate",
+    },
+  ], [{
+    id: "manual-current",
+    title: "Current mission source",
+    url: "https://example.com/shared",
+    sourceType: "web",
+    status: "used",
+  }]);
+
+  assert.deepEqual(reconciled, [
+    {
       id: "manual-current",
       title: "Current mission source",
       url: "https://example.com/shared",
+      publisher: "File publisher",
       sourceType: "web",
       status: "used",
-    }]),
-    /Research source identities are ambiguous/,
-  );
+    },
+    {
+      id: "runner-stale",
+      title: "Stale URL match",
+      url: "https://example.com/shared",
+      sourceType: "web",
+      status: "candidate",
+    },
+  ]);
+  assert.equal(new Set(reconciled.map((source) => source.id)).size, reconciled.length);
 });
 
 test("read reconciliation rejects duplicate file source ids", () => {

--- a/src/lib/research-artifact-contract.test.ts
+++ b/src/lib/research-artifact-contract.test.ts
@@ -6,9 +6,11 @@ import {
   normalizeResearchArtifact,
   normalizeResearchSource,
   parseResearchControl,
+  reconcileResearchSourcesForRead,
   renderSourceLedgerMarkdown,
   researchKnowledgeEntry,
   researchProvenanceHeader,
+  researchSourcesShareIdentity,
   validateResearchArtifactContent,
 } from "./research-artifact-contract.ts";
 
@@ -75,6 +77,91 @@ test("sources require a safe web URL or absolute local path", () => {
   assert.equal(
     normalizeResearchSource({ id: "s1", title: "Relative", localPath: "../notes.md" }).ok,
     false,
+  );
+});
+
+test("source identity matches by id, URL, or local path", () => {
+  const base = {
+    id: "source-a",
+    title: "Source A",
+    url: "https://example.com/a",
+    localPath: "/workspace/a.md",
+    sourceType: "web",
+    status: "used" as const,
+  };
+
+  assert.equal(researchSourcesShareIdentity(base, { ...base, url: "https://example.com/b", localPath: "/workspace/b.md" }), true);
+  assert.equal(researchSourcesShareIdentity(base, { ...base, id: "source-b", localPath: "/workspace/b.md" }), true);
+  assert.equal(researchSourcesShareIdentity(base, { ...base, id: "source-b", url: "https://example.com/b" }), true);
+  assert.equal(
+    researchSourcesShareIdentity(base, {
+      ...base,
+      id: "source-b",
+      url: "https://example.com/b",
+      localPath: "/workspace/b.md",
+    }),
+    false,
+  );
+});
+
+test("read reconciliation keeps mission order and fields before unmatched file sources", () => {
+  const missionSources = [
+    {
+      id: "manual-current",
+      title: "Current title",
+      url: "https://example.com/shared",
+      sourceType: "web",
+      note: "Current note",
+      status: "used" as const,
+      provider: "x" as const,
+      externalId: "post-1",
+      availability: "available" as const,
+    },
+    {
+      id: "manual-only",
+      title: "Manual attachment",
+      localPath: "/workspace/manual.pdf",
+      sourceType: "file",
+      status: "candidate" as const,
+    },
+  ];
+  const fileOnly = {
+    id: "file-only",
+    title: "File only",
+    url: "https://example.com/file-only",
+    sourceType: "web",
+    status: "candidate" as const,
+  };
+
+  assert.deepEqual(
+    reconcileResearchSourcesForRead([
+      {
+        id: "runner-stale",
+        title: "Stale title",
+        url: "https://example.com/shared",
+        publisher: "File publisher",
+        sourceType: "journal",
+        note: "Stale note",
+        status: "candidate",
+      },
+      fileOnly,
+    ], missionSources),
+    [
+      {
+        id: "manual-current",
+        title: "Current title",
+        url: "https://example.com/shared",
+        publisher: "File publisher",
+        sourceType: "web",
+        note: "Current note",
+        status: "used",
+        provider: "x",
+        externalId: "post-1",
+        availability: "available",
+      },
+      missionSources[1],
+      fileOnly,
+    ],
   );
 });
 

--- a/src/lib/research-artifact-contract.ts
+++ b/src/lib/research-artifact-contract.ts
@@ -196,7 +196,7 @@ function ambiguousResearchSourceIdentities(): never {
   throw new Error("Research source identities are ambiguous");
 }
 
-function indexDistinctResearchSourceIds(
+export function indexDistinctResearchSourceIds(
   sources: ResearchSourceRef[],
 ): Map<string, number> {
   const owners = new Map<string, number>();
@@ -209,7 +209,7 @@ function indexDistinctResearchSourceIds(
   return owners;
 }
 
-function researchSourcesShareSecondaryIdentity(
+export function researchSourcesShareSecondaryIdentity(
   left: ResearchSourceRef,
   right: ResearchSourceRef,
 ): boolean {

--- a/src/lib/research-artifact-contract.ts
+++ b/src/lib/research-artifact-contract.ts
@@ -179,6 +179,49 @@ export function parseResearchSourcesFile(raw: string): ResearchSourceRef[] {
   });
 }
 
+export function researchSourcesShareIdentity(
+  left: ResearchSourceRef,
+  right: ResearchSourceRef,
+): boolean {
+  return left.id === right.id ||
+    Boolean(left.url && right.url && left.url === right.url) ||
+    Boolean(
+      left.localPath &&
+      right.localPath &&
+      left.localPath === right.localPath,
+    );
+}
+
+/**
+ * Reconcile a healthy file snapshot with the mission's current user-owned
+ * source state. Mission order and fields win; unmatched file rows follow in
+ * their file order.
+ */
+export function reconcileResearchSourcesForRead(
+  fileSources: ResearchSourceRef[],
+  missionSources: ResearchSourceRef[],
+): ResearchSourceRef[] {
+  const matchedFileIndexes = new Set<number>();
+  const reconciledMissionSources = missionSources.map((missionSource) => {
+    const fileIndex = fileSources.findIndex(
+      (fileSource, index) =>
+        !matchedFileIndexes.has(index) &&
+        researchSourcesShareIdentity(missionSource, fileSource),
+    );
+    if (fileIndex < 0) return missionSource;
+    matchedFileIndexes.add(fileIndex);
+    return {
+      ...fileSources[fileIndex],
+      ...missionSource,
+    };
+  });
+
+  return [
+    ...reconciledMissionSources,
+    ...fileSources.filter((_, index) => !matchedFileIndexes.has(index)),
+  ];
+}
+
 export function normalizeResearchArtifact(
   draft: ResearchArtifactDraft,
 ): ContractResult<{ kind: ResearchArtifactKind; relativePath: string }> {

--- a/src/lib/research-artifact-contract.ts
+++ b/src/lib/research-artifact-contract.ts
@@ -153,6 +153,32 @@ export function normalizeResearchSource(
   };
 }
 
+/** Parse and normalize the authoritative sources.json payload. Keep this
+ * outside the runner so read-only routes can validate the ledger without
+ * importing the runner's orchestration graph. */
+export function parseResearchSourcesFile(raw: string): ResearchSourceRef[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("sources.json is malformed");
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("sources.json must contain an array");
+  }
+  return parsed.map((item, index) => {
+    const normalized = normalizeResearchSource(
+      item as Parameters<typeof normalizeResearchSource>[0],
+    );
+    if (!normalized.ok) {
+      throw new Error(
+        `sources.json source ${index + 1}: ${normalized.reason}`,
+      );
+    }
+    return normalized.value;
+  });
+}
+
 export function normalizeResearchArtifact(
   draft: ResearchArtifactDraft,
 ): ContractResult<{ kind: ResearchArtifactKind; relativePath: string }> {

--- a/src/lib/research-artifact-contract.ts
+++ b/src/lib/research-artifact-contract.ts
@@ -192,66 +192,90 @@ export function researchSourcesShareIdentity(
     );
 }
 
-type ResearchSourceIdentityKind = "id" | "url" | "localPath";
-
-function researchSourceIdentityEntries(
-  source: ResearchSourceRef,
-): Array<readonly [ResearchSourceIdentityKind, string]> {
-  return [
-    ["id", source.id],
-    ...(source.url ? [["url", source.url] as const] : []),
-    ...(source.localPath ? [["localPath", source.localPath] as const] : []),
-  ];
-}
-
 function ambiguousResearchSourceIdentities(): never {
   throw new Error("Research source identities are ambiguous");
 }
 
-function indexDistinctResearchSourceIdentities(
+function indexDistinctResearchSourceIds(
   sources: ResearchSourceRef[],
-): Record<ResearchSourceIdentityKind, Map<string, number>> {
-  const owners = {
-    id: new Map<string, number>(),
-    url: new Map<string, number>(),
-    localPath: new Map<string, number>(),
-  };
+): Map<string, number> {
+  const owners = new Map<string, number>();
 
   sources.forEach((source, index) => {
-    for (const [kind, value] of researchSourceIdentityEntries(source)) {
-      if (owners[kind].has(value)) ambiguousResearchSourceIdentities();
-      owners[kind].set(value, index);
-    }
+    if (owners.has(source.id)) ambiguousResearchSourceIdentities();
+    owners.set(source.id, index);
   });
 
   return owners;
 }
 
+function researchSourcesShareSecondaryIdentity(
+  left: ResearchSourceRef,
+  right: ResearchSourceRef,
+): boolean {
+  return Boolean(left.url && right.url && left.url === right.url) ||
+    Boolean(
+      left.localPath &&
+      right.localPath &&
+      left.localPath === right.localPath,
+    );
+}
+
 /**
  * Reconcile a healthy file snapshot with the mission's current user-owned
- * source state. Mission order and fields win; unmatched file rows follow in
- * their file order.
+ * source state. Exact ids pair first. Remaining rows may bridge by one unique
+ * URL or local-path match; shared secondary identities otherwise stay distinct
+ * or fail closed when they make the bridge ambiguous. Mission order and fields
+ * win, and unmatched file rows follow in their file order.
  */
 export function reconcileResearchSourcesForRead(
   fileSources: ResearchSourceRef[],
   missionSources: ResearchSourceRef[],
 ): ResearchSourceRef[] {
-  const fileIdentityOwners = indexDistinctResearchSourceIdentities(fileSources);
-  indexDistinctResearchSourceIdentities(missionSources);
+  const fileIdOwners = indexDistinctResearchSourceIds(fileSources);
+  indexDistinctResearchSourceIds(missionSources);
 
   const matchedFileIndexes = new Set<number>();
-  const reconciledMissionSources = missionSources.map((missionSource) => {
-    const candidateFileIndexes = new Set<number>();
-    for (const [kind, value] of researchSourceIdentityEntries(missionSource)) {
-      const fileIndex = fileIdentityOwners[kind].get(value);
-      if (fileIndex !== undefined) candidateFileIndexes.add(fileIndex);
-    }
-    if (candidateFileIndexes.size > 1) ambiguousResearchSourceIdentities();
+  const fileIndexByMissionIndex = new Map<number, number>();
 
-    const fileIndex = candidateFileIndexes.values().next().value;
-    if (fileIndex === undefined) return missionSource;
-    if (matchedFileIndexes.has(fileIndex)) ambiguousResearchSourceIdentities();
+  missionSources.forEach((missionSource, missionIndex) => {
+    const fileIndex = fileIdOwners.get(missionSource.id);
+    if (fileIndex === undefined) return;
     matchedFileIndexes.add(fileIndex);
+    fileIndexByMissionIndex.set(missionIndex, fileIndex);
+  });
+
+  const candidateMissionIndexesByFile = new Map<number, number[]>();
+  missionSources.forEach((missionSource, missionIndex) => {
+    if (fileIndexByMissionIndex.has(missionIndex)) return;
+
+    const candidateFileIndexes: number[] = [];
+    fileSources.forEach((fileSource, fileIndex) => {
+      if (
+        !matchedFileIndexes.has(fileIndex) &&
+        researchSourcesShareSecondaryIdentity(missionSource, fileSource)
+      ) {
+        candidateFileIndexes.push(fileIndex);
+      }
+    });
+    if (candidateFileIndexes.length > 1) ambiguousResearchSourceIdentities();
+    const fileIndex = candidateFileIndexes[0];
+    if (fileIndex === undefined) return;
+    const candidateMissionIndexes =
+      candidateMissionIndexesByFile.get(fileIndex) ?? [];
+    candidateMissionIndexes.push(missionIndex);
+    candidateMissionIndexesByFile.set(fileIndex, candidateMissionIndexes);
+  });
+
+  for (const [fileIndex, missionIndexes] of candidateMissionIndexesByFile) {
+    if (missionIndexes.length > 1) ambiguousResearchSourceIdentities();
+    matchedFileIndexes.add(fileIndex);
+    fileIndexByMissionIndex.set(missionIndexes[0], fileIndex);
+  }
+
+  const reconciledMissionSources = missionSources.map((missionSource, missionIndex) => {
+    const fileIndex = fileIndexByMissionIndex.get(missionIndex);
+    if (fileIndex === undefined) return missionSource;
     return {
       ...fileSources[fileIndex],
       ...missionSource,
@@ -262,7 +286,7 @@ export function reconcileResearchSourcesForRead(
     ...reconciledMissionSources,
     ...fileSources.filter((_, index) => !matchedFileIndexes.has(index)),
   ];
-  indexDistinctResearchSourceIdentities(reconciledSources);
+  indexDistinctResearchSourceIds(reconciledSources);
   return reconciledSources;
 }
 

--- a/src/lib/research-artifact-contract.ts
+++ b/src/lib/research-artifact-contract.ts
@@ -192,6 +192,41 @@ export function researchSourcesShareIdentity(
     );
 }
 
+type ResearchSourceIdentityKind = "id" | "url" | "localPath";
+
+function researchSourceIdentityEntries(
+  source: ResearchSourceRef,
+): Array<readonly [ResearchSourceIdentityKind, string]> {
+  return [
+    ["id", source.id],
+    ...(source.url ? [["url", source.url] as const] : []),
+    ...(source.localPath ? [["localPath", source.localPath] as const] : []),
+  ];
+}
+
+function ambiguousResearchSourceIdentities(): never {
+  throw new Error("Research source identities are ambiguous");
+}
+
+function indexDistinctResearchSourceIdentities(
+  sources: ResearchSourceRef[],
+): Record<ResearchSourceIdentityKind, Map<string, number>> {
+  const owners = {
+    id: new Map<string, number>(),
+    url: new Map<string, number>(),
+    localPath: new Map<string, number>(),
+  };
+
+  sources.forEach((source, index) => {
+    for (const [kind, value] of researchSourceIdentityEntries(source)) {
+      if (owners[kind].has(value)) ambiguousResearchSourceIdentities();
+      owners[kind].set(value, index);
+    }
+  });
+
+  return owners;
+}
+
 /**
  * Reconcile a healthy file snapshot with the mission's current user-owned
  * source state. Mission order and fields win; unmatched file rows follow in
@@ -201,14 +236,21 @@ export function reconcileResearchSourcesForRead(
   fileSources: ResearchSourceRef[],
   missionSources: ResearchSourceRef[],
 ): ResearchSourceRef[] {
+  const fileIdentityOwners = indexDistinctResearchSourceIdentities(fileSources);
+  indexDistinctResearchSourceIdentities(missionSources);
+
   const matchedFileIndexes = new Set<number>();
   const reconciledMissionSources = missionSources.map((missionSource) => {
-    const fileIndex = fileSources.findIndex(
-      (fileSource, index) =>
-        !matchedFileIndexes.has(index) &&
-        researchSourcesShareIdentity(missionSource, fileSource),
-    );
-    if (fileIndex < 0) return missionSource;
+    const candidateFileIndexes = new Set<number>();
+    for (const [kind, value] of researchSourceIdentityEntries(missionSource)) {
+      const fileIndex = fileIdentityOwners[kind].get(value);
+      if (fileIndex !== undefined) candidateFileIndexes.add(fileIndex);
+    }
+    if (candidateFileIndexes.size > 1) ambiguousResearchSourceIdentities();
+
+    const fileIndex = candidateFileIndexes.values().next().value;
+    if (fileIndex === undefined) return missionSource;
+    if (matchedFileIndexes.has(fileIndex)) ambiguousResearchSourceIdentities();
     matchedFileIndexes.add(fileIndex);
     return {
       ...fileSources[fileIndex],
@@ -216,10 +258,12 @@ export function reconcileResearchSourcesForRead(
     };
   });
 
-  return [
+  const reconciledSources = [
     ...reconciledMissionSources,
     ...fileSources.filter((_, index) => !matchedFileIndexes.has(index)),
   ];
+  indexDistinctResearchSourceIdentities(reconciledSources);
+  return reconciledSources;
 }
 
 export function normalizeResearchArtifact(

--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -25,6 +25,35 @@ function refIds(spans: FindingsSpan[]): string[] {
   return spans.filter((s): s is Extract<FindingsSpan, { kind: "ref" }> => s.kind === "ref").map((s) => s.id);
 }
 
+function assertUniqueTargetIds(markdown: string): ReturnType<typeof parseFindingsDoc> {
+  const doc = parseFindingsDoc(markdown, SOURCES);
+  const targetIds: string[] = [];
+
+  if (doc.ledeId) targetIds.push(doc.ledeId);
+  for (const section of doc.sections) {
+    targetIds.push(section.id);
+    for (const block of section.blocks) {
+      targetIds.push(block.id);
+      if (block.kind === "ul" || block.kind === "ol") {
+        targetIds.push(...block.items.map((item) => item.id));
+      } else if (block.kind === "table") {
+        targetIds.push(...block.rows.map((row) => row.id));
+      }
+    }
+  }
+
+  assert.equal(new Set(targetIds).size, targetIds.length, "document render target ids must be unique");
+
+  const supportIds = targetsSupportingRef(doc, "S1").map((target) => target.id);
+  assert.equal(new Set(supportIds).size, supportIds.length, "support target ids must be unique");
+  assert.ok(
+    supportIds.every((id) => targetIds.includes(id)),
+    "every support target must resolve to a unique document render target",
+  );
+
+  return doc;
+}
+
 test("ref tone follows the source status", () => {
   assert.equal(refToneForStatus("used"), "accent");
   assert.equal(refToneForStatus("candidate"), "accent");
@@ -132,6 +161,73 @@ test("parses title, lede and collapsible sections", () => {
   );
   // Section ids are stable slugs for the contents rail.
   assert.equal(doc.sections[0].id, "s-current-understanding");
+});
+
+test("repeated headings receive unique section and inherited target ids", () => {
+  const doc = assertUniqueTargetIds(`# Findings
+
+## Results
+
+First claim [S1].
+
+## Results
+
+- Second claim [S1]
+
+## Results
+
+| Finding | Source |
+| --- | --- |
+| Third claim | [S1] |
+`);
+
+  assert.deepEqual(doc.sections.map((section) => section.id), [
+    "s-results",
+    "s-results-2",
+    "s-results-3",
+  ]);
+  assert.deepEqual(doc.sections.map((section) => section.blocks[0].id), [
+    "s-results-block-1",
+    "s-results-2-block-1",
+    "s-results-3-block-1",
+  ]);
+});
+
+test("headings sharing a truncated slug receive unique target ids", () => {
+  const sharedPrefix = "A".repeat(40);
+  const doc = assertUniqueTargetIds(`# Findings
+
+## ${sharedPrefix} first
+
+First claim [S1].
+
+## ${sharedPrefix} second
+
+Second claim [S1].
+`);
+
+  const baseId = `s-${sharedPrefix.toLowerCase()}`;
+  assert.deepEqual(doc.sections.map((section) => section.id), [baseId, `${baseId}-2`]);
+});
+
+test("preamble and an Overview heading cannot share reserved target ids", () => {
+  const doc = assertUniqueTargetIds(`# Findings
+
+> Research question [S1]
+
+Preamble claim [S1].
+
+## Overview
+
+Overview claim [S1].
+`);
+
+  assert.equal(doc.ledeId, "research-question");
+  assert.deepEqual(doc.sections.map((section) => section.id), ["s-overview", "s-overview-2"]);
+  assert.deepEqual(doc.sections.map((section) => section.blocks[0].id), [
+    "s-overview-block-2",
+    "s-overview-2-block-1",
+  ]);
 });
 
 test("provenance comment never becomes prose", () => {

--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -120,6 +120,36 @@ test("strict bracketed missing source ids resolve while bare unknown ids stay pr
   );
 });
 
+test("escaped known refs stay prose beside ordinary bracketed and bare refs", () => {
+  const input = String.raw`Literal \[S1], then [S1] and bare S1.`;
+  const spans = parseInline(input, SOURCES);
+
+  assert.deepEqual(refIds(spans), ["S1", "S1"]);
+  assert.match(
+    spans
+      .filter((span) => span.kind === "text")
+      .map((span) => span.text)
+      .join(""),
+    /Literal \\\[S1\]/,
+  );
+});
+
+test("known and missing bracketed refs follow odd-even escape parity", () => {
+  const input = String.raw`Odd \[S1] \[S99], triple \\\[S2] \\\[S98], even \\[S3] \\[S97], adjacent \[S4][S4].`;
+  const sources = [
+    source("S1", "candidate"),
+    source("S2", "rejected"),
+    source("S3", "used"),
+    source("S4", "used"),
+  ];
+
+  assert.deepEqual(refIds(parseInline(input, sources)), [
+    "S3",
+    "S97",
+    "S4",
+  ]);
+});
+
 test("missing source refs keep markdown code, image, link destination, and URL exclusions", () => {
   const doc = parseFindingsDoc(`# Findings
 

--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -262,6 +262,43 @@ test("linked images consume both destinations before adjacent real citations", (
   ]);
 });
 
+test("reference-style image variants degrade without exposing image fields as citations", () => {
+  const spans = parseInline(
+    "![S1][img], ![S6][], [![S14](image-S6.png)][target], and [![S1][thumb]](https://x.test/S6) then [S14].",
+    SOURCES,
+  );
+
+  assert.deepEqual(refIds(spans), ["S14"]);
+  assert.deepEqual(spans, [
+    { kind: "text", text: "S1" },
+    { kind: "text", text: ", " },
+    { kind: "text", text: "S6" },
+    { kind: "text", text: ", " },
+    { kind: "link", text: "S14", href: "image-S6.png" },
+    { kind: "text", text: ", and " },
+    { kind: "link", text: "S1", href: "https://x.test/S6" },
+    { kind: "text", text: " then" },
+    { kind: "ref-gap", text: " " },
+    { kind: "ref", id: "S14", tone: "accent" },
+    { kind: "text", text: "." },
+  ]);
+});
+
+test("ordinary reference-style prose links remain scan-visible prose", () => {
+  const spans = parseInline("[paper][S1] then [S14].", SOURCES);
+
+  assert.deepEqual(refIds(spans), ["S1", "S14"]);
+  assert.equal(spans.some((span) => span.kind === "link"), false);
+  assert.deepEqual(spans, [
+    { kind: "text", text: "[paper]" },
+    { kind: "ref", id: "S1", tone: "accent" },
+    { kind: "text", text: " then" },
+    { kind: "ref-gap", text: " " },
+    { kind: "ref", id: "S14", tone: "accent" },
+    { kind: "text", text: "." },
+  ]);
+});
+
 test("linked evidence refs populate claim support targets while destinations stay opaque", () => {
   const doc = parseFindingsDoc(`# Findings
 

--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -6,7 +6,7 @@ import {
   parseFindingsDoc,
   parseInline,
   refToneForStatus,
-  sectionsSupportingRef,
+  targetsSupportingRef,
   type FindingsSpan,
 } from "./research-findings-doc.ts";
 
@@ -148,7 +148,7 @@ test("markdown pipe tables become table blocks with ref chips in cells", () => {
   assert.equal(table.header.length, 3);
   assert.equal(table.rows.length, 2);
   // The Source cell of row 1 carries the S14 chip.
-  assert.deepEqual(refIds(table.rows[0][1]), ["S14"]);
+  assert.deepEqual(refIds(table.rows[0].cells[1]), ["S14"]);
 });
 
 test("lists parse into a single ul block", () => {
@@ -177,9 +177,11 @@ Ready.
   assert.ok(architecture);
   assert.equal(architecture.blocks.length, 1);
   assert.deepEqual(architecture.blocks[0], {
+    id: "s-architecture-block-1",
     kind: "code",
     language: "mermaid",
     code: "flowchart TD\n  UI[Research Desk] --> D[Daemon]",
+    refIds: [],
   });
   assert.deepEqual(doc.sections.map((section) => section.heading), ["Architecture", "Runtime"]);
 });
@@ -198,9 +200,11 @@ Body.
   assert.deepEqual(doc.sections.map((section) => section.heading), ["", "Real section"]);
   const overview = doc.sections.find((section) => section.id === "s-overview");
   assert.deepEqual(overview?.blocks[0], {
+    id: "s-overview-block-1",
     kind: "code",
     language: "markdown",
     code: "# This is code, not a section",
+    refIds: [],
   });
 });
 
@@ -211,11 +215,93 @@ test("section and document ref ids are collected in order", () => {
   assert.deepEqual(keyResults?.refIds, ["S14", "S6"]);
 });
 
-test("supports links resolve to the sections that cite a source", () => {
+test("support targets resolve to the claims that cite a source", () => {
   const doc = parseFindingsDoc(FINDINGS, SOURCES);
-  const supportsS14 = sectionsSupportingRef(doc, "S14").map((s) => s.heading);
-  assert.deepEqual(supportsS14, ["Current understanding", "Key results"]);
-  assert.deepEqual(sectionsSupportingRef(doc, "C1").map((s) => s.heading), ["Open questions"]);
+  const supportsS14 = targetsSupportingRef(doc, "S14").map((target) => target.label);
+  assert.deepEqual(supportsS14, ["Current understanding", "Key results · row 1"]);
+  assert.deepEqual(
+    targetsSupportingRef(doc, "C1").map((target) => target.label),
+    ["Open questions · item 1"],
+  );
+});
+
+test("ordered lists and quotations retain stable block identity and reference ids", () => {
+  const doc = parseFindingsDoc(`# Findings
+
+## Evidence
+
+1. First claim [S1]
+2. Second claim S14
+
+> Signed does not mean verified [S6].
+> It remains disputed S14.
+`, SOURCES);
+  const evidence = doc.sections[0];
+  const ordered = evidence.blocks[0];
+  const quote = evidence.blocks[1];
+
+  assert.ok(ordered.kind === "ol");
+  assert.ok(quote.kind === "quote");
+  assert.equal(ordered.id, "s-evidence-block-1");
+  assert.equal(quote.id, "s-evidence-block-2");
+  assert.deepEqual(ordered.refIds, ["S1", "S14"]);
+  assert.deepEqual(quote.refIds, ["S6", "S14"]);
+  assert.equal(
+    quote.spans.map((span) => (span.kind === "ref" ? span.id : span.text)).join(""),
+    "Signed does not mean verified S6. It remains disputed S14.",
+  );
+});
+
+test("list items and table rows expose stable ids and their own reference ids", () => {
+  const doc = parseFindingsDoc(FINDINGS, SOURCES);
+  const questions = doc.sections.find((section) => section.heading === "Open questions");
+  const list = questions?.blocks.find((block) => block.kind === "ul");
+  assert.ok(list?.kind === "ul");
+  assert.equal(list.items[0].id, "s-open-questions-block-1-item-1");
+  assert.deepEqual(list.items[0].refIds, ["C1"]);
+  assert.equal(list.items[1].id, "s-open-questions-block-1-item-2");
+  assert.deepEqual(list.items[1].refIds, []);
+
+  const results = doc.sections.find((section) => section.heading === "Key results");
+  const table = results?.blocks.find((block) => block.kind === "table");
+  assert.ok(table?.kind === "table");
+  assert.equal(table.rows[0].id, "s-key-results-block-1-row-1");
+  assert.deepEqual(table.rows[0].refIds, ["S14"]);
+  assert.equal(table.rows[1].id, "s-key-results-block-1-row-2");
+  assert.deepEqual(table.rows[1].refIds, ["S6"]);
+});
+
+test("support targets include lede, overview, list items, and table rows", () => {
+  const doc = parseFindingsDoc(`# Findings
+
+> Question [S1]
+
+Overview [S1].
+
+## Results
+
+- Claim [S1]
+
+| Finding | Source |
+| --- | --- |
+| Result | [S1] |
+`, SOURCES);
+
+  assert.equal(doc.ledeId, "research-question");
+  assert.deepEqual(targetsSupportingRef(doc, "S1"), [
+    { id: "research-question", label: "Research question", sectionId: null },
+    { id: "s-overview-block-2", label: "Overview", sectionId: "s-overview" },
+    {
+      id: "s-results-block-1-item-1",
+      label: "Results · item 1",
+      sectionId: "s-results",
+    },
+    {
+      id: "s-results-block-2-row-1",
+      label: "Results · row 1",
+      sectionId: "s-results",
+    },
+  ]);
 });
 
 test("headingless findings still yield a single renderable section", () => {

--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { ResearchSourceRef } from "./research-missions.ts";
 import {
+  findRecognizedFindingsRefs,
   parseFindingsDoc,
   parseInline,
   refToneForStatus,
@@ -60,6 +61,29 @@ test("conflicting/rejected source refs carry warn/muted tones", () => {
 test("arbitrary capitalised words are not mistaken for refs", () => {
   const spans = parseInline("The System Self-model is Stable", SOURCES);
   assert.deepEqual(refIds(spans), []);
+});
+
+test("matcher and inline parser reject source ids outside the parser boundary grammar", () => {
+  const sources = [source("^1", "used"), source("-foo-", "used")];
+  const input = "Footnote [^1] and marker -foo- stay prose.";
+
+  assert.deepEqual(findRecognizedFindingsRefs(input, sources), []);
+  assert.deepEqual(refIds(parseInline(input, sources)), []);
+});
+
+test("matcher reports heading refs in order without splitting longer source ids", () => {
+  const input = "# Result from manual-1 compared with manual-C1 and manual-1";
+  const firstManualIndex = input.indexOf("manual-1");
+  const matches = findRecognizedFindingsRefs(input, [
+    source("manual-1", "candidate"),
+    source("manual-C1", "conflicting"),
+  ]);
+
+  assert.deepEqual(matches, [
+    { id: "manual-1", index: firstManualIndex, tone: "accent" },
+    { id: "manual-C1", index: input.indexOf("manual-C1"), tone: "warn" },
+    { id: "manual-1", index: input.indexOf("manual-1", firstManualIndex + 1), tone: "accent" },
+  ]);
 });
 
 test("bold, italic and links parse into styled spans", () => {

--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -186,6 +186,50 @@ test("bold, italic and links parse into styled spans", () => {
   assert.deepEqual({ text: link.text, href: link.href }, { text: "paper", href: "https://x.test/a" });
 });
 
+test("inline-link labels tokenize exact and mixed evidence refs without linking the refs", () => {
+  const spans = parseInline(
+    "[S1](../sources.json), [evidence S14](https://x.test/report), and [paper](https://x.test/plain).",
+    SOURCES,
+  );
+
+  assert.deepEqual(refIds(spans), ["S1", "S14"]);
+  assert.deepEqual(
+    spans.filter(
+      (span): span is Extract<FindingsSpan, { kind: "link" }> =>
+        span.kind === "link",
+    ),
+    [
+      { kind: "link", text: "evidence ", href: "https://x.test/report" },
+      { kind: "link", text: "paper", href: "https://x.test/plain" },
+    ],
+  );
+  assert.equal(
+    spans.some((span) => span.kind === "link" && /S1|S14/.test(span.text)),
+    false,
+  );
+});
+
+test("linked evidence refs populate claim support targets while destinations stay opaque", () => {
+  const doc = parseFindingsDoc(`# Findings
+
+## Linked evidence
+
+[S1](../sources/S99) and [evidence manual-1](https://x.test/S88) support this claim.
+`, [...SOURCES, source("manual-1", "candidate")]);
+  const block = doc.sections[0]?.blocks[0];
+  assert.ok(block?.kind === "p");
+  assert.deepEqual(block.refIds, ["S1", "manual-1"]);
+  assert.deepEqual(doc.refIds, ["S1", "manual-1"]);
+  assert.deepEqual(
+    targetsSupportingRef(doc, "S1").map((target) => target.id),
+    [block.id],
+  );
+  assert.deepEqual(
+    targetsSupportingRef(doc, "manual-1").map((target) => target.id),
+    [block.id],
+  );
+});
+
 const FINDINGS = `<!-- research-provenance
 mission: cave-1
 generated_at: 2026-07-24

--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -209,6 +209,59 @@ test("inline-link labels tokenize exact and mixed evidence refs without linking 
   );
 });
 
+test("inline images consume their whole construct without citing alt text or destinations", () => {
+  const spans = parseInline(
+    "Before ![nested [S1]](https://x.test/assets/S6_(v2).png) after [S14](../sources/S99).",
+    SOURCES,
+  );
+
+  assert.deepEqual(refIds(spans), ["S14"]);
+  assert.deepEqual(
+    spans.filter(
+      (span): span is Extract<FindingsSpan, { kind: "link" }> =>
+        span.kind === "link",
+    ),
+    [
+      {
+        kind: "link",
+        text: "nested [S1]",
+        href: "https://x.test/assets/S6_(v2).png",
+      },
+    ],
+  );
+  assert.deepEqual(spans, [
+    { kind: "text", text: "Before " },
+    {
+      kind: "link",
+      text: "nested [S1]",
+      href: "https://x.test/assets/S6_(v2).png",
+    },
+    { kind: "text", text: " after " },
+    { kind: "ref", id: "S14", tone: "accent" },
+    { kind: "text", text: "." },
+  ]);
+});
+
+test("linked images consume both destinations before adjacent real citations", () => {
+  const spans = parseInline(
+    "[![S1](image-S6.png)](https://x.test/S14) then [evidence S14](../sources/S99).",
+    SOURCES,
+  );
+
+  assert.deepEqual(refIds(spans), ["S14"]);
+  assert.deepEqual(spans, [
+    {
+      kind: "link",
+      text: "S1",
+      href: "https://x.test/S14",
+    },
+    { kind: "text", text: " then " },
+    { kind: "link", text: "evidence ", href: "../sources/S99" },
+    { kind: "ref", id: "S14", tone: "accent" },
+    { kind: "text", text: "." },
+  ]);
+});
+
 test("linked evidence refs populate claim support targets while destinations stay opaque", () => {
   const doc = parseFindingsDoc(`# Findings
 

--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -69,6 +69,25 @@ test("longer ids win over their prefixes and brackets are consumed", () => {
   assert.ok(!text.includes("["), "brackets around a ref must be consumed");
 });
 
+test("whitespace immediately before refs becomes a responsive reference gap", () => {
+  const spans = parseInline(
+    "Identity drifts independently [S1] [S14]. Evidence [S1] supports continuity.",
+    SOURCES,
+  );
+
+  assert.deepEqual(spans, [
+    { kind: "text", text: "Identity drifts independently" },
+    { kind: "ref-gap", text: " " },
+    { kind: "ref", id: "S1", tone: "accent" },
+    { kind: "ref-gap", text: " " },
+    { kind: "ref", id: "S14", tone: "accent" },
+    { kind: "text", text: ". Evidence" },
+    { kind: "ref-gap", text: " " },
+    { kind: "ref", id: "S1", tone: "accent" },
+    { kind: "text", text: " supports continuity." },
+  ]);
+});
+
 test("conflict tokens resolve to warn even without a source row", () => {
   const spans = parseInline("open item C1 remains", SOURCES);
   const ref = spans.find((s) => s.kind === "ref") as Extract<FindingsSpan, { kind: "ref" }>;
@@ -361,6 +380,39 @@ test("markdown pipe tables become table blocks with ref chips in cells", () => {
   assert.deepEqual(refIds(table.rows[0].cells[1]), ["S14"]);
 });
 
+test("marks only recognized table columns whose body cells are entirely references", () => {
+  const doc = parseFindingsDoc(`# Findings
+
+## Redundant
+
+| Finding | Source | Confidence |
+| --- | --- | --- |
+| First result | [S1] [S14] | High |
+| Second result | S6 | Medium |
+
+## Mixed
+
+| Finding | Reference | Evidence |
+| --- | --- | --- |
+| First result | Primary source [S1] | [S14] |
+| Second result | [S6] | Supporting note |
+
+## Unrecognized
+
+| Finding | Owner |
+| --- | --- |
+| First result | [S1] |
+`, SOURCES);
+  const tables = doc.sections.map((section) => section.blocks[0]);
+
+  assert.ok(tables.every((block) => block.kind === "table"));
+  assert.deepEqual(tables.map((block) => block.redundantRefColumnIndexes), [
+    [1],
+    [],
+    [],
+  ]);
+});
+
 test("table headers expose unique reference ids separately from row evidence", () => {
   const doc = parseFindingsDoc(`# Findings
 
@@ -448,6 +500,30 @@ test("support targets resolve to the claims that cite a source", () => {
   assert.deepEqual(
     targetsSupportingRef(doc, "C1").map((target) => target.label),
     ["Open questions · item 1"],
+  );
+});
+
+test("support targets disambiguate duplicate claims only within the same section", () => {
+  const doc = parseFindingsDoc(`# Findings
+
+## Current understanding
+
+First claim [S1].
+
+Second claim [S1].
+
+## Implications
+
+Unique claim [S1].
+`, SOURCES);
+
+  assert.deepEqual(
+    targetsSupportingRef(doc, "S1").map((target) => target.label),
+    [
+      "Current understanding · claim 1/2",
+      "Current understanding · claim 2/2",
+      "Implications",
+    ],
   );
 });
 

--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -361,6 +361,22 @@ test("markdown pipe tables become table blocks with ref chips in cells", () => {
   assert.deepEqual(refIds(table.rows[0].cells[1]), ["S14"]);
 });
 
+test("table headers expose unique reference ids separately from row evidence", () => {
+  const doc = parseFindingsDoc(`# Findings
+
+## Key results
+
+| Finding S14 | Source S14 | Confidence S6 |
+| --- | --- | --- |
+| Scale raises value coherence | S1 | High |
+`, SOURCES);
+  const table = doc.sections[0]?.blocks[0];
+  assert.ok(table?.kind === "table");
+  assert.deepEqual(table.headerRefIds, ["S14", "S6"]);
+  assert.deepEqual(table.rows[0].refIds, ["S1"]);
+  assert.deepEqual(table.refIds, ["S14", "S6", "S1"]);
+});
+
 test("lists parse into a single ul block", () => {
   const doc = parseFindingsDoc(FINDINGS, SOURCES);
   const open = doc.sections.find((s) => s.heading === "Open questions");

--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -230,6 +230,78 @@ Overview claim [S1].
   ]);
 });
 
+test("later section ids disambiguate against earlier generated block ids", () => {
+  const doc = assertUniqueTargetIds(`# Findings
+
+## Results
+
+First claim [S1].
+
+## Results block 1
+
+Second claim [S1].
+`);
+
+  assert.deepEqual(doc.sections.map((section) => section.id), [
+    "s-results",
+    "s-results-block-1-2",
+  ]);
+  assert.deepEqual(doc.sections.map((section) => section.blocks[0].id), [
+    "s-results-block-1",
+    "s-results-block-1-2-block-1",
+  ]);
+});
+
+test("later section ids disambiguate against earlier preamble block ids", () => {
+  const doc = assertUniqueTargetIds(`# Findings
+
+Preamble claim [S1].
+
+## Overview block 1
+
+Section claim [S1].
+`);
+
+  assert.deepEqual(doc.sections.map((section) => section.id), [
+    "s-overview",
+    "s-overview-block-1-2",
+  ]);
+  assert.deepEqual(doc.sections.map((section) => section.blocks[0].id), [
+    "s-overview-block-1",
+    "s-overview-block-1-2-block-1",
+  ]);
+});
+
+test("generated child ids disambiguate against earlier cross-level section ids", () => {
+  const doc = assertUniqueTargetIds(`# Findings
+
+## Results block 1 item 1
+
+Earlier item-shaped section [S1].
+
+## Results block 2 row 1
+
+Earlier row-shaped section [S1].
+
+## Results
+
+- List claim [S1]
+
+| Finding | Source |
+| --- | --- |
+| Table claim | [S1] |
+`);
+
+  const results = doc.sections.at(-1);
+  assert.ok(results);
+  const list = results.blocks[0];
+  const table = results.blocks[1];
+  assert.ok(list.kind === "ul");
+  assert.ok(table.kind === "table");
+  assert.equal(list.items[0].id, "s-results-block-1-item-1-2");
+  assert.equal(table.rows[0].id, "s-results-block-2-row-1-2");
+});
+
 test("provenance comment never becomes prose", () => {
   const doc = parseFindingsDoc(FINDINGS, SOURCES);
   const firstSpan = doc.lede?.[0] as { text?: string } | undefined;

--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -75,6 +75,48 @@ test("conflict tokens resolve to warn even without a source row", () => {
   assert.deepEqual({ id: ref.id, tone: ref.tone }, { id: "C1", tone: "warn" });
 });
 
+test("strict bracketed missing source ids resolve while bare unknown ids stay prose", () => {
+  const spans = parseInline(
+    "Missing [S99] and [R88], but bare S98 and escaped \\[S97] stay prose.",
+    [],
+  );
+  const refs = spans.filter(
+    (span): span is Extract<FindingsSpan, { kind: "ref" }> =>
+      span.kind === "ref",
+  );
+
+  assert.deepEqual(
+    refs.map(({ id, tone }) => ({ id, tone })),
+    [
+      { id: "S99", tone: "unresolved" },
+      { id: "R88", tone: "unresolved" },
+    ],
+  );
+  assert.match(
+    spans
+      .filter((span) => span.kind === "text")
+      .map((span) => span.text)
+      .join(""),
+    /bare S98 and escaped \\?\[S97\] stay prose/,
+  );
+});
+
+test("missing source refs keep markdown code, image, link destination, and URL exclusions", () => {
+  const doc = parseFindingsDoc(`# Findings
+
+Visible [S99], inline \`[S98]\`, image ![S97](image.png), link [paper](https://x.test/[S96]),
+and URL https://x.test/[S95] stay distinct.
+
+<!-- hidden [S94] -->
+
+\`\`\`md
+[S93]
+\`\`\`
+`, []);
+
+  assert.deepEqual(doc.refIds, ["S99"]);
+});
+
 test("conflicting/rejected source refs carry warn/muted tones", () => {
   const spans = parseInline("see S6 and R1 and S14", SOURCES);
   const byId = new Map(
@@ -437,6 +479,38 @@ test("list items and table rows expose stable ids and their own reference ids", 
   assert.deepEqual(table.rows[0].refIds, ["S14"]);
   assert.equal(table.rows[1].id, "s-key-results-block-1-row-2");
   assert.deepEqual(table.rows[1].refIds, ["S6"]);
+});
+
+test("missing refs flow through block, item, row, section, and document provenance", () => {
+  const doc = parseFindingsDoc(`# Findings
+
+## Evidence
+
+Paragraph [S99].
+
+- List claim [R88]
+
+| Finding | Source |
+| --- | --- |
+| Missing ledger row | [S77] |
+`, [source("S1", "used")]);
+  const evidence = doc.sections[0];
+  const paragraph = evidence.blocks[0];
+  const list = evidence.blocks[1];
+  const table = evidence.blocks[2];
+
+  assert.ok(paragraph.kind === "p");
+  assert.ok(list.kind === "ul");
+  assert.ok(table.kind === "table");
+  assert.deepEqual(paragraph.refIds, ["S99"]);
+  assert.deepEqual(list.items[0].refIds, ["R88"]);
+  assert.deepEqual(table.rows[0].refIds, ["S77"]);
+  assert.deepEqual(evidence.refIds, ["S99", "R88", "S77"]);
+  assert.deepEqual(doc.refIds, ["S99", "R88", "S77"]);
+  assert.deepEqual(
+    targetsSupportingRef(doc, "S99").map((target) => target.id),
+    [paragraph.id],
+  );
 });
 
 test("support targets include lede, overview, list items, and table rows", () => {

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -215,20 +215,48 @@ function slugify(heading: string, index: number): string {
   return `s-${base || `section-${index + 1}`}`;
 }
 
+type TargetIdAllocator = {
+  allocate: (baseId: string) => string;
+  release: (id: string) => void;
+};
+
+function createTargetIdAllocator(): TargetIdAllocator {
+  const usedIds = new Set<string>();
+
+  const allocate = (baseId: string) => {
+    let id = baseId;
+    let occurrence = 2;
+    while (usedIds.has(id)) {
+      id = `${baseId}-${occurrence}`;
+      occurrence += 1;
+    }
+    usedIds.add(id);
+    return id;
+  };
+
+  return {
+    allocate,
+    release: (id) => {
+      usedIds.delete(id);
+    },
+  };
+}
+
 function uniqueSectionId(
   heading: string,
   index: number,
-  usedTargetIds: Set<string>,
+  allocator: TargetIdAllocator,
 ): string {
-  const baseId = slugify(heading, index);
-  let sectionId = baseId;
-  let occurrence = 2;
-  while (usedTargetIds.has(sectionId)) {
-    sectionId = `${baseId}-${occurrence}`;
-    occurrence += 1;
+  return allocator.allocate(slugify(heading, index));
+}
+
+function releaseBlockTargetIds(block: FindingsBlock, allocator: TargetIdAllocator): void {
+  allocator.release(block.id);
+  if (block.kind === "ul" || block.kind === "ol") {
+    for (const item of block.items) allocator.release(item.id);
+  } else if (block.kind === "table") {
+    for (const row of block.rows) allocator.release(row.id);
   }
-  usedTargetIds.add(sectionId);
-  return sectionId;
 }
 
 const HEADING_RE = /^(#{1,6})\s+(.+?)\s*#*$/;
@@ -267,6 +295,7 @@ function parseBlocks(
   lines: string[],
   resolver: RefResolver,
   idPrefix: string,
+  allocator: TargetIdAllocator,
 ): FindingsBlock[] {
   const blocks: FindingsBlock[] = [];
   let paragraph: string[] = [];
@@ -275,7 +304,7 @@ function parseBlocks(
 
   const nextBlockId = () => {
     blockIndex += 1;
-    return `${idPrefix}-block-${blockIndex}`;
+    return allocator.allocate(`${idPrefix}-block-${blockIndex}`);
   };
   const refsForSpans = (spans: FindingsSpan[]) => {
     const refIds: string[] = [];
@@ -301,7 +330,7 @@ function parseBlocks(
     if (list && list.items.length) {
       const blockId = nextBlockId();
       const items = list.items.map((spans, itemIndex) => ({
-        id: `${blockId}-item-${itemIndex + 1}`,
+        id: allocator.allocate(`${blockId}-item-${itemIndex + 1}`),
         spans,
         refIds: refsForSpans(spans),
       }));
@@ -358,7 +387,7 @@ function parseBlocks(
         const refIds: string[] = [];
         for (const cell of cells) collectRefIds(cell, refIds);
         rows.push({
-          id: `${blockId}-row-${rows.length + 1}`,
+          id: allocator.allocate(`${blockId}-row-${rows.length + 1}`),
           cells,
           refIds,
         });
@@ -442,6 +471,7 @@ export function stripFindingsComments(markdown: string): string {
  */
 export function parseFindingsDoc(markdown: string, sources: ResearchSourceRef[]): FindingsDoc {
   const resolver = buildRefResolver(sources);
+  const targetIds = createTargetIdAllocator();
   const lines = stripFindingsComments(markdown ?? "").split(/\r?\n/);
 
   let title: string | null = null;
@@ -494,21 +524,20 @@ export function parseFindingsDoc(markdown: string, sources: ResearchSourceRef[])
   // Lede: only a *leading blockquote* becomes the italic tagline under the
   // title (matching the design). Plain opening prose stays body text so a
   // heading-less "title + paragraph" doc doesn't lose its content to a lede.
-  const preambleBlocks = parseBlocks(preamble, resolver, "s-overview");
+  const overviewId = targetIds.allocate("s-overview");
+  const preambleBlocks = parseBlocks(preamble, resolver, overviewId, targetIds);
   let leadBlocks: FindingsBlock[] = preambleBlocks;
   if (preambleBlocks[0]?.kind === "quote") {
     lede = preambleBlocks[0].spans;
-    ledeId = "research-question";
+    releaseBlockTargetIds(preambleBlocks[0], targetIds);
+    ledeId = targetIds.allocate("research-question");
     leadBlocks = preambleBlocks.slice(1);
   }
-
-  const usedTargetIds = new Set<string>();
-  if (ledeId) usedTargetIds.add(ledeId);
-  if (leadBlocks.length) usedTargetIds.add("s-overview");
+  if (!leadBlocks.length) targetIds.release(overviewId);
 
   groups.forEach((group, index) => {
-    const sectionId = uniqueSectionId(group.heading, index, usedTargetIds);
-    const blocks = parseBlocks(group.lines, resolver, sectionId);
+    const sectionId = uniqueSectionId(group.heading, index, targetIds);
+    const blocks = parseBlocks(group.lines, resolver, sectionId, targetIds);
     sections.push({
       id: sectionId,
       heading: group.heading,
@@ -520,7 +549,7 @@ export function parseFindingsDoc(markdown: string, sources: ResearchSourceRef[])
   // Leftover preamble prose (rare) is preserved as a leading, heading-less
   // section rather than discarded.
   if (leadBlocks.length) {
-    sections.unshift({ id: "s-overview", heading: "", blocks: leadBlocks, refIds: sectionRefIds(leadBlocks) });
+    sections.unshift({ id: overviewId, heading: "", blocks: leadBlocks, refIds: sectionRefIds(leadBlocks) });
   }
 
   const refIds: string[] = [];

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -215,6 +215,22 @@ function slugify(heading: string, index: number): string {
   return `s-${base || `section-${index + 1}`}`;
 }
 
+function uniqueSectionId(
+  heading: string,
+  index: number,
+  usedTargetIds: Set<string>,
+): string {
+  const baseId = slugify(heading, index);
+  let sectionId = baseId;
+  let occurrence = 2;
+  while (usedTargetIds.has(sectionId)) {
+    sectionId = `${baseId}-${occurrence}`;
+    occurrence += 1;
+  }
+  usedTargetIds.add(sectionId);
+  return sectionId;
+}
+
 const HEADING_RE = /^(#{1,6})\s+(.+?)\s*#*$/;
 const LIST_RE = /^\s*[-*+]\s+(.+)$/;
 const ORDERED_LIST_RE = /^\s*\d+[.)]\s+(.+)$/;
@@ -486,8 +502,12 @@ export function parseFindingsDoc(markdown: string, sources: ResearchSourceRef[])
     leadBlocks = preambleBlocks.slice(1);
   }
 
+  const usedTargetIds = new Set<string>();
+  if (ledeId) usedTargetIds.add(ledeId);
+  if (leadBlocks.length) usedTargetIds.add("s-overview");
+
   groups.forEach((group, index) => {
-    const sectionId = slugify(group.heading, index);
+    const sectionId = uniqueSectionId(group.heading, index, usedTargetIds);
     const blocks = parseBlocks(group.lines, resolver, sectionId);
     sections.push({
       id: sectionId,

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -24,11 +24,39 @@ export type FindingsSpan =
   | { kind: "ref"; id: string; tone: FindingsRefTone }
   | { kind: "link"; text: string; href: string };
 
+export type FindingsListItem = {
+  id: string;
+  spans: FindingsSpan[];
+  refIds: string[];
+};
+
+export type FindingsTableRow = {
+  id: string;
+  cells: FindingsSpan[][];
+  refIds: string[];
+};
+
+export type FindingsBlockBase = {
+  id: string;
+  refIds: string[];
+};
+
 export type FindingsBlock =
-  | { kind: "p"; spans: FindingsSpan[] }
-  | { kind: "ul"; items: FindingsSpan[][] }
-  | { kind: "table"; header: FindingsSpan[][]; rows: FindingsSpan[][][] }
-  | { kind: "code"; language: string; code: string };
+  | (FindingsBlockBase & { kind: "p"; spans: FindingsSpan[] })
+  | (FindingsBlockBase & { kind: "ul" | "ol"; items: FindingsListItem[] })
+  | (FindingsBlockBase & { kind: "quote"; spans: FindingsSpan[] })
+  | (FindingsBlockBase & {
+      kind: "table";
+      header: FindingsSpan[][];
+      rows: FindingsTableRow[];
+    })
+  | (FindingsBlockBase & { kind: "code"; language: string; code: string });
+
+export type FindingsSupportTarget = {
+  id: string;
+  label: string;
+  sectionId: string | null;
+};
 
 export type FindingsSection = {
   /** Stable slug used for the contents rail anchor and scroll-spy. */
@@ -43,6 +71,7 @@ export type FindingsSection = {
 export type FindingsDoc = {
   title: string | null;
   lede: FindingsSpan[] | null;
+  ledeId: string | null;
   sections: FindingsSection[];
   /** Union of every ref id cited across the document, in first-seen order. */
   refIds: string[];
@@ -188,6 +217,8 @@ function slugify(heading: string, index: number): string {
 
 const HEADING_RE = /^(#{1,6})\s+(.+?)\s*#*$/;
 const LIST_RE = /^\s*[-*+]\s+(.+)$/;
+const ORDERED_LIST_RE = /^\s*\d+[.)]\s+(.+)$/;
+const QUOTE_RE = /^\s*>\s?(.*)$/;
 const TABLE_ROW_RE = /^\s*\|(.+)\|\s*$/;
 const TABLE_SEP_RE = /^\s*\|?[\s:|-]*-[\s:|-]*\|?\s*$/;
 const FENCE_RE = /^\s{0,3}(`{3,}|~{3,})(.*)$/;
@@ -216,20 +247,54 @@ function splitCells(row: string): string[] {
  *  blocks. Consecutive list items merge into one list; pipe tables with a
  *  dash separator become table blocks; wrapped prose lines join into one
  *  paragraph. */
-function parseBlocks(lines: string[], resolver: RefResolver): FindingsBlock[] {
+function parseBlocks(
+  lines: string[],
+  resolver: RefResolver,
+  idPrefix: string,
+): FindingsBlock[] {
   const blocks: FindingsBlock[] = [];
   let paragraph: string[] = [];
-  let list: FindingsSpan[][] | null = null;
+  let list: { kind: "ul" | "ol"; items: FindingsSpan[][] } | null = null;
+  let blockIndex = 0;
+
+  const nextBlockId = () => {
+    blockIndex += 1;
+    return `${idPrefix}-block-${blockIndex}`;
+  };
+  const refsForSpans = (spans: FindingsSpan[]) => {
+    const refIds: string[] = [];
+    collectRefIds(spans, refIds);
+    return refIds;
+  };
 
   const flushParagraph = () => {
     if (paragraph.length) {
       const spans = parseSpans(paragraph.join(" "), resolver);
-      if (spans.length) blocks.push({ kind: "p", spans });
+      if (spans.length) {
+        blocks.push({
+          id: nextBlockId(),
+          kind: "p",
+          spans,
+          refIds: refsForSpans(spans),
+        });
+      }
       paragraph = [];
     }
   };
   const flushList = () => {
-    if (list && list.length) blocks.push({ kind: "ul", items: list });
+    if (list && list.items.length) {
+      const blockId = nextBlockId();
+      const items = list.items.map((spans, itemIndex) => ({
+        id: `${blockId}-item-${itemIndex + 1}`,
+        spans,
+        refIds: refsForSpans(spans),
+      }));
+      const refIds: string[] = [];
+      for (const item of items) {
+        for (const id of item.refIds) if (!refIds.includes(id)) refIds.push(id);
+      }
+      blocks.push({ id: blockId, kind: list.kind, items, refIds });
+    }
     list = null;
   };
 
@@ -254,7 +319,13 @@ function parseBlocks(lines: string[], resolver: RefResolver): FindingsBlock[] {
       for (; i < lines.length && !closingFence.test(lines[i]); i += 1) {
         code.push(lines[i]);
       }
-      blocks.push({ kind: "code", language, code: code.join("\n") });
+      blocks.push({
+        id: nextBlockId(),
+        kind: "code",
+        language,
+        code: code.join("\n"),
+        refIds: [],
+      });
       continue;
     }
 
@@ -262,28 +333,67 @@ function parseBlocks(lines: string[], resolver: RefResolver): FindingsBlock[] {
     if (TABLE_ROW_RE.test(line) && i + 1 < lines.length && TABLE_SEP_RE.test(lines[i + 1])) {
       flushParagraph();
       flushList();
+      const blockId = nextBlockId();
       const header = splitCells(line).map((cell) => parseSpans(cell, resolver));
-      const rows: FindingsSpan[][][] = [];
+      const rows: FindingsTableRow[] = [];
       i += 2;
       for (; i < lines.length && TABLE_ROW_RE.test(lines[i]); i += 1) {
-        rows.push(splitCells(lines[i]).map((cell) => parseSpans(cell, resolver)));
+        const cells = splitCells(lines[i]).map((cell) => parseSpans(cell, resolver));
+        const refIds: string[] = [];
+        for (const cell of cells) collectRefIds(cell, refIds);
+        rows.push({
+          id: `${blockId}-row-${rows.length + 1}`,
+          cells,
+          refIds,
+        });
       }
       i -= 1;
-      blocks.push({ kind: "table", header, rows });
+      const refIds: string[] = [];
+      for (const cell of header) collectRefIds(cell, refIds);
+      for (const row of rows) {
+        for (const id of row.refIds) if (!refIds.includes(id)) refIds.push(id);
+      }
+      blocks.push({ id: blockId, kind: "table", header, rows, refIds });
       continue;
     }
 
-    const listMatch = LIST_RE.exec(line);
+    const unorderedMatch = LIST_RE.exec(line);
+    const orderedMatch = ORDERED_LIST_RE.exec(line);
+    const listMatch = unorderedMatch ?? orderedMatch;
     if (listMatch) {
       flushParagraph();
-      list = list ?? [];
-      list.push(parseSpans(listMatch[1], resolver));
+      const kind = unorderedMatch ? "ul" : "ol";
+      if (list && list.kind !== kind) flushList();
+      list = list ?? { kind, items: [] };
+      list.items.push(parseSpans(listMatch[1], resolver));
+      continue;
+    }
+
+    const quoteMatch = QUOTE_RE.exec(line);
+    if (quoteMatch) {
+      flushParagraph();
+      flushList();
+      const quoteLines = [quoteMatch[1]];
+      for (i += 1; i < lines.length; i += 1) {
+        const nextQuote = QUOTE_RE.exec(lines[i]);
+        if (!nextQuote) break;
+        quoteLines.push(nextQuote[1]);
+      }
+      i -= 1;
+      const spans = parseSpans(quoteLines.join(" "), resolver);
+      if (spans.length) {
+        blocks.push({
+          id: nextBlockId(),
+          kind: "quote",
+          spans,
+          refIds: refsForSpans(spans),
+        });
+      }
       continue;
     }
 
     flushList();
-    // Blockquotes inside the body read as ordinary prose (strip the marker).
-    paragraph.push(line.replace(/^\s*>\s?/, "").trim());
+    paragraph.push(line.trim());
   }
   flushParagraph();
   flushList();
@@ -293,12 +403,7 @@ function parseBlocks(lines: string[], resolver: RefResolver): FindingsBlock[] {
 function sectionRefIds(blocks: FindingsBlock[]): string[] {
   const ids: string[] = [];
   for (const block of blocks) {
-    if (block.kind === "p") collectRefIds(block.spans, ids);
-    else if (block.kind === "ul") for (const item of block.items) collectRefIds(item, ids);
-    else if (block.kind === "table") {
-      for (const cell of block.header) collectRefIds(cell, ids);
-      for (const row of block.rows) for (const cell of row) collectRefIds(cell, ids);
-    }
+    for (const id of block.refIds) if (!ids.includes(id)) ids.push(id);
   }
   return ids;
 }
@@ -325,6 +430,7 @@ export function parseFindingsDoc(markdown: string, sources: ResearchSourceRef[])
 
   let title: string | null = null;
   let lede: FindingsSpan[] | null = null;
+  let ledeId: string | null = null;
   const sections: FindingsSection[] = [];
 
   // Group lines by heading. The first level-1 heading is the title; the region
@@ -372,19 +478,19 @@ export function parseFindingsDoc(markdown: string, sources: ResearchSourceRef[])
   // Lede: only a *leading blockquote* becomes the italic tagline under the
   // title (matching the design). Plain opening prose stays body text so a
   // heading-less "title + paragraph" doc doesn't lose its content to a lede.
-  const preambleBlocks = parseBlocks(preamble, resolver);
-  const firstNonEmpty = preamble.find((line) => line.trim());
-  const leadsWithQuote = Boolean(firstNonEmpty && /^\s*>/.test(firstNonEmpty));
+  const preambleBlocks = parseBlocks(preamble, resolver, "s-overview");
   let leadBlocks: FindingsBlock[] = preambleBlocks;
-  if (leadsWithQuote && preambleBlocks[0]?.kind === "p") {
+  if (preambleBlocks[0]?.kind === "quote") {
     lede = preambleBlocks[0].spans;
+    ledeId = "research-question";
     leadBlocks = preambleBlocks.slice(1);
   }
 
   groups.forEach((group, index) => {
-    const blocks = parseBlocks(group.lines, resolver);
+    const sectionId = slugify(group.heading, index);
+    const blocks = parseBlocks(group.lines, resolver, sectionId);
     sections.push({
-      id: slugify(group.heading, index),
+      id: sectionId,
       heading: group.heading,
       blocks,
       refIds: sectionRefIds(blocks),
@@ -401,16 +507,63 @@ export function parseFindingsDoc(markdown: string, sources: ResearchSourceRef[])
   if (lede) collectRefIds(lede, refIds);
   for (const section of sections) for (const id of section.refIds) if (!refIds.includes(id)) refIds.push(id);
 
-  return { title, lede, sections, refIds };
+  return { title, lede, ledeId, sections, refIds };
 }
 
-/** Sections (id + heading) that cite the given source id — the evidence card's
- *  "Supports" links, derived from where the source is actually referenced. */
-export function sectionsSupportingRef(
+function spansSupportRef(spans: FindingsSpan[], id: string): boolean {
+  return spans.some((span) => span.kind === "ref" && span.id === id);
+}
+
+/** Claim-level targets cited by a source — the evidence card's "Supports"
+ * links, derived from the exact lede, block, list item, or table row. */
+export function targetsSupportingRef(
   doc: FindingsDoc,
   id: string,
-): Array<{ id: string; heading: string }> {
-  return doc.sections
-    .filter((section) => section.heading && section.refIds.includes(id))
-    .map((section) => ({ id: section.id, heading: section.heading }));
+): FindingsSupportTarget[] {
+  const targets: FindingsSupportTarget[] = [];
+
+  if (doc.lede && doc.ledeId && spansSupportRef(doc.lede, id)) {
+    targets.push({
+      id: doc.ledeId,
+      label: "Research question",
+      sectionId: null,
+    });
+  }
+
+  for (const section of doc.sections) {
+    const sectionLabel = section.heading || "Overview";
+    for (const block of section.blocks) {
+      if (block.kind === "p" || block.kind === "quote") {
+        if (block.refIds.includes(id)) {
+          targets.push({
+            id: block.id,
+            label: sectionLabel,
+            sectionId: section.id,
+          });
+        }
+      } else if (block.kind === "ul" || block.kind === "ol") {
+        block.items.forEach((item, itemIndex) => {
+          if (item.refIds.includes(id)) {
+            targets.push({
+              id: item.id,
+              label: `${sectionLabel} · item ${itemIndex + 1}`,
+              sectionId: section.id,
+            });
+          }
+        });
+      } else if (block.kind === "table") {
+        block.rows.forEach((row, rowIndex) => {
+          if (row.refIds.includes(id)) {
+            targets.push({
+              id: row.id,
+              label: `${sectionLabel} · row ${rowIndex + 1}`,
+              sectionId: section.id,
+            });
+          }
+        });
+      }
+    }
+  }
+
+  return targets;
 }

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -21,6 +21,7 @@ export type RecognizedFindingsRef = {
 
 export type FindingsSpan =
   | { kind: "text"; text: string; bold?: boolean; italic?: boolean }
+  | { kind: "ref-gap"; text: string }
   | { kind: "ref"; id: string; tone: FindingsRefTone }
   | { kind: "link"; text: string; href: string };
 
@@ -50,6 +51,7 @@ export type FindingsBlock =
       header: FindingsSpan[][];
       headerRefIds: string[];
       rows: FindingsTableRow[];
+      redundantRefColumnIndexes: number[];
     })
   | (FindingsBlockBase & { kind: "code"; language: string; code: string });
 
@@ -357,9 +359,19 @@ function tokenizeRefs(text: string, resolver: RefResolver, base: { bold?: boolea
     return text ? [{ kind: "text", text, ...base }] : [];
   }
   const spans: FindingsSpan[] = [];
+  const pushTextBeforeRef = (value: string) => {
+    const trailingWhitespace = value.match(/\s+$/)?.[0] ?? "";
+    const prose = trailingWhitespace
+      ? value.slice(0, -trailingWhitespace.length)
+      : value;
+    if (prose) spans.push({ kind: "text", text: prose, ...base });
+    if (trailingWhitespace) {
+      spans.push({ kind: "ref-gap", text: trailingWhitespace });
+    }
+  };
   let last = 0;
   for (const match of matches) {
-    if (match.index > last) spans.push({ kind: "text", text: text.slice(last, match.index), ...base });
+    if (match.index > last) pushTextBeforeRef(text.slice(last, match.index));
     spans.push({ kind: "ref", id: match.id, tone: match.tone });
     last = match.index + match.length;
   }
@@ -494,6 +506,40 @@ function splitCells(row: string): string[] {
     .map((cell) => cell.trim());
 }
 
+const REFERENCE_COLUMN_HEADERS = new Set([
+  "source",
+  "sources",
+  "reference",
+  "references",
+  "evidence",
+  "citation",
+  "citations",
+]);
+
+function referenceColumnHeader(cell: FindingsSpan[]): boolean {
+  const label = cell
+    .filter(
+      (
+        span,
+      ): span is Extract<FindingsSpan, { kind: "text" | "link" }> =>
+        span.kind === "text" || span.kind === "link",
+    )
+    .map((span) => span.text)
+    .join("")
+    .trim()
+    .toLowerCase();
+  return REFERENCE_COLUMN_HEADERS.has(label);
+}
+
+function refOnlyCell(cell: FindingsSpan[]): boolean {
+  return (
+    cell.some((span) => span.kind === "ref") &&
+    cell.every(
+      (span) => span.kind === "ref" || span.kind === "ref-gap",
+    )
+  );
+}
+
 /** Parse the body region (everything after the title/lede or one section) into
  *  blocks. Consecutive list items merge into one list; pipe tables with a
  *  dash separator become table blocks; wrapped prose lines join into one
@@ -602,6 +648,13 @@ function parseBlocks(
       i -= 1;
       const headerRefIds: string[] = [];
       for (const cell of header) collectRefIds(cell, headerRefIds);
+      const redundantRefColumnIndexes = header.flatMap((cell, columnIndex) =>
+        referenceColumnHeader(cell) &&
+        rows.length > 0 &&
+        rows.every((row) => refOnlyCell(row.cells[columnIndex] ?? []))
+          ? [columnIndex]
+          : [],
+      );
       const refIds = [...headerRefIds];
       for (const row of rows) {
         for (const id of row.refIds) if (!refIds.includes(id)) refIds.push(id);
@@ -612,6 +665,7 @@ function parseBlocks(
         header,
         headerRefIds,
         rows,
+        redundantRefColumnIndexes,
         refIds,
       });
       continue;
@@ -830,5 +884,24 @@ export function targetsSupportingRef(
     }
   }
 
-  return targets;
+  const duplicateCounts = new Map<string, number>();
+  for (const target of targets) {
+    if (!target.sectionId) continue;
+    const key = `${target.sectionId}\u0000${target.label}`;
+    duplicateCounts.set(key, (duplicateCounts.get(key) ?? 0) + 1);
+  }
+
+  const duplicateIndexes = new Map<string, number>();
+  return targets.map((target) => {
+    if (!target.sectionId) return target;
+    const key = `${target.sectionId}\u0000${target.label}`;
+    const count = duplicateCounts.get(key) ?? 1;
+    if (count === 1) return target;
+    const index = (duplicateIndexes.get(key) ?? 0) + 1;
+    duplicateIndexes.set(key, index);
+    return {
+      ...target,
+      label: `${target.label} · claim ${index}/${count}`,
+    };
+  });
 }

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -379,6 +379,36 @@ function tokenizeRefs(text: string, resolver: RefResolver, base: { bold?: boolea
   return spans;
 }
 
+function tokenizeLinkLabel(
+  text: string,
+  href: string,
+  resolver: RefResolver,
+): FindingsSpan[] {
+  const strictSourceGroup =
+    /^\s*(?:[SR]\d+\s*)(?:,\s*[SR]\d+\s*)*$/.test(text);
+  const tokenized = tokenizeRefs(
+    strictSourceGroup ? `[${text}]` : text,
+    resolver,
+    {},
+  );
+  const spans: FindingsSpan[] = [];
+
+  for (const span of tokenized) {
+    if (span.kind === "ref") {
+      spans.push(span);
+      continue;
+    }
+    const previous = spans.at(-1);
+    if (previous?.kind === "link" && previous.href === href) {
+      previous.text += span.text;
+    } else {
+      spans.push({ kind: "link", text: span.text, href });
+    }
+  }
+
+  return spans;
+}
+
 // Emphasis + link matcher: **bold**, __bold__, *italic*, _italic_, [text](url).
 const INLINE_RE =
   /(\*\*|__)([\s\S]+?)\1|(\*|_)([\s\S]+?)\3|\[([^\]]+)\]\(([^)\s]+)\)/g;
@@ -411,7 +441,15 @@ function parseSpans(input: string, resolver: RefResolver): FindingsSpan[] {
     } else if (m[3]) {
       spans.push(...tokenizeRefs(m[4], resolver, { italic: true }));
     } else {
-      spans.push({ kind: "link", text: m[5], href: m[6] });
+      const imageLabel =
+        m.index > 0 &&
+        text[m.index - 1] === "!" &&
+        !isEscaped(text, m.index - 1);
+      if (imageLabel || isEscaped(text, m.index)) {
+        spans.push({ kind: "link", text: m[5], href: m[6] });
+      } else {
+        spans.push(...tokenizeLinkLabel(m[5], m[6], resolver));
+      }
     }
     last = m.index + m[0].length;
   }

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -48,6 +48,7 @@ export type FindingsBlock =
   | (FindingsBlockBase & {
       kind: "table";
       header: FindingsSpan[][];
+      headerRefIds: string[];
       rows: FindingsTableRow[];
     })
   | (FindingsBlockBase & { kind: "code"; language: string; code: string });
@@ -599,12 +600,20 @@ function parseBlocks(
         });
       }
       i -= 1;
-      const refIds: string[] = [];
-      for (const cell of header) collectRefIds(cell, refIds);
+      const headerRefIds: string[] = [];
+      for (const cell of header) collectRefIds(cell, headerRefIds);
+      const refIds = [...headerRefIds];
       for (const row of rows) {
         for (const id of row.refIds) if (!refIds.includes(id)) refIds.push(id);
       }
-      blocks.push({ id: blockId, kind: "table", header, rows, refIds });
+      blocks.push({
+        id: blockId,
+        kind: "table",
+        header,
+        headerRefIds,
+        rows,
+        refIds,
+      });
       continue;
     }
 

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -134,6 +134,16 @@ function tokenizeRefs(text: string, resolver: RefResolver, base: { bold?: boolea
 // Emphasis + link matcher: **bold**, __bold__, *italic*, _italic_, [text](url).
 const INLINE_RE =
   /(\*\*|__)([\s\S]+?)\1|(\*|_)([\s\S]+?)\3|\[([^\]]+)\]\(([^)\s]+)\)/g;
+const INLINE_LINK_RE = /^\[([^\]]+)\]\(([^)\s]+)\)/;
+
+export function matchFindingsInlineLinkAt(
+  input: string,
+  index: number,
+): { text: string; href: string; length: number } | null {
+  const match = INLINE_LINK_RE.exec(input.slice(index));
+  if (!match) return null;
+  return { text: match[1], href: match[2], length: match[0].length };
+}
 
 /** Parse one run of inline markdown into spans (emphasis, links, ref chips). */
 export function parseInline(input: string, sources: ResearchSourceRef[]): FindingsSpan[] {
@@ -182,6 +192,18 @@ const TABLE_ROW_RE = /^\s*\|(.+)\|\s*$/;
 const TABLE_SEP_RE = /^\s*\|?[\s:|-]*-[\s:|-]*\|?\s*$/;
 const FENCE_RE = /^\s{0,3}(`{3,}|~{3,})(.*)$/;
 
+export function matchFindingsFenceRun(
+  line: string,
+): { character: "`" | "~"; length: number; suffix: string } | null {
+  const match = FENCE_RE.exec(line);
+  if (!match) return null;
+  return {
+    character: match[1][0] as "`" | "~",
+    length: match[1].length,
+    suffix: match[2],
+  };
+}
+
 function splitCells(row: string): string[] {
   return row
     .replace(/^\s*\|/, "")
@@ -219,16 +241,14 @@ function parseBlocks(lines: string[], resolver: RefResolver): FindingsBlock[] {
       continue;
     }
 
-    const fenceMatch = FENCE_RE.exec(line);
-    if (fenceMatch) {
+    const fenceRun = matchFindingsFenceRun(line);
+    if (fenceRun) {
       flushParagraph();
       flushList();
-      const marker = fenceMatch[1];
-      const markerCharacter = marker[0];
       const closingFence = new RegExp(
-        `^\\s{0,3}${escapeRegExp(markerCharacter)}{${marker.length},}\\s*$`,
+        `^\\s{0,3}${escapeRegExp(fenceRun.character)}{${fenceRun.length},}\\s*$`,
       );
-      const language = fenceMatch[2].trim().split(/\s+/, 1)[0] ?? "";
+      const language = fenceRun.suffix.trim().split(/\s+/, 1)[0] ?? "";
       const code: string[] = [];
       i += 1;
       for (; i < lines.length && !closingFence.test(lines[i]); i += 1) {
@@ -316,18 +336,20 @@ export function parseFindingsDoc(markdown: string, sources: ResearchSourceRef[])
   let headingFence: { character: string; length: number } | null = null;
 
   for (const line of lines) {
-    const fenceMatch = FENCE_RE.exec(line);
-    if (fenceMatch) {
-      const marker = fenceMatch[1];
+    const fenceRun = matchFindingsFenceRun(line);
+    if (fenceRun) {
       if (
         headingFence &&
-        marker[0] === headingFence.character &&
-        marker.length >= headingFence.length &&
-        !fenceMatch[2].trim()
+        fenceRun.character === headingFence.character &&
+        fenceRun.length >= headingFence.length &&
+        !fenceRun.suffix.trim()
       ) {
         headingFence = null;
       } else if (!headingFence) {
-        headingFence = { character: marker[0], length: marker.length };
+        headingFence = {
+          character: fenceRun.character,
+          length: fenceRun.length,
+        };
       }
     }
     const headingMatch = headingFence ? null : HEADING_RE.exec(line);

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -13,6 +13,12 @@ import type { ResearchSourceRef } from "./research-missions.ts";
 
 export type FindingsRefTone = "accent" | "warn" | "muted";
 
+export type RecognizedFindingsRef = {
+  id: string;
+  index: number;
+  tone: FindingsRefTone;
+};
+
 export type FindingsSpan =
   | { kind: "text"; text: string; bold?: boolean; italic?: boolean }
   | { kind: "ref"; id: string; tone: FindingsRefTone }
@@ -79,18 +85,47 @@ function buildRefResolver(sources: ResearchSourceRef[]): RefResolver {
   };
 }
 
+type FindingsRefMatch = RecognizedFindingsRef & { length: number };
+
+function matchRecognizedFindingsRefs(input: string, resolver: RefResolver): FindingsRefMatch[] {
+  if (!resolver.pattern || !input) return [];
+
+  const matches: FindingsRefMatch[] = [];
+  resolver.pattern.lastIndex = 0;
+  for (let match = resolver.pattern.exec(input); match; match = resolver.pattern.exec(input)) {
+    matches.push({
+      id: match[1],
+      index: match.index,
+      length: match[0].length,
+      tone: resolver.toneFor(match[1]),
+    });
+  }
+  return matches;
+}
+
+/** Find references using the exact resolver and boundary grammar used by the
+ * inline findings parser. Matches retain duplicates and input-relative order. */
+export function findRecognizedFindingsRefs(
+  input: string,
+  sources: ResearchSourceRef[],
+): RecognizedFindingsRef[] {
+  return matchRecognizedFindingsRefs(input, buildRefResolver(sources)).map(
+    ({ id, index, tone }) => ({ id, index, tone }),
+  );
+}
+
 /** Split plain text into text/ref spans (no emphasis parsing at this layer). */
 function tokenizeRefs(text: string, resolver: RefResolver, base: { bold?: boolean; italic?: boolean }): FindingsSpan[] {
-  if (!resolver.pattern || !text) {
+  const matches = matchRecognizedFindingsRefs(text, resolver);
+  if (matches.length === 0) {
     return text ? [{ kind: "text", text, ...base }] : [];
   }
   const spans: FindingsSpan[] = [];
   let last = 0;
-  resolver.pattern.lastIndex = 0;
-  for (let m = resolver.pattern.exec(text); m; m = resolver.pattern.exec(text)) {
-    if (m.index > last) spans.push({ kind: "text", text: text.slice(last, m.index), ...base });
-    spans.push({ kind: "ref", id: m[1], tone: resolver.toneFor(m[1]) });
-    last = m.index + m[0].length;
+  for (const match of matches) {
+    if (match.index > last) spans.push({ kind: "text", text: text.slice(last, match.index), ...base });
+    spans.push({ kind: "ref", id: match.id, tone: match.tone });
+    last = match.index + match.length;
   }
   if (last < text.length) spans.push({ kind: "text", text: text.slice(last), ...base });
   return spans;

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -409,10 +409,101 @@ function tokenizeLinkLabel(
   return spans;
 }
 
-// Emphasis + link matcher: **bold**, __bold__, *italic*, _italic_, [text](url).
-const INLINE_RE =
-  /(\*\*|__)([\s\S]+?)\1|(\*|_)([\s\S]+?)\3|\[([^\]]+)\]\(([^)\s]+)\)/g;
 const INLINE_LINK_RE = /^\[([^\]]+)\]\(([^)\s]+)\)/;
+const INLINE_EMPHASIS_RE =
+  /^(?:(\*\*|__)([\s\S]+?)\1|(\*|_)([\s\S]+?)\3)/;
+
+function findBalancedClose(
+  input: string,
+  startIndex: number,
+  open: string,
+  close: string,
+): number {
+  let depth = 1;
+
+  for (let index = startIndex; index < input.length; index += 1) {
+    const character = input[index];
+    if (character === "\\") {
+      index += 1;
+      continue;
+    }
+    if (character === open) {
+      depth += 1;
+      continue;
+    }
+    if (character !== close) continue;
+    depth -= 1;
+    if (depth === 0) return index;
+  }
+
+  return -1;
+}
+
+export function matchFindingsInlineImageAt(
+  input: string,
+  index: number,
+): { text: string; href: string; length: number } | null {
+  if (
+    input[index] !== "!" ||
+    input[index + 1] !== "[" ||
+    isEscaped(input, index)
+  ) {
+    return null;
+  }
+
+  const labelStart = index + 2;
+  const labelEnd = findBalancedClose(input, labelStart, "[", "]");
+  if (labelEnd === -1 || input[labelEnd + 1] !== "(") return null;
+
+  const destinationStart = labelEnd + 2;
+  const destinationEnd = findBalancedClose(
+    input,
+    destinationStart,
+    "(",
+    ")",
+  );
+  if (destinationEnd === -1) return null;
+
+  return {
+    text: input.slice(labelStart, labelEnd),
+    href: input.slice(destinationStart, destinationEnd),
+    length: destinationEnd + 1 - index,
+  };
+}
+
+export function matchFindingsLinkedImageAt(
+  input: string,
+  index: number,
+): { text: string; href: string; length: number } | null {
+  if (
+    input[index] !== "[" ||
+    input[index + 1] !== "!" ||
+    isEscaped(input, index)
+  ) {
+    return null;
+  }
+
+  const image = matchFindingsInlineImageAt(input, index + 1);
+  if (!image) return null;
+
+  const imageEnd = index + 1 + image.length;
+  if (input[imageEnd] !== "]" || input[imageEnd + 1] !== "(") return null;
+
+  const destinationStart = imageEnd + 2;
+  const destinationEnd = findBalancedClose(
+    input,
+    destinationStart,
+    "(",
+    ")",
+  );
+  if (destinationEnd === -1) return null;
+
+  return {
+    text: image.text,
+    href: input.slice(destinationStart, destinationEnd),
+    length: destinationEnd + 1 - index,
+  };
+}
 
 export function matchFindingsInlineLinkAt(
   input: string,
@@ -432,28 +523,77 @@ function parseSpans(input: string, resolver: RefResolver): FindingsSpan[] {
   const text = input.trim();
   if (!text) return [];
   const spans: FindingsSpan[] = [];
-  let last = 0;
-  INLINE_RE.lastIndex = 0;
-  for (let m = INLINE_RE.exec(text); m; m = INLINE_RE.exec(text)) {
-    if (m.index > last) spans.push(...tokenizeRefs(text.slice(last, m.index), resolver, {}));
-    if (m[1]) {
-      spans.push(...tokenizeRefs(m[2], resolver, { bold: true }));
-    } else if (m[3]) {
-      spans.push(...tokenizeRefs(m[4], resolver, { italic: true }));
-    } else {
-      const imageLabel =
-        m.index > 0 &&
-        text[m.index - 1] === "!" &&
-        !isEscaped(text, m.index - 1);
-      if (imageLabel || isEscaped(text, m.index)) {
-        spans.push({ kind: "link", text: m[5], href: m[6] });
-      } else {
-        spans.push(...tokenizeLinkLabel(m[5], m[6], resolver));
-      }
+  let plainStart = 0;
+
+  const pushPlain = (end: number) => {
+    if (end <= plainStart) return;
+    spans.push(...tokenizeRefs(text.slice(plainStart, end), resolver, {}));
+  };
+  const pushImageFallback = (image: { text: string; href: string }) => {
+    if (image.text) {
+      spans.push({ kind: "link", text: image.text, href: image.href });
     }
-    last = m.index + m[0].length;
+  };
+
+  for (let index = 0; index < text.length; ) {
+    const character = text[index];
+    const linkedImage =
+      character === "[" ? matchFindingsLinkedImageAt(text, index) : null;
+    if (linkedImage) {
+      pushPlain(index);
+      pushImageFallback(linkedImage);
+      index += linkedImage.length;
+      plainStart = index;
+      continue;
+    }
+
+    const image =
+      character === "!" ? matchFindingsInlineImageAt(text, index) : null;
+    if (image) {
+      pushPlain(index);
+      pushImageFallback(image);
+      index += image.length;
+      plainStart = index;
+      continue;
+    }
+
+    const link =
+      character === "[" ? matchFindingsInlineLinkAt(text, index) : null;
+    if (link) {
+      pushPlain(index);
+      if (isEscaped(text, index)) {
+        spans.push({ kind: "link", text: link.text, href: link.href });
+      } else {
+        spans.push(...tokenizeLinkLabel(link.text, link.href, resolver));
+      }
+      index += link.length;
+      plainStart = index;
+      continue;
+    }
+
+    const emphasis =
+      character === "*" || character === "_"
+        ? INLINE_EMPHASIS_RE.exec(text.slice(index))
+        : null;
+    if (emphasis) {
+      pushPlain(index);
+      if (emphasis[1]) {
+        spans.push(
+          ...tokenizeRefs(emphasis[2], resolver, { bold: true }),
+        );
+      } else {
+        spans.push(
+          ...tokenizeRefs(emphasis[4], resolver, { italic: true }),
+        );
+      }
+      index += emphasis[0].length;
+      plainStart = index;
+      continue;
+    }
+
+    index += 1;
   }
-  if (last < text.length) spans.push(...tokenizeRefs(text.slice(last), resolver, {}));
+  pushPlain(text.length);
   return spans;
 }
 

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -11,7 +11,7 @@
 
 import type { ResearchSourceRef } from "./research-missions.ts";
 
-export type FindingsRefTone = "accent" | "warn" | "muted";
+export type FindingsRefTone = "accent" | "warn" | "muted" | "unresolved";
 
 export type RecognizedFindingsRef = {
   id: string;
@@ -84,17 +84,22 @@ export function refToneForStatus(status: ResearchSourceRef["status"]): FindingsR
   return "accent";
 }
 
-type RefResolver = { pattern: RegExp | null; toneFor: (id: string) => FindingsRefTone };
+type RefResolver = {
+  pattern: RegExp | null;
+  sourceIds: ReadonlySet<string>;
+  toneFor: (id: string) => FindingsRefTone;
+};
 
 const CONFLICT_ID_RE = /^C\d+$/;
+const STRICT_SOURCE_ID_RE = /^(?:S|R)\d+$/;
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-/** Build the ref tokenizer from the mission's real source ids so only genuine
- *  references become chips — arbitrary capitalised words never do. Conflict
- *  ids (C1, C2, …) are always recognised even when they carry no source row. */
+/** Build the ref tokenizer from the mission's real source ids. Real ids may be
+ *  bare, while missing S#/R# ids must be explicitly bracketed. Conflict ids
+ *  (C1, C2, …) are always recognised even when they carry no source row. */
 function buildRefResolver(sources: ResearchSourceRef[]): RefResolver {
   const toneById = new Map<string, FindingsRefTone>();
   for (const source of sources) {
@@ -110,26 +115,227 @@ function buildRefResolver(sources: ResearchSourceRef[]): RefResolver {
     : null;
   return {
     pattern,
-    toneFor: (id) => toneById.get(id) ?? (CONFLICT_ID_RE.test(id) ? "warn" : "accent"),
+    sourceIds: new Set(toneById.keys()),
+    toneFor: (id) =>
+      toneById.get(id) ??
+      (CONFLICT_ID_RE.test(id) ? "warn" : "unresolved"),
   };
 }
 
 type FindingsRefMatch = RecognizedFindingsRef & { length: number };
 
-function matchRecognizedFindingsRefs(input: string, resolver: RefResolver): FindingsRefMatch[] {
-  if (!resolver.pattern || !input) return [];
+function isEscaped(input: string, index: number): boolean {
+  let slashCount = 0;
+  for (
+    let cursor = index - 1;
+    cursor >= 0 && input[cursor] === "\\";
+    cursor -= 1
+  ) {
+    slashCount += 1;
+  }
+  return slashCount % 2 === 1;
+}
 
+function backtickRunLength(input: string, index: number): number {
+  let length = 0;
+  while (input[index + length] === "`") length += 1;
+  return length;
+}
+
+function isUnsupportedContainerFenceRun(
+  input: string,
+  index: number,
+  runLength: number,
+): boolean {
+  if (runLength < 3) return false;
+
+  const lineStart = input.lastIndexOf("\n", index - 1) + 1;
+  const prefix = input.slice(lineStart, index);
+  return (
+    (index === lineStart && /\s/.test(input[index + runLength] ?? "")) ||
+    /^[ \t]+$/.test(prefix) ||
+    /^(?:[ \t]*(?:>[ \t]?|(?:[-+*]|\d{1,9}[.)])[ \t]+))+[ \t]*$/.test(
+      prefix,
+    )
+  );
+}
+
+function inlineCodeRanges(input: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+
+  for (let index = 0; index < input.length; ) {
+    if (input[index] !== "`" || isEscaped(input, index)) {
+      index += 1;
+      continue;
+    }
+    const openerLength = backtickRunLength(input, index);
+    if (isUnsupportedContainerFenceRun(input, index, openerLength)) {
+      index += openerLength;
+      continue;
+    }
+    let closeIndex = index + openerLength;
+    while (closeIndex < input.length) {
+      if (input[closeIndex] !== "`") {
+        closeIndex += 1;
+        continue;
+      }
+      const closeLength = backtickRunLength(input, closeIndex);
+      if (closeLength === openerLength) break;
+      closeIndex += closeLength;
+    }
+    if (closeIndex >= input.length) {
+      index += openerLength;
+      continue;
+    }
+    const end = closeIndex + openerLength;
+    ranges.push([index, end]);
+    index = end;
+  }
+
+  return ranges;
+}
+
+function bareUrlRanges(input: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+
+  for (let index = 0; index < input.length; ) {
+    const protocol = input.slice(index, index + "https://".length).toLowerCase();
+    const protocolLength = protocol.startsWith("https://")
+      ? "https://".length
+      : protocol.startsWith("http://")
+        ? "http://".length
+        : 0;
+    if (!protocolLength) {
+      index += 1;
+      continue;
+    }
+
+    const rangeStart = index;
+    let parenDepth = 0;
+    index += protocolLength;
+    const authorityStart = index;
+    while (index < input.length) {
+      const character = input[index];
+      if (/\s/.test(character)) break;
+      if (character === "[" && parenDepth === 0) {
+        const hostEnd = input.indexOf("]", index + 1);
+        const bracketedHost =
+          hostEnd === -1 ? "" : input.slice(index + 1, hostEnd);
+        const authorityPrefix = input.slice(authorityStart, index);
+        if (
+          bracketedHost.includes(":") &&
+          !/\s/.test(bracketedHost) &&
+          !/[/?#]/.test(authorityPrefix)
+        ) {
+          index = hostEnd + 1;
+          continue;
+        }
+        const bracketedComponent =
+          hostEnd === -1 ? "" : input.slice(index + 1, hostEnd);
+        if (
+          /[/?#]/.test(authorityPrefix) &&
+          !/[.,;:!?)]/.test(input[index - 1] ?? "") &&
+          bracketedComponent &&
+          !/\s/.test(bracketedComponent)
+        ) {
+          index = hostEnd + 1;
+          continue;
+        }
+        break;
+      }
+      if (character === "(") parenDepth += 1;
+      else if (character === ")" && parenDepth > 0) parenDepth -= 1;
+      index += 1;
+    }
+    ranges.push([rangeStart, index]);
+  }
+
+  return ranges;
+}
+
+function scanStrictBracketedSourceRefs(
+  input: string,
+  resolver: RefResolver,
+): FindingsRefMatch[] {
   const matches: FindingsRefMatch[] = [];
-  resolver.pattern.lastIndex = 0;
-  for (let match = resolver.pattern.exec(input); match; match = resolver.pattern.exec(input)) {
-    matches.push({
-      id: match[1],
-      index: match.index,
-      length: match[0].length,
-      tone: resolver.toneFor(match[1]),
+  const bracketGroup = /\[([^\[\]\r\n]+)\]/g;
+
+  for (
+    let group = bracketGroup.exec(input);
+    group;
+    group = bracketGroup.exec(input)
+  ) {
+    if (isEscaped(input, group.index)) continue;
+    const content = group[1];
+    const tokens = content.split(",");
+    let contentOffset = 0;
+
+    tokens.forEach((token, tokenIndex) => {
+      const id = token.trim();
+      const leadingSpace = token.length - token.trimStart().length;
+      const idIndex = group.index + 1 + contentOffset + leadingSpace;
+      contentOffset += token.length + 1;
+      if (
+        !STRICT_SOURCE_ID_RE.test(id) ||
+        resolver.sourceIds.has(id)
+      ) {
+        return;
+      }
+
+      const firstToken = tokenIndex === 0;
+      const lastToken = tokenIndex === tokens.length - 1;
+      const matchIndex = firstToken ? group.index : idIndex;
+      const matchEnd = lastToken
+        ? group.index + group[0].length
+        : idIndex + id.length;
+      matches.push({
+        id,
+        index: matchIndex,
+        length: matchEnd - matchIndex,
+        tone: "unresolved",
+      });
     });
   }
+
   return matches;
+}
+
+function matchRecognizedFindingsRefs(input: string, resolver: RefResolver): FindingsRefMatch[] {
+  if (!input) return [];
+
+  const matches: FindingsRefMatch[] = [];
+  if (resolver.pattern) {
+    resolver.pattern.lastIndex = 0;
+    for (
+      let match = resolver.pattern.exec(input);
+      match;
+      match = resolver.pattern.exec(input)
+    ) {
+      matches.push({
+        id: match[1],
+        index: match.index,
+        length: match[0].length,
+        tone: resolver.toneFor(match[1]),
+      });
+    }
+  }
+  matches.push(...scanStrictBracketedSourceRefs(input, resolver));
+
+  const opaqueRanges = [...inlineCodeRanges(input), ...bareUrlRanges(input)];
+  return matches
+    .sort((left, right) => left.index - right.index)
+    .filter(
+      (match, index, ordered) =>
+        !opaqueRanges.some(
+          ([start, end]) => match.index >= start && match.index < end,
+        ) &&
+        !ordered
+          .slice(0, index)
+          .some(
+            (previous) =>
+              match.index < previous.index + previous.length,
+          ),
+    );
 }
 
 /** Find references using the exact resolver and boundary grammar used by the
@@ -467,7 +673,8 @@ export function stripFindingsComments(markdown: string): string {
 
 /**
  * Parse findings markdown into the reader's document model. `sources` supplies
- * the id set that turns S14/C1 tokens into chips.
+ * the id set that permits bare source refs; bracketed missing S#/R# refs remain
+ * visible as unresolved evidence.
  */
 export function parseFindingsDoc(markdown: string, sources: ResearchSourceRef[]): FindingsDoc {
   const resolver = buildRefResolver(sources);

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -303,6 +303,23 @@ function scanStrictBracketedSourceRefs(
   return matches;
 }
 
+function escapedBracketRanges(input: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const bracketGroup = /\[([^\[\]\r\n]+)\]/g;
+
+  for (
+    let group = bracketGroup.exec(input);
+    group;
+    group = bracketGroup.exec(input)
+  ) {
+    if (isEscaped(input, group.index)) {
+      ranges.push([group.index, group.index + group[0].length]);
+    }
+  }
+
+  return ranges;
+}
+
 function matchRecognizedFindingsRefs(input: string, resolver: RefResolver): FindingsRefMatch[] {
   if (!input) return [];
 
@@ -324,7 +341,11 @@ function matchRecognizedFindingsRefs(input: string, resolver: RefResolver): Find
   }
   matches.push(...scanStrictBracketedSourceRefs(input, resolver));
 
-  const opaqueRanges = [...inlineCodeRanges(input), ...bareUrlRanges(input)];
+  const opaqueRanges = [
+    ...inlineCodeRanges(input),
+    ...bareUrlRanges(input),
+    ...escapedBracketRanges(input),
+  ];
   return matches
     .sort((left, right) => left.index - right.index)
     .filter(

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -439,10 +439,16 @@ function findBalancedClose(
   return -1;
 }
 
-export function matchFindingsInlineImageAt(
+type FindingsImageBoundary = {
+  text: string;
+  href: string | null;
+  length: number;
+};
+
+function matchFindingsImageBodyAt(
   input: string,
   index: number,
-): { text: string; href: string; length: number } | null {
+): FindingsImageBoundary | null {
   if (
     input[index] !== "!" ||
     input[index + 1] !== "[" ||
@@ -453,28 +459,45 @@ export function matchFindingsInlineImageAt(
 
   const labelStart = index + 2;
   const labelEnd = findBalancedClose(input, labelStart, "[", "]");
-  if (labelEnd === -1 || input[labelEnd + 1] !== "(") return null;
+  if (labelEnd === -1) return null;
 
-  const destinationStart = labelEnd + 2;
-  const destinationEnd = findBalancedClose(
+  const suffixStart = labelEnd + 1;
+  const suffixOpen = input[suffixStart];
+  if (suffixOpen !== "(" && suffixOpen !== "[") {
+    return {
+      text: input.slice(labelStart, labelEnd),
+      href: null,
+      length: labelEnd + 1 - index,
+    };
+  }
+
+  const suffixClose = suffixOpen === "(" ? ")" : "]";
+  const suffixEnd = findBalancedClose(
     input,
-    destinationStart,
-    "(",
-    ")",
+    suffixStart + 1,
+    suffixOpen,
+    suffixClose,
   );
-  if (destinationEnd === -1) return null;
+  if (suffixEnd === -1) return null;
 
   return {
     text: input.slice(labelStart, labelEnd),
-    href: input.slice(destinationStart, destinationEnd),
-    length: destinationEnd + 1 - index,
+    href:
+      suffixOpen === "("
+        ? input.slice(suffixStart + 1, suffixEnd)
+        : null,
+    length: suffixEnd + 1 - index,
   };
 }
 
-export function matchFindingsLinkedImageAt(
+export function matchFindingsImageAt(
   input: string,
   index: number,
-): { text: string; href: string; length: number } | null {
+): FindingsImageBoundary | null {
+  if (input[index] === "!") {
+    return matchFindingsImageBodyAt(input, index);
+  }
+
   if (
     input[index] !== "[" ||
     input[index + 1] !== "!" ||
@@ -483,25 +506,32 @@ export function matchFindingsLinkedImageAt(
     return null;
   }
 
-  const image = matchFindingsInlineImageAt(input, index + 1);
+  const image = matchFindingsImageBodyAt(input, index + 1);
   if (!image) return null;
 
   const imageEnd = index + 1 + image.length;
-  if (input[imageEnd] !== "]" || input[imageEnd + 1] !== "(") return null;
+  if (input[imageEnd] !== "]") return null;
 
-  const destinationStart = imageEnd + 2;
-  const destinationEnd = findBalancedClose(
+  const suffixStart = imageEnd + 1;
+  const suffixOpen = input[suffixStart];
+  if (suffixOpen !== "(" && suffixOpen !== "[") return null;
+
+  const suffixClose = suffixOpen === "(" ? ")" : "]";
+  const suffixEnd = findBalancedClose(
     input,
-    destinationStart,
-    "(",
-    ")",
+    suffixStart + 1,
+    suffixOpen,
+    suffixClose,
   );
-  if (destinationEnd === -1) return null;
+  if (suffixEnd === -1) return null;
 
   return {
     text: image.text,
-    href: input.slice(destinationStart, destinationEnd),
-    length: destinationEnd + 1 - index,
+    href:
+      suffixOpen === "("
+        ? input.slice(suffixStart + 1, suffixEnd)
+        : image.href,
+    length: suffixEnd + 1 - index,
   };
 }
 
@@ -529,26 +559,21 @@ function parseSpans(input: string, resolver: RefResolver): FindingsSpan[] {
     if (end <= plainStart) return;
     spans.push(...tokenizeRefs(text.slice(plainStart, end), resolver, {}));
   };
-  const pushImageFallback = (image: { text: string; href: string }) => {
-    if (image.text) {
+  const pushImageFallback = (image: FindingsImageBoundary) => {
+    if (!image.text) return;
+    if (image.href) {
       spans.push({ kind: "link", text: image.text, href: image.href });
+    } else {
+      spans.push({ kind: "text", text: image.text });
     }
   };
 
   for (let index = 0; index < text.length; ) {
     const character = text[index];
-    const linkedImage =
-      character === "[" ? matchFindingsLinkedImageAt(text, index) : null;
-    if (linkedImage) {
-      pushPlain(index);
-      pushImageFallback(linkedImage);
-      index += linkedImage.length;
-      plainStart = index;
-      continue;
-    }
-
     const image =
-      character === "!" ? matchFindingsInlineImageAt(text, index) : null;
+      character === "!" || character === "["
+        ? matchFindingsImageAt(text, index)
+        : null;
     if (image) {
       pushPlain(index);
       pushImageFallback(image);

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -305,7 +305,7 @@ function sectionRefIds(blocks: FindingsBlock[]): string[] {
 
 /** Strip the leading `<!-- research-provenance … -->` header (and any other
  *  HTML comments) so it never renders as prose. */
-function stripComments(markdown: string): string {
+export function stripFindingsComments(markdown: string): string {
   let current = markdown;
   let previous: string;
   do {
@@ -321,7 +321,7 @@ function stripComments(markdown: string): string {
  */
 export function parseFindingsDoc(markdown: string, sources: ResearchSourceRef[]): FindingsDoc {
   const resolver = buildRefResolver(sources);
-  const lines = stripComments(markdown ?? "").split(/\r?\n/);
+  const lines = stripFindingsComments(markdown ?? "").split(/\r?\n/);
 
   let title: string | null = null;
   let lede: FindingsSpan[] | null = null;

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -482,6 +482,18 @@ const HEADING_RE = /^(#{1,6})\s+(.+?)\s*#*$/;
 const LIST_RE = /^\s*[-*+]\s+(.+)$/;
 const ORDERED_LIST_RE = /^\s*\d+[.)]\s+(.+)$/;
 const QUOTE_RE = /^\s*>\s?(.*)$/;
+
+/** Match the ATX headings that become reader title/section chrome. Their text
+ * is navigation, not a provenance target; integrity scanning shares this exact
+ * boundary so heading-only citations cannot claim evidence support. */
+export function matchFindingsAtxHeading(
+  line: string,
+): { level: number; heading: string } | null {
+  const match = HEADING_RE.exec(line);
+  return match
+    ? { level: match[1].length, heading: match[2].trim() }
+    : null;
+}
 const TABLE_ROW_RE = /^\s*\|(.+)\|\s*$/;
 const TABLE_SEP_RE = /^\s*\|?[\s:|-]*-[\s:|-]*\|?\s*$/;
 const FENCE_RE = /^\s{0,3}(`{3,}|~{3,})(.*)$/;
@@ -774,10 +786,9 @@ export function parseFindingsDoc(markdown: string, sources: ResearchSourceRef[])
         };
       }
     }
-    const headingMatch = headingFence ? null : HEADING_RE.exec(line);
+    const headingMatch = headingFence ? null : matchFindingsAtxHeading(line);
     if (headingMatch) {
-      const level = headingMatch[1].length;
-      const heading = headingMatch[2].trim();
+      const { level, heading } = headingMatch;
       if (title === null && level === 1) {
         title = heading;
         current = null;

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -463,13 +463,7 @@ function matchFindingsImageBodyAt(
 
   const suffixStart = labelEnd + 1;
   const suffixOpen = input[suffixStart];
-  if (suffixOpen !== "(" && suffixOpen !== "[") {
-    return {
-      text: input.slice(labelStart, labelEnd),
-      href: null,
-      length: labelEnd + 1 - index,
-    };
-  }
+  if (suffixOpen !== "(" && suffixOpen !== "[") return null;
 
   const suffixClose = suffixOpen === "(" ? ")" : "]";
   const suffixEnd = findBalancedClose(

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -18,6 +18,23 @@ test("scanner keeps first-seen order and skips bracketed conflict or unknown ids
   assert.deepEqual(scanBracketedSourceIds("Claim [S2, C1, S1, X2, S2, R2]."), ["S2", "S1", "R2"]);
 });
 
+test("scanner ignores markdown syntax that only looks like evidence", () => {
+  assert.deepEqual(
+    scanBracketedSourceIds(
+      [
+        "Claim [S1].",
+        "[paper](https://x.test/evidence/C1)",
+        "```md",
+        "[S2] C2",
+        "```",
+        "Inline `[S3] C3` stays code.",
+        "![S4](https://x.test/assets/report.png)",
+      ].join("\n"),
+    ),
+    ["S1"],
+  );
+});
+
 test("scanner ignores bare source-like prose", () => {
   assert.deepEqual(scanBracketedSourceIds("The model S1 runs in S3 bucket land."), []);
 });
@@ -43,6 +60,26 @@ test("empty ledger with citations reports unavailable and keeps conflicts separa
   });
 });
 
+test("markdown syntax does not create false source or conflict states", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    [
+      "Claim [S1].",
+      "[paper](https://x.test/evidence/C1)",
+      "```md",
+      "[S2] C2",
+      "```",
+      "Inline `S3 C3` stays code.",
+      "![S4](https://x.test/assets/report.png)",
+      "Bare URL https://x.test/conflicts/C4 is not a conflict.",
+    ].join("\n"),
+    [source("S1", "used")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
 test("partially populated ledger reports unresolved ids before conflicts", () => {
   const integrity = deriveResearchFindingsIntegrity("[S1] [S9] C1.", [source("S1", "candidate")]);
   assert.deepEqual(integrity.unresolvedIds, ["S9"]);
@@ -57,6 +94,16 @@ test("used and candidate sources count together but summarize as candidate", () 
     source("S2", "candidate"),
   ]);
   assert.deepEqual(integrity.counts, { candidate: 1, used: 1, conflicting: 0, rejected: 0 });
+  assert.equal(integrity.summary.kind, "candidate");
+  assert.equal(integrity.summary.label, "1 source awaits review");
+});
+
+test("parser-recognized arbitrary source ids count as citations", () => {
+  const integrity = deriveResearchFindingsIntegrity("Manual note cites manual-1 for follow-up.", [
+    source("manual-1", "candidate"),
+  ]);
+  assert.deepEqual(integrity.referencedIds, ["manual-1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
   assert.equal(integrity.summary.kind, "candidate");
   assert.equal(integrity.summary.label, "1 source awaits review");
 });
@@ -122,16 +169,18 @@ test("conflicts deduplicate a marker and conflicting row with the same id", () =
   assert.equal(integrity.summary.label, "1 conflict remains");
 });
 
-test("no citations returns none even when the ledger is populated", () => {
+test("no citations returns none only when no source or conflict ids are detected", () => {
   const integrity = deriveResearchFindingsIntegrity("Plain prose only.", [source("S1", "candidate")]);
   assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
   assert.equal(integrity.summary.kind, "none");
   assert.equal(integrity.summary.label, "This report does not cite sources");
 });
 
-test("rejected-only citations are counted but do not raise the summary", () => {
+test("rejected-only citations summarize as rejected rather than none", () => {
   const integrity = deriveResearchFindingsIntegrity("[R1] [R2]", [source("R1", "rejected"), source("R2", "rejected")]);
   assert.deepEqual(integrity.counts, { candidate: 0, used: 0, conflicting: 0, rejected: 2 });
-  assert.equal(integrity.summary.kind, "none");
-  assert.equal(integrity.summary.label, "This report does not cite sources");
+  assert.deepEqual(integrity.referencedIds, ["R1", "R2"]);
+  assert.equal(integrity.summary.kind, "rejected");
+  assert.equal(integrity.summary.label, "2 rejected sources cited");
 });

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -5,6 +5,7 @@ import {
   deriveResearchFindingsIntegrity,
   scanBracketedSourceIds,
 } from "./research-findings-integrity.ts";
+import { parseFindingsDoc } from "./research-findings-doc.ts";
 
 function source(id: string, status: ResearchSourceRef["status"]): ResearchSourceRef {
   return { id, title: `${id} title`, sourceType: "web", status };
@@ -49,7 +50,7 @@ test("scanner remains stable across repeated calls", () => {
 });
 
 test("empty ledger with citations reports unavailable and keeps conflicts separate", () => {
-  const integrity = deriveResearchFindingsIntegrity("Critical![S1]. Conflict C2.", []);
+  const integrity = deriveResearchFindingsIntegrity("Critical: [S1]. Conflict C2.", []);
   assert.deepEqual(integrity, {
     ledger: "empty",
     referencedIds: ["S1"],
@@ -215,37 +216,16 @@ test("undefined reference-style links preserve visible source suffixes", () => {
   assert.equal(integrity.summary.kind, "unavailable");
 });
 
-test("reference definitions do not create source or conflict markers", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    "[paper]: /docs/manual-1\n[conflict]: /conflicts/C2\nPlain prose.",
-    [source("manual-1", "candidate")],
-  );
-  assert.deepEqual(integrity.referencedIds, []);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.deepEqual(integrity.conflictIds, []);
-  assert.equal(integrity.summary.kind, "none");
-});
+test("reference definitions remain scan-visible when the parser renders them as prose", () => {
+  const markdown = "[paper]: /docs/manual-1/C2";
+  const sources = [source("manual-1", "candidate")];
+  assert.deepEqual(parseFindingsDoc(markdown, sources).refIds, ["manual-1", "C2"]);
 
-test("multiline reference definitions do not expose destinations or titles", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    '[destination]:\n  /docs/S1\n[title]: /report\n  "C2 and S1"\nPlain prose.',
-    [source("S1", "used")],
-  );
-  assert.deepEqual(integrity.referencedIds, []);
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+  assert.deepEqual(integrity.referencedIds, ["manual-1"]);
   assert.deepEqual(integrity.unresolvedIds, []);
-  assert.deepEqual(integrity.conflictIds, []);
-  assert.equal(integrity.summary.kind, "none");
-});
-
-test("multiline reference titles remain hidden until their closing delimiter", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    '[paper]: /report "hidden S1\nand C2"\nVisible [S3].',
-    [source("S1", "used"), source("S3", "candidate")],
-  );
-  assert.deepEqual(integrity.referencedIds, ["S3"]);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.deepEqual(integrity.conflictIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
+  assert.deepEqual(integrity.conflictIds, ["C2"]);
+  assert.equal(integrity.summary.kind, "conflicting");
 });
 
 test("citation prose beginning with a source label is not hidden as a definition", () => {
@@ -272,97 +252,19 @@ test("nested visible citations remain unresolved without ledger rows", () => {
   assert.equal(integrity.summary.kind, "unavailable");
 });
 
-test("reference definitions inside markdown containers remain hidden", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    "> [quoted]: /S1\n- [listed]: /C2\nVisible [S3].",
-    [source("S1", "used"), source("S3", "candidate")],
-  );
-  assert.deepEqual(integrity.referencedIds, ["S3"]);
+test("unsupported container fences remain visible like parser prose", () => {
+  const markdown = "> ~~~\n> [S1] C2\n> ~~~";
+  const sources = [source("S1", "used")];
+  assert.deepEqual(parseFindingsDoc(markdown, sources).refIds, ["S1", "C2"]);
+
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
   assert.deepEqual(integrity.unresolvedIds, []);
-  assert.deepEqual(integrity.conflictIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
+  assert.deepEqual(integrity.conflictIds, ["C2"]);
+  assert.equal(integrity.summary.kind, "conflicting");
 });
 
-test("fenced code inside markdown containers does not create evidence states", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    "> ~~~\n> [S1] C2\n> ~~~\n1. ```\n   [S3] C4\n   ```\nVisible [S5].",
-    [source("S1", "used"), source("S3", "used"), source("S5", "candidate")],
-  );
-  assert.deepEqual(integrity.referencedIds, ["S5"]);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.deepEqual(integrity.conflictIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
-});
-
-test("unclosed container fences stop when their markdown container ends", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    "> ```\n> hidden [S1]\nVisible [S2].\n\n- ~~~\n  hidden [S3]\nVisible [S4].",
-    [
-      source("S1", "used"),
-      source("S2", "candidate"),
-      source("S3", "used"),
-      source("S4", "candidate"),
-    ],
-  );
-  assert.deepEqual(integrity.referencedIds, ["S2", "S4"]);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.deepEqual(integrity.conflictIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
-});
-
-test("fences on list continuation lines inherit the list boundary", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    "- item\n  ```\n  hidden [S1]\nVisible [S2].",
-    [source("S1", "used"), source("S2", "candidate")],
-  );
-  assert.deepEqual(integrity.referencedIds, ["S2"]);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
-});
-
-test("list fences remain active across blank lines", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    "- ~~~\n  hidden [S1]\n\n  still hidden [S2]\n  ~~~\nVisible [S3].",
-    [source("S1", "used"), source("S2", "used"), source("S3", "candidate")],
-  );
-  assert.deepEqual(integrity.referencedIds, ["S3"]);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
-});
-
-test("outer list context resumes after a nested list", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    "- outer\n  - inner\n    detail\n\n  ~~~\n  hidden [S1]\nVisible [S2].",
-    [source("S1", "used"), source("S2", "candidate")],
-  );
-  assert.deepEqual(integrity.referencedIds, ["S2"]);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
-});
-
-test("same-line nested list markers preserve fenced-code boundaries", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    "- - ```\n    hidden [S1] C1\n    ```\nVisible [S2].",
-    [source("S1", "used"), source("S2", "candidate")],
-  );
-  assert.deepEqual(integrity.referencedIds, ["S2"]);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.deepEqual(integrity.conflictIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
-});
-
-test("list-then-blockquote containers preserve fenced-code boundaries", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    "- > ~~~\n  > [S9] C1\n  > ~~~\nVisible [S2].",
-    [source("S2", "candidate")],
-  );
-  assert.deepEqual(integrity.referencedIds, ["S2"]);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.deepEqual(integrity.conflictIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
-});
-
-test("visible document titles count real ledger ids while hidden definitions remain excluded", () => {
+test("visible document titles count real ledger ids without duplicate prose references", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "# Report manual-1\n\n[paper]: /docs/manual-1",
     [source("manual-1", "candidate")],
@@ -393,14 +295,14 @@ test("html comments do not create source or conflict markers", () => {
   assert.equal(integrity.summary.kind, "verified");
 });
 
-test("comment delimiters inside code do not hide visible citations", () => {
-  const integrity = deriveResearchFindingsIntegrity(
-    "`<!--` Visible [S1]. `-->`\n```\n<!--\n```\nVisible [S2]. -->",
-    [source("S1", "used"), source("S2", "candidate")],
-  );
-  assert.deepEqual(integrity.referencedIds, ["S1", "S2"]);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
+test("HTML comments take the same precedence as the findings parser", () => {
+  const markdown = "`<!--` [S1] `-->`";
+  const sources = [source("S1", "used")];
+  assert.deepEqual(parseFindingsDoc(markdown, sources).refIds, []);
+
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.equal(integrity.summary.kind, "none");
 });
 
 test("parser-recognized ids survive bracket prose alternatives", () => {
@@ -487,7 +389,7 @@ test("plural candidate summaries use the exact plural label", () => {
 });
 
 test("used-only sources summarize as verified even when punctuation touches a bare label", () => {
-  const integrity = deriveResearchFindingsIntegrity("Critical![S1]", [source("S1", "used")]);
+  const integrity = deriveResearchFindingsIntegrity("Critical:[S1]", [source("S1", "used")]);
   assert.deepEqual(integrity.counts, { candidate: 0, used: 1, conflicting: 0, rejected: 0 });
   assert.deepEqual(integrity.referencedIds, ["S1"]);
   assert.deepEqual(integrity.conflictIds, []);

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -302,6 +302,16 @@ test("deeply indented backtick lines do not form inline code across prose", () =
   assert.equal(integrity.summary.kind, "verified");
 });
 
+test("indented continuation runs can close an existing inline code span", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "Before ```hidden [S9]\n    ``` after",
+    [],
+  );
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
 test("visible document titles count real ledger ids without duplicate prose references", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "# Report manual-1\n\n[paper]: /docs/manual-1",

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -14,6 +14,10 @@ test("explicit bracketed groups return ids in first-seen order", () => {
   assert.deepEqual(scanBracketedSourceIds("Claim [S1]. Then [S4, S5] and [R2]."), ["S1", "S4", "S5", "R2"]);
 });
 
+test("scanner keeps first-seen order and skips bracketed conflict or unknown ids", () => {
+  assert.deepEqual(scanBracketedSourceIds("Claim [S2, C1, S1, X2, S2, R2]."), ["S2", "S1", "R2"]);
+});
+
 test("scanner ignores bare source-like prose", () => {
   assert.deepEqual(scanBracketedSourceIds("The model S1 runs in S3 bucket land."), []);
 });
@@ -57,11 +61,57 @@ test("used and candidate sources count together but summarize as candidate", () 
   assert.equal(integrity.summary.label, "1 source awaits review");
 });
 
+test("plural unresolved summaries use the exact plural label", () => {
+  const integrity = deriveResearchFindingsIntegrity("[S1] [S2] [S3]", [source("S1", "candidate")]);
+  assert.deepEqual(integrity.unresolvedIds, ["S2", "S3"]);
+  assert.equal(integrity.summary.kind, "unresolved");
+  assert.equal(integrity.summary.label, "2 references are unresolved");
+});
+
+test("bracketed conflict markers stay out of source references", () => {
+  const integrity = deriveResearchFindingsIntegrity("Claim [S1] [C1] [X2].", [source("S1", "candidate")]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, ["C1"]);
+  assert.equal(integrity.summary.kind, "conflicting");
+  assert.equal(integrity.summary.label, "1 conflict remains");
+});
+
+test("plural conflicting summaries use the exact plural label", () => {
+  const integrity = deriveResearchFindingsIntegrity("[S1] [C1] C2.", [
+    source("S1", "used"),
+    source("C1", "conflicting"),
+    source("C2", "conflicting"),
+  ]);
+  assert.deepEqual(integrity.conflictIds, ["C1", "C2"]);
+  assert.equal(integrity.summary.kind, "conflicting");
+  assert.equal(integrity.summary.label, "2 conflicts remain");
+});
+
+test("plural candidate summaries use the exact plural label", () => {
+  const integrity = deriveResearchFindingsIntegrity("[S1] [S2]", [
+    source("S1", "candidate"),
+    source("S2", "candidate"),
+  ]);
+  assert.equal(integrity.summary.kind, "candidate");
+  assert.equal(integrity.summary.label, "2 sources await review");
+});
+
 test("used-only sources summarize as verified", () => {
   const integrity = deriveResearchFindingsIntegrity("[S1]", [source("S1", "used")]);
   assert.deepEqual(integrity.counts, { candidate: 0, used: 1, conflicting: 0, rejected: 0 });
   assert.equal(integrity.summary.kind, "verified");
   assert.equal(integrity.summary.label, "1 source verified");
+});
+
+test("plural verified summaries use the exact plural label", () => {
+  const integrity = deriveResearchFindingsIntegrity("[S1] [S2]", [
+    source("S1", "used"),
+    source("S2", "used"),
+  ]);
+  assert.deepEqual(integrity.counts, { candidate: 0, used: 2, conflicting: 0, rejected: 0 });
+  assert.equal(integrity.summary.kind, "verified");
+  assert.equal(integrity.summary.label, "2 sources verified");
 });
 
 test("conflicts deduplicate a marker and conflicting row with the same id", () => {

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -49,7 +49,7 @@ test("scanner remains stable across repeated calls", () => {
 });
 
 test("empty ledger with citations reports unavailable and keeps conflicts separate", () => {
-  const integrity = deriveResearchFindingsIntegrity("Claim [S1]. Conflict C2.", []);
+  const integrity = deriveResearchFindingsIntegrity("Critical![S1]. Conflict C2.", []);
   assert.deepEqual(integrity, {
     ledger: "empty",
     referencedIds: ["S1"],
@@ -103,12 +103,13 @@ test("used and candidate sources count together but summarize as candidate", () 
   assert.equal(integrity.summary.label, "1 source awaits review");
 });
 
-test("parser-recognized arbitrary source ids count as citations", () => {
-  const integrity = deriveResearchFindingsIntegrity("Manual note cites manual-1 for follow-up.", [
-    source("manual-1", "candidate"),
+test("parser-recognized arbitrary source ids count as citations without creating conflicts", () => {
+  const integrity = deriveResearchFindingsIntegrity("Manual note cites manual-C1 for follow-up.", [
+    source("manual-C1", "candidate"),
   ]);
-  assert.deepEqual(integrity.referencedIds, ["manual-1"]);
+  assert.deepEqual(integrity.referencedIds, ["manual-C1"]);
   assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
   assert.equal(integrity.summary.kind, "candidate");
   assert.equal(integrity.summary.label, "1 source awaits review");
 });
@@ -277,9 +278,11 @@ test("plural candidate summaries use the exact plural label", () => {
   assert.equal(integrity.summary.label, "2 sources await review");
 });
 
-test("used-only sources summarize as verified", () => {
-  const integrity = deriveResearchFindingsIntegrity("[S1]", [source("S1", "used")]);
+test("used-only sources summarize as verified even when punctuation touches a bare label", () => {
+  const integrity = deriveResearchFindingsIntegrity("Critical![S1]", [source("S1", "used")]);
   assert.deepEqual(integrity.counts, { candidate: 0, used: 1, conflicting: 0, rejected: 0 });
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.conflictIds, []);
   assert.equal(integrity.summary.kind, "verified");
   assert.equal(integrity.summary.label, "1 source verified");
 });

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -23,12 +23,15 @@ test("scanner ignores markdown syntax that only looks like evidence", () => {
     scanBracketedSourceIds(
       [
         "Claim [S1].",
-        "[paper](https://x.test/evidence/C1)",
+        "[paper](https://x.test/evidence_(C1))",
         "```md",
         "[S2] C2",
-        "```",
+        "```still-code",
+        "[S9] C2",
+        "```   ",
         "Inline `[S3] C3` stays code.",
-        "![S4](https://x.test/assets/report.png)",
+        "![nested [S4]](https://x.test/assets/report_(v2).png)",
+        "Bare URL https://x.test/conflicts/(C4) is not a conflict.",
       ].join("\n"),
     ),
     ["S1"],
@@ -64,13 +67,15 @@ test("markdown syntax does not create false source or conflict states", () => {
   const integrity = deriveResearchFindingsIntegrity(
     [
       "Claim [S1].",
-      "[paper](https://x.test/evidence/C1)",
+      "[paper](https://x.test/evidence_(C1))",
       "```md",
       "[S2] C2",
-      "```",
+      "```still-code",
+      "[S9] C2",
+      "```   ",
       "Inline `S3 C3` stays code.",
-      "![S4](https://x.test/assets/report.png)",
-      "Bare URL https://x.test/conflicts/C4 is not a conflict.",
+      "![nested [S4]](https://x.test/assets/report_(v2).png)",
+      "Bare URL https://x.test/conflicts/(C4) is not a conflict.",
     ].join("\n"),
     [source("S1", "used")],
   );
@@ -106,6 +111,24 @@ test("parser-recognized arbitrary source ids count as citations", () => {
   assert.deepEqual(integrity.unresolvedIds, []);
   assert.equal(integrity.summary.kind, "candidate");
   assert.equal(integrity.summary.label, "1 source awaits review");
+});
+
+test("inline code removal inserts a space so arbitrary ids are not fabricated", () => {
+  const integrity = deriveResearchFindingsIntegrity("manual`x`-1 stays prose.", [
+    source("manual-1", "candidate"),
+  ]);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
+test("balanced link stripping preserves visible labels while removing destinations", () => {
+  const integrity = deriveResearchFindingsIntegrity("Use [manual-1](https://x.test/docs_(v2)) as evidence.", [
+    source("manual-1", "candidate"),
+  ]);
+  assert.deepEqual(integrity.referencedIds, ["manual-1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
 });
 
 test("plural unresolved summaries use the exact plural label", () => {
@@ -183,4 +206,16 @@ test("rejected-only citations summarize as rejected rather than none", () => {
   assert.deepEqual(integrity.referencedIds, ["R1", "R2"]);
   assert.equal(integrity.summary.kind, "rejected");
   assert.equal(integrity.summary.label, "2 rejected sources cited");
+});
+
+test("failed ledger reports unavailable even without detected citations", () => {
+  const integrity = deriveResearchFindingsIntegrity("Plain prose only.", [], { ledger: "failed" });
+  assert.equal(integrity.ledger, "failed");
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.deepEqual(integrity.summary, {
+    kind: "unavailable",
+    label: "Sources unavailable — references can't be verified",
+  });
 });

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -331,6 +331,17 @@ test("outer list context resumes after a nested list", () => {
   assert.equal(integrity.summary.kind, "candidate");
 });
 
+test("same-line nested list markers preserve fenced-code boundaries", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "- - ```\n    hidden [S1] C1\n    ```\nVisible [S2].",
+    [source("S1", "used"), source("S2", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S2"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
 test("visible document titles count real ledger ids while hidden definitions remain excluded", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "# Report manual-1\n\n[paper]: /docs/manual-1",

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -232,6 +232,24 @@ test("citation prose beginning with a source label is not hidden as a definition
   assert.equal(integrity.summary.kind, "verified");
 });
 
+test("nested brackets do not form a hidden reference definition", () => {
+  const integrity = deriveResearchFindingsIntegrity("[[S1]]: /url", [source("S1", "used")]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
+test("reference definitions inside markdown containers remain hidden", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "> [quoted]: /S1\n- [listed]: /C2\nVisible [S3].",
+    [source("S1", "used"), source("S3", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S3"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
 test("visible document titles count real ledger ids while hidden definitions remain excluded", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "# Report manual-1\n\n[paper]: /docs/manual-1",
@@ -294,6 +312,13 @@ test("escaped backticks remain literal around visible references", () => {
   assert.deepEqual(integrity.referencedIds, ["S1"]);
   assert.deepEqual(integrity.unresolvedIds, []);
   assert.equal(integrity.summary.kind, "verified");
+});
+
+test("backslashes do not escape closing delimiters inside inline code", () => {
+  const integrity = deriveResearchFindingsIntegrity("`[S1]\\` trailing", [source("S1", "used")]);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "none");
 });
 
 test("plural unresolved summaries use the exact plural label", () => {

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -348,24 +348,37 @@ test("indented continuation runs can close an existing inline code span", () => 
   assert.equal(integrity.summary.kind, "none");
 });
 
-test("visible document titles count real ledger ids without duplicate prose references", () => {
+test("document titles do not create evidence integrity references", () => {
   const integrity = deriveResearchFindingsIntegrity(
-    "# Report manual-1\n\n[paper]: /docs/manual-1",
+    "# Report manual-1 [S9] C2",
     [source("manual-1", "candidate")],
   );
-  assert.deepEqual(integrity.referencedIds, ["manual-1"]);
+  assert.deepEqual(integrity.referencedIds, []);
   assert.deepEqual(integrity.unresolvedIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "none");
 });
 
-test("visible section headings count real ledger ids while bare URLs remain excluded", () => {
+test("section headings do not create evidence integrity references but body citations do", () => {
   const integrity = deriveResearchFindingsIntegrity(
-    "# Report\n\n## Result from manual-1\n\nhttps://x.test/manual-1",
-    [source("manual-1", "candidate")],
+    "# Report\n\n## Result from manual-1 [S9] C2\n\nBody evidence [S1].\n\nhttps://x.test/manual-1",
+    [source("manual-1", "candidate"), source("S1", "used")],
   );
-  assert.deepEqual(integrity.referencedIds, ["manual-1"]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
   assert.deepEqual(integrity.unresolvedIds, []);
-  assert.equal(integrity.summary.kind, "candidate");
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
+test("heading-like lines inside fenced code and comments keep their existing opaque semantics", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "```md\n# Hidden [S9] C2\n```\n<!-- ## Hidden [S8] C3 -->\nBody [S1].",
+    [source("S1", "used")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "verified");
 });
 
 test("html comments do not create source or conflict markers", () => {

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -154,6 +154,15 @@ test("balanced link stripping preserves visible labels while removing destinatio
   assert.equal(integrity.summary.kind, "candidate");
 });
 
+test("malformed links preserve citations rendered as ordinary prose", () => {
+  const integrity = deriveResearchFindingsIntegrity("See [paper](bad [S1])", [
+    source("S1", "used"),
+  ]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
 test("bare URL stripping stops before adjacent citations and leaves later conflicts visible", () => {
   const integrity = deriveResearchFindingsIntegrity("See https://x.test/report.[S1] C2.", [source("S1", "used")]);
   assert.deepEqual(integrity.referencedIds, ["S1"]);
@@ -384,6 +393,16 @@ test("html comments do not create source or conflict markers", () => {
   assert.equal(integrity.summary.kind, "verified");
 });
 
+test("comment delimiters inside code do not hide visible citations", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "`<!--` Visible [S1]. `-->`\n```\n<!--\n```\nVisible [S2]. -->",
+    [source("S1", "used"), source("S2", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S1", "S2"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
 test("parser-recognized ids survive bracket prose alternatives", () => {
   const integrity = deriveResearchFindingsIntegrity("[S1; S2]", [
     source("S1", "used"),
@@ -408,6 +427,13 @@ test("a longer backtick run does not close a shorter inline opener", () => {
   assert.deepEqual(integrity.referencedIds, ["S1"]);
   assert.deepEqual(integrity.unresolvedIds, []);
   assert.equal(integrity.summary.kind, "verified");
+});
+
+test("tab-indented fences use the findings parser grammar", () => {
+  const integrity = deriveResearchFindingsIntegrity("\t```\n[S1]", [source("S1", "used")]);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "none");
 });
 
 test("escaped backticks remain literal around visible references", () => {

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -200,6 +200,17 @@ test("bare URL schemes are stripped case-insensitively", () => {
   assert.equal(integrity.summary.kind, "none");
 });
 
+test("bare IPv6 URLs remain opaque without swallowing adjacent citations", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "See http://[::1]/S1 and http://[::1][S2].",
+    [source("S1", "used"), source("S2", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S2"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
 test("linked images do not create referenced ids or summaries", () => {
   const integrity = deriveResearchFindingsIntegrity("[![S9](image.png)](target)", [source("S9", "candidate")]);
   assert.deepEqual(integrity.referencedIds, []);

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -189,6 +189,13 @@ test("reference-style links around inline images do not expose image labels", ()
   assert.equal(integrity.summary.kind, "none");
 });
 
+test("undefined reference-style links preserve visible source suffixes", () => {
+  const integrity = deriveResearchFindingsIntegrity("[paper][S1]", []);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, ["S1"]);
+  assert.equal(integrity.summary.kind, "unavailable");
+});
+
 test("reference definitions do not create source or conflict markers", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "[paper]: /docs/manual-1\n[conflict]: /conflicts/C2\nPlain prose.",
@@ -281,6 +288,16 @@ test("unclosed container fences stop when their markdown container ends", () => 
   assert.deepEqual(integrity.referencedIds, ["S2", "S4"]);
   assert.deepEqual(integrity.unresolvedIds, []);
   assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
+test("fences on list continuation lines inherit the list boundary", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "- item\n  ```\n  hidden [S1]\nVisible [S2].",
+    [source("S1", "used"), source("S2", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S2"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
   assert.equal(integrity.summary.kind, "candidate");
 });
 

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -151,7 +151,7 @@ test("missing and actual references preserve document order", () => {
   assert.deepEqual(integrity.unresolvedIds, ["S9"]);
 });
 
-test("inline code removal inserts a space so arbitrary ids are not fabricated", () => {
+test("inline code boundaries do not fabricate arbitrary ids", () => {
   const integrity = deriveResearchFindingsIntegrity("manual`x`-1 stays prose.", [
     source("manual-1", "candidate"),
   ]);
@@ -160,7 +160,7 @@ test("inline code removal inserts a space so arbitrary ids are not fabricated", 
   assert.equal(integrity.summary.kind, "none");
 });
 
-test("balanced link stripping preserves visible labels while removing destinations", () => {
+test("balanced links expose visible labels while destinations stay opaque", () => {
   const integrity = deriveResearchFindingsIntegrity("Use [manual-1](https://x.test/docs_(v2)) as evidence.", [
     source("manual-1", "candidate"),
   ]);
@@ -217,7 +217,7 @@ test("malformed links preserve citations rendered as ordinary prose", () => {
   assert.equal(integrity.summary.kind, "verified");
 });
 
-test("bare URL stripping preserves parser boundaries before URL schemes", () => {
+test("bare URL boundaries do not split source ids before URL schemes", () => {
   const markdown =
     "S1https://example.test/report C1https://example.test/conflict";
   const sources = [source("S1", "used")];
@@ -231,7 +231,7 @@ test("bare URL stripping preserves parser boundaries before URL schemes", () => 
   assert.equal(integrity.summary.kind, "none");
 });
 
-test("bare URL stripping stops before adjacent citations and leaves later conflicts visible", () => {
+test("bare URL boundaries stop before adjacent citations and leave later conflicts visible", () => {
   const markdown = "See https://x.test/report.[S1] C2.";
   const sources = [source("S1", "used")];
   const doc = parseFindingsDoc(markdown, sources);
@@ -242,6 +242,36 @@ test("bare URL stripping stops before adjacent citations and leaves later confli
   assert.deepEqual(integrity.unresolvedIds, []);
   assert.deepEqual(integrity.conflictIds, ["C2"]);
   assert.equal(integrity.summary.kind, "conflicting");
+});
+
+test("table cell boundaries stop bare URLs before adjacent citations", () => {
+  const markdown = [
+    "| Report | Evidence |",
+    "| --- | --- |",
+    "| https://x.test/report|[S1] |",
+  ].join("\n");
+  const sources = [source("S1", "used")];
+  const doc = parseFindingsDoc(markdown, sources);
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+
+  assert.deepEqual(doc.refIds, ["S1"]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
+test("inline code delimiters cannot consume references from another list item", () => {
+  const markdown = "- `draft\n- [S1]`";
+  const sources = [source("S1", "used")];
+  const doc = parseFindingsDoc(markdown, sources);
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+
+  assert.deepEqual(doc.refIds, ["S1"]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "verified");
 });
 
 test("bare source ids appended to URLs stay aligned with parser URL opacity", () => {
@@ -261,7 +291,7 @@ test("bare source ids appended to URLs stay aligned with parser URL opacity", ()
   }
 });
 
-test("bare URL schemes are stripped case-insensitively", () => {
+test("bare URL schemes remain opaque case-insensitively", () => {
   const integrity = deriveResearchFindingsIntegrity("HTTPS://x.test/S1/C2", [
     source("S1", "used"),
   ]);
@@ -406,17 +436,17 @@ test("nested visible citations remain unresolved without ledger rows", () => {
   assert.equal(integrity.summary.kind, "unavailable");
 });
 
-test("unsupported container fences remain visible like parser prose", () => {
+test("unsupported container fences follow the parser's per-block boundaries", () => {
   const markdown =
     "> ~~~\n> [S1] C2\n> ~~~\n    >  ```\n    > [S9]\n    >  ```";
   const sources = [source("S1", "used")];
   assert.deepEqual(parseFindingsDoc(markdown, sources).refIds, ["S1", "C2"]);
 
   const integrity = deriveResearchFindingsIntegrity(markdown, sources);
-  assert.deepEqual(integrity.referencedIds, ["S1", "S9"]);
-  assert.deepEqual(integrity.unresolvedIds, ["S9"]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
   assert.deepEqual(integrity.conflictIds, ["C2"]);
-  assert.equal(integrity.summary.kind, "unresolved");
+  assert.equal(integrity.summary.kind, "conflicting");
 });
 
 test("deeply indented backtick lines do not form inline code across prose", () => {

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -114,6 +114,28 @@ test("parser-recognized arbitrary source ids count as citations without creating
   assert.equal(integrity.summary.label, "1 source awaits review");
 });
 
+test("parser boundary grammar excludes punctuation-delimited source ids from integrity", () => {
+  const integrity = deriveResearchFindingsIntegrity("Footnote [^1] and marker -foo- stay prose.", [
+    source("^1", "used"),
+    source("-foo-", "used"),
+  ]);
+
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
+test("missing and actual references preserve document order", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "Missing [S9] before manual-1, then actual S1.",
+    [source("manual-1", "candidate"), source("S1", "used")],
+  );
+
+  assert.deepEqual(integrity.referencedIds, ["S9", "manual-1", "S1"]);
+  assert.deepEqual(integrity.unresolvedIds, ["S9"]);
+});
+
 test("inline code removal inserts a space so arbitrary ids are not fabricated", () => {
   const integrity = deriveResearchFindingsIntegrity("manual`x`-1 stays prose.", [
     source("manual-1", "candidate"),

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -176,6 +176,27 @@ test("inline-link labels remain detectable when their ledger row is missing", ()
   assert.equal(integrity.summary.kind, "unavailable");
 });
 
+test("exact and mixed inline-link labels count refs while destination ids stay opaque", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "[S1](../sources/S99) and [evidence S14](https://x.test/S88) plus [paper](https://x.test/S6).",
+    [source("S1", "used"), source("S14", "candidate"), source("S6", "used")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S1", "S14"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
+test("mixed inline-link labels keep arbitrary persisted source ids aligned with the parser", () => {
+  const markdown = "[context manual-1](https://x.test/C9)";
+  const sources = [source("manual-1", "used")];
+  assert.deepEqual(parseFindingsDoc(markdown, sources).refIds, ["manual-1"]);
+  assert.deepEqual(
+    deriveResearchFindingsIntegrity(markdown, sources).referencedIds,
+    ["manual-1"],
+  );
+});
+
 test("escaped inline-link markers still use the findings parser grammar", () => {
   const markdown = "\\[paper](manual-1)";
   const sources = [source("manual-1", "used")];

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -217,12 +217,48 @@ test("malformed links preserve citations rendered as ordinary prose", () => {
   assert.equal(integrity.summary.kind, "verified");
 });
 
+test("bare URL stripping preserves parser boundaries before URL schemes", () => {
+  const markdown =
+    "S1https://example.test/report C1https://example.test/conflict";
+  const sources = [source("S1", "used")];
+  const doc = parseFindingsDoc(markdown, sources);
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+
+  assert.deepEqual(doc.refIds, []);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
 test("bare URL stripping stops before adjacent citations and leaves later conflicts visible", () => {
-  const integrity = deriveResearchFindingsIntegrity("See https://x.test/report.[S1] C2.", [source("S1", "used")]);
+  const markdown = "See https://x.test/report.[S1] C2.";
+  const sources = [source("S1", "used")];
+  const doc = parseFindingsDoc(markdown, sources);
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+
+  assert.deepEqual(doc.refIds, ["S1", "C2"]);
   assert.deepEqual(integrity.referencedIds, ["S1"]);
   assert.deepEqual(integrity.unresolvedIds, []);
   assert.deepEqual(integrity.conflictIds, ["C2"]);
   assert.equal(integrity.summary.kind, "conflicting");
+});
+
+test("bare source ids appended to URLs stay aligned with parser URL opacity", () => {
+  const sources = [source("S1", "used")];
+  for (const markdown of [
+    "https://x.test/reportS1",
+    "https://x.test/report/S1",
+    "https://x.test/report.C1",
+  ]) {
+    const doc = parseFindingsDoc(markdown, sources);
+    const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+
+    assert.deepEqual(doc.refIds, [], markdown);
+    assert.deepEqual(integrity.referencedIds, [], markdown);
+    assert.deepEqual(integrity.unresolvedIds, [], markdown);
+    assert.deepEqual(integrity.conflictIds, [], markdown);
+  }
 });
 
 test("bare URL schemes are stripped case-insensitively", () => {

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -131,6 +131,14 @@ test("balanced link stripping preserves visible labels while removing destinatio
   assert.equal(integrity.summary.kind, "candidate");
 });
 
+test("bare URL stripping stops before adjacent citations and leaves later conflicts visible", () => {
+  const integrity = deriveResearchFindingsIntegrity("See https://x.test/report.[S1] C2.", [source("S1", "used")]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, ["C2"]);
+  assert.equal(integrity.summary.kind, "conflicting");
+});
+
 test("linked images do not create referenced ids or summaries", () => {
   const integrity = deriveResearchFindingsIntegrity("[![S9](image.png)](target)", [source("S9", "candidate")]);
   assert.deepEqual(integrity.referencedIds, []);
@@ -167,6 +175,26 @@ test("reference definitions do not create source or conflict markers", () => {
   assert.deepEqual(integrity.unresolvedIds, []);
   assert.deepEqual(integrity.conflictIds, []);
   assert.equal(integrity.summary.kind, "none");
+});
+
+test("visible document titles count real ledger ids while hidden definitions remain excluded", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "# Report manual-1\n\n[paper]: /docs/manual-1",
+    [source("manual-1", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["manual-1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
+test("visible section headings count real ledger ids while bare URLs remain excluded", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "# Report\n\n## Result from manual-1\n\nhttps://x.test/manual-1",
+    [source("manual-1", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["manual-1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
 });
 
 test("html comments do not create source or conflict markers", () => {

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -292,6 +292,16 @@ test("unsupported container fences remain visible like parser prose", () => {
   assert.equal(integrity.summary.kind, "unresolved");
 });
 
+test("deeply indented backtick lines do not form inline code across prose", () => {
+  const markdown = "    ```\n[S1]\n    ```";
+  const sources = [source("S1", "used")];
+  assert.deepEqual(parseFindingsDoc(markdown, sources).refIds, ["S1"]);
+
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
 test("visible document titles count real ledger ids without duplicate prose references", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "# Report manual-1\n\n[paper]: /docs/manual-1",

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -222,6 +222,16 @@ test("multiline reference titles remain hidden until their closing delimiter", (
   assert.equal(integrity.summary.kind, "candidate");
 });
 
+test("citation prose beginning with a source label is not hidden as a definition", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "[S1]: This source supports the claim.",
+    [source("S1", "used")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
 test("visible document titles count real ledger ids while hidden definitions remain excluded", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "# Report manual-1\n\n[paper]: /docs/manual-1",

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -268,6 +268,22 @@ test("fenced code inside markdown containers does not create evidence states", (
   assert.equal(integrity.summary.kind, "candidate");
 });
 
+test("unclosed container fences stop when their markdown container ends", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "> ```\n> hidden [S1]\nVisible [S2].\n\n- ~~~\n  hidden [S3]\nVisible [S4].",
+    [
+      source("S1", "used"),
+      source("S2", "candidate"),
+      source("S3", "used"),
+      source("S4", "candidate"),
+    ],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S2", "S4"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
 test("visible document titles count real ledger ids while hidden definitions remain excluded", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "# Report manual-1\n\n[paper]: /docs/manual-1",

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -239,12 +239,30 @@ test("nested brackets do not form a hidden reference definition", () => {
   assert.equal(integrity.summary.kind, "verified");
 });
 
+test("nested visible citations remain unresolved without ledger rows", () => {
+  const integrity = deriveResearchFindingsIntegrity("[[S1]]: /url", []);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, ["S1"]);
+  assert.equal(integrity.summary.kind, "unavailable");
+});
+
 test("reference definitions inside markdown containers remain hidden", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "> [quoted]: /S1\n- [listed]: /C2\nVisible [S3].",
     [source("S1", "used"), source("S3", "candidate")],
   );
   assert.deepEqual(integrity.referencedIds, ["S3"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
+test("fenced code inside markdown containers does not create evidence states", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "> ~~~\n> [S1] C2\n> ~~~\n1. ```\n   [S3] C4\n   ```\nVisible [S5].",
+    [source("S1", "used"), source("S3", "used"), source("S5", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S5"]);
   assert.deepEqual(integrity.unresolvedIds, []);
   assert.deepEqual(integrity.conflictIds, []);
   assert.equal(integrity.summary.kind, "candidate");

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -94,6 +94,20 @@ test("partially populated ledger reports unresolved ids before conflicts", () =>
   assert.equal(integrity.summary.label, "1 reference is unresolved");
 });
 
+test("parser and integrity share missing-ref recognition for empty and partial ledgers", () => {
+  for (const sources of [[], [source("S1", "used")]]) {
+    const markdown = "Known S1, missing [S99], rejected-shaped [R88], and bare S98.";
+    const doc = parseFindingsDoc(markdown, sources);
+    const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+
+    assert.deepEqual(
+      doc.refIds.filter((id) => /^(?:S|R)\d+$/.test(id)),
+      integrity.referencedIds,
+    );
+    assert.deepEqual(integrity.unresolvedIds, ["S99", "R88"]);
+  }
+});
+
 test("used and candidate sources count together but summarize as candidate", () => {
   const integrity = deriveResearchFindingsIntegrity("[S1] [S2]", [
     source("S1", "used"),

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -265,6 +265,24 @@ test("linked images do not create referenced ids or summaries", () => {
   assert.equal(integrity.summary.label, "This report does not cite sources");
 });
 
+test("parser and integrity ignore image fields while keeping adjacent linked citations", () => {
+  const markdown =
+    "![S1](https://x.test/assets/S6.png) [![S14](image-S6.png)](https://x.test/S1) [evidence S14](../sources/S99)";
+  const sources = [
+    source("S1", "used"),
+    source("S6", "used"),
+    source("S14", "candidate"),
+  ];
+  const doc = parseFindingsDoc(markdown, sources);
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+
+  assert.deepEqual(doc.refIds, ["S14"]);
+  assert.deepEqual(integrity.referencedIds, ["S14"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
 test("reference-style images are removed in full and collapsed forms", () => {
   const integrity = deriveResearchFindingsIntegrity("![S9][img] and ![S8][]", [
     source("S9", "candidate"),

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -209,6 +209,15 @@ test("reference-style links around inline images do not expose image labels", ()
   assert.equal(integrity.summary.kind, "none");
 });
 
+test("reference-style links around images preserve their visible source suffix", () => {
+  const integrity = deriveResearchFindingsIntegrity("[![alt](image.png)][S1]", [
+    source("S1", "used"),
+  ]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
 test("undefined reference-style links preserve visible source suffixes", () => {
   const integrity = deriveResearchFindingsIntegrity("[paper][S1]", []);
   assert.deepEqual(integrity.referencedIds, ["S1"]);
@@ -253,7 +262,7 @@ test("nested visible citations remain unresolved without ledger rows", () => {
 });
 
 test("unsupported container fences remain visible like parser prose", () => {
-  const markdown = "> ~~~\n> [S1] C2\n> ~~~\n> ```\n> [S9]\n> ```";
+  const markdown = "> ~~~\n> [S1] C2\n> ~~~\n>  ```\n> [S9]\n>  ```";
   const sources = [source("S1", "used")];
   assert.deepEqual(parseFindingsDoc(markdown, sources).refIds, ["S1", "C2"]);
 

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -108,6 +108,37 @@ test("parser and integrity share missing-ref recognition for empty and partial l
   }
 });
 
+test("an escaped known citation remains prose and does not affect integrity", () => {
+  const markdown = String.raw`Literal \[S1]`;
+  const sources = [source("S1", "used")];
+  const doc = parseFindingsDoc(markdown, sources);
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+
+  assert.deepEqual(doc.refIds, []);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
+test("parser and integrity share escape parity for known, missing, and adjacent refs", () => {
+  const markdown = String.raw`Odd \[S1] \[S99], triple \\\[S2] \\\[S98], even \\[S3] \\[S97], adjacent \[S4][S4].`;
+  const sources = [
+    source("S1", "candidate"),
+    source("S2", "rejected"),
+    source("S3", "used"),
+    source("S4", "used"),
+  ];
+  const doc = parseFindingsDoc(markdown, sources);
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+
+  assert.deepEqual(doc.refIds, ["S3", "S97", "S4"]);
+  assert.deepEqual(integrity.referencedIds, ["S3", "S97", "S4"]);
+  assert.deepEqual(integrity.unresolvedIds, ["S97"]);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "unresolved");
+});
+
 test("used and candidate sources count together but summarize as candidate", () => {
   const integrity = deriveResearchFindingsIntegrity("[S1] [S2]", [
     source("S1", "used"),

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -283,32 +283,23 @@ test("parser and integrity ignore image fields while keeping adjacent linked cit
   assert.equal(integrity.summary.kind, "candidate");
 });
 
-test("reference-style images are removed in full and collapsed forms", () => {
-  const integrity = deriveResearchFindingsIntegrity("![S9][img] and ![S8][]", [
-    source("S9", "candidate"),
-    source("S8", "candidate"),
-  ]);
-  assert.deepEqual(integrity.referencedIds, []);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.equal(integrity.summary.kind, "none");
-});
-
-test("reference-style links around inline images do not expose image labels", () => {
-  const integrity = deriveResearchFindingsIntegrity("[![S9](image.png)][target]", [
-    source("S9", "candidate"),
-  ]);
-  assert.deepEqual(integrity.referencedIds, []);
-  assert.deepEqual(integrity.unresolvedIds, []);
-  assert.equal(integrity.summary.kind, "none");
-});
-
-test("reference-style links around images preserve their visible source suffix", () => {
-  const integrity = deriveResearchFindingsIntegrity("[![alt](image.png)][S1]", [
+test("parser and integrity align across reference-style and linked-image variants", () => {
+  const markdown =
+    "![S1][img], ![S6][], [![S14](image-S6.png)][target], [![S1][thumb]](https://x.test/S6), and [![alt](image.png)][S1] then [S14].";
+  const sources = [
     source("S1", "used"),
-  ]);
-  assert.deepEqual(integrity.referencedIds, ["S1"]);
+    source("S6", "used"),
+    source("S14", "candidate"),
+  ];
+
+  const doc = parseFindingsDoc(markdown, sources);
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+
+  assert.deepEqual(doc.refIds, ["S14"]);
+  assert.deepEqual(integrity.referencedIds, ["S14"]);
   assert.deepEqual(integrity.unresolvedIds, []);
-  assert.equal(integrity.summary.kind, "verified");
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
 });
 
 test("undefined reference-style links preserve visible source suffixes", () => {

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -155,6 +155,13 @@ test("balanced link stripping preserves visible labels while removing destinatio
   assert.equal(integrity.summary.kind, "candidate");
 });
 
+test("inline-link labels remain detectable when their ledger row is missing", () => {
+  const integrity = deriveResearchFindingsIntegrity("[S9](https://x.test/doc)", []);
+  assert.deepEqual(integrity.referencedIds, ["S9"]);
+  assert.deepEqual(integrity.unresolvedIds, ["S9"]);
+  assert.equal(integrity.summary.kind, "unavailable");
+});
+
 test("malformed links preserve citations rendered as ordinary prose", () => {
   const integrity = deriveResearchFindingsIntegrity("See [paper](bad [S1])", [
     source("S1", "used"),
@@ -311,6 +318,17 @@ test("HTML comments take the same precedence as the findings parser", () => {
 
   const integrity = deriveResearchFindingsIntegrity(markdown, sources);
   assert.deepEqual(integrity.referencedIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
+test("comment removal repeats until stable like the findings parser", () => {
+  const markdown = "<!<!-- hidden -->-- [S1] C2 -->";
+  const sources = [source("S1", "used")];
+  assert.deepEqual(parseFindingsDoc(markdown, sources).refIds, []);
+
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
   assert.equal(integrity.summary.kind, "none");
 });
 

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -139,6 +139,80 @@ test("linked images do not create referenced ids or summaries", () => {
   assert.equal(integrity.summary.label, "This report does not cite sources");
 });
 
+test("reference-style images are removed in full and collapsed forms", () => {
+  const integrity = deriveResearchFindingsIntegrity("![S9][img] and ![S8][]", [
+    source("S9", "candidate"),
+    source("S8", "candidate"),
+  ]);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
+test("reference-style links around inline images do not expose image labels", () => {
+  const integrity = deriveResearchFindingsIntegrity("[![S9](image.png)][target]", [
+    source("S9", "candidate"),
+  ]);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
+test("reference definitions do not create source or conflict markers", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "[paper]: /docs/manual-1\n[conflict]: /conflicts/C2\nPlain prose.",
+    [source("manual-1", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
+test("html comments do not create source or conflict markers", () => {
+  const integrity = deriveResearchFindingsIntegrity("Visible [S1]. <!-- [S9] C2 -->", [
+    source("S1", "used"),
+    source("S9", "candidate"),
+  ]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
+test("parser-recognized ids survive bracket prose alternatives", () => {
+  const integrity = deriveResearchFindingsIntegrity("[S1; S2]", [
+    source("S1", "used"),
+    source("S2", "used"),
+  ]);
+  assert.deepEqual(integrity.referencedIds, ["S1", "S2"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
+test("parser-recognized arbitrary ids survive bracket prose", () => {
+  const integrity = deriveResearchFindingsIntegrity("[see manual-1]", [
+    source("manual-1", "candidate"),
+  ]);
+  assert.deepEqual(integrity.referencedIds, ["manual-1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
+test("a longer backtick run does not close a shorter inline opener", () => {
+  const integrity = deriveResearchFindingsIntegrity("`draft [S1]``", [source("S1", "used")]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
+test("escaped backticks remain literal around visible references", () => {
+  const integrity = deriveResearchFindingsIntegrity("\\`[S1]\\`", [source("S1", "used")]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
 test("plural unresolved summaries use the exact plural label", () => {
   const integrity = deriveResearchFindingsIntegrity("[S1] [S2] [S3]", [source("S1", "candidate")]);
   assert.deepEqual(integrity.unresolvedIds, ["S2", "S3"]);

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -342,6 +342,17 @@ test("same-line nested list markers preserve fenced-code boundaries", () => {
   assert.equal(integrity.summary.kind, "candidate");
 });
 
+test("list-then-blockquote containers preserve fenced-code boundaries", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "- > ~~~\n  > [S9] C1\n  > ~~~\nVisible [S2].",
+    [source("S2", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S2"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
 test("visible document titles count real ledger ids while hidden definitions remain excluded", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "# Report manual-1\n\n[paper]: /docs/manual-1",

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -131,6 +131,14 @@ test("balanced link stripping preserves visible labels while removing destinatio
   assert.equal(integrity.summary.kind, "candidate");
 });
 
+test("linked images do not create referenced ids or summaries", () => {
+  const integrity = deriveResearchFindingsIntegrity("[![S9](image.png)](target)", [source("S9", "candidate")]);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "none");
+  assert.equal(integrity.summary.label, "This report does not cite sources");
+});
+
 test("plural unresolved summaries use the exact plural label", () => {
   const integrity = deriveResearchFindingsIntegrity("[S1] [S2] [S3]", [source("S1", "candidate")]);
   assert.deepEqual(integrity.unresolvedIds, ["S2", "S3"]);

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -211,6 +211,17 @@ test("bare IPv6 URLs remain opaque without swallowing adjacent citations", () =>
   assert.equal(integrity.summary.kind, "candidate");
 });
 
+test("bracketed URL path and query components remain opaque", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "See https://x.test/[S1] and https://x.test/?q=[S2].",
+    [source("S1", "used"), source("S2", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
 test("linked images do not create referenced ids or summaries", () => {
   const integrity = deriveResearchFindingsIntegrity("[![S9](image.png)](target)", [source("S9", "candidate")]);
   assert.deepEqual(integrity.referencedIds, []);

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -200,6 +200,28 @@ test("reference definitions do not create source or conflict markers", () => {
   assert.equal(integrity.summary.kind, "none");
 });
 
+test("multiline reference definitions do not expose destinations or titles", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    '[destination]:\n  /docs/S1\n[title]: /report\n  "C2 and S1"\nPlain prose.',
+    [source("S1", "used")],
+  );
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
+test("multiline reference titles remain hidden until their closing delimiter", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    '[paper]: /report "hidden S1\nand C2"\nVisible [S3].',
+    [source("S1", "used"), source("S3", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S3"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
 test("visible document titles count real ledger ids while hidden definitions remain excluded", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "# Report manual-1\n\n[paper]: /docs/manual-1",

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ResearchSourceRef } from "./research-missions.ts";
+import {
+  deriveResearchFindingsIntegrity,
+  scanBracketedSourceIds,
+} from "./research-findings-integrity.ts";
+
+function source(id: string, status: ResearchSourceRef["status"]): ResearchSourceRef {
+  return { id, title: `${id} title`, sourceType: "web", status };
+}
+
+test("explicit bracketed groups return ids in first-seen order", () => {
+  assert.deepEqual(scanBracketedSourceIds("Claim [S1]. Then [S4, S5] and [R2]."), ["S1", "S4", "S5", "R2"]);
+});
+
+test("scanner ignores bare source-like prose", () => {
+  assert.deepEqual(scanBracketedSourceIds("The model S1 runs in S3 bucket land."), []);
+});
+
+test("scanner remains stable across repeated calls", () => {
+  const markdown = "First [S1, S2] then [R2].";
+  assert.deepEqual(scanBracketedSourceIds(markdown), ["S1", "S2", "R2"]);
+  assert.deepEqual(scanBracketedSourceIds(markdown), ["S1", "S2", "R2"]);
+});
+
+test("empty ledger with citations reports unavailable and keeps conflicts separate", () => {
+  const integrity = deriveResearchFindingsIntegrity("Claim [S1]. Conflict C2.", []);
+  assert.deepEqual(integrity, {
+    ledger: "empty",
+    referencedIds: ["S1"],
+    unresolvedIds: ["S1"],
+    conflictIds: ["C2"],
+    counts: { candidate: 0, used: 0, conflicting: 0, rejected: 0 },
+    summary: {
+      kind: "unavailable",
+      label: "Sources unavailable — references can't be verified",
+    },
+  });
+});
+
+test("partially populated ledger reports unresolved ids before conflicts", () => {
+  const integrity = deriveResearchFindingsIntegrity("[S1] [S9] C1.", [source("S1", "candidate")]);
+  assert.deepEqual(integrity.unresolvedIds, ["S9"]);
+  assert.deepEqual(integrity.conflictIds, ["C1"]);
+  assert.equal(integrity.summary.kind, "unresolved");
+  assert.equal(integrity.summary.label, "1 reference is unresolved");
+});
+
+test("used and candidate sources count together but summarize as candidate", () => {
+  const integrity = deriveResearchFindingsIntegrity("[S1] [S2]", [
+    source("S1", "used"),
+    source("S2", "candidate"),
+  ]);
+  assert.deepEqual(integrity.counts, { candidate: 1, used: 1, conflicting: 0, rejected: 0 });
+  assert.equal(integrity.summary.kind, "candidate");
+  assert.equal(integrity.summary.label, "1 source awaits review");
+});
+
+test("used-only sources summarize as verified", () => {
+  const integrity = deriveResearchFindingsIntegrity("[S1]", [source("S1", "used")]);
+  assert.deepEqual(integrity.counts, { candidate: 0, used: 1, conflicting: 0, rejected: 0 });
+  assert.equal(integrity.summary.kind, "verified");
+  assert.equal(integrity.summary.label, "1 source verified");
+});
+
+test("conflicts deduplicate a marker and conflicting row with the same id", () => {
+  const integrity = deriveResearchFindingsIntegrity("C1 and again C1.", [source("C1", "conflicting")]);
+  assert.deepEqual(integrity.conflictIds, ["C1"]);
+  assert.deepEqual(integrity.counts, { candidate: 0, used: 0, conflicting: 1, rejected: 0 });
+  assert.equal(integrity.summary.kind, "conflicting");
+  assert.equal(integrity.summary.label, "1 conflict remains");
+});
+
+test("no citations returns none even when the ledger is populated", () => {
+  const integrity = deriveResearchFindingsIntegrity("Plain prose only.", [source("S1", "candidate")]);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.equal(integrity.summary.kind, "none");
+  assert.equal(integrity.summary.label, "This report does not cite sources");
+});
+
+test("rejected-only citations are counted but do not raise the summary", () => {
+  const integrity = deriveResearchFindingsIntegrity("[R1] [R2]", [source("R1", "rejected"), source("R2", "rejected")]);
+  assert.deepEqual(integrity.counts, { candidate: 0, used: 0, conflicting: 0, rejected: 2 });
+  assert.equal(integrity.summary.kind, "none");
+  assert.equal(integrity.summary.label, "This report does not cite sources");
+});

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -162,6 +162,17 @@ test("inline-link labels remain detectable when their ledger row is missing", ()
   assert.equal(integrity.summary.kind, "unavailable");
 });
 
+test("escaped inline-link markers still use the findings parser grammar", () => {
+  const markdown = "\\[paper](manual-1)";
+  const sources = [source("manual-1", "used")];
+  assert.deepEqual(parseFindingsDoc(markdown, sources).refIds, []);
+
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
 test("malformed links preserve citations rendered as ordinary prose", () => {
   const integrity = deriveResearchFindingsIntegrity("See [paper](bad [S1])", [
     source("S1", "used"),
@@ -269,7 +280,8 @@ test("nested visible citations remain unresolved without ledger rows", () => {
 });
 
 test("unsupported container fences remain visible like parser prose", () => {
-  const markdown = "> ~~~\n> [S1] C2\n> ~~~\n>  ```\n> [S9]\n>  ```";
+  const markdown =
+    "> ~~~\n> [S1] C2\n> ~~~\n    >  ```\n    > [S9]\n    >  ```";
   const sources = [source("S1", "used")];
   assert.deepEqual(parseFindingsDoc(markdown, sources).refIds, ["S1", "C2"]);
 

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -302,6 +302,31 @@ test("parser and integrity align across reference-style and linked-image variant
   assert.equal(integrity.summary.kind, "candidate");
 });
 
+test("bare image-like source tokens remain visible with an available ledger", () => {
+  const markdown = "Critical![S1]";
+  const sources = [source("S1", "used")];
+
+  const doc = parseFindingsDoc(markdown, sources);
+  const integrity = deriveResearchFindingsIntegrity(markdown, sources);
+
+  assert.deepEqual(doc.refIds, ["S1"]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "verified");
+});
+
+test("bare image-like source tokens remain visible with a missing ledger", () => {
+  const markdown = "Critical![S1]";
+
+  const doc = parseFindingsDoc(markdown, []);
+  const integrity = deriveResearchFindingsIntegrity(markdown, []);
+
+  assert.deepEqual(doc.refIds, ["S1"]);
+  assert.deepEqual(integrity.referencedIds, ["S1"]);
+  assert.deepEqual(integrity.unresolvedIds, ["S1"]);
+  assert.equal(integrity.summary.kind, "unavailable");
+});
+
 test("undefined reference-style links preserve visible source suffixes", () => {
   const integrity = deriveResearchFindingsIntegrity("[paper][S1]", []);
   assert.deepEqual(integrity.referencedIds, ["S1"]);

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -253,15 +253,15 @@ test("nested visible citations remain unresolved without ledger rows", () => {
 });
 
 test("unsupported container fences remain visible like parser prose", () => {
-  const markdown = "> ~~~\n> [S1] C2\n> ~~~";
+  const markdown = "> ~~~\n> [S1] C2\n> ~~~\n> ```\n> [S9]\n> ```";
   const sources = [source("S1", "used")];
   assert.deepEqual(parseFindingsDoc(markdown, sources).refIds, ["S1", "C2"]);
 
   const integrity = deriveResearchFindingsIntegrity(markdown, sources);
-  assert.deepEqual(integrity.referencedIds, ["S1"]);
-  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.referencedIds, ["S1", "S9"]);
+  assert.deepEqual(integrity.unresolvedIds, ["S9"]);
   assert.deepEqual(integrity.conflictIds, ["C2"]);
-  assert.equal(integrity.summary.kind, "conflicting");
+  assert.equal(integrity.summary.kind, "unresolved");
 });
 
 test("visible document titles count real ledger ids without duplicate prose references", () => {

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -202,7 +202,7 @@ test("bare URL schemes are stripped case-insensitively", () => {
 
 test("bare IPv6 URLs remain opaque without swallowing adjacent citations", () => {
   const integrity = deriveResearchFindingsIntegrity(
-    "See http://[::1]/S1 and http://[::1][S2].",
+    "See http://[::1]/S1, http://user@[::1]/S1/C2, and http://[::1][S2].",
     [source("S1", "used"), source("S2", "candidate")],
   );
   assert.deepEqual(integrity.referencedIds, ["S2"]);

--- a/src/lib/research-findings-integrity.test.ts
+++ b/src/lib/research-findings-integrity.test.ts
@@ -162,6 +162,16 @@ test("bare URL stripping stops before adjacent citations and leaves later confli
   assert.equal(integrity.summary.kind, "conflicting");
 });
 
+test("bare URL schemes are stripped case-insensitively", () => {
+  const integrity = deriveResearchFindingsIntegrity("HTTPS://x.test/S1/C2", [
+    source("S1", "used"),
+  ]);
+  assert.deepEqual(integrity.referencedIds, []);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.deepEqual(integrity.conflictIds, []);
+  assert.equal(integrity.summary.kind, "none");
+});
+
 test("linked images do not create referenced ids or summaries", () => {
   const integrity = deriveResearchFindingsIntegrity("[![S9](image.png)](target)", [source("S9", "candidate")]);
   assert.deepEqual(integrity.referencedIds, []);
@@ -294,6 +304,26 @@ test("unclosed container fences stop when their markdown container ends", () => 
 test("fences on list continuation lines inherit the list boundary", () => {
   const integrity = deriveResearchFindingsIntegrity(
     "- item\n  ```\n  hidden [S1]\nVisible [S2].",
+    [source("S1", "used"), source("S2", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S2"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
+test("list fences remain active across blank lines", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "- ~~~\n  hidden [S1]\n\n  still hidden [S2]\n  ~~~\nVisible [S3].",
+    [source("S1", "used"), source("S2", "used"), source("S3", "candidate")],
+  );
+  assert.deepEqual(integrity.referencedIds, ["S3"]);
+  assert.deepEqual(integrity.unresolvedIds, []);
+  assert.equal(integrity.summary.kind, "candidate");
+});
+
+test("outer list context resumes after a nested list", () => {
+  const integrity = deriveResearchFindingsIntegrity(
+    "- outer\n  - inner\n    detail\n\n  ~~~\n  hidden [S1]\nVisible [S2].",
     [source("S1", "used"), source("S2", "candidate")],
   );
   assert.deepEqual(integrity.referencedIds, ["S2"]);

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -135,33 +135,20 @@ function normalizeReferenceLabel(label: string): string {
   return unescapeCommonMarkPunctuation(label).trim().replace(/\s+/g, " ").toLowerCase();
 }
 
-function isReferenceDefinitionLine(line: string): boolean {
-  let labelStart = 0;
-  while (labelStart < 3 && line[labelStart] === " ") labelStart += 1;
-  if (line[labelStart] !== "[") return false;
-
-  const labelEnd = findBalancedClose(line, labelStart + 1, "[", "]");
-  return labelEnd > labelStart + 1 && line[labelEnd + 1] === ":";
-}
-
-function readReferenceDefinitionLabel(line: string): string | null {
+function readReferenceDefinitionStart(line: string): {
+  label: string;
+  body: string;
+} | null {
   let labelStart = 0;
   while (labelStart < 3 && line[labelStart] === " ") labelStart += 1;
   if (line[labelStart] !== "[") return null;
 
   const labelEnd = findBalancedClose(line, labelStart + 1, "[", "]");
   if (labelEnd <= labelStart + 1 || line[labelEnd + 1] !== ":") return null;
-  return normalizeReferenceLabel(line.slice(labelStart + 1, labelEnd));
-}
-
-function readReferenceDefinitionBody(line: string): string | null {
-  let labelStart = 0;
-  while (labelStart < 3 && line[labelStart] === " ") labelStart += 1;
-  if (line[labelStart] !== "[") return null;
-
-  const labelEnd = findBalancedClose(line, labelStart + 1, "[", "]");
-  if (labelEnd <= labelStart + 1 || line[labelEnd + 1] !== ":") return null;
-  return line.slice(labelEnd + 2).trimStart();
+  return {
+    label: normalizeReferenceLabel(line.slice(labelStart + 1, labelEnd)),
+    body: line.slice(labelEnd + 2),
+  };
 }
 
 function readReferenceDefinitionContinuation(line: string): string | null {
@@ -173,22 +160,41 @@ function readReferenceDefinitionContinuation(line: string): string | null {
   return content.trim() ? content : null;
 }
 
-function readReferenceDefinitionRemainder(destination: string): string {
-  if (destination.startsWith("<")) {
+function readReferenceDestination(input: string): { remainder: string } | null {
+  const destination = input.trimStart();
+  if (!destination) return null;
+
+  if (destination[0] === "<") {
     for (let index = 1; index < destination.length; index += 1) {
+      if (destination[index] === "<" && !isEscaped(destination, index)) return null;
       if (destination[index] === ">" && !isEscaped(destination, index)) {
-        return destination.slice(index + 1).trimStart();
+        return { remainder: destination.slice(index + 1) };
       }
     }
-    return "";
+    return null;
   }
 
-  for (let index = 0; index < destination.length; index += 1) {
-    if (/\s/.test(destination[index]) && !isEscaped(destination, index)) {
-      return destination.slice(index).trimStart();
+  let parenthesisDepth = 0;
+  let index = 0;
+  while (index < destination.length) {
+    const character = destination[index];
+    if (/\s/.test(character)) break;
+    if (character === "\\" && index + 1 < destination.length) {
+      index += 2;
+      continue;
     }
+    if (character === "(") {
+      parenthesisDepth += 1;
+      if (parenthesisDepth > 32) return null;
+    } else if (character === ")") {
+      if (parenthesisDepth === 0) break;
+      parenthesisDepth -= 1;
+    }
+    index += 1;
   }
-  return "";
+
+  if (index === 0 || parenthesisDepth !== 0) return null;
+  return { remainder: destination.slice(index) };
 }
 
 function readReferenceTitleCloser(title: string): "'" | '"' | ")" | null {
@@ -198,11 +204,67 @@ function readReferenceTitleCloser(title: string): "'" | '"' | ")" | null {
   return null;
 }
 
-function referenceTitleIsClosed(title: string, closer: "'" | '"' | ")"): boolean {
-  for (let index = 1; index < title.length; index += 1) {
-    if (title[index] === closer && !isEscaped(title, index)) return true;
+function readReferenceTitleEnd(
+  lines: string[],
+  startLineIndex: number,
+  title: string,
+): number | null {
+  const closer = readReferenceTitleCloser(title);
+  if (!closer) return null;
+
+  let lineIndex = startLineIndex;
+  let current = title;
+  let searchStart = 1;
+  while (true) {
+    for (let index = searchStart; index < current.length; index += 1) {
+      if (current[index] !== closer || isEscaped(current, index)) continue;
+      return current.slice(index + 1).trim() ? null : lineIndex;
+    }
+
+    const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
+    if (!continuation) return null;
+    current = continuation;
+    searchStart = 0;
+    lineIndex += 1;
   }
-  return false;
+}
+
+function readReferenceDefinition(
+  lines: string[],
+  startLineIndex: number,
+): { label: string; endLineIndex: number } | null {
+  const start = readReferenceDefinitionStart(lines[startLineIndex]);
+  if (!start) return null;
+
+  let lineIndex = startLineIndex;
+  let destinationInput = start.body.trimStart();
+  if (!destinationInput) {
+    const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
+    if (!continuation || readReferenceTitleCloser(continuation)) return null;
+    destinationInput = continuation;
+    lineIndex += 1;
+  }
+
+  const destination = readReferenceDestination(destinationInput);
+  if (!destination) return null;
+
+  const separatedRemainder = destination.remainder;
+  const title = separatedRemainder.trimStart();
+  if (title) {
+    if (title === separatedRemainder || !readReferenceTitleCloser(title)) return null;
+    const titleEndLineIndex = readReferenceTitleEnd(lines, lineIndex, title);
+    if (titleEndLineIndex === null) return null;
+    lineIndex = titleEndLineIndex;
+  } else {
+    const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
+    if (continuation && readReferenceTitleCloser(continuation)) {
+      const titleEndLineIndex = readReferenceTitleEnd(lines, lineIndex + 1, continuation);
+      if (titleEndLineIndex === null) return null;
+      lineIndex = titleEndLineIndex;
+    }
+  }
+
+  return { label: start.label, endLineIndex: lineIndex };
 }
 
 function stripFencedCodeAndReferenceDefinitions(markdown: string): {
@@ -234,39 +296,14 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
       strippedLines.push("");
       continue;
     }
-    if (isReferenceDefinitionLine(line)) {
-      const label = readReferenceDefinitionLabel(line);
-      if (label) referenceDefinitionLabels.add(label);
-      strippedLines.push("");
-
-      let destination = readReferenceDefinitionBody(line) ?? "";
-      if (!destination) {
-        const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
-        if (continuation && !readReferenceTitleCloser(continuation)) {
-          destination = continuation;
-          lineIndex += 1;
-          strippedLines.push("");
-        }
-      }
-
-      let title = readReferenceDefinitionRemainder(destination);
-      if (!readReferenceTitleCloser(title)) {
-        const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
-        if (continuation && readReferenceTitleCloser(continuation)) {
-          title = continuation;
-          lineIndex += 1;
-          strippedLines.push("");
-        }
-      }
-
-      const closer = readReferenceTitleCloser(title);
-      while (closer && !referenceTitleIsClosed(title, closer)) {
-        const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
-        if (!continuation) break;
-        title += `\n${continuation}`;
-        lineIndex += 1;
+    const referenceDefinition = readReferenceDefinition(lines, lineIndex);
+    if (referenceDefinition) {
+      referenceDefinitionLabels.add(referenceDefinition.label);
+      while (lineIndex <= referenceDefinition.endLineIndex) {
         strippedLines.push("");
+        lineIndex += 1;
       }
+      lineIndex -= 1;
       continue;
     }
     strippedLines.push(line);

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -1,4 +1,3 @@
-import { parseFindingsDoc } from "./research-findings-doc.ts";
 import type { ResearchSourceRef } from "./research-missions.ts";
 
 export type ResearchIntegritySummaryKind =
@@ -258,8 +257,16 @@ function stripBareUrls(markdown: string): string {
       continue;
     }
 
+    let parenDepth = 0;
     index += protocolLength;
-    while (index < markdown.length && !/\s/.test(markdown[index])) index += 1;
+    while (index < markdown.length) {
+      const character = markdown[index];
+      if (/\s/.test(character)) break;
+      if (character === "[" && parenDepth === 0) break;
+      if (character === "(") parenDepth += 1;
+      else if (character === ")" && parenDepth > 0) parenDepth -= 1;
+      index += 1;
+    }
     sanitized += " ";
   }
 
@@ -431,15 +438,15 @@ export function deriveResearchFindingsIntegrity(
     if (!sourceById.has(source.id)) sourceById.set(source.id, source);
   }
 
-  const parserRecognizedSourceIds = parseFindingsDoc(sanitizedMarkdown, sources).refIds.filter(
-    (id) => sourceById.has(id) && !CONFLICT_ID_RE.test(id),
+  const visibleLedgerSourceIds = uniqueIdsInOrder(
+    [...sourceById.keys()].filter((id) => !CONFLICT_ID_RE.test(id)),
   );
   const unresolvedCandidateIds = scanStrictBracketedSourceIds(sanitizedMarkdown).filter(
     (id) => !sourceById.has(id),
   );
   const referencedIds = scanReferencedIdsInOrder(
     sanitizedMarkdown,
-    uniqueIdsInOrder([...parserRecognizedSourceIds, ...unresolvedCandidateIds]),
+    uniqueIdsInOrder([...visibleLedgerSourceIds, ...unresolvedCandidateIds]),
   );
   const unresolvedIds = referencedIds.filter((id) => !sourceById.has(id));
   const conflictMarkerIds = scanConflictMarkerIds(sanitizedMarkdown);

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -46,14 +46,10 @@ function unavailableSummary(): { kind: ResearchIntegritySummaryKind; label: stri
 }
 
 function preprocessMarkdownForIntegrity(markdown: string): string {
-  const { markdown: withoutBlocks, referenceDefinitionLabels } =
-    stripFencedCodeAndReferenceDefinitions(markdown ?? "");
+  const withoutComments = stripHtmlComments(markdown ?? "");
+  const withoutBlocks = stripFencedCode(withoutComments);
   const withoutCode = stripInlineCode(withoutBlocks);
-  const withoutComments = stripHtmlComments(withoutCode);
-  const withoutMarkdownTargets = stripMarkdownLinksAndImages(
-    withoutComments,
-    referenceDefinitionLabels,
-  );
+  const withoutMarkdownTargets = stripMarkdownLinksAndImages(withoutCode);
   return stripBareUrls(withoutMarkdownTargets);
 }
 
@@ -94,359 +90,36 @@ function findBalancedClose(input: string, startIndex: number, open: string, clos
   return -1;
 }
 
-function isCommonMarkEscapablePunctuation(char: string): boolean {
-  const code = char.charCodeAt(0);
-  return (
-    (code >= 0x21 && code <= 0x2f) ||
-    (code >= 0x3a && code <= 0x40) ||
-    (code >= 0x5b && code <= 0x60) ||
-    (code >= 0x7b && code <= 0x7e)
-  );
-}
-
-function unescapeCommonMarkPunctuation(text: string): string {
-  let result = "";
-  for (let index = 0; index < text.length; index += 1) {
-    if (
-      text[index] === "\\" &&
-      index + 1 < text.length &&
-      isCommonMarkEscapablePunctuation(text[index + 1])
-    ) {
-      result += text[index + 1];
-      index += 1;
-      continue;
-    }
-    result += text[index];
-  }
-  return result;
-}
-
-function normalizeReferenceLabel(label: string): string {
-  return unescapeCommonMarkPunctuation(label).trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-type MarkdownContainer = {
-  blockquoteDepth: number;
-  listIndent: number;
-  segments: Array<
-    | { kind: "blockquote" }
-    | { kind: "list"; width: number }
-  >;
-};
-
-function readReferenceDefinitionContainer(line: string): {
-  content: string;
-  container: MarkdownContainer;
-  listContainers: MarkdownContainer[];
-} {
-  const listContainers: MarkdownContainer[] = [];
-  const segments: MarkdownContainer["segments"] = [];
-  let content = line;
-  let blockquoteDepth = 0;
-  let listIndent = 0;
-
-  while (true) {
-    const blockquoteMatch = content.match(/^ {0,3}>[ \t]?/);
-    if (blockquoteMatch) {
-      segments.push({ kind: "blockquote" });
-      blockquoteDepth += 1;
-      content = content.slice(blockquoteMatch[0].length);
-      continue;
-    }
-
-    const listMatch = content.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])([ \t]+)/);
-    if (!listMatch) break;
-    listIndent += listMatch[0].length;
-    segments.push({ kind: "list", width: listMatch[0].length });
-    listContainers.push({
-      blockquoteDepth,
-      listIndent,
-      segments: [...segments],
-    });
-    content = content.slice(listMatch[0].length);
-  }
-
-  return {
-    content,
-    container: { blockquoteDepth, listIndent, segments },
-    listContainers,
-  };
-}
-
-function readReferenceContainerLine(
-  line: string,
-  container: MarkdownContainer,
-): string | null {
-  let content = line;
-
-  for (const segment of container.segments) {
-    if (segment.kind === "list") {
-      if (!content.startsWith(" ".repeat(segment.width))) return null;
-      content = content.slice(segment.width);
-      continue;
-    }
-
-    const blockquoteMatch = content.match(/^ {0,3}>[ \t]?/);
-    if (!blockquoteMatch) return null;
-    content = content.slice(blockquoteMatch[0].length);
-  }
-
-  return content;
-}
-
-function readReferenceDefinitionStart(line: string): {
-  label: string;
-  body: string;
-} | null {
-  let labelStart = 0;
-  while (labelStart < 3 && line[labelStart] === " ") labelStart += 1;
-  if (line[labelStart] !== "[") return null;
-
-  let labelEnd = -1;
-  for (let index = labelStart + 1; index < line.length; index += 1) {
-    if (line[index] === "[" && !isEscaped(line, index)) return null;
-    if (line[index] === "]" && !isEscaped(line, index)) {
-      labelEnd = index;
-      break;
-    }
-  }
-
-  if (labelEnd <= labelStart + 1 || line[labelEnd + 1] !== ":") return null;
-  const rawLabel = line.slice(labelStart + 1, labelEnd);
-  if (rawLabel.length > 999 || !/\S/.test(rawLabel)) return null;
-  return {
-    label: normalizeReferenceLabel(rawLabel),
-    body: line.slice(labelEnd + 2),
-  };
-}
-
-function readReferenceDefinitionContinuation(line: string): string | null {
-  let indent = 0;
-  while (indent < 3 && line[indent] === " ") indent += 1;
-  if (line[indent] === " " || line[indent] === "\t") return null;
-
-  const content = line.slice(indent);
-  return content.trim() ? content : null;
-}
-
-function readReferenceDestination(input: string): { remainder: string } | null {
-  const destination = input.trimStart();
-  if (!destination) return null;
-
-  if (destination[0] === "<") {
-    for (let index = 1; index < destination.length; index += 1) {
-      if (destination[index] === "<" && !isEscaped(destination, index)) return null;
-      if (destination[index] === ">" && !isEscaped(destination, index)) {
-        return { remainder: destination.slice(index + 1) };
-      }
-    }
-    return null;
-  }
-
-  let parenthesisDepth = 0;
-  let index = 0;
-  while (index < destination.length) {
-    const character = destination[index];
-    if (/\s/.test(character)) break;
-    if (character === "\\" && index + 1 < destination.length) {
-      index += 2;
-      continue;
-    }
-    if (character === "(") {
-      parenthesisDepth += 1;
-      if (parenthesisDepth > 32) return null;
-    } else if (character === ")") {
-      if (parenthesisDepth === 0) break;
-      parenthesisDepth -= 1;
-    }
-    index += 1;
-  }
-
-  if (index === 0 || parenthesisDepth !== 0) return null;
-  return { remainder: destination.slice(index) };
-}
-
-function readReferenceTitleCloser(title: string): "'" | '"' | ")" | null {
-  if (title.startsWith("'")) return "'";
-  if (title.startsWith('"')) return '"';
-  if (title.startsWith("(")) return ")";
-  return null;
-}
-
-function readReferenceTitleEnd(
-  startLineIndex: number,
-  title: string,
-  readContinuation: (lineIndex: number) => string | null,
-): number | null {
-  const closer = readReferenceTitleCloser(title);
-  if (!closer) return null;
-
-  let lineIndex = startLineIndex;
-  let current = title;
-  let searchStart = 1;
-  while (true) {
-    for (let index = searchStart; index < current.length; index += 1) {
-      if (current[index] !== closer || isEscaped(current, index)) continue;
-      return current.slice(index + 1).trim() ? null : lineIndex;
-    }
-
-    const continuation = readContinuation(lineIndex + 1);
-    if (!continuation) return null;
-    current = continuation;
-    searchStart = 0;
-    lineIndex += 1;
-  }
-}
-
-function readReferenceDefinition(
-  lines: string[],
-  startLineIndex: number,
-  containerOverride?: MarkdownContainer,
-): { label: string; endLineIndex: number } | null {
-  const containerLine = containerOverride
-    ? readReferenceContainerLine(lines[startLineIndex], containerOverride)
-    : null;
-  const { content, container } =
-    containerLine === null
-      ? readReferenceDefinitionContainer(lines[startLineIndex])
-      : { content: containerLine, container: containerOverride };
-  const start = readReferenceDefinitionStart(content);
-  if (!start) return null;
-
-  const readContinuation = (lineIndex: number): string | null => {
-    const containerLine = readReferenceContainerLine(lines[lineIndex] ?? "", container);
-    return containerLine === null ? null : readReferenceDefinitionContinuation(containerLine);
-  };
-
-  let lineIndex = startLineIndex;
-  let destinationInput = start.body.trimStart();
-  if (!destinationInput) {
-    const continuation = readContinuation(lineIndex + 1);
-    if (!continuation || readReferenceTitleCloser(continuation)) return null;
-    destinationInput = continuation;
-    lineIndex += 1;
-  }
-
-  const destination = readReferenceDestination(destinationInput);
-  if (!destination) return null;
-
-  const separatedRemainder = destination.remainder;
-  const title = separatedRemainder.trimStart();
-  if (title) {
-    if (title === separatedRemainder || !readReferenceTitleCloser(title)) return null;
-    const titleEndLineIndex = readReferenceTitleEnd(lineIndex, title, readContinuation);
-    if (titleEndLineIndex === null) return null;
-    lineIndex = titleEndLineIndex;
-  } else {
-    const continuation = readContinuation(lineIndex + 1);
-    if (continuation && readReferenceTitleCloser(continuation)) {
-      const titleEndLineIndex = readReferenceTitleEnd(
-        lineIndex + 1,
-        continuation,
-        readContinuation,
-      );
-      if (titleEndLineIndex === null) return null;
-      lineIndex = titleEndLineIndex;
-    }
-  }
-
-  return { label: start.label, endLineIndex: lineIndex };
-}
-
-function stripFencedCodeAndReferenceDefinitions(markdown: string): {
-  markdown: string;
-  referenceDefinitionLabels: Set<string>;
-} {
+function stripFencedCode(markdown: string): string {
   const lines = markdown.split(/\r?\n/);
-  let fence: { character: string; length: number; container: MarkdownContainer } | null = null;
-  const listContainerStack: MarkdownContainer[] = [];
-  const referenceDefinitionLabels = new Set<string>();
+  let fence: { character: string; length: number } | null = null;
   const strippedLines: string[] = [];
 
-  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
-    const line = lines[lineIndex];
+  for (const line of lines) {
+    const run = matchFindingsFenceRun(line);
     if (fence) {
-      const containerLine = readReferenceContainerLine(line, fence.container);
-      if (containerLine !== null) {
-        const run = matchFindingsFenceRun(containerLine);
-        if (
-          run &&
-          run.character === fence.character &&
-          run.length >= fence.length &&
-          !run.suffix.trim()
-        ) {
-          fence = null;
-        }
-        strippedLines.push("");
-        continue;
-      }
       if (
-        fence.container.listIndent > 0 &&
-        fence.container.blockquoteDepth === 0 &&
-        !line.trim()
+        run &&
+        run.character === fence.character &&
+        run.length >= fence.length &&
+        !run.suffix.trim()
       ) {
-        strippedLines.push("");
-        continue;
+        fence = null;
       }
-      fence = null;
-    }
-    const directContainerLine = readReferenceDefinitionContainer(line);
-    let containerLine = directContainerLine;
-    if (directContainerLine.listContainers.length > 0) {
-      for (const directListContainer of directContainerLine.listContainers) {
-        while (
-          listContainerStack.length > 0 &&
-          (listContainerStack.at(-1)?.blockquoteDepth !==
-            directListContainer.blockquoteDepth ||
-            (listContainerStack.at(-1)?.listIndent ?? 0) >= directListContainer.listIndent)
-        ) {
-          listContainerStack.pop();
-        }
-        listContainerStack.push(directListContainer);
-      }
-    } else {
-      let activeListContainer: MarkdownContainer | null = null;
-      for (let stackIndex = listContainerStack.length - 1; stackIndex >= 0; stackIndex -= 1) {
-        const candidate = listContainerStack[stackIndex];
-        const activeContent = readReferenceContainerLine(line, candidate);
-        if (activeContent === null) continue;
-        activeListContainer = candidate;
-        containerLine = { content: activeContent, container: candidate };
-        listContainerStack.splice(stackIndex + 1);
-        break;
-      }
-
-      if (!activeListContainer && line.trim()) listContainerStack.splice(0);
-    }
-
-    const run = matchFindingsFenceRun(containerLine.content);
-    if (run) {
-      fence = {
-        character: run.character,
-        length: run.length,
-        container: containerLine.container,
-      };
       strippedLines.push("");
       continue;
     }
-    const referenceDefinition = readReferenceDefinition(
-      lines,
-      lineIndex,
-      containerLine.container,
-    );
-    if (referenceDefinition) {
-      referenceDefinitionLabels.add(referenceDefinition.label);
-      while (lineIndex <= referenceDefinition.endLineIndex) {
-        strippedLines.push("");
-        lineIndex += 1;
-      }
-      lineIndex -= 1;
+
+    if (run) {
+      fence = { character: run.character, length: run.length };
+      strippedLines.push("");
       continue;
     }
+
     strippedLines.push(line);
   }
 
-  return { markdown: strippedLines.join("\n"), referenceDefinitionLabels };
+  return strippedLines.join("\n");
 }
 
 function isEscaped(input: string, index: number): boolean {
@@ -503,7 +176,7 @@ function stripInlineCode(markdown: string): string {
   return sanitized;
 }
 
-function stripMarkdownLinksAndImages(markdown: string, referenceDefinitionLabels: Set<string>): string {
+function stripMarkdownLinksAndImages(markdown: string): string {
   let sanitized = "";
 
   for (let index = 0; index < markdown.length; ) {
@@ -513,6 +186,18 @@ function stripMarkdownLinksAndImages(markdown: string, referenceDefinitionLabels
       !isEscaped(markdown, index);
     const isLink = markdown[index] === "[" && !isEscaped(markdown, index);
     if (!isImage && !isLink) {
+      sanitized += markdown[index];
+      index += 1;
+      continue;
+    }
+
+    if (isLink && !markdown.startsWith("![", index + 1)) {
+      const inlineLink = matchFindingsInlineLinkAt(markdown, index);
+      if (inlineLink) {
+        sanitized += stripMarkdownLinksAndImages(inlineLink.text);
+        index += inlineLink.length;
+        continue;
+      }
       sanitized += markdown[index];
       index += 1;
       continue;
@@ -530,21 +215,6 @@ function stripMarkdownLinksAndImages(markdown: string, referenceDefinitionLabels
     const suffixStart = labelEnd + 1;
     const suffixOpen = markdown[suffixStart];
     if (suffixOpen === "(" || suffixOpen === "[") {
-      const wrapsImage = markdown.startsWith("![", labelStart);
-      if (suffixOpen === "(" && !isImage && !wrapsImage) {
-        const inlineLink = matchFindingsInlineLinkAt(markdown, index);
-        if (!inlineLink) {
-          sanitized += markdown[index];
-          index += 1;
-          continue;
-        }
-        sanitized += stripMarkdownLinksAndImages(
-          inlineLink.text,
-          referenceDefinitionLabels,
-        );
-        index += inlineLink.length;
-        continue;
-      }
       const suffixClose = suffixOpen === "(" ? ")" : "]";
       const suffixEnd = findBalancedClose(markdown, suffixStart + 1, suffixOpen, suffixClose);
       if (suffixEnd === -1) {
@@ -552,31 +222,10 @@ function stripMarkdownLinksAndImages(markdown: string, referenceDefinitionLabels
         index += 1;
         continue;
       }
-      if (suffixOpen === "[" && !isImage) {
-        const suffixLabel = markdown.slice(suffixStart + 1, suffixEnd);
-        const resolvedLabel = normalizeReferenceLabel(
-          suffixLabel || markdown.slice(labelStart, labelEnd),
-        );
-        if (!referenceDefinitionLabels.has(resolvedLabel)) {
-          sanitized += markdown[index];
-          index += 1;
-          continue;
-        }
-      }
       constructEnd = suffixEnd + 1;
-    } else if (!isImage) {
-      sanitized += markdown[index];
-      index += 1;
-      continue;
-    } else if (!referenceDefinitionLabels.has(normalizeReferenceLabel(markdown.slice(labelStart, labelEnd)))) {
-      sanitized += markdown.slice(index, labelEnd + 1);
-      index = labelEnd + 1;
-      continue;
     }
 
-    sanitized += isImage
-      ? " "
-      : stripMarkdownLinksAndImages(markdown.slice(labelStart, labelEnd), referenceDefinitionLabels);
+    sanitized += " ";
     index = constructEnd;
   }
 

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -1,12 +1,5 @@
 import type { ResearchSourceRef } from "./research-missions.ts";
-import {
-  findRecognizedFindingsRefs,
-  matchFindingsFenceRun,
-  matchFindingsAtxHeading,
-  matchFindingsImageAt,
-  matchFindingsInlineLinkAt,
-  stripFindingsComments,
-} from "./research-findings-doc.ts";
+import { parseFindingsDoc } from "./research-findings-doc.ts";
 
 export type ResearchIntegritySummaryKind =
   | "unavailable"
@@ -48,225 +41,9 @@ function unavailableSummary(): { kind: ResearchIntegritySummaryKind; label: stri
   return { kind: "unavailable", label: "Sources unavailable — references can't be verified" };
 }
 
-function preprocessMarkdownForIntegrity(markdown: string): string {
-  const withoutComments = stripFindingsComments(markdown ?? "");
-  const withoutBlocks = stripFencedCode(withoutComments);
-  const withoutHeadings = stripAtxHeadings(withoutBlocks);
-  const withoutCode = stripInlineCode(withoutHeadings);
-  const withoutMarkdownTargets = stripMarkdownLinksAndImages(withoutCode);
-  return stripBareUrls(withoutMarkdownTargets);
-}
-
-function stripAtxHeadings(markdown: string): string {
-  return markdown
-    .split(/\r?\n/)
-    .map((line) => (matchFindingsAtxHeading(line) ? "" : line))
-    .join("\n");
-}
-
-function stripFencedCode(markdown: string): string {
-  const lines = markdown.split(/\r?\n/);
-  let fence: { character: string; length: number } | null = null;
-  const strippedLines: string[] = [];
-
-  for (const line of lines) {
-    const run = matchFindingsFenceRun(line);
-    if (fence) {
-      if (
-        run &&
-        run.character === fence.character &&
-        run.length >= fence.length &&
-        !run.suffix.trim()
-      ) {
-        fence = null;
-      }
-      strippedLines.push("");
-      continue;
-    }
-
-    if (run) {
-      fence = { character: run.character, length: run.length };
-      strippedLines.push("");
-      continue;
-    }
-
-    strippedLines.push(line);
-  }
-
-  return strippedLines.join("\n");
-}
-
-function isEscaped(input: string, index: number): boolean {
-  let slashCount = 0;
-  for (let cursor = index - 1; cursor >= 0 && input[cursor] === "\\"; cursor -= 1) {
-    slashCount += 1;
-  }
-  return slashCount % 2 === 1;
-}
-
-function backtickRunLength(input: string, index: number): number {
-  let length = 0;
-  while (input[index + length] === "`") length += 1;
-  return length;
-}
-
-function isUnsupportedContainerFenceRun(
-  input: string,
-  index: number,
-  runLength: number,
-): boolean {
-  if (runLength < 3) return false;
-
-  const lineStart = input.lastIndexOf("\n", index - 1) + 1;
-  const prefix = input.slice(lineStart, index);
-  return (
-    /^[ \t]+$/.test(prefix) ||
-    /^(?:[ \t]*(?:>[ \t]?|(?:[-+*]|\d{1,9}[.)])[ \t]+))+[ \t]*$/.test(prefix)
-  );
-}
-
-function findClosingBacktickRun(input: string, startIndex: number, openerLength: number): number {
-  for (let index = startIndex; index < input.length; ) {
-    if (input[index] !== "`") {
-      index += 1;
-      continue;
-    }
-
-    const length = backtickRunLength(input, index);
-    if (length === openerLength) return index;
-    index += length;
-  }
-
-  return -1;
-}
-
-function stripInlineCode(markdown: string): string {
-  let sanitized = "";
-
-  for (let index = 0; index < markdown.length; ) {
-    if (markdown[index] !== "`" || isEscaped(markdown, index)) {
-      sanitized += markdown[index];
-      index += 1;
-      continue;
-    }
-
-    const openerLength = backtickRunLength(markdown, index);
-    if (isUnsupportedContainerFenceRun(markdown, index, openerLength)) {
-      sanitized += markdown.slice(index, index + openerLength);
-      index += openerLength;
-      continue;
-    }
-    const closeIndex = findClosingBacktickRun(markdown, index + openerLength, openerLength);
-    if (closeIndex === -1) {
-      sanitized += markdown.slice(index, index + openerLength);
-      index += openerLength;
-      continue;
-    }
-
-    sanitized += " ";
-    index = closeIndex + openerLength;
-  }
-
-  return sanitized;
-}
-
-function stripMarkdownLinksAndImages(markdown: string): string {
-  let sanitized = "";
-
-  for (let index = 0; index < markdown.length; ) {
-    const image = matchFindingsImageAt(markdown, index);
-    if (image) {
-      sanitized += " ";
-      index += image.length;
-      continue;
-    }
-
-    const isLink = markdown[index] === "[";
-    if (!isLink) {
-      sanitized += markdown[index];
-      index += 1;
-      continue;
-    }
-
-    const inlineLink = matchFindingsInlineLinkAt(markdown, index);
-    if (inlineLink) {
-      sanitized += `[${stripMarkdownLinksAndImages(inlineLink.text)}]`;
-      index += inlineLink.length;
-      continue;
-    }
-
-    sanitized += markdown[index];
-    index += 1;
-  }
-
-  return sanitized;
-}
-
-function stripBareUrls(markdown: string): string {
-  let sanitized = "";
-  for (let index = 0; index < markdown.length; ) {
-    const protocol = markdown.slice(index, index + "https://".length).toLowerCase();
-    const protocolLength = protocol.startsWith("https://")
-      ? "https://".length
-      : protocol.startsWith("http://")
-        ? "http://".length
-        : 0;
-    if (!protocolLength) {
-      sanitized += markdown[index];
-      index += 1;
-      continue;
-    }
-
-    const urlStart = index;
-    let parenDepth = 0;
-    index += protocolLength;
-    const authorityStart = index;
-    while (index < markdown.length) {
-      const character = markdown[index];
-      if (/\s/.test(character)) break;
-      if (character === "[" && parenDepth === 0) {
-        const hostEnd = markdown.indexOf("]", index + 1);
-        const bracketedHost = hostEnd === -1 ? "" : markdown.slice(index + 1, hostEnd);
-        const authorityPrefix = markdown.slice(authorityStart, index);
-        if (
-          bracketedHost.includes(":") &&
-          !/\s/.test(bracketedHost) &&
-          !/[/?#]/.test(authorityPrefix)
-        ) {
-          index = hostEnd + 1;
-          continue;
-        }
-        const bracketedComponent = hostEnd === -1 ? "" : markdown.slice(index + 1, hostEnd);
-        if (
-          /[/?#]/.test(authorityPrefix) &&
-          !/[.,;:!?)]/.test(markdown[index - 1] ?? "") &&
-          bracketedComponent &&
-          !/\s/.test(bracketedComponent)
-        ) {
-          index = hostEnd + 1;
-          continue;
-        }
-        break;
-      }
-      if (character === "(") parenDepth += 1;
-      else if (character === ")" && parenDepth > 0) parenDepth -= 1;
-      index += 1;
-    }
-    // Keep parser offsets and word boundaries while making URL contents opaque.
-    sanitized += "x".repeat(index - urlStart);
-  }
-
-  return sanitized;
-}
-
 export function scanBracketedSourceIds(markdown: string): string[] {
-  return uniqueIdsInOrder(
-    findRecognizedFindingsRefs(
-      preprocessMarkdownForIntegrity(markdown),
-      [],
-    )
-      .filter((match) => SOURCE_ID_RE.test(match.id))
-      .map((match) => match.id),
+  return parseFindingsDoc(markdown, []).refIds.filter((id) =>
+    SOURCE_ID_RE.test(id),
   );
 }
 
@@ -334,31 +111,22 @@ export function deriveResearchFindingsIntegrity(
   options: { ledger?: ResearchFindingsIntegrity["ledger"] } = {},
 ): ResearchFindingsIntegrity {
   const sourceById = new Map<string, ResearchSourceRef>();
-  const sanitizedMarkdown = preprocessMarkdownForIntegrity(markdown);
 
   for (const source of sources) {
     if (!sourceById.has(source.id)) sourceById.set(source.id, source);
   }
 
-  const recognizedRefs = findRecognizedFindingsRefs(sanitizedMarkdown, sources);
-  const actualLedgerRefs = recognizedRefs.filter(
-    (match) => sourceById.has(match.id) && !CONFLICT_ID_RE.test(match.id),
-  );
-  const unresolvedStrictRefs = recognizedRefs.filter(
-    (match) =>
-      SOURCE_ID_RE.test(match.id) &&
-      !sourceById.has(match.id),
-  );
+  const recognizedIds = parseFindingsDoc(markdown, sources).refIds;
   const referencedIds = uniqueIdsInOrder(
-    [...actualLedgerRefs, ...unresolvedStrictRefs]
-      .sort((left, right) => left.index - right.index)
-      .map((match) => match.id),
+    recognizedIds.filter(
+      (id) =>
+        !CONFLICT_ID_RE.test(id) &&
+        (sourceById.has(id) || SOURCE_ID_RE.test(id)),
+    ),
   );
   const unresolvedIds = referencedIds.filter((id) => !sourceById.has(id));
   const conflictMarkerIds = uniqueIdsInOrder(
-    recognizedRefs
-      .filter((match) => CONFLICT_ID_RE.test(match.id))
-      .map((match) => match.id),
+    recognizedIds.filter((id) => CONFLICT_ID_RE.test(id)),
   );
   const conflictingSourceIds = uniqueIdsInOrder(
     sources.filter((source) => source.status === "conflicting").map((source) => source.id),

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -168,14 +168,25 @@ function stripBlockquotePrefix(
 function readReferenceDefinitionContainer(line: string): {
   content: string;
   container: MarkdownContainer;
+  listContainers: MarkdownContainer[];
 } {
   const blockquote = stripBlockquotePrefix(line) ?? { content: line, depth: 0 };
-  const listMatch = blockquote.content.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])([ \t]+)/);
-  const listIndent = listMatch?.[0].length ?? 0;
+  const listContainers: MarkdownContainer[] = [];
+  let content = blockquote.content;
+  let listIndent = 0;
+
+  while (true) {
+    const listMatch = content.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])([ \t]+)/);
+    if (!listMatch) break;
+    listIndent += listMatch[0].length;
+    listContainers.push({ blockquoteDepth: blockquote.depth, listIndent });
+    content = content.slice(listMatch[0].length);
+  }
 
   return {
-    content: blockquote.content.slice(listIndent),
+    content,
     container: { blockquoteDepth: blockquote.depth, listIndent },
+    listContainers,
   };
 }
 
@@ -389,17 +400,18 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
     }
     const directContainerLine = readReferenceDefinitionContainer(line);
     let containerLine = directContainerLine;
-    if (directContainerLine.container.listIndent) {
-      while (
-        listContainerStack.length > 0 &&
-        (listContainerStack.at(-1)?.blockquoteDepth !==
-          directContainerLine.container.blockquoteDepth ||
-          (listContainerStack.at(-1)?.listIndent ?? 0) >=
-            directContainerLine.container.listIndent)
-      ) {
-        listContainerStack.pop();
+    if (directContainerLine.listContainers.length > 0) {
+      for (const directListContainer of directContainerLine.listContainers) {
+        while (
+          listContainerStack.length > 0 &&
+          (listContainerStack.at(-1)?.blockquoteDepth !==
+            directListContainer.blockquoteDepth ||
+            (listContainerStack.at(-1)?.listIndent ?? 0) >= directListContainer.listIndent)
+        ) {
+          listContainerStack.pop();
+        }
+        listContainerStack.push(directListContainer);
       }
-      listContainerStack.push(directContainerLine.container);
     } else {
       let activeListContainer: MarkdownContainer | null = null;
       for (let stackIndex = listContainerStack.length - 1; stackIndex >= 0; stackIndex -= 1) {

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -135,6 +135,61 @@ function normalizeReferenceLabel(label: string): string {
   return unescapeCommonMarkPunctuation(label).trim().replace(/\s+/g, " ").toLowerCase();
 }
 
+type ReferenceDefinitionContainer = {
+  blockquoteDepth: number;
+  listIndent: number;
+};
+
+function stripBlockquotePrefix(
+  line: string,
+  expectedDepth?: number,
+): { content: string; depth: number } | null {
+  let cursor = 0;
+  let depth = 0;
+
+  while (expectedDepth === undefined || depth < expectedDepth) {
+    let markerIndex = cursor;
+    let spaces = 0;
+    while (spaces < 3 && line[markerIndex] === " ") {
+      markerIndex += 1;
+      spaces += 1;
+    }
+    if (line[markerIndex] !== ">") break;
+
+    cursor = markerIndex + 1;
+    if (line[cursor] === " " || line[cursor] === "\t") cursor += 1;
+    depth += 1;
+  }
+
+  if (expectedDepth !== undefined && depth !== expectedDepth) return null;
+  return { content: line.slice(cursor), depth };
+}
+
+function readReferenceDefinitionContainer(line: string): {
+  content: string;
+  container: ReferenceDefinitionContainer;
+} {
+  const blockquote = stripBlockquotePrefix(line) ?? { content: line, depth: 0 };
+  const listMatch = blockquote.content.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])([ \t]+)/);
+  const listIndent = listMatch?.[0].length ?? 0;
+
+  return {
+    content: blockquote.content.slice(listIndent),
+    container: { blockquoteDepth: blockquote.depth, listIndent },
+  };
+}
+
+function readReferenceContainerLine(
+  line: string,
+  container: ReferenceDefinitionContainer,
+): string | null {
+  const blockquote = stripBlockquotePrefix(line, container.blockquoteDepth);
+  if (!blockquote) return null;
+  if (!container.listIndent) return blockquote.content;
+  if (!blockquote.content.startsWith(" ".repeat(container.listIndent))) return null;
+  return blockquote.content.slice(container.listIndent);
+}
+
 function readReferenceDefinitionStart(line: string): {
   label: string;
   body: string;
@@ -143,10 +198,20 @@ function readReferenceDefinitionStart(line: string): {
   while (labelStart < 3 && line[labelStart] === " ") labelStart += 1;
   if (line[labelStart] !== "[") return null;
 
-  const labelEnd = findBalancedClose(line, labelStart + 1, "[", "]");
+  let labelEnd = -1;
+  for (let index = labelStart + 1; index < line.length; index += 1) {
+    if (line[index] === "[" && !isEscaped(line, index)) return null;
+    if (line[index] === "]" && !isEscaped(line, index)) {
+      labelEnd = index;
+      break;
+    }
+  }
+
   if (labelEnd <= labelStart + 1 || line[labelEnd + 1] !== ":") return null;
+  const rawLabel = line.slice(labelStart + 1, labelEnd);
+  if (rawLabel.length > 999 || !/\S/.test(rawLabel)) return null;
   return {
-    label: normalizeReferenceLabel(line.slice(labelStart + 1, labelEnd)),
+    label: normalizeReferenceLabel(rawLabel),
     body: line.slice(labelEnd + 2),
   };
 }
@@ -205,9 +270,9 @@ function readReferenceTitleCloser(title: string): "'" | '"' | ")" | null {
 }
 
 function readReferenceTitleEnd(
-  lines: string[],
   startLineIndex: number,
   title: string,
+  readContinuation: (lineIndex: number) => string | null,
 ): number | null {
   const closer = readReferenceTitleCloser(title);
   if (!closer) return null;
@@ -221,7 +286,7 @@ function readReferenceTitleEnd(
       return current.slice(index + 1).trim() ? null : lineIndex;
     }
 
-    const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
+    const continuation = readContinuation(lineIndex + 1);
     if (!continuation) return null;
     current = continuation;
     searchStart = 0;
@@ -233,13 +298,19 @@ function readReferenceDefinition(
   lines: string[],
   startLineIndex: number,
 ): { label: string; endLineIndex: number } | null {
-  const start = readReferenceDefinitionStart(lines[startLineIndex]);
+  const { content, container } = readReferenceDefinitionContainer(lines[startLineIndex]);
+  const start = readReferenceDefinitionStart(content);
   if (!start) return null;
+
+  const readContinuation = (lineIndex: number): string | null => {
+    const containerLine = readReferenceContainerLine(lines[lineIndex] ?? "", container);
+    return containerLine === null ? null : readReferenceDefinitionContinuation(containerLine);
+  };
 
   let lineIndex = startLineIndex;
   let destinationInput = start.body.trimStart();
   if (!destinationInput) {
-    const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
+    const continuation = readContinuation(lineIndex + 1);
     if (!continuation || readReferenceTitleCloser(continuation)) return null;
     destinationInput = continuation;
     lineIndex += 1;
@@ -252,13 +323,17 @@ function readReferenceDefinition(
   const title = separatedRemainder.trimStart();
   if (title) {
     if (title === separatedRemainder || !readReferenceTitleCloser(title)) return null;
-    const titleEndLineIndex = readReferenceTitleEnd(lines, lineIndex, title);
+    const titleEndLineIndex = readReferenceTitleEnd(lineIndex, title, readContinuation);
     if (titleEndLineIndex === null) return null;
     lineIndex = titleEndLineIndex;
   } else {
-    const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
+    const continuation = readContinuation(lineIndex + 1);
     if (continuation && readReferenceTitleCloser(continuation)) {
-      const titleEndLineIndex = readReferenceTitleEnd(lines, lineIndex + 1, continuation);
+      const titleEndLineIndex = readReferenceTitleEnd(
+        lineIndex + 1,
+        continuation,
+        readContinuation,
+      );
       if (titleEndLineIndex === null) return null;
       lineIndex = titleEndLineIndex;
     }
@@ -328,7 +403,7 @@ function backtickRunLength(input: string, index: number): number {
 
 function findClosingBacktickRun(input: string, startIndex: number, openerLength: number): number {
   for (let index = startIndex; index < input.length; ) {
-    if (input[index] !== "`" || isEscaped(input, index)) {
+    if (input[index] !== "`") {
       index += 1;
       continue;
     }

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -11,7 +11,7 @@ export type ResearchIntegritySummaryKind =
   | "none";
 
 export type ResearchFindingsIntegrity = {
-  ledger: "available" | "empty";
+  ledger: "available" | "empty" | "failed";
   referencedIds: string[];
   unresolvedIds: string[];
   conflictIds: string[];
@@ -43,8 +43,23 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function unavailableSummary(): { kind: ResearchIntegritySummaryKind; label: string } {
+  return { kind: "unavailable", label: "Sources unavailable — references can't be verified" };
+}
+
 function preprocessMarkdownForIntegrity(markdown: string): string {
   return stripBareUrls(stripMarkdownLinksAndImages(stripInlineCode(stripFencedCodeBlocks(markdown ?? ""))));
+}
+
+function isClosingFence(
+  fenceMatch: RegExpExecArray,
+  fence: { character: string; length: number },
+): boolean {
+  return (
+    fenceMatch[1][0] === fence.character &&
+    fenceMatch[1].length >= fence.length &&
+    !fenceMatch[2].trim()
+  );
 }
 
 function stripFencedCodeBlocks(markdown: string): string {
@@ -58,11 +73,11 @@ function stripFencedCodeBlocks(markdown: string): string {
         fence = { character: fenceMatch[1][0], length: fenceMatch[1].length };
         return "";
       }
-      if (fence && fenceMatch && fenceMatch[1][0] === fence.character && fenceMatch[1].length >= fence.length) {
-        fence = null;
+      if (fence) {
+        if (fenceMatch && isClosingFence(fenceMatch, fence)) fence = null;
         return "";
       }
-      return fence ? "" : line;
+      return line;
     })
     .join("\n");
 }
@@ -85,20 +100,87 @@ function stripInlineCode(markdown: string): string {
       index += fenceLength - 1;
       continue;
     }
+    sanitized += " ";
     index = endIndex + fenceLength - 1;
   }
 
   return sanitized;
 }
 
+function findBalancedClose(input: string, startIndex: number, open: string, close: string): number {
+  let depth = 1;
+
+  for (let index = startIndex; index < input.length; index += 1) {
+    const character = input[index];
+    if (character === "\\") {
+      index += 1;
+      continue;
+    }
+    if (character === open) {
+      depth += 1;
+      continue;
+    }
+    if (character !== close) continue;
+    depth -= 1;
+    if (depth === 0) return index;
+  }
+
+  return -1;
+}
+
 function stripMarkdownLinksAndImages(markdown: string): string {
-  return markdown
-    .replace(/!\[[^\]]*]\(([^)\s]+)\)/g, "")
-    .replace(/\[[^\]]+]\(([^)\s]+)\)/g, "");
+  let sanitized = "";
+
+  for (let index = 0; index < markdown.length; index += 1) {
+    const isImage = markdown[index] === "!" && markdown[index + 1] === "[";
+    const isLink = markdown[index] === "[";
+    if (!isImage && !isLink) {
+      sanitized += markdown[index];
+      continue;
+    }
+
+    const labelStart = index + (isImage ? 2 : 1);
+    const labelEnd = findBalancedClose(markdown, labelStart, "[", "]");
+    if (labelEnd === -1) {
+      sanitized += markdown[index];
+      continue;
+    }
+
+    const destinationStart = labelEnd + 1;
+    if (markdown[destinationStart] !== "(") {
+      sanitized += markdown.slice(index, destinationStart);
+      index = destinationStart - 1;
+      continue;
+    }
+
+    const destinationEnd = findBalancedClose(markdown, destinationStart + 1, "(", ")");
+    if (destinationEnd === -1) {
+      sanitized += markdown[index];
+      continue;
+    }
+
+    if (isLink) sanitized += markdown.slice(labelStart, labelEnd);
+    index = destinationEnd;
+  }
+
+  return sanitized;
 }
 
 function stripBareUrls(markdown: string): string {
-  return markdown.replace(/https?:\/\/[^\s<>()]+/g, "");
+  let sanitized = "";
+  let cursor = 0;
+  const urlPattern = /https?:\/\//g;
+
+  for (let match = urlPattern.exec(markdown); match; match = urlPattern.exec(markdown)) {
+    let end = match.index + match[0].length;
+    while (end < markdown.length && !/\s/.test(markdown[end])) end += 1;
+    sanitized += markdown.slice(cursor, match.index);
+    sanitized += " ";
+    cursor = end;
+    urlPattern.lastIndex = end;
+  }
+
+  return sanitized + markdown.slice(cursor);
 }
 
 export function scanBracketedSourceIds(markdown: string): string[] {
@@ -190,9 +272,8 @@ function summarize(
   const unresolvedCount = integrity.unresolvedIds.length;
   const conflictCount = integrity.conflictIds.length;
 
-  if (integrity.ledger === "empty" && integrity.referencedIds.length > 0) {
-    return { kind: "unavailable", label: "Sources unavailable — references can't be verified" };
-  }
+  if (integrity.ledger === "failed") return unavailableSummary();
+  if (integrity.ledger === "empty" && integrity.referencedIds.length > 0) return unavailableSummary();
 
   if (unresolvedCount > 0) {
     return {
@@ -235,6 +316,7 @@ function summarize(
 export function deriveResearchFindingsIntegrity(
   markdown: string,
   sources: ResearchSourceRef[],
+  options: { ledger?: ResearchFindingsIntegrity["ledger"] } = {},
 ): ResearchFindingsIntegrity {
   const sourceById = new Map<string, ResearchSourceRef>();
   const sanitizedMarkdown = preprocessMarkdownForIntegrity(markdown);
@@ -259,7 +341,7 @@ export function deriveResearchFindingsIntegrity(
   const citedUsedCount = referencedIds.filter((id) => sourceById.get(id)?.status === "used").length;
   const citedRejectedCount = referencedIds.filter((id) => sourceById.get(id)?.status === "rejected").length;
   const integrity: ResearchFindingsIntegrity = {
-    ledger: sources.length > 0 ? "available" : "empty",
+    ledger: options.ledger ?? (sources.length > 0 ? "available" : "empty"),
     referencedIds,
     unresolvedIds,
     conflictIds,

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -3,9 +3,8 @@ import {
   findRecognizedFindingsRefs,
   matchFindingsFenceRun,
   matchFindingsAtxHeading,
-  matchFindingsInlineImageAt,
+  matchFindingsImageAt,
   matchFindingsInlineLinkAt,
-  matchFindingsLinkedImageAt,
   stripFindingsComments,
 } from "./research-findings-doc.ts";
 
@@ -63,27 +62,6 @@ function stripAtxHeadings(markdown: string): string {
     .split(/\r?\n/)
     .map((line) => (matchFindingsAtxHeading(line) ? "" : line))
     .join("\n");
-}
-
-function findBalancedClose(input: string, startIndex: number, open: string, close: string): number {
-  let depth = 1;
-
-  for (let index = startIndex; index < input.length; index += 1) {
-    const character = input[index];
-    if (character === "\\") {
-      index += 1;
-      continue;
-    }
-    if (character === open) {
-      depth += 1;
-      continue;
-    }
-    if (character !== close) continue;
-    depth -= 1;
-    if (depth === 0) return index;
-  }
-
-  return -1;
 }
 
 function stripFencedCode(markdown: string): string {
@@ -196,72 +174,29 @@ function stripMarkdownLinksAndImages(markdown: string): string {
   let sanitized = "";
 
   for (let index = 0; index < markdown.length; ) {
-    const linkedImage = matchFindingsLinkedImageAt(markdown, index);
-    if (linkedImage) {
+    const image = matchFindingsImageAt(markdown, index);
+    if (image) {
       sanitized += " ";
-      index += linkedImage.length;
+      index += image.length;
       continue;
     }
 
-    const inlineImage = matchFindingsInlineImageAt(markdown, index);
-    if (inlineImage) {
-      sanitized += " ";
-      index += inlineImage.length;
-      continue;
-    }
-
-    const isImage =
-      markdown[index] === "!" &&
-      markdown[index + 1] === "[" &&
-      !isEscaped(markdown, index);
     const isLink = markdown[index] === "[";
-    if (!isImage && !isLink) {
+    if (!isLink) {
       sanitized += markdown[index];
       index += 1;
       continue;
     }
 
-    if (isLink) {
-      if (markdown.startsWith("![", index + 1)) {
-        sanitized += markdown[index];
-        index += 1;
-        continue;
-      }
-      const inlineLink = matchFindingsInlineLinkAt(markdown, index);
-      if (inlineLink) {
-        sanitized += `[${stripMarkdownLinksAndImages(inlineLink.text)}]`;
-        index += inlineLink.length;
-        continue;
-      }
-      sanitized += markdown[index];
-      index += 1;
+    const inlineLink = matchFindingsInlineLinkAt(markdown, index);
+    if (inlineLink) {
+      sanitized += `[${stripMarkdownLinksAndImages(inlineLink.text)}]`;
+      index += inlineLink.length;
       continue;
     }
 
-    const labelStart = index + (isImage ? 2 : 1);
-    const labelEnd = findBalancedClose(markdown, labelStart, "[", "]");
-    if (labelEnd === -1) {
-      sanitized += markdown[index];
-      index += 1;
-      continue;
-    }
-
-    let constructEnd = labelEnd + 1;
-    const suffixStart = labelEnd + 1;
-    const suffixOpen = markdown[suffixStart];
-    if (suffixOpen === "(" || suffixOpen === "[") {
-      const suffixClose = suffixOpen === "(" ? ")" : "]";
-      const suffixEnd = findBalancedClose(markdown, suffixStart + 1, suffixOpen, suffixClose);
-      if (suffixEnd === -1) {
-        sanitized += markdown[index];
-        index += 1;
-        continue;
-      }
-      constructEnd = suffixEnd + 1;
-    }
-
-    sanitized += " ";
-    index = constructEnd;
+    sanitized += markdown[index];
+    index += 1;
   }
 
   return sanitized;

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -145,7 +145,7 @@ function isUnsupportedContainerFenceRun(
 
   const lineStart = input.lastIndexOf("\n", index - 1) + 1;
   const prefix = input.slice(lineStart, index);
-  return /^(?: {0,3}(?:>[ \t]?|(?:[-+*]|\d{1,9}[.)])[ \t]+))+$/.test(prefix);
+  return /^(?: {0,3}(?:>[ \t]?|(?:[-+*]|\d{1,9}[.)])[ \t]+))+[ \t]{0,3}$/.test(prefix);
 }
 
 function findClosingBacktickRun(input: string, startIndex: number, openerLength: number): number {
@@ -213,7 +213,12 @@ function stripMarkdownLinksAndImages(markdown: string): string {
       continue;
     }
 
-    if (isLink && !markdown.startsWith("![", index + 1)) {
+    if (isLink) {
+      if (markdown.startsWith("![", index + 1)) {
+        sanitized += markdown[index];
+        index += 1;
+        continue;
+      }
       const inlineLink = matchFindingsInlineLinkAt(markdown, index);
       if (inlineLink) {
         sanitized += stripMarkdownLinksAndImages(inlineLink.text);

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -3,7 +3,9 @@ import {
   findRecognizedFindingsRefs,
   matchFindingsFenceRun,
   matchFindingsAtxHeading,
+  matchFindingsInlineImageAt,
   matchFindingsInlineLinkAt,
+  matchFindingsLinkedImageAt,
   stripFindingsComments,
 } from "./research-findings-doc.ts";
 
@@ -194,6 +196,20 @@ function stripMarkdownLinksAndImages(markdown: string): string {
   let sanitized = "";
 
   for (let index = 0; index < markdown.length; ) {
+    const linkedImage = matchFindingsLinkedImageAt(markdown, index);
+    if (linkedImage) {
+      sanitized += " ";
+      index += linkedImage.length;
+      continue;
+    }
+
+    const inlineImage = matchFindingsInlineImageAt(markdown, index);
+    if (inlineImage) {
+      sanitized += " ";
+      index += inlineImage.length;
+      continue;
+    }
+
     const isImage =
       markdown[index] === "!" &&
       markdown[index + 1] === "[" &&

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -355,7 +355,7 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
 } {
   const lines = markdown.split(/\r?\n/);
   let fence: { character: string; length: number; container: MarkdownContainer } | null = null;
-  let activeListContainer: MarkdownContainer | null = null;
+  const listContainerStack: MarkdownContainer[] = [];
   const referenceDefinitionLabels = new Set<string>();
   const strippedLines: string[] = [];
 
@@ -376,23 +376,43 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
         strippedLines.push("");
         continue;
       }
+      const blockquoteLine = stripBlockquotePrefix(line, fence.container.blockquoteDepth);
+      if (
+        fence.container.listIndent > 0 &&
+        blockquoteLine !== null &&
+        !blockquoteLine.content.trim()
+      ) {
+        strippedLines.push("");
+        continue;
+      }
       fence = null;
     }
     const directContainerLine = readReferenceDefinitionContainer(line);
     let containerLine = directContainerLine;
     if (directContainerLine.container.listIndent) {
-      activeListContainer = directContainerLine.container;
-    } else if (activeListContainer) {
-      const activeContent = readReferenceContainerLine(line, activeListContainer);
-      if (activeContent !== null) {
-        containerLine = { content: activeContent, container: activeListContainer };
-      } else {
-        const activeBlockquote = stripBlockquotePrefix(
-          line,
-          activeListContainer.blockquoteDepth,
-        );
-        if (activeBlockquote?.content.trim()) activeListContainer = null;
+      while (
+        listContainerStack.length > 0 &&
+        (listContainerStack.at(-1)?.blockquoteDepth !==
+          directContainerLine.container.blockquoteDepth ||
+          (listContainerStack.at(-1)?.listIndent ?? 0) >=
+            directContainerLine.container.listIndent)
+      ) {
+        listContainerStack.pop();
       }
+      listContainerStack.push(directContainerLine.container);
+    } else {
+      let activeListContainer: MarkdownContainer | null = null;
+      for (let stackIndex = listContainerStack.length - 1; stackIndex >= 0; stackIndex -= 1) {
+        const candidate = listContainerStack[stackIndex];
+        const activeContent = readReferenceContainerLine(line, candidate);
+        if (activeContent === null) continue;
+        activeListContainer = candidate;
+        containerLine = { content: activeContent, container: candidate };
+        listContainerStack.splice(stackIndex + 1);
+        break;
+      }
+
+      if (!activeListContainer && line.trim()) listContainerStack.splice(0);
     }
 
     const run = readFenceRun(containerLine.content);
@@ -547,9 +567,10 @@ function stripMarkdownLinksAndImages(markdown: string, referenceDefinitionLabels
 function stripBareUrls(markdown: string): string {
   let sanitized = "";
   for (let index = 0; index < markdown.length; ) {
-    const protocolLength = markdown.startsWith("https://", index)
+    const protocol = markdown.slice(index, index + "https://".length).toLowerCase();
+    const protocolLength = protocol.startsWith("https://")
       ? "https://".length
-      : markdown.startsWith("http://", index)
+      : protocol.startsWith("http://")
         ? "http://".length
         : 0;
     if (!protocolLength) {

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -19,10 +19,8 @@ export type ResearchFindingsIntegrity = {
   summary: { kind: ResearchIntegritySummaryKind; label: string };
 };
 
-const BRACKETED_TOKEN_RE = /\[\s*([^\[\]]+?)\s*\]/g;
 const SOURCE_ID_RE = /^(?:S|R)\d+$/;
 const CONFLICT_ID_RE = /^C\d+$/;
-const FENCE_RE = /^\s{0,3}(`{3,}|~{3,})(.*)$/;
 
 function emptyCounts(): Record<ResearchSourceRef["status"], number> {
   return { candidate: 0, used: 0, conflicting: 0, rejected: 0 };
@@ -39,72 +37,49 @@ function uniqueIdsInOrder(ids: string[]): string[] {
   return unique;
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function unavailableSummary(): { kind: ResearchIntegritySummaryKind; label: string } {
   return { kind: "unavailable", label: "Sources unavailable — references can't be verified" };
 }
 
 function preprocessMarkdownForIntegrity(markdown: string): string {
-  return stripBareUrls(stripMarkdownLinksAndImages(stripInlineCode(stripFencedCodeBlocks(markdown ?? ""))));
+  const withoutComments = stripHtmlComments(markdown ?? "");
+  const withoutBlocks = stripFencedCodeAndReferenceDefinitions(withoutComments);
+  const withoutCode = stripInlineCode(withoutBlocks);
+  const withoutMarkdownTargets = stripMarkdownLinksAndImages(withoutCode);
+  return stripBareUrls(withoutMarkdownTargets);
 }
 
-function isClosingFence(
-  fenceMatch: RegExpExecArray,
-  fence: { character: string; length: number },
-): boolean {
-  return (
-    fenceMatch[1][0] === fence.character &&
-    fenceMatch[1].length >= fence.length &&
-    !fenceMatch[2].trim()
-  );
-}
-
-function stripFencedCodeBlocks(markdown: string): string {
-  const lines = markdown.split(/\r?\n/);
-  let fence: { character: string; length: number } | null = null;
-
-  return lines
-    .map((line) => {
-      const fenceMatch = FENCE_RE.exec(line);
-      if (!fence && fenceMatch) {
-        fence = { character: fenceMatch[1][0], length: fenceMatch[1].length };
-        return "";
-      }
-      if (fence) {
-        if (fenceMatch && isClosingFence(fenceMatch, fence)) fence = null;
-        return "";
-      }
-      return line;
-    })
-    .join("\n");
-}
-
-function stripInlineCode(markdown: string): string {
+function stripHtmlComments(markdown: string): string {
   let sanitized = "";
+  let cursor = 0;
 
-  for (let index = 0; index < markdown.length; index += 1) {
-    if (markdown[index] !== "`") {
-      sanitized += markdown[index];
-      continue;
-    }
-
-    let fenceLength = 1;
-    while (markdown[index + fenceLength] === "`") fenceLength += 1;
-    const marker = "`".repeat(fenceLength);
-    const endIndex = markdown.indexOf(marker, index + fenceLength);
-    if (endIndex === -1) {
-      sanitized += marker;
-      index += fenceLength - 1;
-      continue;
-    }
-    sanitized += " ";
-    index = endIndex + fenceLength - 1;
+  while (cursor < markdown.length) {
+    const commentStart = markdown.indexOf("<!--", cursor);
+    if (commentStart === -1) return sanitized + markdown.slice(cursor);
+    const commentEnd = markdown.indexOf("-->", commentStart + 4);
+    if (commentEnd === -1) return sanitized + markdown.slice(cursor);
+    sanitized += markdown.slice(cursor, commentStart);
+    cursor = commentEnd + 3;
   }
 
   return sanitized;
+}
+
+type FenceRun = { character: "`" | "~"; length: number; suffix: string };
+
+function readFenceRun(line: string): FenceRun | null {
+  let index = 0;
+  while (index < 3 && line[index] === " ") index += 1;
+
+  const character = line[index];
+  if (character !== "`" && character !== "~") return null;
+
+  const runStart = index;
+  while (line[index] === character) index += 1;
+  const length = index - runStart;
+  if (length < 3) return null;
+
+  return { character, length, suffix: line.slice(index) };
 }
 
 function findBalancedClose(input: string, startIndex: number, open: string, close: string): number {
@@ -128,14 +103,109 @@ function findBalancedClose(input: string, startIndex: number, open: string, clos
   return -1;
 }
 
+function isReferenceDefinitionLine(line: string): boolean {
+  let labelStart = 0;
+  while (labelStart < 3 && line[labelStart] === " ") labelStart += 1;
+  if (line[labelStart] !== "[") return false;
+
+  const labelEnd = findBalancedClose(line, labelStart + 1, "[", "]");
+  return labelEnd > labelStart + 1 && line[labelEnd + 1] === ":";
+}
+
+function stripFencedCodeAndReferenceDefinitions(markdown: string): string {
+  const lines = markdown.split(/\r?\n/);
+  let fence: { character: string; length: number } | null = null;
+
+  return lines
+    .map((line) => {
+      const run = readFenceRun(line);
+      if (fence) {
+        if (
+          run &&
+          run.character === fence.character &&
+          run.length >= fence.length &&
+          !run.suffix.trim()
+        ) {
+          fence = null;
+        }
+        return "";
+      }
+      if (run) {
+        fence = { character: run.character, length: run.length };
+        return "";
+      }
+      if (isReferenceDefinitionLine(line)) return "";
+      return line;
+    })
+    .join("\n");
+}
+
+function isEscaped(input: string, index: number): boolean {
+  let slashCount = 0;
+  for (let cursor = index - 1; cursor >= 0 && input[cursor] === "\\"; cursor -= 1) {
+    slashCount += 1;
+  }
+  return slashCount % 2 === 1;
+}
+
+function backtickRunLength(input: string, index: number): number {
+  let length = 0;
+  while (input[index + length] === "`") length += 1;
+  return length;
+}
+
+function findClosingBacktickRun(input: string, startIndex: number, openerLength: number): number {
+  for (let index = startIndex; index < input.length; ) {
+    if (input[index] !== "`" || isEscaped(input, index)) {
+      index += 1;
+      continue;
+    }
+
+    const length = backtickRunLength(input, index);
+    if (length === openerLength) return index;
+    index += length;
+  }
+
+  return -1;
+}
+
+function stripInlineCode(markdown: string): string {
+  let sanitized = "";
+
+  for (let index = 0; index < markdown.length; ) {
+    if (markdown[index] !== "`" || isEscaped(markdown, index)) {
+      sanitized += markdown[index];
+      index += 1;
+      continue;
+    }
+
+    const openerLength = backtickRunLength(markdown, index);
+    const closeIndex = findClosingBacktickRun(markdown, index + openerLength, openerLength);
+    if (closeIndex === -1) {
+      sanitized += markdown.slice(index, index + openerLength);
+      index += openerLength;
+      continue;
+    }
+
+    sanitized += " ";
+    index = closeIndex + openerLength;
+  }
+
+  return sanitized;
+}
+
 function stripMarkdownLinksAndImages(markdown: string): string {
   let sanitized = "";
 
-  for (let index = 0; index < markdown.length; index += 1) {
-    const isImage = markdown[index] === "!" && markdown[index + 1] === "[";
-    const isLink = markdown[index] === "[";
+  for (let index = 0; index < markdown.length; ) {
+    const isImage =
+      markdown[index] === "!" &&
+      markdown[index + 1] === "[" &&
+      !isEscaped(markdown, index);
+    const isLink = markdown[index] === "[" && !isEscaped(markdown, index);
     if (!isImage && !isLink) {
       sanitized += markdown[index];
+      index += 1;
       continue;
     }
 
@@ -143,24 +213,32 @@ function stripMarkdownLinksAndImages(markdown: string): string {
     const labelEnd = findBalancedClose(markdown, labelStart, "[", "]");
     if (labelEnd === -1) {
       sanitized += markdown[index];
+      index += 1;
       continue;
     }
 
-    const destinationStart = labelEnd + 1;
-    if (markdown[destinationStart] !== "(") {
-      sanitized += markdown.slice(index, destinationStart);
-      index = destinationStart - 1;
-      continue;
-    }
-
-    const destinationEnd = findBalancedClose(markdown, destinationStart + 1, "(", ")");
-    if (destinationEnd === -1) {
+    let constructEnd = labelEnd + 1;
+    const suffixStart = labelEnd + 1;
+    const suffixOpen = markdown[suffixStart];
+    if (suffixOpen === "(" || suffixOpen === "[") {
+      const suffixClose = suffixOpen === "(" ? ")" : "]";
+      const suffixEnd = findBalancedClose(markdown, suffixStart + 1, suffixOpen, suffixClose);
+      if (suffixEnd === -1) {
+        sanitized += markdown[index];
+        index += 1;
+        continue;
+      }
+      constructEnd = suffixEnd + 1;
+    } else if (!isImage) {
       sanitized += markdown[index];
+      index += 1;
       continue;
     }
 
-    if (isLink) sanitized += stripMarkdownLinksAndImages(markdown.slice(labelStart, labelEnd));
-    index = destinationEnd;
+    sanitized += isImage
+      ? " "
+      : stripMarkdownLinksAndImages(markdown.slice(labelStart, labelEnd));
+    index = constructEnd;
   }
 
   return sanitized;
@@ -168,88 +246,116 @@ function stripMarkdownLinksAndImages(markdown: string): string {
 
 function stripBareUrls(markdown: string): string {
   let sanitized = "";
-  let cursor = 0;
-  const urlPattern = /https?:\/\//g;
+  for (let index = 0; index < markdown.length; ) {
+    const protocolLength = markdown.startsWith("https://", index)
+      ? "https://".length
+      : markdown.startsWith("http://", index)
+        ? "http://".length
+        : 0;
+    if (!protocolLength) {
+      sanitized += markdown[index];
+      index += 1;
+      continue;
+    }
 
-  for (let match = urlPattern.exec(markdown); match; match = urlPattern.exec(markdown)) {
-    let end = match.index + match[0].length;
-    while (end < markdown.length && !/\s/.test(markdown[end])) end += 1;
-    sanitized += markdown.slice(cursor, match.index);
+    index += protocolLength;
+    while (index < markdown.length && !/\s/.test(markdown[index])) index += 1;
     sanitized += " ";
-    cursor = end;
-    urlPattern.lastIndex = end;
   }
 
-  return sanitized + markdown.slice(cursor);
+  return sanitized;
 }
 
-export function scanBracketedSourceIds(markdown: string): string[] {
+function scanStrictBracketedSourceIds(sanitizedMarkdown: string): string[] {
   const ids: string[] = [];
   const seen = new Set<string>();
-  const sanitized = preprocessMarkdownForIntegrity(markdown);
 
-  BRACKETED_TOKEN_RE.lastIndex = 0;
-  for (let match = BRACKETED_TOKEN_RE.exec(sanitized); match; match = BRACKETED_TOKEN_RE.exec(sanitized)) {
-    for (const token of match[1].split(",")) {
+  for (let index = 0; index < sanitizedMarkdown.length; ) {
+    if (sanitizedMarkdown[index] !== "[" || isEscaped(sanitizedMarkdown, index)) {
+      index += 1;
+      continue;
+    }
+
+    const closeIndex = findBalancedClose(sanitizedMarkdown, index + 1, "[", "]");
+    if (closeIndex === -1) {
+      index += 1;
+      continue;
+    }
+    for (const token of sanitizedMarkdown.slice(index + 1, closeIndex).split(",")) {
       const id = token.trim();
       if (!SOURCE_ID_RE.test(id) || seen.has(id)) continue;
       seen.add(id);
       ids.push(id);
     }
+    index = closeIndex + 1;
   }
 
   return ids;
+}
+
+export function scanBracketedSourceIds(markdown: string): string[] {
+  return scanStrictBracketedSourceIds(preprocessMarkdownForIntegrity(markdown));
+}
+
+function isTokenCharacter(character: string | undefined): boolean {
+  if (!character) return false;
+  const code = character.charCodeAt(0);
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    code === 95 ||
+    (code >= 97 && code <= 122)
+  );
 }
 
 function scanConflictMarkerIds(markdown: string): string[] {
   const ids: string[] = [];
   const seen = new Set<string>();
 
-  const conflictPattern = /\[\s*([^\[\]]+?)\s*\]|\b(C\d+)\b/g;
-  for (let match = conflictPattern.exec(markdown); match; match = conflictPattern.exec(markdown)) {
-    if (match[1] !== undefined) {
-      for (const token of match[1].split(",")) {
-        const id = token.trim();
-        if (!CONFLICT_ID_RE.test(id) || seen.has(id)) continue;
-        seen.add(id);
-        ids.push(id);
-      }
+  for (let index = 0; index < markdown.length; ) {
+    if (markdown[index] !== "C" || isTokenCharacter(markdown[index - 1])) {
+      index += 1;
       continue;
     }
 
-    const id = match[2];
-    if (!id || seen.has(id)) continue;
-    seen.add(id);
-    ids.push(id);
+    let endIndex = index + 1;
+    while (endIndex < markdown.length && /\d/.test(markdown[endIndex])) endIndex += 1;
+    if (endIndex === index + 1 || isTokenCharacter(markdown[endIndex])) {
+      index += 1;
+      continue;
+    }
+
+    const id = markdown.slice(index, endIndex);
+    if (!seen.has(id)) {
+      seen.add(id);
+      ids.push(id);
+    }
+    index = endIndex;
   }
 
   return ids;
 }
 
-function scanReferencedIdsInOrder(markdown: string, actualSourceIds: Set<string>): string[] {
+function scanReferencedIdsInOrder(markdown: string, candidates: string[]): string[] {
   const ids: string[] = [];
   const seen = new Set<string>();
-  const actualIds = [...actualSourceIds].sort((a, b) => b.length - a.length);
-  const pattern = actualIds.length
-    ? new RegExp(`\\[\\s*([^\\[\\]]+?)\\s*\\]|\\b(${actualIds.map(escapeRegExp).join("|")})\\b`, "g")
-    : /\[\s*([^\[\]]+?)\s*\]/g;
+  const longestFirst = uniqueIdsInOrder(candidates.filter(Boolean)).sort(
+    (left, right) => right.length - left.length,
+  );
 
-  for (let match = pattern.exec(markdown); match; match = pattern.exec(markdown)) {
-    if (match[1] !== undefined) {
-      for (const token of match[1].split(",")) {
-        const id = token.trim();
-        if (CONFLICT_ID_RE.test(id) || seen.has(id)) continue;
-        if (!SOURCE_ID_RE.test(id) && !actualSourceIds.has(id)) continue;
+  for (let index = 0; index < markdown.length; index += 1) {
+    if (isTokenCharacter(markdown[index - 1])) continue;
+
+    for (const id of longestFirst) {
+      if (!markdown.startsWith(id, index)) continue;
+      if (isTokenCharacter(markdown[index + id.length])) continue;
+      if (!seen.has(id)) {
         seen.add(id);
         ids.push(id);
       }
-      continue;
+      index += id.length - 1;
+      break;
     }
-
-    const id = match[2];
-    if (!id || seen.has(id) || CONFLICT_ID_RE.test(id)) continue;
-    seen.add(id);
-    ids.push(id);
   }
 
   return ids;
@@ -325,12 +431,16 @@ export function deriveResearchFindingsIntegrity(
     if (!sourceById.has(source.id)) sourceById.set(source.id, source);
   }
 
-  const parserRecognizedSourceIds = new Set(
-    parseFindingsDoc(sanitizedMarkdown, sources).refIds.filter(
-      (id) => sourceById.has(id) && !CONFLICT_ID_RE.test(id),
-    ),
+  const parserRecognizedSourceIds = parseFindingsDoc(sanitizedMarkdown, sources).refIds.filter(
+    (id) => sourceById.has(id) && !CONFLICT_ID_RE.test(id),
   );
-  const referencedIds = scanReferencedIdsInOrder(sanitizedMarkdown, parserRecognizedSourceIds);
+  const unresolvedCandidateIds = scanStrictBracketedSourceIds(sanitizedMarkdown).filter(
+    (id) => !sourceById.has(id),
+  );
+  const referencedIds = scanReferencedIdsInOrder(
+    sanitizedMarkdown,
+    uniqueIdsInOrder([...parserRecognizedSourceIds, ...unresolvedCandidateIds]),
+  );
   const unresolvedIds = referencedIds.filter((id) => !sourceById.has(id));
   const conflictMarkerIds = scanConflictMarkerIds(sanitizedMarkdown);
   const conflictingSourceIds = uniqueIdsInOrder(

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -275,6 +275,16 @@ function stripBareUrls(markdown: string): string {
           index = hostEnd + 1;
           continue;
         }
+        const bracketedComponent = hostEnd === -1 ? "" : markdown.slice(index + 1, hostEnd);
+        if (
+          /[/?#]/.test(authorityPrefix) &&
+          !/[.,;:!?)]/.test(markdown[index - 1] ?? "") &&
+          bracketedComponent &&
+          !/\s/.test(bracketedComponent)
+        ) {
+          index = hostEnd + 1;
+          continue;
+        }
         break;
       }
       if (character === "(") parenDepth += 1;

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -2,6 +2,7 @@ import type { ResearchSourceRef } from "./research-missions.ts";
 import {
   findRecognizedFindingsRefs,
   matchFindingsFenceRun,
+  matchFindingsAtxHeading,
   matchFindingsInlineLinkAt,
   stripFindingsComments,
 } from "./research-findings-doc.ts";
@@ -49,9 +50,17 @@ function unavailableSummary(): { kind: ResearchIntegritySummaryKind; label: stri
 function preprocessMarkdownForIntegrity(markdown: string): string {
   const withoutComments = stripFindingsComments(markdown ?? "");
   const withoutBlocks = stripFencedCode(withoutComments);
-  const withoutCode = stripInlineCode(withoutBlocks);
+  const withoutHeadings = stripAtxHeadings(withoutBlocks);
+  const withoutCode = stripInlineCode(withoutHeadings);
   const withoutMarkdownTargets = stripMarkdownLinksAndImages(withoutCode);
   return stripBareUrls(withoutMarkdownTargets);
+}
+
+function stripAtxHeadings(markdown: string): string {
+  return markdown
+    .split(/\r?\n/)
+    .map((line) => (matchFindingsAtxHeading(line) ? "" : line))
+    .join("\n");
 }
 
 function findBalancedClose(input: string, startIndex: number, open: string, close: string): number {

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -217,6 +217,7 @@ function stripBareUrls(markdown: string): string {
       continue;
     }
 
+    const urlStart = index;
     let parenDepth = 0;
     index += protocolLength;
     const authorityStart = index;
@@ -251,7 +252,8 @@ function stripBareUrls(markdown: string): string {
       else if (character === ")" && parenDepth > 0) parenDepth -= 1;
       index += 1;
     }
-    sanitized += " ";
+    // Keep parser offsets and word boundaries while making URL contents opaque.
+    sanitized += "x".repeat(index - urlStart);
   }
 
   return sanitized;

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -138,54 +138,47 @@ function normalizeReferenceLabel(label: string): string {
 type MarkdownContainer = {
   blockquoteDepth: number;
   listIndent: number;
+  segments: Array<
+    | { kind: "blockquote" }
+    | { kind: "list"; width: number }
+  >;
 };
-
-function stripBlockquotePrefix(
-  line: string,
-  expectedDepth?: number,
-): { content: string; depth: number } | null {
-  let cursor = 0;
-  let depth = 0;
-
-  while (expectedDepth === undefined || depth < expectedDepth) {
-    let markerIndex = cursor;
-    let spaces = 0;
-    while (spaces < 3 && line[markerIndex] === " ") {
-      markerIndex += 1;
-      spaces += 1;
-    }
-    if (line[markerIndex] !== ">") break;
-
-    cursor = markerIndex + 1;
-    if (line[cursor] === " " || line[cursor] === "\t") cursor += 1;
-    depth += 1;
-  }
-
-  if (expectedDepth !== undefined && depth !== expectedDepth) return null;
-  return { content: line.slice(cursor), depth };
-}
 
 function readReferenceDefinitionContainer(line: string): {
   content: string;
   container: MarkdownContainer;
   listContainers: MarkdownContainer[];
 } {
-  const blockquote = stripBlockquotePrefix(line) ?? { content: line, depth: 0 };
   const listContainers: MarkdownContainer[] = [];
-  let content = blockquote.content;
+  const segments: MarkdownContainer["segments"] = [];
+  let content = line;
+  let blockquoteDepth = 0;
   let listIndent = 0;
 
   while (true) {
+    const blockquoteMatch = content.match(/^ {0,3}>[ \t]?/);
+    if (blockquoteMatch) {
+      segments.push({ kind: "blockquote" });
+      blockquoteDepth += 1;
+      content = content.slice(blockquoteMatch[0].length);
+      continue;
+    }
+
     const listMatch = content.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])([ \t]+)/);
     if (!listMatch) break;
     listIndent += listMatch[0].length;
-    listContainers.push({ blockquoteDepth: blockquote.depth, listIndent });
+    segments.push({ kind: "list", width: listMatch[0].length });
+    listContainers.push({
+      blockquoteDepth,
+      listIndent,
+      segments: [...segments],
+    });
     content = content.slice(listMatch[0].length);
   }
 
   return {
     content,
-    container: { blockquoteDepth: blockquote.depth, listIndent },
+    container: { blockquoteDepth, listIndent, segments },
     listContainers,
   };
 }
@@ -194,11 +187,21 @@ function readReferenceContainerLine(
   line: string,
   container: MarkdownContainer,
 ): string | null {
-  const blockquote = stripBlockquotePrefix(line, container.blockquoteDepth);
-  if (!blockquote) return null;
-  if (!container.listIndent) return blockquote.content;
-  if (!blockquote.content.startsWith(" ".repeat(container.listIndent))) return null;
-  return blockquote.content.slice(container.listIndent);
+  let content = line;
+
+  for (const segment of container.segments) {
+    if (segment.kind === "list") {
+      if (!content.startsWith(" ".repeat(segment.width))) return null;
+      content = content.slice(segment.width);
+      continue;
+    }
+
+    const blockquoteMatch = content.match(/^ {0,3}>[ \t]?/);
+    if (!blockquoteMatch) return null;
+    content = content.slice(blockquoteMatch[0].length);
+  }
+
+  return content;
 }
 
 function readReferenceDefinitionStart(line: string): {
@@ -387,11 +390,10 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
         strippedLines.push("");
         continue;
       }
-      const blockquoteLine = stripBlockquotePrefix(line, fence.container.blockquoteDepth);
       if (
         fence.container.listIndent > 0 &&
-        blockquoteLine !== null &&
-        !blockquoteLine.content.trim()
+        fence.container.blockquoteDepth === 0 &&
+        !line.trim()
       ) {
         strippedLines.push("");
         continue;

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -1,0 +1,152 @@
+import type { ResearchSourceRef } from "./research-missions.ts";
+
+export type ResearchIntegritySummaryKind =
+  | "unavailable"
+  | "unresolved"
+  | "conflicting"
+  | "candidate"
+  | "verified"
+  | "none";
+
+export type ResearchFindingsIntegrity = {
+  ledger: "available" | "empty";
+  referencedIds: string[];
+  unresolvedIds: string[];
+  conflictIds: string[];
+  counts: Record<ResearchSourceRef["status"], number>;
+  summary: { kind: ResearchIntegritySummaryKind; label: string };
+};
+
+const BRACKETED_SOURCE_RE = /\[\s*([A-Z]\d+(?:\s*,\s*[A-Z]\d+)*)\s*\]/g;
+const CONFLICT_MARKER_RE = /\b(C\d+)\b/g;
+
+function emptyCounts(): Record<ResearchSourceRef["status"], number> {
+  return { candidate: 0, used: 0, conflicting: 0, rejected: 0 };
+}
+
+function uniqueIdsInOrder(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const id of ids) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    unique.push(id);
+  }
+  return unique;
+}
+
+export function scanBracketedSourceIds(markdown: string): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+
+  BRACKETED_SOURCE_RE.lastIndex = 0;
+  for (let match = BRACKETED_SOURCE_RE.exec(markdown); match; match = BRACKETED_SOURCE_RE.exec(markdown)) {
+    for (const id of match[1].split(",")) {
+      const trimmed = id.trim();
+      if (!trimmed || seen.has(trimmed)) continue;
+      seen.add(trimmed);
+      ids.push(trimmed);
+    }
+  }
+
+  return ids;
+}
+
+function scanConflictMarkerIds(markdown: string): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  const bareMarkdown = markdown.replace(/\[[^\[\]]*\]/g, " ");
+
+  CONFLICT_MARKER_RE.lastIndex = 0;
+  for (let match = CONFLICT_MARKER_RE.exec(bareMarkdown); match; match = CONFLICT_MARKER_RE.exec(bareMarkdown)) {
+    const id = match[1];
+    if (seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+
+  return ids;
+}
+
+function countStatuses(sources: ResearchSourceRef[]): Record<ResearchSourceRef["status"], number> {
+  const counts = emptyCounts();
+  for (const source of sources) {
+    counts[source.status] += 1;
+  }
+  return counts;
+}
+
+function summarize(
+  integrity: ResearchFindingsIntegrity,
+  citedCandidateCount: number,
+  citedUsedCount: number,
+): { kind: ResearchIntegritySummaryKind; label: string } {
+  const unresolvedCount = integrity.unresolvedIds.length;
+  const conflictCount = integrity.conflictIds.length;
+
+  if (integrity.ledger === "empty" && integrity.referencedIds.length > 0) {
+    return { kind: "unavailable", label: "Sources unavailable — references can't be verified" };
+  }
+
+  if (unresolvedCount > 0) {
+    return {
+      kind: "unresolved",
+      label: unresolvedCount === 1 ? "1 reference is unresolved" : `${unresolvedCount} references are unresolved`,
+    };
+  }
+
+  if (conflictCount > 0) {
+    return {
+      kind: "conflicting",
+      label: conflictCount === 1 ? "1 conflict remains" : `${conflictCount} conflicts remain`,
+    };
+  }
+
+  if (citedCandidateCount > 0) {
+    return {
+      kind: "candidate",
+      label: citedCandidateCount === 1 ? "1 source awaits review" : `${citedCandidateCount} sources await review`,
+    };
+  }
+
+  if (citedUsedCount > 0) {
+    return {
+      kind: "verified",
+      label: citedUsedCount === 1 ? "1 source verified" : `${citedUsedCount} sources verified`,
+    };
+  }
+
+  return { kind: "none", label: "This report does not cite sources" };
+}
+
+export function deriveResearchFindingsIntegrity(
+  markdown: string,
+  sources: ResearchSourceRef[],
+): ResearchFindingsIntegrity {
+  const referencedIds = scanBracketedSourceIds(markdown);
+  const sourceById = new Map<string, ResearchSourceRef>();
+
+  for (const source of sources) {
+    if (!sourceById.has(source.id)) sourceById.set(source.id, source);
+  }
+
+  const unresolvedIds = referencedIds.filter((id) => !sourceById.has(id));
+  const conflictMarkerIds = scanConflictMarkerIds(markdown);
+  const conflictingSourceIds = uniqueIdsInOrder(
+    sources.filter((source) => source.status === "conflicting").map((source) => source.id),
+  );
+  const conflictIds = uniqueIdsInOrder([...conflictMarkerIds, ...conflictingSourceIds]);
+  const citedCandidateCount = referencedIds.filter((id) => sourceById.get(id)?.status === "candidate").length;
+  const citedUsedCount = referencedIds.filter((id) => sourceById.get(id)?.status === "used").length;
+  const integrity: ResearchFindingsIntegrity = {
+    ledger: sources.length > 0 ? "available" : "empty",
+    referencedIds,
+    unresolvedIds,
+    conflictIds,
+    counts: countStatuses(sources),
+    summary: { kind: "none", label: "This report does not cite sources" },
+  };
+
+  integrity.summary = summarize(integrity, citedCandidateCount, citedUsedCount);
+  return integrity;
+}

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -355,17 +355,20 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
     const line = lines[lineIndex];
     if (fence) {
       const containerLine = readReferenceContainerLine(line, fence.container);
-      const run = containerLine === null ? null : readFenceRun(containerLine);
-      if (
-        run &&
-        run.character === fence.character &&
-        run.length >= fence.length &&
-        !run.suffix.trim()
-      ) {
-        fence = null;
+      if (containerLine !== null) {
+        const run = readFenceRun(containerLine);
+        if (
+          run &&
+          run.character === fence.character &&
+          run.length >= fence.length &&
+          !run.suffix.trim()
+        ) {
+          fence = null;
+        }
+        strippedLines.push("");
+        continue;
       }
-      strippedLines.push("");
-      continue;
+      fence = null;
     }
     const containerLine = readReferenceDefinitionContainer(line);
     const run = readFenceRun(containerLine.content);

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -1,5 +1,9 @@
 import type { ResearchSourceRef } from "./research-missions.ts";
-import { findRecognizedFindingsRefs } from "./research-findings-doc.ts";
+import {
+  findRecognizedFindingsRefs,
+  matchFindingsFenceRun,
+  matchFindingsInlineLinkAt,
+} from "./research-findings-doc.ts";
 
 export type ResearchIntegritySummaryKind =
   | "unavailable"
@@ -42,11 +46,14 @@ function unavailableSummary(): { kind: ResearchIntegritySummaryKind; label: stri
 }
 
 function preprocessMarkdownForIntegrity(markdown: string): string {
-  const withoutComments = stripHtmlComments(markdown ?? "");
   const { markdown: withoutBlocks, referenceDefinitionLabels } =
-    stripFencedCodeAndReferenceDefinitions(withoutComments);
+    stripFencedCodeAndReferenceDefinitions(markdown ?? "");
   const withoutCode = stripInlineCode(withoutBlocks);
-  const withoutMarkdownTargets = stripMarkdownLinksAndImages(withoutCode, referenceDefinitionLabels);
+  const withoutComments = stripHtmlComments(withoutCode);
+  const withoutMarkdownTargets = stripMarkdownLinksAndImages(
+    withoutComments,
+    referenceDefinitionLabels,
+  );
   return stripBareUrls(withoutMarkdownTargets);
 }
 
@@ -64,23 +71,6 @@ function stripHtmlComments(markdown: string): string {
   }
 
   return sanitized;
-}
-
-type FenceRun = { character: "`" | "~"; length: number; suffix: string };
-
-function readFenceRun(line: string): FenceRun | null {
-  let index = 0;
-  while (index < 3 && line[index] === " ") index += 1;
-
-  const character = line[index];
-  if (character !== "`" && character !== "~") return null;
-
-  const runStart = index;
-  while (line[index] === character) index += 1;
-  const length = index - runStart;
-  if (length < 3) return null;
-
-  return { character, length, suffix: line.slice(index) };
 }
 
 function findBalancedClose(input: string, startIndex: number, open: string, close: string): number {
@@ -378,7 +368,7 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
     if (fence) {
       const containerLine = readReferenceContainerLine(line, fence.container);
       if (containerLine !== null) {
-        const run = readFenceRun(containerLine);
+        const run = matchFindingsFenceRun(containerLine);
         if (
           run &&
           run.character === fence.character &&
@@ -429,7 +419,7 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
       if (!activeListContainer && line.trim()) listContainerStack.splice(0);
     }
 
-    const run = readFenceRun(containerLine.content);
+    const run = matchFindingsFenceRun(containerLine.content);
     if (run) {
       fence = {
         character: run.character,
@@ -540,6 +530,21 @@ function stripMarkdownLinksAndImages(markdown: string, referenceDefinitionLabels
     const suffixStart = labelEnd + 1;
     const suffixOpen = markdown[suffixStart];
     if (suffixOpen === "(" || suffixOpen === "[") {
+      const wrapsImage = markdown.startsWith("![", labelStart);
+      if (suffixOpen === "(" && !isImage && !wrapsImage) {
+        const inlineLink = matchFindingsInlineLinkAt(markdown, index);
+        if (!inlineLink) {
+          sanitized += markdown[index];
+          index += 1;
+          continue;
+        }
+        sanitized += stripMarkdownLinksAndImages(
+          inlineLink.text,
+          referenceDefinitionLabels,
+        );
+        index += inlineLink.length;
+        continue;
+      }
       const suffixClose = suffixOpen === "(" ? ")" : "]";
       const suffixEnd = findBalancedClose(markdown, suffixStart + 1, suffixOpen, suffixClose);
       if (suffixEnd === -1) {

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -17,8 +17,9 @@ export type ResearchFindingsIntegrity = {
   summary: { kind: ResearchIntegritySummaryKind; label: string };
 };
 
-const BRACKETED_SOURCE_RE = /\[\s*([A-Z]\d+(?:\s*,\s*[A-Z]\d+)*)\s*\]/g;
-const CONFLICT_MARKER_RE = /\b(C\d+)\b/g;
+const BRACKETED_SOURCE_RE = /\[\s*([^\[\]]+?)\s*\]/g;
+const SOURCE_ID_RE = /^(?:S|R)\d+$/;
+const CONFLICT_MARKER_RE = /\[\s*(C\d+)\s*\]|\b(C\d+)\b/g;
 
 function emptyCounts(): Record<ResearchSourceRef["status"], number> {
   return { candidate: 0, used: 0, conflicting: 0, rejected: 0 };
@@ -43,7 +44,7 @@ export function scanBracketedSourceIds(markdown: string): string[] {
   for (let match = BRACKETED_SOURCE_RE.exec(markdown); match; match = BRACKETED_SOURCE_RE.exec(markdown)) {
     for (const id of match[1].split(",")) {
       const trimmed = id.trim();
-      if (!trimmed || seen.has(trimmed)) continue;
+      if (!SOURCE_ID_RE.test(trimmed) || seen.has(trimmed)) continue;
       seen.add(trimmed);
       ids.push(trimmed);
     }
@@ -55,11 +56,10 @@ export function scanBracketedSourceIds(markdown: string): string[] {
 function scanConflictMarkerIds(markdown: string): string[] {
   const ids: string[] = [];
   const seen = new Set<string>();
-  const bareMarkdown = markdown.replace(/\[[^\[\]]*\]/g, " ");
 
   CONFLICT_MARKER_RE.lastIndex = 0;
-  for (let match = CONFLICT_MARKER_RE.exec(bareMarkdown); match; match = CONFLICT_MARKER_RE.exec(bareMarkdown)) {
-    const id = match[1];
+  for (let match = CONFLICT_MARKER_RE.exec(markdown); match; match = CONFLICT_MARKER_RE.exec(markdown)) {
+    const id = match[1] ?? match[2];
     if (seen.has(id)) continue;
     seen.add(id);
     ids.push(id);

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -297,47 +297,14 @@ function stripBareUrls(markdown: string): string {
   return sanitized;
 }
 
-type IndexedSourceId = { id: string; index: number };
-
-function scanStrictBracketedSourceIds(sanitizedMarkdown: string): IndexedSourceId[] {
-  const matches: IndexedSourceId[] = [];
-
-  for (let index = 0; index < sanitizedMarkdown.length; ) {
-    if (sanitizedMarkdown[index] !== "[" || isEscaped(sanitizedMarkdown, index)) {
-      index += 1;
-      continue;
-    }
-
-    const closeIndex = findBalancedClose(sanitizedMarkdown, index + 1, "[", "]");
-    if (closeIndex === -1) {
-      index += 1;
-      continue;
-    }
-
-    let tokenStart = index + 1;
-    for (let tokenEnd = tokenStart; tokenEnd <= closeIndex; tokenEnd += 1) {
-      if (tokenEnd < closeIndex && sanitizedMarkdown[tokenEnd] !== ",") continue;
-      const token = sanitizedMarkdown.slice(tokenStart, tokenEnd);
-      const id = token.trim();
-      if (SOURCE_ID_RE.test(id)) {
-        matches.push({
-          id,
-          index: tokenStart + token.length - token.trimStart().length,
-        });
-      }
-      tokenStart = tokenEnd + 1;
-    }
-    index += 1;
-  }
-
-  return matches;
-}
-
 export function scanBracketedSourceIds(markdown: string): string[] {
   return uniqueIdsInOrder(
-    scanStrictBracketedSourceIds(preprocessMarkdownForIntegrity(markdown)).map(
-      (match) => match.id,
-    ),
+    findRecognizedFindingsRefs(
+      preprocessMarkdownForIntegrity(markdown),
+      [],
+    )
+      .filter((match) => SOURCE_ID_RE.test(match.id))
+      .map((match) => match.id),
   );
 }
 
@@ -415,8 +382,10 @@ export function deriveResearchFindingsIntegrity(
   const actualLedgerRefs = recognizedRefs.filter(
     (match) => sourceById.has(match.id) && !CONFLICT_ID_RE.test(match.id),
   );
-  const unresolvedStrictRefs = scanStrictBracketedSourceIds(sanitizedMarkdown).filter(
-    (match) => !sourceById.has(match.id),
+  const unresolvedStrictRefs = recognizedRefs.filter(
+    (match) =>
+      SOURCE_ID_RE.test(match.id) &&
+      !sourceById.has(match.id),
   );
   const referencedIds = uniqueIdsInOrder(
     [...actualLedgerRefs, ...unresolvedStrictRefs]

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -154,6 +154,57 @@ function readReferenceDefinitionLabel(line: string): string | null {
   return normalizeReferenceLabel(line.slice(labelStart + 1, labelEnd));
 }
 
+function readReferenceDefinitionBody(line: string): string | null {
+  let labelStart = 0;
+  while (labelStart < 3 && line[labelStart] === " ") labelStart += 1;
+  if (line[labelStart] !== "[") return null;
+
+  const labelEnd = findBalancedClose(line, labelStart + 1, "[", "]");
+  if (labelEnd <= labelStart + 1 || line[labelEnd + 1] !== ":") return null;
+  return line.slice(labelEnd + 2).trimStart();
+}
+
+function readReferenceDefinitionContinuation(line: string): string | null {
+  let indent = 0;
+  while (indent < 3 && line[indent] === " ") indent += 1;
+  if (line[indent] === " " || line[indent] === "\t") return null;
+
+  const content = line.slice(indent);
+  return content.trim() ? content : null;
+}
+
+function readReferenceDefinitionRemainder(destination: string): string {
+  if (destination.startsWith("<")) {
+    for (let index = 1; index < destination.length; index += 1) {
+      if (destination[index] === ">" && !isEscaped(destination, index)) {
+        return destination.slice(index + 1).trimStart();
+      }
+    }
+    return "";
+  }
+
+  for (let index = 0; index < destination.length; index += 1) {
+    if (/\s/.test(destination[index]) && !isEscaped(destination, index)) {
+      return destination.slice(index).trimStart();
+    }
+  }
+  return "";
+}
+
+function readReferenceTitleCloser(title: string): "'" | '"' | ")" | null {
+  if (title.startsWith("'")) return "'";
+  if (title.startsWith('"')) return '"';
+  if (title.startsWith("(")) return ")";
+  return null;
+}
+
+function referenceTitleIsClosed(title: string, closer: "'" | '"' | ")"): boolean {
+  for (let index = 1; index < title.length; index += 1) {
+    if (title[index] === closer && !isEscaped(title, index)) return true;
+  }
+  return false;
+}
+
 function stripFencedCodeAndReferenceDefinitions(markdown: string): {
   markdown: string;
   referenceDefinitionLabels: Set<string>;
@@ -161,8 +212,10 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
   const lines = markdown.split(/\r?\n/);
   let fence: { character: string; length: number } | null = null;
   const referenceDefinitionLabels = new Set<string>();
+  const strippedLines: string[] = [];
 
-  const strippedLines = lines.map((line) => {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
     const run = readFenceRun(line);
     if (fence) {
       if (
@@ -173,19 +226,51 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
       ) {
         fence = null;
       }
-      return "";
+      strippedLines.push("");
+      continue;
     }
     if (run) {
       fence = { character: run.character, length: run.length };
-      return "";
+      strippedLines.push("");
+      continue;
     }
     if (isReferenceDefinitionLine(line)) {
       const label = readReferenceDefinitionLabel(line);
       if (label) referenceDefinitionLabels.add(label);
-      return "";
+      strippedLines.push("");
+
+      let destination = readReferenceDefinitionBody(line) ?? "";
+      if (!destination) {
+        const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
+        if (continuation && !readReferenceTitleCloser(continuation)) {
+          destination = continuation;
+          lineIndex += 1;
+          strippedLines.push("");
+        }
+      }
+
+      let title = readReferenceDefinitionRemainder(destination);
+      if (!readReferenceTitleCloser(title)) {
+        const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
+        if (continuation && readReferenceTitleCloser(continuation)) {
+          title = continuation;
+          lineIndex += 1;
+          strippedLines.push("");
+        }
+      }
+
+      const closer = readReferenceTitleCloser(title);
+      while (closer && !referenceTitleIsClosed(title, closer)) {
+        const continuation = readReferenceDefinitionContinuation(lines[lineIndex + 1] ?? "");
+        if (!continuation) break;
+        title += `\n${continuation}`;
+        lineIndex += 1;
+        strippedLines.push("");
+      }
+      continue;
     }
-    return line;
-  });
+    strippedLines.push(line);
+  }
 
   return { markdown: strippedLines.join("\n"), referenceDefinitionLabels };
 }

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -259,6 +259,11 @@ function stripBareUrls(markdown: string): string {
 
     let parenDepth = 0;
     index += protocolLength;
+    if (markdown[index] === "[") {
+      const hostEnd = markdown.indexOf("]", index + 1);
+      const bracketedHost = hostEnd === -1 ? "" : markdown.slice(index + 1, hostEnd);
+      if (bracketedHost && !/\s/.test(bracketedHost)) index = hostEnd + 1;
+    }
     while (index < markdown.length) {
       const character = markdown[index];
       if (/\s/.test(character)) break;

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -259,15 +259,24 @@ function stripBareUrls(markdown: string): string {
 
     let parenDepth = 0;
     index += protocolLength;
-    if (markdown[index] === "[") {
-      const hostEnd = markdown.indexOf("]", index + 1);
-      const bracketedHost = hostEnd === -1 ? "" : markdown.slice(index + 1, hostEnd);
-      if (bracketedHost && !/\s/.test(bracketedHost)) index = hostEnd + 1;
-    }
+    const authorityStart = index;
     while (index < markdown.length) {
       const character = markdown[index];
       if (/\s/.test(character)) break;
-      if (character === "[" && parenDepth === 0) break;
+      if (character === "[" && parenDepth === 0) {
+        const hostEnd = markdown.indexOf("]", index + 1);
+        const bracketedHost = hostEnd === -1 ? "" : markdown.slice(index + 1, hostEnd);
+        const authorityPrefix = markdown.slice(authorityStart, index);
+        if (
+          bracketedHost.includes(":") &&
+          !/\s/.test(bracketedHost) &&
+          !/[/?#]/.test(authorityPrefix)
+        ) {
+          index = hostEnd + 1;
+          continue;
+        }
+        break;
+      }
       if (character === "(") parenDepth += 1;
       else if (character === ")" && parenDepth > 0) parenDepth -= 1;
       index += 1;

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -144,12 +144,7 @@ function findClosingBacktickRun(input: string, startIndex: number, openerLength:
     }
 
     const length = backtickRunLength(input, index);
-    if (
-      length === openerLength &&
-      !isUnsupportedContainerFenceRun(input, index, length)
-    ) {
-      return index;
-    }
+    if (length === openerLength) return index;
     index += length;
   }
 

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -297,8 +297,15 @@ function readReferenceTitleEnd(
 function readReferenceDefinition(
   lines: string[],
   startLineIndex: number,
+  containerOverride?: MarkdownContainer,
 ): { label: string; endLineIndex: number } | null {
-  const { content, container } = readReferenceDefinitionContainer(lines[startLineIndex]);
+  const containerLine = containerOverride
+    ? readReferenceContainerLine(lines[startLineIndex], containerOverride)
+    : null;
+  const { content, container } =
+    containerLine === null
+      ? readReferenceDefinitionContainer(lines[startLineIndex])
+      : { content: containerLine, container: containerOverride };
   const start = readReferenceDefinitionStart(content);
   if (!start) return null;
 
@@ -348,6 +355,7 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
 } {
   const lines = markdown.split(/\r?\n/);
   let fence: { character: string; length: number; container: MarkdownContainer } | null = null;
+  let activeListContainer: MarkdownContainer | null = null;
   const referenceDefinitionLabels = new Set<string>();
   const strippedLines: string[] = [];
 
@@ -370,7 +378,23 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
       }
       fence = null;
     }
-    const containerLine = readReferenceDefinitionContainer(line);
+    const directContainerLine = readReferenceDefinitionContainer(line);
+    let containerLine = directContainerLine;
+    if (directContainerLine.container.listIndent) {
+      activeListContainer = directContainerLine.container;
+    } else if (activeListContainer) {
+      const activeContent = readReferenceContainerLine(line, activeListContainer);
+      if (activeContent !== null) {
+        containerLine = { content: activeContent, container: activeListContainer };
+      } else {
+        const activeBlockquote = stripBlockquotePrefix(
+          line,
+          activeListContainer.blockquoteDepth,
+        );
+        if (activeBlockquote?.content.trim()) activeListContainer = null;
+      }
+    }
+
     const run = readFenceRun(containerLine.content);
     if (run) {
       fence = {
@@ -381,7 +405,11 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
       strippedLines.push("");
       continue;
     }
-    const referenceDefinition = readReferenceDefinition(lines, lineIndex);
+    const referenceDefinition = readReferenceDefinition(
+      lines,
+      lineIndex,
+      containerLine.container,
+    );
     if (referenceDefinition) {
       referenceDefinitionLabels.add(referenceDefinition.label);
       while (lineIndex <= referenceDefinition.endLineIndex) {
@@ -484,6 +512,17 @@ function stripMarkdownLinksAndImages(markdown: string, referenceDefinitionLabels
         sanitized += markdown[index];
         index += 1;
         continue;
+      }
+      if (suffixOpen === "[" && !isImage) {
+        const suffixLabel = markdown.slice(suffixStart + 1, suffixEnd);
+        const resolvedLabel = normalizeReferenceLabel(
+          suffixLabel || markdown.slice(labelStart, labelEnd),
+        );
+        if (!referenceDefinitionLabels.has(resolvedLabel)) {
+          sanitized += markdown[index];
+          index += 1;
+          continue;
+        }
       }
       constructEnd = suffixEnd + 1;
     } else if (!isImage) {

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -159,7 +159,7 @@ function stripMarkdownLinksAndImages(markdown: string): string {
       continue;
     }
 
-    if (isLink) sanitized += markdown.slice(labelStart, labelEnd);
+    if (isLink) sanitized += stripMarkdownLinksAndImages(markdown.slice(labelStart, labelEnd));
     index = destinationEnd;
   }
 

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -136,6 +136,18 @@ function backtickRunLength(input: string, index: number): number {
   return length;
 }
 
+function isUnsupportedContainerFenceRun(
+  input: string,
+  index: number,
+  runLength: number,
+): boolean {
+  if (runLength < 3) return false;
+
+  const lineStart = input.lastIndexOf("\n", index - 1) + 1;
+  const prefix = input.slice(lineStart, index);
+  return /^(?: {0,3}(?:>[ \t]?|(?:[-+*]|\d{1,9}[.)])[ \t]+))+$/.test(prefix);
+}
+
 function findClosingBacktickRun(input: string, startIndex: number, openerLength: number): number {
   for (let index = startIndex; index < input.length; ) {
     if (input[index] !== "`") {
@@ -144,7 +156,12 @@ function findClosingBacktickRun(input: string, startIndex: number, openerLength:
     }
 
     const length = backtickRunLength(input, index);
-    if (length === openerLength) return index;
+    if (
+      length === openerLength &&
+      !isUnsupportedContainerFenceRun(input, index, length)
+    ) {
+      return index;
+    }
     index += length;
   }
 
@@ -162,6 +179,11 @@ function stripInlineCode(markdown: string): string {
     }
 
     const openerLength = backtickRunLength(markdown, index);
+    if (isUnsupportedContainerFenceRun(markdown, index, openerLength)) {
+      sanitized += markdown.slice(index, index + openerLength);
+      index += openerLength;
+      continue;
+    }
     const closeIndex = findClosingBacktickRun(markdown, index + openerLength, openerLength);
     if (closeIndex === -1) {
       sanitized += markdown.slice(index, index + openerLength);

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -42,9 +42,10 @@ function unavailableSummary(): { kind: ResearchIntegritySummaryKind; label: stri
 
 function preprocessMarkdownForIntegrity(markdown: string): string {
   const withoutComments = stripHtmlComments(markdown ?? "");
-  const withoutBlocks = stripFencedCodeAndReferenceDefinitions(withoutComments);
+  const { markdown: withoutBlocks, referenceDefinitionLabels } =
+    stripFencedCodeAndReferenceDefinitions(withoutComments);
   const withoutCode = stripInlineCode(withoutBlocks);
-  const withoutMarkdownTargets = stripMarkdownLinksAndImages(withoutCode);
+  const withoutMarkdownTargets = stripMarkdownLinksAndImages(withoutCode, referenceDefinitionLabels);
   return stripBareUrls(withoutMarkdownTargets);
 }
 
@@ -102,6 +103,37 @@ function findBalancedClose(input: string, startIndex: number, open: string, clos
   return -1;
 }
 
+function isCommonMarkEscapablePunctuation(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return (
+    (code >= 0x21 && code <= 0x2f) ||
+    (code >= 0x3a && code <= 0x40) ||
+    (code >= 0x5b && code <= 0x60) ||
+    (code >= 0x7b && code <= 0x7e)
+  );
+}
+
+function unescapeCommonMarkPunctuation(text: string): string {
+  let result = "";
+  for (let index = 0; index < text.length; index += 1) {
+    if (
+      text[index] === "\\" &&
+      index + 1 < text.length &&
+      isCommonMarkEscapablePunctuation(text[index + 1])
+    ) {
+      result += text[index + 1];
+      index += 1;
+      continue;
+    }
+    result += text[index];
+  }
+  return result;
+}
+
+function normalizeReferenceLabel(label: string): string {
+  return unescapeCommonMarkPunctuation(label).trim().replace(/\s+/g, " ").toLowerCase();
+}
+
 function isReferenceDefinitionLine(line: string): boolean {
   let labelStart = 0;
   while (labelStart < 3 && line[labelStart] === " ") labelStart += 1;
@@ -111,32 +143,50 @@ function isReferenceDefinitionLine(line: string): boolean {
   return labelEnd > labelStart + 1 && line[labelEnd + 1] === ":";
 }
 
-function stripFencedCodeAndReferenceDefinitions(markdown: string): string {
+function readReferenceDefinitionLabel(line: string): string | null {
+  let labelStart = 0;
+  while (labelStart < 3 && line[labelStart] === " ") labelStart += 1;
+  if (line[labelStart] !== "[") return null;
+
+  const labelEnd = findBalancedClose(line, labelStart + 1, "[", "]");
+  if (labelEnd <= labelStart + 1 || line[labelEnd + 1] !== ":") return null;
+  return normalizeReferenceLabel(line.slice(labelStart + 1, labelEnd));
+}
+
+function stripFencedCodeAndReferenceDefinitions(markdown: string): {
+  markdown: string;
+  referenceDefinitionLabels: Set<string>;
+} {
   const lines = markdown.split(/\r?\n/);
   let fence: { character: string; length: number } | null = null;
+  const referenceDefinitionLabels = new Set<string>();
 
-  return lines
-    .map((line) => {
-      const run = readFenceRun(line);
-      if (fence) {
-        if (
-          run &&
-          run.character === fence.character &&
-          run.length >= fence.length &&
-          !run.suffix.trim()
-        ) {
-          fence = null;
-        }
-        return "";
+  const strippedLines = lines.map((line) => {
+    const run = readFenceRun(line);
+    if (fence) {
+      if (
+        run &&
+        run.character === fence.character &&
+        run.length >= fence.length &&
+        !run.suffix.trim()
+      ) {
+        fence = null;
       }
-      if (run) {
-        fence = { character: run.character, length: run.length };
-        return "";
-      }
-      if (isReferenceDefinitionLine(line)) return "";
-      return line;
-    })
-    .join("\n");
+      return "";
+    }
+    if (run) {
+      fence = { character: run.character, length: run.length };
+      return "";
+    }
+    if (isReferenceDefinitionLine(line)) {
+      const label = readReferenceDefinitionLabel(line);
+      if (label) referenceDefinitionLabels.add(label);
+      return "";
+    }
+    return line;
+  });
+
+  return { markdown: strippedLines.join("\n"), referenceDefinitionLabels };
 }
 
 function isEscaped(input: string, index: number): boolean {
@@ -193,7 +243,7 @@ function stripInlineCode(markdown: string): string {
   return sanitized;
 }
 
-function stripMarkdownLinksAndImages(markdown: string): string {
+function stripMarkdownLinksAndImages(markdown: string, referenceDefinitionLabels: Set<string>): string {
   let sanitized = "";
 
   for (let index = 0; index < markdown.length; ) {
@@ -232,11 +282,15 @@ function stripMarkdownLinksAndImages(markdown: string): string {
       sanitized += markdown[index];
       index += 1;
       continue;
+    } else if (!referenceDefinitionLabels.has(normalizeReferenceLabel(markdown.slice(labelStart, labelEnd)))) {
+      sanitized += markdown.slice(index, labelEnd + 1);
+      index = labelEnd + 1;
+      continue;
     }
 
     sanitized += isImage
       ? " "
-      : stripMarkdownLinksAndImages(markdown.slice(labelStart, labelEnd));
+      : stripMarkdownLinksAndImages(markdown.slice(labelStart, labelEnd), referenceDefinitionLabels);
     index = constructEnd;
   }
 
@@ -344,8 +398,13 @@ function scanConflictMarkerIds(markdown: string): string[] {
 }
 
 function scanReferencedIdsInOrder(markdown: string, candidates: string[]): string[] {
-  const ids: string[] = [];
-  const seen = new Set<string>();
+  return uniqueIdsInOrder(scanMatchedIds(markdown, candidates).map((match) => match.id));
+}
+
+type IdMatch = { id: string; start: number; end: number };
+
+function scanMatchedIds(markdown: string, candidates: string[]): IdMatch[] {
+  const matches: IdMatch[] = [];
   const longestFirst = uniqueIdsInOrder(candidates.filter(Boolean)).sort(
     (left, right) => right.length - left.length,
   );
@@ -356,16 +415,26 @@ function scanReferencedIdsInOrder(markdown: string, candidates: string[]): strin
     for (const id of longestFirst) {
       if (!markdown.startsWith(id, index)) continue;
       if (isTokenCharacter(markdown[index + id.length])) continue;
-      if (!seen.has(id)) {
-        seen.add(id);
-        ids.push(id);
-      }
+      matches.push({ id, start: index, end: index + id.length });
       index += id.length - 1;
       break;
     }
   }
 
-  return ids;
+  return matches;
+}
+
+function maskMatchedSpans(markdown: string, matches: IdMatch[]): string {
+  if (matches.length === 0) return markdown;
+
+  let masked = "";
+  let cursor = 0;
+  for (const match of matches) {
+    masked += markdown.slice(cursor, match.start);
+    masked += " ".repeat(match.end - match.start);
+    cursor = match.end;
+  }
+  return masked + markdown.slice(cursor);
 }
 
 function countStatuses(sources: ResearchSourceRef[]): Record<ResearchSourceRef["status"], number> {
@@ -449,7 +518,11 @@ export function deriveResearchFindingsIntegrity(
     uniqueIdsInOrder([...visibleLedgerSourceIds, ...unresolvedCandidateIds]),
   );
   const unresolvedIds = referencedIds.filter((id) => !sourceById.has(id));
-  const conflictMarkerIds = scanConflictMarkerIds(sanitizedMarkdown);
+  const maskedConflictMarkdown = maskMatchedSpans(
+    sanitizedMarkdown,
+    scanMatchedIds(sanitizedMarkdown, visibleLedgerSourceIds),
+  );
+  const conflictMarkerIds = scanConflictMarkerIds(maskedConflictMarkdown);
   const conflictingSourceIds = uniqueIdsInOrder(
     sources.filter((source) => source.status === "conflicting").map((source) => source.id),
   );

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -135,7 +135,7 @@ function normalizeReferenceLabel(label: string): string {
   return unescapeCommonMarkPunctuation(label).trim().replace(/\s+/g, " ").toLowerCase();
 }
 
-type ReferenceDefinitionContainer = {
+type MarkdownContainer = {
   blockquoteDepth: number;
   listIndent: number;
 };
@@ -167,7 +167,7 @@ function stripBlockquotePrefix(
 
 function readReferenceDefinitionContainer(line: string): {
   content: string;
-  container: ReferenceDefinitionContainer;
+  container: MarkdownContainer;
 } {
   const blockquote = stripBlockquotePrefix(line) ?? { content: line, depth: 0 };
   const listMatch = blockquote.content.match(/^ {0,3}(?:[-+*]|\d{1,9}[.)])([ \t]+)/);
@@ -181,7 +181,7 @@ function readReferenceDefinitionContainer(line: string): {
 
 function readReferenceContainerLine(
   line: string,
-  container: ReferenceDefinitionContainer,
+  container: MarkdownContainer,
 ): string | null {
   const blockquote = stripBlockquotePrefix(line, container.blockquoteDepth);
   if (!blockquote) return null;
@@ -347,14 +347,15 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
   referenceDefinitionLabels: Set<string>;
 } {
   const lines = markdown.split(/\r?\n/);
-  let fence: { character: string; length: number } | null = null;
+  let fence: { character: string; length: number; container: MarkdownContainer } | null = null;
   const referenceDefinitionLabels = new Set<string>();
   const strippedLines: string[] = [];
 
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
     const line = lines[lineIndex];
-    const run = readFenceRun(line);
     if (fence) {
+      const containerLine = readReferenceContainerLine(line, fence.container);
+      const run = containerLine === null ? null : readFenceRun(containerLine);
       if (
         run &&
         run.character === fence.character &&
@@ -366,8 +367,14 @@ function stripFencedCodeAndReferenceDefinitions(markdown: string): {
       strippedLines.push("");
       continue;
     }
+    const containerLine = readReferenceDefinitionContainer(line);
+    const run = readFenceRun(containerLine.content);
     if (run) {
-      fence = { character: run.character, length: run.length };
+      fence = {
+        character: run.character,
+        length: run.length,
+        container: containerLine.container,
+      };
       strippedLines.push("");
       continue;
     }
@@ -555,7 +562,7 @@ function scanStrictBracketedSourceIds(sanitizedMarkdown: string): IndexedSourceI
       }
       tokenStart = tokenEnd + 1;
     }
-    index = closeIndex + 1;
+    index += 1;
   }
 
   return matches;

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -130,7 +130,7 @@ function isUnsupportedContainerFenceRun(
 
   const lineStart = input.lastIndexOf("\n", index - 1) + 1;
   const prefix = input.slice(lineStart, index);
-  return /^(?: {0,3}(?:>[ \t]?|(?:[-+*]|\d{1,9}[.)])[ \t]+))+[ \t]{0,3}$/.test(prefix);
+  return /^(?:[ \t]*(?:>[ \t]?|(?:[-+*]|\d{1,9}[.)])[ \t]+))+[ \t]*$/.test(prefix);
 }
 
 function findClosingBacktickRun(input: string, startIndex: number, openerLength: number): number {
@@ -191,7 +191,7 @@ function stripMarkdownLinksAndImages(markdown: string): string {
       markdown[index] === "!" &&
       markdown[index + 1] === "[" &&
       !isEscaped(markdown, index);
-    const isLink = markdown[index] === "[" && !isEscaped(markdown, index);
+    const isLink = markdown[index] === "[";
     if (!isImage && !isLink) {
       sanitized += markdown[index];
       index += 1;

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -1,3 +1,4 @@
+import { parseFindingsDoc } from "./research-findings-doc.ts";
 import type { ResearchSourceRef } from "./research-missions.ts";
 
 export type ResearchIntegritySummaryKind =
@@ -6,6 +7,7 @@ export type ResearchIntegritySummaryKind =
   | "conflicting"
   | "candidate"
   | "verified"
+  | "rejected"
   | "none";
 
 export type ResearchFindingsIntegrity = {
@@ -17,9 +19,10 @@ export type ResearchFindingsIntegrity = {
   summary: { kind: ResearchIntegritySummaryKind; label: string };
 };
 
-const BRACKETED_SOURCE_RE = /\[\s*([^\[\]]+?)\s*\]/g;
+const BRACKETED_TOKEN_RE = /\[\s*([^\[\]]+?)\s*\]/g;
 const SOURCE_ID_RE = /^(?:S|R)\d+$/;
-const CONFLICT_MARKER_RE = /\[\s*(C\d+)\s*\]|\b(C\d+)\b/g;
+const CONFLICT_ID_RE = /^C\d+$/;
+const FENCE_RE = /^\s{0,3}(`{3,}|~{3,})(.*)$/;
 
 function emptyCounts(): Record<ResearchSourceRef["status"], number> {
   return { candidate: 0, used: 0, conflicting: 0, rejected: 0 };
@@ -36,17 +39,80 @@ function uniqueIdsInOrder(ids: string[]): string[] {
   return unique;
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function preprocessMarkdownForIntegrity(markdown: string): string {
+  return stripBareUrls(stripMarkdownLinksAndImages(stripInlineCode(stripFencedCodeBlocks(markdown ?? ""))));
+}
+
+function stripFencedCodeBlocks(markdown: string): string {
+  const lines = markdown.split(/\r?\n/);
+  let fence: { character: string; length: number } | null = null;
+
+  return lines
+    .map((line) => {
+      const fenceMatch = FENCE_RE.exec(line);
+      if (!fence && fenceMatch) {
+        fence = { character: fenceMatch[1][0], length: fenceMatch[1].length };
+        return "";
+      }
+      if (fence && fenceMatch && fenceMatch[1][0] === fence.character && fenceMatch[1].length >= fence.length) {
+        fence = null;
+        return "";
+      }
+      return fence ? "" : line;
+    })
+    .join("\n");
+}
+
+function stripInlineCode(markdown: string): string {
+  let sanitized = "";
+
+  for (let index = 0; index < markdown.length; index += 1) {
+    if (markdown[index] !== "`") {
+      sanitized += markdown[index];
+      continue;
+    }
+
+    let fenceLength = 1;
+    while (markdown[index + fenceLength] === "`") fenceLength += 1;
+    const marker = "`".repeat(fenceLength);
+    const endIndex = markdown.indexOf(marker, index + fenceLength);
+    if (endIndex === -1) {
+      sanitized += marker;
+      index += fenceLength - 1;
+      continue;
+    }
+    index = endIndex + fenceLength - 1;
+  }
+
+  return sanitized;
+}
+
+function stripMarkdownLinksAndImages(markdown: string): string {
+  return markdown
+    .replace(/!\[[^\]]*]\(([^)\s]+)\)/g, "")
+    .replace(/\[[^\]]+]\(([^)\s]+)\)/g, "");
+}
+
+function stripBareUrls(markdown: string): string {
+  return markdown.replace(/https?:\/\/[^\s<>()]+/g, "");
+}
+
 export function scanBracketedSourceIds(markdown: string): string[] {
   const ids: string[] = [];
   const seen = new Set<string>();
+  const sanitized = preprocessMarkdownForIntegrity(markdown);
 
-  BRACKETED_SOURCE_RE.lastIndex = 0;
-  for (let match = BRACKETED_SOURCE_RE.exec(markdown); match; match = BRACKETED_SOURCE_RE.exec(markdown)) {
-    for (const id of match[1].split(",")) {
-      const trimmed = id.trim();
-      if (!SOURCE_ID_RE.test(trimmed) || seen.has(trimmed)) continue;
-      seen.add(trimmed);
-      ids.push(trimmed);
+  BRACKETED_TOKEN_RE.lastIndex = 0;
+  for (let match = BRACKETED_TOKEN_RE.exec(sanitized); match; match = BRACKETED_TOKEN_RE.exec(sanitized)) {
+    for (const token of match[1].split(",")) {
+      const id = token.trim();
+      if (!SOURCE_ID_RE.test(id) || seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
     }
   }
 
@@ -57,10 +123,49 @@ function scanConflictMarkerIds(markdown: string): string[] {
   const ids: string[] = [];
   const seen = new Set<string>();
 
-  CONFLICT_MARKER_RE.lastIndex = 0;
-  for (let match = CONFLICT_MARKER_RE.exec(markdown); match; match = CONFLICT_MARKER_RE.exec(markdown)) {
-    const id = match[1] ?? match[2];
-    if (seen.has(id)) continue;
+  const conflictPattern = /\[\s*([^\[\]]+?)\s*\]|\b(C\d+)\b/g;
+  for (let match = conflictPattern.exec(markdown); match; match = conflictPattern.exec(markdown)) {
+    if (match[1] !== undefined) {
+      for (const token of match[1].split(",")) {
+        const id = token.trim();
+        if (!CONFLICT_ID_RE.test(id) || seen.has(id)) continue;
+        seen.add(id);
+        ids.push(id);
+      }
+      continue;
+    }
+
+    const id = match[2];
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+
+  return ids;
+}
+
+function scanReferencedIdsInOrder(markdown: string, actualSourceIds: Set<string>): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  const actualIds = [...actualSourceIds].sort((a, b) => b.length - a.length);
+  const pattern = actualIds.length
+    ? new RegExp(`\\[\\s*([^\\[\\]]+?)\\s*\\]|\\b(${actualIds.map(escapeRegExp).join("|")})\\b`, "g")
+    : /\[\s*([^\[\]]+?)\s*\]/g;
+
+  for (let match = pattern.exec(markdown); match; match = pattern.exec(markdown)) {
+    if (match[1] !== undefined) {
+      for (const token of match[1].split(",")) {
+        const id = token.trim();
+        if (CONFLICT_ID_RE.test(id) || seen.has(id)) continue;
+        if (!SOURCE_ID_RE.test(id) && !actualSourceIds.has(id)) continue;
+        seen.add(id);
+        ids.push(id);
+      }
+      continue;
+    }
+
+    const id = match[2];
+    if (!id || seen.has(id) || CONFLICT_ID_RE.test(id)) continue;
     seen.add(id);
     ids.push(id);
   }
@@ -80,6 +185,7 @@ function summarize(
   integrity: ResearchFindingsIntegrity,
   citedCandidateCount: number,
   citedUsedCount: number,
+  citedRejectedCount: number,
 ): { kind: ResearchIntegritySummaryKind; label: string } {
   const unresolvedCount = integrity.unresolvedIds.length;
   const conflictCount = integrity.conflictIds.length;
@@ -116,6 +222,13 @@ function summarize(
     };
   }
 
+  if (citedRejectedCount > 0) {
+    return {
+      kind: "rejected",
+      label: citedRejectedCount === 1 ? "1 rejected source cited" : `${citedRejectedCount} rejected sources cited`,
+    };
+  }
+
   return { kind: "none", label: "This report does not cite sources" };
 }
 
@@ -123,21 +236,28 @@ export function deriveResearchFindingsIntegrity(
   markdown: string,
   sources: ResearchSourceRef[],
 ): ResearchFindingsIntegrity {
-  const referencedIds = scanBracketedSourceIds(markdown);
   const sourceById = new Map<string, ResearchSourceRef>();
+  const sanitizedMarkdown = preprocessMarkdownForIntegrity(markdown);
 
   for (const source of sources) {
     if (!sourceById.has(source.id)) sourceById.set(source.id, source);
   }
 
+  const parserRecognizedSourceIds = new Set(
+    parseFindingsDoc(sanitizedMarkdown, sources).refIds.filter(
+      (id) => sourceById.has(id) && !CONFLICT_ID_RE.test(id),
+    ),
+  );
+  const referencedIds = scanReferencedIdsInOrder(sanitizedMarkdown, parserRecognizedSourceIds);
   const unresolvedIds = referencedIds.filter((id) => !sourceById.has(id));
-  const conflictMarkerIds = scanConflictMarkerIds(markdown);
+  const conflictMarkerIds = scanConflictMarkerIds(sanitizedMarkdown);
   const conflictingSourceIds = uniqueIdsInOrder(
     sources.filter((source) => source.status === "conflicting").map((source) => source.id),
   );
   const conflictIds = uniqueIdsInOrder([...conflictMarkerIds, ...conflictingSourceIds]);
   const citedCandidateCount = referencedIds.filter((id) => sourceById.get(id)?.status === "candidate").length;
   const citedUsedCount = referencedIds.filter((id) => sourceById.get(id)?.status === "used").length;
+  const citedRejectedCount = referencedIds.filter((id) => sourceById.get(id)?.status === "rejected").length;
   const integrity: ResearchFindingsIntegrity = {
     ledger: sources.length > 0 ? "available" : "empty",
     referencedIds,
@@ -147,6 +267,6 @@ export function deriveResearchFindingsIntegrity(
     summary: { kind: "none", label: "This report does not cite sources" },
   };
 
-  integrity.summary = summarize(integrity, citedCandidateCount, citedUsedCount);
+  integrity.summary = summarize(integrity, citedCandidateCount, citedUsedCount, citedRejectedCount);
   return integrity;
 }

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -130,7 +130,10 @@ function isUnsupportedContainerFenceRun(
 
   const lineStart = input.lastIndexOf("\n", index - 1) + 1;
   const prefix = input.slice(lineStart, index);
-  return /^(?:[ \t]*(?:>[ \t]?|(?:[-+*]|\d{1,9}[.)])[ \t]+))+[ \t]*$/.test(prefix);
+  return (
+    /^[ \t]+$/.test(prefix) ||
+    /^(?:[ \t]*(?:>[ \t]?|(?:[-+*]|\d{1,9}[.)])[ \t]+))+[ \t]*$/.test(prefix)
+  );
 }
 
 function findClosingBacktickRun(input: string, startIndex: number, openerLength: number): number {

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -1,4 +1,5 @@
 import type { ResearchSourceRef } from "./research-missions.ts";
+import { findRecognizedFindingsRefs } from "./research-findings-doc.ts";
 
 export type ResearchIntegritySummaryKind =
   | "unavailable"
@@ -327,9 +328,10 @@ function stripBareUrls(markdown: string): string {
   return sanitized;
 }
 
-function scanStrictBracketedSourceIds(sanitizedMarkdown: string): string[] {
-  const ids: string[] = [];
-  const seen = new Set<string>();
+type IndexedSourceId = { id: string; index: number };
+
+function scanStrictBracketedSourceIds(sanitizedMarkdown: string): IndexedSourceId[] {
+  const matches: IndexedSourceId[] = [];
 
   for (let index = 0; index < sanitizedMarkdown.length; ) {
     if (sanitizedMarkdown[index] !== "[" || isEscaped(sanitizedMarkdown, index)) {
@@ -342,99 +344,32 @@ function scanStrictBracketedSourceIds(sanitizedMarkdown: string): string[] {
       index += 1;
       continue;
     }
-    for (const token of sanitizedMarkdown.slice(index + 1, closeIndex).split(",")) {
+
+    let tokenStart = index + 1;
+    for (let tokenEnd = tokenStart; tokenEnd <= closeIndex; tokenEnd += 1) {
+      if (tokenEnd < closeIndex && sanitizedMarkdown[tokenEnd] !== ",") continue;
+      const token = sanitizedMarkdown.slice(tokenStart, tokenEnd);
       const id = token.trim();
-      if (!SOURCE_ID_RE.test(id) || seen.has(id)) continue;
-      seen.add(id);
-      ids.push(id);
+      if (SOURCE_ID_RE.test(id)) {
+        matches.push({
+          id,
+          index: tokenStart + token.length - token.trimStart().length,
+        });
+      }
+      tokenStart = tokenEnd + 1;
     }
     index = closeIndex + 1;
-  }
-
-  return ids;
-}
-
-export function scanBracketedSourceIds(markdown: string): string[] {
-  return scanStrictBracketedSourceIds(preprocessMarkdownForIntegrity(markdown));
-}
-
-function isTokenCharacter(character: string | undefined): boolean {
-  if (!character) return false;
-  const code = character.charCodeAt(0);
-  return (
-    (code >= 48 && code <= 57) ||
-    (code >= 65 && code <= 90) ||
-    code === 95 ||
-    (code >= 97 && code <= 122)
-  );
-}
-
-function scanConflictMarkerIds(markdown: string): string[] {
-  const ids: string[] = [];
-  const seen = new Set<string>();
-
-  for (let index = 0; index < markdown.length; ) {
-    if (markdown[index] !== "C" || isTokenCharacter(markdown[index - 1])) {
-      index += 1;
-      continue;
-    }
-
-    let endIndex = index + 1;
-    while (endIndex < markdown.length && /\d/.test(markdown[endIndex])) endIndex += 1;
-    if (endIndex === index + 1 || isTokenCharacter(markdown[endIndex])) {
-      index += 1;
-      continue;
-    }
-
-    const id = markdown.slice(index, endIndex);
-    if (!seen.has(id)) {
-      seen.add(id);
-      ids.push(id);
-    }
-    index = endIndex;
-  }
-
-  return ids;
-}
-
-function scanReferencedIdsInOrder(markdown: string, candidates: string[]): string[] {
-  return uniqueIdsInOrder(scanMatchedIds(markdown, candidates).map((match) => match.id));
-}
-
-type IdMatch = { id: string; start: number; end: number };
-
-function scanMatchedIds(markdown: string, candidates: string[]): IdMatch[] {
-  const matches: IdMatch[] = [];
-  const longestFirst = uniqueIdsInOrder(candidates.filter(Boolean)).sort(
-    (left, right) => right.length - left.length,
-  );
-
-  for (let index = 0; index < markdown.length; index += 1) {
-    if (isTokenCharacter(markdown[index - 1])) continue;
-
-    for (const id of longestFirst) {
-      if (!markdown.startsWith(id, index)) continue;
-      if (isTokenCharacter(markdown[index + id.length])) continue;
-      matches.push({ id, start: index, end: index + id.length });
-      index += id.length - 1;
-      break;
-    }
   }
 
   return matches;
 }
 
-function maskMatchedSpans(markdown: string, matches: IdMatch[]): string {
-  if (matches.length === 0) return markdown;
-
-  let masked = "";
-  let cursor = 0;
-  for (const match of matches) {
-    masked += markdown.slice(cursor, match.start);
-    masked += " ".repeat(match.end - match.start);
-    cursor = match.end;
-  }
-  return masked + markdown.slice(cursor);
+export function scanBracketedSourceIds(markdown: string): string[] {
+  return uniqueIdsInOrder(
+    scanStrictBracketedSourceIds(preprocessMarkdownForIntegrity(markdown)).map(
+      (match) => match.id,
+    ),
+  );
 }
 
 function countStatuses(sources: ResearchSourceRef[]): Record<ResearchSourceRef["status"], number> {
@@ -507,22 +442,24 @@ export function deriveResearchFindingsIntegrity(
     if (!sourceById.has(source.id)) sourceById.set(source.id, source);
   }
 
-  const visibleLedgerSourceIds = uniqueIdsInOrder(
-    [...sourceById.keys()].filter((id) => !CONFLICT_ID_RE.test(id)),
+  const recognizedRefs = findRecognizedFindingsRefs(sanitizedMarkdown, sources);
+  const actualLedgerRefs = recognizedRefs.filter(
+    (match) => sourceById.has(match.id) && !CONFLICT_ID_RE.test(match.id),
   );
-  const unresolvedCandidateIds = scanStrictBracketedSourceIds(sanitizedMarkdown).filter(
-    (id) => !sourceById.has(id),
+  const unresolvedStrictRefs = scanStrictBracketedSourceIds(sanitizedMarkdown).filter(
+    (match) => !sourceById.has(match.id),
   );
-  const referencedIds = scanReferencedIdsInOrder(
-    sanitizedMarkdown,
-    uniqueIdsInOrder([...visibleLedgerSourceIds, ...unresolvedCandidateIds]),
+  const referencedIds = uniqueIdsInOrder(
+    [...actualLedgerRefs, ...unresolvedStrictRefs]
+      .sort((left, right) => left.index - right.index)
+      .map((match) => match.id),
   );
   const unresolvedIds = referencedIds.filter((id) => !sourceById.has(id));
-  const maskedConflictMarkdown = maskMatchedSpans(
-    sanitizedMarkdown,
-    scanMatchedIds(sanitizedMarkdown, visibleLedgerSourceIds),
+  const conflictMarkerIds = uniqueIdsInOrder(
+    recognizedRefs
+      .filter((match) => CONFLICT_ID_RE.test(match.id))
+      .map((match) => match.id),
   );
-  const conflictMarkerIds = scanConflictMarkerIds(maskedConflictMarkdown);
   const conflictingSourceIds = uniqueIdsInOrder(
     sources.filter((source) => source.status === "conflicting").map((source) => source.id),
   );

--- a/src/lib/research-findings-integrity.ts
+++ b/src/lib/research-findings-integrity.ts
@@ -3,6 +3,7 @@ import {
   findRecognizedFindingsRefs,
   matchFindingsFenceRun,
   matchFindingsInlineLinkAt,
+  stripFindingsComments,
 } from "./research-findings-doc.ts";
 
 export type ResearchIntegritySummaryKind =
@@ -46,27 +47,11 @@ function unavailableSummary(): { kind: ResearchIntegritySummaryKind; label: stri
 }
 
 function preprocessMarkdownForIntegrity(markdown: string): string {
-  const withoutComments = stripHtmlComments(markdown ?? "");
+  const withoutComments = stripFindingsComments(markdown ?? "");
   const withoutBlocks = stripFencedCode(withoutComments);
   const withoutCode = stripInlineCode(withoutBlocks);
   const withoutMarkdownTargets = stripMarkdownLinksAndImages(withoutCode);
   return stripBareUrls(withoutMarkdownTargets);
-}
-
-function stripHtmlComments(markdown: string): string {
-  let sanitized = "";
-  let cursor = 0;
-
-  while (cursor < markdown.length) {
-    const commentStart = markdown.indexOf("<!--", cursor);
-    if (commentStart === -1) return sanitized + markdown.slice(cursor);
-    const commentEnd = markdown.indexOf("-->", commentStart + 4);
-    if (commentEnd === -1) return sanitized + markdown.slice(cursor);
-    sanitized += markdown.slice(cursor, commentStart);
-    cursor = commentEnd + 3;
-  }
-
-  return sanitized;
 }
 
 function findBalancedClose(input: string, startIndex: number, open: string, close: string): number {
@@ -221,7 +206,7 @@ function stripMarkdownLinksAndImages(markdown: string): string {
       }
       const inlineLink = matchFindingsInlineLinkAt(markdown, index);
       if (inlineLink) {
-        sanitized += stripMarkdownLinksAndImages(inlineLink.text);
+        sanitized += `[${stripMarkdownLinksAndImages(inlineLink.text)}]`;
         index += inlineLink.length;
         continue;
       }

--- a/src/lib/research-mission-client.test.ts
+++ b/src/lib/research-mission-client.test.ts
@@ -191,6 +191,17 @@ test("getResearchMissionFile fetches the file payload with encoded segments", as
         content: "[]",
         workspacePath: "/tmp/research-missions/mission-1",
         updatedAt: "2026-07-24T00:00:00.000Z",
+        sourceLedger: {
+          state: "available",
+          sources: [
+            {
+              id: "manual-primary",
+              title: "Primary source",
+              sourceType: "web",
+              status: "used",
+            },
+          ],
+        },
       },
     }), { status: 200, headers: { "content-type": "application/json" } });
   }) as typeof fetch;
@@ -199,6 +210,87 @@ test("getResearchMissionFile fetches the file payload with encoded segments", as
     assert.deepEqual(calls, ["/api/research/missions/mission%201/files/source-ledger"]);
     assert.equal(file.content, "[]");
     assert.equal(file.workspacePath, "/tmp/research-missions/mission-1");
+    assert.equal(file.sourceLedger.state, "available");
+    assert.equal(file.sourceLedger.sources[0]?.id, "manual-primary");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getResearchMissionFile fails closed when legacy responses omit the source-ledger snapshot", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => Response.json({
+    ok: true,
+    file: {
+      key: "findings",
+      kind: "findings",
+      title: "Findings",
+      fileName: "findings.md",
+      relativePath: "findings.md",
+      content: "# Findings",
+      workspacePath: "/workspace/mission-1",
+      updatedAt: "2026-07-24T00:00:00.000Z",
+    },
+  })) as typeof fetch;
+  try {
+    const file = await getResearchMissionFile("mission-1", "findings");
+    assert.deepEqual(file.sourceLedger, { state: "failed", sources: [] });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getResearchMissionFile rejects inconsistent source-ledger claims as failed", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => Response.json({
+    ok: true,
+    file: {
+      key: "findings",
+      kind: "findings",
+      title: "Findings",
+      fileName: "findings.md",
+      relativePath: "findings.md",
+      content: "# Findings",
+      workspacePath: "/workspace/mission-1",
+      updatedAt: "2026-07-24T00:00:00.000Z",
+      sourceLedger: { state: "available", sources: [] },
+    },
+  })) as typeof fetch;
+  try {
+    const file = await getResearchMissionFile("mission-1", "findings");
+    assert.deepEqual(file.sourceLedger, { state: "failed", sources: [] });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getResearchMissionFile strips stale sources from an explicit failed ledger", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => Response.json({
+    ok: true,
+    file: {
+      key: "findings",
+      kind: "findings",
+      title: "Findings",
+      fileName: "findings.md",
+      relativePath: "findings.md",
+      content: "# Findings",
+      workspacePath: "/workspace/mission-1",
+      updatedAt: "2026-07-24T00:00:00.000Z",
+      sourceLedger: {
+        state: "failed",
+        sources: [{
+          id: "stale-source",
+          title: "Stale source",
+          sourceType: "web",
+          status: "used",
+        }],
+      },
+    },
+  })) as typeof fetch;
+  try {
+    const file = await getResearchMissionFile("mission-1", "findings");
+    assert.deepEqual(file.sourceLedger, { state: "failed", sources: [] });
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/src/lib/research-mission-client.ts
+++ b/src/lib/research-mission-client.ts
@@ -3,8 +3,13 @@ import type {
   ResearchArtifactKind,
   ResearchMission,
   ResearchMissionActionInput,
+  ResearchSourceLedgerSnapshot,
 } from "./research-missions.ts";
-import { parseResearchMission } from "./research-missions.ts";
+import {
+  parseResearchMission,
+  parseResearchSources,
+  RESEARCH_ARTIFACT_KINDS,
+} from "./research-missions.ts";
 import type { AutomationStatus } from "./codex-automations-types.ts";
 import type { ResearchAutomationScheduleInput } from "./server/research-mission-runner.ts";
 import { publishSchedulesChanged } from "./board-cache-events.ts";
@@ -30,6 +35,7 @@ export type ResearchMissionFile = {
   content: string | null;
   workspacePath: string;
   updatedAt: string;
+  sourceLedger: ResearchSourceLedgerSnapshot;
 };
 
 export type ResearchMissionFileResponse =
@@ -79,6 +85,67 @@ function parseMissionListResponse(value: unknown): ResearchMissionListResponse {
     : { ok: true, missions: missions as ResearchMission[] };
 }
 
+function failedSourceLedger(): ResearchSourceLedgerSnapshot {
+  return { state: "failed", sources: [] };
+}
+
+function parseSourceLedgerSnapshot(
+  value: unknown,
+): ResearchSourceLedgerSnapshot {
+  if (!isRecord(value)) return failedSourceLedger();
+  if (value.state === "failed") return failedSourceLedger();
+  if (value.state !== "available" && value.state !== "empty") {
+    return failedSourceLedger();
+  }
+  const sources = parseResearchSources(value.sources);
+  if (!sources) return failedSourceLedger();
+  const expectedState = sources.length > 0 ? "available" : "empty";
+  if (value.state !== expectedState) return failedSourceLedger();
+  return expectedState === "available"
+    ? { state: "available", sources }
+    : { state: "empty", sources: [] };
+}
+
+function parseMissionFileResponse(value: unknown): ResearchMissionFileResponse {
+  if (!isRecord(value) || value.ok !== true || !isRecord(value.file)) {
+    if (isRecord(value) && value.ok === false) {
+      return {
+        ok: false,
+        ...(typeof value.error === "string" ? { error: value.error } : {}),
+      };
+    }
+    return { ok: false, error: "Research file returned an invalid response" };
+  }
+  const file = value.file;
+  if (
+    typeof file.key !== "string" ||
+    typeof file.kind !== "string" ||
+    !RESEARCH_ARTIFACT_KINDS.includes(file.kind as ResearchArtifactKind) ||
+    typeof file.title !== "string" ||
+    typeof file.fileName !== "string" ||
+    typeof file.relativePath !== "string" ||
+    (file.content !== null && typeof file.content !== "string") ||
+    typeof file.workspacePath !== "string" ||
+    typeof file.updatedAt !== "string"
+  ) {
+    return { ok: false, error: "Research file returned an invalid response" };
+  }
+  return {
+    ok: true,
+    file: {
+      key: file.key,
+      kind: file.kind as ResearchArtifactKind,
+      title: file.title,
+      fileName: file.fileName,
+      relativePath: file.relativePath,
+      content: file.content as string | null,
+      workspacePath: file.workspacePath,
+      updatedAt: file.updatedAt,
+      sourceLedger: parseSourceLedgerSnapshot(file.sourceLedger),
+    },
+  };
+}
+
 export function isActiveResearchMission(mission: ResearchMission): boolean {
   return ["queued", "planning", "running"].includes(mission.status);
 }
@@ -125,7 +192,7 @@ export async function getResearchMissionFile(
     `/api/research/missions/${encodeURIComponent(missionId)}/files/${encodeURIComponent(artifactKey)}`,
     { cache: "no-store", signal },
   );
-  const data = await readJson(response) as ResearchMissionFileResponse;
+  const data = parseMissionFileResponse(await readJson(response));
   if (!data.ok) throw new Error(data.error ?? "request failed");
   return data.file;
 }

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -10,6 +10,7 @@ import {
   ensureStandardArtifactRefs,
   normalizeResearchBounds,
   parseResearchMission,
+  parseResearchSources,
   RESEARCH_AUDIENCE_MAX_LENGTH,
   RESEARCH_BOUND_LIMITS,
   RESEARCH_CONSTRAINT_MAX_COUNT,
@@ -111,6 +112,24 @@ test("mission parser refuses unknown external-provider identity on a source", ()
   // array is exactly what an agent writing sources.json can put there.
   assert.equal(withSource({ provider: ["x"] }), null);
   assert.equal(withSource({ availability: ["deleted"] }), null);
+});
+
+test("source-array parser reuses mission source validation without a mission wrapper", () => {
+  const validSource = {
+    id: "manual-primary-source",
+    title: "Primary source",
+    url: "https://example.com/source",
+    sourceType: "web",
+    status: "used",
+  } as const;
+
+  assert.deepEqual(parseResearchSources([validSource]), [validSource]);
+  assert.deepEqual(parseResearchSources([]), []);
+  assert.equal(parseResearchSources({ sources: [validSource] }), null);
+  assert.equal(
+    parseResearchSources([{ ...validSource, status: "invented" }]),
+    null,
+  );
 });
 
 test("mission parser preserves valid title provenance and rejects unknown values", () => {

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -200,6 +200,10 @@ export type ResearchSourceRef = {
   availability?: ResearchSourceAvailability;
 };
 
+export type ResearchSourceLedgerSnapshot =
+  | { state: "available"; sources: ResearchSourceRef[] }
+  | { state: "empty" | "failed"; sources: [] };
+
 export type ResearchSourceDraft = Partial<ResearchSourceRef> & {
   id: string;
   title: string;
@@ -710,6 +714,19 @@ function parseResearchSource(value: unknown): ResearchSourceRef | null {
   };
 }
 
+/** Parse the canonical sources.json payload without requiring a mission
+ * wrapper. This is shared by mission hydration and file-serving routes so both
+ * surfaces apply exactly the same source-row validation. */
+export function parseResearchSources(
+  value: unknown,
+): ResearchSourceRef[] | null {
+  if (!Array.isArray(value)) return null;
+  const sources = value.map(parseResearchSource);
+  return sources.some((source) => source === null)
+    ? null
+    : sources as ResearchSourceRef[];
+}
+
 function parseResearchAutomation(value: unknown): ResearchAutomationLink | null {
   if (!isRecord(value)
     || typeof value.id !== "string"
@@ -823,10 +840,10 @@ export function parseResearchMission(value: unknown): ResearchMission | null {
   }
   const iterations = value.iterations.map(parseResearchIteration);
   const artifacts = value.artifacts.map(parseResearchArtifact);
-  const sources = value.sources.map(parseResearchSource);
+  const sources = parseResearchSources(value.sources);
   if (iterations.some((iteration) => iteration === null)
     || artifacts.some((artifact) => artifact === null)
-    || sources.some((source) => source === null)) {
+    || sources === null) {
     return null;
   }
   const automation = value.automation === undefined
@@ -862,7 +879,7 @@ export function parseResearchMission(value: unknown): ResearchMission | null {
     ...(automationId !== undefined ? { automationId } : {}),
     iterations: iterations as ResearchIteration[],
     artifacts: artifacts as ResearchArtifactRef[],
-    sources: sources as ResearchSourceRef[],
+    sources,
     ...(lastError !== undefined ? { lastError } : {}),
   };
 }

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -1467,7 +1467,7 @@ test("an active private owner blocks lifecycle, artifact, and schedule mutations
   );
 });
 
-test("manual sources normalize, dedupe, and remain revisable", async () => {
+test("manual sources normalize, preserve same-URL versions, and remain revisable", async () => {
   let stored = checkpointMission();
   const runner = makeResearchMissionRunner(deps({
     loadMission: async () => structuredClone(stored),
@@ -1486,9 +1486,13 @@ test("manual sources normalize, dedupe, and remain revisable", async () => {
     sourceId: "manual-1",
     patch: { status: "conflicting", note: "Different target cohort" },
   });
-  assert.equal(result.sources.length, 1);
-  assert.equal(result.sources[0].status, "conflicting");
-  assert.equal(result.sources[0].note, "Different target cohort");
+  assert.equal(result.sources.length, 2);
+  assert.equal(result.sources.find((source) => source.id === "manual-1")?.status, "conflicting");
+  assert.equal(
+    result.sources.find((source) => source.id === "manual-1")?.note,
+    "Different target cohort",
+  );
+  assert.equal(result.sources.find((source) => source.id === "manual-2")?.status, "used");
 });
 
 test("attach-saved-link materializes a matching familiar's Article and remains idempotent", async () => {

--- a/src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
+++ b/src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
@@ -408,13 +408,90 @@ test("manually attached sources survive evidence reconciliation", async () => {
     }],
   }));
   const result = await runner.reconcile(stored);
-  assert.equal(result.sources.length, 2);
+  assert.equal(result.sources.length, 3);
   const manual = result.sources.find((source) => source.id === "manual-memo");
   assert.ok(manual, "the manual-only source must survive the reconcile");
   assert.equal(manual?.status, "candidate");
-  const collided = result.sources.find((source) => source.url === "https://example.com/source");
-  assert.equal(collided?.id, "source-1", "the flow-written entry wins a url collision");
-  assert.equal(collided?.status, "used");
+  const versions = result.sources.filter(
+    (source) => source.url === "https://example.com/source",
+  );
+  assert.deepEqual(
+    versions.map((source) => source.id),
+    ["source-1", "manual-dup"],
+    "distinct source ids may intentionally share a URL",
+  );
+  assert.equal(versions[0]?.status, "used");
+  assert.equal(versions[1]?.status, "candidate");
+});
+
+test("ambiguous provider-backed source bridges fail closed", async () => {
+  let stored = checkpointMission({
+    status: "running",
+    iterations: [{
+      ...checkpointMission().iterations[0],
+      status: "running",
+      finishedAt: undefined,
+    }],
+    sources: [
+      {
+        id: "attached-v1",
+        title: "Attached source v1",
+        url: "https://example.com/versioned",
+        sourceType: "web",
+        status: "candidate",
+        provider: "x",
+        externalId: "version-1",
+      },
+      {
+        id: "attached-v2",
+        title: "Attached source v2",
+        url: "https://example.com/versioned",
+        sourceType: "web",
+        status: "candidate",
+        provider: "x",
+        externalId: "version-2",
+      },
+    ],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    loadFlowRun: async () => ({ ...RUN, status: "succeeded", finishedAt: NOW.toISOString() }),
+    loadConversation: async () => ({
+      sessionId: "session-1",
+      familiarId: "sage",
+      harness: "codex",
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+      turns: [{
+        id: "turn-1",
+        role: "assistant",
+        text: [
+          "@@research-control",
+          '{"decision":"complete","reason":"Done","confidence":0.9}',
+          "@@research-artifacts-written",
+        ].join("\n"),
+        createdAt: NOW.toISOString(),
+      }],
+    }),
+    readMissionFile: async () => "# Complete\n",
+    readSources: async () => [{
+      id: "agent-written",
+      title: "Agent source",
+      url: "https://example.com/versioned",
+      sourceType: "web",
+      status: "used",
+    }],
+  }));
+
+  await assert.rejects(
+    () => runner.reconcile(stored),
+    /source identities are ambiguous/i,
+  );
+  assert.deepEqual(
+    stored.sources.map((source) => source.id),
+    ["attached-v1", "attached-v2"],
+    "an ambiguous ledger must not overwrite either stored identity",
+  );
 });
 
 test("one poisoned mission degrades to its stored snapshot instead of failing the list", async () => {

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -9,6 +9,7 @@ import {
   normalizeResearchSource,
   parseResearchControl,
   parseResearchSourcesFile,
+  researchSourcesShareIdentity,
   renderSourceLedgerMarkdown,
   researchKnowledgeEntry,
   type ResearchProvenance,
@@ -286,11 +287,9 @@ function mergeResearchSource(
   sources: ResearchSourceRef[],
   source: ResearchSourceRef,
 ): ResearchSourceRef[] {
-  const index = sources.findIndex((item) => (
-    source.url && item.url === source.url
-  ) || (
-    source.localPath && item.localPath === source.localPath
-  ) || item.id === source.id);
+  const index = sources.findIndex((item) =>
+    researchSourcesShareIdentity(source, item)
+  );
   if (index < 0) return [source, ...sources];
   return sources.map((item, itemIndex) => itemIndex === index ? {
     ...item,
@@ -310,12 +309,8 @@ function mergeFileSources(
   stored: ResearchSourceRef[],
   file: ResearchSourceRef[],
 ): ResearchSourceRef[] {
-  const matches = (source: ResearchSourceRef, item: ResearchSourceRef) => (
-    source.url && item.url === source.url
-  ) || (
-    source.localPath && item.localPath === source.localPath
-  ) || source.id === item.id;
-  const matchesFileEntry = (item: ResearchSourceRef) => file.some((source) => matches(source, item));
+  const matchesFileEntry = (item: ResearchSourceRef) =>
+    file.some((source) => researchSourcesShareIdentity(source, item));
   // The agent's sources.json wins on every field it owns, but external-provider
   // IDENTITY is Cave's, not the agent's: it is written by the attach route and
   // by hydration, and the agent is never told to reproduce it. Without this
@@ -325,7 +320,11 @@ function mergeFileSources(
   // that the source was an X post at all (cave-v3ajh, #4816 criterion 4).
   const merged = file.map((source) => {
     if (source.provider !== undefined) return source;
-    const displaced = stored.find((item) => item.provider !== undefined && matches(source, item));
+    const displaced = stored.find(
+      (item) =>
+        item.provider !== undefined &&
+        researchSourcesShareIdentity(source, item),
+    );
     if (!displaced) return source;
     return {
       ...source,

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -8,6 +8,7 @@ import type { KnowledgeEntry } from "./knowledge-vault.ts";
 import {
   normalizeResearchSource,
   parseResearchControl,
+  parseResearchSourcesFile,
   renderSourceLedgerMarkdown,
   researchKnowledgeEntry,
   type ResearchProvenance,
@@ -68,8 +69,9 @@ import {
 } from "./research-mission-lifecycle.ts";
 
 export {
+  parseResearchSourcesFile,
   withinStartupGrace,
-} from "./research-mission-lifecycle.ts";
+};
 export type { ResearchFlowStartResult } from "./research-mission-lifecycle.ts";
 
 export const RESEARCH_SESSION_OWNER_REPAIR_REQUIRED =
@@ -2058,25 +2060,6 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
     },
     act,
   };
-}
-
-export function parseResearchSourcesFile(raw: string): ResearchSourceRef[] {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error("sources.json is malformed");
-  }
-  if (!Array.isArray(parsed)) throw new Error("sources.json must contain an array");
-  return parsed.map((item, index) => {
-    const normalized = normalizeResearchSource(
-      item as Parameters<typeof normalizeResearchSource>[0],
-    );
-    if (!normalized.ok) {
-      throw new Error(`sources.json source ${index + 1}: ${normalized.reason}`);
-    }
-    return normalized.value;
-  });
 }
 
 /**

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -6,10 +6,11 @@ import { hasUnpairedUtf16Surrogate } from "../utf16.ts";
 import { daemonSessionAlreadyGone } from "./daemon-session-error.ts";
 import type { KnowledgeEntry } from "./knowledge-vault.ts";
 import {
+  indexDistinctResearchSourceIds,
   normalizeResearchSource,
   parseResearchControl,
   parseResearchSourcesFile,
-  researchSourcesShareIdentity,
+  researchSourcesShareSecondaryIdentity,
   renderSourceLedgerMarkdown,
   researchKnowledgeEntry,
   type ResearchProvenance,
@@ -287,9 +288,7 @@ function mergeResearchSource(
   sources: ResearchSourceRef[],
   source: ResearchSourceRef,
 ): ResearchSourceRef[] {
-  const index = sources.findIndex((item) =>
-    researchSourcesShareIdentity(source, item)
-  );
+  const index = sources.findIndex((item) => item.id === source.id);
   if (index < 0) return [source, ...sources];
   return sources.map((item, itemIndex) => itemIndex === index ? {
     ...item,
@@ -302,15 +301,57 @@ function mergeResearchSource(
  * Merge the flow-written sources.json ledger into the stored mission sources
  * instead of replacing them: manually attached sources live only in
  * mission.json (attach-source), so a wholesale replace silently wiped them on
- * every settle. File entries win on url/localPath/id collision; manual-only
- * entries survive.
+ * every settle. File entries win on exact ids; manual-only entries survive.
+ * A unique provider-backed URL/path bridge carries Cave-owned identity fields
+ * onto an agent-written entry without collapsing ordinary versioned sources.
  */
 function mergeFileSources(
   stored: ResearchSourceRef[],
   file: ResearchSourceRef[],
 ): ResearchSourceRef[] {
-  const matchesFileEntry = (item: ResearchSourceRef) =>
-    file.some((source) => researchSourcesShareIdentity(source, item));
+  const storedIdOwners = indexDistinctResearchSourceIds(stored);
+  indexDistinctResearchSourceIds(file);
+  const storedIndexByFileIndex = new Map<number, number>();
+  const matchedStoredIndexes = new Set<number>();
+
+  file.forEach((source, fileIndex) => {
+    const storedIndex = storedIdOwners.get(source.id);
+    if (storedIndex === undefined) return;
+    storedIndexByFileIndex.set(fileIndex, storedIndex);
+    matchedStoredIndexes.add(storedIndex);
+  });
+
+  const candidateFileIndexesByStored = new Map<number, number[]>();
+  file.forEach((source, fileIndex) => {
+    if (storedIndexByFileIndex.has(fileIndex)) return;
+    const candidateStoredIndexes: number[] = [];
+    stored.forEach((item, storedIndex) => {
+      if (
+        !matchedStoredIndexes.has(storedIndex) &&
+        item.provider !== undefined &&
+        researchSourcesShareSecondaryIdentity(source, item)
+      ) {
+        candidateStoredIndexes.push(storedIndex);
+      }
+    });
+    if (candidateStoredIndexes.length > 1) {
+      throw new Error("Research source identities are ambiguous");
+    }
+    const storedIndex = candidateStoredIndexes[0];
+    if (storedIndex === undefined) return;
+    const candidateFileIndexes = candidateFileIndexesByStored.get(storedIndex) ?? [];
+    candidateFileIndexes.push(fileIndex);
+    candidateFileIndexesByStored.set(storedIndex, candidateFileIndexes);
+  });
+
+  for (const [storedIndex, fileIndexes] of candidateFileIndexesByStored) {
+    if (fileIndexes.length > 1) {
+      throw new Error("Research source identities are ambiguous");
+    }
+    matchedStoredIndexes.add(storedIndex);
+    storedIndexByFileIndex.set(fileIndexes[0], storedIndex);
+  }
+
   // The agent's sources.json wins on every field it owns, but external-provider
   // IDENTITY is Cave's, not the agent's: it is written by the attach route and
   // by hydration, and the agent is never told to reproduce it. Without this
@@ -318,14 +359,11 @@ function mergeFileSources(
   // the identity-only ref and silently drops provider/externalId/availability,
   // so a COMPLETED mission — which never hydrates again — would keep no record
   // that the source was an X post at all (cave-v3ajh, #4816 criterion 4).
-  const merged = file.map((source) => {
+  const merged = file.map((source, fileIndex) => {
     if (source.provider !== undefined) return source;
-    const displaced = stored.find(
-      (item) =>
-        item.provider !== undefined &&
-        researchSourcesShareIdentity(source, item),
-    );
-    if (!displaced) return source;
+    const storedIndex = storedIndexByFileIndex.get(fileIndex);
+    const displaced = storedIndex === undefined ? undefined : stored[storedIndex];
+    if (displaced?.provider === undefined) return source;
     return {
       ...source,
       provider: displaced.provider,
@@ -333,7 +371,10 @@ function mergeFileSources(
       ...(displaced.availability !== undefined ? { availability: displaced.availability } : {}),
     };
   });
-  return [...merged, ...stored.filter((item) => !matchesFileEntry(item))];
+  return [
+    ...merged,
+    ...stored.filter((_, storedIndex) => !matchedStoredIndexes.has(storedIndex)),
+  ];
 }
 
 const PATCHABLE_SOURCE_FIELDS = [

--- a/src/lib/use-focus-trap-stack.test.tsx
+++ b/src/lib/use-focus-trap-stack.test.tsx
@@ -142,13 +142,15 @@ function TrapProbe({
   probeId,
   active,
   onEscape,
+  restoreFocus,
 }: {
   probeId: string;
   active: boolean;
   onEscape: () => void;
+  restoreFocus?: () => boolean;
 }) {
   const containerRef = useRef<unknown>(null);
-  useFocusTrap(active, containerRef as never, { onEscape });
+  useFocusTrap(active, containerRef as never, { onEscape, restoreFocus });
   return <div data-probe-id={probeId} ref={containerRef as never} />;
 }
 
@@ -170,6 +172,44 @@ afterEach(() => {
 });
 
 describe("useFocusTrap stack-awareness (cave-rl980 Task 5 nested modal findings)", () => {
+  test("a late-bound gate suppresses focus restoration during a direct layer transition", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    restoreGlobals = stubDomGlobals(activeHolder, win);
+
+    const trigger = makeElement("trigger", activeHolder);
+    const dialogControl = makeElement("dialog-control", activeHolder);
+    const container = makeContainer([dialogControl], activeHolder);
+    let shouldRestore = true;
+
+    activeHolder.current = trigger;
+    act(() => {
+      renderer = create(
+        <TrapProbe
+          probeId="dialog"
+          active
+          onEscape={() => {}}
+          restoreFocus={() => shouldRestore}
+        />,
+        { createNodeMock: () => container },
+      );
+    });
+    expect(activeHolder.current).toBe(dialogControl);
+
+    shouldRestore = false;
+    act(() => {
+      renderer!.update(
+        <TrapProbe
+          probeId="dialog"
+          active={false}
+          onEscape={() => {}}
+          restoreFocus={() => shouldRestore}
+        />,
+      );
+    });
+    expect(activeHolder.current).toBe(dialogControl);
+  });
+
   test("Escape closes only the topmost (child) trap while both are active, then the parent resumes", () => {
     const activeHolder: { current: FakeElement | null } = { current: null };
     const win = makeWindowStub();

--- a/src/lib/use-focus-trap.test.ts
+++ b/src/lib/use-focus-trap.test.ts
@@ -149,8 +149,13 @@ assert.match(
 );
 assert.match(
   source,
-  /if \(!hadTrapAbove\) \{\s*\n\s*returnFocusRef\.current\?\.focus\(\);\s*\n\s*\}/,
+  /if \(!hadTrapAbove && restoreFocusRef\.current\(\) !== false\) \{\s*\n\s*returnFocusRef\.current\?\.focus\(\);\s*\n\s*\}/,
   "focus restoration on deactivate is skipped while a nested trap is still active above it",
+);
+assert.match(
+  source,
+  /restoreFocusRef\.current\(\) !== false/,
+  "callers can suppress restoration when focus is deliberately moving into a replacement layer",
 );
 
 // Test seam: a stray trap left registered by a failed test must not leak

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -19,6 +19,8 @@ type Options = {
    *  focusable child exists, focuses the container itself — caller MUST give
    *  the container `tabIndex={-1}` so this is reachable. */
   focusFirst?: boolean;
+  /** Late-bound restoration gate for transitions directly into another layer. */
+  restoreFocus?: () => boolean;
 };
 
 /**
@@ -90,8 +92,9 @@ export const FocusTrapOwnerHiddenContext = createContext(false);
 /**
  * Trap focus inside `containerRef` while `active` is true. Saves the
  * previously-focused element on activate→deactivate and restores it on
- * deactivate. Tab/Shift+Tab cycle through focusable descendants. Escape
- * calls onEscape.
+ * deactivate unless `restoreFocus` declines a direct transition into another
+ * layer. Tab/Shift+Tab cycle through focusable descendants. Escape calls
+ * onEscape.
  *
  * Stack-aware: every active trap in the app registers on a shared
  * module-level stack (see trapStack above), and only the TOPMOST one ever
@@ -113,10 +116,11 @@ export const FocusTrapOwnerHiddenContext = createContext(false);
 export function useFocusTrap(
   active: boolean,
   containerRef: RefObject<HTMLElement | null>,
-  { onEscape, focusFirst = true }: Options = {},
+  { onEscape, focusFirst = true, restoreFocus = () => true }: Options = {},
 ) {
   const returnFocusRef = useRef<HTMLElement | null>(null);
   const onEscapeRef = useRef(onEscape);
+  const restoreFocusRef = useRef(restoreFocus);
   // Stable per-hook-instance identity for the trap stack — assigned once
   // (lazy ref init) and unaffected by StrictMode's double render/effect
   // invocation, which reuses this same ref cell rather than re-creating it.
@@ -129,6 +133,9 @@ export function useFocusTrap(
   useEffect(() => {
     onEscapeRef.current = onEscape;
   }, [onEscape]);
+  useEffect(() => {
+    restoreFocusRef.current = restoreFocus;
+  }, [restoreFocus]);
 
   useEffect(() => {
     if (!active) return;
@@ -209,7 +216,7 @@ export function useFocusTrap(
       // back to us (if we're still mounted and active) or, chaining
       // outward, to whatever was focused before the outermost trap ever
       // activated.
-      if (!hadTrapAbove) {
+      if (!hadTrapAbove && restoreFocusRef.current() !== false) {
         returnFocusRef.current?.focus();
       }
     };

--- a/src/styles/document-reader.css
+++ b/src/styles/document-reader.css
@@ -289,6 +289,13 @@
   line-height: 1.15;
 }
 
+.document-reader__context {
+  margin: calc(-1 * var(--space-2)) 0 var(--space-4);
+  color: var(--text-secondary);
+  font-size: calc(var(--text-lg) * var(--reader-text-scale));
+  line-height: var(--cave-reading-leading, 1.6);
+}
+
 .document-reader__lede {
   margin: 0 0 var(--space-5);
   padding-left: var(--space-4);

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -523,6 +523,7 @@
 .research-provenance-edge__item {
   display: inline-flex;
   min-width: var(--space-8);
+  max-width: 100%;
   min-height: var(--space-8);
   align-items: center;
   justify-content: center;
@@ -537,9 +538,12 @@
 .research-provenance-edge__anchor {
   display: inline-flex;
   min-width: var(--space-6);
+  max-width: 100%;
   min-height: var(--space-6);
+  box-sizing: border-box;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
   padding-inline: var(--space-1);
   border: 1px solid color-mix(
     in oklch,
@@ -554,6 +558,18 @@
     border-color var(--duration-fast) var(--ease-standard),
     color var(--duration-fast) var(--ease-standard),
     transform var(--duration-fast) var(--ease-standard);
+}
+
+.research-source-id-label {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.research-provenance-edge__anchor.research-source-id-label {
+  display: inline-flex;
 }
 
 .research-provenance-edge__item:hover .research-provenance-edge__anchor,
@@ -680,6 +696,8 @@
 
 .rr-inline-ref {
   display: none;
+  max-width: calc(var(--space-12) + var(--space-4));
+  overflow: hidden;
 }
 
 .rr-inline-ref-gap {
@@ -706,6 +724,11 @@
     background var(--duration-fast) var(--ease-standard),
     border-color var(--duration-fast) var(--ease-standard),
     color var(--duration-fast) var(--ease-standard);
+}
+
+.rr-src__head .rr-sref {
+  max-width: calc(var(--space-12) + var(--space-4));
+  overflow: hidden;
 }
 
 .rr-sref--warn {
@@ -1024,6 +1047,10 @@
   flex-direction: column;
   gap: var(--space-5);
   padding: var(--space-4);
+}
+
+.research-evidence-inspector__failure {
+  margin: 0;
 }
 
 .research-evidence-inspector__group {
@@ -1498,6 +1525,8 @@
 }
 
 .rr-tip__id {
+  max-width: calc(var(--space-12) + var(--space-8));
+  overflow: hidden;
   color: var(--research-accent);
   font: 600 var(--text-xs) var(--font-mono);
 }

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -1,10 +1,4 @@
-/* Research Reader — typeset findings deliverable viewer.
- *
- * Ported from the Claude Design handoff "Research Reader.dc.html". Imported by
- * research-reader.tsx (component-scoped, not a global sheet). Every colour is a
- * semantic token; state tints derive via color-mix. Compact mono labels keep
- * the design's px sizes through the `font:` shorthand — the type-scale gate
- * governs the standalone `font-size` property, which uses tokens throughout. */
+/* Research Reader — a reading-first findings plane with claim-aligned evidence. */
 
 .research-reader-overlay {
   position: fixed;
@@ -13,34 +7,44 @@
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding: 34px var(--space-6);
+  padding: var(--space-4);
   overflow: auto;
   background: var(--backdrop-scrim);
   -webkit-font-smoothing: antialiased;
 }
 
+.research-reader,
+.research-reader * {
+  box-sizing: border-box;
+}
+
 .research-reader {
-  width: min(76rem, 100%);
-  max-width: 100%;
-  background: var(--bg-raised);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-panel);
-  overflow: hidden;
-  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.55);
-  transition: width var(--duration-slow) var(--ease-emphasized);
+  --research-accent: var(--accent-presence);
+  --research-accent-soft: color-mix(
+    in oklch,
+    var(--research-accent) 14%,
+    transparent
+  );
+  width: min(96rem, 100%);
+  height: calc(100dvh - var(--space-8));
+  max-height: calc(100dvh - var(--space-8));
   display: flex;
   flex-direction: column;
-  max-height: calc(100vh - 68px);
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-popover);
   color: var(--text-primary);
-  font-family: var(--font-inter);
+  font-family: var(--font-sans);
   container-name: research-reader;
   container-type: inline-size;
 }
-.research-reader[data-expanded="true"] { width: min(88rem, 100%); }
 
-.research-reader svg { display: block; }
+.research-reader svg {
+  display: block;
+}
 
-/* ── layout grid: document [+ handle + rail]; TOC appears when expanded ── */
 .research-reader__grid {
   position: relative;
   display: grid;
@@ -48,268 +52,1304 @@
   flex: 1;
   grid-template-columns: minmax(0, 1fr);
   overflow: hidden;
+  transition:
+    grid-template-columns var(--duration-slow) var(--ease-emphasized);
 }
-.research-reader[data-rail="true"] .research-reader__grid {
-  grid-template-columns: minmax(0, 1fr) 9px var(--rail-w, 300px);
-}
-.research-reader[data-expanded="true"] .research-reader__grid {
-  grid-template-columns: minmax(0, 1fr);
-}
-.research-reader[data-expanded="true"][data-rail="true"] .research-reader__grid {
-  grid-template-columns: minmax(0, 1fr) 9px var(--rail-w, 300px);
-}
-.research-reader[data-expanded="true"][data-toc="false"] .research-reader__grid {
-  grid-template-columns: minmax(0, 1fr);
-}
-.research-reader[data-expanded="true"][data-toc="false"][data-rail="true"] .research-reader__grid {
-  grid-template-columns: minmax(0, 1fr) 9px var(--rail-w, 300px);
-}
-.rr-col { overflow: auto; min-height: 0; }
 
-/* ── progress bar (expanded only) ── */
-.rr-pbar { display: none; height: 3px; background: var(--bg-elevated); flex: none; }
-.research-reader[data-expanded="true"] .rr-pbar { display: block; }
-.rr-pbar__fill { height: 100%; background: var(--research-accent); }
+.research-reader[data-inspector="true"] .research-reader__grid {
+  grid-template-columns:
+    minmax(0, 1fr)
+    minmax(18rem, var(--rail-w, 22rem));
+}
 
-/* ── header toolbar ── */
+.rr-col {
+  min-height: 0;
+  overflow: auto;
+}
+
+/* Progress is present but subordinate to the report and its evidence edge. */
+.rr-pbar {
+  height: var(--ring-width);
+  flex: none;
+  overflow: hidden;
+  background: transparent;
+}
+
+.rr-pbar__fill {
+  width: 0;
+  height: 100%;
+  background: var(--research-accent);
+  transition: width var(--duration-fast) var(--ease-standard);
+}
+
+/* Compact one-line chrome: lifecycle, integrity, identity, then controls. */
 .rr-head {
+  z-index: 6;
   display: flex;
+  min-height: var(--space-12);
   align-items: center;
   gap: var(--space-3);
-  padding: var(--space-3) var(--space-5);
-  border-bottom: 1px solid var(--border);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--border-hairline);
+  background: var(--glass-raised);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   flex: none;
 }
-.rr-head__actions { display: flex; align-items: center; gap: 6px; margin-left: auto; flex: none; }
-.rr-head__sep { width: 1px; height: 20px; background: var(--border); margin: 0 2px; }
 
-.rr-tb-extra { display: none; }
-.research-reader[data-expanded="true"] .rr-tb-extra { display: contents; }
-.rr-tgl-toc { display: none; }
-.research-reader[data-expanded="true"] .rr-tgl-toc { display: inline-flex; }
-
-.rr-ic-collapse { display: none; }
-.research-reader[data-expanded="true"] .rr-ic-expand { display: none; }
-.research-reader[data-expanded="true"] .rr-ic-collapse { display: block; }
-.rr-ic-copied { display: none; }
-.research-reader[data-copied="true"] .rr-ic-copied { display: block; }
-.research-reader[data-copied="true"] .rr-ic-clip { display: none; }
-
-/* ── source-ref chips ── */
-.rr-sref {
-  font: 600 11.5px var(--font-mono);
-  color: var(--research-accent);
-  background: color-mix(in oklch, var(--research-accent) 13%, transparent);
-  border: 1px solid color-mix(in oklch, var(--research-accent) 26%, transparent);
-  border-radius: 5px;
-  padding: 0 5px;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: background var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast);
-}
-.rr-sref--warn { color: var(--color-warning); background: color-mix(in oklch, var(--color-warning) 13%, transparent); border-color: color-mix(in oklch, var(--color-warning) 30%, transparent); }
-.rr-sref--muted { color: var(--text-muted); background: color-mix(in oklch, var(--text-muted) 12%, transparent); border-color: var(--border); }
-.rr-sref.is-match { background: color-mix(in oklch, var(--research-accent) 30%, transparent); border-color: var(--research-accent); color: var(--text-primary); }
-.rr-sref--warn.is-match { background: color-mix(in oklch, var(--color-warning) 30%, transparent); border-color: var(--color-warning); }
-
-/* ── header meta + status ── */
-.rr-meta { font: 400 11.5px var(--font-mono); color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
-.rr-status { display: inline-flex; align-items: center; gap: 6px; font: 600 10px var(--font-mono); letter-spacing: 0.06em; text-transform: uppercase; color: var(--color-success); flex: none; }
-.rr-status--muted { color: var(--text-muted); }
-.rr-status__dot { width: 6px; height: 6px; border-radius: var(--radius-pill); background: currentColor; display: block; }
-
-/* ── confidence chips ── */
-.rr-cf { font: 600 9px var(--font-mono); text-transform: uppercase; border-radius: 3px; padding: 2px 6px; white-space: nowrap; }
-.rr-cf--high { color: var(--color-success); background: color-mix(in oklch, var(--color-success) 14%, transparent); }
-.rr-cf--med { color: var(--color-warning); background: color-mix(in oklch, var(--color-warning) 14%, transparent); }
-.rr-cf--low { color: var(--text-muted); background: color-mix(in oklch, var(--text-muted) 12%, transparent); }
-
-/* ── buttons ── */
-.rr-btn {
-  display: inline-flex;
+.rr-head__actions {
+  display: flex;
   align-items: center;
-  gap: 6px;
-  font: 500 12px var(--font-inter);
-  color: var(--text-secondary);
-  background: var(--bg-subtle);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-control);
-  padding: 6px 11px;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: background var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast);
+  gap: var(--space-1);
+  margin-left: auto;
+  flex: none;
 }
-.rr-btn:hover { background: var(--bg-hover); border-color: var(--border-strong); color: var(--text-primary); }
-.rr-btn--accent { color: var(--research-accent); background: var(--research-accent-soft); border-color: color-mix(in oklch, var(--research-accent) 40%, transparent); }
-.rr-btn--accent:hover { background: color-mix(in oklch, var(--research-accent) 22%, transparent); color: var(--research-accent); }
-.rr-btn:disabled { opacity: 0.5; cursor: default; }
 
-.rr-iconbtn {
+.rr-head__sep {
+  width: 1px;
+  height: var(--space-5);
+  margin-inline: var(--space-1);
+  background: var(--border-hairline);
+}
+
+.rr-meta {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font: 400 var(--text-xs) var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rr-status,
+.rr-integrity {
   display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-1);
+  overflow: hidden;
+  font: 600 var(--text-2xs) var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+  flex: none;
+}
+
+.rr-status {
+  color: var(--color-success);
+}
+
+.rr-status--muted {
+  color: var(--text-muted);
+}
+
+.rr-status__dot,
+.rr-srcstat__dot {
+  width: calc(var(--space-1) + var(--ring-width));
+  height: calc(var(--space-1) + var(--ring-width));
+  border-radius: var(--radius-pill);
+  background: currentColor;
+  flex: none;
+}
+
+.rr-integrity {
+  max-width: min(18rem, 28cqw);
+  padding-left: var(--space-3);
+  border-left: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+}
+
+.rr-integrity--verified {
+  color: var(--color-success);
+}
+
+.rr-integrity--candidate,
+.rr-integrity--conflicting,
+.rr-integrity--unresolved,
+.rr-integrity--unavailable {
+  color: var(--color-warning);
+}
+
+.rr-integrity--rejected {
+  color: var(--color-danger);
+}
+
+.rr-integrity--none {
+  color: var(--text-muted);
+}
+
+.rr-btn,
+.rr-iconbtn,
+.research-evidence-inspector__close {
+  display: inline-flex;
+  min-height: var(--space-8);
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: var(--radius-control);
-  color: var(--text-muted);
-  background: transparent;
   border: 1px solid transparent;
+  border-radius: var(--radius-control);
   cursor: pointer;
-  transition: background var(--duration-fast), color var(--duration-fast);
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
 }
-.rr-iconbtn:hover { background: var(--bg-hover); color: var(--text-primary); }
-.rr-iconbtn[aria-pressed="true"] { color: var(--research-accent); background: var(--research-accent-soft); }
 
-/* ── evidence rail ── */
-.rr-rail { display: none; padding: 18px 16px; background: var(--bg-subtle); border-left: 1px solid var(--border-hairline); }
-.research-reader[data-rail="true"] .rr-rail { display: block; }
-.rr-railhead { cursor: pointer; padding: 5px 6px; margin: -5px -6px 10px; border-radius: var(--radius-control); transition: background var(--duration-fast); display: flex; align-items: center; justify-content: space-between; background: none; border: none; width: calc(100% + 12px); }
-.rr-railhead:hover { background: var(--bg-hover); }
-.rr-railhead__label { font: 600 10px var(--font-mono); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-muted); }
-.rr-rail__list { display: flex; flex-direction: column; gap: 8px; }
+.rr-btn {
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+  border-color: var(--border-hairline);
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+  font: 500 var(--text-sm) var(--font-sans);
+  white-space: nowrap;
+}
 
-/* ── resize handle ── */
-.rr-railhandle { display: none; position: relative; cursor: col-resize; background: transparent; touch-action: none; }
-.research-reader[data-rail="true"] .rr-railhandle { display: block; }
-.rr-railhandle::before { content: ""; position: absolute; inset: 0 4px; background: var(--border-hairline); transition: background var(--duration-fast); }
-.rr-railhandle:hover::before, .rr-railhandle[data-drag="true"]::before { background: color-mix(in oklch, var(--research-accent) 55%, transparent); }
-.rr-railgrip { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 3px; height: 30px; border-radius: 2px; background: var(--border-strong); transition: background var(--duration-fast); }
-.rr-railhandle:hover .rr-railgrip, .rr-railhandle[data-drag="true"] .rr-railgrip { background: var(--research-accent); }
+.rr-btn:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
 
-/* ── source cards ── */
-.rr-src { padding: 10px 11px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--bg-raised); transition: border-color var(--duration-fast); }
-.rr-src:hover { border-color: var(--border-strong); }
-.rr-src__toggle { display: block; width: 100%; text-align: left; background: none; border: none; padding: 0; margin: 0; font: inherit; color: inherit; cursor: pointer; }
-.rr-src--accent { border-color: color-mix(in oklch, var(--research-accent) 30%, transparent); box-shadow: 0 0 0 1px color-mix(in oklch, var(--research-accent) 16%, transparent); }
-.rr-src--warn { border-color: color-mix(in oklch, var(--color-warning) 30%, transparent); }
-.rr-src--rejected { border-style: dashed; }
-.rr-src[data-open="true"] { border-color: var(--research-accent); background: var(--bg-elevated); }
-.rr-src--warn[data-open="true"] { border-color: var(--color-warning); }
-.rr-src.is-match { border-color: var(--research-accent); box-shadow: 0 0 0 1px var(--research-accent); }
-.rr-src__head { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; }
-.rr-src__title { font-size: var(--text-sm); font-weight: 500; color: var(--text-primary); line-height: 1.4; }
-.rr-src--rejected .rr-src__title { color: var(--text-secondary); }
-.rr-src__meta { font: 400 10px var(--font-mono); color: var(--text-muted); margin-top: 3px; }
-.rr-srcstat { display: inline-flex; align-items: center; gap: 4px; font: 600 9px var(--font-mono); text-transform: uppercase; }
-.rr-srcstat--ok { color: var(--color-success); }
-.rr-srcstat--warn { color: var(--color-warning); }
-.rr-srcstat--muted { color: var(--text-muted); }
-.rr-srcstat__dot { width: 5px; height: 5px; border-radius: var(--radius-pill); background: currentColor; display: block; }
-.rr-srccaret { margin-left: auto; color: var(--text-muted); transition: transform var(--duration-fast) var(--ease-standard); flex: none; }
-.rr-src[data-open="true"] .rr-srccaret { transform: rotate(180deg); }
+.rr-btn--accent {
+  border-color: color-mix(
+    in oklch,
+    var(--research-accent) 38%,
+    var(--border-hairline)
+  );
+  background: var(--research-accent-soft);
+  color: var(--research-accent);
+}
 
-.rr-srcdetail { display: none; margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border-hairline); }
-.rr-src[data-open="true"] .rr-srcdetail { display: block; }
-.rr-sd-quote { font-family: var(--font-eb-garamond); font-style: italic; font-size: var(--text-sm); line-height: 1.5; color: var(--text-secondary); border-left: 2px solid var(--research-accent); padding-left: 10px; margin-bottom: 10px; }
-.rr-src--warn .rr-sd-quote { border-left-color: var(--color-warning); }
-.rr-sd-row { display: flex; gap: 8px; margin-bottom: 5px; }
-.rr-sd-row .rr-sd-k { flex: none; width: 62px; font: 600 9px var(--font-mono); letter-spacing: 0.05em; text-transform: uppercase; color: var(--text-muted); padding-top: 2px; }
-.rr-sd-row .rr-sd-v { color: var(--text-secondary); font-size: 11.5px; line-height: 1.45; }
-.rr-sd-supports { margin-top: 9px; display: flex; flex-wrap: wrap; gap: 6px; align-items: center; font-size: var(--text-xs); color: var(--text-muted); }
-.rr-sd-supports__label { font: 600 9px var(--font-mono); letter-spacing: 0.05em; text-transform: uppercase; }
-.rr-sd-supportlink { color: var(--research-accent); text-decoration: none; font-weight: 500; font-size: var(--text-xs); background: var(--research-accent-soft); border: none; border-radius: var(--radius-pill); padding: 1px 8px; cursor: pointer; font-family: var(--font-inter); }
-.rr-sd-supportlink:hover { background: color-mix(in oklch, var(--research-accent) 22%, transparent); }
-.rr-sd-actions { display: flex; gap: 6px; margin-top: 11px; }
-.rr-sd-btn { flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 5px; font: 500 11px var(--font-inter); padding: 6px 8px; border-radius: var(--radius-control); border: 1px solid var(--border); background: var(--bg-raised); color: var(--text-secondary); cursor: pointer; transition: background var(--duration-fast), border-color var(--duration-fast), color var(--duration-fast); }
-.rr-sd-btn:hover { background: var(--bg-hover); color: var(--text-primary); border-color: var(--border-strong); }
-.rr-sd-btn:disabled { opacity: 0.5; cursor: default; }
-.rr-sd-btn--accent { color: var(--research-accent); background: var(--research-accent-soft); border-color: color-mix(in oklch, var(--research-accent) 40%, transparent); }
-.rr-sd-btn--accent:hover { background: color-mix(in oklch, var(--research-accent) 22%, transparent); color: var(--research-accent); }
+.rr-btn--accent:hover {
+  background: color-mix(
+    in oklch,
+    var(--research-accent) 22%,
+    transparent
+  );
+  color: var(--research-accent);
+}
 
-/* ── "more sources" strip ── */
-.rr-more { margin-top: 6px; }
-.rr-more__label { font: 600 9px var(--font-mono); letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 8px; }
-/* Stacks vertically and rides the rail's own scroll (.rr-col is overflow:auto,
-   .rr-rail__list is already a column). It used to be a row with overflow-x and
-   152px fixed cards, which put a second, competing scroll axis inside an
-   otherwise vertical surface: titles truncated mid-word and 12 of 14 sources
-   sat off the rail edge (cave-l2hkx). No overflow here on purpose — the rail
-   scrolls, this does not. */
-.rr-srcscroll { display: flex; flex-direction: column; gap: 8px; }
-.rr-srcmini { width: 100%; padding: 9px 10px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--bg-raised); cursor: pointer; transition: border-color var(--duration-fast); text-align: left; }
-.rr-srcmini:hover { border-color: var(--border-strong); }
-.rr-srcmini--rejected { border-style: dashed; }
-.rr-srcmini__title { font-size: var(--text-xs); font-weight: 500; color: var(--text-primary); line-height: 1.35; margin-top: 6px; }
-.rr-srcmini--rejected .rr-srcmini__title { color: var(--text-secondary); }
-.rr-srcmini__meta { font: 400 9px var(--font-mono); color: var(--text-muted); margin-top: 4px; }
+.rr-btn:disabled,
+.rr-sd-btn:disabled {
+  opacity: var(--opacity-disabled);
+  cursor: default;
+}
 
-/* ── tooltip ── */
+.rr-iconbtn,
+.research-evidence-inspector__close {
+  width: var(--space-8);
+  min-width: var(--space-8);
+  padding: 0;
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.rr-iconbtn:hover,
+.research-evidence-inspector__close:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.rr-iconbtn[aria-pressed="true"] {
+  border-color: color-mix(
+    in oklch,
+    var(--research-accent) 38%,
+    var(--border-hairline)
+  );
+  background: var(--research-accent-soft);
+  color: var(--research-accent);
+}
+
+/* Research-scoped DocumentReader material. Memories retain the shared defaults. */
+.research-reader .document-reader {
+  min-width: 0;
+  background: var(--bg-panel);
+}
+
+.research-reader .document-reader__layout {
+  min-width: 0;
+}
+
+.research-reader .rr-doc {
+  --rr-paper-pad-inline: var(--space-12);
+  padding: var(--space-8) var(--space-6);
+  background: var(--bg-base);
+}
+
+.research-reader .document-reader__toolbar {
+  width: min(
+    100%,
+    calc(
+      var(--document-reader-prose-measure) +
+        var(--rr-paper-pad-inline) +
+        var(--rr-paper-pad-inline)
+    )
+  );
+  padding: 0 0 var(--space-3);
+}
+
+.research-reader .document-reader__preferences-trigger,
+.research-reader .document-reader__contents-trigger {
+  background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+}
+
+.research-reader .rr-doc__column {
+  width: min(
+    100%,
+    calc(
+      var(--document-reader-prose-measure) +
+        var(--rr-paper-pad-inline) +
+        var(--rr-paper-pad-inline)
+    )
+  );
+  max-width: none;
+  min-height: 100%;
+  padding: var(--space-10) var(--rr-paper-pad-inline) var(--space-12);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background: var(--bg-raised);
+}
+
+.research-reader .document-reader__title {
+  margin-bottom: var(--space-5);
+  color: var(--text-primary);
+}
+
+.research-reader .document-reader__context {
+  display: -webkit-box;
+  overflow: hidden;
+  margin-bottom: var(--space-5);
+  color: var(--text-secondary);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.research-reader .document-reader__context p {
+  color: inherit;
+}
+
+.research-reader .document-reader__lede {
+  border-left-color: var(--research-accent);
+  color: var(--text-secondary);
+}
+
+.research-reader .document-reader__heading {
+  position: relative;
+}
+
+.research-reader .document-reader__heading::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(-1 * var(--space-4));
+  width: var(--ring-width);
+  border-radius: var(--radius-pill);
+  background: color-mix(
+    in oklch,
+    var(--research-accent) 52%,
+    transparent
+  );
+  content: "";
+}
+
+.research-reader .document-reader__column p,
+.research-reader .document-reader__column li,
+.research-reader .document-reader__column blockquote {
+  color: var(--text-primary);
+}
+
+.research-reader .rr-codeblock,
+.research-reader .rr-krblock {
+  width: calc(
+    100% + var(--rr-paper-pad-inline) + var(--rr-paper-pad-inline)
+  );
+  max-width: calc(
+    100% + var(--rr-paper-pad-inline) + var(--rr-paper-pad-inline)
+  );
+}
+
+.rr-codeblock {
+  min-width: 0;
+  margin-block: var(--space-2) var(--space-5);
+}
+
+.rr-codeblock .cave-md > .cm-mermaid-diagram {
+  margin: 0;
+}
+
+/* Contents is a native split-view material, not a permanent dashboard rail. */
+.research-reader .rr-toc {
+  padding: var(--space-5) var(--space-3);
+  border-right-color: var(--border-strong);
+  background: var(--bg-elevated);
+}
+
+.research-reader .rr-toc__links::before {
+  background: var(--border-strong);
+}
+
+.research-reader .rr-toclink {
+  min-height: var(--space-8);
+  color: var(--text-secondary);
+  line-height: var(--leading-normal);
+  overflow-wrap: anywhere;
+}
+
+.research-reader .rr-toclink[data-active="true"] {
+  border-left: var(--ring-width) solid var(--research-accent);
+  background: color-mix(
+    in oklch,
+    var(--research-accent) 18%,
+    var(--bg-elevated)
+  );
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.research-reader .rr-toclink[data-active="true"]::before {
+  box-shadow: 0 0 0 var(--ring-width) var(--bg-elevated);
+}
+
+.research-reader .rr-toc__meta {
+  border-top-color: var(--border-strong);
+}
+
+/* Structural provenance: content and its evidence remain layout siblings. */
+.rr-block-row,
+.rr-list-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--space-10);
+  gap: var(--space-3);
+  align-items: start;
+}
+
+.rr-block-row > :first-child,
+.rr-list-row > :first-child {
+  min-width: 0;
+}
+
+.rr-block-row > p,
+.rr-block-row > blockquote {
+  margin-bottom: var(--space-4);
+}
+
+.rr-list-row {
+  position: relative;
+  padding-left: 0;
+}
+
+.research-reader .document-reader__column ol {
+  counter-reset: rr-ordered-item;
+  list-style: none;
+}
+
+.research-reader .document-reader__column ul {
+  list-style: none;
+}
+
+.research-reader .document-reader__column ol > .rr-list-row {
+  counter-increment: rr-ordered-item;
+}
+
+.research-reader .document-reader__column ol > .rr-list-row::before,
+.research-reader .document-reader__column ul > .rr-list-row::before {
+  position: absolute;
+  right: calc(100% + var(--space-2));
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: calc(var(--text-sm) * var(--reader-text-scale));
+}
+
+.research-reader .document-reader__column ol > .rr-list-row::before {
+  content: counter(rr-ordered-item) ".";
+}
+
+.research-reader .document-reader__column ul > .rr-list-row::before {
+  content: "•";
+}
+
+.research-provenance-edge {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-1);
+}
+
+.research-provenance-edge__item {
+  display: inline-flex;
+  min-width: var(--space-8);
+  min-height: var(--space-8);
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1);
+  border: 1px solid color-mix(
+    in oklch,
+    var(--research-accent) 38%,
+    var(--border-hairline)
+  );
+  border-radius: var(--radius-pill);
+  background: var(--research-accent-soft);
+  color: var(--research-accent);
+  font: 600 var(--text-2xs) var(--font-mono);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard);
+}
+
+.research-provenance-edge__item:hover,
+.research-provenance-edge__item.is-selected {
+  border-color: var(--research-accent);
+  background: color-mix(
+    in oklch,
+    var(--research-accent) 28%,
+    transparent
+  );
+  color: var(--text-primary);
+}
+
+.research-provenance-edge__item.is-selected {
+  box-shadow: inset 0 0 0 var(--ring-width) var(--research-accent);
+}
+
+.research-provenance-edge__item--warn {
+  border-width: var(--ring-width);
+  border-color: color-mix(
+    in oklch,
+    var(--color-warning) 42%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-warning) 14%,
+    transparent
+  );
+  color: var(--color-warning);
+  text-decoration: underline wavy;
+}
+
+.research-provenance-edge__item--warn:hover,
+.research-provenance-edge__item--warn.is-selected {
+  border-color: var(--color-warning);
+  background: color-mix(
+    in oklch,
+    var(--color-warning) 28%,
+    transparent
+  );
+}
+
+.research-provenance-edge__item--muted {
+  border-style: dashed;
+  border-color: color-mix(
+    in oklch,
+    var(--text-muted) 38%,
+    var(--border-hairline)
+  );
+  background: color-mix(in oklch, var(--text-muted) 12%, transparent);
+  color: var(--text-muted);
+  text-decoration: line-through;
+}
+
+.research-provenance-edge__item--unresolved {
+  border-style: dotted;
+  border-color: color-mix(
+    in oklch,
+    var(--color-danger) 42%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-danger) 14%,
+    transparent
+  );
+  color: var(--color-danger);
+  font-style: italic;
+}
+
+.rr-inline-ref {
+  display: none;
+}
+
+.rr-sref {
+  align-items: center;
+  justify-content: center;
+  min-height: var(--space-6);
+  padding-inline: var(--space-1);
+  border: 1px solid color-mix(
+    in oklch,
+    var(--research-accent) 30%,
+    var(--border-hairline)
+  );
+  border-radius: var(--radius-control);
+  background: var(--research-accent-soft);
+  color: var(--research-accent);
+  font: 600 var(--text-xs) var(--font-mono);
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+.rr-sref--warn {
+  border-color: color-mix(
+    in oklch,
+    var(--color-warning) 38%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-warning) 14%,
+    transparent
+  );
+  color: var(--color-warning);
+  text-decoration: underline wavy;
+}
+
+.rr-sref--muted {
+  border-style: dashed;
+  border-color: var(--border-hairline);
+  background: color-mix(in oklch, var(--text-muted) 12%, transparent);
+  color: var(--text-muted);
+}
+
+.rr-sref.is-match {
+  border-color: var(--research-accent);
+  background: color-mix(
+    in oklch,
+    var(--research-accent) 28%,
+    transparent
+  );
+  color: var(--text-primary);
+}
+
+.rr-sref--warn.is-match {
+  border-color: var(--color-warning);
+  background: color-mix(
+    in oklch,
+    var(--color-warning) 28%,
+    transparent
+  );
+}
+
+/* Tables keep evidence attached to the row and out of the reading cell. */
+.rr-krblock {
+  position: relative;
+  margin-block: var(--space-2) var(--space-5);
+}
+
+.rr-krframe {
+  overflow: auto;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-raised);
+}
+
+.rr-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-base);
+}
+
+.rr-table thead th,
+.rr-table tbody td {
+  padding: var(--space-3);
+  text-align: left;
+  vertical-align: top;
+}
+
+.rr-table thead th {
+  border-bottom: 1px solid var(--border-strong);
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  font: 600 var(--text-2xs) var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+
+.rr-table tbody td {
+  border-bottom: 1px solid var(--border-hairline);
+  color: var(--text-secondary);
+  line-height: var(--leading-normal);
+}
+
+.rr-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.rr-table__evidence {
+  position: sticky;
+  right: 0;
+  width: var(--space-12);
+  min-width: var(--space-12);
+  padding-inline: var(--space-2) !important;
+  background: var(--bg-raised);
+  text-align: right !important;
+}
+
+.rr-table thead .rr-table__evidence {
+  background: var(--bg-subtle);
+}
+
+.rr-table__evidence .research-provenance-edge {
+  justify-content: center;
+}
+
+.rr-krfocus {
+  position: absolute;
+  top: var(--space-2);
+  right: calc(var(--space-12) + var(--space-2));
+  z-index: 2;
+  display: inline-flex;
+  width: var(--space-8);
+  height: var(--space-8);
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-popover);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+.rr-krblock:hover .rr-krfocus,
+.rr-krfocus:focus-visible {
+  opacity: 1;
+}
+
+.rr-krfocus:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+/* Evidence inspector: one elevated plane with quiet internal hierarchy. */
+.rr-rail {
+  display: none;
+  min-width: 0;
+  padding: 0;
+  border-left: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+}
+
+.research-reader[data-inspector="true"] .rr-rail {
+  display: block;
+}
+
+.rr-railhandle {
+  position: absolute;
+  z-index: 7;
+  top: 0;
+  right: var(--rail-w, 22rem);
+  bottom: 0;
+  display: none;
+  width: var(--space-2);
+  cursor: col-resize;
+  touch-action: none;
+  transform: translateX(50%);
+}
+
+.research-reader[data-inspector="true"] .rr-railhandle {
+  display: block;
+}
+
+.rr-railhandle::before {
+  position: absolute;
+  inset-block: 0;
+  left: calc(50% - (var(--ring-width) / 2));
+  width: var(--ring-width);
+  background: var(--border-strong);
+  content: "";
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.rr-railhandle:hover::before,
+.rr-railhandle[data-drag="true"]::before {
+  background: var(--research-accent);
+}
+
+.rr-railgrip {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: var(--space-1);
+  height: var(--space-8);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  background: var(--bg-elevated);
+  transform: translate(-50%, -50%);
+}
+
+.research-evidence-inspector {
+  min-height: 100%;
+  color: var(--text-primary);
+}
+
+.research-evidence-inspector__header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-1) var(--space-3);
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--border-strong);
+  background: var(--bg-elevated);
+}
+
+.research-evidence-inspector__heading {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.research-evidence-inspector__heading h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--text-lg);
+  font-weight: 600;
+}
+
+.research-evidence-inspector__count {
+  color: var(--text-muted);
+  font: 500 var(--text-2xs) var(--font-mono);
+  text-transform: uppercase;
+}
+
+.research-evidence-inspector__integrity {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.research-evidence-inspector__close {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+}
+
+.research-evidence-inspector__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-4);
+}
+
+.research-evidence-inspector__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.research-evidence-inspector__group + .research-evidence-inspector__group {
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-hairline);
+}
+
+.research-evidence-inspector__group-label {
+  margin: 0;
+  color: var(--text-muted);
+  font: 600 var(--text-2xs) var(--font-mono);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+}
+
+.rr-src {
+  padding: var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: transparent;
+  box-shadow: none;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.rr-src:hover {
+  border-color: var(--border-strong);
+}
+
+.rr-src--warn {
+  border-color: color-mix(
+    in oklch,
+    var(--color-warning) 38%,
+    var(--border-hairline)
+  );
+}
+
+.rr-src--rejected {
+  border-style: dashed;
+}
+
+.rr-src[data-open="true"] {
+  background: color-mix(
+    in oklch,
+    var(--text-primary) 5%,
+    var(--bg-elevated)
+  );
+}
+
+.rr-src.is-selected {
+  border-color: var(--research-accent);
+  background: color-mix(
+    in oklch,
+    var(--research-accent) 10%,
+    var(--bg-elevated)
+  );
+  box-shadow: inset var(--ring-width) 0 0 var(--research-accent);
+}
+
+.rr-src--warn.is-selected {
+  border-color: var(--color-warning);
+  box-shadow: inset var(--ring-width) 0 0 var(--color-warning);
+}
+
+.rr-src__toggle {
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.rr-src__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.rr-src__title {
+  display: block;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  line-height: var(--leading-normal);
+}
+
+.rr-src--rejected .rr-src__title {
+  color: var(--text-secondary);
+}
+
+.rr-src__meta {
+  display: block;
+  margin-top: var(--space-1);
+  color: var(--text-muted);
+  font: 400 var(--text-2xs) var(--font-mono);
+  line-height: var(--leading-normal);
+}
+
+.rr-srcstat {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font: 600 var(--text-2xs) var(--font-mono);
+  text-transform: uppercase;
+}
+
+.rr-srcstat--ok {
+  color: var(--color-success);
+}
+
+.rr-srcstat--warn {
+  color: var(--color-warning);
+}
+
+.rr-srcstat--muted {
+  color: var(--text-muted);
+}
+
+.rr-srccaret {
+  margin-left: auto;
+  color: var(--text-muted);
+  flex: none;
+  transition: transform var(--duration-fast) var(--ease-standard);
+}
+
+.rr-src[data-open="true"] .rr-srccaret {
+  transform: rotate(180deg);
+}
+
+.rr-srcdetail {
+  display: none;
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-hairline);
+}
+
+.rr-src[data-open="true"] .rr-srcdetail {
+  display: block;
+}
+
+.rr-sd-quote {
+  margin-bottom: var(--space-3);
+  padding-left: var(--space-3);
+  border-left: var(--ring-width) solid var(--research-accent);
+  color: var(--text-secondary);
+  font-family: var(--font-serif);
+  font-size: var(--text-sm);
+  font-style: italic;
+  line-height: var(--leading-relaxed);
+}
+
+.rr-src--warn .rr-sd-quote {
+  border-left-color: var(--color-warning);
+}
+
+.rr-sd-row {
+  display: grid;
+  grid-template-columns: var(--space-12) minmax(0, 1fr);
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.rr-sd-k {
+  padding-top: var(--space-1);
+  color: var(--text-muted);
+  font: 600 var(--text-2xs) var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+
+.rr-sd-v {
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  overflow-wrap: anywhere;
+}
+
+.rr-sd-supports {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+  margin-top: var(--space-3);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.rr-sd-supports__label {
+  font: 600 var(--text-2xs) var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+
+.rr-sd-supportlink {
+  min-height: var(--space-6);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid color-mix(
+    in oklch,
+    var(--research-accent) 30%,
+    var(--border-hairline)
+  );
+  border-radius: var(--radius-pill);
+  background: var(--research-accent-soft);
+  color: var(--research-accent);
+  font: 500 var(--text-xs) var(--font-sans);
+  cursor: pointer;
+}
+
+.rr-sd-supportlink:hover {
+  background: color-mix(
+    in oklch,
+    var(--research-accent) 22%,
+    transparent
+  );
+}
+
+.rr-sd-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
+.rr-sd-btn {
+  display: inline-flex;
+  min-height: var(--space-8);
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-raised);
+  color: var(--text-secondary);
+  font: 500 var(--text-xs) var(--font-sans);
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+.rr-sd-btn:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.rr-sd-btn--accent {
+  border-color: color-mix(
+    in oklch,
+    var(--research-accent) 38%,
+    var(--border-hairline)
+  );
+  background: var(--research-accent-soft);
+  color: var(--research-accent);
+}
+
+.rr-sd-btn--accent:hover {
+  background: color-mix(
+    in oklch,
+    var(--research-accent) 22%,
+    transparent
+  );
+  color: var(--research-accent);
+}
+
+/* Retained vertical source-strip contract: the inspector owns scrolling. */
+.rr-more {
+  margin-top: var(--space-2);
+}
+
+.rr-more__label {
+  margin-bottom: var(--space-2);
+  color: var(--text-muted);
+  font: 600 var(--text-2xs) var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+
+.rr-srcscroll {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.rr-srcmini {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.rr-srcmini:hover {
+  border-color: var(--border-strong);
+}
+
+.rr-srcmini--rejected {
+  border-style: dashed;
+}
+
+.rr-srcmini__title {
+  margin-top: var(--space-2);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  line-height: var(--leading-normal);
+}
+
+.rr-srcmini__meta {
+  margin-top: var(--space-1);
+  color: var(--text-muted);
+  font: 400 var(--text-2xs) var(--font-mono);
+}
+
+.rr-cf {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--space-6);
+  padding-inline: var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  font: 600 var(--text-2xs) var(--font-mono);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.rr-cf--high {
+  border-color: color-mix(
+    in oklch,
+    var(--color-success) 38%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-success) 14%,
+    transparent
+  );
+  color: var(--color-success);
+}
+
+.rr-cf--med {
+  border-color: color-mix(
+    in oklch,
+    var(--color-warning) 38%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-warning) 14%,
+    transparent
+  );
+  color: var(--color-warning);
+}
+
+.rr-cf--low {
+  border-color: var(--border-hairline);
+  background: color-mix(in oklch, var(--text-muted) 12%, transparent);
+  color: var(--text-muted);
+}
+
+/* Temporary overlays use the existing elevated material and popover shadow. */
 .rr-tip {
   position: fixed;
   z-index: 80;
-  max-width: 264px;
-  padding: 11px 13px;
-  border-radius: var(--radius-md);
-  background: var(--bg-elevated);
+  max-width: 18rem;
+  padding: var(--space-3);
   border: 1px solid var(--border-strong);
-  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5);
+  border-radius: var(--radius-card);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-popover);
   pointer-events: none;
   opacity: 0;
-  transform: translateY(calc(-100% + 4px));
-  transition: opacity var(--duration-fast), transform var(--duration-fast);
-  font-family: var(--font-inter);
+  transform: translateY(calc(-100% + var(--space-1)));
+  font-family: var(--font-sans);
+  transition:
+    opacity var(--duration-fast) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard);
 }
-.rr-tip[data-show="true"] { opacity: 1; transform: translateY(-100%); }
-.rr-tip__head { display: flex; align-items: center; gap: 7px; margin-bottom: 5px; }
-.rr-tip__id { font: 600 11px var(--font-mono); color: var(--research-accent); }
-.rr-tip__status { display: inline-flex; align-items: center; gap: 4px; font: 600 9px var(--font-mono); text-transform: uppercase; }
-.rr-tip__title { font-size: var(--text-sm); font-weight: 500; color: var(--text-primary); line-height: 1.4; margin-bottom: 3px; }
-.rr-tip__meta { font: 400 10px var(--font-mono); color: var(--text-muted); }
 
-/* ── key results table + focus overlay ── */
-.rr-krblock { position: relative; margin-block: var(--space-1) var(--space-4); }
-.rr-krfocus {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  z-index: 2;
+.rr-tip[data-show="true"] {
+  opacity: 1;
+  transform: translateY(-100%);
+}
+
+.rr-tip__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-1);
+}
+
+.rr-tip__id {
+  color: var(--research-accent);
+  font: 600 var(--text-xs) var(--font-mono);
+}
+
+.rr-tip__status {
   display: inline-flex;
   align-items: center;
+  gap: var(--space-1);
+  font: 600 var(--text-2xs) var(--font-mono);
+  text-transform: uppercase;
+}
+
+.rr-tip__title {
+  margin-bottom: var(--space-1);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  line-height: var(--leading-normal);
+}
+
+.rr-tip__meta {
+  color: var(--text-muted);
+  font: 400 var(--text-2xs) var(--font-mono);
+}
+
+.rr-kroverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: var(--radius-control);
+  padding: var(--space-8);
+  background: var(--backdrop-scrim);
+  backdrop-filter: blur(var(--glass-blur));
+}
+
+.rr-kroverlay-card {
+  width: min(72rem, 100%);
+  max-height: calc(100dvh - var(--space-12));
+  overflow: auto;
+  padding: var(--space-6);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-panel);
   background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity var(--duration-fast), background var(--duration-fast), color var(--duration-fast);
+  box-shadow: var(--shadow-popover);
 }
-.rr-krblock:hover .rr-krfocus, .rr-krfocus:focus-visible { opacity: 1; }
-.rr-krfocus:hover { background: var(--bg-hover); color: var(--text-primary); border-color: var(--border-strong); }
-.rr-krframe { border: 1px solid var(--border); border-radius: var(--radius-md); overflow: auto; }
-.rr-table { width: 100%; border-collapse: collapse; font-size: var(--text-base); }
-.rr-table thead th { text-align: left; padding: 9px 14px; font: 600 10px var(--font-mono); letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-muted); border-bottom: 1px solid var(--border); background: var(--bg-subtle); }
-.rr-table thead th + th { padding: 9px 12px; }
-.rr-table tbody td { padding: 11px 14px; color: var(--text-secondary); line-height: 1.5; border-bottom: 1px solid var(--border-hairline); vertical-align: top; }
-.rr-table tbody td + td { padding: 11px 12px; }
-.rr-table tbody tr:last-child td { border-bottom: none; }
 
-.rr-kroverlay { position: fixed; inset: 0; z-index: 80; display: flex; align-items: center; justify-content: center; padding: 5vh 6vw; background: oklch(0 0 0 / 62%); backdrop-filter: blur(3px); }
-.rr-kroverlay-card { width: min(1040px, 100%); max-height: 90vh; overflow: auto; background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius-panel); box-shadow: 0 30px 90px rgba(0, 0, 0, 0.6); padding: 26px 34px 34px; }
-.rr-kroverlay-card .rr-table { font-size: 14.5px; }
-.rr-kroverlay-card thead th { padding: 12px 16px; font-size: 10.5px; letter-spacing: 0.07em; }
-.rr-kroverlay-card tbody td { padding: 16px; line-height: 1.55; }
-.rr-kroverlay__head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 18px; padding-bottom: 16px; border-bottom: 1px solid var(--border-hairline); }
-.rr-kroverlay__title { font-family: var(--font-eb-garamond); font-size: 22px; font-weight: 600; color: var(--text-primary); line-height: 1.1; }
-.rr-kroverlay__sub { font: 400 11.5px var(--font-mono); color: var(--text-muted); margin-top: 5px; }
-
-.rr-codeblock {
-  width: 100%;
-  max-width: 100%;
-  min-width: 0;
-  margin-block: var(--space-2) var(--space-4);
-  margin-inline: 0;
-  transform: none;
+.rr-kroverlay__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-5);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--border-hairline);
 }
-.rr-codeblock .cave-md > .cm-mermaid-diagram { margin: 0; }
 
-/* ── empty state ── */
-.rr-empty { padding: 60px 48px; text-align: center; color: var(--text-muted); font-size: var(--text-md); }
+.rr-kroverlay__title {
+  color: var(--text-primary);
+  font-family: var(--font-serif);
+  font-size: var(--text-xl);
+  font-weight: 600;
+  line-height: var(--leading-tight);
+}
 
+.rr-kroverlay__sub {
+  margin-top: var(--space-1);
+  color: var(--text-muted);
+  font: 400 var(--text-xs) var(--font-mono);
+}
+
+.rr-kroverlay-card .rr-table {
+  font-size: var(--text-md);
+}
+
+.rr-kroverlay-card .rr-table thead th,
+.rr-kroverlay-card .rr-table tbody td {
+  padding: var(--space-4);
+}
+
+.rr-empty {
+  padding: var(--space-12) var(--space-8);
+  color: var(--text-muted);
+  font-size: var(--text-md);
+  text-align: center;
+}
+
+/* Medium readers keep the report stable and overlay evidence from the right. */
 @container research-reader (max-width: 62rem) {
-  .research-reader[data-rail="true"] .research-reader__grid {
+  .research-reader[data-inspector="true"] .research-reader__grid {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -317,9 +1357,9 @@
     display: none !important;
   }
 
-  .research-reader[data-rail="true"] .rr-rail {
+  .research-reader[data-inspector="true"] .rr-rail {
     position: absolute;
-    z-index: 4;
+    z-index: 8;
     inset-block: 0;
     right: 0;
     display: block;
@@ -330,16 +1370,112 @@
   }
 }
 
+/* Provenance has one focusable representation at the reading breakpoint. */
+@container document-reader (max-width: 52rem) {
+  .research-provenance-edge {
+    display: none;
+  }
+
+  .rr-inline-ref {
+    display: inline-flex;
+  }
+
+  .rr-table__evidence {
+    display: none;
+  }
+
+  .rr-block-row,
+  .rr-list-row {
+    display: block;
+  }
+}
+
+/* Narrow readers turn both side surfaces into native full-body sheets. */
 @container research-reader (max-width: 42rem) {
-  .research-reader[data-rail="true"] .rr-rail {
+  .rr-head {
+    gap: var(--space-2);
+    padding-inline: var(--space-2);
+  }
+
+  .rr-status {
+    max-width: 5rem;
+  }
+
+  .rr-integrity {
+    max-width: 7rem;
+    padding-left: var(--space-2);
+  }
+
+  .rr-meta {
+    display: none;
+  }
+
+  .rr-btn--accent {
+    width: var(--space-8);
+    min-width: var(--space-8);
+    overflow: hidden;
+    padding: 0;
+    gap: 0;
+    font-size: 0;
+  }
+
+  .research-reader[data-inspector="true"] .rr-rail {
     inset: 0;
     width: 100%;
     border-left: 0;
+    box-shadow: none;
+  }
+
+  .research-reader .rr-doc {
+    --rr-paper-pad-inline: var(--space-4);
+    padding: var(--space-4) var(--space-2);
+  }
+
+  .research-reader .rr-doc__column {
+    padding-block: var(--space-6) var(--space-8);
+  }
+
+  .research-reader .document-reader__toolbar {
+    padding-inline: var(--space-2);
+  }
+
+  .rr-kroverlay {
+    padding: var(--space-2);
+  }
+
+  .rr-kroverlay-card {
+    max-height: calc(100dvh - var(--space-4));
+    padding: var(--space-4);
+  }
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .rr-btn,
+  .rr-iconbtn,
+  .research-evidence-inspector__close,
+  .research-provenance-edge__item,
+  .rr-inline-ref,
+  .rr-sd-btn,
+  .rr-sd-supportlink {
+    min-height: var(--touch-target);
+  }
+
+  .rr-iconbtn,
+  .research-evidence-inspector__close,
+  .research-provenance-edge__item {
+    min-width: var(--touch-target);
+  }
+
+  .rr-krfocus {
+    opacity: 1;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .research-reader,
   .research-reader *,
-  .rr-tip { transition: none !important; }
+  .rr-tip,
+  .rr-kroverlay-card {
+    transition: none !important;
+  }
 }

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -3,7 +3,7 @@
 .research-reader-overlay {
   position: fixed;
   inset: 0;
-  z-index: 70;
+  z-index: 350;
   display: flex;
   align-items: flex-start;
   justify-content: center;
@@ -500,6 +500,8 @@
   color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: calc(var(--text-sm) * var(--reader-text-scale));
+  inline-size: max-content;
+  white-space: nowrap;
 }
 
 .research-reader .document-reader__column ol > .rr-list-row::before {
@@ -733,6 +735,22 @@
   text-decoration: line-through;
 }
 
+.rr-sref--unresolved {
+  border-style: dotted;
+  border-color: color-mix(
+    in oklch,
+    var(--color-danger) 42%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-danger) 14%,
+    transparent
+  );
+  color: var(--color-danger);
+  font-style: italic;
+}
+
 .rr-sref.is-match {
   border-color: var(--research-accent);
   background: color-mix(
@@ -762,6 +780,18 @@
   background: color-mix(
     in oklch,
     var(--color-danger) 14%,
+    transparent
+  );
+  color: var(--color-danger);
+  box-shadow: inset 0 0 0 var(--ring-width) var(--color-danger);
+}
+
+.rr-sref--unresolved.is-match {
+  border-style: dotted;
+  border-color: var(--color-danger);
+  background: color-mix(
+    in oklch,
+    var(--color-danger) 20%,
     transparent
   );
   color: var(--color-danger);
@@ -1424,7 +1454,7 @@
 /* Temporary overlays use the existing elevated material and popover shadow. */
 .rr-tip {
   position: fixed;
-  z-index: 80;
+  z-index: 360;
   max-width: 18rem;
   padding: var(--space-3);
   border: 1px solid var(--border-strong);
@@ -1481,7 +1511,7 @@
 .rr-kroverlay {
   position: fixed;
   inset: 0;
-  z-index: 80;
+  z-index: 360;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -846,8 +846,8 @@
 .rr-table__evidence {
   position: sticky;
   right: 0;
-  width: var(--space-12);
-  min-width: var(--space-12);
+  width: calc(var(--space-12) + var(--space-4));
+  min-width: calc(var(--space-12) + var(--space-4));
   padding-inline: var(--space-2) !important;
   background: var(--bg-raised);
   text-align: right !important;
@@ -855,6 +855,13 @@
 
 .rr-table thead .rr-table__evidence {
   background: var(--bg-subtle);
+}
+
+.rr-table__evidence-heading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
 }
 
 .rr-table__evidence .research-provenance-edge {
@@ -1595,10 +1602,15 @@
   }
 }
 
-/* Provenance has one focusable representation at the reading breakpoint. */
-@container document-reader (max-width: 52rem) {
+/* 65rem = the intended 52rem document plus the 13rem Contents rail. Keeping
+   the outer threshold here prevents rail reflow from compressing the report. */
+@container document-reader (max-width: 65rem) {
   .research-reader .rr-doc {
     --research-evidence-edge-reserve: 0;
+  }
+
+  .research-reader .document-reader--rail .document-reader__layout {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .research-reader[data-toc="true"]

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -682,6 +682,10 @@
   display: none;
 }
 
+.rr-inline-ref-gap {
+  display: none;
+}
+
 .rr-sref {
   align-items: center;
   justify-content: center;
@@ -851,6 +855,10 @@
   padding-inline: var(--space-2) !important;
   background: var(--bg-raised);
   text-align: right !important;
+}
+
+.rr-table__redundant-reference {
+  display: none;
 }
 
 .rr-table thead .rr-table__evidence {
@@ -1633,6 +1641,14 @@
 
   .rr-inline-ref {
     display: inline-flex;
+  }
+
+  .rr-inline-ref-gap {
+    display: inline;
+  }
+
+  .rr-table__redundant-reference {
+    display: table-cell;
   }
 
   .rr-table__evidence {

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -20,6 +20,7 @@
 
 .research-reader {
   --research-accent: var(--accent-presence);
+  --rr-chrome-control-size: calc(var(--space-6) + var(--space-1));
   --research-accent-soft: color-mix(
     in oklch,
     var(--research-accent) 14%,
@@ -86,6 +87,7 @@
 .rr-head {
   z-index: 6;
   display: flex;
+  min-width: 0;
   min-height: var(--space-12);
   align-items: center;
   gap: var(--space-3);
@@ -98,6 +100,7 @@
 
 .rr-head__actions {
   display: flex;
+  min-width: 0;
   align-items: center;
   gap: var(--space-1);
   margin-left: auto;
@@ -118,6 +121,7 @@
   font: 400 var(--text-xs) var(--font-mono);
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1 1 auto;
 }
 
 .rr-status,
@@ -132,7 +136,15 @@
   text-overflow: ellipsis;
   text-transform: uppercase;
   white-space: nowrap;
-  flex: none;
+  flex: 0 1 auto;
+}
+
+.rr-status__label,
+.rr-integrity__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .rr-status {
@@ -244,6 +256,12 @@
   color: var(--text-muted);
 }
 
+.rr-head .rr-iconbtn {
+  width: var(--rr-chrome-control-size);
+  min-width: var(--rr-chrome-control-size);
+  min-height: var(--rr-chrome-control-size);
+}
+
 .rr-iconbtn:hover,
 .research-evidence-inspector__close:hover {
   background: var(--bg-hover);
@@ -267,6 +285,7 @@
 }
 
 .research-reader .document-reader__layout {
+  position: relative;
   min-width: 0;
 }
 
@@ -292,6 +311,12 @@
 .research-reader .document-reader__contents-trigger {
   background: var(--glass-elevated);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+}
+
+/* Research owns Contents in the persistent chrome; never render a second
+   DocumentReader trigger for the same panel. */
+.research-reader .document-reader__compact-nav {
+  display: none;
 }
 
 .research-reader .rr-doc__column {
@@ -1347,8 +1372,9 @@
   text-align: center;
 }
 
-/* Medium readers keep the report stable and overlay evidence from the right. */
-@container research-reader (max-width: 62rem) {
+/* 80rem is shared with INSPECTOR_OVERLAY_MAX_REM. Below it, overlaying avoids
+   subtracting the resizable 32.5rem rail from the 66ch report and its gutters. */
+@container research-reader (max-width: 80rem) {
   .research-reader[data-inspector="true"] .research-reader__grid {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -1372,6 +1398,20 @@
 
 /* Provenance has one focusable representation at the reading breakpoint. */
 @container document-reader (max-width: 52rem) {
+  .research-reader[data-toc="true"]
+    .document-reader--rail
+    .document-reader__toc {
+    position: absolute;
+    z-index: 7;
+    inset-block: 0;
+    left: 0;
+    display: block;
+    width: min(18rem, 86cqw);
+    border-right: 1px solid var(--border-strong);
+    background: var(--bg-elevated);
+    box-shadow: var(--shadow-popover);
+  }
+
   .research-provenance-edge {
     display: none;
   }
@@ -1411,8 +1451,8 @@
   }
 
   .rr-btn--accent {
-    width: var(--space-8);
-    min-width: var(--space-8);
+    width: var(--rr-chrome-control-size);
+    min-width: var(--rr-chrome-control-size);
     overflow: hidden;
     padding: 0;
     gap: 0;
@@ -1423,6 +1463,15 @@
     inset: 0;
     width: 100%;
     border-left: 0;
+    box-shadow: none;
+  }
+
+  .research-reader[data-toc="true"]
+    .document-reader--rail
+    .document-reader__toc {
+    inset: 0;
+    width: 100%;
+    border-right: 0;
     box-shadow: none;
   }
 
@@ -1452,6 +1501,7 @@
 @media (hover: none) and (pointer: coarse) {
   .rr-btn,
   .rr-iconbtn,
+  .research-reader .rr-head__actions > .ui-icon-btn,
   .research-evidence-inspector__close,
   .research-provenance-edge__item,
   .rr-inline-ref,
@@ -1461,6 +1511,7 @@
   }
 
   .rr-iconbtn,
+  .research-reader .rr-head__actions > .ui-icon-btn,
   .research-evidence-inspector__close,
   .research-provenance-edge__item {
     min-width: var(--touch-target);

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -291,6 +291,10 @@
 
 .research-reader .rr-doc {
   --rr-paper-pad-inline: var(--space-12);
+  --research-paper-border-width: 1px;
+  --research-evidence-edge-reserve: calc(
+    var(--space-10) + var(--space-3)
+  );
   padding: var(--space-8) var(--space-6);
   background: var(--bg-base);
 }
@@ -300,8 +304,11 @@
     100%,
     calc(
       var(--document-reader-prose-measure) +
+        var(--research-evidence-edge-reserve) +
         var(--rr-paper-pad-inline) +
-        var(--rr-paper-pad-inline)
+        var(--rr-paper-pad-inline) +
+        var(--research-paper-border-width) +
+        var(--research-paper-border-width)
     )
   );
   padding: 0 0 var(--space-3);
@@ -324,14 +331,17 @@
     100%,
     calc(
       var(--document-reader-prose-measure) +
+        var(--research-evidence-edge-reserve) +
         var(--rr-paper-pad-inline) +
-        var(--rr-paper-pad-inline)
+        var(--rr-paper-pad-inline) +
+        var(--research-paper-border-width) +
+        var(--research-paper-border-width)
     )
   );
   max-width: none;
   min-height: 100%;
   padding: var(--space-10) var(--rr-paper-pad-inline) var(--space-12);
-  border: 1px solid var(--border-hairline);
+  border: var(--research-paper-border-width) solid var(--border-hairline);
   border-radius: var(--radius-panel);
   background: var(--bg-raised);
 }
@@ -571,12 +581,36 @@
   border-style: dashed;
   border-color: color-mix(
     in oklch,
-    var(--text-muted) 38%,
+    var(--color-danger) 38%,
     var(--border-hairline)
   );
-  background: color-mix(in oklch, var(--text-muted) 12%, transparent);
-  color: var(--text-muted);
+  background: color-mix(
+    in oklch,
+    var(--color-danger) 14%,
+    transparent
+  );
+  color: var(--color-danger);
   text-decoration: line-through;
+}
+
+.research-provenance-edge__item--muted:hover,
+.research-provenance-edge__item--muted.is-selected {
+  border-style: dashed;
+  border-color: color-mix(
+    in oklch,
+    var(--color-danger) 42%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-danger) 14%,
+    transparent
+  );
+  color: var(--color-danger);
+}
+
+.research-provenance-edge__item--muted.is-selected {
+  box-shadow: inset 0 0 0 var(--ring-width) var(--color-danger);
 }
 
 .research-provenance-edge__item--unresolved {
@@ -638,9 +672,18 @@
 
 .rr-sref--muted {
   border-style: dashed;
-  border-color: var(--border-hairline);
-  background: color-mix(in oklch, var(--text-muted) 12%, transparent);
-  color: var(--text-muted);
+  border-color: color-mix(
+    in oklch,
+    var(--color-danger) 38%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-danger) 14%,
+    transparent
+  );
+  color: var(--color-danger);
+  text-decoration: line-through;
 }
 
 .rr-sref.is-match {
@@ -660,6 +703,22 @@
     var(--color-warning) 28%,
     transparent
   );
+}
+
+.rr-sref--muted.is-match {
+  border-style: dashed;
+  border-color: color-mix(
+    in oklch,
+    var(--color-danger) 42%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-danger) 14%,
+    transparent
+  );
+  color: var(--color-danger);
+  box-shadow: inset 0 0 0 var(--ring-width) var(--color-danger);
 }
 
 /* Tables keep evidence attached to the row and out of the reading cell. */
@@ -919,6 +978,16 @@
 
 .rr-src--rejected {
   border-style: dashed;
+  border-color: color-mix(
+    in oklch,
+    var(--color-danger) 38%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-danger) 14%,
+    transparent
+  );
 }
 
 .rr-src[data-open="true"] {
@@ -942,6 +1011,26 @@
 .rr-src--warn.is-selected {
   border-color: var(--color-warning);
   box-shadow: inset var(--ring-width) 0 0 var(--color-warning);
+}
+
+.rr-src--rejected:hover,
+.rr-src--rejected[data-open="true"],
+.rr-src--rejected.is-selected {
+  border-style: dashed;
+  border-color: color-mix(
+    in oklch,
+    var(--color-danger) 42%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-danger) 14%,
+    transparent
+  );
+}
+
+.rr-src--rejected.is-selected {
+  box-shadow: inset var(--ring-width) 0 0 var(--color-danger);
 }
 
 .rr-src__toggle {
@@ -973,7 +1062,8 @@
 }
 
 .rr-src--rejected .rr-src__title {
-  color: var(--text-secondary);
+  color: var(--color-danger);
+  text-decoration: line-through;
 }
 
 .rr-src__meta {
@@ -1002,6 +1092,10 @@
 
 .rr-srcstat--muted {
   color: var(--text-muted);
+}
+
+.rr-srcstat--rejected {
+  color: var(--color-danger);
 }
 
 .rr-srccaret {
@@ -1039,6 +1133,10 @@
 
 .rr-src--warn .rr-sd-quote {
   border-left-color: var(--color-warning);
+}
+
+.rr-src--rejected .rr-sd-quote {
+  border-left-color: var(--color-danger);
 }
 
 .rr-sd-row {
@@ -1190,6 +1288,25 @@
 
 .rr-srcmini--rejected {
   border-style: dashed;
+  border-color: color-mix(
+    in oklch,
+    var(--color-danger) 38%,
+    var(--border-hairline)
+  );
+  background: color-mix(
+    in oklch,
+    var(--color-danger) 14%,
+    transparent
+  );
+  color: var(--color-danger);
+}
+
+.rr-srcmini--rejected:hover {
+  border-color: color-mix(
+    in oklch,
+    var(--color-danger) 42%,
+    var(--border-hairline)
+  );
 }
 
 .rr-srcmini__title {
@@ -1204,6 +1321,11 @@
   margin-top: var(--space-1);
   color: var(--text-muted);
   font: 400 var(--text-2xs) var(--font-mono);
+}
+
+.rr-srcmini--rejected .rr-srcmini__title {
+  color: var(--color-danger);
+  text-decoration: line-through;
 }
 
 .rr-cf {
@@ -1398,6 +1520,10 @@
 
 /* Provenance has one focusable representation at the reading breakpoint. */
 @container document-reader (max-width: 52rem) {
+  .research-reader .rr-doc {
+    --research-evidence-edge-reserve: 0;
+  }
+
   .research-reader[data-toc="true"]
     .document-reader--rail
     .document-reader__toc {
@@ -1505,6 +1631,8 @@
   .research-evidence-inspector__close,
   .research-provenance-edge__item,
   .rr-inline-ref,
+  .rr-krfocus,
+  .research-reader .document-reader__preferences-trigger,
   .rr-sd-btn,
   .rr-sd-supportlink {
     min-height: var(--touch-target);
@@ -1513,7 +1641,11 @@
   .rr-iconbtn,
   .research-reader .rr-head__actions > .ui-icon-btn,
   .research-evidence-inspector__close,
-  .research-provenance-edge__item {
+  .research-provenance-edge__item,
+  .rr-inline-ref,
+  .rr-krfocus,
+  .rr-btn--accent,
+  .research-reader .document-reader__preferences-trigger {
     min-width: var(--touch-target);
   }
 

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -1632,7 +1632,12 @@
   .research-provenance-edge__item,
   .rr-inline-ref,
   .rr-krfocus,
+  .research-reader .document-reader__toc-link,
+  .research-reader .rr-toclink,
   .research-reader .document-reader__preferences-trigger,
+  .research-reader .document-reader__size-step,
+  .research-reader .document-reader__preference-option,
+  .research-reader .document-reader__reset,
   .rr-sd-btn,
   .rr-sd-supportlink {
     min-height: var(--touch-target);
@@ -1645,7 +1650,8 @@
   .rr-inline-ref,
   .rr-krfocus,
   .rr-btn--accent,
-  .research-reader .document-reader__preferences-trigger {
+  .research-reader .document-reader__preferences-trigger,
+  .research-reader .document-reader__size-step {
     min-width: var(--touch-target);
   }
 

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -394,7 +394,13 @@
   color: var(--text-primary);
 }
 
-.research-reader .rr-codeblock,
+.research-reader .rr-codeblock {
+  width: calc(100% - var(--research-evidence-edge-reserve));
+  max-width: calc(100% - var(--research-evidence-edge-reserve));
+  margin-inline: 0;
+  transform: none;
+}
+
 .research-reader .rr-krblock {
   width: calc(
     100% + var(--rr-paper-pad-inline) + var(--rr-paper-pad-inline)
@@ -518,7 +524,21 @@
   min-height: var(--space-8);
   align-items: center;
   justify-content: center;
-  padding: var(--space-1);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--research-accent);
+  font: 600 var(--text-2xs) var(--font-mono);
+  cursor: pointer;
+}
+
+.research-provenance-edge__anchor {
+  display: inline-flex;
+  min-width: var(--space-6);
+  min-height: var(--space-6);
+  align-items: center;
+  justify-content: center;
+  padding-inline: var(--space-1);
   border: 1px solid color-mix(
     in oklch,
     var(--research-accent) 38%,
@@ -526,9 +546,7 @@
   );
   border-radius: var(--radius-pill);
   background: var(--research-accent-soft);
-  color: var(--research-accent);
-  font: 600 var(--text-2xs) var(--font-mono);
-  cursor: pointer;
+  color: inherit;
   transition:
     background var(--duration-fast) var(--ease-standard),
     border-color var(--duration-fast) var(--ease-standard),
@@ -536,8 +554,9 @@
     transform var(--duration-fast) var(--ease-standard);
 }
 
-.research-provenance-edge__item:hover,
-.research-provenance-edge__item.is-selected {
+.research-provenance-edge__item:hover .research-provenance-edge__anchor,
+.research-provenance-edge__item.is-selected
+  .research-provenance-edge__anchor {
   border-color: var(--research-accent);
   background: color-mix(
     in oklch,
@@ -547,11 +566,13 @@
   color: var(--text-primary);
 }
 
-.research-provenance-edge__item.is-selected {
+.research-provenance-edge__item.is-selected
+  .research-provenance-edge__anchor {
   box-shadow: inset 0 0 0 var(--ring-width) var(--research-accent);
 }
 
-.research-provenance-edge__item--warn {
+.research-provenance-edge__item--warn
+  .research-provenance-edge__anchor {
   border-width: var(--ring-width);
   border-color: color-mix(
     in oklch,
@@ -567,8 +588,10 @@
   text-decoration: underline wavy;
 }
 
-.research-provenance-edge__item--warn:hover,
-.research-provenance-edge__item--warn.is-selected {
+.research-provenance-edge__item--warn:hover
+  .research-provenance-edge__anchor,
+.research-provenance-edge__item--warn.is-selected
+  .research-provenance-edge__anchor {
   border-color: var(--color-warning);
   background: color-mix(
     in oklch,
@@ -577,7 +600,8 @@
   );
 }
 
-.research-provenance-edge__item--muted {
+.research-provenance-edge__item--muted
+  .research-provenance-edge__anchor {
   border-style: dashed;
   border-color: color-mix(
     in oklch,
@@ -593,8 +617,10 @@
   text-decoration: line-through;
 }
 
-.research-provenance-edge__item--muted:hover,
-.research-provenance-edge__item--muted.is-selected {
+.research-provenance-edge__item--muted:hover
+  .research-provenance-edge__anchor,
+.research-provenance-edge__item--muted.is-selected
+  .research-provenance-edge__anchor {
   border-style: dashed;
   border-color: color-mix(
     in oklch,
@@ -609,11 +635,13 @@
   color: var(--color-danger);
 }
 
-.research-provenance-edge__item--muted.is-selected {
+.research-provenance-edge__item--muted.is-selected
+  .research-provenance-edge__anchor {
   box-shadow: inset 0 0 0 var(--ring-width) var(--color-danger);
 }
 
-.research-provenance-edge__item--unresolved {
+.research-provenance-edge__item--unresolved
+  .research-provenance-edge__anchor {
   border-style: dotted;
   border-color: color-mix(
     in oklch,
@@ -627,6 +655,25 @@
   );
   color: var(--color-danger);
   font-style: italic;
+}
+
+.research-provenance-edge__item--unresolved:hover
+  .research-provenance-edge__anchor,
+.research-provenance-edge__item--unresolved.is-selected
+  .research-provenance-edge__anchor {
+  border-style: dotted;
+  border-color: var(--color-danger);
+  background: color-mix(
+    in oklch,
+    var(--color-danger) 20%,
+    transparent
+  );
+  color: var(--color-danger);
+}
+
+.research-provenance-edge__item--unresolved.is-selected
+  .research-provenance-edge__anchor {
+  box-shadow: inset 0 0 0 var(--ring-width) var(--color-danger);
 }
 
 .rr-inline-ref {

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -700,8 +700,35 @@
   overflow: hidden;
 }
 
+.rr-wide-ref {
+  display: inline-flex;
+  max-width: calc(var(--space-12) + var(--space-4));
+  align-items: baseline;
+  overflow: hidden;
+  color: var(--research-accent);
+  font: 600 var(--text-xs) var(--font-mono);
+  vertical-align: baseline;
+  white-space: nowrap;
+}
+
+.rr-wide-ref--warn {
+  color: var(--color-warning);
+  text-decoration: underline wavy;
+}
+
+.rr-wide-ref--muted {
+  color: var(--color-danger);
+  text-decoration: line-through;
+}
+
+.rr-wide-ref--unresolved {
+  color: var(--color-danger);
+  font-style: italic;
+  text-decoration: underline dotted;
+}
+
 .rr-inline-ref-gap {
-  display: none;
+  display: inline;
 }
 
 .rr-sref {
@@ -1665,6 +1692,10 @@
   }
 
   .research-provenance-edge {
+    display: none;
+  }
+
+  .rr-wide-ref {
     display: none;
   }
 

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -168,6 +168,9 @@ test.describe("research reader", () => {
     const table = reader.locator(".rr-table");
     await expect(table).toContainText("Scale raises value coherence");
     await expect(table.locator(".rr-cf--high")).toHaveText("High");
+    await expect(
+      reader.getByRole("region", { name: "Evidence references · 2" }).first(),
+    ).toBeVisible();
     const marginReference = reader.locator(
       ".research-provenance-edge__item",
       { hasText: "S14" },
@@ -328,6 +331,67 @@ test.describe("research reader", () => {
 
     await reader.getByRole("button", { name: "Close" }).click();
     await expect(page.locator(".research-reader")).toHaveCount(0);
+  });
+
+  test("focused table traps Tab and Escape returns focus to its invoker", async ({ page }) => {
+    await openReader(page);
+    const reader = page.locator(".research-reader");
+    const focusTable = reader.getByRole("button", { name: "Focus table" });
+
+    await focusTable.click();
+    const tableDialog = page.getByRole("dialog", { name: "Key results" });
+    await expect(tableDialog).toBeVisible();
+    await expect(
+      tableDialog.getByRole("button", { name: "Close focused table" }),
+    ).toBeFocused();
+
+    for (let step = 0; step < 8; step += 1) {
+      await page.keyboard.press("Tab");
+      expect(
+        await tableDialog.evaluate((dialog) =>
+          dialog.contains(document.activeElement),
+        ),
+      ).toBe(true);
+    }
+
+    await page.keyboard.press("Escape");
+    await expect(tableDialog).toHaveCount(0);
+    await expect(focusTable).toBeFocused();
+    await expect(reader).toBeVisible();
+  });
+
+  test("Escape closes Contents and Evidence in most-recently-opened order", async ({ page }) => {
+    await openReader(page);
+    const reader = page.locator(".research-reader");
+    const contentsToggle = reader.getByRole("button", {
+      name: /^(Show|Hide) contents$/,
+    });
+    const evidenceToggle = reader.getByRole("button", {
+      name: /^(Show|Hide) evidence$/,
+    });
+    const contents = reader.locator(".rr-toc");
+    const evidence = reader.locator(".research-evidence-inspector");
+
+    await contentsToggle.click();
+    await evidenceToggle.click();
+    await page.keyboard.press("Escape");
+    await expect(evidence).toBeHidden();
+    await expect(contents).toBeVisible();
+    await expect(evidenceToggle).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(contents).toBeHidden();
+    await expect(contentsToggle).toBeFocused();
+
+    await evidenceToggle.click();
+    await contentsToggle.click();
+    await page.keyboard.press("Escape");
+    await expect(contents).toBeHidden();
+    await expect(evidence).toBeVisible();
+    await expect(contentsToggle).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(evidence).toBeHidden();
+    await expect(evidenceToggle).toBeFocused();
+    await expect(reader).toBeVisible();
   });
 
   test("narrow overlay transfers focus, inerts covered controls, and returns focus correctly", async ({ page }) => {

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -26,6 +26,15 @@ generated_at: 2026-07-24
 
 Identity has **three** components and can drift independently S1 S14.
 
+\`\`\`ts
+const identity = preserve(agent);
+\`\`\`
+
+\`\`\`mermaid
+graph LR
+  Agent --> Identity
+\`\`\`
+
 ## Key results
 
 | Finding | Source | Confidence |
@@ -180,19 +189,57 @@ test.describe("research reader", () => {
       claimWidthBeforeInspector.preferred,
       0,
     );
+    const opaqueBlocks = reader.locator(".rr-codeblock");
+    await expect(opaqueBlocks).toHaveCount(2);
+    await expect(opaqueBlocks.nth(1).locator(".cm-mermaid-diagram")).toBeVisible();
+    for (const opaqueBlock of await opaqueBlocks.all()) {
+      await expect(
+        opaqueBlock.locator(".research-provenance-edge"),
+      ).toHaveCount(0);
+      expect(
+        await opaqueBlock.evaluate((element) => element.getBoundingClientRect().width),
+      ).toBeCloseTo(claimWidthBeforeInspector.actual, 0);
+    }
 
     await marginReference.click();
     await expect(reader).toHaveAttribute("data-inspector", "true");
     await expect(reader.locator(".document-reader")).not.toHaveAttribute("inert", "");
     const railHandle = reader.locator(".rr-railhandle");
     const handleBox = await railHandle.boundingBox();
+    const readerBox = await reader.boundingBox();
     expect(handleBox).not.toBeNull();
+    expect(readerBox).not.toBeNull();
     await page.mouse.move(
       handleBox!.x + handleBox!.width / 2,
       handleBox!.y + handleBox!.height / 2,
     );
     await page.mouse.down();
-    await page.mouse.move(handleBox!.x - 260, handleBox!.y + handleBox!.height / 2);
+    await page.mouse.move(
+      readerBox!.x + readerBox!.width - 260,
+      handleBox!.y + handleBox!.height / 2,
+    );
+    await page.mouse.up();
+    await expect.poll(async () => {
+      const currentHandleBox = await railHandle.boundingBox();
+      const currentRailBox = await reader.locator(".rr-rail").boundingBox();
+      if (!currentHandleBox || !currentRailBox) return Number.POSITIVE_INFINITY;
+      return Math.abs(
+        currentHandleBox.x +
+          currentHandleBox.width / 2 -
+          currentRailBox.x,
+      );
+    }).toBeLessThan(2);
+    const minimumHandleBox = await railHandle.boundingBox();
+    expect(minimumHandleBox).not.toBeNull();
+    await page.mouse.move(
+      minimumHandleBox!.x + minimumHandleBox!.width / 2,
+      minimumHandleBox!.y + minimumHandleBox!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      minimumHandleBox!.x - 260,
+      minimumHandleBox!.y + minimumHandleBox!.height / 2,
+    );
     await page.mouse.up();
     const claimWidthAtMaxRail = await measuredClaim
       .locator(":scope > :first-child")
@@ -207,6 +254,15 @@ test.describe("research reader", () => {
     await expect(s14card).toHaveAttribute("data-selected", "true");
     await expect(s14card).toHaveAttribute("data-open", "true");
     await expect(s14card.locator(".rr-sd-quote")).toContainText("rise monotonically");
+    const paintedAnchor = marginReference.locator(
+      ".research-provenance-edge__anchor",
+    );
+    const hitBox = await marginReference.boundingBox();
+    const anchorBox = await paintedAnchor.boundingBox();
+    expect(hitBox).not.toBeNull();
+    expect(anchorBox).not.toBeNull();
+    expect(hitBox!.width).toBeGreaterThan(anchorBox!.width);
+    expect(hitBox!.height).toBeGreaterThan(anchorBox!.height);
 
     const support = s14card.locator(".rr-sd-supportlink").first();
     await support.click();

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -1,4 +1,8 @@
 import { expect, test, type Page } from "@playwright/test";
+import type {
+  ResearchMission,
+  ResearchSourceRef,
+} from "@/lib/research-missions";
 
 // Research Reader — the typeset findings deliverable viewer (Research
 // Reader.dc.html handoff). Reached from the Research Desk artifact rail: a
@@ -87,6 +91,11 @@ const COMPLETED_MISSION = {
     { id: "S2", title: "Persona vectors and steering", url: "https://example.com/s2", publisher: "arXiv", publishedAt: "2024", sourceType: "web", status: "used" },
     { id: "S4", title: "Utility engineering in LMs", url: "https://example.com/s4", publisher: "arXiv", publishedAt: "2025", sourceType: "web", status: "used" },
   ],
+} satisfies ResearchMission;
+
+type SourceLedgerFixture = {
+  state: "available" | "empty" | "failed";
+  sources: ResearchSourceRef[];
 };
 
 async function openReader(
@@ -94,9 +103,11 @@ async function openReader(
   {
     markdown = FINDINGS_MD,
     mission = COMPLETED_MISSION,
+    sourceLedgers,
   }: {
     markdown?: string;
-    mission?: typeof COMPLETED_MISSION;
+    mission?: ResearchMission;
+    sourceLedgers?: SourceLedgerFixture[];
   } = {},
 ) {
   await page.addInitScript(() => {
@@ -111,9 +122,20 @@ async function openReader(
   await page.route(/\/api\/research\/missions\?/, (route) => route.fulfill({ json: { ok: true, missions: [mission] } }));
   await page.route("**/api/research/links", (route) => route.fulfill({ json: { ok: true, links: [] } }));
   await page.route(/\/api\/research\/generations/, (route) => route.fulfill({ json: { ok: true, generations: [] } }));
-  // The artifact file route feeds the reader its findings markdown.
-  await page.route("**/api/research/missions/*/files/**", (route) =>
-    route.fulfill({
+  const defaultLedger: SourceLedgerFixture = {
+    state: mission.sources.length > 0 ? "available" : "empty",
+    sources: mission.sources,
+  };
+  let fileRequestIndex = 0;
+  // The artifact file route feeds the reader its findings markdown and the
+  // independently read source-ledger snapshot from the same request.
+  await page.route("**/api/research/missions/*/files/**", (route) => {
+    const ledger =
+      sourceLedgers?.[
+        Math.min(fileRequestIndex, sourceLedgers.length - 1)
+      ] ?? defaultLedger;
+    fileRequestIndex += 1;
+    return route.fulfill({
       json: {
         ok: true,
         file: {
@@ -125,10 +147,11 @@ async function openReader(
           content: markdown,
           workspacePath: "/tmp/m-done/findings.md",
           updatedAt: iso(45),
+          sourceLedger: ledger,
         },
       },
-    }),
-  );
+    });
+  });
 
   await page.goto("/");
   await page.locator(".shell-frame").waitFor({ timeout: 60_000 });
@@ -524,6 +547,187 @@ Verified claim [S1]. Missing claim [S99].`,
     await expect(tableDialog).toHaveCount(0);
     await expect(focusTable).toBeFocused();
     await expect(reader).toBeVisible();
+  });
+
+  test("focused table evidence closes the table before opening and focusing the inspector", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openReader(page);
+    const reader = page.locator(".research-reader");
+
+    await reader.getByRole("button", { name: "Focus table" }).click();
+    const tableDialog = page.getByRole("dialog", { name: "Key results" });
+    const focusedReference = tableDialog
+      .locator(
+        '[data-research-reference-id="S14"][data-research-reference-representation="edge"]',
+      )
+      .first();
+    await expect(focusedReference).toBeVisible();
+    await focusedReference.click();
+
+    await expect(tableDialog).toHaveCount(0);
+    const inspector = reader.locator(".research-evidence-inspector");
+    await expect(inspector).toBeVisible();
+    const selectedToggle = inspector.locator(
+      '[data-source-id="S14"] .research-evidence-card__toggle',
+    );
+    await expect(selectedToggle).toBeFocused();
+    await expect(inspector.locator('[data-source-id="S14"]')).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+  });
+
+  test("failed source ledger never reuses stale mission sources and retries to current truth", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    const currentSource = COMPLETED_MISSION.sources.find(
+      (source) => source.id === "S1",
+    )!;
+    await openReader(page, {
+      markdown: "# Findings\n\n## Result\n\nClaim [S1].",
+      sourceLedgers: [
+        { state: "failed", sources: [] },
+        { state: "available", sources: [currentSource] },
+      ],
+    });
+    const reader = page.locator(".research-reader");
+
+    await expect(reader.locator(".rr-integrity")).toHaveText(
+      "Sources unavailable — references can't be verified",
+    );
+    await expect(
+      reader.locator('[data-source-id="S1"]'),
+    ).toHaveCount(0);
+    await expect(
+      reader.locator('[data-research-reference-id="S1"]').first(),
+    ).toHaveAttribute("aria-label", "Missing source S1");
+
+    await reader.getByRole("button", { name: "Show evidence" }).click();
+    const inspector = reader.locator(".research-evidence-inspector");
+    await expect(inspector).toContainText("Sources unavailable");
+    await expect(inspector).toContainText(
+      "The source ledger could not be read.",
+    );
+    await expect(inspector.locator(".research-evidence-card")).toHaveCount(0);
+
+    await inspector.getByRole("button", { name: "Retry sources" }).click();
+    await expect(reader.locator(".rr-integrity")).toHaveText(
+      "1 source verified",
+    );
+    await expect(inspector.locator('[data-source-id="S1"]')).toHaveCount(1);
+    await expect(
+      reader.locator('[data-research-reference-id="S1"]').first(),
+    ).toHaveAttribute("aria-label", "Open evidence S1");
+  });
+
+  test("headingless findings use the artifact title and omit dead Contents chrome", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openReader(page, {
+      markdown: "Opening claim [S1].\n\nA second paragraph keeps the report readable.",
+      sourceLedgers: [{
+        state: "available",
+        sources: [COMPLETED_MISSION.sources.find((source) => source.id === "S1")!],
+      }],
+    });
+    const reader = page.locator(".research-reader");
+
+    await expect(reader.locator(".document-reader__title")).toHaveText(
+      "Findings",
+    );
+    await expect(reader).toContainText("Opening claim");
+    await expect(
+      reader.getByRole("button", { name: /^(Show|Hide) contents$/ }),
+    ).toHaveCount(0);
+
+    await reader.getByRole("button", { name: "Show evidence" }).click();
+    await page.keyboard.press("Escape");
+    await expect(reader.locator(".research-evidence-inspector")).toBeHidden();
+    await expect(
+      reader.getByRole("button", { name: "Show evidence" }),
+    ).toBeFocused();
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".research-reader")).toHaveCount(0);
+  });
+
+  test("long source ids stay compact without losing their full accessible identity", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    const longId = `manual-${"x".repeat(121)}`;
+    const longSource = {
+      id: longId,
+      title: "Manually curated primary source",
+      sourceType: "manual",
+      status: "used",
+    } as const;
+    await openReader(page, {
+      markdown: `# Findings\n\n## Result\n\nClaim [${longId}].`,
+      mission: {
+        ...COMPLETED_MISSION,
+        sources: [longSource],
+      },
+      sourceLedgers: [{ state: "available", sources: [longSource] }],
+    });
+    const reader = page.locator(".research-reader");
+    const edgeReference = reader.locator(
+      `[data-research-reference-id="${longId}"][data-research-reference-representation="edge"]`,
+    );
+    await expect(edgeReference).toHaveAttribute(
+      "aria-label",
+      `Open evidence ${longId}`,
+    );
+    const edgeLabel = edgeReference.locator(
+      `[data-research-source-id-label="${longId}"]`,
+    );
+    await expect(edgeLabel).toHaveAttribute("title", longId);
+    await expect(edgeLabel).toContainText("…");
+    expect(
+      await edgeReference.evaluate((element) => {
+        const row = element.closest(".rr-block-row");
+        const content = row?.firstElementChild?.getBoundingClientRect();
+        const edge = element.getBoundingClientRect();
+        return {
+          contained: element.scrollWidth <= element.clientWidth,
+          separated: Boolean(content) && content!.right <= edge.left,
+        };
+      }),
+    ).toEqual({ contained: true, separated: true });
+
+    await edgeReference.click();
+    const inspector = reader.locator(".research-evidence-inspector");
+    const sourceToggle = inspector.locator(
+      `[data-source-id="${longId}"] .research-evidence-card__toggle`,
+    );
+    await expect(sourceToggle).toHaveAttribute(
+      "aria-label",
+      `Collapse evidence ${longId}: Manually curated primary source`,
+    );
+    await expect(
+      sourceToggle.locator(`[data-research-source-id-label="${longId}"]`),
+    ).toHaveAttribute("title", longId);
+    await inspector
+      .getByRole("button", { name: "Close evidence inspector" })
+      .click();
+
+    await page.setViewportSize({ width: 1000, height: 800 });
+    const inlineReference = reader.locator(
+      `[data-research-reference-id="${longId}"][data-research-reference-representation="inline"]`,
+    );
+    await expect(inlineReference).toBeVisible();
+    await expect(inlineReference).toHaveAttribute(
+      "aria-label",
+      `Open evidence ${longId}`,
+    );
+    const inlineLabel = inlineReference.locator(
+      `[data-research-source-id-label="${longId}"]`,
+    );
+    await expect(inlineLabel).toHaveAttribute("title", longId);
+    expect(
+      await inlineReference.evaluate(
+        (element) =>
+          element.scrollWidth <= element.clientWidth &&
+          element.getBoundingClientRect().right <=
+            element.closest(".document-reader__column")!.getBoundingClientRect()
+              .right,
+      ),
+    ).toBe(true);
   });
 
   test("wide Escape closes Contents and Evidence in most-recently-opened order", async ({ page }) => {

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -130,59 +130,72 @@ async function openReader(page: Page) {
 test.describe("research reader", () => {
   test.describe.configure({ timeout: 180_000 });
 
-  test("typesets findings, chips the sources, and cross-links the evidence rail", async ({ page }) => {
+  test("typesets semantic findings and links evidence back to its supported claim", async ({ page }) => {
     await openReader(page);
     const reader = page.locator(".research-reader");
 
-    // Title, lede, and the collapsible sections all typeset from the markdown.
-    await expect(reader.locator(".rr-doc h1")).toHaveText("Identity Preservation for Agents during Self-Evolution");
+    await expect(reader).toHaveAttribute("data-toc", "false");
+    await expect(reader).toHaveAttribute("data-inspector", "false");
+    await expect(reader.locator(".document-reader__title")).toHaveText("Identity Preservation for Agents during Self-Evolution");
     await expect(reader.locator(".rr-lede")).toContainText("stay recognisably itself");
     for (const heading of ["Current understanding", "Key results", "Open questions"]) {
-      await expect(reader.locator(".rr-h2-btn", { hasText: heading })).toBeVisible();
+      const semanticHeading = reader.getByRole("heading", { name: heading });
+      await expect(semanticHeading).toBeVisible();
+      await expect(semanticHeading.getByRole("button")).toHaveCount(0);
     }
+    await expect(reader.locator(".rr-toc")).toBeHidden();
+    await expect(reader.locator(".research-evidence-inspector")).toBeHidden();
 
-    // Key Results markdown table renders with a confidence chip and a source chip.
     const table = reader.locator(".rr-table");
     await expect(table).toContainText("Scale raises value coherence");
     await expect(table.locator(".rr-cf--high")).toHaveText("High");
     await expect(table.locator(".rr-sref", { hasText: "S14" }).first()).toBeVisible();
 
-    // Evidence rail is built from the real ledger sources.
-    const rail = reader.locator(".rr-rail");
-    await expect(rail).toContainText("Evidence · 4 used");
-    await expect(rail.locator(".rr-src", { hasText: "Emergent value coherence at scale" })).toBeVisible();
-
-    // Collapsing a section hides its body.
-    const openQ = reader.locator(".rr-h2-btn", { hasText: "Open questions" });
-    await openQ.click();
-    await expect(openQ).toHaveAttribute("aria-expanded", "false");
-
-    // Clicking a prose S14 chip opens its evidence card, revealing the quote.
-    await reader.locator(".rr-doc .rr-sref", { hasText: "S14" }).first().click();
-    const s14card = rail.locator(".rr-src", { hasText: "Emergent value coherence at scale" });
+    await reader.getByRole("button", { name: "Open evidence S14" }).first().click();
+    await expect(reader).toHaveAttribute("data-inspector", "true");
+    await expect(reader.locator(".document-reader")).not.toHaveAttribute("inert", "");
+    const inspector = reader.locator(".research-evidence-inspector");
+    const s14card = inspector.locator('[data-source-id="S14"]');
+    await expect(inspector).toBeVisible();
+    await expect(s14card).toHaveAttribute("data-selected", "true");
     await expect(s14card).toHaveAttribute("data-open", "true");
     await expect(s14card.locator(".rr-sd-quote")).toContainText("rise monotonically");
-    // The card's Supports links are derived from the sections that cite S14.
-    await expect(s14card.locator(".rr-sd-supportlink", { hasText: "Key results" })).toBeVisible();
+
+    const support = s14card.locator(".rr-sd-supportlink").first();
+    await support.click();
+    await expect(reader).toHaveAttribute("data-inspector", "false");
+    const focusedTarget = reader.locator("[data-document-target]:focus");
+    await expect(focusedTarget).toHaveCount(1);
+    expect(await focusedTarget.evaluate((target) => {
+      const scroller = target.closest(".document-reader__scroll");
+      if (!scroller) return false;
+      const targetRect = target.getBoundingClientRect();
+      const scrollerRect = scroller.getBoundingClientRect();
+      return (
+        targetRect.bottom > scrollerRect.top &&
+        targetRect.top < scrollerRect.bottom
+      );
+    })).toBe(true);
   });
 
-  test("expands to reveal the contents rail and copies the findings", async ({ page }) => {
+  test("opens dedicated contents and evidence panels while retaining reader actions", async ({ page }) => {
     await openReader(page);
     const reader = page.locator(".research-reader");
 
-    // Contents rail is hidden until expanded.
     await expect(reader.locator(".rr-toc")).toBeHidden();
-    await reader.getByRole("button", { name: "More research reader actions" }).click();
-    await expect(page.getByRole("menuitemcheckbox", { name: "Contents" })).toBeVisible();
-    await page.getByRole("menuitemcheckbox", { name: "Contents" }).click();
-    await expect(reader).toHaveAttribute("data-expanded", "true");
+    await reader.getByRole("button", { name: "Show contents" }).click();
     await expect(reader).toHaveAttribute("data-toc", "true");
     await expect(reader.locator(".rr-toc")).toBeVisible();
     await expect(reader.locator(".rr-toclink", { hasText: "Key results" })).toBeVisible();
 
-    // Copy is offered for a written deliverable (clipboard success itself is
-    // environment-dependent under headless, so assert the affordance, not the
-    // confirmation).
+    const evidenceToggle = reader.getByRole("button", { name: "Show evidence" });
+    await evidenceToggle.click();
+    const inspector = reader.locator(".research-evidence-inspector");
+    await expect(inspector).toBeVisible();
+    await inspector.getByRole("button", { name: "Close evidence inspector" }).click();
+    await expect(inspector).toBeHidden();
+    await expect(evidenceToggle).toBeFocused();
+
     await reader.getByRole("button", { name: "More research reader actions" }).click();
     await expect(page.getByRole("menuitem", { name: "Copy findings" })).toBeEnabled();
     await page.keyboard.press("Escape");
@@ -194,18 +207,56 @@ test.describe("research reader", () => {
     await expect(preferences).toContainText("Hyphenation");
     await page.keyboard.press("Escape");
 
-    // Close dismisses the reader.
     await reader.getByRole("button", { name: "Close" }).click();
     await expect(page.locator(".research-reader")).toHaveCount(0);
   });
 
-  test("narrow rail mode collapses to one grid column and preserves prose gutters", async ({ page }) => {
+  test("narrow overlay transfers focus, inerts covered controls, and returns focus correctly", async ({ page }) => {
     await page.setViewportSize({ width: 400, height: 720 });
     await openReader(page);
     const reader = page.locator(".research-reader");
-    await reader.getByRole("button", { name: "More research reader actions" }).click();
-    await expect(page.getByRole("menuitemcheckbox", { name: "Contents" })).toBeVisible();
-    await page.getByRole("menuitemcheckbox", { name: "Contents" }).click();
+    const documentReader = reader.locator(".document-reader");
+    const evidenceToggle = reader.getByRole("button", { name: "Show evidence" });
+
+    await evidenceToggle.click();
+    const inspector = reader.locator(".research-evidence-inspector");
+    await expect(inspector).toBeVisible();
+    await expect(documentReader).toHaveAttribute("inert", "");
+    await expect(inspector.getByRole("button", { name: "Close evidence inspector" })).toBeFocused();
+    for (let step = 0; step < 5; step += 1) {
+      await page.keyboard.press("Tab");
+      expect(await documentReader.evaluate((element) =>
+        element.contains(document.activeElement),
+      )).toBe(false);
+    }
+
+    await page.keyboard.press("Escape");
+    await expect(inspector).toBeHidden();
+    await expect(documentReader).not.toHaveAttribute("inert", "");
+    await expect(evidenceToggle).toBeFocused();
+
+    const inlineReference = reader.locator(".rr-inline-ref", { hasText: "S14" }).first();
+    await inlineReference.click();
+    await expect(documentReader).toHaveAttribute("inert", "");
+    await expect(inspector).toContainText("Emergent value coherence at scale");
+    await expect(
+      inspector.locator('[data-source-id="S14"] .research-evidence-card__toggle'),
+    ).toBeFocused();
+    await inspector.getByRole("button", { name: "Close evidence inspector" }).click();
+    await expect(documentReader).not.toHaveAttribute("inert", "");
+    await expect(inlineReference).toBeFocused();
+
+    await inlineReference.click();
+    await inspector.locator('[data-source-id="S14"] .rr-sd-supportlink').first().click();
+    await expect(documentReader).not.toHaveAttribute("inert", "");
+    await expect(reader.locator("[data-document-target]:focus")).toHaveCount(1);
+
+    await reader.getByRole("button", { name: "Show contents" }).click();
+    await expect(reader).toHaveAttribute("data-toc", "true");
+    await expect(reader.getByRole("button", { name: "Hide contents" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
 
     const columns = await reader.locator(".document-reader__layout").evaluate(
       (element) => getComputedStyle(element).gridTemplateColumns,

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -89,7 +89,16 @@ const COMPLETED_MISSION = {
   ],
 };
 
-async function openReader(page: Page) {
+async function openReader(
+  page: Page,
+  {
+    markdown = FINDINGS_MD,
+    mission = COMPLETED_MISSION,
+  }: {
+    markdown?: string;
+    mission?: typeof COMPLETED_MISSION;
+  } = {},
+) {
   await page.addInitScript(() => {
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
     window.localStorage.setItem("cave:active-familiar", "rida");
@@ -99,7 +108,7 @@ async function openReader(page: Page) {
   );
   await page.route("**/api/sessions/list**", (route) => route.fulfill({ json: { ok: true, sessions: [] } }));
   await page.route(/\/api\/roles(\?|$)/, (route) => route.fulfill({ json: { roles: [] } }));
-  await page.route(/\/api\/research\/missions\?/, (route) => route.fulfill({ json: { ok: true, missions: [COMPLETED_MISSION] } }));
+  await page.route(/\/api\/research\/missions\?/, (route) => route.fulfill({ json: { ok: true, missions: [mission] } }));
   await page.route("**/api/research/links", (route) => route.fulfill({ json: { ok: true, links: [] } }));
   await page.route(/\/api\/research\/generations/, (route) => route.fulfill({ json: { ok: true, generations: [] } }));
   // The artifact file route feeds the reader its findings markdown.
@@ -113,7 +122,7 @@ async function openReader(page: Page) {
           title: "Findings",
           fileName: "findings.md",
           relativePath: "findings.md",
-          content: FINDINGS_MD,
+          content: markdown,
           workspacePath: "/tmp/m-done/findings.md",
           updatedAt: iso(45),
         },
@@ -412,5 +421,89 @@ test.describe("research reader", () => {
     });
     expect(gutters.left).toBeGreaterThan(0);
     expect(gutters.right).toBeGreaterThan(0);
+  });
+
+  test("mobile modal stacking and missing refs stay truthful at multi-digit list markers", async ({ page }) => {
+    await page.setViewportSize({ width: 400, height: 720 });
+    const orderedItems = Array.from(
+      { length: 10 },
+      (_, index) =>
+        `${index + 1}. ${index === 9 ? "Missing evidence [S99]" : `Finding ${index + 1}`}`,
+    ).join("\n");
+    await openReader(page, {
+      markdown: `# Findings\n\n## Results\n\n${orderedItems}`,
+    });
+
+    const reader = page.locator(".research-reader");
+    const overlay = page.locator(".research-reader-overlay");
+    const mobileTabs = page.locator(".mobile-bottom-tabs");
+    await expect(mobileTabs).toBeVisible();
+    const layers = await Promise.all([
+      overlay.evaluate((element) => Number(getComputedStyle(element).zIndex)),
+      mobileTabs.evaluate((element) => Number(getComputedStyle(element).zIndex)),
+    ]);
+    expect(layers[0]).toBe(350);
+    expect(layers[0]).toBeGreaterThan(layers[1]);
+    expect(layers[0]).toBeLessThan(400);
+    await reader.getByRole("button", {
+      name: "More research reader actions",
+    }).click();
+    const popoverPortal = page.locator(".ui-popover-portal");
+    await expect(popoverPortal).toBeVisible();
+    expect(
+      await popoverPortal.evaluate((element) =>
+        Number(getComputedStyle(element).zIndex),
+      ),
+    ).toBeGreaterThan(layers[0]);
+    await page.keyboard.press("Escape");
+
+    await page.evaluate(() => {
+      document.documentElement.style.fontSize = "20px";
+    });
+    const rows = reader.locator("ol > .rr-list-row");
+    await expect(rows).toHaveCount(10);
+    const markerState = await rows.nth(9).evaluate((element) => {
+      const marker = getComputedStyle(element, "::before");
+      const firstContent = element.parentElement?.querySelector<HTMLElement>(
+        ".rr-list-row > :first-child",
+      );
+      const currentContent = element.querySelector<HTMLElement>(
+        ":scope > :first-child",
+      );
+      return {
+        content: marker.content,
+        whiteSpace: marker.whiteSpace,
+        inlineSize: marker.inlineSize,
+        aligned:
+          Boolean(firstContent && currentContent) &&
+          Math.abs(
+            firstContent!.getBoundingClientRect().left -
+              currentContent!.getBoundingClientRect().left,
+          ) < 1,
+      };
+    });
+    expect(markerState.content).toContain("counter(rr-ordered-item)");
+    expect(markerState.whiteSpace).toBe("nowrap");
+    expect(markerState.inlineSize).not.toBe("auto");
+    expect(markerState.aligned).toBe(true);
+
+    const missingEdge = reader.locator(
+      '[data-research-provenance-id="S99"]',
+    );
+    await expect(missingEdge).toHaveCount(1);
+    await expect(missingEdge).toHaveAttribute("data-tone", "unresolved");
+    await expect(missingEdge).toBeHidden();
+    const missingRef = reader.getByRole("button", {
+      name: "Missing source S99",
+    });
+    await expect(missingRef).toBeVisible();
+    await missingRef.click();
+    await expect(
+      page.locator(
+        'div.sr-only[role="status"][aria-live="polite"][aria-atomic="true"]',
+      ),
+    ).toContainText("Evidence S99 has no source record.");
+    await expect(reader.locator(".research-evidence-inspector")).toBeHidden();
+    await expect(reader.locator('[data-source-id="S99"]')).toHaveCount(0);
   });
 });

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -360,7 +360,8 @@ test.describe("research reader", () => {
     await expect(reader).toBeVisible();
   });
 
-  test("Escape closes Contents and Evidence in most-recently-opened order", async ({ page }) => {
+  test("wide Escape closes Contents and Evidence in most-recently-opened order", async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 900 });
     await openReader(page);
     const reader = page.locator(".research-reader");
     const contentsToggle = reader.getByRole("button", {
@@ -374,6 +375,8 @@ test.describe("research reader", () => {
 
     await contentsToggle.click();
     await evidenceToggle.click();
+    await evidence.locator('[data-source-id="S14"] .research-evidence-card__toggle').click();
+    await expect(evidence.locator('[data-source-id="S14"]')).toHaveAttribute("data-open", "true");
     await page.keyboard.press("Escape");
     await expect(evidence).toBeHidden();
     await expect(contents).toBeVisible();
@@ -384,6 +387,8 @@ test.describe("research reader", () => {
 
     await evidenceToggle.click();
     await contentsToggle.click();
+    await contents.getByRole("button", { name: "Key results" }).click();
+    await expect(reader.getByRole("heading", { name: "Key results" })).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(contents).toBeHidden();
     await expect(evidence).toBeVisible();
@@ -391,7 +396,170 @@ test.describe("research reader", () => {
     await page.keyboard.press("Escape");
     await expect(evidence).toBeHidden();
     await expect(evidenceToggle).toBeFocused();
+
+    await contentsToggle.click();
+    await evidenceToggle.click();
+    await expect(contents).toBeVisible();
+    await expect(evidence).toBeVisible();
+    await page.setViewportSize({ width: 1200, height: 800 });
+    await expect(contents).toBeHidden();
+    await expect(evidence).toBeVisible();
+    await evidence.locator('[data-source-id="S6"] .research-evidence-card__toggle').click();
+    await page.keyboard.press("Escape");
+    await expect(evidence).toBeHidden();
     await expect(reader).toBeVisible();
+  });
+
+  test("Evidence overlay keeps only the requested side panel accessible", async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 800 });
+    await openReader(page);
+    const reader = page.locator(".research-reader");
+    const contentsToggle = reader.getByRole("button", {
+      name: /^(Show|Hide) contents$/,
+    });
+    const evidenceToggle = reader.getByRole("button", {
+      name: /^(Show|Hide) evidence$/,
+    });
+    const contents = reader.locator(".rr-toc");
+    const evidence = reader.locator(".research-evidence-inspector");
+
+    await contentsToggle.click();
+    await contents.getByRole("button", { name: "Key results" }).click();
+    await evidenceToggle.click();
+    await expect(contents).toBeHidden();
+    await expect(evidence).toBeVisible();
+    await evidence.locator('[data-source-id="S14"] .research-evidence-card__toggle').click();
+    await expect(evidence.locator('[data-source-id="S14"]')).toHaveAttribute("data-open", "true");
+    await page.keyboard.press("Escape");
+    await expect(evidence).toBeHidden();
+
+    await evidenceToggle.click();
+    await evidence.locator('[data-source-id="S6"] .research-evidence-card__toggle').click();
+    await contentsToggle.click();
+    await expect(evidence).toBeHidden();
+    await expect(contents).toBeVisible();
+    await expect(contents.locator(".document-reader__toc-link:focus")).toHaveCount(1);
+    await contents.getByRole("button", { name: "Open questions" }).click();
+    await page.keyboard.press("Escape");
+    await expect(contents).toBeHidden();
+    await expect(reader).toBeVisible();
+  });
+
+  test("Contents preserves the configured prose measure on both sides of 65rem", async ({ page }) => {
+    await page.setViewportSize({ width: 1080, height: 800 });
+    await openReader(page);
+    const reader = page.locator(".research-reader");
+    const claim = reader
+      .locator(".rr-block-row", {
+        hasText: "Identity has three components",
+      })
+      .locator(":scope > :first-child");
+    const measure = () =>
+      claim.evaluate((element) => {
+        const probe = document.createElement("span");
+        probe.style.cssText =
+          "display:block;position:absolute;visibility:hidden;width:var(--document-reader-prose-measure)";
+        element.parentElement!.append(probe);
+        const result = {
+          actual: element.getBoundingClientRect().width,
+          preferred: probe.getBoundingClientRect().width,
+        };
+        probe.remove();
+        return result;
+      });
+
+    await reader.getByRole("button", { name: "Show contents" }).click();
+    const aboveBoundary = await measure();
+    expect(aboveBoundary.actual).toBeGreaterThanOrEqual(
+      aboveBoundary.preferred - 8,
+    );
+    expect(
+      (
+        await reader.locator(".document-reader__layout").evaluate(
+          (element) => getComputedStyle(element).gridTemplateColumns,
+        )
+      )
+        .trim()
+        .split(/\s+/),
+    ).toHaveLength(2);
+
+    await page.setViewportSize({ width: 1064, height: 800 });
+    await expect(reader.locator(".rr-toc")).toBeVisible();
+    const belowBoundary = await measure();
+    expect(belowBoundary.actual).toBeGreaterThanOrEqual(
+      belowBoundary.preferred - 8,
+    );
+    expect(belowBoundary.actual).toBeGreaterThanOrEqual(
+      aboveBoundary.actual - 8,
+    );
+    expect(
+      (
+        await reader.locator(".document-reader__layout").evaluate(
+          (element) => getComputedStyle(element).gridTemplateColumns,
+        )
+      )
+        .trim()
+        .split(/\s+/),
+    ).toHaveLength(1);
+  });
+
+  test("table header citations open their real source from the Evidence heading", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openReader(page, {
+      markdown: FINDINGS_MD.replace(
+        "| Finding | Source | Confidence |",
+        "| Finding | Source S14 | Confidence |",
+      ),
+    });
+    const reader = page.locator(".research-reader");
+    const evidenceHeading = reader.locator(
+      ".rr-table thead .rr-table__evidence",
+    );
+    await expect(evidenceHeading).toContainText("Evidence");
+    const headerReference = evidenceHeading.locator(
+      '[data-research-reference-id="S14"]',
+    );
+    await expect(headerReference).toBeVisible();
+    await expect(
+      reader.locator(".rr-table thead .rr-inline-ref", { hasText: "S14" }),
+    ).toBeHidden();
+
+    await headerReference.click();
+    const inspector = reader.locator(".research-evidence-inspector");
+    const sourceCard = inspector.locator('[data-source-id="S14"]');
+    await expect(sourceCard).toHaveAttribute("data-selected", "true");
+    await expect(sourceCard).toHaveAttribute("data-open", "true");
+    const popupPromise = page.waitForEvent("popup");
+    await sourceCard.getByRole("button", { name: "Open source" }).click();
+    const popup = await popupPromise;
+    await expect(popup).toHaveURL("https://example.com/s14");
+    await popup.close();
+  });
+
+  test("responsive inspector close restores focus to the visible reference representation", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openReader(page);
+    const reader = page.locator(".research-reader");
+    const marginReference = reader
+      .locator(
+        '[data-research-reference-id="S14"][data-research-reference-representation="edge"]',
+      )
+      .first();
+    await marginReference.click();
+    const inspector = reader.locator(".research-evidence-inspector");
+    await expect(inspector).toBeVisible();
+
+    await page.setViewportSize({ width: 1000, height: 800 });
+    await expect(marginReference).toBeHidden();
+    const inlineReference = reader
+      .locator(
+        '[data-research-reference-id="S14"][data-research-reference-representation="inline"]',
+      )
+      .first();
+    await expect(inlineReference).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(inspector).toBeHidden();
+    await expect(inlineReference).toBeFocused();
   });
 
   test("narrow overlay transfers focus, inerts covered controls, and returns focus correctly", async ({ page }) => {
@@ -461,12 +629,13 @@ test.describe("research reader", () => {
 
     await evidenceToggle.click();
     await expect(reader.locator(".research-evidence-inspector")).toBeVisible();
+    await expect(reader.locator(".rr-toc")).toBeHidden();
     await expect(documentReader).toHaveAttribute("inert", "");
     await reader
       .getByRole("button", { name: "Close evidence inspector" })
       .click();
-    await expect(reader.locator(".rr-toc")).toBeVisible();
-    await expect(documentScroll).toHaveAttribute("inert", "");
+    await expect(reader.locator(".rr-toc")).toBeHidden();
+    await expect(documentScroll).not.toHaveAttribute("inert", "");
 
     const columns = await reader.locator(".document-reader__layout").evaluate(
       (element) => getComputedStyle(element).gridTemplateColumns,

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -353,6 +353,53 @@ Identity drifts independently [S1] [S14]. Evidence [S1] supports continuity.`,
     );
   });
 
+  test("linked citation labels select evidence and retain hyperlink text and Supports", async ({ page }) => {
+    await page.setViewportSize({ width: 1000, height: 800 });
+    await openReader(page, {
+      markdown: `# Findings
+
+## Linked evidence
+
+[S1](../sources.json) and [evidence S14](https://example.com/report) support this claim. [paper](https://example.com/plain) is context.`,
+    });
+    const reader = page.locator(".research-reader");
+    const paragraph = reader.locator(".rr-block-row", {
+      hasText: "support this claim",
+    });
+    const exactReference = paragraph.locator(
+      '[data-research-reference-id="S1"][data-research-reference-representation="inline"]',
+    );
+    const mixedReference = paragraph.locator(
+      '[data-research-reference-id="S14"][data-research-reference-representation="inline"]',
+    );
+
+    await expect(exactReference).toBeVisible();
+    await expect(mixedReference).toBeVisible();
+    await expect(
+      paragraph.getByRole("link", { name: "evidence" }),
+    ).toHaveAttribute("href", "https://example.com/report");
+    await expect(
+      paragraph.getByRole("link", { name: "paper" }),
+    ).toHaveAttribute("href", "https://example.com/plain");
+    await expect(paragraph.getByRole("link", { name: "S1" })).toHaveCount(0);
+
+    await exactReference.click();
+    const inspector = reader.locator(".research-evidence-inspector");
+    await expect(inspector.locator('[data-source-id="S1"]')).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+    await inspector.getByRole("button", { name: "Close evidence inspector" }).click();
+
+    await mixedReference.click();
+    const selectedCard = inspector.locator('[data-source-id="S14"]');
+    await expect(selectedCard).toHaveAttribute("data-selected", "true");
+    await selectedCard.locator(".rr-sd-supportlink").click();
+
+    await expect(inspector).toBeHidden();
+    await expect(paragraph).toBeFocused();
+  });
+
   test("hides only redundant author reference columns when generated evidence is visible", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
     await openReader(page, {

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -295,6 +295,128 @@ test.describe("research reader", () => {
     })).toBe(true);
   });
 
+  test("preserves prose spacing around consecutive inline references across layouts", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openReader(page, {
+      markdown: `# Findings
+
+## Result
+
+Identity drifts independently [S1] [S14]. Evidence [S1] supports continuity.`,
+    });
+    const paragraph = page.locator(".rr-block-row p");
+    const visibleText = () =>
+      paragraph.evaluate((element) => {
+        const readVisibleText = (node: Node): string => {
+          if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? "";
+          if (!(node instanceof HTMLElement)) return "";
+          if (getComputedStyle(node).display === "none") return "";
+          return Array.from(node.childNodes, readVisibleText).join("");
+        };
+        return readVisibleText(element);
+      });
+
+    await expect(paragraph.locator(".rr-inline-ref")).toHaveCount(3);
+    await expect(paragraph.locator(".rr-inline-ref-gap")).toHaveCount(3);
+    expect(await visibleText()).toBe(
+      "Identity drifts independently. Evidence supports continuity.",
+    );
+
+    await page.setViewportSize({ width: 1000, height: 800 });
+    await expect(paragraph.locator(".rr-inline-ref").first()).toBeVisible();
+    await expect(paragraph.locator(".rr-inline-ref-gap").first()).toBeVisible();
+    expect(await visibleText()).toBe(
+      "Identity drifts independently S1 S14. Evidence S1 supports continuity.",
+    );
+  });
+
+  test("hides only redundant author reference columns when generated evidence is visible", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openReader(page, {
+      markdown: `# Findings
+
+## Redundant
+
+| Finding | Source | Confidence |
+| --- | --- | --- |
+| First result | [S1] [S14] | High |
+| Second result | [S6] | Medium |
+
+## Mixed
+
+| Finding | Source | Confidence |
+| --- | --- | --- |
+| First result | Primary source [S1] | High |
+| Second result | [S6] | Medium |`,
+    });
+    const tables = page.locator(".rr-table");
+    const redundantSourceHeader = tables
+      .nth(0)
+      .locator("thead th")
+      .nth(1);
+    const mixedSourceHeader = tables
+      .nth(1)
+      .locator("thead th")
+      .nth(1);
+
+    await expect(redundantSourceHeader).toHaveClass(
+      /rr-table__redundant-reference/,
+    );
+    await expect(redundantSourceHeader).toBeHidden();
+    await expect(
+      tables.nth(0).locator("tbody tr").first().locator("td").nth(1),
+    ).toBeHidden();
+    await expect(tables.nth(0).locator(".rr-table__evidence").first()).toBeVisible();
+    await expect(mixedSourceHeader).not.toHaveClass(
+      /rr-table__redundant-reference/,
+    );
+    await expect(mixedSourceHeader).toBeVisible();
+
+    await page.setViewportSize({ width: 1000, height: 800 });
+    await expect(redundantSourceHeader).toBeVisible();
+    await expect(
+      tables.nth(0).locator("tbody tr").first().locator("td").nth(1),
+    ).toBeVisible();
+    await expect(tables.nth(0).locator(".rr-table__evidence").first()).toBeHidden();
+  });
+
+  test("committed real and missing references dismiss transient previews", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openReader(page, {
+      markdown: `# Findings
+
+## Result
+
+Verified claim [S1]. Missing claim [S99].`,
+    });
+    const reader = page.locator(".research-reader");
+    const tip = page.locator(".rr-tip");
+    const realReference = reader.locator(
+      '[data-research-reference-id="S1"][data-research-reference-representation="edge"]',
+    );
+
+    await realReference.hover();
+    await expect(tip).toHaveAttribute("data-show", "true");
+    await realReference.click();
+    await expect(reader.locator(".research-evidence-inspector")).toBeVisible();
+    await expect(tip).toHaveAttribute("data-show", "false");
+    await expect(tip).toHaveCSS("opacity", "0");
+
+    await reader
+      .getByRole("button", { name: "Close evidence inspector" })
+      .click();
+    await page.setViewportSize({ width: 1000, height: 800 });
+    const missingReference = reader.getByRole("button", {
+      name: "Missing source S99",
+    });
+    await missingReference.hover();
+    await expect(tip).toHaveAttribute("data-show", "true");
+    await missingReference.click();
+    await expect(tip).toHaveAttribute("data-show", "false");
+    await expect(tip).toHaveCSS("opacity", "0");
+    await expect(reader.locator(".research-evidence-inspector")).toBeHidden();
+  });
+
   test("published findings keep lifecycle truth separate from an unavailable empty source ledger", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
     await openReader(page, {

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -318,18 +318,22 @@ test.describe("research reader", () => {
     })).toBe(true);
   });
 
-  test("preserves prose spacing around consecutive inline references across layouts", async ({ page }) => {
+  test("preserves authored grammatical and trailing refs while switching the sole interactive representation", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
     await openReader(page, {
       markdown: `# Findings
 
 ## Result
 
-Identity drifts independently [S1] [S14]. Evidence [S1] supports continuity.`,
+S1 contradicts S14.
+
+Evidence remains mixed [S1] [S14].`,
     });
-    const paragraph = page.locator(".rr-block-row p");
-    const visibleText = () =>
-      paragraph.evaluate((element) => {
+    const rows = page.locator(".rr-block-row", { has: page.locator("p") });
+    const grammaticalRow = rows.nth(0);
+    const trailingRow = rows.nth(1);
+    const visibleText = (row: typeof grammaticalRow) =>
+      row.locator("p").evaluate((element) => {
         const readVisibleText = (node: Node): string => {
           if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? "";
           if (!(node instanceof HTMLElement)) return "";
@@ -339,18 +343,33 @@ Identity drifts independently [S1] [S14]. Evidence [S1] supports continuity.`,
         return readVisibleText(element);
       });
 
-    await expect(paragraph.locator(".rr-inline-ref")).toHaveCount(3);
-    await expect(paragraph.locator(".rr-inline-ref-gap")).toHaveCount(3);
-    expect(await visibleText()).toBe(
-      "Identity drifts independently. Evidence supports continuity.",
+    for (const row of [grammaticalRow, trailingRow]) {
+      await expect(row.locator(".rr-wide-ref")).toHaveCount(2);
+      await expect(row.locator(".rr-wide-ref").first()).toBeVisible();
+      await expect(row.locator(".rr-inline-ref")).toHaveCount(2);
+      await expect(row.locator(".rr-inline-ref").first()).toBeHidden();
+      await expect(row.locator(".research-provenance-edge__item")).toHaveCount(2);
+      await expect(row.locator(".research-provenance-edge__item").first()).toBeVisible();
+      await expect(row.locator("button:visible")).toHaveCount(2);
+    }
+    await expect(
+      grammaticalRow.locator('.rr-wide-ref[aria-hidden="true"]'),
+    ).toHaveCount(2);
+    expect(await visibleText(grammaticalRow)).toBe("S1 contradicts S14.");
+    expect(await visibleText(trailingRow)).toBe(
+      "Evidence remains mixed S1 S14.",
     );
 
     await page.setViewportSize({ width: 1000, height: 800 });
-    await expect(paragraph.locator(".rr-inline-ref").first()).toBeVisible();
-    await expect(paragraph.locator(".rr-inline-ref-gap").first()).toBeVisible();
-    expect(await visibleText()).toBe(
-      "Identity drifts independently S1 S14. Evidence S1 supports continuity.",
-    );
+    for (const row of [grammaticalRow, trailingRow]) {
+      await expect(row.locator(".rr-wide-ref").first()).toBeHidden();
+      await expect(row.locator(".rr-inline-ref").first()).toBeVisible();
+      await expect(row.locator(".rr-inline-ref-gap").first()).toBeVisible();
+      await expect(row.locator(".research-provenance-edge__item").first()).toBeHidden();
+      await expect(row.locator("button:visible")).toHaveCount(2);
+    }
+    expect(await visibleText(grammaticalRow)).toBe("S1 contradicts S14.");
+    expect(await visibleText(trailingRow)).toBe("Evidence remains mixed S1 S14.");
   });
 
   test("linked citation labels select evidence and retain hyperlink text and Supports", async ({ page }) => {
@@ -716,6 +735,16 @@ Verified claim [S1]. Missing claim [S99].`,
     const edgeReference = reader.locator(
       `[data-research-reference-id="${longId}"][data-research-reference-representation="edge"]`,
     );
+    const wideVisualReference = reader.locator(
+      `.rr-wide-ref [data-research-source-id-label="${longId}"]`,
+    );
+    await expect(wideVisualReference).toBeVisible();
+    await expect(wideVisualReference).toHaveAttribute("title", longId);
+    await expect(wideVisualReference).toContainText("…");
+    await expect(wideVisualReference.locator("xpath=..")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
     await expect(edgeReference).toHaveAttribute(
       "aria-label",
       `Open evidence ${longId}`,
@@ -757,6 +786,7 @@ Verified claim [S1]. Missing claim [S99].`,
     const inlineReference = reader.locator(
       `[data-research-reference-id="${longId}"][data-research-reference-representation="inline"]`,
     );
+    await expect(wideVisualReference).toBeHidden();
     await expect(inlineReference).toBeVisible();
     await expect(inlineReference).toHaveAttribute(
       "aria-label",

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -131,6 +131,7 @@ test.describe("research reader", () => {
   test.describe.configure({ timeout: 180_000 });
 
   test("typesets semantic findings and links evidence back to its supported claim", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
     await openReader(page);
     const reader = page.locator(".research-reader");
 
@@ -149,11 +150,35 @@ test.describe("research reader", () => {
     const table = reader.locator(".rr-table");
     await expect(table).toContainText("Scale raises value coherence");
     await expect(table.locator(".rr-cf--high")).toHaveText("High");
-    await expect(table.locator(".rr-sref", { hasText: "S14" }).first()).toBeVisible();
+    const marginReference = reader.locator(
+      ".research-provenance-edge__item",
+      { hasText: "S14" },
+    ).first();
+    await expect(marginReference).toBeVisible();
+    await expect(
+      table.locator(".rr-inline-ref", { hasText: "S14" }).first(),
+    ).toBeHidden();
+    const paperWidthBeforeInspector = await reader
+      .locator(".rr-doc__column")
+      .evaluate((element) => element.getBoundingClientRect().width);
 
-    await reader.getByRole("button", { name: "Open evidence S14" }).first().click();
+    await marginReference.click();
     await expect(reader).toHaveAttribute("data-inspector", "true");
     await expect(reader.locator(".document-reader")).not.toHaveAttribute("inert", "");
+    const railHandle = reader.locator(".rr-railhandle");
+    const handleBox = await railHandle.boundingBox();
+    expect(handleBox).not.toBeNull();
+    await page.mouse.move(
+      handleBox!.x + handleBox!.width / 2,
+      handleBox!.y + handleBox!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(handleBox!.x - 260, handleBox!.y + handleBox!.height / 2);
+    await page.mouse.up();
+    const paperWidthAtMaxRail = await reader
+      .locator(".rr-doc__column")
+      .evaluate((element) => element.getBoundingClientRect().width);
+    expect(paperWidthAtMaxRail).toBeCloseTo(paperWidthBeforeInspector, 0);
     const inspector = reader.locator(".research-evidence-inspector");
     const s14card = inspector.locator('[data-source-id="S14"]');
     await expect(inspector).toBeVisible();
@@ -216,7 +241,14 @@ test.describe("research reader", () => {
     await openReader(page);
     const reader = page.locator(".research-reader");
     const documentReader = reader.locator(".document-reader");
+    const documentScroll = reader.locator(".document-reader__scroll");
     const evidenceToggle = reader.getByRole("button", { name: "Show evidence" });
+    const chrome = reader.locator(".rr-head");
+
+    expect(await chrome.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+    await expect(reader.locator(".rr-status")).toBeVisible();
+    await expect(reader.locator(".rr-integrity")).toBeVisible();
+    await expect(reader.locator(".research-provenance-edge__item").first()).toBeHidden();
 
     await evidenceToggle.click();
     const inspector = reader.locator(".research-evidence-inspector");
@@ -236,6 +268,7 @@ test.describe("research reader", () => {
     await expect(evidenceToggle).toBeFocused();
 
     const inlineReference = reader.locator(".rr-inline-ref", { hasText: "S14" }).first();
+    await expect(inlineReference).toBeVisible();
     await inlineReference.click();
     await expect(documentReader).toHaveAttribute("inert", "");
     await expect(inspector).toContainText("Emergent value coherence at scale");
@@ -253,10 +286,25 @@ test.describe("research reader", () => {
 
     await reader.getByRole("button", { name: "Show contents" }).click();
     await expect(reader).toHaveAttribute("data-toc", "true");
+    await expect(reader.locator(".rr-toc")).toBeVisible();
+    await expect(reader.locator(".document-reader__compact-nav")).toBeHidden();
+    await expect(documentScroll).toHaveAttribute("inert", "");
+    await expect(
+      reader.locator('.rr-toclink[data-active="true"]'),
+    ).toBeFocused();
     await expect(reader.getByRole("button", { name: "Hide contents" })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
+
+    await evidenceToggle.click();
+    await expect(reader.locator(".research-evidence-inspector")).toBeVisible();
+    await expect(documentReader).toHaveAttribute("inert", "");
+    await reader
+      .getByRole("button", { name: "Close evidence inspector" })
+      .click();
+    await expect(reader.locator(".rr-toc")).toBeVisible();
+    await expect(documentScroll).toHaveAttribute("inert", "");
 
     const columns = await reader.locator(".document-reader__layout").evaluate(
       (element) => getComputedStyle(element).gridTemplateColumns,

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -158,9 +158,28 @@ test.describe("research reader", () => {
     await expect(
       table.locator(".rr-inline-ref", { hasText: "S14" }).first(),
     ).toBeHidden();
-    const paperWidthBeforeInspector = await reader
-      .locator(".rr-doc__column")
-      .evaluate((element) => element.getBoundingClientRect().width);
+    const measuredClaim = reader.locator(".rr-block-row", {
+      hasText: "Identity has three components",
+    });
+    const claimWidthBeforeInspector = await measuredClaim.evaluate((element) => {
+      const prose = element.firstElementChild as HTMLElement;
+      const probe = document.createElement("span");
+      probe.style.display = "block";
+      probe.style.position = "absolute";
+      probe.style.visibility = "hidden";
+      probe.style.width = "var(--document-reader-prose-measure)";
+      element.append(probe);
+      const widths = {
+        actual: prose.getBoundingClientRect().width,
+        preferred: probe.getBoundingClientRect().width,
+      };
+      probe.remove();
+      return widths;
+    });
+    expect(claimWidthBeforeInspector.actual).toBeCloseTo(
+      claimWidthBeforeInspector.preferred,
+      0,
+    );
 
     await marginReference.click();
     await expect(reader).toHaveAttribute("data-inspector", "true");
@@ -175,10 +194,13 @@ test.describe("research reader", () => {
     await page.mouse.down();
     await page.mouse.move(handleBox!.x - 260, handleBox!.y + handleBox!.height / 2);
     await page.mouse.up();
-    const paperWidthAtMaxRail = await reader
-      .locator(".rr-doc__column")
+    const claimWidthAtMaxRail = await measuredClaim
+      .locator(":scope > :first-child")
       .evaluate((element) => element.getBoundingClientRect().width);
-    expect(paperWidthAtMaxRail).toBeCloseTo(paperWidthBeforeInspector, 0);
+    expect(claimWidthAtMaxRail).toBeCloseTo(
+      claimWidthBeforeInspector.actual,
+      0,
+    );
     const inspector = reader.locator(".research-evidence-inspector");
     const s14card = inspector.locator('[data-source-id="S14"]');
     await expect(inspector).toBeVisible();
@@ -249,6 +271,10 @@ test.describe("research reader", () => {
     await expect(reader.locator(".rr-status")).toBeVisible();
     await expect(reader.locator(".rr-integrity")).toBeVisible();
     await expect(reader.locator(".research-provenance-edge__item").first()).toBeHidden();
+    await expect(reader.locator(".rr-doc")).toHaveCSS(
+      "--research-evidence-edge-reserve",
+      "0",
+    );
 
     await evidenceToggle.click();
     const inspector = reader.locator(".research-evidence-inspector");

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -213,7 +213,9 @@ test.describe("research reader", () => {
       ).toBeCloseTo(claimWidthBeforeInspector.actual, 0);
     }
 
-    await marginReference.click();
+    await marginReference.focus();
+    await expect(marginReference).toBeFocused();
+    await page.keyboard.press("Enter");
     await expect(reader).toHaveAttribute("data-inspector", "true");
     await expect(reader.locator(".document-reader")).not.toHaveAttribute("inert", "");
     const railHandle = reader.locator(".rr-railhandle");
@@ -291,6 +293,48 @@ test.describe("research reader", () => {
         targetRect.top < scrollerRect.bottom
       );
     })).toBe(true);
+  });
+
+  test("published findings keep lifecycle truth separate from an unavailable empty source ledger", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openReader(page, {
+      markdown: "# Findings\n\n## Result\n\nClaim [S1].",
+      mission: {
+        ...COMPLETED_MISSION,
+        artifacts: COMPLETED_MISSION.artifacts.map((artifact) => ({
+          ...artifact,
+          state: "published",
+        })),
+        sources: [],
+      },
+    });
+    const reader = page.locator(".research-reader");
+    const edgeReference = reader.locator(
+      '[data-research-reference-id="S1"][data-research-reference-representation="edge"]',
+    );
+    const inlineReference = reader.locator(
+      '[data-research-reference-id="S1"][data-research-reference-representation="inline"]',
+    );
+
+    await expect(reader.locator(".rr-status")).toContainText("Published");
+    await expect(reader.locator(".rr-integrity")).toHaveText(
+      "Sources unavailable — references can't be verified",
+    );
+    await expect(edgeReference).toHaveAttribute("data-tone", "unresolved");
+    await expect(inlineReference).toHaveClass(/rr-sref--unresolved/);
+    await expect(inlineReference).toHaveAttribute("aria-label", "Missing source S1");
+    await expect(edgeReference).toBeVisible();
+    await expect(inlineReference).toBeHidden();
+
+    await edgeReference.click();
+    await expect(
+      page.locator(
+        'div.sr-only[role="status"][aria-live="polite"][aria-atomic="true"]',
+      ),
+    ).toContainText("Evidence S1 has no source record.");
+    await expect(reader).toHaveAttribute("data-inspector", "false");
+    await expect(reader.locator(".research-evidence-inspector")).toBeHidden();
+    await expect(reader.locator('[data-source-id="S1"]')).toHaveCount(0);
   });
 
   test("opens dedicated contents and evidence panels while retaining reader actions", async ({ page }) => {

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -172,7 +172,7 @@ test.describe("research reader", () => {
   test.describe.configure({ timeout: 180_000 });
 
   test("typesets semantic findings and links evidence back to its supported claim", async ({ page }) => {
-    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.setViewportSize({ width: 1920, height: 1080 });
     await openReader(page);
     const reader = page.locator(".research-reader");
 
@@ -242,6 +242,8 @@ test.describe("research reader", () => {
     await expect(reader).toHaveAttribute("data-inspector", "true");
     await expect(reader.locator(".document-reader")).not.toHaveAttribute("inert", "");
     const railHandle = reader.locator(".rr-railhandle");
+    await expect(railHandle).toBeVisible();
+    await expect(marginReference).toBeVisible();
     const handleBox = await railHandle.boundingBox();
     const readerBox = await reader.boundingBox();
     expect(handleBox).not.toBeNull();
@@ -278,13 +280,11 @@ test.describe("research reader", () => {
       minimumHandleBox!.y + minimumHandleBox!.height / 2,
     );
     await page.mouse.up();
-    const claimWidthAtMaxRail = await measuredClaim
-      .locator(":scope > :first-child")
-      .evaluate((element) => element.getBoundingClientRect().width);
-    expect(claimWidthAtMaxRail).toBeCloseTo(
-      claimWidthBeforeInspector.actual,
-      0,
-    );
+    await expect.poll(
+      () => measuredClaim
+        .locator(":scope > :first-child")
+        .evaluate((element) => element.getBoundingClientRect().width),
+    ).toBeCloseTo(claimWidthBeforeInspector.actual, 0);
     const inspector = reader.locator(".research-evidence-inspector");
     const s14card = inspector.locator('[data-source-id="S14"]');
     await expect(inspector).toBeVisible();

--- a/tests/research-reader.spec.ts
+++ b/tests/research-reader.spec.ts
@@ -229,6 +229,13 @@ test.describe("research reader", () => {
     await openReader(page);
     const reader = page.locator(".research-reader");
 
+    await expect(reader.getByRole("button", { name: "Publish" })).toHaveAttribute(
+      "title",
+      "Publish",
+    );
+    await expect(
+      reader.getByRole("button", { name: "More research reader actions" }),
+    ).toHaveAttribute("title", "More research reader actions");
     await expect(reader.locator(".rr-toc")).toBeHidden();
     await reader.getByRole("button", { name: "Show contents" }).click();
     await expect(reader).toHaveAttribute("data-toc", "true");


### PR DESCRIPTION
## Summary

- rebuild the findings report as a reading-first Evidence Edge surface with native Contents and Evidence panels
- add semantic provenance targets, evidence-integrity states, and truthful source-ledger reconciliation
- preserve shared DocumentReader defaults while adding focused accessibility, responsive, parser, and browser coverage

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` — 1,399 test files passed
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all pnpm test:api` — 255 tests passed
- `pnpm check:tests-wired` — 1,969 test files wired
- Research Reader Playwright — 19 reader scenarios passed
- `git diff --check`

Bead: `cave-6gcw8`