### PR TITLE
fix(ci): bound daemon-less E2E memory (cave-dejw3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,7 +517,35 @@ jobs:
       - run: pnpm exec playwright install --with-deps chromium webkit
 
       - name: Validate end-to-end behavior
-        run: pnpm exec playwright test --shard=${{ matrix.shard }}/8 --workers=1
+        env:
+          PLAYWRIGHT_SHARD: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+
+          telemetry_pid=""
+          if [ "$PLAYWRIGHT_SHARD" = "3" ]; then
+            telemetry() {
+              while true; do
+                echo "::group::E2E shard 3 telemetry $(date --iso-8601=seconds)"
+                free -h || true
+                df -h / || true
+                if [ -r /sys/fs/cgroup/memory.events ]; then
+                  cat /sys/fs/cgroup/memory.events || true
+                fi
+                ps -eo pid,ppid,stat,etimes,rss,pcpu,pmem,comm --sort=-rss | head -n 21 || true
+                echo "::endgroup::"
+                sleep 30
+              done
+            }
+            telemetry &
+            telemetry_pid=$!
+            trap 'kill "$telemetry_pid" 2>/dev/null || true; wait "$telemetry_pid" 2>/dev/null || true' EXIT
+          fi
+
+          pnpm exec playwright test \
+            --shard="$PLAYWRIGHT_SHARD/8" \
+            --workers=1 \
+            --reporter="github,line"
 
   frontend-e2e-agentic:
     name: Frontend E2E (agentic)

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,7 @@ const withBundleAnalyzer = bundleAnalyzer({
 
 const conformanceBuild =
   process.env.COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL === "1";
+const daemonlessE2E = process.env.COVEN_CAVE_E2E === "1";
 
 const nextConfig: NextConfig = {
   env: {
@@ -118,13 +119,20 @@ const nextConfig: NextConfig = {
     turbopackPluginRuntimeStrategy: conformanceBuild
       ? "workerThreads"
       : undefined,
-    // Next 16.2 enables Turbopack's persistent dev cache by default. In this
-    // app the cache reaches multiple gigabytes, then its SST compaction can
-    // starve the PostCSS child-process IPC until Turbopack panics while
-    // processing globals.css ("timeout while receiving message from process").
-    // Keep dev state in memory instead; a dev-server restart is an acceptable
-    // cache boundary and avoids the failing compaction path.
-    turbopackFileSystemCacheForDev: false,
+    // Next 16.2 enables Turbopack's persistent dev cache by default. In a
+    // long-lived desktop session the cache reaches multiple gigabytes, then
+    // its SST compaction can starve the PostCSS child-process IPC until
+    // Turbopack panics while processing globals.css ("timeout while receiving
+    // message from process"). Keep that local-dev workaround intact.
+    //
+    // Playwright is a different bounded workload: every shard starts cold in
+    // an isolated checkout and exits after the suite. Without a persistent
+    // cache, shard 3 retained 13.36 GiB in next-server, exhausted a 16 GiB
+    // hosted runner plus all 3 GiB of swap, and lost the runner. Persist the
+    // short-lived E2E graph so Next 16.3's full eviction mode can reclaim its
+    // in-memory copy after each snapshot instead of retaining every compile.
+    turbopackFileSystemCacheForDev: daemonlessE2E,
+    turbopackMemoryEviction: daemonlessE2E ? "full" : false,
     // Tree-shake the icon + syntax-highlight kitchens so the per-route
     // bundle only includes the icons and grammars actually referenced.
     // @iconify/react in particular has a flat icon-name surface that

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -232,6 +232,15 @@ export default defineConfig({
     reuseExistingServer: false,
     env: {
       COVEN_CAVE_E2E: "1",
+      // Full Turbopack eviction only runs after a filesystem-cache snapshot.
+      // Next 16.3's own eviction fixture removes the minimum active window and
+      // shortens the idle checkpoint so a cold multi-surface compile can be
+      // persisted and reclaimed before the next one. Without these timings,
+      // shard 3 reached 19.67 GiB across next-server and its compiler children
+      // before the first eviction; with them it repeatedly reclaimed at a
+      // 12.70 GiB combined peak and completed all 51 tests.
+      TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS: "1000",
+      TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS: "0",
       // Crafts stay hidden in production by default. Their dedicated E2E
       // specs exercise the explicitly enabled surface through this fixture.
       NEXT_PUBLIC_CAVE_CRAFTS: "1",

--- a/scripts/ci-recovery-workflow.test.mjs
+++ b/scripts/ci-recovery-workflow.test.mjs
@@ -124,12 +124,31 @@ const defaultE2e = ciWorkflow.jobs["frontend-e2e"].steps.find(
 assert.ok(defaultE2e, "CI keeps default-off end-to-end coverage");
 assert.deepEqual(ciWorkflow.jobs["frontend-e2e"].strategy.matrix.shard, [1, 2, 3, 4, 5, 6, 7, 8]);
 assert.equal(ciWorkflow.jobs["frontend-e2e"].strategy["fail-fast"], false);
-assert.equal(
-  defaultE2e.run,
-  "pnpm exec playwright test --shard=${{ matrix.shard }}/8 --workers=1",
-  "default end-to-end coverage is distributed across independently retryable runners",
+assert.deepEqual(
+  defaultE2e.env,
+  { PLAYWRIGHT_SHARD: "${{ matrix.shard }}" },
+  "the shard number is available to both the runner and its diagnostics",
 );
-assert.equal(defaultE2e.env, undefined, "default end-to-end coverage does not enable agentic recommendations");
+assert.match(
+  defaultE2e.run,
+  /pnpm exec playwright test \\\n\s+--shard="\$PLAYWRIGHT_SHARD\/8" \\\n\s+--workers=1 \\\n\s+--reporter="github,line"/,
+  "default end-to-end coverage is distributed across named, independently retryable runners",
+);
+assert.match(
+  defaultE2e.run,
+  /if \[ "\$PLAYWRIGHT_SHARD" = "3" \]; then[\s\S]*free -h[\s\S]*df -h \/[\s\S]*\/sys\/fs\/cgroup\/memory\.events[\s\S]*ps -eo pid,ppid,stat,etimes,rss,pcpu,pmem,comm[\s\S]*sleep 30/,
+  "the repeatedly terminated shard streams bounded host telemetry before a runner can disappear",
+);
+assert.match(
+  defaultE2e.run,
+  /trap 'kill "\$telemetry_pid" 2>\/dev\/null \|\| true; wait "\$telemetry_pid" 2>\/dev\/null \|\| true' EXIT/,
+  "the shard telemetry process is reaped after Playwright exits",
+);
+assert.equal(
+  defaultE2e.env.NEXT_PUBLIC_CAVE_AGENTIC_RECOMMENDATIONS,
+  undefined,
+  "default end-to-end coverage does not enable agentic recommendations",
+);
 
 const agenticE2e = ciWorkflow.jobs["frontend-e2e-agentic"].steps.find(
   (step) => step.name === "Validate flag-enabled agentic journeys",

--- a/scripts/turbopack-dev-cache.test.mjs
+++ b/scripts/turbopack-dev-cache.test.mjs
@@ -1,15 +1,55 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 
-const nextConfig = await readFile(
-  new URL("../next.config.ts", import.meta.url),
-  "utf8",
-);
+const previousE2E = process.env.COVEN_CAVE_E2E;
 
-assert.match(
-  nextConfig,
-  /turbopackFileSystemCacheForDev:\s*false/,
+async function loadConfig(e2e) {
+  if (e2e === undefined) delete process.env.COVEN_CAVE_E2E;
+  else process.env.COVEN_CAVE_E2E = e2e;
+
+  try {
+    const url = new URL(`../next.config.ts?cache-test=${randomUUID()}`, import.meta.url);
+    return (await import(url.href)).default;
+  } finally {
+    if (previousE2E === undefined) delete process.env.COVEN_CAVE_E2E;
+    else process.env.COVEN_CAVE_E2E = previousE2E;
+  }
+}
+
+const localConfig = await loadConfig(undefined);
+const e2eConfig = await loadConfig("1");
+const playwrightConfig = await readFile(new URL("../playwright.config.ts", import.meta.url), "utf8");
+
+assert.equal(
+  localConfig.experimental.turbopackFileSystemCacheForDev,
+  false,
   "dev must keep Turbopack's persistent filesystem cache disabled so multi-gigabyte compaction cannot stall the PostCSS worker",
+);
+assert.equal(
+  localConfig.experimental.turbopackMemoryEviction,
+  false,
+  "ordinary local dev explicitly disables eviction with its intentionally disabled filesystem cache",
+);
+assert.equal(
+  e2eConfig.experimental.turbopackFileSystemCacheForDev,
+  true,
+  "daemon-less E2E persists its short-lived Turbopack graph so compiled data can be evicted",
+);
+assert.equal(
+  e2eConfig.experimental.turbopackMemoryEviction,
+  "full",
+  "daemon-less E2E evicts every persisted snapshot instead of exhausting the runner",
+);
+assert.match(
+  playwrightConfig,
+  /TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS:\s*"1000"/,
+  "E2E snapshots after the same bounded idle window exercised by Next's eviction fixture",
+);
+assert.match(
+  playwrightConfig,
+  /TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS:\s*"0"/,
+  "cold E2E compiles may snapshot before their retained graph exhausts the runner",
 );
 
 console.log("turbopack-dev-cache.test.mjs: ok");

--- a/src/app/api/running-activity/route.test.ts
+++ b/src/app/api/running-activity/route.test.ts
@@ -3,7 +3,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { readFile } from "node:fs/promises";
 
-import { buildRunningActivityPayload } from "@/lib/running-activity";
+import {
+  buildRunningActivityPayload,
+  emptyRunningActivityPayload,
+} from "@/lib/running-activity";
+import { GET } from "./route";
 
 const route = await readFile(new URL("./route.ts", import.meta.url), "utf8");
 const lib = await readFile(new URL("../../../lib/running-activity.ts", import.meta.url), "utf8");
@@ -39,6 +43,52 @@ test("each source is isolated so one failure cannot sink the response", () => {
 test("sessions use the read-only, subprocess-free projection", () => {
   assert.match(route, /sweepArchives: false/);
   assert.match(route, /enrichGit: false/);
+});
+
+test("daemon-less E2E returns a complete idle payload before loading live sources", async () => {
+  const handler = route.slice(route.indexOf("export async function GET"));
+  const guard = handler.indexOf('process.env.COVEN_CAVE_E2E === "1"');
+  const liveSources = handler.indexOf("const sessionsSource");
+
+  assert.ok(guard >= 0, "the route recognizes the Playwright daemon-less environment");
+  assert.ok(liveSources > guard, "the E2E response returns before any live source is loaded");
+  assert.match(handler, /return NextResponse\.json\(emptyRunningActivityPayload\(\)\)/);
+
+  const payload = emptyRunningActivityPayload("2026-08-30T00:00:00.000Z");
+  assert.equal(payload.ok, true);
+  assert.equal(payload.total, 0);
+  assert.deepEqual(payload.items, []);
+  assert.deepEqual(payload.unavailable, []);
+  assert.deepEqual(
+    Object.fromEntries(Object.entries(payload.sources).map(([id, state]) => [id, state.count])),
+    { sessions: 0, board: 0, automations: 0, flows: 0, workflows: 0 },
+  );
+
+  const previousE2E = process.env.COVEN_CAVE_E2E;
+  process.env.COVEN_CAVE_E2E = "1";
+  try {
+    const response = await GET();
+    const routedPayload = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(routedPayload.total, 0);
+    assert.deepEqual(routedPayload.items, []);
+    assert.deepEqual(routedPayload.unavailable, []);
+    assert.deepEqual(
+      Object.fromEntries(
+        Object.entries(routedPayload.sources).map(([id, state]) => [id, state]),
+      ),
+      {
+        sessions: { ok: true, count: 0 },
+        board: { ok: true, count: 0 },
+        automations: { ok: true, count: 0 },
+        flows: { ok: true, count: 0 },
+        workflows: { ok: true, count: 0 },
+      },
+    );
+  } finally {
+    if (previousE2E === undefined) delete process.env.COVEN_CAVE_E2E;
+    else process.env.COVEN_CAVE_E2E = previousE2E;
+  }
 });
 
 test("automations use the daemon run ledger after local run-history retirement", () => {

--- a/src/app/api/running-activity/route.ts
+++ b/src/app/api/running-activity/route.ts
@@ -13,6 +13,7 @@ import {
   automationActivityItems,
   boardTaskActivityItems,
   buildRunningActivityPayload,
+  emptyRunningActivityPayload,
   flowActivityItems,
   sessionActivityItems,
   workflowActivityItems,
@@ -69,6 +70,14 @@ async function listAutomationRuns(): Promise<AutomationRunRecord[]> {
 }
 
 export async function GET() {
+  // Browser E2E is explicitly daemon-less. The popover is mounted on every
+  // desktop page, so letting its poll fall through would fan each test into
+  // five real stores (including the Coven automation daemon) unless that
+  // individual spec happened to know about this shell-owned endpoint.
+  if (process.env.COVEN_CAVE_E2E === "1") {
+    return NextResponse.json(emptyRunningActivityPayload());
+  }
+
   // Sessions: read-only, subprocess-free projection (no archive sweeps, no git
   // enrichment) of the same list the workspace polls. A hard daemon outage is
   // honest partial-source status, not an empty-but-fine list.

--- a/src/lib/running-activity.ts
+++ b/src/lib/running-activity.ts
@@ -278,6 +278,22 @@ export function buildRunningActivityPayload(
   return { ok: true, generatedAt, total: items.length, items, sources: state, unavailable };
 }
 
+/** A complete, schema-valid idle response for daemon-less callers. */
+export function emptyRunningActivityPayload(
+  generatedAt = new Date().toISOString(),
+): RunningActivityPayload {
+  return buildRunningActivityPayload(
+    {
+      sessions: { ok: true, items: [] },
+      board: { ok: true, items: [] },
+      automations: { ok: true, items: [] },
+      flows: { ok: true, items: [] },
+      workflows: { ok: true, items: [] },
+    },
+    generatedAt,
+  );
+}
+
 /** Fetch the aggregated running activity; resolves null on any failure. */
 export async function fetchRunningActivity(
   fetchImpl: typeof fetch = fetch,


### PR DESCRIPTION
## Summary

- Keep running-activity polling daemon-less under `COVEN_CAVE_E2E=1` by returning the schema-valid idle payload instead of probing adapters.
- Give shard 3 named Playwright output and periodic host/process memory telemetry.
- Enable Turbopack's filesystem cache plus full memory eviction only for Playwright, with Next 16.3.1's upstream eviction-fixture snapshot timings.
- Preserve the existing filesystem-cache workaround for ordinary local development; production behavior is unchanged.

## Root cause and fix evidence

The first CI attempt reached 13.36 GiB in `next-server`, filled all 15 GiB of runner RAM and 3 GiB of swap, and was shut down at 29/51 tests. Full eviction without early snapshots still peaked at 19.67 GiB locally before its first reclaim.

With the snapshot timing controls, the exact cold shard 3 run showed repeated eviction, peaked at 12.70 GB across the compiler process tree, completed 51/51 in 3.6 minutes, and exited normally.

## Verification

- `node scripts/running-activity-route.test.mjs` (6/6)
- running-activity library tests (10/10)
- `node scripts/turbopack-dev-cache.test.mjs`
- `node scripts/ci-recovery-workflow.test.mjs`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` (1,975/1,975)
- exact cold Playwright shard 3 (51/51)
- `pnpm build`

Broader Windows-host boundaries remain pre-existing: `test:api` reaches a WSL `node` lookup failure after three files, and `test:app` reaches the fake `bd.cmd` `spawnSync EINVAL` boundary after 64 files.

Refs #5194

Bead: cave-dejw3