### PR TITLE
fix(worktrees): launch bd safely on Windows

### DIFF
--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -17,6 +17,7 @@ import {
 import {
   collectWorktreeLifecycleInventory,
   discountUnrepresentableExecutableBitChanges,
+  formatLifecycleInventoryFailure,
   type OrphanedWorktreeMetadataRecord,
   type WorktreeMetadataClaimError,
 } from "./worktree-lifecycle-inventory.ts";
@@ -54,6 +55,8 @@ type CommandResult = {
   status: number | null;
   stdout: string;
   stderr: string;
+  /** Set when the OS could not start the requested executable. */
+  executionError?: string;
 };
 
 type ManagedCreateOptions = {
@@ -187,6 +190,7 @@ function command(
     status: result.status,
     stdout: typeof result.stdout === "string" ? result.stdout : "",
     stderr,
+    ...(errorMessage ? { executionError: errorMessage } : {}),
   };
 }
 
@@ -535,6 +539,11 @@ function parseExactBead(
 function loadExactBead(root: string, beadId: string): ExactBead {
   const result = command("bd", ["show", beadId, "--json"], root);
   if (!result.ok) {
+    if (result.executionError) {
+      throw new CliError(
+        `Beads CLI could not be executed: ${result.stderr || result.executionError}`,
+      );
+    }
     throw new CliError(result.stderr || `bd show ${beadId} failed`);
   }
   return parseExactBead(result.stdout, beadId);
@@ -1898,7 +1907,7 @@ function execute(
     ),
   ];
   if (errors.length > 0) {
-    throw new CliError(`lifecycle inventory is incomplete: ${errors.join("; ")}`);
+    throw new CliError(formatLifecycleInventoryFailure(errors));
   }
   // A local admission preflight can identify a refusal cheaply, but it cannot
   // replace the complete inventory. Check the inventory first so an outage

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -133,7 +133,85 @@ type CommandResult = {
   status: number | null;
   stdout: string;
   stderr: string;
+  /** Set when the OS could not start the requested executable. */
+  executionError?: string;
 };
+
+const BEADS_ROLE_WARNING = /^\s*warning:\s*beads\.role\s+not configured\b/i;
+const BEADS_ROLE_FIX = /^\s*Fix:\s*git\s+config\s+beads\.role\b.*$/i;
+
+/**
+ * Remove Beads' informational role warning while preserving every other
+ * stderr line. `bd list --json` remains valid JSON when this warning is the
+ * only diagnostic, so treating all stderr as a failed inventory would turn a
+ * harmless first-run hint into an exit-1 lifecycle refusal.
+ */
+export function filterBeadsInventoryStderr(stderr: string): string {
+  const retained: string[] = [];
+  let suppressRoleFix = false;
+  for (const line of stderr.split(/\r?\n/)) {
+    if (BEADS_ROLE_WARNING.test(line)) {
+      suppressRoleFix = true;
+      continue;
+    }
+    if (suppressRoleFix && line.trim().length === 0) continue;
+    if (suppressRoleFix && BEADS_ROLE_FIX.test(line)) {
+      suppressRoleFix = false;
+      continue;
+    }
+    suppressRoleFix = false;
+    retained.push(line);
+  }
+  return retained.join("\n").trim();
+}
+
+export type LifecycleInventoryFailureKind =
+  | "beads-execution"
+  | "github-transient"
+  | "inventory";
+
+/** Classify only the failure families that change the operator's next action. */
+export function classifyLifecycleInventoryFailure(
+  message: string,
+): LifecycleInventoryFailureKind {
+  if (
+    /Beads CLI could not be executed|bd invocation failed|spawn(?:Sync)?\s+bd\b[^\n]*(?:ENOENT|not found|cannot find the file)/i.test(
+      message,
+    )
+  ) {
+    return "beads-execution";
+  }
+  if (
+    /could not query GitHub|associated PR inventory query failed|workflow inventory failed for|\b(?:rate limit|secondary rate limit|quota)\b|GitHub[^\n;]*(?:unavailable|failed|timed out)|(?:API|GraphQL)[^\n;]*(?:unavailable|failed|timed out|rate limit|quota)/i.test(
+      message,
+    )
+  ) {
+    return "github-transient";
+  }
+  return "inventory";
+}
+
+/**
+ * Keep exit-1 lifecycle diagnostics actionable: a missing/unlaunchable `bd`
+ * needs a local install fix, while a GitHub or GraphQL quota/read failure
+ * needs a retry. All other validation failures retain the existing wording.
+ */
+export function formatLifecycleInventoryFailure(errors: readonly string[]): string {
+  const unique = [...new Set(errors.map((error) => error.trim()).filter(Boolean))];
+  const beadsExecution = unique.filter(
+    (error) => classifyLifecycleInventoryFailure(error) === "beads-execution",
+  );
+  if (beadsExecution.length > 0) {
+    return `lifecycle inventory could not execute bd: ${beadsExecution.join("; ")}`;
+  }
+  const githubTransient = unique.filter(
+    (error) => classifyLifecycleInventoryFailure(error) === "github-transient",
+  );
+  if (githubTransient.length > 0) {
+    return `lifecycle inventory is unavailable due to a transient GitHub/GraphQL failure; retry: ${githubTransient.join("; ")}`;
+  }
+  return `lifecycle inventory is incomplete: ${unique.join("; ")}`;
+}
 
 type WorktreeEntry = {
   path: string;
@@ -411,15 +489,16 @@ function runCommand(
       status: result.status,
       stdout: typeof result.stdout === "string" ? result.stdout : "",
       stderr: [stderr, spawnError].filter(Boolean).join(": "),
+      ...(spawnError ? { executionError: spawnError } : {}),
     };
   } catch (error) {
+    const executionError = error instanceof Error ? error.message : "unknown spawn error";
     return {
       ok: false,
       status: null,
       stdout: "",
-      stderr: `${executable} invocation failed: ${
-        error instanceof Error ? error.message : "unknown spawn error"
-      }`,
+      stderr: `${executable} invocation failed: ${executionError}`,
+      executionError,
     };
   }
 }
@@ -1957,8 +2036,15 @@ function fetchTasks(root: string): { tasks: BeadTask[]; error: string | null } {
     root,
     120_000,
   );
-  if (!result.ok || result.stderr) {
-    return { tasks: [], error: result.stderr || "Beads inventory unavailable" };
+  const meaningfulStderr = filterBeadsInventoryStderr(result.stderr);
+  if (result.executionError) {
+    return {
+      tasks: [],
+      error: `Beads CLI could not be executed: ${meaningfulStderr || result.executionError}`,
+    };
+  }
+  if (!result.ok || meaningfulStderr) {
+    return { tasks: [], error: meaningfulStderr || "Beads inventory unavailable" };
   }
   try {
     const parsed = parseJson<

--- a/scripts/worktree-lifecycle-rest-pr-inventory.test.mjs
+++ b/scripts/worktree-lifecycle-rest-pr-inventory.test.mjs
@@ -3,6 +3,9 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  classifyLifecycleInventoryFailure,
+  filterBeadsInventoryStderr,
+  formatLifecycleInventoryFailure,
   parseRestPullRequestLines,
   parseRestPullRequestPages,
 } from "./worktree-lifecycle-inventory.ts";
@@ -60,6 +63,55 @@ test("the lifecycle PR inventory uses REST endpoints and never invokes GraphQL",
   assert.match(source, /commits\/\$\{encodeURIComponent\(oid\)\}\/pulls\?per_page=100/);
   assert.match(source, /pulls\?state=all&per_page=100/);
   assert.match(source, /"--jq"/);
+});
+
+test("Beads role guidance is ignorable, while unrelated stderr remains an inventory error", () => {
+  assert.equal(
+    filterBeadsInventoryStderr(
+      "warning: beads.role not configured (GH#2950).\n    Fix: git config beads.role maintainer\n",
+    ),
+    "",
+  );
+  assert.equal(
+    filterBeadsInventoryStderr(
+      "warning: beads.role not configured (GH#2950).\n\n    Fix: git config beads.role contributor\nBeads inventory omitted records\n",
+    ),
+    "Beads inventory omitted records",
+  );
+  assert.equal(
+    filterBeadsInventoryStderr("Fix: git config beads.role maintainer\n"),
+    "Fix: git config beads.role maintainer",
+    "a fix line without its warning is not silently discarded",
+  );
+});
+
+test("exit-1 inventory diagnostics distinguish bd execution from transient GitHub failures", () => {
+  assert.equal(
+    classifyLifecycleInventoryFailure(
+      "Beads CLI could not be executed: spawnSync bd ENOENT",
+    ),
+    "beads-execution",
+  );
+  assert.equal(
+    classifyLifecycleInventoryFailure(
+      "pull request inventory could not query GitHub — API rate limit exceeded",
+    ),
+    "github-transient",
+  );
+  assert.equal(
+    classifyLifecycleInventoryFailure("Beads inventory returned malformed data"),
+    "inventory",
+  );
+  assert.match(
+    formatLifecycleInventoryFailure(["Beads CLI could not be executed: spawnSync bd ENOENT"]),
+    /could not execute bd/i,
+  );
+  assert.match(
+    formatLifecycleInventoryFailure([
+      "pull request inventory could not query GitHub — API rate limit exceeded",
+    ]),
+    /inventory is unavailable.*transient GitHub\/GraphQL.*retry/i,
+  );
 });
 
 test("the normal test runner enables TypeScript stripping for this suite", () => {

--- a/src/lib/bd-bin.test.ts
+++ b/src/lib/bd-bin.test.ts
@@ -106,6 +106,48 @@ const silent = () => {};
   );
 }
 
+// The stock Windows release installer uses %LOCALAPPDATA%\Programs\bd. The
+// environment object can arrive with PowerShell/Explorer casing (`Path` and
+// `LocalAppData`), so discovery must not require the user to edit PATH in the
+// already-running Cave process.
+{
+  const stockDir = "C:\\Users\\dev\\AppData\\Local\\Programs\\bd";
+  const stockExe = path.win32.join(stockDir, "bd.exe");
+  const launch = resolveBdLaunchCommand({
+    platform: "win32",
+    env: {
+      Path: "C:\\Windows\\system32",
+      LocalAppData: "C:\\Users\\dev\\AppData\\Local",
+    },
+    isFile: onlyFiles([stockExe]),
+    resolveShim,
+    warn: silent,
+  });
+  assert.deepEqual(launch, { command: stockExe, fixedArgs: [] });
+  assert.ok(
+    bdSearchDirs(
+      { Path: "C:\\Windows\\system32", LocalAppData: "C:\\Users\\dev\\AppData\\Local" },
+      "win32",
+    ).includes(stockDir),
+    "the documented stock install directory belongs in Windows discovery",
+  );
+}
+
+// A source install commonly lands in the default Go bin directory when no
+// PATH entry was inherited.
+{
+  const goDir = "C:\\Users\\dev\\go\\bin";
+  const goExe = path.win32.join(goDir, "bd.exe");
+  const launch = resolveBdLaunchCommand({
+    platform: "win32",
+    env: { Path: "C:\\Windows\\system32", UserProfile: "C:\\Users\\dev" },
+    isFile: onlyFiles([goExe]),
+    resolveShim,
+    warn: silent,
+  });
+  assert.deepEqual(launch, { command: goExe, fixedArgs: [] });
+}
+
 // Nothing found: fall back to the bare name so the caller's existing ENOENT
 // path reports what it always did, rather than a novel message.
 {
@@ -154,7 +196,7 @@ const silent = () => {};
   const overrideShim = "C:\\custom\\bd.cmd";
   const launch = resolveBdLaunchCommand({
     platform: "win32",
-    env: { BD_BIN: overrideShim, PATH: NPM_DIR },
+    env: { Bd_Bin: overrideShim, PATH: NPM_DIR },
     isFile: onlyFiles([overrideShim]),
     resolveShim: (binary) => ({ command: "node.exe", fixedArgs: [`${binary}-target`] }),
     warn: silent,

--- a/src/lib/bd-bin.ts
+++ b/src/lib/bd-bin.ts
@@ -36,7 +36,7 @@
 
 import { statSync } from "node:fs";
 import path from "node:path";
-import { windowsShimLaunchCommandForBinary } from "./coven-bin.ts";
+import { environmentValue, windowsShimLaunchCommandForBinary } from "./coven-bin.ts";
 
 export type BdLaunchCommand = {
   /** argv[0] to hand to spawn/execFile. */
@@ -91,26 +91,40 @@ function defaultIsFile(candidate: string): boolean {
  * Directories to probe for a `bd` launcher, PATH first.
  *
  * PATH order is authoritative — an explicitly installed `bd` earlier on PATH
- * must win over the npm global prefix. The npm directories are appended, not
- * prepended, so they only rescue a minimal PATH (a GUI-launched process, a
- * stripped CI env) rather than overriding a deliberate one.
+ * must win over the known installer directories. Those directories are
+ * appended, not prepended, so they only rescue a minimal PATH (a GUI-launched
+ * process, a stripped CI env) rather than overriding a deliberate one. The
+ * release installer uses `%LOCALAPPDATA%\\Programs\\bd`; a source install
+ * commonly lands in the user's Go bin directory.
  */
 export function bdSearchDirs(
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,
 ): string[] {
   const pathApi = pathApiFor(platform);
-  const fromPath = (env.PATH ?? env.Path ?? "").split(pathApi.delimiter);
-  const npmDirs =
+  const fromPath = (environmentValue(env, "PATH", platform) ?? env.Path ?? "").split(
+    pathApi.delimiter,
+  );
+  const appData = environmentValue(env, "APPDATA", platform);
+  const localAppData = environmentValue(env, "LOCALAPPDATA", platform);
+  const npmPrefix = environmentValue(env, "npm_config_prefix", platform);
+  const goBin = environmentValue(env, "GOBIN", platform);
+  const goPath = environmentValue(env, "GOPATH", platform);
+  const userProfile = environmentValue(env, "USERPROFILE", platform);
+  const knownDirs =
     platform === "win32"
       ? [
-          env.APPDATA ? pathApi.join(env.APPDATA, "npm") : null,
-          env.npm_config_prefix ?? null,
+          appData ? pathApi.join(appData, "npm") : null,
+          npmPrefix ?? null,
+          localAppData ? pathApi.join(localAppData, "Programs", "bd") : null,
+          goBin ?? null,
+          goPath ? pathApi.join(goPath, "bin") : null,
+          userProfile ? pathApi.join(userProfile, "go", "bin") : null,
         ]
       : [];
   const seen = new Set<string>();
   const dirs: string[] = [];
-  for (const dir of [...fromPath, ...npmDirs]) {
+  for (const dir of [...fromPath, ...knownDirs]) {
     const trimmed = dir?.trim();
     if (!trimmed || seen.has(trimmed)) continue;
     seen.add(trimmed);
@@ -148,7 +162,7 @@ export function resolveBdLaunchCommand(
     ((binary, shimPlatform) =>
       windowsShimLaunchCommandForBinary(binary, shimPlatform) as BdLaunchCommand);
 
-  const override = env[BD_BIN_ENV_KEY]?.trim();
+  const override = environmentValue(env, BD_BIN_ENV_KEY, platform)?.trim();
   if (override) {
     if (isFile(override)) return launchForBinary(override, platform, resolveShim);
     (dependencies.warn ?? ((message: string) => console.error(message)))(

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -392,7 +392,8 @@ function verifiedAbsoluteBinary(
   }
 }
 
-function environmentValue(
+/** Read one process environment key case-insensitively on Windows. */
+export function environmentValue(
   env: NodeJS.ProcessEnv,
   key: string,
   platform: NodeJS.Platform,


### PR DESCRIPTION
## Summary

- Resolve stock Windows Beads launchers without requiring PATH edits or `shell: true`.
- Ignore only the harmless `beads.role not configured` inventory warning.
- Make exit-1 lifecycle diagnostics distinguish an unlaunchable Beads CLI from transient GitHub/GraphQL failures.

## Verification

- `src/lib/bd-bin.test.ts`
- `src/lib/coven-bin.test.ts`
- `scripts/worktree-lifecycle-rest-pr-inventory.test.mjs` (6/6)
- `src/lib/worktree-lifecycle.test.ts`
- TypeScript syntax checks for lifecycle scripts
- `git diff --check`

Implements Bead `cave-zuc`. The fallback worktree used for this branch was required because the lifecycle inventory gate currently reports a malformed Git worktree inventory; it is preserved for lifecycle follow-up.