### PR TITLE
fix(research): align input character limits

### DIFF
--- a/src/app/api/github/review/route.test.ts
+++ b/src/app/api/github/review/route.test.ts
@@ -1,6 +1,10 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import {
+  GITHUB_REVIEW_BODY_MAX_LENGTH,
+  validateGitHubReviewBody,
+} from "../../../../lib/github-review.ts";
 
 const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
 
@@ -25,5 +29,13 @@ assert.doesNotMatch(source, /:\s*token\b/, "review route must not return token m
 console.log("github-review-route.test.ts OK");
 assert.match(source, /new Set\(\["APPROVE", "REQUEST_CHANGES", "COMMENT"\]\)/, "review events are allow-listed");
 assert.match(source, /event !== "APPROVE" && !text/, "non-approve reviews require a body");
-assert.match(source, /GITHUB_REVIEW_BODY_MAX_LENGTH/, "review body cap is shared between the UI and route");
-assert.match(source, /review body must be at most/, "oversized review bodies fail before GitHub dispatch");
+assert.match(source, /validateGitHubReviewBody/, "oversized review bodies fail before GitHub dispatch");
+
+const exactBody = validateGitHubReviewBody("x".repeat(GITHUB_REVIEW_BODY_MAX_LENGTH));
+assert.equal(exactBody.ok, true, "the exact review body boundary is accepted");
+const oversizedBody = validateGitHubReviewBody("x".repeat(GITHUB_REVIEW_BODY_MAX_LENGTH + 1));
+assert.equal(oversizedBody.ok, false, "an over-limit review body is refused");
+assert.equal(
+  oversizedBody.ok ? null : oversizedBody.error,
+  `review body must be at most ${GITHUB_REVIEW_BODY_MAX_LENGTH} characters`,
+);

--- a/src/app/api/github/review/route.ts
+++ b/src/app/api/github/review/route.ts
@@ -12,7 +12,7 @@
 
 import { NextResponse } from "next/server";
 import { resolveGitHubToken } from "@/lib/github-token";
-import { GITHUB_REVIEW_BODY_MAX_LENGTH } from "@/lib/github-review";
+import { validateGitHubReviewBody } from "@/lib/github-review";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -32,7 +32,7 @@ export async function POST(req: Request) {
   const repo = typeof body.repo === "string" ? body.repo.trim() : "";
   const number = Number.parseInt(String(body.number ?? ""), 10);
   const event = typeof body.event === "string" ? body.event.toUpperCase() : "";
-  const text = typeof body.body === "string" ? body.body.trim() : "";
+  const reviewBody = validateGitHubReviewBody(body.body);
 
   if (!REPO_RE.test(repo)) {
     return NextResponse.json({ ok: false, error: "invalid repo" }, { status: 400 });
@@ -43,14 +43,12 @@ export async function POST(req: Request) {
   if (!EVENTS.has(event)) {
     return NextResponse.json({ ok: false, error: "invalid event" }, { status: 400 });
   }
+  if (!reviewBody.ok) {
+    return NextResponse.json({ ok: false, error: reviewBody.error }, { status: 400 });
+  }
+  const text = reviewBody.value;
   if (event !== "APPROVE" && !text) {
     return NextResponse.json({ ok: false, error: "review body required" }, { status: 400 });
-  }
-  if (text.length > GITHUB_REVIEW_BODY_MAX_LENGTH) {
-    return NextResponse.json(
-      { ok: false, error: `review body must be at most ${GITHUB_REVIEW_BODY_MAX_LENGTH} characters` },
-      { status: 400 },
-    );
   }
 
   const token = resolveGitHubToken();

--- a/src/app/api/research/missions/[id]/actions/route.test.ts
+++ b/src/app/api/research/missions/[id]/actions/route.test.ts
@@ -50,6 +50,8 @@ test("errors map by kind: unknown action 400, client mistakes 400, missing missi
   assert.match(source, /message === RESEARCH_SESSION_OWNER_REPAIR_REQUIRED\) return 409/);
   assert.match(source, /message === RESEARCH_ACTIVE_SESSION_OWNER_CONFLICT\) return 409/);
   assert.match(source, /VALIDATION_ERRORS\.has\(message\)/);
+  assert.match(source, /RESEARCH_DIRECTION_MAX_LENGTH/);
+  assert.doesNotMatch(source, /refined direction must be at most 2000 characters/);
   assert.match(source, /startsWith\('Project root "'\)/);
   assert.match(source, /startsWith\("invalid source"\)/);
   assert.match(source, /return 400;/);

--- a/src/app/api/research/missions/[id]/actions/route.ts
+++ b/src/app/api/research/missions/[id]/actions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import {
   allowedResearchActions,
+  RESEARCH_DIRECTION_MAX_LENGTH,
   type ResearchMissionActionInput,
   type ResearchMissionStatus,
 } from "@/lib/research-missions";
@@ -49,7 +50,7 @@ const VALIDATION_ERRORS = new Set([
   "research source not found",
   "refined direction required",
   "invalid refined direction",
-  "refined direction must be at most 2000 characters",
+  `refined direction must be at most ${RESEARCH_DIRECTION_MAX_LENGTH} characters`,
   "invalid project root override",
   "research mission is not settled yet",
   "rejected artifacts need a new working version before publishing",

--- a/src/components/role-surfaces/research-mission-composer.tsx
+++ b/src/components/role-surfaces/research-mission-composer.tsx
@@ -233,6 +233,9 @@ export function ResearchMissionComposer({
 }: Props) {
   const { announce } = useAnnouncer();
   const [intent, setIntent] = useState("");
+  const setBoundedIntent = useCallback((value: string) => {
+    setIntent(value.slice(0, RESEARCH_INTENT_MAX_LENGTH));
+  }, []);
   const [mode, setModeState] = useState<"auto" | ResearchMissionMode>(initialMode ?? "auto");
   const [bounds, setBounds] = useState<ResearchBounds>(
     defaultResearchPlan(initialMode ?? "brief").bounds,
@@ -321,10 +324,10 @@ export function ResearchMissionComposer({
       return;
     }
     appliedRecommendedDraftRevision.current = recommendedDraft.revision;
-    setIntent(recommendedDraft.value);
+    setBoundedIntent(recommendedDraft.value);
     setMenuDismissed(false);
     setMenuCursor(0);
-  }, [recommendedDraft]);
+  }, [recommendedDraft, setBoundedIntent]);
 
   // Every setMode caller is an explicit pick — mode cards, slash commands,
   // Reset to Auto, cross-tab preselect — so a deliberate switch clears the
@@ -348,7 +351,7 @@ export function ResearchMissionComposer({
   useEffect(() => {
     if (!initialDraft || appliedInitialDraftId.current === initialDraft.proposalId) return;
     appliedInitialDraftId.current = initialDraft.proposalId;
-    setIntent(initialDraft.question);
+    setBoundedIntent(initialDraft.question);
     setMode(initialDraft.mode);
     boundsDirtyRef.current = true;
     const draftPlan = defaultResearchPlan(initialDraft.mode).bounds;
@@ -357,13 +360,18 @@ export function ResearchMissionComposer({
       sourceTarget: initialDraft.sourceTarget,
       wallClockMinutes: initialDraft.wallClockMinutes,
     });
-  }, [initialDraft, setMode]);
+  }, [initialDraft, setBoundedIntent, setMode]);
 
   const inferred = useMemo(() => inferResearchMissionMode(intent), [intent]);
   const effectiveMode = mode === "auto" ? inferred.mode : mode;
   const plan = useMemo(() => defaultResearchPlan(effectiveMode), [effectiveMode]);
   const trimmedIntent = intent.trim();
   const intentTooShort = trimmedIntent.length > 0 && trimmedIntent.length < RESEARCH_INTENT_MIN_LENGTH;
+  const intentDescriptionId = error
+    ? "research-mission-error"
+    : intentTooShort
+      ? "research-intent-minimum"
+      : "research-plan-review";
   // Grow the box with the brief instead of scrolling three fixed rows. The CSS
   // caps it at ~12 lines, so `auto` then scrollHeight settles at the smaller of
   // content height and that ceiling; past it the element scrolls as before.
@@ -514,7 +522,7 @@ export function ResearchMissionComposer({
 
   const runCommand = (command: SlashCommand) => {
     const stripped = stripSlashToken(intent);
-    setIntent(stripped);
+    setBoundedIntent(stripped);
     setMenuCursor(0);
     if (command.run === "mode" && command.mode) {
       setMode(command.mode);
@@ -574,7 +582,7 @@ export function ResearchMissionComposer({
         announce(result.error);
         return;
       }
-      setIntent("");
+      setBoundedIntent("");
       announce(`Started ${result.mission.title}.`);
     } catch {
       setError("Research could not start. Check the runtime and try again.");
@@ -598,7 +606,7 @@ export function ResearchMissionComposer({
             maxLength={RESEARCH_INTENT_MAX_LENGTH}
             value={intent}
             onChange={(event) => {
-              setIntent(event.target.value);
+              setBoundedIntent(event.target.value);
               setMenuDismissed(false);
               setMenuCursor(0);
             }}
@@ -610,11 +618,8 @@ export function ResearchMissionComposer({
             aria-expanded={menuOpen}
             aria-controls="research-cmd-menu"
             aria-activedescendant={menuOpen ? `research-cmd-${menuItems[menuIndex].cmd.slice(1)}` : undefined}
-            aria-describedby={error
-              ? "research-mission-error"
-              : intentTooShort
-                ? "research-intent-minimum"
-                : "research-plan-review"}
+            aria-describedby={`${intentDescriptionId} research-intent-count`}
+            aria-errormessage={error ? "research-mission-error" : undefined}
           />
           {menuOpen ? (
             <div className="research-cmd-menu" id="research-cmd-menu" role="listbox" aria-label="Prompt commands">
@@ -651,6 +656,7 @@ export function ResearchMissionComposer({
             className={`research-intent-count${
               intent.length >= RESEARCH_INTENT_MAX_LENGTH * 0.9 ? " research-intent-count--near" : ""
             }`}
+            id="research-intent-count"
           >
             {intent.length.toLocaleString()} / {RESEARCH_INTENT_MAX_LENGTH.toLocaleString()}
           </span>
@@ -688,7 +694,7 @@ export function ResearchMissionComposer({
                 // tooltip and the pill carries a headline. Rendering the seed
                 // raw put "## Report topic **…" markdown on the chip.
                 title={chip.title}
-                onClick={() => setIntent(chip.brief)}
+                onClick={() => setBoundedIntent(chip.brief)}
               >
                 {summarizeRecommendationTitle(chip.title)}
               </button>
@@ -754,7 +760,7 @@ export function ResearchMissionComposer({
                   type="button"
                   className="research-recs__card focus-ring"
                   onClick={() => {
-                    setIntent(assembleBrief(rec.brief));
+                    setBoundedIntent(assembleBrief(rec.brief));
                     setBriefShown(true);
                     setRecsOpen(false);
                     setBriefNote(`Loaded from ${rec.why}.`);
@@ -923,7 +929,7 @@ export function ResearchMissionComposer({
         draft={intent}
         onClose={() => setBuilderOpen(false)}
         onApply={(prompt, filled) => {
-          setIntent(prompt);
+          setBoundedIntent(prompt);
           setBuilderOpen(false);
           setBriefShown(true);
           setBriefNote(null);

--- a/src/components/role-surfaces/research-tab-desk.test.ts
+++ b/src/components/role-surfaces/research-tab-desk.test.ts
@@ -74,6 +74,7 @@ test("checkpoint direction can be drafted agentically without auto-continuing", 
   assert.match(detail, /maxLength=\{RESEARCH_DIRECTION_MAX_LENGTH\}/);
   assert.match(detail, /research-refine-direction-count/);
   assert.match(detail, /direction\.length\.toLocaleString\(\)\} \/ \{RESEARCH_DIRECTION_MAX_LENGTH\.toLocaleString\(\)/);
+  assert.doesNotMatch(detail, /research-refine-direction-count"[^>]*aria-live/);
   assert.match(
     detail,
     /onClick=\{\(\) => void runAction\(\{[\s\S]{0,180}?action: "refine",[\s\S]{0,180}?direction,[\s\S]{0,180}?approveCostUnavailable/,

--- a/src/components/role-surfaces/research-tab-prompt.test.ts
+++ b/src/components/role-surfaces/research-tab-prompt.test.ts
@@ -27,6 +27,10 @@ test("intent keeps the shared min-length gate with aria-invalid wiring", () => {
   assert.match(composer, /trimmed\.length < RESEARCH_INTENT_MIN_LENGTH \|\| submitting/);
   // …and too-short input explains itself accessibly.
   assert.match(composer, /aria-invalid=\{Boolean\(error\) \|\| intentTooShort\}/);
+  assert.match(composer, /maxLength=\{RESEARCH_INTENT_MAX_LENGTH\}/);
+  assert.match(composer, /aria-describedby=\{`\$\{intentDescriptionId\} research-intent-count`\}/);
+  assert.match(composer, /id="research-intent-count"/);
+  assert.doesNotMatch(composer, /research-intent-count" aria-live/);
   assert.match(composer, /id="research-intent-minimum"/);
   assert.match(composer, /"research-intent-minimum"\s*:\s*"research-plan-review"/);
   // Start failures stay visible as alerts; the daemon-offline note is honest.

--- a/src/components/role-surfaces/review-inspector.tsx
+++ b/src/components/role-surfaces/review-inspector.tsx
@@ -439,12 +439,17 @@ export function ReviewInspector({
             maxLength={GITHUB_REVIEW_BODY_MAX_LENGTH}
             disabled={!selected}
             aria-invalid={noteError ? true : undefined}
+            aria-describedby="rd-inspector-note-count"
+            aria-errormessage={noteError ? "rd-inspector-note-error" : undefined}
             onChange={(event) =>
               onNote(event.target.value.slice(0, GITHUB_REVIEW_BODY_MAX_LENGTH))
             }
           />
+          <span id="rd-inspector-note-count" className="rd-character-count">
+            {note.length.toLocaleString()} / {GITHUB_REVIEW_BODY_MAX_LENGTH.toLocaleString()}
+          </span>
           {noteError ? (
-            <span className="rd-error" role="alert">
+            <span id="rd-inspector-note-error" className="rd-error" role="alert">
               {noteError}
             </span>
           ) : null}

--- a/src/components/role-surfaces/review-verdict-dock.tsx
+++ b/src/components/role-surfaces/review-verdict-dock.tsx
@@ -419,13 +419,14 @@ export function ReviewVerdictDock({
               }
               aria-describedby="rd-review-help rd-review-count"
               aria-invalid={noteError ? true : undefined}
+              aria-errormessage={noteError ? "rd-review-error" : undefined}
             />
             <span id="rd-review-count" className="rd-character-count">
               {note.length.toLocaleString()} /{" "}
               {GITHUB_REVIEW_BODY_MAX_LENGTH.toLocaleString()}
             </span>
             {noteError ? (
-              <span className="rd-error" role="alert">
+              <span id="rd-review-error" className="rd-error" role="alert">
                 {noteError}
               </span>
             ) : null}

--- a/src/components/role-surfaces/reviewer-surface.test.ts
+++ b/src/components/role-surfaces/reviewer-surface.test.ts
@@ -237,11 +237,17 @@ test("review threads render at their line, and an unplaced one is still shown", 
 test("the note is reachable without opening a dialog, and required for changes", () => {
   assert.doesNotMatch(surface, /<textarea/);
   assert.match(inspector, /id="rd-inspector-note"/);
+  assert.match(inspector, /maxLength=\{GITHUB_REVIEW_BODY_MAX_LENGTH\}/);
+  assert.match(inspector, /aria-describedby="rd-inspector-note-count"/);
+  assert.match(inspector, /id="rd-inspector-note-count"/);
+  assert.doesNotMatch(inspector, /rd-inspector-note-count"[^>]*aria-live/);
   assert.match(verdict, /open=\{reviewMode != null\}/);
   assert.match(verdict, /Review note · \{reviewMode === "changes" \? "Required" : "Optional"\}/);
   assert.match(verdict, /The draft stays with this session/);
   assert.match(verdict, /maxLength=\{GITHUB_REVIEW_BODY_MAX_LENGTH\}/);
   assert.match(verdict, /aria-describedby="rd-review-help rd-review-count"/);
+  assert.match(verdict, /aria-errormessage=\{noteError \? "rd-review-error"/);
+  assert.doesNotMatch(verdict, /rd-review-count"[^>]*aria-live/);
   assert.match(surface, /A note is required — GitHub sends it/);
 });
 

--- a/src/lib/github-review.ts
+++ b/src/lib/github-review.ts
@@ -1,2 +1,18 @@
 /** Cave-owned ceiling for a pull-request review body before GitHub dispatch. */
-export const GITHUB_REVIEW_BODY_MAX_LENGTH = 10_000;
+export const GITHUB_REVIEW_BODY_MAX_LENGTH = 5_000;
+
+export type GitHubReviewBodyValidation =
+  | { ok: true; value: string }
+  | { ok: false; error: string };
+
+/** Normalize and validate the body before it can reach the GitHub API. */
+export function validateGitHubReviewBody(value: unknown): GitHubReviewBodyValidation {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (text.length > GITHUB_REVIEW_BODY_MAX_LENGTH) {
+    return {
+      ok: false,
+      error: `review body must be at most ${GITHUB_REVIEW_BODY_MAX_LENGTH} characters`,
+    };
+  }
+  return { ok: true, value: text };
+}

--- a/src/lib/research-generations.test.ts
+++ b/src/lib/research-generations.test.ts
@@ -38,8 +38,17 @@ test("extractive and media kind unions stay explicit and composable", () => {
   assert.equal(isResearchGenerationMediaKind("slides"), false);
 });
 
-test("generation directions use the shared 10,000-character ceiling", () => {
-  assert.equal(RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH, 10_000);
+test("generation directions use the shared 5,000-character ceiling", () => {
+  assert.equal(RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH, 5_000);
+  const overLimit = validateCreateResearchGenerationInput({
+    familiarId: "nova", kind: "blog", sourceMissionId: "m-1",
+    directions: "x".repeat(RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH + 1),
+  });
+  assert.equal(overLimit.ok, false);
+  assert.equal(
+    overLimit.ok ? null : overLimit.error,
+    `directions must be at most ${RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH} characters`,
+  );
   assert.equal(
     validateCreateResearchGenerationInput({
       familiarId: "nova", kind: "blog", sourceMissionId: "m-1",

--- a/src/lib/research-generations.ts
+++ b/src/lib/research-generations.ts
@@ -636,7 +636,7 @@ export function isResearchGenerationContent(
 const FAMILIAR_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
 const MISSION_ID_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
-export const RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH = 10_000;
+export const RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH = 5_000;
 
 export function isValidResearchGenerationFamiliarId(value: unknown): value is string {
   return (

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -193,9 +193,9 @@ test("create input carries a valid origin through and refuses a malformed one", 
   assert.equal(refused.ok === false && refused.error.includes("origin.surface"), true);
 });
 
-test("research prompt limits validate intent capacity and pin the shared direction ceiling", () => {
-  assert.equal(RESEARCH_INTENT_MAX_LENGTH, 25_000);
-  assert.equal(RESEARCH_DIRECTION_MAX_LENGTH, 10_000);
+test("research prompt limits validate the shared intent and direction ceilings", () => {
+  assert.equal(RESEARCH_INTENT_MAX_LENGTH, 20_000);
+  assert.equal(RESEARCH_DIRECTION_MAX_LENGTH, 5_000);
   assert.equal(
     validateCreateResearchMissionInput({ ...validMission(), intent: "i".repeat(RESEARCH_INTENT_MAX_LENGTH) }).ok,
     true,
@@ -203,6 +203,18 @@ test("research prompt limits validate intent capacity and pin the shared directi
   assert.equal(
     validateCreateResearchMissionInput({ ...validMission(), intent: "i".repeat(RESEARCH_INTENT_MAX_LENGTH + 1) }).ok,
     false,
+  );
+  const atDirectionLimit = parseResearchMission({
+    ...validMission(),
+    direction: "d".repeat(RESEARCH_DIRECTION_MAX_LENGTH),
+  });
+  assert.equal(atDirectionLimit?.direction?.length, RESEARCH_DIRECTION_MAX_LENGTH);
+  assert.equal(
+    parseResearchMission({
+      ...validMission(),
+      direction: "d".repeat(RESEARCH_DIRECTION_MAX_LENGTH + 1),
+    }),
+    null,
   );
 });
 

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -888,17 +888,17 @@ export function parseResearchMission(value: unknown): ResearchMission | null {
  *  that would still spend a real familiar session. Enforced by the create
  *  validator (server) and the desk composer (client). */
 export const RESEARCH_INTENT_MIN_LENGTH = 8;
-/** Upper bound on a mission brief. Raised 10k → 25k (cave-e8z): real briefs
+/** Upper bound on a mission brief. Raised 10k → 20k (cave-e8z): real briefs
  *  carry pasted context — prior findings, source lists, constraints — and hit
  *  the old cap, which surfaced only as a server rejection after the writing was
  *  done. The composer now shows the count as you type, so the ceiling is
  *  visible rather than discovered. */
-export const RESEARCH_INTENT_MAX_LENGTH = 25_000;
+export const RESEARCH_INTENT_MAX_LENGTH = 20_000;
 export const RESEARCH_TITLE_MAX_LENGTH = 160;
 export const RESEARCH_DELIVERABLE_MAX_LENGTH = 160;
 export const RESEARCH_AUDIENCE_MAX_LENGTH = 500;
 export const RESEARCH_PROJECT_ROOT_MAX_LENGTH = 2_000;
-export const RESEARCH_DIRECTION_MAX_LENGTH = 10_000;
+export const RESEARCH_DIRECTION_MAX_LENGTH = 5_000;
 export const RESEARCH_CONSTRAINT_MAX_COUNT = 20;
 export const RESEARCH_CONSTRAINT_MAX_LENGTH = 500;
 export const RESEARCH_INITIAL_SAVED_LINK_MAX_COUNT = 500;

--- a/src/lib/research-recommendation-context.test.ts
+++ b/src/lib/research-recommendation-context.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { SavedLink } from "./link-organizer.ts";
+import { RESEARCH_INTENT_MAX_LENGTH } from "./research-missions.ts";
 import type { ResearchMission } from "./research-missions.ts";
 import {
   buildResearchRecommendationContext,
@@ -38,7 +39,7 @@ function link(id: string): SavedLink {
 }
 
 test("bounds and compacts long mission and link context before fingerprinting", () => {
-  const longIntent = "x".repeat(25_000);
+  const longIntent = "x".repeat(RESEARCH_INTENT_MAX_LENGTH);
   const missions = Array.from({ length: 30 }, (_, index) => mission(String(index), longIntent));
   const links = Array.from({ length: 30 }, (_, index) => link(String(index)));
 

--- a/src/lib/server/flow-copilot-session.test.ts
+++ b/src/lib/server/flow-copilot-session.test.ts
@@ -509,7 +509,7 @@ test("the current maximum Research input is measured and pathological quoting fa
   assert.equal(plainPrompt.split(plainDeliverable).length - 1, 1);
   assert.equal(plainPrompt.split(plainAudience).length - 1, 1);
   const plainArgs = flowLaunchArgs(plainPrompt);
-  // cave-r3vmj raised RESEARCH_INTENT_MAX_LENGTH to 25k so real briefs can carry
+  // cave-e8z sets RESEARCH_INTENT_MAX_LENGTH to 20k so real briefs can carry
   // pasted context. The supervised transport still carries the prompt on argv,
   // so a maximum-length intent exceeds the bounded Windows command line even
   // with plain quoting — the guard fails closed with the actionable message


### PR DESCRIPTION
## Summary

Align the Research and Review Desk input ceilings with the product contract and make the limits visible and accessible before dispatch.

- Research mission intent is capped at 20,000 characters.
- Research direction and generation direction inputs are capped at 5,000 characters.
- GitHub review bodies are capped at 5,000 characters through a shared validator.
- Client inputs clamp programmatically populated drafts as well as keystrokes.
- Research and review surfaces render quiet character counters and connect them to the fields' descriptions and errors.
- Server validation and regression coverage use the same exported constants.

Bead: cave-e8z

## Verification

- Focused Research, Review Desk, API, and generation suites passed.
- Typecheck passed.
- Changed-file ESLint passed.
- Test-wiring, UI consistency, clock consistency, conflict-marker, and diff checks passed.
- Full pnpm lint is not clean on this checkout because it stops at seven unrelated pre-existing undefined-token findings.

The branch is based on origin/main at 334d21e13dc31f61c9ae7788317e58272e5084e7.