### PR TITLE
Fix nested AvatarLightbox modal ownership

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1146,6 +1146,7 @@ export const SUITES = {
     "src/components/use-openai-voice-preview.test.tsx",
     "src/components/theme-script.test.ts",
     "src/components/ui/error-state.test.ts",
+    "src/components/ui/avatar-lightbox.behavior.test.tsx",
     "src/components/ui/avatar-lightbox.test.ts",
     "src/components/ui/live-region.test.ts",
     "src/components/workspace-chat-handoff.test.ts",
@@ -2443,6 +2444,7 @@ const RAW_SOURCE_SCANNER_TESTS = new Set([
 const VITEST_TESTS = new Set([
   // renders the parameterized ApprovalCard through react-test-renderer (JSX)
   "src/components/ui/beautiful/ApprovalCard.test.tsx",
+  "src/components/ui/avatar-lightbox.behavior.test.tsx",
   "src/components/ui/overflow-menu-submenu.test.tsx",
   "src/lib/home-composer-context.test.ts",
   "src/components/auto-status-card.test.tsx",

--- a/src/components/chat-sidebar-wiring.behavior.test.ts
+++ b/src/components/chat-sidebar-wiring.behavior.test.ts
@@ -29,7 +29,10 @@ const mockProjects = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("@/lib/use-focus-trap", () => ({ useFocusTrap: () => undefined }));
+vi.mock("@/lib/use-focus-trap", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/use-focus-trap")>()),
+  useFocusTrap: () => undefined,
+}));
 vi.mock("@/lib/use-projects", () => ({ useProjects: () => mockProjects.state }));
 vi.mock("@/lib/use-project-overrides", () => ({ useProjectOverrides: () => ({}) }));
 vi.mock("@/lib/use-pinned-sessions", () => ({ usePinnedSessions: () => [] }));

--- a/src/components/command-palette-canonical-memory-behavior.test.tsx
+++ b/src/components/command-palette-canonical-memory-behavior.test.tsx
@@ -19,7 +19,8 @@ vi.mock("@/lib/canonical-memory-resources", () => ({
 vi.mock("@/lib/use-projects", () => ({
   useProjects: () => ({ projects: [] }),
 }));
-vi.mock("@/lib/use-focus-trap", () => ({
+vi.mock("@/lib/use-focus-trap", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/use-focus-trap")>()),
   useFocusTrap: () => {},
 }));
 vi.mock("@/lib/datetime-format", () => ({

--- a/src/components/role-surfaces/research-studio-podcast-direction.test.tsx
+++ b/src/components/role-surfaces/research-studio-podcast-direction.test.tsx
@@ -9,7 +9,10 @@ import { createElement } from "react";
 import { act, create } from "react-test-renderer";
 import { describe, expect, test, vi } from "vitest";
 
-vi.mock("@/lib/use-focus-trap", () => ({ useFocusTrap: () => {} }));
+vi.mock("@/lib/use-focus-trap", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/use-focus-trap")>()),
+  useFocusTrap: () => {},
+}));
 vi.mock("@/components/ui/live-region", () => ({
   useAnnouncer: () => ({ announce: () => {} }),
 }));

--- a/src/components/ui/avatar-lightbox.behavior.test.tsx
+++ b/src/components/ui/avatar-lightbox.behavior.test.tsx
@@ -345,4 +345,130 @@ describe("AvatarLightbox nested in Popover", () => {
     expect(ownerClose).not.toHaveBeenCalled();
     expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(1);
   });
+
+  test("an initially-open Popover still owns Escape ahead of the Modal", () => {
+    const ownerClose = vi.fn();
+
+    function InitiallyOpenActions() {
+      const anchorRef = useRef(null);
+      const [open, setOpen] = useState(true);
+      return (
+        <>
+          <button ref={anchorRef}>Actions</button>
+          <Popover
+            open={open}
+            onOpenChange={setOpen}
+            anchorRef={anchorRef}
+            ariaLabel="Initially open actions"
+          >
+            <button>Run</button>
+          </Popover>
+        </>
+      );
+    }
+
+    function Scene() {
+      const anchorRef = useRef(null);
+      return (
+        <>
+          <button ref={anchorRef}>anchor</button>
+          <Popover open onOpenChange={ownerClose} anchorRef={anchorRef} ariaLabel="Avatar menu">
+            <AvatarLightbox
+              src="/avatar.png"
+              label="Wren"
+              footerActions={<InitiallyOpenActions />}
+            >
+              <span>avatar</span>
+            </AvatarLightbox>
+          </Popover>
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene />, { createNodeMock });
+    });
+    act(() => hostButton("Enlarge Wren avatar").props.onClick());
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(3);
+
+    act(() => dispatchEscape());
+    expect(ownerClose).not.toHaveBeenCalled();
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(2);
+  });
+
+  test("deep portal ownership propagates through a nested Popover", () => {
+    const ownerClose = vi.fn();
+
+    function NestedActions() {
+      const anchorRef = useRef(null);
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button ref={anchorRef} aria-label="Open nested actions" onClick={() => setOpen(true)}>
+            Actions
+          </button>
+          <Popover
+            open={open}
+            onOpenChange={setOpen}
+            anchorRef={anchorRef}
+            ariaLabel="Nested actions"
+          >
+            <AvatarLightbox src="/finch.png" label="Finch">
+              <span>finch</span>
+            </AvatarLightbox>
+          </Popover>
+        </>
+      );
+    }
+
+    function Scene() {
+      const anchorRef = useRef(null);
+      return (
+        <>
+          <button ref={anchorRef}>anchor</button>
+          <Popover open onOpenChange={ownerClose} anchorRef={anchorRef} ariaLabel="Avatar menu">
+            <AvatarLightbox
+              src="/wren.png"
+              label="Wren"
+              footerActions={<NestedActions />}
+            >
+              <span>wren</span>
+            </AvatarLightbox>
+          </Popover>
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene />, { createNodeMock });
+    });
+    act(() => hostButton("Enlarge Wren avatar").props.onClick());
+    act(() => hostButton("Open nested actions").props.onClick());
+    act(() => hostButton("Enlarge Finch avatar").props.onClick());
+
+    const popovers = renderer.root.findAll(
+      (node) =>
+        node.type === "div" &&
+        typeof node.props.className === "string" &&
+        node.props.className.split(/\s+/).includes("ui-popover"),
+    );
+    expect(popovers).toHaveLength(2);
+    expect(popovers.every((node) => node.props["data-covered"] === true)).toBe(true);
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(4);
+
+    const deepestBackdropNode = nodesByClass.get("ui-modal-backdrop");
+    act(() => dispatchDocument("mousedown", deepestBackdropNode));
+    expect(ownerClose).not.toHaveBeenCalled();
+
+    act(() => dispatchEscape());
+    expect(ownerClose).not.toHaveBeenCalled();
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(3);
+    const remainingPopovers = renderer.root.findAll(
+      (node) =>
+        node.type === "div" &&
+        typeof node.props.className === "string" &&
+        node.props.className.split(/\s+/).includes("ui-popover"),
+    );
+    expect(remainingPopovers.filter((node) => node.props["data-covered"] === true)).toHaveLength(1);
+  });
 });

--- a/src/components/ui/avatar-lightbox.behavior.test.tsx
+++ b/src/components/ui/avatar-lightbox.behavior.test.tsx
@@ -287,6 +287,51 @@ describe("AvatarLightbox nested in Popover", () => {
     expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(1);
   });
 
+  test("sibling Popovers inside one Modal do not share an Escape handler", () => {
+    const firstClose = vi.fn();
+    const secondClose = vi.fn();
+
+    function ModalContents() {
+      const firstAnchorRef = useRef(null);
+      const secondAnchorRef = useRef(null);
+      return (
+        <>
+          <button ref={firstAnchorRef}>first anchor</button>
+          <Popover
+            open
+            onOpenChange={firstClose}
+            anchorRef={firstAnchorRef}
+            ariaLabel="First modal menu"
+          >
+            first
+          </Popover>
+          <button ref={secondAnchorRef}>second anchor</button>
+          <Popover
+            open
+            onOpenChange={secondClose}
+            anchorRef={secondAnchorRef}
+            ariaLabel="Second modal menu"
+          >
+            second
+          </Popover>
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(
+        <Modal open onClose={() => {}} ariaLabel="Parent modal">
+          <ModalContents />
+        </Modal>,
+        { createNodeMock },
+      );
+    });
+    act(() => dispatchEscape());
+    expect(firstClose).not.toHaveBeenCalled();
+    expect(secondClose).toHaveBeenCalledOnce();
+    expect(secondClose).toHaveBeenCalledWith(false);
+  });
+
   test("ordinary parent re-renders do not churn layer registration", () => {
     const cleanup = vi.fn();
     const register = vi.fn(() => cleanup);

--- a/src/components/ui/avatar-lightbox.behavior.test.tsx
+++ b/src/components/ui/avatar-lightbox.behavior.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@/lib/icon", () => ({
 }));
 
 import { AvatarLightbox } from "./avatar-lightbox";
-import { Popover, PopoverLayersContext } from "./popover";
+import { Popover, PopoverLayersContext, PopoverSubmenu } from "./popover";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -183,6 +183,46 @@ afterEach(() => {
 });
 
 describe("AvatarLightbox nested in Popover", () => {
+  test("Escape closes only the most recently opened independent root Popover", () => {
+    const firstClose = vi.fn();
+    const secondClose = vi.fn();
+
+    function Scene() {
+      const firstAnchorRef = useRef(null);
+      const secondAnchorRef = useRef(null);
+      return (
+        <>
+          <button ref={firstAnchorRef}>first anchor</button>
+          <Popover
+            open
+            onOpenChange={firstClose}
+            anchorRef={firstAnchorRef}
+            ariaLabel="First menu"
+          >
+            first
+          </Popover>
+          <button ref={secondAnchorRef}>second anchor</button>
+          <Popover
+            open
+            onOpenChange={secondClose}
+            anchorRef={secondAnchorRef}
+            ariaLabel="Second menu"
+          >
+            second
+          </Popover>
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene />, { createNodeMock });
+    });
+    act(() => dispatchEscape());
+    expect(firstClose).not.toHaveBeenCalled();
+    expect(secondClose).toHaveBeenCalledOnce();
+    expect(secondClose).toHaveBeenCalledWith(false);
+  });
+
   test("ordinary parent re-renders do not churn layer registration", () => {
     const cleanup = vi.fn();
     const register = vi.fn(() => cleanup);
@@ -470,5 +510,72 @@ describe("AvatarLightbox nested in Popover", () => {
         node.props.className.split(/\s+/).includes("ui-popover"),
     );
     expect(remainingPopovers.filter((node) => node.props["data-covered"] === true)).toHaveLength(1);
+  });
+
+  test("a submenu that launches a Modal is covered with every ancestor", () => {
+    const ownerClose = vi.fn();
+
+    function SubmenuActions() {
+      return (
+        <PopoverSubmenu label="More">
+          <AvatarLightbox src="/finch.png" label="Finch">
+            <span>finch</span>
+          </AvatarLightbox>
+        </PopoverSubmenu>
+      );
+    }
+
+    function Scene() {
+      const anchorRef = useRef(null);
+      return (
+        <>
+          <button ref={anchorRef}>anchor</button>
+          <Popover open onOpenChange={ownerClose} anchorRef={anchorRef} ariaLabel="Avatar menu">
+            <AvatarLightbox
+              src="/wren.png"
+              label="Wren"
+              footerActions={<SubmenuActions />}
+            >
+              <span>wren</span>
+            </AvatarLightbox>
+          </Popover>
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene />, { createNodeMock });
+    });
+    act(() => hostButton("Enlarge Wren avatar").props.onClick());
+    const submenuTrigger = renderer.root.find(
+      (node) => node.type === "button" && node.props["aria-haspopup"] === "menu",
+    );
+    act(() => submenuTrigger.props.onClick());
+    act(() => hostButton("Enlarge Finch avatar").props.onClick());
+
+    const panels = renderer.root.findAll(
+      (node) =>
+        node.type === "div" &&
+        typeof node.props.className === "string" &&
+        node.props.className.split(/\s+/).includes("ui-popover"),
+    );
+    expect(panels).toHaveLength(2);
+    expect(panels.every((node) => node.props["data-covered"] === true)).toBe(true);
+    expect(panels.every((node) => node.props.inert === true)).toBe(true);
+    expect(
+      panels.find((node) => node.props.className.includes("ui-popover-submenu"))?.props.style
+        .visibility,
+    ).toBe("hidden");
+
+    act(() => dispatchEscape());
+    expect(ownerClose).not.toHaveBeenCalled();
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(2);
+    const visibleSubmenu = renderer.root.find(
+      (node) =>
+        node.type === "div" &&
+        typeof node.props.className === "string" &&
+        node.props.className.split(/\s+/).includes("ui-popover-submenu"),
+    );
+    expect(visibleSubmenu.props["data-covered"]).toBeUndefined();
   });
 });

--- a/src/components/ui/avatar-lightbox.behavior.test.tsx
+++ b/src/components/ui/avatar-lightbox.behavior.test.tsx
@@ -1,0 +1,239 @@
+// @ts-nocheck -- react-test-renderer has no bundled types.
+import { useRef } from "react";
+import { act, create } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("react-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, createPortal: (children) => children };
+});
+
+vi.mock("@/lib/icon", () => ({
+  Icon: ({ name, ...props }) => <span {...props} data-icon={name} />,
+}));
+
+import { AvatarLightbox } from "./avatar-lightbox";
+import { Popover, PopoverLayersContext } from "./popover";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let renderer;
+let activeElement;
+let body;
+let windowListeners;
+let documentListeners;
+let nodesByClass;
+
+function addListener(store, type, listener, options) {
+  const listeners = store.get(type) ?? [];
+  listeners.push({ listener, capture: options === true || options?.capture === true });
+  store.set(type, listeners);
+}
+
+function removeListener(store, type, listener, options) {
+  const capture = options === true || options?.capture === true;
+  store.set(
+    type,
+    (store.get(type) ?? []).filter(
+      (entry) => entry.listener !== listener || entry.capture !== capture,
+    ),
+  );
+}
+
+function installDom() {
+  windowListeners = new Map();
+  documentListeners = new Map();
+  nodesByClass = new Map();
+  body = {
+    nodeType: 1,
+    contains: () => false,
+    focus() {
+      activeElement = body;
+    },
+  };
+  activeElement = body;
+
+  vi.stubGlobal("document", {
+    body,
+    get activeElement() {
+      return activeElement;
+    },
+    addEventListener(type, listener, options) {
+      addListener(documentListeners, type, listener, options);
+    },
+    removeEventListener(type, listener, options) {
+      removeListener(documentListeners, type, listener, options);
+    },
+  });
+  vi.stubGlobal("window", {
+    innerWidth: 1280,
+    innerHeight: 800,
+    visualViewport: undefined,
+    addEventListener(type, listener, options) {
+      addListener(windowListeners, type, listener, options);
+    },
+    removeEventListener(type, listener, options) {
+      removeListener(windowListeners, type, listener, options);
+    },
+  });
+  vi.stubGlobal("requestAnimationFrame", (callback) => {
+    callback(0);
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+}
+
+function makeNode(props) {
+  const node = {
+    nodeType: 1,
+    scrollHeight: 240,
+    offsetWidth: 240,
+    getBoundingClientRect: () => ({
+      top: 100,
+      left: 200,
+      right: 300,
+      bottom: 132,
+      width: 100,
+      height: 32,
+    }),
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    getClientRects: () => [{ width: 1, height: 1 }],
+    hasAttribute: () => false,
+    contains(target) {
+      return target === node;
+    },
+    focus() {
+      activeElement = node;
+    },
+  };
+  if (typeof props.className === "string") {
+    for (const className of props.className.split(/\s+/)) nodesByClass.set(className, node);
+  }
+  return node;
+}
+
+function createNodeMock(element) {
+  return makeNode(element.props ?? {});
+}
+
+function hostButton(label) {
+  return renderer.root.find(
+    (node) => node.type === "button" && node.props["aria-label"] === label,
+  );
+}
+
+function backdrop() {
+  return renderer.root.find(
+    (node) =>
+      node.type === "div" &&
+      typeof node.props.className === "string" &&
+      node.props.className.includes("ui-modal-backdrop"),
+  );
+}
+
+function dispatchDocument(type, target) {
+  for (const { listener } of documentListeners.get(type) ?? []) listener({ target });
+}
+
+function dispatchEscape() {
+  let stopped = false;
+  const event = {
+    key: "Escape",
+    stopPropagation() {
+      stopped = true;
+    },
+  };
+  const listeners = windowListeners.get("keydown") ?? [];
+  for (const { listener } of listeners.filter((entry) => entry.capture)) listener(event);
+  if (stopped) return;
+  for (const { listener } of listeners.filter((entry) => !entry.capture)) listener(event);
+}
+
+beforeEach(() => {
+  installDom();
+});
+
+afterEach(() => {
+  if (renderer) {
+    act(() => renderer.unmount());
+    renderer = null;
+  }
+  vi.unstubAllGlobals();
+});
+
+describe("AvatarLightbox nested in Popover", () => {
+  test("ordinary parent re-renders do not churn layer registration", () => {
+    const cleanup = vi.fn();
+    const register = vi.fn(() => cleanup);
+    const layers = { register, contains: () => false };
+
+    function Scene({ revision }) {
+      return (
+        <PopoverLayersContext.Provider value={layers}>
+          <span>{revision}</span>
+          <AvatarLightbox src="/avatar.png" label="Wren">
+            <span>avatar</span>
+          </AvatarLightbox>
+        </PopoverLayersContext.Provider>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene revision={1} />, { createNodeMock });
+    });
+    act(() => hostButton("Enlarge Wren avatar").props.onClick());
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    act(() => renderer.update(<Scene revision={2} />));
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    act(() => backdrop().props.onClick());
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  test("backdrop and Escape dismiss only the lightbox and return focus to its trigger", () => {
+    const popoverClose = vi.fn();
+
+    function Scene() {
+      const anchorRef = useRef(null);
+      return (
+        <>
+          <button ref={anchorRef}>anchor</button>
+          <Popover open onOpenChange={popoverClose} anchorRef={anchorRef} ariaLabel="Avatar menu">
+            <AvatarLightbox src="/avatar.png" label="Wren">
+              <span>avatar</span>
+            </AvatarLightbox>
+          </Popover>
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene />, { createNodeMock });
+    });
+
+    const trigger = hostButton("Enlarge Wren avatar");
+    activeElement = makeNode(trigger.props);
+    act(() => trigger.props.onClick());
+    const firstBackdrop = backdrop();
+    const backdropNode = nodesByClass.get("ui-modal-backdrop");
+
+    act(() => dispatchDocument("mousedown", backdropNode));
+    expect(popoverClose).not.toHaveBeenCalled();
+    act(() => firstBackdrop.props.onClick());
+    expect(popoverClose).not.toHaveBeenCalled();
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(1);
+
+    const reopenedTrigger = hostButton("Enlarge Wren avatar");
+    const triggerNode = makeNode(reopenedTrigger.props);
+    activeElement = triggerNode;
+    act(() => reopenedTrigger.props.onClick());
+    act(() => dispatchEscape());
+    expect(popoverClose).not.toHaveBeenCalled();
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(1);
+    expect(activeElement).toBe(triggerNode);
+  });
+});

--- a/src/components/ui/avatar-lightbox.behavior.test.tsx
+++ b/src/components/ui/avatar-lightbox.behavior.test.tsx
@@ -166,7 +166,9 @@ describe("AvatarLightbox nested in Popover", () => {
   test("ordinary parent re-renders do not churn layer registration", () => {
     const cleanup = vi.fn();
     const register = vi.fn(() => cleanup);
-    const layers = { register, contains: () => false };
+    const uncover = vi.fn();
+    const cover = vi.fn(() => uncover);
+    const layers = { register, contains: () => false, cover };
 
     function Scene({ revision }) {
       return (
@@ -184,14 +186,19 @@ describe("AvatarLightbox nested in Popover", () => {
     });
     act(() => hostButton("Enlarge Wren avatar").props.onClick());
     expect(register).toHaveBeenCalledTimes(1);
+    expect(cover).toHaveBeenCalledTimes(1);
     expect(cleanup).not.toHaveBeenCalled();
+    expect(uncover).not.toHaveBeenCalled();
 
     act(() => renderer.update(<Scene revision={2} />));
     expect(register).toHaveBeenCalledTimes(1);
+    expect(cover).toHaveBeenCalledTimes(1);
     expect(cleanup).not.toHaveBeenCalled();
+    expect(uncover).not.toHaveBeenCalled();
 
     act(() => backdrop().props.onClick());
     expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(uncover).toHaveBeenCalledTimes(1);
   });
 
   test("backdrop and Escape dismiss only the lightbox and return focus to its trigger", () => {
@@ -218,6 +225,14 @@ describe("AvatarLightbox nested in Popover", () => {
     const trigger = hostButton("Enlarge Wren avatar");
     activeElement = makeNode(trigger.props);
     act(() => trigger.props.onClick());
+    expect(
+      renderer.root.find(
+        (node) =>
+          node.type === "div" &&
+          typeof node.props.className === "string" &&
+          node.props.className.split(/\s+/).includes("ui-popover"),
+      ).props["data-covered"],
+    ).toBe(true);
     const firstBackdrop = backdrop();
     const backdropNode = nodesByClass.get("ui-modal-backdrop");
 
@@ -226,6 +241,14 @@ describe("AvatarLightbox nested in Popover", () => {
     act(() => firstBackdrop.props.onClick());
     expect(popoverClose).not.toHaveBeenCalled();
     expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(1);
+    expect(
+      renderer.root.find(
+        (node) =>
+          node.type === "div" &&
+          typeof node.props.className === "string" &&
+          node.props.className.split(/\s+/).includes("ui-popover"),
+      ).props["data-covered"],
+    ).toBeUndefined();
 
     const reopenedTrigger = hostButton("Enlarge Wren avatar");
     const triggerNode = makeNode(reopenedTrigger.props);

--- a/src/components/ui/avatar-lightbox.behavior.test.tsx
+++ b/src/components/ui/avatar-lightbox.behavior.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/lib/icon", () => ({
 }));
 
 import { AvatarLightbox } from "./avatar-lightbox";
+import { Modal } from "./modal";
 import { Popover, PopoverLayersContext, PopoverSubmenu } from "./popover";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -147,16 +148,27 @@ function dispatchDocument(type, target) {
 
 function dispatchEscape() {
   let stopped = false;
+  let immediateStopped = false;
   const event = {
     key: "Escape",
     stopPropagation() {
       stopped = true;
     },
+    stopImmediatePropagation() {
+      stopped = true;
+      immediateStopped = true;
+    },
   };
   const listeners = windowListeners.get("keydown") ?? [];
-  for (const { listener } of listeners.filter((entry) => entry.capture)) listener(event);
+  for (const { listener } of listeners.filter((entry) => entry.capture)) {
+    listener(event);
+    if (immediateStopped) return;
+  }
   if (stopped) return;
-  for (const { listener } of listeners.filter((entry) => !entry.capture)) listener(event);
+  for (const { listener } of listeners.filter((entry) => !entry.capture)) {
+    listener(event);
+    if (immediateStopped) return;
+  }
 }
 
 function dispatchTab() {
@@ -221,6 +233,58 @@ describe("AvatarLightbox nested in Popover", () => {
     expect(firstClose).not.toHaveBeenCalled();
     expect(secondClose).toHaveBeenCalledOnce();
     expect(secondClose).toHaveBeenCalledWith(false);
+  });
+
+  test("a newer independent Modal owns Escape over a covered Popover tree", () => {
+    const ownerClose = vi.fn();
+    const independentClose = vi.fn();
+
+    function Scene() {
+      const anchorRef = useRef(null);
+      const [independentOpen, setIndependentOpen] = useState(false);
+      return (
+        <>
+          <button ref={anchorRef}>anchor</button>
+          <Popover open onOpenChange={ownerClose} anchorRef={anchorRef} ariaLabel="Avatar menu">
+            <AvatarLightbox src="/wren.png" label="Wren">
+              <span>wren</span>
+            </AvatarLightbox>
+          </Popover>
+          <button
+            aria-label="Open independent modal"
+            onClick={() => setIndependentOpen(true)}
+          >
+            Open
+          </button>
+          <Modal
+            open={independentOpen}
+            onClose={() => {
+              independentClose();
+              setIndependentOpen(false);
+            }}
+            ariaLabel="Independent modal"
+          >
+            Independent
+          </Modal>
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene />, { createNodeMock });
+    });
+    act(() => hostButton("Enlarge Wren avatar").props.onClick());
+    act(() => hostButton("Open independent modal").props.onClick());
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(3);
+
+    act(() => dispatchEscape());
+    expect(independentClose).toHaveBeenCalledOnce();
+    expect(ownerClose).not.toHaveBeenCalled();
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(2);
+
+    act(() => dispatchEscape());
+    expect(ownerClose).not.toHaveBeenCalled();
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(1);
   });
 
   test("ordinary parent re-renders do not churn layer registration", () => {

--- a/src/components/ui/avatar-lightbox.behavior.test.tsx
+++ b/src/components/ui/avatar-lightbox.behavior.test.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck -- react-test-renderer has no bundled types.
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { act, create } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -23,6 +23,7 @@ let body;
 let windowListeners;
 let documentListeners;
 let nodesByClass;
+let modalFocusable;
 
 function addListener(store, type, listener, options) {
   const listeners = store.get(type) ?? [];
@@ -49,6 +50,14 @@ function installDom() {
     contains: () => false,
     focus() {
       activeElement = body;
+      modalFocusable = {
+        nodeType: 1,
+        hasAttribute: () => false,
+        getClientRects: () => [{ width: 1, height: 1 }],
+        focus() {
+          activeElement = modalFocusable;
+        },
+      };
     },
   };
   activeElement = body;
@@ -84,6 +93,8 @@ function installDom() {
 }
 
 function makeNode(props) {
+  const classes = typeof props.className === "string" ? props.className.split(/\s+/) : [];
+  const isModal = classes.includes("ui-modal");
   const node = {
     nodeType: 1,
     scrollHeight: 240,
@@ -96,8 +107,8 @@ function makeNode(props) {
       width: 100,
       height: 32,
     }),
-    querySelector: () => null,
-    querySelectorAll: () => [],
+    querySelector: () => (isModal ? modalFocusable : null),
+    querySelectorAll: () => (isModal ? [modalFocusable] : []),
     getClientRects: () => [{ width: 1, height: 1 }],
     hasAttribute: () => false,
     contains(target) {
@@ -107,9 +118,7 @@ function makeNode(props) {
       activeElement = node;
     },
   };
-  if (typeof props.className === "string") {
-    for (const className of props.className.split(/\s+/)) nodesByClass.set(className, node);
-  }
+  for (const className of classes) nodesByClass.set(className, node);
   return node;
 }
 
@@ -147,6 +156,17 @@ function dispatchEscape() {
   const listeners = windowListeners.get("keydown") ?? [];
   for (const { listener } of listeners.filter((entry) => entry.capture)) listener(event);
   if (stopped) return;
+  for (const { listener } of listeners.filter((entry) => !entry.capture)) listener(event);
+}
+
+function dispatchTab() {
+  const event = {
+    key: "Tab",
+    shiftKey: false,
+    preventDefault() {},
+  };
+  const listeners = windowListeners.get("keydown") ?? [];
+  for (const { listener } of listeners.filter((entry) => entry.capture)) listener(event);
   for (const { listener } of listeners.filter((entry) => !entry.capture)) listener(event);
 }
 
@@ -258,5 +278,71 @@ describe("AvatarLightbox nested in Popover", () => {
     expect(popoverClose).not.toHaveBeenCalled();
     expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(1);
     expect(activeElement).toBe(triggerNode);
+  });
+
+  test("a Popover opened inside the lightbox remains interactive and closes before the Modal", () => {
+    const ownerClose = vi.fn();
+
+    function NestedActions() {
+      const anchorRef = useRef(null);
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button ref={anchorRef} aria-label="Open nested actions" onClick={() => setOpen(true)}>
+            Actions
+          </button>
+          <Popover
+            open={open}
+            onOpenChange={setOpen}
+            anchorRef={anchorRef}
+            ariaLabel="Nested actions"
+          >
+            <button aria-label="Nested action">Run</button>
+          </Popover>
+        </>
+      );
+    }
+
+    function Scene() {
+      const anchorRef = useRef(null);
+      return (
+        <>
+          <button ref={anchorRef}>anchor</button>
+          <Popover open onOpenChange={ownerClose} anchorRef={anchorRef} ariaLabel="Avatar menu">
+            <AvatarLightbox
+              src="/avatar.png"
+              label="Wren"
+              footerActions={<NestedActions />}
+            >
+              <span>avatar</span>
+            </AvatarLightbox>
+          </Popover>
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene />, { createNodeMock });
+    });
+    act(() => hostButton("Enlarge Wren avatar").props.onClick());
+    act(() => hostButton("Open nested actions").props.onClick());
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(3);
+
+    const nestedPanelNode = nodesByClass.get("ui-popover");
+    activeElement = nestedPanelNode;
+    act(() => dispatchDocument("mousedown", nestedPanelNode));
+    expect(ownerClose).not.toHaveBeenCalled();
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(3);
+
+    act(() => dispatchTab());
+    expect(activeElement).toBe(nestedPanelNode);
+
+    act(() => dispatchEscape());
+    expect(ownerClose).not.toHaveBeenCalled();
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(2);
+
+    act(() => dispatchEscape());
+    expect(ownerClose).not.toHaveBeenCalled();
+    expect(renderer.root.findAllByProps({ role: "dialog" })).toHaveLength(1);
   });
 });

--- a/src/components/ui/avatar-lightbox.test.ts
+++ b/src/components/ui/avatar-lightbox.test.ts
@@ -50,14 +50,18 @@ assert.match(
 );
 assert.match(
   src,
-  /usePopoverLayerRegistration\(layerEl, enlarged, closeLightbox\)/,
-  "registers the complete Modal as an inside and Escape layer of any ancestor Popover",
+  /usePopoverLayerRegistration\(layerEl, enlarged, closeLightbox, true\)/,
+  "registers the complete Modal as an inside and Escape layer and covers its owning Popover",
 );
 assert.match(
   src,
   /onLayerElement=\{setLayerEl\}/,
   "wires the Modal's backdrop callback through to the registration hook",
 );
-assert.match(src, /abovePopovers/, "stacks the nested Modal above its owning Popover");
+assert.doesNotMatch(
+  src,
+  /abovePopovers/,
+  "does not force every lightbox above Popovers opened from inside the Modal",
+);
 
 console.log("avatar-lightbox.test.ts: ok");

--- a/src/components/ui/avatar-lightbox.test.ts
+++ b/src/components/ui/avatar-lightbox.test.ts
@@ -38,14 +38,11 @@ assert.match(
   "caller classes are conditionally appended to the trigger's reset classes",
 );
 
-console.log("avatar-lightbox.test.ts: ok");
-
 // Popover focus-trap conflict fix (cave-fzr4p): a Modal's focus trap steals
 // focus the instant it opens, which an ancestor Popover reads as focus
 // leaving its panel and self-dismisses — unmounting both. AvatarLightbox must
-// register its Modal's dialog element as an "inside" layer via the shared
-// PopoverLayersContext hook so that doesn't happen; a no-op when there is no
-// ancestor Popover.
+// register its complete Modal layer as "inside" and as the deepest Escape
+// owner. A no-op when there is no ancestor Popover.
 assert.match(
   src,
   /from "\.\/popover"/,
@@ -53,12 +50,14 @@ assert.match(
 );
 assert.match(
   src,
-  /usePopoverLayerRegistration\(dialogEl\)/,
-  "registers the Modal's dialog element as an inside layer of any ancestor Popover",
+  /usePopoverLayerRegistration\(layerEl, enlarged, closeLightbox\)/,
+  "registers the complete Modal as an inside and Escape layer of any ancestor Popover",
 );
 assert.match(
   src,
-  /onDialogElement=\{setDialogEl\}/,
-  "wires the Modal's dialog element callback through to the registration hook",
+  /onLayerElement=\{setLayerEl\}/,
+  "wires the Modal's backdrop callback through to the registration hook",
 );
+assert.match(src, /abovePopovers/, "stacks the nested Modal above its owning Popover");
 
+console.log("avatar-lightbox.test.ts: ok");

--- a/src/components/ui/avatar-lightbox.tsx
+++ b/src/components/ui/avatar-lightbox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import { Modal } from "./modal";
 import { usePopoverLayerRegistration } from "./popover";
 
@@ -44,15 +44,13 @@ export function AvatarLightbox({
   triggerClassName,
 }: AvatarLightboxProps) {
   const [enlarged, setEnlarged] = useState(false);
-  const [dialogEl, setDialogEl] = useState<HTMLDivElement | null>(null);
+  const [layerEl, setLayerEl] = useState<HTMLDivElement | null>(null);
   const noun = category.toLowerCase();
+  const closeLightbox = useCallback(() => setEnlarged(false), []);
 
-  // If this trigger renders inside a Popover, mark the enlarged Modal as an
-  // "inside" layer for as long as it's open — otherwise the Modal's focus
-  // trap steals focus the instant it opens, which the Popover reads as focus
-  // leaving its panel and self-dismisses, unmounting both (cave-fzr4p). A
-  // no-op when there is no ancestor Popover.
-  usePopoverLayerRegistration(dialogEl);
+  // If this trigger renders inside a Popover, its complete Modal layer counts
+  // as inside and owns Escape until it closes. A no-op outside a Popover.
+  usePopoverLayerRegistration(layerEl, enlarged, closeLightbox);
 
   return (
     <>
@@ -68,10 +66,11 @@ export function AvatarLightbox({
       {enlarged ? (
         <Modal
           open
-          onClose={() => setEnlarged(false)}
+          onClose={closeLightbox}
           breadcrumb={[label, category]}
           footerActions={footerActions}
-          onDialogElement={setDialogEl}
+          onLayerElement={setLayerEl}
+          abovePopovers
         >
           <div className="grid aspect-square w-full max-w-[320px] place-items-center overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)]">
             <img src={src} alt={`${label} ${noun}`} className="h-full w-full object-cover" />

--- a/src/components/ui/avatar-lightbox.tsx
+++ b/src/components/ui/avatar-lightbox.tsx
@@ -49,8 +49,9 @@ export function AvatarLightbox({
   const closeLightbox = useCallback(() => setEnlarged(false), []);
 
   // If this trigger renders inside a Popover, its complete Modal layer counts
-  // as inside and owns Escape until it closes. A no-op outside a Popover.
-  usePopoverLayerRegistration(layerEl, enlarged, closeLightbox);
+  // as inside, owns Escape, and covers that Popover until it closes. A no-op
+  // outside a Popover.
+  usePopoverLayerRegistration(layerEl, enlarged, closeLightbox, true);
 
   return (
     <>
@@ -70,7 +71,6 @@ export function AvatarLightbox({
           breadcrumb={[label, category]}
           footerActions={footerActions}
           onLayerElement={setLayerEl}
-          abovePopovers
         >
           <div className="grid aspect-square w-full max-w-[320px] place-items-center overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)]">
             <img src={src} alt={`${label} ${noun}`} className="h-full w-full object-cover" />

--- a/src/components/ui/modal.test.ts
+++ b/src/components/ui/modal.test.ts
@@ -38,13 +38,18 @@ assert.match(src, /dismissOnEscape\?: boolean/, "Modal exposes a dismissOnEscape
 assert.match(src, /dismissOnEscape = true/, "dismissOnEscape defaults to true");
 assert.match(
   src,
-  /useFocusTrap\(open, dialogRef, \{\s*onEscape: dismissOnEscape \? onClose : undefined,\s*portalLayers,\s*\}\)/,
+  /useFocusTrap\(open, dialogRef, \{\s*onEscape: dismissOnEscape \? onClose : undefined,\s*portalLayers,\s*portalRootId: portalLayerRootId,\s*\}\)/,
   "the trap stays active while busy; only the Esc dismissal callback is gated",
 );
 assert.match(
   src,
   /<FocusTrapPortalLayersContext\.Provider value=\{portalLayers\}>/,
   "body-portaled descendants can join the Modal's focus boundary",
+);
+assert.match(
+  src,
+  /<PortalLayerRootContext\.Provider value=\{portalLayerRootId\}>[\s\S]{0,120}<PortalLayerDepthContext\.Provider value=\{ownerLayerDepth \+ 1\}>/,
+  "nested traps share a root while increasing their portal depth",
 );
 
 // Optional escape hatch (cave-fzr4p): Modal itself stays Popover-agnostic, but

--- a/src/components/ui/modal.test.ts
+++ b/src/components/ui/modal.test.ts
@@ -59,14 +59,13 @@ assert.match(
 );
 assert.match(
   src,
-  /ref=\{setLayerElement\}[\s\S]{0,120}className=\{`ui-modal-backdrop/,
+  /ref=\{setLayerElement\}[\s\S]{0,120}className="ui-modal-backdrop"/,
   "the stable callback ref exposes the backdrop rather than only the inner dialog",
 );
-assert.match(src, /abovePopovers\?: boolean/, "Modal can opt into the nested-popover layer");
-assert.match(
+assert.doesNotMatch(
   src,
-  /ui-modal-backdrop--above-popovers/,
-  "the nested-popover layer receives a dedicated stacking class",
+  /abovePopovers|ui-modal-backdrop--above-popovers/,
+  "Modal keeps the shared layer order; its owning Popover is covered instead",
 );
 
 console.log("modal.test.ts: ok");

--- a/src/components/ui/modal.test.ts
+++ b/src/components/ui/modal.test.ts
@@ -42,26 +42,31 @@ assert.match(
   "the trap stays active while busy; only the Esc dismissal callback is gated",
 );
 
-console.log("modal.test.ts: ok");
-
 // Optional escape hatch (cave-fzr4p): Modal itself stays Popover-agnostic, but
-// exposes its dialog DOM node via a callback ref so a caller like
+// exposes its complete backdrop layer via a callback ref so a caller like
 // AvatarLightbox can register it as an "inside" layer of an ancestor Popover.
-// Without this, opening a focus-trapped Modal from inside a Popover steals
-// focus, which the Popover reads as focus leaving its panel — self-dismissing
-// and unmounting both.
+// Registering only the inner dialog leaves backdrop presses outside that layer,
+// so the Popover dismisses before the Modal can close itself.
 assert.match(
   src,
-  /onDialogElement\?: \(el: HTMLDivElement \| null\) => void;/,
-  "Modal accepts an optional onDialogElement callback",
+  /onLayerElement\?: \(el: HTMLDivElement \| null\) => void;/,
+  "Modal accepts an optional onLayerElement callback",
 );
 assert.match(
   src,
-  /const setDialogElement = useCallback\(\s*\(el: HTMLDivElement \| null\) => \{\s*dialogRef\.current = el;\s*onDialogElement\?\.\(el\);\s*\},\s*\[onDialogElement\],\s*\);/,
-  "the dialog uses a memoized callback ref so ordinary re-renders do not unregister and re-register the popover layer",
+  /const setLayerElement = useCallback\(\s*\(el: HTMLDivElement \| null\) => \{\s*onLayerElement\?\.\(el\);\s*\},\s*\[onLayerElement\],\s*\);/,
+  "the complete modal layer uses a memoized callback ref",
 );
 assert.match(
   src,
-  /ref=\{setDialogElement\}/,
-  "the stable callback ref keeps the internal focus-trap ref and forwards the node to the caller",
+  /ref=\{setLayerElement\}[\s\S]{0,120}className=\{`ui-modal-backdrop/,
+  "the stable callback ref exposes the backdrop rather than only the inner dialog",
 );
+assert.match(src, /abovePopovers\?: boolean/, "Modal can opt into the nested-popover layer");
+assert.match(
+  src,
+  /ui-modal-backdrop--above-popovers/,
+  "the nested-popover layer receives a dedicated stacking class",
+);
+
+console.log("modal.test.ts: ok");

--- a/src/components/ui/modal.test.ts
+++ b/src/components/ui/modal.test.ts
@@ -38,8 +38,13 @@ assert.match(src, /dismissOnEscape\?: boolean/, "Modal exposes a dismissOnEscape
 assert.match(src, /dismissOnEscape = true/, "dismissOnEscape defaults to true");
 assert.match(
   src,
-  /useFocusTrap\(open, dialogRef, \{ onEscape: dismissOnEscape \? onClose : undefined \}\)/,
+  /useFocusTrap\(open, dialogRef, \{\s*onEscape: dismissOnEscape \? onClose : undefined,\s*portalLayers,\s*\}\)/,
   "the trap stays active while busy; only the Esc dismissal callback is gated",
+);
+assert.match(
+  src,
+  /<FocusTrapPortalLayersContext\.Provider value=\{portalLayers\}>/,
+  "body-portaled descendants can join the Modal's focus boundary",
 );
 
 // Optional escape hatch (cave-fzr4p): Modal itself stays Popover-agnostic, but

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -30,8 +30,6 @@ type ModalProps = {
    *  unmount. This lets a caller register the whole Modal — including backdrop
    *  presses — with an owning portaled layer such as Popover. */
   onLayerElement?: (el: HTMLDivElement | null) => void;
-  /** Stack above Popovers when this Modal was launched from inside one. */
-  abovePopovers?: boolean;
 };
 
 export function Modal({
@@ -47,7 +45,6 @@ export function Modal({
   ariaLabel,
   ariaDescribedBy,
   onLayerElement,
-  abovePopovers,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const headingId = useId();
@@ -67,7 +64,7 @@ export function Modal({
   return createPortal(
     <div
       ref={setLayerElement}
-      className={`ui-modal-backdrop${abovePopovers ? " ui-modal-backdrop--above-popovers" : ""}`}
+      className="ui-modal-backdrop"
       onClick={dismissOnBackdrop ? onClose : undefined}
       role="presentation"
     >

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useCallback, useId, useRef, type ReactNode } from "react";
+import { useCallback, useId, useMemo, useRef, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
-import { useFocusTrap } from "@/lib/use-focus-trap";
+import {
+  FocusTrapPortalLayersContext,
+  useFocusTrap,
+} from "@/lib/use-focus-trap";
 
 type ModalProps = {
   open: boolean;
@@ -47,6 +50,7 @@ export function Modal({
   onLayerElement,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
+  const portalLayerElementsRef = useRef<Set<HTMLElement>>(new Set());
   const headingId = useId();
   const setLayerElement = useCallback(
     (el: HTMLDivElement | null) => {
@@ -54,10 +58,30 @@ export function Modal({
     },
     [onLayerElement],
   );
+  const portalLayers = useMemo(
+    () => ({
+      register: (el: HTMLElement) => {
+        portalLayerElementsRef.current.add(el);
+        return () => {
+          portalLayerElementsRef.current.delete(el);
+        };
+      },
+      contains: (node: Node | null) => {
+        if (!node) return false;
+        for (const el of portalLayerElementsRef.current) if (el.contains(node)) return true;
+        return false;
+      },
+      elements: () => Array.from(portalLayerElementsRef.current),
+    }),
+    [],
+  );
 
   // Keep the trap active regardless of dismissability — an undefined onEscape
   // makes Esc a no-op without releasing Tab cycling or focus return.
-  useFocusTrap(open, dialogRef, { onEscape: dismissOnEscape ? onClose : undefined });
+  useFocusTrap(open, dialogRef, {
+    onEscape: dismissOnEscape ? onClose : undefined,
+    portalLayers,
+  });
 
   if (!open || typeof document === "undefined") return null;
 
@@ -83,39 +107,41 @@ export function Modal({
         aria-describedby={ariaDescribedBy}
         tabIndex={-1}
       >
-        {breadcrumb ? (
-          <header className="ui-modal-header">
-            <div className="ui-modal-header-breadcrumb" id={headingId}>
-              {breadcrumb.map((segment, i) => (
-                <span key={i} className="contents">
-                  {i > 0 ? (
-                    <span className="ui-modal-header-breadcrumb-sep" aria-hidden>
-                      ›
-                    </span>
-                  ) : null}
-                  {i === breadcrumb.length - 1 ? <strong>{segment}</strong> : <span>{segment}</span>}
-                </span>
-              ))}
-            </div>
-            <button
-              type="button"
-              className="ui-modal-close focus-ring"
-              onClick={onClose}
-              aria-label="Close"
-            >
-              <Icon name="ph:x" width={14} />
-            </button>
-          </header>
-        ) : null}
+        <FocusTrapPortalLayersContext.Provider value={portalLayers}>
+          {breadcrumb ? (
+            <header className="ui-modal-header">
+              <div className="ui-modal-header-breadcrumb" id={headingId}>
+                {breadcrumb.map((segment, i) => (
+                  <span key={i} className="contents">
+                    {i > 0 ? (
+                      <span className="ui-modal-header-breadcrumb-sep" aria-hidden>
+                        ›
+                      </span>
+                    ) : null}
+                    {i === breadcrumb.length - 1 ? <strong>{segment}</strong> : <span>{segment}</span>}
+                  </span>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="ui-modal-close focus-ring"
+                onClick={onClose}
+                aria-label="Close"
+              >
+                <Icon name="ph:x" width={14} />
+              </button>
+            </header>
+          ) : null}
 
-        <div className="ui-modal-body">{children}</div>
+          <div className="ui-modal-body">{children}</div>
 
-        {footerPills || footerActions ? (
-          <footer className="ui-modal-footer">
-            <div className="ui-modal-footer-pills">{footerPills}</div>
-            <div className="ui-modal-footer-actions">{footerActions}</div>
-          </footer>
-        ) : null}
+          {footerPills || footerActions ? (
+            <footer className="ui-modal-footer">
+              <div className="ui-modal-footer-pills">{footerPills}</div>
+              <div className="ui-modal-footer-actions">{footerActions}</div>
+            </footer>
+          ) : null}
+        </FocusTrapPortalLayersContext.Provider>
       </div>
     </div>,
     document.body,

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -51,7 +51,7 @@ export function Modal({
   onLayerElement,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
-  const portalLayerElementsRef = useRef<Set<HTMLElement>>(new Set());
+  const portalLayerElementsRef = useRef<Map<HTMLElement, number>>(new Map());
   const ownerLayerDepth = useContext(PortalLayerDepthContext);
   const headingId = useId();
   const setLayerElement = useCallback(
@@ -63,17 +63,22 @@ export function Modal({
   const portalLayers = useMemo(
     () => ({
       register: (el: HTMLElement) => {
-        portalLayerElementsRef.current.add(el);
+        portalLayerElementsRef.current.set(
+          el,
+          (portalLayerElementsRef.current.get(el) ?? 0) + 1,
+        );
         return () => {
-          portalLayerElementsRef.current.delete(el);
+          const next = (portalLayerElementsRef.current.get(el) ?? 1) - 1;
+          if (next === 0) portalLayerElementsRef.current.delete(el);
+          else portalLayerElementsRef.current.set(el, next);
         };
       },
       contains: (node: Node | null) => {
         if (!node) return false;
-        for (const el of portalLayerElementsRef.current) if (el.contains(node)) return true;
+        for (const el of portalLayerElementsRef.current.keys()) if (el.contains(node)) return true;
         return false;
       },
-      elements: () => Array.from(portalLayerElementsRef.current),
+      elements: () => Array.from(portalLayerElementsRef.current.keys()),
     }),
     [],
   );

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useId, useMemo, useRef, type ReactNode } from "react";
+import { useCallback, useContext, useId, useMemo, useRef, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@/lib/icon";
 import {
   FocusTrapPortalLayersContext,
+  PortalLayerDepthContext,
   useFocusTrap,
 } from "@/lib/use-focus-trap";
 
@@ -51,6 +52,7 @@ export function Modal({
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const portalLayerElementsRef = useRef<Set<HTMLElement>>(new Set());
+  const ownerLayerDepth = useContext(PortalLayerDepthContext);
   const headingId = useId();
   const setLayerElement = useCallback(
     (el: HTMLDivElement | null) => {
@@ -108,39 +110,41 @@ export function Modal({
         tabIndex={-1}
       >
         <FocusTrapPortalLayersContext.Provider value={portalLayers}>
-          {breadcrumb ? (
-            <header className="ui-modal-header">
-              <div className="ui-modal-header-breadcrumb" id={headingId}>
-                {breadcrumb.map((segment, i) => (
-                  <span key={i} className="contents">
-                    {i > 0 ? (
-                      <span className="ui-modal-header-breadcrumb-sep" aria-hidden>
-                        ›
-                      </span>
-                    ) : null}
-                    {i === breadcrumb.length - 1 ? <strong>{segment}</strong> : <span>{segment}</span>}
-                  </span>
-                ))}
-              </div>
-              <button
-                type="button"
-                className="ui-modal-close focus-ring"
-                onClick={onClose}
-                aria-label="Close"
-              >
-                <Icon name="ph:x" width={14} />
-              </button>
-            </header>
-          ) : null}
+          <PortalLayerDepthContext.Provider value={ownerLayerDepth + 1}>
+            {breadcrumb ? (
+              <header className="ui-modal-header">
+                <div className="ui-modal-header-breadcrumb" id={headingId}>
+                  {breadcrumb.map((segment, i) => (
+                    <span key={i} className="contents">
+                      {i > 0 ? (
+                        <span className="ui-modal-header-breadcrumb-sep" aria-hidden>
+                          ›
+                        </span>
+                      ) : null}
+                      {i === breadcrumb.length - 1 ? <strong>{segment}</strong> : <span>{segment}</span>}
+                    </span>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  className="ui-modal-close focus-ring"
+                  onClick={onClose}
+                  aria-label="Close"
+                >
+                  <Icon name="ph:x" width={14} />
+                </button>
+              </header>
+            ) : null}
 
-          <div className="ui-modal-body">{children}</div>
+            <div className="ui-modal-body">{children}</div>
 
-          {footerPills || footerActions ? (
-            <footer className="ui-modal-footer">
-              <div className="ui-modal-footer-pills">{footerPills}</div>
-              <div className="ui-modal-footer-actions">{footerActions}</div>
-            </footer>
-          ) : null}
+            {footerPills || footerActions ? (
+              <footer className="ui-modal-footer">
+                <div className="ui-modal-footer-pills">{footerPills}</div>
+                <div className="ui-modal-footer-actions">{footerActions}</div>
+              </footer>
+            ) : null}
+          </PortalLayerDepthContext.Provider>
         </FocusTrapPortalLayersContext.Provider>
       </div>
     </div>,

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -26,13 +26,12 @@ type ModalProps = {
   ariaLabel?: string;
   /** Description element inside the modal body. */
   ariaDescribedBy?: string;
-  /** Called with the dialog's DOM node once mounted, and null on unmount. For
-   *  a caller that needs to register the dialog with something outside this
-   *  component's own tree — e.g. AvatarLightbox marking it as an "inside"
-   *  layer of an ancestor Popover, so the Popover's outside-click/focus-out
-   *  dismissal doesn't fire the instant this focus-trapped dialog steals
-   *  focus (cave-fzr4p). Optional; Modal itself stays Popover-agnostic. */
-  onDialogElement?: (el: HTMLDivElement | null) => void;
+  /** Called with the complete backdrop layer once mounted, and null on
+   *  unmount. This lets a caller register the whole Modal — including backdrop
+   *  presses — with an owning portaled layer such as Popover. */
+  onLayerElement?: (el: HTMLDivElement | null) => void;
+  /** Stack above Popovers when this Modal was launched from inside one. */
+  abovePopovers?: boolean;
 };
 
 export function Modal({
@@ -47,16 +46,16 @@ export function Modal({
   dismissOnEscape = true,
   ariaLabel,
   ariaDescribedBy,
-  onDialogElement,
+  onLayerElement,
+  abovePopovers,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const headingId = useId();
-  const setDialogElement = useCallback(
+  const setLayerElement = useCallback(
     (el: HTMLDivElement | null) => {
-      dialogRef.current = el;
-      onDialogElement?.(el);
+      onLayerElement?.(el);
     },
-    [onDialogElement],
+    [onLayerElement],
   );
 
   // Keep the trap active regardless of dismissability — an undefined onEscape
@@ -67,12 +66,13 @@ export function Modal({
 
   return createPortal(
     <div
-      className="ui-modal-backdrop"
+      ref={setLayerElement}
+      className={`ui-modal-backdrop${abovePopovers ? " ui-modal-backdrop--above-popovers" : ""}`}
       onClick={dismissOnBackdrop ? onClose : undefined}
       role="presentation"
     >
       <div
-        ref={setDialogElement}
+        ref={dialogRef}
         className={`ui-modal${wide ? " ui-modal--wide" : ""}`}
         onClick={(e) => e.stopPropagation()}
         role="dialog"

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -6,7 +6,9 @@ import { Icon } from "@/lib/icon";
 import {
   FocusTrapPortalLayersContext,
   PortalLayerDepthContext,
+  PortalLayerRootContext,
   useFocusTrap,
+  usePortalLayerRootId,
 } from "@/lib/use-focus-trap";
 
 type ModalProps = {
@@ -53,6 +55,7 @@ export function Modal({
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const portalLayerElementsRef = useRef<Map<HTMLElement, number>>(new Map());
   const ownerLayerDepth = useContext(PortalLayerDepthContext);
+  const portalLayerRootId = usePortalLayerRootId();
   const headingId = useId();
   const setLayerElement = useCallback(
     (el: HTMLDivElement | null) => {
@@ -88,6 +91,7 @@ export function Modal({
   useFocusTrap(open, dialogRef, {
     onEscape: dismissOnEscape ? onClose : undefined,
     portalLayers,
+    portalRootId: portalLayerRootId,
   });
 
   if (!open || typeof document === "undefined") return null;
@@ -115,41 +119,43 @@ export function Modal({
         tabIndex={-1}
       >
         <FocusTrapPortalLayersContext.Provider value={portalLayers}>
-          <PortalLayerDepthContext.Provider value={ownerLayerDepth + 1}>
-            {breadcrumb ? (
-              <header className="ui-modal-header">
-                <div className="ui-modal-header-breadcrumb" id={headingId}>
-                  {breadcrumb.map((segment, i) => (
-                    <span key={i} className="contents">
-                      {i > 0 ? (
-                        <span className="ui-modal-header-breadcrumb-sep" aria-hidden>
-                          ›
-                        </span>
-                      ) : null}
-                      {i === breadcrumb.length - 1 ? <strong>{segment}</strong> : <span>{segment}</span>}
-                    </span>
-                  ))}
-                </div>
-                <button
-                  type="button"
-                  className="ui-modal-close focus-ring"
-                  onClick={onClose}
-                  aria-label="Close"
-                >
-                  <Icon name="ph:x" width={14} />
-                </button>
-              </header>
-            ) : null}
+          <PortalLayerRootContext.Provider value={portalLayerRootId}>
+            <PortalLayerDepthContext.Provider value={ownerLayerDepth + 1}>
+              {breadcrumb ? (
+                <header className="ui-modal-header">
+                  <div className="ui-modal-header-breadcrumb" id={headingId}>
+                    {breadcrumb.map((segment, i) => (
+                      <span key={i} className="contents">
+                        {i > 0 ? (
+                          <span className="ui-modal-header-breadcrumb-sep" aria-hidden>
+                            ›
+                          </span>
+                        ) : null}
+                        {i === breadcrumb.length - 1 ? <strong>{segment}</strong> : <span>{segment}</span>}
+                      </span>
+                    ))}
+                  </div>
+                  <button
+                    type="button"
+                    className="ui-modal-close focus-ring"
+                    onClick={onClose}
+                    aria-label="Close"
+                  >
+                    <Icon name="ph:x" width={14} />
+                  </button>
+                </header>
+              ) : null}
 
-            <div className="ui-modal-body">{children}</div>
+              <div className="ui-modal-body">{children}</div>
 
-            {footerPills || footerActions ? (
-              <footer className="ui-modal-footer">
-                <div className="ui-modal-footer-pills">{footerPills}</div>
-                <div className="ui-modal-footer-actions">{footerActions}</div>
-              </footer>
-            ) : null}
-          </PortalLayerDepthContext.Provider>
+              {footerPills || footerActions ? (
+                <footer className="ui-modal-footer">
+                  <div className="ui-modal-footer-pills">{footerPills}</div>
+                  <div className="ui-modal-footer-actions">{footerActions}</div>
+                </footer>
+              ) : null}
+            </PortalLayerDepthContext.Provider>
+          </PortalLayerRootContext.Provider>
         </FocusTrapPortalLayersContext.Provider>
       </div>
     </div>,

--- a/src/components/ui/overflow-menu-submenu.test.tsx
+++ b/src/components/ui/overflow-menu-submenu.test.tsx
@@ -319,14 +319,26 @@ describe("OverflowMenu + PopoverSubmenu", () => {
     expect(findButton("First submenu item")).toBeTruthy();
 
     const rootEscape = [...windowListeners.get("keydown")][0];
-    act(() => rootEscape({ key: "Escape", stopPropagation() {} }));
+    act(() =>
+      rootEscape({
+        key: "Escape",
+        stopPropagation() {},
+        stopImmediatePropagation() {},
+      }),
+    );
     expect(findButton("First submenu item")).toBeUndefined();
     expect(findButton("Choose priority")).toBeTruthy();
 
     // With no focused descendant left, the root Popover still owns the next
     // Escape and returns focus to its overflow trigger when it closes.
     activeElement = body;
-    act(() => rootEscape({ key: "Escape", stopPropagation() {} }));
+    act(() =>
+      rootEscape({
+        key: "Escape",
+        stopPropagation() {},
+        stopImmediatePropagation() {},
+      }),
+    );
     expect(findOverflowTrigger().props["aria-expanded"]).toBe(false);
     expect(activeElement.getAttribute("aria-label")).toBe("More actions");
   });

--- a/src/components/ui/popover-submenu.test.ts
+++ b/src/components/ui/popover-submenu.test.ts
@@ -78,10 +78,15 @@ test("pre-measure pass carries minWidth so flip/clamp math sees the rendered wid
 test("Escape closes one submenu level per press before the root menu", () => {
   assert.match(
     src,
-    /const closeDeepest = submenuEscapeStack\[submenuEscapeStack\.length - 1\];\s*if \(closeDeepest\) \{\s*closeDeepest\(\);\s*return;\s*\}\s*onOpenChange\(false\);/,
-    "root Escape handler pops the submenu stack first",
+    /const deepest = submenuEscapeStack\.reduce<EscapeLayer \| undefined>[\s\S]{0,500}if \(deepest\) \{\s*deepest\.close\(\);\s*return;\s*\}\s*onOpenChange\(false\);/,
+    "root Escape handler selects the deepest registered layer first",
   );
-  assert.match(src, /submenuEscapeStack\.push\(closeSelf\);/, "open flyouts join the Escape stack");
+  assert.match(src, /usePopoverEscapeLayer\(open, closeToRow\);/, "open flyouts join the Escape stack");
+  assert.match(
+    src,
+    /candidate\.depth > current\.depth/,
+    "Escape precedence follows layer depth rather than effect registration order",
+  );
 });
 
 test("hover-intent opens for mouse pointers only, after a delay", () => {

--- a/src/components/ui/popover-submenu.test.ts
+++ b/src/components/ui/popover-submenu.test.ts
@@ -28,7 +28,7 @@ test("trigger row and flyout expose their configured popup semantics", () => {
 });
 
 test("flyouts register as inside layers so root dismissal ignores them", () => {
-  assert.match(src, /const onDocClick = \(e: MouseEvent\) => \{\s*const t = e\.target as Node;\s*if \(layers\.contains\(t\)\) return;/, "outside-click consults the layer registry");
+  assert.match(src, /const onDocClick = \(e: MouseEvent\) => \{\s*(?:if \(covered\) return;\s*)?const t = e\.target as Node;\s*if \(layers\.contains\(t\)\) return;/, "outside-click consults the layer registry");
   assert.match(src, /if \(layers\.contains\(next\)\) return;/, "root focus-out consults the layer registry");
   assert.match(src, /return layers\.register\(el\);/, "open flyouts register with the root popover");
 });

--- a/src/components/ui/popover-submenu.test.ts
+++ b/src/components/ui/popover-submenu.test.ts
@@ -30,7 +30,21 @@ test("trigger row and flyout expose their configured popup semantics", () => {
 test("flyouts register as inside layers so root dismissal ignores them", () => {
   assert.match(src, /const onDocClick = \(e: MouseEvent\) => \{\s*(?:if \(covered\) return;\s*)?const t = e\.target as Node;\s*if \(layers\.contains\(t\)\) return;/, "outside-click consults the layer registry");
   assert.match(src, /if \(layers\.contains\(next\)\) return;/, "root focus-out consults the layer registry");
-  assert.match(src, /return layers\.register\(el\);/, "open flyouts register with the root popover");
+  assert.match(
+    src,
+    /useRegisterPopoverOwner\(open, panelRef, parentLayers, focusTrapPortalLayers\)/,
+    "open flyouts register with every owning portal boundary",
+  );
+  assert.match(
+    src,
+    /className="ui-popover ui-popover-submenu"[\s\S]{0,300}data-covered=\{covered \|\| undefined\}[\s\S]{0,120}aria-hidden=\{covered \|\| undefined\}[\s\S]{0,120}inert=\{covered \|\| undefined\}/,
+    "a submenu owner is hidden and inert while its descendant Modal is active",
+  );
+  assert.match(
+    src,
+    /style=\{covered \? \{ \.\.\.style, visibility: "hidden" \} : style\}/,
+    "covered state overrides the submenu's inline visible positioning style",
+  );
 });
 
 test("keyboard: ArrowRight/Enter opens focusing first item; ArrowLeft returns to the row", () => {
@@ -78,7 +92,7 @@ test("pre-measure pass carries minWidth so flip/clamp math sees the rendered wid
 test("Escape closes one submenu level per press before the root menu", () => {
   assert.match(
     src,
-    /const deepest = submenuEscapeStack\.reduce<EscapeLayer \| undefined>[\s\S]{0,500}if \(deepest\) \{\s*deepest\.close\(\);\s*return;\s*\}\s*onOpenChange\(false\);/,
+    /const deepest = submenuEscapeStack[\s\S]{0,120}\.filter\(\(entry\) => entry\.rootId === escapeRootId\)[\s\S]{0,500}if \(deepest\) \{\s*deepest\.close\(\);\s*return;\s*\}\s*onOpenChange\(false\);/,
     "root Escape handler selects the deepest registered layer first",
   );
   assert.match(src, /usePopoverEscapeLayer\(open, closeToRow\);/, "open flyouts join the Escape stack");

--- a/src/components/ui/popover-submenu.test.ts
+++ b/src/components/ui/popover-submenu.test.ts
@@ -92,7 +92,7 @@ test("pre-measure pass carries minWidth so flip/clamp math sees the rendered wid
 test("Escape closes one submenu level per press before the root menu", () => {
   assert.match(
     src,
-    /const deepest = submenuEscapeStack[\s\S]{0,120}\.filter\(\(entry\) => entry\.rootId === escapeRootId\)[\s\S]{0,500}if \(deepest\) \{\s*deepest\.close\(\);\s*return;\s*\}\s*onOpenChange\(false\);/,
+    /const deepest = submenuEscapeStack[\s\S]{0,260}entry\.rootId === escapeRootId && entry\.treeId === escapeTreeId[\s\S]{0,500}if \(deepest\) \{\s*deepest\.close\(\);\s*return;\s*\}\s*onOpenChange\(false\);/,
     "root Escape handler selects the deepest registered layer first",
   );
   assert.match(src, /usePopoverEscapeLayer\(open, closeToRow\);/, "open flyouts join the Escape stack");

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -291,13 +291,9 @@ for (const file of ["../composer-runtime-chip.tsx", "../project-picker.tsx", "..
   );
 }
 
-console.log("popover.test.ts: ok");
-
 // Layer registration is exported for consumers outside popover.tsx (e.g.
-// AvatarLightbox's Modal, cave-fzr4p) to mark their own portaled dialog as
-// "inside" a Popover — otherwise a focus-trapped Modal opened from inside a
-// Popover steals focus, the Popover reads that as focus leaving its panel,
-// and self-dismisses out from under the Modal.
+// AvatarLightbox's Modal, cave-fzr4p) to mark their own complete portaled layer
+// as "inside" a Popover and optionally become its deepest Escape owner.
 assert.match(
   src,
   /export const PopoverLayersContext = createContext/,
@@ -305,7 +301,7 @@ assert.match(
 );
 assert.match(
   src,
-  /export function usePopoverLayerRegistration\(el: HTMLElement \| null\)/,
+  /export function usePopoverLayerRegistration\(\s*el: HTMLElement \| null,\s*active = Boolean\(el\),\s*onEscape\?: \(\) => void,/,
   "exports a hook that registers an element as an inside layer",
 );
 assert.match(
@@ -313,4 +309,19 @@ assert.match(
   /usePopoverLayerRegistration[\s\S]{0,200}if \(!el \|\| !layers\) return;\s*return layers\.register\(el\);/,
   "the hook is a no-op with no ancestor Popover and unregisters on cleanup/element change",
 );
+assert.match(
+  src,
+  /usePopoverEscapeLayer\(Boolean\(layers && active && onEscape\), onEscape \?\? NOOP\)/,
+  "a registered modal can absorb Escape before the owning Popover closes",
+);
 
+const nestedModalZ = Number(
+  primitivesCss.match(/\.ui-modal-backdrop--above-popovers\s*\{[^}]*?z-index:\s*(\d+)/)?.[1],
+);
+assert.ok(Number.isFinite(nestedModalZ), "found the nested modal z-index");
+assert.ok(
+  nestedModalZ > portalZ,
+  `nested modal (z ${nestedModalZ}) must stack above its owning popover (z ${portalZ})`,
+);
+
+console.log("popover.test.ts: ok");

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -201,13 +201,8 @@ assert.match(
 );
 assert.match(
   src,
-  /parentLayers\?\.register\(popoverRef\.current\)/,
-  "a nested Popover registers its portal with the owning Popover",
-);
-assert.match(
-  src,
-  /focusTrapPortalLayers\?\.register\(popoverRef\.current\)/,
-  "a Popover inside a Modal remains part of the Modal focus boundary",
+  /useRegisterPopoverOwner\(open, popoverRef, parentLayers, focusTrapPortalLayers\)/,
+  "each Popover registers its panel with its owning Popover and Modal boundaries",
 );
 assert.match(
   src,

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -206,6 +206,11 @@ assert.match(
 );
 assert.match(
   src,
+  /if \(!active \|\| !el \|\| !layers\) return;[\s\S]{0,300}\[active, el, layers, coverOwner\]/,
+  "closing releases owner cover during layout cleanup before focus restoration",
+);
+assert.match(
+  src,
   /register: \(el: HTMLElement\) => \{[\s\S]{0,220}parentLayers\?\.register\(el\)[\s\S]{0,160}focusTrapPortalLayers\?\.register\(el\)/,
   "descendant portals propagate through every ancestor Popover and Modal boundary",
 );
@@ -331,7 +336,7 @@ assert.match(
 );
 assert.match(
   src,
-  /usePopoverLayerRegistration[\s\S]{0,300}if \(!el \|\| !layers\) return;\s*const unregister = layers\.register\(el\);/,
+  /usePopoverLayerRegistration[\s\S]{0,300}if \(!active \|\| !el \|\| !layers\) return;\s*const unregister = layers\.register\(el\);/,
   "the hook is a no-op with no ancestor Popover and registers the complete child layer",
 );
 assert.match(

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -199,6 +199,26 @@ assert.match(
   /anchorRef\.current\?\.contains\(next\)/,
   "focus moving back to the anchor doesn't close the popover",
 );
+assert.match(
+  src,
+  /parentLayers\?\.register\(popoverRef\.current\)/,
+  "a nested Popover registers its portal with the owning Popover",
+);
+assert.match(
+  src,
+  /focusTrapPortalLayers\?\.register\(popoverRef\.current\)/,
+  "a Popover inside a Modal remains part of the Modal focus boundary",
+);
+assert.match(
+  src,
+  /if \(covered\) return;[\s\S]{0,200}const t = e\.target as Node/,
+  "a covered owner ignores outside-click dismissal while its child Modal is active",
+);
+assert.match(
+  src,
+  /data-covered=\{covered \|\| undefined\}[\s\S]{0,120}aria-hidden=\{covered \|\| undefined\}[\s\S]{0,120}inert=\{covered \|\| undefined\}/,
+  "a covered owner is removed from pointer, focus, and accessibility interaction",
+);
 
 // A `checked` row used to be a menuitemradio unconditionally, so every
 // standalone boolean toggle in a popover menu announced as one choice among

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -211,6 +211,16 @@ assert.match(
 );
 assert.match(
   src,
+  /register: \(el: HTMLElement\) => \{[\s\S]{0,220}parentLayers\?\.register\(el\)[\s\S]{0,160}focusTrapPortalLayers\?\.register\(el\)/,
+  "descendant portals propagate through every ancestor Popover and Modal boundary",
+);
+assert.match(
+  src,
+  /cover: \(\) => \{[\s\S]{0,180}parentLayers\?\.cover\(\)/,
+  "cover ownership propagates through the complete Popover chain",
+);
+assert.match(
+  src,
   /if \(covered\) return;[\s\S]{0,200}const t = e\.target as Node/,
   "a covered owner ignores outside-click dismissal while its child Modal is active",
 );

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -301,27 +301,33 @@ assert.match(
 );
 assert.match(
   src,
-  /export function usePopoverLayerRegistration\(\s*el: HTMLElement \| null,\s*active = Boolean\(el\),\s*onEscape\?: \(\) => void,/,
+  /export function usePopoverLayerRegistration\(\s*el: HTMLElement \| null,\s*active = Boolean\(el\),\s*onEscape\?: \(\) => void,\s*coverOwner = false,/,
   "exports a hook that registers an element as an inside layer",
 );
 assert.match(
   src,
-  /usePopoverLayerRegistration[\s\S]{0,200}if \(!el \|\| !layers\) return;\s*return layers\.register\(el\);/,
-  "the hook is a no-op with no ancestor Popover and unregisters on cleanup/element change",
+  /usePopoverLayerRegistration[\s\S]{0,300}if \(!el \|\| !layers\) return;\s*const unregister = layers\.register\(el\);/,
+  "the hook is a no-op with no ancestor Popover and registers the complete child layer",
 );
 assert.match(
   src,
   /usePopoverEscapeLayer\(Boolean\(layers && active && onEscape\), onEscape \?\? NOOP\)/,
   "a registered modal can absorb Escape before the owning Popover closes",
 );
-
-const nestedModalZ = Number(
-  primitivesCss.match(/\.ui-modal-backdrop--above-popovers\s*\{[^}]*?z-index:\s*(\d+)/)?.[1],
+assert.match(
+  src,
+  /const uncover = coverOwner \? layers\.cover\(\) : NOOP;[\s\S]{0,160}uncover\(\);/,
+  "a modal layer covers its owner and reliably releases it on cleanup",
 );
-assert.ok(Number.isFinite(nestedModalZ), "found the nested modal z-index");
-assert.ok(
-  nestedModalZ > portalZ,
-  `nested modal (z ${nestedModalZ}) must stack above its owning popover (z ${portalZ})`,
+assert.match(
+  src,
+  /data-covered=\{covered \|\| undefined\}/,
+  "the owning Popover exposes its covered state to CSS",
+);
+assert.match(
+  primitivesCss,
+  /\.ui-popover\[data-covered\]\s*\{[^}]*visibility:\s*hidden;[^}]*pointer-events:\s*none;/,
+  "a covered owner is hidden and inert while its portaled Modal remains visible",
 );
 
 console.log("popover.test.ts: ok");

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -57,14 +57,14 @@ export function usePopoverLayerRegistration(
 ) {
   const layers = useContext(PopoverLayersContext);
   useLayoutEffect(() => {
-    if (!el || !layers) return;
+    if (!active || !el || !layers) return;
     const unregister = layers.register(el);
     const uncover = coverOwner ? layers.cover() : NOOP;
     return () => {
       unregister();
       uncover();
     };
-  }, [el, layers, coverOwner]);
+  }, [active, el, layers, coverOwner]);
   usePopoverEscapeLayer(Boolean(layers && active && onEscape), onEscape ?? NOOP);
 }
 

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -31,6 +31,7 @@ import { computeSubmenuPosition } from "@/lib/submenu-position";
 export const PopoverLayersContext = createContext<{
   register: (el: HTMLElement) => () => void;
   contains: (node: Node | null) => boolean;
+  cover: () => () => void;
 } | null>(null);
 const NOOP = () => {};
 
@@ -45,12 +46,18 @@ export function usePopoverLayerRegistration(
   el: HTMLElement | null,
   active = Boolean(el),
   onEscape?: () => void,
+  coverOwner = false,
 ) {
   const layers = useContext(PopoverLayersContext);
   useLayoutEffect(() => {
     if (!el || !layers) return;
-    return layers.register(el);
-  }, [el, layers]);
+    const unregister = layers.register(el);
+    const uncover = coverOwner ? layers.cover() : NOOP;
+    return () => {
+      unregister();
+      uncover();
+    };
+  }, [el, layers, coverOwner]);
   usePopoverEscapeLayer(Boolean(layers && active && onEscape), onEscape ?? NOOP);
 }
 
@@ -157,6 +164,8 @@ export function Popover({
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const [style, setStyle] = useState<CSSProperties>({});
   const [compact, setCompact] = useState(false);
+  const [covered, setCovered] = useState(false);
+  const coverCountRef = useRef(0);
 
   // Registry of portal-rendered descendant layers (cascading submenus): they
   // live outside this panel's DOM subtree but count as "inside" for dismissal.
@@ -174,6 +183,17 @@ export function Popover({
         if (popoverRef.current?.contains(node)) return true;
         for (const el of layersRef.current) if (el.contains(node)) return true;
         return false;
+      },
+      cover: () => {
+        coverCountRef.current += 1;
+        setCovered(true);
+        let released = false;
+        return () => {
+          if (released) return;
+          released = true;
+          coverCountRef.current = Math.max(0, coverCountRef.current - 1);
+          if (coverCountRef.current === 0) setCovered(false);
+        };
       },
     }),
     [],
@@ -319,6 +339,7 @@ export function Popover({
         role="dialog"
         aria-label={ariaLabel}
         data-compact={compact || undefined}
+        data-covered={covered || undefined}
         tabIndex={-1}
         onBlur={(e) => {
           const next = e.relatedTarget as Node | null;

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -15,7 +15,10 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { Icon, type IconName } from "@/lib/icon";
-import { FocusTrapPortalLayersContext } from "@/lib/use-focus-trap";
+import {
+  FocusTrapPortalLayersContext,
+  PortalLayerDepthContext,
+} from "@/lib/use-focus-trap";
 import { computeSubmenuPosition } from "@/lib/submenu-position";
 
 // ── Submenu plumbing ─────────────────────────────────────────────────────────
@@ -73,7 +76,13 @@ const SubmenuGroupContext = createContext<{
 // listener (which stopPropagation()s before React handlers run) pops this
 // stack — closing one submenu level per press — and only closes the popover
 // itself once no flyout remains open.
-const submenuEscapeStack: Array<() => void> = [];
+type EscapeLayer = {
+  close: () => void;
+  depth: number;
+  order: number;
+};
+const submenuEscapeStack: EscapeLayer[] = [];
+let nextEscapeLayerOrder = 1;
 
 
 
@@ -130,18 +139,23 @@ export function usePopoverInitialFocus(open: boolean, panelSelector: string) {
  */
 export function usePopoverEscapeLayer(active: boolean, close: () => void) {
   const closeRef = useRef(close);
+  const ownerDepth = useContext(PortalLayerDepthContext);
   useEffect(() => {
     closeRef.current = close;
   });
   useEffect(() => {
     if (!active) return;
-    const closeSelf = () => closeRef.current();
-    submenuEscapeStack.push(closeSelf);
+    const entry = {
+      close: () => closeRef.current(),
+      depth: ownerDepth + 1,
+      order: nextEscapeLayerOrder++,
+    };
+    submenuEscapeStack.push(entry);
     return () => {
-      const i = submenuEscapeStack.indexOf(closeSelf);
+      const i = submenuEscapeStack.indexOf(entry);
       if (i !== -1) submenuEscapeStack.splice(i, 1);
     };
-  }, [active]);
+  }, [active, ownerDepth]);
 }
 
 /**
@@ -163,6 +177,7 @@ export function Popover({
   children,
 }: PopoverProps) {
   const parentLayers = useContext(PopoverLayersContext);
+  const parentLayerDepth = useContext(PortalLayerDepthContext);
   const focusTrapPortalLayers = useContext(FocusTrapPortalLayersContext);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const [style, setStyle] = useState<CSSProperties>({});
@@ -177,7 +192,11 @@ export function Popover({
     () => ({
       register: (el: HTMLElement) => {
         layersRef.current.add(el);
+        const unregisterParent = parentLayers?.register(el) ?? NOOP;
+        const unregisterFocusTrap = focusTrapPortalLayers?.register(el) ?? NOOP;
         return () => {
+          unregisterFocusTrap();
+          unregisterParent();
           layersRef.current.delete(el);
         };
       },
@@ -190,16 +209,18 @@ export function Popover({
       cover: () => {
         coverCountRef.current += 1;
         setCovered(true);
+        const uncoverParent = parentLayers?.cover() ?? NOOP;
         let released = false;
         return () => {
           if (released) return;
           released = true;
+          uncoverParent();
           coverCountRef.current = Math.max(0, coverCountRef.current - 1);
           if (coverCountRef.current === 0) setCovered(false);
         };
       },
     }),
-    [],
+    [parentLayers, focusTrapPortalLayers],
   );
   useLayoutEffect(() => {
     if (!open || !popoverRef.current) return;
@@ -295,9 +316,17 @@ export function Popover({
         e.stopPropagation();
         // An open cascading submenu absorbs the press first (one level per
         // Escape); the popover itself closes only when none remain.
-        const closeDeepest = submenuEscapeStack[submenuEscapeStack.length - 1];
-        if (closeDeepest) {
-          closeDeepest();
+        const deepest = submenuEscapeStack.reduce<EscapeLayer | undefined>(
+          (current, candidate) =>
+            !current ||
+            candidate.depth > current.depth ||
+            (candidate.depth === current.depth && candidate.order > current.order)
+              ? candidate
+              : current,
+          undefined,
+        );
+        if (deepest) {
+          deepest.close();
           return;
         }
         onOpenChange(false);
@@ -374,7 +403,9 @@ export function Popover({
         }}
       >
         <PopoverLayersContext.Provider value={layers}>
-          <SubmenuGroup>{children}</SubmenuGroup>
+          <PortalLayerDepthContext.Provider value={parentLayerDepth + 1}>
+            <SubmenuGroup>{children}</SubmenuGroup>
+          </PortalLayerDepthContext.Provider>
         </PopoverLayersContext.Provider>
       </div>
     </div>,
@@ -536,6 +567,7 @@ export function PopoverSubmenu({
 }) {
   const id = useId();
   const layers = useContext(PopoverLayersContext);
+  const parentLayerDepth = useContext(PortalLayerDepthContext);
   const group = useContext(SubmenuGroupContext);
   const rowRef = useRef<HTMLButtonElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -577,20 +609,14 @@ export function PopoverSubmenu({
     return layers.register(el);
   }, [open, layers]);
 
+  const closeToRow = useCallback(() => {
+    setOpen(false);
+    rowRef.current?.focus();
+  }, [setOpen]);
+
   // While open, join the Escape stack so the root popover's window-capture
   // Escape handler closes this flyout (deepest first) instead of the menu.
-  useEffect(() => {
-    if (!open) return;
-    const closeSelf = () => {
-      setOpen(false);
-      rowRef.current?.focus();
-    };
-    submenuEscapeStack.push(closeSelf);
-    return () => {
-      const i = submenuEscapeStack.indexOf(closeSelf);
-      if (i !== -1) submenuEscapeStack.splice(i, 1);
-    };
-  }, [open, setOpen]);
+  usePopoverEscapeLayer(open, closeToRow);
 
   const position = useCallback(() => {
     const row = rowRef.current;
@@ -651,11 +677,6 @@ export function PopoverSubmenu({
 
   const focusFirstItem = () => {
     wantsFirstItemFocus.current = true;
-  };
-
-  const closeToRow = () => {
-    setOpen(false);
-    rowRef.current?.focus();
   };
 
   return (
@@ -737,7 +758,9 @@ export function PopoverSubmenu({
                 }}
               >
                 <div className="ui-popover-body" role="presentation">
-                  <SubmenuGroup>{children}</SubmenuGroup>
+                  <PortalLayerDepthContext.Provider value={parentLayerDepth + 1}>
+                    <SubmenuGroup>{children}</SubmenuGroup>
+                  </PortalLayerDepthContext.Provider>
                 </div>
               </div>
             </div>,

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -42,7 +42,10 @@ type PopoverLayers = {
   cover: () => () => void;
 };
 export const PopoverLayersContext = createContext<PopoverLayers | null>(null);
+const PopoverEscapeTreeContext = createContext<number | null>(null);
 const NOOP = () => {};
+let nextEscapeTreeId = 1;
+let nextEscapeHandlerId = 1;
 
 /**
  * Registers `el` as an "inside" layer of an ancestor Popover (if any) for as
@@ -85,9 +88,18 @@ type EscapeLayer = {
   depth: number;
   order: number;
   rootId: number;
+  treeId: number;
+};
+type EscapeHandler = {
+  id: number;
+  rootId: number;
+  treeId: number;
+  order: number;
 };
 const submenuEscapeStack: EscapeLayer[] = [];
+const popoverEscapeHandlers: EscapeHandler[] = [];
 let nextEscapeLayerOrder = 1;
+let nextEscapeHandlerOrder = 1;
 
 function usePopoverLayerRegistry(
   ownerRef: React.RefObject<HTMLElement | null>,
@@ -209,23 +221,25 @@ export function usePopoverEscapeLayer(active: boolean, close: () => void) {
   const closeRef = useRef(close);
   const ownerDepth = useContext(PortalLayerDepthContext);
   const rootId = useContext(PortalLayerRootContext);
+  const treeId = useContext(PopoverEscapeTreeContext);
   useEffect(() => {
     closeRef.current = close;
   });
   useEffect(() => {
-    if (!active || rootId === null) return;
+    if (!active || rootId === null || treeId === null) return;
     const entry = {
       close: () => closeRef.current(),
       depth: ownerDepth + 1,
       order: nextEscapeLayerOrder++,
       rootId,
+      treeId,
     };
     submenuEscapeStack.push(entry);
     return () => {
       const i = submenuEscapeStack.indexOf(entry);
       if (i !== -1) submenuEscapeStack.splice(i, 1);
     };
-  }, [active, ownerDepth, rootId]);
+  }, [active, ownerDepth, rootId, treeId]);
 }
 
 /**
@@ -249,9 +263,15 @@ export function Popover({
   const parentLayers = useContext(PopoverLayersContext);
   const parentLayerDepth = useContext(PortalLayerDepthContext);
   const focusTrapPortalLayers = useContext(FocusTrapPortalLayersContext);
+  const inheritedEscapeTreeId = useContext(PopoverEscapeTreeContext);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const escapeRootId = usePortalLayerRootId();
   const isEscapeRoot = parentLayers === null;
+  const ownEscapeTreeIdRef = useRef(0);
+  const escapeHandlerIdRef = useRef(0);
+  if (ownEscapeTreeIdRef.current === 0) ownEscapeTreeIdRef.current = nextEscapeTreeId++;
+  if (escapeHandlerIdRef.current === 0) escapeHandlerIdRef.current = nextEscapeHandlerId++;
+  const escapeTreeId = inheritedEscapeTreeId ?? ownEscapeTreeIdRef.current;
   const [style, setStyle] = useState<CSSProperties>({});
   const [compact, setCompact] = useState(false);
   const { covered, layers } = usePopoverLayerRegistry(
@@ -262,8 +282,20 @@ export function Popover({
   useRegisterPopoverOwner(open, popoverRef, parentLayers, focusTrapPortalLayers);
   useEffect(() => {
     if (!open || !isEscapeRoot) return;
-    return acquirePortalLayerRoot(escapeRootId).release;
-  }, [open, isEscapeRoot, escapeRootId]);
+    const root = acquirePortalLayerRoot(escapeRootId);
+    const entry = {
+      id: escapeHandlerIdRef.current,
+      rootId: escapeRootId,
+      treeId: escapeTreeId,
+      order: nextEscapeHandlerOrder++,
+    };
+    popoverEscapeHandlers.push(entry);
+    return () => {
+      const index = popoverEscapeHandlers.indexOf(entry);
+      if (index !== -1) popoverEscapeHandlers.splice(index, 1);
+      root.release();
+    };
+  }, [open, isEscapeRoot, escapeRootId, escapeTreeId]);
   usePopoverEscapeLayer(
     Boolean(parentLayers && open),
     useCallback(() => onOpenChange(false), [onOpenChange]),
@@ -342,15 +374,27 @@ export function Popover({
       if (e.key === "Escape") {
         if (parentLayers) return;
         if (!isTopmostPortalLayerRoot(escapeRootId)) return;
+        const activeHandler = popoverEscapeHandlers
+          .filter((entry) => entry.rootId === escapeRootId)
+          .reduce<EscapeHandler | undefined>(
+            (current, candidate) =>
+              !current || candidate.order > current.order ? candidate : current,
+            undefined,
+          );
+        if (activeHandler?.id !== escapeHandlerIdRef.current) return;
         // Consume the Escape so it doesn't bubble to a parent dialog's keydown
         // handler (e.g. the Settings panel, which closes itself on Escape). The
         // listener is registered in the capture phase below so it runs before any
-        // such parent handler; stopPropagation then prevents that handler firing.
-        e.stopPropagation();
+        // such parent handler; immediate propagation also prevents sibling root
+        // listeners on window from handling the same event after synchronous close.
+        e.stopImmediatePropagation();
         // An open cascading submenu absorbs the press first (one level per
         // Escape); the popover itself closes only when none remain.
         const deepest = submenuEscapeStack
-          .filter((entry) => entry.rootId === escapeRootId)
+          .filter(
+            (entry) =>
+              entry.rootId === escapeRootId && entry.treeId === escapeTreeId,
+          )
           .reduce<EscapeLayer | undefined>(
           (current, candidate) =>
             !current ||
@@ -438,11 +482,13 @@ export function Popover({
         }}
       >
         <PopoverLayersContext.Provider value={layers}>
-          <PortalLayerRootContext.Provider value={escapeRootId}>
-            <PortalLayerDepthContext.Provider value={parentLayerDepth + 1}>
-              <SubmenuGroup>{children}</SubmenuGroup>
-            </PortalLayerDepthContext.Provider>
-          </PortalLayerRootContext.Provider>
+          <PopoverEscapeTreeContext.Provider value={escapeTreeId}>
+            <PortalLayerRootContext.Provider value={escapeRootId}>
+              <PortalLayerDepthContext.Provider value={parentLayerDepth + 1}>
+                <SubmenuGroup>{children}</SubmenuGroup>
+              </PortalLayerDepthContext.Provider>
+            </PortalLayerRootContext.Provider>
+          </PopoverEscapeTreeContext.Provider>
         </PopoverLayersContext.Provider>
       </div>
     </div>,

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -32,6 +32,7 @@ export const PopoverLayersContext = createContext<{
   register: (el: HTMLElement) => () => void;
   contains: (node: Node | null) => boolean;
 } | null>(null);
+const NOOP = () => {};
 
 /**
  * Registers `el` as an "inside" layer of an ancestor Popover (if any) for as
@@ -40,12 +41,17 @@ export const PopoverLayersContext = createContext<{
  * unconditionally from a shared component that may or may not be nested in
  * one (e.g. AvatarLightbox's Modal).
  */
-export function usePopoverLayerRegistration(el: HTMLElement | null) {
+export function usePopoverLayerRegistration(
+  el: HTMLElement | null,
+  active = Boolean(el),
+  onEscape?: () => void,
+) {
   const layers = useContext(PopoverLayersContext);
   useLayoutEffect(() => {
     if (!el || !layers) return;
     return layers.register(el);
   }, [el, layers]);
+  usePopoverEscapeLayer(Boolean(layers && active && onEscape), onEscape ?? NOOP);
 }
 
 // One open flyout per menu level: siblings coordinate through their level's

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -16,8 +16,12 @@ import {
 import { createPortal } from "react-dom";
 import { Icon, type IconName } from "@/lib/icon";
 import {
+  acquirePortalLayerRoot,
   FocusTrapPortalLayersContext,
+  isTopmostPortalLayerRoot,
   PortalLayerDepthContext,
+  PortalLayerRootContext,
+  usePortalLayerRootId,
 } from "@/lib/use-focus-trap";
 import { computeSubmenuPosition } from "@/lib/submenu-position";
 
@@ -38,9 +42,7 @@ type PopoverLayers = {
   cover: () => () => void;
 };
 export const PopoverLayersContext = createContext<PopoverLayers | null>(null);
-const PopoverEscapeRootContext = createContext<number | null>(null);
 const NOOP = () => {};
-let nextEscapeRootId = 1;
 
 /**
  * Registers `el` as an "inside" layer of an ancestor Popover (if any) for as
@@ -84,11 +86,8 @@ type EscapeLayer = {
   order: number;
   rootId: number;
 };
-type EscapeRoot = { id: number; order: number };
 const submenuEscapeStack: EscapeLayer[] = [];
-const popoverEscapeRoots: EscapeRoot[] = [];
 let nextEscapeLayerOrder = 1;
-let nextEscapeRootOrder = 1;
 
 function usePopoverLayerRegistry(
   ownerRef: React.RefObject<HTMLElement | null>,
@@ -209,7 +208,7 @@ export function usePopoverInitialFocus(open: boolean, panelSelector: string) {
 export function usePopoverEscapeLayer(active: boolean, close: () => void) {
   const closeRef = useRef(close);
   const ownerDepth = useContext(PortalLayerDepthContext);
-  const rootId = useContext(PopoverEscapeRootContext);
+  const rootId = useContext(PortalLayerRootContext);
   useEffect(() => {
     closeRef.current = close;
   });
@@ -249,12 +248,9 @@ export function Popover({
 }: PopoverProps) {
   const parentLayers = useContext(PopoverLayersContext);
   const parentLayerDepth = useContext(PortalLayerDepthContext);
-  const inheritedEscapeRootId = useContext(PopoverEscapeRootContext);
   const focusTrapPortalLayers = useContext(FocusTrapPortalLayersContext);
   const popoverRef = useRef<HTMLDivElement | null>(null);
-  const ownEscapeRootIdRef = useRef(0);
-  if (ownEscapeRootIdRef.current === 0) ownEscapeRootIdRef.current = nextEscapeRootId++;
-  const escapeRootId = inheritedEscapeRootId ?? ownEscapeRootIdRef.current;
+  const escapeRootId = usePortalLayerRootId();
   const isEscapeRoot = parentLayers === null;
   const [style, setStyle] = useState<CSSProperties>({});
   const [compact, setCompact] = useState(false);
@@ -266,12 +262,7 @@ export function Popover({
   useRegisterPopoverOwner(open, popoverRef, parentLayers, focusTrapPortalLayers);
   useEffect(() => {
     if (!open || !isEscapeRoot) return;
-    const entry = { id: escapeRootId, order: nextEscapeRootOrder++ };
-    popoverEscapeRoots.push(entry);
-    return () => {
-      const index = popoverEscapeRoots.indexOf(entry);
-      if (index !== -1) popoverEscapeRoots.splice(index, 1);
-    };
+    return acquirePortalLayerRoot(escapeRootId).release;
   }, [open, isEscapeRoot, escapeRootId]);
   usePopoverEscapeLayer(
     Boolean(parentLayers && open),
@@ -350,12 +341,7 @@ export function Popover({
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         if (parentLayers) return;
-        const activeRoot = popoverEscapeRoots.reduce<EscapeRoot | undefined>(
-          (current, candidate) =>
-            !current || candidate.order > current.order ? candidate : current,
-          undefined,
-        );
-        if (activeRoot?.id !== escapeRootId) return;
+        if (!isTopmostPortalLayerRoot(escapeRootId)) return;
         // Consume the Escape so it doesn't bubble to a parent dialog's keydown
         // handler (e.g. the Settings panel, which closes itself on Escape). The
         // listener is registered in the capture phase below so it runs before any
@@ -452,11 +438,11 @@ export function Popover({
         }}
       >
         <PopoverLayersContext.Provider value={layers}>
-          <PopoverEscapeRootContext.Provider value={escapeRootId}>
+          <PortalLayerRootContext.Provider value={escapeRootId}>
             <PortalLayerDepthContext.Provider value={parentLayerDepth + 1}>
               <SubmenuGroup>{children}</SubmenuGroup>
             </PortalLayerDepthContext.Provider>
-          </PopoverEscapeRootContext.Provider>
+          </PortalLayerRootContext.Provider>
         </PopoverLayersContext.Provider>
       </div>
     </div>,

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -32,12 +32,15 @@ import { computeSubmenuPosition } from "@/lib/submenu-position";
 // that, the Modal stealing focus reads to the Popover as focus leaving its
 // panel and self-dismisses, unmounting both (see usePopoverLayerRegistration
 // below, and cave-fzr4p).
-export const PopoverLayersContext = createContext<{
+type PopoverLayers = {
   register: (el: HTMLElement) => () => void;
   contains: (node: Node | null) => boolean;
   cover: () => () => void;
-} | null>(null);
+};
+export const PopoverLayersContext = createContext<PopoverLayers | null>(null);
+const PopoverEscapeRootContext = createContext<number | null>(null);
 const NOOP = () => {};
+let nextEscapeRootId = 1;
 
 /**
  * Registers `el` as an "inside" layer of an ancestor Popover (if any) for as
@@ -72,17 +75,83 @@ const SubmenuGroupContext = createContext<{
   setOpenId: (id: string | null) => void;
 } | null>(null);
 
-// Deepest-first Escape routing: the root Popover's window-capture Escape
-// listener (which stopPropagation()s before React handlers run) pops this
-// stack — closing one submenu level per press — and only closes the popover
-// itself once no flyout remains open.
+// Deepest-first Escape routing: entries are scoped to their owning root and
+// ranked by explicit portal depth, so effect timing and unrelated open roots
+// cannot steal one another's Escape presses.
 type EscapeLayer = {
   close: () => void;
   depth: number;
   order: number;
+  rootId: number;
 };
+type EscapeRoot = { id: number; order: number };
 const submenuEscapeStack: EscapeLayer[] = [];
+const popoverEscapeRoots: EscapeRoot[] = [];
 let nextEscapeLayerOrder = 1;
+let nextEscapeRootOrder = 1;
+
+function usePopoverLayerRegistry(
+  ownerRef: React.RefObject<HTMLElement | null>,
+  parentLayers: PopoverLayers | null,
+  focusTrapPortalLayers: React.ContextType<typeof FocusTrapPortalLayersContext>,
+) {
+  const [covered, setCovered] = useState(false);
+  const coverCountRef = useRef(0);
+  const layersRef = useRef<Set<HTMLElement>>(new Set());
+  const layers = useMemo<PopoverLayers>(
+    () => ({
+      register: (el: HTMLElement) => {
+        layersRef.current.add(el);
+        const unregisterParent = parentLayers?.register(el) ?? NOOP;
+        const unregisterFocusTrap = focusTrapPortalLayers?.register(el) ?? NOOP;
+        return () => {
+          unregisterFocusTrap();
+          unregisterParent();
+          layersRef.current.delete(el);
+        };
+      },
+      contains: (node: Node | null) => {
+        if (!node) return false;
+        if (ownerRef.current?.contains(node)) return true;
+        for (const el of layersRef.current) if (el.contains(node)) return true;
+        return false;
+      },
+      cover: () => {
+        coverCountRef.current += 1;
+        setCovered(true);
+        const uncoverParent = parentLayers?.cover() ?? NOOP;
+        let released = false;
+        return () => {
+          if (released) return;
+          released = true;
+          uncoverParent();
+          coverCountRef.current = Math.max(0, coverCountRef.current - 1);
+          if (coverCountRef.current === 0) setCovered(false);
+        };
+      },
+    }),
+    [ownerRef, parentLayers, focusTrapPortalLayers],
+  );
+  return { covered, layers };
+}
+
+function useRegisterPopoverOwner(
+  active: boolean,
+  ownerRef: React.RefObject<HTMLElement | null>,
+  parentLayers: PopoverLayers | null,
+  focusTrapPortalLayers: React.ContextType<typeof FocusTrapPortalLayersContext>,
+) {
+  useLayoutEffect(() => {
+    if (!active || !ownerRef.current) return;
+    const unregisterParent = parentLayers?.register(ownerRef.current) ?? NOOP;
+    const unregisterFocusTrap =
+      focusTrapPortalLayers?.register(ownerRef.current) ?? NOOP;
+    return () => {
+      unregisterFocusTrap();
+      unregisterParent();
+    };
+  }, [active, ownerRef, parentLayers, focusTrapPortalLayers]);
+}
 
 
 
@@ -140,22 +209,24 @@ export function usePopoverInitialFocus(open: boolean, panelSelector: string) {
 export function usePopoverEscapeLayer(active: boolean, close: () => void) {
   const closeRef = useRef(close);
   const ownerDepth = useContext(PortalLayerDepthContext);
+  const rootId = useContext(PopoverEscapeRootContext);
   useEffect(() => {
     closeRef.current = close;
   });
   useEffect(() => {
-    if (!active) return;
+    if (!active || rootId === null) return;
     const entry = {
       close: () => closeRef.current(),
       depth: ownerDepth + 1,
       order: nextEscapeLayerOrder++,
+      rootId,
     };
     submenuEscapeStack.push(entry);
     return () => {
       const i = submenuEscapeStack.indexOf(entry);
       if (i !== -1) submenuEscapeStack.splice(i, 1);
     };
-  }, [active, ownerDepth]);
+  }, [active, ownerDepth, rootId]);
 }
 
 /**
@@ -178,60 +249,30 @@ export function Popover({
 }: PopoverProps) {
   const parentLayers = useContext(PopoverLayersContext);
   const parentLayerDepth = useContext(PortalLayerDepthContext);
+  const inheritedEscapeRootId = useContext(PopoverEscapeRootContext);
   const focusTrapPortalLayers = useContext(FocusTrapPortalLayersContext);
   const popoverRef = useRef<HTMLDivElement | null>(null);
+  const ownEscapeRootIdRef = useRef(0);
+  if (ownEscapeRootIdRef.current === 0) ownEscapeRootIdRef.current = nextEscapeRootId++;
+  const escapeRootId = inheritedEscapeRootId ?? ownEscapeRootIdRef.current;
+  const isEscapeRoot = parentLayers === null;
   const [style, setStyle] = useState<CSSProperties>({});
   const [compact, setCompact] = useState(false);
-  const [covered, setCovered] = useState(false);
-  const coverCountRef = useRef(0);
-
-  // Registry of portal-rendered descendant layers (cascading submenus): they
-  // live outside this panel's DOM subtree but count as "inside" for dismissal.
-  const layersRef = useRef<Set<HTMLElement>>(new Set());
-  const layers = useMemo(
-    () => ({
-      register: (el: HTMLElement) => {
-        layersRef.current.add(el);
-        const unregisterParent = parentLayers?.register(el) ?? NOOP;
-        const unregisterFocusTrap = focusTrapPortalLayers?.register(el) ?? NOOP;
-        return () => {
-          unregisterFocusTrap();
-          unregisterParent();
-          layersRef.current.delete(el);
-        };
-      },
-      contains: (node: Node | null) => {
-        if (!node) return false;
-        if (popoverRef.current?.contains(node)) return true;
-        for (const el of layersRef.current) if (el.contains(node)) return true;
-        return false;
-      },
-      cover: () => {
-        coverCountRef.current += 1;
-        setCovered(true);
-        const uncoverParent = parentLayers?.cover() ?? NOOP;
-        let released = false;
-        return () => {
-          if (released) return;
-          released = true;
-          uncoverParent();
-          coverCountRef.current = Math.max(0, coverCountRef.current - 1);
-          if (coverCountRef.current === 0) setCovered(false);
-        };
-      },
-    }),
-    [parentLayers, focusTrapPortalLayers],
+  const { covered, layers } = usePopoverLayerRegistry(
+    popoverRef,
+    parentLayers,
+    focusTrapPortalLayers,
   );
-  useLayoutEffect(() => {
-    if (!open || !popoverRef.current) return;
-    const unregisterParent = parentLayers?.register(popoverRef.current) ?? NOOP;
-    const unregisterFocusTrap =
-      focusTrapPortalLayers?.register(popoverRef.current) ?? NOOP;
+  useRegisterPopoverOwner(open, popoverRef, parentLayers, focusTrapPortalLayers);
+  useEffect(() => {
+    if (!open || !isEscapeRoot) return;
+    const entry = { id: escapeRootId, order: nextEscapeRootOrder++ };
+    popoverEscapeRoots.push(entry);
     return () => {
-      unregisterFocusTrap();
-      unregisterParent();
+      const index = popoverEscapeRoots.indexOf(entry);
+      if (index !== -1) popoverEscapeRoots.splice(index, 1);
     };
-  }, [open, parentLayers, focusTrapPortalLayers]);
+  }, [open, isEscapeRoot, escapeRootId]);
   usePopoverEscapeLayer(
     Boolean(parentLayers && open),
     useCallback(() => onOpenChange(false), [onOpenChange]),
@@ -309,6 +350,12 @@ export function Popover({
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         if (parentLayers) return;
+        const activeRoot = popoverEscapeRoots.reduce<EscapeRoot | undefined>(
+          (current, candidate) =>
+            !current || candidate.order > current.order ? candidate : current,
+          undefined,
+        );
+        if (activeRoot?.id !== escapeRootId) return;
         // Consume the Escape so it doesn't bubble to a parent dialog's keydown
         // handler (e.g. the Settings panel, which closes itself on Escape). The
         // listener is registered in the capture phase below so it runs before any
@@ -316,7 +363,9 @@ export function Popover({
         e.stopPropagation();
         // An open cascading submenu absorbs the press first (one level per
         // Escape); the popover itself closes only when none remain.
-        const deepest = submenuEscapeStack.reduce<EscapeLayer | undefined>(
+        const deepest = submenuEscapeStack
+          .filter((entry) => entry.rootId === escapeRootId)
+          .reduce<EscapeLayer | undefined>(
           (current, candidate) =>
             !current ||
             candidate.depth > current.depth ||
@@ -403,9 +452,11 @@ export function Popover({
         }}
       >
         <PopoverLayersContext.Provider value={layers}>
-          <PortalLayerDepthContext.Provider value={parentLayerDepth + 1}>
-            <SubmenuGroup>{children}</SubmenuGroup>
-          </PortalLayerDepthContext.Provider>
+          <PopoverEscapeRootContext.Provider value={escapeRootId}>
+            <PortalLayerDepthContext.Provider value={parentLayerDepth + 1}>
+              <SubmenuGroup>{children}</SubmenuGroup>
+            </PortalLayerDepthContext.Provider>
+          </PopoverEscapeRootContext.Provider>
         </PopoverLayersContext.Provider>
       </div>
     </div>,
@@ -566,8 +617,9 @@ export function PopoverSubmenu({
   children: ReactNode;
 }) {
   const id = useId();
-  const layers = useContext(PopoverLayersContext);
+  const parentLayers = useContext(PopoverLayersContext);
   const parentLayerDepth = useContext(PortalLayerDepthContext);
+  const focusTrapPortalLayers = useContext(FocusTrapPortalLayersContext);
   const group = useContext(SubmenuGroupContext);
   const rowRef = useRef<HTMLButtonElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -578,6 +630,11 @@ export function PopoverSubmenu({
   // panel at its real rendered width (the CSS floor is narrower than the
   // call sites' minWidth props).
   const [style, setStyle] = useState<CSSProperties>({ visibility: "hidden", minWidth });
+  const { covered, layers } = usePopoverLayerRegistry(
+    panelRef,
+    parentLayers,
+    focusTrapPortalLayers,
+  );
   // Keyboard-open intent: the first item can only be focused once the panel
   // is positioned and visible — focus() on a visibility:hidden subtree is
   // silently ignored by the browser.
@@ -601,13 +658,8 @@ export function PopoverSubmenu({
   };
   useEffect(() => clearHoverTimer, []);
 
-  // Register the flyout as an inside layer of the root popover while open.
-  useLayoutEffect(() => {
-    if (!open) return;
-    const el = panelRef.current;
-    if (!el || !layers) return;
-    return layers.register(el);
-  }, [open, layers]);
+  // Register the flyout as an inside layer of every owning portal boundary.
+  useRegisterPopoverOwner(open, panelRef, parentLayers, focusTrapPortalLayers);
 
   const closeToRow = useCallback(() => {
     setOpen(false);
@@ -735,9 +787,12 @@ export function PopoverSubmenu({
               <div
                 ref={panelRef}
                 className="ui-popover ui-popover-submenu"
-                style={style}
+                style={covered ? { ...style, visibility: "hidden" } : style}
                 role={panelRole}
                 aria-label={typeof label === "string" ? label : undefined}
+                data-covered={covered || undefined}
+                aria-hidden={covered || undefined}
+                inert={covered || undefined}
                 onKeyDown={(e) => {
                   // ArrowLeft/Escape step back to the trigger row; Escape stops
                   // here so the root menu stays open (one level per press).
@@ -752,16 +807,18 @@ export function PopoverSubmenu({
                   if (!next) return;
                   // Nested flyouts portal to body — consult the root registry
                   // (they register there) so descending a level doesn't close us.
-                  if (layers ? layers.contains(next) : panelRef.current?.contains(next)) return;
+                  if (layers.contains(next)) return;
                   if (rowRef.current?.contains(next)) return;
                   setOpen(false);
                 }}
               >
-                <div className="ui-popover-body" role="presentation">
-                  <PortalLayerDepthContext.Provider value={parentLayerDepth + 1}>
-                    <SubmenuGroup>{children}</SubmenuGroup>
-                  </PortalLayerDepthContext.Provider>
-                </div>
+                <PopoverLayersContext.Provider value={layers}>
+                  <div className="ui-popover-body" role="presentation">
+                    <PortalLayerDepthContext.Provider value={parentLayerDepth + 1}>
+                      <SubmenuGroup>{children}</SubmenuGroup>
+                    </PortalLayerDepthContext.Provider>
+                  </div>
+                </PopoverLayersContext.Provider>
               </div>
             </div>,
             document.body,

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -15,6 +15,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { Icon, type IconName } from "@/lib/icon";
+import { FocusTrapPortalLayersContext } from "@/lib/use-focus-trap";
 import { computeSubmenuPosition } from "@/lib/submenu-position";
 
 // ── Submenu plumbing ─────────────────────────────────────────────────────────
@@ -161,6 +162,8 @@ export function Popover({
   ariaLabel,
   children,
 }: PopoverProps) {
+  const parentLayers = useContext(PopoverLayersContext);
+  const focusTrapPortalLayers = useContext(FocusTrapPortalLayersContext);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const [style, setStyle] = useState<CSSProperties>({});
   const [compact, setCompact] = useState(false);
@@ -197,6 +200,20 @@ export function Popover({
       },
     }),
     [],
+  );
+  useLayoutEffect(() => {
+    if (!open || !popoverRef.current) return;
+    const unregisterParent = parentLayers?.register(popoverRef.current) ?? NOOP;
+    const unregisterFocusTrap =
+      focusTrapPortalLayers?.register(popoverRef.current) ?? NOOP;
+    return () => {
+      unregisterFocusTrap();
+      unregisterParent();
+    };
+  }, [open, parentLayers, focusTrapPortalLayers]);
+  usePopoverEscapeLayer(
+    Boolean(parentLayers && open),
+    useCallback(() => onOpenChange(false), [onOpenChange]),
   );
 
   const compute = useCallback(() => {
@@ -270,6 +287,7 @@ export function Popover({
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
+        if (parentLayers) return;
         // Consume the Escape so it doesn't bubble to a parent dialog's keydown
         // handler (e.g. the Settings panel, which closes itself on Escape). The
         // listener is registered in the capture phase below so it runs before any
@@ -286,6 +304,7 @@ export function Popover({
       }
     };
     const onDocClick = (e: MouseEvent) => {
+      if (covered) return;
       const t = e.target as Node;
       if (layers.contains(t)) return;
       if (anchorRef.current?.contains(t)) return;
@@ -309,7 +328,7 @@ export function Popover({
       vv?.removeEventListener("resize", onReflow);
       vv?.removeEventListener("scroll", onReflow);
     };
-  }, [open, onOpenChange, anchorRef, compute, layers]);
+  }, [open, onOpenChange, anchorRef, compute, layers, parentLayers, covered]);
 
   // Return focus to the trigger when the popover closes, so keyboard users aren't
   // stranded (Escape, item-select, or outside-click on empty space all leave focus
@@ -340,8 +359,11 @@ export function Popover({
         aria-label={ariaLabel}
         data-compact={compact || undefined}
         data-covered={covered || undefined}
+        aria-hidden={covered || undefined}
+        inert={covered || undefined}
         tabIndex={-1}
         onBlur={(e) => {
+          if (covered) return;
           const next = e.relatedTarget as Node | null;
           // relatedTarget is null when focus leaves the document (window blur,
           // native pickers) — don't treat that as Tab-out.

--- a/src/components/workspace-sidebar-attention.test.ts
+++ b/src/components/workspace-sidebar-attention.test.ts
@@ -243,7 +243,10 @@ const sidebarPrefs = vi.hoisted(() => ({
   pinnedIds: [] as string[],
 }));
 
-vi.mock("@/lib/use-focus-trap", () => ({ useFocusTrap: () => undefined }));
+vi.mock("@/lib/use-focus-trap", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/use-focus-trap")>()),
+  useFocusTrap: () => undefined,
+}));
 vi.mock("@/lib/use-minute-tick", () => ({ useMinuteTick: () => 0 }));
 vi.mock("@/lib/use-projects", () => ({ useProjects: () => mockProjects.state }));
 vi.mock("@/lib/use-project-overrides", () => ({ useProjectOverrides: () => ({}) }));

--- a/src/lib/use-focus-trap-stack.test.tsx
+++ b/src/lib/use-focus-trap-stack.test.tsx
@@ -43,8 +43,10 @@ import { afterEach, describe, expect, test } from "vitest";
 import {
   FocusTrapOwnerHiddenContext,
   PortalLayerDepthContext,
+  PortalLayerRootContext,
   resetFocusTrapStackForTest,
   useFocusTrap,
+  usePortalLayerRootId,
 } from "@/lib/use-focus-trap";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -112,12 +114,19 @@ function makeWindowStub() {
      *  onEscape triggering a state update inside the same act() call) must
      *  not perturb the iteration. */
     dispatchKeydown(partial: { key: string; shiftKey?: boolean }) {
+      let immediateStopped = false;
       const event = {
         key: partial.key,
         shiftKey: partial.shiftKey ?? false,
         preventDefault: () => {},
+        stopImmediatePropagation: () => {
+          immediateStopped = true;
+        },
       };
-      for (const fn of [...listeners]) fn(event);
+      for (const fn of [...listeners]) {
+        fn(event);
+        if (immediateStopped) break;
+      }
     },
   };
 }
@@ -302,22 +311,26 @@ describe("useFocusTrap stack-awareness (cave-rl980 Task 5 nested modal findings)
 
     function ParentWithInitiallyOpenChild() {
       const parentRef = useRef<unknown>(null);
+      const rootId = usePortalLayerRootId();
       useFocusTrap(true, parentRef as never, {
         onEscape: () => {
           parentEscapeCount += 1;
         },
+        portalRootId: rootId,
       });
       return (
         <div data-probe-id="parent" ref={parentRef as never}>
-          <PortalLayerDepthContext.Provider value={1}>
-            <TrapProbe
-              probeId="child"
-              active
-              onEscape={() => {
-                childEscapeCount += 1;
-              }}
-            />
-          </PortalLayerDepthContext.Provider>
+          <PortalLayerRootContext.Provider value={rootId}>
+            <PortalLayerDepthContext.Provider value={1}>
+              <TrapProbe
+                probeId="child"
+                active
+                onEscape={() => {
+                  childEscapeCount += 1;
+                }}
+              />
+            </PortalLayerDepthContext.Provider>
+          </PortalLayerRootContext.Provider>
         </div>
       );
     }
@@ -335,6 +348,118 @@ describe("useFocusTrap stack-awareness (cave-rl980 Task 5 nested modal findings)
     });
     expect(childEscapeCount).toBe(1);
     expect(parentEscapeCount).toBe(0);
+  });
+
+  test("one Escape cannot fall through after the child synchronously unregisters", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    restoreGlobals = stubDomGlobals(activeHolder, win);
+
+    const parentFocusable = makeElement("parent-focusable", activeHolder);
+    const childFocusable = makeElement("child-focusable", activeHolder);
+    const parentContainer = makeContainer([parentFocusable], activeHolder);
+    const childContainer = makeContainer([childFocusable], activeHolder);
+    let parentEscapeCount = 0;
+    let childEscapeCount = 0;
+
+    function Scene() {
+      const parentRef = useRef<unknown>(null);
+      const [showChild, setShowChild] = useState(true);
+      const rootId = usePortalLayerRootId();
+      useFocusTrap(true, parentRef as never, {
+        onEscape: () => {
+          parentEscapeCount += 1;
+        },
+        portalRootId: rootId,
+      });
+      return (
+        <div data-probe-id="parent" ref={parentRef as never}>
+          <PortalLayerRootContext.Provider value={rootId}>
+            <PortalLayerDepthContext.Provider value={1}>
+              {showChild ? (
+                <TrapProbe
+                  probeId="child"
+                  active
+                  onEscape={() => {
+                    childEscapeCount += 1;
+                    setShowChild(false);
+                  }}
+                />
+              ) : null}
+            </PortalLayerDepthContext.Provider>
+          </PortalLayerRootContext.Provider>
+        </div>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene />, {
+        createNodeMock: (element) =>
+          element.props["data-probe-id"] === "parent" ? parentContainer : childContainer,
+      });
+    });
+    act(() => {
+      win.dispatchKeydown({ key: "Escape" });
+    });
+    expect(childEscapeCount).toBe(1);
+    expect(parentEscapeCount).toBe(0);
+  });
+
+  test("a newer independent root outranks an older deeper root", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    restoreGlobals = stubDomGlobals(activeHolder, win);
+
+    const oldFocusable = makeElement("old-focusable", activeHolder);
+    const newFocusable = makeElement("new-focusable", activeHolder);
+    const oldContainer = makeContainer([oldFocusable], activeHolder);
+    const newContainer = makeContainer([newFocusable], activeHolder);
+    let oldEscapeCount = 0;
+    let newEscapeCount = 0;
+
+    function Scene({ showNew }: { showNew: boolean }) {
+      return (
+        <>
+          <PortalLayerDepthContext.Provider value={3}>
+            <TrapProbe
+              probeId="old"
+              active
+              onEscape={() => {
+                oldEscapeCount += 1;
+              }}
+            />
+          </PortalLayerDepthContext.Provider>
+          {showNew ? (
+            <TrapProbe
+              probeId="new"
+              active
+              onEscape={() => {
+                newEscapeCount += 1;
+              }}
+            />
+          ) : null}
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene showNew={false} />, {
+        createNodeMock: (element) =>
+          element.props["data-probe-id"] === "old" ? oldContainer : newContainer,
+      });
+    });
+    expect(activeHolder.current).toBe(oldFocusable);
+
+    act(() => {
+      renderer!.update(<Scene showNew />);
+    });
+    expect(activeHolder.current).toBe(newFocusable);
+
+    act(() => {
+      win.dispatchKeydown({ key: "Escape" });
+    });
+    expect(newEscapeCount).toBe(1);
+    expect(oldEscapeCount).toBe(0);
   });
 
   test("Tab containment is owned solely by the topmost trap — the background trap never inspects its own focusables", () => {

--- a/src/lib/use-focus-trap-stack.test.tsx
+++ b/src/lib/use-focus-trap-stack.test.tsx
@@ -42,6 +42,7 @@ import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, describe, expect, test } from "vitest";
 import {
   FocusTrapOwnerHiddenContext,
+  PortalLayerDepthContext,
   resetFocusTrapStackForTest,
   useFocusTrap,
 } from "@/lib/use-focus-trap";
@@ -283,6 +284,57 @@ describe("useFocusTrap stack-awareness (cave-rl980 Task 5 nested modal findings)
     });
     expect(parentEscapeCount).toBe(1);
     expect(childEscapeCount).toBe(1);
+  });
+
+  test("an initially-mounted nested trap owns focus and Escape by layer depth", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    restoreGlobals = stubDomGlobals(activeHolder, win);
+
+    const trigger = makeElement("trigger", activeHolder);
+    const parentFocusable = makeElement("parent-focusable", activeHolder);
+    const childFocusable = makeElement("child-focusable", activeHolder);
+    const parentContainer = makeContainer([parentFocusable], activeHolder);
+    const childContainer = makeContainer([childFocusable], activeHolder);
+    activeHolder.current = trigger;
+    let parentEscapeCount = 0;
+    let childEscapeCount = 0;
+
+    function ParentWithInitiallyOpenChild() {
+      const parentRef = useRef<unknown>(null);
+      useFocusTrap(true, parentRef as never, {
+        onEscape: () => {
+          parentEscapeCount += 1;
+        },
+      });
+      return (
+        <div data-probe-id="parent" ref={parentRef as never}>
+          <PortalLayerDepthContext.Provider value={1}>
+            <TrapProbe
+              probeId="child"
+              active
+              onEscape={() => {
+                childEscapeCount += 1;
+              }}
+            />
+          </PortalLayerDepthContext.Provider>
+        </div>
+      );
+    }
+
+    act(() => {
+      renderer = create(<ParentWithInitiallyOpenChild />, {
+        createNodeMock: (element) =>
+          element.props["data-probe-id"] === "parent" ? parentContainer : childContainer,
+      });
+    });
+    expect(activeHolder.current).toBe(childFocusable);
+
+    act(() => {
+      win.dispatchKeydown({ key: "Escape" });
+    });
+    expect(childEscapeCount).toBe(1);
+    expect(parentEscapeCount).toBe(0);
   });
 
   test("Tab containment is owned solely by the topmost trap — the background trap never inspects its own focusables", () => {

--- a/src/lib/use-focus-trap-stack.test.tsx
+++ b/src/lib/use-focus-trap-stack.test.tsx
@@ -355,20 +355,24 @@ describe("useFocusTrap stack-awareness (cave-rl980 Task 5 nested modal findings)
     const win = makeWindowStub();
     restoreGlobals = stubDomGlobals(activeHolder, win);
 
+    const trigger = makeElement("trigger", activeHolder);
     const parentFocusable = makeElement("parent-focusable", activeHolder);
     const childFocusable = makeElement("child-focusable", activeHolder);
     const parentContainer = makeContainer([parentFocusable], activeHolder);
     const childContainer = makeContainer([childFocusable], activeHolder);
     let parentEscapeCount = 0;
     let childEscapeCount = 0;
+    activeHolder.current = trigger;
 
     function Scene() {
       const parentRef = useRef<unknown>(null);
+      const [parentActive, setParentActive] = useState(true);
       const [showChild, setShowChild] = useState(true);
       const rootId = usePortalLayerRootId();
-      useFocusTrap(true, parentRef as never, {
+      useFocusTrap(parentActive, parentRef as never, {
         onEscape: () => {
           parentEscapeCount += 1;
+          setParentActive(false);
         },
         portalRootId: rootId,
       });
@@ -403,6 +407,13 @@ describe("useFocusTrap stack-awareness (cave-rl980 Task 5 nested modal findings)
     });
     expect(childEscapeCount).toBe(1);
     expect(parentEscapeCount).toBe(0);
+    expect(activeHolder.current).toBe(parentFocusable);
+
+    act(() => {
+      win.dispatchKeydown({ key: "Escape" });
+    });
+    expect(parentEscapeCount).toBe(1);
+    expect(activeHolder.current).toBe(trigger);
   });
 
   test("a newer independent root outranks an older deeper root", () => {

--- a/src/lib/use-focus-trap.test.ts
+++ b/src/lib/use-focus-trap.test.ts
@@ -112,12 +112,12 @@ assert.match(
 // leave two entries for the same logical trap.
 assert.match(
   source,
-  /function registerTrap\(id: number, depth: number\): void \{/,
+  /function registerTrap\(id: number, depth: number, rootId: number\): void \{/,
   "registerTrap is keyed by the stable id",
 );
 assert.match(
   source,
-  /const stale = trapStack\.findIndex\(\(entry\) => entry\.id === id\);\s*\n\s*if \(stale !== -1\) trapStack\.splice\(stale, 1\);/,
+  /const stale = trapStack\.findIndex\(\(entry\) => entry\.id === id\);\s*\n\s*if \(stale !== -1\) \{[\s\S]{0,160}trapStack\.splice\(stale, 1\);/,
   "registerTrap removes any stale entry for the same id before pushing (StrictMode safety)",
 );
 assert.match(
@@ -132,13 +132,18 @@ assert.match(
 );
 assert.match(
   source,
-  /a\.depth - b\.depth \|\| a\.order - b\.order/,
-  "layer depth owns focus and Escape, with activation order only breaking ties",
+  /a\.rootOrder - b\.rootOrder \|\| a\.depth - b\.depth \|\| a\.order - b\.order/,
+  "newer independent roots win globally, then depth and activation order rank nested traps",
 );
 assert.match(
   source,
-  /registerTrap\(trapId, ownerLayerDepth \+ 1\);[\s\S]{0,120}if \(focusFirst && isTopmostTrap\(trapId\)\)/,
+  /registerTrap\(trapId, ownerLayerDepth \+ 1, trapRootId\);[\s\S]{0,120}if \(focusFirst && isTopmostTrap\(trapId\)\)/,
   "the trap registers its depth before deciding whether it may take initial focus",
+);
+assert.match(
+  source,
+  /if \(e\.key === "Escape"\) \{\s*e\.stopImmediatePropagation\(\);\s*onEscapeRef\.current\?\.\(\);/,
+  "the top trap claims an Escape before synchronous cleanup can expose a lower trap",
 );
 
 // Only the topmost trap acts on a keydown — everything below it is a

--- a/src/lib/use-focus-trap.test.ts
+++ b/src/lib/use-focus-trap.test.ts
@@ -112,7 +112,7 @@ assert.match(
 // leave two entries for the same logical trap.
 assert.match(
   source,
-  /function registerTrap\(id: number\): void \{/,
+  /function registerTrap\(id: number, depth: number\): void \{/,
   "registerTrap is keyed by the stable id",
 );
 assert.match(
@@ -128,7 +128,17 @@ assert.match(
 assert.match(
   source,
   /function isTopmostTrap\(id: number\): boolean \{/,
-  "isTopmostTrap checks the id against the top of the stack",
+  "isTopmostTrap resolves the deepest active trap",
+);
+assert.match(
+  source,
+  /a\.depth - b\.depth \|\| a\.order - b\.order/,
+  "layer depth owns focus and Escape, with activation order only breaking ties",
+);
+assert.match(
+  source,
+  /registerTrap\(trapId, ownerLayerDepth \+ 1\);[\s\S]{0,120}if \(focusFirst && isTopmostTrap\(trapId\)\)/,
+  "the trap registers its depth before deciding whether it may take initial focus",
 );
 
 // Only the topmost trap acts on a keydown — everything below it is a

--- a/src/lib/use-focus-trap.test.ts
+++ b/src/lib/use-focus-trap.test.ts
@@ -18,7 +18,7 @@ assert.match(
 assert.match(source, /document\.activeElement/, "captures document.activeElement on activate");
 assert.match(
   source,
-  /returnFocusRef\.current\?\.focus\(\)/,
+  /\(rootReturnFocus \?\? returnTarget\)\?\.focus\(\)/,
   "restores focus on deactivate",
 );
 
@@ -112,17 +112,17 @@ assert.match(
 // leave two entries for the same logical trap.
 assert.match(
   source,
-  /function registerTrap\(id: number, depth: number, rootId: number\): void \{/,
+  /function registerTrap\(\s*id: number,\s*depth: number,\s*rootId: number,[\s\S]{0,180}\): void \{/,
   "registerTrap is keyed by the stable id",
 );
 assert.match(
   source,
-  /const stale = trapStack\.findIndex\(\(entry\) => entry\.id === id\);\s*\n\s*if \(stale !== -1\) \{[\s\S]{0,160}trapStack\.splice\(stale, 1\);/,
+  /const stale = trapStack\.findIndex\(\(entry\) => entry\.id === id\);\s*\n\s*if \(stale !== -1\) \{[\s\S]{0,300}trapStack\.splice\(stale, 1\);/,
   "registerTrap removes any stale entry for the same id before pushing (StrictMode safety)",
 );
 assert.match(
   source,
-  /function unregisterTrap\(id: number\): \{ hadTrapAbove: boolean \} \{/,
+  /function unregisterTrap\(id: number\): \{[\s\S]{0,140}hadTrapAbove: boolean;/,
   "unregisterTrap is keyed by the stable id, not stack position",
 );
 assert.match(
@@ -137,7 +137,7 @@ assert.match(
 );
 assert.match(
   source,
-  /registerTrap\(trapId, ownerLayerDepth \+ 1, trapRootId\);[\s\S]{0,120}if \(focusFirst && isTopmostTrap\(trapId\)\)/,
+  /registerTrap\(\s*trapId,\s*ownerLayerDepth \+ 1,\s*trapRootId,[\s\S]{0,220}\);[\s\S]{0,120}if \(focusFirst && isTopmostTrap\(trapId\)\)/,
   "the trap registers its depth before deciding whether it may take initial focus",
 );
 assert.match(
@@ -159,13 +159,13 @@ assert.match(
 // trap's own eventual restoration instead of fighting its containment.
 assert.match(
   source,
-  /const \{ hadTrapAbove \} = unregisterTrap\(trapId\);/,
+  /const \{ hadTrapAbove, nextTopmost, rootReturnFocus \} = unregisterTrap\(trapId\);/,
   "cleanup captures whether a trap was layered above before restoring focus",
 );
 assert.match(
   source,
-  /if \(!hadTrapAbove && restoreFocusRef\.current\(\) !== false\) \{\s*\n\s*returnFocusRef\.current\?\.focus\(\);\s*\n\s*\}/,
-  "focus restoration on deactivate is skipped while a nested trap is still active above it",
+  /if \(!hadTrapAbove && restoreFocusRef\.current\(\) !== false\) \{[\s\S]{0,300}if \(nextTopmost\) \{[\s\S]{0,220}focusTrap\(nextTopmost\);[\s\S]{0,120}\(rootReturnFocus \?\? returnTarget\)\?\.focus\(\);/,
+  "focus restoration stays inside a remaining trap and returns to the root trigger last",
 );
 assert.match(
   source,

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -32,6 +32,7 @@ export type FocusTrapPortalLayers = {
 };
 
 export const FocusTrapPortalLayersContext = createContext<FocusTrapPortalLayers | null>(null);
+export const PortalLayerDepthContext = createContext(0);
 
 /**
  * One entry per currently-ACTIVE trap, in activation order — the

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -35,27 +35,31 @@ export const FocusTrapPortalLayersContext = createContext<FocusTrapPortalLayers 
 export const PortalLayerDepthContext = createContext(0);
 
 /**
- * One entry per currently-ACTIVE trap, in activation order — the
- * module-level stack every useFocusTrap instance in the app shares. Keyed by
- * a stable per-hook-instance `id` (see `idRef` below), never by object
+ * One entry per currently-ACTIVE trap. Layer depth determines ownership and
+ * activation order breaks ties, so an initially-mounted descendant still wins
+ * even though React runs its passive effect before its ancestor's. Entries are
+ * keyed by a stable per-hook-instance `id` (see `idRef` below), never by object
  * identity, so a React StrictMode mount→cleanup→mount cycle registers and
- * unregisters the SAME logical trap without ever leaving a duplicate behind:
- * `registerTrap` removes any existing entry for `id` before pushing, and
- * `unregisterTrap` finds and removes `id` from wherever it sits — not just
- * the top — because an ancestor trap can legitimately deactivate while a
- * still-active nested trap remains above it (e.g. a drawer closing out from
- * under an open child dialog; see FocusTrapOwnerHiddenContext below, which
- * exists to make that the rare case rather than the normal one).
+ * unregisters the SAME logical trap without leaving a duplicate behind.
  */
-type TrapEntry = { readonly id: number };
+type TrapEntry = {
+  readonly id: number;
+  readonly depth: number;
+  readonly order: number;
+};
 
 const trapStack: TrapEntry[] = [];
 let nextTrapId = 1;
+let nextTrapOrder = 1;
 
-function registerTrap(id: number): void {
+function compareTrapOrder(a: TrapEntry, b: TrapEntry): number {
+  return a.depth - b.depth || a.order - b.order;
+}
+
+function registerTrap(id: number, depth: number): void {
   const stale = trapStack.findIndex((entry) => entry.id === id);
   if (stale !== -1) trapStack.splice(stale, 1);
-  trapStack.push({ id });
+  trapStack.push({ id, depth, order: nextTrapOrder++ });
 }
 
 /** Removes `id` (wherever it sits) and reports whether a still-active trap
@@ -65,13 +69,19 @@ function registerTrap(id: number): void {
 function unregisterTrap(id: number): { hadTrapAbove: boolean } {
   const index = trapStack.findIndex((entry) => entry.id === id);
   if (index === -1) return { hadTrapAbove: false };
-  const hadTrapAbove = index < trapStack.length - 1;
+  const entry = trapStack[index];
+  const hadTrapAbove = trapStack.some((candidate) => compareTrapOrder(candidate, entry) > 0);
   trapStack.splice(index, 1);
   return { hadTrapAbove };
 }
 
 function isTopmostTrap(id: number): boolean {
-  return trapStack.length > 0 && trapStack[trapStack.length - 1].id === id;
+  const topmost = trapStack.reduce<TrapEntry | undefined>(
+    (current, candidate) =>
+      !current || compareTrapOrder(candidate, current) > 0 ? candidate : current,
+    undefined,
+  );
+  return topmost?.id === id;
 }
 
 /** Test seam — drops every registered trap. Prevents a test that mounts a
@@ -108,8 +118,8 @@ export const FocusTrapOwnerHiddenContext = createContext(false);
  * onEscape.
  *
  * Stack-aware: every active trap in the app registers on a shared
- * module-level stack (see trapStack above), and only the TOPMOST one ever
- * acts on a keydown or restores focus on deactivation — everything below it
+ * module-level stack (see trapStack above), and only the deepest/topmost one
+ * ever acts on a keydown or restores focus on deactivation — everything below it
  * is a complete no-op until the trap above it deactivates, at which point it
  * "resumes" (the very next keydown routes to it again; no explicit re-focus
  * step is needed). This is what lets a body-portaled child dialog opened
@@ -138,6 +148,7 @@ export function useFocusTrap(
   const idRef = useRef(0);
   if (idRef.current === 0) idRef.current = nextTrapId++;
   const ownerHidden = useContext(FocusTrapOwnerHiddenContext);
+  const ownerLayerDepth = useContext(PortalLayerDepthContext);
 
   // Keep the latest callback reachable from the keydown handler without
   // making it a useEffect dep.
@@ -154,8 +165,10 @@ export function useFocusTrap(
     if (!container) return;
 
     returnFocusRef.current = (document.activeElement as HTMLElement) ?? null;
+    const trapId = idRef.current;
+    registerTrap(trapId, ownerLayerDepth + 1);
 
-    if (focusFirst) {
+    if (focusFirst && isTopmostTrap(trapId)) {
       const first = container.querySelector<HTMLElement>(FOCUSABLE);
       if (first) {
         first.focus();
@@ -165,9 +178,6 @@ export function useFocusTrap(
         container.focus();
       }
     }
-
-    const trapId = idRef.current;
-    registerTrap(trapId);
 
     function onKey(e: KeyboardEvent) {
       // Only the topmost active trap owns the keyboard (see trapStack doc
@@ -239,7 +249,7 @@ export function useFocusTrap(
         returnFocusRef.current?.focus();
       }
     };
-  }, [active, containerRef, focusFirst, portalLayers]); // intentionally no onEscape
+  }, [active, containerRef, focusFirst, portalLayers, ownerLayerDepth]); // intentionally no onEscape
 
   // If an ancestor "modal owner" becomes hidden while this trap is still
   // active, ask it to close through the SAME callback Escape already uses

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -23,6 +23,8 @@ type Options = {
   restoreFocus?: () => boolean;
   /** Body-portaled descendants that remain part of this trap's focus boundary. */
   portalLayers?: FocusTrapPortalLayers;
+  /** Root shared by nested traps; independent roots compete by activation order. */
+  portalRootId?: number;
 };
 
 export type FocusTrapPortalLayers = {
@@ -33,33 +35,74 @@ export type FocusTrapPortalLayers = {
 
 export const FocusTrapPortalLayersContext = createContext<FocusTrapPortalLayers | null>(null);
 export const PortalLayerDepthContext = createContext(0);
+export const PortalLayerRootContext = createContext<number | null>(null);
+let nextPortalLayerRootId = 1;
+
+export function usePortalLayerRootId(): number {
+  const inheritedRootId = useContext(PortalLayerRootContext);
+  const ownRootIdRef = useRef(0);
+  if (ownRootIdRef.current === 0) ownRootIdRef.current = nextPortalLayerRootId++;
+  return inheritedRootId ?? ownRootIdRef.current;
+}
 
 /**
- * One entry per currently-ACTIVE trap. Layer depth determines ownership and
- * activation order breaks ties, so an initially-mounted descendant still wins
- * even though React runs its passive effect before its ancestor's. Entries are
- * keyed by a stable per-hook-instance `id` (see `idRef` below), never by object
- * identity, so a React StrictMode mount→cleanup→mount cycle registers and
- * unregisters the SAME logical trap without leaving a duplicate behind.
+ * One entry per currently-ACTIVE trap. The newest independent root wins;
+ * within that root, layer depth determines ownership and activation order
+ * breaks ties. An initially-mounted descendant therefore still wins even
+ * though React runs its passive effect before its ancestor's. Entries are
+ * keyed by a stable per-hook-instance `id` (see `idRef` below), never by
+ * object identity, so a React StrictMode mount→cleanup→mount cycle registers
+ * and unregisters the SAME logical trap without leaving a duplicate behind.
  */
 type TrapEntry = {
   readonly id: number;
   readonly depth: number;
   readonly order: number;
+  readonly rootId: number;
+  readonly rootOrder: number;
 };
 
 const trapStack: TrapEntry[] = [];
+const trapRoots = new Map<number, { order: number; count: number }>();
 let nextTrapId = 1;
 let nextTrapOrder = 1;
+let nextTrapRootOrder = 1;
 
 function compareTrapOrder(a: TrapEntry, b: TrapEntry): number {
-  return a.depth - b.depth || a.order - b.order;
+  return a.rootOrder - b.rootOrder || a.depth - b.depth || a.order - b.order;
 }
 
-function registerTrap(id: number, depth: number): void {
+function acquireTrapRoot(rootId: number): number {
+  const current = trapRoots.get(rootId);
+  if (current) {
+    current.count += 1;
+    return current.order;
+  }
+  const order = nextTrapRootOrder++;
+  trapRoots.set(rootId, { order, count: 1 });
+  return order;
+}
+
+function releaseTrapRoot(rootId: number): void {
+  const current = trapRoots.get(rootId);
+  if (!current) return;
+  current.count -= 1;
+  if (current.count === 0) trapRoots.delete(rootId);
+}
+
+function registerTrap(id: number, depth: number, rootId: number): void {
   const stale = trapStack.findIndex((entry) => entry.id === id);
-  if (stale !== -1) trapStack.splice(stale, 1);
-  trapStack.push({ id, depth, order: nextTrapOrder++ });
+  if (stale !== -1) {
+    releaseTrapRoot(trapStack[stale].rootId);
+    trapStack.splice(stale, 1);
+  }
+  trapStack.push({
+    id,
+    depth,
+    order: nextTrapOrder++,
+    rootId,
+    rootOrder: acquireTrapRoot(rootId),
+  });
 }
 
 /** Removes `id` (wherever it sits) and reports whether a still-active trap
@@ -72,6 +115,7 @@ function unregisterTrap(id: number): { hadTrapAbove: boolean } {
   const entry = trapStack[index];
   const hadTrapAbove = trapStack.some((candidate) => compareTrapOrder(candidate, entry) > 0);
   trapStack.splice(index, 1);
+  releaseTrapRoot(entry.rootId);
   return { hadTrapAbove };
 }
 
@@ -89,6 +133,7 @@ function isTopmostTrap(id: number): boolean {
  *  later test in the same file/process. */
 export function resetFocusTrapStackForTest(): void {
   trapStack.length = 0;
+  trapRoots.clear();
 }
 
 /**
@@ -137,7 +182,13 @@ export const FocusTrapOwnerHiddenContext = createContext(false);
 export function useFocusTrap(
   active: boolean,
   containerRef: RefObject<HTMLElement | null>,
-  { onEscape, focusFirst = true, restoreFocus = () => true, portalLayers }: Options = {},
+  {
+    onEscape,
+    focusFirst = true,
+    restoreFocus = () => true,
+    portalLayers,
+    portalRootId,
+  }: Options = {},
 ) {
   const returnFocusRef = useRef<HTMLElement | null>(null);
   const onEscapeRef = useRef(onEscape);
@@ -149,6 +200,10 @@ export function useFocusTrap(
   if (idRef.current === 0) idRef.current = nextTrapId++;
   const ownerHidden = useContext(FocusTrapOwnerHiddenContext);
   const ownerLayerDepth = useContext(PortalLayerDepthContext);
+  const inheritedRootId = useContext(PortalLayerRootContext);
+  const ownRootIdRef = useRef(0);
+  if (ownRootIdRef.current === 0) ownRootIdRef.current = nextPortalLayerRootId++;
+  const trapRootId = portalRootId ?? inheritedRootId ?? ownRootIdRef.current;
 
   // Keep the latest callback reachable from the keydown handler without
   // making it a useEffect dep.
@@ -166,7 +221,7 @@ export function useFocusTrap(
 
     returnFocusRef.current = (document.activeElement as HTMLElement) ?? null;
     const trapId = idRef.current;
-    registerTrap(trapId, ownerLayerDepth + 1);
+    registerTrap(trapId, ownerLayerDepth + 1, trapRootId);
 
     if (focusFirst && isTopmostTrap(trapId)) {
       const first = container.querySelector<HTMLElement>(FOCUSABLE);
@@ -187,6 +242,7 @@ export function useFocusTrap(
       if (!isTopmostTrap(trapId)) return;
 
       if (e.key === "Escape") {
+        e.stopImmediatePropagation();
         onEscapeRef.current?.();
         return;
       }
@@ -249,7 +305,14 @@ export function useFocusTrap(
         returnFocusRef.current?.focus();
       }
     };
-  }, [active, containerRef, focusFirst, portalLayers, ownerLayerDepth]); // intentionally no onEscape
+  }, [
+    active,
+    containerRef,
+    focusFirst,
+    portalLayers,
+    ownerLayerDepth,
+    trapRootId,
+  ]); // intentionally no onEscape
 
   // If an ancestor "modal owner" becomes hidden while this trap is still
   // active, ask it to close through the SAME callback Escape already uses

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -21,7 +21,17 @@ type Options = {
   focusFirst?: boolean;
   /** Late-bound restoration gate for transitions directly into another layer. */
   restoreFocus?: () => boolean;
+  /** Body-portaled descendants that remain part of this trap's focus boundary. */
+  portalLayers?: FocusTrapPortalLayers;
 };
+
+export type FocusTrapPortalLayers = {
+  register: (el: HTMLElement) => () => void;
+  contains: (node: Node | null) => boolean;
+  elements: () => readonly HTMLElement[];
+};
+
+export const FocusTrapPortalLayersContext = createContext<FocusTrapPortalLayers | null>(null);
 
 /**
  * One entry per currently-ACTIVE trap, in activation order — the
@@ -116,7 +126,7 @@ export const FocusTrapOwnerHiddenContext = createContext(false);
 export function useFocusTrap(
   active: boolean,
   containerRef: RefObject<HTMLElement | null>,
-  { onEscape, focusFirst = true, restoreFocus = () => true }: Options = {},
+  { onEscape, focusFirst = true, restoreFocus = () => true, portalLayers }: Options = {},
 ) {
   const returnFocusRef = useRef<HTMLElement | null>(null);
   const onEscapeRef = useRef(onEscape);
@@ -171,7 +181,12 @@ export function useFocusTrap(
       }
       if (e.key === "Tab" && container) {
         const focusables = Array.from(
-          container.querySelectorAll<HTMLElement>(FOCUSABLE),
+          new Set([
+            ...container.querySelectorAll<HTMLElement>(FOCUSABLE),
+            ...(portalLayers?.elements() ?? []).flatMap((layer) =>
+              Array.from(layer.querySelectorAll<HTMLElement>(FOCUSABLE)),
+            ),
+          ]),
         ).filter(
           (el) =>
             !el.hasAttribute("disabled") &&
@@ -190,7 +205,10 @@ export function useFocusTrap(
         // the page BEHIND the dialog and the "trap" never applies again.
         // (Live-reproduced: the home composer's mount autofocus stole focus
         // from the onboarding wizard and Tab toured the covered workspace.)
-        if (!activeEl || !container.contains(activeEl)) {
+        if (
+          !activeEl ||
+          (!container.contains(activeEl) && !portalLayers?.contains(activeEl))
+        ) {
           e.preventDefault();
           (e.shiftKey ? last : first).focus();
           return;
@@ -220,7 +238,7 @@ export function useFocusTrap(
         returnFocusRef.current?.focus();
       }
     };
-  }, [active, containerRef, focusFirst]); // intentionally no onEscape
+  }, [active, containerRef, focusFirst, portalLayers]); // intentionally no onEscape
 
   // If an ancestor "modal owner" becomes hidden while this trap is still
   // active, ask it to close through the SAME callback Escape already uses

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -60,10 +60,11 @@ type TrapEntry = {
   readonly order: number;
   readonly rootId: number;
   readonly rootOrder: number;
+  readonly releaseRoot: () => void;
 };
 
 const trapStack: TrapEntry[] = [];
-const trapRoots = new Map<number, { order: number; count: number }>();
+const portalLayerRoots = new Map<number, { order: number; count: number }>();
 let nextTrapId = 1;
 let nextTrapOrder = 1;
 let nextTrapRootOrder = 1;
@@ -72,36 +73,63 @@ function compareTrapOrder(a: TrapEntry, b: TrapEntry): number {
   return a.rootOrder - b.rootOrder || a.depth - b.depth || a.order - b.order;
 }
 
-function acquireTrapRoot(rootId: number): number {
-  const current = trapRoots.get(rootId);
+export function acquirePortalLayerRoot(rootId: number): {
+  order: number;
+  release: () => void;
+} {
+  const current = portalLayerRoots.get(rootId);
+  let order: number;
   if (current) {
     current.count += 1;
-    return current.order;
+    order = current.order;
+  } else {
+    order = nextTrapRootOrder++;
+    portalLayerRoots.set(rootId, { order, count: 1 });
   }
-  const order = nextTrapRootOrder++;
-  trapRoots.set(rootId, { order, count: 1 });
-  return order;
+  let released = false;
+  return {
+    order,
+    release: () => {
+      if (released) return;
+      released = true;
+      releasePortalLayerRoot(rootId);
+    },
+  };
 }
 
-function releaseTrapRoot(rootId: number): void {
-  const current = trapRoots.get(rootId);
+function releasePortalLayerRoot(rootId: number): void {
+  const current = portalLayerRoots.get(rootId);
   if (!current) return;
   current.count -= 1;
-  if (current.count === 0) trapRoots.delete(rootId);
+  if (current.count === 0) portalLayerRoots.delete(rootId);
+}
+
+export function isTopmostPortalLayerRoot(rootId: number): boolean {
+  let topmostId: number | null = null;
+  let topmostOrder = -1;
+  for (const [candidateId, candidate] of portalLayerRoots) {
+    if (candidate.order > topmostOrder) {
+      topmostId = candidateId;
+      topmostOrder = candidate.order;
+    }
+  }
+  return topmostId === rootId;
 }
 
 function registerTrap(id: number, depth: number, rootId: number): void {
   const stale = trapStack.findIndex((entry) => entry.id === id);
   if (stale !== -1) {
-    releaseTrapRoot(trapStack[stale].rootId);
+    trapStack[stale].releaseRoot();
     trapStack.splice(stale, 1);
   }
+  const root = acquirePortalLayerRoot(rootId);
   trapStack.push({
     id,
     depth,
     order: nextTrapOrder++,
     rootId,
-    rootOrder: acquireTrapRoot(rootId),
+    rootOrder: root.order,
+    releaseRoot: root.release,
   });
 }
 
@@ -115,7 +143,7 @@ function unregisterTrap(id: number): { hadTrapAbove: boolean } {
   const entry = trapStack[index];
   const hadTrapAbove = trapStack.some((candidate) => compareTrapOrder(candidate, entry) > 0);
   trapStack.splice(index, 1);
-  releaseTrapRoot(entry.rootId);
+  entry.releaseRoot();
   return { hadTrapAbove };
 }
 
@@ -133,7 +161,7 @@ function isTopmostTrap(id: number): boolean {
  *  later test in the same file/process. */
 export function resetFocusTrapStackForTest(): void {
   trapStack.length = 0;
-  trapRoots.clear();
+  portalLayerRoots.clear();
 }
 
 /**

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -61,10 +61,20 @@ type TrapEntry = {
   readonly rootId: number;
   readonly rootOrder: number;
   readonly releaseRoot: () => void;
+  readonly container: HTMLElement;
+  readonly portalLayers?: FocusTrapPortalLayers;
 };
 
 const trapStack: TrapEntry[] = [];
-const portalLayerRoots = new Map<number, { order: number; count: number }>();
+const portalLayerRoots = new Map<
+  number,
+  {
+    order: number;
+    count: number;
+    trapCount: number;
+    returnFocus: HTMLElement | null;
+  }
+>();
 let nextTrapId = 1;
 let nextTrapOrder = 1;
 let nextTrapRootOrder = 1;
@@ -84,7 +94,12 @@ export function acquirePortalLayerRoot(rootId: number): {
     order = current.order;
   } else {
     order = nextTrapRootOrder++;
-    portalLayerRoots.set(rootId, { order, count: 1 });
+    portalLayerRoots.set(rootId, {
+      order,
+      count: 1,
+      trapCount: 0,
+      returnFocus: null,
+    });
   }
   let released = false;
   return {
@@ -116,13 +131,35 @@ export function isTopmostPortalLayerRoot(rootId: number): boolean {
   return topmostId === rootId;
 }
 
-function registerTrap(id: number, depth: number, rootId: number): void {
+function topmostTrap(): TrapEntry | undefined {
+  return trapStack.reduce<TrapEntry | undefined>(
+    (current, candidate) =>
+      !current || compareTrapOrder(candidate, current) > 0 ? candidate : current,
+    undefined,
+  );
+}
+
+function registerTrap(
+  id: number,
+  depth: number,
+  rootId: number,
+  container: HTMLElement,
+  portalLayers: FocusTrapPortalLayers | undefined,
+  returnFocus: HTMLElement | null,
+): void {
   const stale = trapStack.findIndex((entry) => entry.id === id);
   if (stale !== -1) {
+    const staleRoot = portalLayerRoots.get(trapStack[stale].rootId);
+    if (staleRoot) staleRoot.trapCount = Math.max(0, staleRoot.trapCount - 1);
     trapStack[stale].releaseRoot();
     trapStack.splice(stale, 1);
   }
   const root = acquirePortalLayerRoot(rootId);
+  const rootState = portalLayerRoots.get(rootId);
+  if (rootState) {
+    if (rootState.trapCount === 0) rootState.returnFocus = returnFocus;
+    rootState.trapCount += 1;
+  }
   trapStack.push({
     id,
     depth,
@@ -130,6 +167,8 @@ function registerTrap(id: number, depth: number, rootId: number): void {
     rootId,
     rootOrder: root.order,
     releaseRoot: root.release,
+    container,
+    portalLayers,
   });
 }
 
@@ -137,23 +176,49 @@ function registerTrap(id: number, depth: number, rootId: number): void {
  *  was layered above it — the caller uses this to decide whether restoring
  *  its own saved focus is safe right now, or whether the trap still on top
  *  owns focus until IT deactivates and performs its own restoration. */
-function unregisterTrap(id: number): { hadTrapAbove: boolean } {
+function unregisterTrap(id: number): {
+  hadTrapAbove: boolean;
+  nextTopmost?: TrapEntry;
+  rootReturnFocus: HTMLElement | null;
+} {
   const index = trapStack.findIndex((entry) => entry.id === id);
-  if (index === -1) return { hadTrapAbove: false };
+  if (index === -1) return { hadTrapAbove: false, rootReturnFocus: null };
   const entry = trapStack[index];
   const hadTrapAbove = trapStack.some((candidate) => compareTrapOrder(candidate, entry) > 0);
   trapStack.splice(index, 1);
+  const rootState = portalLayerRoots.get(entry.rootId);
+  let rootReturnFocus: HTMLElement | null = null;
+  if (rootState) {
+    rootState.trapCount = Math.max(0, rootState.trapCount - 1);
+    if (rootState.trapCount === 0) {
+      rootReturnFocus = rootState.returnFocus;
+      rootState.returnFocus = null;
+    }
+  }
   entry.releaseRoot();
-  return { hadTrapAbove };
+  return { hadTrapAbove, nextTopmost: topmostTrap(), rootReturnFocus };
 }
 
 function isTopmostTrap(id: number): boolean {
-  const topmost = trapStack.reduce<TrapEntry | undefined>(
-    (current, candidate) =>
-      !current || compareTrapOrder(candidate, current) > 0 ? candidate : current,
-    undefined,
-  );
-  return topmost?.id === id;
+  return topmostTrap()?.id === id;
+}
+
+function trapContains(entry: TrapEntry, node: HTMLElement): boolean {
+  return entry.container.contains(node) || Boolean(entry.portalLayers?.contains(node));
+}
+
+function focusTrap(entry: TrapEntry): void {
+  const first =
+    entry.container.querySelector<HTMLElement>(FOCUSABLE) ??
+    entry.portalLayers
+      ?.elements()
+      .flatMap((layer) => Array.from(layer.querySelectorAll<HTMLElement>(FOCUSABLE)))
+      .find(
+        (el) =>
+          !el.hasAttribute("disabled") &&
+          (typeof el.getClientRects !== "function" || el.getClientRects().length > 0),
+      );
+  (first ?? entry.container).focus();
 }
 
 /** Test seam — drops every registered trap. Prevents a test that mounts a
@@ -249,7 +314,14 @@ export function useFocusTrap(
 
     returnFocusRef.current = (document.activeElement as HTMLElement) ?? null;
     const trapId = idRef.current;
-    registerTrap(trapId, ownerLayerDepth + 1, trapRootId);
+    registerTrap(
+      trapId,
+      ownerLayerDepth + 1,
+      trapRootId,
+      container,
+      portalLayers,
+      returnFocusRef.current,
+    );
 
     if (focusFirst && isTopmostTrap(trapId)) {
       const first = container.querySelector<HTMLElement>(FOCUSABLE);
@@ -321,7 +393,7 @@ export function useFocusTrap(
     window.addEventListener("keydown", onKey);
     return () => {
       window.removeEventListener("keydown", onKey);
-      const { hadTrapAbove } = unregisterTrap(trapId);
+      const { hadTrapAbove, nextTopmost, rootReturnFocus } = unregisterTrap(trapId);
       // Skip restoring focus if a still-active nested trap sits above where
       // we were: an ancestor closing out from under an open child must not
       // fight that child's own containment. That trap owns focus until IT
@@ -330,7 +402,13 @@ export function useFocusTrap(
       // outward, to whatever was focused before the outermost trap ever
       // activated.
       if (!hadTrapAbove && restoreFocusRef.current() !== false) {
-        returnFocusRef.current?.focus();
+        const returnTarget = returnFocusRef.current;
+        if (nextTopmost) {
+          if (returnTarget && trapContains(nextTopmost, returnTarget)) returnTarget.focus();
+          else focusTrap(nextTopmost);
+        } else {
+          (rootReturnFocus ?? returnTarget)?.focus();
+        }
       }
     };
   }, [

--- a/src/styles/globals/primitives.css
+++ b/src/styles/globals/primitives.css
@@ -16,13 +16,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  /* Above app drawers and mobile navigation; below portaled popovers (400). */
+  /* Above app drawers and mobile navigation; below portaled popovers (400).
+     A Popover that launches a Modal hides its own panel while the Modal is
+     open, so later Popovers launched from inside the Modal still layer above. */
   z-index: 350;
   padding: var(--space-4);
   animation: ui-modal-fade-in var(--duration-fast) var(--ease-decelerate);
-}
-.ui-modal-backdrop--above-popovers {
-  z-index: 450;
 }
 
 @keyframes browser-progress {
@@ -1508,6 +1507,10 @@
   pointer-events: auto;
   animation: ui-popover-enter var(--duration-fast) var(--ease-decelerate);
   overflow: hidden;
+}
+.ui-popover[data-covered] {
+  visibility: hidden;
+  pointer-events: none;
 }
 @keyframes ui-popover-enter {
   from { opacity: 0; transform: translateY(-2px); }

--- a/src/styles/globals/primitives.css
+++ b/src/styles/globals/primitives.css
@@ -21,6 +21,9 @@
   padding: var(--space-4);
   animation: ui-modal-fade-in var(--duration-fast) var(--ease-decelerate);
 }
+.ui-modal-backdrop--above-popovers {
+  z-index: 450;
+}
 
 @keyframes browser-progress {
   0%   { transform: translateX(-100%); width: 60%; }


### PR DESCRIPTION
## Summary
- register the complete AvatarLightbox modal layer with its owning Popover
- route Escape and backdrop dismissal to the lightbox without closing the Popover
- stack nested modals above Popovers and prevent callback-ref registration churn
- add rendered lifecycle coverage for rerenders, backdrop presses, Escape, and focus return

## Validation
- focused Modal, AvatarLightbox, Popover, and submenu tests
- rendered AvatarLightbox/Popover interaction tests
- lint, typecheck, test wiring, and diff checks

Closes cave-58hcp