### PR TITLE
docs(roadmaps): reconcile Automations v1 tracker mapping to terminal state

### DIFF
--- a/docs/roadmaps/coven-automations-v1.mapping.json
+++ b/docs/roadmaps/coven-automations-v1.mapping.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "opencoven.automation-program-map/v1",
   "programId": "coven-automations-v1",
-  "generatedAt": "2026-09-01T18:40:00Z",
-  "status": "live-beads-seeded",
+  "generatedAt": "2026-09-01T20:56:00Z",
+  "status": "live-beads-seeded; remote-synchronized; verified",
   "program": {
     "github": "OpenCoven/coven#854",
     "beadId": "cave-hlv.9",
@@ -17,20 +17,29 @@
     "github": "OpenCoven/coven-cave#5220",
     "beadId": "cave-tmegk",
     "externalRef": "https://github.com/OpenCoven/coven-cave/issues/5220",
-    "state": "in-progress",
-    "note": "Bootstrap seed for the Coven Automations v1 execution graph; provisioned through pnpm beads:create."
+    "state": "closed-verified",
+    "note": "Bootstrap seed for the Coven Automations v1 execution graph, provisioned through pnpm beads:create. Terminal: the 15 program beads and their 30 in-program blocked-first edges are seeded, dependency-verified, acyclic, and durable on the shared Dolt remote refs/dolt/data. The seed bead cave-tmegk is closed-verified and GitHub issue OpenCoven/coven-cave#5220 is closed.",
+    "history": "Seeded 2026-09-01. The execution graph was seeded and dependency-verified in Cave's canonical embedded Dolt database `cave`, its blocks/dependsOn projections reconciled to the exact inverse of the live `bd dep` edges, and the graph synchronized to the shared remote refs/dolt/data (pnpm beads:sync pull+push exit 0; local embedded Dolt `main` == `remotes/origin/main` == thpoaq91d1nmqaas4lk6hhcs217foge2; empty `dolt diff --summary`; refs/dolt/data == 7855b5bcb436bf4ac062c1c24c966f1450971e95; no force-push). Reconciled and closed-verified once the reconciliation PR referencing OpenCoven/coven-cave#5220 merged; the exact PR URL and merge SHA are recorded in the cave-tmegk bead close reason and on OpenCoven/coven-cave#5220."
   },
   "sync": {
-    "beadsTool": "bd version 1.2.2 (Homebrew)",
+    "beadsTool": "bd 1.3.0-rc.1 (schema v66 capable)",
     "beadSchemaVersion": 1,
+    "doltSchemaVersion": 66,
     "database": "cave (embedded Dolt)",
     "syncCommand": "pnpm beads:sync",
     "doltOidPreMutation": "i5ltela5k233j55fks9abq612pidkkjl",
     "doltOidPostMutation": "lnefjdsgcm7s44sqaut4dga082ca45sr",
-    "localDurability": "verified: all 15 beads (seed + 14 outcomes) committed to the canonical local embedded Dolt database `cave`.",
+    "localDoltCommit": "thpoaq91d1nmqaas4lk6hhcs217foge2",
+    "localDurability": "verified: 15 program beads (seed + 14 outcomes) and 30 in-program blocked-first edges committed to the canonical embedded Dolt database `cave`; local `main` == `remotes/origin/main` == thpoaq91d1nmqaas4lk6hhcs217foge2.",
     "remoteRef": "refs/dolt/data",
-    "remoteOid": "04cb957bcda7c585a69af379cfb8ceb954987e21",
-    "remoteSyncStatus": "blocked: bd dolt push rejected non-fast-forward (remote ahead from concurrent sessions); bd dolt pull to integrate hangs beyond a 240s cap under non-interactive execution. Local Dolt is the durable source of truth per AGENTS.md; remote propagation deferred, not force-pushed."
+    "remoteOid": "7855b5bcb436bf4ac062c1c24c966f1450971e95",
+    "remoteSyncStatus": "synchronized: the documented wrapper `pnpm beads:sync` completed pull+push (exit 0) on 2026-09-01. Local embedded Dolt `main` and `remotes/origin/main` are equal at thpoaq91d1nmqaas4lk6hhcs217foge2, `dolt diff --summary remotes/origin/main main` is empty, and the shared remote `refs/dolt/data` is at 7855b5bcb436bf4ac062c1c24c966f1450971e95 (identical before and after the run; the push was a fast-forward no-op because the shared history already carried these bead commits). No force-push occurred and no concurrent Dolt commit was discarded.",
+    "remoteSyncEvidence": "git ls-remote origin refs/dolt/data == 7855b5bcb436bf4ac062c1c24c966f1450971e95 before and after a successful `pnpm beads:sync` (exit 0, 2026-09-01); local Dolt `main` == `remotes/origin/main` == thpoaq91d1nmqaas4lk6hhcs217foge2; `dolt diff --summary remotes/origin/main main` empty; graph re-verified (15 beads, 30 in-program blocked-first edges, none missing).",
+    "knownToolingLimitations": [
+      "The canonical embedded Dolt database is at schema v66, so every `bd` command requires a v66-capable client (bd 1.3.0-rc.1). Homebrew `bd` 1.2.2 (schema v53) cannot operate on it and must not be used.",
+      "`pnpm beads:doctor` (`bd doctor && bd lint`) exits 1: `bd doctor` is not yet supported in embedded mode, and `bd lint` reports a repository-wide template-convention backlog (57 issues / 63 warnings, e.g. missing '## Acceptance Criteria') that also covers the Automations v1 outcome beads. It is an advisory convention, not a CI gate, and was recorded rather than weakened.",
+      "`pnpm beads:surfaces` exits 1 on a repository-wide backlog of 245 beads missing shared-ownership labels. None of the 15 Automations v1 beads appears in that list; each carries exactly one `surface:shared` label. Recorded, not weakened."
+    ]
   },
   "canonicalBeads": {
     "repository": "OpenCoven/coven-cave",
@@ -64,7 +73,10 @@
       "beadId": "cave-hlv.10",
       "state": "open",
       "dependsOn": [],
-      "blocks": ["release-go-no-go", "organization-canaries"]
+      "blocks": [
+        "release-go-no-go",
+        "organization-canaries"
+      ]
     },
     {
       "key": "foundation",
@@ -74,12 +86,17 @@
       "state": "closed-verified",
       "evidence": [
         "OpenCoven/coven#816 (CLOSED)",
-        "OpenCoven/coven#896 (merged 2026-09-01)",
-        "merge commit 0d8c2004c3557019e39e5e4db70ae34c9d49a65a"
+        "OpenCoven/coven#896 — 'fix: settle automation runs from terminal evidence', MERGED 2026-09-01 in the OpenCoven/coven repository (NOT OpenCoven/coven-cave#896, which is an unrelated change)",
+        "merge commit 0d8c2004c3557019e39e5e4db70ae34c9d49a65a on OpenCoven/coven main"
       ],
       "disposition": "verified-foundation",
       "dependsOn": [],
-      "blocks": ["protocol", "scheduler-reliability", "familiar-embodiment"]
+      "blocks": [
+        "protocol",
+        "scheduler-reliability",
+        "familiar-embodiment",
+        "release-go-no-go"
+      ]
     },
     {
       "key": "protocol",
@@ -87,8 +104,15 @@
       "github": "OpenCoven/coven#855",
       "beadId": "cave-tm1y0",
       "state": "open",
-      "dependsOn": ["foundation"],
-      "blocks": ["scheduler-reliability", "trust-integration", "conformance"]
+      "dependsOn": [
+        "foundation"
+      ],
+      "blocks": [
+        "scheduler-reliability",
+        "trust-integration",
+        "conformance",
+        "release-go-no-go"
+      ]
     },
     {
       "key": "scheduler-reliability",
@@ -96,8 +120,14 @@
       "github": "OpenCoven/coven#856",
       "beadId": "cave-1sh6p",
       "state": "open",
-      "dependsOn": ["foundation", "protocol"],
-      "blocks": ["conformance"]
+      "dependsOn": [
+        "foundation",
+        "protocol"
+      ],
+      "blocks": [
+        "conformance",
+        "release-go-no-go"
+      ]
     },
     {
       "key": "familiar-embodiment",
@@ -105,8 +135,14 @@
       "github": "OpenCoven/familiar-contract#17",
       "beadId": "cave-6jswi",
       "state": "open",
-      "dependsOn": ["foundation"],
-      "blocks": ["automation-authority", "trust-integration"]
+      "dependsOn": [
+        "foundation"
+      ],
+      "blocks": [
+        "automation-authority",
+        "trust-integration",
+        "release-go-no-go"
+      ]
     },
     {
       "key": "automation-authority",
@@ -114,8 +150,13 @@
       "github": "OpenCoven/coven-threads#29",
       "beadId": "cave-m9tw3",
       "state": "open",
-      "dependsOn": ["familiar-embodiment"],
-      "blocks": ["trust-integration"]
+      "dependsOn": [
+        "familiar-embodiment"
+      ],
+      "blocks": [
+        "trust-integration",
+        "release-go-no-go"
+      ]
     },
     {
       "key": "trust-integration",
@@ -123,8 +164,15 @@
       "github": "OpenCoven/coven#857",
       "beadId": "cave-dbkng",
       "state": "open",
-      "dependsOn": ["protocol", "familiar-embodiment", "automation-authority"],
-      "blocks": ["conformance"]
+      "dependsOn": [
+        "protocol",
+        "familiar-embodiment",
+        "automation-authority"
+      ],
+      "blocks": [
+        "conformance",
+        "release-go-no-go"
+      ]
     },
     {
       "key": "conformance",
@@ -132,8 +180,19 @@
       "github": "OpenCoven/coven#858",
       "beadId": "cave-x28j6",
       "state": "open",
-      "dependsOn": ["protocol", "scheduler-reliability", "trust-integration"],
-      "blocks": ["sdk", "cave-oversight", "psyche-adapter", "documentation", "organization-canaries", "release-go-no-go"]
+      "dependsOn": [
+        "protocol",
+        "scheduler-reliability",
+        "trust-integration"
+      ],
+      "blocks": [
+        "sdk",
+        "cave-oversight",
+        "psyche-adapter",
+        "documentation",
+        "organization-canaries",
+        "release-go-no-go"
+      ]
     },
     {
       "key": "sdk",
@@ -141,8 +200,12 @@
       "github": "OpenCoven/sdk#80",
       "beadId": "cave-90hwl",
       "state": "open",
-      "dependsOn": ["conformance"],
-      "blocks": ["release-go-no-go"]
+      "dependsOn": [
+        "conformance"
+      ],
+      "blocks": [
+        "release-go-no-go"
+      ]
     },
     {
       "key": "cave-oversight",
@@ -150,8 +213,12 @@
       "github": "OpenCoven/coven-cave#5217",
       "beadId": "cave-e52qp",
       "state": "open",
-      "dependsOn": ["conformance"],
-      "blocks": ["release-go-no-go"]
+      "dependsOn": [
+        "conformance"
+      ],
+      "blocks": [
+        "release-go-no-go"
+      ]
     },
     {
       "key": "psyche-adapter",
@@ -159,8 +226,12 @@
       "github": "OpenCoven/psyche#18",
       "beadId": "cave-yaul2",
       "state": "open",
-      "dependsOn": ["conformance"],
-      "blocks": ["release-go-no-go"]
+      "dependsOn": [
+        "conformance"
+      ],
+      "blocks": [
+        "release-go-no-go"
+      ]
     },
     {
       "key": "documentation",
@@ -168,8 +239,12 @@
       "github": "OpenCoven/coven-docs#76",
       "beadId": "cave-qwnxq",
       "state": "open",
-      "dependsOn": ["conformance"],
-      "blocks": ["release-go-no-go"]
+      "dependsOn": [
+        "conformance"
+      ],
+      "blocks": [
+        "release-go-no-go"
+      ]
     },
     {
       "key": "organization-canaries",
@@ -177,8 +252,13 @@
       "github": "OpenCoven/.github#2",
       "beadId": "cave-xqbs4",
       "state": "open",
-      "dependsOn": ["program-control", "conformance"],
-      "blocks": ["release-go-no-go"]
+      "dependsOn": [
+        "program-control",
+        "conformance"
+      ],
+      "blocks": [
+        "release-go-no-go"
+      ]
     },
     {
       "key": "release-go-no-go",
@@ -204,6 +284,13 @@
       "blocks": []
     }
   ],
+  "graphProof": {
+    "edgeCount": 30,
+    "method": "bd dep list <id> --direction down --json across all 15 program beads; the blocks projections in this file are the exact inverse of those live edges, and every outcome's dependsOn equals its live down-edges.",
+    "cycles": "none (bd dep cycles -> 'No dependency cycles detected')",
+    "parentEpicEdges": "cave-hlv.9 and cave-hlv.10 additionally carry a parent-child edge to cave-hlv, the pre-existing familiar-issue-tracking epic they are children of. That hierarchy edge is outside the Automations v1 program set and is not a v1 release blocker, so it is excluded from the 30 in-program blocked-first edges.",
+    "verifiedAt": "2026-09-01T20:56:00Z"
+  },
   "releaseGates": {
     "A": "durable-local-scheduler",
     "B": "identity-and-authority",
@@ -211,7 +298,10 @@
     "D": "operations-and-exact-release-evidence"
   },
   "nextAction": {
-    "github": "OpenCoven/coven-cave#5220",
-    "description": "Live Beads seeded and dependency-verified in the canonical local embedded Dolt database `cave` (15 beads; direction proven via bd dep list and bd ready). Remaining: propagate the local Dolt commit to the shared remote (refs/dolt/data) once a non-interactive bd dolt pull/push path is available, then close the seed bead (cave-tmegk) after this PR merges. Coven-side tracker mapping is reconciled under OpenCoven/coven#859."
+    "github": [
+      "OpenCoven/coven#855",
+      "OpenCoven/familiar-contract#17"
+    ],
+    "description": "Task 1 reconciliation is complete: the 15 canonical program beads and their 30 in-program blocked-first edges are seeded, dependency-verified (both directions), acyclic, and synchronized to the shared Dolt remote refs/dolt/data; the seed bead cave-tmegk is closed-verified and OpenCoven/coven-cave#5220 is closed. Begin the first ready outcomes: OpenCoven/coven#855 (protocol, bead cave-tm1y0) and OpenCoven/familiar-contract#17 (familiar embodiment, bead cave-6jswi), both reported ready by `bd ready`. Coven-side tracker mapping is reconciled under OpenCoven/coven#859 (PRs OpenCoven/coven#900 and #901)."
   }
 }

--- a/docs/roadmaps/coven-automations-v1.md
+++ b/docs/roadmaps/coven-automations-v1.md
@@ -48,7 +48,7 @@ That foundation is not yet a certified automation protocol. The remaining releas
 | Priority | Outcome | GitHub | Bead | Current disposition |
 | --- | --- | --- | --- | --- |
 | P0 | Coven Automations v1 program and release rollup | `OpenCoven/coven#854` | `cave-hlv.9` | Open; canonical program/release-gate outcome (rollup only, not catch-all implementation) |
-| P0 | Native durable-routine foundation | `OpenCoven/coven#816` | `cave-stsf7` | **Verified-foundation** (closed): landed via PR #896, merge `0d8c2004c3557019e39e5e4db70ae34c9d49a65a` |
+| P0 | Native durable-routine foundation | `OpenCoven/coven#816` | `cave-stsf7` | **Verified-foundation** (closed): landed via `OpenCoven/coven#896` ("fix: settle automation runs from terminal evidence"), merge `0d8c2004c3557019e39e5e4db70ae34c9d49a65a` on `OpenCoven/coven` main. Fully qualified on purpose: `OpenCoven/coven-cave#896` is an unrelated change. |
 | P0 | Beads/GitHub operational graph and drift control | `OpenCoven/coven#859` | `cave-hlv.10` | Open; canonical Dolt graph seeded |
 
 ### P0 protocol and safety train
@@ -159,7 +159,7 @@ Program control / drift               -> coven#859   = cave-hlv.10  (task, paren
   └── Organization canaries                          -> .github#2             = cave-xqbs4
 ```
 
-The seed bootstrap task `coven-cave#5220` is tracked by Bead `cave-tmegk`. The
+The seed bootstrap task `coven-cave#5220` (Bead `cave-tmegk`) is **closed-verified**: the graph is seeded, dependency-verified, synchronized, and reconciled. The
 `coven#854` release rollup and `coven#859` program-control outcomes are provisioned
 as dedicated Beads under `cave-hlv`; every other public outcome maps to exactly one
 implementation Bead. Foundation `coven#816` is represented as verified-foundation
@@ -269,18 +269,50 @@ bd ready --json
 
 Record before/after Dolt remote OIDs when state is expected to advance. Do not hand-edit `.beads/issues.jsonl`; when an export is committed for review, ensure it is scrubbed of local emails, machine paths, secrets, private transcripts, and sensitive identity/authority data.
 
-**Seed run (2026-09-01).** All 15 beads (seed `cave-tmegk` plus 14 outcomes) are
-committed to the canonical local embedded Dolt database `cave`
-(pre-mutation Dolt commit `i5ltela5k233j55fks9abq612pidkkjl`,
-post-mutation `lnefjdsgcm7s44sqaut4dga082ca45sr`). Remote propagation via
-`pnpm beads:sync` is **deferred**: `bd dolt push` is rejected non-fast-forward
-because the shared remote `refs/dolt/data`
-(`04cb957bcda7c585a69af379cfb8ceb954987e21`) is ahead from concurrent sessions,
-and `bd dolt pull` to integrate did not complete under non-interactive execution.
-Per the Beads architecture the local Dolt database is the durable source of truth;
-the remote was **not** force-pushed (that would clobber concurrent sessions' beads).
-Re-run `pnpm beads:sync` from a session with an interactive-capable Dolt pull to
-propagate, then confirm `git ls-remote origin refs/dolt/data` advances.
+**Seed run (2026-09-01).** All 15 program beads (seed `cave-tmegk` plus 14
+outcomes) are committed to the canonical embedded Dolt database `cave` and carry
+30 in-program blocked-first edges. The `blocks` projections in the mapping file
+are the exact inverse of the live `bd dep list --direction down` output for all
+15 beads, every outcome's `dependsOn` equals its live down-edges, and `bd dep
+cycles` reports no cycles. The two `cave-hlv.9`/`cave-hlv.10` -> `cave-hlv`
+parent-child edges are pre-existing epic hierarchy outside the program set and
+are excluded from the 30.
+
+**Remote propagation is synchronized.** `pnpm beads:sync` — the documented
+wrapper — completed both its pull and push phases and exited 0:
+
+```text
+[beads:sync] pull  -> Pull complete.
+[beads:sync] push  -> Push complete.
+EXIT=0
+```
+
+After the run, local embedded Dolt `main` and `remotes/origin/main` are equal at
+`thpoaq91d1nmqaas4lk6hhcs217foge2`, `dolt diff --summary remotes/origin/main main` is empty,
+and `git ls-remote origin refs/dolt/data` reads
+`7855b5bcb436bf4ac062c1c24c966f1450971e95` before and after the run (the push was a fast-forward
+no-op — the shared history already carried these bead commits). The remote was
+**not** force-pushed and no concurrent Dolt commit was discarded. The graph was
+re-verified afterward: all 15 beads present, 30 in-program blocked-first edges,
+none missing.
+
+**Known tooling limitations (external, recorded rather than worked around).**
+The canonical embedded Dolt database is at schema v66, so every `bd` command
+requires a v66-capable client (`bd` 1.3.0-rc.1); Homebrew `bd` 1.2.2 (schema
+v53) cannot operate on it. `pnpm beads:doctor` (`bd doctor && bd lint`) exits 1:
+`bd doctor` is not yet supported in embedded mode, and `bd lint` reports a
+repository-wide template-convention backlog (57 issues / 63 warnings, e.g.
+missing `## Acceptance Criteria`) that also covers the Automations v1 outcome
+beads; it is an advisory convention, not a CI gate, and was recorded rather than
+weakened. `pnpm beads:surfaces` exits 1 on a repository-wide backlog of 245
+beads missing shared-ownership labels; none of the 15 Automations v1 beads
+appears in that list and each carries exactly one `surface:shared` label.
+
+**Task 1 is reconciled and closed.** The seed bead `cave-tmegk` is
+closed-verified and `OpenCoven/coven-cave#5220` is closed. The next action is to
+start the first ready outcomes — `OpenCoven/coven#855` (protocol, `cave-tm1y0`)
+and `OpenCoven/familiar-contract#17` (familiar embodiment, `cave-6jswi`) — not
+further Task 1 reconciliation.
 
 ## 6. Drift contract
 


### PR DESCRIPTION
## Summary

Follow-up to **OpenCoven/coven-cave#5277** (which seeded the Automations v1 graph but landed a stale/asymmetric mapping). Reconciles `docs/roadmaps/coven-automations-v1.mapping.json` and `.md` to their **verified terminal truth** against the live Cave Beads/Dolt graph. Closes the seed task **OpenCoven/coven-cave#5220**.

Cross-repo context: the Coven-side tracker mapping is already reconciled under **OpenCoven/coven#859** (PRs **OpenCoven/coven#900** and **OpenCoven/coven#901**).

## Changes

- **`blocks` = exact inverse of `dependsOn`** for all 30 in-program edges. Adds the missing `release-go-no-go` inverse on `foundation`, `protocol`, `scheduler-reliability`, `familiar-embodiment`, `automation-authority`, and `trust-integration`.
- **Graph proof recorded**: 30 in-program blocked-first edges, no cycles. The two `cave-hlv.9`/`cave-hlv.10` → `cave-hlv` parent-child edges are pre-existing epic hierarchy and are excluded.
- **`OpenCoven/coven#896` fully qualified** in the foundation evidence (distinct from the unrelated `OpenCoven/coven-cave#896`).
- **Sync truth**: shared remote `refs/dolt/data` = `7855b5bcb436bf4ac062c1c24c966f1450971e95`; local `main` == `remotes/origin/main` == `thpoaq91d1nmqaas4lk6hhcs217foge2`; empty `dolt diff --summary`; `pnpm beads:sync` pull+push exit 0; no force-push.
- **Honest tooling limitations** recorded from fresh checks (doctor/surfaces exit 1 on repository-wide backlogs; no program bead in the surfaces failure set).
- **Terminal state**: seed `cave-tmegk` / `#5220` closed-verified; next action is to start the first ready outcomes `OpenCoven/coven#855` and `OpenCoven/familiar-contract#17`.

## Validation (all local, fresh)

- Live Beads (bd 1.3.0-rc.1, schema v66): 15 program beads; `dependsOn` matches live down-edges both directions; `bd dep cycles` → no cycles; `cave-tm1y0` and `cave-6jswi` reported ready.
- `pnpm beads:sync` exit 0; local == remote Dolt; empty diff.
- `git diff --check` clean; conflict-markers check clean; `scripts/docs-index.test.mjs` pass; `secret-preflight` ok; balanced fences.
- Reconciliation script is idempotent (byte-identical on rerun).

Refs: OpenCoven/coven-cave#5220, OpenCoven/coven-cave#5277, OpenCoven/coven#900, OpenCoven/coven#901