### PR TITLE
Keep composer Tools opaque on hover

### DIFF
--- a/src/components/chat-composer-command-capsule.test.ts
+++ b/src/components/chat-composer-command-capsule.test.ts
@@ -32,6 +32,20 @@ assert.match(
   /\.cave-composer-edge-actions \{[\s\S]*?transform:\s*translateY\(-50%\);/,
   "Tools and Task ride across the input capsule's top border",
 );
+const toolsHoverMatch = css.match(
+  /\.cave-composer-tools-tab:hover:not\(:disabled\) \{([\s\S]*?)\}/,
+);
+assert.ok(toolsHoverMatch, "expected a dedicated Tools hover treatment");
+assert.match(
+  toolsHoverMatch[1],
+  /background:\s*color-mix\(in oklch, var\(--bg-panel\) 94%, var\(--bg-base\)\);/,
+  "the Tools hover state keeps the same opaque panel surface",
+);
+assert.doesNotMatch(
+  toolsHoverMatch[1],
+  /transparent/,
+  "hovering Tools must not replace its opaque surface with transparency",
+);
 assert.match(
   css,
   /\.cave-composer-control-row \{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto;/,

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -126,8 +126,15 @@
 .cave-composer-tools-tab:hover:not(:disabled),
 .cave-composer-task-tab:hover {
   border-color: color-mix(in oklch, var(--accent-presence) 48%, var(--border-strong));
-  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
   color: var(--text-primary);
+}
+
+.cave-composer-tools-tab:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--bg-panel) 94%, var(--bg-base));
+}
+
+.cave-composer-task-tab:hover {
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
 }
 
 .cave-composer-tools-tab[aria-expanded="true"] {


### PR DESCRIPTION
## Summary

- keep the Tools control on its opaque panel surface while hovered
- preserve the existing border and text hover emphasis
- leave the linked Task control's existing hover treatment unchanged
- add a source contract that rejects transparent Tools hover backgrounds

## Verification

- production build
- browser computed-style check before/after hover (background and opacity unchanged)
- pnpm typecheck
- pnpm lint
- node --experimental-strip-types src/components/chat-composer-command-capsule.test.ts
- pnpm check:tests-wired

Bead: cave-odu9d