### PR TITLE
Remove band-shed tests pinning CSS already dead before 641ccac12

### DIFF
--- a/src/components/chat-queue-group.test.ts
+++ b/src/components/chat-queue-group.test.ts
@@ -84,24 +84,16 @@ test("rows reuse the shared band grammar — no second vocabulary", () => {
   }
 });
 
-test("the dashboard sheds the Queue band before the Chats band", () => {
-  // The mock encodes group priority as width — chats widest, queue smallest —
-  // so on a short pane the Queue goes first and Chats survive one tier longer.
-  const css = readFileSync(new URL("../styles/home-dashboard.css", import.meta.url), "utf8");
-  const tierFor = (kind) =>
-    css.match(
-      new RegExp(
-        `@container \\(max-height: (\\d+)px\\) \\{\\s*\\n\\s*\\.cave-sf__band\\[data-kind="${kind}"\\]`,
-      ),
-    );
-  const queueTier = tierFor("queue");
-  const chatsTier = tierFor("chats");
-  assert.ok(queueTier && chatsTier, "both bands declare a shed tier");
-  assert.ok(
-    Number(queueTier[1]) > Number(chatsTier[1]),
-    "Queue hides at a taller pane than the Chats band — it sheds first",
-  );
-});
+// The per-kind "sheds the Queue band before the Chats band" compact-height
+// assertion was removed in cave-drsph. It pinned a
+// `.cave-sf__band[data-kind="queue"]` @container rule in home-dashboard.css
+// that "Compact home dashboard and composer" (641ccac12) deleted as dead CSS
+// -- ChatStartFromBands renders one active band at a time via tabs
+// (`.cave-sf__source`) and a single deck (`.cave-sf__deck`), never a stacked
+// `.cave-sf__band` per kind, so that selector never matched real markup even
+// before the cleanup. The compact-height tiers that remain intentionally no
+// longer hide whole bands by pane height (see the CSS's own "nothing is
+// hidden solely because the pane is short" comment).
 
 test("starting a follow-up opens the work in place", () => {
   // The dashboard has no composer of its own, so it briefs a fresh chat

--- a/src/components/chat-reviews-group.test.ts
+++ b/src/components/chat-reviews-group.test.ts
@@ -69,29 +69,16 @@ test("rows reuse the shared band grammar — no third vocabulary", () => {
   }
 });
 
-test("Reviews sheds first — before Queue, and long before the Chats band", () => {
-  // Both are extra-source groups (each costs a request); the page's own data
-  // — board cards and threads — survives longer. Reviews is the quietest, so
-  // it is the first band a short pane gives up.
-  const css = readFileSync(new URL("../styles/home-dashboard.css", import.meta.url), "utf8");
-  assert.match(
-    css,
-    /@container \(max-height: 760px\) \{\s*\n\s*\.cave-sf__band\[data-kind="reviews"\] \{/,
-    "Reviews owns the earliest shed tier",
-  );
-  const tier = (kind) =>
-    Number(
-      css.match(
-        new RegExp(
-          `@container \\(max-height: (\\d+)px\\) \\{\\s*\\n\\s*\\.cave-sf__band\\[data-kind="${kind}"\\]`,
-        ),
-      )[1],
-    );
-  assert.ok(
-    tier("reviews") > tier("queue") && tier("queue") > tier("chats"),
-    "shed order is reviews, then queue, then chats",
-  );
-});
+// The "Reviews sheds first" compact-height assertion was removed in
+// cave-drsph. It pinned a `.cave-sf__band[data-kind="reviews"]` @container
+// rule in home-dashboard.css that "Compact home dashboard and composer"
+// (641ccac12) deleted as dead CSS -- ChatStartFromBands renders one active
+// band at a time via tabs (`.cave-sf__source`) and a single deck
+// (`.cave-sf__deck`), never a stacked `.cave-sf__band` per kind, so that
+// selector never matched real markup even before the cleanup. The
+// compact-height tiers that remain intentionally no longer hide whole bands
+// by pane height (see the CSS's own "nothing is hidden solely because the
+// pane is short" comment).
 
 test("starting a review opens the work in place", () => {
   assert.match(


### PR DESCRIPTION
## What

Removes two obsolete test assertions that pinned an `@container (max-height: …px) { .cave-sf__band[data-kind="…"] { ... } }` compact-height rule in `src/styles/home-dashboard.css`:

- `chat-queue-group.test.ts`: "the dashboard sheds the Queue band before the Chats band"
- `chat-reviews-group.test.ts`: "Reviews sheds first — before Queue, and long before the Chats band"

## Why

`main` is currently red (tracked by #5265, auto-closes when green). `pnpm main:health` traces it to `641ccac12` ("Compact home dashboard and composer"), which intentionally redesigned the compact-height tiers in `home-dashboard.css` — its own comment says "nothing is hidden solely because the pane is short" — and removed the `.cave-sf__band[data-kind="…"]` shed rules these two tests asserted on.

That redesign is the right direction, not a regression: `.cave-sf__band[data-kind="…"]` was already fully dead CSS *before* `641ccac12` too. `ChatStartFromBands` (the actual component backing both the empty-state page and the new-chat dashboard) renders bands as a single-active tabbed deck — `.cave-sf__source` tab buttons plus one `.cave-sf__deck` panel — never as stacked, always-rendered `.cave-sf__band` elements. Grepping `src/` confirms `.cave-sf__band` never appears in any component, only in these two test files and the CSS itself. So the selector these tests pinned never matched real markup, in any version of the CSS — this was a stale-test problem, not a live UI regression, and the fix is removing the tests rather than restoring the CSS.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (two pre-existing banked token warnings, unrelated)
- `pnpm test:app` — full suite, 1405 test files, all pass

Fixes cave-drsph.