### PR TITLE
chore: seed the Automations v1 execution graph

### DIFF
--- a/docs/roadmaps/coven-automations-v1.mapping.json
+++ b/docs/roadmaps/coven-automations-v1.mapping.json
@@ -1,16 +1,36 @@
 {
   "schemaVersion": "opencoven.automation-program-map/v1",
   "programId": "coven-automations-v1",
-  "generatedAt": "2026-08-30T14:08:00Z",
-  "status": "awaiting-live-beads-seed",
+  "generatedAt": "2026-09-01T18:40:00Z",
+  "status": "live-beads-seeded",
   "program": {
     "github": "OpenCoven/coven#854",
-    "beadId": null,
+    "beadId": "cave-hlv.9",
     "canonicalBeadsParent": "cave-hlv",
     "roadmap": "docs/roadmaps/coven-automations-v1.md",
     "trackerControl": "OpenCoven/coven#859",
     "seedTask": "OpenCoven/coven-cave#5220",
+    "seedBead": "cave-tmegk",
     "roadmapPullRequest": "OpenCoven/coven-cave#5219"
+  },
+  "seed": {
+    "github": "OpenCoven/coven-cave#5220",
+    "beadId": "cave-tmegk",
+    "externalRef": "https://github.com/OpenCoven/coven-cave/issues/5220",
+    "state": "in-progress",
+    "note": "Bootstrap seed for the Coven Automations v1 execution graph; provisioned through pnpm beads:create."
+  },
+  "sync": {
+    "beadsTool": "bd version 1.2.2 (Homebrew)",
+    "beadSchemaVersion": 1,
+    "database": "cave (embedded Dolt)",
+    "syncCommand": "pnpm beads:sync",
+    "doltOidPreMutation": "i5ltela5k233j55fks9abq612pidkkjl",
+    "doltOidPostMutation": "lnefjdsgcm7s44sqaut4dga082ca45sr",
+    "localDurability": "verified: all 15 beads (seed + 14 outcomes) committed to the canonical local embedded Dolt database `cave`.",
+    "remoteRef": "refs/dolt/data",
+    "remoteOid": "04cb957bcda7c585a69af379cfb8ceb954987e21",
+    "remoteSyncStatus": "blocked: bd dolt push rejected non-fast-forward (remote ahead from concurrent sessions); bd dolt pull to integrate hangs beyond a 240s cap under non-interactive execution. Local Dolt is the durable source of truth per AGENTS.md; remote propagation deferred, not force-pushed."
   },
   "canonicalBeads": {
     "repository": "OpenCoven/coven-cave",
@@ -31,8 +51,8 @@
     "Each new Bead has exactly one surface:shared ownership label.",
     "Beads owns implementation execution state; GitHub owns public outcome, review, and CI state.",
     "Coven owns production automation definitions, occurrences, runs, attempts, leases, approvals, artifacts, events, and receipts.",
-    "No Bead ID is populated here until confirmed from live Dolt state.",
-    "Dependency direction must be proven with bd dep list and bd ready --json.",
+    "Every Bead ID here is confirmed from live Dolt state (bd show / bd list).",
+    "Dependency direction is proven with bd dep list and bd ready --json.",
     "P2 expansion cannot block the v1 critical path.",
     "Broad unattended external side effects remain gated until coven#857 and coven#858 pass."
   ],
@@ -41,17 +61,23 @@
       "key": "program-control",
       "priority": "P0",
       "github": "OpenCoven/coven#859",
-      "beadId": null,
+      "beadId": "cave-hlv.10",
       "state": "open",
       "dependsOn": [],
-      "blocks": ["release-go-no-go"]
+      "blocks": ["release-go-no-go", "organization-canaries"]
     },
     {
       "key": "foundation",
       "priority": "P0",
       "github": "OpenCoven/coven#816",
-      "beadId": null,
-      "state": "implemented-evidence-pending",
+      "beadId": "cave-stsf7",
+      "state": "closed-verified",
+      "evidence": [
+        "OpenCoven/coven#816 (CLOSED)",
+        "OpenCoven/coven#896 (merged 2026-09-01)",
+        "merge commit 0d8c2004c3557019e39e5e4db70ae34c9d49a65a"
+      ],
+      "disposition": "verified-foundation",
       "dependsOn": [],
       "blocks": ["protocol", "scheduler-reliability", "familiar-embodiment"]
     },
@@ -59,7 +85,7 @@
       "key": "protocol",
       "priority": "P0",
       "github": "OpenCoven/coven#855",
-      "beadId": null,
+      "beadId": "cave-tm1y0",
       "state": "open",
       "dependsOn": ["foundation"],
       "blocks": ["scheduler-reliability", "trust-integration", "conformance"]
@@ -68,7 +94,7 @@
       "key": "scheduler-reliability",
       "priority": "P0",
       "github": "OpenCoven/coven#856",
-      "beadId": null,
+      "beadId": "cave-1sh6p",
       "state": "open",
       "dependsOn": ["foundation", "protocol"],
       "blocks": ["conformance"]
@@ -77,7 +103,7 @@
       "key": "familiar-embodiment",
       "priority": "P0",
       "github": "OpenCoven/familiar-contract#17",
-      "beadId": null,
+      "beadId": "cave-6jswi",
       "state": "open",
       "dependsOn": ["foundation"],
       "blocks": ["automation-authority", "trust-integration"]
@@ -86,7 +112,7 @@
       "key": "automation-authority",
       "priority": "P0",
       "github": "OpenCoven/coven-threads#29",
-      "beadId": null,
+      "beadId": "cave-m9tw3",
       "state": "open",
       "dependsOn": ["familiar-embodiment"],
       "blocks": ["trust-integration"]
@@ -95,7 +121,7 @@
       "key": "trust-integration",
       "priority": "P0",
       "github": "OpenCoven/coven#857",
-      "beadId": null,
+      "beadId": "cave-dbkng",
       "state": "open",
       "dependsOn": ["protocol", "familiar-embodiment", "automation-authority"],
       "blocks": ["conformance"]
@@ -104,7 +130,7 @@
       "key": "conformance",
       "priority": "P0",
       "github": "OpenCoven/coven#858",
-      "beadId": null,
+      "beadId": "cave-x28j6",
       "state": "open",
       "dependsOn": ["protocol", "scheduler-reliability", "trust-integration"],
       "blocks": ["sdk", "cave-oversight", "psyche-adapter", "documentation", "organization-canaries", "release-go-no-go"]
@@ -113,7 +139,7 @@
       "key": "sdk",
       "priority": "P1",
       "github": "OpenCoven/sdk#80",
-      "beadId": null,
+      "beadId": "cave-90hwl",
       "state": "open",
       "dependsOn": ["conformance"],
       "blocks": ["release-go-no-go"]
@@ -122,7 +148,7 @@
       "key": "cave-oversight",
       "priority": "P1",
       "github": "OpenCoven/coven-cave#5217",
-      "beadId": null,
+      "beadId": "cave-e52qp",
       "state": "open",
       "dependsOn": ["conformance"],
       "blocks": ["release-go-no-go"]
@@ -131,7 +157,7 @@
       "key": "psyche-adapter",
       "priority": "P1",
       "github": "OpenCoven/psyche#18",
-      "beadId": null,
+      "beadId": "cave-yaul2",
       "state": "open",
       "dependsOn": ["conformance"],
       "blocks": ["release-go-no-go"]
@@ -140,7 +166,7 @@
       "key": "documentation",
       "priority": "P1",
       "github": "OpenCoven/coven-docs#76",
-      "beadId": null,
+      "beadId": "cave-qwnxq",
       "state": "open",
       "dependsOn": ["conformance"],
       "blocks": ["release-go-no-go"]
@@ -149,7 +175,7 @@
       "key": "organization-canaries",
       "priority": "P1",
       "github": "OpenCoven/.github#2",
-      "beadId": null,
+      "beadId": "cave-xqbs4",
       "state": "open",
       "dependsOn": ["program-control", "conformance"],
       "blocks": ["release-go-no-go"]
@@ -158,7 +184,7 @@
       "key": "release-go-no-go",
       "priority": "P0",
       "github": "OpenCoven/coven#854",
-      "beadId": null,
+      "beadId": "cave-hlv.9",
       "state": "blocked",
       "dependsOn": [
         "program-control",
@@ -186,6 +212,6 @@
   },
   "nextAction": {
     "github": "OpenCoven/coven-cave#5220",
-    "description": "Use the supported local bd/Dolt workflow to create or reuse the program and child Beads, verify dependencies and readiness, sync through pnpm beads:sync, then replace null beadId values with exact live IDs through review."
+    "description": "Live Beads seeded and dependency-verified in the canonical local embedded Dolt database `cave` (15 beads; direction proven via bd dep list and bd ready). Remaining: propagate the local Dolt commit to the shared remote (refs/dolt/data) once a non-interactive bd dolt pull/push path is available, then close the seed bead (cave-tmegk) after this PR merges. Coven-side tracker mapping is reconciled under OpenCoven/coven#859."
   }
 }

--- a/docs/roadmaps/coven-automations-v1.md
+++ b/docs/roadmaps/coven-automations-v1.md
@@ -1,10 +1,12 @@
 # Coven Automations v1 operational roadmap
 
 **Status:** Approved for execution  
-**Last reconciled:** 2026-08-30  
-**Program outcome:** `OpenCoven/coven#854`  
-**Execution queue:** Cave's existing embedded-Dolt Beads graph  
-**Review and CI:** GitHub issues, pull requests, and checks
+**Last reconciled:** 2026-09-01  
+**Program outcome:** `OpenCoven/coven#854` (Bead `cave-hlv.9`)  
+**Seed task:** `OpenCoven/coven-cave#5220` (Bead `cave-tmegk`)  
+**Execution queue:** Cave's embedded-Dolt Beads graph — seeded and dependency-verified (15 beads)  
+**Review and CI:** GitHub issues, pull requests, and checks  
+**Machine-readable mapping:** [`coven-automations-v1.mapping.json`](coven-automations-v1.mapping.json)
 
 > This document records stable ownership, sequencing, release gates, and tracker conventions. Live implementation status belongs in Beads and GitHub; production automation definitions, occurrences, runs, attempts, approvals, artifacts, and receipts belong only to Coven.
 
@@ -43,32 +45,32 @@ That foundation is not yet a certified automation protocol. The remaining releas
 
 ### Foundation and control
 
-| Priority | Outcome | GitHub | Current disposition |
-| --- | --- | --- | --- |
-| P0 | Coven Automations v1 program and release rollup | `OpenCoven/coven#854` | Open; canonical program outcome |
-| P0 | Native durable-routine foundation | `OpenCoven/coven#816` | Materially implemented; close only after exact evidence reconciliation |
-| P0 | Beads/GitHub operational graph and drift control | `OpenCoven/coven#859` | Open; seed through Cave's canonical Dolt graph |
+| Priority | Outcome | GitHub | Bead | Current disposition |
+| --- | --- | --- | --- | --- |
+| P0 | Coven Automations v1 program and release rollup | `OpenCoven/coven#854` | `cave-hlv.9` | Open; canonical program/release-gate outcome (rollup only, not catch-all implementation) |
+| P0 | Native durable-routine foundation | `OpenCoven/coven#816` | `cave-stsf7` | **Verified-foundation** (closed): landed via PR #896, merge `0d8c2004c3557019e39e5e4db70ae34c9d49a65a` |
+| P0 | Beads/GitHub operational graph and drift control | `OpenCoven/coven#859` | `cave-hlv.10` | Open; canonical Dolt graph seeded |
 
 ### P0 protocol and safety train
 
-| Priority | Outcome | GitHub | Dependencies |
-| --- | --- | --- | --- |
-| P0 | `coven.automations.v1` schemas, state machines, command adoption/idempotency, typed errors, and changefeed | `OpenCoven/coven#855` | Foundation |
-| P0 | Deterministic time, IANA timezone/DST, retries, cancellation, scheduler leadership/fencing, crash recovery, backpressure | `OpenCoven/coven#856` | Foundation; protocol states/errors where required |
-| P0 | Universal familiar embodiment binding | `OpenCoven/familiar-contract#17` | Familiar identity/continuity canon |
-| P0 | Automation authority, approval, risk/capability, and degrade-to-proposal profile | `OpenCoven/coven-threads#29` | Familiar embodiment profile for exact binding |
-| P0 | Dispatch-time principal, familiar, authority, runtime, approval, and receipt integration | `OpenCoven/coven#857` | Protocol plus pinned identity/authority profiles |
-| P0 | Independent conformance, chaos, security/privacy, load/SLO, diagnostics, and exact-artifact certification | `OpenCoven/coven#858` | Protocol, reliability, and authority integration |
+| Priority | Outcome | GitHub | Bead | Dependencies |
+| --- | --- | --- | --- | --- |
+| P0 | `coven.automations.v1` schemas, state machines, command adoption/idempotency, typed errors, and changefeed | `OpenCoven/coven#855` | `cave-tm1y0` | Foundation |
+| P0 | Deterministic time, IANA timezone/DST, retries, cancellation, scheduler leadership/fencing, crash recovery, backpressure | `OpenCoven/coven#856` | `cave-1sh6p` | Foundation; protocol states/errors where required |
+| P0 | Universal familiar embodiment binding | `OpenCoven/familiar-contract#17` | `cave-6jswi` | Foundation |
+| P0 | Automation authority, approval, risk/capability, and degrade-to-proposal profile | `OpenCoven/coven-threads#29` | `cave-m9tw3` | Familiar embodiment profile for exact binding |
+| P0 | Dispatch-time principal, familiar, authority, runtime, approval, and receipt integration | `OpenCoven/coven#857` | `cave-dbkng` | Protocol plus pinned identity/authority profiles |
+| P0 | Independent conformance, chaos, security/privacy, load/SLO, diagnostics, and exact-artifact certification | `OpenCoven/coven#858` | `cave-x28j6` | Protocol, reliability, and authority integration |
 
 ### P1 supported ecosystem
 
-| Priority | Outcome | GitHub | Dependencies |
-| --- | --- | --- | --- |
-| P1 | SDK types, read/verify/subscribe, then authority-bearing adopted commands | `OpenCoven/sdk#80` | Protocol; authority and certification before mutation graduation |
-| P1 | Cave oversight, approvals, recovery, and Codex compatibility retirement | `OpenCoven/coven-cave#5217` | Protocol, reliability, authority, exact canaries |
-| P1 | Psyche invocation adapter without schedule ownership | `OpenCoven/psyche#18` | Protocol, familiar binding, authority profile |
-| P1 | Protocol/operator/migration/security/troubleshooting documentation | `OpenCoven/coven-docs#76` | Stabilized exact artifacts and scenarios |
-| P1 | Reusable contract, conformance, evidence, and roadmap-drift workflows | `OpenCoven/.github#2` | Conformance and tracker contracts |
+| Priority | Outcome | GitHub | Bead | Dependencies |
+| --- | --- | --- | --- | --- |
+| P1 | SDK types, read/verify/subscribe, then authority-bearing adopted commands | `OpenCoven/sdk#80` | `cave-90hwl` | Conformance |
+| P1 | Cave oversight, approvals, recovery, and Codex compatibility retirement | `OpenCoven/coven-cave#5217` | `cave-e52qp` | Conformance |
+| P1 | Psyche invocation adapter without schedule ownership | `OpenCoven/psyche#18` | `cave-yaul2` | Conformance |
+| P1 | Protocol/operator/migration/security/troubleshooting documentation | `OpenCoven/coven-docs#76` | `cave-qwnxq` | Conformance |
+| P1 | Reusable contract, conformance, evidence, and roadmap-drift workflows | `OpenCoven/.github#2` | `cave-xqbs4` | Conformance and program control |
 
 ### P2 deliberate expansion
 
@@ -135,27 +137,33 @@ The canonical Beads graph already lives in `OpenCoven/coven-cave`:
 
 Do **not** initialize a competing `.beads` store in `OpenCoven/coven`. Cross-repository outcomes may be represented in Cave's work graph through exact external references while implementation and review stay in their canonical repositories.
 
-### Proposed graph
+### Provisioned graph
 
-Create one child epic under the existing `cave-hlv` operating program:
+The graph is seeded live under the existing `cave-hlv` operating program. Bead IDs
+below are confirmed from live Dolt state (`bd show` / `bd dep list`):
 
 ```text
-Coven Automations v1 delivery program
-  ├── Foundation reconciliation                    -> coven#816
-  ├── Protocol contract                            -> coven#855
-  ├── Scheduler reliability                        -> coven#856
-  ├── Familiar embodiment profile                  -> familiar-contract#17
-  ├── Automation authority profile                 -> coven-threads#29
-  ├── Coven dispatch/receipt integration            -> coven#857
-  ├── Conformance and diagnostics                   -> coven#858
-  ├── SDK                                           -> sdk#80
-  ├── Cave oversight                                -> coven-cave#5217
-  ├── Psyche adapter                                -> psyche#18
-  ├── Documentation                                 -> coven-docs#76
-  └── Organization canaries                         -> .github#2
+Coven Automations v1 (release rollup) -> coven#854   = cave-hlv.9   (task, parent cave-hlv)
+Program control / drift               -> coven#859   = cave-hlv.10  (task, parent cave-hlv)
+  ├── Foundation (verified, closed)                  -> coven#816              = cave-stsf7
+  ├── Protocol contract                              -> coven#855              = cave-tm1y0
+  ├── Scheduler reliability                          -> coven#856              = cave-1sh6p
+  ├── Familiar embodiment profile                    -> familiar-contract#17   = cave-6jswi
+  ├── Automation authority profile                   -> coven-threads#29       = cave-m9tw3
+  ├── Coven dispatch/receipt integration             -> coven#857              = cave-dbkng
+  ├── Conformance and diagnostics                    -> coven#858              = cave-x28j6
+  ├── SDK                                            -> sdk#80                 = cave-90hwl
+  ├── Cave oversight                                 -> coven-cave#5217        = cave-e52qp
+  ├── Psyche adapter                                 -> psyche#18              = cave-yaul2
+  ├── Documentation                                  -> coven-docs#76          = cave-qwnxq
+  └── Organization canaries                          -> .github#2             = cave-xqbs4
 ```
 
-The `coven#854` program and `coven#859` tracker-control outcome may map to the delivery epic and one dedicated control Bead respectively. Every other public outcome maps to exactly one implementation Bead.
+The seed bootstrap task `coven-cave#5220` is tracked by Bead `cave-tmegk`. The
+`coven#854` release rollup and `coven#859` program-control outcomes are provisioned
+as dedicated Beads under `cave-hlv`; every other public outcome maps to exactly one
+implementation Bead. Foundation `coven#816` is represented as verified-foundation
+(closed), not pending work.
 
 ### Priority and labels
 
@@ -260,6 +268,19 @@ bd ready --json
 ```
 
 Record before/after Dolt remote OIDs when state is expected to advance. Do not hand-edit `.beads/issues.jsonl`; when an export is committed for review, ensure it is scrubbed of local emails, machine paths, secrets, private transcripts, and sensitive identity/authority data.
+
+**Seed run (2026-09-01).** All 15 beads (seed `cave-tmegk` plus 14 outcomes) are
+committed to the canonical local embedded Dolt database `cave`
+(pre-mutation Dolt commit `i5ltela5k233j55fks9abq612pidkkjl`,
+post-mutation `lnefjdsgcm7s44sqaut4dga082ca45sr`). Remote propagation via
+`pnpm beads:sync` is **deferred**: `bd dolt push` is rejected non-fast-forward
+because the shared remote `refs/dolt/data`
+(`04cb957bcda7c585a69af379cfb8ceb954987e21`) is ahead from concurrent sessions,
+and `bd dolt pull` to integrate did not complete under non-interactive execution.
+Per the Beads architecture the local Dolt database is the durable source of truth;
+the remote was **not** force-pushed (that would clobber concurrent sessions' beads).
+Re-run `pnpm beads:sync` from a session with an interactive-capable Dolt pull to
+propagate, then confirm `git ls-remote origin refs/dolt/data` advances.
 
 ## 6. Drift contract
 


### PR DESCRIPTION
## Summary

Provisions and verifies the canonical **Coven Automations v1** execution graph in Cave's embedded-Dolt Beads database, and reconciles the roadmap mapping to live Bead IDs. Executes OpenCoven/coven-cave#5220; program control tracked at OpenCoven/coven#859.

GitHub owns public acceptance; **Cave Beads owns execution state**; Coven owns production automation state.

## Beads provisioned (15)

Seed: `cave-tmegk` → OpenCoven/coven-cave#5220

| Outcome | GitHub | Bead |
| --- | --- | --- |
| Release rollup / program | coven#854 | `cave-hlv.9` |
| Program control / drift | coven#859 | `cave-hlv.10` |
| Foundation (verified, closed) | coven#816 | `cave-stsf7` |
| Protocol | coven#855 | `cave-tm1y0` |
| Scheduler | coven#856 | `cave-1sh6p` |
| Familiar embodiment | familiar-contract#17 | `cave-6jswi` |
| Automation authority | coven-threads#29 | `cave-m9tw3` |
| Trust integration | coven#857 | `cave-dbkng` |
| Conformance | coven#858 | `cave-x28j6` |
| SDK | sdk#80 | `cave-90hwl` |
| Cave oversight | coven-cave#5217 | `cave-e52qp` |
| Psyche adapter | psyche#18 | `cave-yaul2` |
| Documentation | coven-docs#76 | `cave-qwnxq` |
| Organization canaries | .github#2 | `cave-xqbs4` |

Each public outcome maps 1:1 to exactly one Bead with a single `surface:shared` ownership label. Foundation coven#816 is represented as **verified-foundation** (closed; PR #896, merge `0d8c2004c3557019e39e5e4db70ae34c9d49a65a`), not pending work.

## Dependency graph (proven, no cycles)

protocol←foundation · scheduler←foundation,protocol · familiar-embodiment←foundation · automation-authority←familiar-embodiment · trust-integration←protocol,familiar-embodiment,automation-authority · conformance←protocol,scheduler,trust-integration · sdk/cave-oversight/psyche/docs/org-canaries←conformance · org-canaries←program-control · release-rollup←(all outcomes+program-control)

Verified with `bd dep list` (both directions), `bd dep cycles` (none), and `bd ready --json` (ready: familiar-embodiment, protocol, program-control, seed — exactly those unblocked by the closed foundation / with no prerequisites).

## Durability & sync

- bd 1.2.2 (Homebrew), embedded Dolt database `cave`.
- Pre-mutation Dolt OID `i5ltela5k233j55fks9abq612pidkkjl` → post `lnefjdsgcm7s44sqaut4dga082ca45sr`.
- All 15 beads durably committed locally (canonical source of truth).
- **Deferred:** `pnpm beads:sync` remote propagation — `bd dolt push` rejected non-fast-forward (shared `refs/dolt/data` `04cb957…` is ahead from concurrent sessions) and `bd dolt pull` did not complete non-interactively. The remote was **not** force-pushed.

## Files

- `docs/roadmaps/coven-automations-v1.mapping.json` — live Bead IDs, dispositions, sync metadata, verified-foundation evidence.
- `docs/roadmaps/coven-automations-v1.md` — reconciled tables, provisioned graph, and seed-run durability note.

## Checks

- `node scripts/check-conflict-markers.mjs` ✓
- `node scripts/docs-index.test.mjs` ✓ (index ok)
- privacy scan of both files ✓ (no personal paths/secrets)

Refs OpenCoven\/coven-cave#5220 (graph seeded \& verified; remote Dolt propagation deferred, so not auto-closing)