### PR TITLE
fix(settings): hide macOS-only reachability card on Windows

### DIFF
--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -325,6 +325,11 @@ assert.ok(
   "desktop reachability must remain before Phone write access in the Phone settings flow",
 );
 assert.match(
+  phoneSettings,
+  /if \(!status && !error\) return null;[\s\S]{0,120}if \(status && !status\.supported\) return null;/,
+  "the reachability card must render nothing while the platform is unsupported so Windows never shows macOS-only copy (issue #5191)",
+);
+assert.match(
   bridge,
   /desktop_reachability_configure/,
   "the Settings controls must persist through the native macOS authority",

--- a/src/components/settings-phone.test.ts
+++ b/src/components/settings-phone.test.ts
@@ -122,6 +122,29 @@ test("Phone never promotes prototype-only device facts to production UI", () => 
   assert.doesNotMatch(component, /PAIR CODE|fake QR/i);
 });
 
+test("Phone hides the macOS-only reachability card on unsupported platforms", () => {
+  assert.match(
+    component,
+    /if \(!status && !error\) return null;/,
+    "the reachability card renders nothing while the native status is unresolved",
+  );
+  assert.match(
+    component,
+    /if \(status && !status\.supported\) return null;/,
+    "unsupported platforms render no reachability card instead of macOS copy (issue #5191)",
+  );
+  assert.doesNotMatch(
+    component,
+    /Loading Mac reachability/,
+    "the loading state must not flash macOS-specific reachability copy",
+  );
+  assert.doesNotMatch(
+    component,
+    /These controls are available in the macOS desktop app\./,
+    "the unsupported-platform note is replaced by hiding the card entirely",
+  );
+});
+
 test("Phone CSS follows the token and responsive-pane contracts", () => {
   assert.match(
     css,

--- a/src/components/settings-phone.tsx
+++ b/src/components/settings-phone.tsx
@@ -343,6 +343,15 @@ function DesktopReachabilityCard() {
       : "Prevent idle sleep whenever this Mac has a paired phone."
     : "Starts after a phone pairs. Off leaves the Mac’s normal sleep settings unchanged.";
 
+  // Desktop reachability is a macOS-only feature: the sleep policy and the
+  // LaunchAgent-backed background helper have no Windows or browser equivalent.
+  // While the native status is unresolved, and once it reports an unsupported
+  // platform, render nothing so Windows never sees macOS-specific reachability
+  // copy (issue #5191). A failed native read keeps the retry card below — that
+  // failure shape belongs to the desktop shell too.
+  if (!status && !error) return null;
+  if (status && !status.supported) return null;
+
   return (
     <section
       id={settingsGroupId("Keep this Mac reachable")}
@@ -350,7 +359,7 @@ function DesktopReachabilityCard() {
       className="settings-phone-card settings-phone-reachability"
     >
       <p className="settings-phone-card__kicker">Keep this Mac reachable</p>
-      {!status && error ? (
+      {!status ? (
         <ErrorState
           compact
           headline="Couldn’t load Mac reachability settings"
@@ -361,14 +370,6 @@ function DesktopReachabilityCard() {
             </Button>
           }
         />
-      ) : !status ? (
-        <p role="status" className="settings-phone-card__status">
-          Loading Mac reachability…
-        </p>
-      ) : !status.supported ? (
-        <p role="status" className="settings-phone-card__status">
-          {status.detail ?? "These controls are available in the macOS desktop app."}
-        </p>
       ) : (
         <>
           {status.pairedPhoneSeen && (!status.config.daemonMode || !status.launchAgentInstalled) ? (


### PR DESCRIPTION
# Windows Phone settings show "Keep this Mac reachable" copy

Fixes #5191

## Summary

The Phone settings page rendered the desktop-reachability card on every
platform, so Windows users saw macOS-specific copy:

> **Keep this Mac reachable**
> Desktop reachability controls are available in the macOS app.

Desktop reachability is a macOS-only feature: the caffeinate sleep policy and
the LaunchAgent-backed background helper have no Windows or browser equivalent
(`supported: cfg!(target_os = "macos")` in `desktop_reachability.rs`). This PR
takes the third option the issue offers — hide the section when the feature is
not available on the current platform — so Windows (and browser) shells render
no reachability card at all, and macOS keeps the card exactly as it was.

## What changed

`src/components/settings-phone.tsx` — `DesktopReachabilityCard`:

- Renders `null` while the native status is unresolved (no more "Loading Mac
  reachability…" flash of macOS copy), and once status reports
  `supported: false`.
- The failed-native-read path keeps its retry card: that failure shape belongs
  to the desktop shell too, so macOS keeps its error + Retry affordance.
- The macOS rendering, the `settingsGroupId("Keep this Mac reachable")` anchor,
  and the card's position in the side stack are unchanged.

`scripts/desktop-reachability.test.mjs`,
`src/components/settings-phone.test.ts` — contract assertions pinning the new
behavior (card renders nothing while unsupported; the "Loading Mac
reachability…" and unsupported-note copy are gone).

The "Build it with Xcode" install card is intentionally untouched, per the
issue's note that it may be contributor-facing.

## Verification

- `node src/components/settings-phone.test.ts` — 6 pass, 0 fail
- `node scripts/desktop-reachability.test.mjs` — ok
- `node src/components/mobile-handoff.test.ts` — OK (pins the side-stack order
  and the reachability-card contracts)
- `node src/components/settings-overview.test.ts`,
  `settings-shell-polish.test.ts`, `settings-daemon-multihost.test.ts`,
  `src/lib/mobile-handoff.test.ts`, `src/lib/desktop-reachability.test.ts` — all pass
- `pnpm typecheck` (tsc --noEmit) — clean
- `pnpm lint:source` (eslint over src, --max-warnings=0) — clean
