### PR TITLE
Bake absolute node path into the beads-jsonl merge driver

### DIFF
--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -88,11 +88,26 @@ git -C "$REPO_ROOT" config merge.beads-jsonl.name \
 # value is per-clone anyway, so baking in this machine's resolution costs
 # nothing and survives whatever PATH invokes git later. Fail loudly now
 # rather than writing a config we already know will fail silently later.
+#
+# `command -v` can report a shell function or alias name instead of a real
+# executable (neither is meaningful once baked into a git config run by a
+# different process), and can report a path that is relative if PATH itself
+# contains a relative entry. Require an executable regular file, and
+# normalize to an absolute path rather than trusting the string as-is.
 node_bin=$(command -v node || true)
-if [ -z "$node_bin" ]; then
-  echo "ERROR: node not found on PATH; cannot install a GUI-safe" >&2
-  echo "  merge.beads-jsonl.driver (cave-f13bp). Install Node, then" >&2
-  echo "  re-run this script." >&2
+if [ -n "$node_bin" ] && [ ! -f "$node_bin" ]; then
+  node_bin=""
+fi
+if [ -n "$node_bin" ]; then
+  case "$node_bin" in
+    /*) : ;;
+    *) node_bin=$(cd "$(dirname "$node_bin")" && pwd)/$(basename "$node_bin") ;;
+  esac
+fi
+if [ -z "$node_bin" ] || [ ! -x "$node_bin" ]; then
+  echo "ERROR: node not found (as an executable file) on PATH; cannot" >&2
+  echo "  install a GUI-safe merge.beads-jsonl.driver (cave-f13bp)." >&2
+  echo "  Install Node, then re-run this script." >&2
   exit 1
 fi
 

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -80,10 +80,27 @@ fi
 # which is the correct direction to fail.
 git -C "$REPO_ROOT" config merge.beads-jsonl.name \
   "union .beads/interactions.jsonl by record id (cave-1poit)"
+# cave-f13bp: a bare "node" resolves fine in an interactive shell but NOT
+# under GitHub Desktop, which invokes git with a minimal PATH that excludes
+# nvm/homebrew/asdf install locations. That left a GUI-driven merge stash
+# conflicted with "node: command not found" instead of running the driver.
+# Resolve node's absolute path once, here, at install time — a git config
+# value is per-clone anyway, so baking in this machine's resolution costs
+# nothing and survives whatever PATH invokes git later. Fail loudly now
+# rather than writing a config we already know will fail silently later.
+node_bin=$(command -v node || true)
+if [ -z "$node_bin" ]; then
+  echo "ERROR: node not found on PATH; cannot install a GUI-safe" >&2
+  echo "  merge.beads-jsonl.driver (cave-f13bp). Install Node, then" >&2
+  echo "  re-run this script." >&2
+  exit 1
+fi
+
 # %O/%A/%B are quoted as defence in depth. Measured behaviour is that git
 # substitutes relative, space-free temp names, so this is not load-bearing —
 # see the note in scripts/beads-jsonl-merge-driver.mjs before "fixing" it.
+# node_bin is quoted for real: an absolute install path CAN contain spaces.
 git -C "$REPO_ROOT" config merge.beads-jsonl.driver \
-  'node scripts/beads-jsonl-merge-driver.mjs "%O" "%A" "%B"'
+  "\"$node_bin\" scripts/beads-jsonl-merge-driver.mjs \"%O\" \"%A\" \"%B\""
 
-echo "OK merge.beads-jsonl -> scripts/beads-jsonl-merge-driver.mjs"
+echo "OK merge.beads-jsonl -> scripts/beads-jsonl-merge-driver.mjs ($node_bin)"

--- a/scripts/install-git-hooks.test.mjs
+++ b/scripts/install-git-hooks.test.mjs
@@ -213,6 +213,43 @@ test("cave-f13bp: the driver resolves to an ABSOLUTE node path, not a bare 'node
   }
 });
 
+test("cave-f13bp: a shell FUNCTION named 'node' does not count as a resolved node — install still fails", () => {
+  // `command -v` can report a shell function or alias instead of a real
+  // executable. Neither means anything once baked into a git config that a
+  // different process (git, from a GUI client) will later run directly — so
+  // the installer must require an executable regular file, not just any
+  // non-empty `command -v` output.
+  const dir = scaffold();
+  try {
+    const wrapper = join(dir, "run-with-fake-node-function.sh");
+    writeFileSync(
+      wrapper,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "node() { echo fake; }",
+        "export -f node",
+        `exec bash "${join(dir, "scripts", "install-git-hooks.sh")}"`,
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    assert.throws(
+      () => execFileSync("bash", [wrapper], { cwd: dir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }),
+      /node/i,
+      "installer must fail when the only 'node' on PATH is a shell function",
+    );
+
+    assert.throws(
+      () => git(dir, "config", "--get", "merge.beads-jsonl.driver"),
+      "no driver config must be written when node resolves to a non-file",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("cave-f13bp: install FAILS LOUDLY when node cannot be resolved, rather than writing a config we already know will break later", () => {
   // A silent fallback to the bare "node" would just relocate the failure to
   // whatever GUI merge eventually runs the driver — exactly the bug being

--- a/scripts/install-git-hooks.test.mjs
+++ b/scripts/install-git-hooks.test.mjs
@@ -160,14 +160,89 @@ test("the merge driver is registered regardless of the hook decision", () => {
         git(dir, "config", "core.hooksPath", ".beads/hooks");
       }
       runInstaller(dir);
-      assert.equal(
+      assert.match(
         git(dir, "config", "--get", "merge.beads-jsonl.driver"),
-        'node scripts/beads-jsonl-merge-driver.mjs "%O" "%A" "%B"',
+        /^"[^"]+node[^"]*" scripts\/beads-jsonl-merge-driver\.mjs "%O" "%A" "%B"$/,
         `driver must be registered when hooksPath is ${preset}`,
       );
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  }
+});
+
+test("cave-f13bp: the driver resolves to an ABSOLUTE node path, not a bare 'node'", () => {
+  // GitHub Desktop invokes git with a PATH that cannot resolve nvm/homebrew/
+  // asdf installs of node, so a bare "node" left a GUI-driven merge
+  // conflicted with "node: command not found". The installer must bake in
+  // this machine's resolved node path instead of trusting the invoker's PATH.
+  const dir = scaffold();
+  try {
+    runInstaller(dir);
+    const driver = git(dir, "config", "--get", "merge.beads-jsonl.driver");
+    const match = /^"([^"]+)" scripts\/beads-jsonl-merge-driver\.mjs "%O" "%A" "%B"$/.exec(driver);
+    assert.ok(match, `driver config must quote an absolute node path, got: ${driver}`);
+    const [, nodePath] = match;
+    assert.notEqual(nodePath, "node", "must not fall back to the bare, PATH-dependent 'node'");
+    assert.ok(
+      nodePath.startsWith("/") || /^[A-Za-z]:[\\/]/.test(nodePath),
+      `resolved node path must be absolute, got: ${nodePath}`,
+    );
+
+    // The config must actually run: invoke it exactly as git would, with an
+    // empty PATH, to prove the fix (a bare "node" fails here with ENOENT).
+    const [nodeBinary, scriptRelPath] = driver
+      .match(/^"([^"]+)" (\S+) "%O" "%A" "%B"$/)
+      ?.slice(1) ?? [];
+    assert.ok(nodeBinary && scriptRelPath, "driver config must be parseable");
+    mkdirSync(join(dir, "scripts"), { recursive: true });
+    cpSync(
+      join(repoRoot, "scripts", "beads-jsonl-merge-driver.mjs"),
+      join(dir, "scripts", "beads-jsonl-merge-driver.mjs"),
+    );
+    writeFileSync(join(dir, "a.jsonl"), "");
+    writeFileSync(join(dir, "b.jsonl"), "");
+    writeFileSync(join(dir, "o.jsonl"), "");
+    execFileSync(nodeBinary, [scriptRelPath, "o.jsonl", "a.jsonl", "b.jsonl"], {
+      cwd: dir,
+      env: { PATH: "" },
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("cave-f13bp: install FAILS LOUDLY when node cannot be resolved, rather than writing a config we already know will break later", () => {
+  // A silent fallback to the bare "node" would just relocate the failure to
+  // whatever GUI merge eventually runs the driver — exactly the bug being
+  // fixed. Restrict the installer's PATH to directories that hold bash/git
+  // but never node (they are unrelated install trees on every platform this
+  // matters on), and require the script to exit non-zero and change nothing.
+  const dir = scaffold();
+  try {
+    const bashDir = dirname(execFileSync("which", ["bash"], { encoding: "utf8" }).trim());
+    const gitDir = dirname(execFileSync("which", ["git"], { encoding: "utf8" }).trim());
+    const restrictedPath = Array.from(new Set([bashDir, gitDir])).join(":");
+
+    assert.throws(
+      () =>
+        execFileSync("bash", [join(dir, "scripts", "install-git-hooks.sh")], {
+          cwd: dir,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+          env: { PATH: restrictedPath },
+        }),
+      /node/i,
+      "installer must fail (and mention node) when node is unresolvable",
+    );
+
+    assert.throws(
+      () => git(dir, "config", "--get", "merge.beads-jsonl.driver"),
+      "no driver config must be written on a failed install",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Problem

GitHub Desktop invokes git with a minimal PATH that excludes nvm/homebrew/
asdf node install locations. The registered `merge.beads-jsonl.driver`
(`node scripts/beads-jsonl-merge-driver.mjs "%O" "%A" "%B"`) relied on
resolving `node` from the invoker's PATH, so a GUI-driven merge failed with
`node: command not found`, leaving the stash conflicted instead of cleanly
resolved.

## Fix

`scripts/install-git-hooks.sh` now resolves `node`'s absolute path once, at
install time (git config is per-clone anyway), and writes that quoted
absolute path into the driver config instead of a bare, PATH-dependent
`node`. If node cannot be resolved on PATH during install, the script now
fails loudly and writes no driver config — rather than silently falling back
to the exact command that caused this bug.

## Verification

- `scripts/install-git-hooks.test.mjs`: 9/9 (new coverage proves the
  resolved path is absolute, actually runs a real merge with an empty
  `PATH`, and that install fails hard when node is unresolvable)
- `scripts/beads-jsonl-merge-driver.test.mjs`: 9/9 (unchanged behavior)
- `pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired`: all pass

Closes cave-f13bp.