### PR TITLE
fix(research): bound stored paper metadata and gate zoom on ready state

### DIFF
--- a/src/components/research-paper-viewer.tsx
+++ b/src/components/research-paper-viewer.tsx
@@ -331,7 +331,7 @@ export default function ResearchPaperViewer({
             variant="ghost"
             leadingIcon="ph:minus"
             aria-label="Zoom out"
-            disabled={zoomIndex <= 0}
+            disabled={!ready || zoomIndex <= 0}
             onClick={() => setZoomIndex((current) => Math.max(0, current - 1))}
           />
           <span className="research-paper-view__readout">
@@ -342,7 +342,7 @@ export default function ResearchPaperViewer({
             variant="ghost"
             leadingIcon="ph:plus"
             aria-label="Zoom in"
-            disabled={zoomIndex >= ZOOM_STEPS.length - 1}
+            disabled={!ready || zoomIndex >= ZOOM_STEPS.length - 1}
             onClick={() =>
               setZoomIndex((current) => Math.min(ZOOM_STEPS.length - 1, current + 1))
             }

--- a/src/lib/server/hf-paper-metadata.test.ts
+++ b/src/lib/server/hf-paper-metadata.test.ts
@@ -44,6 +44,26 @@ test("degrades to null on malformed JSON", async () => {
   assert.equal(result, null);
 });
 
+test("degrades to null when content-length declares a body over the cap", async () => {
+  const result = await fetchHfPaperMetadata("2401.12345", {
+    fetchImpl: async () =>
+      new Response(JSON.stringify(PAYLOAD), {
+        status: 200,
+        headers: { "content-length": String(2 * 1024 * 1024) },
+      }),
+  });
+  assert.equal(result, null);
+});
+
+test("degrades to null when the actual body stream exceeds the cap", async () => {
+  const hugeTitle = "x".repeat(2 * 1024 * 1024);
+  const result = await fetchHfPaperMetadata("2401.12345", {
+    fetchImpl: async () =>
+      new Response(JSON.stringify({ ...PAYLOAD, title: hugeTitle }), { status: 200 }),
+  });
+  assert.equal(result, null);
+});
+
 test("refuses an id that is not an arXiv id, without issuing a request", async () => {
   let called = false;
   const result = await fetchHfPaperMetadata("../etc/passwd", {

--- a/src/lib/server/hf-paper-metadata.ts
+++ b/src/lib/server/hf-paper-metadata.ts
@@ -24,7 +24,10 @@ const MAX_RESPONSE_BYTES = 1 * 1024 * 1024;
 /**
  * Reads and parses the response body without ever buffering past
  * `maxBytes` — `response.json()` has no such cap and would hold the whole
- * body in memory before this function got a chance to reject it.
+ * body in memory before this function got a chance to reject it. A response
+ * with no readable stream fails closed rather than falling back to
+ * `response.json()`, which would silently drop the hard cap this function
+ * exists to guarantee.
  */
 async function readBoundedJson(
   response: Response,
@@ -34,11 +37,7 @@ async function readBoundedJson(
   if (contentLength && Number(contentLength) > maxBytes) return null;
 
   const reader = response.body?.getReader();
-  if (!reader) {
-    // No streamable body (e.g. some fetch mocks) — still bounded by
-    // TIMEOUT_MS above, just not by byte count.
-    return (await response.json()) as Record<string, unknown>;
-  }
+  if (!reader) return null;
 
   const chunks: Uint8Array[] = [];
   let total = 0;
@@ -53,7 +52,7 @@ async function readBoundedJson(
     }
     chunks.push(value);
   }
-  const text = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8");
+  const text = Buffer.concat(chunks).toString("utf8");
   return JSON.parse(text) as Record<string, unknown>;
 }
 

--- a/src/lib/server/hf-paper-metadata.ts
+++ b/src/lib/server/hf-paper-metadata.ts
@@ -13,6 +13,50 @@ export type HfPaperMetadata = {
  */
 const TIMEOUT_MS = 5_000;
 
+/**
+ * A paper's title/authors/abstract JSON is a few KB; this is generous
+ * headroom against a hostile or accidentally-huge HF response rather than a
+ * realistic ceiling. Unbounded, the title alone could land verbatim in the
+ * links store and be rendered in the resource row (cave-gnvfa).
+ */
+const MAX_RESPONSE_BYTES = 1 * 1024 * 1024;
+
+/**
+ * Reads and parses the response body without ever buffering past
+ * `maxBytes` — `response.json()` has no such cap and would hold the whole
+ * body in memory before this function got a chance to reject it.
+ */
+async function readBoundedJson(
+  response: Response,
+  maxBytes: number,
+): Promise<Record<string, unknown> | null> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength && Number(contentLength) > maxBytes) return null;
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    // No streamable body (e.g. some fetch mocks) — still bounded by
+    // TIMEOUT_MS above, just not by byte count.
+    return (await response.json()) as Record<string, unknown>;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => {});
+      return null;
+    }
+    chunks.push(value);
+  }
+  const text = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8");
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
 export async function fetchHfPaperMetadata(
   arxivId: string,
   options: { fetchImpl?: typeof fetch } = {},
@@ -26,7 +70,8 @@ export async function fetchHfPaperMetadata(
       signal: controller.signal,
     });
     if (!response.ok) return null;
-    const body = (await response.json()) as Record<string, unknown>;
+    const body = await readBoundedJson(response, MAX_RESPONSE_BYTES);
+    if (!body) return null;
     const title = typeof body.title === "string" ? body.title : "";
     if (!title) return null;
     const authors = Array.isArray(body.authors)

--- a/src/lib/server/research-links.test.ts
+++ b/src/lib/server/research-links.test.ts
@@ -630,6 +630,34 @@ test("enrichment metadata sets the stored title and paper block", async () => {
   });
 });
 
+test("a paper block with an oversized field is dropped whole, not truncated", async () => {
+  const url = "https://huggingface.co/papers/2403.22222";
+  const oversizedTitle: HfPaperMetadata = {
+    title: "x".repeat(1_001),
+    authors: ["A. Author"],
+    abstract: "An abstract.",
+    publishedAt: "2024-01-22T00:00:00.000Z",
+  };
+  const { added } = await saveResearchLinks([url], "desk", new Map([[url, { paper: oversizedTitle }]]));
+  assert.equal(added.length, 1);
+  assert.equal(added[0].paper, undefined, "an oversized title must not land in the store");
+
+  const url2 = "https://huggingface.co/papers/2403.33333";
+  const tooManyAuthors: HfPaperMetadata = {
+    title: "A Well-Formed Paper",
+    authors: Array.from({ length: 501 }, (_, i) => `Author ${i}`),
+    abstract: "An abstract.",
+    publishedAt: "2024-01-22T00:00:00.000Z",
+  };
+  const { added: added2 } = await saveResearchLinks(
+    [url2],
+    "desk",
+    new Map([[url2, { paper: tooManyAuthors }]]),
+  );
+  assert.equal(added2.length, 1);
+  assert.equal(added2[0].paper, undefined, "an oversized author count must not land in the store");
+});
+
 test("a URL that merely embeds a paper URL never gets a paper block", async () => {
   // The stored arxivId drives the Read affordance and is interpolated into the
   // PDF route's URL, so it has to come from classifying THIS url — not from

--- a/src/lib/server/research-links.ts
+++ b/src/lib/server/research-links.ts
@@ -122,13 +122,34 @@ function normalizeXArticleBlock(value: unknown, rawUrl: string): XArticleSnapsho
   };
 }
 
+/**
+ * This is the trust boundary for a user-editable file on disk, so it must
+ * bound every field it accepts, not just type-check it — an unbounded field
+ * here (e.g. a hostile or accidentally-huge upstream response, see
+ * `hf-paper-metadata.ts`) would otherwise land verbatim in the store and be
+ * rendered in the resource row (cave-gnvfa). Bounds are generous relative to
+ * a real arXiv paper; anything past them drops the whole block, same as any
+ * other malformed input here.
+ */
+const MAX_HF_PAPER_TITLE_CHARS = 1_000;
+const MAX_HF_PAPER_ABSTRACT_CHARS = 20_000;
+const MAX_HF_PAPER_PUBLISHED_AT_CHARS = 64;
+const MAX_HF_PAPER_AUTHORS = 500;
+const MAX_HF_PAPER_AUTHOR_NAME_CHARS = 200;
+
 function isHfPaperMetadata(value: unknown): value is HfPaperMetadata {
   return isRecord(value)
     && typeof value.title === "string"
+    && value.title.length <= MAX_HF_PAPER_TITLE_CHARS
     && Array.isArray(value.authors)
-    && value.authors.every((author) => typeof author === "string")
+    && value.authors.length <= MAX_HF_PAPER_AUTHORS
+    && value.authors.every(
+      (author) => typeof author === "string" && author.length <= MAX_HF_PAPER_AUTHOR_NAME_CHARS,
+    )
     && typeof value.abstract === "string"
-    && typeof value.publishedAt === "string";
+    && value.abstract.length <= MAX_HF_PAPER_ABSTRACT_CHARS
+    && typeof value.publishedAt === "string"
+    && value.publishedAt.length <= MAX_HF_PAPER_PUBLISHED_AT_CHARS;
 }
 
 function normalizeResearchLinkEnrichment(


### PR DESCRIPTION
Two findings deferred from the #4688 final review (`cave-gnvfa`), neither exploitable beyond the local user but both robustness/consistency gaps in shipped code (merged as `6fbacc841`).

## 1. Unbounded stored paper metadata

`isHfPaperMetadata` (`src/lib/server/research-links.ts`) validated the **type** of every paper-block field but bounded nothing. It's the trust boundary for a user-editable file on disk, so an unbounded field there matters: a hostile or accidentally-huge HF response could land a giant title/abstract/author list verbatim in the store and be rendered in the resource row.

- Added caps (title/abstract/publishedAt length; author count and per-author length) that drop the whole block on overflow — consistent with how malformed input is already handled there (never silently truncated).
- Also capped the HF metadata fetch itself (`src/lib/server/hf-paper-metadata.ts`) at 1 MiB via a streamed, size-checked read, rather than relying solely on the 5s abort timeout to bound `response.json()`.

## 2. Zoom not gated on ready state in the error path

`research-paper-viewer.tsx` gated Prev/Next on `!ready` but gated zoom only on the step bounds. In the error state (a render failure *after* the document already opened), `opened` stays non-null and `live.current` stays true, so a zoom click still re-runs the render effect and can paint a successful page under the still-visible error banner — with no in-flight feedback, since `pending` requires `ready === true`. Retry already worked, so this was a consistency wrinkle rather than a break.

Fixed by gating the zoom buttons on `!ready`, matching Prev/Next.

## Verification

- `pnpm exec vitest run` (targeted): `hf-paper-metadata.test.ts`, `research-links.test.ts` — 37/37 passed, including 3 new regression tests (oversized title, oversized author count, content-length cap, streamed-body cap).
- `pnpm typecheck` — clean
- `pnpm lint` — clean (pre-existing `--destructive`/`--shadow-popover` token warnings, unrelated)
- `pnpm check:tests-wired` — 1984 files
- `pnpm test:app` — 1405/1405 test files passed

Closes `cave-gnvfa`.
