### PR TITLE
fix(research): gate iteration limit on computed number, not array length

### DIFF
--- a/src/lib/server/research-mission-lifecycle.test.ts
+++ b/src/lib/server/research-mission-lifecycle.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { parseResearchMission } from "../research-missions.ts";
-import { applyStartResult, createMissionRecord } from "./research-mission-lifecycle.ts";
+import {
+  applyStartResult,
+  createMissionRecord,
+  stopBeforeNextIteration,
+} from "./research-mission-lifecycle.ts";
 
 const INPUT = {
   familiarId: "sage",
@@ -94,4 +98,42 @@ test("applyStartResult keeps private process-owner provenance out of mission sta
   }, new Date("2026-07-24T00:01:00.000Z"));
   assert.equal("sessionAuthority" in (retained.iterations[0] ?? {}), false);
   assert.equal("sessionOwnerKind" in (retained.iterations[0] ?? {}), false);
+});
+
+test("stopBeforeNextIteration gates on the computed next iteration number, not array length", () => {
+  const mission = createMissionRecord(
+    { ...INPUT, bounds: { ...INPUT.bounds, maxIterations: 3 } },
+    "mission-1",
+    new Date("2026-07-24T00:00:00.000Z"),
+  );
+
+  // Contiguous numbering: length and the computed number agree.
+  const contiguous = {
+    ...mission,
+    iterations: [
+      { number: 1, status: "completed" as const },
+      { number: 2, status: "completed" as const },
+      { number: 3, status: "completed" as const },
+    ],
+  };
+  assert.equal(
+    stopBeforeNextIteration(contiguous, new Date("2026-07-24T00:10:00.000Z")),
+    "Iteration limit reached",
+  );
+
+  // Gapped numbering (e.g. iterations 1 and 3, maxIterations 3): the array
+  // has only 2 entries, so a length-based gate would wrongly allow starting
+  // iteration 4, one past the limit. Gating on the computed next number
+  // (3 + 1 = 4 > 3) correctly refuses it.
+  const gapped = {
+    ...mission,
+    iterations: [
+      { number: 1, status: "completed" as const },
+      { number: 3, status: "completed" as const },
+    ],
+  };
+  assert.equal(
+    stopBeforeNextIteration(gapped, new Date("2026-07-24T00:10:00.000Z")),
+    "Iteration limit reached",
+  );
 });

--- a/src/lib/server/research-mission-lifecycle.ts
+++ b/src/lib/server/research-mission-lifecycle.ts
@@ -7,6 +7,7 @@ import type {
   ResearchSessionOwnerKind,
 } from "./research-session-authority.ts";
 import {
+  nextResearchIterationNumber,
   researchArtifactKindForMode,
   RESEARCH_COST_UNAVAILABLE_STOP_REASON,
   RESEARCH_RUNTIME_DEFAULT_HARNESS,
@@ -170,7 +171,11 @@ export function stopBeforeNextIteration(
   now: Date,
   options: { allowCostUnavailable?: boolean } = {},
 ): string | null {
-  if (mission.iterations.length >= mission.bounds.maxIterations) return "Iteration limit reached";
+  // Gate on the iteration number the runner would actually start next, not
+  // the array length: they agree for contiguous numbering, but a persisted
+  // mission with gapped iteration numbers would let a length-based gate pass
+  // when the computed next number is already past the limit.
+  if (nextResearchIterationNumber(mission) > mission.bounds.maxIterations) return "Iteration limit reached";
   const startedAt = mission.startedAt ? Date.parse(mission.startedAt) : Number.NaN;
   if (Number.isFinite(startedAt) && now.getTime() - startedAt >= mission.bounds.wallClockMinutes * 60_000) {
     return "Wall-clock limit reached";

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -1046,7 +1046,8 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
     mission: ResearchMission,
     options: { allowCostUnavailable?: boolean } = {},
   ): Promise<ResearchMission> => {
-    const stopReason = stopBeforeNextIteration(mission, deps.now(), options);
+    const now = deps.now();
+    const stopReason = stopBeforeNextIteration(mission, now, options);
     if (stopReason) {
       if (mission.status === "completed" || mission.status === "cancelled") {
         return mission;
@@ -1055,12 +1056,12 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       return saveUpdated({
         ...mission,
         status: atIterationLimit ? "completed" : "paused",
-        ...(atIterationLimit ? { finishedAt: deps.now().toISOString() } : {}),
+        ...(atIterationLimit ? { finishedAt: now.toISOString() } : {}),
         lastError: stopReason,
       });
     }
     const number = nextResearchIterationNumber(mission);
-    const timestamp = deps.now().toISOString();
+    const timestamp = now.toISOString();
     const workingArtifact = mission.artifacts[0]?.state === "rejected" ? {
       ...mission.artifacts[0],
       key: `primary-i${number}`,


### PR DESCRIPTION
## Summary

`stopBeforeNextIteration` (`src/lib/server/research-mission-lifecycle.ts`) refused a new iteration when `mission.iterations.length >= bounds.maxIterations`, while `nextResearchIterationNumber` (the value the runner actually uses to number and label the next iteration, and what `researchContinueLabel`'s UI gate already compares against) computes `iterations.at(-1).number + 1`.

With contiguous numbering from 1 these agree exactly, and every current writer keeps numbering contiguous. But a persisted mission with gapped iteration numbers (e.g. iterations 1 and 3 with `maxIterations` 3) would let the length-based gate (2 >= 3 is false) pass while the runner started iteration 4 — one past the planned limit.

## Change

- Gate `stopBeforeNextIteration` on `nextResearchIterationNumber(mission) > mission.bounds.maxIterations` instead of array length, keeping it in sync with `researchContinueLabel`'s existing `next > max` check.
- Consolidated `startNextIteration`'s three separate `deps.now()` calls into a single `now` while touching this function, so the stop check and the persisted timestamps (`finishedAt`, iteration `timestamp`) read the same instant.
- Added a regression test covering both contiguous and gapped-numbering cases.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (pre-existing unrelated `--destructive`/`--shadow-popover` token warnings only)
- `pnpm check:tests-wired` — 1984 files
- `pnpm test:app` — 1405/1405 passed
- Targeted: `research-mission-lifecycle.test.ts`, `research-mission-runner-*.test.ts`, `research-missions.test.ts` all pass

Bead: cave-oct20. Raised by copilot-pull-request-reviewer on PR #4728; deliberately deferred out of that PR since it was scoped to UI copy and this is shared lifecycle code with its own suite.