### PR TITLE
Broadcast one message to multiple selected chats

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -673,6 +673,7 @@ export const SUITES = {
     "src/components/chat-start-from-bands.test.ts",
     "src/components/chat-start-from-deadspace.test.ts",
     "src/components/chat-inline-composer.test.ts",
+    "src/lib/chat-broadcast.test.ts",
     "src/lib/chat-new-session-defaults.test.ts",
     "src/components/chat-new-dashboard.test.ts",
     "src/components/user-chat-avatar.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -79,6 +79,7 @@ const contracts: RouteContract[] = [
   { route: "/chat/conversation/[id]", methods: ["GET", "POST", "PUT", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/chat/conversation/[id]/turns/[turnId]", methods: ["DELETE"], kind: "json" },
   { route: "/chat/model-state", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/chat/broadcast", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/chat/rewrite", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/chat/search", methods: ["GET"], kind: "json" },
   { route: "/chat/send", methods: ["POST"], kind: "stream", readsJson: true },

--- a/src/app/api/chat/broadcast/route.ts
+++ b/src/app/api/chat/broadcast/route.ts
@@ -1,0 +1,191 @@
+import { NextResponse } from "next/server";
+
+import { loadConversation } from "@/lib/cave-conversations";
+import {
+  BROADCAST_CONCURRENCY,
+  normalizeBroadcastTargets,
+  runBounded,
+  type BroadcastResult,
+} from "@/lib/chat-broadcast";
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/chat/broadcast — send one message into many existing chats.
+ *
+ * Server-side rather than a client fan-out for three reasons: the browser would
+ * otherwise hold N concurrent SSE connections open while the user keeps
+ * browsing; the concurrency ceiling belongs somewhere a single client cannot
+ * opt out of; and the caller wants ONE response carrying a per-target outcome,
+ * which is what the sessions list renders on each row.
+ *
+ * The internal `fetch("/api/chat/send")` follows `src/app/api/salem/route.ts`,
+ * which already calls that route server-to-server.
+ *
+ * ── Deliver and detach ──────────────────────────────────────────────────────
+ * A target resolves as soon as its send is ACCEPTED — the response opens and
+ * announces `{ kind: "session" }` — not when its reply finishes. Waiting for
+ * every reply would hold one HTTP request open across N multi-minute agent
+ * turns; "delivered" is also the honest claim here, since the reply lands in
+ * each chat's own transcript where the user reads it.
+ *
+ * The turn still completes server-side after we stop reading: `/api/chat/send`
+ * treats a bare transport abort as "the client vanished" and lets the turn
+ * finish and persist, bounded by CHAT_DETACH_MAX_MS (10 minutes). So a reply
+ * longer than that ceiling can be cut short. That is the accepted cost of not
+ * blocking the request; a user who needs to watch a long reply opens the chat,
+ * which re-attaches through /api/chat/stream.
+ */
+
+/** Long enough to cover a cold harness spawn, short enough that one wedged
+ *  target cannot hold a broadcast open. Only bounds the ACCEPT window — the
+ *  turn itself runs on past it, server-side. */
+const ACCEPT_TIMEOUT_MS = 30_000;
+
+type SendOutcome = Pick<BroadcastResult, "ok" | "runId" | "error" | "code">;
+
+/**
+ * Fire one send and resolve once it is accepted.
+ *
+ * `familiarId` is read from the target's own conversation, never from the
+ * caller: `/api/chat/send` answers 404 when the body's familiar does not match
+ * the persisted one, and a broadcast may legitimately span familiars.
+ *
+ * `projectRoot` is deliberately NOT passed. A continued turn omits it, and the
+ * send route then recovers the conversation's own cwd from its recorded
+ * runtime (or the daemon's session record). Passing the caller's active
+ * project instead would run someone else's chat in the wrong directory.
+ */
+async function sendOne(req: Request, sessionId: string, text: string): Promise<SendOutcome> {
+  const conversation = await loadConversation(sessionId).catch(() => null);
+  if (!conversation) {
+    return { ok: false, code: "conversation_not_found", error: "conversation not found" };
+  }
+
+  const runId = crypto.randomUUID();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ACCEPT_TIMEOUT_MS);
+  try {
+    const res = await fetch(new URL("/api/chat/send", req.url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        familiarId: conversation.familiarId,
+        prompt: text,
+        sessionId,
+        runId,
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok || !res.body) {
+      const detail = await res.text().catch(() => "");
+      return {
+        ok: false,
+        code: "send_rejected",
+        error: `send refused with ${res.status}${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+      };
+    }
+    // Read only far enough to see the run acknowledged, then let go. Cancelling
+    // the reader is what detaches us; the turn continues server-side.
+    const accepted = await waitForAccept(res.body);
+    if (!accepted.ok) return { ok: false, code: "send_failed", error: accepted.error };
+    return { ok: true, runId };
+  } catch (err) {
+    const aborted = err instanceof Error && err.name === "AbortError";
+    return {
+      ok: false,
+      code: "send_failed",
+      error: aborted
+        ? `send was not acknowledged within ${Math.round(ACCEPT_TIMEOUT_MS / 1000)}s`
+        : err instanceof Error
+          ? err.message
+          : "send failed",
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Consume SSE frames until the run is acknowledged.
+ *
+ * `session` means accepted. An `error` frame before it is a real per-target
+ * failure and must be reported rather than counted as delivered — this is the
+ * case `/api/inbox/bulk` has no precedent for, since its actions cannot fail
+ * individually the way a spawned harness can.
+ */
+async function waitForAccept(body: ReadableStream<Uint8Array>): Promise<{ ok: true } | { ok: false; error: string }> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return { ok: false, error: "stream closed before the run was acknowledged" };
+      }
+      buffer += decoder.decode(value, { stream: true });
+      const frames = buffer.split("\n\n");
+      buffer = frames.pop() ?? "";
+      for (const frame of frames) {
+        const line = frame.split(/\r?\n/).find((item) => item.startsWith("data:"));
+        if (!line) continue;
+        let event: { kind?: string; message?: string; isError?: boolean };
+        try {
+          event = JSON.parse(line.slice(5).trim());
+        } catch {
+          continue;
+        }
+        if (event.kind === "session") return { ok: true };
+        if (event.kind === "error") return { ok: false, error: event.message ?? "send failed" };
+        // A `done` that arrives without a preceding `session` is a refusal that
+        // still framed itself as a stream (the offline/travel queue path does
+        // this). Treat an error-flagged done as a failure, not a delivery.
+        if (event.kind === "done" && event.isError) {
+          return { ok: false, error: event.message ?? "send failed" };
+        }
+        if (event.kind === "done") return { ok: true };
+      }
+    }
+  } finally {
+    // Detach. The turn keeps running and persisting on the server.
+    await reader.cancel().catch(() => undefined);
+  }
+}
+
+export async function POST(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+
+  let body: { text?: unknown; targets?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+
+  const text = typeof body.text === "string" ? body.text.trim() : "";
+  if (!text) {
+    return NextResponse.json({ ok: false, error: "text is required" }, { status: 400 });
+  }
+
+  const targets = normalizeBroadcastTargets(body.targets);
+  if (targets.length === 0) {
+    return NextResponse.json(
+      { ok: false, error: "targets must be a non-empty array of session ids" },
+      { status: 400 },
+    );
+  }
+
+  const results = await runBounded(targets, BROADCAST_CONCURRENCY, async (target) => {
+    const outcome = await sendOne(req, target.sessionId, text);
+    return { sessionId: target.sessionId, ...outcome } satisfies BroadcastResult;
+  });
+
+  // 200 with a per-target result array even when some targets failed: the
+  // operation ran, and the caller needs the breakdown to retry only the
+  // failures. `ok` reports whether EVERY target was delivered.
+  return NextResponse.json({ ok: results.every((r) => r.ok), results });
+}

--- a/src/components/chat-broadcast-composer.tsx
+++ b/src/components/chat-broadcast-composer.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+/**
+ * The broadcast composer (cave-g7yg6) — write once, send into every selected
+ * chat.
+ *
+ * Deliberately small: one textarea and one verb. It is not a chat view, and it
+ * never shows replies. Each target answers in its own thread, which is where
+ * the user reads it; a panel that streamed N replies here would be a second
+ * chat surface competing with the real ones.
+ *
+ * It posts ONE request to /api/chat/broadcast and reports the per-target result
+ * array back to the caller. The fan-out, its concurrency ceiling and the
+ * per-familiar resolution all live on the server — see that route.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { Icon } from "@/lib/icon";
+import { useFocusTrap } from "@/lib/use-focus-trap";
+import type { BroadcastResult } from "@/lib/chat-broadcast";
+
+export function ChatBroadcastComposer({
+  count,
+  targets,
+  onClose,
+  onSent,
+}: {
+  /** How many chats this will reach — named in the heading and the verb. */
+  count: number;
+  targets: readonly string[];
+  onClose: () => void;
+  onSent: (results: BroadcastResult[]) => void;
+}) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [text, setText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  useFocusTrap(true, panelRef, { onEscape: () => (busy ? undefined : onClose()) });
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const trimmed = text.trim();
+
+  async function send() {
+    if (!trimmed || busy || targets.length === 0) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/chat/broadcast", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: trimmed, targets: targets.map((sessionId) => ({ sessionId })) }),
+      });
+      const data: { ok?: boolean; error?: string; results?: BroadcastResult[] } = await res
+        .json()
+        .catch(() => ({}));
+      if (!res.ok || !Array.isArray(data.results)) {
+        setError(data.error ?? `broadcast failed with ${res.status}`);
+        return;
+      }
+      // Partial failure is NOT an error state here — the caller renders the
+      // per-row outcome, so a mixed result still closes the composer with the
+      // failures visible in the list behind it.
+      onSent(data.results);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "broadcast failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="chat-broadcast fixed inset-0 z-[220] flex items-center justify-center" role="presentation">
+      <button
+        type="button"
+        aria-label="Cancel broadcast"
+        className="absolute inset-0 bg-[var(--backdrop-scrim)]"
+        onClick={() => (busy ? undefined : onClose())}
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Broadcast to ${count} chat${count === 1 ? "" : "s"}`}
+        tabIndex={-1}
+        className="chat-broadcast__panel relative flex w-[min(92vw,520px)] flex-col gap-3 rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-raised)] p-4 shadow-[0_16px_48px_rgba(0,0,0,0.28)]"
+      >
+        <h2 className="chat-broadcast__title">
+          Broadcast to {count} chat{count === 1 ? "" : "s"}
+        </h2>
+        <p className="chat-broadcast__note">
+          Each chat answers on its own. Replies land in their own threads, not here.
+        </p>
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              void send();
+            }
+          }}
+          rows={5}
+          placeholder="Message to send to every selected chat…"
+          className="chat-broadcast__input focus-ring"
+          disabled={busy}
+        />
+        {error ? (
+          <p role="alert" className="chat-broadcast__error">
+            <Icon name="ph:warning-circle" width={13} aria-hidden /> {error}
+          </p>
+        ) : null}
+        <div className="chat-broadcast__actions">
+          <button type="button" className="focus-ring chat-broadcast__cancel" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="focus-ring chat-broadcast__send"
+            onClick={() => void send()}
+            disabled={!trimmed || busy}
+          >
+            {busy ? "Sending…" : `Send to ${count}`}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -94,6 +94,8 @@ import {
   type ChatSessionStatusFilter,
 } from "@/lib/chat-session-status";
 import { groupChatRowsByActivity } from "@/lib/chat-session-activity";
+import { failedTargets, type BroadcastResult } from "@/lib/chat-broadcast";
+import { ChatBroadcastComposer } from "@/components/chat-broadcast-composer";
 import {
   CHAT_SESSION_KIND,
   CHAT_SESSION_KIND_ORDER,
@@ -233,6 +235,12 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
+  // Broadcast (cave-g7yg6) — one message into every selected chat. The fan-out,
+  // its concurrency ceiling and the per-target result all live on
+  // /api/chat/broadcast; this surface only picks the targets and renders the
+  // outcome.
+  const [broadcastOpen, setBroadcastOpen] = useState(false);
+  const [broadcastState, setBroadcastState] = useState<Record<string, "sent" | "failed">>({});
   // Bulk delete is deferred + undoable: rows hide immediately, the DELETEs fire
   // only after the undo window, and Undo restores the batch.
   const { pending: deletePending, scheduleDelete: scheduleBulkDelete, undo: undoBulkDelete, commit: commitBulkDelete } = useUndoDelete<SessionRow[]>();
@@ -1239,6 +1247,19 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                 <span className="text-[length:var(--text-xs)] text-[var(--text-muted)]">{selectedVisibleCount} selected</span>
               </div>
               <div className="flex items-center gap-1">
+                {/* Broadcast (cave-g7yg6) leads the cluster: it is the only
+                    action here that writes into the selected chats rather
+                    than filing them, so it does not belong beside Archive and
+                    Delete as if it were another disposition. */}
+                <Button
+                  variant="secondary"
+                  size="xs"
+                  leadingIcon="ph:broadcast"
+                  disabled={bulkBusy || selectedVisibleCount === 0}
+                  onClick={() => setBroadcastOpen(true)}
+                >
+                  Broadcast
+                </Button>
                 <Button
                   variant="secondary"
                   size="xs"
@@ -1593,6 +1614,19 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                                 full line. What survives is what the pill does
                                 NOT say: whether the chat is kept, deferred or
                                 archived. */}
+                            {/* Broadcast outcome (cave-g7yg6). Transient, and
+                                per row: a failed target has to be visible on
+                                the row it failed for, because a broadcast that
+                                half-worked and said nothing is worse than one
+                                that failed outright. */}
+                            {broadcastState[s.id] ? (
+                              <span
+                                className="chat-list-row-broadcast"
+                                data-state={broadcastState[s.id]}
+                              >
+                                {broadcastState[s.id] === "sent" ? "Sent" : "Failed"}
+                              </span>
+                            ) : null}
                             {retentionMark ? (
                               <span className="chat-list-row-preview truncate text-[length:var(--text-sm)] text-[var(--text-muted)]">
                                 {s.keep ? (
@@ -1853,6 +1887,26 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
           undoAriaLabel="Undo delete"
           onUndo={undoBulkDelete}
           onDismiss={commitBulkDelete}
+        />
+      ) : null}
+      {broadcastOpen ? (
+        <ChatBroadcastComposer
+          count={selectedVisibleCount}
+          // The VISIBLE selection, matching every other bulk action here: a row
+          // hidden behind a collapsed section must not receive a broadcast it
+          // was never shown to be selected for (chat-list-collapse.test.ts).
+          targets={visibleIds.filter((id) => selectedIds.has(id))}
+          onClose={() => setBroadcastOpen(false)}
+          onSent={(results: BroadcastResult[]) => {
+            const next: Record<string, "sent" | "failed"> = {};
+            for (const r of results) next[r.sessionId] = r.ok ? "sent" : "failed";
+            setBroadcastState(next);
+            // Keep only the failures selected — a retry re-sends to those and
+            // nothing else, since a send is not idempotent.
+            const failures = new Set(failedTargets(results).map((t) => t.sessionId));
+            setSelectedIds(failures);
+            if (failures.size === 0) exitSelect();
+          }}
         />
       ) : null}
     </div>

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -2,6 +2,10 @@
 
 import { useEffect, useId, useMemo, useState } from "react";
 import { useMinuteTick } from "@/lib/use-minute-tick";
+import { useMultiSelect } from "@/lib/use-multi-select";
+import { SelectionToolbar } from "@/components/ui/selection-toolbar";
+import { failedTargets, type BroadcastResult } from "@/lib/chat-broadcast";
+import { ChatBroadcastComposer } from "@/components/chat-broadcast-composer";
 import { Icon, type IconName } from "@/lib/icon";
 import { ProjectAvatar } from "@/components/project-avatar";
 import { sessionRailTitle } from "@/lib/session-rail-title";
@@ -180,6 +184,14 @@ type ThreadRowProps = {
   onOpen: () => void;
   /** ⌥↵ / ⌥-click / drag: open beside the current chat in a split pane. */
   onOpenInSplit?: () => void;
+  /** Broadcast select mode (cave-g7yg6). The row becomes a checkbox and its
+   *  click picks instead of opens. Both split-pane affordances stand down —
+   *  ⌥-click and drag-to-split would otherwise fire from inside a picker. */
+  selectMode?: boolean;
+  selected?: boolean;
+  onToggleSelect?: () => void;
+  /** Transient per-row outcome after a broadcast: "sent" | "failed". */
+  broadcast?: "sent" | "failed" | null;
   onTogglePin: () => void;
   /** Archive/unarchive via the sessions PATCH (same endpoint as chat-list). */
   onToggleArchive: () => void;
@@ -203,6 +215,10 @@ function ThreadRow({
   onOpenUrl,
   onOpen,
   onOpenInSplit,
+  selectMode = false,
+  selected = false,
+  onToggleSelect,
+  broadcast = null,
   onTogglePin,
   onToggleArchive,
   archiving,
@@ -245,9 +261,20 @@ function ThreadRow({
       {prStatus ? <ThreadPrBadge prStatus={prStatus} onOpenUrl={onOpenUrl} /> : null}
       <button
         type="button"
-        aria-current={active ? "page" : undefined}
+        // Same markup contract the board and the chat list already use for
+        // select mode, so assistive tech reads one pattern across surfaces.
+        role={selectMode ? "checkbox" : undefined}
+        aria-checked={selectMode ? selected : undefined}
+        aria-current={!selectMode && active ? "page" : undefined}
         aria-describedby={attentionDescription ? attentionDescriptionId : undefined}
         onClick={(e) => {
+          // Select mode intercepts FIRST. This row's click is overloaded —
+          // ⌥-click opens a split pane — so without this the modifier path
+          // would still fire from inside a picker.
+          if (selectMode) {
+            onToggleSelect?.();
+            return;
+          }
           // ⌥-click opens beside the current chat instead of replacing it.
           if (e.altKey && onOpenInSplit) {
             onOpenInSplit();
@@ -258,6 +285,7 @@ function ThreadRow({
         onKeyDown={(e) => {
           // ⌥↵ opens in a split pane (keyboard twin of drag-to-split); stop
           // the native button activation so onClick doesn't also fire.
+          if (selectMode) return;
           if (e.key === "Enter" && e.altKey && onOpenInSplit) {
             e.preventDefault();
             onOpenInSplit();
@@ -265,7 +293,7 @@ function ThreadRow({
         }}
         // Dragging the row onto the chat surface snaps it into a split pane
         // (chat-split-host's drop zone; same protocol as the project rail).
-        draggable={Boolean(onOpenInSplit)}
+        draggable={Boolean(onOpenInSplit) && !selectMode}
         onDragStart={(e) => {
           if (!onOpenInSplit) return;
           e.dataTransfer.setData(CHAT_SESSION_DRAG_MIME, session.id);
@@ -278,7 +306,18 @@ function ThreadRow({
         }}
         className="cnav__thread-main focus-ring"
       >
-        {prStatus ? null : leadGlyph ? (
+        {/* In select mode the leading slot IS the checkbox — the status dot,
+            PR badge and heuristic glyph all describe the thread, and none of
+            them says whether it is picked. Colour is not the only channel:
+            role=checkbox + aria-checked carry the same state (cave-g7yg6). */}
+        {selectMode ? (
+          <span
+            aria-hidden
+            className={`cnav__lead cnav__select-box${selected ? " is-on" : ""}`}
+          >
+            <Icon name="ph:check-bold" width={9} aria-hidden />
+          </span>
+        ) : prStatus ? null : leadGlyph ? (
           <Icon name={leadGlyph} width={13} className="cnav__lead" aria-hidden />
         ) : (
           <span className={`cnav__dot ${statusDotClass(session.status)}`} aria-hidden />
@@ -292,7 +331,15 @@ function ThreadRow({
         <span className="cnav__thread-copy">
           <span className="cnav__thread-line">
             <span className="cnav__thread-title" title={title}>{title}</span>
-            {confirming ? null : (
+            {/* Broadcast outcome replaces the timestamp while it shows: a
+                failed target must be visible on its own row, since a
+                broadcast that half-worked and said nothing is worse than one
+                that failed outright. */}
+            {broadcast ? (
+              <span className="cnav__broadcast" data-state={broadcast}>
+                {broadcast === "sent" ? "Sent" : "Failed"}
+              </span>
+            ) : confirming ? null : (
               <span className="cnav__time">{bareTimeAt(session.updated_at || session.created_at, now)}</span>
             )}
           </span>
@@ -573,6 +620,51 @@ export function SidebarChatsSection({
     [recentSessions, now],
   );
 
+  // ── Broadcast select mode (cave-g7yg6) ──────────────────────────────────
+  //
+  // `visibleThreads` is what select-all acts on and what the hook keys its
+  // reset to. It is the rows actually ON SCREEN — a section collapsed behind
+  // "Show N more" is excluded, so Select all can never pick a chat the user
+  // cannot see and then broadcast into it.
+  const visibleThreads = useMemo(() => {
+    const rows: SessionRow[] = [];
+    const seen = new Set<string>();
+    const push = (list: SessionRow[], key: string, previewed: boolean) => {
+      const shown = previewed && !showAllByKey.has(key) ? list.slice(0, THREADS_PREVIEW) : list;
+      for (const session of shown) {
+        if (seen.has(session.id)) continue;
+        seen.add(session.id);
+        rows.push(session);
+      }
+    };
+    push(pinnedSessions, "pinned", false);
+    push(attentionSessions, "attention", true);
+    for (const bucket of recentBuckets) push(bucket.sessions, `bucket:${bucket.key}`, true);
+    return rows;
+  }, [pinnedSessions, attentionSessions, recentBuckets, showAllByKey]);
+
+  const select = useMultiSelect(visibleThreads, (session) => session.id);
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [broadcastState, setBroadcastState] = useState<Record<string, "sent" | "failed">>({});
+
+  // A broadcast's outcome is per row, and it clears itself: the markers say
+  // "this just happened", not "this is what this chat is". Failures are why the
+  // selection is not simply dropped — a retry must target only the failures,
+  // since nothing about a send is idempotent.
+  function applyBroadcastResults(results: BroadcastResult[]) {
+    const next: Record<string, "sent" | "failed"> = {};
+    for (const r of results) next[r.sessionId] = r.ok ? "sent" : "failed";
+    setBroadcastState(next);
+    const failures = failedTargets(results).map((t) => t.sessionId);
+    select.exit();
+    if (failures.length > 0) {
+      // Re-enter select mode holding exactly the failures, so the obvious next
+      // action — press Broadcast again — retries those and nothing else.
+      select.setSelectMode(true);
+      for (const id of failures) select.toggle(id);
+    }
+  }
+
   const togglePin = (sessionId: string) => {
     toggleStoredPinnedSession(sessionId);
   };
@@ -642,6 +734,39 @@ export function SidebarChatsSection({
             <Icon name="ph:sidebar-simple-fill" width={15} aria-hidden />
           </span>
         </button>
+        {/* Entering select mode is its own control rather than a row gesture:
+            the rows are already overloaded (⌥-click splits, drag splits), and
+            a long-press or modifier would be a fourth meaning on one target. */}
+        {!select.selectMode && visibleThreads.length > 1 ? (
+          <button
+            type="button"
+            className="cnav__select-enter focus-ring"
+            title="Select chats to broadcast a message to"
+            onClick={() => select.setSelectMode(true)}
+          >
+            <Icon name="ph:list-checks-bold" width={13} aria-hidden />
+            <span>Select</span>
+          </button>
+        ) : null}
+        {select.selectMode ? (
+          <div className="cnav__select-bar">
+            <SelectionToolbar
+              allSelected={select.allSelected(visibleThreads)}
+              count={select.selectedCount}
+              onToggleSelectAll={() => select.toggleSelectAll(visibleThreads)}
+              onCancel={select.exit}
+            >
+              <button
+                type="button"
+                className="focus-ring cnav__broadcast-open"
+                disabled={select.selectedCount === 0}
+                onClick={() => setComposerOpen(true)}
+              >
+                Broadcast
+              </button>
+            </SelectionToolbar>
+          </div>
+        ) : null}
         {deleteError ? (
           <div role="alert" className="cnav__error">
             <Icon name="ph:warning-circle" width={13} className="shrink-0" aria-hidden />
@@ -715,6 +840,10 @@ export function SidebarChatsSection({
                           onOpenInSplit={
                             onOpenSessionInSplit ? () => onOpenSessionInSplit(session) : undefined
                           }
+                          selectMode={select.selectMode}
+                          selected={select.isSelected(session.id)}
+                          onToggleSelect={() => select.toggle(session.id)}
+                          broadcast={broadcastState[session.id] ?? null}
                           onTogglePin={() => togglePin(session.id)}
                           onToggleArchive={() => void setSessionArchived(session, !session.archived_at)}
                           archiving={archivingId !== null}
@@ -776,6 +905,10 @@ export function SidebarChatsSection({
                             onOpenInSplit={
                               onOpenSessionInSplit ? () => onOpenSessionInSplit(session) : undefined
                             }
+                            selectMode={select.selectMode}
+                            selected={select.isSelected(session.id)}
+                            onToggleSelect={() => select.toggle(session.id)}
+                            broadcast={broadcastState[session.id] ?? null}
                             onTogglePin={() => togglePin(session.id)}
                             onToggleArchive={() => void setSessionArchived(session, !session.archived_at)}
                             archiving={archivingId !== null}
@@ -805,6 +938,14 @@ export function SidebarChatsSection({
           </>
           </nav>
         </div>
+        {composerOpen ? (
+          <ChatBroadcastComposer
+            count={select.selectedCount}
+            targets={[...select.selectedIds]}
+            onClose={() => setComposerOpen(false)}
+            onSent={applyBroadcastResults}
+          />
+        ) : null}
     </div>
   );
 }

--- a/src/lib/chat-broadcast.test.ts
+++ b/src/lib/chat-broadcast.test.ts
@@ -1,0 +1,90 @@
+// @ts-nocheck
+// Broadcast fan-out mechanics (cave-g7yg6).
+//
+// The concurrency ceiling is the point of this module. Every /api/chat/send
+// spawns an OS process and that route carries no rate limit or cap of its own,
+// so an unbounded fan-out over a large selection starts that many harness
+// children and model calls at once. The existing group-chat broadcast is an
+// unthrottled Promise.all (src/lib/group-chat.ts:902) — the behaviour this
+// deliberately does not copy.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BROADCAST_CONCURRENCY,
+  failedTargets,
+  normalizeBroadcastTargets,
+  runBounded,
+} from "./chat-broadcast.ts";
+
+test("runBounded never exceeds its limit, and observes the real peak", async () => {
+  let inFlight = 0;
+  let peak = 0;
+  const items = Array.from({ length: 25 }, (_, i) => i);
+  const seen = await runBounded(items, 4, async (n) => {
+    inFlight += 1;
+    peak = Math.max(peak, inFlight);
+    // Yield across several turns so overlap is genuinely possible — a task that
+    // resolves synchronously would keep the peak at 1 and the assertion would
+    // pass without testing anything.
+    await new Promise((r) => setTimeout(r, 5));
+    inFlight -= 1;
+    return n * 2;
+  });
+  assert.equal(peak, 4, `expected the cap to be reached and not exceeded, saw ${peak}`);
+  assert.deepEqual(seen, items.map((n) => n * 2), "results keep input order");
+});
+
+test("runBounded starts no more workers than there is work", async () => {
+  let started = 0;
+  await runBounded([1, 2], BROADCAST_CONCURRENCY, async (n) => {
+    started += 1;
+    await new Promise((r) => setTimeout(r, 1));
+    return n;
+  });
+  assert.equal(started, 2, "two items must not schedule four task invocations");
+});
+
+test("runBounded refuses a limit below 1 rather than hanging", async () => {
+  await assert.rejects(() => runBounded([1], 0, async (n) => n), RangeError);
+});
+
+test("a throwing task propagates instead of being mapped to a failed target", async () => {
+  // Callers resolve their own per-target errors into result objects; a throw
+  // here is a bug in the caller, and swallowing it would hide that.
+  await assert.rejects(
+    () => runBounded([1, 2], 2, async () => { throw new Error("boom"); }),
+    /boom/,
+  );
+});
+
+test("targets are explicit, trimmed and de-duplicated", () => {
+  // De-duplication is a safety property, not tidiness: two concurrent runs on
+  // one conversation collide in the stop registry, where the second overwrites
+  // the first and a later session-keyed Stop reaches only the newer run.
+  assert.deepEqual(
+    normalizeBroadcastTargets([{ sessionId: "a" }, { sessionId: " a " }, { sessionId: "b" }]),
+    [{ sessionId: "a" }, { sessionId: "b" }],
+  );
+  // Bare strings are accepted so a caller can pass ids directly.
+  assert.deepEqual(normalizeBroadcastTargets(["a", "a", "c"]), [{ sessionId: "a" }, { sessionId: "c" }]);
+  // Anything unusable yields no targets, and the route turns that into a 400
+  // rather than a silent no-op broadcast.
+  assert.deepEqual(normalizeBroadcastTargets(null), []);
+  assert.deepEqual(normalizeBroadcastTargets([{}, "", "   ", 7]), []);
+});
+
+test("a retry targets the failures and nothing else", () => {
+  // Nothing about a send is idempotent — runId is a Stop token, not a dedupe
+  // key — so re-broadcasting the whole selection would double-post to every
+  // target that already succeeded.
+  const results = [
+    { sessionId: "a", ok: true, runId: "r1" },
+    { sessionId: "b", ok: false, error: "conversation not found", code: "conversation_not_found" },
+    { sessionId: "c", ok: true, runId: "r2" },
+    { sessionId: "d", ok: false, error: "send refused with 403", code: "send_rejected" },
+  ];
+  assert.deepEqual(failedTargets(results), [{ sessionId: "b" }, { sessionId: "d" }]);
+});
+
+console.log("chat-broadcast.test.ts: ok");

--- a/src/lib/chat-broadcast.ts
+++ b/src/lib/chat-broadcast.ts
@@ -1,0 +1,116 @@
+/**
+ * Broadcast — one message into many existing chats (cave-g7yg6).
+ *
+ * Each target keeps its own session and its own reply. There is no server-side
+ * group-session primitive, so a broadcast is N `/api/chat/send` calls, exactly
+ * as the Coven group chat already does (`src/lib/group-chat.ts:902`).
+ *
+ * What is deliberately NOT copied from there is the fan-out itself: that one is
+ * an unthrottled `Promise.all`. Every send spawns an OS process (a harness
+ * child) and `/api/chat/send` carries no rate limit or concurrency cap of its
+ * own, so an unbounded broadcast over a large selection would start that many
+ * agent processes and model calls at once. `runBounded` below is the fix.
+ *
+ * This module is pure — no fetch, no Next, no React — so the concurrency
+ * ceiling and the per-target outcome shape can be tested without a server.
+ */
+
+/** Concurrent sends in flight. Matches MAX_COVEN_DELEGATIONS_PER_TURN, the
+ *  existing house ceiling for agent fan-out (`src/lib/group-chat.ts`). */
+export const BROADCAST_CONCURRENCY = 4;
+
+export type BroadcastTarget = { sessionId: string };
+
+export type BroadcastResult = {
+  sessionId: string;
+  ok: boolean;
+  /** Present on success — the per-send token /api/chat/stop targets. */
+  runId?: string;
+  /** Present on failure. Human-readable. */
+  error?: string;
+  /** Present on failure when the cause is machine-classifiable. */
+  code?: BroadcastFailureCode;
+};
+
+export type BroadcastFailureCode =
+  | "conversation_not_found"
+  | "send_rejected"
+  | "send_failed";
+
+export type BroadcastResponse = {
+  ok: boolean;
+  results: BroadcastResult[];
+};
+
+/**
+ * Run `task` over `items` with at most `limit` in flight, preserving input
+ * order in the returned array.
+ *
+ * A rejected task is a bug in the caller, not a target failure — every caller
+ * here resolves its own errors into a result object — so a throw propagates
+ * rather than being silently mapped to a failed target.
+ */
+export async function runBounded<T, R>(
+  items: readonly T[],
+  limit: number,
+  task: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (limit < 1) throw new RangeError("limit must be at least 1");
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await task(items[index], index);
+    }
+  };
+  // Never start more workers than there is work — `limit` workers over 2 items
+  // would leave idle promises resolving immediately, which is harmless but
+  // makes the concurrency assertions in the tests read as passing for the
+  // wrong reason.
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  );
+  return results;
+}
+
+/**
+ * Normalize a request body into an explicit, de-duplicated target list.
+ *
+ * There is no `all: true` affordance and there never should be: a broadcast
+ * cannot be unsent, so the caller names every recipient. This mirrors the rule
+ * `/api/inbox/bulk` applies to its destructive actions.
+ *
+ * De-duplication is not tidiness. Sending twice into one session concurrently
+ * is unsafe — the stop registry keys one entry per conversation and the second
+ * run overwrites the first, so a later session-keyed Stop would reach only the
+ * newer of the two (`src/lib/server/chat-stop-registry.ts`).
+ */
+export function normalizeBroadcastTargets(raw: unknown): BroadcastTarget[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const targets: BroadcastTarget[] = [];
+  for (const entry of raw) {
+    const sessionId =
+      typeof entry === "string"
+        ? entry
+        : entry && typeof entry === "object" && typeof (entry as { sessionId?: unknown }).sessionId === "string"
+          ? (entry as { sessionId: string }).sessionId
+          : "";
+    const trimmed = sessionId.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    targets.push({ sessionId: trimmed });
+  }
+  return targets;
+}
+
+/** The ids a retry should re-send to: the failures, and only those.
+ *
+ *  Nothing about a send is idempotent — `runId` is a Stop token, not a dedupe
+ *  key, so re-posting the same body appends another user turn. Retrying the
+ *  whole selection would double-post to every target that already succeeded. */
+export function failedTargets(results: readonly BroadcastResult[]): BroadcastTarget[] {
+  return results.filter((r) => !r.ok).map((r) => ({ sessionId: r.sessionId }));
+}

--- a/src/styles/chat-inner-rail.css
+++ b/src/styles/chat-inner-rail.css
@@ -231,3 +231,162 @@
   flex: 1 1 auto;
   min-height: 0;
 }
+
+/* ── Broadcast select mode (cave-g7yg6) ──────────────────────────────────────
+ *
+ * The rail is 280px wide, so the shared SelectionToolbar — built for the board
+ * and the chat list, where a row is the width of the page — needs its type and
+ * padding brought down rather than being dropped in at full size. */
+.cnav__select-enter {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  align-self: flex-start;
+  margin-inline: var(--space-3);
+  margin-block-start: var(--space-2);
+  padding: 2px var(--space-2);
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  cursor: pointer;
+}
+
+.cnav__select-enter:hover {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.cnav__select-bar {
+  flex: none;
+  padding-inline: var(--space-2);
+  padding-block-start: var(--space-2);
+}
+
+/* The toolbar's own margin assumes a page-width list; inside the rail it would
+   push the first thread out of view. */
+.cnav__select-bar [role="toolbar"] {
+  margin-bottom: var(--space-2);
+  gap: var(--space-1);
+  padding-inline: var(--space-2);
+}
+
+.cnav__broadcast-open {
+  border: 0;
+  border-radius: var(--radius-control);
+  padding: 2px var(--space-2);
+  background: var(--accent-presence);
+  color: var(--accent-presence-foreground);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.cnav__broadcast-open:disabled {
+  background: color-mix(in oklch, var(--text-muted) 22%, transparent);
+  color: var(--text-muted);
+  cursor: default;
+}
+
+/* Checkbox in the row's leading slot — the same box-and-tick the chat list
+   uses, so select mode reads identically on both surfaces. */
+.cnav__select-box {
+  display: grid;
+  place-items: center;
+  width: 14px;
+  height: 14px;
+  flex: none;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm, 4px);
+  color: transparent;
+}
+
+.cnav__select-box.is-on {
+  border-color: var(--accent-presence);
+  background: var(--accent-presence);
+  color: var(--accent-presence-foreground);
+}
+
+/* Per-row broadcast outcome. Sits where the timestamp does, so it reads as
+   "what just happened to this row" rather than as new chrome. Failed carries
+   the danger tone because it is the one that needs acting on. */
+.cnav__broadcast {
+  flex: none;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+}
+
+.cnav__broadcast[data-state="sent"] {
+  color: var(--color-success);
+}
+
+.cnav__broadcast[data-state="failed"] {
+  color: var(--color-danger);
+}
+
+/* The broadcast composer — one textarea and one verb. Deliberately not a chat
+   view: replies land in each target's own thread, never here. */
+.chat-broadcast__title {
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  font-weight: 650;
+}
+
+.chat-broadcast__note {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.chat-broadcast__input {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  padding: var(--space-2) var(--space-3);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.chat-broadcast__error {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--color-danger);
+  font-size: var(--text-xs);
+}
+
+.chat-broadcast__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.chat-broadcast__cancel {
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  padding: var(--space-1) var(--space-3);
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.chat-broadcast__send {
+  border: 0;
+  border-radius: var(--radius-control);
+  background: var(--accent-presence);
+  padding: var(--space-1) var(--space-3);
+  color: var(--accent-presence-foreground);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.chat-broadcast__send:disabled {
+  background: color-mix(in oklch, var(--text-muted) 22%, transparent);
+  color: var(--text-muted);
+  cursor: default;
+}

--- a/src/styles/chat-list.css
+++ b/src/styles/chat-list.css
@@ -377,3 +377,19 @@
     animation: none;
   }
 }
+
+/* Broadcast outcome on a chat-list row (cave-g7yg6). Same two states the rail
+   uses, so the result reads identically wherever the broadcast was started. */
+.chat-list-row-broadcast {
+  flex: none;
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.chat-list-row-broadcast[data-state="sent"] {
+  color: var(--color-success);
+}
+
+.chat-list-row-broadcast[data-state="failed"] {
+  color: var(--color-danger);
+}


### PR DESCRIPTION
Adds broadcast: multi-select chats in the sessions list and send one message
to all of them. Each target keeps its own session and reply — a fan-out, not
a shared room. Concurrency capped at 4, deliver-and-detach (no waiting for
replies), works across the docked rail, full chat list, and mobile sheet.

Verification:
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `src/lib/chat-broadcast.test.ts` — new unit tests for the broadcast core
- `src/app/api/api-contracts.test.ts` — updated for the new route

Bead: cave-g7yg6