### PR TITLE
test(release): pin checksums build dependency edge

### DIFF
--- a/scripts/release-promotion-workflow.test.mjs
+++ b/scripts/release-promotion-workflow.test.mjs
@@ -828,6 +828,11 @@ test("the release-notes guard disclosure is on exactly when its own hatch was pu
 
 test("checksums publishes SHA256SUMS only for a wholly successful build", async () => {
   const release = await workflow("release.yml");
+  assert.deepEqual(
+    [...needs(release.jobs.checksums)].sort(),
+    ["build", "source-version"],
+    "checksums must wait for the complete build matrix and stamped source",
+  );
   const condition = release.jobs.checksums.if;
 
   assert.equal(


### PR DESCRIPTION
## Summary
- Pin the release workflow regression test to require checksums to wait on both the build matrix and stamped source-version.
- Protect the existing release artifact publication edge against future dependency removal.

## Verification
- `node --test scripts/release-promotion-workflow.test.mjs` (11/11)
- `pnpm check:tests-wired` (1,977 files)
- targeted ESLint
- YAML edge parse
- `git diff --check`

Bead: cave-meuwb