### PR TITLE
feat(code): add review-first Coding Desk

### DIFF
--- a/docs/role-surfaces.md
+++ b/docs/role-surfaces.md
@@ -204,6 +204,18 @@ never fake production data.
   Generation and verified normalizations pass through `cave-board` mutators in
   one lock-checked atomic batch, so a stale or failed apply leaves the proposal
   reviewable and preserves the explicit error.
+- **Coding Desk** (`code`, role `coder`) — the Coding familiar's review-first
+  room. It opens in **Reviewable**, showing only active human-created sessions
+  that are outside configured familiar workspaces, verified inside a Git work
+  tree, and enriched with a canonical GitHub `repositoryUrl`; linked worktrees
+  remain eligible when that proof points back to their `repositoryRoot`.
+  **All local** is the explicit escape hatch back to the older generic Code
+  visibility, so familiar workspaces, non-GitHub or unverified repositories,
+  rootless sessions, and missing familiar-workspace classification stay
+  reachable there. Missing Git or workspace classification therefore fails
+  closed for Reviewable only, and the rail and header picker read from the same
+  queue model so their eligibility, ordering, and repository headings stay in
+  sync.
 - **Review Deck** (`reviewer-review-deck`, role `reviewer`) — a three-column
   cockpit built from sessions carrying PRs, working changes, or branches. Each
   column answers exactly one question, so a control's position tells you what

--- a/docs/superpowers/plans/2026-09-01-review-first-coding-desk.md
+++ b/docs/superpowers/plans/2026-09-01-review-first-coding-desk.md
@@ -1,6 +1,6 @@
 # Review-First Coding Desk Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make the Coding Desk default to a minimal, actionable queue of human-created sessions in verified GitHub repositories outside familiar workspaces, while preserving explicit access to every other local session.
 

--- a/docs/superpowers/plans/2026-09-01-review-first-coding-desk.md
+++ b/docs/superpowers/plans/2026-09-01-review-first-coding-desk.md
@@ -1,0 +1,1028 @@
+# Review-First Coding Desk Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Coding Desk default to a minimal, actionable queue of human-created sessions in verified GitHub repositories outside familiar workspaces, while preserving explicit access to every other local session.
+
+**Architecture:** Extend the existing bounded session enrichment with sanitized GitHub repository identity and trusted familiar-workspace classification. Build one pure review-queue model that owns eligibility, priority, grouping, and counts; both the session rail and header picker consume that model. Preserve existing deep-link types and GitHub readers while simplifying their presentation into Review, Work, and GitHub layers.
+
+**Tech Stack:** TypeScript, React 19, Next.js 16, Node.js test runner, Playwright, Tailwind utilities, semantic CSS tokens, bounded `git` subprocess enrichment.
+
+---
+
+## File structure
+
+### New files
+
+- `src/lib/code-review-queue.ts`
+  - Pure eligibility, exclusion, priority, sorting, repository grouping, and
+    selected-session override logic.
+- `src/lib/code-review-queue.test.ts`
+  - Exhaustive model tests independent of React.
+- `src/components/code-review-queue-controls.tsx`
+  - Shared Reviewable / All local switch and excluded-session count action.
+- `src/components/code-review-queue-controls.test.tsx`
+  - Accessible control behavior.
+
+### Modified files
+
+- `src/lib/types.ts`
+  - Add sanitized repository identity and familiar-workspace classification to
+    session rows.
+- `src/lib/session-git-enrich.ts`
+  - Resolve and normalize `remote.origin.url` through the existing bounded Git
+    runner.
+- `src/lib/session-git-enrich.test.ts`
+  - Cover GitHub, non-GitHub, malformed, and credential-bearing remotes.
+- `src/lib/familiar-workspace-sessions.ts`
+  - Add a pure annotation helper in addition to the existing collapse helper.
+- `src/lib/familiar-workspace-sessions.test.ts`
+  - Cover trusted annotation and relocated roots.
+- `src/lib/server/sessions-list.ts`
+  - Optionally annotate familiar-workspace membership.
+- `src/app/api/sessions/list/route.ts`
+  - Parse and cache the classification request.
+- `src/lib/server/sessions-list.test.ts`
+  - Prove route-facing classification is opt-in and read-only.
+- `src/components/workspace.tsx`
+  - Request classification for the shared live session list.
+- `src/lib/code-session-picker.ts`
+  - Consume precomputed review groups instead of independently filtering.
+- `src/lib/code-session-picker.test.ts`
+  - Prove picker and rail receive identical queue ordering.
+- `src/components/code-session-picker.tsx`
+  - Render the shared queue mode and compact repository-first rows.
+- `src/components/code-session-rail.tsx`
+  - Render the same model and queue controls.
+- `src/components/code-view.tsx`
+  - Own queue mode, simplify top-level navigation, preserve filtered deep-link
+    overrides, and add queue keyboard navigation.
+- `src/components/code-workbench.tsx`
+  - Pass queue state into the picker and use content-aware panel defaults.
+- `src/components/code-surface-mode.test.ts`
+  - Pin the simplified navigation and shared queue wiring.
+- `src/styles/globals/surface-code-room.css`
+  - Compact queue controls and rows using existing semantic tokens.
+- `tests/code-surface.spec.ts`
+  - Exercise default eligibility, All local, repository grouping, top-level
+    navigation, and deep-link overrides.
+- `scripts/run-tests.mjs`
+  - Register new unit/component tests.
+
+## Task 1: Add verified GitHub repository identity
+
+**Files:**
+- Modify: `src/lib/types.ts`
+- Modify: `src/lib/session-git-enrich.ts`
+- Modify: `src/lib/session-git-enrich.test.ts`
+
+- [ ] **Step 1: Write failing enrichment tests**
+
+Add `remote.origin.url` responses to `REPO_SCRIPT` and assert canonical identity:
+
+```ts
+const REPO_SCRIPT = {
+  "rev-parse --is-inside-work-tree": "true",
+  "branch --show-current": "feat/thing",
+  "rev-parse --show-toplevel": (root) => root,
+  "rev-parse --git-dir": ".git",
+  "rev-parse --git-common-dir": ".git",
+  "config --get remote.origin.url": "git@github.com:acme/repo-a.git",
+  "symbolic-ref --short refs/remotes/origin/HEAD": "origin/main",
+  "diff origin/main...feat/thing --shortstat":
+    " 3 files changed, 10 insertions(+), 2 deletions(-)",
+};
+
+assert.equal(rows[0].git.repositoryUrl, "https://github.com/acme/repo-a");
+```
+
+Add separate cases where the runner returns:
+
+```ts
+"https://token@github.com/acme/private.git"
+"https://gitlab.com/acme/repo-a.git"
+"not a remote"
+null
+```
+
+Each must leave `repositoryUrl` absent while preserving valid branch/worktree
+context.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+node --test --experimental-strip-types src/lib/session-git-enrich.test.ts
+```
+
+Expected: FAIL because `SessionGitContext` has no `repositoryUrl` and the
+enricher does not query `remote.origin.url`.
+
+- [ ] **Step 3: Add the typed field and bounded origin probe**
+
+In `src/lib/types.ts`:
+
+```ts
+export type SessionGitContext = {
+  branch?: string | null;
+  worktreeRoot?: string | null;
+  isWorktree?: boolean;
+  repositoryRoot?: string | null;
+  /** Canonical GitHub origin; absent for missing, malformed, credential-bearing, or non-GitHub remotes. */
+  repositoryUrl?: string | null;
+};
+```
+
+In `src/lib/session-git-enrich.ts`, import the existing sanitizer:
+
+```ts
+import { normalizeGitHubRepoUrl } from "./github-repo-link.ts";
+```
+
+Read the independent repository facts together:
+
+```ts
+const [currentBranch, worktreeRoot, gitDirRaw, commonDirRaw, originRemote] =
+  await Promise.all([
+    git(trimmed, ["branch", "--show-current"]),
+    git(trimmed, ["rev-parse", "--show-toplevel"]),
+    git(trimmed, ["rev-parse", "--git-dir"]),
+    git(trimmed, ["rev-parse", "--git-common-dir"]),
+    git(trimmed, ["config", "--get", "remote.origin.url"]),
+  ]);
+const repositoryUrl = normalizeGitHubRepoUrl(originRemote);
+```
+
+Return `repositoryUrl` only when normalization succeeds:
+
+```ts
+return {
+  branch,
+  worktreeRoot,
+  isWorktree,
+  ...(repositoryRoot ? { repositoryRoot } : {}),
+  ...(repositoryUrl ? { repositoryUrl } : {}),
+};
+```
+
+- [ ] **Step 4: Run focused validation**
+
+Run:
+
+```bash
+node --test --experimental-strip-types src/lib/session-git-enrich.test.ts
+pnpm typecheck
+```
+
+Expected: all enrichment tests pass and TypeScript reports no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/types.ts src/lib/session-git-enrich.ts src/lib/session-git-enrich.test.ts
+git commit -m "feat(code): identify GitHub repository sessions"
+```
+
+## Task 2: Classify familiar workspace sessions
+
+**Files:**
+- Modify: `src/lib/types.ts`
+- Modify: `src/lib/familiar-workspace-sessions.ts`
+- Modify: `src/lib/familiar-workspace-sessions.test.ts`
+- Modify: `src/lib/server/sessions-list.ts`
+- Modify: `src/app/api/sessions/list/route.ts`
+- Modify: `src/lib/server/sessions-list.test.ts`
+- Modify: `src/components/workspace.tsx`
+
+- [ ] **Step 1: Write failing pure classification tests**
+
+Add:
+
+```ts
+const classified = classifyFamiliarWorkspaceSessions(
+  [
+    row("workspace", `${WS_ROOT}/nova`),
+    row("relocated", "/opt/coven/nova-ws/notes"),
+    row("project", "/home/test/Documents/GitHub/acme/repo"),
+    row("rootless", ""),
+  ],
+  WS_ROOT,
+  ["/opt/coven/nova-ws"],
+);
+
+assert.deepEqual(
+  classified.map(({ id, familiarWorkspace }) => ({ id, familiarWorkspace })),
+  [
+    { id: "workspace", familiarWorkspace: true },
+    { id: "relocated", familiarWorkspace: true },
+    { id: "project", familiarWorkspace: false },
+    { id: "rootless", familiarWorkspace: false },
+  ],
+);
+```
+
+- [ ] **Step 2: Run the pure test and verify RED**
+
+Run:
+
+```bash
+node --test --experimental-strip-types src/lib/familiar-workspace-sessions.test.ts
+```
+
+Expected: FAIL because `classifyFamiliarWorkspaceSessions` does not exist.
+
+- [ ] **Step 3: Add the classification field and helper**
+
+In `SessionRow`:
+
+```ts
+/** Trusted server classification; true only for configured familiar workspace roots. */
+familiarWorkspace?: boolean;
+```
+
+In `familiar-workspace-sessions.ts`:
+
+```ts
+export function classifyFamiliarWorkspaceSessions(
+  sessions: SessionRow[],
+  familiarWorkspacesRoot: string,
+  declaredWorkspaceRoots: readonly string[] = [],
+): SessionRow[] {
+  const prefixes = normalizeFamiliarWorkspacePrefixes(
+    familiarWorkspacesRoot,
+    declaredWorkspaceRoots,
+  );
+  return sessions.map((session) => ({
+    ...session,
+    familiarWorkspace: matchesFamiliarWorkspacePrefix(
+      session.project_root,
+      prefixes,
+    ),
+  }));
+}
+```
+
+Refactor `collapseFamiliarWorkspaceSessions()` to call the same normalized
+prefix logic without changing its existing result.
+
+- [ ] **Step 4: Write failing sessions-list option tests**
+
+Extend `ComputeSessionsListOptions` test coverage to prove:
+
+```ts
+await computeSessionsList(false, "nova", false, {
+  classifyFamiliarWorkspace: true,
+});
+```
+
+returns `familiarWorkspace: true` for a configured familiar workspace and
+`false` for a project session, without invoking either archive sweep beyond the
+existing defaults.
+
+Also assert the route cache key differs between:
+
+```text
+active:nova:full:classified
+active:nova:full:unclassified
+```
+
+- [ ] **Step 5: Implement opt-in server classification**
+
+Extend the options:
+
+```ts
+export type ComputeSessionsListOptions = {
+  sweepArchives?: boolean;
+  enrichGit?: boolean;
+  classifyFamiliarWorkspace?: boolean;
+};
+```
+
+Add one helper in `sessions-list.ts`:
+
+```ts
+async function applyFamiliarWorkspaceClassification(
+  sessions: SessionRow[],
+  enabled: boolean,
+): Promise<SessionRow[]> {
+  if (!enabled) return sessions;
+  return classifyFamiliarWorkspaceSessions(
+    sessions,
+    familiarWorkspacesRoot(),
+    Array.from((await readFamiliarWorkspaces()).values()),
+  );
+}
+```
+
+Apply it after familiar scoping and before returning both normal and degraded
+payloads.
+
+Parse `classifyFamiliarWorkspace=1` in the route, include it in the cache key,
+and pass it through the options bag.
+
+- [ ] **Step 6: Request classification from Workspace**
+
+Replace the mutually exclusive query construction with:
+
+```ts
+const params = new URLSearchParams({ classifyFamiliarWorkspace: "1" });
+if (capturedActiveId) params.set("familiarId", capturedActiveId);
+else params.set("collapseFamiliarWorkspace", "1");
+const sessionsResult = await fetch(`/api/sessions/list?${params}`, {
+  cache: "no-store",
+});
+```
+
+This adds metadata to scoped views without changing global Chat visibility.
+
+- [ ] **Step 7: Run focused validation**
+
+Run:
+
+```bash
+node --test --experimental-strip-types \
+  src/lib/familiar-workspace-sessions.test.ts \
+  src/lib/server/sessions-list.test.ts
+pnpm typecheck
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/types.ts src/lib/familiar-workspace-sessions.ts \
+  src/lib/familiar-workspace-sessions.test.ts src/lib/server/sessions-list.ts \
+  src/app/api/sessions/list/route.ts src/lib/server/sessions-list.test.ts \
+  src/components/workspace.tsx
+git commit -m "feat(code): classify familiar workspace sessions"
+```
+
+## Task 3: Build the shared review queue model
+
+**Files:**
+- Create: `src/lib/code-review-queue.ts`
+- Create: `src/lib/code-review-queue.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write failing eligibility and ordering tests**
+
+Use a typed fixture with valid GitHub identity:
+
+```ts
+function reviewableRow(over: Partial<SessionRow> = {}): SessionRow {
+  return row({
+    project_root: "/repo/acme-app",
+    git: {
+      branch: "main",
+      worktreeRoot: "/repo/acme-app",
+      isWorktree: false,
+      repositoryUrl: "https://github.com/acme/app",
+    },
+    familiarWorkspace: false,
+    ...over,
+  });
+}
+```
+
+Assert Reviewable excludes:
+
+```ts
+archived_at !== null
+generated === true
+project_root === ""
+git == null
+git.repositoryUrl == null
+familiarWorkspace !== false
+```
+
+The last rule is deliberately fail-closed: missing trusted classification
+stays in All local.
+
+Assert linked worktrees remain eligible:
+
+```ts
+assert.equal(
+  codeSessionEligibility(
+    reviewableRow({
+      git: {
+        branch: "feat/a",
+        worktreeRoot: "/repo/app/.worktrees/a",
+        isWorktree: true,
+        repositoryRoot: "/repo/app",
+        repositoryUrl: "https://github.com/acme/app",
+      },
+    }),
+  ).reviewable,
+  true,
+);
+```
+
+Create rows for each priority and assert this order:
+
+```ts
+["failed", "open-pr-changed", "running", "changed-idle", "clean-idle"]
+```
+
+Assert repository groups use `acme/app`, sort by their best session, and the
+selected-session override includes an otherwise excluded deep-linked row with
+`outsideCurrentFilter: true`.
+
+- [ ] **Step 2: Run the model test and verify RED**
+
+Run:
+
+```bash
+node --test --experimental-strip-types src/lib/code-review-queue.test.ts
+```
+
+Expected: FAIL because the model does not exist.
+
+- [ ] **Step 3: Implement the pure model**
+
+Define:
+
+```ts
+export type CodeQueueMode = "reviewable" | "all";
+
+export type CodeSessionEligibility = {
+  reviewable: boolean;
+  reason:
+    | "eligible"
+    | "archived"
+    | "generated"
+    | "rootless"
+    | "unverified_git"
+    | "non_github"
+    | "workspace_unclassified"
+    | "familiar_workspace";
+};
+
+export type CodeReviewQueue = {
+  groups: CodeReviewGroup[];
+  sessions: SessionRow[];
+  reviewableCount: number;
+  allLocalCount: number;
+  excludedCount: number;
+  outsideCurrentFilter: boolean;
+};
+```
+
+Use `gitHubRepoSlug()` for Reviewable group labels and the existing project
+basename behavior for All local.
+
+Priority must be a pure numeric function:
+
+```ts
+function reviewPriority(row: SessionRow): number {
+  if (codeSessionActivity(row) === "error") return 0;
+  if (
+    row.pullRequest &&
+    (row.pullRequest.state ?? "open").toLowerCase() === "open" &&
+    codeSessionDiffstat(row)
+  ) return 1;
+  if (codeSessionActivity(row) === "running") return 2;
+  if (codeSessionDiffstat(row)) return 3;
+  return 4;
+}
+```
+
+Sort by priority, then descending `updated_at`, then stable `id`.
+
+- [ ] **Step 4: Preserve generic Code visibility without a dependency cycle**
+
+Import and call the existing `isCodeRailSession()` from the new queue model.
+Do not import `codeReviewQueue()` back into `code-surface.ts`; that would create
+a cycle because the queue also uses `codeSessionActivity()` and
+`codeSessionDiffstat()`.
+
+The All local branch begins with:
+
+```ts
+const allLocal = rows.filter(isCodeRailSession);
+const visible =
+  mode === "reviewable"
+    ? allLocal.filter((row) => codeSessionEligibility(row).reviewable)
+    : allLocal;
+```
+
+Existing `groupCodeRailSessions()` and its rootless-session tests remain
+unchanged for non-Desk callers.
+
+- [ ] **Step 5: Register and run tests**
+
+Add `src/lib/code-review-queue.test.ts` beside the other Code model tests in
+`scripts/run-tests.mjs`.
+
+Run:
+
+```bash
+node --test --experimental-strip-types \
+  src/lib/code-review-queue.test.ts
+pnpm check:tests-wired
+pnpm typecheck
+```
+
+Expected: all tests pass and the new test is wired.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/code-review-queue.ts src/lib/code-review-queue.test.ts \
+  scripts/run-tests.mjs
+git commit -m "feat(code): add review-first session queue"
+```
+
+## Task 4: Share queue controls between rail and picker
+
+**Files:**
+- Create: `src/components/code-review-queue-controls.tsx`
+- Create: `src/components/code-review-queue-controls.test.tsx`
+- Modify: `src/lib/code-session-picker.ts`
+- Modify: `src/lib/code-session-picker.test.ts`
+- Modify: `src/components/code-session-picker.tsx`
+- Modify: `src/components/code-session-rail.tsx`
+- Modify: `src/components/code-view.tsx`
+- Modify: `src/components/code-workbench.tsx`
+- Modify: `src/styles/globals/surface-code-room.css`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write failing control behavior tests**
+
+Render:
+
+```tsx
+<CodeReviewQueueControls
+  mode="reviewable"
+  reviewableCount={3}
+  allLocalCount={7}
+  onModeChange={onModeChange}
+/>
+```
+
+Assert:
+
+- `Reviewable 3` has `aria-pressed="true"`;
+- `All local 7` has `aria-pressed="false"`;
+- activating All local calls `onModeChange("all")`;
+- both buttons have accessible names without relying on icon color.
+
+- [ ] **Step 2: Run the component test and verify RED**
+
+Run:
+
+```bash
+node --test --experimental-strip-types src/components/code-review-queue-controls.test.tsx
+```
+
+Expected: FAIL because the component does not exist.
+
+- [ ] **Step 3: Implement the shared control**
+
+Use two compact buttons:
+
+```tsx
+export function CodeReviewQueueControls(props: CodeReviewQueueControlsProps) {
+  return (
+    <div className="code-queue-filter" role="group" aria-label="Session scope">
+      <button
+        type="button"
+        aria-pressed={props.mode === "reviewable"}
+        onClick={() => props.onModeChange("reviewable")}
+      >
+        Reviewable <span>{props.reviewableCount}</span>
+      </button>
+      <button
+        type="button"
+        aria-pressed={props.mode === "all"}
+        onClick={() => props.onModeChange("all")}
+      >
+        All local <span>{props.allLocalCount}</span>
+      </button>
+    </div>
+  );
+}
+```
+
+Use existing focus classes and semantic tokens. Do not add new palette values.
+
+- [ ] **Step 4: Make CodeView own queue state**
+
+Add:
+
+```ts
+const [queueMode, setQueueMode] = useState<CodeQueueMode>("reviewable");
+const queue = useMemo(
+  () => codeReviewQueue(sessions, queueMode, selectedId ?? deepLink?.sessionId ?? null),
+  [sessions, queueMode, selectedId, deepLink?.sessionId],
+);
+```
+
+Replace `groupCodeRailSessions(sessions)` with `queue.groups`, and use those
+same groups for auto-selection and pending-open resolution.
+
+Pass `queue`, `queueMode`, and `setQueueMode` to the rail and selected
+workbench. Do not persist `queueMode`.
+
+- [ ] **Step 5: Make picker and rail consume the same queue**
+
+Change both components to accept precomputed `CodeReviewQueue`. Neither
+component may call `groupCodeRailSessions()` or independently decide
+eligibility.
+
+The picker may still apply its text and repository-chip filters to
+`queue.sessions`, but it must preserve queue order.
+
+Render `CodeReviewQueueControls`:
+
+- at the top of the open rail;
+- below the search field in the picker.
+
+Add `data-code-session-search=""` to the picker input so the queue-level `/`
+shortcut has a stable, non-styling focus target.
+
+When `queue.outsideCurrentFilter` is true, render:
+
+```tsx
+<span className="code-queue-filter__notice">Outside current filter</span>
+```
+
+- [ ] **Step 6: Compact the row hierarchy**
+
+For open rail rows:
+
+```tsx
+<span className="code-session-row__title">{title}</span>
+<span className="code-session-row__meta">
+  {branch}
+  {diffstat}
+  {row.pullRequest ? <PrChip ... /> : null}
+  <span>{relativeTime(row.updated_at)}</span>
+</span>
+```
+
+Use one textual status treatment in the accessible name. Remove the open-row
+activity dot; retain a small state mark only in the collapsed icon rail where
+there is no room for text.
+
+- [ ] **Step 7: Update focused tests**
+
+Add picker-model parity assertions:
+
+```ts
+assert.deepEqual(
+  picker.groups.flatMap((group) => group.sessions.map((row) => row.id)),
+  queue.sessions.map((row) => row.id),
+);
+```
+
+Run:
+
+```bash
+node --test --experimental-strip-types \
+  src/components/code-review-queue-controls.test.tsx \
+  src/lib/code-session-picker.test.ts \
+  src/components/code-surface-mode.test.ts
+pnpm lint:design
+pnpm typecheck
+```
+
+Expected: all tests pass with no lint warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/code-review-queue-controls.tsx \
+  src/components/code-review-queue-controls.test.tsx \
+  src/lib/code-session-picker.ts src/lib/code-session-picker.test.ts \
+  src/components/code-session-picker.tsx src/components/code-session-rail.tsx \
+  src/components/code-view.tsx src/components/code-workbench.tsx \
+  src/styles/globals/surface-code-room.css scripts/run-tests.mjs
+git commit -m "feat(code): share review queue across the desk"
+```
+
+## Task 5: Simplify top-level navigation
+
+**Files:**
+- Modify: `src/components/code-view.tsx`
+- Modify: `src/components/code-surface-mode.test.ts`
+- Modify: `tests/code-surface.spec.ts`
+
+- [ ] **Step 1: Write failing navigation tests**
+
+Assert the top tablist exposes only:
+
+```text
+Review
+Work
+GitHub
+```
+
+When GitHub is selected, assert a secondary tablist named `GitHub filter`
+contains:
+
+```text
+Activity
+PRs
+Issues
+Reviews
+```
+
+Assert deep links with `ctab=prs`, `ctab=issues`, and `ctab=reviews` select the
+GitHub top-level tab and the corresponding secondary filter.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+node --test --experimental-strip-types src/components/code-surface-mode.test.ts
+pnpm exec playwright test tests/code-surface.spec.ts --project=chromium --grep "top tabs"
+```
+
+Expected: FAIL because six top-level tabs are still rendered.
+
+- [ ] **Step 3: Render three primary destinations**
+
+Keep the existing `CodeTopTab` values to preserve URL compatibility. Render:
+
+```tsx
+<PrimaryTab selected={topTab === "sessions"} onSelect={() => setTopTab("sessions")}>
+  Review
+</PrimaryTab>
+<PrimaryTab selected={topTab === "work"} onSelect={() => setTopTab("work")}>
+  Work
+</PrimaryTab>
+<PrimaryTab
+  selected={githubTab !== null}
+  onSelect={() => setTopTab(githubTab ?? "activity")}
+>
+  GitHub
+</PrimaryTab>
+```
+
+When `githubTab` is non-null, render the existing `CODE_GITHUB_TABS` as a
+secondary tablist and continue passing `GITHUB_TAB_FILTER[githubTab]` to
+`GitHubView`.
+
+- [ ] **Step 4: Preserve pending navigation**
+
+Do not change `topTabForNavigation()`, `parseCodeDeepLink()`, or
+`codeTopTabForGitHubTarget()`. Their existing values continue to select the
+secondary GitHub filter.
+
+- [ ] **Step 5: Run focused validation**
+
+Run:
+
+```bash
+node --test --experimental-strip-types src/components/code-surface-mode.test.ts
+pnpm exec playwright test tests/code-surface.spec.ts --project=chromium \
+  --grep "code surface|legacy GitHub mode"
+pnpm typecheck
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/code-view.tsx \
+  src/components/code-surface-mode.test.ts tests/code-surface.spec.ts
+git commit -m "refactor(code): simplify Coding Desk navigation"
+```
+
+## Task 6: Add content-aware panel defaults and queue keyboard flow
+
+**Files:**
+- Modify: `src/components/code-view.tsx`
+- Modify: `src/components/code-workbench.tsx`
+- Modify: `src/components/code-surface-mode.test.ts`
+- Modify: `tests/code-surface.spec.ts`
+
+- [ ] **Step 1: Write failing queue keyboard tests**
+
+In `code-surface-mode.test.ts`, assert `CodeView`:
+
+- imports the existing `isCodeShortcutTarget()` guard;
+- opens `.code-picker__trigger` and focuses `[data-code-session-search]` for
+  `/`;
+- moves DOM focus between `[data-code-session-id]` rows for `j` and `k`;
+- toggles Reviewable / All local for `Shift+A`;
+- returns before handling keys when `isCodeShortcutTarget()` rejects the
+  target.
+
+In Playwright, focus the queue, press `j`, `k`, and `Enter`, then assert the
+expected row opens. Focus the session-search input and assert typing `j`, `k`,
+and `/` changes the query rather than navigating.
+
+- [ ] **Step 2: Run keyboard tests and verify RED**
+
+Run:
+
+```bash
+node --test --experimental-strip-types src/components/code-surface-mode.test.ts
+pnpm exec playwright test tests/code-surface.spec.ts --project=chromium \
+  --grep "queue keyboard"
+```
+
+Expected: FAIL because CodeView has no queue-level keyboard handler.
+
+- [ ] **Step 3: Implement queue keyboard navigation**
+
+In `CodeView`, reuse `isCodeShortcutTarget()` and handle only unmodified `/`,
+`j`, `k`, plus `Shift+A`. Open the picker before focusing its search:
+
+```ts
+if (event.key === "/" && !event.metaKey && !event.ctrlKey && !event.altKey) {
+  event.preventDefault();
+  roomRef.current
+    ?.querySelector<HTMLButtonElement>(".code-picker__trigger")
+    ?.click();
+  requestAnimationFrame(() => {
+    roomRef.current
+      ?.querySelector<HTMLInputElement>("[data-code-session-search]")
+      ?.focus();
+  });
+} else if (event.key.toLowerCase() === "j" && !event.shiftKey) {
+  moveQueueFocus(1);
+} else if (event.key.toLowerCase() === "k" && !event.shiftKey) {
+  moveQueueFocus(-1);
+} else if (event.key.toLowerCase() === "a" && event.shiftKey) {
+  setQueueMode((mode) => (mode === "reviewable" ? "all" : "reviewable"));
+}
+```
+
+`moveQueueFocus()` queries visible `[data-code-session-id]` buttons, moves from
+the active row with wraparound, and calls `.focus()`. Rail rows retain native
+button Enter behavior, which uses the existing `onSelect()` path.
+
+- [ ] **Step 4: Write failing panel-default tests**
+
+Assert:
+
+- a clean session with no pull request initializes `railOpen` false;
+- a session with `diff` or an open pull request initializes `railOpen` true;
+- an explicit user toggle is remembered per session ID;
+- terminal open state is remembered per session ID;
+- routed file/diff navigation still overrides the stored state and opens the
+  required panel.
+
+- [ ] **Step 5: Implement per-session panel state**
+
+Use refs keyed by session ID:
+
+```ts
+const railOpenBySession = useRef(new Map<string, boolean>());
+const terminalOpenBySession = useRef(new Map<string, boolean>());
+
+function defaultRailOpen(session: SessionRow): boolean {
+  return Boolean(codeSessionDiffstat(session) || session.pullRequest);
+}
+```
+
+On session change, read the stored value or `defaultRailOpen(row)`. Every
+explicit rail/terminal toggle writes the current session's value. Existing
+routed-open effects remain authoritative.
+
+- [ ] **Step 6: Run focused validation**
+
+Run:
+
+```bash
+node --test --experimental-strip-types \
+  src/components/code-surface-mode.test.ts
+pnpm exec playwright test tests/code-surface.spec.ts --project=chromium \
+  --grep "queue|review rail|terminal"
+pnpm lint:design
+pnpm typecheck
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/code-view.tsx src/components/code-workbench.tsx \
+  src/components/code-surface-mode.test.ts tests/code-surface.spec.ts
+git commit -m "feat(code): streamline Coding Desk review flow"
+```
+
+## Task 7: End-to-end acceptance and documentation
+
+**Files:**
+- Modify: `tests/code-surface.spec.ts`
+- Modify: `docs/role-surfaces.md`
+- Modify: `docs/superpowers/specs/2026-09-01-review-first-coding-desk-design.md`
+
+- [ ] **Step 1: Add the complete E2E fixture matrix**
+
+Create sessions for:
+
+```ts
+const reviewable = mkSession({
+  id: "reviewable",
+  project_root: "/repo/alpha",
+  git: {
+    branch: "feat/alpha",
+    worktreeRoot: "/repo/alpha/.worktrees/alpha",
+    isWorktree: true,
+    repositoryRoot: "/repo/alpha",
+    repositoryUrl: "https://github.com/acme/alpha",
+  },
+  familiarWorkspace: false,
+});
+
+const familiarWorkspace = mkSession({
+  id: "workspace",
+  project_root: "/home/test/.coven/workspaces/familiars/nova",
+  familiarWorkspace: true,
+});
+
+const nonGithub = mkSession({
+  id: "gitlab",
+  project_root: "/repo/gitlab",
+  git: { branch: "main", isWorktree: false },
+  familiarWorkspace: false,
+});
+
+const rootless = mkSession({ id: "rootless", project_root: "" });
+```
+
+- [ ] **Step 2: Assert the default and explicit escape hatch**
+
+Verify:
+
+- only `reviewable` appears on initial load;
+- the repository heading is `acme/alpha`;
+- `All local` reveals workspace, non-GitHub, and rootless sessions;
+- returning to Reviewable hides them;
+- a deep link to `gitlab` opens it with `Outside current filter`;
+- reloading resets to Reviewable.
+
+- [ ] **Step 3: Update product documentation**
+
+Document in `docs/role-surfaces.md`:
+
+```md
+The Coding Desk opens in Reviewable mode. A reviewable session is active,
+human-created, outside configured familiar workspaces, inside a Git work tree,
+and attached to a canonical GitHub origin. All local sessions remain available
+through the explicit All local scope.
+```
+
+Update the design document only if implementation names differ; preserve every
+eligibility and fail-closed rule.
+
+- [ ] **Step 4: Run the complete targeted gate**
+
+Run:
+
+```bash
+pnpm check:tests-wired
+pnpm test:app
+pnpm exec playwright test tests/code-surface.spec.ts --project=chromium
+pnpm lint
+pnpm typecheck
+pnpm build
+git diff --check
+```
+
+Expected: every command succeeds with no new warnings.
+
+- [ ] **Step 5: Request code review**
+
+Review the full branch diff from `origin/main` through `HEAD`, specifically for:
+
+- sessions incorrectly hidden from All local;
+- non-GitHub or credential-bearing remotes entering Reviewable;
+- familiar-workspace classification bypass;
+- deep links that become unreachable;
+- keyboard handlers stealing input or terminal keys;
+- panel state leaking between sessions;
+- mobile/narrow layout regressions.
+
+- [ ] **Step 6: Commit acceptance updates**
+
+```bash
+git add tests/code-surface.spec.ts docs/role-surfaces.md \
+  docs/superpowers/specs/2026-09-01-review-first-coding-desk-design.md
+git commit -m "test(code): verify review-first Coding Desk"
+```
+
+## Completion criteria
+
+- Reviewable is the non-persisted default on every Coding Desk entry.
+- Reviewable contains only active, human-created sessions with trusted
+  non-workspace classification and canonical GitHub origin.
+- Linked Git worktrees remain visible.
+- All local preserves every session allowed by the previous generic Code
+  visibility rule.
+- Rail and picker use one queue result and cannot drift.
+- Review ordering reflects actionable state before recency.
+- Review, Work, and GitHub are the only primary destinations.
+- Existing GitHub deep links and pending file/diff navigation remain valid.
+- Empty panels do not consume full-width space by default.
+- Queue shortcuts never capture text-entry or terminal keystrokes.
+- Focused unit, E2E, lint, typecheck, and build gates pass.

--- a/docs/superpowers/specs/2026-09-01-review-first-coding-desk-design.md
+++ b/docs/superpowers/specs/2026-09-01-review-first-coding-desk-design.md
@@ -1,0 +1,207 @@
+# Review-First Coding Desk Design
+
+**Date:** 2026-09-01
+
+## Goal
+
+Make the Coding Desk a minimal, review-oriented workspace that answers three
+questions immediately:
+
+1. Which repository sessions need attention?
+2. What changed in the selected session?
+3. What is the next useful action?
+
+The default session queue must contain only human-created, active sessions that
+are outside familiar workspaces and are attached to a verified GitHub
+repository. Other local sessions remain reachable through an explicit
+secondary filter.
+
+## Current problems
+
+- `isCodeRailSession()` excludes only archived and generated sessions, so
+  rootless folders, non-Git repositories, non-GitHub repositories, and familiar
+  workspace sessions can enter the Desk.
+- The top bar exposes six equal-weight destinations: Sessions, Work, Activity,
+  PRs, Issues, and Reviews. This makes the primary review workflow compete with
+  secondary GitHub browsing.
+- Session rows optimize for recency and repeat status through both a dot and a
+  word, but do not prioritize failures, open pull requests, or changed work.
+- The session rail and header picker use related but independently assembled
+  lists, making filtering and ordering liable to drift.
+- File, review, and terminal panels can all consume space even when they have
+  no actionable content.
+
+## Definitions
+
+### Familiar workspace
+
+A path equal to or nested under the configured familiar workspace roots,
+including the default `~/.coven/workspaces/familiars/*` tree and relocated
+workspace roots from familiar configuration.
+
+Linked Git worktrees are not familiar workspaces. They are valid repository
+work and remain eligible.
+
+### Verified GitHub repository session
+
+A session is verified when all of the following are true:
+
+- it is not archived;
+- it is not generator-created;
+- its project root exists and Git confirms it is inside a work tree;
+- its `remote.origin.url` normalizes through `normalizeGitHubRepoUrl()` to
+  `https://github.com/{owner}/{repo}`;
+- its project root is not inside a familiar workspace.
+
+A non-empty `project_root`, branch name, pull-request URL, or generic Git
+context is not sufficient proof by itself.
+
+## Information architecture
+
+The top-level Desk navigation becomes:
+
+- **Review** — the default repository-session queue and selected workbench;
+- **Work** — scheduled and queued work;
+- **GitHub** — activity, pull requests, issues, and review requests.
+
+The current Activity, PRs, Issues, and Reviews destinations become secondary
+filters inside GitHub. Deep links continue to resolve to their equivalent
+GitHub filter.
+
+## Session queue
+
+### Modes
+
+The queue has two modes:
+
+- **Reviewable** — default; only verified GitHub repository sessions outside
+  familiar workspaces.
+- **All local** — explicit opt-in; every current session accepted by the
+  existing archived/generated visibility posture.
+
+The mode is shared by the rail and session picker. It is not silently persisted
+across devices. Opening the Desk starts in Reviewable mode.
+
+When sessions are excluded, the queue header may show a muted count such as
+`7 other local` that switches to All local. Excluded paths and remote URLs are
+never exposed in the count or empty state.
+
+### Ordering
+
+Reviewable sessions sort by actionable state before recency:
+
+1. failed;
+2. open pull request with changes;
+3. running;
+4. changed and idle;
+5. clean idle.
+
+Rows remain grouped by GitHub repository. Repository groups sort by the highest
+priority session they contain, then by newest update. Sessions within a group
+use the same priority and recency ordering.
+
+### Row hierarchy
+
+Each compact row contains:
+
+- primary: session title;
+- secondary: branch, when attributable to that session;
+- trailing signals: pull-request number, diffstat or changed-file count, and
+  relative update time;
+- one accessible status treatment, not a redundant dot plus status word.
+
+Repository identity belongs in the group heading as `owner/repo`, avoiding
+repetition on every row.
+
+## Repository evidence
+
+`SessionGitContext` gains a canonical, optional `repositoryUrl`. Git enrichment
+reads `remote.origin.url` through the existing bounded `GitRunner` and accepts
+it only after `normalizeGitHubRepoUrl()` succeeds.
+
+The server also classifies familiar-workspace membership from trusted local
+configuration and returns a boolean session field. The browser never infers
+familiar workspace membership from string fragments or a hard-coded home path.
+
+The pure Coding Desk model derives:
+
+- whether a session is reviewable;
+- why it is excluded;
+- repository grouping;
+- actionable priority;
+- Reviewable and All local counts.
+
+This model is the single source used by both the rail and header picker.
+
+## Workbench chrome
+
+- Source remains the visual center.
+- The review rail opens automatically only when the selected session has
+  changes or a pull request; otherwise it starts as the existing narrow spine.
+- The terminal starts as its compact bottom bar and retains the user's explicit
+  open state per session.
+- Empty review, pull-request, and inspector content does not reserve a full
+  column.
+- Pane widths continue to use existing resizable primitives and semantic
+  tokens.
+
+## Keyboard and focus
+
+- `/` focuses session search when the queue or workbench is active.
+- `J` and `K` move through visible sessions while focus is outside text input.
+- `Enter` opens the focused session.
+- A dedicated shortcut toggles Reviewable and All local.
+- Existing deep-link and pending-file navigation still select an otherwise
+  excluded session for that navigation only, with an `Outside current filter`
+  indicator. Direct navigation must never appear broken because of the default
+  filter.
+
+## Empty and degraded states
+
+- No reviewable sessions: `No GitHub repository sessions need review.`
+- Git is unavailable or times out: the session is excluded from Reviewable and
+  remains available in All local.
+- Origin is absent, malformed, credential-bearing, or non-GitHub: exclude from
+  Reviewable without rendering the raw remote.
+- Familiar workspace classification fails: fail closed for Reviewable and keep
+  the session in All local.
+- A selected session becomes ineligible after refresh: keep it mounted until
+  the user changes selection, then return to the filtered queue.
+
+## Accessibility
+
+- Reviewable and All local use a labeled single-select control with counts.
+- Status is conveyed by text and accessible names, not color alone.
+- Group headings identify repository boundaries.
+- Keyboard navigation follows DOM order and preserves visible focus.
+- Compact rows retain the existing minimum pointer target.
+
+## Validation
+
+### Unit coverage
+
+- GitHub and non-GitHub origin normalization;
+- familiar workspace exclusion, including relocated roots;
+- linked worktree inclusion;
+- rootless, missing, archived, and generated exclusions;
+- actionable sorting and repository grouping;
+- picker and rail parity;
+- deep-link override behavior.
+
+### Integration coverage
+
+- the default Desk shows only Reviewable sessions;
+- All local reveals excluded sessions without changing global chat visibility;
+- GitHub subfilters preserve existing Activity, PR, Issue, and Review behavior;
+- narrow layouts remain list-first;
+- review rail and terminal defaults respond to selected-session content;
+- keyboard search and queue traversal work without stealing text-input keys.
+
+## Non-goals
+
+- Deleting or archiving excluded sessions.
+- Treating every Git repository as a GitHub repository.
+- Excluding linked Git worktrees.
+- Changing global chat session visibility.
+- Replacing the existing source, diff, terminal, or GitHub readers.
+- Adding a new repository registry or background filesystem crawler.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -2460,6 +2460,7 @@ const VITEST_TESTS = new Set([
   "src/components/project-picker-focus.test.tsx",
   "src/components/project-root-workspace-notice.behavior.test.tsx",
   "src/components/code-session-picker.test.tsx",
+  "src/components/code-shortcuts-dialog.test.tsx",
   // rendered JSX for the shared reviewable/all queue scope control
   "src/components/code-review-queue-controls.test.tsx",
   "src/components/streaming-turn-response.test.tsx",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -917,6 +917,7 @@ export const SUITES = {
     "src/components/code-editor.test.ts",
     "src/components/code-surface-mode.test.ts",
     "src/lib/code-surface.test.ts",
+    "src/lib/code-review-queue.test.ts",
     "src/lib/code-session-picker.test.ts",
     "src/lib/code-outline.test.ts",
     "src/lib/code-side-rail.test.ts",
@@ -2147,6 +2148,9 @@ const ALIAS_LOADER = new Set([
   "src/lib/cave-board-retention.test.ts",
   // same reason: the idempotence suite loads cave-board.ts directly.
   "src/lib/cave-board-backfill-idempotence.test.ts",
+  // the queue imports github-repo-link.ts and code-surface.ts through "@/lib"
+  // aliases, so the resolver must be loaded before the module graph can link.
+  "src/lib/code-review-queue.test.ts",
   // the picker imports the module under test, which resolves
   // "@/lib/code-surface" for the shared session-visibility rule.
   "src/lib/code-session-picker.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -918,6 +918,7 @@ export const SUITES = {
     "src/components/code-editor.test.ts",
     "src/components/code-surface-mode.test.ts",
     "src/components/code-review-queue-controls.test.tsx",
+    "src/components/code-session-picker.test.tsx",
     "src/lib/code-surface.test.ts",
     "src/lib/code-review-queue.test.ts",
     "src/lib/code-session-picker.test.ts",
@@ -2458,6 +2459,7 @@ const VITEST_TESTS = new Set([
   "src/components/auto-status-card.test.tsx",
   "src/components/project-picker-focus.test.tsx",
   "src/components/project-root-workspace-notice.behavior.test.tsx",
+  "src/components/code-session-picker.test.tsx",
   // rendered JSX for the shared reviewable/all queue scope control
   "src/components/code-review-queue-controls.test.tsx",
   "src/components/streaming-turn-response.test.tsx",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -916,6 +916,7 @@ export const SUITES = {
     "src/components/session-changes-inner.test.ts",
     "src/components/code-editor.test.ts",
     "src/components/code-surface-mode.test.ts",
+    "src/components/code-review-queue-controls.test.tsx",
     "src/lib/code-surface.test.ts",
     "src/lib/code-review-queue.test.ts",
     "src/lib/code-session-picker.test.ts",
@@ -2148,12 +2149,6 @@ const ALIAS_LOADER = new Set([
   "src/lib/cave-board-retention.test.ts",
   // same reason: the idempotence suite loads cave-board.ts directly.
   "src/lib/cave-board-backfill-idempotence.test.ts",
-  // the queue imports github-repo-link.ts and code-surface.ts through "@/lib"
-  // aliases, so the resolver must be loaded before the module graph can link.
-  "src/lib/code-review-queue.test.ts",
-  // the picker imports the module under test, which resolves
-  // "@/lib/code-surface" for the shared session-visibility rule.
-  "src/lib/code-session-picker.test.ts",
   // the session-finished emit test loads session-finished-inbox-emit.ts,
   // which resolves "@/lib/cave-inbox", "@/lib/cave-config" and friends as
   // runtime values; the suite cannot load without the alias resolver.
@@ -2462,6 +2457,8 @@ const VITEST_TESTS = new Set([
   "src/components/auto-status-card.test.tsx",
   "src/components/project-picker-focus.test.tsx",
   "src/components/project-root-workspace-notice.behavior.test.tsx",
+  // rendered JSX for the shared reviewable/all queue scope control
+  "src/components/code-review-queue-controls.test.tsx",
   "src/components/streaming-turn-response.test.tsx",
   "src/components/settings-client-access.test.tsx",
   "src/components/settings-save-feedback.behavior.test.tsx",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -108,6 +108,7 @@ export const SUITES = {
     "src/lib/board-cache-events.test.ts",
     "src/lib/surface-warmup-registry.test.ts",
     "src/components/workspace-surface-warmup.test.ts",
+    "src/components/code-shortcuts-dialog.test.tsx",
     "src/components/workspace-canonical-memory-warmup.test.ts",
     "src/components/workspace-canonical-memory-navigation.test.ts",
     "src/components/workspace-canonical-memory-navigation-behavior.test.tsx",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -32,6 +32,7 @@ export const SUITES = {
     "src/lib/native-notify.test.ts",
     "src/lib/session-list-equal.test.ts",
     "src/lib/familiar-workspace-sessions.test.ts",
+    "src/components/code-work-scheduler.test.ts",
     "src/lib/session-list-deletes.test.ts",
     "src/lib/use-undo-delete-deferred.test.ts",
     "src/lib/tool-edit-stat.test.ts",

--- a/src/app/api/sessions/list/route.test.ts
+++ b/src/app/api/sessions/list/route.test.ts
@@ -24,36 +24,50 @@ assert.match(
 
 assert.match(
   source,
+  /classifyFamiliarWorkspace\s*=\s*\n?\s*url\.searchParams\.get\("classifyFamiliarWorkspace"\)\s*===\s*"1"/,
+  "the list route parses the opt-in classifyFamiliarWorkspace query param",
+);
+
+assert.match(
+  source,
   /cacheKey\s*=[\s\S]{0,160}collapseFamiliarWorkspace\s*\?\s*"collapse"\s*:\s*"full"/,
   "the cache key varies by collapse mode so full and collapsed views never alias",
 );
 
 assert.match(
   source,
-  /computeSessionsList\(includeArchived,\s*familiarId,\s*collapseFamiliarWorkspace\)/,
-  "the collapse flag is threaded into computeSessionsList",
-);
-
-// No options argument: the route must keep the auto-archive sweeps and git
-// enrichment it has always run. The dashboard read is the caller that opts out,
-// and this pins the route to the default so the extraction cannot quietly
-// disable the sweeps for the poll that is the only thing driving them.
-assert.doesNotMatch(
-  source,
-  /computeSessionsList\([^)]*sweepArchives/,
-  "the list route uses default compute options (sweeps and git enrichment on)",
+  /cacheKey\s*=[\s\S]{0,220}classifyFamiliarWorkspace\s*\?\s*"classified"\s*:\s*"unclassified"/,
+  "the cache key varies by classification mode so metadata-bearing and plain views never alias",
 );
 
 assert.match(
+  source,
+  /computeSessionsList\(\s*includeArchived,\s*familiarId,\s*collapseFamiliarWorkspace,\s*\{\s*classifyFamiliarWorkspace\s*\}\s*\)/,
+  "the collapse and classification flags are threaded into computeSessionsList",
+);
+
+// The route now passes only the classification option. Sweeps and git
+// enrichment still rely on computeSessionsList's defaults — the dashboard read
+// is the caller that opts those out, and this pins the route to not override
+// them while still forwarding classification.
+assert.match(
+  source,
+  /computeSessionsList\([\s\S]{0,120}\{\s*classifyFamiliarWorkspace\s*\}\s*\)/,
+  "the list route passes only the classification compute option",
+);
+assert.doesNotMatch(source, /sweepArchives\s*:/, "the list route leaves archive sweeps on by default");
+assert.doesNotMatch(source, /enrichGit\s*:/, "the list route leaves git enrichment on by default");
+
+assert.match(
   helper,
-  /if \(!collapseFamiliarWorkspace\) return sessions;/,
-  "the collapse helper is a no-op (and skips the FS read) when the flag is off",
+  /if \(!collapseFamiliarWorkspace && !classifyFamiliarWorkspace\) return null;/,
+  "the familiar-workspace roots loader is a no-op (and skips the FS read) when both flags are off",
 );
 
 assert.equal(
-  (helper.match(/applyFamiliarWorkspaceCollapse\(/g) || []).length,
+  (helper.match(/applyFamiliarWorkspacePresentation\(/g) || []).length,
   3,
-  "applyFamiliarWorkspaceCollapse is defined once and called in BOTH the happy and degraded paths",
+  "applyFamiliarWorkspacePresentation is defined once and called in BOTH the happy and degraded paths",
 );
 
 assert.match(

--- a/src/app/api/sessions/list/route.ts
+++ b/src/app/api/sessions/list/route.ts
@@ -15,23 +15,27 @@ export const dynamic = "force-dynamic";
 // handlers, and session mutators must be able to bust the cache so
 // post-mutation refreshes never serve the pre-mutation list.
 //
-// No options are passed to computeSessionsList: this route keeps the default
-// behaviour it has always had, auto-archive sweeps and git enrichment included.
+// The route forwards only the opt-in familiar-workspace metadata toggle.
+// Auto-archive sweeps and git enrichment still come from computeSessionsList's
+// defaults, preserving the polling behaviour this route has always owned.
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const includeArchived = url.searchParams.get("includeArchived") === "1";
   const familiarId = url.searchParams.get("familiarId")?.trim() || null;
   const collapseFamiliarWorkspace =
     url.searchParams.get("collapseFamiliarWorkspace") === "1";
+  const classifyFamiliarWorkspace =
+    url.searchParams.get("classifyFamiliarWorkspace") === "1";
   if (familiarId && !isValidFamiliarId(familiarId)) {
     return NextResponse.json({ ok: false, error: "invalid familiar id", sessions: [] }, { status: 400 });
   }
-  // Cache per (archived, familiar, collapse) — each view differs by its result set.
+  // Cache per (archived, familiar, collapse, classification) — these views
+  // differ both by membership and by whether trusted familiar metadata is present.
   const cacheKey = `${includeArchived ? "archived" : "active"}:${familiarId ?? "all"}:${
     collapseFamiliarWorkspace ? "collapse" : "full"
-  }`;
+  }:${classifyFamiliarWorkspace ? "classified" : "unclassified"}`;
   const result = await sessionsListCache.get(cacheKey, () =>
-    computeSessionsList(includeArchived, familiarId, collapseFamiliarWorkspace),
+    computeSessionsList(includeArchived, familiarId, collapseFamiliarWorkspace, { classifyFamiliarWorkspace }),
   );
   return NextResponse.json(result.payload, result.init);
 }

--- a/src/components/code-review-queue-controls.test.tsx
+++ b/src/components/code-review-queue-controls.test.tsx
@@ -1,0 +1,79 @@
+// @ts-nocheck — react-test-renderer ships no types; rendered control behavior test.
+import { act, create } from "react-test-renderer";
+import { expect, test, vi } from "vitest";
+
+import { CodeReviewQueueControls } from "./code-review-queue-controls";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function textContent(node: unknown): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textContent).join("");
+  if (node && typeof node === "object" && "children" in node) {
+    return textContent((node as { children: unknown }).children);
+  }
+  return "";
+}
+
+function findButton(renderer: ReturnType<typeof create>, label: string) {
+  return renderer.root.find(
+    (node) => node.type === "button" && textContent(node.children).includes(label),
+  );
+}
+
+test("renders compact Session scope controls with counts, pressed state, and the outside-filter notice", async () => {
+  let renderer;
+  await act(async () => {
+    renderer = create(
+      <CodeReviewQueueControls
+        mode="reviewable"
+        reviewableCount={3}
+        allLocalCount={8}
+        outsideCurrentFilter
+        onModeChange={() => {}}
+      />,
+    );
+  });
+
+  const scope = renderer.root.findByProps({ role: "group", "aria-label": "Session scope" });
+  expect(textContent(scope.children)).toContain("Reviewable");
+  expect(textContent(scope.children)).toContain("3");
+  expect(textContent(scope.children)).toContain("All local");
+  expect(textContent(scope.children)).toContain("8");
+
+  const reviewable = findButton(renderer, "Reviewable");
+  const allLocal = findButton(renderer, "All local");
+  expect(reviewable.props["aria-pressed"]).toBe(true);
+  expect(allLocal.props["aria-pressed"]).toBe(false);
+
+  const notice = renderer.root.findByProps({ className: "code-queue-filter__notice" });
+  expect(textContent(notice.children)).toBe("Outside current filter");
+
+  await act(async () => renderer.unmount());
+});
+
+test("clicking the controls emits the requested queue mode", async () => {
+  const onModeChange = vi.fn();
+  let renderer;
+  await act(async () => {
+    renderer = create(
+      <CodeReviewQueueControls
+        mode="all"
+        reviewableCount={2}
+        allLocalCount={5}
+        onModeChange={onModeChange}
+      />,
+    );
+  });
+
+  const reviewable = findButton(renderer, "Reviewable");
+  const allLocal = findButton(renderer, "All local");
+
+  await act(async () => reviewable.props.onClick());
+  await act(async () => allLocal.props.onClick());
+
+  expect(onModeChange).toHaveBeenNthCalledWith(1, "reviewable");
+  expect(onModeChange).toHaveBeenNthCalledWith(2, "all");
+
+  await act(async () => renderer.unmount());
+});

--- a/src/components/code-review-queue-controls.tsx
+++ b/src/components/code-review-queue-controls.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { CodeQueueMode } from "../lib/code-review-queue";
+
+const OPTIONS: ReadonlyArray<{
+  id: CodeQueueMode;
+  label: string;
+  countKey: "reviewableCount" | "allLocalCount";
+}> = [
+  { id: "reviewable", label: "Reviewable", countKey: "reviewableCount" },
+  { id: "all", label: "All local", countKey: "allLocalCount" },
+];
+
+export type CodeReviewQueueControlsProps = {
+  mode: CodeQueueMode;
+  reviewableCount: number;
+  allLocalCount: number;
+  outsideCurrentFilter?: boolean;
+  onModeChange: (mode: CodeQueueMode) => void;
+};
+
+export function CodeReviewQueueControls({
+  mode,
+  reviewableCount,
+  allLocalCount,
+  outsideCurrentFilter = false,
+  onModeChange,
+}: CodeReviewQueueControlsProps) {
+  const counts = { reviewableCount, allLocalCount };
+
+  return (
+    <div className="code-queue-filter">
+      <div role="group" aria-label="Session scope" className="code-queue-filter__group">
+        {OPTIONS.map((option) => {
+          const on = mode === option.id;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              aria-pressed={on}
+              className="focus-ring code-queue-filter__button"
+              data-on={on ? "true" : undefined}
+              onClick={() => onModeChange(option.id)}
+            >
+              <span className="code-queue-filter__label">{option.label}</span>
+              <span className="code-queue-filter__count">{counts[option.countKey]}</span>
+            </button>
+          );
+        })}
+      </div>
+      {outsideCurrentFilter ? (
+        <p className="code-queue-filter__notice">Outside current filter</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/code-session-picker.test.tsx
+++ b/src/components/code-session-picker.test.tsx
@@ -62,6 +62,14 @@ const QUEUE = {
 
 QUEUE.groups[0].sessions = QUEUE.sessions;
 
+const EMPTY_REVIEWABLE_QUEUE = {
+  reviewableCount: 0,
+  allLocalCount: 4,
+  outsideCurrentFilter: false,
+  sessions: [],
+  groups: [],
+};
+
 describe("CodeSessionPicker neutral landing trigger", () => {
   test("renders Search sessions with no selected session, keeps queue controls, and filters typed queries", async () => {
     const onCreate = vi.fn();
@@ -105,6 +113,38 @@ describe("CodeSessionPicker neutral landing trigger", () => {
     await act(async () => input.props.onKeyDown({ key: "Enter", preventDefault() {} }));
 
     expect(onCreate).toHaveBeenCalledWith("Brand new session");
+
+    await act(async () => renderer.unmount());
+  });
+
+  test("renders the approved reviewable empty copy after opening an empty picker", async () => {
+    let renderer;
+    await act(async () => {
+      renderer = create(
+        <CodeSessionPicker
+          queue={EMPTY_REVIEWABLE_QUEUE}
+          mode="reviewable"
+          selected={null}
+          onModeChange={() => {}}
+          onSelect={() => {}}
+        />,
+      );
+    });
+
+    const trigger = renderer.root.find(
+      (node) => node.type === "button" && node.props.className === "focus-ring code-picker__trigger",
+    );
+
+    await act(async () => trigger.props.onClick());
+
+    const empty = renderer.root.find(
+      (node) =>
+        node.type === "p" &&
+        node.props.className === "code-picker__empty-text" &&
+        textContent(node.children) === "No GitHub repository sessions need review.",
+    );
+    expect(textContent(empty.children)).toBe("No GitHub repository sessions need review.");
+    expect(textContent(renderer.toJSON())).not.toContain("No reviewable sessions match this scope.");
 
     await act(async () => renderer.unmount());
   });

--- a/src/components/code-session-picker.test.tsx
+++ b/src/components/code-session-picker.test.tsx
@@ -1,0 +1,111 @@
+// @ts-nocheck — react-test-renderer ships no types; rendered picker behavior test.
+import { act, create } from "react-test-renderer";
+import { describe, expect, test, vi } from "vitest";
+
+import { CodeSessionPicker } from "./code-session-picker";
+
+vi.mock("@/lib/icon", () => ({ Icon: () => null }));
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({
+    open,
+    ariaLabel,
+    children,
+  }: {
+    open: boolean;
+    ariaLabel?: string;
+    children: unknown;
+  }) => (open ? <div role="dialog" aria-label={ariaLabel}>{children}</div> : null),
+  usePopoverInitialFocus: () => {},
+}));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function textContent(node: unknown): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textContent).join("");
+  if (node && typeof node === "object" && "children" in node) {
+    return textContent((node as { children: unknown }).children);
+  }
+  return "";
+}
+
+const QUEUE = {
+  reviewableCount: 2,
+  allLocalCount: 3,
+  outsideCurrentFilter: true,
+  sessions: [
+    {
+      id: "s-new",
+      title: "Wire the flux capacitor",
+      project_root: "/repo/alpha",
+      updated_at: "2026-08-08T10:00:00.000Z",
+      status: "running",
+      git: { branch: "feat/flux", repositoryUrl: "https://github.com/acme/alpha" },
+    },
+    {
+      id: "s-local",
+      title: "Scratchpad session",
+      project_root: "/repo/alpha",
+      updated_at: "2026-08-08T09:00:00.000Z",
+      status: "idle",
+      git: { branch: "scratch/local", repositoryUrl: "https://github.com/acme/alpha" },
+    },
+  ],
+  groups: [
+    {
+      key: "repo:alpha",
+      label: "acme/alpha",
+      sessions: [],
+    },
+  ],
+};
+
+QUEUE.groups[0].sessions = QUEUE.sessions;
+
+describe("CodeSessionPicker neutral landing trigger", () => {
+  test("renders Search sessions with no selected session, keeps queue controls, and filters typed queries", async () => {
+    const onCreate = vi.fn();
+    let renderer;
+    await act(async () => {
+      renderer = create(
+        <CodeSessionPicker
+          queue={QUEUE}
+          mode="reviewable"
+          selected={null}
+          onModeChange={() => {}}
+          onSelect={() => {}}
+          onCreate={onCreate}
+        />,
+      );
+    });
+
+    const trigger = renderer.root.find(
+      (node) => node.type === "button" && node.props.className === "focus-ring code-picker__trigger",
+    );
+    expect(textContent(trigger.children)).toContain("Search sessions");
+
+    await act(async () => trigger.props.onClick());
+
+    expect(textContent(renderer.toJSON())).toContain("Outside current filter");
+
+    const rowsBefore = renderer.root.findAll(
+      (node) => node.type === "button" && typeof node.props["data-code-session-id"] === "string",
+    );
+    expect(rowsBefore.every((row) => row.props["aria-selected"] === false)).toBe(true);
+
+    const input = renderer.root.findByProps({ "data-code-session-search": "" });
+    await act(async () => input.props.onChange({ target: { value: "Scratch" } }));
+
+    const rowsAfterFilter = renderer.root.findAll(
+      (node) => node.type === "button" && typeof node.props["data-code-session-id"] === "string",
+    );
+    expect(rowsAfterFilter.map((row) => row.props["data-code-session-id"])).toEqual(["s-local"]);
+
+    await act(async () => input.props.onChange({ target: { value: "Brand new session" } }));
+    await act(async () => input.props.onKeyDown({ key: "Enter", preventDefault() {} }));
+
+    expect(onCreate).toHaveBeenCalledWith("Brand new session");
+
+    await act(async () => renderer.unmount());
+  });
+});

--- a/src/components/code-session-picker.tsx
+++ b/src/components/code-session-picker.tsx
@@ -5,8 +5,9 @@
  *
  * The `Cody Code Reading v2` frame replaces the permanently-docked session rail
  * with a header control: the current session's name in a button, opening a
- * filterable list grouped by project. The room gets the rail's width back and
- * the switch becomes an explicit act rather than an always-on column.
+ * filterable list from the same precomputed queue the rail uses. The room gets
+ * the rail's width back and the switch becomes an explicit act rather than an
+ * always-on column.
  *
  * The filter searches title, project and branch (`code-session-picker.ts`), and
  * a miss is not a dead end — Enter on an unmatched query offers to start a
@@ -15,6 +16,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { CodeReviewQueueControls } from "@/components/code-review-queue-controls";
 import { Icon } from "@/lib/icon";
 import { Popover, usePopoverInitialFocus } from "@/components/ui/popover";
 import { relativeTime } from "@/lib/relative-time";
@@ -22,6 +24,7 @@ import {
   codeSessionPickerResult,
   type CodeSessionPickerChip,
 } from "@/lib/code-session-picker";
+import type { CodeQueueMode, CodeReviewQueue } from "@/lib/code-review-queue";
 import { codeSessionActivity, codeSessionBranch } from "@/lib/code-surface";
 import type { SessionRow } from "@/lib/types";
 
@@ -68,8 +71,10 @@ function SessionRowButton({
 }
 
 export type CodeSessionPickerProps = {
-  sessions: SessionRow[];
+  queue: CodeReviewQueue;
+  mode: CodeQueueMode;
   selected: SessionRow;
+  onModeChange: (mode: CodeQueueMode) => void;
   onSelect: (sessionId: string) => void;
   /**
    * Start a new session from an unmatched query — the frame's Enter path. The
@@ -80,14 +85,16 @@ export type CodeSessionPickerProps = {
 };
 
 export function CodeSessionPicker({
-  sessions,
+  queue,
+  mode,
   selected,
+  onModeChange,
   onSelect,
   onCreate,
 }: CodeSessionPickerProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [project, setProject] = useState<string | null>(null);
+  const [groupKey, setGroupKey] = useState<string | null>(null);
   const anchorRef = useRef<HTMLButtonElement | null>(null);
 
   // Reopening with the last search still applied reads as missing sessions, so
@@ -95,15 +102,15 @@ export function CodeSessionPicker({
   useEffect(() => {
     if (!open) {
       setQuery("");
-      setProject(null);
+      setGroupKey(null);
     }
   }, [open]);
 
   usePopoverInitialFocus(open, "[data-code-picker-panel]");
 
   const result = useMemo(
-    () => codeSessionPickerResult(sessions, query, project),
-    [project, query, sessions],
+    () => codeSessionPickerResult(queue, query, groupKey),
+    [groupKey, query, queue],
   );
 
   const pick = useCallback(
@@ -136,7 +143,7 @@ export function CodeSessionPicker({
   );
 
   const chipButton = (chip: CodeSessionPickerChip) => {
-    const on = chip.root === project || (chip.root === null && project === null);
+    const on = chip.key === groupKey || (chip.key === null && groupKey === null);
     return (
       <button
         key={chip.id}
@@ -144,7 +151,7 @@ export function CodeSessionPicker({
         aria-pressed={on}
         className="focus-ring code-picker__chip"
         data-on={on ? "true" : undefined}
-        onClick={() => setProject(chip.root)}
+        onClick={() => setGroupKey(chip.key)}
       >
         {chip.label}
         <span className="code-picker__chip-count">{chip.count}</span>
@@ -185,6 +192,7 @@ export function CodeSessionPicker({
               placeholder="Search sessions…"
               aria-label="Search sessions by title, project or branch"
               className="code-picker__search-input"
+              data-code-session-search=""
             />
             {query ? (
               <button
@@ -197,12 +205,22 @@ export function CodeSessionPicker({
               </button>
             ) : null}
           </div>
+          <CodeReviewQueueControls
+            mode={mode}
+            reviewableCount={queue.reviewableCount}
+            allLocalCount={queue.allLocalCount}
+            outsideCurrentFilter={queue.outsideCurrentFilter}
+            onModeChange={(next) => {
+              setGroupKey(null);
+              onModeChange(next);
+            }}
+          />
           {result.chips.length > 1 ? (
             <div className="code-picker__chips">{result.chips.map(chipButton)}</div>
           ) : null}
           <div className="code-picker__list" role="listbox" aria-label="Sessions">
             {result.groups.map((group) => (
-              <div key={group.root || "unknown"} className="code-picker__group">
+              <div key={group.key || "unknown"} className="code-picker__group">
                 <div className="code-picker__group-head">
                   <span className="code-picker__group-label">{group.label}</span>
                   <span className="code-picker__group-count">{group.sessions.length}</span>

--- a/src/components/code-session-picker.tsx
+++ b/src/components/code-session-picker.tsx
@@ -75,7 +75,7 @@ function SessionRowButton({
 export type CodeSessionPickerProps = {
   queue: CodeReviewQueue;
   mode: CodeQueueMode;
-  selected: SessionRow;
+  selected: SessionRow | null;
   onModeChange: (mode: CodeQueueMode) => void;
   onSelect: (sessionId: string) => void;
   /**
@@ -161,6 +161,8 @@ export function CodeSessionPicker({
     );
   };
 
+  const triggerTitle = selected?.title || selected?.id || "Search sessions";
+
   return (
     <>
       <button
@@ -171,7 +173,7 @@ export function CodeSessionPicker({
         className="focus-ring code-picker__trigger"
         onClick={() => setOpen((value) => !value)}
       >
-        <span className="code-picker__trigger-title">{selected.title || selected.id}</span>
+        <span className="code-picker__trigger-title">{triggerTitle}</span>
         <Icon name="ph:caret-down" width={11} height={11} aria-hidden />
       </button>
       <Popover
@@ -231,7 +233,7 @@ export function CodeSessionPicker({
                   <SessionRowButton
                     key={row.id}
                     row={row}
-                    selected={row.id === selected.id}
+                    selected={row.id === selected?.id}
                     onPick={() => pick(row.id)}
                   />
                 ))}

--- a/src/components/code-session-picker.tsx
+++ b/src/components/code-session-picker.tsx
@@ -162,6 +162,10 @@ export function CodeSessionPicker({
   };
 
   const triggerTitle = selected?.title || selected?.id || "Search sessions";
+  const emptyMessage =
+    mode === "reviewable"
+      ? "No GitHub repository sessions need review."
+      : "No coding sessions yet.";
 
   return (
     <>
@@ -252,7 +256,7 @@ export function CodeSessionPicker({
               </div>
             ) : null}
             {!result.offersCreate && result.count === 0 ? (
-              <p className="code-picker__empty-text">No coding sessions yet.</p>
+              <p className="code-picker__empty-text">{emptyMessage}</p>
             ) : null}
           </div>
         </div>

--- a/src/components/code-session-picker.tsx
+++ b/src/components/code-session-picker.tsx
@@ -53,6 +53,7 @@ function SessionRowButton({
       aria-selected={selected}
       className="focus-ring code-picker__row"
       data-selected={selected ? "true" : undefined}
+      data-code-session-id={row.id}
       onClick={onPick}
     >
       {/* Activity is carried by the word beside the dot, never the dot alone. */}

--- a/src/components/code-session-picker.tsx
+++ b/src/components/code-session-picker.tsx
@@ -9,10 +9,11 @@
  * the rail's width back and the switch becomes an explicit act rather than an
  * always-on column.
  *
- * The filter searches title, project and branch (`code-session-picker.ts`), and
- * a miss is not a dead end — Enter on an unmatched query offers to start a
- * session with that name, which is the frame's own affordance and the reason
- * the empty state is a button rather than a shrug.
+ * The filter searches title, project, repository and branch
+ * (`code-session-picker.ts`), and a miss is not a dead end — Enter on an
+ * unmatched query offers to start a session with that name, which is the
+ * frame's own affordance and the reason the empty state is a button rather
+ * than a shrug.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -190,7 +191,7 @@ export function CodeSessionPicker({
               onChange={(event) => setQuery(event.target.value)}
               onKeyDown={onQueryKeyDown}
               placeholder="Search sessions…"
-              aria-label="Search sessions by title, project or branch"
+              aria-label="Search sessions by title, project, repository or branch"
               className="code-picker__search-input"
               data-code-session-search=""
             />

--- a/src/components/code-session-rail.tsx
+++ b/src/components/code-session-rail.tsx
@@ -116,8 +116,8 @@ export function CodeSessionRail({
         {scopeControls}
         {newButton}
         <div className="px-3 py-4 text-[length:var(--text-xs)] text-[var(--text-muted)]">
-          {mode === "reviewable" && queue.allLocalCount > 0
-            ? "No reviewable sessions match this scope. Switch to All local to browse the rest."
+          {mode === "reviewable"
+            ? "No GitHub repository sessions need review."
             : "No coding sessions yet. Start one here — or from Chat — and it will appear with its branch, diff, and PR context."}
         </div>
       </div>

--- a/src/components/code-session-rail.tsx
+++ b/src/components/code-session-rail.tsx
@@ -2,19 +2,33 @@
 
 /**
  * CodeSessionRail — left rail of the Code surface (cave-k0ua): every active
- * coding conversation grouped by project, newest first, with per-session git
- * attribution badges (branch, PR, diffstat, worktree). Selection drives the
- * workbench; the rail never mutates sessions itself.
+ * coding conversation from the shared review queue, with per-session branch,
+ * diff, PR and recency context. Selection drives the workbench; the rail never
+ * mutates sessions itself.
  */
 
 import { Icon } from "@/lib/icon";
+import { CodeReviewQueueControls } from "@/components/code-review-queue-controls";
+import type { CodeQueueMode, CodeReviewQueue } from "@/lib/code-review-queue";
+import { relativeTime } from "@/lib/relative-time";
 import {
   codeSessionActivity,
   codeSessionBranch,
   codeSessionDiffstat,
-  groupCodeRailSessions,
 } from "@/lib/code-surface";
 import type { SessionRow } from "@/lib/types";
+
+const ACTIVITY_WORD = {
+  running: "Running",
+  error: "Failed",
+  idle: "Idle",
+} as const;
+
+const ACTIVITY_A11Y = {
+  running: "running",
+  error: "failed",
+  idle: "idle",
+} as const;
 
 function PrChip({ pr }: { pr: NonNullable<SessionRow["pullRequest"]> }) {
   const state = (pr.state ?? "").toLowerCase();
@@ -47,7 +61,9 @@ function ActivityDot({ row }: { row: SessionRow }) {
 }
 
 export type CodeSessionRailProps = {
-  sessions: SessionRow[];
+  queue: CodeReviewQueue;
+  mode: CodeQueueMode;
+  onModeChange: (mode: CodeQueueMode) => void;
   selectedId: string | null;
   onSelect: (sessionId: string) => void;
   onNewSession?: () => void;
@@ -56,15 +72,28 @@ export type CodeSessionRailProps = {
 };
 
 export function CodeSessionRail({
-  sessions,
+  queue,
+  mode,
+  onModeChange,
   selectedId,
   onSelect,
   onNewSession,
   open = true,
   onExpand,
 }: CodeSessionRailProps) {
-  const groups = groupCodeRailSessions(sessions);
+  const groups = queue.groups;
   const openRailClassName = onExpand ? "py-2" : "overflow-y-auto py-2";
+  const scopeControls = open ? (
+    <div className="px-2 pb-2">
+      <CodeReviewQueueControls
+        mode={mode}
+        reviewableCount={queue.reviewableCount}
+        allLocalCount={queue.allLocalCount}
+        outsideCurrentFilter={queue.outsideCurrentFilter}
+        onModeChange={onModeChange}
+      />
+    </div>
+  ) : null;
 
   const newButton = open && onNewSession ? (
     <div className="px-2 pb-1">
@@ -84,10 +113,12 @@ export function CodeSessionRail({
     }
     return (
       <div className="flex h-full flex-col py-2">
+        {scopeControls}
         {newButton}
         <div className="px-3 py-4 text-[length:var(--text-xs)] text-[var(--text-muted)]">
-          No coding sessions yet. Start one here — or from Chat — and it will
-          appear with its branch, diff, and PR context.
+          {mode === "reviewable" && queue.allLocalCount > 0
+            ? "No reviewable sessions match this scope. Switch to All local to browse the rest."
+            : "No coding sessions yet. Start one here — or from Chat — and it will appear with its branch, diff, and PR context."}
         </div>
       </div>
     );
@@ -105,13 +136,14 @@ export function CodeSessionRail({
       }`}
 
     >
+      {scopeControls}
       {newButton}
       {groups.map((group) => (
-        <section key={group.root || "(unknown)"} className="mb-2">
+        <section key={group.key || "(unknown)"} className="mb-2">
           {open ? (
             <div
               className="truncate px-3 py-1 text-[length:var(--text-2xs)] font-semibold uppercase tracking-wider text-[var(--text-secondary)]"
-              title={group.root || undefined}
+              title={group.key || undefined}
             >
               {group.label}
             </div>
@@ -123,6 +155,13 @@ export function CodeSessionRail({
               const selected = row.id === selectedId;
               const title = row.title || row.id;
               const activity = codeSessionActivity(row);
+              const activityText = ACTIVITY_WORD[activity];
+              const activityTone =
+                activity === "running"
+                  ? "text-[var(--color-success)]"
+                  : activity === "error"
+                    ? "text-[var(--color-danger)]"
+                    : "text-[var(--text-muted)]";
               return (
                 <li key={row.id}>
                   <button
@@ -132,7 +171,7 @@ export function CodeSessionRail({
                       onSelect(row.id);
                     }}
                     aria-current={selected ? "true" : undefined}
-                    aria-label={open ? undefined : `Open ${title} in ${group.label}, ${activity}`}
+                    aria-label={open ? undefined : `Open ${title} in ${group.label}, ${ACTIVITY_A11Y[activity]}`}
                     title={open ? undefined : title}
                     className={
                       open
@@ -146,17 +185,16 @@ export function CodeSessionRail({
                   >
                     {open ? (
                       <>
-                        <span className="flex min-w-0 items-center gap-1.5">
-                          <ActivityDot row={row} />
+                        <span className="flex min-w-0 items-start justify-between gap-2">
                           <span className="min-w-0 truncate text-[length:var(--text-xs)] text-[var(--text-primary)]">
                             {title}
                           </span>
+                          <span className={`shrink-0 font-mono text-[length:var(--text-2xs)] uppercase tracking-wide ${activityTone}`}>
+                            {activityText}
+                          </span>
                         </span>
-                        {(branch || diffstat || row.pullRequest || row.git?.isWorktree) ? (
-                          <span className="flex min-w-0 items-center gap-1.5 pl-3">
-                            {row.git?.isWorktree ? (
-                              <Icon name="ph:git-fork" width={10} height={10} className="shrink-0 text-[var(--text-muted)]" />
-                            ) : null}
+                        {(branch || diffstat || row.pullRequest || row.updated_at) ? (
+                          <span className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
                             {branch ? (
                               <span className="min-w-0 truncate font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]" title={branch}>
                                 {branch}
@@ -166,6 +204,7 @@ export function CodeSessionRail({
                               <span className="shrink-0 font-mono text-[length:var(--text-2xs)] text-[var(--text-secondary)]">{diffstat}</span>
                             ) : null}
                             {row.pullRequest ? <PrChip pr={row.pullRequest} /> : null}
+                            <span className="shrink-0 text-[var(--text-secondary)]">{relativeTime(row.updated_at)}</span>
                           </span>
                         ) : null}
                       </>

--- a/src/components/code-session-rail.tsx
+++ b/src/components/code-session-rail.tsx
@@ -171,6 +171,7 @@ export function CodeSessionRail({
                       onSelect(row.id);
                     }}
                     aria-current={selected ? "true" : undefined}
+                    data-code-session-id={row.id}
                     aria-label={open ? undefined : `Open ${title} in ${group.label}, ${ACTIVITY_A11Y[activity]}`}
                     title={open ? undefined : title}
                     className={

--- a/src/components/code-shortcuts-dialog.test.tsx
+++ b/src/components/code-shortcuts-dialog.test.tsx
@@ -1,0 +1,88 @@
+// @ts-nocheck — react-test-renderer ships no types; rendered shortcut-dialog behavior test.
+import React from "react";
+import { act, create } from "react-test-renderer";
+import { expect, test, vi, beforeEach, afterEach } from "vitest";
+
+import { CodeShortcutsDialog } from "./code-shortcuts-dialog";
+import { defaultCodeKeymap } from "@/lib/code-shortcuts";
+
+vi.mock("react-dom", () => ({ createPortal: (node: unknown) => node }));
+vi.mock("@/lib/icon", () => ({ Icon: () => null }));
+
+const announce = vi.fn();
+vi.mock("@/components/ui/live-region", () => ({
+  useAnnouncer: () => ({ announce }),
+}));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+(globalThis as { document?: unknown }).document = { body: {} };
+
+type WindowListener = (event: KeyboardEvent) => void;
+
+let listeners: Record<string, WindowListener[]>;
+let previousWindow: typeof globalThis.window | undefined;
+
+function dispatchKey(event: Partial<KeyboardEvent> & { key: string }) {
+  const keyboardEvent = {
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    stopPropagation() {},
+    ...event,
+  } as KeyboardEvent;
+  for (const listener of listeners.keydown ?? []) listener(keyboardEvent);
+  return keyboardEvent;
+}
+
+beforeEach(() => {
+  listeners = {};
+  previousWindow = globalThis.window;
+  globalThis.window = {
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      const fn = typeof listener === "function" ? listener : listener.handleEvent.bind(listener);
+      listeners[type] ??= [];
+      listeners[type].push(fn as WindowListener);
+    },
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      const fn = typeof listener === "function" ? listener : listener.handleEvent.bind(listener);
+      listeners[type] = (listeners[type] ?? []).filter((candidate) => candidate !== fn);
+    },
+  } as typeof globalThis.window;
+  announce.mockReset();
+});
+
+afterEach(() => {
+  if (previousWindow) globalThis.window = previousWindow;
+  else delete (globalThis as { window?: typeof globalThis.window }).window;
+});
+
+test("reserved queue combos are refused during rebinding", () => {
+  const onChange = vi.fn();
+  let renderer;
+  act(() => {
+    renderer = create(
+      <CodeShortcutsDialog
+        open
+        onClose={() => {}}
+        keymap={defaultCodeKeymap()}
+        onChange={onChange}
+      />,
+    );
+  });
+
+  const rebind = renderer.root.findAll(
+    (node) => node.type === "button" && node.children.join("") === "Rebind",
+  )[0];
+  act(() => rebind.props.onClick());
+  act(() => {
+    dispatchKey({ key: "/", shiftKey: false });
+  });
+
+  expect(onChange).not.toHaveBeenCalled();
+  expect(announce).toHaveBeenCalledWith("That shortcut is reserved for the session queue.");
+});

--- a/src/components/code-shortcuts-dialog.tsx
+++ b/src/components/code-shortcuts-dialog.tsx
@@ -18,25 +18,17 @@ import { useCallback, useEffect, useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
-import { CODE_ROOM_SHORTCUT_HINTS } from "@/lib/code-room-shortcuts";
 import {
+  CODE_FIXED_QUEUE_SHORTCUTS,
+  CODE_FIXED_TERMINAL_SHORTCUTS,
   CODE_SHORTCUTS,
   bindCodeShortcut,
   codeComboChips,
   codeComboFromEvent,
+  codeReservedComboOwner,
   defaultCodeKeymap,
   type CodeShortcutId,
 } from "@/lib/code-shortcuts";
-
-/** Human labels for the fixed terminal bindings. */
-const FIXED_LABEL: Record<string, string> = {
-  "focus-next-terminal": "Focus the next terminal pane",
-  "focus-previous-terminal": "Focus the previous terminal pane",
-  "split-right": "Split the pane right",
-  "split-down": "Split the pane down",
-  "close-terminal": "Close the pane",
-  "toggle-broadcast": "Broadcast typing to every pane",
-};
 
 export type CodeShortcutsDialogProps = {
   open: boolean;
@@ -67,6 +59,11 @@ export function CodeShortcutsDialog({ open, onClose, keymap, onChange }: CodeSho
       if (combo === "Escape") {
         setCapturing(null);
         announce("Rebinding cancelled.");
+        return;
+      }
+      const reservedOwner = codeReservedComboOwner(combo);
+      if (reservedOwner) {
+        announce(`That shortcut is reserved for the ${reservedOwner}.`);
         return;
       }
       const displaced = CODE_SHORTCUTS.find((s) => s.id !== capturing && keymap[s.id] === combo);
@@ -153,16 +150,35 @@ export function CodeShortcutsDialog({ open, onClose, keymap, onChange }: CodeSho
           );
         })}
       </ul>
-      {/* The terminal's own bindings are FIXED — they resolve inside a focused
-          pane, before this keymap is consulted. Listing them here is what stops
-          a rebind from silently colliding with a key that will never reach it. */}
+      {/* Queue and terminal bindings are FIXED — they resolve before this
+          per-session keymap. Listing them here is what stops a rebind from
+          silently colliding with a key that will never reach it. */}
+      <p className="code-keys__section">Session queue — fixed</p>
+      <ul className="code-keys">
+        {CODE_FIXED_QUEUE_SHORTCUTS.map((shortcut) => (
+          <li key={shortcut.id} className="code-keys__row">
+            <span className="code-keys__label">{shortcut.label}</span>
+            <span className="code-keys__combo">
+              {codeComboChips(shortcut.combo, apple).map((chip, i) => (
+                <kbd key={`${shortcut.id}-${chip}-${i}`} className="code-keys__kbd">
+                  {chip}
+                </kbd>
+              ))}
+            </span>
+          </li>
+        ))}
+      </ul>
       <p className="code-keys__section">Terminal panes — fixed</p>
       <ul className="code-keys">
-        {(Object.entries(CODE_ROOM_SHORTCUT_HINTS) as [string, string][]).map(([id, hint]) => (
-          <li key={id} className="code-keys__row">
-            <span className="code-keys__label">{FIXED_LABEL[id] ?? id}</span>
+        {CODE_FIXED_TERMINAL_SHORTCUTS.map((shortcut) => (
+          <li key={shortcut.id} className="code-keys__row">
+            <span className="code-keys__label">{shortcut.label}</span>
             <span className="code-keys__combo">
-              <kbd className="code-keys__kbd">{hint}</kbd>
+              {codeComboChips(shortcut.combo, apple).map((chip, i) => (
+                <kbd key={`${shortcut.id}-${chip}-${i}`} className="code-keys__kbd">
+                  {chip}
+                </kbd>
+              ))}
             </span>
           </li>
         ))}

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -334,8 +334,8 @@ assert.match(
 );
 assert.match(
   codeView,
-  /import\s*\{[\s\S]*isCodeShortcutTarget[\s\S]*\}\s*from "@\/lib\/code-shortcuts";/,
-  "CodeView reuses the shared shortcut-target guard rather than re-implementing typing detection",
+  /import\s*\{[\s\S]*codeComboFromEvent[\s\S]*isCodeShortcutTarget[\s\S]*\}\s*from "@\/lib\/code-shortcuts";/,
+  "CodeView reuses the shared combo normalizer and shortcut-target guard rather than re-implementing typing detection",
 );
 assert.match(
   codeView,
@@ -344,13 +344,13 @@ assert.match(
 );
 assert.match(
   codeView,
-  /if \(!isCodeShortcutTarget\(event\.target\)\) return;[\s\S]*\.code-picker__trigger[\s\S]*\[data-code-session-search\]/,
-  "the room keydown handler guards typing targets and slash-focuses the picker search",
+  /if \(event\.defaultPrevented\) return;[\s\S]*if \(!isCodeShortcutTarget\(event\.target\)\) return;[\s\S]*const combo = codeComboFromEvent\(event\);[\s\S]*combo === "\/"[\s\S]*\.code-picker__trigger[\s\S]*\[data-code-session-search\]/,
+  "the room keydown handler honors earlier owners, normalizes combos once, and slash-focuses the picker search",
 );
 assert.match(
   codeView,
-  /querySelectorAll<HTMLButtonElement>\("\[data-code-session-id\]"\)[\s\S]*event\.key\.toLowerCase\(\)[\s\S]*rows\[nextIndex\]\?\.focus\(\)/,
-  "the room keydown handler walks visible session rows by their data-code-session-id markers",
+  /querySelectorAll<HTMLButtonElement>\("\[data-code-session-id\]"\)[\s\S]*combo === "J" \|\| combo === "K"[\s\S]*rows\[nextIndex\]\?\.focus\(\)[\s\S]*combo === "Shift\+A"/,
+  "the room keydown handler walks visible session rows and toggles scope from normalized fixed queue combos",
 );
 assert.match(
   codeView,
@@ -1006,6 +1006,21 @@ assert.match(
   workbench,
   /setStep\("source"\);/,
   "a routed file open drills into Source so the target is actually visible",
+);
+assert.match(
+  workbench,
+  /const initialTabNeedsMeasuredLayout = initialTab === "files" && measuredWidth === null && typeof ResizeObserver !== "undefined" && !isMobile;/,
+  "a file-tab deep link waits for a real narrow/wide layout decision before it is consumed",
+);
+assert.match(
+  workbench,
+  /if \(initialTabNeedsMeasuredLayout\) return;[\s\S]*if \(initialTab === "files" && !fitsSplit\) setStep\("files"\);/,
+  "a narrow file-tab deep link survives until layout is known, then drills into Files rather than leaving them hidden behind Source",
+);
+assert.match(
+  workbench,
+  /if \(event\.defaultPrevented\) return;[\s\S]*const action = codeShortcutForCombo\(keymap, codeComboFromEvent\(event\)\);/,
+  "the workbench shortcut handler honors fixed-key owners before consulting the rebindable keymap",
 );
 
 // A rail closed to its spine while the room was wide must not survive into the

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -173,6 +173,26 @@ assert.match(
 );
 assert.match(
   codeView,
+  /role="tablist"[\s\S]*aria-label="Code surface"[\s\S]*Review[\s\S]*Work[\s\S]*GitHub/,
+  "the primary Coding Desk tablist is simplified to Review, Work, and GitHub",
+);
+assert.match(
+  codeView,
+  /const githubTab: CodeGithubTab \| null = isCodeGithubTab\(topTab\) \? topTab : null;/,
+  "the simplified GitHub primary selection is still driven by the existing CodeTopTab GitHub values",
+);
+assert.match(
+  codeView,
+  /aria-selected=\{githubTab !== null\}[\s\S]*onClick=\{\(\) => setTopTab\(githubTab \?\? "activity"\)\}/,
+  "activating the GitHub primary tab preserves the current GitHub subtab when present and otherwise falls back to Activity",
+);
+assert.match(
+  codeView,
+  /githubTab \? \(\s*<div[\s\S]*role="tablist"[\s\S]*aria-label="GitHub filter"[\s\S]*CODE_GITHUB_TABS\.map\(\(id\) =>/,
+  "an active GitHub tab renders the secondary GitHub filter tablist from the existing tab metadata",
+);
+assert.match(
+  codeView,
   /activity: "all"[\s\S]*prs: "pr"[\s\S]*issues: "issue"[\s\S]*reviews: "review_request"/,
   "Coding Desk preserves the former all feed and each specialized filter",
 );

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -183,13 +183,28 @@ assert.match(
 );
 assert.match(
   codeView,
-  /aria-selected=\{githubTab !== null\}[\s\S]*onClick=\{\(\) => setTopTab\(githubTab \?\? "activity"\)\}/,
-  "activating the GitHub primary tab preserves the current GitHub subtab when present and otherwise falls back to Activity",
+  /const \[lastGithubTab, setLastGithubTab\] = useState<CodeGithubTab>\([\s\S]*?\?\? "activity",\s*\);[\s\S]*const lastGithubTabRef = useRef\(lastGithubTab\);/,
+  "CodeView keeps a remembered GitHub subtab in state and a ref so leaving GitHub does not reset the secondary filter",
+);
+assert.match(
+  codeView,
+  /aria-selected=\{githubTab !== null\}[\s\S]*onClick=\{\(\) => setTopTab\(lastGithubTabRef\.current\)\}/,
+  "activating the GitHub primary tab re-enters the last remembered GitHub subtab instead of always resetting to Activity",
 );
 assert.match(
   codeView,
   /githubTab \? \(\s*<div[\s\S]*role="tablist"[\s\S]*aria-label="GitHub filter"[\s\S]*CODE_GITHUB_TABS\.map\(\(id\) =>/,
   "an active GitHub tab renders the secondary GitHub filter tablist from the existing tab metadata",
+);
+assert.match(
+  codeView,
+  /role="tablist"[\s\S]*aria-label="GitHub filter"[\s\S]*aria-orientation="horizontal"[\s\S]*CODE_GITHUB_TABS\.map\(\(id\) =>[\s\S]*id=\{githubFilterTabId\(id\)\}[\s\S]*aria-controls=\{githubFilterPanelId\(id\)\}[\s\S]*tabIndex=\{githubTab === id \? 0 : -1\}[\s\S]*onKeyDown=\{\(event\) => handleGithubFilterKeyDown\(event, id\)\}/,
+  "the secondary GitHub filter is a keyboard-operable tablist with roving tabindex and stable aria wiring",
+);
+assert.match(
+  codeView,
+  /role="tabpanel"[\s\S]*id=\{githubFilterPanelId\(githubTab\)\}[\s\S]*aria-labelledby=\{githubFilterTabId\(githubTab\)\}/,
+  "the visible GitHub surface is exposed as the tabpanel controlled by the selected GitHub filter tab",
 );
 assert.match(
   codeView,

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -344,13 +344,18 @@ assert.match(
 );
 assert.match(
   codeView,
-  /if \(event\.defaultPrevented\) return;[\s\S]*if \(!isCodeShortcutTarget\(event\.target\)\) return;[\s\S]*const combo = codeComboFromEvent\(event\);[\s\S]*combo === "\/"[\s\S]*\.code-picker__trigger[\s\S]*\[data-code-session-search\]/,
-  "the room keydown handler honors earlier owners, normalizes combos once, and slash-focuses the picker search",
+  /if \(event\.defaultPrevented\) return;[\s\S]*if \(!isCodeShortcutTarget\(event\.target\)\) return;[\s\S]*const combo = codeComboFromEvent\(event\);[\s\S]*combo === "\/"[\s\S]*stopImmediatePropagation\(\)[\s\S]*activeQueuePickerTrigger\(\)[\s\S]*\[data-code-picker-panel\] \[data-code-session-search\]/,
+  "the room keydown handler normalizes combos once, claims slash before broader listeners can steal it, and focuses the active picker search",
 );
 assert.match(
   codeView,
   /querySelectorAll<HTMLButtonElement>\("\[data-code-session-id\]"\)[\s\S]*combo === "J" \|\| combo === "K"[\s\S]*rows\[nextIndex\]\?\.focus\(\)[\s\S]*combo === "Shift\+A"/,
   "the room keydown handler walks visible session rows and toggles scope from normalized fixed queue combos",
+);
+assert.match(
+  codeView,
+  /window\.addEventListener\("keydown", onKeyDown, true\)/,
+  "queue shortcuts listen in capture phase so the narrow landing's slash reaches the Code surface before broader slash search handlers",
 );
 assert.match(
   codeView,
@@ -670,6 +675,11 @@ assert.match(
   codeView,
   /\{fitsRail \? \(\s*<SurfaceRail[\s\S]*\) : \(\s*<div[\s\S]*<CodeSessionRail/,
   "the measured layout uses the collapsible rail only when it fits and preserves narrow list-first drill-in",
+);
+assert.match(
+  codeView,
+  /\{!selected \? \(\s*<div className="px-2 pt-2">[\s\S]*<CodeSessionPicker[\s\S]*selected=\{null\}/,
+  "the narrow list-first landing mounts the shared picker with no selected session so slash search still has an owner after Back",
 );
 assert.match(
   codeView,

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -698,6 +698,11 @@ assert.doesNotMatch(
 );
 assert.match(
   rail,
+  /aria-current=\{selected \? "true" : undefined\}[\s\S]*data-code-session-id=\{row\.id\}/,
+  "visible rail row buttons expose the same stable session-id marker the queue shortcuts walk",
+);
+assert.match(
+  rail,
   /aria-label=\{open \? undefined : `Open \$\{title\} in \$\{group\.label\}, \$\{ACTIVITY_A11Y\[activity\]\}`\}/,
   "collapsed session buttons identify the session, project, and activity without relying on color",
 );

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -1,6 +1,10 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import {
+  codeSessionHasOpenPr,
+  resolveCodeWorkbenchPanels,
+} from "../lib/code-surface.ts";
 
 // Pin suite for the dedicated Code surface (cave-k0ua).
 //
@@ -30,6 +34,83 @@ const chatView = await readFile(new URL("./chat-view.tsx", import.meta.url), "ut
 const registerRooms = await readFile(new URL("./role-surfaces/register.tsx", import.meta.url), "utf8");
 const codeRoom = await readFile(new URL("./role-surfaces/code-room.tsx", import.meta.url), "utf8");
 const pendingNavigation = await readFile(new URL("../lib/pending-code-navigation.ts", import.meta.url), "utf8");
+
+const reviewRow = (over = {}) => ({
+  diff: null,
+  pullRequest: null,
+  ...over,
+});
+
+assert.equal(codeSessionHasOpenPr(reviewRow()), false, "sessions without PR context do not count as open review work");
+assert.equal(
+  codeSessionHasOpenPr(reviewRow({ pullRequest: { repo: "acme/alpha" } })),
+  true,
+  "PR context with no terminal state still counts as open by current queue semantics",
+);
+assert.equal(
+  codeSessionHasOpenPr(reviewRow({ pullRequest: { repo: "acme/alpha", state: "open" } })),
+  true,
+  "explicitly open PRs count as open review work",
+);
+assert.equal(
+  codeSessionHasOpenPr(reviewRow({ pullRequest: { repo: "acme/alpha", state: "closed" } })),
+  false,
+  "closed PRs do not auto-open the review rail",
+);
+assert.equal(
+  codeSessionHasOpenPr(reviewRow({ pullRequest: { repo: "acme/alpha", state: "merged" } })),
+  false,
+  "merged PRs do not auto-open the review rail",
+);
+assert.deepEqual(
+  resolveCodeWorkbenchPanels({ row: reviewRow() }),
+  { reviewOpen: false, terminalOpen: false },
+  "a clean session starts with the compact bottom bar and the review rail closed",
+);
+assert.deepEqual(
+  resolveCodeWorkbenchPanels({
+    row: reviewRow({ diff: { additions: 3, deletions: 1 } }),
+  }),
+  { reviewOpen: true, terminalOpen: false },
+  "a changed session starts with the review rail open",
+);
+assert.deepEqual(
+  resolveCodeWorkbenchPanels({
+    row: reviewRow({ pullRequest: { repo: "acme/alpha", state: "open" } }),
+  }),
+  { reviewOpen: true, terminalOpen: false },
+  "an open PR starts with the review rail open even when the diff is clean",
+);
+assert.deepEqual(
+  resolveCodeWorkbenchPanels({
+    row: reviewRow(),
+    reviewOpen: false,
+    terminalOpen: false,
+    initialTab: "pr",
+  }),
+  { reviewOpen: true, terminalOpen: false },
+  "routed PR navigation reopens the rail even when the stored state says closed",
+);
+assert.deepEqual(
+  resolveCodeWorkbenchPanels({
+    row: reviewRow(),
+    reviewOpen: false,
+    terminalOpen: false,
+    initialTab: "terminal",
+  }),
+  { reviewOpen: false, terminalOpen: true },
+  "routed terminal navigation reopens the drawer even when the stored state says closed",
+);
+assert.deepEqual(
+  resolveCodeWorkbenchPanels({
+    row: reviewRow(),
+    reviewOpen: false,
+    terminalOpen: false,
+    openTarget: { kind: "changes", path: "src/example.ts", nonce: 7 },
+  }),
+  { reviewOpen: true, terminalOpen: false },
+  "routed diff navigation reopens the rail even when the stored state says closed",
+);
 
 // ── Mode vocabulary ──────────────────────────────────────────────────────────
 
@@ -253,6 +334,26 @@ assert.match(
 );
 assert.match(
   codeView,
+  /import\s*\{[\s\S]*isCodeShortcutTarget[\s\S]*\}\s*from "@\/lib\/code-shortcuts";/,
+  "CodeView reuses the shared shortcut-target guard rather than re-implementing typing detection",
+);
+assert.match(
+  codeView,
+  /useRef\(new Map<string, boolean>\(\)\)[\s\S]*useRef\(new Map<string, boolean>\(\)\)/,
+  "CodeView keeps review-rail and terminal open state in per-session ref Maps",
+);
+assert.match(
+  codeView,
+  /if \(!isCodeShortcutTarget\(event\.target\)\) return;[\s\S]*\.code-picker__trigger[\s\S]*\[data-code-session-search\]/,
+  "the room keydown handler guards typing targets and slash-focuses the picker search",
+);
+assert.match(
+  codeView,
+  /querySelectorAll<HTMLButtonElement>\("\[data-code-session-id\]"\)[\s\S]*event\.key\.toLowerCase\(\)[\s\S]*rows\[nextIndex\]\?\.focus\(\)/,
+  "the room keydown handler walks visible session rows by their data-code-session-id markers",
+);
+assert.match(
+  codeView,
   /if \(!pendingOpen\) return;[\s\S]*const byId = pendingQueueSelectedId\s*\?\s*queueSessions\.find\(\(row\) => row\.id === pendingQueueSelectedId\)/,
   "the pending-open effect reuses the resolved queue override id so excluded sessions remain selectable from queue.sessions",
 );
@@ -284,6 +385,11 @@ assert.match(
   /const workRoot = codeSessionWorkRoot\(row\);/,
   "the workbench derives one work root for the tree, the viewer and the rail",
 );
+assert.match(
+  workbench,
+  /const panels = resolveCodeWorkbenchPanels\(\{[\s\S]*row,[\s\S]*initialTab,[\s\S]*openTarget[\s\S]*\}\);/,
+  "CodeWorkbench derives its panel defaults from the shared pure model so source tests can pin the content-aware opening rules",
+);
 
 // The three columns, in order.
 assert.match(
@@ -298,7 +404,7 @@ assert.match(
 // only its `visible` prop changes.
 assert.match(
   workbench,
-  /<CodeTerminalDrawer[\s\S]{0,240}open=\{termOpen\}/,
+  /<CodeTerminalDrawer[\s\S]{0,240}open=\{panels\.terminalOpen\}/,
   "the terminal drawer sits outside the column body, so no step can unmount it",
 );
 assert.doesNotMatch(
@@ -904,12 +1010,12 @@ assert.match(
 // in review on #4418 — every check was green.)
 assert.match(
   workbench,
-  /open=\{fitsSplit \? railOpen : true\}/,
+  /open=\{fitsSplit \? panels\.reviewOpen : true\}/,
   "the narrow Review step always renders an open rail, so it can never be a blank sliver",
 );
 assert.match(
   workbench,
-  /onOpenChange=\{fitsSplit \? setRailOpen : \(\) => setStep\("source"\)\}/,
+  /onOpenChange=\{fitsSplit \? onReviewOpenChange : \(\) => setStep\("source"\)\}/,
   "closing the rail on a narrow room steps back to the source rather than leaving nothing",
 );
 

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -521,9 +521,39 @@ assert.match(
   "the measured layout uses the collapsible rail only when it fits and preserves narrow list-first drill-in",
 );
 assert.match(
+  codeView,
+  /const \[queueMode, setQueueMode\] = useState<CodeQueueMode>\("reviewable"\);[\s\S]*const queue = useMemo\(\s*\(\) => codeReviewQueue\(sessions, queueMode, queueSelectedId\),/,
+  "CodeView owns the non-persisted reviewable/all mode and one shared precomputed queue",
+);
+assert.match(
+  codeView,
+  /<CodeSessionRail[\s\S]*queue=\{queue\}[\s\S]*mode=\{queueMode\}[\s\S]*onModeChange=\{setQueueMode\}/,
+  "the rail renders from the shared queue and the room-owned scope toggle",
+);
+assert.match(
+  codeView,
+  /<CodeWorkbench[\s\S]*queue=\{queue\}[\s\S]*queueMode=\{queueMode\}[\s\S]*onQueueModeChange=\{setQueueMode\}/,
+  "the selected workbench receives the same queue and scope control the rail uses",
+);
+assert.match(
   rail,
-  /aria-label=\{open \? undefined : `Open \$\{title\} in \$\{group\.label\}, \$\{activity\}`\}/,
+  /const groups = queue\.groups;/,
+  "the rail renders the precomputed queue groups instead of regrouping sessions locally",
+);
+assert.doesNotMatch(
+  rail,
+  /groupCodeRailSessions/,
+  "the rail never re-runs session grouping — queue ownership stays in CodeView",
+);
+assert.match(
+  rail,
+  /aria-label=\{open \? undefined : `Open \$\{title\} in \$\{group\.label\}, \$\{ACTIVITY_A11Y\[activity\]\}`\}/,
   "collapsed session buttons identify the session, project, and activity without relying on color",
+);
+assert.match(
+  rail,
+  /<CodeReviewQueueControls[\s\S]*outsideCurrentFilter=\{queue\.outsideCurrentFilter\}/,
+  "open rail scope controls surface the outside-filter notice in the shared queue chrome",
 );
 assert.match(
   rail,

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -213,6 +213,16 @@ assert.match(
 );
 assert.match(
   codeView,
+  /const pendingQueueSelectedId = useMemo\(\s*\(\) => resolvePendingCodeOpenSessionId\(sessions, pendingOpen\),[\s\S]*const queueSelectedId = pendingQueueSelectedId \?\? \(typeof selectedId === "string" \? selectedId : null\);[\s\S]*const queue = useMemo\(\s*\(\) => codeReviewQueue\(sessions, queueMode, queueSelectedId\),/,
+  "CodeView resolves a root-only pending open into the selected queue override before reviewable filtering, with selectedId as the fallback",
+);
+assert.match(
+  codeView,
+  /if \(!pendingOpen\) return;[\s\S]*const byId = pendingQueueSelectedId\s*\?\s*queueSessions\.find\(\(row\) => row\.id === pendingQueueSelectedId\)/,
+  "the pending-open effect reuses the resolved queue override id so excluded sessions remain selectable from queue.sessions",
+);
+assert.match(
+  codeView,
   /if \(!pendingOpen\) return;[\s\S]*setTopTab\("sessions"\);\s*setInitialGithubTarget\(null\);\s*if \(target\) setSelectedId\(target\.id\);[\s\S]*setWorkbenchTarget\(root && !target \? null : \{ open: pendingOpen, sessionId: target\?\.id \?\? null \}\);/,
   "file/diff navigation supersedes a pending GitHub detail so it cannot replay: the pending-open effect must switch to Sessions, clear the latched GitHub target, then keep the existing session/workbench selection flow",
 );
@@ -522,7 +532,7 @@ assert.match(
 );
 assert.match(
   codeView,
-  /const \[queueMode, setQueueMode\] = useState<CodeQueueMode>\("reviewable"\);[\s\S]*const queue = useMemo\(\s*\(\) => codeReviewQueue\(sessions, queueMode, queueSelectedId\),/,
+  /const \[queueMode, setQueueMode\] = useState<CodeQueueMode>\("reviewable"\);[\s\S]*const pendingQueueSelectedId = useMemo\(/,
   "CodeView owns the non-persisted reviewable/all mode and one shared precomputed queue",
 );
 assert.match(

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -30,7 +30,7 @@
  * record.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import dynamic from "next/dynamic";
 import { Icon } from "@/lib/icon";
 import {
@@ -100,6 +100,10 @@ function topTabForNavigation(request: PendingCodeNavigation): CodeTopTab {
     : request.topTab;
 }
 
+function githubTabFromTopTab(topTab: CodeTopTab | null | undefined): CodeGithubTab | null {
+  return isCodeGithubTab(topTab) ? topTab : null;
+}
+
 export type CodeViewProps = {
   sessions: SessionRow[];
   onJumpToSession: (sessionId: string, familiarId?: string | null) => void;
@@ -150,6 +154,24 @@ export function CodeView({
         ? topTabForNavigation(navigationRequest)
         : deepLink?.topTab ?? "sessions",
   );
+  const [lastGithubTab, setLastGithubTab] = useState<CodeGithubTab>(
+    githubTabFromTopTab(
+      pendingOpen
+        ? navigationRequest
+          ? topTabForNavigation(navigationRequest)
+          : deepLink?.topTab ?? null
+        : navigationRequest
+          ? topTabForNavigation(navigationRequest)
+          : deepLink?.topTab ?? null,
+    ) ?? "activity",
+  );
+  const lastGithubTabRef = useRef(lastGithubTab);
+  const rememberGithubTab = useCallback((nextTopTab: CodeTopTab | null | undefined) => {
+    const nextGithubTab = githubTabFromTopTab(nextTopTab);
+    if (!nextGithubTab || lastGithubTabRef.current === nextGithubTab) return;
+    lastGithubTabRef.current = nextGithubTab;
+    setLastGithubTab(nextGithubTab);
+  }, []);
   const [initialGithubTarget, setInitialGithubTarget] = useState<GitHubItemTarget | null>(
     pendingOpen
       ? null
@@ -164,15 +186,58 @@ export function CodeView({
   useEffect(() => {
     if (!navigationRequest) return;
     if (handledNavigationNonceRef.current === navigationRequest.nonce) return;
-    setTopTab(topTabForNavigation(navigationRequest));
+    const nextTopTab = topTabForNavigation(navigationRequest);
+    setTopTab(nextTopTab);
+    rememberGithubTab(nextTopTab);
     setInitialGithubTarget(
       navigationRequest.kind === "github-item" ? navigationRequest.target : null,
     );
     setGithubNavigationKey(navigationRequest.nonce);
     handledNavigationNonceRef.current = navigationRequest.nonce;
     onNavigationHandled?.(navigationRequest.nonce);
-  }, [navigationRequest, onNavigationHandled]);
+  }, [navigationRequest, onNavigationHandled, rememberGithubTab]);
   const githubTab: CodeGithubTab | null = isCodeGithubTab(topTab) ? topTab : null;
+  const githubFilterBaseId = useId().replaceAll(":", "");
+  const githubFilterRefs = useRef<Record<CodeGithubTab, HTMLButtonElement | null>>({
+    activity: null,
+    prs: null,
+    issues: null,
+    reviews: null,
+  });
+  const githubFilterTabId = useCallback(
+    (id: CodeGithubTab) => `${githubFilterBaseId}-github-filter-tab-${id}`,
+    [githubFilterBaseId],
+  );
+  const githubFilterPanelId = useCallback(
+    (id: CodeGithubTab) => `${githubFilterBaseId}-github-filter-panel-${id}`,
+    [githubFilterBaseId],
+  );
+  const selectGithubTab = useCallback((id: CodeGithubTab, focus = false) => {
+    rememberGithubTab(id);
+    setTopTab(id);
+    if (focus) githubFilterRefs.current[id]?.focus();
+  }, [rememberGithubTab]);
+  const handleGithubFilterKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>, id: CodeGithubTab) => {
+      if (event.altKey || event.ctrlKey || event.metaKey) return;
+      const currentIndex = CODE_GITHUB_TABS.indexOf(id);
+      if (currentIndex < 0) return;
+      let nextIndex: number | null = null;
+      if (event.key === "ArrowRight") {
+        nextIndex = (currentIndex + 1) % CODE_GITHUB_TABS.length;
+      } else if (event.key === "ArrowLeft") {
+        nextIndex = (currentIndex - 1 + CODE_GITHUB_TABS.length) % CODE_GITHUB_TABS.length;
+      } else if (event.key === "Home") {
+        nextIndex = 0;
+      } else if (event.key === "End") {
+        nextIndex = CODE_GITHUB_TABS.length - 1;
+      }
+      if (nextIndex === null) return;
+      event.preventDefault();
+      selectGithubTab(CODE_GITHUB_TABS[nextIndex], true);
+    },
+    [selectGithubTab],
+  );
   // Selection is tri-state for the mobile drill-in: `undefined` = nothing
   // chosen yet (auto-pick allowed), `null` = the user explicitly went Back to
   // the session list (auto-pick must NOT re-select), string = a session.
@@ -333,7 +398,7 @@ export function CodeView({
               type="button"
               role="tab"
               aria-selected={githubTab !== null}
-              onClick={() => setTopTab(githubTab ?? "activity")}
+              onClick={() => setTopTab(lastGithubTabRef.current)}
               className={`focus-ring-inset inline-flex items-center gap-1.5 rounded px-2 py-1 text-[length:var(--text-xs)] ${
                 githubTab !== null
                   ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
@@ -352,15 +417,23 @@ export function CodeView({
           <div
             role="tablist"
             aria-label="GitHub filter"
+            aria-orientation="horizontal"
             className="mt-1 flex min-w-0 items-center gap-1 overflow-x-auto"
           >
             {CODE_GITHUB_TABS.map((id) => (
               <button
                 key={id}
+                ref={(node) => {
+                  githubFilterRefs.current[id] = node;
+                }}
                 type="button"
                 role="tab"
+                id={githubFilterTabId(id)}
                 aria-selected={githubTab === id}
-                onClick={() => setTopTab(id)}
+                aria-controls={githubFilterPanelId(id)}
+                tabIndex={githubTab === id ? 0 : -1}
+                onClick={() => selectGithubTab(id)}
+                onKeyDown={(event) => handleGithubFilterKeyDown(event, id)}
                 className={`focus-ring-inset inline-flex items-center gap-1.5 rounded px-2 py-1 text-[length:var(--text-xs)] ${
                   githubTab === id
                     ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
@@ -379,7 +452,12 @@ export function CodeView({
           <LazyWorkScheduler onJumpToSession={onJumpToSession} />
         </div>
       ) : githubTab ? (
-        <div className="min-h-0 flex-1">
+        <div
+          role="tabpanel"
+          id={githubFilterPanelId(githubTab)}
+          aria-labelledby={githubFilterTabId(githubTab)}
+          className="min-h-0 flex-1"
+        >
           <LazyGitHubView
             key={githubNavigationKey}
             onJumpToSession={onJumpToSession}

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -311,14 +311,27 @@ export function CodeView({
     if (roomRef.current?.contains(node)) return true;
     return Boolean(document.querySelector("[data-code-picker-panel]")?.contains(node));
   }, []);
-  const visibleQueueRows = useCallback(() => {
-    return [...document.querySelectorAll<HTMLButtonElement>("[data-code-session-id]")]
+  const visibleQueueRows = useCallback((target: EventTarget | null) => {
+    const node = target instanceof Node ? target : null;
+    const pickerPanel = document.querySelector<HTMLElement>("[data-code-picker-panel]");
+    const scope =
+      node && pickerPanel?.contains(node)
+        ? pickerPanel
+        : roomRef.current;
+    if (!scope) return [];
+    const seenSessionIds = new Set<string>();
+    return [...scope.querySelectorAll<HTMLButtonElement>("[data-code-session-id]")]
       .filter((row) => {
-        if (!queueTargetBelongsToRoom(row)) return false;
         const style = window.getComputedStyle(row);
-        return style.display !== "none" && style.visibility !== "hidden" && row.getClientRects().length > 0;
+        if (style.display === "none" || style.visibility === "hidden" || row.getClientRects().length === 0) {
+          return false;
+        }
+        const sessionId = row.dataset.codeSessionId;
+        if (!sessionId || seenSessionIds.has(sessionId)) return false;
+        seenSessionIds.add(sessionId);
+        return true;
       });
-  }, [queueTargetBelongsToRoom]);
+  }, []);
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (topTab !== "sessions") return;
@@ -335,7 +348,7 @@ export function CodeView({
       }
       const key = event.key.toLowerCase();
       if ((key === "j" || key === "k") && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
-        const rows = visibleQueueRows();
+        const rows = visibleQueueRows(event.target);
         if (!rows.length) return;
         event.preventDefault();
         const active = document.activeElement as HTMLElement | null;

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -5,16 +5,17 @@
  * multi-session coding tab. Reverses the earlier Code-mode retirement on the
  * owner's request; default-on since phase 2 (cave-m6ys).
  *
- * Phase 3+ (this shape): top-level Sessions/Activity/PRs/Issues/Reviews tabs, the session rail
+ * Phase 3+ (this shape): top-level Review/Work/GitHub tabs, with GitHub
+ * carrying a secondary Activity/PRs/Issues/Reviews filter, the session rail
  * (grouped by project, git-attribution badges, + New session) and the
  * per-session Coding Desk — a persistent terminal center beside a resizable
  * context dock (Changes | Files | Pull request | Inspector | GitHub | Browser)
  * with the follow-up composer (code-composer.tsx) under both. New sessions
  * start via code-new-session.tsx — project + familiar + optional fresh
- * worktree. CodeView hosts the whole GitHubView under the
- * Activity/PRs/Issues/Reviews tabs; the dock's GitHub tab mounts a second,
- * session-scoped copy so triage never has to displace a running shell.
- * Workspace routing lives outside this component.
+ * worktree. CodeView hosts the whole GitHubView under the GitHub destination;
+ * the dock's GitHub tab mounts a second, session-scoped copy so triage never
+ * has to displace a running shell. Workspace routing lives outside this
+ * component.
  *
  * TWO GITHUB SURFACES ARE INTENTIONAL (cave-xxp9f, owner decision 2026-08-15).
  * The 2026-07-26 Coding Room design said "there is no top-level GitHub page",
@@ -76,7 +77,7 @@ const LazyWorkScheduler = dynamic(
   { ssr: false },
 );
 
-// The GitHub content tabs and the GitHubView filter each one drives.
+// The GitHub sub-tabs and the GitHubView filter each one drives.
 const GITHUB_TAB_FILTER: Record<CodeGithubTab, GitHubFilter> = {
   activity: "all",
   prs: "pr",
@@ -293,61 +294,85 @@ export function CodeView({
 
   return (
     <div ref={roomRef} className="flex h-full min-h-0 flex-col">
-      <div className="flex shrink-0 items-center gap-1 border-b border-[var(--border-hairline)] px-3 py-1.5">
-        <div
-          role="tablist"
-          aria-label="Code surface"
-          className="flex min-w-0 items-center gap-1 overflow-x-auto"
-        >
-          <button
-            type="button"
-            role="tab"
-            aria-selected={topTab === "sessions"}
-            onClick={() => setTopTab("sessions")}
-            className={`focus-ring-inset inline-flex items-center gap-1.5 rounded px-2 py-1 text-[length:var(--text-xs)] ${
-              topTab === "sessions"
-                ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
-                : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-            }`}
+      <div className="shrink-0 border-b border-[var(--border-hairline)] px-3 py-1.5">
+        <div className="flex items-center gap-1">
+          <div
+            role="tablist"
+            aria-label="Code surface"
+            className="flex min-w-0 items-center gap-1 overflow-x-auto"
           >
-            <Icon name="ph:code" width={14} height={14} />
-            Sessions
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={topTab === "work"}
-            onClick={() => setTopTab("work")}
-            className={`focus-ring-inset inline-flex items-center gap-1.5 rounded px-2 py-1 text-[length:var(--text-xs)] ${
-              topTab === "work"
-                ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
-                : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-            }`}
-          >
-            <Icon name="ph:list-checks" width={14} height={14} />
-            Work
-          </button>
-          {CODE_GITHUB_TABS.map((id) => (
             <button
-              key={id}
               type="button"
               role="tab"
-              aria-selected={topTab === id}
-              onClick={() => setTopTab(id)}
+              aria-selected={topTab === "sessions"}
+              onClick={() => setTopTab("sessions")}
               className={`focus-ring-inset inline-flex items-center gap-1.5 rounded px-2 py-1 text-[length:var(--text-xs)] ${
-                topTab === id
+                topTab === "sessions"
                   ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
                   : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
               }`}
             >
-              <Icon name={GITHUB_TAB_META[id].icon} width={14} height={14} />
-              {GITHUB_TAB_META[id].label}
+              <Icon name="ph:code" width={14} height={14} />
+              Review
             </button>
-          ))}
+            <button
+              type="button"
+              role="tab"
+              aria-selected={topTab === "work"}
+              onClick={() => setTopTab("work")}
+              className={`focus-ring-inset inline-flex items-center gap-1.5 rounded px-2 py-1 text-[length:var(--text-xs)] ${
+                topTab === "work"
+                  ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
+                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+              }`}
+            >
+              <Icon name="ph:list-checks" width={14} height={14} />
+              Work
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={githubTab !== null}
+              onClick={() => setTopTab(githubTab ?? "activity")}
+              className={`focus-ring-inset inline-flex items-center gap-1.5 rounded px-2 py-1 text-[length:var(--text-xs)] ${
+                githubTab !== null
+                  ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
+                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+              }`}
+            >
+              <Icon name="ph:github-logo" width={14} height={14} />
+              GitHub
+            </button>
+          </div>
+          <div className="ml-auto shrink-0">
+            <GithubOrganizationSettings />
+          </div>
         </div>
-        <div className="ml-auto shrink-0">
-          <GithubOrganizationSettings />
-        </div>
+        {githubTab ? (
+          <div
+            role="tablist"
+            aria-label="GitHub filter"
+            className="mt-1 flex min-w-0 items-center gap-1 overflow-x-auto"
+          >
+            {CODE_GITHUB_TABS.map((id) => (
+              <button
+                key={id}
+                type="button"
+                role="tab"
+                aria-selected={githubTab === id}
+                onClick={() => setTopTab(id)}
+                className={`focus-ring-inset inline-flex items-center gap-1.5 rounded px-2 py-1 text-[length:var(--text-xs)] ${
+                  githubTab === id
+                    ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
+                    : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                }`}
+              >
+                <Icon name={GITHUB_TAB_META[id].icon} width={14} height={14} />
+                {GITHUB_TAB_META[id].label}
+              </button>
+            ))}
+          </div>
+        ) : null}
       </div>
       {topTab === "work" ? (
         <div className="min-h-0 flex-1">

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -32,7 +32,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { Icon } from "@/lib/icon";
-import { codeReviewQueue, type CodeQueueMode } from "@/lib/code-review-queue";
+import {
+  codeReviewQueue,
+  resolvePendingCodeOpenSessionId,
+  type CodeQueueMode,
+} from "@/lib/code-review-queue";
 import {
   CODE_GITHUB_TABS,
   CODE_ROOM_RAIL_WIDTH_PX,
@@ -205,7 +209,11 @@ export function CodeView({
     setNarrowLanding(narrowLandingRef.current);
   }, [roomWidth, isMobile]);
 
-  const queueSelectedId = pendingOpen?.sessionId ?? (typeof selectedId === "string" ? selectedId : null);
+  const pendingQueueSelectedId = useMemo(
+    () => resolvePendingCodeOpenSessionId(sessions, pendingOpen),
+    [pendingOpen, sessions],
+  );
+  const queueSelectedId = pendingQueueSelectedId ?? (typeof selectedId === "string" ? selectedId : null);
   const queue = useMemo(
     () => codeReviewQueue(sessions, queueMode, queueSelectedId),
     [queueMode, queueSelectedId, sessions],
@@ -223,8 +231,8 @@ export function CodeView({
   useEffect(() => {
     if (!pendingOpen) return;
     const queueSessions = queue.sessions;
-    const byId = pendingOpen.sessionId
-      ? queueSessions.find((row) => row.id === pendingOpen.sessionId)
+    const byId = pendingQueueSelectedId
+      ? queueSessions.find((row) => row.id === pendingQueueSelectedId)
       : undefined;
     const root = pendingOpen.kind === "files" ? pendingOpen.root : undefined;
     const trim = (p: string) => p.replace(/\/+$/, "");
@@ -243,7 +251,7 @@ export function CodeView({
     // last one — dismissing is "I've read this", not "never show me these".
     setOriginDismissed(false);
     onPendingOpenHandled?.();
-  }, [onPendingOpenHandled, pendingOpen, queue.sessions]);
+  }, [onPendingOpenHandled, pendingOpen, pendingQueueSelectedId, queue.sessions]);
 
   // Only opens raised from a conversation carry an origin; a file picked from
   // the tree shows nothing, because there is no conversation to point back to.

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -49,7 +49,7 @@ import {
   type CodeTopTab,
   type CodeWorkbenchTab,
 } from "@/lib/code-surface";
-import { isCodeShortcutTarget } from "@/lib/code-shortcuts";
+import { codeComboFromEvent, isCodeShortcutTarget } from "@/lib/code-shortcuts";
 import type { Filter as GitHubFilter } from "@/components/github-view-data";
 import { CodeSessionRail } from "@/components/code-session-rail";
 import { CodeWorkbench } from "@/components/code-workbench";
@@ -334,10 +334,12 @@ export function CodeView({
   }, []);
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
       if (topTab !== "sessions") return;
       if (!queueTargetBelongsToRoom(event.target)) return;
       if (!isCodeShortcutTarget(event.target)) return;
-      if (event.key === "/" && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      const combo = codeComboFromEvent(event);
+      if (combo === "/") {
         event.preventDefault();
         const picker = document.querySelector<HTMLElement>(".code-picker__trigger");
         if (!document.querySelector("[data-code-picker-panel]")) picker?.click();
@@ -346,8 +348,7 @@ export function CodeView({
         });
         return;
       }
-      const key = event.key.toLowerCase();
-      if ((key === "j" || key === "k") && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      if (combo === "J" || combo === "K") {
         const rows = visibleQueueRows(event.target);
         if (!rows.length) return;
         event.preventDefault();
@@ -361,18 +362,18 @@ export function CodeView({
         );
         const nextIndex =
           currentIndex >= 0
-            ? key === "j"
+            ? combo === "J"
               ? (currentIndex + 1) % rows.length
               : (currentIndex - 1 + rows.length) % rows.length
             : selectedIndex >= 0
               ? selectedIndex
-              : key === "j"
+              : combo === "J"
                 ? 0
                 : rows.length - 1;
         rows[nextIndex]?.focus();
         return;
       }
-      if (key === "a" && event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      if (combo === "Shift+A") {
         event.preventDefault();
         setQueueMode((current) => (current === "reviewable" ? "all" : "reviewable"));
       }

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/lib/code-surface";
 import { codeComboFromEvent, isCodeShortcutTarget } from "@/lib/code-shortcuts";
 import type { Filter as GitHubFilter } from "@/components/github-view-data";
+import { CodeSessionPicker } from "@/components/code-session-picker";
 import { CodeSessionRail } from "@/components/code-session-rail";
 import { CodeWorkbench } from "@/components/code-workbench";
 import { CodeNewSession } from "@/components/code-new-session";
@@ -311,6 +312,13 @@ export function CodeView({
     if (roomRef.current?.contains(node)) return true;
     return Boolean(document.querySelector("[data-code-picker-panel]")?.contains(node));
   }, []);
+  const activeQueuePickerTrigger = useCallback(() => {
+    if (!roomRef.current) return null;
+    return [...roomRef.current.querySelectorAll<HTMLElement>(".code-picker__trigger")].find((trigger) => {
+      const style = window.getComputedStyle(trigger);
+      return style.display !== "none" && style.visibility !== "hidden" && trigger.getClientRects().length > 0;
+    }) ?? null;
+  }, []);
   const visibleQueueRows = useCallback((target: EventTarget | null) => {
     const node = target instanceof Node ? target : null;
     const pickerPanel = document.querySelector<HTMLElement>("[data-code-picker-panel]");
@@ -341,10 +349,11 @@ export function CodeView({
       const combo = codeComboFromEvent(event);
       if (combo === "/") {
         event.preventDefault();
-        const picker = document.querySelector<HTMLElement>(".code-picker__trigger");
+        event.stopImmediatePropagation();
+        const picker = activeQueuePickerTrigger();
         if (!document.querySelector("[data-code-picker-panel]")) picker?.click();
         requestAnimationFrame(() => {
-          document.querySelector<HTMLElement>("[data-code-session-search]")?.focus();
+          document.querySelector<HTMLElement>("[data-code-picker-panel] [data-code-session-search]")?.focus();
         });
         return;
       }
@@ -352,6 +361,7 @@ export function CodeView({
         const rows = visibleQueueRows(event.target);
         if (!rows.length) return;
         event.preventDefault();
+        event.stopImmediatePropagation();
         const active = document.activeElement as HTMLElement | null;
         const currentIndex = rows.findIndex((row) => row === active || row.contains(active));
         const selectedIndex = rows.findIndex(
@@ -375,12 +385,13 @@ export function CodeView({
       }
       if (combo === "Shift+A") {
         event.preventDefault();
+        event.stopImmediatePropagation();
         setQueueMode((current) => (current === "reviewable" ? "all" : "reviewable"));
       }
     };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [queueTargetBelongsToRoom, topTab, visibleQueueRows]);
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [activeQueuePickerTrigger, queueTargetBelongsToRoom, topTab, visibleQueueRows]);
 
   // Consume a routed file/diff open (cave-ohcj): select the raising chat
   // session's workbench — or, for a Projects-hub root browse, the newest
@@ -610,6 +621,21 @@ export function CodeView({
             <div
               className={`${selected ? "hidden" : "block w-full"} shrink-0 border-[var(--border-hairline)]`}
             >
+              {!selected ? (
+                <div className="px-2 pt-2">
+                  <CodeSessionPicker
+                    queue={queue}
+                    mode={queueMode}
+                    selected={null}
+                    onModeChange={setQueueMode}
+                    onSelect={selectSession}
+                    onCreate={(seed) => {
+                      setNewSessionSeed(seed);
+                      setNewSessionOpen(true);
+                    }}
+                  />
+                </div>
+              ) : null}
               <CodeSessionRail
                 queue={queue}
                 mode={queueMode}

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -47,7 +47,9 @@ import {
   parseCodeDeepLink,
   type CodeGithubTab,
   type CodeTopTab,
+  type CodeWorkbenchTab,
 } from "@/lib/code-surface";
+import { isCodeShortcutTarget } from "@/lib/code-shortcuts";
 import type { Filter as GitHubFilter } from "@/components/github-view-data";
 import { CodeSessionRail } from "@/components/code-session-rail";
 import { CodeWorkbench } from "@/components/code-workbench";
@@ -245,6 +247,13 @@ export function CodeView({
     deepLink?.sessionId ?? undefined,
   );
   const [queueMode, setQueueMode] = useState<CodeQueueMode>("reviewable");
+  const reviewRailOpenBySessionRef = useRef(new Map<string, boolean>());
+  const terminalOpenBySessionRef = useRef(new Map<string, boolean>());
+  const [, setPanelStateVersion] = useState(0);
+  const [initialWorkbenchTab, setInitialWorkbenchTab] = useState<{
+    sessionId: string;
+    tab: CodeWorkbenchTab;
+  } | null>(deepLink?.sessionId ? { sessionId: deepLink.sessionId, tab: deepLink.workbenchTab } : null);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   // The workbench picker offers "start a new session about <query>" when the
   // filter matches nothing. There is no title field to set — a session's title
@@ -284,6 +293,80 @@ export function CodeView({
     () => codeReviewQueue(sessions, queueMode, queueSelectedId),
     [queueMode, queueSelectedId, sessions],
   );
+  const setSessionReviewRailOpen = useCallback((sessionId: string, open: boolean) => {
+    const states = reviewRailOpenBySessionRef.current;
+    if (states.get(sessionId) === open) return;
+    states.set(sessionId, open);
+    setPanelStateVersion((value) => value + 1);
+  }, []);
+  const setSessionTerminalOpen = useCallback((sessionId: string, open: boolean) => {
+    const states = terminalOpenBySessionRef.current;
+    if (states.get(sessionId) === open) return;
+    states.set(sessionId, open);
+    setPanelStateVersion((value) => value + 1);
+  }, []);
+  const queueTargetBelongsToRoom = useCallback((target: EventTarget | null) => {
+    const node = target instanceof Node ? target : null;
+    if (!node) return false;
+    if (roomRef.current?.contains(node)) return true;
+    return Boolean(document.querySelector("[data-code-picker-panel]")?.contains(node));
+  }, []);
+  const visibleQueueRows = useCallback(() => {
+    return [...document.querySelectorAll<HTMLButtonElement>("[data-code-session-id]")]
+      .filter((row) => {
+        if (!queueTargetBelongsToRoom(row)) return false;
+        const style = window.getComputedStyle(row);
+        return style.display !== "none" && style.visibility !== "hidden" && row.getClientRects().length > 0;
+      });
+  }, [queueTargetBelongsToRoom]);
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (topTab !== "sessions") return;
+      if (!queueTargetBelongsToRoom(event.target)) return;
+      if (!isCodeShortcutTarget(event.target)) return;
+      if (event.key === "/" && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
+        event.preventDefault();
+        const picker = document.querySelector<HTMLElement>(".code-picker__trigger");
+        if (!document.querySelector("[data-code-picker-panel]")) picker?.click();
+        requestAnimationFrame(() => {
+          document.querySelector<HTMLElement>("[data-code-session-search]")?.focus();
+        });
+        return;
+      }
+      const key = event.key.toLowerCase();
+      if ((key === "j" || key === "k") && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
+        const rows = visibleQueueRows();
+        if (!rows.length) return;
+        event.preventDefault();
+        const active = document.activeElement as HTMLElement | null;
+        const currentIndex = rows.findIndex((row) => row === active || row.contains(active));
+        const selectedIndex = rows.findIndex(
+          (row) =>
+            row.getAttribute("aria-selected") === "true" ||
+            row.getAttribute("aria-current") === "true" ||
+            row.dataset.selected === "true",
+        );
+        const nextIndex =
+          currentIndex >= 0
+            ? key === "j"
+              ? (currentIndex + 1) % rows.length
+              : (currentIndex - 1 + rows.length) % rows.length
+            : selectedIndex >= 0
+              ? selectedIndex
+              : key === "j"
+                ? 0
+                : rows.length - 1;
+        rows[nextIndex]?.focus();
+        return;
+      }
+      if (key === "a" && event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
+        event.preventDefault();
+        setQueueMode((current) => (current === "reviewable" ? "all" : "reviewable"));
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [queueTargetBelongsToRoom, topTab, visibleQueueRows]);
 
   // Consume a routed file/diff open (cave-ohcj): select the raising chat
   // session's workbench — or, for a Projects-hub root browse, the newest
@@ -310,6 +393,7 @@ export function CodeView({
     setTopTab("sessions");
     setInitialGithubTarget(null);
     if (target) setSelectedId(target.id);
+    if (target && pendingOpen.kind === "changes") setSessionReviewRailOpen(target.id, true);
     // Root browse with no matching session: there is no workbench to focus —
     // land on the surface and leave the rail/selection as-is.
     setWorkbenchTarget(root && !target ? null : { open: pendingOpen, sessionId: target?.id ?? null });
@@ -317,7 +401,7 @@ export function CodeView({
     // last one — dismissing is "I've read this", not "never show me these".
     setOriginDismissed(false);
     onPendingOpenHandled?.();
-  }, [onPendingOpenHandled, pendingOpen, pendingQueueSelectedId, queue.sessions]);
+  }, [onPendingOpenHandled, pendingOpen, pendingQueueSelectedId, queue.sessions, setSessionReviewRailOpen]);
 
   // Only opens raised from a conversation carry an origin; a file picked from
   // the tree shows nothing, because there is no conversation to point back to.
@@ -572,7 +656,16 @@ export function CodeView({
                       setNewSessionSeed(seed);
                       setNewSessionOpen(true);
                     }}
-                    initialTab={deepLink?.sessionId === selected.id ? deepLink?.workbenchTab : undefined}
+                    reviewOpen={reviewRailOpenBySessionRef.current.get(selected.id)}
+                    terminalOpen={terminalOpenBySessionRef.current.get(selected.id)}
+                    onReviewOpenChange={(open) => setSessionReviewRailOpen(selected.id, open)}
+                    onTerminalOpenChange={(open) => setSessionTerminalOpen(selected.id, open)}
+                    initialTab={initialWorkbenchTab?.sessionId === selected.id ? initialWorkbenchTab.tab : undefined}
+                    onInitialTabHandled={() => {
+                      setInitialWorkbenchTab((current) =>
+                        current?.sessionId === selected.id ? null : current,
+                      );
+                    }}
                     openTarget={
                       workbenchTarget && (workbenchTarget.sessionId ?? selected.id) === selected.id
                         ? workbenchTarget.open

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -32,12 +32,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { Icon } from "@/lib/icon";
+import { codeReviewQueue, type CodeQueueMode } from "@/lib/code-review-queue";
 import {
   CODE_GITHUB_TABS,
   CODE_ROOM_RAIL_WIDTH_PX,
   codeRoomFitsRail,
   codeSessionWorkRoot,
-  groupCodeRailSessions,
   isCodeGithubTab,
   parseCodeDeepLink,
   type CodeGithubTab,
@@ -174,6 +174,7 @@ export function CodeView({
   const [selectedId, setSelectedId] = useState<string | null | undefined>(
     deepLink?.sessionId ?? undefined,
   );
+  const [queueMode, setQueueMode] = useState<CodeQueueMode>("reviewable");
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   // The workbench picker offers "start a new session about <query>" when the
   // filter matches nothing. There is no title field to set — a session's title
@@ -204,7 +205,11 @@ export function CodeView({
     setNarrowLanding(narrowLandingRef.current);
   }, [roomWidth, isMobile]);
 
-  const groups = useMemo(() => groupCodeRailSessions(sessions), [sessions]);
+  const queueSelectedId = pendingOpen?.sessionId ?? (typeof selectedId === "string" ? selectedId : null);
+  const queue = useMemo(
+    () => codeReviewQueue(sessions, queueMode, queueSelectedId),
+    [queueMode, queueSelectedId, sessions],
+  );
 
   // Consume a routed file/diff open (cave-ohcj): select the raising chat
   // session's workbench — or, for a Projects-hub root browse, the newest
@@ -217,14 +222,15 @@ export function CodeView({
   } | null>(null);
   useEffect(() => {
     if (!pendingOpen) return;
+    const queueSessions = queue.sessions;
     const byId = pendingOpen.sessionId
-      ? groups.flatMap((g) => g.sessions).find((row) => row.id === pendingOpen.sessionId)
+      ? queueSessions.find((row) => row.id === pendingOpen.sessionId)
       : undefined;
     const root = pendingOpen.kind === "files" ? pendingOpen.root : undefined;
     const trim = (p: string) => p.replace(/\/+$/, "");
     const byRoot =
       !byId && root
-        ? groups.flatMap((g) => g.sessions).find((row) => trim(codeSessionWorkRoot(row)) === trim(root))
+        ? queueSessions.find((row) => trim(codeSessionWorkRoot(row)) === trim(root))
         : undefined;
     const target = byId ?? byRoot;
     setTopTab("sessions");
@@ -237,7 +243,7 @@ export function CodeView({
     // last one — dismissing is "I've read this", not "never show me these".
     setOriginDismissed(false);
     onPendingOpenHandled?.();
-  }, [groups, onPendingOpenHandled, pendingOpen]);
+  }, [onPendingOpenHandled, pendingOpen, queue.sessions]);
 
   // Only opens raised from a conversation carry an origin; a file picked from
   // the tree shows nothing, because there is no conversation to point back to.
@@ -259,12 +265,8 @@ export function CodeView({
 
   const selected = useMemo(() => {
     if (!selectedId) return null;
-    for (const group of groups) {
-      const hit = group.sessions.find((row) => row.id === selectedId);
-      if (hit) return hit;
-    }
-    return null;
-  }, [groups, selectedId]);
+    return queue.sessions.find((row) => row.id === selectedId) ?? null;
+  }, [queue.sessions, selectedId]);
 
   // Land on the newest session so the surface is immediately useful; keep the
   // user's explicit pick as long as that session is still visible. Skipped
@@ -277,9 +279,9 @@ export function CodeView({
     if (selectedId === null) return;
     if (narrowLanding !== false) return;
     if (selectedId && pendingNewIdRef.current === selectedId) return;
-    const first = groups[0]?.sessions[0];
+    const first = queue.sessions[0];
     if (first) setSelectedId(first.id);
-  }, [groups, selected, selectedId, narrowLanding]);
+  }, [narrowLanding, queue.sessions, selected, selectedId]);
 
   return (
     <div ref={roomRef} className="flex h-full min-h-0 flex-col">
@@ -385,7 +387,9 @@ export function CodeView({
             >
               {(open, setOpen) => (
                 <CodeSessionRail
-                  sessions={sessions}
+                  queue={queue}
+                  mode={queueMode}
+                  onModeChange={setQueueMode}
                   selectedId={selectedId ?? null}
                   onSelect={selectSession}
                   open={open}
@@ -398,7 +402,9 @@ export function CodeView({
               className={`${selected ? "hidden" : "block w-full"} shrink-0 border-[var(--border-hairline)]`}
             >
               <CodeSessionRail
-                sessions={sessions}
+                queue={queue}
+                mode={queueMode}
+                onModeChange={setQueueMode}
                 selectedId={selectedId ?? null}
                 onSelect={selectSession}
                 onNewSession={() => {
@@ -442,9 +448,11 @@ export function CodeView({
                   <CodeWorkbench
                     key={selected.id}
                     row={selected}
-                    // The workbench header carries its own session picker
-                    // (cave-0rcku), so it needs the same list the rail shows.
-                    sessions={sessions}
+                    // The workbench header carries the same shared queue scope
+                    // as the rail, so switching lenses cannot drift.
+                    queue={queue}
+                    queueMode={queueMode}
+                    onQueueModeChange={setQueueMode}
                     onSelectSession={(id) => {
                       setWorkbenchTarget(null);
                       setSelectedId(id);

--- a/src/components/code-work-scheduler.test.ts
+++ b/src/components/code-work-scheduler.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const source = readFileSync(
+  path.join(import.meta.dirname, "code-work-scheduler.tsx"),
+  "utf8",
+);
+
+test("CodeWorkScheduler requests the classified familiar-workspace session view", () => {
+  assert.match(
+    source,
+    /readJson\(\s*"\/api\/sessions\/list\?collapseFamiliarWorkspace=1&classifyFamiliarWorkspace=1",\s*signal,\s*\)/,
+    "scheduler should share the classified familiar-workspace sessions cache entry",
+  );
+});

--- a/src/components/code-work-scheduler.tsx
+++ b/src/components/code-work-scheduler.tsx
@@ -173,7 +173,10 @@ export function CodeWorkScheduler({
         readJson(`/api/beads?mode=ready&${query}`, signal),
         readJson(`/api/beads?mode=blocked&${query}`, signal),
         readJson("/api/familiars", signal),
-        readJson("/api/sessions/list?collapseFamiliarWorkspace=1", signal),
+        readJson(
+          "/api/sessions/list?collapseFamiliarWorkspace=1&classifyFamiliarWorkspace=1",
+          signal,
+        ),
       ]);
       if (seq !== seqRef.current) return;
 

--- a/src/components/code-workbench.tsx
+++ b/src/components/code-workbench.tsx
@@ -173,6 +173,7 @@ export function CodeWorkbench({
   // split, so viewport width systematically overstates what it actually got.
   // Three crushed columns is the failure this prevents.
   const fitsSplit = codeWorkbenchFitsSplit(measuredWidth, isMobile);
+  const initialTabNeedsMeasuredLayout = initialTab === "files" && measuredWidth === null && typeof ResizeObserver !== "undefined" && !isMobile;
   const [step, setStep] = useState<CodeWorkbenchStep>("source");
   const { announce } = useAnnouncer();
   const announcedStepRef = useRef<CodeWorkbenchStep | null>(null);
@@ -223,18 +224,20 @@ export function CodeWorkbench({
   // closed rail (and drills the narrow room to the right step) so the routed
   // target is actually visible rather than silently correct behind something.
   useEffect(() => {
+    if (initialTabNeedsMeasuredLayout) return;
     if (!initialTab) return;
     if (handledInitialTabRef.current === initialTab) return;
     handledInitialTabRef.current = initialTab;
     const nextRailTab = codeRailTabForWorkbenchTab(initialTab);
     if (initialTab === "terminal") onTerminalOpenChange(true);
+    if (initialTab === "files" && !fitsSplit) setStep("files");
     if (nextRailTab) {
       setRailTab(nextRailTab);
       onReviewOpenChange(true);
       setStep("review");
     }
     onInitialTabHandled?.();
-  }, [initialTab, onInitialTabHandled, onReviewOpenChange, onTerminalOpenChange]);
+  }, [fitsSplit, initialTab, initialTabNeedsMeasuredLayout, onInitialTabHandled, onReviewOpenChange, onTerminalOpenChange]);
 
   useEffect(() => {
     if (!openTarget) return;
@@ -274,6 +277,7 @@ export function CodeWorkbench({
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
       // Never steal a keystroke from a field — the composer, the picker's
       // filter, the editor — nor from a focused TERMINAL pane, where Ctrl+P
       // and Ctrl+C belong to the shell. Both exclusions live in one predicate

--- a/src/components/code-workbench.tsx
+++ b/src/components/code-workbench.tsx
@@ -54,6 +54,7 @@ import {
   codeSessionDiffstat,
   codeSessionWorkRoot,
   codeWorkbenchFitsSplit,
+  resolveCodeWorkbenchPanels,
   type CodeWorkbenchStep,
   type CodeWorkbenchTab,
 } from "@/lib/code-surface";
@@ -93,30 +94,40 @@ export function CodeWorkbench({
   row,
   queue,
   queueMode,
+  reviewOpen,
+  terminalOpen,
   initialTab,
   openTarget,
   onQueueModeChange,
+  onReviewOpenChange,
+  onTerminalOpenChange,
   onSelectSession,
   onNewSession,
   onJumpToSession,
   onRefresh,
+  onInitialTabHandled,
 }: {
   row: SessionRow;
   /** The shared precomputed queue, for the header picker. */
   queue: CodeReviewQueue;
   queueMode: CodeQueueMode;
+  reviewOpen?: boolean;
+  terminalOpen?: boolean;
   /** Deep-linked review tab (?wtab=), mapped through the rail vocabulary. */
   initialTab?: CodeWorkbenchTab;
   /** A routed file/diff open (cave-ohcj): lands on the file or the review rail
    *  with that path focused. `nonce` re-triggers the jump for a repeat path. */
   openTarget?: PendingCodeOpen;
   onQueueModeChange: (mode: CodeQueueMode) => void;
+  onReviewOpenChange: (open: boolean) => void;
+  onTerminalOpenChange: (open: boolean) => void;
   onSelectSession?: (sessionId: string) => void;
   /** Receives the picker's unmatched query, which seeds the kickoff prompt. */
   onNewSession?: (seed: string) => void;
   onJumpToSession: (sessionId: string, familiarId?: string | null) => void;
   /** Re-poll the enriched session list (branch/worktree chips) after inspector mutations. */
   onRefresh?: () => void;
+  onInitialTabHandled?: () => void;
 }) {
   const workRoot = codeSessionWorkRoot(row);
   const branch = codeSessionBranch(row);
@@ -125,6 +136,8 @@ export function CodeWorkbench({
   const prRepo = pr?.repo ?? null;
   const prNumber = pr?.number ?? null;
   const running = codeSessionActivity(row) === "running";
+  const handledOpenNonceRef = useRef<number | null>(null);
+  const handledInitialTabRef = useRef<CodeWorkbenchTab | null>(null);
 
   // ── Layout state ───────────────────────────────────────────────────────────
   // Measured against the workbench's OWN body, not the viewport: this renders
@@ -140,10 +153,8 @@ export function CodeWorkbench({
   const [railTab, setRailTab] = useState<CodeRailTab>(() =>
     codeRailTabForWorkbenchTab(initialTab) ?? "changes",
   );
-  const [railOpen, setRailOpen] = useState(true);
   const [railWidth, setRailWidth] = useState(CODE_RAIL_DEFAULT_WIDTH_PX);
   const [treeChangedOnly, setTreeChangedOnly] = useState(false);
-  const [termOpen, setTermOpen] = useState(false);
   const [inspectorOpen, setInspectorOpen] = useState(false);
   // The frame's `prFull`: the reader replaces the columns, and the room keeps
   // your file, your rail width and your step for the trip back.
@@ -188,6 +199,16 @@ export function CodeWorkbench({
     setPrFull(false);
   }, [row.id]);
 
+  const panels = resolveCodeWorkbenchPanels({
+    row,
+    reviewOpen,
+    terminalOpen,
+    initialTab:
+      handledInitialTabRef.current === initialTab ? undefined : initialTab,
+    openTarget:
+      openTarget && handledOpenNonceRef.current === openTarget.nonce ? undefined : openTarget,
+  });
+
   const openPath = useCallback(
     (path: string) => {
       setSelectedPath(
@@ -202,18 +223,33 @@ export function CodeWorkbench({
   // closed rail (and drills the narrow room to the right step) so the routed
   // target is actually visible rather than silently correct behind something.
   useEffect(() => {
+    if (!initialTab) return;
+    if (handledInitialTabRef.current === initialTab) return;
+    handledInitialTabRef.current = initialTab;
+    const nextRailTab = codeRailTabForWorkbenchTab(initialTab);
+    if (initialTab === "terminal") onTerminalOpenChange(true);
+    if (nextRailTab) {
+      setRailTab(nextRailTab);
+      onReviewOpenChange(true);
+      setStep("review");
+    }
+    onInitialTabHandled?.();
+  }, [initialTab, onInitialTabHandled, onReviewOpenChange, onTerminalOpenChange]);
+
+  useEffect(() => {
     if (!openTarget) return;
+    handledOpenNonceRef.current = openTarget.nonce;
     setRangeLabel(openTarget.origin?.selectionLabel ?? null);
     if (openTarget.kind === "changes") {
       setRailTab("changes");
-      setRailOpen(true);
+      onReviewOpenChange(true);
       setStep("review");
     } else if (openTarget.path) {
       openPath(openTarget.path);
       setFocusLine(openTarget.line ?? null);
       setStep("source");
     }
-  }, [openPath, openTarget]);
+  }, [onReviewOpenChange, openPath, openTarget]);
 
   const changes = useWorktreeChanges(workRoot, running);
 
@@ -247,13 +283,13 @@ export function CodeWorkbench({
       if (!action) return;
       event.preventDefault();
       if (action === "help") setKeysOpen((open) => !open);
-      else if (action === "terminal") setTermOpen((open) => !open);
+      else if (action === "terminal") onTerminalOpenChange(!panels.terminalOpen);
       else if (action === "changes") {
         setRailTab("changes");
-        setRailOpen(true);
+        onReviewOpenChange(true);
       } else if (action === "pr") {
         setRailTab("pr");
-        setRailOpen(true);
+        onReviewOpenChange(true);
       } else if (action === "files") {
         roomRef.current?.querySelector<HTMLElement>('[role="tree"]')?.focus();
       } else if (action === "outline") {
@@ -268,7 +304,7 @@ export function CodeWorkbench({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [keymap]);
+  }, [keymap, onReviewOpenChange, onTerminalOpenChange, panels.terminalOpen]);
 
   const changedFiles = useMemo(() => changes.files, [changes.files]);
 
@@ -416,8 +452,8 @@ export function CodeWorkbench({
             // survive into the narrow step — the Review step would render a
             // 28px sliver with no control to recover it. The state itself is
             // left alone so returning to the split restores what you chose.
-            open={fitsSplit ? railOpen : true}
-            onOpenChange={fitsSplit ? setRailOpen : () => setStep("source")}
+            open={fitsSplit ? panels.reviewOpen : true}
+            onOpenChange={fitsSplit ? onReviewOpenChange : () => setStep("source")}
             widthPx={fitsSplit ? railWidth : roomWidth}
             onWidthChange={setRailWidth}
             roomWidthPx={roomWidth}
@@ -432,8 +468,8 @@ export function CodeWorkbench({
         sessionId={row.id}
         projectRoot={workRoot}
         running={running}
-        open={termOpen}
-        onOpenChange={setTermOpen}
+        open={panels.terminalOpen}
+        onOpenChange={onTerminalOpenChange}
       />
 
       <CodeComposer row={row} onJumpToSession={onJumpToSession} />

--- a/src/components/code-workbench.tsx
+++ b/src/components/code-workbench.tsx
@@ -73,6 +73,7 @@ import {
 } from "@/lib/code-shortcuts";
 import { useWorktreeChanges } from "@/lib/use-worktree-changes";
 import type { PendingCodeOpen } from "@/lib/pending-code-open";
+import type { CodeQueueMode, CodeReviewQueue } from "@/lib/code-review-queue";
 import type { SessionRow } from "@/lib/types";
 
 // The reader pulls a markdown renderer and a diff highlighter; the room opens
@@ -90,22 +91,26 @@ const STEP_LABEL: Record<CodeWorkbenchStep, string> = {
 
 export function CodeWorkbench({
   row,
-  sessions,
+  queue,
+  queueMode,
   initialTab,
   openTarget,
+  onQueueModeChange,
   onSelectSession,
   onNewSession,
   onJumpToSession,
   onRefresh,
 }: {
   row: SessionRow;
-  /** Every code session, for the header picker. */
-  sessions: SessionRow[];
+  /** The shared precomputed queue, for the header picker. */
+  queue: CodeReviewQueue;
+  queueMode: CodeQueueMode;
   /** Deep-linked review tab (?wtab=), mapped through the rail vocabulary. */
   initialTab?: CodeWorkbenchTab;
   /** A routed file/diff open (cave-ohcj): lands on the file or the review rail
    *  with that path focused. `nonce` re-triggers the jump for a repeat path. */
   openTarget?: PendingCodeOpen;
+  onQueueModeChange: (mode: CodeQueueMode) => void;
   onSelectSession?: (sessionId: string) => void;
   /** Receives the picker's unmatched query, which seeds the kickoff prompt. */
   onNewSession?: (seed: string) => void;
@@ -271,8 +276,10 @@ export function CodeWorkbench({
     <div className="code-room" data-testid="code-workbench">
       <div className="code-room__header" data-testid="code-workbench-header">
         <CodeSessionPicker
-          sessions={sessions}
+          queue={queue}
+          mode={queueMode}
           selected={row}
+          onModeChange={onQueueModeChange}
           onSelect={(id) => onSelectSession?.(id)}
           onCreate={onNewSession}
         />

--- a/src/components/recent-activity-rollup.test.ts
+++ b/src/components/recent-activity-rollup.test.ts
@@ -59,7 +59,7 @@ assert.match(
 assert.doesNotMatch(source, /fetch\s*\(/, "Recent Activity performs no mount-time session request");
 assert.doesNotMatch(source, /usePausablePoll|setInterval|POLL_MS/, "Recent Activity owns no refresh interval");
 assert.equal(
-  [...workspace.matchAll(/fetch\(`\/api\/sessions\/list\$\{scope\}`/g)].length,
+  [...workspace.matchAll(/fetch\(`\/api\/sessions\/list\?\$\{params\.toString\(\)\}`/g)].length,
   1,
   "the mounted Workspace/sidebar path has one session-list request per refresh",
 );

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -207,8 +207,8 @@ assert.match(
 );
 assert.match(
   codeWorkbench,
-  /setRailTab\("changes"\);\s*setRailOpen\(true\);/,
-  "a routed diff open shows Changes in an OPEN rail — a correct-but-hidden rail reads as a no-op",
+  /setRailTab\("changes"\);\s*onReviewOpenChange\(true\);/,
+  "a routed diff open shows Changes and asks the host to reopen the review rail",
 );
 assert.match(
   codeWorkbench,

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -182,8 +182,8 @@ assert.match(
 );
 assert.match(
   codeView,
-  /if \(!pendingOpen\) return;[\s\S]*pendingOpen\.sessionId[\s\S]*\.find\(\(row\) => row\.id === pendingOpen\.sessionId\)[\s\S]*setTopTab\("sessions"\);[\s\S]*if \(target\) setSelectedId\(target\.id\);[\s\S]*onPendingOpenHandled\?\.\(\)/,
-  "CodeView should consume pending opens by selecting the raising session's workbench",
+  /const pendingQueueSelectedId = useMemo\(\s*\(\) => resolvePendingCodeOpenSessionId\(sessions, pendingOpen\),[\s\S]*if \(!pendingOpen\) return;[\s\S]*const byId = pendingQueueSelectedId\s*\?\s*queueSessions\.find\(\(row\) => row\.id === pendingQueueSelectedId\)[\s\S]*setTopTab\("sessions"\);[\s\S]*if \(target\) setSelectedId\(target\.id\);[\s\S]*onPendingOpenHandled\?\.\(\)/,
+  "CodeView should consume pending opens by selecting the resolved queue-visible workbench session",
 );
 assert.match(
   codeView,

--- a/src/components/workspace-sidebar-wiring.test.ts
+++ b/src/components/workspace-sidebar-wiring.test.ts
@@ -171,7 +171,7 @@ assert.doesNotMatch(
 );
 assert.match(
   workspace,
-  /const capturedActiveId = activeIdRef\.current;\s*\n\s*const capturedScopeKey = chatAttentionProjectionScopeKey\(capturedActiveId\);[\s\S]*?const scope = capturedActiveId/,
+  /const capturedActiveId = activeIdRef\.current;\s*\n\s*const capturedScopeKey = chatAttentionProjectionScopeKey\(capturedActiveId\);\s*\n\s*const reqId = \+\+loadSessionsReqRef\.current;\s*\n\s*const isCurrent = \(\) => isCurrentSessionListRequest\(\{[\s\S]*?capturedScopeKey,[\s\S]*?currentScopeKey: chatAttentionProjectionScopeKey\(activeIdRef\.current\),/,
   "loadSessions captures the current familiar and attention projection scope from activeIdRef",
 );
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1906,10 +1906,11 @@ export function Workspace() {
         // contradictory versus the clean project-scoped familiar homes. Scoped
         // views already drop them via project-grant scoping, so collapse is only
         // applied to the unscoped view.
-        const scope = capturedActiveId
-          ? `?familiarId=${encodeURIComponent(capturedActiveId)}`
-          : "?collapseFamiliarWorkspace=1";
-        const sessionsResult = await fetch(`/api/sessions/list${scope}`, { cache: "no-store" });
+        const params = new URLSearchParams();
+        params.set("classifyFamiliarWorkspace", "1");
+        if (capturedActiveId) params.set("familiarId", capturedActiveId);
+        else params.set("collapseFamiliarWorkspace", "1");
+        const sessionsResult = await fetch(`/api/sessions/list?${params.toString()}`, { cache: "no-store" });
         const json = await sessionsResult.json();
         if (!isCurrent()) return; // superseded by a newer load / scope change
         if (!json.ok) {

--- a/src/lib/code-review-queue.test.ts
+++ b/src/lib/code-review-queue.test.ts
@@ -10,15 +10,15 @@ import {
 import type { SessionGitContext, SessionRow } from "./types.ts";
 
 const NOW = "2026-09-01T12:00:00.000Z";
-const DEFAULT_ROOT = "/Users/dev/code/acme-alpha/.worktrees/feat-queue";
+const DEFAULT_ROOT = "/Users/dev/code/acme-alpha";
 const DEFAULT_REPO_URL = "https://github.com/acme/alpha";
 
 function gitFixture(overrides: Partial<SessionGitContext> = {}): SessionGitContext {
   return {
     branch: "feat/queue",
-    isWorktree: true,
+    isWorktree: false,
     worktreeRoot: DEFAULT_ROOT,
-    repositoryRoot: "/Users/dev/code/acme-alpha",
+    repositoryRoot: null,
     repositoryUrl: DEFAULT_REPO_URL,
     ...overrides,
   };
@@ -76,11 +76,11 @@ test("CodeSessionEligibility reason union stays exact", () => {
   assert.equal(mode, "reviewable");
 });
 
-test("codeSessionEligibility keeps canonical GitHub worktrees reviewable", () => {
+test("codeSessionEligibility keeps verified GitHub repositories reviewable", () => {
   assert.deepEqual(codeSessionEligibility(sessionFixture()), {
     reviewable: true,
     reason: "eligible",
-  });
+  }, "normal repository checkouts stay eligible when enrichment proves the GitHub repository root");
 
   assert.deepEqual(
     codeSessionEligibility(
@@ -122,15 +122,22 @@ test("codeSessionEligibility fails closed with explicit reasons", () => {
       expected: "unverified_git",
     },
     {
-      name: "shared checkouts without worktree proof",
+      name: "missing git worktree root",
       overrides: {
         git: gitFixture({
-          isWorktree: false,
-          worktreeRoot: "/Users/dev/code/acme-alpha",
-          repositoryRoot: null,
+          worktreeRoot: null,
         }),
         pullRequest: { repo: "acme/alpha", number: 42, state: "open", branch: "feat/queue" },
         diff: { additions: 4, deletions: 1 },
+      },
+      expected: "unverified_git",
+    },
+    {
+      name: "blank git worktree root",
+      overrides: {
+        git: gitFixture({
+          worktreeRoot: "   ",
+        }),
       },
       expected: "unverified_git",
     },
@@ -310,13 +317,13 @@ test("codeReviewQueue keeps all local Code-visible rows and root labels in all m
         updated_at: "2026-09-01T12:06:00.000Z",
       }),
       sessionFixture({
-        id: "shared-running",
+        id: "unverified-running",
         project_root: "/Users/dev/code/shared",
         updated_at: "2026-09-01T12:05:00.000Z",
         status: "running",
         git: gitFixture({
           isWorktree: false,
-          worktreeRoot: "/Users/dev/code/shared",
+          worktreeRoot: null,
           repositoryRoot: null,
           repositoryUrl: "https://github.com/acme/shared",
         }),
@@ -336,7 +343,7 @@ test("codeReviewQueue keeps all local Code-visible rows and root labels in all m
     null,
   );
 
-  assert.equal(queue.reviewableCount, 2, "only canonical GitHub worktrees count as reviewable");
+  assert.equal(queue.reviewableCount, 2, "only verified GitHub repositories count as reviewable");
   assert.equal(queue.allLocalCount, 4, "archived and generated rows remain outside generic Code visibility");
   assert.equal(queue.excludedCount, 2);
   assert.equal(queue.outsideCurrentFilter, false);
@@ -344,12 +351,12 @@ test("codeReviewQueue keeps all local Code-visible rows and root labels in all m
     queue.groups.map((group) => ({ key: group.key, label: group.label, ids: group.sessions.map((row) => row.id) })),
     [
       { key: "/Users/dev/code/bravo", label: "bravo", ids: ["bravo-failed"] },
-      { key: "/Users/dev/code/shared", label: "shared", ids: ["shared-running"] },
+      { key: "/Users/dev/code/shared", label: "shared", ids: ["unverified-running"] },
       { key: "/Users/dev/code/alpha", label: "alpha", ids: ["alpha-clean"] },
       { key: "", label: "(unknown)", ids: ["rootless"] },
     ],
   );
-  assert.deepEqual(queue.sessions.map((row) => row.id), ["bravo-failed", "shared-running", "alpha-clean", "rootless"]);
+  assert.deepEqual(queue.sessions.map((row) => row.id), ["bravo-failed", "unverified-running", "alpha-clean", "rootless"]);
 });
 
 test("codeReviewQueue appends one selected outside-filter row without changing counts", () => {

--- a/src/lib/code-review-queue.test.ts
+++ b/src/lib/code-review-queue.test.ts
@@ -288,6 +288,28 @@ test("codeReviewQueue groups reviewable sessions by canonical GitHub repo and pr
   ]);
 });
 
+test("codeReviewQueue treats blank pull request state as open when prioritizing review work", () => {
+  const queue = codeReviewQueue(
+    [
+      sessionFixture({
+        id: "running",
+        status: "running",
+        updated_at: "2026-09-01T12:01:00.000Z",
+      }),
+      sessionFixture({
+        id: "blank-pr-state",
+        diff: { additions: 2, deletions: 1 },
+        pullRequest: { repo: "acme/alpha", number: 7, state: "   ", branch: "feat/review" },
+        updated_at: "2026-09-01T12:00:00.000Z",
+      }),
+    ],
+    "reviewable",
+    null,
+  );
+
+  assert.deepEqual(queue.sessions.map((row) => row.id), ["blank-pr-state", "running"]);
+});
+
 test("codeReviewQueue keeps all local Code-visible rows and root labels in all mode", () => {
   const queue = codeReviewQueue(
     [

--- a/src/lib/code-review-queue.test.ts
+++ b/src/lib/code-review-queue.test.ts
@@ -1,0 +1,398 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { NO_CHAT_ATTENTION } from "./chat-attention.ts";
+import {
+  codeReviewQueue,
+  codeSessionEligibility,
+  type CodeQueueMode,
+  type CodeSessionEligibility,
+} from "./code-review-queue.ts";
+import type { SessionGitContext, SessionRow } from "./types.ts";
+
+const NOW = "2026-09-01T12:00:00.000Z";
+const DEFAULT_ROOT = "/Users/dev/code/acme-alpha/.worktrees/feat-queue";
+const DEFAULT_REPO_URL = "https://github.com/acme/alpha";
+
+function gitFixture(overrides: Partial<SessionGitContext> = {}): SessionGitContext {
+  return {
+    branch: "feat/queue",
+    isWorktree: true,
+    worktreeRoot: DEFAULT_ROOT,
+    repositoryRoot: "/Users/dev/code/acme-alpha",
+    repositoryUrl: DEFAULT_REPO_URL,
+    ...overrides,
+  };
+}
+
+function sessionFixture(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "session-1",
+    project_root: DEFAULT_ROOT,
+    harness: "coven",
+    title: "Queue session",
+    status: "idle",
+    exit_code: null,
+    archived_at: null,
+    created_at: NOW,
+    updated_at: NOW,
+    attention: NO_CHAT_ATTENTION,
+    generated: false,
+    git: gitFixture(),
+    workBranch: "feat/queue",
+    diff: null,
+    familiarWorkspace: false,
+    ...overrides,
+  };
+}
+
+function eligibilityReason(reason: CodeSessionEligibility["reason"]): string {
+  switch (reason) {
+    case "eligible":
+    case "archived":
+    case "generated":
+    case "rootless":
+    case "unverified_git":
+    case "non_github":
+    case "workspace_unclassified":
+    case "familiar_workspace":
+      return reason;
+  }
+}
+
+test("CodeSessionEligibility reason union stays exact", () => {
+  const reasons = [
+    "eligible",
+    "archived",
+    "generated",
+    "rootless",
+    "unverified_git",
+    "non_github",
+    "workspace_unclassified",
+    "familiar_workspace",
+  ] as const;
+  assert.deepEqual(reasons.map(eligibilityReason), reasons);
+
+  const mode: CodeQueueMode = "reviewable";
+  assert.equal(mode, "reviewable");
+});
+
+test("codeSessionEligibility keeps canonical GitHub worktrees reviewable", () => {
+  assert.deepEqual(codeSessionEligibility(sessionFixture()), {
+    reviewable: true,
+    reason: "eligible",
+  });
+
+  assert.deepEqual(
+    codeSessionEligibility(
+      sessionFixture({
+        id: "linked-worktree",
+        project_root: "/Users/dev/code/acme-alpha/.worktrees/pr-12",
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/acme-alpha/.worktrees/pr-12",
+          repositoryRoot: "/Users/dev/code/acme-alpha",
+          repositoryUrl: DEFAULT_REPO_URL,
+        }),
+      }),
+    ),
+    { reviewable: true, reason: "eligible" },
+    "linked worktrees stay eligible when server enrichment proves the canonical GitHub repository",
+  );
+});
+
+test("codeSessionEligibility fails closed with explicit reasons", () => {
+  const cases: Array<{ name: string; overrides: Partial<SessionRow>; expected: CodeSessionEligibility["reason"] }> = [
+    {
+      name: "archived sessions",
+      overrides: { archived_at: NOW },
+      expected: "archived",
+    },
+    {
+      name: "generated sessions",
+      overrides: { generated: true },
+      expected: "generated",
+    },
+    {
+      name: "rootless sessions",
+      overrides: { project_root: "" },
+      expected: "rootless",
+    },
+    {
+      name: "missing git context",
+      overrides: { git: null },
+      expected: "unverified_git",
+    },
+    {
+      name: "shared checkouts without worktree proof",
+      overrides: {
+        git: gitFixture({
+          isWorktree: false,
+          worktreeRoot: "/Users/dev/code/acme-alpha",
+          repositoryRoot: null,
+        }),
+        pullRequest: { repo: "acme/alpha", number: 42, state: "open", branch: "feat/queue" },
+        diff: { additions: 4, deletions: 1 },
+      },
+      expected: "unverified_git",
+    },
+    {
+      name: "missing canonical repository identity",
+      overrides: {
+        git: gitFixture({ repositoryUrl: null }),
+        pullRequest: { repo: "acme/alpha", number: 42, state: "open", branch: "feat/queue" },
+      },
+      expected: "non_github",
+    },
+    {
+      name: "noncanonical repository identity",
+      overrides: {
+        git: gitFixture({ repositoryUrl: "git@github.com:acme/alpha.git" }),
+      },
+      expected: "non_github",
+    },
+    {
+      name: "missing workspace classification",
+      overrides: { familiarWorkspace: undefined },
+      expected: "workspace_unclassified",
+    },
+    {
+      name: "familiar workspaces",
+      overrides: { familiarWorkspace: true },
+      expected: "familiar_workspace",
+    },
+  ];
+
+  for (const { name, overrides, expected } of cases) {
+    assert.deepEqual(
+      codeSessionEligibility(sessionFixture({ id: name.replace(/\s+/g, "-"), ...overrides })),
+      { reviewable: false, reason: expected },
+      name,
+    );
+  }
+});
+
+test("codeReviewQueue groups reviewable sessions by canonical GitHub repo and priority", () => {
+  const queue = codeReviewQueue(
+    [
+      sessionFixture({
+        id: "a-running",
+        project_root: "/Users/dev/code/repo-a/.worktrees/run",
+        title: "Running",
+        updated_at: "2026-09-01T12:03:00.000Z",
+        status: "running",
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/repo-a/.worktrees/run",
+          repositoryRoot: "/Users/dev/code/repo-a",
+          repositoryUrl: "https://github.com/acme/repo-a",
+        }),
+      }),
+      sessionFixture({
+        id: "a-pr",
+        project_root: "/Users/dev/code/repo-a/.worktrees/pr",
+        title: "Open PR",
+        updated_at: "2026-09-01T12:04:00.000Z",
+        diff: { additions: 5, deletions: 2 },
+        pullRequest: { repo: "acme/repo-a", number: 7, state: "open", branch: "feat/pr" },
+        git: gitFixture({
+          branch: "feat/pr",
+          worktreeRoot: "/Users/dev/code/repo-a/.worktrees/pr",
+          repositoryRoot: "/Users/dev/code/repo-a",
+          repositoryUrl: "https://github.com/acme/repo-a",
+        }),
+        workBranch: "feat/pr",
+      }),
+      sessionFixture({
+        id: "a-changed-a",
+        project_root: "/Users/dev/code/repo-a/.worktrees/change-a",
+        title: "Changed A",
+        updated_at: "2026-09-01T12:02:00.000Z",
+        diff: { additions: 3, deletions: 0 },
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/repo-a/.worktrees/change-a",
+          repositoryRoot: "/Users/dev/code/repo-a",
+          repositoryUrl: "https://github.com/acme/repo-a",
+        }),
+      }),
+      sessionFixture({
+        id: "a-changed-b",
+        project_root: "/Users/dev/code/repo-a/.worktrees/change-b",
+        title: "Changed B",
+        updated_at: "2026-09-01T12:02:00.000Z",
+        diff: { additions: 1, deletions: 1 },
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/repo-a/.worktrees/change-b",
+          repositoryRoot: "/Users/dev/code/repo-a",
+          repositoryUrl: "https://github.com/acme/repo-a",
+        }),
+      }),
+      sessionFixture({
+        id: "b-failed",
+        project_root: "/Users/dev/code/repo-b/.worktrees/fail",
+        title: "Failed",
+        updated_at: "2026-09-01T12:01:00.000Z",
+        status: "exited",
+        exit_code: 2,
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/repo-b/.worktrees/fail",
+          repositoryRoot: "/Users/dev/code/repo-b",
+          repositoryUrl: "https://github.com/acme/repo-b",
+        }),
+      }),
+      sessionFixture({
+        id: "c-clean",
+        project_root: "/Users/dev/code/repo-c/.worktrees/clean",
+        title: "Clean",
+        updated_at: "2026-09-01T12:05:00.000Z",
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/repo-c/.worktrees/clean",
+          repositoryRoot: "/Users/dev/code/repo-c",
+          repositoryUrl: "https://github.com/acme/repo-c",
+        }),
+      }),
+    ],
+    "reviewable",
+    null,
+  );
+
+  assert.equal(queue.reviewableCount, 6);
+  assert.equal(queue.allLocalCount, 6);
+  assert.equal(queue.excludedCount, 0);
+  assert.equal(queue.outsideCurrentFilter, false);
+  assert.deepEqual(
+    queue.groups.map((group) => ({ key: group.key, label: group.label, ids: group.sessions.map((row) => row.id) })),
+    [
+      { key: "https://github.com/acme/repo-b", label: "acme/repo-b", ids: ["b-failed"] },
+      {
+        key: "https://github.com/acme/repo-a",
+        label: "acme/repo-a",
+        ids: ["a-pr", "a-running", "a-changed-a", "a-changed-b"],
+      },
+      { key: "https://github.com/acme/repo-c", label: "acme/repo-c", ids: ["c-clean"] },
+    ],
+  );
+  assert.deepEqual(queue.sessions.map((row) => row.id), [
+    "b-failed",
+    "a-pr",
+    "a-running",
+    "a-changed-a",
+    "a-changed-b",
+    "c-clean",
+  ]);
+});
+
+test("codeReviewQueue keeps all local Code-visible rows and root labels in all mode", () => {
+  const queue = codeReviewQueue(
+    [
+      sessionFixture({
+        id: "bravo-failed",
+        project_root: "/Users/dev/code/bravo",
+        updated_at: "2026-09-01T12:01:00.000Z",
+        status: "exited",
+        exit_code: 1,
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/bravo/.worktrees/fail",
+          repositoryRoot: "/Users/dev/code/bravo",
+          repositoryUrl: "https://github.com/acme/bravo",
+        }),
+      }),
+      sessionFixture({
+        id: "alpha-clean",
+        project_root: "/Users/dev/code/alpha",
+        updated_at: "2026-09-01T12:00:00.000Z",
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/alpha/.worktrees/clean",
+          repositoryRoot: "/Users/dev/code/alpha",
+          repositoryUrl: "https://github.com/acme/alpha",
+        }),
+      }),
+      sessionFixture({
+        id: "rootless",
+        project_root: "",
+        updated_at: "2026-09-01T12:06:00.000Z",
+      }),
+      sessionFixture({
+        id: "shared-running",
+        project_root: "/Users/dev/code/shared",
+        updated_at: "2026-09-01T12:05:00.000Z",
+        status: "running",
+        git: gitFixture({
+          isWorktree: false,
+          worktreeRoot: "/Users/dev/code/shared",
+          repositoryRoot: null,
+          repositoryUrl: "https://github.com/acme/shared",
+        }),
+      }),
+      sessionFixture({
+        id: "archived",
+        project_root: "/Users/dev/code/archived",
+        archived_at: "2026-09-01T11:30:00.000Z",
+      }),
+      sessionFixture({
+        id: "generated",
+        project_root: "/Users/dev/code/generated",
+        generated: true,
+      }),
+    ],
+    "all",
+    null,
+  );
+
+  assert.equal(queue.reviewableCount, 2, "only canonical GitHub worktrees count as reviewable");
+  assert.equal(queue.allLocalCount, 4, "archived and generated rows remain outside generic Code visibility");
+  assert.equal(queue.excludedCount, 2);
+  assert.equal(queue.outsideCurrentFilter, false);
+  assert.deepEqual(
+    queue.groups.map((group) => ({ key: group.key, label: group.label, ids: group.sessions.map((row) => row.id) })),
+    [
+      { key: "/Users/dev/code/bravo", label: "bravo", ids: ["bravo-failed"] },
+      { key: "/Users/dev/code/shared", label: "shared", ids: ["shared-running"] },
+      { key: "/Users/dev/code/alpha", label: "alpha", ids: ["alpha-clean"] },
+      { key: "", label: "(unknown)", ids: ["rootless"] },
+    ],
+  );
+  assert.deepEqual(queue.sessions.map((row) => row.id), ["bravo-failed", "shared-running", "alpha-clean", "rootless"]);
+});
+
+test("codeReviewQueue appends one selected outside-filter row without changing counts", () => {
+  const rows = [
+    sessionFixture({
+      id: "eligible",
+      project_root: "/Users/dev/code/repo-z/.worktrees/eligible",
+      git: gitFixture({
+        worktreeRoot: "/Users/dev/code/repo-z/.worktrees/eligible",
+        repositoryRoot: "/Users/dev/code/repo-z",
+        repositoryUrl: "https://github.com/acme/repo-z",
+      }),
+    }),
+    sessionFixture({
+      id: "selected-rootless",
+      project_root: "",
+      updated_at: "2026-09-01T12:30:00.000Z",
+    }),
+  ];
+
+  const reviewable = codeReviewQueue(rows, "reviewable", "selected-rootless");
+  assert.equal(reviewable.reviewableCount, 1);
+  assert.equal(reviewable.allLocalCount, 2);
+  assert.equal(reviewable.excludedCount, 1);
+  assert.equal(reviewable.outsideCurrentFilter, true);
+  assert.deepEqual(reviewable.sessions.map((row) => row.id), ["eligible", "selected-rootless"]);
+  assert.equal(reviewable.groups.at(-1)?.sessions.at(-1)?.id, "selected-rootless");
+
+  const allLocal = codeReviewQueue(
+    [
+      ...rows,
+      sessionFixture({ id: "selected-archived", archived_at: "2026-09-01T11:45:00.000Z" }),
+    ],
+    "all",
+    "selected-archived",
+  );
+  assert.equal(allLocal.reviewableCount, 1);
+  assert.equal(allLocal.allLocalCount, 2);
+  assert.equal(allLocal.excludedCount, 1);
+  assert.equal(allLocal.outsideCurrentFilter, true);
+  assert.equal(allLocal.sessions.at(-1)?.id, "selected-archived");
+
+  const alreadyIncluded = codeReviewQueue(rows, "reviewable", "eligible");
+  assert.equal(alreadyIncluded.outsideCurrentFilter, false);
+  assert.deepEqual(alreadyIncluded.sessions.map((row) => row.id), ["eligible"]);
+});

--- a/src/lib/code-review-queue.test.ts
+++ b/src/lib/code-review-queue.test.ts
@@ -4,9 +4,11 @@ import { NO_CHAT_ATTENTION } from "./chat-attention.ts";
 import {
   codeReviewQueue,
   codeSessionEligibility,
+  resolvePendingCodeOpenSessionId,
   type CodeQueueMode,
   type CodeSessionEligibility,
 } from "./code-review-queue.ts";
+import type { PendingCodeOpen } from "./pending-code-open.ts";
 import type { SessionGitContext, SessionRow } from "./types.ts";
 
 const NOW = "2026-09-01T12:00:00.000Z";
@@ -524,4 +526,66 @@ test("codeReviewQueue includes one selected outside-filter row without changing 
   const alreadyIncluded = codeReviewQueue(rows, "reviewable", "eligible");
   assert.equal(alreadyIncluded.outsideCurrentFilter, false);
   assert.deepEqual(alreadyIncluded.sessions.map((row) => row.id), ["eligible"]);
+});
+
+test("root-only pending opens resolve an all-local session override before the reviewable queue", () => {
+  const root = "/Users/dev/code/repo-a/.worktrees/review-desk";
+  const rows = [
+    sessionFixture({
+      id: "eligible-pr",
+      project_root: root,
+      updated_at: "2026-09-01T12:01:00.000Z",
+      diff: { additions: 4, deletions: 1 },
+      pullRequest: { repo: "acme/repo-a", number: 9, state: "open", branch: "feat/pr" },
+      git: gitFixture({
+        branch: "feat/pr",
+        worktreeRoot: root,
+        repositoryRoot: "/Users/dev/code/repo-a",
+        repositoryUrl: "https://github.com/acme/repo-a",
+      }),
+      workBranch: "feat/pr",
+    }),
+    sessionFixture({
+      id: "familiar-newest",
+      project_root: root,
+      updated_at: "2026-09-01T12:04:00.000Z",
+      familiarWorkspace: true,
+      git: gitFixture({
+        worktreeRoot: root,
+        repositoryRoot: "/Users/dev/code/repo-a",
+        repositoryUrl: "https://github.com/acme/repo-a",
+      }),
+    }),
+    sessionFixture({
+      id: "generated-newer-still-hidden",
+      project_root: root,
+      updated_at: "2026-09-01T12:05:00.000Z",
+      generated: true,
+      git: gitFixture({
+        worktreeRoot: root,
+        repositoryRoot: "/Users/dev/code/repo-a",
+        repositoryUrl: "https://github.com/acme/repo-a",
+      }),
+    }),
+  ];
+  const pendingRootOpen = { kind: "files", root, nonce: 1 } satisfies PendingCodeOpen;
+  const overrideId = resolvePendingCodeOpenSessionId(rows, pendingRootOpen);
+
+  assert.equal(overrideId, "familiar-newest");
+  assert.equal(
+    resolvePendingCodeOpenSessionId(rows, {
+      kind: "changes",
+      path: "src/demo.ts",
+      sessionId: "eligible-pr",
+      nonce: 2,
+    }),
+    "eligible-pr",
+    "sessionId-driven pending opens keep their explicit target",
+  );
+
+  const queue = codeReviewQueue(rows, "reviewable", overrideId);
+  assert.equal(queue.outsideCurrentFilter, true);
+  assert.equal(queue.sessions.some((row) => row.id === "familiar-newest"), true);
+  assert.equal(queue.sessions.filter((row) => row.id === "familiar-newest").length, 1);
+  assert.equal(queue.sessions.some((row) => row.id === "generated-newer-still-hidden"), false);
 });

--- a/src/lib/code-review-queue.test.ts
+++ b/src/lib/code-review-queue.test.ts
@@ -359,7 +359,128 @@ test("codeReviewQueue keeps all local Code-visible rows and root labels in all m
   assert.deepEqual(queue.sessions.map((row) => row.id), ["bravo-failed", "unverified-running", "alpha-clean", "rootless"]);
 });
 
-test("codeReviewQueue appends one selected outside-filter row without changing counts", () => {
+test("codeReviewQueue sorts a selected generated override inside an existing reviewable group", () => {
+  const queue = codeReviewQueue(
+    [
+      sessionFixture({
+        id: "repo-changed",
+        project_root: "/Users/dev/code/repo-a/.worktrees/changed",
+        updated_at: "2026-09-01T12:01:00.000Z",
+        diff: { additions: 3, deletions: 1 },
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/repo-a/.worktrees/changed",
+          repositoryRoot: "/Users/dev/code/repo-a",
+          repositoryUrl: "https://github.com/acme/repo-a",
+        }),
+      }),
+      sessionFixture({
+        id: "repo-clean",
+        project_root: "/Users/dev/code/repo-a/.worktrees/clean",
+        updated_at: "2026-09-01T12:00:00.000Z",
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/repo-a/.worktrees/clean",
+          repositoryRoot: "/Users/dev/code/repo-a",
+          repositoryUrl: "https://github.com/acme/repo-a",
+        }),
+      }),
+      sessionFixture({
+        id: "selected-generated-running",
+        project_root: "/Users/dev/code/repo-a/.worktrees/generated",
+        updated_at: "2026-09-01T12:02:00.000Z",
+        status: "running",
+        generated: true,
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/repo-a/.worktrees/generated",
+          repositoryRoot: "/Users/dev/code/repo-a",
+          repositoryUrl: "https://github.com/acme/repo-a",
+        }),
+      }),
+    ],
+    "reviewable",
+    "selected-generated-running",
+  );
+
+  assert.equal(queue.reviewableCount, 2);
+  assert.equal(queue.allLocalCount, 2);
+  assert.equal(queue.excludedCount, 0);
+  assert.equal(queue.outsideCurrentFilter, true);
+  assert.deepEqual(queue.groups.map((group) => group.sessions.map((row) => row.id)), [
+    ["selected-generated-running", "repo-changed", "repo-clean"],
+  ]);
+  assert.deepEqual(queue.sessions.map((row) => row.id), [
+    "selected-generated-running",
+    "repo-changed",
+    "repo-clean",
+  ]);
+  assert.equal(queue.sessions.filter((row) => row.id === "selected-generated-running").length, 1);
+});
+
+test("codeReviewQueue re-sorts groups when a selected archived override creates a higher-priority repo", () => {
+  const queue = codeReviewQueue(
+    [
+      sessionFixture({
+        id: "repo-pr",
+        project_root: "/Users/dev/code/repo-a/.worktrees/pr",
+        updated_at: "2026-09-01T12:01:00.000Z",
+        diff: { additions: 5, deletions: 2 },
+        pullRequest: { repo: "acme/repo-a", number: 7, state: "open", branch: "feat/pr" },
+        git: gitFixture({
+          branch: "feat/pr",
+          worktreeRoot: "/Users/dev/code/repo-a/.worktrees/pr",
+          repositoryRoot: "/Users/dev/code/repo-a",
+          repositoryUrl: "https://github.com/acme/repo-a",
+        }),
+        workBranch: "feat/pr",
+      }),
+      sessionFixture({
+        id: "repo-clean",
+        project_root: "/Users/dev/code/repo-z/.worktrees/clean",
+        updated_at: "2026-09-01T12:00:00.000Z",
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/repo-z/.worktrees/clean",
+          repositoryRoot: "/Users/dev/code/repo-z",
+          repositoryUrl: "https://github.com/acme/repo-z",
+        }),
+      }),
+      sessionFixture({
+        id: "selected-archived-failed",
+        project_root: "/Users/dev/code/repo-b/.worktrees/fail",
+        updated_at: "2026-09-01T12:02:00.000Z",
+        status: "exited",
+        exit_code: 1,
+        archived_at: "2026-09-01T12:03:00.000Z",
+        git: gitFixture({
+          worktreeRoot: "/Users/dev/code/repo-b/.worktrees/fail",
+          repositoryRoot: "/Users/dev/code/repo-b",
+          repositoryUrl: "https://github.com/acme/repo-b",
+        }),
+      }),
+    ],
+    "reviewable",
+    "selected-archived-failed",
+  );
+
+  assert.equal(queue.reviewableCount, 2);
+  assert.equal(queue.allLocalCount, 2);
+  assert.equal(queue.excludedCount, 0);
+  assert.equal(queue.outsideCurrentFilter, true);
+  assert.deepEqual(
+    queue.groups.map((group) => ({ key: group.key, ids: group.sessions.map((row) => row.id) })),
+    [
+      { key: "https://github.com/acme/repo-b", ids: ["selected-archived-failed"] },
+      { key: "https://github.com/acme/repo-a", ids: ["repo-pr"] },
+      { key: "https://github.com/acme/repo-z", ids: ["repo-clean"] },
+    ],
+  );
+  assert.deepEqual(queue.sessions.map((row) => row.id), [
+    "selected-archived-failed",
+    "repo-pr",
+    "repo-clean",
+  ]);
+  assert.equal(queue.sessions.filter((row) => row.id === "selected-archived-failed").length, 1);
+});
+
+test("codeReviewQueue includes one selected outside-filter row without changing counts", () => {
   const rows = [
     sessionFixture({
       id: "eligible",
@@ -382,8 +503,8 @@ test("codeReviewQueue appends one selected outside-filter row without changing c
   assert.equal(reviewable.allLocalCount, 2);
   assert.equal(reviewable.excludedCount, 1);
   assert.equal(reviewable.outsideCurrentFilter, true);
-  assert.deepEqual(reviewable.sessions.map((row) => row.id), ["eligible", "selected-rootless"]);
-  assert.equal(reviewable.groups.at(-1)?.sessions.at(-1)?.id, "selected-rootless");
+  assert.equal(reviewable.sessions.some((row) => row.id === "selected-rootless"), true);
+  assert.equal(reviewable.sessions.filter((row) => row.id === "selected-rootless").length, 1);
 
   const allLocal = codeReviewQueue(
     [
@@ -397,7 +518,8 @@ test("codeReviewQueue appends one selected outside-filter row without changing c
   assert.equal(allLocal.allLocalCount, 2);
   assert.equal(allLocal.excludedCount, 1);
   assert.equal(allLocal.outsideCurrentFilter, true);
-  assert.equal(allLocal.sessions.at(-1)?.id, "selected-archived");
+  assert.equal(allLocal.sessions.some((row) => row.id === "selected-archived"), true);
+  assert.equal(allLocal.sessions.filter((row) => row.id === "selected-archived").length, 1);
 
   const alreadyIncluded = codeReviewQueue(rows, "reviewable", "eligible");
   assert.equal(alreadyIncluded.outsideCurrentFilter, false);

--- a/src/lib/code-review-queue.ts
+++ b/src/lib/code-review-queue.ts
@@ -65,9 +65,10 @@ function trimTrailingSlashes(path: string): string {
 function reviewPriority(row: SessionRow): number {
   const activity = codeSessionActivity(row);
   if (activity === "error") return 0;
+  const pullRequestState = row.pullRequest?.state?.trim().toLowerCase();
   if (
     row.pullRequest &&
-    (row.pullRequest.state ?? "open").toLowerCase() === "open" &&
+    (!pullRequestState || pullRequestState === "open") &&
     codeSessionDiffstat(row)
   ) {
     return 1;

--- a/src/lib/code-review-queue.ts
+++ b/src/lib/code-review-queue.ts
@@ -1,10 +1,10 @@
-import { gitHubRepoSlug, normalizeGitHubRepoUrl } from "@/lib/github-repo-link";
+import { gitHubRepoSlug, normalizeGitHubRepoUrl } from "./github-repo-link.ts";
 import {
   codeSessionActivity,
   codeSessionDiffstat,
   isCodeRailSession,
-} from "@/lib/code-surface";
-import type { SessionRow } from "@/lib/types";
+} from "./code-surface.ts";
+import type { SessionRow } from "./types.ts";
 
 export type CodeQueueMode = "reviewable" | "all";
 

--- a/src/lib/code-review-queue.ts
+++ b/src/lib/code-review-queue.ts
@@ -1,0 +1,196 @@
+import { gitHubRepoSlug, normalizeGitHubRepoUrl } from "@/lib/github-repo-link";
+import {
+  codeSessionActivity,
+  codeSessionDiffstat,
+  isCodeRailSession,
+} from "@/lib/code-surface";
+import type { SessionRow } from "@/lib/types";
+
+export type CodeQueueMode = "reviewable" | "all";
+
+export type CodeSessionEligibility = {
+  reviewable: boolean;
+  reason:
+    | "eligible"
+    | "archived"
+    | "generated"
+    | "rootless"
+    | "unverified_git"
+    | "non_github"
+    | "workspace_unclassified"
+    | "familiar_workspace";
+};
+
+export type CodeReviewGroup = {
+  key: string;
+  label: string;
+  sessions: SessionRow[];
+};
+
+export type CodeReviewQueue = {
+  groups: CodeReviewGroup[];
+  sessions: SessionRow[];
+  reviewableCount: number;
+  allLocalCount: number;
+  excludedCount: number;
+  outsideCurrentFilter: boolean;
+};
+
+type GroupRecord = {
+  key: string;
+  label: string;
+  sessions: SessionRow[];
+  bestPriority: number;
+  newestUpdate: number;
+};
+
+function projectLabel(root: string): string {
+  const trimmed = root.replace(/[\\/]+$/, "");
+  const idx = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  const base = idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+  return base || trimmed || "(unknown)";
+}
+
+function updatedAt(row: SessionRow): number {
+  const parsed = Date.parse(row.updated_at);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function reviewPriority(row: SessionRow): number {
+  const activity = codeSessionActivity(row);
+  if (activity === "error") return 0;
+  if (
+    row.pullRequest &&
+    (row.pullRequest.state ?? "open").toLowerCase() === "open" &&
+    codeSessionDiffstat(row)
+  ) {
+    return 1;
+  }
+  if (activity === "running") return 2;
+  if (codeSessionDiffstat(row)) return 3;
+  return 4;
+}
+
+function compareSessions(a: SessionRow, b: SessionRow): number {
+  const priorityDelta = reviewPriority(a) - reviewPriority(b);
+  if (priorityDelta !== 0) return priorityDelta;
+  const updateDelta = updatedAt(b) - updatedAt(a);
+  if (updateDelta !== 0) return updateDelta;
+  return a.id.localeCompare(b.id);
+}
+
+function groupKey(row: SessionRow, mode: CodeQueueMode): string {
+  if (mode === "reviewable") {
+    const repositoryUrl = row.git?.repositoryUrl?.trim();
+    if (repositoryUrl) return repositoryUrl;
+  }
+  return row.project_root || "";
+}
+
+function groupLabel(row: SessionRow, mode: CodeQueueMode): string {
+  if (mode === "reviewable") {
+    const slug = gitHubRepoSlug(row.git?.repositoryUrl);
+    if (slug) return slug;
+  }
+  return row.project_root ? projectLabel(row.project_root) : "(unknown)";
+}
+
+function buildGroups(rows: readonly SessionRow[], mode: CodeQueueMode): GroupRecord[] {
+  const byKey = new Map<string, GroupRecord>();
+  for (const row of rows) {
+    const key = groupKey(row, mode);
+    const label = groupLabel(row, mode);
+    const existing = byKey.get(key);
+    if (existing) existing.sessions.push(row);
+    else byKey.set(key, { key, label, sessions: [row], bestPriority: Number.POSITIVE_INFINITY, newestUpdate: 0 });
+  }
+
+  const groups = [...byKey.values()];
+  for (const group of groups) {
+    group.sessions.sort(compareSessions);
+    group.bestPriority = group.sessions.length ? reviewPriority(group.sessions[0]) : Number.POSITIVE_INFINITY;
+    group.newestUpdate = group.sessions.reduce((newest, row) => Math.max(newest, updatedAt(row)), 0);
+  }
+
+  groups.sort((a, b) => {
+    if (mode === "all") {
+      if (!a.key && b.key) return 1;
+      if (a.key && !b.key) return -1;
+    }
+    const priorityDelta = a.bestPriority - b.bestPriority;
+    if (priorityDelta !== 0) return priorityDelta;
+    const updateDelta = b.newestUpdate - a.newestUpdate;
+    if (updateDelta !== 0) return updateDelta;
+    const labelDelta = a.label.localeCompare(b.label);
+    if (labelDelta !== 0) return labelDelta;
+    return a.key.localeCompare(b.key);
+  });
+
+  return groups;
+}
+
+export function codeSessionEligibility(row: SessionRow): CodeSessionEligibility {
+  if (row.archived_at) return { reviewable: false, reason: "archived" };
+  if (row.generated) return { reviewable: false, reason: "generated" };
+  if (!row.project_root.trim()) return { reviewable: false, reason: "rootless" };
+
+  const git = row.git;
+  if (!git || git.isWorktree !== true || !git.worktreeRoot?.trim()) {
+    return { reviewable: false, reason: "unverified_git" };
+  }
+
+  const repositoryUrl = git.repositoryUrl?.trim();
+  if (!repositoryUrl || normalizeGitHubRepoUrl(repositoryUrl) !== repositoryUrl) {
+    return { reviewable: false, reason: "non_github" };
+  }
+
+  if (row.familiarWorkspace === undefined) {
+    return { reviewable: false, reason: "workspace_unclassified" };
+  }
+  if (row.familiarWorkspace) return { reviewable: false, reason: "familiar_workspace" };
+  return { reviewable: true, reason: "eligible" };
+}
+
+export function codeReviewQueue(
+  rows: readonly SessionRow[],
+  mode: CodeQueueMode,
+  selectedId: string | null,
+): CodeReviewQueue {
+  const allLocal = rows.filter((row) => isCodeRailSession(row));
+  const reviewable = allLocal.filter((row) => codeSessionEligibility(row).reviewable);
+  const visible = mode === "reviewable" ? reviewable : allLocal;
+  const groups = buildGroups(visible, mode);
+
+  let outsideCurrentFilter = false;
+  if (selectedId) {
+    const selected = rows.find((row) => row.id === selectedId) ?? null;
+    const alreadyVisible = visible.some((row) => row.id === selectedId);
+    if (selected && !alreadyVisible) {
+      outsideCurrentFilter = true;
+      const key = groupKey(selected, mode);
+      const label = groupLabel(selected, mode);
+      const existingGroup = groups.find((group) => group.key === key);
+      if (existingGroup) {
+        if (!existingGroup.sessions.some((row) => row.id === selected.id)) existingGroup.sessions.push(selected);
+      } else {
+        groups.push({
+          key,
+          label,
+          sessions: [selected],
+          bestPriority: reviewPriority(selected),
+          newestUpdate: updatedAt(selected),
+        });
+      }
+    }
+  }
+
+  const flatSessions = groups.flatMap((group) => group.sessions);
+  return {
+    groups: groups.map(({ key, label, sessions }) => ({ key, label, sessions })),
+    sessions: flatSessions,
+    reviewableCount: reviewable.length,
+    allLocalCount: allLocal.length,
+    excludedCount: allLocal.length - reviewable.length,
+    outsideCurrentFilter,
+  };
+}

--- a/src/lib/code-review-queue.ts
+++ b/src/lib/code-review-queue.ts
@@ -158,31 +158,13 @@ export function codeReviewQueue(
 ): CodeReviewQueue {
   const allLocal = rows.filter((row) => isCodeRailSession(row));
   const reviewable = allLocal.filter((row) => codeSessionEligibility(row).reviewable);
-  const visible = mode === "reviewable" ? reviewable : allLocal;
-  const groups = buildGroups(visible, mode);
-
   let outsideCurrentFilter = false;
-  if (selectedId) {
-    const selected = rows.find((row) => row.id === selectedId) ?? null;
-    const alreadyVisible = visible.some((row) => row.id === selectedId);
-    if (selected && !alreadyVisible) {
-      outsideCurrentFilter = true;
-      const key = groupKey(selected, mode);
-      const label = groupLabel(selected, mode);
-      const existingGroup = groups.find((group) => group.key === key);
-      if (existingGroup) {
-        if (!existingGroup.sessions.some((row) => row.id === selected.id)) existingGroup.sessions.push(selected);
-      } else {
-        groups.push({
-          key,
-          label,
-          sessions: [selected],
-          bestPriority: reviewPriority(selected),
-          newestUpdate: updatedAt(selected),
-        });
-      }
-    }
-  }
+  const visible = mode === "reviewable" ? reviewable : allLocal;
+  const selected = selectedId ? rows.find((row) => row.id === selectedId) ?? null : null;
+  const alreadyVisible = selected ? visible.some((row) => row.id === selected.id) : false;
+  const visibleWithSelected = selected && !alreadyVisible ? [...visible, selected] : visible;
+  if (selected && !alreadyVisible) outsideCurrentFilter = true;
+  const groups = buildGroups(visibleWithSelected, mode);
 
   const flatSessions = groups.flatMap((group) => group.sessions);
   return {

--- a/src/lib/code-review-queue.ts
+++ b/src/lib/code-review-queue.ts
@@ -135,7 +135,7 @@ export function codeSessionEligibility(row: SessionRow): CodeSessionEligibility 
   if (!row.project_root.trim()) return { reviewable: false, reason: "rootless" };
 
   const git = row.git;
-  if (!git || git.isWorktree !== true || !git.worktreeRoot?.trim()) {
+  if (!git || !git.worktreeRoot?.trim()) {
     return { reviewable: false, reason: "unverified_git" };
   }
 

--- a/src/lib/code-review-queue.ts
+++ b/src/lib/code-review-queue.ts
@@ -1,7 +1,9 @@
 import { gitHubRepoSlug, normalizeGitHubRepoUrl } from "./github-repo-link.ts";
+import type { PendingCodeOpen } from "./pending-code-open.ts";
 import {
   codeSessionActivity,
   codeSessionDiffstat,
+  codeSessionWorkRoot,
   isCodeRailSession,
 } from "./code-surface.ts";
 import type { SessionRow } from "./types.ts";
@@ -54,6 +56,10 @@ function projectLabel(root: string): string {
 function updatedAt(row: SessionRow): number {
   const parsed = Date.parse(row.updated_at);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function trimTrailingSlashes(path: string): string {
+  return path.replace(/\/+$/, "");
 }
 
 function reviewPriority(row: SessionRow): number {
@@ -149,6 +155,29 @@ export function codeSessionEligibility(row: SessionRow): CodeSessionEligibility 
   }
   if (row.familiarWorkspace) return { reviewable: false, reason: "familiar_workspace" };
   return { reviewable: true, reason: "eligible" };
+}
+
+export function resolvePendingCodeOpenSessionId(
+  rows: readonly SessionRow[],
+  pendingOpen: PendingCodeOpen | null | undefined,
+): string | null {
+  if (!pendingOpen) return null;
+  if (pendingOpen.sessionId) return pendingOpen.sessionId;
+  if (pendingOpen.kind !== "files" || !pendingOpen.root) return null;
+
+  const root = trimTrailingSlashes(pendingOpen.root);
+  let newestMatch: SessionRow | null = null;
+  let newestTimestamp = Number.NEGATIVE_INFINITY;
+  for (const row of rows) {
+    if (!isCodeRailSession(row)) continue;
+    if (trimTrailingSlashes(codeSessionWorkRoot(row)) !== root) continue;
+    const rowUpdatedAt = updatedAt(row);
+    if (!newestMatch || rowUpdatedAt > newestTimestamp) {
+      newestMatch = row;
+      newestTimestamp = rowUpdatedAt;
+    }
+  }
+  return newestMatch?.id ?? null;
 }
 
 export function codeReviewQueue(

--- a/src/lib/code-session-picker.test.ts
+++ b/src/lib/code-session-picker.test.ts
@@ -31,12 +31,60 @@ assert.equal(codeSessionMatchesQuery(row(), "   "), true);
 // at least as often as by name.
 assert.equal(codeSessionMatchesQuery(row(), "LOOPBACK"), true);
 assert.equal(codeSessionMatchesQuery(row(), "coven-cave"), true);
+assert.equal(
+  codeSessionMatchesQuery(
+    row({ git: { repositoryUrl: "https://github.com/acme/coven-cave" } }),
+    "acme/coven-cave",
+  ),
+  true,
+);
 assert.equal(codeSessionMatchesQuery(row({ workBranch: "feat/cave-8i8q5-x-api" }), "8i8q5"), true);
 assert.equal(codeSessionMatchesQuery(row(), "nothing-here"), false);
 
 // The project label is matched, not the whole absolute path — otherwise every
 // session matches "Users".
 assert.equal(codeSessionMatchesQuery(row(), "/Users/x/code"), false);
+
+// Reviewable groups show canonical owner/repo labels, so the same slug must be
+// searchable even when multiple local checkouts share one basename.
+{
+  const rows = [
+    row({
+      id: "acme",
+      project_root: "/Users/x/worktrees/coven-cave",
+      git: { repositoryUrl: "https://github.com/acme/coven-cave" },
+    }),
+    row({
+      id: "other",
+      title: "Other fork",
+      project_root: "/Users/x/sandboxes/coven-cave",
+      git: { repositoryUrl: "https://github.com/other/coven-cave" },
+    }),
+  ];
+  const sharedBasename = queue([
+    {
+      key: "https://github.com/acme/coven-cave",
+      label: "acme/coven-cave",
+      sessions: [rows[0]],
+    },
+    {
+      key: "https://github.com/other/coven-cave",
+      label: "other/coven-cave",
+      sessions: [rows[1]],
+    },
+  ]);
+
+  const slugMatch = codeSessionPickerResult(sharedBasename, "other/coven-cave", null);
+  assert.equal(slugMatch.offersCreate, false);
+  assert.equal(slugMatch.count, 1);
+  assert.deepEqual(slugMatch.groups.map((group) => group.label), ["other/coven-cave"]);
+  assert.deepEqual(slugMatch.groups[0].sessions.map((session) => session.id), ["other"]);
+
+  const basenameMatch = codeSessionPickerResult(sharedBasename, "coven-cave", null);
+  assert.equal(basenameMatch.offersCreate, false);
+  assert.equal(basenameMatch.count, 2);
+  assert.deepEqual(basenameMatch.groups.map((group) => group.label), ["acme/coven-cave", "other/coven-cave"]);
+}
 
 // ── Grouping ─────────────────────────────────────────────────────────────────
 

--- a/src/lib/code-session-picker.test.ts
+++ b/src/lib/code-session-picker.test.ts
@@ -14,6 +14,13 @@ function row(over = {}) {
   };
 }
 
+function queue(groups) {
+  return {
+    groups,
+    sessions: groups.flatMap((group) => group.sessions),
+  };
+}
+
 // ── Filtering ────────────────────────────────────────────────────────────────
 
 // A blank query is not a filter — it must not hide anything.
@@ -39,30 +46,57 @@ assert.equal(codeSessionMatchesQuery(row(), "/Users/x/code"), false);
     row({ id: "b", updated_at: "2026-08-08T11:00:00.000Z" }),
     row({ id: "c", project_root: "/Users/x/code/coven-pocket", updated_at: "2026-08-08T12:00:00.000Z" }),
   ];
-  const result = codeSessionPickerResult(rows, "", null);
+  const result = codeSessionPickerResult(
+    queue([
+      {
+        key: "repo-pocket",
+        label: "acme/coven-pocket",
+        sessions: [rows[2]],
+      },
+      {
+        key: "repo-cave",
+        label: "acme/coven-cave",
+        sessions: [rows[1], rows[0]],
+      },
+    ]),
+    "",
+    null,
+  );
   assert.equal(result.groups.length, 2);
-  // Newest group first, newest session first inside it.
-  assert.equal(result.groups[0].label, "coven-pocket");
-  assert.equal(result.groups[1].label, "coven-cave");
+  // The picker inherits the queue's group and session order verbatim.
+  assert.equal(result.groups[0].label, "acme/coven-pocket");
+  assert.equal(result.groups[1].label, "acme/coven-cave");
   assert.deepEqual(result.groups[1].sessions.map((s) => s.id), ["b", "a"]);
+  assert.deepEqual(result.groups.flatMap((group) => group.sessions).map((s) => s.id), ["c", "b", "a"]);
   assert.equal(result.count, 3);
   assert.equal(result.offersCreate, false);
 }
 
-// Archived and generated sessions never reach the picker — the rail's own
-// visibility rule, reused so the two lenses cannot drift apart.
+// The picker does not re-decide queue eligibility. Whatever ordering and
+// visibility CodeView already computed is the source of truth here.
 {
-  const rows = [row({ id: "keep" }), row({ id: "gone", archived_at: "2026-08-01T00:00:00.000Z" }), row({ id: "gen", generated: true })];
-  const result = codeSessionPickerResult(rows, "", null);
-  assert.deepEqual(result.groups[0].sessions.map((s) => s.id), ["keep"]);
-}
-
-// A session with no project root lands in a trailing "(unknown)" group rather
-// than being dropped: a session you cannot find is worse than an ugly label.
-{
-  const rows = [row({ id: "orphan", project_root: "" }), row({ id: "normal" })];
-  const result = codeSessionPickerResult(rows, "", null);
-  assert.equal(result.groups.at(-1).label, "(unknown)");
+  const rows = [
+    row({ id: "running", workBranch: "feat/reviewable-first" }),
+    row({ id: "fallback", workBranch: "chore/elsewhere" }),
+    row({ id: "tail", workBranch: "feat/reviewable-first-tail" }),
+  ];
+  const result = codeSessionPickerResult(
+    queue([
+      {
+        key: "repo-a",
+        label: "acme/repo-a",
+        sessions: [rows[0], rows[2]],
+      },
+      {
+        key: "repo-b",
+        label: "acme/repo-b",
+        sessions: [rows[1]],
+      },
+    ]),
+    "reviewable-first",
+    null,
+  );
+  assert.deepEqual(result.groups.flatMap((group) => group.sessions).map((s) => s.id), ["running", "tail"]);
   assert.equal(result.count, 2);
 }
 
@@ -77,17 +111,31 @@ assert.equal(codeSessionMatchesQuery(row(), "/Users/x/code"), false);
     row({ id: "b" }),
     row({ id: "c", project_root: "/Users/x/code/coven-pocket" }),
   ];
-  const all = codeSessionPickerResult(rows, "", null);
-  const scoped = codeSessionPickerResult(rows, "", "/Users/x/code/coven-pocket");
+  const sharedQueue = queue([
+    {
+      key: "repo-cave",
+      label: "acme/coven-cave",
+      sessions: [rows[1], rows[0]],
+    },
+    {
+      key: "repo-pocket",
+      label: "acme/coven-pocket",
+      sessions: [rows[2]],
+    },
+  ]);
+  const all = codeSessionPickerResult(sharedQueue, "", null);
+  const scoped = codeSessionPickerResult(sharedQueue, "", "repo-pocket");
   assert.deepEqual(
     all.chips.map((c) => [c.label, c.count]),
     scoped.chips.map((c) => [c.label, c.count]),
   );
-  // "All" leads, then projects by size.
-  assert.equal(all.chips[0].root, null);
-  assert.deepEqual(all.chips.map((c) => c.label), ["All", "coven-cave", "coven-pocket"]);
-  // The project filter narrows the groups even though the chips held still.
+  // "All" leads, then queue order.
+  assert.equal(all.chips[0].key, null);
+  assert.deepEqual(all.chips.map((c) => c.label), ["All", "acme/coven-cave", "acme/coven-pocket"]);
+  // The scope filter narrows the groups even though the chips held still.
   assert.equal(scoped.groups.length, 1);
+  assert.equal(scoped.groups[0].label, "acme/coven-pocket");
+  assert.deepEqual(scoped.groups[0].sessions.map((session) => session.id), ["c"]);
   assert.equal(scoped.count, 1);
 }
 
@@ -95,8 +143,15 @@ assert.equal(codeSessionMatchesQuery(row(), "/Users/x/code"), false);
 
 // A miss on a typed query offers to become a session; an empty workspace does
 // not — there is no name to create it under.
-assert.equal(codeSessionPickerResult([row()], "zzz", null).offersCreate, true);
-assert.equal(codeSessionPickerResult([], "", null).offersCreate, false);
-assert.equal(codeSessionPickerResult([], "", null).count, 0);
+assert.equal(
+  codeSessionPickerResult(
+    queue([{ key: "repo-cave", label: "acme/coven-cave", sessions: [row()] }]),
+    "zzz",
+    null,
+  ).offersCreate,
+  true,
+);
+assert.equal(codeSessionPickerResult(queue([]), "", null).offersCreate, false);
+assert.equal(codeSessionPickerResult(queue([]), "", null).count, 0);
 
 console.log("code-session-picker: ok");

--- a/src/lib/code-session-picker.ts
+++ b/src/lib/code-session-picker.ts
@@ -3,9 +3,10 @@
  *
  * The `Cody Code Reading v2` frame replaces the always-on session rail with a
  * header picker: one button carrying the current session, opening a filterable,
- * project-grouped list. This module is the whole decision layer — filtering,
- * chip counts, grouping and the empty-state affordance — so the popover itself
- * stays presentational and the rules stay behaviourally testable.
+ * queue-grouped list. This module is the whole decision layer — filtering,
+ * chip counts and the empty-state affordance on top of the shared queue — so
+ * the popover itself stays presentational and the rules stay behaviourally
+ * testable.
  *
  * Two rules the frame is explicit about and this encodes:
  *
@@ -20,27 +21,27 @@
 import {
   codeSessionActivity,
   codeSessionBranch,
-  isCodeRailSession,
   type CodeSessionActivity,
-} from "@/lib/code-surface";
-import type { SessionRow } from "@/lib/types";
+} from "./code-surface.ts";
+import type { CodeReviewQueue } from "./code-review-queue.ts";
+import type { SessionRow } from "./types.ts";
 
-/** A project bucket in the open picker: one repo root, newest session first. */
+/** A queue bucket in the open picker: one shared rail group, in queue order. */
 export type CodeSessionPickerGroup = {
-  /** Absolute project root shared by the group's sessions. */
-  root: string;
-  /** Short display label (basename of the root). */
+  /** Shared queue-group key (canonical repo in reviewable mode, root in all). */
+  key: string;
+  /** Short display label from the precomputed queue. */
   label: string;
   sessions: SessionRow[];
 };
 
-/** A filter chip above the list: "all", then one per project in the result. */
+/** A filter chip above the list: "All", then one per visible queue group. */
 export type CodeSessionPickerChip = {
   id: string;
   label: string;
   count: number;
-  /** null on the "All" chip — it clears the project filter rather than setting one. */
-  root: string | null;
+  /** null on the "All" chip — it clears the group filter rather than setting one. */
+  key: string | null;
 };
 
 export type CodeSessionPickerResult = {
@@ -62,11 +63,6 @@ function projectLabel(root: string): string {
   return trimmed.slice(idx + 1) || trimmed || "(unknown)";
 }
 
-function updatedAt(row: SessionRow): number {
-  const t = Date.parse(row.updated_at);
-  return Number.isFinite(t) ? t : 0;
-}
-
 /**
  * Does this session match the typed filter? Title, project label and branch,
  * case-insensitively. A blank query matches everything.
@@ -84,46 +80,37 @@ export function codeSessionMatchesQuery(row: SessionRow, query: string): boolean
 }
 
 /**
- * Everything the open picker renders, for one (query, project) pair.
+ * Everything the open picker renders, for one (query, queue-group) pair.
  *
- * Chips count against the QUERY-filtered set but ignore the project filter, so
- * the counts stay stable while you click between projects — a chip whose count
+ * Chips count against the QUERY-filtered set but ignore the group filter, so
+ * the counts stay stable while you click between groups — a chip whose count
  * changed because you selected it would read as the filter having deleted work.
  */
 export function codeSessionPickerResult(
-  rows: readonly SessionRow[],
+  queue: Pick<CodeReviewQueue, "groups" | "sessions">,
   query: string,
-  projectRoot: string | null,
+  groupKey: string | null,
 ): CodeSessionPickerResult {
-  const visible = rows.filter((row) => isCodeRailSession(row) && codeSessionMatchesQuery(row, query));
-
-  const byRoot = new Map<string, SessionRow[]>();
-  for (const row of visible) {
-    const root = row.project_root || "";
-    const list = byRoot.get(root);
-    if (list) list.push(row);
-    else byRoot.set(root, [row]);
-  }
+  const visible = queue.sessions.filter((row) => codeSessionMatchesQuery(row, query));
+  const visibleIds = new Set(visible.map((row) => row.id));
 
   const chips: CodeSessionPickerChip[] = [
-    { id: "all", label: "All", count: visible.length, root: null },
+    { id: "all", label: "All", count: visible.length, key: null },
   ];
   const groups: CodeSessionPickerGroup[] = [];
-  for (const [root, sessions] of byRoot) {
-    sessions.sort((a, b) => updatedAt(b) - updatedAt(a));
-    const label = root ? projectLabel(root) : "(unknown)";
-    chips.push({ id: root || "unknown", label, count: sessions.length, root });
-    if (projectRoot === null || projectRoot === root) {
-      groups.push({ root, label, sessions });
+  for (const group of queue.groups) {
+    const sessions = group.sessions.filter((row) => visibleIds.has(row.id));
+    if (sessions.length === 0) continue;
+    chips.push({
+      id: group.key ? `group:${group.key}` : `group:${group.label}`,
+      label: group.label,
+      count: sessions.length,
+      key: group.key,
+    });
+    if (groupKey === null || groupKey === group.key) {
+      groups.push({ key: group.key, label: group.label, sessions });
     }
   }
-
-  groups.sort((a, b) => {
-    if (!a.root && b.root) return 1;
-    if (a.root && !b.root) return -1;
-    return updatedAt(b.sessions[0]) - updatedAt(a.sessions[0]);
-  });
-  chips.sort((a, b) => (a.root === null ? -1 : b.root === null ? 1 : b.count - a.count));
 
   const count = groups.reduce((total, group) => total + group.sessions.length, 0);
   return { groups, chips, count, offersCreate: count === 0 && query.trim().length > 0 };

--- a/src/lib/code-session-picker.ts
+++ b/src/lib/code-session-picker.ts
@@ -24,6 +24,7 @@ import {
   type CodeSessionActivity,
 } from "./code-surface.ts";
 import type { CodeReviewQueue } from "./code-review-queue.ts";
+import { gitHubRepoSlug } from "./github-repo-link.ts";
 import type { SessionRow } from "./types.ts";
 
 /** A queue bucket in the open picker: one shared rail group, in queue order. */
@@ -64,8 +65,9 @@ function projectLabel(root: string): string {
 }
 
 /**
- * Does this session match the typed filter? Title, project label and branch,
- * case-insensitively. A blank query matches everything.
+ * Does this session match the typed filter? Title, local project basename,
+ * canonical GitHub owner/repo slug and branch, case-insensitively. A blank
+ * query matches everything.
  */
 export function codeSessionMatchesQuery(row: SessionRow, query: string): boolean {
   const needle = query.trim().toLowerCase();
@@ -74,6 +76,7 @@ export function codeSessionMatchesQuery(row: SessionRow, query: string): boolean
     row.title ?? "",
     row.id,
     row.project_root ? projectLabel(row.project_root) : "",
+    gitHubRepoSlug(row.git?.repositoryUrl) ?? "",
     codeSessionBranch(row) ?? "",
   ];
   return haystacks.some((value) => value.toLowerCase().includes(needle));

--- a/src/lib/code-shortcuts.test.ts
+++ b/src/lib/code-shortcuts.test.ts
@@ -48,6 +48,12 @@ assert.deepEqual(mergeCodeKeymap({ nope: "Mod+Z", help: 7 }), defaultCodeKeymap(
 // to survive a reload or the dialog's unbind does nothing.
 assert.equal(mergeCodeKeymap({ help: "" }).help, "");
 assert.equal(mergeCodeKeymap({ terminal: "Mod+T" }).terminal, "Mod+T");
+// Reserved combos stay with their fixed owners. Old saved keymaps that tried
+// to take one must sanitize back to a valid map rather than double-fire.
+assert.equal(mergeCodeKeymap({ prompt: "/" }).prompt, defaultCodeKeymap().prompt);
+assert.equal(mergeCodeKeymap({ files: "J" }).files, defaultCodeKeymap().files);
+assert.equal(mergeCodeKeymap({ outline: "K" }).outline, defaultCodeKeymap().outline);
+assert.equal(mergeCodeKeymap({ terminal: "Shift+A" }).terminal, defaultCodeKeymap().terminal);
 
 // ── Combos from events ───────────────────────────────────────────────────────
 
@@ -112,6 +118,15 @@ assert.equal(isCodeShortcutTarget(el("DIV", { closest: (s) => (s === ".xterm" ? 
   assert.equal(map.changes, "");
   assert.equal(codeShortcutForCombo(map, "Mod+Shift+C"), "terminal");
 }
+// Reserved combos are owned by the fixed queue/terminal handlers, never by a
+// per-session workbench binding.
+{
+  const before = defaultCodeKeymap();
+  assert.deepEqual(bindCodeShortcut(before, "prompt", "/"), before);
+  assert.deepEqual(bindCodeShortcut(before, "files", "J"), before);
+  assert.deepEqual(bindCodeShortcut(before, "outline", "K"), before);
+  assert.deepEqual(bindCodeShortcut(before, "terminal", "Shift+A"), before);
+}
 // Binding never mutates the input.
 {
   const before = defaultCodeKeymap();
@@ -133,5 +148,9 @@ assert.equal(isCodeShortcutTarget(el("DIV", { closest: (s) => (s === ".xterm" ? 
 assert.deepEqual(codeComboChips("Mod+Shift+C", true), ["⌘", "⇧", "C"]);
 assert.deepEqual(codeComboChips("Mod+Shift+C", false), ["Ctrl", "Shift", "C"]);
 assert.deepEqual(codeComboChips("", true), []);
+
+for (const reserved of ["/", "J", "K", "Shift+A"]) {
+  assert.ok(CODE_RESERVED_COMBOS.includes(reserved), `${reserved} stays reserved by the queue`);
+}
 
 console.log("code-shortcuts: ok");

--- a/src/lib/code-shortcuts.ts
+++ b/src/lib/code-shortcuts.ts
@@ -31,16 +31,23 @@ export type CodeShortcutDef = {
   combo: string;
 };
 
+export type CodeFixedShortcutDef = {
+  id: string;
+  label: string;
+  combo: string;
+};
+
 /**
  * The bindable set. Deliberately only actions this surface owns — global
  * navigation already has bindings elsewhere, and shadowing them from a
  * per-surface dialog is how two keymaps start disagreeing.
  *
- * These must also stay clear of the Room's FIXED terminal bindings
- * (`code-room-shortcuts.ts`: ⇧⌘→ ⇧⌘← ⇧⌘D ⇧⌘E ⇧⌘X ⇧⌘B). Those resolve first,
- * inside the terminal, and are not rebindable — a default that collided would
- * be dead on arrival in exactly the pane it was meant for. `defaultCodeKeymap`
- * is asserted against that list in `code-shortcuts.test.ts`.
+ * These must also stay clear of the Room's FIXED bindings: the terminal-pane
+ * controls (`code-room-shortcuts.ts`: ⇧⌘→ ⇧⌘← ⇧⌘D ⇧⌘E ⇧⌘X ⇧⌘B) and the session
+ * queue's own `/`, `J`, `K`, and `Shift+A`. Those resolve first and are not
+ * rebindable — a default that collided would be dead on arrival in exactly the
+ * surface it was meant for. `defaultCodeKeymap` is asserted against that list
+ * in `code-shortcuts.test.ts`.
  */
 export const CODE_SHORTCUTS: readonly CodeShortcutDef[] = [
   { id: "picker", label: "Switch session", combo: "Mod+P" },
@@ -54,13 +61,27 @@ export const CODE_SHORTCUTS: readonly CodeShortcutDef[] = [
 ] as const;
 
 /** Fixed terminal bindings the rebindable set must never collide with. */
+export const CODE_FIXED_TERMINAL_SHORTCUTS: readonly CodeFixedShortcutDef[] = [
+  { id: "focus-next-terminal", label: "Focus the next terminal pane", combo: "Mod+Shift+ArrowRight" },
+  { id: "focus-previous-terminal", label: "Focus the previous terminal pane", combo: "Mod+Shift+ArrowLeft" },
+  { id: "split-right", label: "Split the pane right", combo: "Mod+Shift+D" },
+  { id: "split-down", label: "Split the pane down", combo: "Mod+Shift+E" },
+  { id: "close-terminal", label: "Close the pane", combo: "Mod+Shift+X" },
+  { id: "toggle-broadcast", label: "Broadcast typing to every pane", combo: "Mod+Shift+B" },
+] as const;
+
+/** Fixed queue bindings owned by the Sessions view, not the per-session room. */
+export const CODE_FIXED_QUEUE_SHORTCUTS: readonly CodeFixedShortcutDef[] = [
+  { id: "queue-search", label: "Search sessions", combo: "/" },
+  { id: "queue-next", label: "Focus the next visible session", combo: "J" },
+  { id: "queue-previous", label: "Focus the previous visible session", combo: "K" },
+  { id: "queue-scope", label: "Toggle Reviewable / All local", combo: "Shift+A" },
+] as const;
+
+/** Every non-rebindable combo, in the same normalized grammar as storage/events. */
 export const CODE_RESERVED_COMBOS: readonly string[] = [
-  "Mod+Shift+ArrowRight",
-  "Mod+Shift+ArrowLeft",
-  "Mod+Shift+D",
-  "Mod+Shift+E",
-  "Mod+Shift+X",
-  "Mod+Shift+B",
+  ...CODE_FIXED_TERMINAL_SHORTCUTS.map((shortcut) => shortcut.combo),
+  ...CODE_FIXED_QUEUE_SHORTCUTS.map((shortcut) => shortcut.combo),
 ] as const;
 
 export type CodeKeymap = Partial<Record<CodeShortcutId, string>>;
@@ -84,9 +105,19 @@ export function mergeCodeKeymap(stored: unknown): Record<CodeShortcutId, string>
   if (!stored || typeof stored !== "object") return map;
   for (const shortcut of CODE_SHORTCUTS) {
     const value = (stored as Record<string, unknown>)[shortcut.id];
-    if (typeof value === "string") map[shortcut.id] = value;
+    if (typeof value === "string" && !isCodeReservedCombo(value)) map[shortcut.id] = value;
   }
   return map;
+}
+
+export function isCodeReservedCombo(combo: string): boolean {
+  return CODE_RESERVED_COMBOS.includes(combo);
+}
+
+export function codeReservedComboOwner(combo: string): "session queue" | "terminal panes" | null {
+  if (CODE_FIXED_QUEUE_SHORTCUTS.some((shortcut) => shortcut.combo === combo)) return "session queue";
+  if (CODE_FIXED_TERMINAL_SHORTCUTS.some((shortcut) => shortcut.combo === combo)) return "terminal panes";
+  return null;
 }
 
 /**
@@ -140,6 +171,7 @@ export function bindCodeShortcut(
   id: CodeShortcutId,
   combo: string,
 ): Record<CodeShortcutId, string> {
+  if (combo && isCodeReservedCombo(combo)) return { ...keymap };
   const next = { ...keymap };
   if (combo) {
     for (const shortcut of CODE_SHORTCUTS) {

--- a/src/lib/code-surface.ts
+++ b/src/lib/code-surface.ts
@@ -5,6 +5,7 @@
  * behavioral tests for pure logic, source pins for wiring).
  */
 
+import type { PendingCodeOpen } from "./pending-code-open.ts";
 import type { SessionRow } from "./types.ts";
 
 /** Workbench tabs within a selected session. Diff/Files/Terminal/PR land in
@@ -230,6 +231,46 @@ export function codeSessionDiffstat(row: SessionRow): string | null {
   if (!diff) return null;
   if (!diff.additions && !diff.deletions) return null;
   return `+${diff.additions} \u2212${diff.deletions}`;
+}
+
+export function codeSessionHasOpenPr(row: SessionRow): boolean {
+  if (!row.pullRequest) return false;
+  const state = row.pullRequest.state?.trim().toLowerCase();
+  return !state || state === "open";
+}
+
+export type CodeWorkbenchPanels = {
+  reviewOpen: boolean;
+  terminalOpen: boolean;
+};
+
+export function defaultCodeWorkbenchPanels(row: SessionRow): CodeWorkbenchPanels {
+  return {
+    reviewOpen: Boolean(codeSessionDiffstat(row) || codeSessionHasOpenPr(row)),
+    terminalOpen: false,
+  };
+}
+
+export function resolveCodeWorkbenchPanels({
+  row,
+  reviewOpen,
+  terminalOpen,
+  initialTab,
+  openTarget,
+}: {
+  row: SessionRow;
+  reviewOpen?: boolean | null;
+  terminalOpen?: boolean | null;
+  initialTab?: CodeWorkbenchTab | null;
+  openTarget?: PendingCodeOpen | null;
+}): CodeWorkbenchPanels {
+  const defaults = defaultCodeWorkbenchPanels(row);
+  const forceReviewOpen =
+    Boolean(codeRailTabForWorkbenchTab(initialTab)) || openTarget?.kind === "changes";
+  return {
+    reviewOpen: forceReviewOpen ? true : reviewOpen ?? defaults.reviewOpen,
+    terminalOpen: initialTab === "terminal" ? true : terminalOpen ?? defaults.terminalOpen,
+  };
 }
 
 /**

--- a/src/lib/code-surface.ts
+++ b/src/lib/code-surface.ts
@@ -5,7 +5,7 @@
  * behavioral tests for pure logic, source pins for wiring).
  */
 
-import type { SessionRow } from "@/lib/types";
+import type { SessionRow } from "./types.ts";
 
 /** Workbench tabs within a selected session. Diff/Files/Terminal/PR land in
  *  follow-up PRs; the vocabulary is fixed here so deep links stay stable. */

--- a/src/lib/coven-paths.test.ts
+++ b/src/lib/coven-paths.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import {
@@ -147,6 +147,62 @@ try {
     Array.from((await readFamiliarWorkspaces()).entries()),
     [],
     "the forgiving familiar-workspace reader stays compatible for existing callers",
+  );
+
+  await rm(path.join(process.env.COVEN_HOME, "familiars.toml"), { recursive: true, force: true });
+
+  for (const malformed of [
+    {
+      name: "unterminated quoted workspace",
+      raw: `[[familiar]]
+id = "nova"
+workspace = "/Users/example/nova
+`,
+      error: /unterminated/i,
+    },
+    {
+      name: "invalid assignment syntax",
+      raw: `[[familiar]]
+id = "nova"
+workspace: "/Users/example/nova"
+`,
+      error: /invalid assignment/i,
+    },
+    {
+      name: "workspace assignment whose familiar id cannot be parsed",
+      raw: `[[familiar]]
+id = "nova
+workspace = "/Users/example/nova"
+`,
+      error: /id/i,
+    },
+  ]) {
+    await writeFile(path.join(process.env.COVEN_HOME, "familiars.toml"), malformed.raw);
+    await assert.rejects(
+      () => readFamiliarWorkspacesStrict(),
+      malformed.error,
+      `strict familiar-workspace reads reject ${malformed.name}`,
+    );
+  }
+
+  const partiallyMalformed = `[[familiar]]
+id = "ember"
+workspace = "~/coven/ember"
+
+[[familiar]]
+id = "nova"
+workspace = "/Users/example/nova
+`;
+  await writeFile(path.join(process.env.COVEN_HOME, "familiars.toml"), partiallyMalformed);
+  await assert.rejects(
+    () => readFamiliarWorkspacesStrict(),
+    /unterminated/i,
+    "strict familiar-workspace reads fail closed on partially written familiar blocks",
+  );
+  assert.deepEqual(
+    Array.from((await readFamiliarWorkspaces()).entries()),
+    Array.from(parseFamiliarWorkspaces(partiallyMalformed).entries()),
+    "forgiving familiar-workspace reads stay aligned with the legacy parser for existing callers",
   );
 } finally {
   await rm(strictScratch, { recursive: true, force: true });

--- a/src/lib/coven-paths.test.ts
+++ b/src/lib/coven-paths.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile, rm } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import {
@@ -11,6 +11,8 @@ import {
   familiarWorkspace,
   familiarWorkspacesRoot,
   parseFamiliarWorkspaces,
+  readFamiliarWorkspaces,
+  readFamiliarWorkspacesStrict,
 } from "./coven-paths.ts";
 
 const originalEnv = {
@@ -111,3 +113,42 @@ const chatSendRuntime = await readFile("src/app/api/chat/send/chat-send-runtime.
 assert.match(chatSend, /resolveFamiliarWorkspace/);
 assert.match(chatSendRuntime, /Resolve a familiar workspace/);
 assert.doesNotMatch(chatSend, /\.openclaw\/workspace/);
+
+const covenPathsSource = await readFile("src/lib/coven-paths.ts", "utf8");
+assert.match(
+  covenPathsSource,
+  /if \(\(error as NodeJS\.ErrnoException \| undefined\)\?\.code === "ENOENT"\) return new Map\(\);/,
+  "strict familiar-workspace reads treat only a missing familiars.toml as empty",
+);
+
+const strictScratch = path.join(process.cwd(), `.coven-paths-strict-${process.pid}`);
+try {
+  process.env.COVEN_HOME = path.join(strictScratch, "home");
+  delete process.env.COVEN_CAVE_HOME;
+  delete process.env.COVEN_WORKSPACES_ROOT;
+  delete process.env.COVEN_WORKSPACE_ROOT;
+  delete process.env.WORKSPACE_ROOT;
+  delete process.env.NEXT_PUBLIC_WORKSPACE_ROOT;
+
+  assert.deepEqual(
+    Array.from((await readFamiliarWorkspacesStrict()).entries()),
+    [],
+    "missing familiars.toml legitimately means no declared relocated workspaces",
+  );
+
+  await mkdir(path.join(process.env.COVEN_HOME, "familiars.toml"), { recursive: true });
+
+  await assert.rejects(
+    () => readFamiliarWorkspacesStrict(),
+    /EISDIR/,
+    "non-ENOENT familiar-workspace read failures propagate from the strict path",
+  );
+  assert.deepEqual(
+    Array.from((await readFamiliarWorkspaces()).entries()),
+    [],
+    "the forgiving familiar-workspace reader stays compatible for existing callers",
+  );
+} finally {
+  await rm(strictScratch, { recursive: true, force: true });
+  restoreEnv();
+}

--- a/src/lib/coven-paths.ts
+++ b/src/lib/coven-paths.ts
@@ -154,10 +154,19 @@ export function parseFamiliarWorkspaces(raw: string): Map<string, string> {
   return workspaces;
 }
 
-export async function readFamiliarWorkspaces(): Promise<Map<string, string>> {
+export async function readFamiliarWorkspacesStrict(): Promise<Map<string, string>> {
   try {
     const raw = await readFile(path.join(/* turbopackIgnore: true */ covenHome(), "familiars.toml"), "utf8");
     return parseFamiliarWorkspaces(raw);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") return new Map();
+    throw error;
+  }
+}
+
+export async function readFamiliarWorkspaces(): Promise<Map<string, string>> {
+  try {
+    return await readFamiliarWorkspacesStrict();
   } catch {
     return new Map();
   }

--- a/src/lib/coven-paths.ts
+++ b/src/lib/coven-paths.ts
@@ -142,6 +142,122 @@ function readTomlString(block: string, key: string): string | null {
   return bare?.[1] ?? null;
 }
 
+function parseStrictTomlAssignment(line: string, key: "id" | "workspace"): string | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) return null;
+  if (!trimmed.startsWith(key)) return null;
+  const next = trimmed[key.length];
+  if (next && /[A-Za-z0-9_]/.test(next)) return null;
+  let cursor = key.length;
+  while (cursor < trimmed.length && /\s/.test(trimmed[cursor]!)) cursor++;
+  if (trimmed[cursor] !== "=") {
+    throw new Error(`invalid assignment syntax for familiar ${key}`);
+  }
+  cursor++;
+  while (cursor < trimmed.length && /\s/.test(trimmed[cursor]!)) cursor++;
+  if (cursor >= trimmed.length) {
+    throw new Error(`missing familiar ${key} value`);
+  }
+
+  const start = trimmed[cursor]!;
+  if (start === '"' || start === "'") {
+    const quote = start;
+    cursor++;
+    let value = "";
+    while (cursor < trimmed.length) {
+      const char = trimmed[cursor]!;
+      if (quote === '"' && char === "\\" && cursor + 1 < trimmed.length) {
+        value += char + trimmed[cursor + 1]!;
+        cursor += 2;
+        continue;
+      }
+      if (char === quote) {
+        cursor++;
+        while (cursor < trimmed.length && /\s/.test(trimmed[cursor]!)) cursor++;
+        if (cursor < trimmed.length && trimmed[cursor] !== "#") {
+          throw new Error(`invalid assignment syntax for familiar ${key}`);
+        }
+        return value;
+      }
+      value += char;
+      cursor++;
+    }
+    throw new Error(`unterminated quoted familiar ${key}`);
+  }
+
+  const valueStart = cursor;
+  while (cursor < trimmed.length && !/\s|#/.test(trimmed[cursor]!)) cursor++;
+  const value = trimmed.slice(valueStart, cursor);
+  while (cursor < trimmed.length && /\s/.test(trimmed[cursor]!)) cursor++;
+  if (cursor < trimmed.length && trimmed[cursor] !== "#") {
+    throw new Error(`invalid assignment syntax for familiar ${key}`);
+  }
+  return value;
+}
+
+function parseFamiliarWorkspacesStrict(raw: string): Map<string, string> {
+  const workspaces = new Map<string, string>();
+  let inFamiliar = false;
+  let familiarId: string | null = null;
+  let workspace: string | null = null;
+  let workspaceLine = 0;
+
+  const flush = () => {
+    if (!inFamiliar) return;
+    if (workspace !== null) {
+      if (!familiarId) {
+        throw new Error(
+          `workspace assignment in familiar block whose id cannot be parsed (line ${workspaceLine})`,
+        );
+      }
+      workspaces.set(
+        familiarId,
+        path.resolve(/* turbopackIgnore: true */ expandHome(workspace)),
+      );
+    }
+    inFamiliar = false;
+    familiarId = null;
+    workspace = null;
+    workspaceLine = 0;
+  };
+
+  for (const [index, rawLine] of raw.split(/\r?\n/).entries()) {
+    const lineNumber = index + 1;
+    const line = rawLine.trim();
+    if (line === "[[familiar]]") {
+      flush();
+      inFamiliar = true;
+      continue;
+    }
+    if (line.startsWith("[")) {
+      flush();
+      continue;
+    }
+    if (!inFamiliar) continue;
+    try {
+      const parsedId = parseStrictTomlAssignment(rawLine, "id");
+      if (parsedId !== null && familiarId === null) {
+        familiarId = parsedId;
+      }
+      const parsedWorkspace = parseStrictTomlAssignment(rawLine, "workspace");
+      if (parsedWorkspace !== null && workspace === null) {
+        workspace = parsedWorkspace;
+        workspaceLine = lineNumber;
+      }
+    } catch (error) {
+      const reason =
+        error instanceof Error ? error.message : "invalid familiar workspace assignment";
+      throw new Error(`Malformed familiars.toml at line ${lineNumber}: ${reason}`);
+    }
+  }
+  flush();
+  return workspaces;
+}
+
+function familiarWorkspacesFile(): string {
+  return path.join(/* turbopackIgnore: true */ covenHome(), "familiars.toml");
+}
+
 export function parseFamiliarWorkspaces(raw: string): Map<string, string> {
   const workspaces = new Map<string, string>();
   const blocks = raw.split(/^\s*\[\[familiar\]\]\s*$/m).slice(1);
@@ -156,8 +272,8 @@ export function parseFamiliarWorkspaces(raw: string): Map<string, string> {
 
 export async function readFamiliarWorkspacesStrict(): Promise<Map<string, string>> {
   try {
-    const raw = await readFile(path.join(/* turbopackIgnore: true */ covenHome(), "familiars.toml"), "utf8");
-    return parseFamiliarWorkspaces(raw);
+    const raw = await readFile(familiarWorkspacesFile(), "utf8");
+    return parseFamiliarWorkspacesStrict(raw);
   } catch (error) {
     if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") return new Map();
     throw error;
@@ -166,7 +282,8 @@ export async function readFamiliarWorkspacesStrict(): Promise<Map<string, string
 
 export async function readFamiliarWorkspaces(): Promise<Map<string, string>> {
   try {
-    return await readFamiliarWorkspacesStrict();
+    const raw = await readFile(familiarWorkspacesFile(), "utf8");
+    return parseFamiliarWorkspaces(raw);
   } catch {
     return new Map();
   }

--- a/src/lib/familiar-workspace-sessions.test.ts
+++ b/src/lib/familiar-workspace-sessions.test.ts
@@ -83,6 +83,21 @@ describe("collapseFamiliarWorkspaceSessions", () => {
     const sessions = [row("a", "/repo/a"), row("b", "")];
     assert.equal(collapseFamiliarWorkspaceSessions(sessions, WS_ROOT).length, 2);
   });
+
+  it("drops trusted familiar-workspace rows even after project_root degrades to empty", () => {
+    const kept = collapseFamiliarWorkspaceSessions(
+      [
+        { ...row("degraded-local", ""), familiarWorkspace: true },
+        row("real-project", "/repo/a"),
+        row("rootless", ""),
+      ],
+      WS_ROOT,
+    );
+    assert.deepEqual(
+      kept.map((session) => session.id),
+      ["real-project", "rootless"],
+    );
+  });
 });
 
 describe("classifyFamiliarWorkspaceSessions", () => {

--- a/src/lib/familiar-workspace-sessions.test.ts
+++ b/src/lib/familiar-workspace-sessions.test.ts
@@ -109,4 +109,16 @@ describe("classifyFamiliarWorkspaceSessions", () => {
       ],
     );
   });
+
+  it("preserves an earlier true mark when a later pass no longer has the original cwd", () => {
+    const [classified] = classifyFamiliarWorkspaceSessions(
+      [{ ...row("degraded-local", ""), familiarWorkspace: true }],
+      WS_ROOT,
+    );
+    assert.equal(
+      classified?.familiarWorkspace,
+      true,
+      "metadata-only reclassification must not overwrite a trusted true mark with false",
+    );
+  });
 });

--- a/src/lib/familiar-workspace-sessions.test.ts
+++ b/src/lib/familiar-workspace-sessions.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  classifyFamiliarWorkspaceSessions,
   collapseFamiliarWorkspaceSessions,
   isFamiliarWorkspaceRoot,
 } from "./familiar-workspace-sessions.ts";
@@ -81,5 +82,31 @@ describe("collapseFamiliarWorkspaceSessions", () => {
   it("is a no-op when nothing is a familiar workspace", () => {
     const sessions = [row("a", "/repo/a"), row("b", "")];
     assert.equal(collapseFamiliarWorkspaceSessions(sessions, WS_ROOT).length, 2);
+  });
+});
+
+describe("classifyFamiliarWorkspaceSessions", () => {
+  it("annotates root, nested, relocated, normal-project, and rootless rows", () => {
+    const classified = classifyFamiliarWorkspaceSessions(
+      [
+        row("workspace-root", `${WS_ROOT}/nova`),
+        row("workspace-nested", `${WS_ROOT}/nova/notes`),
+        row("workspace-relocated", "/opt/coven/nova-ws/memory"),
+        row("project", "/home/test/Documents/GitHub/OpenCoven/coven-cave"),
+        row("rootless", ""),
+      ],
+      WS_ROOT,
+      ["/opt/coven/nova-ws"],
+    );
+    assert.deepEqual(
+      classified.map(({ id, familiarWorkspace }) => ({ id, familiarWorkspace })),
+      [
+        { id: "workspace-root", familiarWorkspace: true },
+        { id: "workspace-nested", familiarWorkspace: true },
+        { id: "workspace-relocated", familiarWorkspace: true },
+        { id: "project", familiarWorkspace: false },
+        { id: "rootless", familiarWorkspace: false },
+      ],
+    );
   });
 });

--- a/src/lib/familiar-workspace-sessions.ts
+++ b/src/lib/familiar-workspace-sessions.ts
@@ -88,3 +88,20 @@ export function collapseFamiliarWorkspaceSessions(
     (session) => !matchesFamiliarWorkspacePrefix(session.project_root, prefixes),
   );
 }
+
+/**
+ * Annotate each row with trusted familiar-workspace membership from configured
+ * roots. False means the server checked the path against known familiar
+ * workspace roots and it did not match; callers use this as metadata only.
+ */
+export function classifyFamiliarWorkspaceSessions(
+  sessions: SessionRow[],
+  familiarWorkspacesRoot: string,
+  declaredWorkspaceRoots: readonly string[] = [],
+): SessionRow[] {
+  const prefixes = normalizeFamiliarWorkspacePrefixes(familiarWorkspacesRoot, declaredWorkspaceRoots);
+  return sessions.map((session) => ({
+    ...session,
+    familiarWorkspace: matchesFamiliarWorkspacePrefix(session.project_root, prefixes),
+  }));
+}

--- a/src/lib/familiar-workspace-sessions.ts
+++ b/src/lib/familiar-workspace-sessions.ts
@@ -102,6 +102,8 @@ export function classifyFamiliarWorkspaceSessions(
   const prefixes = normalizeFamiliarWorkspacePrefixes(familiarWorkspacesRoot, declaredWorkspaceRoots);
   return sessions.map((session) => ({
     ...session,
-    familiarWorkspace: matchesFamiliarWorkspacePrefix(session.project_root, prefixes),
+    familiarWorkspace:
+      session.familiarWorkspace === true ||
+      matchesFamiliarWorkspacePrefix(session.project_root, prefixes),
   }));
 }

--- a/src/lib/familiar-workspace-sessions.ts
+++ b/src/lib/familiar-workspace-sessions.ts
@@ -85,7 +85,9 @@ export function collapseFamiliarWorkspaceSessions(
   // Normalize the prefix list once, then test each row inline.
   const prefixes = normalizeFamiliarWorkspacePrefixes(familiarWorkspacesRoot, declaredWorkspaceRoots);
   return sessions.filter(
-    (session) => !matchesFamiliarWorkspacePrefix(session.project_root, prefixes),
+    (session) =>
+      session.familiarWorkspace !== true &&
+      !matchesFamiliarWorkspacePrefix(session.project_root, prefixes),
   );
 }
 

--- a/src/lib/server/sessions-list.test.ts
+++ b/src/lib/server/sessions-list.test.ts
@@ -25,7 +25,13 @@ const previousEnv = {
 };
 const scratchRoot = path.join(process.cwd(), `.slct-${process.pid}`);
 const covenHome = path.join(scratchRoot, "h");
+const projectsPath = path.join(scratchRoot, "projects.json");
 const projectRoot = path.join(scratchRoot, "p");
+const familiarRootProject = path.join(covenHome, "workspaces", "familiars", "nova");
+const familiarNestedProject = path.join(familiarRootProject, "notes");
+const relocatedProjectRoot = path.join(scratchRoot, "relocated-nova");
+const normalProjectRoot = path.join(scratchRoot, "repo");
+const rootlessCwd = path.join(scratchRoot, "scratch");
 const configPath = path.join(covenHome, "cave", "config.json");
 
 let stopDaemon = async () => {};
@@ -89,56 +95,184 @@ const STALE = {
   harness: "claude",
   runtime: null,
   title: "Stale chat",
-  createdAt: "2026-08-01T10:00:00.000Z",
-  updatedAt: "2026-08-01T11:00:00.000Z",
+  createdAt: "2000-08-01T10:00:00.000Z",
+  updatedAt: "2000-08-01T11:00:00.000Z",
   turns: [
     {
       id: "u1",
       role: "user",
       text: "Anything left?",
-      createdAt: "2026-08-01T10:00:00.000Z",
+      createdAt: "2000-08-01T10:00:00.000Z",
       parentId: null,
     },
     {
       id: "a1",
       role: "assistant",
       text: "No.",
-      createdAt: "2026-08-01T11:00:00.000Z",
+      createdAt: "2000-08-01T11:00:00.000Z",
       parentId: "u1",
     },
   ],
   activeLeafId: "a1",
 };
 
+function chat(sessionId, runtime, updatedAt) {
+  return {
+    sessionId,
+    familiarId: "charm",
+    harness: "claude",
+    runtime,
+    title: sessionId,
+    createdAt: updatedAt,
+    updatedAt,
+    turns: [
+      {
+        id: `${sessionId}-u`,
+        role: "user",
+        text: "Anything left?",
+        createdAt: updatedAt,
+        parentId: null,
+      },
+      {
+        id: `${sessionId}-a`,
+        role: "assistant",
+        text: "No.",
+        createdAt: updatedAt,
+        parentId: `${sessionId}-u`,
+      },
+    ],
+    activeLeafId: `${sessionId}-a`,
+  };
+}
+
+async function saveFixtureConversation(saveConversation, clearConversationListMetadataCache, conversation) {
+  const createdAt = conversation.createdAt;
+  const updatedAt = conversation.updatedAt;
+  await saveConversation(conversation);
+  const convPath = path.join(covenHome, "cave", "conversations", `${conversation.sessionId}.json`);
+  const saved = JSON.parse(await readFile(convPath, "utf8"));
+  await writeFile(
+    convPath,
+    JSON.stringify({ ...saved, createdAt, updatedAt }),
+  );
+  clearConversationListMetadataCache();
+}
+
+async function writeProjects(clearCaveStoreReadCache) {
+  await writeFile(
+    projectsPath,
+    JSON.stringify({
+      version: 1,
+      projects: [
+        {
+          id: "familiar-root",
+          name: "Familiar Root",
+          root: familiarRootProject,
+          createdAt: "2026-08-23T00:00:00.000Z",
+          updatedAt: "2026-08-23T00:00:00.000Z",
+        },
+        {
+          id: "familiar-nested",
+          name: "Familiar Nested",
+          root: familiarNestedProject,
+          createdAt: "2026-08-23T00:00:00.000Z",
+          updatedAt: "2026-08-23T00:00:00.000Z",
+        },
+        {
+          id: "relocated",
+          name: "Relocated Familiar",
+          root: relocatedProjectRoot,
+          createdAt: "2026-08-23T00:00:00.000Z",
+          updatedAt: "2026-08-23T00:00:00.000Z",
+        },
+        {
+          id: "normal",
+          name: "Normal Project",
+          root: normalProjectRoot,
+          createdAt: "2026-08-23T00:00:00.000Z",
+          updatedAt: "2026-08-23T00:00:00.000Z",
+        },
+        {
+          id: "stale",
+          name: "Stale Project",
+          root: projectRoot,
+          createdAt: "2000-08-01T00:00:00.000Z",
+          updatedAt: "2000-08-01T00:00:00.000Z",
+        },
+      ],
+    }),
+  );
+  clearCaveStoreReadCache();
+}
+
+async function writeFamiliarsToml(clearCaveStoreReadCache) {
+  await writeFile(
+    path.join(covenHome, "familiars.toml"),
+    `[[familiar]]
+id = "nova"
+workspace = "${relocatedProjectRoot}"
+`,
+  );
+  clearCaveStoreReadCache();
+}
+
 const realNow = Date.now;
 try {
   process.env.COVEN_HOME = covenHome;
   delete process.env.COVEN_SOCKET;
-  delete process.env.CAVE_PROJECTS_PATH_OVERRIDE;
+  process.env.CAVE_PROJECTS_PATH_OVERRIDE = projectsPath;
 
   const { computeSessionsList } = await import("./sessions-list.ts");
   const { loadState } = await import("../cave-config.ts");
   const { saveConversation, clearConversationListMetadataCache } = await import(
     "../cave-conversations.ts"
   );
+  const { clearCaveStoreReadCache } = await import("./store-read-cache.ts");
 
   async function reset() {
     await rm(scratchRoot, { recursive: true, force: true });
     await mkdir(covenHome, { recursive: true });
     await mkdir(projectRoot, { recursive: true });
+    await mkdir(familiarRootProject, { recursive: true });
+    await mkdir(familiarNestedProject, { recursive: true });
+    await mkdir(relocatedProjectRoot, { recursive: true });
+    await mkdir(normalProjectRoot, { recursive: true });
+    await mkdir(rootlessCwd, { recursive: true });
+    await mkdir(path.dirname(projectsPath), { recursive: true });
+    await writeProjects(clearCaveStoreReadCache);
+    await writeFamiliarsToml(clearCaveStoreReadCache);
     clearConversationListMetadataCache();
-    await saveConversation({ ...STALE, runtime: `local:${projectRoot}` });
-    // saveConversation stamps `updatedAt` with the wall clock, so the row it
-    // produces is always zero days idle and would never be due for the sweep.
-    // Rewriting the file is how the sibling route test ages a fixture, and it
-    // is what makes the positive control below actually exercise the sweep.
-    const convPath = path.join(covenHome, "cave", "conversations", `${STALE.sessionId}.json`);
-    const saved = JSON.parse(await readFile(convPath, "utf8"));
-    await writeFile(
-      convPath,
-      JSON.stringify({ ...saved, updatedAt: STALE.updatedAt }),
+    clearCaveStoreReadCache();
+    await saveFixtureConversation(
+      saveConversation,
+      clearConversationListMetadataCache,
+      { ...STALE, runtime: `local:${projectRoot}` },
     );
-    clearConversationListMetadataCache();
+    await saveFixtureConversation(
+      saveConversation,
+      clearConversationListMetadataCache,
+      chat("familiar-root", `local:${familiarRootProject}`, "2099-08-23T11:00:00.000Z"),
+    );
+    await saveFixtureConversation(
+      saveConversation,
+      clearConversationListMetadataCache,
+      chat("familiar-nested", `local:${familiarNestedProject}`, "2099-08-23T11:05:00.000Z"),
+    );
+    await saveFixtureConversation(
+      saveConversation,
+      clearConversationListMetadataCache,
+      chat("familiar-relocated", `local:${relocatedProjectRoot}`, "2099-08-23T11:10:00.000Z"),
+    );
+    await saveFixtureConversation(
+      saveConversation,
+      clearConversationListMetadataCache,
+      chat("normal-project", `local:${normalProjectRoot}`, "2099-08-23T11:15:00.000Z"),
+    );
+    await saveFixtureConversation(
+      saveConversation,
+      clearConversationListMetadataCache,
+      chat("rootless", `local:${rootlessCwd}`, "2099-08-23T11:20:00.000Z"),
+    );
   }
 
   /** sessionIds cave state currently records as archived. */
@@ -149,7 +283,7 @@ try {
 
   Date.now = () => Date.parse("2026-08-23T12:00:00.000Z");
 
-  const daemonUrl = await startDaemon([]);
+  let daemonUrl = await startDaemon([]);
 
   // --- read-only: the sweep must not run --------------------------------
   await reset();
@@ -161,6 +295,26 @@ try {
     enrichGit: false,
   });
   assert.equal(readOnly.payload.ok, true, "the read-only compute still returns a list");
+  const readOnlyIds = readOnly.payload.sessions.map((row) => row.id);
+  assert.deepEqual(
+    readOnlyIds,
+    [
+      "rootless",
+      "normal-project",
+      "familiar-relocated",
+      "familiar-nested",
+      "familiar-root",
+      "stale-chat",
+    ],
+    "read-only classification-off compute keeps the same session membership",
+  );
+  for (const row of readOnly.payload.sessions) {
+    assert.equal(
+      row.familiarWorkspace,
+      undefined,
+      "classification remains absent unless explicitly requested",
+    );
+  }
 
   assert.deepEqual(
     await archivedIds(),
@@ -168,8 +322,50 @@ try {
     "computeSessionsList with sweepArchives:false archived a session — a dashboard GET must never mutate cave state",
   );
 
+  const classified = await computeSessionsList(false, null, false, {
+    sweepArchives: false,
+    enrichGit: false,
+    classifyFamiliarWorkspace: true,
+  });
+  assert.equal(classified.payload.ok, true, "opt-in classification returns a list");
+  assert.deepEqual(
+    classified.payload.sessions.map((row) => row.id),
+    readOnlyIds,
+    "trusted familiar-workspace classification is metadata-only and does not change result membership",
+  );
+  const classifiedById = new Map(classified.payload.sessions.map((row) => [row.id, row]));
+  assert.equal(classifiedById.get("familiar-root")?.familiarWorkspace, true);
+  assert.equal(classifiedById.get("familiar-nested")?.familiarWorkspace, true);
+  assert.equal(classifiedById.get("familiar-relocated")?.familiarWorkspace, true);
+  assert.equal(classifiedById.get("normal-project")?.familiarWorkspace, false);
+  assert.equal(classifiedById.get("rootless")?.familiarWorkspace, false);
+  assert.equal(classifiedById.get("stale-chat")?.familiarWorkspace, false);
+
+  await stopDaemon();
+  stopDaemon = async () => {};
+  const degradedClassified = await computeSessionsList(false, null, false, {
+    sweepArchives: false,
+    enrichGit: false,
+    classifyFamiliarWorkspace: true,
+  });
+  assert.equal(degradedClassified.payload.ok, true, "degraded compute still returns local rows");
+  assert.equal(degradedClassified.payload.degraded, true);
+  assert.deepEqual(
+    degradedClassified.payload.sessions.map((row) => row.id),
+    readOnlyIds,
+    "degraded classification keeps the same session membership",
+  );
+  const degradedById = new Map(degradedClassified.payload.sessions.map((row) => [row.id, row]));
+  assert.equal(degradedById.get("familiar-root")?.familiarWorkspace, true);
+  assert.equal(degradedById.get("familiar-nested")?.familiarWorkspace, true);
+  assert.equal(degradedById.get("familiar-relocated")?.familiarWorkspace, true);
+  assert.equal(degradedById.get("normal-project")?.familiarWorkspace, false);
+  assert.equal(degradedById.get("rootless")?.familiarWorkspace, false);
+  assert.equal(degradedById.get("stale-chat")?.familiarWorkspace, false);
+
   // --- default: the sweep still runs ------------------------------------
   await reset();
+  daemonUrl = await startDaemon([]);
   await writeConfig(daemonUrl);
 
   const swept = await computeSessionsList(true, null, false);

--- a/src/lib/server/sessions-list.test.ts
+++ b/src/lib/server/sessions-list.test.ts
@@ -485,6 +485,27 @@ workspace = "${relocatedProjectRoot}
       "malformed familiar-workspace config leaves classification unavailable instead of stamping false onto rows",
     );
   }
+  const malformedCollapsedBaseline = await computeSessionsList(false, null, true, {
+    sweepArchives: false,
+    enrichGit: false,
+  });
+  const malformedCollapsedClassified = await computeSessionsList(false, null, true, {
+    sweepArchives: false,
+    enrichGit: false,
+    classifyFamiliarWorkspace: true,
+  });
+  assert.deepEqual(
+    malformedCollapsedClassified.payload.sessions.map((row) => row.id),
+    malformedCollapsedBaseline.payload.sessions.map((row) => row.id),
+    "classification failure preserves the existing forgiving collapse view",
+  );
+  for (const row of malformedCollapsedClassified.payload.sessions) {
+    assert.equal(
+      row.familiarWorkspace,
+      undefined,
+      "collapsed rows still leave classification unavailable after malformed config",
+    );
+  }
 
   await reset();
   await rm(path.join(covenHome, "familiars.toml"), { force: true });

--- a/src/lib/server/sessions-list.test.ts
+++ b/src/lib/server/sessions-list.test.ts
@@ -437,6 +437,55 @@ try {
     "degraded local familiar-workspace chats keep trusted classification from their original runtime cwd",
   );
 
+  const degradedCollapsedUnregistered = await computeSessionsList(false, null, true, {
+    sweepArchives: false,
+    enrichGit: false,
+    classifyFamiliarWorkspace: true,
+  });
+  assert.equal(degradedCollapsedUnregistered.payload.ok, true);
+  assert.equal(degradedCollapsedUnregistered.payload.degraded, true);
+  assert.deepEqual(
+    degradedCollapsedUnregistered.payload.sessions.map((row) => row.id),
+    ["rootless", "normal-project", "stale-chat"],
+    "collapseFamiliarWorkspace also removes degraded local chats that only retain the trusted familiarWorkspace marker",
+  );
+  assert.equal(
+    degradedCollapsedUnregistered.payload.sessions.find(
+      (row) => row.id === "familiar-unregistered-local",
+    ),
+    undefined,
+    "collapseFamiliarWorkspace removes an unregistered degraded familiar-workspace chat instead of leaving it in the no-project bucket",
+  );
+
+  await reset();
+  await writeFile(
+    path.join(covenHome, "familiars.toml"),
+    `[[familiar]]
+id = "nova"
+workspace = "${relocatedProjectRoot}
+`,
+  );
+  clearCaveStoreReadCache();
+  const malformedClassificationUnknown = await computeSessionsList(false, null, false, {
+    sweepArchives: false,
+    enrichGit: false,
+    classifyFamiliarWorkspace: true,
+  });
+  assert.equal(malformedClassificationUnknown.payload.ok, true);
+  assert.equal(malformedClassificationUnknown.payload.degraded, true);
+  assert.deepEqual(
+    malformedClassificationUnknown.payload.sessions.map((row) => row.id),
+    readOnlyIds,
+    "malformed familiar-workspace config keeps classification metadata-only so session membership stays unchanged",
+  );
+  for (const row of malformedClassificationUnknown.payload.sessions) {
+    assert.equal(
+      row.familiarWorkspace,
+      undefined,
+      "malformed familiar-workspace config leaves classification unavailable instead of stamping false onto rows",
+    );
+  }
+
   await reset();
   await rm(path.join(covenHome, "familiars.toml"), { force: true });
   await mkdir(path.join(covenHome, "familiars.toml"), { recursive: true });

--- a/src/lib/server/sessions-list.test.ts
+++ b/src/lib/server/sessions-list.test.ts
@@ -401,6 +401,66 @@ try {
     "degraded computeSessionsList classification archived a session despite sweepArchives:false",
   );
 
+  await reset();
+  const unregisteredWorkspaceRoot = path.join(
+    covenHome,
+    "workspaces",
+    "familiars",
+    "ember",
+  );
+  await mkdir(unregisteredWorkspaceRoot, { recursive: true });
+  await saveFixtureConversation(
+    saveConversation,
+    clearConversationListMetadataCache,
+    chat(
+      "familiar-unregistered-local",
+      `local:${unregisteredWorkspaceRoot}`,
+      "2099-08-23T11:12:30.000Z",
+    ),
+  );
+  const degradedUnregistered = await computeSessionsList(false, null, false, {
+    sweepArchives: false,
+    enrichGit: false,
+    classifyFamiliarWorkspace: true,
+  });
+  const degradedUnregisteredRow = degradedUnregistered.payload.sessions.find(
+    (row) => row.id === "familiar-unregistered-local",
+  );
+  assert.equal(
+    degradedUnregisteredRow?.project_root,
+    "",
+    "degraded local familiar-workspace chats still stay in the no-project bucket",
+  );
+  assert.equal(
+    degradedUnregisteredRow?.familiarWorkspace,
+    true,
+    "degraded local familiar-workspace chats keep trusted classification from their original runtime cwd",
+  );
+
+  await reset();
+  await rm(path.join(covenHome, "familiars.toml"), { force: true });
+  await mkdir(path.join(covenHome, "familiars.toml"), { recursive: true });
+  clearCaveStoreReadCache();
+  const strictFailureUnknown = await computeSessionsList(false, null, false, {
+    sweepArchives: false,
+    enrichGit: false,
+    classifyFamiliarWorkspace: true,
+  });
+  assert.equal(strictFailureUnknown.payload.ok, true);
+  assert.equal(strictFailureUnknown.payload.degraded, true);
+  assert.deepEqual(
+    strictFailureUnknown.payload.sessions.map((row) => row.id),
+    readOnlyIds,
+    "classification read failures stay metadata-only and do not change degraded session membership",
+  );
+  for (const row of strictFailureUnknown.payload.sessions) {
+    assert.equal(
+      row.familiarWorkspace,
+      undefined,
+      "strict familiar-workspace read failures leave classification unknown so later filters fail closed",
+    );
+  }
+
   // --- default: the sweep still runs ------------------------------------
   await reset();
   daemonUrl = await startDaemon([]);

--- a/src/lib/server/sessions-list.test.ts
+++ b/src/lib/server/sessions-list.test.ts
@@ -22,10 +22,12 @@ const previousEnv = {
   COVEN_HOME: process.env.COVEN_HOME,
   COVEN_SOCKET: process.env.COVEN_SOCKET,
   CAVE_PROJECTS_PATH_OVERRIDE: process.env.CAVE_PROJECTS_PATH_OVERRIDE,
+  CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE: process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE,
 };
 const scratchRoot = path.join(process.cwd(), `.slct-${process.pid}`);
 const covenHome = path.join(scratchRoot, "h");
 const projectsPath = path.join(scratchRoot, "projects.json");
+const permissionsPath = path.join(scratchRoot, "project-permissions.json");
 const projectRoot = path.join(scratchRoot, "p");
 const familiarRootProject = path.join(covenHome, "workspaces", "familiars", "nova");
 const familiarNestedProject = path.join(familiarRootProject, "notes");
@@ -216,11 +218,35 @@ workspace = "${relocatedProjectRoot}"
   clearCaveStoreReadCache();
 }
 
+async function writePermissions() {
+  await writeFile(
+    permissionsPath,
+    JSON.stringify({
+      version: 2,
+      projectGrants: [
+        {
+          familiarId: "nova",
+          projectId: "relocated",
+          access: "write",
+          source: "human",
+          grantedAt: "2026-08-23T00:00:00.000Z",
+        },
+      ],
+      accessGroups: [],
+      grantProposals: [],
+      permissionAudit: [],
+      grantAudit: [],
+      repairAudit: [],
+    }),
+  );
+}
+
 const realNow = Date.now;
 try {
   process.env.COVEN_HOME = covenHome;
   delete process.env.COVEN_SOCKET;
   process.env.CAVE_PROJECTS_PATH_OVERRIDE = projectsPath;
+  process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE = permissionsPath;
 
   const { computeSessionsList } = await import("./sessions-list.ts");
   const { loadState } = await import("../cave-config.ts");
@@ -241,6 +267,7 @@ try {
     await mkdir(path.dirname(projectsPath), { recursive: true });
     await writeProjects(clearCaveStoreReadCache);
     await writeFamiliarsToml(clearCaveStoreReadCache);
+    await writePermissions();
     clearConversationListMetadataCache();
     clearCaveStoreReadCache();
     await saveFixtureConversation(
@@ -340,9 +367,15 @@ try {
   assert.equal(classifiedById.get("normal-project")?.familiarWorkspace, false);
   assert.equal(classifiedById.get("rootless")?.familiarWorkspace, false);
   assert.equal(classifiedById.get("stale-chat")?.familiarWorkspace, false);
+  assert.deepEqual(
+    await archivedIds(),
+    before,
+    "computeSessionsList classification archived a session despite sweepArchives:false",
+  );
 
   await stopDaemon();
   stopDaemon = async () => {};
+  const beforeDegraded = await archivedIds();
   const degradedClassified = await computeSessionsList(false, null, false, {
     sweepArchives: false,
     enrichGit: false,
@@ -362,6 +395,11 @@ try {
   assert.equal(degradedById.get("normal-project")?.familiarWorkspace, false);
   assert.equal(degradedById.get("rootless")?.familiarWorkspace, false);
   assert.equal(degradedById.get("stale-chat")?.familiarWorkspace, false);
+  assert.deepEqual(
+    await archivedIds(),
+    beforeDegraded,
+    "degraded computeSessionsList classification archived a session despite sweepArchives:false",
+  );
 
   // --- default: the sweep still runs ------------------------------------
   await reset();
@@ -376,6 +414,27 @@ try {
     afterDefault.includes("stale-chat"),
     "the default compute must still perform the idle sweep the session poll is the only driver of; " +
       `archived ids were ${JSON.stringify(afterDefault)}`,
+  );
+
+  await reset();
+  await writeConfig(daemonUrl);
+  const scopedClassified = await computeSessionsList(false, "nova", false, {
+    classifyFamiliarWorkspace: true,
+  });
+  assert.equal(scopedClassified.payload.ok, true, "scoped classified compute still returns a list");
+  assert.deepEqual(
+    scopedClassified.payload.sessions.map((row) => row.id),
+    ["rootless", "familiar-relocated"],
+    "familiar-scoped classification keeps only granted and rootless rows while preserving familiar-workspace metadata",
+  );
+  const scopedClassifiedById = new Map(
+    scopedClassified.payload.sessions.map((row) => [row.id, row]),
+  );
+  assert.equal(scopedClassifiedById.get("familiar-relocated")?.familiarWorkspace, true);
+  assert.equal(scopedClassifiedById.get("rootless")?.familiarWorkspace, false);
+  assert.ok(
+    (await archivedIds()).includes("stale-chat"),
+    "the explicit scoped classified compute still preserves the default idle sweep",
   );
 
   // The positive control above is what makes the negative one meaningful: if

--- a/src/lib/server/sessions-list.ts
+++ b/src/lib/server/sessions-list.ts
@@ -57,7 +57,10 @@ import {
   sweepStaleRunningGhosts,
 } from "@/lib/server/stale-running-sweep";
 import { enrichSessionsWithGitContext } from "@/lib/session-git-enrich";
-import { collapseFamiliarWorkspaceSessions } from "@/lib/familiar-workspace-sessions";
+import {
+  classifyFamiliarWorkspaceSessions,
+  collapseFamiliarWorkspaceSessions,
+} from "@/lib/familiar-workspace-sessions";
 import { familiarWorkspacesRoot, readFamiliarWorkspaces } from "@/lib/coven-paths";
 import type { SessionsListResult } from "@/lib/server/sessions-list-cache";
 import { loadProjects, projectForRoot } from "@/lib/cave-projects";
@@ -78,9 +81,15 @@ export type ComputeSessionsListOptions = {
   sweepArchives?: boolean;
   /** Attach git branch/diff/PR context. Spawns `git` subprocesses. */
   enrichGit?: boolean;
+  /** Attach trusted familiar-workspace metadata without changing membership. */
+  classifyFamiliarWorkspace?: boolean;
 };
 
-const DEFAULT_OPTIONS = { sweepArchives: true, enrichGit: true } as const;
+const DEFAULT_OPTIONS = {
+  sweepArchives: true,
+  enrichGit: true,
+  classifyFamiliarWorkspace: false,
+} as const;
 
 type DaemonSession = {
   id: string;
@@ -204,16 +213,43 @@ async function applyAutoArchiveSweep(
  * a familiar-workspace root would leak into the unscoped view while the daemon
  * is unavailable. No-op (and no FS read) when the flag is off.
  */
-async function applyFamiliarWorkspaceCollapse(
-  sessions: SessionRow[],
+type FamiliarWorkspaceRoots = {
+  root: string;
+  declaredRoots: string[];
+};
+
+async function loadFamiliarWorkspaceRoots(
   collapseFamiliarWorkspace: boolean,
-): Promise<SessionRow[]> {
-  if (!collapseFamiliarWorkspace) return sessions;
-  return collapseFamiliarWorkspaceSessions(
-    sessions,
-    familiarWorkspacesRoot(),
-    Array.from((await readFamiliarWorkspaces()).values()),
-  );
+  classifyFamiliarWorkspace: boolean,
+): Promise<FamiliarWorkspaceRoots | null> {
+  if (!collapseFamiliarWorkspace && !classifyFamiliarWorkspace) return null;
+  return {
+    root: familiarWorkspacesRoot(),
+    declaredRoots: Array.from((await readFamiliarWorkspaces()).values()),
+  };
+}
+
+/**
+ * Apply the opt-in familiar-workspace view shaping to an already-scoped list.
+ * Collapse changes membership; classification is metadata-only. Both consume
+ * the same configured root snapshot so one compute path never re-reads
+ * familiars.toml just to attach metadata after filtering.
+ */
+function applyFamiliarWorkspacePresentation(
+  sessions: SessionRow[],
+  familiarWorkspaceRoots: FamiliarWorkspaceRoots | null,
+  collapseFamiliarWorkspace: boolean,
+  classifyFamiliarWorkspace: boolean,
+): SessionRow[] {
+  if (!collapseFamiliarWorkspace && !classifyFamiliarWorkspace) return sessions;
+  if (!familiarWorkspaceRoots) return sessions;
+  const { root, declaredRoots } = familiarWorkspaceRoots;
+  const visible = collapseFamiliarWorkspace
+    ? collapseFamiliarWorkspaceSessions(sessions, root, declaredRoots)
+    : sessions;
+  return classifyFamiliarWorkspace
+    ? classifyFamiliarWorkspaceSessions(visible, root, declaredRoots)
+    : visible;
 }
 
 export async function computeSessionsList(
@@ -224,12 +260,15 @@ export async function computeSessionsList(
 ): Promise<SessionsListResult> {
   const sweepArchives = options.sweepArchives ?? DEFAULT_OPTIONS.sweepArchives;
   const enrichGit = options.enrichGit ?? DEFAULT_OPTIONS.enrichGit;
+  const classifyFamiliarWorkspace =
+    options.classifyFamiliarWorkspace ?? DEFAULT_OPTIONS.classifyFamiliarWorkspace;
   const withGitContext = async (rows: SessionRow[]): Promise<SessionRow[]> =>
     enrichGit ? enrichSessionsWithGitContext(rows) : rows;
-  const [res, state, projects] = await Promise.all([
+  const [res, state, projects, familiarWorkspaceRoots] = await Promise.all([
     callDaemon<DaemonSession[]>({ path: "/api/v1/sessions" }),
     loadState(),
     loadProjects(),
+    loadFamiliarWorkspaceRoots(collapseFamiliarWorkspace, classifyFamiliarWorkspace),
   ]);
   const localConversations = (await listConversations()).map((conv) => {
     // Resolve every live chat against the in-process run registry so an
@@ -261,9 +300,11 @@ export async function computeSessionsList(
           error: res.error ?? `daemon http ${res.status}`,
           sessions: await applyMergedPrAutoArchive(
             await withGitContext(
-              await applyFamiliarWorkspaceCollapse(
+              applyFamiliarWorkspacePresentation(
                 await scopeForFamiliar(localSessions, projects, familiarId),
+                familiarWorkspaceRoots,
                 collapseFamiliarWorkspace,
+                classifyFamiliarWorkspace,
               ),
             ),
             state,
@@ -311,7 +352,12 @@ export async function computeSessionsList(
   );
 
   const scoped = await scopeForFamiliar(sessions, projects, familiarId);
-  const visible = await applyFamiliarWorkspaceCollapse(scoped, collapseFamiliarWorkspace);
+  const visible = applyFamiliarWorkspacePresentation(
+    scoped,
+    familiarWorkspaceRoots,
+    collapseFamiliarWorkspace,
+    classifyFamiliarWorkspace,
+  );
   return {
     payload: {
       ok: true,

--- a/src/lib/server/sessions-list.ts
+++ b/src/lib/server/sessions-list.ts
@@ -220,8 +220,8 @@ async function applyAutoArchiveSweep(
  */
 type FamiliarWorkspaceRoots = {
   root: string;
-  declaredRoots: string[];
-  classificationAvailable: boolean;
+  collapseDeclaredRoots: string[];
+  classificationDeclaredRoots: string[] | null;
 };
 
 async function loadFamiliarWorkspaceRoots(
@@ -233,21 +233,24 @@ async function loadFamiliarWorkspaceRoots(
   if (!classifyFamiliarWorkspace) {
     return {
       root,
-      declaredRoots: Array.from((await readFamiliarWorkspaces()).values()),
-      classificationAvailable: false,
+      collapseDeclaredRoots: Array.from((await readFamiliarWorkspaces()).values()),
+      classificationDeclaredRoots: null,
     };
   }
   try {
+    const declaredRoots = Array.from((await readFamiliarWorkspacesStrict()).values());
     return {
       root,
-      declaredRoots: Array.from((await readFamiliarWorkspacesStrict()).values()),
-      classificationAvailable: true,
+      collapseDeclaredRoots: declaredRoots,
+      classificationDeclaredRoots: declaredRoots,
     };
   } catch {
     return {
       root,
-      declaredRoots: [],
-      classificationAvailable: false,
+      collapseDeclaredRoots: collapseFamiliarWorkspace
+        ? Array.from((await readFamiliarWorkspaces()).values())
+        : [],
+      classificationDeclaredRoots: null,
     };
   }
 }
@@ -256,12 +259,15 @@ function familiarWorkspaceForCwd(
   familiarWorkspaceRoots: FamiliarWorkspaceRoots | null,
   classifyFamiliarWorkspace: boolean,
 ): ((cwd: string) => boolean | undefined) | undefined {
-  if (!classifyFamiliarWorkspace || !familiarWorkspaceRoots?.classificationAvailable) return undefined;
+  if (!classifyFamiliarWorkspace || !familiarWorkspaceRoots?.classificationDeclaredRoots) {
+    return undefined;
+  }
+  const classificationDeclaredRoots = familiarWorkspaceRoots.classificationDeclaredRoots;
   return (cwd: string) =>
     isFamiliarWorkspaceRoot(
       cwd,
       familiarWorkspaceRoots.root,
-      familiarWorkspaceRoots.declaredRoots,
+      classificationDeclaredRoots,
     );
 }
 
@@ -279,12 +285,13 @@ function applyFamiliarWorkspacePresentation(
 ): SessionRow[] {
   if (!collapseFamiliarWorkspace && !classifyFamiliarWorkspace) return sessions;
   if (!familiarWorkspaceRoots) return sessions;
-  const { root, declaredRoots } = familiarWorkspaceRoots;
+  const { root, collapseDeclaredRoots, classificationDeclaredRoots } =
+    familiarWorkspaceRoots;
   const visible = collapseFamiliarWorkspace
-    ? collapseFamiliarWorkspaceSessions(sessions, root, declaredRoots)
+    ? collapseFamiliarWorkspaceSessions(sessions, root, collapseDeclaredRoots)
     : sessions;
-  return classifyFamiliarWorkspace && familiarWorkspaceRoots.classificationAvailable
-    ? classifyFamiliarWorkspaceSessions(visible, root, declaredRoots)
+  return classifyFamiliarWorkspace && classificationDeclaredRoots
+    ? classifyFamiliarWorkspaceSessions(visible, root, classificationDeclaredRoots)
     : visible;
 }
 

--- a/src/lib/server/sessions-list.ts
+++ b/src/lib/server/sessions-list.ts
@@ -60,8 +60,13 @@ import { enrichSessionsWithGitContext } from "@/lib/session-git-enrich";
 import {
   classifyFamiliarWorkspaceSessions,
   collapseFamiliarWorkspaceSessions,
+  isFamiliarWorkspaceRoot,
 } from "@/lib/familiar-workspace-sessions";
-import { familiarWorkspacesRoot, readFamiliarWorkspaces } from "@/lib/coven-paths";
+import {
+  familiarWorkspacesRoot,
+  readFamiliarWorkspaces,
+  readFamiliarWorkspacesStrict,
+} from "@/lib/coven-paths";
 import type { SessionsListResult } from "@/lib/server/sessions-list-cache";
 import { loadProjects, projectForRoot } from "@/lib/cave-projects";
 import { filterProjectsForFamiliar } from "@/lib/project-permissions";
@@ -216,6 +221,7 @@ async function applyAutoArchiveSweep(
 type FamiliarWorkspaceRoots = {
   root: string;
   declaredRoots: string[];
+  classificationAvailable: boolean;
 };
 
 async function loadFamiliarWorkspaceRoots(
@@ -223,10 +229,40 @@ async function loadFamiliarWorkspaceRoots(
   classifyFamiliarWorkspace: boolean,
 ): Promise<FamiliarWorkspaceRoots | null> {
   if (!collapseFamiliarWorkspace && !classifyFamiliarWorkspace) return null;
-  return {
-    root: familiarWorkspacesRoot(),
-    declaredRoots: Array.from((await readFamiliarWorkspaces()).values()),
-  };
+  const root = familiarWorkspacesRoot();
+  if (!classifyFamiliarWorkspace) {
+    return {
+      root,
+      declaredRoots: Array.from((await readFamiliarWorkspaces()).values()),
+      classificationAvailable: false,
+    };
+  }
+  try {
+    return {
+      root,
+      declaredRoots: Array.from((await readFamiliarWorkspacesStrict()).values()),
+      classificationAvailable: true,
+    };
+  } catch {
+    return {
+      root,
+      declaredRoots: [],
+      classificationAvailable: false,
+    };
+  }
+}
+
+function familiarWorkspaceForCwd(
+  familiarWorkspaceRoots: FamiliarWorkspaceRoots | null,
+  classifyFamiliarWorkspace: boolean,
+): ((cwd: string) => boolean | undefined) | undefined {
+  if (!classifyFamiliarWorkspace || !familiarWorkspaceRoots?.classificationAvailable) return undefined;
+  return (cwd: string) =>
+    isFamiliarWorkspaceRoot(
+      cwd,
+      familiarWorkspaceRoots.root,
+      familiarWorkspaceRoots.declaredRoots,
+    );
 }
 
 /**
@@ -247,7 +283,7 @@ function applyFamiliarWorkspacePresentation(
   const visible = collapseFamiliarWorkspace
     ? collapseFamiliarWorkspaceSessions(sessions, root, declaredRoots)
     : sessions;
-  return classifyFamiliarWorkspace
+  return classifyFamiliarWorkspace && familiarWorkspaceRoots.classificationAvailable
     ? classifyFamiliarWorkspaceSessions(visible, root, declaredRoots)
     : visible;
 }
@@ -270,6 +306,10 @@ export async function computeSessionsList(
     loadProjects(),
     loadFamiliarWorkspaceRoots(collapseFamiliarWorkspace, classifyFamiliarWorkspace),
   ]);
+  const classifyFamiliarWorkspaceForCwd = familiarWorkspaceForCwd(
+    familiarWorkspaceRoots,
+    classifyFamiliarWorkspace,
+  );
   const localConversations = (await listConversations()).map((conv) => {
     // Resolve every live chat against the in-process run registry so an
     // existing conversation's follow-up cannot retain stale attention while
@@ -287,7 +327,13 @@ export async function computeSessionsList(
   const projectRootForCwd = (cwd: string) => projectForRoot(cwd, projects)?.root ?? null;
   if (!res.ok || !res.data) {
     const localSessions = await applyAutoArchiveSweep(
-      localConversationSessionRows(localConversations, state, includeArchived, projectRootForCwd),
+      localConversationSessionRows(
+        localConversations,
+        state,
+        includeArchived,
+        projectRootForCwd,
+        classifyFamiliarWorkspaceForCwd,
+      ),
       state,
       includeArchived,
       sweepArchives,
@@ -341,6 +387,7 @@ export async function computeSessionsList(
       includeArchived,
       isValidDaemonProjectRoot: isKnownProjectOrValidDir,
       projectRootForCwd,
+      familiarWorkspaceForCwd: classifyFamiliarWorkspaceForCwd,
     }).map((session) =>
       hasActiveChatRun(session.id)
         ? { ...session, status: "running", exit_code: 0, attention: NO_CHAT_ATTENTION }

--- a/src/lib/session-git-enrich.test.ts
+++ b/src/lib/session-git-enrich.test.ts
@@ -10,11 +10,13 @@
  *  3. the is-inside-work-tree gate short-circuits non-repo dirs
  *  4. missing directories never spawn git at all
  *  5. per-root dedup — many sessions on one root probe git once
- *  6. diffstat vs base ref + parseShortstat parsing
- *  7. MAX_DIFF_CALLS global cap
- *  8. failed base-ref resolution yields no diff and does not consume the cap
- *  9. root-level concurrency stays within ROOT_CONCURRENCY
- * 10. rows without a root pass through untouched
+ *  6. GitHub origin normalization plus missing/malformed/non-GitHub/credential
+ *     remote omission without losing branch/worktree context
+ *  7. diffstat vs base ref + parseShortstat parsing
+ *  8. MAX_DIFF_CALLS global cap
+ *  9. failed base-ref resolution yields no diff and does not consume the cap
+ * 10. root-level concurrency stays within ROOT_CONCURRENCY
+ * 11. rows without a root pass through untouched
  */
 
 import assert from "node:assert/strict";
@@ -66,6 +68,7 @@ const REPO_SCRIPT = {
   "rev-parse --show-toplevel": (root) => root,
   "rev-parse --git-dir": ".git",
   "rev-parse --git-common-dir": ".git",
+  "config --get remote.origin.url": "git@github.com:acme/repo-a.git",
   "symbolic-ref --short refs/remotes/origin/HEAD": "origin/main",
   "diff origin/main...feat/thing --shortstat": " 3 files changed, 10 insertions(+), 2 deletions(-)",
 };
@@ -80,6 +83,7 @@ const REPO_SCRIPT = {
     branch: "feat/thing",
     worktreeRoot: rootA,
     isWorktree: false,
+    repositoryUrl: "https://github.com/acme/repo-a",
   });
   assert.deepEqual(rows[0].diff, { additions: 10, deletions: 2 });
 }
@@ -141,9 +145,56 @@ const REPO_SCRIPT = {
   assert.equal(diffCalls.length, 1, "one diff per root, not per session");
   const gateCalls = calls.filter((c) => c.args.join(" ") === "rev-parse --is-inside-work-tree");
   assert.equal(gateCalls.length, 1, "one context probe set per root");
+  const originCalls = calls.filter((c) => c.args.join(" ") === "config --get remote.origin.url");
+  assert.equal(originCalls.length, 1, "one origin probe per root, not per session");
 }
 
-// ── 6. parseShortstat parsing ────────────────────────────────────────────────
+// ── 6. repositoryUrl only reflects valid canonical GitHub origins ───────────
+{
+  const cases = [
+    {
+      name: "missing remote",
+      remote: null,
+    },
+    {
+      name: "malformed remote",
+      remote: "not a remote",
+    },
+    {
+      name: "non-GitHub remote",
+      remote: "https://gitlab.com/acme/repo-a.git",
+    },
+    {
+      name: "credential-bearing remote",
+      remote: "https://token@github.com/acme/private.git",
+    },
+  ];
+
+  for (const [index, testCase] of cases.entries()) {
+    const root = makeRoot(`repo-remote-${index}`);
+    const { runner, calls } = fakeGit({
+      ...REPO_SCRIPT,
+      "config --get remote.origin.url": testCase.remote,
+    });
+    const rows = await enrichSessionsWithGitContext([session(`s${index}`, root)], runner);
+    assert.deepEqual(
+      rows[0].git,
+      {
+        branch: "feat/thing",
+        worktreeRoot: root,
+        isWorktree: false,
+      },
+      `${testCase.name} must preserve branch/worktree context without repositoryUrl`,
+    );
+    assert.equal(
+      calls.some((c) => c.args.join(" ") === "config --get remote.origin.url"),
+      true,
+      `${testCase.name} must still probe remote.origin.url`,
+    );
+  }
+}
+
+// ── 7. parseShortstat parsing ────────────────────────────────────────────────
 {
   assert.deepEqual(parseShortstat(" 3 files changed, 10 insertions(+), 2 deletions(-)"), {
     additions: 10,
@@ -157,7 +208,7 @@ const REPO_SCRIPT = {
   assert.equal(parseShortstat(null), null);
 }
 
-// ── 7. the global diff cap holds across many roots ──────────────────────────
+// ── 8. the global diff cap holds across many roots ──────────────────────────
 {
   const roots = Array.from({ length: MAX_DIFF_CALLS + 8 }, (_, i) => makeRoot(`repo-cap-${i}`));
   const { runner, calls } = fakeGit(REPO_SCRIPT);
@@ -176,7 +227,7 @@ const REPO_SCRIPT = {
   );
 }
 
-// ── 8. missing base ref: no diff, and the cap is not consumed ───────────────
+// ── 9. missing base ref: no diff, and the cap is not consumed ───────────────
 {
   const noBase = makeRoot("repo-no-base");
   const withBase = makeRoot("repo-with-base");
@@ -196,7 +247,7 @@ const REPO_SCRIPT = {
   assert.equal(diffCalls.length, 1, "the failed-base root must not consume a diff slot");
 }
 
-// ── 9. root-level concurrency stays bounded ─────────────────────────────────
+// ── 10. root-level concurrency stays bounded ────────────────────────────────
 {
   const roots = Array.from({ length: 12 }, (_, i) => makeRoot(`repo-conc-${i}`));
   let inFlight = 0;
@@ -234,7 +285,7 @@ const REPO_SCRIPT = {
   assert.ok(peak >= 2, "roots must actually be probed in parallel");
 }
 
-// ── 10. rootless rows pass through untouched ────────────────────────────────
+// ── 11. rootless rows pass through untouched ────────────────────────────────
 {
   const { runner, calls } = fakeGit(REPO_SCRIPT);
   const bare = { id: "s1", project_root: "", harness: "codex", title: "s1", status: "completed" };
@@ -246,7 +297,7 @@ const REPO_SCRIPT = {
   assert.equal(calls.length, 0);
 }
 
-// ── 11. PR attribution is per session, never per root-current-branch ────────
+// ── 12. PR attribution is per session, never per root-current-branch ────────
 // (cave-9q24: stamping the root's checked-out branch's PR onto every session
 // sharing the root let one merged PR mass-archive unrelated chats.)
 {
@@ -324,7 +375,7 @@ const REPO_SCRIPT = {
   }
 }
 
-// 12. Transcript fallback (cave-u9wl): a chat that reported a PR URL in a
+// 13. Transcript fallback (cave-u9wl): a chat that reported a PR URL in a
 // reply gets URL-resolved PR context tagged attribution:"transcript" — even
 // with no project root — and branch attribution always wins when present.
 {

--- a/src/lib/session-git-enrich.ts
+++ b/src/lib/session-git-enrich.ts
@@ -23,6 +23,7 @@ import { promisify } from "node:util";
 import fs from "node:fs";
 import path from "node:path";
 import { branchPrCache, prUrlCache, type BranchPrCache, type PrUrlCache } from "./branch-pr-context.ts";
+import { normalizeGitHubRepoUrl } from "./github-repo-link.ts";
 import type { SessionGitContext, SessionRow } from "./types.ts";
 
 const execFileAsync = promisify(execFile);
@@ -83,11 +84,12 @@ async function readGitContext(git: GitRunner, projectRoot: string): Promise<Sess
   if ((await git(trimmed, ["rev-parse", "--is-inside-work-tree"])) !== "true") return null;
 
   // Independent probes — run together instead of serially.
-  const [currentBranch, worktreeRoot, gitDirRaw, commonDirRaw] = await Promise.all([
+  const [currentBranch, worktreeRoot, gitDirRaw, commonDirRaw, originRemote] = await Promise.all([
     git(trimmed, ["branch", "--show-current"]),
     git(trimmed, ["rev-parse", "--show-toplevel"]),
     git(trimmed, ["rev-parse", "--git-dir"]),
     git(trimmed, ["rev-parse", "--git-common-dir"]),
+    git(trimmed, ["config", "--get", "remote.origin.url"]),
   ]);
   const branch = currentBranch ?? (await git(trimmed, ["rev-parse", "--short", "HEAD"]));
   const gitDir = resolveGitPath(trimmed, gitDirRaw);
@@ -97,6 +99,7 @@ async function readGitContext(git: GitRunner, projectRoot: string): Promise<Sess
     isWorktree && commonDir && path.basename(commonDir) === ".git"
       ? path.dirname(commonDir)
       : null;
+  const repositoryUrl = normalizeGitHubRepoUrl(originRemote);
 
   if (!branch && !worktreeRoot && !isWorktree) return null;
   return {
@@ -104,6 +107,7 @@ async function readGitContext(git: GitRunner, projectRoot: string): Promise<Sess
     worktreeRoot,
     isWorktree,
     ...(repositoryRoot ? { repositoryRoot } : {}),
+    ...(repositoryUrl ? { repositoryUrl } : {}),
   };
 }
 

--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -1612,6 +1612,39 @@ assert.equal(analyticsRows[0].origin, "chat", "analytics discussion origin maps 
     "mergeSessionRows threads the resolver through to local-only rows",
   );
 
+  const familiarWorkspaceRuntime = "local:/Users/example/.coven/workspaces/familiars/nova";
+  const familiarWorkspaceRows = localConversationSessionRows(
+    [conv("workspace-classified", familiarWorkspaceRuntime)],
+    bareState,
+    false,
+    projectRootForCwd,
+    (cwd) => cwd === "/Users/example/.coven/workspaces/familiars/nova",
+  );
+  assert.equal(
+    familiarWorkspaceRows[0]?.project_root,
+    "",
+    "trusted familiar workspace classification must not change no-project grouping",
+  );
+  assert.equal(
+    familiarWorkspaceRows[0]?.familiarWorkspace,
+    true,
+    "local familiar-workspace runtimes can still carry trusted classification after project_root backfill drops the cwd",
+  );
+
+  const mergedFamiliarWorkspace = mergeSessionRows({
+    daemonSessions: [],
+    localConversations: [conv("workspace-classified", familiarWorkspaceRuntime)],
+    state: bareState,
+    includeArchived: false,
+    projectRootForCwd,
+    familiarWorkspaceForCwd: (cwd) => cwd === "/Users/example/.coven/workspaces/familiars/nova",
+  });
+  assert.equal(
+    mergedFamiliarWorkspace[0]?.familiarWorkspace,
+    true,
+    "mergeSessionRows threads trusted familiar-workspace classification into local-only rows",
+  );
+
   const runtimeTransitions = [
     {
       id: "runtime-local-to-ssh",

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -50,6 +50,9 @@ type MergeOptions = {
   /** Map a local conversation's recorded cwd to a registered project root
    *  (null = no registered project). See localConversationToSession. */
   projectRootForCwd?: (cwd: string) => string | null;
+  /** Attach trusted familiar-workspace metadata from the original local cwd
+   *  without changing no-project grouping. Undefined leaves it unknown. */
+  familiarWorkspaceForCwd?: (cwd: string) => boolean | undefined;
 };
 
 const DAEMON_AUTHORITATIVE_TERMINAL_STATUSES = new Set(["archived", "killed", "orphaned", "stopped"]);
@@ -110,6 +113,7 @@ function localConversationToSession(
   conv: LocalConversationSummary,
   state: CaveState,
   projectRootForCwd?: (cwd: string) => string | null,
+  familiarWorkspaceForCwd?: (cwd: string) => boolean | undefined,
   now = Date.now(),
 ): SessionRow {
   const keep = Boolean(state.sessionKeep?.[conv.sessionId]);
@@ -128,6 +132,7 @@ function localConversationToSession(
   // design (see resolveChatProjectSelection in chat-projects.ts).
   const cwd = conversationLocalCwd(conv.runtime);
   const projectRoot = (cwd ? projectRootForCwd?.(cwd) : null) ?? "";
+  const familiarWorkspace = cwd ? familiarWorkspaceForCwd?.(cwd) : undefined;
   return {
     id: conv.sessionId,
     project_root: projectRoot,
@@ -158,6 +163,7 @@ function localConversationToSession(
     ...(keep ? { keep: true } : {}),
     ...(pinned ? { pinned: true } : {}),
     ...(extendedUntil ? { archive_extended_until: extendedUntil } : {}),
+    ...(familiarWorkspace === undefined ? {} : { familiarWorkspace }),
   };
 }
 
@@ -171,10 +177,19 @@ export function localConversationSessionRows(
   state: CaveState,
   includeArchived: boolean,
   projectRootForCwd?: (cwd: string) => string | null,
+  familiarWorkspaceForCwd?: (cwd: string) => boolean | undefined,
 ): SessionRow[] {
   const now = Date.now();
   return localConversations
-    .map((conv) => localConversationToSession(conv, state, projectRootForCwd, now))
+    .map((conv) =>
+      localConversationToSession(
+        conv,
+        state,
+        projectRootForCwd,
+        familiarWorkspaceForCwd,
+        now,
+      ),
+    )
     .filter((row) => visibleSession(row, state, includeArchived))
     .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
 }
@@ -186,6 +201,7 @@ export function mergeSessionRows({
   includeArchived,
   isValidDaemonProjectRoot,
   projectRootForCwd,
+  familiarWorkspaceForCwd,
 }: MergeOptions): SessionRow[] {
   const now = Date.now();
   const seen = new Set<string>();
@@ -238,7 +254,13 @@ export function mergeSessionRows({
     if (isValidDaemonProjectRoot && !isValidDaemonProjectRoot(session.project_root)) {
       if (local && isDaemonRecoverableStatus(session.status)) {
         seen.add(stateSessionId);
-        const recovered = localConversationToSession(local, state, projectRootForCwd, now);
+        const recovered = localConversationToSession(
+          local,
+          state,
+          projectRootForCwd,
+          familiarWorkspaceForCwd,
+          now,
+        );
         const archived_at = state.sessionArchived[stateSessionId] ?? session.archived_at;
         const attention =
           isArchivedStatus(session.status)
@@ -344,7 +366,15 @@ export function mergeSessionRows({
   }
 
   for (const row of localConversations
-    .map((conv) => localConversationToSession(conv, state, projectRootForCwd, now))
+    .map((conv) =>
+      localConversationToSession(
+        conv,
+        state,
+        projectRootForCwd,
+        familiarWorkspaceForCwd,
+        now,
+      ),
+    )
     .filter((session) => visibleSession(session, state, includeArchived))
     .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1))) {
     if (seen.has(row.id)) continue;

--- a/src/lib/session-project-scope.test.ts
+++ b/src/lib/session-project-scope.test.ts
@@ -74,8 +74,8 @@ test("the sessions/list route scopes by familiar grants", () => {
   assert.match(route, /searchParams\.get\("familiarId"\)/, "reads the familiarId param");
   assert.match(
     route,
-    /computeSessionsList\(includeArchived, familiarId, collapseFamiliarWorkspace\)/,
-    "threads the parsed familiar id into the scoped compute",
+    /computeSessionsList\(includeArchived,\s*familiarId,\s*collapseFamiliarWorkspace,\s*\{\s*classifyFamiliarWorkspace\s*\}\)/,
+    "threads the parsed familiar id and classification flag into the scoped compute",
   );
 });
 
@@ -95,7 +95,11 @@ test("chat surface consumers pass the active familiar scope", () => {
     /useProjects\(\)/,
     "ProjectsView loads unscoped — it manages the grants themselves",
   );
-  assert.match(read("src/components/workspace.tsx"), /\/api\/sessions\/list\$\{scope\}/, "workspace scopes the session poll by familiar");
+  const workspace = read("src/components/workspace.tsx");
+  assert.match(workspace, /params\.set\("classifyFamiliarWorkspace",\s*"1"\)/, "workspace always requests trusted familiar-workspace classification");
+  assert.match(workspace, /if \(capturedActiveId\) params\.set\("familiarId", capturedActiveId\);/, "workspace scopes the session poll by familiar when one is active");
+  assert.match(workspace, /else params\.set\("collapseFamiliarWorkspace",\s*"1"\);/, "workspace collapses familiar workspace rows only in the unscoped poll");
+  assert.match(workspace, /\/api\/sessions\/list\?\$\{params\.toString\(\)\}/, "workspace sends the assembled shared session-list query");
 });
 
 test("chat/send still gates project access for the acting familiar", () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -139,6 +139,9 @@ export type SessionGitContext = {
   /** Main checkout that owns this linked worktree, derived from
    *  `git rev-parse --git-common-dir`. Present only for linked worktrees. */
   repositoryRoot?: string | null;
+  /** Canonical GitHub origin; absent for missing, malformed, credential-bearing,
+   *  or non-GitHub remotes. */
+  repositoryUrl?: string | null;
 };
 
 export type SessionPullRequestContext = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -130,6 +130,8 @@ export type SessionRow = {
   pinned?: boolean;
   /** Cave-local auto-archive defer-until timestamp, if set. */
   archive_extended_until?: string | null;
+  /** Trusted server classification; true only for configured familiar workspace roots. */
+  familiarWorkspace?: boolean;
 };
 
 export type SessionGitContext = {

--- a/src/styles/globals/surface-code-room.css
+++ b/src/styles/globals/surface-code-room.css
@@ -317,6 +317,59 @@
 .code-room__action[aria-expanded="true"] { background: var(--bg-hover); color: var(--text-primary); }
 .code-room__inspector { padding: var(--space-2); max-height: 60vh; overflow-y: auto; }
 
+/* ── Shared queue scope controls ── */
+.code-queue-filter {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-1);
+}
+.code-queue-filter__group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+.code-queue-filter__button {
+  display: inline-flex;
+  flex: 1;
+  min-height: var(--space-6);
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-1);
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+}
+.code-queue-filter__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.code-queue-filter__button:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.code-queue-filter__button[aria-pressed="true"],
+.code-queue-filter__button[data-on="true"] {
+  background: color-mix(in oklab, var(--accent-presence) 14%, transparent);
+  border-color: color-mix(in oklab, var(--accent-presence) 38%, transparent);
+  color: var(--text-primary);
+}
+.code-queue-filter__count {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.code-queue-filter__notice {
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
 /* ── Body: three columns ── */
 .code-room__body {
   display: flex;

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
 // The dedicated Code surface (cave-k0ua): a Codex-style multi-session coding
 // workbench — session rail grouped by project, per-session workbench
@@ -84,10 +84,171 @@ const ALL_LOCAL_ONLY = mkSession({
     isWorktree: true,
   },
 });
+const REVIEW_ROOT = mkSession({
+  id: "s-review-root",
+  title: "Review root checkout",
+  status: "running",
+  updated_at: "2026-06-12T13:00:00.000Z",
+  project_root: "/repo/alpha",
+  familiarWorkspace: false,
+  workBranch: "feat/review-root",
+  git: {
+    branch: "feat/review-root",
+    repositoryUrl: "https://github.com/acme/alpha",
+    worktreeRoot: "/repo/alpha",
+    repositoryRoot: null,
+    isWorktree: false,
+  },
+  pullRequest: { repo: "acme/alpha", number: 42, url: "https://github.com/acme/alpha/pull/42", state: "open" },
+  diff: { additions: 9, deletions: 2 },
+});
+const REVIEW_LINKED = mkSession({
+  id: "s-review-linked",
+  title: "Linked worktree review",
+  status: "idle",
+  updated_at: "2026-06-12T12:20:00.000Z",
+  project_root: "/repo/alpha/.worktrees/review-linked",
+  familiarWorkspace: false,
+  git: {
+    branch: "feat/review-linked",
+    repositoryUrl: "https://github.com/acme/alpha",
+    worktreeRoot: "/repo/alpha/.worktrees/review-linked",
+    repositoryRoot: "/repo/alpha",
+    isWorktree: true,
+  },
+});
+const FAMILIAR_WORKSPACE = mkSession({
+  id: "s-familiar",
+  title: "Familiar workspace scratch",
+  status: "idle",
+  updated_at: "2026-06-12T12:10:00.000Z",
+  project_root: "/Users/dev/.coven/workspaces/familiars/nova/project",
+  familiarWorkspace: true,
+  git: {
+    branch: "feat/familiar-scratch",
+    repositoryUrl: "https://github.com/acme/alpha",
+    worktreeRoot: "/Users/dev/.coven/workspaces/familiars/nova/project",
+    repositoryRoot: null,
+    isWorktree: false,
+  },
+});
+const NON_GITHUB = mkSession({
+  id: "s-non-github",
+  title: "Private forge session",
+  status: "running",
+  updated_at: "2026-06-12T12:40:00.000Z",
+  project_root: "/Users/dev/code/private-forge",
+  familiarWorkspace: false,
+  git: {
+    branch: "feat/private-forge",
+    repositoryUrl: null,
+    worktreeRoot: "/Users/dev/code/private-forge",
+    repositoryRoot: null,
+    isWorktree: false,
+  },
+});
+const ROOTLESS = mkSession({
+  id: "s-rootless",
+  title: "Rootless handoff",
+  status: "idle",
+  updated_at: "2026-06-12T12:00:00.000Z",
+  project_root: "",
+  familiarWorkspace: false,
+  git: null,
+});
+const UNCLASSIFIED = mkSession({
+  id: "s-unclassified",
+  title: "Unclassified workspace session",
+  status: "idle",
+  updated_at: "2026-06-12T12:30:00.000Z",
+  project_root: "/Users/dev/code/unclassified",
+  git: {
+    branch: "feat/unclassified",
+    repositoryUrl: "https://github.com/acme/unclassified",
+    worktreeRoot: "/Users/dev/code/unclassified",
+    repositoryRoot: null,
+    isWorktree: false,
+  },
+  diff: { additions: 1, deletions: 1 },
+});
+const ARCHIVED_LOCAL = mkSession({
+  id: "s-archived",
+  title: "Archived importer",
+  status: "idle",
+  updated_at: "2026-06-12T11:50:00.000Z",
+  archived_at: "2026-06-12T13:05:00.000Z",
+  project_root: "/Users/dev/code/archived",
+  familiarWorkspace: false,
+  git: {
+    branch: "feat/archived",
+    repositoryUrl: "https://github.com/acme/archived",
+    worktreeRoot: "/Users/dev/code/archived",
+    repositoryRoot: null,
+    isWorktree: false,
+  },
+});
+const GENERATED_LOCAL = mkSession({
+  id: "s-generated",
+  title: "Generated planner run",
+  status: "idle",
+  updated_at: "2026-06-12T11:45:00.000Z",
+  generated: true,
+  project_root: "/Users/dev/code/generated",
+  familiarWorkspace: false,
+  git: {
+    branch: "feat/generated",
+    repositoryUrl: "https://github.com/acme/generated",
+    worktreeRoot: "/Users/dev/code/generated",
+    repositoryRoot: null,
+    isWorktree: false,
+  },
+});
+
+const REVIEW_FIRST_MATRIX = [
+  REVIEW_ROOT,
+  REVIEW_LINKED,
+  FAMILIAR_WORKSPACE,
+  NON_GITHUB,
+  ROOTLESS,
+  UNCLASSIFIED,
+  ARCHIVED_LOCAL,
+  GENERATED_LOCAL,
+];
+const REVIEW_FIRST_REVIEWABLE_IDS = ["s-review-root", "s-review-linked"];
+const REVIEW_FIRST_ALL_LOCAL_IDS = [
+  "s-review-root",
+  "s-non-github",
+  "s-unclassified",
+  "s-review-linked",
+  "s-familiar",
+  "s-rootless",
+];
+const REVIEW_FIRST_EXCLUDED_ONLY = [
+  FAMILIAR_WORKSPACE,
+  NON_GITHUB,
+  ROOTLESS,
+  UNCLASSIFIED,
+  ARCHIVED_LOCAL,
+  GENERATED_LOCAL,
+];
+const REVIEW_FIRST_EXCLUDED_ONLY_IDS = [
+  "s-non-github",
+  "s-unclassified",
+  "s-familiar",
+  "s-rootless",
+];
 
 async function activeCodeSessionId(page: Page) {
   return page.evaluate(
     () => document.activeElement?.getAttribute("data-code-session-id") ?? null,
+  );
+}
+
+async function visibleCodeSessionIds(scope: Locator) {
+  return scope.locator("[data-code-session-id]").evaluateAll((nodes) =>
+    nodes
+      .map((node) => node.getAttribute("data-code-session-id"))
+      .filter((id): id is string => typeof id === "string" && id.length > 0),
   );
 }
 
@@ -259,6 +420,122 @@ async function mockWorkScheduler(page: Page) {
 test.describe.configure({ mode: "serial" });
 
 test.describe("code surface (Coding familiar's room)", () => {
+  test("review-first queue defaults to Reviewable, keeps rail/picker order aligned, and resets on reload", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await base(page, REVIEW_FIRST_MATRIX);
+    await page.goto("/?mode=code", { waitUntil: "domcontentloaded" });
+
+    const rail = page.getByRole("complementary", { name: "Coding sessions" });
+    const scope = rail.getByRole("group", { name: "Session scope" });
+    const reviewableButton = scope.getByRole("button", { name: /Reviewable/ });
+    const allLocalButton = scope.getByRole("button", { name: /All local/ });
+    const pickerTrigger = page.locator(".code-picker__trigger");
+
+    await expect(rail).toBeVisible({ timeout: 30_000 });
+    await expect(reviewableButton).toHaveAttribute("aria-pressed", "true");
+    await expect(rail.getByText("acme/alpha", { exact: true })).toBeVisible();
+    await expect(page.getByTestId("code-workbench-header").getByRole("button", { name: /Review root checkout/ })).toBeVisible();
+    await expect(rail.locator('[data-code-session-id="s-review-linked"]')).toBeVisible();
+    await expect.poll(() => visibleCodeSessionIds(rail)).toEqual(REVIEW_FIRST_REVIEWABLE_IDS);
+    await expect(rail.locator('[data-code-session-id="s-familiar"]')).toHaveCount(0);
+    await expect(rail.locator('[data-code-session-id="s-non-github"]')).toHaveCount(0);
+    await expect(rail.locator('[data-code-session-id="s-rootless"]')).toHaveCount(0);
+    await expect(rail.locator('[data-code-session-id="s-unclassified"]')).toHaveCount(0);
+
+    await pickerTrigger.click();
+    const picker = page.getByRole("dialog", { name: "Switch session" });
+    await expect(picker).toBeVisible();
+    await expect.poll(() => visibleCodeSessionIds(picker)).toEqual(REVIEW_FIRST_REVIEWABLE_IDS);
+    await page.keyboard.press("Escape");
+    await expect(picker).toHaveCount(0);
+
+    await allLocalButton.click();
+    await expect(allLocalButton).toHaveAttribute("aria-pressed", "true");
+    await expect.poll(() => visibleCodeSessionIds(rail)).toEqual(REVIEW_FIRST_ALL_LOCAL_IDS);
+    await expect(rail.locator('[data-code-session-id="s-archived"]')).toHaveCount(0);
+    await expect(rail.locator('[data-code-session-id="s-generated"]')).toHaveCount(0);
+
+    await pickerTrigger.click();
+    await expect(picker.getByRole("group", { name: "Session scope" }).getByRole("button", { name: /All local/ })).toHaveAttribute("aria-pressed", "true");
+    await expect.poll(() => visibleCodeSessionIds(picker)).toEqual(REVIEW_FIRST_ALL_LOCAL_IDS);
+    await page.keyboard.press("Escape");
+    await expect(picker).toHaveCount(0);
+
+    const reviewRow = rail.locator('[data-code-session-id="s-review-root"]');
+    await reviewRow.focus();
+    await expect.poll(() => activeCodeSessionId(page)).toBe("s-review-root");
+    await page.keyboard.press("j");
+    await expect.poll(() => activeCodeSessionId(page)).toBe("s-non-github");
+    await page.keyboard.press("k");
+    await expect.poll(() => activeCodeSessionId(page)).toBe("s-review-root");
+
+    await reviewableButton.click();
+    await expect(reviewableButton).toHaveAttribute("aria-pressed", "true");
+    await expect.poll(() => visibleCodeSessionIds(rail)).toEqual(REVIEW_FIRST_REVIEWABLE_IDS);
+
+    await page.goto("/?mode=code", { waitUntil: "domcontentloaded" });
+    const reloadedRail = page.getByRole("complementary", { name: "Coding sessions" });
+    const reloadedScope = reloadedRail.getByRole("group", { name: "Session scope" });
+    await expect(reloadedRail).toBeVisible({ timeout: 30_000 });
+    await expect(reloadedScope.getByRole("button", { name: /Reviewable/ })).toHaveAttribute("aria-pressed", "true");
+    await expect.poll(() => visibleCodeSessionIds(reloadedRail)).toEqual(REVIEW_FIRST_REVIEWABLE_IDS);
+    await expect(reloadedRail.locator('[data-code-session-id="s-non-github"]')).toHaveCount(0);
+  });
+
+  test("a deep-linked excluded non-GitHub session stays open outside the current filter without leaking raw path details", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await base(page, REVIEW_FIRST_MATRIX);
+    await page.goto("/?mode=code&session=s-non-github", { waitUntil: "domcontentloaded" });
+
+    const rail = page.getByRole("complementary", { name: "Coding sessions" });
+    const scope = rail.getByRole("group", { name: "Session scope" });
+
+    await expect(rail).toBeVisible({ timeout: 30_000 });
+    await expect(scope.getByRole("button", { name: /Reviewable/ })).toHaveAttribute("aria-pressed", "true");
+    await expect(rail.getByText("Outside current filter")).toBeVisible();
+    await expect(page.getByTestId("code-workbench-header").getByRole("button", { name: /Private forge session/ })).toBeVisible();
+    await expect(rail.locator("[data-code-session-id]")).toHaveCount(3);
+    await expect(rail.locator('[data-code-session-id="s-review-root"]')).toBeVisible();
+    await expect(rail.locator('[data-code-session-id="s-review-linked"]')).toBeVisible();
+    await expect(rail.locator('[data-code-session-id="s-non-github"]')).toBeVisible();
+    await expect(rail.locator('[data-code-session-id="s-familiar"]')).toHaveCount(0);
+    await expect(rail.locator('[data-code-session-id="s-rootless"]')).toHaveCount(0);
+    await expect(rail.locator('[data-code-session-id="s-unclassified"]')).toHaveCount(0);
+    await expect(page.getByText("/Users/dev/code/private-forge")).toHaveCount(0);
+    await expect(page.getByText("/Users/dev/.coven/workspaces/familiars/nova/project")).toHaveCount(0);
+  });
+
+  test("reviewable empty state uses the approved copy and All local remains the explicit escape hatch", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await base(page, REVIEW_FIRST_EXCLUDED_ONLY);
+    await page.goto("/?mode=code", { waitUntil: "domcontentloaded" });
+
+    const rail = page.getByRole("complementary", { name: "Coding sessions" });
+    const scope = rail.getByRole("group", { name: "Session scope" });
+
+    await expect(rail).toBeVisible({ timeout: 30_000 });
+    await expect(scope.getByRole("button", { name: /Reviewable/ })).toHaveAttribute("aria-pressed", "true");
+    await expect(rail.getByText("No GitHub repository sessions need review.")).toBeVisible();
+    await expect(rail.getByText("No reviewable sessions match this scope.")).toHaveCount(0);
+    await expect(page.getByText("/Users/dev/code/private-forge")).toHaveCount(0);
+    await expect(page.getByText("/Users/dev/code/unclassified")).toHaveCount(0);
+
+    await scope.getByRole("button", { name: /All local/ }).click();
+    await expect(scope.getByRole("button", { name: /All local/ })).toHaveAttribute("aria-pressed", "true");
+    await expect.poll(() => visibleCodeSessionIds(rail)).toEqual(REVIEW_FIRST_EXCLUDED_ONLY_IDS);
+    await expect(rail.locator('[data-code-session-id="s-archived"]')).toHaveCount(0);
+    await expect(rail.locator('[data-code-session-id="s-generated"]')).toHaveCount(0);
+  });
+
   test("landing: rail groups sessions, newest auto-selected, attribution chips in the header", async ({ page, isMobile }) => {
     test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
     await base(page);

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -536,6 +536,33 @@ test.describe("code surface (Coding familiar's room)", () => {
     await expect(rail.locator('[data-code-session-id="s-generated"]')).toHaveCount(0);
   });
 
+  test("narrow reviewable empty landing keeps a single shared picker and shows the approved empty copy", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, "desktop-only narrow viewport; mobile drill-in lives in tests/mobile/");
+    await page.setViewportSize({ width: 760, height: 900 });
+    await base(page, REVIEW_FIRST_EXCLUDED_ONLY);
+    await page.goto("/?mode=code", { waitUntil: "domcontentloaded" });
+
+    const scope = page.getByRole("group", { name: "Session scope" });
+    const pickerTrigger = page.locator(".code-picker__trigger");
+
+    await expect(page.getByRole("button", { name: "Search sessions" })).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(scope.getByRole("button", { name: /Reviewable/ })).toHaveAttribute("aria-pressed", "true");
+    await expect(pickerTrigger).toHaveCount(1);
+
+    await pickerTrigger.click();
+    const picker = page.getByRole("dialog", { name: "Switch session" });
+    await expect(picker).toBeVisible();
+    await expect(picker.locator(".code-picker__empty-text")).toHaveText(
+      "No GitHub repository sessions need review.",
+    );
+    await expect(picker.getByText("No reviewable sessions match this scope.")).toHaveCount(0);
+  });
+
   test("landing: rail groups sessions, newest auto-selected, attribution chips in the header", async ({ page, isMobile }) => {
     test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
     await base(page);

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -333,24 +333,32 @@ test.describe("code surface (Coding familiar's room)", () => {
     await expect(page.getByRole("heading", { name: "Release alert" })).toBeVisible({ timeout: 30_000 });
   });
 
-  test("GitHub deep links keep the GitHub primary tab active and select the matching filter", async ({ page }) => {
-    await base(page);
-    await mockGitHubActivity(page);
-    await page.goto("/?mode=code&ctab=issues", { waitUntil: "domcontentloaded" });
+  for (const { ctab, filter } of [
+    { ctab: "prs", filter: "PRs" },
+    { ctab: "issues", filter: "Issues" },
+    { ctab: "reviews", filter: "Reviews" },
+  ] as const) {
+    test(`GitHub deep link ctab=${ctab} keeps the GitHub primary tab active and selects ${filter}`, async ({
+      page,
+    }) => {
+      await base(page);
+      await mockGitHubActivity(page);
+      await page.goto(`/?mode=code&ctab=${ctab}`, { waitUntil: "domcontentloaded" });
 
-    const topTabs = page.getByRole("tablist", { name: "Code surface" });
-    await expect(topTabs).toBeVisible({ timeout: 30_000 });
-    await expect(topTabs.getByRole("tab", { name: "GitHub" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-    const githubFilter = page.getByRole("tablist", { name: "GitHub filter" });
-    await expect(githubFilter).toBeVisible({ timeout: 30_000 });
-    await expect(githubFilter.getByRole("tab", { name: "Issues" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-  });
+      const topTabs = page.getByRole("tablist", { name: "Code surface" });
+      await expect(topTabs).toBeVisible({ timeout: 30_000 });
+      await expect(topTabs.getByRole("tab", { name: "GitHub" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      const githubFilter = page.getByRole("tablist", { name: "GitHub filter" });
+      await expect(githubFilter).toBeVisible({ timeout: 30_000 });
+      await expect(githubFilter.getByRole("tab", { name: filter })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+  }
 
   test("a non-coding familiar sees the closed Coding Desk door", async ({ page }) => {
     await base(page, [NEWEST, OLDER], "general");

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -58,6 +58,38 @@ const OLDER = mkSession({
     isWorktree: true,
   },
 });
+const CLEAN = mkSession({
+  id: "s-clean",
+  title: "Tidy the docs",
+  status: "idle",
+  project_root: "/repo/alpha",
+  familiarWorkspace: false,
+  git: {
+    branch: "docs/tidy",
+    repositoryUrl: "https://github.com/acme/alpha",
+    worktreeRoot: "/repo/alpha/.worktrees/docs-tidy",
+    isWorktree: true,
+  },
+});
+const ALL_LOCAL_ONLY = mkSession({
+  id: "s-local",
+  title: "Scratchpad session",
+  status: "idle",
+  project_root: "/repo/alpha",
+  familiarWorkspace: true,
+  git: {
+    branch: "scratch/local",
+    repositoryUrl: "https://github.com/acme/alpha",
+    worktreeRoot: "/repo/alpha/.worktrees/scratch-local",
+    isWorktree: true,
+  },
+});
+
+async function activeCodeSessionId(page: Page) {
+  return page.evaluate(
+    () => document.activeElement?.getAttribute("data-code-session-id") ?? null,
+  );
+}
 
 async function base(
   page: Page,
@@ -306,6 +338,146 @@ test.describe("code surface (Coding familiar's room)", () => {
     // The worktree mark on the branch row (the Root env row also contains
     // "feat-flux" inside the worktree path, so match the ⑂-prefixed form).
     await expect(inspector.getByText("⑂ feat-flux")).toBeVisible();
+  });
+
+  test("queue keyboard flow navigates rows, opens search with slash, and keeps typing inside the picker query", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await base(page, [NEWEST, OLDER, ALL_LOCAL_ONLY]);
+    await page.goto("/?mode=code", { waitUntil: "domcontentloaded" });
+
+    const trigger = page.locator(".code-picker__trigger");
+    await expect(trigger).toBeVisible({ timeout: 30_000 });
+
+    await trigger.click();
+    const selectedRow = page.locator('[data-code-session-id="s-new"]');
+    const olderRow = page.locator('[data-code-session-id="s-old"]');
+    await expect(selectedRow).toBeVisible();
+    await expect(olderRow).toBeVisible();
+
+    await trigger.focus();
+    await page.keyboard.press("j");
+    await expect
+      .poll(() => activeCodeSessionId(page))
+      .toBe("s-new");
+    await expect(
+      page.getByTestId("code-workbench-header").getByRole("button", { name: /Wire the flux capacitor/ }),
+    ).toBeVisible();
+
+    await page.keyboard.press("j");
+    await expect
+      .poll(() => activeCodeSessionId(page))
+      .toBe("s-old");
+    await expect(
+      page.getByTestId("code-workbench-header").getByRole("button", { name: /Wire the flux capacitor/ }),
+    ).toBeVisible();
+
+    await page.keyboard.press("j");
+    await expect
+      .poll(() => activeCodeSessionId(page))
+      .toBe("s-new");
+
+    await page.keyboard.press("k");
+    await expect
+      .poll(() => activeCodeSessionId(page))
+      .toBe("s-old");
+
+    await page.keyboard.press("Enter");
+    await expect(
+      page.getByTestId("code-workbench-header").getByRole("button", { name: /Fix login retry/ }),
+    ).toBeVisible();
+
+    const scope = page
+      .getByRole("navigation", { name: "Coding sessions" })
+      .getByRole("group", { name: "Session scope" });
+    await expect(scope.getByRole("button", { name: /Reviewable/ })).toHaveAttribute("aria-pressed", "true");
+    await trigger.focus();
+    await page.keyboard.press("Shift+A");
+    await expect(scope.getByRole("button", { name: /All local/ })).toHaveAttribute("aria-pressed", "true");
+
+    await page.keyboard.press("/");
+    const search = page.locator("[data-code-session-search]");
+    const pickerScope = page
+      .getByRole("dialog", { name: "Switch session" })
+      .getByRole("group", { name: "Session scope" });
+    await expect(search).toBeFocused();
+    await expect(page.locator('[data-code-session-id="s-local"]')).toBeVisible();
+    await page.keyboard.press("j");
+    await page.keyboard.press("k");
+    await page.keyboard.press("/");
+    await expect(search).toHaveValue("jk/");
+    await expect
+      .poll(() => activeCodeSessionId(page))
+      .toBe(null);
+
+    await page.keyboard.press("Shift+A");
+    await expect(pickerScope.getByRole("button", { name: /All local/ })).toHaveAttribute("aria-pressed", "true");
+    await expect(search).toHaveValue("jk/A");
+  });
+
+  test("review rail and terminal panel state stays per-session with content-aware defaults", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await base(page, [NEWEST, CLEAN]);
+    await page.goto("/?mode=code", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("code-review-rail")).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByRole("button", { name: "Show the review rail" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Close the terminal drawer" })).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Hide the review rail" }).click();
+    await expect(page.getByRole("button", { name: "Show the review rail" })).toBeVisible();
+    await page.getByRole("button", { name: "Open the terminal drawer" }).click();
+    await expect(page.getByRole("button", { name: "Close the terminal drawer" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    await expect(page.getByText("Terminal · this worktree")).toBeVisible();
+
+    await page.locator(".code-picker__trigger").click();
+    await page.locator('[data-code-session-id="s-clean"]').click();
+    await expect(
+      page.getByTestId("code-workbench-header").getByRole("button", { name: /Tidy the docs/ }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Show the review rail" })).toBeVisible();
+    await expect(page.getByTestId("code-review-rail")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Close the terminal drawer" })).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Show the review rail" }).click();
+    await expect(page.getByTestId("code-review-rail")).toBeVisible();
+    await page.getByRole("button", { name: "Open the terminal drawer" }).click();
+    await expect(page.getByRole("button", { name: "Close the terminal drawer" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    await expect(page.getByText("Terminal · this worktree")).toBeVisible();
+
+    await page.locator(".code-picker__trigger").click();
+    await page.locator('[data-code-session-id="s-new"]').click();
+    await expect(
+      page.getByTestId("code-workbench-header").getByRole("button", { name: /Wire the flux capacitor/ }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Show the review rail" })).toBeVisible();
+    await expect(page.getByTestId("code-review-rail")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Close the terminal drawer" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+
+    await page.locator(".code-picker__trigger").click();
+    await page.locator('[data-code-session-id="s-clean"]').click();
+    await expect(
+      page.getByTestId("code-workbench-header").getByRole("button", { name: /Tidy the docs/ }),
+    ).toBeVisible();
+    await expect(page.getByTestId("code-review-rail")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Close the terminal drawer" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
   });
 
   test("?mode=code&session=<id>&wtab=files deep link selects the session and tab", async ({ page, isMobile }) => {

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -204,6 +204,26 @@ async function mockGitHubActivity(page: Page) {
   );
 }
 
+async function mockWorkScheduler(page: Page) {
+  await page.route("**/api/queue/readiness", (route) =>
+    route.fulfill({
+      json: {
+        readiness: {
+          ok: true,
+          message: "",
+          project: { id: "e2e-project", name: "E2E Project", root: "/repo/alpha" },
+        },
+      },
+    }),
+  );
+  await page.route("**/api/beads?mode=ready**", (route) =>
+    route.fulfill({ json: { ok: true, data: [] } }),
+  );
+  await page.route("**/api/beads?mode=blocked**", (route) =>
+    route.fulfill({ json: { ok: true, data: [], blockers: [] } }),
+  );
+}
+
 test.describe.configure({ mode: "serial" });
 
 test.describe("code surface (Coding familiar's room)", () => {
@@ -359,6 +379,108 @@ test.describe("code surface (Coding familiar's room)", () => {
       );
     });
   }
+
+  test("GitHub preserves the last selected PRs, Issues, or Reviews filter after visiting Review or Work", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await base(page);
+    await mockGitHubActivity(page);
+    await mockWorkScheduler(page);
+    await page.goto("/?mode=code&ctab=prs", { waitUntil: "domcontentloaded" });
+
+    const topTabs = page.getByRole("tablist", { name: "Code surface" });
+    const githubFilter = page.getByRole("tablist", { name: "GitHub filter" });
+    await expect(topTabs).toBeVisible({ timeout: 30_000 });
+    await expect(githubFilter).toBeVisible({ timeout: 30_000 });
+
+    for (const step of [
+      { filter: "PRs", detour: "Work" },
+      { filter: "Issues", detour: "Review" },
+      { filter: "Reviews", detour: "Work" },
+    ] as const) {
+      await githubFilter.getByRole("tab", { name: step.filter }).click();
+      await expect(githubFilter.getByRole("tab", { name: step.filter })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+
+      await topTabs.getByRole("tab", { name: step.detour }).click();
+      await expect(topTabs.getByRole("tab", { name: step.detour })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+
+      await topTabs.getByRole("tab", { name: "GitHub" }).click();
+      await expect(topTabs.getByRole("tab", { name: "GitHub" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      await expect(githubFilter.getByRole("tab", { name: step.filter })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    }
+  });
+
+  test("the GitHub filter tablist uses roving tabindex and arrow-key selection with wraparound", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await base(page);
+    await mockGitHubActivity(page);
+    await page.goto("/?mode=code&ctab=prs", { waitUntil: "domcontentloaded" });
+
+    const githubFilter = page.getByRole("tablist", { name: "GitHub filter" });
+    const activityTab = githubFilter.getByRole("tab", { name: "Activity" });
+    const prsTab = githubFilter.getByRole("tab", { name: "PRs" });
+    const issuesTab = githubFilter.getByRole("tab", { name: "Issues" });
+    const reviewsTab = githubFilter.getByRole("tab", { name: "Reviews" });
+
+    await expect(githubFilter).toBeVisible({ timeout: 30_000 });
+    await expect(prsTab).toHaveAttribute("aria-selected", "true");
+    await expect(prsTab).toHaveAttribute("tabindex", "0");
+    await expect(activityTab).toHaveAttribute("tabindex", "-1");
+    const prsPanelId = await prsTab.getAttribute("aria-controls");
+    if (!prsPanelId) throw new Error("PRs tab should control a GitHub tabpanel");
+    const prsTabId = await prsTab.getAttribute("id");
+    if (!prsTabId) throw new Error("PRs tab should expose a stable id");
+    await expect(page.locator(`#${prsPanelId}`)).toHaveAttribute("role", "tabpanel");
+    await expect(page.locator(`#${prsPanelId}`)).toHaveAttribute("aria-labelledby", prsTabId);
+
+    await prsTab.focus();
+    await expect(prsTab).toBeFocused();
+
+    await page.keyboard.press("ArrowRight");
+    await expect(issuesTab).toBeFocused();
+    await expect(issuesTab).toHaveAttribute("aria-selected", "true");
+    await expect(issuesTab).toHaveAttribute("tabindex", "0");
+    await expect(prsTab).toHaveAttribute("tabindex", "-1");
+
+    await page.keyboard.press("ArrowLeft");
+    await expect(prsTab).toBeFocused();
+    await expect(prsTab).toHaveAttribute("aria-selected", "true");
+
+    await page.keyboard.press("End");
+    await expect(reviewsTab).toBeFocused();
+    await expect(reviewsTab).toHaveAttribute("aria-selected", "true");
+
+    await page.keyboard.press("ArrowRight");
+    await expect(activityTab).toBeFocused();
+    await expect(activityTab).toHaveAttribute("aria-selected", "true");
+
+    await page.keyboard.press("Home");
+    await expect(activityTab).toBeFocused();
+    await expect(activityTab).toHaveAttribute("aria-selected", "true");
+
+    await page.keyboard.press("ArrowLeft");
+    await expect(reviewsTab).toBeFocused();
+    await expect(reviewsTab).toHaveAttribute("aria-selected", "true");
+    await expect(reviewsTab).toHaveAttribute("tabindex", "0");
+    await expect(activityTab).toHaveAttribute("tabindex", "-1");
+  });
 
   test("a non-coding familiar sees the closed Coding Desk door", async ({ page }) => {
     await base(page, [NEWEST, OLDER], "general");

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -340,32 +340,29 @@ test.describe("code surface (Coding familiar's room)", () => {
     await expect(inspector.getByText("⑂ feat-flux")).toBeVisible();
   });
 
-  test("queue keyboard flow navigates rows, opens search with slash, and keeps typing inside the picker query", async ({
+  test("visible rail keyboard flow navigates rows and Enter opens the focused session", async ({
     page,
     isMobile,
   }) => {
     test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
-    await base(page, [NEWEST, OLDER, ALL_LOCAL_ONLY]);
+    await base(page, [NEWEST, OLDER]);
     await page.goto("/?mode=code", { waitUntil: "domcontentloaded" });
 
-    const trigger = page.locator(".code-picker__trigger");
-    await expect(trigger).toBeVisible({ timeout: 30_000 });
-
-    await trigger.click();
-    const selectedRow = page.locator('[data-code-session-id="s-new"]');
-    const olderRow = page.locator('[data-code-session-id="s-old"]');
+    const rail = page.getByRole("navigation", { name: "Coding sessions" });
+    await expect(rail).toBeVisible({ timeout: 30_000 });
+    const selectedRow = rail.locator('button[data-code-session-id="s-new"]');
+    const olderRow = rail.locator('button[data-code-session-id="s-old"]');
     await expect(selectedRow).toBeVisible();
     await expect(olderRow).toBeVisible();
 
-    await trigger.focus();
-    await page.keyboard.press("j");
-    await expect
-      .poll(() => activeCodeSessionId(page))
-      .toBe("s-new");
     await expect(
       page.getByTestId("code-workbench-header").getByRole("button", { name: /Wire the flux capacitor/ }),
     ).toBeVisible();
 
+    await selectedRow.focus();
+    await expect
+      .poll(() => activeCodeSessionId(page))
+      .toBe("s-new");
     await page.keyboard.press("j");
     await expect
       .poll(() => activeCodeSessionId(page))
@@ -388,6 +385,18 @@ test.describe("code surface (Coding familiar's room)", () => {
     await expect(
       page.getByTestId("code-workbench-header").getByRole("button", { name: /Fix login retry/ }),
     ).toBeVisible();
+  });
+
+  test("slash opens picker search and keeps typing inside the picker query", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await base(page, [NEWEST, OLDER, ALL_LOCAL_ONLY]);
+    await page.goto("/?mode=code", { waitUntil: "domcontentloaded" });
+
+    const trigger = page.locator(".code-picker__trigger");
+    await expect(trigger).toBeVisible({ timeout: 30_000 });
 
     const scope = page
       .getByRole("navigation", { name: "Coding sessions" })
@@ -396,14 +405,12 @@ test.describe("code surface (Coding familiar's room)", () => {
     await trigger.focus();
     await page.keyboard.press("Shift+A");
     await expect(scope.getByRole("button", { name: /All local/ })).toHaveAttribute("aria-pressed", "true");
-
     await page.keyboard.press("/");
     const search = page.locator("[data-code-session-search]");
-    const pickerScope = page
-      .getByRole("dialog", { name: "Switch session" })
-      .getByRole("group", { name: "Session scope" });
+    const picker = page.getByRole("dialog", { name: "Switch session" });
+    const pickerScope = picker.getByRole("group", { name: "Session scope" });
     await expect(search).toBeFocused();
-    await expect(page.locator('[data-code-session-id="s-local"]')).toBeVisible();
+    await expect(picker.locator('[data-code-session-id="s-local"]')).toBeVisible();
     await page.keyboard.press("j");
     await page.keyboard.press("k");
     await page.keyboard.press("/");
@@ -439,7 +446,7 @@ test.describe("code surface (Coding familiar's room)", () => {
     await expect(page.getByText("Terminal · this worktree")).toBeVisible();
 
     await page.locator(".code-picker__trigger").click();
-    await page.locator('[data-code-session-id="s-clean"]').click();
+    await page.getByRole("dialog", { name: "Switch session" }).locator('[data-code-session-id="s-clean"]').click();
     await expect(
       page.getByTestId("code-workbench-header").getByRole("button", { name: /Tidy the docs/ }),
     ).toBeVisible();
@@ -457,7 +464,7 @@ test.describe("code surface (Coding familiar's room)", () => {
     await expect(page.getByText("Terminal · this worktree")).toBeVisible();
 
     await page.locator(".code-picker__trigger").click();
-    await page.locator('[data-code-session-id="s-new"]').click();
+    await page.getByRole("dialog", { name: "Switch session" }).locator('[data-code-session-id="s-new"]').click();
     await expect(
       page.getByTestId("code-workbench-header").getByRole("button", { name: /Wire the flux capacitor/ }),
     ).toBeVisible();
@@ -469,7 +476,7 @@ test.describe("code surface (Coding familiar's room)", () => {
     );
 
     await page.locator(".code-picker__trigger").click();
-    await page.locator('[data-code-session-id="s-clean"]').click();
+    await page.getByRole("dialog", { name: "Switch session" }).locator('[data-code-session-id="s-clean"]').click();
     await expect(
       page.getByTestId("code-workbench-header").getByRole("button", { name: /Tidy the docs/ }),
     ).toBeVisible();

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -504,6 +504,76 @@ test.describe("code surface (Coding familiar's room)", () => {
       .not.toContain("session=");
   });
 
+  test("a narrow desktop ?wtab=files deep link drills into Files once layout is known", async ({ page, isMobile }) => {
+    test.skip(!!isMobile, "desktop-only narrow viewport; mobile drill-in lives in tests/mobile/");
+    await page.setViewportSize({ width: 760, height: 900 });
+    await base(page);
+    await page.goto("/?mode=code&session=s-old&wtab=files", { waitUntil: "domcontentloaded" });
+
+    const header = page.getByTestId("code-workbench-header");
+    await expect(header.getByRole("button", { name: /Fix login retry/ })).toBeVisible({ timeout: 30_000 });
+    const steps = page.getByRole("tablist", { name: "Workbench step" });
+    await expect(steps).toBeVisible();
+    await expect(steps.getByRole("tab", { name: "Files" })).toHaveAttribute("aria-selected", "true");
+    await expect(page.getByTestId("code-workbench-tree")).toBeVisible();
+    await expect(page.getByTestId("code-review-rail")).toHaveCount(0);
+  });
+
+  test("fixed queue shortcuts ignore conflicting saved workbench bindings", async ({ page, isMobile }) => {
+    test.skip(!!isMobile, "desktop-only (mobile drill-in covered in tests/mobile/)");
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await base(page, [NEWEST, OLDER, ALL_LOCAL_ONLY]);
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "cave.code.keymap",
+        JSON.stringify({
+          prompt: "/",
+          files: "J",
+          outline: "K",
+          terminal: "Shift+A",
+        }),
+      );
+    });
+    await page.goto("/?mode=code", { waitUntil: "domcontentloaded" });
+
+    const trigger = page.locator(".code-picker__trigger");
+    const terminalOpen = page.getByRole("button", { name: "Close the terminal drawer" });
+    const tree = page.getByTestId("code-workbench-tree");
+    const scope = page
+      .getByRole("navigation", { name: "Coding sessions" })
+      .getByRole("group", { name: "Session scope" });
+    const selectedRow = page
+      .getByRole("navigation", { name: "Coding sessions" })
+      .locator('button[data-code-session-id="s-new"]');
+
+    await expect(trigger).toBeVisible({ timeout: 30_000 });
+    await expect(terminalOpen).toHaveCount(0);
+    await expect(scope.getByRole("button", { name: /Reviewable/ })).toHaveAttribute("aria-pressed", "true");
+
+    await trigger.focus();
+    await page.keyboard.press("Shift+A");
+    await expect(scope.getByRole("button", { name: /All local/ })).toHaveAttribute("aria-pressed", "true");
+    await expect(terminalOpen).toHaveCount(0);
+
+    await page.keyboard.press("/");
+    const picker = page.getByRole("dialog", { name: "Switch session" });
+    const search = picker.locator("[data-code-session-search]");
+    await expect(search).toBeFocused();
+
+    await selectedRow.focus();
+    await page.keyboard.press("j");
+    await expect
+      .poll(() => activeCodeSessionId(page))
+      .toBe("s-old");
+    await expect(tree).not.toBeFocused();
+
+    await page.keyboard.press("k");
+    await expect
+      .poll(() => activeCodeSessionId(page))
+      .toBe("s-new");
+    await expect(tree).not.toBeFocused();
+  });
+
   test("legacy GitHub mode lands on Activity and preserves notifications", async ({ page }) => {
     await base(page);
     await mockGitHubActivity(page);

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -2,8 +2,8 @@ import { expect, test, type Page } from "@playwright/test";
 
 // The dedicated Code surface (cave-k0ua): a Codex-style multi-session coding
 // workbench — session rail grouped by project, per-session workbench
-// (Diff | Files | Terminal | PR), inspector column, and the GitHub content top
-// tabs (Activity | PRs | Issues | Reviews).
+// (Diff | Files | Terminal | PR), inspector column, and simplified top-level
+// navigation (Review | Work | GitHub) with GitHub sub-filters.
 // Default-on since phase 2 (cave-m6ys); since cave-cc5r it lives as the
 // Coding familiar's Role Surface room (`?mode=code` aliases onto
 // `surface:code`), so the mocked familiar carries the explicit
@@ -35,12 +35,29 @@ const NEWEST = mkSession({
   title: "Wire the flux capacitor",
   project_root: "/repo/alpha",
   updated_at: NEW_ISO,
+  familiarWorkspace: false,
   workBranch: "feat/flux",
-  git: { branch: "feat/flux", worktreeRoot: "/repo/alpha/.worktrees/feat-flux", isWorktree: true },
+  git: {
+    branch: "feat/flux",
+    repositoryUrl: "https://github.com/acme/alpha",
+    worktreeRoot: "/repo/alpha/.worktrees/feat-flux",
+    isWorktree: true,
+  },
   pullRequest: { repo: "acme/alpha", number: 7, url: "https://github.com/acme/alpha/pull/7", state: "open" },
   diff: { additions: 12, deletions: 3 },
 });
-const OLDER = mkSession({ id: "s-old", title: "Fix login retry", project_root: "/repo/alpha" });
+const OLDER = mkSession({
+  id: "s-old",
+  title: "Fix login retry",
+  project_root: "/repo/alpha",
+  familiarWorkspace: false,
+  git: {
+    branch: "main",
+    repositoryUrl: "https://github.com/acme/alpha",
+    worktreeRoot: "/repo/alpha/.worktrees/fix-login-retry",
+    isWorktree: true,
+  },
+});
 
 async function base(
   page: Page,
@@ -195,16 +212,16 @@ test.describe("code surface (Coding familiar's room)", () => {
     await base(page);
     await page.goto("/?mode=code", { waitUntil: "domcontentloaded" });
 
-    // Top tabs: Sessions active, then the GitHub content tabs (PRs · Issues ·
-    // Reviews) that replaced the single generic GitHub tab.
+    // Top tabs: Review is the default landing, with Work and one GitHub
+    // primary destination replacing the previous equal-weight GitHub tabs.
     const topTabs = page.getByRole("tablist", { name: "Code surface" });
     await expect(topTabs).toBeVisible({ timeout: 30_000 });
-    await expect(topTabs.getByRole("tab", { name: "Sessions" })).toHaveAttribute("aria-selected", "true");
-    await expect(topTabs.getByRole("tab", { name: "Activity" })).toBeVisible();
-    await expect(topTabs.getByRole("tab", { name: "PRs" })).toBeVisible();
-    await expect(topTabs.getByRole("tab", { name: "Issues" })).toBeVisible();
-    await expect(topTabs.getByRole("tab", { name: "Reviews" })).toBeVisible();
-    await expect(topTabs.getByRole("tab", { name: "GitHub", exact: true })).toHaveCount(0);
+    await expect(topTabs.getByRole("tab", { name: "Review" })).toHaveAttribute("aria-selected", "true");
+    await expect(topTabs.getByRole("tab", { name: "Work" })).toBeVisible();
+    await expect(topTabs.getByRole("tab", { name: "GitHub" })).toBeVisible();
+    await expect(topTabs.getByRole("tab", { name: "Sessions", exact: true })).toHaveCount(0);
+    await expect(topTabs.getByRole("tab", { name: "Activity", exact: true })).toHaveCount(0);
+    await expect(page.getByRole("tablist", { name: "GitHub filter" })).toHaveCount(0);
 
     // Rail: both sessions listed under their project group.
     const rail = page.getByRole("navigation", { name: "Coding sessions" });
@@ -303,11 +320,36 @@ test.describe("code surface (Coding familiar's room)", () => {
     // (cave-u5fh7). Every other assertion for this surface in this file already
     // carries the 30s budget.
     await expect(topTabs).toBeVisible({ timeout: 30_000 });
-    await expect(topTabs.getByRole("tab", { name: "Activity" })).toHaveAttribute(
+    await expect(topTabs.getByRole("tab", { name: "GitHub" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    const githubFilter = page.getByRole("tablist", { name: "GitHub filter" });
+    await expect(githubFilter).toBeVisible({ timeout: 30_000 });
+    await expect(githubFilter.getByRole("tab", { name: "Activity" })).toHaveAttribute(
       "aria-selected",
       "true",
     );
     await expect(page.getByRole("heading", { name: "Release alert" })).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("GitHub deep links keep the GitHub primary tab active and select the matching filter", async ({ page }) => {
+    await base(page);
+    await mockGitHubActivity(page);
+    await page.goto("/?mode=code&ctab=issues", { waitUntil: "domcontentloaded" });
+
+    const topTabs = page.getByRole("tablist", { name: "Code surface" });
+    await expect(topTabs).toBeVisible({ timeout: 30_000 });
+    await expect(topTabs.getByRole("tab", { name: "GitHub" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    const githubFilter = page.getByRole("tablist", { name: "GitHub filter" });
+    await expect(githubFilter).toBeVisible({ timeout: 30_000 });
+    await expect(githubFilter.getByRole("tab", { name: "Issues" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   test("a non-coding familiar sees the closed Coding Desk door", async ({ page }) => {
@@ -346,7 +388,7 @@ test.describe("code surface (Coding familiar's room)", () => {
 
     const sessionsTab = page
       .getByRole("tablist", { name: "Code surface" })
-      .getByRole("tab", { name: "Sessions" });
+      .getByRole("tab", { name: "Review" });
     // Establish keyboard modality before programmatically selecting the exact
     // tab under test so Chromium applies the :focus-visible inset ring.
     await page.keyboard.press("Tab");

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -424,6 +424,43 @@ test.describe("code surface (Coding familiar's room)", () => {
     await expect(search).toHaveValue("jk/A");
   });
 
+  test("narrow landing slash opens the shared picker after Back to sessions", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, "desktop-only narrow viewport; mobile drill-in lives in tests/mobile/");
+    await page.setViewportSize({ width: 760, height: 900 });
+    await base(page, [NEWEST, OLDER, ALL_LOCAL_ONLY]);
+    await page.goto("/?mode=code", { waitUntil: "domcontentloaded" });
+
+    const rail = page.getByRole("navigation", { name: "Coding sessions" });
+    const newest = rail.locator('button[data-code-session-id="s-new"]');
+    await expect(rail).toBeVisible({ timeout: 30_000 });
+    await newest.click();
+    await expect(
+      page.getByTestId("code-workbench-header").getByRole("button", { name: /Wire the flux capacitor/ }),
+    ).toBeVisible();
+    await expect(page.locator(".code-picker__trigger")).toHaveCount(1);
+
+    await page.getByRole("button", { name: "Back to sessions" }).click();
+    await expect(page.locator(".code-picker__trigger")).toHaveCount(1);
+    await expect(page.getByRole("button", { name: "Search sessions" })).toBeVisible();
+
+    const older = rail.locator('button[data-code-session-id="s-old"]');
+    await older.focus();
+    await page.keyboard.press("/");
+
+    const picker = page.getByRole("dialog", { name: "Switch session" });
+    const search = picker.locator("[data-code-session-search]");
+    await expect(search).toHaveCount(1);
+    await expect(search).toBeFocused();
+
+    await page.keyboard.type("Fix");
+    await expect(search).toHaveValue("Fix");
+    await expect(picker.locator('[data-code-session-id="s-old"]')).toBeVisible();
+    await expect(picker.locator('[data-code-session-id="s-new"]')).toHaveCount(0);
+  });
+
   test("review rail and terminal panel state stays per-session with content-aware defaults", async ({
     page,
     isMobile,

--- a/tests/mobile/code-surface-drill-in.spec.ts
+++ b/tests/mobile/code-surface-drill-in.spec.ts
@@ -34,6 +34,15 @@ const SESSION = {
   archived_at: null,
   created_at: ISO,
   updated_at: ISO,
+  familiarWorkspace: false,
+  workBranch: "feat/auth-flow",
+  git: {
+    branch: "feat/auth-flow",
+    repositoryUrl: "https://github.com/acme/alpha",
+    worktreeRoot: "/repo/alpha",
+    repositoryRoot: null,
+    isWorktree: false,
+  },
 };
 
 async function base(page: Page) {


### PR DESCRIPTION
## Summary
- default the Coding Desk to a fail-closed Reviewable queue backed by canonical GitHub and familiar-workspace evidence
- share queue scope, ordering, search, navigation, keyboard flow, and compact session presentation across the rail and picker
- simplify navigation to Review, Work, and GitHub; add content-aware per-session panel state and complete desktop/mobile acceptance coverage

## Test plan
- [x] `pnpm check:tests-wired`
- [x] `pnpm test:app`
- [x] `pnpm exec playwright test tests/code-surface.spec.ts tests/mobile/code-surface-drill-in.spec.ts --project=desktop --project=pixel-5 --project=iphone-13`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `git diff --check`