### PR TITLE
Sanitize squash attribution metadata

### DIFF
--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -262,13 +262,25 @@ expected_head=$(git rev-parse HEAD)
 actual_head=$(gh pr view <#> --json headRefOid --jq .headRefOid)
 test "$actual_head" = "$expected_head"
 gh pr checks <#> --required
-gh pr merge <#> --squash --match-head-commit "$expected_head"
+squash_input=$(mktemp)
+squash_message=$(mktemp)
+trap 'rm -f "$squash_input" "$squash_message"' EXIT
+gh pr view <#> --json title,body,commits > "$squash_input"
+node scripts/pr-squash-message.mjs < "$squash_input" > "$squash_message"
+squash_subject=$(jq -er .subject "$squash_message")
+squash_body=$(jq -er .body "$squash_message")
+gh pr merge <#> --squash --match-head-commit "$expected_head" --subject "$squash_subject" --body "$squash_body"
 ```
 
 Repeat the exact-head and required-check verification in the merge command's
 shell: shell variables from Phase 5 may not persist between tool calls.
 `--match-head-commit` then makes GitHub reject the merge if the PR head changes
 between that final check and the merge.
+
+`scripts/pr-squash-message.mjs` removes AI-generated attribution footers and AI
+co-author trailers from the PR body and commit messages before constructing the
+explicit squash message. It preserves each valid human numeric GitHub no-reply
+trailer once and fails closed on ambiguous non-GitHub co-author identities.
 
 Do not pass `--delete-branch`. That flag asks `gh` to delete both local and
 remote branches immediately after merging. Local retirement belongs to the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,14 @@ expected_head=$(git rev-parse HEAD)
 actual_head=$(gh pr view <#> --json headRefOid --jq .headRefOid)
 test "$actual_head" = "$expected_head"
 gh pr checks <#> --required
-gh pr merge <#> --squash --match-head-commit "$expected_head"
+squash_input=$(mktemp)
+squash_message=$(mktemp)
+trap 'rm -f "$squash_input" "$squash_message"' EXIT
+gh pr view <#> --json title,body,commits > "$squash_input"
+node scripts/pr-squash-message.mjs < "$squash_input" > "$squash_message"
+squash_subject=$(jq -er .subject "$squash_message")
+squash_body=$(jq -er .body "$squash_message")
+gh pr merge <#> --squash --match-head-commit "$expected_head" --subject "$squash_subject" --body "$squash_body"
 ```
 
 `gh pr merge` on a blocked PR suggests `--admin`. Don't. It bypasses the

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -84,7 +84,7 @@ test("skill offers a PR as the only path onto main", () => {
   );
   const mergeCommands = skill.match(/^gh pr merge .*$/gm) ?? [];
   assert.ok(
-    mergeCommands.includes('gh pr merge <#> --squash --match-head-commit "$expected_head"'),
+    mergeCommands.includes('gh pr merge <#> --squash --match-head-commit "$expected_head" --subject "$squash_subject" --body "$squash_body"'),
   );
   assert.ok(mergeCommands.every((command) => !command.includes("--delete-branch")));
 });
@@ -112,7 +112,7 @@ test("skill requires all checks on the exact current PR head", () => {
 test("CLAUDE.md documents the same exact-head, patrol-safe merge", () => {
   const mergeCommands = claude.match(/^gh pr merge .*$/gm) ?? [];
   assert.ok(
-    mergeCommands.includes('gh pr merge <#> --squash --match-head-commit "$expected_head"'),
+    mergeCommands.includes('gh pr merge <#> --squash --match-head-commit "$expected_head" --subject "$squash_subject" --body "$squash_body"'),
   );
   assert.ok(mergeCommands.every((command) => !command.includes("--delete-branch")));
   assert.ok(claude.includes('test "$actual_head" = "$expected_head"'));
@@ -190,6 +190,10 @@ test("skill carries the repository's no-AI-attribution rule", () => {
   );
   assert.ok(skill.includes("No AI attribution"));
   assert.ok(skill.includes("ID+username@users.noreply.github.com"));
+  assert.ok(skill.includes("node scripts/pr-squash-message.mjs"));
+  assert.ok(skill.includes("squash_subject=$(jq -er .subject"));
+  assert.ok(skill.includes("squash_body=$(jq -er .body"));
+  assert.ok(claude.includes("node scripts/pr-squash-message.mjs"));
 });
 
 test("skill uses the managed worktree command in its documented form", () => {

--- a/scripts/git-hooks-commit-msg.test.mjs
+++ b/scripts/git-hooks-commit-msg.test.mjs
@@ -57,6 +57,12 @@ function runHook(message) {
 }
 
 {
+  const result = runHook("fix: reject alphanumeric model login\n\nCo-authored-by: GPT-4o <12345+gpt-4o@users.noreply.github.com>\n");
+  assert.notEqual(result.status, 0, "alphanumeric GPT model identities must be blocked");
+  assert.match(result.stderr, /AI model, assistant, vendor, or coding harness/i);
+}
+
+{
   const result = runHook("fix: reject alternate generated footer\n\nMade with Claude Code\n");
   assert.notEqual(result.status, 0, "alternate AI attribution footers must be blocked");
   assert.match(result.stderr, /AI model, assistant, vendor, or coding harness/i);

--- a/scripts/git-hooks-commit-msg.test.mjs
+++ b/scripts/git-hooks-commit-msg.test.mjs
@@ -28,9 +28,38 @@ function runHook(message) {
 }
 
 {
+  const result = runHook("fix: preserve a human whose name overlaps a model\n\nCo-authored-by: Claude Martin <98765+claude-martin@users.noreply.github.com>\n");
+  assert.equal(result.status, 0, result.stderr);
+}
+
+{
   const result = runHook("fix: reject vendor attribution\n\nCo-authored-by: Claude Fable 5 <noreply@anthropic.com>\n");
   assert.notEqual(result.status, 0, "AI/vendor co-author trailers must be blocked");
   assert.match(result.stderr, /numeric no-reply identity/i);
+}
+
+{
+  const result = runHook("fix: reject linked assistant attribution\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\n");
+  assert.notEqual(result.status, 0, "numeric GitHub identities for AI assistants must be blocked");
+  assert.match(result.stderr, /AI model, assistant, vendor, or coding harness/i);
+}
+
+{
+  const result = runHook("fix: reject generated footer\n\nGenerated with GitHub Copilot\n");
+  assert.notEqual(result.status, 0, "AI-generated attribution footers must be blocked");
+  assert.match(result.stderr, /AI model, assistant, vendor, or coding harness/i);
+}
+
+{
+  const result = runHook("fix: reject broader AI attribution\n\nCo-authored-by: Anthropic <12345+anthropic@users.noreply.github.com>\n");
+  assert.notEqual(result.status, 0, "AI vendor identities must be blocked");
+  assert.match(result.stderr, /AI model, assistant, vendor, or coding harness/i);
+}
+
+{
+  const result = runHook("fix: reject alternate generated footer\n\nMade with Claude Code\n");
+  assert.notEqual(result.status, 0, "alternate AI attribution footers must be blocked");
+  assert.match(result.stderr, /AI model, assistant, vendor, or coding harness/i);
 }
 
 {

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -15,8 +15,8 @@ fi
 trailer_re='^[[:space:]]*[Cc][Oo]-[Aa][Uu][Tt][Hh][Oo][Rr][Ee][Dd]-[Bb][Yy]:'
 human_identity_re='^[[:space:]]*[Cc][Oo]-[Aa][Uu][Tt][Hh][Oo][Rr][Ee][Dd]-[Bb][Yy]:[[:space:]]+.+[[:space:]]+<[0-9]+\+[A-Za-z0-9-]+@users\.noreply\.github\.com>[[:space:]]*$'
 github_identity_re='<[0-9]+\+([A-Za-z0-9-]+)@users\.noreply\.github\.com>'
-ai_login_re='^(copilot|github-copilot|copilot-swe-agent|chatgpt|gpt-[0-9.]+|openai|anthropic|codex|cursor|aider|devin-ai|gemini-ai|grok|xai|meta-ai|mistral-ai|qwen-ai|deepseek-ai|kimi-ai|codeium|windsurf|sourcegraph-cody)$'
-ai_identity_re='(^|[^[:alnum:]])(copilot|claude|chatgpt|gpt(-[0-9.]+)?|openai|anthropic|codex|cursor|aider|devin|gemini|grok|xai|llama|metaai|mistral|qwen|deepseek|kimi|codeium|windsurf|cody)([^[:alnum:]]|$)'
+ai_login_re='^(copilot|github-copilot|copilot-swe-agent|chatgpt|gpt-[0-9][A-Za-z0-9.-]*|openai|anthropic|codex|cursor|aider|devin-ai|gemini-ai|grok|xai|meta-ai|mistral-ai|qwen-ai|deepseek-ai|kimi-ai|codeium|windsurf|sourcegraph-cody)$'
+ai_identity_re='(^|[^[:alnum:]])(copilot|claude|chatgpt|gpt(-[0-9][A-Za-z0-9.-]*)?|openai|anthropic|codex|cursor|aider|devin|gemini|grok|xai|llama|metaai|mistral|qwen|deepseek|kimi|codeium|windsurf|cody)([^[:alnum:]]|$)'
 ai_footer_re='(generated|authored|written|assisted|made|powered)[[:space:]]+(with|by)'
 
 shopt -s nocasematch

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -14,10 +14,26 @@ fi
 
 trailer_re='^[[:space:]]*[Cc][Oo]-[Aa][Uu][Tt][Hh][Oo][Rr][Ee][Dd]-[Bb][Yy]:'
 human_identity_re='^[[:space:]]*[Cc][Oo]-[Aa][Uu][Tt][Hh][Oo][Rr][Ee][Dd]-[Bb][Yy]:[[:space:]]+.+[[:space:]]+<[0-9]+\+[A-Za-z0-9-]+@users\.noreply\.github\.com>[[:space:]]*$'
+github_identity_re='<[0-9]+\+([A-Za-z0-9-]+)@users\.noreply\.github\.com>'
+ai_login_re='^(copilot|github-copilot|copilot-swe-agent|chatgpt|gpt-[0-9.]+|openai|anthropic|codex|cursor|aider|devin-ai|gemini-ai|grok|xai|meta-ai|mistral-ai|qwen-ai|deepseek-ai|kimi-ai|codeium|windsurf|sourcegraph-cody)$'
+ai_identity_re='(^|[^[:alnum:]])(copilot|claude|chatgpt|gpt(-[0-9.]+)?|openai|anthropic|codex|cursor|aider|devin|gemini|grok|xai|llama|metaai|mistral|qwen|deepseek|kimi|codeium|windsurf|cody)([^[:alnum:]]|$)'
+ai_footer_re='(generated|authored|written|assisted|made|powered)[[:space:]]+(with|by)'
+
+shopt -s nocasematch
 
 while IFS= read -r line || [ -n "$line" ]; do
-  if [[ "$line" =~ $trailer_re ]] && ! [[ "$line" =~ $human_identity_re ]]; then
-    printf '%s\n' "[commit-msg blocked] Co-authored-by trailers must credit a person with GitHub's numeric no-reply identity: Full Name <ID+username@users.noreply.github.com>." >&2
+  if [[ "$line" =~ $trailer_re ]]; then
+    if ! [[ "$line" =~ $human_identity_re ]]; then
+      printf '%s\n' "[commit-msg blocked] Co-authored-by trailers must credit a person with GitHub's numeric no-reply identity: Full Name <ID+username@users.noreply.github.com>." >&2
+      exit 1
+    fi
+    [[ "$line" =~ $github_identity_re ]]
+    if [[ "${BASH_REMATCH[1]}" =~ $ai_login_re ]]; then
+      printf '%s\n' "[commit-msg blocked] Do not credit an AI model, assistant, vendor, or coding harness in commit metadata." >&2
+      exit 1
+    fi
+  elif [[ "$line" =~ $ai_footer_re ]] && [[ "$line" =~ $ai_identity_re ]]; then
+    printf '%s\n' "[commit-msg blocked] Do not credit an AI model, assistant, vendor, or coding harness in commit metadata." >&2
     exit 1
   fi
 done < "$message_file"

--- a/scripts/pr-squash-message.mjs
+++ b/scripts/pr-squash-message.mjs
@@ -6,11 +6,11 @@ const HUMAN_EMAIL_RE = /^([0-9]+)\+([A-Za-z0-9-]+)@users\.noreply\.github\.com$/
 const CO_AUTHOR_PREFIX_RE = /^\s*Co-authored-by:/i;
 const CO_AUTHOR_RE = /^\s*Co-authored-by:\s+(.+?)\s+<([^<>]+)>\s*$/i;
 const AI_LOGIN_RE =
-  /^(copilot|github-copilot|copilot-swe-agent|chatgpt|gpt-[0-9.]+|openai|anthropic|codex|cursor|aider|devin-ai|gemini-ai|grok|xai|meta-ai|mistral-ai|qwen-ai|deepseek-ai|kimi-ai|codeium|windsurf|sourcegraph-cody)$/i;
+  /^(copilot|github-copilot|copilot-swe-agent|chatgpt|gpt-[0-9][a-z0-9.-]*|openai|anthropic|codex|cursor|aider|devin-ai|gemini-ai|grok|xai|meta-ai|mistral-ai|qwen-ai|deepseek-ai|kimi-ai|codeium|windsurf|sourcegraph-cody)$/i;
 const AI_IDENTITY_RE =
-  /(?:^|[^a-z0-9])(copilot|claude|chatgpt|gpt(?:-[0-9.]+)?|openai|anthropic|codex|cursor|aider|devin|gemini|grok|xai|llama|metaai|mistral|qwen|deepseek|kimi|codeium|windsurf|cody)(?:[^a-z0-9]|$)/i;
+  /(?:^|[^a-z0-9])(copilot|claude|chatgpt|gpt(?:-[0-9][a-z0-9.-]*)?|openai|anthropic|codex|cursor|aider|devin|gemini|grok|xai|llama|metaai|mistral|qwen|deepseek|kimi|codeium|windsurf|cody)(?:[^a-z0-9]|$)/i;
 const AI_FOOTER_RE =
-  /(?:generated|authored|written|assisted|made|powered)\s+(?:with|by).*?(?:copilot|claude|chatgpt|gpt(?:-[0-9.]+)?|openai|anthropic|codex|cursor|aider|devin|gemini|grok|xai|llama|metaai|mistral|qwen|deepseek|kimi|codeium|windsurf|cody)/i;
+  /(?:generated|authored|written|assisted|made|powered)\s+(?:with|by).*?(?:copilot|claude|chatgpt|gpt(?:-[0-9][a-z0-9.-]*)?|openai|anthropic|codex|cursor|aider|devin|gemini|grok|xai|llama|metaai|mistral|qwen|deepseek|kimi|codeium|windsurf|cody)/i;
 
 function fail(message) {
   throw new Error(`pr-squash-message: ${message}`);

--- a/scripts/pr-squash-message.mjs
+++ b/scripts/pr-squash-message.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+const HUMAN_EMAIL_RE = /^([0-9]+)\+([A-Za-z0-9-]+)@users\.noreply\.github\.com$/;
+const CO_AUTHOR_PREFIX_RE = /^\s*Co-authored-by:/i;
+const CO_AUTHOR_RE = /^\s*Co-authored-by:\s+(.+?)\s+<([^<>]+)>\s*$/i;
+const AI_LOGIN_RE =
+  /^(copilot|github-copilot|copilot-swe-agent|chatgpt|gpt-[0-9.]+|openai|anthropic|codex|cursor|aider|devin-ai|gemini-ai|grok|xai|meta-ai|mistral-ai|qwen-ai|deepseek-ai|kimi-ai|codeium|windsurf|sourcegraph-cody)$/i;
+const AI_IDENTITY_RE =
+  /(?:^|[^a-z0-9])(copilot|claude|chatgpt|gpt(?:-[0-9.]+)?|openai|anthropic|codex|cursor|aider|devin|gemini|grok|xai|llama|metaai|mistral|qwen|deepseek|kimi|codeium|windsurf|cody)(?:[^a-z0-9]|$)/i;
+const AI_FOOTER_RE =
+  /(?:generated|authored|written|assisted|made|powered)\s+(?:with|by).*?(?:copilot|claude|chatgpt|gpt(?:-[0-9.]+)?|openai|anthropic|codex|cursor|aider|devin|gemini|grok|xai|llama|metaai|mistral|qwen|deepseek|kimi|codeium|windsurf|cody)/i;
+
+function fail(message) {
+  throw new Error(`pr-squash-message: ${message}`);
+}
+
+function parseCoAuthor(line) {
+  if (!CO_AUTHOR_PREFIX_RE.test(line)) return null;
+
+  const match = CO_AUTHOR_RE.exec(line);
+  if (!match) fail(`malformed Co-authored-by trailer: ${line.trim()}`);
+
+  const name = match[1].trim();
+  const email = match[2].trim();
+  if (!name) fail(`malformed Co-authored-by trailer: ${line.trim()}`);
+  const emailMatch = HUMAN_EMAIL_RE.exec(email);
+
+  if (!emailMatch) {
+    if (AI_IDENTITY_RE.test(`${name} ${email}`)) return { kind: "ai" };
+    fail(
+      `Co-authored-by trailers must use a numeric GitHub no-reply identity: ${line.trim()}`,
+    );
+  }
+  if (AI_LOGIN_RE.test(emailMatch[2])) return { kind: "ai" };
+
+  return {
+    kind: "human",
+    emailKey: email.toLowerCase(),
+    trailer: `Co-authored-by: ${name} <${email}>`,
+  };
+}
+
+function cleanBody(body, humanTrailers) {
+  const kept = [];
+  for (const line of String(body ?? "").replace(/\r\n?/g, "\n").split("\n")) {
+    const coAuthor = parseCoAuthor(line);
+    if (coAuthor?.kind === "human") {
+      humanTrailers.set(coAuthor.emailKey, coAuthor.trailer);
+      continue;
+    }
+    if (coAuthor?.kind === "ai" || AI_FOOTER_RE.test(line)) continue;
+    kept.push(line);
+  }
+  return kept.join("\n").trim();
+}
+
+export function prepareSquashMessage(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    fail("expected a JSON object on stdin");
+  }
+
+  const subject = String(input.title ?? "").replace(/\s+/g, " ").trim();
+  if (!subject) fail("pull request title is required");
+
+  const humanTrailers = new Map();
+  const body = cleanBody(input.body, humanTrailers);
+  const commits = Array.isArray(input.commits) ? input.commits : [];
+  for (const commit of commits) {
+    cleanBody(commit?.messageBody, humanTrailers);
+  }
+
+  const trailers = [...humanTrailers.values()];
+  return {
+    subject,
+    body: [body, trailers.join("\n")].filter(Boolean).join("\n\n"),
+  };
+}
+
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const input = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  process.stdout.write(`${JSON.stringify(prepareSquashMessage(input))}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/pr-squash-message.test.mjs
+++ b/scripts/pr-squash-message.test.mjs
@@ -26,6 +26,7 @@ test("strips AI attribution and preserves unique human GitHub trailers", () => {
       "Made with Claude Code",
       "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>",
       "Co-authored-by: GPT-5 <23456+gpt-5@users.noreply.github.com>",
+      "Co-authored-by: GPT-4o <34567+gpt-4o@users.noreply.github.com>",
       "Co-authored-by: Val Alexander <68980965+BunsDev@users.noreply.github.com>",
     ].join("\n"),
     commits: [
@@ -54,7 +55,7 @@ test("strips AI attribution and preserves unique human GitHub trailers", () => {
       "Co-authored-by: Claude Martin <98765+claude-martin@users.noreply.github.com>",
     ].join("\n"),
   );
-  assert.doesNotMatch(message.body, /Copilot|GPT-5|Generated with|Made with/i);
+  assert.doesNotMatch(message.body, /Copilot|GPT-5|GPT-4o|Generated with|Made with/i);
 });
 
 test("refuses ambiguous non-GitHub co-author trailers", () => {

--- a/scripts/pr-squash-message.test.mjs
+++ b/scripts/pr-squash-message.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const script = path.join(root, "scripts", "pr-squash-message.mjs");
+
+function prepareMessage(input) {
+  return spawnSync(process.execPath, [script], {
+    cwd: root,
+    encoding: "utf8",
+    input: JSON.stringify(input),
+  });
+}
+
+test("strips AI attribution and preserves unique human GitHub trailers", () => {
+  const result = prepareMessage({
+    title: "Protect squash attribution",
+    body: [
+      "## Summary",
+      "Keep published history human-authored.",
+      "",
+      "Generated with GitHub Copilot",
+      "Made with Claude Code",
+      "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>",
+      "Co-authored-by: GPT-5 <23456+gpt-5@users.noreply.github.com>",
+      "Co-authored-by: Val Alexander <68980965+BunsDev@users.noreply.github.com>",
+    ].join("\n"),
+    commits: [
+      {
+        messageHeadline: "fix: preserve contributor credit",
+        messageBody: [
+          "Co-authored-by: Val Alexander <68980965+BunsDev@users.noreply.github.com>",
+          "Co-authored-by: Jane Doe <12345+jane-doe@users.noreply.github.com>",
+          "Co-authored-by: Claude Martin <98765+claude-martin@users.noreply.github.com>",
+        ].join("\n"),
+      },
+    ],
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const message = JSON.parse(result.stdout);
+  assert.equal(message.subject, "Protect squash attribution");
+  assert.equal(
+    message.body,
+    [
+      "## Summary",
+      "Keep published history human-authored.",
+      "",
+      "Co-authored-by: Val Alexander <68980965+BunsDev@users.noreply.github.com>",
+      "Co-authored-by: Jane Doe <12345+jane-doe@users.noreply.github.com>",
+      "Co-authored-by: Claude Martin <98765+claude-martin@users.noreply.github.com>",
+    ].join("\n"),
+  );
+  assert.doesNotMatch(message.body, /Copilot|GPT-5|Generated with|Made with/i);
+});
+
+test("refuses ambiguous non-GitHub co-author trailers", () => {
+  const result = prepareMessage({
+    title: "Protect squash attribution",
+    body: "Co-authored-by: Jane Doe <jane@Someones-Mac.local>",
+    commits: [],
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /numeric GitHub no-reply identity/i);
+});
+
+test("refuses malformed co-author lines instead of carrying them forward", () => {
+  const result = prepareMessage({
+    title: "Protect squash attribution",
+    body: "Co-authored-by: Jane Doe jane@example.com",
+    commits: [],
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /malformed Co-authored-by trailer/i);
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1449,6 +1449,7 @@ export const SUITES = {
     "scripts/worktree-retention-push.test.mjs",
     "scripts/branch-curator-manual-cleanup-contract.test.mjs",
     "scripts/branch-to-merge-contract.test.mjs",
+    "scripts/pr-squash-message.test.mjs",
     "scripts/git-hooks-pre-commit.test.mjs",
     "scripts/git-hooks-commit-msg.test.mjs",
     "scripts/secret-preflight.test.mjs",


### PR DESCRIPTION
## What changed
- reject AI service co-author identities even when they use numeric GitHub no-reply addresses
- reject common generated-attribution footers in commit messages
- construct every squash merge from an explicit sanitized subject and body
- preserve unique human numeric GitHub no-reply trailers and fail closed on malformed attribution

## Evidence
- reproduced the original leak against PRs #5207 and #5208, then confirmed the sanitizer removes it
- focused hook, sanitizer, and branch-to-merge contract tests pass
- all 1,405 app test files pass with the repository fixture Git override
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`

The full API suite reached an unrelated `worktree-lifecycle-create.test.mjs` fixture timeout under current machine load; an isolated retry timed out at a different assertion, while all changed tests remained green.

Bead: `cave-iojc4`