### PR TITLE
fix(chat): keep skill paste handoff responsive

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -4836,8 +4836,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const filled = `/skill ${s.id}`;
     const carried = skillCarryOverText(input);
     if (s.argumentHint && !carried && input.trim().toLowerCase() !== filled.toLowerCase()) {
-      setInput(`${filled} `);
-      inputRef.current?.focus();
+      const next = `${filled} `;
+      // A picker selection replaces the controlled value. Keep the hook's
+      // caret and the native textarea selection in the same commit before a
+      // paste can arrive (Windows WebView otherwise pastes at the old
+      // `/skill` caret and leaves the selected skill detached).
+      completeComposerText(next, next.length);
       return;
     }
     setInput("");
@@ -5020,7 +5024,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       // A hinted skill submitted without arguments (and not already the exact
       // `/skill <id>` form — that means "run it anyway") autofills for editing.
       if (skill.argumentHint && !skillArgs && trimmed.toLowerCase() !== `/skill ${skill.id}`.toLowerCase()) {
-        setInput(`/skill ${skill.id} `);
+        const next = `/skill ${skill.id} `;
+        completeComposerText(next, next.length);
         return true;
       }
       setInput("");

--- a/src/lib/slash-skill.test.ts
+++ b/src/lib/slash-skill.test.ts
@@ -151,6 +151,19 @@ assert.deepEqual(
   { text: "/skill code-review ", caret: 19 },
   "re-picking replaces the previous command rather than nesting it",
 );
+// Regression for #5198: once the picker has selected a skill, a paste must
+// land after the command head so the skill remains resolvable and the pasted
+// prompt becomes its argument instead of corrupting `/skill <id>`.
+const selectedSkill = skillComposerInsertion("/skill", SKILLS[1]);
+const pastedAfterSelection =
+  selectedSkill.text.slice(0, selectedSkill.caret) +
+  "inspect the auth path" +
+  selectedSkill.text.slice(selectedSkill.caret);
+assert.deepEqual(
+  resolveSkillInvocation(pastedAfterSelection.slice("/skill ".length), SKILLS),
+  { skill: SKILLS[1], args: "inspect the auth path" },
+  "pasted prompt stays attached to the selected skill at the restored caret",
+);
 
 // ── resolveSkillInvocation: whole name first, then first-token + args ────────
 assert.deepEqual(
@@ -205,6 +218,16 @@ assert.match(chatView, /const carried = skillCarryOverText\(input\);/, "chat-vie
 assert.match(chatView, /const invokeSkillOption = \(s: SkillOption\)/, "chat-view shares one skill-invoke helper across picker, menu and clicks");
 assert.match(chatView, /onPickSkill: \(s\) => invokeSkillOption\(s\)/, "the hook's skill picks route through chat-view's invoke helper");
 assert.match(chatView, /s\.argumentHint && !carried && input\.trim\(\)\.toLowerCase\(\) !== filled\.toLowerCase\(\)/, "a hinted skill autofills /skill <id> only over scaffolding, never over a typed message");
+assert.match(
+  chatView,
+  /if \(s\.argumentHint && !carried && input\.trim\(\)\.toLowerCase\(\) !== filled\.toLowerCase\(\)\) \{[\s\S]*?completeComposerText\(next, next\.length\);/,
+  "a picked hinted skill commits its caret with the controlled value before pasted text can arrive",
+);
+assert.match(
+  chatView,
+  /if \(skill\.argumentHint && !skillArgs && trimmed\.toLowerCase\(\) !== `\/skill \$\{skill\.id\}`\.toLowerCase\(\)\) \{[\s\S]*?completeComposerText\(next, next\.length\);/,
+  "typed hinted-skill autofill uses the same caret-safe handoff",
+);
 assert.match(menusHook, /skillCommandMatches\(activeInvocation\.commandToken, skills\)/, "the shared hook surfaces skills at the active slash token");
 assert.match(chatView, /role="listbox" aria-label="Skills"/, "chat-view renders a Skills listbox");
 assert.match(menusHook, /fetch\("\/api\/skills\/local"/, "the shared hook sources skills from the local skill scan");

--- a/src/lib/use-attachment-staging.test.ts
+++ b/src/lib/use-attachment-staging.test.ts
@@ -46,6 +46,12 @@ assert.match(
 );
 
 // ── Paste: files win over text, plain-text paste untouched ───────────────────
+const pasteHandler = src.match(/const handlePaste = useCallback\([\s\S]*?\[addFiles\],\s*\);/)?.[0] ?? "";
+assert.match(
+  pasteHandler,
+  /if \(!hasDraggedFiles\(e\.clipboardData\.types\)\) return;/,
+  "text-only clipboard data skips WebView file-item inspection so native paste remains responsive",
+);
 assert.match(
   src,
   /\.filter\(\(item\) => item\.kind === "file"\)[\s\S]*?if \(pastedFiles\.length > 0\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*void addFiles\(pastedFiles\);/,

--- a/src/lib/use-attachment-staging.ts
+++ b/src/lib/use-attachment-staging.ts
@@ -81,9 +81,12 @@ export function useAttachmentStaging(opts?: {
 
   // Paste-to-attach: clipboard files (screenshots, copied files) win over any
   // text payload riding along. Only preventDefault when files were actually
-  // consumed so a plain-text paste is untouched.
+  // consumed so a plain-text paste is untouched. Check the advertised type
+  // first: Windows WebView can make touching clipboard file items on a
+  // text-only paste synchronous, while a real file paste advertises `Files`.
   const handlePaste = useCallback(
     (e: ClipboardEvent) => {
+      if (!hasDraggedFiles(e.clipboardData.types)) return;
       const pastedFiles = Array.from(e.clipboardData.items)
         .filter((item) => item.kind === "file")
         .map((item) => item.getAsFile())


### PR DESCRIPTION
## Summary

Keep the Windows/WebView composer responsive after a `/skill` selection and paste. Text-only clipboard events now skip synchronous file inspection, and skill autofill updates the controlled textarea plus caret together.

Fixes #5198
Bead: `cave-s3w4l`

## Verification

- Targeted slash-skill, attachment, composer, cancellation, send-state, menu, and markdown tests passed.
- `pnpm typecheck` passed.
- Source ESLint, `check:tests-wired`, `check:test-clocks`, and `git diff --check` passed.

Native Windows/Tauri reproduction was unavailable from WSL.