### PR TITLE
fix(vault): smooth the secret visibility transition

### DIFF
--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -93,6 +93,7 @@ function AddMappingForm({
   const [desc, setDesc]       = useState(initial?.description ?? "");
   const [required, setReq]    = useState(initial?.required ?? false);
   const [showInput, setShowInput] = useState(false);
+  const [inputVisibilityChanged, setInputVisibilityChanged] = useState(false);
   const [busy, setBusy]       = useState(false);
   const [err, setErr]         = useState<string | null>(null);
   const { announce } = useAnnouncer();
@@ -131,6 +132,11 @@ function AddMappingForm({
           : provider.referencePrefix!;
       });
     }
+  }
+
+  function toggleInputVisibility() {
+    setShowInput((current) => !current);
+    setInputVisibilityChanged(true);
   }
 
   async function pasteFromClipboard() {
@@ -244,6 +250,7 @@ function AddMappingForm({
           <div className="vault-paste-field">
             <textarea
               className={`vault-add-input vault-paste-input focus-ring${showInput ? "" : " vault-paste-input--masked"}`}
+              data-visibility-transition={inputVisibilityChanged ? (showInput ? "reveal" : "mask") : undefined}
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder={initial?.storage === "encrypted"
@@ -257,8 +264,9 @@ function AddMappingForm({
               <button
                 type="button"
                 className="vault-btn focus-ring vault-paste-button"
-                onClick={() => setShowInput((current) => !current)}
+                onClick={toggleInputVisibility}
                 aria-pressed={showInput}
+                aria-label={showInput ? "Hide secret text" : "Show secret text"}
               >
                 {showInput ? "Hide" : "Show"}
               </button>

--- a/src/lib/vault.test.ts
+++ b/src/lib/vault.test.ts
@@ -224,6 +224,31 @@ assert.match(
   "Vault error status keeps the danger token",
 );
 assert.match(
+  panelSource,
+  /data-visibility-transition=\{inputVisibilityChanged \? \(showInput \? "reveal" : "mask"\) : undefined\}/,
+  "secret visibility changes expose their direction without animating the initial masked render",
+);
+assert.match(
+  panelStylesSource,
+  /\.vault-paste-input\[data-visibility-transition="reveal"\]\s*\{[^}]*animation:\s*vault-paste-reveal var\(--duration-slow\) var\(--ease-standard\)/,
+  "revealing secret text uses the design-system motion tokens",
+);
+assert.match(
+  panelStylesSource,
+  /@keyframes vault-paste-reveal\s*\{[\s\S]*?color:\s*transparent;[\s\S]*?-webkit-text-security:\s*none;/,
+  "the reveal swaps the discrete text-security mode while the glyphs are transparent",
+);
+assert.match(
+  panelStylesSource,
+  /@keyframes vault-paste-mask\s*\{[\s\S]*?color:\s*transparent;[\s\S]*?-webkit-text-security:\s*disc;/,
+  "the mask swaps the discrete text-security mode while the glyphs are transparent",
+);
+assert.match(
+  panelStylesSource,
+  /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.vault-paste-input\[data-visibility-transition\][\s\S]*?animation:\s*none;/,
+  "secret visibility changes respect reduced-motion preferences",
+);
+assert.match(
   themesSource,
   /\.vault-row-error\s*\{[^}]*color:\s*var\(--color-danger\)/,
   "Vault row errors keep the danger token",

--- a/src/styles/vault-panel.css
+++ b/src/styles/vault-panel.css
@@ -56,10 +56,69 @@
   resize: vertical;
   font-family: var(--font-mono, monospace);
   line-height: var(--leading-normal);
+  caret-color: currentColor;
 }
 
 .vault-paste-input--masked {
   -webkit-text-security: disc;
+}
+
+.vault-paste-input[data-visibility-transition="reveal"] {
+  animation: vault-paste-reveal var(--duration-slow) var(--ease-standard);
+}
+
+.vault-paste-input[data-visibility-transition="mask"] {
+  animation: vault-paste-mask var(--duration-slow) var(--ease-standard);
+}
+
+@keyframes vault-paste-reveal {
+  0% {
+    color: var(--text-primary);
+    -webkit-text-security: disc;
+  }
+
+  45% {
+    color: transparent;
+    -webkit-text-security: disc;
+  }
+
+  55% {
+    color: transparent;
+    -webkit-text-security: none;
+  }
+
+  100% {
+    color: var(--text-primary);
+    -webkit-text-security: none;
+  }
+}
+
+@keyframes vault-paste-mask {
+  0% {
+    color: var(--text-primary);
+    -webkit-text-security: none;
+  }
+
+  45% {
+    color: transparent;
+    -webkit-text-security: none;
+  }
+
+  55% {
+    color: transparent;
+    -webkit-text-security: disc;
+  }
+
+  100% {
+    color: var(--text-primary);
+    -webkit-text-security: disc;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vault-paste-input[data-visibility-transition] {
+    animation: none;
+  }
 }
 
 .vault-paste-actions {


### PR DESCRIPTION
## Summary
- The Vault secret Show/Hide control swapped `-webkit-text-security` discretely, making the paste textarea feel choppy and buggy.
- Cross-fades only the glyph color, swaps the masking mode while the glyphs are transparent, keeps the field chrome stable, and disables the animation under `prefers-reduced-motion`.
- Adds a `data-visibility-transition` attribute (set only after the first user-initiated toggle) so the transition never plays on the initial masked render.
- Adds an `aria-label` on the Show/Hide button reflecting its current action.

## Validation
- `node --experimental-strip-types src/lib/vault.test.ts` — focused Vault regression test passes
- `pnpm typecheck` — clean
- `pnpm lint` — clean (token reference scan, design codemod check, ESLint)
- `pnpm check:tests-wired` — 1977 files wired
- `pnpm test:app` — 1403/1403 test files passed

cave-pd7t8