### PR TITLE
fix(shell): label expanded sidebar

### DIFF
--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -42,8 +42,13 @@ assert.match(
 );
 assert.match(
   shell,
-  /<div className="shell-window-titlebar" data-tauri-drag-region="deep" aria-label="Coven window" \/>[\s\S]*?<div className="shell-top" data-tauri-drag-region="deep">[\s\S]*?\{navToggle\}[\s\S]*?\{historyNav\}[\s\S]*?<div className="shell-top__bar" data-tauri-drag-region="deep">\{renderedTopBar\}<\/div>[\s\S]*?\{rightChatToggle\}/,
+  /<div className="shell-window-titlebar" data-tauri-drag-region="deep" aria-label="Coven window">[\s\S]*?<div className="shell-window-titlebar__rail">[\s\S]*?<span className="shell-window-titlebar__title">OpenCoven<\/span>[\s\S]*?<\/div>[\s\S]*?<\/div>[\s\S]*?<div className="shell-top" data-tauri-drag-region="deep">[\s\S]*?\{navToggle\}[\s\S]*?\{historyNav\}[\s\S]*?<div className="shell-top__bar" data-tauri-drag-region="deep">\{renderedTopBar\}<\/div>[\s\S]*?\{rightChatToggle\}/,
   "the functional controls share one titlebar row from left toggle through search/actions to the right toggle",
+);
+assert.equal(
+  shell.match(/<span className="shell-window-titlebar__title">OpenCoven<\/span>/g)?.length,
+  1,
+  "the expanded native siderail should expose one OpenCoven identity label",
 );
 // `deep` (not the bare attribute) is load-bearing: Tauri drag.js only drags a
 // bare region on DIRECT presses on the attributed element, so empty chrome
@@ -424,6 +429,26 @@ assert.match(
   css,
   /:root\[data-tauri-titlebar\]\[data-window-fullscreen\] \.shell-window-titlebar__rail \{\s*padding-left: var\(--space-3\);/,
   "fullscreen titlebar controls sit flush with the standard app gutter",
+);
+assert.match(
+  css,
+  /:root\[data-tauri-titlebar\] \.shell-window-titlebar__rail \{[^}]*justify-content:\s*center;[^}]*padding-left:\s*max\(var\(--titlebar-lights-inset\), var\(--space-3\)\);[^}]*padding-right:\s*var\(--space-3\);[^}]*overflow:\s*hidden;/,
+  "the siderail identity is centered inside the traffic-light-safe portion of the expanded rail",
+);
+assert.match(
+  css,
+  /:root\[data-tauri-titlebar\]\[data-traffic-lights="hidden"\] \.shell-window-titlebar__title \{\s*visibility:\s*hidden;/,
+  "the identity label stays hidden with the collapsed desktop rail",
+);
+assert.match(
+  css,
+  /:root\[data-tauri-titlebar\]\[data-window-fullscreen\] \.shell-window-titlebar__rail \{\s*padding-left:\s*var\(--space-3\);/,
+  "fullscreen centers the identity without reserving space for absent traffic lights",
+);
+assert.match(
+  css,
+  /@media \(max-width: 1023px\) \{[\s\S]*?:root\[data-tauri-titlebar\] \.shell-window-titlebar__title \{\s*display:\s*none;/,
+  "the siderail identity stays out of the mobile drawer titlebar",
 );
 assert.match(
   css,

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -1469,13 +1469,11 @@ function ShellInner({
       {/* Keyboard/SR users can jump straight past the chrome to the active
           surface. Visually hidden until focused (see .skip-link in globals). */}
       <a className="skip-link" href="#shell-main-content">Skip to main content</a>
-      {/* No wordmark here. It sat at flex-start of this strip and rendered
-          UNDERNEATH the macOS traffic lights — the 78px reserve lives on
-          .shell-window-titlebar__rail, an element this markup never had, so
-          the inset never applied to the title. An app-name label in the
-          titlebar is redundant anyway (the menu bar names the app), so the
-          strip is now purely a drag region. */}
-      <div className="shell-window-titlebar" data-tauri-drag-region="deep" aria-label="Coven window" />
+      <div className="shell-window-titlebar" data-tauri-drag-region="deep" aria-label="Coven window">
+        <div className="shell-window-titlebar__rail">
+          <span className="shell-window-titlebar__title">OpenCoven</span>
+        </div>
+      </div>
       {/* `deep` (not the bare attribute) matters: drag.js's bare value only
           drags on DIRECT presses on the attributed element, so empty chrome
           inside .menu-bar / .top-bar wrappers would short-circuit the walk and

--- a/src/styles/globals/desktop-chrome.css
+++ b/src/styles/globals/desktop-chrome.css
@@ -254,11 +254,13 @@ button:active > .edge-rail-chip {
     order: -1;
     display: flex;
     align-items: center;
+    justify-content: center;
     flex: 0 0 var(--shell-nav-chrome-width);
     width: var(--shell-nav-chrome-width);
     height: 100%;
     min-width: 0;
     padding-left: max(var(--titlebar-lights-inset), var(--space-3));
+    padding-right: var(--space-3);
     overflow: hidden;
     background: color-mix(in oklch, var(--bg-raised) 88%, transparent);
     border-right: 1px solid var(--border-hairline);
@@ -380,6 +382,10 @@ button:active > .edge-rail-chip {
 
 @media (max-width: 1023px) {
   :root[data-tauri-titlebar] .shell-window-titlebar__controls {
+    display: none;
+  }
+
+  :root[data-tauri-titlebar] .shell-window-titlebar__title {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary
- add the OpenCoven identity label to the expanded macOS siderail title strip
- center it within the traffic-light-safe region and reclaim the full width in fullscreen
- keep it hidden for collapsed rails and mobile drawers
- add structural guards for expanded, collapsed, fullscreen, and mobile states

## Validation
- `node --experimental-strip-types src/components/shell-edge-rails.test.ts`
- `node --experimental-strip-types src/components/shell-chrome-revamp.test.ts`
- `node --experimental-strip-types src/components/menu-bar-icon-size.test.ts`
- `pnpm typecheck`
- focused ESLint
- `pnpm check:ui-consistency`