### PR TITLE
fix(paths): reject remote Windows Coven homes

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1471,6 +1471,7 @@ export const SUITES = {
     "scripts/main-health-workflow.test.mjs",
     "scripts/worktree-lifecycle-create.test.mjs",
     "src/lib/coven-paths.test.ts",
+    "src/lib/coven-home.test.ts",
     "src/lib/server/cave-home-migration-backup-recovery.test.ts",
     "src/lib/server/cave-home-migration-json-merge.test.ts",
     "src/lib/server/cave-home-migration-status-recovery.test.ts",

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -31,6 +31,7 @@ import {
   scrubSidecarInternalEnv,
   vaultFreeDiscoveryEnv,
 } from "./child-spawn-env.ts";
+import { covenHomePath } from "./coven-home.ts";
 import { managedNodePaths, managedNodeSpawnEnv } from "./server/managed-node-toolchain.ts";
 import { loadVaultMap } from "./vault.ts";
 import { isWindowsRemoteExecutablePath } from "./windows-local-path.ts";
@@ -739,7 +740,7 @@ function spawnEnv(
   }
   env.COVEN_HARNESS_ADAPTER_DIRS = covenAdapterDirsEnvValue(
     process.env.COVEN_HARNESS_ADAPTER_DIRS,
-    process.env.COVEN_HOME,
+    covenHomePath(process.env, HOME, process.platform),
   );
   // npm emits `npm warn Unknown env config <key>` to stderr for any config
   // key it no longer recognizes (e.g. a stale `_jsr-registry`,

--- a/src/lib/coven-daemon.ts
+++ b/src/lib/coven-daemon.ts
@@ -21,11 +21,13 @@ import {
   recordDaemonDiagnosticEvent,
   type DaemonDiagnosticContext,
 } from "./server/daemon-diagnostics.ts";
+import { covenHomePath } from "./coven-home.ts";
 import { isRemoteWindowsPath } from "./windows-local-path.ts";
 
 // Re-exported so the socket resolver's own callers and tests keep importing the
 // boundary from the module that applies it.
 export { isRemoteWindowsPath } from "./windows-local-path.ts";
+export { covenHomePath } from "./coven-home.ts";
 
 type SocketPathResolverOptions = {
   platform?: NodeJS.Platform;
@@ -253,19 +255,6 @@ function recordRefusedRemoteTarget(source: RefusedSocketSource): void {
  * So this is a deliberate stopping point, not an oversight. Read the paragraph
  * above before "fixing" it.
  */
-function covenHomePath(
-  env: Record<string, string | undefined>,
-  homeDir: string,
-  platform: NodeJS.Platform,
-): string {
-  const configured = env.COVEN_HOME;
-  if (configured) {
-    if (!(platform === "win32" && isRemoteWindowsPath(configured))) return configured;
-    reportRefusedRemoteTarget("coven-home-env", configured);
-  }
-  return path.join(homeDir, ".coven");
-}
-
 function daemonStatusSocket(
   covenHome: string,
   readFile: ReadTextFile,
@@ -344,7 +333,12 @@ export function resolveDaemonSocketPath(options: SocketPathResolverOptions = {})
       }
     });
 
-  const covenHome = covenHomePath(env, homeDir, platform);
+  const covenHome = covenHomePath(
+    env,
+    homeDir,
+    platform,
+    (configured) => reportRefusedRemoteTarget("coven-home-env", configured),
+  );
 
   if (env.COVEN_SOCKET) {
     if (platform !== "win32") return env.COVEN_SOCKET;

--- a/src/lib/coven-home.test.ts
+++ b/src/lib/coven-home.test.ts
@@ -1,0 +1,70 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { covenHomePath } from "./coven-home.ts";
+
+const localHome = "C:/Users/Sonic";
+const remoteHome = String.raw`\\evil-host\share\.coven`;
+
+assert.equal(
+  covenHomePath({ COVEN_HOME: remoteHome }, localHome, "win32"),
+  path.join(localHome, ".coven"),
+  "a remote COVEN_HOME must fall back to the local home",
+);
+assert.equal(
+  covenHomePath({ COVEN_HOME: "D:/coven-home" }, localHome, "win32"),
+  "D:/coven-home",
+  "a local Windows COVEN_HOME remains honored",
+);
+assert.equal(
+  covenHomePath({ COVEN_HOME: "/opt/coven-home" }, "/home/cave", "linux"),
+  "/opt/coven-home",
+  "a Unix COVEN_HOME remains honored",
+);
+
+let refused: string | undefined;
+assert.equal(
+  covenHomePath(
+    { COVEN_HOME: remoteHome },
+    localHome,
+    "win32",
+    (configured) => { refused = configured; },
+  ),
+  path.join(localHome, ".coven"),
+);
+assert.equal(refused, remoteHome, "the daemon can retain refusal diagnostics");
+
+assert.equal(
+  covenHomePath(
+    { COVEN_HOME: remoteHome },
+    localHome,
+    "win32",
+    () => { throw new Error("diagnostics unavailable"); },
+  ),
+  path.join(localHome, ".coven"),
+  "diagnostic failure must not weaken the local fallback",
+);
+
+const consumers = [
+  "src/lib/coven-paths.ts",
+  "src/lib/coven-bin.ts",
+  "src/lib/server/adapter-conflict-heal.ts",
+  "src/lib/server/craft-drafts.ts",
+  "src/lib/openclaw-compatibility.ts",
+  "src/lib/opencode-compatibility.ts",
+  "src/lib/grok-compatibility.ts",
+];
+
+for (const consumer of consumers) {
+  const source = await readFile(consumer, "utf8");
+  assert.match(source, /coven-home\.ts/, `${consumer} must import the shared resolver`);
+  assert.match(source, /\bcovenHomePath\(/, `${consumer} must call the shared resolver`);
+  assert.doesNotMatch(
+    source,
+    /process\.env\.COVEN_HOME\s*\|\|/,
+    `${consumer} must not restore an unchecked COVEN_HOME fallback`,
+  );
+}
+
+console.log("coven-home.test.ts: ok");

--- a/src/lib/coven-home.ts
+++ b/src/lib/coven-home.ts
@@ -1,0 +1,34 @@
+import { homedir } from "node:os";
+import path from "node:path";
+import { isRemoteWindowsPath } from "./windows-local-path.ts";
+
+export type CovenHomeEnvironment = Record<string, string | undefined>;
+export type CovenHomeRemoteRefusal = (configuredHome: string) => void;
+
+/**
+ * Resolve the user's Coven home, refusing an explicit Windows path that does
+ * not prove it stays on this machine. An explicit remote override falls back
+ * to the local home rather than becoming a remote file read or write.
+ *
+ * The optional callback lets daemon discovery retain its existing diagnostic
+ * event without making this low-level path resolver depend on daemon code.
+ * Callback failures cannot turn a refused path into an exception: the local
+ * fallback is the fail-closed result either way.
+ */
+export function covenHomePath(
+  env: CovenHomeEnvironment = process.env,
+  homeDir: string = homedir(),
+  platform: NodeJS.Platform = process.platform,
+  onRemoteRefused?: CovenHomeRemoteRefusal,
+): string {
+  const configured = env.COVEN_HOME;
+  if (configured) {
+    if (!(platform === "win32" && isRemoteWindowsPath(configured))) return configured;
+    try {
+      onRemoteRefused?.(configured);
+    } catch {
+      // A diagnostic failure must not weaken the path boundary.
+    }
+  }
+  return path.join(homeDir, ".coven");
+}

--- a/src/lib/coven-paths.ts
+++ b/src/lib/coven-paths.ts
@@ -2,9 +2,10 @@ import fs from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
+import { covenHomePath } from "./coven-home.ts";
 
 export function covenHome(): string {
-  return process.env.COVEN_HOME || path.join(/* turbopackIgnore: true */ homedir(), ".coven");
+  return covenHomePath(process.env, homedir(), process.platform);
 }
 
 /**

--- a/src/lib/grok-compatibility.ts
+++ b/src/lib/grok-compatibility.ts
@@ -8,8 +8,8 @@
 import { createHash, createPublicKey, randomBytes, verify } from "node:crypto";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import * as fs from "node:fs/promises";
-import { homedir } from "node:os";
 import path from "node:path";
+import { covenHomePath } from "./coven-home.ts";
 
 export type GrokRunCapabilities = {
   version: string | null;
@@ -462,7 +462,7 @@ function configuredGrokRegistrySource(): RegistrySource {
 }
 
 function defaultCachePath(): string {
-  return path.join(process.env.COVEN_CAVE_HOME || path.join(process.env.COVEN_HOME || homedir(), ".coven", "cave"), "grok-schema-bundle-v1.json");
+  return path.join(process.env.COVEN_CAVE_HOME || path.join(covenHomePath(), "cave"), "grok-schema-bundle-v1.json");
 }
 
 function trustAnchorPath(file: string): string { return `${file}.anchor`; }

--- a/src/lib/openclaw-compatibility.ts
+++ b/src/lib/openclaw-compatibility.ts
@@ -1,12 +1,12 @@
 import { createHash, createPublicKey, randomBytes, verify } from "node:crypto";
 import * as registryFs from "node:fs/promises";
-import { homedir } from "node:os";
 import path from "node:path";
 
 import { AgentEventSchema, HelloOkSchema } from "@openclaw/gateway-protocol";
 import { Value } from "typebox/value";
 
 import { writeJsonAtomic } from "./server/atomic-write.ts";
+import { covenHomePath } from "./coven-home.ts";
 
 const MAX_OPENCLAW_TOOL_PROFILES = 32;
 const MAX_OPENCLAW_PROFILE_LIST = 16;
@@ -757,7 +757,7 @@ function meetsOpenClawCheckpoint(
 }
 
 function defaultOpenClawCacheDir(): string {
-  const covenRoot = process.env.COVEN_HOME || path.join(homedir(), ".coven");
+  const covenRoot = covenHomePath();
   return process.env.COVEN_CAVE_HOME || path.join(covenRoot, "cave");
 }
 

--- a/src/lib/opencode-compatibility.ts
+++ b/src/lib/opencode-compatibility.ts
@@ -1,6 +1,6 @@
 import { createHash, createPublicKey, randomBytes, verify } from "node:crypto";
 import * as registryFs from "node:fs/promises";
-import { homedir } from "node:os";
+import { covenHomePath } from "./coven-home.ts";
 
 type RegistryFs = typeof registryFs;
 
@@ -627,7 +627,7 @@ function localPathChild(parent: string, child: string): string {
 
 function cachePath(): string {
   // The registry cache is mutable per-user state, never an application asset.
-  const covenRoot = process.env.COVEN_HOME || localPathChild(homedir(), ".coven");
+  const covenRoot = covenHomePath();
   const caveRoot = process.env.COVEN_CAVE_HOME || localPathChild(covenRoot, "cave");
   return localPathChild(caveRoot, CACHE_FILE);
 }

--- a/src/lib/server/adapter-conflict-heal.ts
+++ b/src/lib/server/adapter-conflict-heal.ts
@@ -17,8 +17,8 @@
 // off the `.json` extension the CLI scans, and let the caller retry the turn.
 
 import { rename, stat } from "node:fs/promises";
-import { homedir } from "node:os";
 import path from "node:path";
+import { covenHomePath } from "../coven-home.ts";
 
 export type BuiltinAdapterConflict = {
   /** Adapter id the CLI reported (e.g. "copilot"). */
@@ -50,8 +50,7 @@ export function detectBuiltinAdapterConflict(
 
 /** The adapters directory Cave scaffolds into (honors COVEN_HOME). */
 export function covenAdaptersDir(): string {
-  const home = process.env.COVEN_HOME?.trim() || path.join(homedir(), ".coven");
-  return path.join(home, "adapters");
+  return path.join(covenHomePath(), "adapters");
 }
 
 export function shadowedMarkerPath(manifestPath: string): string {

--- a/src/lib/server/craft-drafts.ts
+++ b/src/lib/server/craft-drafts.ts
@@ -1,7 +1,7 @@
 import { mkdir, readdir, readFile, rm } from "node:fs/promises";
 import path from "node:path";
-import { homedir } from "node:os";
 import { writeJsonAtomic } from "./atomic-write.ts";
+import { covenHomePath } from "../coven-home.ts";
 import type { CraftDraft } from "../craft-draft.ts";
 
 const DRAFTS_DIR = "craft-drafts";
@@ -18,7 +18,7 @@ export type CraftDraftStoreOptions = {
 };
 
 function covenHome(opts: CraftDraftStoreOptions = {}): string {
-  return opts.covenHome ?? process.env.COVEN_HOME ?? path.join(homedir(), ".coven");
+  return opts.covenHome ?? covenHomePath();
 }
 
 function draftDir(opts: CraftDraftStoreOptions = {}): string {


### PR DESCRIPTION
## Summary
- Centralize Coven-home resolution with a fail-closed local fallback for remote Windows COVEN_HOME values.
- Route daemon, path, adapter, draft, OpenClaw, OpenCode, Grok, and binary consumers through the shared resolver.
- Preserve daemon refusal diagnostics and wire the new focused test into the app runner.

## Verification
- `node --experimental-strip-types src/lib/coven-home.test.ts`
- `node --experimental-strip-types src/lib/coven-daemon.test.ts`
- `node --experimental-strip-types src/lib/coven-paths.test.ts`
- `pnpm check:tests-wired` (1,978 files)
- `git diff --check`

Typecheck/lint were attempted but unavailable in the worktree after dependency installation exhausted disk space (ENOSPC).

Bead: cave-ckk.2