### PR TITLE
Polish chat response actions

### DIFF
--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -418,6 +418,11 @@ assert.match(
   "Compact response menu rows restore full touch targets on coarse pointers",
 );
 assert.match(
+  css,
+  /\.cave-response-menu \.ui-popover-item > svg:first-child \{[\s\S]*color: var\(--text-muted\);/,
+  "Only the leading row icon is muted — a trailing checked-item checkmark is also a direct <svg> child and must not be dimmed",
+);
+assert.match(
   overflowMenu,
   /popoverClassName\?: string;[\s\S]*className=\{popoverClassName\}/,
   "OverflowMenu exposes a scoped class for the portaled menu surface",

--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -9,6 +9,7 @@ const markdownStream = readFileSync(new URL("../lib/message-markdown-stream.ts",
 const markdownPreview = readFileSync(new URL("../lib/markdown-preview.ts", import.meta.url), "utf8");
 const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 const domWiring = readFileSync(new URL("./message-dom-wiring.ts", import.meta.url), "utf8");
+const overflowMenu = readFileSync(new URL("./ui/overflow-menu.tsx", import.meta.url), "utf8");
 
 // StrictMode regression guard: a ref-based "same text" check poisons itself
 // when the first (dev double-invoke) effect run is cancelled — run 2 then
@@ -156,7 +157,7 @@ assert.match(
 );
 assert.match(
   source,
-  /<CopyBubble text=\{content\} response \/>[\s\S]*?aria-label="Retry response"[\s\S]*?aria-expanded=\{!collapsed\}[\s\S]*?<OverflowMenu ariaLabel="More response actions"/,
+  /<CopyBubble text=\{content\} response \/>[\s\S]*?aria-label="Retry response"[\s\S]*?aria-expanded=\{!collapsed\}[\s\S]*?<OverflowMenu[\s\S]*?ariaLabel="More response actions"[\s\S]*?minWidth=\{156\}[\s\S]*?popoverClassName="cave-response-menu"/,
   "assistant response controls prioritize Copy, Retry, Collapse, and More",
 );
 assert.match(
@@ -388,8 +389,38 @@ assert.match(
 );
 assert.match(
   css,
+  /@media \(pointer: coarse\) \{[\s\S]*\.cave-bubble-actions \.cave-copy-btn-bubble \{[\s\S]*min-width: var\(--touch-target\);[\s\S]*min-height: var\(--touch-target\);[\s\S]*\.cave-response-more \{[\s\S]*min-width: var\(--touch-target\);[\s\S]*min-height: var\(--touch-target\);/,
+  "Every coarse-pointer viewport keeps full touch targets in the response toolbar",
+);
+assert.match(
+  css,
   /@media \(max-width: 767px\) and \(pointer: coarse\) \{[\s\S]*\.cave-bubble-actions\s*\{[\s\S]*position: static;[\s\S]*justify-content: flex-end;/,
   "Phone bubble actions should move into normal flow instead of overlaying message text",
+);
+assert.match(
+  css,
+  /\.cave-bubble-actions \.cave-response-action \{[\s\S]*min-height: 24px;[\s\S]*padding-inline: 6px;[\s\S]*border-radius: var\(--radius-sm\);[\s\S]*font-family: inherit;/,
+  "Desktop response actions use a compact, app-native control treatment",
+);
+assert.match(
+  css,
+  /\.ui-popover\.cave-response-menu \{[\s\S]*border-radius: var\(--radius-control\);[\s\S]*box-shadow:/,
+  "The response overflow uses a scoped, refined popover shell",
+);
+assert.match(
+  css,
+  /\.cave-response-menu \.ui-popover-item \{[\s\S]*min-height: 28px;[\s\S]*padding: var\(--space-1\) 7px;[\s\S]*font-size: var\(--text-xs\);/,
+  "The response overflow menu keeps desktop rows dense and readable",
+);
+assert.match(
+  css,
+  /@media \(pointer: coarse\) \{[\s\S]*\.cave-response-menu \.ui-popover-item \{[\s\S]*min-height: var\(--touch-target\);/,
+  "Compact response menu rows restore full touch targets on coarse pointers",
+);
+assert.match(
+  overflowMenu,
+  /popoverClassName\?: string;[\s\S]*className=\{popoverClassName\}/,
+  "OverflowMenu exposes a scoped class for the portaled menu surface",
 );
 
 // CHAT-D7-08 CSS half: the wrapper owns horizontal overflow; cells restore

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -1372,7 +1372,13 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
             </span>
           ) : null}
           {hasMoreActions ? (
-            <OverflowMenu ariaLabel="More response actions" size="xs" className="cave-response-more">
+            <OverflowMenu
+              ariaLabel="More response actions"
+              size="xs"
+              minWidth={156}
+              className="cave-response-more"
+              popoverClassName="cave-response-menu"
+            >
               {onReply ? (
                 <PopoverItem icon="ph:arrow-bend-up-left" onSelect={onReply}>
                   Reply

--- a/src/components/ui/overflow-menu.tsx
+++ b/src/components/ui/overflow-menu.tsx
@@ -18,6 +18,8 @@ export type OverflowMenuProps = {
   minWidth?: number;
   /** Extra class on the trigger button (e.g. "reveal-on-hover"). */
   className?: string;
+  /** Extra class on the portaled popover panel for consumer-scoped styling. */
+  popoverClassName?: string;
   disabled?: boolean;
   /** PopoverItem / PopoverSeparator / PopoverLabel children. */
   children: ReactNode;
@@ -38,6 +40,7 @@ export function OverflowMenu({
   placement = "bottom-end",
   minWidth = 180,
   className,
+  popoverClassName,
   disabled,
   children,
 }: OverflowMenuProps) {
@@ -151,6 +154,7 @@ export function OverflowMenu({
         anchorRef={triggerRef}
         placement={placement}
         minWidth={minWidth}
+        className={popoverClassName}
         ariaLabel={ariaLabel}
       >
         <div ref={menuRef} onClick={onBodyClick} onKeyDown={onBodyKeyDown}>

--- a/src/styles/cave-chat/bubbles.css
+++ b/src/styles/cave-chat/bubbles.css
@@ -24,8 +24,8 @@
 .cave-bubble-actions {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-1);
-  margin-top: var(--space-2);
+  gap: 3px;
+  margin-top: 6px;
   opacity: 0;
   transition: opacity var(--duration-fast, 120ms) var(--ease-standard, ease);
 }
@@ -43,21 +43,81 @@
   right: auto;
   opacity: 1;
 }
-.cave-response-action {
+.cave-bubble-actions .cave-response-action {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-1);
-  min-height: var(--space-8);
-  padding-inline: var(--space-2);
-  border-radius: var(--radius-control);
+  min-height: 24px;
+  padding-inline: 6px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
   color: var(--text-secondary);
+  font-family: inherit;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0;
+  backdrop-filter: none;
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
 }
-.cave-response-action:hover,
-.cave-response-action:focus-visible {
+.cave-bubble-actions .cave-response-action:hover,
+.cave-bubble-actions .cave-response-action:focus-visible {
+  border-color: var(--border-hairline);
+  background: var(--bg-hover);
   color: var(--text-primary);
 }
 .cave-response-more {
+  width: 24px;
+  height: 24px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
   color: var(--text-secondary);
+}
+.cave-response-more:hover,
+.cave-response-more:focus-visible {
+  border-color: var(--border-hairline);
+}
+.cave-response-more.ui-icon-btn--active {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.ui-popover.cave-response-menu {
+  border-color: color-mix(in oklch, var(--border-strong) 82%, transparent);
+  border-radius: var(--radius-control);
+  box-shadow:
+    0 10px 28px oklch(0 0 0 / 32%),
+    0 2px 7px oklch(0 0 0 / 16%);
+}
+.cave-response-menu .ui-popover-body {
+  padding: var(--space-1);
+}
+.cave-response-menu .ui-popover-item {
+  min-height: 28px;
+  gap: 7px;
+  padding: var(--space-1) 7px;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  line-height: 1.25;
+}
+.cave-response-menu .ui-popover-item:hover,
+.cave-response-menu .ui-popover-item:focus-visible,
+.cave-response-menu .ui-popover-item[data-active="true"] {
+  color: var(--text-primary);
+}
+.cave-response-menu .ui-popover-item > svg {
+  flex: none;
+  color: var(--text-muted);
+}
+.cave-response-menu .ui-popover-separator {
+  margin: 3px var(--space-1);
 }
 
 /* Touch devices have no hover (CHAT-D6-04) — keep per-message actions
@@ -66,6 +126,21 @@
   .cave-bubble-actions,
   .cave-copy-btn-bubble {
     opacity: 1;
+  }
+
+  .cave-response-menu .ui-popover-item {
+    min-height: var(--touch-target);
+  }
+
+  .cave-bubble-actions .cave-copy-btn-bubble {
+    min-width: var(--touch-target);
+    min-height: var(--touch-target);
+    border-radius: var(--radius-control);
+  }
+
+  .cave-response-more {
+    min-width: var(--touch-target);
+    min-height: var(--touch-target);
   }
 }
 
@@ -77,17 +152,6 @@
     flex-wrap: wrap;
     gap: var(--space-2);
     margin-top: var(--space-2);
-  }
-
-  .cave-bubble-actions .cave-copy-btn-bubble {
-    min-width: 44px;
-    min-height: 44px;
-    border-radius: var(--radius-control);
-  }
-
-  .cave-response-more {
-    min-width: 44px;
-    min-height: 44px;
   }
 
   .cave-bubble-assistant .cave-bubble-actions {

--- a/src/styles/cave-chat/bubbles.css
+++ b/src/styles/cave-chat/bubbles.css
@@ -112,7 +112,7 @@
 .cave-response-menu .ui-popover-item[data-active="true"] {
   color: var(--text-primary);
 }
-.cave-response-menu .ui-popover-item > svg {
+.cave-response-menu .ui-popover-item > svg:first-child {
   flex: none;
   color: var(--text-muted);
 }


### PR DESCRIPTION
## Summary
- replace the outlined response-action pills with a compact, borderless toolbar treatment
- tighten the response overflow menu width, row density, spacing, radius, and visual hierarchy
- keep 44px controls and menu rows on every coarse-pointer viewport
- add a scoped popover class hook so the response menu does not alter shared menus

## Validation
- full app suite: 1,403 test files passed
- focused response-action and streaming tests passed
- lint, typecheck, UI consistency, token drift, and diff checks passed
- desktop and touch layouts visually verified in Chromium