### PR TITLE
fix(familiars): route Studio destinations correctly

### DIFF
--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -141,6 +141,12 @@ assert.match(
 
 assert.match(
   chatSurface,
+  /hasFamiliarSettingsPending\(\)[\s\S]*?setScope\("familiar"\)/,
+  "a persisted Studio handoff must select the Familiar scope on a fresh Chat mount",
+);
+
+assert.match(
+  chatSurface,
   /scopeHistoryId = "chat:scope"[\s\S]*?id:\s*scopeHistoryId/,
   "ChatSurface should register its scope strip as a navigation level so Back steps between tabs instead of leaving Chat",
 );
@@ -295,6 +301,12 @@ assert.match(
   workspace,
   /mode === "chat"[\s\S]*<ChatSurface/,
   "Workspace should mount ChatSurface for the internal chat mode",
+);
+
+assert.match(
+  workspace,
+  /const familiarSettingsPending = hasFamiliarSettingsPending\(\)[\s\S]*?commitMode\("chat"\)[\s\S]*?if \(familiarSettingsPending\) return;/,
+  "Workspace must not emit the generic conversation landing after a Familiar Settings handoff",
 );
 
 assert.match(

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -16,7 +16,7 @@ import {
   ProjectsView,
   WorkspaceRail,
 } from "@/components/lazy-surfaces";
-import { CHAT_OPEN_PROJECTS_EVENT, CHAT_OPEN_COVEN_EVENT, CHAT_OPEN_CONVERSATION_EVENT, CHAT_OPEN_SKILLS_EVENT, consumeCovenTabPending, consumeProjectsTabPending, consumeSkillsTabPending } from "@/lib/chat-tab-events";
+import { CHAT_OPEN_PROJECTS_EVENT, CHAT_OPEN_COVEN_EVENT, CHAT_OPEN_CONVERSATION_EVENT, CHAT_OPEN_SKILLS_EVENT, consumeCovenTabPending, consumeProjectsTabPending, consumeSkillsTabPending, hasFamiliarSettingsPending } from "@/lib/chat-tab-events";
 import { requestDebugOpen, useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { Tabs } from "@/components/ui/tabs";
@@ -387,6 +387,14 @@ export function ChatSurface({
     window.addEventListener(CHAT_OPEN_CONVERSATION_EVENT, open);
     return () => window.removeEventListener(CHAT_OPEN_CONVERSATION_EVENT, open);
   }, []);
+
+  // Studio actions navigate through the same Chat document, but retain their
+  // Familiar Settings target in localStorage so it survives the reload. The
+  // target must select the Familiar scope before its nested consumer can open
+  // Settings; otherwise the first Chat mount stays on generic Sessions.
+  useEffect(() => {
+    if (hasFamiliarSettingsPending()) setScope("familiar");
+  }, [setScope]);
 
   useEffect(() => {
     if (!pendingChatAction) return;

--- a/src/components/familiar-tab-settings.test.ts
+++ b/src/components/familiar-tab-settings.test.ts
@@ -39,6 +39,13 @@ assert.match(settings, /localDaemonReady/);
 assert.match(settings, /allFamiliars/);
 assert.match(settings, /<Tabs<FamiliarSettingsTab>/);
 assert.match(settings, /initialTab\?: FamiliarSettingsTab/);
+assert.match(settings, /const displayedTab = tab === "contract" \? "identity" : tab;/);
+assert.match(
+  settings,
+  /tab !== "contract"[\s\S]*?familiar-studio-grimoire[\s\S]*?grimoire\?\.focus\(\{ preventScroll: true \}\)/,
+  "the contract handoff focuses the existing Grimoire section for keyboard users",
+);
+assert.match(settings, /tab === "identity" \|\| tab === "contract"/);
 assert.match(
   settings,
   /useState<FamiliarSettingsTab>\(\s*initialTab && initialTab !== "projects" \? initialTab : "identity",?\s*\)/,

--- a/src/components/familiar-tab-settings.tsx
+++ b/src/components/familiar-tab-settings.tsx
@@ -66,6 +66,10 @@ export function FamiliarSettingsSection({
   const [tab, setTab] = useState<FamiliarSettingsTab>(
     initialTab && initialTab !== "projects" ? initialTab : "identity",
   );
+  // Contract is a focused handoff into the Grimoire section of Identity, not
+  // a second editor or a fabricated route. Keep the internal destination
+  // distinct while the visible tablist remains the canonical five tabs.
+  const displayedTab = tab === "contract" ? "identity" : tab;
   useEffect(() => {
     // `projects` no longer names a tab here. Rather than silently landing on
     // Identity, hand the request to the surface that owns project access now.
@@ -76,6 +80,15 @@ export function FamiliarSettingsSection({
     }
     if (initialTab) setTab(initialTab);
   }, [initialTab]);
+  useEffect(() => {
+    if (tab !== "contract") return;
+    const focusFrame = requestAnimationFrame(() => {
+      const grimoire = document.querySelector<HTMLElement>(".familiar-studio-grimoire");
+      grimoire?.scrollIntoView({ block: "nearest" });
+      grimoire?.focus({ preventScroll: true });
+    });
+    return () => cancelAnimationFrame(focusFrame);
+  }, [tab]);
   const raw = useMemo(
     () => familiars.find((item) => item.id === familiar.id),
     [familiars, familiar.id],
@@ -97,7 +110,7 @@ export function FamiliarSettingsSection({
           variant="underline"
           idPrefix="familiar-settings"
           ariaLabel="Familiar settings"
-          value={tab}
+          value={displayedTab}
           onChange={setTab}
           items={SETTINGS_TABS}
         />
@@ -105,12 +118,12 @@ export function FamiliarSettingsSection({
 
       <div
         role="tabpanel"
-        id={`familiar-settings-panel-${tab}`}
-        aria-labelledby={`familiar-settings-tab-${tab}`}
+        id={`familiar-settings-panel-${displayedTab}`}
+        aria-labelledby={`familiar-settings-tab-${displayedTab}`}
         className="familiar-tab__settings-body familiar-studio__body"
       >
         {tab === "chat" ? <ChatSettingsView /> : null}
-        {tab === "identity" ? (
+        {tab === "identity" || tab === "contract" ? (
           <FamiliarStudioIdentityTab
             key={`${familiar.id}:identity`}
             familiar={familiar}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -174,7 +174,7 @@ import {
   SettingsShell,
   RailTerminalPanel,
 } from "@/components/lazy-surfaces";
-import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT, CHAT_OPEN_CONVERSATION_EVENT, CHAT_OPEN_COVEN_EVENT, markCovenTabPending, markProjectsTabPending } from "@/lib/chat-tab-events";
+import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT, CHAT_OPEN_CONVERSATION_EVENT, CHAT_OPEN_COVEN_EVENT, hasFamiliarSettingsPending, markCovenTabPending, markProjectsTabPending } from "@/lib/chat-tab-events";
 import { HomeComposer } from "@/components/home-composer";
 import { ChatSurface } from "@/components/chat-surface";
 import { RightChatPanel } from "@/components/right-chat-panel";
@@ -852,7 +852,13 @@ export function Workspace() {
       return;
     }
     if (next === "chat") {
+      const familiarSettingsPending = hasFamiliarSettingsPending();
       commitMode("chat");
+      // A Studio handoff already has a concrete nested Chat destination. Do
+      // not emit the ordinary conversation landing event after the Chat
+      // surface consumes that handoff, or it would overwrite Familiar with
+      // generic Sessions during the same mount.
+      if (familiarSettingsPending) return;
       window.setTimeout(() => window.dispatchEvent(new CustomEvent(CHAT_OPEN_CONVERSATION_EVENT)), 0);
       return;
     }

--- a/src/lib/chat-tab-events.ts
+++ b/src/lib/chat-tab-events.ts
@@ -15,14 +15,18 @@ export const CHAT_OPEN_COVEN_EVENT = "cave:chat-open-coven";
  * the ordinary Chat destination without unmounting the surface. */
 export const CHAT_OPEN_CONVERSATION_EVENT = "cave:chat-open-conversation";
 
-/** Nested tab in Chat → Familiar → Settings for a studio handoff. */
+/** Nested destination in Chat → Familiar → Settings for a studio handoff. */
 export type FamiliarSettingsTab =
   | "chat"
   | "identity"
   | "brain"
   | "memory"
   | "projects"
-  | "vault";
+  | "vault"
+  // Contract is rendered inside the Identity editor rather than as a visible
+  // tab, but it remains a distinct handoff target so Open Contract can land on
+  // the real Grimoire section instead of merely selecting Identity.
+  | "contract";
 
 export type FamiliarSettingsTarget = {
   tab?: FamiliarSettingsTab;
@@ -40,6 +44,16 @@ export function markFamiliarSettingsPending(tab?: FamiliarSettingsTab): void {
     );
   } catch {
     /* storage may be unavailable */
+  }
+}
+
+/** Check whether a fresh Chat mount has a one-shot Familiar destination. */
+export function hasFamiliarSettingsPending(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(FAMILIAR_SETTINGS_TARGET_KEY) !== null;
+  } catch {
+    return false;
   }
 }
 

--- a/src/lib/familiar-studio-context.test.ts
+++ b/src/lib/familiar-studio-context.test.ts
@@ -12,6 +12,7 @@ assert.match(source, /activeFamiliarId/, "State exposes activeFamiliarId");
 assert.match(source, /activeTab/, "State exposes activeTab");
 assert.match(source, /createContext/, "Uses React context");
 assert.match(source, /markFamiliarSettingsPending\(chatSettingsTabFor\(tab\)\)/, "studio handoffs target Chat Familiar Settings");
+assert.match(source, /case "contract":\s*return "contract";/, "contract handoffs keep their focused Chat destination");
 assert.match(source, /setFamiliarScope\(\[familiarId\]\)/, "studio handoffs preserve the selected familiar");
 assert.match(source, /window\.location\.assign\("\/\?mode=chat"\)/, "studio handoffs navigate to Chat");
 assert.doesNotMatch(source, /window\.location\.assign\("\/settings#familiars"\)/, "studio handoffs no longer target retired Settings Familiars");

--- a/src/lib/familiar-studio-context.tsx
+++ b/src/lib/familiar-studio-context.tsx
@@ -61,8 +61,9 @@ function chatSettingsTabFor(tab?: FamiliarStudioTab): FamiliarSettingsTab | unde
       return "projects";
     case "vault":
       return "vault";
-    case "identity":
     case "contract":
+      return "contract";
+    case "identity":
       return "identity";
     default:
       return undefined;

--- a/tests/familiar-studio-destinations.spec.ts
+++ b/tests/familiar-studio-destinations.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const FAMILIAR = {
+  id: "nova",
+  display_name: "Nova",
+  role: "Orchestrator",
+  harness: "codex",
+  status: "active",
+  icon: "ph:sparkle-fill",
+};
+
+const CONTRACT = {
+  ok: true,
+  present: { soul: true, identity: true, ward: true, memory: true },
+  report: { pass: true, violations: [] },
+};
+
+async function installFixtures(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:familiar-scope", JSON.stringify(["nova"]));
+    window.localStorage.setItem("cave:active-familiar", "nova");
+  });
+  await page.route("**/api/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname === "/api/familiars") {
+      return route.fulfill({ json: { ok: true, familiars: [FAMILIAR] } });
+    }
+    if (/^\/api\/familiars\/[^/]+\/contract$/.test(pathname)) {
+      return route.fulfill({ json: CONTRACT });
+    }
+    if (pathname === "/api/sessions/list") {
+      return route.fulfill({ json: { ok: true, sessions: [] } });
+    }
+    if (pathname === "/api/roles") {
+      return route.fulfill({ json: { ok: true, roles: [] } });
+    }
+    if (pathname === "/api/skills/local") {
+      return route.fulfill({ json: { ok: true, skills: [] } });
+    }
+    if (pathname === "/api/capabilities") {
+      return route.fulfill({ json: { ok: true, harness_capabilities: [] } });
+    }
+    if (pathname === "/api/harnesses") {
+      return route.fulfill({ json: { ok: true, harnesses: [] } });
+    }
+    return route.abort();
+  });
+}
+
+function waitForChatDocumentHandoff(page: Page) {
+  return page.waitForRequest(
+    (request) => {
+      if (request.resourceType() !== "document") return false;
+      const url = new URL(request.url());
+      return url.pathname === "/" && url.searchParams.get("mode") === "chat";
+    },
+    { timeout: 30_000 },
+  );
+}
+
+async function expectFamiliarSettings(page: Page) {
+  const chatSections = page.getByRole("tablist", { name: "Chat sections" });
+  await expect(chatSections).toBeVisible({ timeout: 60_000 });
+  await expect(chatSections.getByRole("tab", { name: "Familiar", exact: true })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+
+  const familiarSections = page.getByRole("tablist", { name: "Familiar sections" });
+  await expect(familiarSections).toBeVisible({ timeout: 60_000 });
+  await expect(familiarSections.getByRole("tab", { name: "Settings", exact: true })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+
+  const settings = page.getByRole("region", { name: "Settings for Nova" });
+  await expect(settings).toBeVisible({ timeout: 30_000 });
+  await expect(
+    settings.getByRole("tab", { name: "Identity", exact: true }),
+  ).toHaveAttribute("aria-selected", "true");
+  return settings;
+}
+
+test("Familiar profile Edit in Studio reaches Chat Familiar Settings Identity", async ({ page }) => {
+  await installFixtures(page);
+  await page.goto("/?mode=agents", { waitUntil: "domcontentloaded" });
+  await expect(page.locator(".familiars-view")).toBeVisible({ timeout: 60_000 });
+
+  await page.getByRole("button", { name: "Open Nova", exact: true }).click();
+  await page.getByRole("button", { name: "Nova options", exact: true }).click();
+  const options = page.getByRole("dialog", { name: "Familiar options" });
+  await expect(options).toBeVisible();
+
+  const handoff = waitForChatDocumentHandoff(page);
+  await options.getByRole("menuitem", { name: "Edit in Studio", exact: true }).click();
+  const request = await handoff;
+  expect(new URL(request.url()).pathname).toBe("/");
+  expect(new URL(request.url()).searchParams.get("mode")).toBe("chat");
+
+  await expectFamiliarSettings(page);
+});
+
+test("Familiar Identity Open Contract reaches the focused Grimoire section", async ({ page }) => {
+  await installFixtures(page);
+  await page.goto("/?mode=chat", { waitUntil: "domcontentloaded" });
+  await expect(page.locator(".chat-surface")).toBeVisible({ timeout: 60_000 });
+
+  const chatSections = page.getByRole("tablist", { name: "Chat sections" });
+  await expect(chatSections).toBeVisible({ timeout: 60_000 });
+  await chatSections.getByRole("tab", { name: "Familiar", exact: true }).click();
+  const familiarSections = page.getByRole("tablist", { name: "Familiar sections" });
+  await expect(familiarSections).toBeVisible({ timeout: 60_000 });
+  await familiarSections.getByRole("tab", { name: "Identity", exact: true }).click();
+
+  const contract = page.getByRole("region", { name: "Identity contract" });
+  await expect(contract).toBeVisible({ timeout: 30_000 });
+  await expect(contract).toContainText("SOUL.md", { timeout: 30_000 });
+
+  const handoff = waitForChatDocumentHandoff(page);
+  await contract.getByRole("button", { name: "Open contract →", exact: true }).click();
+  const request = await handoff;
+  expect(new URL(request.url()).pathname).toBe("/");
+  expect(new URL(request.url()).searchParams.get("mode")).toBe("chat");
+
+  const settings = await expectFamiliarSettings(page);
+  const grimoire = settings.locator(".familiar-studio-grimoire");
+  await expect(grimoire).toBeVisible({ timeout: 30_000 });
+  await expect(grimoire).toBeFocused({ timeout: 30_000 });
+  await expect(grimoire.getByRole("heading", { name: "Grimoire files" })).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Route Familiar setup `Edit in Studio` into Chat → Familiar → Settings → Identity, and route `Open Contract` into the existing Identity editor with the Grimoire files section focused. Projects continue to use the canonical Chat Projects surface; no retired route is recreated.

Fixes #5196
Fixes #5197
Bead: `cave-eilgz`

## Verification

- Focused source tests passed.
- Focused Playwright coverage passed: 2 tests.
- `pnpm typecheck` passed.
- Targeted ESLint and `git diff --check` passed.
- Design codemod and token checks completed; full lint was not completed in the worker session.

The repository engine warning remains present under Node 24.15.0.