### PR TITLE
Fix duplicate chat run-rail keys

### DIFF
--- a/src/lib/chat-run-rail.test.ts
+++ b/src/lib/chat-run-rail.test.ts
@@ -74,6 +74,30 @@ const turn = (id, tools) => ({
   assert.equal(model.totalMs, 0);
   for (const s of model.segments) assert.ok(Number.isFinite(s.ratio) && s.ratio > 0, "no NaN widths when nothing reported a duration");
 }
+{
+  const repeatedTools = [
+    turn("assistant-1", [
+      { id: "create_5", name: "create", status: "ok", durationMs: 10 },
+      { id: "view_5", name: "view", status: "ok", durationMs: 10 },
+    ]),
+    turn("assistant-2", [
+      { id: "create_5", name: "create", status: "ok", durationMs: 10 },
+      { id: "view_5", name: "view", status: "ok", durationMs: 10 },
+    ]),
+  ];
+  const first = runRailModel(repeatedTools, { nowMs: NOW });
+  const second = runRailModel(repeatedTools, { nowMs: NOW });
+  assert.equal(
+    new Set(first.segments.map((segment) => segment.id)).size,
+    first.segments.length,
+    "tool ids that repeat across turns still produce unique timeline identities",
+  );
+  assert.deepEqual(
+    first.segments.map((segment) => segment.id),
+    second.segments.map((segment) => segment.id),
+    "timeline identities remain stable across equivalent renders",
+  );
+}
 
 // ── tool mix ────────────────────────────────────────────────────────────────
 {

--- a/src/lib/chat-run-rail.ts
+++ b/src/lib/chat-run-rail.ts
@@ -133,12 +133,18 @@ export function runRailModel(
   let lastCall: { name: string; input?: string; durationMs?: number; error: boolean } | null = null;
 
   for (const turn of turns) {
-    for (const tool of turn.tools ?? []) {
+    for (const [toolIndex, tool] of (turn.tools ?? []).entries()) {
       const category = toolCategory(tool.name);
       const durationMs = Math.max(0, tool.durationMs ?? 0);
       totalMs += durationMs;
       counts.set(category, (counts.get(category) ?? 0) + 1);
-      segments.push({ id: tool.id, category, ratio: 0, durationMs, status: tool.status });
+      segments.push({
+        id: JSON.stringify([turn.id, tool.id, toolIndex]),
+        category,
+        ratio: 0,
+        durationMs,
+        status: tool.status,
+      });
       if (tool.status === "running") {
         running += 1;
         // Last running call wins: the newest is the one in flight.


### PR DESCRIPTION
## Summary
- scope timeline segment identities by turn and tool position
- preserve stable identities when raw tool IDs repeat across turns
- cover the reported `create_5` and `view_5` collision pattern

## Verification
- `node --experimental-strip-types src/lib/chat-run-rail.test.ts`
- `node --experimental-strip-types src/components/chat-run-rail.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`

Bead: `cave-ne9lf`