### PR TITLE
fix(build): ignore semantic index runtime paths

### DIFF
--- a/src/lib/server/research-resource-semantic-index.ts
+++ b/src/lib/server/research-resource-semantic-index.ts
@@ -1056,7 +1056,7 @@ export async function rebuildResearchResourceSemanticIndex(
     // Cross-process handles observe the marker and release their SQLite file
     // descriptors. Rename retries cover Windows handles still unwinding.
     await new Promise((resolve) => setTimeout(resolve, 50));
-    const currentIdentity = existsSync(file) ? lstatSync(file) : null;
+    const currentIdentity = existsSync(/* turbopackIgnore: true */ file) ? lstatSync(file) : null;
     const sameFile = expectedIdentity === null
       ? currentIdentity === null
       : currentIdentity !== null
@@ -1067,7 +1067,7 @@ export async function rebuildResearchResourceSemanticIndex(
       syncDirectory(path.dirname(file));
       lostRace = true;
     } else {
-      quarantinePath = existsSync(file)
+      quarantinePath = existsSync(/* turbopackIgnore: true */ file)
         ? `${file}.corrupt-${Date.now()}-${randomBytes(4).toString("hex")}`
         : null;
       if (quarantinePath) {


### PR DESCRIPTION
## Summary

Draft follow-up for the unrelated Turbopack tracing failure observed while validating cave-p1seb / PR #5249.

Adds `/* turbopackIgnore: true */` to the two runtime-derived `existsSync(file)` calls in `src/lib/server/research-resource-semantic-index.ts`, preserving the existing race/quarantine behavior.

## Verification

- Focused semantic-index/protocol tests: 38/38
- Protocol suites: 102/102 and 113/113
- Syntax checks
- `git diff --check`

## Relationship to #5249

This is intentionally separate from the podcast generation change. It should be merged/validated independently, then PR #5249 can be re-run against the repaired conformance tracing path.