### PR TITLE
Retry Tailscale CLI probe once on timeout in mobile handoff

### DIFF
--- a/src/app/api/mobile-handoff/route.test.ts
+++ b/src/app/api/mobile-handoff/route.test.ts
@@ -47,5 +47,25 @@ assert.match(
   /function runTailscaleOnce\(args: string\[\], timeoutMs = 8000\): Promise<TailscaleResult> \{/,
   "the single-attempt spawn logic is a separate function the retry wrapper calls twice at most",
 );
+assert.match(
+  route,
+  /const TAILSCALE_TERMINATION_FAILED =\s*\n\s*"Tailscale command timed out and its process tree could not be stopped";/,
+  "failed timeout cleanup has a distinct non-retryable result",
+);
+assert.match(
+  route,
+  /const terminated = await terminateProcessTree\(child\);\s*\n\s*finish\(\{\s*\n\s*ok: false,\s*\n\s*status: null,\s*\n\s*stdout: stdout\.text\(\),\s*\n\s*stderr: terminated \? TAILSCALE_TIMED_OUT : TAILSCALE_TERMINATION_FAILED,/,
+  "the timeout result waits for process-tree termination and reports cleanup failure",
+);
+assert.match(
+  route,
+  /child\.on\("close", \(status\) => \{\s*\n\s*if \(timedOut\) return;/,
+  "a timed-out child's close event cannot resolve before process-tree cleanup completes",
+);
+assert.match(
+  route,
+  /child\.on\("error", \(error\) => \{\s*\n\s*if \(timedOut\) return;/,
+  "a timed-out child's error event cannot resolve before process-tree cleanup completes",
+);
 
 console.log("mobile-handoff route.test.ts OK");

--- a/src/app/api/mobile-handoff/route.test.ts
+++ b/src/app/api/mobile-handoff/route.test.ts
@@ -39,7 +39,7 @@ assert.match(
 );
 assert.match(
   route,
-  /async function runTailscale\(args: string\[\], timeoutMs = 8000\): Promise<TailscaleResult> \{\s*\n\s*const first = await runTailscaleOnce\(args, timeoutMs\);\s*\n\s*if \(first\.ok \|\| first\.stderr !== TAILSCALE_TIMED_OUT\) return first;\s*\n\s*return runTailscaleOnce\(args, timeoutMs\);\s*\n\}/,
+  /async function runTailscale\(args: string\[\], timeoutMs = 8000\): Promise<TailscaleResult> \{\s*\n\s*const first = await runTailscaleOnce\(args, timeoutMs\);\s*\n\s*if \(first\.ok \|\| first\.cleanupFailed \|\| first\.stderr !== TAILSCALE_TIMED_OUT\) return first;\s*\n\s*return runTailscaleOnce\(args, timeoutMs\);\s*\n\}/,
   "a timed-out probe is retried exactly once before the caller sees a failure",
 );
 assert.match(
@@ -66,6 +66,28 @@ assert.match(
   route,
   /child\.on\("error", \(error\) => \{\s*\n\s*if \(timedOut\) return;/,
   "a timed-out child's error event cannot resolve before process-tree cleanup completes",
+);
+assert.match(
+  route,
+  /type TailscaleResult = \{[\s\S]{0,180}?cleanupFailed: boolean;/,
+  "callers receive a typed signal when timeout cleanup is unconfirmed",
+);
+assert.match(
+  route,
+  /if \(first\.ok \|\| first\.cleanupFailed \|\| first\.stderr !== TAILSCALE_TIMED_OUT\) return first;/,
+  "cleanup failure is terminal and cannot trigger the same-command retry",
+);
+assert.match(
+  route,
+  /cleanupFailed: !terminated,/,
+  "the timeout result records whether process-tree cleanup failed",
+);
+assert.equal(
+  route.match(
+    /if \((?:serve|status)\.cleanupFailed\) return tailscaleCleanupFailureResponse\((?:serve|status), backend\);/g,
+  )?.length,
+  4,
+  "both Serve probe ladders abort after an unconfirmed cleanup before another command starts",
 );
 
 console.log("mobile-handoff route.test.ts OK");

--- a/src/app/api/mobile-handoff/route.test.ts
+++ b/src/app/api/mobile-handoff/route.test.ts
@@ -26,4 +26,26 @@ assert.match(
   "a refused persisted file returns null instead of trusting the armed value (cave-8pd39)",
 );
 
+// Source pins for the runTailscale() retry-on-timeout wrapper (cave-j2056).
+// The local Tailscale daemon/system-extension IPC occasionally stalls a
+// single CLI invocation for several seconds even while Tailscale is fully
+// connected; without a retry that stall hard-fails pairing readiness with
+// "tailscale is not connected" and the QR code never renders, even though
+// Tailscale is genuinely connected.
+assert.match(
+  route,
+  /const TAILSCALE_TIMED_OUT = "Tailscale command timed out";/,
+  "the timeout stderr string is a shared constant, not duplicated inline",
+);
+assert.match(
+  route,
+  /async function runTailscale\(args: string\[\], timeoutMs = 8000\): Promise<TailscaleResult> \{\s*\n\s*const first = await runTailscaleOnce\(args, timeoutMs\);\s*\n\s*if \(first\.ok \|\| first\.stderr !== TAILSCALE_TIMED_OUT\) return first;\s*\n\s*return runTailscaleOnce\(args, timeoutMs\);\s*\n\}/,
+  "a timed-out probe is retried exactly once before the caller sees a failure",
+);
+assert.match(
+  route,
+  /function runTailscaleOnce\(args: string\[\], timeoutMs = 8000\): Promise<TailscaleResult> \{/,
+  "the single-attempt spawn logic is a separate function the retry wrapper calls twice at most",
+);
+
 console.log("mobile-handoff route.test.ts OK");

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -41,6 +41,7 @@ type TailscaleResult = {
   status: number | null;
   stdout: string;
   stderr: string;
+  cleanupFailed: boolean;
 };
 
 const TAILSCALE_TIMED_OUT = "Tailscale command timed out";
@@ -57,7 +58,7 @@ const TAILSCALE_TERMINATION_FAILED =
 // Tailscale was connected) into a brief, invisible delay. cave-j2056
 async function runTailscale(args: string[], timeoutMs = 8000): Promise<TailscaleResult> {
   const first = await runTailscaleOnce(args, timeoutMs);
-  if (first.ok || first.stderr !== TAILSCALE_TIMED_OUT) return first;
+  if (first.ok || first.cleanupFailed || first.stderr !== TAILSCALE_TIMED_OUT) return first;
   return runTailscaleOnce(args, timeoutMs);
 }
 
@@ -88,6 +89,7 @@ function runTailscaleOnce(args: string[], timeoutMs = 8000): Promise<TailscaleRe
         status: null,
         stdout: stdout.text(),
         stderr: terminated ? TAILSCALE_TIMED_OUT : TAILSCALE_TERMINATION_FAILED,
+        cleanupFailed: !terminated,
       });
     }, timeoutMs);
 
@@ -107,6 +109,7 @@ function runTailscaleOnce(args: string[], timeoutMs = 8000): Promise<TailscaleRe
         stderr: missing
           ? "Tailscale CLI not found. Install Tailscale or set TAILSCALE_BIN to the tailscale executable."
           : safeProcessErrorMessage(error, "Tailscale CLI"),
+        cleanupFailed: false,
       });
     });
     child.on("close", (status) => {
@@ -116,6 +119,7 @@ function runTailscaleOnce(args: string[], timeoutMs = 8000): Promise<TailscaleRe
         status,
         stdout: stdout.text(),
         stderr: stderr.text(),
+        cleanupFailed: false,
       });
     });
   });
@@ -247,6 +251,13 @@ function mobileUnavailableResponse(
   details?: { stderr?: string; backendUrl?: string; steps?: PairingStep[] },
 ) {
   return NextResponse.json({ ok: false, unavailable: true, error, ...details });
+}
+
+function tailscaleCleanupFailureResponse(result: TailscaleResult, backend: string) {
+  return mobileUnavailableResponse(
+    "Tailscale did not stop a timed-out command. Retry after the previous command exits.",
+    { stderr: result.stderr, backendUrl: backend },
+  );
 }
 
 function mobileAccessUnavailableResponse() {
@@ -394,12 +405,14 @@ async function ensureNativeAppServeReady(
   const parsedSelf = parseServeStatus(self.stdout);
   const selfStatus: unknown = "error" in parsedSelf ? null : parsedSelf.value;
   const serve = await runTailscale(["serve", "--bg", backend]);
+  if (serve.cleanupFailed) return tailscaleCleanupFailureResponse(serve, backend);
   const serveWarning = serve.ok
     ? null
     : serve.stderr || "Tailscale Serve could not be (re)started.";
 
   let serveStatus: unknown = {};
   const status = await runTailscale(["serve", "status", "--json"]);
+  if (status.cleanupFailed) return tailscaleCleanupFailureResponse(status, backend);
   if (status.ok) {
     const parsed = parseServeStatus(status.stdout);
     if (!("error" in parsed)) serveStatus = parsed.value;
@@ -578,6 +591,7 @@ async function mobileHandoffReady(
   // though the serve config (and tunnel) is already live in the daemon. Capture
   // the error as a non-fatal warning and try to produce a working link anyway.
   const serve = await runTailscale(["serve", "--bg", backend]);
+  if (serve.cleanupFailed) return tailscaleCleanupFailureResponse(serve, backend);
   const serveWarning = serve.ok
     ? null
     : serve.stderr || "Tailscale Serve could not be (re)started.";
@@ -585,6 +599,7 @@ async function mobileHandoffReady(
   // Prefer the real serve config when it's readable.
   let serveStatus: unknown = {};
   const status = await runTailscale(["serve", "status", "--json"]);
+  if (status.cleanupFailed) return tailscaleCleanupFailureResponse(status, backend);
   if (status.ok) {
     const parsed = parseServeStatus(status.stdout);
     if (!("error" in parsed)) serveStatus = parsed.value;

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -43,7 +43,23 @@ type TailscaleResult = {
   stderr: string;
 };
 
-function runTailscale(args: string[], timeoutMs = 8000): Promise<TailscaleResult> {
+const TAILSCALE_TIMED_OUT = "Tailscale command timed out";
+
+// The local Tailscale daemon/system-extension IPC occasionally stalls a
+// single CLI invocation for several seconds (observed on macOS with the
+// managed/sysext install) even while Tailscale itself is fully connected.
+// Any of the sequential probes below can be the one that stalls — not just
+// the first. A retried invocation almost always returns immediately, so one
+// bounded retry turns a spurious "Tailscale command timed out" (which used
+// to hard-block the whole pairing screen, including the QR code, even though
+// Tailscale was connected) into a brief, invisible delay. cave-j2056
+async function runTailscale(args: string[], timeoutMs = 8000): Promise<TailscaleResult> {
+  const first = await runTailscaleOnce(args, timeoutMs);
+  if (first.ok || first.stderr !== TAILSCALE_TIMED_OUT) return first;
+  return runTailscaleOnce(args, timeoutMs);
+}
+
+function runTailscaleOnce(args: string[], timeoutMs = 8000): Promise<TailscaleResult> {
   return new Promise((resolve) => {
     const bin = tailscaleBin();
     const child = spawn(bin, args, {
@@ -69,7 +85,7 @@ function runTailscale(args: string[], timeoutMs = 8000): Promise<TailscaleResult
           ok: false,
           status: null,
           stdout: stdout.text(),
-          stderr: "Tailscale command timed out",
+          stderr: TAILSCALE_TIMED_OUT,
         });
       });
     }, timeoutMs);
@@ -97,7 +113,7 @@ function runTailscale(args: string[], timeoutMs = 8000): Promise<TailscaleResult
           ok: false,
           status: null,
           stdout: stdout.text(),
-          stderr: "Tailscale command timed out",
+          stderr: TAILSCALE_TIMED_OUT,
         });
         return;
       }

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -44,6 +44,8 @@ type TailscaleResult = {
 };
 
 const TAILSCALE_TIMED_OUT = "Tailscale command timed out";
+const TAILSCALE_TERMINATION_FAILED =
+  "Tailscale command timed out and its process tree could not be stopped";
 
 // The local Tailscale daemon/system-extension IPC occasionally stalls a
 // single CLI invocation for several seconds (observed on macOS with the
@@ -78,15 +80,14 @@ function runTailscaleOnce(args: string[], timeoutMs = 8000): Promise<TailscaleRe
       clearTimeout(timer);
       resolve(result);
     };
-    const timer = setTimeout(() => {
+    const timer = setTimeout(async () => {
       timedOut = true;
-      void terminateProcessTree(child).then(() => {
-        finish({
-          ok: false,
-          status: null,
-          stdout: stdout.text(),
-          stderr: TAILSCALE_TIMED_OUT,
-        });
+      const terminated = await terminateProcessTree(child);
+      finish({
+        ok: false,
+        status: null,
+        stdout: stdout.text(),
+        stderr: terminated ? TAILSCALE_TIMED_OUT : TAILSCALE_TERMINATION_FAILED,
       });
     }, timeoutMs);
 
@@ -97,6 +98,7 @@ function runTailscaleOnce(args: string[], timeoutMs = 8000): Promise<TailscaleRe
       stderr.append(chunk);
     });
     child.on("error", (error) => {
+      if (timedOut) return;
       const missing = (error as NodeJS.ErrnoException).code === "ENOENT";
       finish({
         ok: false,
@@ -108,15 +110,7 @@ function runTailscaleOnce(args: string[], timeoutMs = 8000): Promise<TailscaleRe
       });
     });
     child.on("close", (status) => {
-      if (timedOut) {
-        finish({
-          ok: false,
-          status: null,
-          stdout: stdout.text(),
-          stderr: TAILSCALE_TIMED_OUT,
-        });
-        return;
-      }
+      if (timedOut) return;
       finish({
         ok: status === 0,
         status,


### PR DESCRIPTION
## Problem

Pairing QR codes in the Phone/QR pairing screen intermittently never
rendered, showing "Tailscale connected" alongside "Tailscale command
timed out" — even though Tailscale was genuinely connected.

## Root cause

Reproduced directly against a running packaged desktop build. On
machines where Tailscale is installed as a managed/system-extension
build (`io.tailscale.ipn.macsys.network-extension`, not a standalone
GUI app), the local daemon IPC can intermittently stall a single CLI
invocation for several seconds.

Real-time monitoring of the server's child processes during repeated
requests showed the stall moves between *different* probe subcommands
across requests (sometimes `status --self --json`, sometimes `serve
status --json`) — it is not a fixed hang on one specific invocation.
Isolated re-runs of the identical binary/args/env outside the app are
consistently fast, which rules out spawn options, PATH/env
construction, binary path casing, and stdin handling as the cause.

## Fix

`runTailscale()` in `src/app/api/mobile-handoff/route.ts` now retries
exactly once, immediately, if the first attempt times out. The
original spawn logic is preserved as `runTailscaleOnce()`. All 9
existing call sites are unaffected since they already call the
`runTailscale` wrapper.

## Verification

- `node --experimental-strip-types --test src/app/api/mobile-handoff/route.test.ts` — pass (added 3 new regex-pin assertions covering the retry wrapper)
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test:api` — the only failing suite (`check-merge-tree-freshness.test.mjs`) fails on `main` too, from a local `safe.bareRepository` git config conflict unrelated to this change

cave-j2056