### PR TITLE
docs: record daemon fault-injection CI coverage decision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1201,9 +1201,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Routine PR conformance runs this bounded fault harness on Ubuntu.
-      # Release-candidate and release platform validation supply the Windows
-      # and macOS host proof without restoring the costly three-OS PR matrix.
+      # PR CI runs this same bounded fault harness on Linux and Windows.
+      # Release CI supplies the macOS host proof without restoring the costly
+      # full PR matrix.
       - name: Test daemon connectivity fault recovery
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1201,9 +1201,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # PR CI runs this same bounded fault harness on Linux and Windows.
-      # Release CI supplies the macOS host proof without restoring the costly
-      # full PR matrix.
+      # Routine PR conformance runs this bounded fault harness on Ubuntu.
+      # Release-candidate and release platform validation supply the Windows
+      # and macOS host proof without restoring the costly three-OS PR matrix.
       - name: Test daemon connectivity fault recovery
         shell: bash
         run: |

--- a/docs/daemon-connectivity-reliability.md
+++ b/docs/daemon-connectivity-reliability.md
@@ -111,7 +111,7 @@ evidence. Full cross-layer correlation remains `cave-58eoq.3`.
 | 6 | High | Shipped in PR #4495: `cave-58eoq.2` | The window previously could open onto a sidecar that was listening but incompatible or only partially initialized | Rust readiness proved child log + TCP only | Native GUI and background-daemon startup now require the same bounded sidecar-token-authenticated identity/protocol/version/bundle/dependency handshake before navigation, publication, or retained daemon state |
 | 7 | Medium | Fixed in this branch | Incompatible, unauthorized, unhealthy, unreachable, misconfigured, and status-unavailable responses appeared as generic “Offline” | Settings ignored the route's machine-readable `availability`; the shared type omitted the route's `incompatible` value | Complete the shared taxonomy, fail closed on contradictory fields, render distinct labels/tones, and expose sanitized reason text |
 | 8 | Medium | Open: `cave-58eoq.3` | Support cannot follow one startup/recovery across Rust, sidecar, daemon requests, and CLI children | Logs are component-local and no shared correlation/diagnostic-bundle contract was found | Add correlation IDs, structured lifecycle events, bounded retention, and a redacted export manifest |
-| 9 | Medium | Open: `cave-58eoq.4` | Green happy-path tests can miss races, stale endpoints, hangs, resets, and orphaned children | Coverage is strong for helpers but sparse for full post-ready crash/revive and cross-component fault sequences | Add deterministic OS-matrix fault injection and repeated lifecycle stress |
+| 9 | Medium | Shipped in PR #4496: `cave-58eoq.4` | Green happy-path tests can miss races, stale endpoints, hangs, resets, and orphaned children | The bounded harness covers delayed readiness, crashes, hangs, stale ownership, permission ambiguity, version skew, duplicate starts, cancellation, sleep/wake, stale completions, unusual paths, and repeated lifecycle cleanup | Routine PR conformance runs these assertions on Ubuntu when path selection enables the conformance lane; full-validation and release platform validation run the same harness on Ubuntu, Windows, and macOS |
 | 10 | Medium | Implemented in this branch: `cave-58eoq.5` | Startup/recovery improvements could not be compared rigorously | No shared definitions or retained distributions for authenticated time-to-ready and recovery success | Local privacy-safe metrics and reproducible baseline/fault runs establish the measurement contract and budgets |
 | 11 | Medium | Open: `cave-58eoq.6` | An unreviewed CLI/socket path could inherit secrets, hang, overrun output, or mis-handle unusual paths | The high-impact PTY, remote tokenless-development, and bearer-transport bypasses are closed, but the remaining spawn and endpoint touch-set has not been proven exhaustive | Audit every remaining spawn/socket boundary and pin environment, quoting, timeout, size, cancellation, permission, and compatibility contracts |
 
@@ -284,9 +284,9 @@ work.
 
 | Risk | Owner |
 | --- | --- |
-| Windows post-ready supervision is shipped; release-host fault injection is still required | `cave-58eoq.4` |
+| Windows post-ready supervision and cross-platform fault injection are shipped; release-host validation remains a release gate | Release platform validation |
 | No cross-component correlation/export contract | `cave-58eoq.3` |
-| Full OS fault-injection and lifecycle stress matrix is incomplete | `cave-58eoq.4` |
+| Routine pull-request fault coverage is path-gated; documentation-only changes do not run the bounded harness | Explicit coverage boundary in `cave-5tpxy` |
 | Exhaustive remaining CLI spawn and socket/pipe security proof is incomplete after closing the PTY and remote tokenless-development authentication bypasses | `cave-58eoq.6` |
 | Direct loopback is intentionally sufficient for prompt-free browser REST and PTY access; this does not distinguish OS users on shared machines | Accepted product tradeoff in `cave-99eon` |
 | One-click repairs are not yet implemented for every classified failure | Follow from the issue whose evidence identifies the repair boundary |
@@ -294,8 +294,10 @@ work.
 
 ## Daemon fault-injection CI coverage decision
 
-Routine pull-request validation runs the bounded daemon fault-injection suite
-on Ubuntu as part of cross-environment conformance. It does not currently
+Routine pull-request validation is path-aware. When changed paths select the
+Ubuntu frontend/conformance lane, that lane runs the bounded daemon
+fault-injection suite as part of cross-environment conformance; documentation-
+only changes do not run it. The routine pull-request workflow does not
 provision a Windows or macOS fault-injection runner for every pull request.
 Release-candidate and release platform validation run the same bounded fault
 harness on `ubuntu-24.04`, `windows-latest`, and `macos-15`, so Windows and

--- a/docs/daemon-connectivity-reliability.md
+++ b/docs/daemon-connectivity-reliability.md
@@ -294,12 +294,15 @@ work.
 
 ## Daemon fault-injection CI coverage decision
 
-Per-pull-request daemon fault-injection coverage is intentionally funded on
-Ubuntu and Windows only. The release platform-validation matrix runs the same
-bounded fault harness on `ubuntu-24.04`, `windows-latest`, and `macos-15`, so
-macOS host behavior is exercised in release validation without adding a third
-runner to every pull request. This is an explicit coverage boundary for
-`cave-58eoq.4`, not a claim that macOS is unsupported or untested.
+Routine pull-request validation runs the bounded daemon fault-injection suite
+on Ubuntu as part of cross-environment conformance. It does not currently
+provision a Windows or macOS fault-injection runner for every pull request.
+Release-candidate and release platform validation run the same bounded fault
+harness on `ubuntu-24.04`, `windows-latest`, and `macos-15`, so Windows and
+macOS host behavior is exercised before release without restoring the costly
+three-OS matrix to routine pull requests. This is an explicit coverage boundary
+for `cave-58eoq.4`, not a claim that Windows or macOS is unsupported or
+untested.
 
 ## Reliability measurement contract
 This contract measures local reliability without turning diagnostics into an

--- a/docs/daemon-connectivity-reliability.md
+++ b/docs/daemon-connectivity-reliability.md
@@ -291,6 +291,16 @@ work.
 | Direct loopback is intentionally sufficient for prompt-free browser REST and PTY access; this does not distinguish OS users on shared machines | Accepted product tradeoff in `cave-99eon` |
 | One-click repairs are not yet implemented for every classified failure | Follow from the issue whose evidence identifies the repair boundary |
 | Hardware-only Windows installer/Defender and macOS signing/quarantine behavior still require release-host validation | Release validation checklist |
+
+## Daemon fault-injection CI coverage decision
+
+Per-pull-request daemon fault-injection coverage is intentionally funded on
+Ubuntu and Windows only. The release platform-validation matrix runs the same
+bounded fault harness on `ubuntu-24.04`, `windows-latest`, and `macos-15`, so
+macOS host behavior is exercised in release validation without adding a third
+runner to every pull request. This is an explicit coverage boundary for
+`cave-58eoq.4`, not a claim that macOS is unsupported or untested.
+
 ## Reliability measurement contract
 This contract measures local reliability without turning diagnostics into an
 activity log. It covers packaged sidecar startup, frontend reconnection, and


### PR DESCRIPTION
## Summary

- record the decision not to fund a per-PR macOS daemon fault-injection runner
- document that routine PR conformance runs the bounded fault harness on Ubuntu
- document release-candidate/release platform validation on Ubuntu, Windows, and macOS
- align the reliability contract and the release workflow comment with the live coverage boundary
- update cave-58eoq.4 acceptance wording to match the current release-validation boundary

Bead: cave-5tpxy
Closes #4896

## Verification

- `git diff --check`
- docs and workflow-comment changes were checked against `.github/workflows/ci.yml`, `.github/workflows/full-validation.yml`, and `.github/workflows/release.yml`
- final branch is based on live `main` `bf4ee1eaac914aa8d5d4a9539467a1c634d9a8e0`
