### PR TITLE
fix(research): classify local daemon update gaps

### DIFF
--- a/src/lib/coven-daemon.test.ts
+++ b/src/lib/coven-daemon.test.ts
@@ -13,6 +13,7 @@ const {
   extractDaemonError,
   normalizeWindowsDaemonSocket,
   isRemoteWindowsPath,
+  resolveDaemonSocket,
   resolveDaemonSocketPath,
   daemonTargetForConfig,
   callDaemonTarget,
@@ -117,6 +118,39 @@ const {
     },
   });
   assert.equal(socket, "\\\\.\\pipe\\coven-daemon-abc123.sock");
+}
+
+// A local CLI update removes daemon.json between daemon generations. The
+// resolver must expose that gap as unavailable, then notice the next canonical
+// local named pipe without caching the missing descriptor.
+{
+  const published = String.raw`\\.\pipe\coven-daemon-restarted.sock`;
+  let descriptorPresent = true;
+  const resolve = () => resolveDaemonSocket({
+    platform: "win32",
+    env: { COVEN_HOME: "C:/Users/Sonic/.coven" },
+    homeDir: "C:/Users/Sonic",
+    statSync: () => descriptorPresent ? { size: 128 } : null,
+    readFileSync: () => JSON.stringify({ socket: published }),
+  });
+
+  assert.deepEqual(resolve(), {
+    socketPath: published,
+    source: "daemon-status-file",
+    availability: "available",
+  });
+  descriptorPresent = false;
+  assert.deepEqual(resolve(), {
+    socketPath: "C:/Users/Sonic/.coven/coven.sock",
+    source: "canonical-local",
+    availability: "unavailable",
+  });
+  descriptorPresent = true;
+  assert.deepEqual(resolve(), {
+    socketPath: published,
+    source: "daemon-status-file",
+    availability: "available",
+  });
 }
 
 // An oversized daemon.json is never read or parsed: its size is the writer's
@@ -237,6 +271,25 @@ const {
       `${forged} should be refused without taking the local daemon down with it`,
     );
   }
+}
+
+// Resolution keeps an explicit remote override attached to the safe local
+// fallback, so a later local pipe cannot make Research treat that override as
+// an owner-local authority.
+{
+  const resolution = resolveDaemonSocket({
+    platform: "win32",
+    env: {
+      COVEN_SOCKET: String.raw`\\evil-host\pipe\coven`,
+      COVEN_HOME: "C:/Users/Sonic/.coven",
+    },
+    homeDir: "C:/Users/Sonic",
+    statSync: () => ({ size: 128 }),
+    readFileSync: () => JSON.stringify({ socket: String.raw`\\.\pipe\coven-daemon-local.sock` }),
+  });
+  assert.deepEqual(resolution.refusedSources, ["coven-socket-env"]);
+  assert.equal(resolution.source, "daemon-status-file");
+  assert.equal(resolution.availability, "available");
 }
 
 // The half of the precedence contract that did NOT change: an *accepted*

--- a/src/lib/coven-daemon.ts
+++ b/src/lib/coven-daemon.ts
@@ -29,7 +29,7 @@ import { isRemoteWindowsPath } from "./windows-local-path.ts";
 export { isRemoteWindowsPath } from "./windows-local-path.ts";
 export { covenHomePath } from "./coven-home.ts";
 
-type SocketPathResolverOptions = {
+export type SocketPathResolverOptions = {
   platform?: NodeJS.Platform;
   env?: Record<string, string | undefined>;
   homeDir?: string;
@@ -49,8 +49,24 @@ type ReadTextFile = (filePath: string, encoding: BufferEncoding) => string;
 const DAEMON_STATUS_FILE_MAX_BYTES = 4 * 1024;
 
 const WINDOWS_PIPE_PREFIX = "\\\\.\\pipe\\";
+export type RefusedSocketSource = "coven-socket-env" | "coven-home-env" | "daemon-status-file";
+
+export type DaemonSocketResolution = {
+  socketPath: string;
+  source: "coven-socket-env" | "daemon-status-file" | "canonical-local";
+  availability: "available" | "unavailable";
+  /** Configured sources that were refused before this safe result was built. */
+  refusedSources?: readonly RefusedSocketSource[];
+};
+
 export type DaemonTarget =
-  | { mode: "local"; label: "Local daemon"; socketPath: string }
+  | {
+      mode: "local";
+      label: "Local daemon";
+      socketPath: string;
+      /** Call-time resolver evidence; absent on persisted/test-created targets. */
+      socketResolution?: DaemonSocketResolution;
+    }
   | { mode: "hub"; label: "Server hub"; url: string; accessToken?: string }
   | { mode: "unconfigured-hub"; label: "Server hub"; error: string };
 
@@ -73,8 +89,6 @@ export function normalizeWindowsDaemonSocket(socket: string): string {
 
   return `${WINDOWS_PIPE_PREFIX}${trimmed}`;
 }
-
-type RefusedSocketSource = "coven-socket-env" | "coven-home-env" | "daemon-status-file";
 
 /**
  * Values already reported, so one refusal is one event.
@@ -317,7 +331,7 @@ function localWindowsDaemonSocket(
   return { kind: "accepted", socket: normalized };
 }
 
-export function resolveDaemonSocketPath(options: SocketPathResolverOptions = {}): string {
+export function resolveDaemonSocket(options: SocketPathResolverOptions = {}): DaemonSocketResolution {
   const platform = options.platform ?? process.platform;
   const env = options.env ?? process.env;
   const homeDir = options.homeDir ?? homedir();
@@ -333,23 +347,55 @@ export function resolveDaemonSocketPath(options: SocketPathResolverOptions = {})
       }
     });
 
+  const refusedSources: RefusedSocketSource[] = [];
+  const rememberRefusal = (source: RefusedSocketSource) => {
+    if (!refusedSources.includes(source)) refusedSources.push(source);
+  };
+  const withRefusedSources = (
+    resolution: Omit<DaemonSocketResolution, "refusedSources">,
+  ): DaemonSocketResolution => refusedSources.length > 0
+    ? { ...resolution, refusedSources: [...refusedSources] }
+    : resolution;
+
   const covenHome = covenHomePath(
     env,
     homeDir,
     platform,
-    (configured) => reportRefusedRemoteTarget("coven-home-env", configured),
+    (configured) => {
+      rememberRefusal("coven-home-env");
+      reportRefusedRemoteTarget("coven-home-env", configured);
+    },
   );
 
   if (env.COVEN_SOCKET) {
-    if (platform !== "win32") return env.COVEN_SOCKET;
+    if (platform !== "win32") {
+      return withRefusedSources({
+        socketPath: env.COVEN_SOCKET,
+        source: "coven-socket-env",
+        availability: "available",
+      });
+    }
     const configured = localWindowsDaemonSocket(env.COVEN_SOCKET, "coven-socket-env");
     // An accepted COVEN_SOCKET is still the whole answer: it outranks
     // `daemon.json`, and that precedence is what the override is for.
-    if (configured.kind === "accepted") return configured.socket;
+    if (configured.kind === "accepted") {
+      return withRefusedSources({
+        socketPath: configured.socket,
+        source: "coven-socket-env",
+        availability: "available",
+      });
+    }
     // A value that names nothing is not a redirection and not a request to go
     // look elsewhere either; it stays on the old "COVEN_SOCKET was set, so
     // daemon.json is not consulted" path.
-    if (configured.kind === "unnamed") return path.join(covenHome, "coven.sock");
+    if (configured.kind === "unnamed") {
+      return withRefusedSources({
+        socketPath: path.join(covenHome, "coven.sock"),
+        source: "canonical-local",
+        availability: "unavailable",
+      });
+    }
+    rememberRefusal("coven-socket-env");
     // A *refused* one falls through to `daemon.json`, exactly as if
     // COVEN_SOCKET had been unset.
     //
@@ -374,10 +420,31 @@ export function resolveDaemonSocketPath(options: SocketPathResolverOptions = {})
     const published = statusSocket
       ? localWindowsDaemonSocket(statusSocket, "daemon-status-file")
       : null;
-    if (published?.kind === "accepted") return published.socket;
+    if (published?.kind === "accepted") {
+      return withRefusedSources({
+        socketPath: published.socket,
+        source: "daemon-status-file",
+        availability: "available",
+      });
+    }
+    if (published?.kind === "refused") rememberRefusal("daemon-status-file");
+
+    return withRefusedSources({
+      socketPath: path.join(covenHome, "coven.sock"),
+      source: "canonical-local",
+      availability: "unavailable",
+    });
   }
 
-  return path.join(covenHome, "coven.sock");
+  return withRefusedSources({
+    socketPath: path.join(covenHome, "coven.sock"),
+    source: "canonical-local",
+    availability: "available",
+  });
+}
+
+export function resolveDaemonSocketPath(options: SocketPathResolverOptions = {}): string {
+  return resolveDaemonSocket(options).socketPath;
 }
 
 /**
@@ -385,7 +452,7 @@ export function resolveDaemonSocketPath(options: SocketPathResolverOptions = {})
  * COVEN_SOCKET env change is honored without an app restart.
  */
 export function socketPath(): string {
-  return resolveDaemonSocketPath();
+  return resolveDaemonSocket().socketPath;
 }
 
 function hubTargetFromUrl(rawUrl: string): Extract<DaemonTarget, { mode: "hub" }> | null {
@@ -424,7 +491,13 @@ export function daemonTargetForConfig(config: Pick<CaveConfig, "multiHost">): Da
 }
 
 export function localDaemonTarget(): Extract<DaemonTarget, { mode: "local" }> {
-  return { mode: "local", label: "Local daemon", socketPath: socketPath() };
+  const socketResolution = resolveDaemonSocket();
+  return {
+    mode: "local",
+    label: "Local daemon",
+    socketPath: socketResolution.socketPath,
+    socketResolution,
+  };
 }
 
 async function loadDaemonTarget(): Promise<DaemonTarget> {

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -5,6 +5,7 @@ import { PassThrough } from "node:stream";
 import { test } from "node:test";
 import { readFile } from "node:fs/promises";
 import { sanitizeAboutDiagnosticText } from "./about-diagnostics.ts";
+import { localDaemonTarget } from "./coven-daemon.ts";
 import {
   directDaemonLaunchCommand,
   parseDaemonLifecycleInspection,
@@ -20,9 +21,7 @@ import {
 
 const daemonStart = await readFile(new URL("./daemon-start.ts", import.meta.url), "utf8");
 const readinessSource = await readFile(new URL("./daemon-readiness.ts", import.meta.url), "utf8");
-const covenDaemon = await readFile(new URL("./coven-daemon.ts", import.meta.url), "utf8");
 
-assert.match(covenDaemon, /export function localDaemonTarget\(\)[\s\S]*mode: "local"[\s\S]*socketPath: socketPath\(\)/);
 assert.match(daemonStart, /waitForDaemonReadiness/);
 assert.match(daemonStart, /runnerExitGraceMs: startTimeoutMs/, "the daemonizing CLI launcher gets the complete health deadline");
 assert.match(daemonStart, /path: "\/api\/v1\/health"/);
@@ -41,6 +40,36 @@ assert.match(daemonStart, /RuntimeStartupCoordinator/, "duplicate launches and r
 assert.match(daemonStart, /code: "address_in_use"/, "an address someone else holds has its own actionable outcome");
 assert.match(daemonStart, /inspectDaemonAddress/, "occupancy is proven by connecting, not inferred from a failed health probe");
 assert.match(daemonStart, /daemonStartCoordinator\.run/, "production starts enter the shared coordinator");
+
+test("local daemon targets keep their socket path and resolution provenance aligned", () => {
+  const previousSocket = process.env.COVEN_SOCKET;
+  const previousHome = process.env.COVEN_HOME;
+  const expectedSocket = process.platform === "win32"
+    ? String.raw`\\.\pipe\coven-daemon-target-test.sock`
+    : "/tmp/coven-daemon-target-test.sock";
+  const expectedHome = process.platform === "win32"
+    ? String.raw`C:\Users\Cave\.coven`
+    : "/tmp/coven-daemon-target-test-home";
+
+  process.env.COVEN_SOCKET = expectedSocket;
+  process.env.COVEN_HOME = expectedHome;
+  try {
+    const target = localDaemonTarget();
+    assert.equal(target.mode, "local");
+    assert.equal(target.label, "Local daemon");
+    assert.deepEqual(target.socketResolution, {
+      socketPath: expectedSocket,
+      source: "coven-socket-env",
+      availability: "available",
+    });
+    assert.equal(target.socketPath, target.socketResolution.socketPath);
+  } finally {
+    if (previousSocket === undefined) delete process.env.COVEN_SOCKET;
+    else process.env.COVEN_SOCKET = previousSocket;
+    if (previousHome === undefined) delete process.env.COVEN_HOME;
+    else process.env.COVEN_HOME = previousHome;
+  }
+});
 
 for (const [payload, expected] of [
   [{ status: "running", ok: true }, { status: "running" }],

--- a/src/lib/server/flow-executor.test.ts
+++ b/src/lib/server/flow-executor.test.ts
@@ -9,8 +9,11 @@ import type {
   DaemonTarget,
 } from "../coven-daemon.ts";
 import {
+  classifyResearchDaemonTarget,
   INVALID_RESEARCH_WRITE_GRANT_DIAGNOSTIC,
   isOwnerLocalResearchDaemonTarget,
+  LOCAL_RESEARCH_DAEMON_UNAVAILABLE_DIAGNOSTIC,
+  localResearchDaemonUnavailableDiagnostic,
   OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC,
   dispatchResearchDaemonRequest,
   researchSessionLaunchPolicy,
@@ -204,6 +207,42 @@ assert.deepEqual(
 assert.match(SESSION_LAUNCH_POLICY_REQUIRED_DIAGNOSTIC, /Update Coven, restart the daemon/i);
 assert.match(INVALID_RESEARCH_WRITE_GRANT_DIAGNOSTIC, /verify the Research artifact workspace/i);
 assert.match(OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC, /owner-local Coven daemon socket/i);
+assert.deepEqual(localResearchDaemonUnavailableDiagnostic(), {
+  code: "local-unavailable",
+  message: LOCAL_RESEARCH_DAEMON_UNAVAILABLE_DIAGNOSTIC,
+  retryable: true,
+});
+const missingWindowsDaemon = {
+  mode: "local" as const,
+  label: "Local daemon" as const,
+  socketPath: "C:/Users/Sonic/.coven/coven.sock",
+  socketResolution: {
+    socketPath: "C:/Users/Sonic/.coven/coven.sock",
+    source: "canonical-local" as const,
+    availability: "unavailable" as const,
+  },
+};
+assert.equal(
+  classifyResearchDaemonTarget(missingWindowsDaemon, "win32"),
+  "local-unavailable",
+  "a missing Windows daemon descriptor is a retryable local update window",
+);
+const remoteOverrideWithLocalFallback = {
+  mode: "local" as const,
+  label: "Local daemon" as const,
+  socketPath: "\\\\.\\pipe\\coven-daemon-local",
+  socketResolution: {
+    socketPath: "\\\\.\\pipe\\coven-daemon-local",
+    source: "daemon-status-file" as const,
+    availability: "available" as const,
+    refusedSources: ["coven-socket-env" as const],
+  },
+};
+assert.equal(
+  classifyResearchDaemonTarget(remoteOverrideWithLocalFallback, "win32"),
+  "nonlocal",
+  "a refused remote COVEN_SOCKET remains fail-closed after local fallback",
+);
 for (const [socketPath, platform, expected] of [
   ["\\\\.\\pipe\\coven-daemon-local", "win32", true],
   ["\\\\remote-host\\pipe\\coven-daemon", "win32", false],
@@ -223,7 +262,7 @@ for (const [socketPath, platform, expected] of [
 }
 assert.match(
   source,
-  /shouldRequestResearchSessionLaunchPolicy\(\{[\s\S]*trustedLocalResearch: options\.trustedLocalResearch === true,[\s\S]*harness(?:: binding\.harness)?,[\s\S]*pinnedResearchDaemonTarget = localDaemonTarget\(\);[\s\S]*isOwnerLocalResearchDaemonTarget\(pinnedResearchDaemonTarget\)[\s\S]*OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC[\s\S]*callDaemonTarget<Record<string, unknown>>\(\s*pinnedResearchDaemonTarget,\s*daemonHealthRequest\(\),[\s\S]*supportsSessionLaunchPolicy\(health\.data\)[\s\S]*SESSION_LAUNCH_POLICY_REQUIRED_DIAGNOSTIC/,
+  /shouldRequestResearchSessionLaunchPolicy\(\{[\s\S]*trustedLocalResearch: options\.trustedLocalResearch === true,[\s\S]*harness(?:: binding\.harness)?,[\s\S]*pinnedResearchDaemonTarget = localDaemonTarget\(\);[\s\S]*classifyResearchDaemonTarget\(pinnedResearchDaemonTarget\)[\s\S]*localResearchDaemonUnavailableDiagnostic\(\)[\s\S]*status: 503,[\s\S]*diagnostic[\s\S]*isOwnerLocalResearchDaemonTarget\(pinnedResearchDaemonTarget\)[\s\S]*OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC[\s\S]*callDaemonTarget<Record<string, unknown>>\(\s*pinnedResearchDaemonTarget,\s*daemonHealthRequest\(\),[\s\S]*supportsSessionLaunchPolicy\(health\.data\)[\s\S]*SESSION_LAUNCH_POLICY_REQUIRED_DIAGNOSTIC/,
   "only trusted local Research probes one pinned local daemon target and old daemons fail closed",
 );
 assert.equal(

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -50,13 +50,16 @@ import { isAllowedHarness, normalizeProjectRoot } from "@/lib/server/session-sec
 import { travelLocalQueueStatus } from "@/lib/travel-offline-queue";
 import { daemonHealthRequest } from "@/lib/server/daemon-health-request";
 import {
+  classifyResearchDaemonTarget,
   INVALID_RESEARCH_WRITE_GRANT_DIAGNOSTIC,
   isOwnerLocalResearchDaemonTarget,
+  localResearchDaemonUnavailableDiagnostic,
   OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC,
   researchSessionLaunchPolicy,
   SESSION_LAUNCH_POLICY_REQUIRED_DIAGNOSTIC,
   shouldRequestResearchSessionLaunchPolicy,
   supportsSessionLaunchPolicy,
+  type ResearchSessionLaunchDiagnostic,
   dispatchResearchDaemonRequest,
   validatedResearchLaunchAddDirs,
 } from "@/lib/server/research-launch-policy";
@@ -83,6 +86,7 @@ export type StartFlowSessionResult = {
   queued?: boolean;
   queueItem?: CaveTravelQueueItem;
   unavailable?: boolean;
+  diagnostic?: ResearchSessionLaunchDiagnostic;
   cleanupUnconfirmed?: boolean;
   /** Exact in-process owner cleanup; functions are intentionally not persisted. */
   cleanupSession?: () => Promise<void>;
@@ -491,7 +495,21 @@ export async function startFlowSession(
     // config for every request; a concurrent local -> hub config change must
     // never move the later policy-bearing POST across that trust boundary.
     pinnedResearchDaemonTarget = localDaemonTarget();
-    if (!isOwnerLocalResearchDaemonTarget(pinnedResearchDaemonTarget)) {
+    const targetClassification = classifyResearchDaemonTarget(pinnedResearchDaemonTarget);
+    if (targetClassification === "local-unavailable") {
+      const diagnostic = localResearchDaemonUnavailableDiagnostic();
+      return {
+        ok: false,
+        status: 503,
+        unavailable: true,
+        error: diagnostic.message,
+        diagnostic,
+      };
+    }
+    if (
+      targetClassification === "nonlocal"
+      || !isOwnerLocalResearchDaemonTarget(pinnedResearchDaemonTarget)
+    ) {
       return {
         ok: false,
         status: 409,

--- a/src/lib/server/research-launch-policy.ts
+++ b/src/lib/server/research-launch-policy.ts
@@ -18,6 +18,23 @@ export const INVALID_RESEARCH_WRITE_GRANT_DIAGNOSTIC =
 export const OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC =
   "Unattended Research writes require the owner-local Coven daemon socket. Remove the remote COVEN_SOCKET override, restart Cave, and try again.";
 
+export const LOCAL_RESEARCH_DAEMON_UNAVAILABLE_DIAGNOSTIC =
+  "The local Coven daemon is temporarily unavailable while the Coven CLI updates. Wait for the update to finish, then retry Research.";
+
+export type ResearchSessionLaunchDiagnostic = {
+  code: "local-unavailable";
+  message: typeof LOCAL_RESEARCH_DAEMON_UNAVAILABLE_DIAGNOSTIC;
+  retryable: true;
+};
+
+export function localResearchDaemonUnavailableDiagnostic(): ResearchSessionLaunchDiagnostic {
+  return {
+    code: "local-unavailable",
+    message: LOCAL_RESEARCH_DAEMON_UNAVAILABLE_DIAGNOSTIC,
+    retryable: true,
+  };
+}
+
 export type ResearchSessionLaunchPolicy = {
   approval: "never";
   sandbox: "workspace-write";
@@ -111,6 +128,7 @@ export function isOwnerLocalResearchDaemonTarget(
   target: LocalDaemonTarget,
   platform: NodeJS.Platform = process.platform,
 ): boolean {
+  if (target.socketResolution?.refusedSources?.length) return false;
   const socketPath = target.socketPath.trim();
   if (!socketPath || socketPath.includes("\0")) return false;
   if (platform === "win32") {
@@ -118,6 +136,33 @@ export function isOwnerLocalResearchDaemonTarget(
     return socketPath.toLowerCase().startsWith(prefix) && socketPath.length > prefix.length;
   }
   return path.posix.isAbsolute(socketPath);
+}
+
+export type ResearchDaemonTargetClassification =
+  | "owner-local"
+  | "local-unavailable"
+  | "nonlocal";
+
+/**
+ * Keep the Windows canonical fallback distinct from an explicitly refused
+ * target. The former is the expected gap while the local CLI replaces a
+ * stopped daemon; the latter is a trust-boundary violation and must fail
+ * closed even when a later fallback happens to expose a local pipe.
+ */
+export function classifyResearchDaemonTarget(
+  target: LocalDaemonTarget,
+  platform: NodeJS.Platform = process.platform,
+): ResearchDaemonTargetClassification {
+  const resolution = target.socketResolution;
+  if (resolution?.refusedSources?.length) return "nonlocal";
+  if (
+    platform === "win32"
+    && resolution?.source === "canonical-local"
+    && resolution.availability === "unavailable"
+  ) {
+    return "local-unavailable";
+  }
+  return isOwnerLocalResearchDaemonTarget(target, platform) ? "owner-local" : "nonlocal";
 }
 
 /**

--- a/src/lib/server/research-mission-lifecycle.ts
+++ b/src/lib/server/research-mission-lifecycle.ts
@@ -13,6 +13,7 @@ import {
   STANDARD_RESEARCH_ARTIFACTS,
 } from "../research-missions.ts";
 import type { FlowRunRecord } from "../flows.ts";
+import type { ResearchSessionLaunchDiagnostic } from "./research-launch-policy.ts";
 
 export type ResearchFlowStartResult = {
   ok: boolean;
@@ -27,6 +28,7 @@ export type ResearchFlowStartResult = {
   run?: FlowRunRecord;
   queued?: boolean;
   unavailable?: boolean;
+  diagnostic?: ResearchSessionLaunchDiagnostic;
   /** A start failed after launch and its process owner could not prove cleanup. */
   cleanupUnconfirmed?: boolean;
   /** Exact in-process owner cleanup; ignored by durable mission serialization. */


### PR DESCRIPTION
## Summary

Classify the Windows daemon descriptor gap during a local Coven CLI update as a typed, retryable local-unavailable state before a Research session is created.

- Daemon socket resolution now returns provenance and availability instead of collapsing every fallback to a string.
- Missing or temporarily absent canonical Windows daemon descriptors produce a 503-style local-unavailable diagnostic.
- Explicit remote COVEN_SOCKET and daemon-status targets remain fail-closed, even if resolution later finds a local pipe.
- The existing string resolver remains available for non-Research callers.
- Regression coverage exercises descriptor disappearance/reappearance, named-pipe resolution, and remote override refusal.

Bead: cave-c2e

## Verification

- coven-daemon.test.ts passed.
- flow-executor.test.ts passed through the repository's alias-aware runner arguments.
- Research lifecycle tests: 74 passed.
- Daemon status route tests passed.
- Test wiring, diff checks, and conflict checks passed.
- Native Windows runtime verification was unavailable; the named-pipe behavior is covered through the resolver seam.
- The local Node runtime is 24.15.0 while package metadata requests >=24.18.0.

Based on origin/main at 334d21e13dc31f61c9ae7788317e58272e5084e7.