### PR TITLE
Clarify Research Desk topic decisions

### DIFF
--- a/src/components/role-surfaces/research-tab-prompt.test.ts
+++ b/src/components/role-surfaces/research-tab-prompt.test.ts
@@ -11,6 +11,7 @@ import { buildPromptEnhancement } from "../../lib/prompt-enhancer.ts";
 
 const promptTab = readFileSync(new URL("./research-tab-prompt.tsx", import.meta.url), "utf8");
 const composer = readFileSync(new URL("./research-mission-composer.tsx", import.meta.url), "utf8");
+const decisionCard = readFileSync(new URL("./research-topic-decision-card.tsx", import.meta.url), "utf8");
 const recommendationContext = readFileSync(
   new URL("../../lib/research-recommendation-context.ts", import.meta.url),
   "utf8",
@@ -18,6 +19,7 @@ const recommendationContext = readFileSync(
 // The prompt sheet rides with the mode-gated surface (bundle budget, #3264
 // pattern), so selector pins read the sheet itself, not the root globals.
 const css = readFileSync(new URL("../../styles/globals/surface-research-prompt.css", import.meta.url), "utf8");
+const decisionCss = readFileSync(new URL("../../styles/research-topic-decision.css", import.meta.url), "utf8");
 
 // ── Intake validation (unchanged contract from the pre-redesign composer) ────
 
@@ -310,8 +312,8 @@ test("agentic topic recommendations keep client and server evidence freshness se
   assert.match(promptTab, /revisionRequestRef/);
 });
 
-test("suggested topics use shared grounded cards and retain explicit Research actions", () => {
-  assert.match(promptTab, /AgenticRecommendationCard/);
+test("suggested topics render as explicit research decision briefs", () => {
+  assert.match(promptTab, /ResearchTopicDecisionCard/);
   assert.match(promptTab, /Suggested next topics/);
   assert.match(promptTab, /Add to prompt/);
   assert.match(promptTab, /Start mission/);
@@ -324,6 +326,26 @@ test("suggested topics use shared grounded cards and retain explicit Research ac
   assert.match(promptTab, /Started mission ".+"\./);
   assert.match(promptTab, /Refined mission ".+"\./);
   assert.match(promptTab, /state=\{agenticCardState/);
+  assert.match(decisionCard, /Why this surfaced/);
+  assert.match(decisionCard, /Evidence trail/);
+  assert.match(decisionCard, /Verification and approval/);
+  assert.match(decisionCard, /View verification checks/);
+  assert.match(decisionCard, /researchRecommendationDisplayText/);
+  assert.match(decisionCard, /research-topic-decision__rank-rail/);
+  assert.match(decisionCard, /research-topic-decision__evidence-list/);
+  assert.match(decisionCard, /research-topic-decision__footer/);
+  assert.match(decisionCard, /<Button[\s\S]*?\{actionLabel\}[\s\S]*?<\/Button>/);
+  assert.match(
+    decisionCard,
+    /disabled=\{recommendation\.verification\.status === "blocked"\}/,
+    "blocked recommendations cannot activate an action",
+  );
+  assert.match(
+    decisionCard,
+    /busy \? `\$\{actionLabel\}…` : actionLabel/,
+    "the action keeps its verb while revalidation is in progress",
+  );
+  assert.doesNotMatch(promptTab, /research-topic-recommendations__actions/);
   // "Start mission" builds its request through the shared intent→run builder,
   // so assert the built request rather than the call site's spelling: the mode
   // is auto-routed from the topic and no inferred title is persisted.
@@ -415,7 +437,11 @@ test("prompt tab styles are token-driven and container-responsive", () => {
   // compact mode summary must ride the scoped research tokens.
   assert.match(css, /\.research-mode-picker__state \{[^}]*var\(--research-accent\)/);
   assert.match(css, /\.research-topic-recommendations \{/);
-  assert.match(css, /\.research-topic-recommendations__card \.agentic-recommendation-card__actions \{/);
+  assert.match(decisionCard, /@\/styles\/research-topic-decision\.css/);
+  assert.match(decisionCss, /\.research-topic-decision \{/);
+  assert.match(decisionCss, /\.research-topic-decision__rank-rail \{/);
+  assert.match(decisionCss, /\.research-topic-decision__evidence-list \{/);
+  assert.match(decisionCss, /\.research-topic-decision__footer \{/);
   assert.match(css, /@container research-desk \(max-width: 560px\) \{[\s\S]*\.research-topic-recommendations/);
 });
 

--- a/src/components/role-surfaces/research-tab-prompt.test.ts
+++ b/src/components/role-surfaces/research-tab-prompt.test.ts
@@ -334,6 +334,9 @@ test("suggested topics render as explicit research decision briefs", () => {
   assert.match(decisionCard, /research-topic-decision__rank-rail/);
   assert.match(decisionCard, /research-topic-decision__evidence-list/);
   assert.match(decisionCard, /research-topic-decision__footer/);
+  assert.match(promptTab, /recommendationItems\.map\(\(recommendation, index\) =>/);
+  assert.doesNotMatch(promptTab, /recommendationItems\.indexOf\(recommendation\)/);
+  assert.match(decisionCard, /key=\{`\$\{index\}:\$\{reason\}`\}/);
   assert.match(decisionCard, /<Button[\s\S]*?\{actionLabel\}[\s\S]*?<\/Button>/);
   assert.match(
     decisionCard,

--- a/src/components/role-surfaces/research-tab-prompt.tsx
+++ b/src/components/role-surfaces/research-tab-prompt.tsx
@@ -33,7 +33,6 @@ import { useAnnouncer } from "@/components/ui/live-region";
 import {
   parseAgenticRecommendationsOutput,
   type AgenticRecommendation,
-  type RankedAgenticRecommendation,
 } from "@/lib/agentic-recommendations";
 import { linkCategoryMeta, type SavedLinkSummary } from "@/lib/link-organizer";
 import {
@@ -59,6 +58,7 @@ import {
   ResearchMissionComposer,
   type AttachedResearchLink,
 } from "./research-mission-composer";
+import { ResearchTopicDecisionCard } from "./research-topic-decision-card";
 import type { ResearchTabProps } from "./researcher-surface";
 import { useResearchLinks } from "./use-research-links";
 import type { TopicProposalDraftV1 } from "@/lib/research-topic-discovery";
@@ -528,29 +528,21 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode, 
                   {recommendationItems.map((recommendation) => {
                     const payload = researchTopicPayload(recommendation);
                     if (!payload) return null;
-                    const rankedRecommendation: RankedAgenticRecommendation = {
+                    const rankedRecommendation: ResearchTopicRecommendation = {
                       ...recommendation,
                       ordinal: recommendationItems.indexOf(recommendation) + 1,
                     };
                     return (
-                      <article key={rankedRecommendation.id} className="research-topic-recommendations__card">
-                        <AgenticRecommendationCard recommendation={rankedRecommendation} title={payload.topic} />
-                        <div className="research-topic-recommendations__actions">
-                          <button
-                            type="button"
-                            className="research-topic-recommendations__action focus-ring"
-                            disabled={topicActionId === rankedRecommendation.id}
-                            onClick={() => void activateTopic({
+                      <ResearchTopicDecisionCard
+                        key={rankedRecommendation.id}
+                        recommendation={rankedRecommendation}
+                        actionLabel={topicActionLabel(payload)}
+                        busy={topicActionId === rankedRecommendation.id}
+                        onAction={() => void activateTopic({
                               ...recommendation,
                               ordinal: rankedRecommendation.ordinal,
                             })}
-                          >
-                            {topicActionId === rankedRecommendation.id
-                              ? `${topicActionLabel(payload)}…`
-                              : topicActionLabel(payload)}
-                          </button>
-                        </div>
-                      </article>
+                      />
                     );
                   })}
                 </div>

--- a/src/components/role-surfaces/research-tab-prompt.tsx
+++ b/src/components/role-surfaces/research-tab-prompt.tsx
@@ -525,12 +525,12 @@ export function ResearchTabPrompt({ research, context, onNavigate, initialMode, 
                 />
               ) : (
                 <div className="research-topic-recommendations__cards">
-                  {recommendationItems.map((recommendation) => {
+                  {recommendationItems.map((recommendation, index) => {
                     const payload = researchTopicPayload(recommendation);
                     if (!payload) return null;
                     const rankedRecommendation: ResearchTopicRecommendation = {
                       ...recommendation,
-                      ordinal: recommendationItems.indexOf(recommendation) + 1,
+                      ordinal: index + 1,
                     };
                     return (
                       <ResearchTopicDecisionCard

--- a/src/components/role-surfaces/research-topic-decision-card.tsx
+++ b/src/components/role-surfaces/research-topic-decision-card.tsx
@@ -95,7 +95,7 @@ export function ResearchTopicDecisionCard({
           {rankReasons.length > 0 ? (
             <ul className="research-topic-decision__signals">
               {rankReasons.map((reason, index) => (
-                <li key={reason}>
+                <li key={`${index}:${reason}`}>
                   <span>{rankReasons.length === 1 ? "Ranking signal" : `Signal ${index + 1}`}</span>
                   <strong>{reason}</strong>
                 </li>

--- a/src/components/role-surfaces/research-topic-decision-card.tsx
+++ b/src/components/role-surfaces/research-topic-decision-card.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import "@/styles/research-topic-decision.css";
+
+import { Button } from "@/components/ui/button";
+import type {
+  AgenticEvidenceKind,
+  AgenticVerificationCheckState,
+} from "@/lib/agentic-recommendations";
+import { researchRecommendationDisplayText } from "@/lib/research-recommendation-display";
+import {
+  type ResearchTopicRecommendation,
+} from "@/lib/research-topic-recommendations";
+
+const evidenceKindLabels: Record<AgenticEvidenceKind, string> = {
+  task: "Task",
+  dependency: "Dependency",
+  github: "GitHub",
+  mission: "Mission",
+  "saved-link": "Saved link",
+  vault: "Vault",
+  session: "Session",
+  message: "Message",
+  artifact: "Artifact",
+};
+
+const verificationLabels: Record<AgenticVerificationCheckState, string> = {
+  passed: "Passed",
+  pending: "Pending",
+  failed: "Failed",
+};
+
+const statusLabels: Record<ResearchTopicRecommendation["verification"]["status"], string> = {
+  verified: "Verified",
+  proposal: "Proposal",
+  blocked: "Blocked",
+};
+
+export type ResearchTopicDecisionCardProps = {
+  recommendation: ResearchTopicRecommendation;
+  actionLabel: string;
+  busy?: boolean;
+  onAction: () => void;
+};
+
+export function ResearchTopicDecisionCard({
+  recommendation,
+  actionLabel,
+  busy = false,
+  onAction,
+}: ResearchTopicDecisionCardProps) {
+  const title = researchRecommendationDisplayText(recommendation.payload.topic);
+  const goal = researchRecommendationDisplayText(recommendation.inferredGoal);
+  const rationale = researchRecommendationDisplayText(recommendation.rationale);
+  const rankReasons = recommendation.rankReasons.map(researchRecommendationDisplayText);
+  const evidenceCount = recommendation.evidenceRefs.length;
+  const approvalLabel = recommendation.application.requiresApproval
+    ? "Review required"
+    : "No approval required";
+  const reversibilityLabel = recommendation.application.reversible
+    ? "Reversible"
+    : "Not reversible";
+
+  return (
+    <article
+      className="research-topic-decision"
+      aria-label={`Suggested topic, rank ${recommendation.ordinal}: ${title}`}
+    >
+      <div className="research-topic-decision__rank-rail" aria-label={`Rank ${recommendation.ordinal}`}>
+        <span>Rank</span>
+        <strong>{String(recommendation.ordinal).padStart(2, "0")}</strong>
+      </div>
+
+      <div className="research-topic-decision__body">
+        <header className="research-topic-decision__header">
+          <div className="research-topic-decision__meta">
+            <span
+              className="research-topic-decision__status"
+              data-status={recommendation.verification.status}
+            >
+              {statusLabels[recommendation.verification.status]}
+            </span>
+            <span>{evidenceCount} {evidenceCount === 1 ? "source" : "sources"}</span>
+          </div>
+          <h4>{title}</h4>
+          <p className="research-topic-decision__goal">
+            <span>Next step</span>
+            {goal}
+          </p>
+        </header>
+
+        <section className="research-topic-decision__reason" aria-label="Why this surfaced">
+          <h5>Why this surfaced</h5>
+          <p>{rationale}</p>
+          {rankReasons.length > 0 ? (
+            <ul className="research-topic-decision__signals">
+              {rankReasons.map((reason, index) => (
+                <li key={reason}>
+                  <span>{rankReasons.length === 1 ? "Ranking signal" : `Signal ${index + 1}`}</span>
+                  <strong>{reason}</strong>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </section>
+
+        <section className="research-topic-decision__evidence" aria-label="Evidence trail">
+          <header>
+            <h5>Evidence trail</h5>
+            <span>{evidenceCount} linked</span>
+          </header>
+          <ol className="research-topic-decision__evidence-list">
+            {recommendation.evidenceRefs.map((evidence) => (
+              <li key={`${evidence.kind}:${evidence.id}`}>
+                <span>{evidenceKindLabels[evidence.kind]}</span>
+                <strong>{researchRecommendationDisplayText(evidence.label)}</strong>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <footer className="research-topic-decision__footer">
+          <section
+            className="research-topic-decision__safety"
+            data-status={recommendation.verification.status}
+            aria-label="Verification and approval"
+          >
+            <p>{approvalLabel} · {reversibilityLabel}</p>
+            {recommendation.verification.checks.length > 0 ? (
+              <details>
+                <summary className="focus-ring">View verification checks</summary>
+                <ul>
+                  {recommendation.verification.checks.map((check) => (
+                    <li key={check.id} data-state={check.state}>
+                      <strong>{verificationLabels[check.state]}</strong>
+                      <span>{researchRecommendationDisplayText(check.detail)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            ) : null}
+          </section>
+          <Button
+            className="research-topic-decision__action"
+            size="sm"
+            variant="primary"
+            loading={busy}
+            disabled={recommendation.verification.status === "blocked"}
+            onClick={onAction}
+          >
+            {busy ? `${actionLabel}…` : actionLabel}
+          </Button>
+        </footer>
+      </div>
+    </article>
+  );
+}

--- a/src/lib/research-recommendation-display.ts
+++ b/src/lib/research-recommendation-display.ts
@@ -1,0 +1,9 @@
+export function researchRecommendationDisplayText(value: string): string {
+  return value
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^#{1,6}\s+/, "")
+    .replace(/\*\*(?=\S)(.+?\S)\*\*/g, "$1")
+    .replace(/__(?=\S)(.+?\S)__/g, "$1")
+    .replace(/`(?=\S)(.+?\S)`/g, "$1");
+}

--- a/src/lib/research-topic-recommendations.test.ts
+++ b/src/lib/research-topic-recommendations.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { SavedLink } from "./link-organizer.ts";
+import { researchRecommendationDisplayText } from "./research-recommendation-display.ts";
 import type { ResearchMission } from "./research-missions.ts";
 import {
   recommendResearchTopics,
@@ -96,6 +97,21 @@ function context(
     ...overrides,
   };
 }
+
+test("cleans presentation-only Markdown without removing meaningful punctuation", () => {
+  assert.equal(
+    researchRecommendationDisplayText("  ## **Designing agent systems**  "),
+    "Designing agent systems",
+  );
+  assert.equal(
+    researchRecommendationDisplayText("Compare **RAG** with __long context__ and `memory`"),
+    "Compare RAG with long context and memory",
+  );
+  assert.equal(
+    researchRecommendationDisplayText("C# throughput is 2 * 3"),
+    "C# throughput is 2 * 3",
+  );
+});
 
 test("proposes a new topic from collective Coven session history", () => {
   const result = recommendResearchTopics(context({

--- a/src/styles/globals/surface-research-prompt.css
+++ b/src/styles/globals/surface-research-prompt.css
@@ -767,8 +767,7 @@
   color: var(--text-muted);
   font-size: var(--text-xs);
 }
-.research-topic-recommendations__refresh,
-.research-topic-recommendations__action {
+.research-topic-recommendations__refresh {
   flex: none;
   min-height: var(--touch-target);
   padding: var(--space-2) var(--space-3);
@@ -780,13 +779,8 @@
   font-weight: 600;
   cursor: pointer;
 }
-.research-topic-recommendations__refresh:hover,
-.research-topic-recommendations__action:hover:not(:disabled) {
+.research-topic-recommendations__refresh:hover {
   background: color-mix(in oklch, var(--research-accent) 16%, transparent);
-}
-.research-topic-recommendations__action:disabled {
-  cursor: default;
-  opacity: 0.65;
 }
 .research-topic-recommendations__reduced,
 .research-topic-recommendations__action-error {
@@ -807,20 +801,6 @@
 .research-topic-recommendations__cards {
   display: grid;
   gap: var(--space-3);
-}
-.research-topic-recommendations__card {
-  display: grid;
-  gap: var(--space-2);
-}
-.research-topic-recommendations__card .agentic-recommendation-card {
-  background: var(--bg-base);
-}
-.research-topic-recommendations__card .agentic-recommendation-card__actions {
-  display: none;
-}
-.research-topic-recommendations__actions {
-  display: flex;
-  justify-content: flex-end;
 }
 
 /* ═══ Quick saves — a docked bar with a sheet that lifts over the intake ═══ */

--- a/src/styles/research-topic-decision.css
+++ b/src/styles/research-topic-decision.css
@@ -1,0 +1,281 @@
+.research-topic-decision {
+  container: research-topic-decision / inline-size;
+  display: grid;
+  grid-template-columns: var(--space-10) minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-base);
+}
+
+.research-topic-decision__rank-rail {
+  display: grid;
+  align-content: start;
+  justify-items: center;
+  gap: var(--space-1);
+  padding: var(--space-4) var(--space-2);
+  border-right: 1px solid color-mix(in oklch, var(--research-accent) 28%, var(--border-hairline));
+  background: color-mix(in oklch, var(--research-accent) 8%, var(--bg-subtle));
+  color: var(--research-accent);
+}
+
+.research-topic-decision__rank-rail span,
+.research-topic-decision__meta,
+.research-topic-decision__goal span,
+.research-topic-decision__reason h5,
+.research-topic-decision__evidence h5,
+.research-topic-decision__evidence > header span {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+
+.research-topic-decision__rank-rail strong {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-lg);
+  line-height: var(--leading-tight);
+}
+
+.research-topic-decision__body {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-4);
+  padding: var(--space-4);
+}
+
+.research-topic-decision__header,
+.research-topic-decision__reason,
+.research-topic-decision__evidence,
+.research-topic-decision__safety {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.research-topic-decision__meta,
+.research-topic-decision__evidence > header,
+.research-topic-decision__footer,
+.research-topic-decision__safety li {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.research-topic-decision__meta {
+  flex-wrap: wrap;
+  color: var(--text-muted);
+}
+
+.research-topic-decision__status {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid color-mix(in oklch, var(--color-warning) 42%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--color-warning) 10%, transparent);
+  color: var(--color-warning);
+}
+
+.research-topic-decision__status[data-status="verified"] {
+  border-color: color-mix(in oklch, var(--color-success) 42%, transparent);
+  background: color-mix(in oklch, var(--color-success) 10%, transparent);
+  color: var(--color-success);
+}
+
+.research-topic-decision__status[data-status="blocked"] {
+  border-color: var(--danger-border);
+  background: var(--danger-bg);
+  color: var(--danger-text);
+}
+
+.research-topic-decision__header h4 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--text-lg);
+  line-height: var(--leading-tight);
+}
+
+.research-topic-decision__goal {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: var(--space-3);
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+}
+
+.research-topic-decision__goal span,
+.research-topic-decision__reason h5,
+.research-topic-decision__evidence h5,
+.research-topic-decision__evidence > header span {
+  color: var(--text-muted);
+}
+
+.research-topic-decision__reason,
+.research-topic-decision__evidence,
+.research-topic-decision__footer {
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-hairline);
+}
+
+.research-topic-decision__reason h5,
+.research-topic-decision__reason p,
+.research-topic-decision__reason ul,
+.research-topic-decision__evidence h5,
+.research-topic-decision__evidence ol,
+.research-topic-decision__safety p {
+  margin: 0;
+}
+
+.research-topic-decision__reason p,
+.research-topic-decision__reason li {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+}
+
+.research-topic-decision__signals,
+.research-topic-decision__safety ul {
+  display: grid;
+  gap: var(--space-1);
+  padding: 0;
+  list-style: none;
+}
+
+.research-topic-decision__signals li {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: var(--space-2);
+}
+
+.research-topic-decision__signals span,
+.research-topic-decision__evidence-list li > span {
+  color: var(--research-accent);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+
+.research-topic-decision__signals strong {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 400;
+}
+
+.research-topic-decision__evidence > header {
+  justify-content: space-between;
+}
+
+.research-topic-decision__evidence-list {
+  display: grid;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  list-style: none;
+}
+
+.research-topic-decision__evidence-list li {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(var(--space-10), max-content) minmax(0, 1fr);
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-subtle);
+}
+
+.research-topic-decision__evidence-list li + li {
+  border-top: 1px solid var(--border-hairline);
+}
+
+.research-topic-decision__evidence-list strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.research-topic-decision__footer {
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.research-topic-decision__safety {
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+
+.research-topic-decision__safety li[data-state="passed"] > strong {
+  color: var(--color-success);
+}
+
+.research-topic-decision__safety li[data-state="failed"] > strong {
+  color: var(--color-danger);
+}
+
+.research-topic-decision__safety[data-status="blocked"] > p {
+  color: var(--danger-text);
+}
+
+.research-topic-decision__safety li[data-state="pending"] > strong {
+  color: var(--color-warning);
+}
+
+.research-topic-decision__safety details {
+  width: fit-content;
+}
+
+.research-topic-decision__safety summary {
+  border-radius: var(--radius-control);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.research-topic-decision__safety ul {
+  margin: var(--space-2) 0 0;
+}
+
+.research-topic-decision__action {
+  flex: none;
+}
+
+@container research-desk (max-width: 560px) {
+  .research-topic-decision {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .research-topic-decision__rank-rail {
+    display: flex;
+    align-items: baseline;
+    justify-content: flex-start;
+    padding: var(--space-2) var(--space-4);
+    border-right: 0;
+    border-bottom: 1px solid color-mix(in oklch, var(--research-accent) 28%, var(--border-hairline));
+  }
+
+  .research-topic-decision__goal,
+  .research-topic-decision__signals li,
+  .research-topic-decision__evidence-list li {
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-1);
+  }
+
+  .research-topic-decision__footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .research-topic-decision__action {
+    width: 100%;
+  }
+}

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -1467,11 +1467,16 @@ test.describe("research desk tabs", () => {
       const topics = intake.getByRole("region", { name: "Suggested next topics" });
       await expect(topics).toBeVisible();
       await expect(topics).toContainText("Compare vector index recall against latency");
-      await expect(topics).toContainText("mission: Vector DB pricing landscape");
-      await expect(topics).toContainText("saved-link: acme/vector-bench");
-      await expect(topics).toContainText("saved-link: X Article 1881");
-      await expect(topics).toContainText("vault: Vector retrieval notes");
-      await expect(topics.getByText("Why this recommendation?").first()).toBeVisible();
+      await expect(topics).toContainText("Mission");
+      await expect(topics).toContainText("Vector DB pricing landscape");
+      await expect(topics).toContainText("Saved link");
+      await expect(topics).toContainText("acme/vector-bench");
+      await expect(topics).toContainText("X Article 1881");
+      await expect(topics).toContainText("Vault");
+      await expect(topics).toContainText("Vector retrieval notes");
+      await expect(topics.getByText("Why this surfaced").first()).toBeVisible();
+      await expect(topics.getByText("Evidence trail").first()).toBeVisible();
+      await expect(topics.getByText("Review required").first()).toBeVisible();
       await expect.poll(() => handles.recommendationRequests).toBeGreaterThan(0);
       expect(handles.recommendationMethods.every((method) => method === "GET")).toBe(true);
 
@@ -1706,7 +1711,7 @@ test.describe("research desk tabs", () => {
       await expect.poll(() => handles.recommendationRevisionRequests).toBe(revisionRequests + 1);
       await refresh.focus();
       await page.keyboard.press("Tab");
-      await expect(topics.getByText("Why this recommendation?").first()).toBeFocused();
+      await expect(topics.getByText("View verification checks").first()).toBeFocused();
       await page.evaluate(() => {
         window.dispatchEvent(new Event("focus"));
         document.dispatchEvent(new Event("visibilitychange"));


### PR DESCRIPTION
## What changed
- replace the generic ready recommendation card with a Research-specific decision brief
- make rank, rationale, evidence, approval risk, verification, and the next action immediately legible
- normalize display-only Markdown artifacts without changing stored recommendation data
- disable blocked recommendations and preserve the action verb while work is in progress

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- focused Research source and unit tests
- targeted Research Desk Playwright journeys
- `pnpm build`

Bead: `cave-l5g48`