### PR TITLE
feat(avatars): extend lightbox peek to more familiar avatar surfaces

### DIFF
--- a/src/components/coven-agent-section.tsx
+++ b/src/components/coven-agent-section.tsx
@@ -188,7 +188,7 @@ export function CovenAgentSection({
       <div className="coven-section__head">
         <div className="coven-section__avatar" data-live={meta.live ? "true" : "false"}>
           {familiar ? (
-            <FamiliarAvatar familiar={familiar} size="lg" title={name} />
+            <FamiliarAvatar familiar={familiar} size="lg" title={name} expandable />
           ) : (
             <Icon name="ph:sparkle" width={16} height={16} aria-hidden />
           )}

--- a/src/components/coven-inspector.tsx
+++ b/src/components/coven-inspector.tsx
@@ -77,7 +77,7 @@ export function CovenInspector({
           <ul className="coven-inspector__threads">
             {threaded.map((familiar) => (
               <li key={familiar.id} className="coven-inspector__thread">
-                <FamiliarAvatar familiar={familiar} size="sm" />
+                <FamiliarAvatar familiar={familiar} size="sm" expandable />
                 <span className="coven-inspector__thread-name">{familiar.display_name}</span>
                 <button
                   type="button"


### PR DESCRIPTION
## What

Extends the proven avatar-lightbox pattern (`expandable` on `FamiliarAvatar`,
backed by `AvatarLightbox`) to two more non-Popover familiar-avatar surfaces:

- `coven-agent-section.tsx` — the group-chat agent header avatar.
- `coven-inspector.tsx` — the threads list avatar.

## Why

cave-ocy8: "Expand avatar into a lightbox on tap." The infrastructure landed
in #2931 (`expandable` prop + `AvatarLightbox` portal modal), wired in exactly
one place (`familiar-inline-card.tsx`). This PR extends it to more surfaces
where peeking makes sense without breaking anything.

`familiar-switcher.tsx`'s popover header avatar and
`coven-roster-popover.tsx`'s roster rows were also tried, but review caught
that both render inside a `Popover`, which dismisses on blur when focus
leaves its panel. `AvatarLightbox`'s `Modal` is focus-trapped, so opening it
there would immediately steal focus and close the popover, unmounting the
avatar/modal with it — the lightbox would flash or never stay open. Fixing
that needs the popover's `PopoverLayersContext` (already used by
`PopoverSubmenu`) to also treat the `Modal`'s portal as an "inside" layer,
which is its own piece of work; left both of those call sites unwired rather
than land a broken lightbox.

Every other `FamiliarAvatar`/`ProjectAvatar` call site renders the avatar
inside an existing clickable row or button (select a familiar, switch a
project, open a menu) — adding a second nested interactive trigger there
would violate the "no nested controls" convention, so those are left as-is.
The user's own avatar (`UserChatAvatar`) and project avatars already have the
lightbox wired wherever it doesn't collide with an existing click action
(`project-settings-modal.tsx`, `project-picker.tsx`).

## Verification

- `pnpm typecheck` — clean
- `pnpm exec eslint` on the changed files — clean
- `pnpm test:app` — 1405/1405 passed

cave-ocy8
