### PR TITLE
Remove duplicate desktop familiar selector

### DIFF
--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -7,6 +7,10 @@ const railController = await readFile(new URL("../lib/use-workspace-rail-control
 const chatRouter = await readFile(new URL("./chat-router.tsx", import.meta.url), "utf8");
 const agentsMemoryView = await readFile(new URL("./familiars-memory-view.tsx", import.meta.url), "utf8");
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+const auxiliarySurfaces = await readFile(
+  new URL("../styles/cave-chat/auxiliary-surfaces.css", import.meta.url),
+  "utf8",
+);
 
 assert.match(
   chatSurface,
@@ -108,13 +112,17 @@ assert.match(
   /scope === "coven" \?[\s\S]*<GroupChatView[\s\S]*familiars=\{resolvedFamiliars\}/,
   "ChatSurface should render GroupChatView for the coven scope",
 );
-// Familiar selection now lives in a shared full-width context row above the
-// scope tabs (cave-3pnnq) — the header still carries only its scope tabs below
-// that row, so the selector is not a duplicate of the sidebar switcher.
+// The shell titlebar is the desktop selector authority. Chat retains its
+// context row only for mobile, where the desktop titlebar is hidden.
 assert.match(
   chatSurface,
   /chat-familiar-context[\s\S]*?<FamiliarQuickSwitch[\s\S]*?familiars=\{resolvedFamiliars\}[\s\S]*?activeFamiliarId=\{activeFamiliarId\}[\s\S]*?onSelectFamiliar=\{\(id\) => \{\s*if \(id\) onSetActiveFamiliar\(id\);\s*\}\}[\s\S]*?labeled[\s\S]*?singleRequired[\s\S]*?chat-scope-tabs chat-scope-tabs--minimal/,
-  "ChatSurface renders the shared familiar selector above its section tabs, wired through onSetActiveFamiliar",
+  "ChatSurface retains the mobile familiar selector above its section tabs",
+);
+assert.match(
+  auxiliarySurfaces,
+  /@media \(min-width: 1024px\) \{[\s\S]*?\.chat-familiar-context \{\s*display: none;\s*\}[\s\S]*?\}/,
+  "desktop Chat hides the duplicate in-surface familiar selector",
 );
 assert.match(
   chatSurface,

--- a/src/styles/cave-chat/auxiliary-surfaces.css
+++ b/src/styles/cave-chat/auxiliary-surfaces.css
@@ -1178,11 +1178,9 @@
   color: var(--text-muted);
 }
 
-/* ── Familiar context row (cave-3pnnq) ─────────────────────────────────────
- *   The shared familiar selector sits directly above the Chat section tabs so
- *   a familiar is established before a scope is chosen. Its bottom border is
- *   the single divider between the selector and the tab row; the tab row keeps
- *   its own bottom border for the content boundary below. */
+/* ── Mobile familiar context row ───────────────────────────────────────────
+ *   Desktop uses the shell titlebar selector. Keep this route above the Chat
+ *   tabs only where the titlebar is unavailable. */
 .chat-familiar-context {
   display: flex;
   align-items: center;
@@ -1195,4 +1193,9 @@
 .chat-familiar-context .familiar-switcher__trigger--labeled {
   width: 100%;
   max-width: none;
+}
+@media (min-width: 1024px) {
+  .chat-familiar-context {
+    display: none;
+  }
 }

--- a/tests/chat-code-workflow.spec.ts
+++ b/tests/chat-code-workflow.spec.ts
@@ -888,9 +888,9 @@ test("resized desktop Chromium pins theme, constrained-pane, responsive-sheet, a
   const constrainedRail = await requiredBounds(page, ".workspace-rail");
   const shellDetail = await requiredBounds(page, ".shell-detail");
   expectBoundsNear(constrainedChat, { x: 9, y: 43, width: 1102, height: 680 });
-  // The shared familiar selector now sits above the Home/Chat tabs inside the
-  // rail header (cave-3pnnq), shifting the rail content down 45px.
-  expectBoundsNear(constrainedRail, { x: 831, y: 122, width: 280, height: 601 });
+  // Desktop familiar selection belongs to the shell titlebar, so the code rail
+  // begins immediately below the Chat tabs instead of reserving a duplicate row.
+  expectBoundsNear(constrainedRail, { x: 831, y: 77, width: 280, height: 646 });
   const shellContract = await page.locator(".shell-detail").evaluate((element) => {
     const style = getComputedStyle(element);
     const rootStyle = getComputedStyle(document.documentElement);


### PR DESCRIPTION
## Summary
- hide the redundant in-surface familiar selector at desktop widths
- keep the selector available on mobile where the desktop titlebar is absent
- lock the responsive ownership contract in the Chat surface test

## Verification
- focused Chat/sidebar/context-switcher contract tests
- `pnpm build`
- `pnpm lint`
- `pnpm check:tests-wired`
- Playwright at 1440x900 and 390x844

Bead: `cave-i8kbm`