### PR TITLE
fix(design): retire safe undefined token references

### DIFF
--- a/scripts/design-system/token-reference-scan.mjs
+++ b/scripts/design-system/token-reference-scan.mjs
@@ -424,32 +424,23 @@ export const BANKED_UNDEFINED_NO_FALLBACK = new Map([
   // Semantic colour names from a vocabulary this repo never adopted. The
   // foundations sheet spells these --text-primary / --text-secondary /
   // --bg-panel / --border-hairline; these are the ones that got typed anyway.
-  ["--bg-inset", 2],
+  // cave-z2sbd first slice: direct contract aliases retired in source:
+  // --bg-inset -> --bg-sunken; border-muted/panel/subtle -> --border-hairline;
+  // fg-primary -> --text-primary; surface-raised/sunken -> --bg-raised/sunken;
+  // text-danger -> --danger-text; text-strong -> --text-primary;
+  // text-success/warning -> --color-success/warning; danger -> --color-danger;
+  // focus-ring -> --ring-focus; motion-fast -> --duration-fast;
+  // font-display -> --font-serif.
   // --bg-surface is gone: defined in foundations.css as an alias of --bg-base
   // (cave-w387r). It was the worst entry in this bank — the Thread Signal card
   // asked for a mix with NO transparent component and still rendered
   // see-through.
-  ["--border-muted", 1],
-  ["--border-panel", 11],
-  ["--border-subtle", 3],
-  ["--fg-primary", 5],
   ["--surface-muted", 1],
-  ["--surface-raised", 1],
-  ["--surface-sunken", 1],
-  ["--text-danger", 7],
-  ["--text-strong", 1],
-  ["--text-success", 1],
-  ["--text-warning", 7],
-  ["--danger", 2],
-  ["--focus-ring", 2],
   // Scale steps that do not exist: the space scale is 1/2/3/4/5/6/8/10.
   ["--space-7", 8],
   ["--space-9", 3],
   // Shadow and motion vocabularies that were never defined here.
   ["--shadow-elevated", 1],
-  ["--motion-fast", 13],
-  // A font role with no definition; the type system is serif/sans/mono.
-  ["--font-display", 1],
   // Vendored Beautiful UI's own shadow token, which did not come across with
   // the components (src/components/ui/beautiful/, MIT, beautifului.dev).
   ["--bui-shadow-bui-btn", 1],
@@ -463,7 +454,9 @@ export const BANKED_UNDEFINED_NO_FALLBACK = new Map([
  * an author reads the right remedy.
  */
 export const BANKED_UNDEFINED_WITH_FALLBACK = new Map([
-  ["--accent-fg", 1],
+  // cave-z2sbd first slice: accent-fg -> --accent-presence-foreground,
+  // surface-raised -> --bg-raised, text-faint -> --text-muted, and
+  // text-warning -> --color-warning are direct contract mappings.
   // --bg-surface is defined now (cave-w387r). This entry was the sole usage
   // that carried a fallback, and its `var(--bg-surface, var(--background))` is
   // what told us the token's intended value.
@@ -472,9 +465,6 @@ export const BANKED_UNDEFINED_WITH_FALLBACK = new Map([
   ["--gh-diff-gutter", 2],
   ["--metric-accent", 2],
   ["--shadow-panel", 1],
-  ["--surface-raised", 2],
-  ["--text-faint", 1],
-  ["--text-warning", 1],
 ]);
 
 /**

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -63,7 +63,7 @@ export default function AppError({
               cursor: "pointer",
               fontSize: 13,
               fontWeight: 500,
-              color: "var(--accent-fg, #fff)",
+              color: "var(--accent-presence-foreground, #fff)",
               background: "var(--accent-presence, #7c6cf0)",
             }}
           >

--- a/src/components/afs-pane.tsx
+++ b/src/components/afs-pane.tsx
@@ -131,7 +131,7 @@ export function AfsPane({ sessionId }: { sessionId: string }) {
             aria-selected={tab === id}
             className={`focus-ring rounded px-2 py-1 text-[length:var(--text-xs)] transition-colors ${
               tab === id
-                ? "bg-[var(--surface-raised)] text-[var(--text-primary)]"
+                ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
                 : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
             }`}
             onClick={() => setTab(id)}
@@ -155,7 +155,7 @@ export function AfsPane({ sessionId }: { sessionId: string }) {
 function PaneError({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
     <div className="flex items-center gap-2 p-3 text-[length:var(--text-xs)] text-[var(--text-secondary)]">
-      <span className="text-[var(--text-danger)]">{message}</span>
+      <span className="text-[var(--danger-text)]">{message}</span>
       <Button size="sm" variant="ghost" onClick={onRetry}>
         Retry
       </Button>
@@ -223,7 +223,7 @@ function ChangesPane({ sessionId }: { sessionId: string }) {
     return <p className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">Loading changes…</p>;
   }
   if (state.phase === "error") {
-    return <p className="text-[length:var(--text-xs)] text-[var(--text-danger)]">{state.message}</p>;
+    return <p className="text-[length:var(--text-xs)] text-[var(--danger-text)]">{state.message}</p>;
   }
 
   const diff = state.data;
@@ -242,7 +242,7 @@ function ChangesPane({ sessionId }: { sessionId: string }) {
             {diff.counts.bytes} bytes
           </p>
           {diff.truncated ? (
-            <p className="mb-1 text-[length:var(--text-xs)] text-[var(--text-warning)]">
+            <p className="mb-1 text-[length:var(--text-xs)] text-[var(--color-warning)]">
               Diff truncated — this list is incomplete.
             </p>
           ) : null}
@@ -312,7 +312,7 @@ function TreeRow({
       ) : null}
       {node.change?.attribution === "unknown" ? (
         <span
-          className="shrink-0 text-[var(--text-warning)]"
+          className="shrink-0 text-[var(--color-warning)]"
           title="No provenance record explains this change"
         >
           unattributed
@@ -376,7 +376,7 @@ function PatchPanel({
         </span>
       </div>
       {selected.attribution === "unknown" ? (
-        <p className="text-[length:var(--text-xs)] text-[var(--text-warning)]">
+        <p className="text-[length:var(--text-xs)] text-[var(--color-warning)]">
           This selected change has no recorded provenance.
         </p>
       ) : null}
@@ -384,14 +384,14 @@ function PatchPanel({
         <p className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">Loading patch…</p>
       ) : null}
       {fileDiff?.phase === "error" ? (
-        <p role="alert" className="text-[length:var(--text-xs)] text-[var(--text-danger)]">
+        <p role="alert" className="text-[length:var(--text-xs)] text-[var(--danger-text)]">
           {fileDiff.message}
         </p>
       ) : null}
       {fileDiff?.phase === "ready" ? (
         <>
           {fileDiff.data.truncated ? (
-            <p className="text-[length:var(--text-xs)] text-[var(--text-warning)]">
+            <p className="text-[length:var(--text-xs)] text-[var(--color-warning)]">
               Patch truncated — the daemon response is incomplete.
             </p>
           ) : null}
@@ -466,7 +466,7 @@ function TimelinePane({ sessionId }: { sessionId: string }) {
     return <p className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">Loading timeline…</p>;
   }
   if (state.phase === "error") {
-    return <p className="text-[length:var(--text-xs)] text-[var(--text-danger)]">{state.message}</p>;
+    return <p className="text-[length:var(--text-xs)] text-[var(--danger-text)]">{state.message}</p>;
   }
   if (groups.length === 0) {
     return <p className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">No recorded operations.</p>;
@@ -508,7 +508,7 @@ function TimelinePane({ sessionId }: { sessionId: string }) {
         </Button>
       ) : null}
       {moreError ? (
-        <p role="alert" className="text-[length:var(--text-xs)] text-[var(--text-danger)]">
+        <p role="alert" className="text-[length:var(--text-xs)] text-[var(--danger-text)]">
           {moreError}
         </p>
       ) : null}
@@ -533,7 +533,7 @@ function TimelineRow({ entry, onTrace }: { entry: AfsTimelineEntry; onTrace: () 
         ) : null}
       </div>
       {entry.toolCallId == null ? (
-        <p className="pl-12 text-[var(--text-warning)]">unlinked</p>
+        <p className="pl-12 text-[var(--color-warning)]">unlinked</p>
       ) : entry.toolCall ? (
         <details className="mt-1 pl-12 text-[var(--text-secondary)]">
           <summary className="focus-ring cursor-pointer rounded-[var(--radius-control)]">
@@ -549,7 +549,7 @@ function TimelineRow({ entry, onTrace }: { entry: AfsTimelineEntry; onTrace: () 
           </div>
         </details>
       ) : (
-        <p className="pl-12 text-[var(--text-warning)]">Linked tool details unavailable</p>
+        <p className="pl-12 text-[var(--color-warning)]">Linked tool details unavailable</p>
       )}
     </li>
   );
@@ -648,7 +648,7 @@ function CommitPane({
       <label className="flex flex-col gap-1">
         <span className="text-[var(--text-secondary)]">Branch</span>
         <input
-          className="focus-ring rounded border border-[var(--border-subtle)] bg-[var(--surface-sunken)] px-2 py-1 text-[var(--text-primary)]"
+          className="focus-ring rounded border border-[var(--border-hairline)] bg-[var(--bg-sunken)] px-2 py-1 text-[var(--text-primary)]"
           value={branch}
           onChange={(event) => {
             previewRequestRef.current += 1;
@@ -662,7 +662,7 @@ function CommitPane({
       </label>
 
       {availability.enabled ? null : (
-        <p className="text-[var(--text-warning)]">{availability.reason}</p>
+        <p className="text-[var(--color-warning)]">{availability.reason}</p>
       )}
 
       <div className="flex flex-wrap gap-2">
@@ -687,7 +687,7 @@ function CommitPane({
         <p className="text-[var(--text-secondary)]">Validating the commit with the daemon…</p>
       ) : null}
       {preview?.phase === "error" ? (
-        <p role="alert" className="text-[var(--text-danger)]">
+        <p role="alert" className="text-[var(--danger-text)]">
           {preview.message}
         </p>
       ) : null}
@@ -708,7 +708,7 @@ function CommitPane({
       {result ? (
         <p
           role={result.kind === "error" ? "alert" : "status"}
-          className={result.kind === "ok" ? "text-[var(--text-success)]" : "text-[var(--text-danger)]"}
+          className={result.kind === "ok" ? "text-[var(--color-success)]" : "text-[var(--danger-text)]"}
         >
           {result.message}
         </p>

--- a/src/components/code-session-pr-panel.tsx
+++ b/src/components/code-session-pr-panel.tsx
@@ -587,7 +587,7 @@ export function CodeSessionPrPanel({ row }: { row: SessionRow }) {
               <h2 className="text-[length:var(--text-sm)] font-semibold text-[var(--text-primary)]">
                 Actions
               </h2>
-              <div className="rounded-lg border border-[var(--border-muted)] bg-[var(--surface-muted)] p-3 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+              <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--surface-muted)] p-3 text-[length:var(--text-xs)] text-[var(--text-muted)]">
                 This PR was detected from the chat transcript, so it is shown for reference only.
                 Review and merge actions stay disabled until a PR is resolved from this session&apos;s work branch.
               </div>

--- a/src/components/directory-picker-modal.tsx
+++ b/src/components/directory-picker-modal.tsx
@@ -631,7 +631,7 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
                   event.preventDefault();
                   submitPathDraft();
                 }}
-                className="flex h-9 items-center gap-2 rounded-[var(--radius-control)] border border-[var(--border-strong)] bg-[var(--bg-inset)] px-2 transition-colors focus-within:border-[var(--ring-focus)]"
+                className="flex h-9 items-center gap-2 rounded-[var(--radius-control)] border border-[var(--border-strong)] bg-[var(--bg-sunken)] px-2 transition-colors focus-within:border-[var(--ring-focus)]"
               >
                 <label
                   htmlFor="directory-picker-path"
@@ -683,7 +683,7 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
             </div>
 
             <div className="flex items-center gap-2 px-5 pb-2">
-              <label className="flex h-[34px] min-w-0 flex-1 items-center gap-2 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-inset)] px-2.5 transition-colors focus-within:border-[color-mix(in_oklch,var(--accent-presence)_50%,transparent)]">
+              <label className="flex h-[34px] min-w-0 flex-1 items-center gap-2 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-sunken)] px-2.5 transition-colors focus-within:border-[color-mix(in_oklch,var(--accent-presence)_50%,transparent)]">
                 <Icon name="ph:magnifying-glass" width={15} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
                 <input
                   className="h-full w-full min-w-0 bg-transparent text-base text-[var(--foreground)] outline-none placeholder:text-[var(--text-muted)]"

--- a/src/components/marketplace/knowledge-pack-seed-modal.tsx
+++ b/src/components/marketplace/knowledge-pack-seed-modal.tsx
@@ -183,12 +183,12 @@ export function KnowledgePackSeedModal({ open, manifest, alreadyInstalled, onClo
         <section className="flex flex-col gap-2">
           <h3 className="text-[length:var(--text-sm)] font-semibold text-[var(--text-primary)]">1. Choose where the pack should seed</h3>
           <div className="grid gap-2 @min-[620px]:grid-cols-2">
-            <label className="focus-within:ring-2 focus-within:ring-[var(--focus-ring)] rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] p-3">
+            <label className="focus-within:ring-2 focus-within:ring-[var(--ring-focus)] rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] p-3">
               <input className="focus-ring mr-2" type="radio" name="knowledge-pack-target" checked={target === "vault"} onChange={() => setTarget("vault")} />
               <span className="text-[length:var(--text-base)] font-medium text-[var(--text-primary)]">Knowledge vault</span>
               <p className="mt-1 text-[length:var(--text-sm)] text-[var(--text-muted)]">Collections appear in the Grimoire; entries start disabled for prompt injection — agents look them up on demand.</p>
             </label>
-            <label className="focus-within:ring-2 focus-within:ring-[var(--focus-ring)] rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] p-3">
+            <label className="focus-within:ring-2 focus-within:ring-[var(--ring-focus)] rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] p-3">
               <input className="focus-ring mr-2" type="radio" name="knowledge-pack-target" checked={target === "project"} onChange={() => setTarget("project")} />
               <span className="text-[length:var(--text-base)] font-medium text-[var(--text-primary)]">Project folder</span>
               <p className="mt-1 text-[length:var(--text-sm)] text-[var(--text-muted)]">Seed folders into a project tree, like <code>ok seed</code>.</p>

--- a/src/components/quick-chat-primitives.tsx
+++ b/src/components/quick-chat-primitives.tsx
@@ -29,7 +29,7 @@ export function FamiliarMark({ familiar, size = "sm" }: { familiar: Familiar; si
       alt=""
       className={`${sizeClass} rounded-[var(--radius-control)] object-cover`}
       fallback={
-        <span className={`grid ${sizeClass} place-items-center rounded-[var(--radius-control)] bg-[var(--bg-elevated)] font-semibold text-[var(--fg-primary)]`}>
+        <span className={`grid ${sizeClass} place-items-center rounded-[var(--radius-control)] bg-[var(--bg-elevated)] font-semibold text-[var(--text-primary)]`}>
           {initials(familiar)}
         </span>
       }

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -153,7 +153,7 @@ export function TrayQuickChat() {
   }, [addTab, closeTab]);
 
   return (
-    <main className="tray-quick-chat min-h-screen text-[var(--fg-primary)]">
+    <main className="tray-quick-chat min-h-screen text-[var(--text-primary)]">
       <h1 className="sr-only">Quick chat</h1>
       <section className="tray-quick-chat__frame">
         {/* The tray window is created with decorations(false) (see lib.rs), so

--- a/src/lib/undefined-token-reference.test.ts
+++ b/src/lib/undefined-token-reference.test.ts
@@ -219,6 +219,7 @@ const names = (list: { name: string }[]) => list.map((x) => x.name);
       <p className="text-[var(--fg-primary)] caret-[var(--fg-secondary)]">{note}</p>
       <small className="text-[var(--fg-secondary)]">{sub}</small>
       <footer className="text-[var(--fg-primary)]" />
+      <i className="bg-[var(--surface-muted)]" />
     </div>
   );
 }`;
@@ -230,20 +231,21 @@ const names = (list: { name: string }[]) => list.map((x) => x.name);
   const tally = tallyByName(fixture.undefinedRefs) as Map<string, number>;
   assert.deepEqual(
     Object.fromEntries(tally),
-    { "--text-danger": 3, "--fg-primary": 7, "--fg-secondary": 2 },
-    "the three undefined tokens are found, and --bg-base on the same line is not flagged",
+    { "--text-danger": 3, "--fg-primary": 7, "--fg-secondary": 2, "--surface-muted": 1 },
+    "the undefined tokens are found, and --bg-base on the same line is not flagged",
   );
   assert.ok(
     fixture.references.some((r: Ref) => r.name === "--bg-base"),
     "--bg-base is still counted as a reference — it is simply a defined one",
   );
 
-  // Now the gate, not just the scanner. The three tokens take three DIFFERENT
+  // Now the gate, not just the scanner. The four tokens take three DIFFERENT
   // paths through it, which is why the fixture keeps the real multiplicities:
-  //   --fg-secondary  unbanked        -> fails outright
-  //   --fg-primary    banked at 5, 7  -> fails as "went UP"
-  //   --text-danger   banked at 7, 3  -> does NOT fail, and must not
-  // An equivalent mutant would reach only the first and still look green.
+  //   --fg-secondary  unbanked             -> fails outright
+  //   --fg-primary    retired by z2sbd      -> fails outright
+  //   --text-danger   retired by z2sbd      -> fails outright
+  //   --surface-muted banked at 1, used 1  -> does NOT fail, and must not
+  // An equivalent mutant would reach only the unbanked path and still look green.
   const verdict = assessTokenReferences({
     undefinedRefs: fixture.undefinedRefs,
     themeScopedOnlyRefs: [],
@@ -255,11 +257,15 @@ const names = (list: { name: string }[]) => list.map((x) => x.name);
     `an unbanked undefined token must fail outright: ${verdict.failures.join(" | ")}`,
   );
   assert.ok(
-    verdict.failures.some((f: string) => f.includes("--fg-primary") && f.includes("went UP")),
-    `a banked token used more must fail: ${verdict.failures.join(" | ")}`,
+    verdict.failures.some((f: string) => f.includes("--fg-primary") && f.includes("undefined token, NO fallback")),
+    `a retired undefined token must fail outright: ${verdict.failures.join(" | ")}`,
   );
   assert.ok(
-    !verdict.failures.some((f: string) => f.includes("--text-danger")),
+    verdict.failures.some((f: string) => f.includes("--text-danger") && f.includes("undefined token, NO fallback")),
+    `a second retired undefined token must fail outright: ${verdict.failures.join(" | ")}`,
+  );
+  assert.ok(
+    !verdict.failures.some((f: string) => f.includes("--surface-muted")),
     "a banked token still under its count is not a new defect",
   );
   assert.ok(
@@ -269,8 +275,8 @@ const names = (list: { name: string }[]) => list.map((x) => x.name);
 
   // The "went UP" branch, isolated: a banked name over its banked count.
   const overBank = assessTokenReferences({
-    undefinedRefs: Array.from({ length: 6 }, (_, i) => ({
-      name: "--fg-primary",
+    undefinedRefs: Array.from({ length: 2 }, (_, i) => ({
+      name: "--surface-muted",
       fallback: false,
       file: "src/components/research-run-surface.tsx",
       line: 240 + i,
@@ -280,17 +286,17 @@ const names = (list: { name: string }[]) => list.map((x) => x.name);
   });
   assert.equal(overBank.ok, false);
   assert.ok(
-    overBank.failures.some((f: string) => f.includes("--fg-primary") && f.includes("went UP")),
+    overBank.failures.some((f: string) => f.includes("--surface-muted") && f.includes("went UP")),
     `a banked name over its count must fail: ${overBank.failures.join(" | ")}`,
   );
 
   // …and exactly at the banked count it must NOT fail, or the gate fires on
   // the tree it was measured against.
   const atBank = assessTokenReferences({
-    undefinedRefs: Array.from({ length: 5 }, (_, i) => ({
-      name: "--fg-primary",
+    undefinedRefs: Array.from({ length: 1 }, (_, i) => ({
+      name: "--surface-muted",
       fallback: false,
-      file: "src/components/quick-chat-primitives.tsx",
+      file: "src/components/research-run-surface.tsx",
       line: 32 + i,
     })),
     themeScopedOnlyRefs: [],

--- a/src/styles/board/github-detail.css
+++ b/src/styles/board/github-detail.css
@@ -283,7 +283,7 @@
 }
 .gh-diff__no {
   padding:0 6px; text-align:right; user-select:none;
-  color:var(--text-faint, var(--text-muted)); opacity:0.7; font-size:10px;
+  color:var(--text-muted); opacity:0.7; font-size:10px;
   border-right:1px solid color-mix(in oklch, var(--border-hairline) 60%, transparent);
 }
 /* Color set on the line so it inherits to the component's <code> child AND

--- a/src/styles/cave-chat/auxiliary-surfaces.css
+++ b/src/styles/cave-chat/auxiliary-surfaces.css
@@ -261,7 +261,7 @@
   transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
 }
 .cave-launch__card:hover {
-  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border-panel));
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
   transform: translateY(-1px);
 }

--- a/src/styles/cave-chat/bubbles.css
+++ b/src/styles/cave-chat/bubbles.css
@@ -230,7 +230,7 @@
   align-items: center;
   gap: 6px;
   padding: 5px var(--space-3);
-  border: 1px solid var(--border-panel);
+  border: 1px solid var(--border-hairline);
   border-radius: var(--radius-pill);
   background: transparent;
   color: var(--text-muted);
@@ -304,7 +304,7 @@
   flex-direction: column;
   gap: 3px;
   min-width: 0;
-  border: 1px solid var(--border-panel);
+  border: 1px solid var(--border-hairline);
   border-radius: 7px;
   background: color-mix(in oklch, var(--bg-elevated) 78%, transparent);
   padding: var(--space-2) 11px;
@@ -413,7 +413,7 @@
 }
 
 .cave-chat-empty-prompt:hover {
-  border-color: color-mix(in oklch, var(--accent-presence) 34%, var(--border-panel));
+  border-color: color-mix(in oklch, var(--accent-presence) 34%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
   color: var(--text-primary);
   transform: translateY(-1px);
@@ -465,7 +465,7 @@
 
 .cave-chat-empty-prompt:focus-visible {
   outline: none;
-  border-color: color-mix(in oklch, var(--accent-presence) 62%, var(--border-panel));
+  border-color: color-mix(in oklch, var(--accent-presence) 62%, var(--border-hairline));
   box-shadow: 0 0 0 2px color-mix(in oklch, var(--accent-presence) 28%, transparent);
 }
 
@@ -525,7 +525,7 @@
 }
 
 button.cave-chat-empty-task:hover:not(:disabled) {
-  border-color: color-mix(in oklch, var(--accent-presence) 34%, var(--border-panel));
+  border-color: color-mix(in oklch, var(--accent-presence) 34%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
   color: var(--text-primary);
 }
@@ -537,7 +537,7 @@ button.cave-chat-empty-task:hover:not(:disabled) {
 
 .cave-chat-empty-task:focus-visible {
   outline: none;
-  border-color: color-mix(in oklch, var(--accent-presence) 62%, var(--border-panel));
+  border-color: color-mix(in oklch, var(--accent-presence) 62%, var(--border-hairline));
   box-shadow: 0 0 0 2px color-mix(in oklch, var(--accent-presence) 28%, transparent);
 }
 
@@ -674,7 +674,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
   align-items: center;
   gap: var(--space-2);
   min-height: 38px;
-  border: 1px dashed color-mix(in oklch, var(--accent-presence) 38%, var(--border-panel));
+  border: 1px dashed color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
   border-radius: 7px;
   background: color-mix(in oklch, var(--accent-presence) 5%, transparent);
   padding: 0 11px;
@@ -708,7 +708,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 }
 
 .cave-chat-empty-task-tile:hover {
-  border-color: color-mix(in oklch, var(--accent-presence) 62%, var(--border-panel));
+  border-color: color-mix(in oklch, var(--accent-presence) 62%, var(--border-hairline));
   background: color-mix(in oklch, var(--accent-presence) 9%, transparent);
 }
 
@@ -723,7 +723,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
   align-items: center;
   gap: var(--space-2);
   min-height: 38px;
-  border: 1px dashed color-mix(in oklch, var(--accent-presence) 45%, var(--border-panel));
+  border: 1px dashed color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
   border-radius: 7px;
   background: color-mix(in oklch, var(--accent-presence) 8%, transparent);
   padding: 0 11px;
@@ -790,7 +790,7 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 
 .cave-chat-empty-recent:focus-visible {
   outline: none;
-  border-color: color-mix(in oklch, var(--accent-presence) 62%, var(--border-panel));
+  border-color: color-mix(in oklch, var(--accent-presence) 62%, var(--border-hairline));
   box-shadow: 0 0 0 2px color-mix(in oklch, var(--accent-presence) 28%, transparent);
 }
 

--- a/src/styles/dev-shell-recovery.css
+++ b/src/styles/dev-shell-recovery.css
@@ -22,7 +22,7 @@
   padding: var(--space-6);
   border: 1px solid var(--border);
   border-radius: var(--radius-panel);
-  background: var(--surface-raised, var(--background));
+  background: var(--bg-raised, var(--background));
   box-shadow: var(--shadow-panel, none);
   text-align: left;
 }

--- a/src/styles/familiar-analytics.css
+++ b/src/styles/familiar-analytics.css
@@ -2634,7 +2634,7 @@
   color: var(--accent-presence);
 }
 .fa-board__summary-copy > b {
-  font-family: var(--font-display);
+  font-family: var(--font-serif);
   font-size: var(--text-xl);
   font-weight: 600;
   color: var(--text-primary);
@@ -2891,7 +2891,7 @@
   grid-template-columns: 1fr auto;
   gap: var(--space-1) var(--space-2);
   padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border-hairline);
   border-radius: var(--radius-md);
   background: var(--bg-subtle);
 }
@@ -2917,7 +2917,7 @@
   gap: var(--space-3);
   align-items: center;
   padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--border-subtle);
+  border: 1px solid var(--border-hairline);
   border-radius: var(--radius-md);
 }
 .fa-runtime-attempt > span {

--- a/src/styles/gh-card-composer.css
+++ b/src/styles/gh-card-composer.css
@@ -43,7 +43,7 @@
   background: color-mix(in oklch, var(--bg-panel) 60%, transparent);
   cursor: text;
   text-align: left;
-  transition: border-color var(--motion-fast) var(--ease-standard);
+  transition: border-color var(--duration-fast) var(--ease-standard);
 }
 
 .ghc-rest-pill:hover {
@@ -83,7 +83,7 @@
   font-size: var(--text-2xs);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: border-color var(--motion-fast) var(--ease-standard);
+  transition: border-color var(--duration-fast) var(--ease-standard);
 }
 
 .ghc-reaction:hover {
@@ -263,7 +263,7 @@
   font-size: var(--text-xs);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: background var(--motion-fast) var(--ease-standard);
+  transition: background var(--duration-fast) var(--ease-standard);
 }
 
 .ghc-seg__item--on {
@@ -329,7 +329,7 @@
   font-size: var(--text-xs);
   line-height: 1;
   cursor: pointer;
-  transition: background var(--motion-fast) var(--ease-standard);
+  transition: background var(--duration-fast) var(--ease-standard);
 }
 
 .ghc-tool:hover {
@@ -556,7 +556,7 @@
   display: inline-flex;
   flex-shrink: 0;
   color: var(--text-muted);
-  transition: transform var(--motion-fast) var(--ease-standard);
+  transition: transform var(--duration-fast) var(--ease-standard);
 }
 
 .ghc-sec__caret--open {
@@ -657,7 +657,7 @@
   font-size: var(--text-2xs);
   color: var(--text-primary);
   cursor: pointer;
-  transition: background var(--motion-fast) var(--ease-standard);
+  transition: background var(--duration-fast) var(--ease-standard);
 }
 
 .ghc-mini:hover {
@@ -705,7 +705,7 @@
   flex-shrink: 0;
   border-radius: var(--radius-pill);
   background: var(--bg-hover);
-  transition: background var(--motion-fast) var(--ease-standard);
+  transition: background var(--duration-fast) var(--ease-standard);
 }
 
 .ghc-switch__track--on {
@@ -719,8 +719,8 @@
   height: 11px;
   border-radius: var(--radius-pill);
   background: var(--text-secondary);
-  transition: left var(--motion-fast) var(--ease-standard),
-    background var(--motion-fast) var(--ease-standard);
+  transition: left var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
 }
 
 .ghc-switch__track--on .ghc-switch__knob {
@@ -871,7 +871,7 @@
   border-radius: 3px;
   color: var(--text-muted);
   cursor: pointer;
-  transition: background var(--motion-fast) var(--ease-standard);
+  transition: background var(--duration-fast) var(--ease-standard);
 }
 
 .ghc-chip__x:hover {
@@ -890,7 +890,7 @@
   font-size: var(--text-2xs);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: color var(--motion-fast) var(--ease-standard);
+  transition: color var(--duration-fast) var(--ease-standard);
 }
 
 .ghc-add:hover {
@@ -951,7 +951,7 @@
   font-weight: 500;
   color: var(--accent-presence-soft);
   cursor: pointer;
-  transition: background var(--motion-fast) var(--ease-standard);
+  transition: background var(--duration-fast) var(--ease-standard);
 }
 
 .ghc-draft-cta:hover {
@@ -1087,7 +1087,7 @@
   font-weight: 500;
   color: var(--text-muted);
   cursor: pointer;
-  transition: background var(--motion-fast) var(--ease-standard);
+  transition: background var(--duration-fast) var(--ease-standard);
 }
 
 /* Accent for the reversible verbs once there is a body to send. */

--- a/src/styles/globals/desktop-chrome.css
+++ b/src/styles/globals/desktop-chrome.css
@@ -2121,9 +2121,9 @@ a.mobile-handoff__link:hover {
 .mobile-handoff__error {
   margin: 0;
   padding: var(--space-2) 10px;
-  border: 1px solid color-mix(in srgb, var(--danger) 45%, var(--border-hairline));
+  border: 1px solid color-mix(in srgb, var(--color-danger) 45%, var(--border-hairline));
   border-radius: var(--radius-control);
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  background: color-mix(in srgb, var(--color-danger) 12%, transparent);
   color: var(--text-primary);
   font-size: var(--text-sm);
   line-height: 1.45;
@@ -2146,5 +2146,5 @@ a.mobile-handoff__link:hover {
    quiet card treatment so it reads as diagnostics, not another CTA. */
 .mobile-handoff__steps {
   margin: 0;
-  background: color-mix(in srgb, var(--surface-raised, transparent) 55%, transparent);
+  background: color-mix(in srgb, var(--bg-raised, transparent) 55%, transparent);
 }

--- a/src/styles/globals/shell-cards-and-controls.css
+++ b/src/styles/globals/shell-cards-and-controls.css
@@ -636,7 +636,7 @@ details[open] > .cave-edit-card__summary::before {
   border: 1px solid var(--border-hairline);
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  color: var(--fg-primary);
+  color: var(--text-primary);
   /* Layered elevation: an inner top highlight + two soft drop shadows read as a
      crisp floating panel rather than one flat blur. */
   box-shadow:

--- a/src/styles/globals/surface-chat-overlays.css
+++ b/src/styles/globals/surface-chat-overlays.css
@@ -45,7 +45,7 @@
 }
 .quick-chat-bubble--user {
   max-width: 84%;
-  color: var(--fg-primary);
+  color: var(--text-primary);
   background: color-mix(in oklch, var(--accent-presence) 20%, var(--bg-base));
   border: 1px solid color-mix(in oklch, var(--accent-presence) 34%, transparent);
   border-bottom-right-radius: 5px;
@@ -199,7 +199,7 @@
   text-align: left;
   font-size: 12.5px;
   line-height: 1.4;
-  color: var(--fg-primary);
+  color: var(--text-primary);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;

--- a/src/styles/globals/surface-research-prompt.css
+++ b/src/styles/globals/surface-research-prompt.css
@@ -122,7 +122,7 @@
   pointer-events: none;
 }
 .research-intent-count--near {
-  color: var(--text-warning, var(--text-strong));
+  color: var(--color-warning, var(--text-primary));
 }
 
 /* ── Slash-command palette (design 548–559): anchored under the textarea. ── */


### PR DESCRIPTION
## Summary

- Replace 63 undefined custom-property references with existing design tokens.
- Retire those counts from the scanner bank while preserving the remaining 32 banked references.
- Expand the undefined-token fixture so banked and unbanked paths remain covered.

## Verification

- `node scripts/design-system/token-reference-scan.mjs`
- `node --experimental-strip-types src/lib/undefined-token-reference.test.ts`
- `node --experimental-strip-types src/lib/design-token-drift.test.ts`
- `git diff --check`

Closes cave-z2sbd