### PR TITLE
fix(familiars): re-render the glyph grid when the lazy catalog lands

### DIFF
--- a/src/components/familiar-glyph-loading.test.ts
+++ b/src/components/familiar-glyph-loading.test.ts
@@ -26,6 +26,26 @@ assert.match(
   /catch\(\(\) => \{[\s\S]*guaranteed core fallback/,
   "failed lazy loads retain a visible core fallback",
 );
+// Issue #5192: the catalogue-landed signal used to ride a setState whose value
+// the render never read. The React Compiler memoizes that shape away, so the
+// 800 mounted picker glyphs never re-rendered and stayed on the sparkle
+// fallback. The loaded set must reach render through a store React itself
+// re-renders on, and the render must consume it.
+assert.match(
+  glyph,
+  /useSyncExternalStore\(/,
+  "catalog-loaded signal must re-render through a store, not an unread setState",
+);
+assert.match(
+  glyph,
+  /fullCatalogNames/,
+  "the loaded catalog snapshot must be read in render, not only in effects",
+);
+assert.doesNotMatch(
+  glyph,
+  /const \[, \w+\] = useState/,
+  "no unread-setState force-update may come back (React Compiler memoizes it away)",
+);
 
 assert.doesNotMatch(
   workspace,

--- a/src/components/familiar-glyph.tsx
+++ b/src/components/familiar-glyph.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Icon as IconifyIcon, addCollection } from "@iconify/react";
-import { useEffect, useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 // Defaults, inferred-role glyphs, and summoning choices render immediately
 // from this ~10 KiB collection. The ~638 KiB searchable picker catalogue is a
 // separate async chunk and is only fetched when an uncommon selected glyph or
@@ -19,6 +19,12 @@ const CORE_GLYPH_NAMES = new Set(
 
 let fullGlyphNames: Set<string> | null = null;
 let fullCatalogPromise: Promise<Set<string>> | null = null;
+const fullCatalogListeners = new Set<() => void>();
+
+/** Tell every subscribed FamiliarGlyph that the offline catalogue landed. */
+function notifyFullCatalogListeners() {
+  for (const listener of fullCatalogListeners) listener();
+}
 
 /** Register the full offline catalogue once, shared by every uncommon glyph. */
 export function loadFullFamiliarGlyphCatalog(): Promise<Set<string>> {
@@ -33,6 +39,10 @@ export function loadFullFamiliarGlyphCatalog(): Promise<Set<string>> {
         );
         return fullGlyphNames;
       })
+      .then((names) => {
+        notifyFullCatalogListeners();
+        return names;
+      })
       .catch((error) => {
         fullCatalogPromise = null;
         throw error;
@@ -41,9 +51,30 @@ export function loadFullFamiliarGlyphCatalog(): Promise<Set<string>> {
   return fullCatalogPromise;
 }
 
+// The loaded-name set is delivered through useSyncExternalStore rather than a
+// per-instance setState bump: a setter whose value the render never reads is
+// exactly the shape the React Compiler memoizes away, which left every mounted
+// glyph stuck on the default fallback after the catalogue loaded (issue #5192 —
+// the Familiar identity picker rendered ~788 of 800 entries as the same
+// sparkle). A store subscription re-renders through React itself, so the
+// compiler cannot skip it.
+function subscribeFullCatalog(onStoreChange: () => void): () => void {
+  fullCatalogListeners.add(onStoreChange);
+  return () => {
+    fullCatalogListeners.delete(onStoreChange);
+  };
+}
+
+function getFullCatalogSnapshot(): Set<string> | null {
+  return fullGlyphNames;
+}
+
 /** Never hand Iconify an unavailable name: it renders no placeholder itself. */
-function renderableGlyphName(name: string): string {
-  return CORE_GLYPH_NAMES.has(name) || fullGlyphNames?.has(name)
+function renderableGlyphName(
+  name: string,
+  fullCatalogNames: Set<string> | null,
+): string {
+  return CORE_GLYPH_NAMES.has(name) || fullCatalogNames?.has(name)
     ? name
     : DEFAULT_FAMILIAR_GLYPH.name;
 }
@@ -85,22 +116,18 @@ type Props = {
 
 export function FamiliarGlyph({ glyph, size = "md", className, title }: Props) {
   const px = SIZE_PX[size];
-  const [, markCatalogLoaded] = useState(0);
-  const needsFullCatalog = !CORE_GLYPH_NAMES.has(glyph.name) && !fullGlyphNames;
+  const fullCatalogNames = useSyncExternalStore(
+    subscribeFullCatalog,
+    getFullCatalogSnapshot,
+    getFullCatalogSnapshot,
+  );
+  const needsFullCatalog = !CORE_GLYPH_NAMES.has(glyph.name) && !fullCatalogNames;
 
   useEffect(() => {
     if (!needsFullCatalog) return;
-    let active = true;
-    void loadFullFamiliarGlyphCatalog()
-      .then(() => {
-        if (active) markCatalogLoaded((revision) => revision + 1);
-      })
-      .catch(() => {
-        // Keep the guaranteed core fallback when a lazy chunk cannot load.
-      });
-    return () => {
-      active = false;
-    };
+    void loadFullFamiliarGlyphCatalog().catch(() => {
+      // Keep the guaranteed core fallback when a lazy chunk cannot load.
+    });
   }, [needsFullCatalog, glyph.name]);
 
   ensureCoreRegistered();
@@ -110,7 +137,7 @@ export function FamiliarGlyph({ glyph, size = "md", className, title }: Props) {
       title={title}
     >
       <IconifyIcon
-        icon={renderableGlyphName(glyph.name)}
+        icon={renderableGlyphName(glyph.name, fullCatalogNames)}
         width={px}
         height={px}
         aria-label={title}

--- a/tests/familiar-glyph-picker.spec.ts
+++ b/tests/familiar-glyph-picker.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Issue #5192 — the Familiar identity picker reported ~800 icons but rendered
+// nearly all of them as the same sparkle glyph. The lazy full-catalogue load
+// completed, but the "catalogue landed" signal rode a setState whose value the
+// render never read, which the React Compiler memoizes away — so the already-
+// mounted grid never re-rendered. This spec drives the real picker (React
+// Compiler runs in dev too) and fails unless the grid actually shows distinct
+// glyphs once the offline catalogue lands.
+
+const NOVA = {
+  id: "nova",
+  display_name: "Nova",
+  role: "Research assistant",
+  status: "active",
+  harness: "coven",
+};
+
+async function installPickerRoutes(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    // openFamiliarStudioSettingsTab("identity", "nova") handoff, replayed:
+    // lands the fresh chat surface on Familiar → Settings → Identity.
+    window.localStorage.setItem("cave:familiar-scope", JSON.stringify(["nova"]));
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem(
+      "cave:familiar-settings-target:v1",
+      JSON.stringify({ tab: "identity" }),
+    );
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/api/familiars") {
+      await route.fulfill({ json: { ok: true, familiars: [NOVA] } });
+      return;
+    }
+    if (url.pathname === "/api/familiars/removed") {
+      await route.fulfill({ json: { ok: true, removed: [] } });
+      return;
+    }
+    if (url.pathname.startsWith("/api/familiars/")) {
+      await route.fulfill({ json: { ok: true } });
+      return;
+    }
+    await route.fulfill({ status: 503, json: { ok: false, error: "not needed for this spec" } });
+  });
+}
+
+async function glyphGridStats(page: Page) {
+  return page.evaluate(() => {
+    const buttons = [...document.querySelectorAll('[data-glyph-button="true"]')];
+    const bodies = new Map<string, number>();
+    let withoutSvg = 0;
+    for (const button of buttons) {
+      const svg = button.querySelector("svg");
+      if (!svg) {
+        withoutSvg += 1;
+        continue;
+      }
+      const key = svg.innerHTML.replace(/\s+/g, " ").trim();
+      bodies.set(key, (bodies.get(key) ?? 0) + 1);
+    }
+    const counts = [...bodies.values()].sort((a, b) => b - a);
+    return {
+      buttons: buttons.length,
+      distinct: bodies.size,
+      withoutSvg,
+      mostRepeated: counts[0] ?? 0,
+    };
+  });
+}
+
+test("identity icon picker renders distinct glyphs once the catalog loads", async ({ page }) => {
+  test.setTimeout(240_000);
+  await installPickerRoutes(page);
+
+  await page.goto("/?mode=chat", { waitUntil: "domcontentloaded", timeout: 120_000 });
+
+  // Wait for hydration before driving the surface.
+  await page
+    .locator("[role='tablist'][aria-label='Chat sections']")
+    .waitFor({ state: "visible", timeout: 120_000 });
+  await page.waitForTimeout(2_000);
+
+  // The app's own "Manage skills" handoff: switches the chat surface to the
+  // Familiar scope, whose mount consumes the pending settings target and
+  // renders Settings → Identity → the Icon picker.
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent("cave:chat-open-skills"));
+  });
+
+  const panel = page.locator(".familiar-glyph-picker-panel").first();
+  await panel.waitFor({ state: "visible", timeout: 120_000 });
+  await page
+    .locator('[data-glyph-button="true"]')
+    .first()
+    .waitFor({ state: "visible", timeout: 120_000 });
+
+  // The lazy offline catalogue lands shortly after first paint. Poll until the
+  // grid settles (distinct count stops climbing) so this measures the steady
+  // state rather than the pre-load flash.
+  let stats = await glyphGridStats(page);
+  for (let attempt = 0; attempt < 30 && stats.distinct < stats.buttons; attempt += 1) {
+    await page.waitForTimeout(1_000);
+    const next = await glyphGridStats(page);
+    if (next.distinct === stats.distinct && next.distinct > 1) break;
+    stats = next;
+  }
+
+  // The picker offers one entry per Phosphor base name; the seeded catalog is
+  // ~1530 entries and the panel renders the first 800. A healthy grid shows a
+  // distinct glyph per entry — the regression rendered 788 of 800 as the same
+  // sparkle fallback.
+  expect(stats.buttons).toBeGreaterThan(700);
+  expect(stats.distinct).toBeGreaterThan(700);
+  // A single body may legitimately repeat a handful of times only.
+  expect(stats.mostRepeated).toBeLessThan(10);
+  expect(stats.withoutSvg).toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes #5192 — the Familiar Identity icon picker offered ~800 entries but rendered nearly all of them as the same sparkle glyph. On the issue's screenshots almost every cell draws `ph:sparkle-fill`; only the handful of glyphs in the tiny always-loaded core collection rendered correctly. The picker itself is fine — the entries, the search, and the selection are all right; the *rendering* of already-mounted glyphs was stuck.

## Root cause

`FamiliarGlyph` lazy-loads the full offline Phosphor catalogue (~638 KiB, one `-fill` variant per base name) when it must render a glyph outside the 21-icon startup core. Before the catalogue lands, it renders the guaranteed default (`ph:sparkle-fill`) instead of handing Iconify an unavailable name.

The bug is how the "catalogue landed" signal reached the mounted glyphs: a force-update `useState` whose **value the render never read**:

```tsx
const [, markCatalogLoaded] = useState(0);
...
.then(() => { if (active) markCatalogLoaded((revision) => revision + 1); })
```

Cave builds with `reactCompiler: true` (cave-n9a8). The React Compiler memoizes render output by the values it actually reads; this component's output depends on `glyph` and the registered-name set — but never on that state *value*. So when the setter fires, React re-runs the function, every memo-cache slot check passes on unchanged inputs, and the component returns the tree captured before the catalogue registered. Verified in the compiled production chunk: all output slots are cached on props only, the state slot appears in no dependency list.

Net effect: each mounted `FamiliarGlyph` renders the sparkle fallback once and never self-corrects. Measured in the real production build (React Compiler on) against the Familiar → Settings → Identity picker: **800 glyph buttons, 13 distinct SVG bodies, 788 of them the identical sparkle**. Typing in the picker's search box remounts the grid — and every remounted cell renders correctly — which pinpoints the missing re-render rather than a data or bundle failure.

This also silently affects every other `FamiliarGlyph` surface (chat header avatar, inline cards): a saved uncommon glyph shows the sparkle until an unrelated parent re-render remounts it.

## The fix

Deliver the loaded-name set through `useSyncExternalStore`:

- the module-level catalogue load now notifies subscribers when the set lands;
- `FamiliarGlyph` subscribes and reads the snapshot in render, and `renderableGlyphName()` consumes the snapshot — so the output genuinely depends on store data and the compiler cannot elide the update;
- the per-instance effect is reduced to triggering the shared load (unchanged trigger semantics, unchanged guaranteed-fallback-on-failure behavior).

No changes to the catalogue data, the picker, or the bundling: the 638 KiB catalogue stays lazy and out of the startup graph (`pnpm build`'s bundle-budget gate still verifies that).

## Verification

Production build (`next build`, Turbopack, React Compiler on), driving Familiar → Settings → Identity → Icon with a mocked roster, counting distinct `<svg>` bodies across the grid:

| build | buttons | distinct bodies | most-repeated body |
| --- | --- | --- | --- |
| before | 800 | 13 | 788 (the sparkle fallback) |
| after | 800 | **800** | 1 |

The new Playwright spec (`tests/familiar-glyph-picker.spec.ts`) drives the real picker and asserts the grid renders a distinct glyph per entry:

- on this branch: **passes** (dev server, React Compiler on);
- on the pre-fix renderer (only file reverted): **fails with `Received: 13`** — it pins the actual regression, not just the source shape.

Other local checks: `next build` + bundle-budget + standalone-budget green; the glyph-related unit/source tests pass (`familiar-glyph-loading`, `familiar-glyph-picker-panel`, `familiar-studio-look-tab`, `familiar-avatar`, `glyph-picker-roving`, `familiar-glyph`, `familiar-resolve`, `icon-subset`, `familiar-summoning-circle`).

## Test plan

- [ ] CI `Frontend build` (lint / typecheck / unit / build, plus the daemon-less Playwright run including the new spec)
- [ ] Reviewer sanity check: Familiar → Settings → Identity → Icon shows distinct glyphs, and picking one persists and renders everywhere the familiar appears
