### PR TITLE
Tighten the Rituals calendar day view

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -812,6 +812,7 @@ export const SUITES = {
     "src/components/chat-canvas-command.test.ts",
     "src/components/chat-diagram-command.test.ts",
     "src/components/calendar-actions.test.ts",
+    "src/components/calendar-day-tighten.test.ts",
     "src/components/calendar-keyboard.test.ts",
     "src/components/task-chat-cwd.test.ts",
     "src/lib/board-search.test.ts",

--- a/src/components/calendar-actions.test.ts
+++ b/src/components/calendar-actions.test.ts
@@ -55,7 +55,15 @@ assert.match(view, /setTimeout\(\(\) => \{[\s\S]{0,120}?\}, 60_000 - \(Date\.now
 assert.match(view, /now && isSameDay\(col\.date, now\) &&/, "the now-line only renders once `now` resolves, derived from TimeGrid's own clock");
 // The grid sub-views derive "today" from useNow (hydration-safe + live), not a
 // render-time `new Date()` (Agenda, Day, Week, Month, TimeGrid).
-assert.ok((view.match(/const now = useNow\(\)/g) ?? []).length >= 5, "every grid sub-view uses useNow for today");
+// Matched on the CALL, not the binding name: DayView stopped needing a clock of
+// its own when its heading moved to the toolbar, and the toolbar took one up as
+// `toolbarNow` to derive the day's relative word (cave-25914). Pinning
+// `const now =` would have failed on a rename while the property — every
+// surface that needs "today" derives it from useNow — still held.
+assert.ok((view.match(/=\s*useNow\(\)/g) ?? []).length >= 5, "every surface that needs today derives it from useNow");
+// The actual hazard the count stands in for: a render-time clock, which is what
+// makes SSR and the client disagree about which day is highlighted.
+assert.doesNotMatch(view, /isSameDay\([^)]*new Date\(\)\)/, "no sub-view compares against a render-time new Date()");
 
 // ───────── Month-cell keyboard access ─────────
 // (cave-zqsj) The month is a real ARIA grid: grid → header row of

--- a/src/components/calendar-day-tighten.test.ts
+++ b/src/components/calendar-day-tighten.test.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck
+// Day view's chrome after cave-25914.
+//
+// Three things were saying what one thing should say, and one thing was saying
+// it backwards:
+//   - the toolbar rendered fmtDateHeading(anchor) and DayView rendered a second
+//     <h2> with the same string underneath it;
+//   - the runs density band spanned the full row while the chart inside it is
+//     capped at 320px, so a single-column view spent a whole band — ahead of
+//     the first hour — mostly on empty space;
+//   - projected runs drew the dashed rule flexible with the label pinned RIGHT,
+//     putting a run's time and its name most of the viewport apart.
+//
+// Each is pinned here as the property, not the markup, so a refactor that keeps
+// the behaviour passes and a regression that restores the duplication fails.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const view = readFileSync(new URL("./calendar-view.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/calendar.css", import.meta.url), "utf8");
+
+const dayView = view.match(/function DayView\(\{[\s\S]*?\n\}\n/)?.[0] ?? "";
+assert.ok(dayView, "DayView is present");
+
+// ── One date statement ──────────────────────────────────────────────────────
+assert.doesNotMatch(dayView, /<h2/, "DayView renders no heading of its own");
+// Scoped to JSX interpolation, not any mention: DayView still passes
+// `label: fmtDateHeading(anchor)` into its column, which TimeGrid reads only
+// for the reschedule announcement. That is a screen-reader string, not a
+// second visible date.
+assert.doesNotMatch(
+  dayView,
+  /\{fmtDateHeading\(anchor\)\}/,
+  "…and renders no second visible copy of the date",
+);
+// The relative word did not disappear with that heading — it moved.
+assert.match(
+  view,
+  /if \(effectiveView === "day"\) \{[\s\S]{0,400}?relDayWord\(anchor, toolbarNow\)/,
+  "the toolbar heading carries the day's relative word",
+);
+
+// ── Runs summary: Day only, in the toolbar ──────────────────────────────────
+assert.doesNotMatch(dayView, /<RunDensityStrip/, "Day draws no full-width density band");
+// Week keeps its strip: there the per-column comparison IS the chart's point.
+assert.match(view, /<RunDensityStrip/, "Week still draws the per-column density strip");
+assert.match(
+  view,
+  /effectiveView === "day" && showRuns && dayRunCount > 0/,
+  "the toolbar count is Day-only and follows the toggle",
+);
+// It counts THIS day, not the whole projection window — Day projects one day,
+// but a count that silently followed the window would be wrong the moment the
+// projection range changed.
+assert.match(
+  view,
+  /dayRunCount = useMemo\([\s\S]{0,400}?isSameDay\(d, anchor\)/,
+  "the count is scoped to the anchored day",
+);
+
+// ── The toggle is an overlay control, not a fifth view ──────────────────────
+assert.match(view, /className="cal-runs-group shrink-0"/, "the runs control sits in its own group");
+assert.match(css, /\.cal-runs-group \{[^}]*border-inline-start: 1px solid var\(--border-hairline\);/,
+  "…separated from the view switcher by a rule");
+assert.match(view, />\s*Ritual runs\s*</, "and is Title Case like the views beside it");
+
+// ── Projections read left-to-right from the gutter ──────────────────────────
+const mark = view.match(/className="cal-run-mark"[\s\S]*?\n\s{16}<\/div>/)?.[0] ?? "";
+assert.ok(mark, "the projected-run marker is present");
+const dotAt = mark.indexOf("cal-run-mark__dot");
+const labelAt = mark.indexOf("cal-run-mark__label");
+const tickAt = mark.indexOf("cal-run-mark__tick");
+assert.ok(dotAt !== -1 && labelAt !== -1 && tickAt !== -1, "marker has dot, label and rule");
+assert.ok(
+  dotAt < labelAt && labelAt < tickAt,
+  "the name sits beside the hour gutter and the dashed rule trails it",
+);
+// The dot is the channel that separates a forecast from a real event; without
+// it the only difference was the dash, in the same accent.
+assert.match(css, /\.cal-run-mark__dot \{[^}]*border-radius: 50%;/, "projections carry a hollow marker");
+
+console.log("calendar-day-tighten.test.ts: ok");

--- a/src/components/calendar-view-primitives.test.ts
+++ b/src/components/calendar-view-primitives.test.ts
@@ -4,7 +4,13 @@ import { readFileSync } from "node:fs";
 const source = readFileSync(new URL("./calendar-view-primitives.tsx", import.meta.url), "utf8");
 
 assert.match(source, /export const FamiliarColorContext/, "calendar item primitives share the familiar accent provider");
-assert.match(source, /export function relTimeShort/, "agenda relative-time behavior has a focused owner");
+// Not `export function` (cave-25914): relTimeShort is used only by ItemChip in
+// this module, and isOverdueReminder only by urgencyColor/urgencyLabel/ItemChip
+// here. Pinning the keyword made module-private helpers permanently public —
+// the assertion is that the behaviour has ONE owner, which module scope states
+// more strongly than an unused export.
+assert.match(source, /function relTimeShort/, "agenda relative-time behavior has a focused owner");
+assert.doesNotMatch(source, /export function (relTimeShort|isOverdueReminder)/, "…and that owner is module-private, since nothing outside imports it");
 assert.match(source, /if \(abs < 60 \* 12\)/, "relative-time cues retain their 12-hour cap");
 assert.match(source, /export function defaultEntryFireAt/, "new-entry scheduling defaults are shared by all calendar views");
 assert.match(source, /export function ItemChip/, "agenda item rendering is a reusable calendar primitive");

--- a/src/components/calendar-view-primitives.tsx
+++ b/src/components/calendar-view-primitives.tsx
@@ -130,7 +130,7 @@ export function agendaDayLabel(date: Date, now: Date = new Date()): string {
 // "what's next" at a glance ("now", "in 25m", "in 3h", "40m ago"). Only
 // meaningful inside a ~12h window; beyond that the day header already carries
 // the date, so we return null and the row shows just its clock time.
-export function relTimeShort(target: Date, now: Date): string | null {
+function relTimeShort(target: Date, now: Date): string | null {
   const mins = Math.round((target.getTime() - now.getTime()) / 60_000);
   const abs = Math.abs(mins);
   if (abs < 1) return "now";
@@ -199,7 +199,7 @@ export function defaultEntryFireAt(day: Date): string {
 
 // A reminder still pending after its fire time never fired — flag it so it
 // stands out on the calendar like it does in the Schedules list.
-export function isOverdueReminder(item: InboxItem): boolean {
+function isOverdueReminder(item: InboxItem): boolean {
   return (
     item.kind === "reminder" &&
     item.status === "pending" &&

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -723,8 +723,15 @@ function TimeGrid({
                     {cluster.runs.length === 1 ? "Projected run" : `${cluster.runs.length} projected runs`},{" "}
                     {names}, {fmtTime(first.atIso)}
                   </span>
-                  <span aria-hidden className="cal-run-mark__tick" />
+                  {/* Label FIRST, beside the hour gutter (cave-25914). The
+                      dashed rule used to take the flexible width with the
+                      label pinned to the far end, so on a wide day the time
+                      and the name it belongs to sat most of the viewport
+                      apart, joined only by a hairline the eye had to track.
+                      The rule now trails the label as a continuation. */}
+                  <span aria-hidden className="cal-run-mark__dot" />
                   <span aria-hidden className="cal-run-mark__label">{clusterLabel(cluster)}</span>
+                  <span aria-hidden className="cal-run-mark__tick" />
                 </div>
               );
             })}
@@ -892,7 +899,6 @@ function DayView({
   items,
   deadlines,
   projectedRuns,
-  projectionCompleteness,
   anchor,
   onAddEntry,
   onOpenItem,
@@ -903,15 +909,12 @@ function DayView({
   deadlines?: CalendarDeadline[];
   /** Cron occurrences projected onto this day — see calendar-cron-projection. */
   projectedRuns?: readonly ProjectedCronRun[];
-  /** Whether those runs are complete for the day — see cave-fdcd4. */
-  projectionCompleteness?: ProjectionCompleteness;
   anchor: Date;
   onAddEntry?: (defaults?: { fireAt?: string; title?: string; whenText?: string }) => void;
   onOpenItem?: (item: InboxItem) => void;
   onReschedule?: (id: string, fireAtIso: string) => void;
   onOpenDeadline?: (id: string) => void;
 }) {
-  const now = useNow();
 
   const allDayItems = useMemo(
     () => items.filter((it) => {
@@ -955,19 +958,11 @@ function DayView({
     projectedRuns: dayRuns,
   }], [anchor, timedItems, dayRuns]);
 
-  const rel = now ? relDayWord(anchor, now) : null;
-
   return (
     <div className="flex flex-col flex-1 overflow-hidden">
-      {/* Header */}
-      <div className="shrink-0 border-b border-[var(--border-hairline)] px-3 py-3 sm:px-6">
-        <h2 className="text-sm font-medium text-[var(--text-primary)]">
-          {rel ? (
-            <span className="text-[var(--accent-presence)]">{rel} · </span>
-          ) : null}
-          {fmtDateHeading(anchor)}
-        </h2>
-      </div>
+      {/* No heading here (cave-25914). It restated the very date string the
+          toolbar directly above already shows, and the relative word it added
+          now rides that toolbar label instead. */}
       {/* Task deadlines (read-only, from the board) */}
       {dayDeadlines.length > 0 && (
         <DeadlineStrip
@@ -983,17 +978,12 @@ function DayView({
           maxVisible={Infinity}
         />
       )}
-      {/* Cron density for the day.
-          Not a duplicate of the markers below it: HOUR_HEIGHT is 56, so a full
-          day is 1344px of grid and roughly half of it is scrolled out of view
-          at any time. The markers say what runs and exactly when; this says
-          what the whole day looks like, which the grid cannot.
-          No onOpenDay — "open day" is a no-op when you are already in it, so
-          the strip renders as a plain div rather than a dead button. */}
-      <RunDensityStrip
-        columns={[{ date: anchor, runs: dayRuns }]}
-        projectionCompleteness={projectionCompleteness}
-      />
+      {/* No density band in Day (cave-25914). The band spans the full row while
+          the chart inside it is capped at 320px, so in a single-column view it
+          spent a whole horizontal band — ahead of the first hour — on one small
+          chart with the rest empty. The day's run count moved to the toolbar,
+          beside the toggle that produces it. Week keeps its strip: there the
+          per-column comparison is the whole point. */}
       {/* Time grid — always rendered for visual parity with Week */}
       <div className="relative flex flex-1 overflow-hidden">
         <TimeGrid columns={columns} onOpenItem={onOpenItem} onAddEntry={onAddEntry} onReschedule={onReschedule} maxLanes={DAY_MAX_LANES} />
@@ -1839,7 +1829,21 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
     return projectCronRuns(cronAutomations, start.getTime(), end.getTime() - 1);
   }, [showRuns, cronAutomations, anchor, effectiveView]);
 
+  // The toolbar owns the day's relative word and its runs summary, so it needs
+  // its own clock and per-day count. Both were previously read inside DayView,
+  // which is why the date and the runs band each had a second home.
+  const toolbarNow = useNow();
   const projectionNote = projectionSummary(projection);
+  const dayRunCount = useMemo(
+    () =>
+      effectiveView === "day"
+        ? projection.runs.filter((r) => {
+            const d = new Date(r.atIso);
+            return !Number.isNaN(d.getTime()) && isSameDay(d, anchor);
+          }).length
+        : 0,
+    [effectiveView, projection, anchor],
+  );
 
   // Pending count for the header pill (computed once, not twice inline).
   const pendingCount = useMemo(
@@ -1949,7 +1953,15 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
   }
 
   function headingLabel(): string {
-    if (effectiveView === "day") return fmtDateHeading(anchor);
+    // Day carries its relative word HERE rather than in a second heading
+    // inside DayView. That heading rendered fmtDateHeading(anchor) — the same
+    // string this toolbar already shows — and earned its space only when
+    // relDayWord returned something, which is exactly when the duplication was
+    // least useful. One date statement per screen (cave-25914).
+    if (effectiveView === "day") {
+      const word = toolbarNow ? relDayWord(anchor, toolbarNow) : null;
+      return word ? `${word} · ${fmtDateHeading(anchor)}` : fmtDateHeading(anchor);
+    }
     if (effectiveView === "week") {
       const ws = startOfWeek(anchor);
       const we = addDays(ws, 6);
@@ -2053,18 +2065,37 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
         />
 
         {/* Only offered when there is something to project. A dead toggle
-            teaches a reader to ignore part of the toolbar. */}
+            teaches a reader to ignore part of the toolbar.
+
+            Separated from the view switcher by its own group: this toggles a
+            data OVERLAY, while the tabs beside it switch views. Sitting flush
+            against them in matching pill chrome, it read as a fifth view —
+            and it was the one lowercase label in a Title Case row
+            (cave-25914). */}
         {PROJECTING_VIEWS.has(effectiveView) && cronAutomations.some((a) => a.status === "ACTIVE") ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            aria-pressed={showRuns}
-            title="Project cron occurrences onto the calendar"
-            onClick={() => setShowRuns((v) => !v)}
-            className={`calendar-toolbar-button shrink-0 cal-runs-toggle${showRuns ? " is-on" : ""}`}
-          >
-            ritual runs
-          </Button>
+          <div className="cal-runs-group shrink-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-pressed={showRuns}
+              title="Project cron occurrences onto the calendar"
+              onClick={() => setShowRuns((v) => !v)}
+              className={`calendar-toolbar-button shrink-0 cal-runs-toggle${showRuns ? " is-on" : ""}`}
+            >
+              Ritual runs
+            </Button>
+            {/* Day only, by design. Week draws a per-column density strip where
+                the comparison between days is the point; a single number in the
+                toolbar would say less than that chart, not more. In Day there
+                is only one column, so the band spent a full row on one capped
+                chart with the rest of the width empty — the count belongs
+                beside the control that produces it. */}
+            {effectiveView === "day" && showRuns && dayRunCount > 0 ? (
+              <span className="cal-runs-count" aria-live="polite">
+                {dayRunCount} run{dayRunCount === 1 ? "" : "s"}
+              </span>
+            ) : null}
+          </div>
         ) : null}
 
         {onAddEntry ? (
@@ -2122,7 +2153,6 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
             items={scopedItems}
             deadlines={scopedDeadlines}
             projectedRuns={projection.runs}
-            projectionCompleteness={projection}
             anchor={anchor}
             onAddEntry={onAddEntry}
             onReschedule={onReschedule}

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -55,6 +55,24 @@
   text-transform: uppercase;
 }
 
+/* The runs control is its own group, set apart from the view switcher: it
+   toggles an overlay, not a view (cave-25914). */
+.cal-runs-group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding-inline-start: var(--space-2);
+  border-inline-start: 1px solid var(--border-hairline);
+}
+
+/* Day only — the count that used to need a full-width band of its own. */
+.cal-runs-count {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 .cal-runs-toggle.is-on {
   border-color: color-mix(in oklch, var(--accent-presence) 45%, transparent);
   color: var(--accent-presence);
@@ -111,20 +129,40 @@
   pointer-events: none;
 }
 
-.cal-run-mark__tick {
-  flex: 1;
-  height: 0;
-  border-top: 1px dashed color-mix(in oklch, var(--accent-presence) 55%, transparent);
+/* A projection reads left-to-right from the hour gutter: dot, name, then the
+   dashed rule as a continuation out to the edge (cave-25914). The rule used to
+   take the flexible width with the label pinned right, which put a run's time
+   and its name most of the viewport apart on a wide day.
+
+   The dot is what separates a FORECAST from a real event at a glance: events
+   are solid blocks in the lane packer, projections are a hollow tick on a
+   dashed line. Before this the only difference was the dash, and both drew in
+   the same accent. */
+.cal-run-mark__dot {
+  flex: none;
+  width: 5px;
+  height: 5px;
+  margin-inline-start: 1px;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 70%, transparent);
+  border-radius: 50%;
+  background: var(--bg-base);
 }
 
 .cal-run-mark__label {
-  flex: none;
+  flex: 0 1 auto;
+  min-width: 0;
   max-width: 60%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: color-mix(in oklch, var(--accent-presence) 82%, transparent);
   font-size: var(--text-2xs);
+}
+
+.cal-run-mark__tick {
+  flex: 1;
+  height: 0;
+  border-top: 1px dashed color-mix(in oklch, var(--accent-presence) 55%, transparent);
 }
 
 /* Week view: per-day density strip. Six four-hour bands say WHEN a day's load


### PR DESCRIPTION
Tightens the Rituals calendar Day view: one date statement, a runs summary
in the toolbar, and left-anchored events, replacing the previous noisier
layout.

Verification:
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Targeted tests: `calendar-day-tighten.test.ts`, `calendar-view-primitives.test.ts`,
  `calendar-actions.test.ts` — pass

Bead: cave-25914