### PR TITLE
fix(branch-curator): accept canonical creation reflogs

### DIFF
--- a/.agents/skills/branch-curator/references/deletion-proof.md
+++ b/.agents/skills/branch-curator/references/deletion-proof.md
@@ -461,7 +461,9 @@ test "$archives_safe" -eq 1 ||
 
 Use the repository's object format, a numeric cutoff, and raw reflog records.
 The raw parser must prove both old and new nonzero OIDs, including the old OID
-of the oldest retained record:
+of the oldest retained record. Git may omit the tab-delimited message only from
+the first canonical creation record, whose old OID is all zeroes; every other
+message-less or malformed record fails closed:
 
 ```bash
 now_epoch=$(date +%s) ||
@@ -500,12 +502,14 @@ emit_reflog_records() {
     function valid(o) { return length(o) == width && o ~ /^[0-9a-f]+$/ }
     function zero(o) { return o ~ /^0+$/ }
     {
-      tab=index($0, "\t"); if (!tab) { bad=1; next }
-      n=split(substr($0, 1, tab-1), parts, " ")
+      tab=index($0, "\t")
+      prefix=tab ? substr($0, 1, tab-1) : $0
+      n=split(prefix, parts, " ")
       if (n < 6 || !valid(parts[1]) || !valid(parts[2]) ||
           parts[n-2] !~ /^<[^<>[:space:]]+>$/ ||
           parts[n-1] !~ /^[0-9]+$/ ||
           parts[n] !~ /^[+-][0-9][0-9][0-9][0-9]$/) { bad=1; next }
+      if (!tab && !(NR == 1 && zero(parts[1]))) { bad=1; next }
       if (!zero(parts[1])) print parts[n-1], parts[1]
       if (!zero(parts[2])) print parts[n-1], parts[2]
     }

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 function read(path) {
@@ -31,6 +34,50 @@ const implementationPlan = read(
 const evals = JSON.parse(
   read(".agents/skills/branch-curator/evals/evals.json"),
 ).evals;
+
+function runDocumentedReflogParser(contents) {
+  const functionMatch = proof.match(/emit_reflog_records\(\) \{[\s\S]*?\n\}/);
+  assert.ok(functionMatch, "missing documented emit_reflog_records function");
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "branch-curator-reflog-"));
+  const fixture = path.join(fixtureRoot, "HEAD");
+  fs.writeFileSync(fixture, contents);
+  try {
+    return spawnSync(
+      "bash",
+      ["-c", `oid_width=40\n${functionMatch[0]}\nemit_reflog_records "$1"`, "branch-curator-reflog", fixture],
+      { encoding: "utf8" },
+    );
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+test("normative reflog parser accepts only the canonical message-less creation record", () => {
+  const zero = "0".repeat(40);
+  const created = "98be54a3a6901e3c60706fb09ef5e81121128b36";
+  const committed = "c79e68eb6017b66be9e1bf9685adb61ed049288c";
+  const creation = `${zero} ${created} Val Alexander <68980965+BunsDev@users.noreply.github.com> 1788294729 -0500\n`;
+  const update = `${created} ${committed} Val Alexander <68980965+BunsDev@users.noreply.github.com> 1788296310 -0500\tcommit: reconcile tracker\n`;
+
+  const accepted = runDocumentedReflogParser(creation + update);
+  assert.equal(accepted.status, 0, accepted.stderr);
+  assert.deepEqual(accepted.stdout.trim().split("\n"), [
+    `1788294729 ${created}`,
+    `1788296310 ${created}`,
+    `1788296310 ${committed}`,
+  ]);
+
+  const missingLaterMessage = runDocumentedReflogParser(
+    creation +
+      `${created} ${committed} Val Alexander <68980965+BunsDev@users.noreply.github.com> 1788296310 -0500\n`,
+  );
+  assert.notEqual(missingLaterMessage.status, 0, "later message-less records must fail closed");
+
+  const nonCreationFirstRecord = runDocumentedReflogParser(
+    `${created} ${committed} Val Alexander <68980965+BunsDev@users.noreply.github.com> 1788296310 -0500\n`,
+  );
+  assert.notEqual(nonCreationFirstRecord.status, 0, "message-less first records with a nonzero old OID must fail closed");
+});
 
 test("Branch Curator separates automatic and maintainer-authorized cleanup", () => {
   const profiles = section(


### PR DESCRIPTION
## Summary
- accept Git’s canonical message-less initial linked-worktree reflog record
- continue rejecting later message-less records and first records with a nonzero old OID
- execute the documented parser against regression fixtures

## Verification
- `node --test scripts/branch-curator-manual-cleanup-contract.test.mjs`
- `git diff --check`

Bead: cave-iha5a