### PR TITLE
fix(mobile): reject non-HTTPS Serve handoffs

### DIFF
--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -78,6 +78,13 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
   });
   assert.match(missingRoute.error, /tailscale serve route not found/);
   assert.equal(missingRoute.stderr, undefined);
+
+  const nonHttpsRoute = serveRouteFailure({
+    backendUrl: "http://127.0.0.1:3020",
+    routeReason: "tailscale serve route for http://127.0.0.1:3020 is not an HTTPS listener",
+  });
+  assert.match(nonHttpsRoute.error, /not an HTTPS listener/);
+  assert.match(nonHttpsRoute.error, /Enable HTTPS for this tailnet/);
 }
 
 {
@@ -103,6 +110,78 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
     findServeUrl(variants, "http://127.0.0.1:3000"),
     serveUrl,
   );
+}
+
+{
+  // An HTTP-only Serve listener must never be relabeled as HTTPS. The
+  // explicit route also blocks the MagicDNS fallback, even after a successful
+  // `serve --bg` mutation, because the listener is known to be non-HTTPS.
+  const backend = "http://127.0.0.1:3020";
+  const httpOnlyStatus = {
+    TCP: {
+      "3020": { HTTP: true },
+    },
+    Web: {
+      [`${serveHost}:3020`]: {
+        Handlers: {
+          "/": {
+            Proxy: backend,
+          },
+        },
+      },
+    },
+  };
+  assert.equal(findServeUrl(httpOnlyStatus, backend), null);
+
+  const browserProof = tailnetDiscoveryProof({
+    selfStatus: { Self: { DNSName: `${serveHost}.` } },
+    serveStatus: httpOnlyStatus,
+    backendUrl: backend,
+    allowMagicDnsFallback: true,
+  });
+  assert.deepEqual(browserProof, {
+    ok: false,
+    reason: `tailscale serve route for ${backend} is not an HTTPS listener`,
+  });
+
+  // The native app's explicitly supported Tailscale-IP HTTP path remains
+  // available, but it is not a browser invite proof.
+  assert.deepEqual(
+    nativeAppDiscoveryProof({
+      selfStatus: {
+        Self: {
+          DNSName: `${serveHost}.`,
+          TailscaleIPs: ["100.101.102.103"],
+        },
+      },
+      serveStatus: httpOnlyStatus,
+      backendUrl: backend,
+      allowMagicDnsFallback: false,
+    }),
+    {
+      ok: true,
+      host: "100.101.102.103:3020",
+      serveUrl: "http://100.101.102.103:3020/",
+      source: "tailscale-ip-http",
+    },
+  );
+}
+
+{
+  // HTTPS Serve on a non-default port is accepted only when the listener
+  // protocol is explicit in the Serve status.
+  const backend = "http://127.0.0.1:3020";
+  const httpsStatus = {
+    TCP: {
+      "3020": { HTTPS: true },
+    },
+    Web: {
+      [`${serveHost}:3020`]: {
+        Handlers: { "/": { Proxy: backend } },
+      },
+    },
+  };
+  assert.equal(findServeUrl(httpsStatus, backend), `https://${serveHost}:3020/`);
 }
 
 {

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -46,6 +46,13 @@ export function serveRouteFailure({
 }
 
 type TailscaleServeStatus = {
+  TCP?: Record<
+    string,
+    {
+      HTTP?: unknown;
+      HTTPS?: unknown;
+    }
+  >;
   Web?: Record<
     string,
     {
@@ -59,8 +66,55 @@ type TailscaleServeStatus = {
   >;
 };
 
+type ServeRouteInspection = {
+  httpsUrl: string | null;
+  hasNonHttpsRoute: boolean;
+};
+
 function normalizeServeHost(host: string) {
-  return host.endsWith(":443") ? host.slice(0, -4) : host;
+  const trimmed = host.trim();
+  const candidate = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  try {
+    const normalized = new URL(candidate).host;
+    return normalized.endsWith(":443") ? normalized.slice(0, -4) : normalized;
+  } catch {
+    return trimmed.endsWith(":443") ? trimmed.slice(0, -4) : trimmed;
+  }
+}
+
+function serveEndpointPort(host: string) {
+  const trimmed = host.trim();
+  const candidate = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  try {
+    return new URL(candidate).port || "443";
+  } catch {
+    return trimmed.match(/:(\d+)$/)?.[1] ?? "443";
+  }
+}
+
+function serveRouteProtocol(status: TailscaleServeStatus, host: string) {
+  const scheme = host.match(/^([a-z][a-z\d+.-]*):\/\//i)?.[1].toLowerCase();
+  const port = serveEndpointPort(host);
+  const tcp = status.TCP?.[port];
+  if (tcp && typeof tcp === "object") {
+    const isHttps = tcp.HTTPS === true;
+    const isHttp = tcp.HTTP === true;
+    if (isHttps && !isHttp) return scheme === "http" ? ("unknown" as const) : ("https" as const);
+    if (isHttp && !isHttps) return scheme === "https" ? ("unknown" as const) : ("http" as const);
+    return "unknown" as const;
+  }
+
+  if (scheme === "https") return "https" as const;
+  if (scheme === "http") return "http" as const;
+
+  // A host key without an explicit port is the normal HTTPS Serve shape. For
+  // non-443 routes, an absent protocol declaration is not enough evidence to
+  // mint an HTTPS URL: it may be an HTTP-only listener.
+  return port === "443" ? ("https" as const) : ("unknown" as const);
 }
 
 // Tailscale may store the proxy target with a trailing slash or as `localhost`
@@ -252,7 +306,15 @@ export function tailnetDiscoveryProof({
   backendUrl: string;
   allowMagicDnsFallback?: boolean;
 }): TailnetDiscoveryProof {
-  const fromServe = findServeUrl(serveStatus, backendUrl);
+  const routes = inspectServeRoutes(serveStatus, backendUrl);
+  if (routes.hasNonHttpsRoute && !routes.httpsUrl) {
+    return {
+      ok: false,
+      reason: `tailscale serve route for ${backendUrl} is not an HTTPS listener`,
+    };
+  }
+
+  const fromServe = routes.httpsUrl;
   const host = magicDnsHost(selfStatus);
   if (fromServe) {
     return {
@@ -330,10 +392,19 @@ export function nativeAppDiscoveryProof({
 }
 
 export function findServeUrl(status: unknown, backendUrl: string) {
-  const web = (status as TailscaleServeStatus | null)?.Web;
-  if (!web || typeof web !== "object") return null;
+  return inspectServeRoutes(status, backendUrl).httpsUrl;
+}
+
+function inspectServeRoutes(status: unknown, backendUrl: string): ServeRouteInspection {
+  const typedStatus = status as TailscaleServeStatus | null;
+  const web = typedStatus?.Web;
+  if (!web || typeof web !== "object") {
+    return { httpsUrl: null, hasNonHttpsRoute: false };
+  }
 
   const wantTarget = normalizeProxyTarget(backendUrl);
+  let httpsUrl: string | null = null;
+  let hasNonHttpsRoute = false;
   for (const [host, config] of Object.entries(web)) {
     const handlers = config?.Handlers;
     if (!handlers || typeof handlers !== "object") continue;
@@ -341,11 +412,15 @@ export function findServeUrl(status: unknown, backendUrl: string) {
       if (!handler?.Proxy || normalizeProxyTarget(handler.Proxy) !== wantTarget) continue;
       const normalizedPath = path.startsWith("/") ? path : `/${path}`;
       const suffix = normalizedPath === "/" ? "/" : normalizedPath;
-      return `https://${normalizeServeHost(host)}${suffix}`;
+      if (serveRouteProtocol(typedStatus ?? {}, host) === "https") {
+        httpsUrl ??= `https://${normalizeServeHost(host)}${suffix}`;
+      } else {
+        hasNonHttpsRoute = true;
+      }
     }
   }
 
-  return null;
+  return { httpsUrl, hasNonHttpsRoute };
 }
 
 export function buildInviteUrl({


### PR DESCRIPTION
## Summary

Make mobile handoff discovery protocol-aware: HTTP-only or ambiguous non-443 Tailscale Serve routes cannot be relabeled as HTTPS, while explicit HTTPS routes and the native Tailscale-IP HTTP fallback remain supported.

Fixes #5190
Bead: `cave-akdjr`

## Verification

- Focused `mobile-handoff.test.ts` passed.
- `pnpm typecheck` passed.
- Targeted ESLint and `git diff --check` passed.

A real Tailscale cross-environment check was unavailable because local Tailscale is `NeedsLogin`.