### PR TITLE
fix(dev-app): diagnose owned server OOM exits

### DIFF
--- a/scripts/dev-app-teardown.test.mjs
+++ b/scripts/dev-app-teardown.test.mjs
@@ -138,6 +138,13 @@ echo "server_command $$" >>"${pidFile}"
 exit 0
 `;
 
+const fakeOomPnpm = (pidFile) => `#!/usr/bin/env bash
+echo "server_command $$" >>"${pidFile}"
+sleep 0.2
+echo "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory" >&2
+exit 134
+`;
+
 const readPids = (pidFile) =>
   Object.fromEntries(
     readFileSync(pidFile, "utf8")
@@ -310,7 +317,67 @@ async function assertUnavailableOriginNeverOpensTauri() {
   }
 }
 
+async function assertOomExitIsPromptAndDistinct() {
+  const port = await freePort();
+  const pidFile = path.join(root, "pids-oom.txt");
+  writeFileSync(path.join(fakeBin, "pnpm"), fakeOomPnpm(pidFile));
+  chmodSync(path.join(fakeBin, "pnpm"), 0o755);
+
+  const wrapper = spawn("bash", [path.join(fakeScripts, "dev-app.sh")], {
+    cwd: root,
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      PORT: String(port),
+      COVEN_CAVE_AUTH_TOKEN: "",
+      // A regression that falls back to the origin probe's full grace period
+      // must not make this test wait three minutes to learn about the OOM.
+      COVEN_CAVE_DEV_SERVER_GRACE_SECONDS: "30",
+    },
+  });
+  wrapper.unref();
+
+  const output = [];
+  wrapper.stdout.on("data", (chunk) => output.push(chunk.toString()));
+  wrapper.stderr.on("data", (chunk) => output.push(chunk.toString()));
+  const closed = new Promise((resolve) => wrapper.once("close", resolve));
+  const startedAt = Date.now();
+  try {
+    await waitFor(() => wrapper.exitCode !== null, {
+      timeoutMs: 5_000,
+      label: "the launcher to report the owned dev-server OOM promptly",
+    });
+    await closed;
+
+    const elapsedMs = Date.now() - startedAt;
+    const logs = output.join("");
+    assert.ok(elapsedMs < 5_000, `the OOM diagnosis took ${elapsedMs}ms`);
+    assert.match(
+      logs,
+      /owned dev server exited with status 134 after running out of memory/,
+      "an owned dev-server OOM must report the child status and cause",
+    );
+    assert.match(
+      logs,
+      /Ineffective mark-compacts near heap limit/,
+      "the OOM signature must remain visible in the launcher diagnosis",
+    );
+    assert.doesNotMatch(
+      logs,
+      /did not return the root document within 30s/,
+      "an OOM must not be disguised as the full generic origin timeout",
+    );
+  } finally {
+    try {
+      process.kill(wrapper.pid, "SIGKILL");
+    } catch {}
+  }
+}
+
 try {
+  await assertOomExitIsPromptAndDistinct();
   await assertTeardown("SIGTERM");
   await assertTeardown("SIGINT");
   await assertHungOriginStopsOwnedTree();

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -90,9 +90,12 @@ esac
 TAURI_OVERRIDE_CONFIG="$(mktemp)"
 WATCHDOG_VERDICT="$(mktemp)"
 DEV_STARTUP_MARKER="$(mktemp)"
+DEV_SERVER_LOG="$(mktemp)"
+DEV_SERVER_EXIT_STATUS="$(mktemp)"
 tauri_pid=""
 server_pid=""
 watchdog_pid=""
+readiness_pid=""
 
 # Every descendant of a pid, children before parents. The launcher only ever
 # walks PIDs it started, never a process guessed from a loopback port.
@@ -137,19 +140,63 @@ terminate_process_tree() {
 cleanup() {
   trap - EXIT INT TERM HUP
   if [ -n "$watchdog_pid" ]; then
-    kill "$watchdog_pid" 2>/dev/null || true
+    terminate_process_tree "$watchdog_pid"
+    wait "$watchdog_pid" 2>/dev/null || true
     watchdog_pid=""
   fi
+  terminate_process_tree "$readiness_pid"
+  if [ -n "$readiness_pid" ]; then
+    wait "$readiness_pid" 2>/dev/null || true
+    readiness_pid=""
+  fi
   terminate_process_tree "$tauri_pid"
-  terminate_process_tree "$server_pid"
+  if [ -n "$tauri_pid" ]; then
+    wait "$tauri_pid" 2>/dev/null || true
+    tauri_pid=""
+  fi
+  if [ -n "$server_pid" ]; then
+    if [ -s "$DEV_SERVER_EXIT_STATUS" ]; then
+      # The wrapper records the status immediately after the pipeline drains;
+      # reap that naturally completed job instead of treating a brief zombie
+      # state as a live process tree and waiting through the TERM/KILL grace.
+      wait "$server_pid" 2>/dev/null || true
+    else
+      terminate_process_tree "$server_pid"
+      wait "$server_pid" 2>/dev/null || true
+    fi
+    server_pid=""
+  fi
   if [ "${should_start_server:-false}" = true ] && port_is_listening "$dev_port" >/dev/null 2>&1; then
     echo "[dev:app] warning: 127.0.0.1:${dev_port} is still listening after teardown" >&2
   fi
-  rm -f "$TAURI_OVERRIDE_CONFIG" "$WATCHDOG_VERDICT" "$DEV_STARTUP_MARKER"
+  rm -f "$TAURI_OVERRIDE_CONFIG" "$WATCHDOG_VERDICT" "$DEV_STARTUP_MARKER" "$DEV_SERVER_LOG" "$DEV_SERVER_EXIT_STATUS"
 }
 trap cleanup EXIT
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM HUP
+
+server_exit_status() {
+  if [ -s "$DEV_SERVER_EXIT_STATUS" ]; then
+    tr -d '\r\n' <"$DEV_SERVER_EXIT_STATUS"
+  else
+    printf '%s\n' "unknown"
+  fi
+}
+
+report_owned_server_exit() {
+  local status
+  status="$(server_exit_status)"
+  if grep -Fq "Ineffective mark-compacts near heap limit" "$DEV_SERVER_LOG"; then
+    echo "[dev:app] ERROR: the owned dev server exited with status ${status} after running out of memory." >&2
+    echo "[dev:app]        V8 reported 'Ineffective mark-compacts near heap limit'; restart the dev server." >&2
+    echo "[dev:app]        Raising COVEN_CAVE_HEAP_LIMIT_MB only defers the upstream dev-toolchain retention." >&2
+    printf 'dev-server-oom\n' >"$WATCHDOG_VERDICT"
+  else
+    echo "[dev:app] ERROR: the owned dev server exited with status ${status} before the loopback origin was ready." >&2
+    echo "[dev:app]        Scroll up for the dev-server output and restart it." >&2
+    printf 'dev-server-exited\n' >"$WATCHDOG_VERDICT"
+  fi
+}
 
 # This credential is accepted only by the root-document readiness probe. Unlike
 # the mobile access secret, disclosing it to a process that later reclaims the
@@ -239,7 +286,19 @@ if [ "$should_start_server" = true ]; then
   echo "[dev:app] dev server heap ceiling: ${dev_node_options}"
   # Bind explicitly to loopback. Git Bash exports HOSTNAME from the host (often
   # a non-loopback machine name), so relying on server.ts's default is unsafe.
-  HOSTNAME=127.0.0.1 PORT="$dev_port" NODE_OPTIONS="$dev_node_options" pnpm dev &
+  # Keep the child's status and output under this wrapper's control. The status
+  # file lets readiness and the long-lived watchdog interrupt their own bounded
+  # probes as soon as the server dies, while the log lets us distinguish V8's
+  # OOM signature from an ordinary failed start without hiding the server output
+  # from the operator.
+  run_owned_dev_server() {
+    set +e
+    HOSTNAME=127.0.0.1 PORT="$dev_port" NODE_OPTIONS="$dev_node_options" pnpm dev 2>&1 | tee "$DEV_SERVER_LOG"
+    local status="${PIPESTATUS[0]}"
+    printf '%s\n' "$status" >"$DEV_SERVER_EXIT_STATUS"
+    return "$status"
+  }
+  run_owned_dev_server &
   server_pid=$!
 fi
 
@@ -247,7 +306,34 @@ initial_timeout_ms=$((DEV_SERVER_GRACE_SECONDS * 1000))
 if [ "$initial_timeout_ms" -lt 100 ]; then
   initial_timeout_ms=100
 fi
-if ! origin_is_ready "$dev_port" "$initial_timeout_ms"; then
+if [ "$should_start_server" = true ]; then
+  # Run the long startup probe beside the launcher so a dead owned server can
+  # interrupt it. Calling origin_is_ready synchronously here used to hide an
+  # OOM behind the full 180-second origin timeout.
+  origin_is_ready "$dev_port" "$initial_timeout_ms" &
+  readiness_pid=$!
+  readiness_status=0
+  while kill -0 "$readiness_pid" 2>/dev/null; do
+    if [ -s "$DEV_SERVER_EXIT_STATUS" ]; then
+      report_owned_server_exit
+      terminate_process_tree "$readiness_pid"
+      wait "$readiness_pid" 2>/dev/null || true
+      readiness_pid=""
+      exit 1
+    fi
+    sleep 0.1
+  done
+  wait "$readiness_pid" || readiness_status=$?
+  readiness_pid=""
+  if [ -s "$DEV_SERVER_EXIT_STATUS" ]; then
+    report_owned_server_exit
+    exit 1
+  fi
+  if [ "$readiness_status" -ne 0 ]; then
+    echo "[dev:app] loopback origin on 127.0.0.1:${dev_port} did not return the root document within ${DEV_SERVER_GRACE_SECONDS}s; desktop shell was not opened" >&2
+    exit 1
+  fi
+elif ! origin_is_ready "$dev_port" "$initial_timeout_ms"; then
   echo "[dev:app] loopback origin on 127.0.0.1:${dev_port} did not return the root document within ${DEV_SERVER_GRACE_SECONDS}s; desktop shell was not opened" >&2
   exit 1
 fi
@@ -262,6 +348,11 @@ CONF
 watch_dev_server() {
   local down_for=0
   while kill -0 "$tauri_pid" 2>/dev/null; do
+    if [ -n "$server_pid" ] && [ -s "$DEV_SERVER_EXIT_STATUS" ]; then
+      report_owned_server_exit
+      terminate_process_tree "$tauri_pid"
+      return 0
+    fi
     if origin_is_ready "$dev_port"; then
       down_for=0
     else
@@ -307,6 +398,12 @@ fi
 tauri_status=0
 wait "$tauri_pid" || tauri_status=$?
 tauri_pid=""
+
+# The watchdog can race a very short Tauri exit. Preserve the owned server's
+# specific diagnosis even if its background loop did not get a scheduling turn.
+if [ -n "$server_pid" ] && [ -s "$DEV_SERVER_EXIT_STATUS" ] && [ ! -s "$WATCHDOG_VERDICT" ]; then
+  report_owned_server_exit
+fi
 
 if [ -s "$WATCHDOG_VERDICT" ]; then
   exit 1

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -75,7 +75,7 @@ assert.match(
 
 assert.match(
   source,
-  /HOSTNAME=127\.0\.0\.1 PORT="\$dev_port" NODE_OPTIONS="\$dev_node_options" pnpm dev &/,
+  /run_owned_dev_server\(\) \{[\s\S]*?HOSTNAME=127\.0\.0\.1 PORT="\$dev_port" NODE_OPTIONS="\$dev_node_options" pnpm dev 2>&1 \| tee "\$DEV_SERVER_LOG"/,
   "the launcher must bind its owned dev server to the Tauri loopback devUrl on Windows and POSIX",
 );
 assert.match(
@@ -91,7 +91,7 @@ assert.match(
 // unbounded one — the same shape as the port capture above.
 assert.ok(
   source.indexOf("dev_node_options=") <
-    source.indexOf('HOSTNAME=127.0.0.1 PORT="$dev_port" NODE_OPTIONS="$dev_node_options" pnpm dev &'),
+    source.indexOf('HOSTNAME=127.0.0.1 PORT="$dev_port" NODE_OPTIONS="$dev_node_options" pnpm dev 2>&1 | tee "$DEV_SERVER_LOG"'),
   "the heap ceiling must be resolved before the owned dev server starts",
 );
 assert.match(
@@ -110,6 +110,32 @@ assert.match(
 
 assert.match(
   source,
+  /DEV_SERVER_LOG="\$\(mktemp\)"[\s\S]*?DEV_SERVER_EXIT_STATUS="\$\(mktemp\)"/,
+  "the launcher must retain owned server output and its exit status for diagnosis",
+);
+assert.match(
+  source,
+  /run_owned_dev_server\(\) \{[\s\S]*?pnpm dev 2>&1 \| tee "\$DEV_SERVER_LOG"[\s\S]*?PIPESTATUS\[0\][\s\S]*?DEV_SERVER_EXIT_STATUS/,
+  "the owned server wrapper must preserve the child status while still streaming output",
+);
+assert.match(
+  source,
+  /report_owned_server_exit\(\) \{[\s\S]*?Ineffective mark-compacts near heap limit[\s\S]*?after running out of memory[\s\S]*?dev-server-oom/,
+  "the launcher must identify the V8 OOM signature with a distinct diagnosis",
+);
+assert.match(
+  source,
+  /origin_is_ready "\$dev_port" "\$initial_timeout_ms" &[\s\S]*?DEV_SERVER_EXIT_STATUS[\s\S]*?report_owned_server_exit/,
+  "initial readiness must be interruptible when the owned server exits",
+);
+assert.match(
+  source,
+  /watch_dev_server\(\) \{[\s\S]*?DEV_SERVER_EXIT_STATUS[\s\S]*?report_owned_server_exit[\s\S]*?terminate_process_tree "\$tauri_pid"/,
+  "the running watchdog must report an owned server exit before generic origin grace expires",
+);
+
+assert.match(
+  source,
   /if \[ -z "\$\{COVEN_CAVE_AUTH_TOKEN:-\}" \]; then[\s\S]*?randomBytes\(32\)\.toString\("hex"\)[\s\S]*?export COVEN_CAVE_AUTH_TOKEN[\s\S]*?if \[ -n "\$\{COVEN_CAVE_AUTH_TOKEN:-\}" \]; then[\s\S]*?encodeURIComponent\(process\.env\.COVEN_CAVE_AUTH_TOKEN\)[\s\S]*?dev_url\+="#covenCaveToken=\$\{sidecar_token_fragment\}"/,
   "the launcher must mint a missing sidecar token and carry it into the desktop webview",
 );
@@ -120,7 +146,7 @@ assert.match(
 );
 assert.ok(
   source.indexOf("export COVEN_CAVE_DEV_PROBE_TOKEN") <
-    source.indexOf('HOSTNAME=127.0.0.1 PORT="$dev_port" NODE_OPTIONS="$dev_node_options" pnpm dev &'),
+    source.indexOf('HOSTNAME=127.0.0.1 PORT="$dev_port" NODE_OPTIONS="$dev_node_options" pnpm dev 2>&1 | tee "$DEV_SERVER_LOG"'),
   "the readiness-only token must be exported before the owned dev server starts",
 );
 
@@ -131,12 +157,12 @@ assert.match(
 );
 assert.ok(
   source.indexOf("export COVEN_CAVE_AUTH_TOKEN") <
-    source.indexOf('HOSTNAME=127.0.0.1 PORT="$dev_port" NODE_OPTIONS="$dev_node_options" pnpm dev &'),
+    source.indexOf('HOSTNAME=127.0.0.1 PORT="$dev_port" NODE_OPTIONS="$dev_node_options" pnpm dev 2>&1 | tee "$DEV_SERVER_LOG"'),
   "the sidecar token must be exported before the owned dev server starts",
 );
 assert.ok(
   source.indexOf("export COVEN_CAVE_AUTH_TOKEN") <
-    source.indexOf('HOSTNAME=127.0.0.1 PORT="$dev_port" NODE_OPTIONS="$dev_node_options" pnpm dev &'),
+    source.indexOf('HOSTNAME=127.0.0.1 PORT="$dev_port" NODE_OPTIONS="$dev_node_options" pnpm dev 2>&1 | tee "$DEV_SERVER_LOG"'),
   "the minted token must be exported before the owned dev server starts",
 );
 assert.match(


### PR DESCRIPTION
## Summary
- Capture the owned dev-server output and exit status.
- Interrupt startup/watchdog readiness waits when the owned server dies.
- Report V8 out-of-memory exits distinctly instead of hiding them behind the generic origin timeout.
- Preserve teardown coverage for the owned process tree.

## Verification
- `node --test scripts/dev-app.test.mjs scripts/dev-app-teardown.test.mjs` (2/2)
- `pnpm check:tests-wired` (1,977 files)
- `bash -n scripts/dev-app.sh`
- `git diff --check`

Bead: cave-3tra6