### PR TITLE
fix(worktrees): prove retention from an exact remote branch

### DIFF
--- a/.agents/skills/branch-curator/references/deletion-proof.md
+++ b/.agents/skills/branch-curator/references/deletion-proof.md
@@ -461,7 +461,9 @@ test "$archives_safe" -eq 1 ||
 
 Use the repository's object format, a numeric cutoff, and raw reflog records.
 The raw parser must prove both old and new nonzero OIDs, including the old OID
-of the oldest retained record:
+of the oldest retained record. Git may omit the tab-delimited message only from
+the first canonical creation record, whose old OID is all zeroes; every other
+message-less or malformed record fails closed:
 
 ```bash
 now_epoch=$(date +%s) ||
@@ -500,12 +502,14 @@ emit_reflog_records() {
     function valid(o) { return length(o) == width && o ~ /^[0-9a-f]+$/ }
     function zero(o) { return o ~ /^0+$/ }
     {
-      tab=index($0, "\t"); if (!tab) { bad=1; next }
-      n=split(substr($0, 1, tab-1), parts, " ")
+      tab=index($0, "\t")
+      prefix=tab ? substr($0, 1, tab-1) : $0
+      n=split(prefix, parts, " ")
       if (n < 6 || !valid(parts[1]) || !valid(parts[2]) ||
           parts[n-2] !~ /^<[^<>[:space:]]+>$/ ||
           parts[n-1] !~ /^[0-9]+$/ ||
           parts[n] !~ /^[+-][0-9][0-9][0-9][0-9]$/) { bad=1; next }
+      if (!tab && !(NR == 1 && zero(parts[1]))) { bad=1; next }
       if (!zero(parts[1])) print parts[n-1], parts[1]
       if (!zero(parts[2])) print parts[n-1], parts[2]
     }

--- a/.agents/skills/branch-curator/references/deletion-proof.md
+++ b/.agents/skills/branch-curator/references/deletion-proof.md
@@ -787,12 +787,17 @@ of stdout, and exactly the documented four-key allow object. After the final
 allow-object validation, nothing except the worktree removal itself may
 intervene:
 
-If the exact source branch still exists or `HEAD` is an ancestor of an
-advertised branch/tag, leave `strict_guard_retention_args` empty and use the
-ordinary bounded proof. If GitHub squash-merged the exact candidate and
-auto-deleted its source branch, populate the array only after a fresh exact PR
-detail query has proved: one numeric PR, `state == closed`, `merged == true`, a
-valid `merged_at`, `head.sha == audited_worktree_head_oid`,
+When the audited candidate is retained by one exact remote branch, populate the
+array with `--retained-by-remote-branch`, the audited remote and full branch ref,
+and `--expected-remote-oid` with the freshly fetched exact branch OID. This mode
+queries, fetches, and rechecks only that branch, so a large unrelated remote
+namespace cannot turn exact retention into an unbounded scan. Otherwise, if the
+exact source branch still exists or `HEAD` is an ancestor of an advertised
+branch/tag, leave `strict_guard_retention_args` empty and use the ordinary
+bounded proof. If GitHub squash-merged the exact candidate and auto-deleted its
+source branch, populate the array only after a fresh exact PR detail query has
+proved: one numeric PR, `state == closed`, `merged == true`, a valid
+`merged_at`, `head.sha == audited_worktree_head_oid`,
 `base.ref == audited_remote_main_branch`, and
 `base.repo.full_name == audited_gh_repo`.
 The strict guard reauthenticates those facts and queries/fetches only the exact

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 function read(path) {
@@ -31,6 +34,50 @@ const implementationPlan = read(
 const evals = JSON.parse(
   read(".agents/skills/branch-curator/evals/evals.json"),
 ).evals;
+
+function runDocumentedReflogParser(contents) {
+  const functionMatch = proof.match(/emit_reflog_records\(\) \{[\s\S]*?\n\}/);
+  assert.ok(functionMatch, "missing documented emit_reflog_records function");
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "branch-curator-reflog-"));
+  const fixture = path.join(fixtureRoot, "HEAD");
+  fs.writeFileSync(fixture, contents);
+  try {
+    return spawnSync(
+      "bash",
+      ["-c", `oid_width=40\n${functionMatch[0]}\nemit_reflog_records "$1"`, "branch-curator-reflog", fixture],
+      { encoding: "utf8" },
+    );
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+test("normative reflog parser accepts only the canonical message-less creation record", () => {
+  const zero = "0".repeat(40);
+  const created = "98be54a3a6901e3c60706fb09ef5e81121128b36";
+  const committed = "c79e68eb6017b66be9e1bf9685adb61ed049288c";
+  const creation = `${zero} ${created} Val Alexander <68980965+BunsDev@users.noreply.github.com> 1788294729 -0500\n`;
+  const update = `${created} ${committed} Val Alexander <68980965+BunsDev@users.noreply.github.com> 1788296310 -0500\tcommit: reconcile tracker\n`;
+
+  const accepted = runDocumentedReflogParser(creation + update);
+  assert.equal(accepted.status, 0, accepted.stderr);
+  assert.deepEqual(accepted.stdout.trim().split("\n"), [
+    `1788294729 ${created}`,
+    `1788296310 ${created}`,
+    `1788296310 ${committed}`,
+  ]);
+
+  const missingLaterMessage = runDocumentedReflogParser(
+    creation +
+      `${created} ${committed} Val Alexander <68980965+BunsDev@users.noreply.github.com> 1788296310 -0500\n`,
+  );
+  assert.notEqual(missingLaterMessage.status, 0, "later message-less records must fail closed");
+
+  const nonCreationFirstRecord = runDocumentedReflogParser(
+    `${created} ${committed} Val Alexander <68980965+BunsDev@users.noreply.github.com> 1788296310 -0500\n`,
+  );
+  assert.notEqual(nonCreationFirstRecord.status, 0, "message-less first records with a nonzero old OID must fail closed");
+});
 
 test("Branch Curator separates automatic and maintainer-authorized cleanup", () => {
   const profiles = section(

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -333,6 +333,8 @@ test("normative proof scopes remote deletion and uses exact expected OIDs", () =
     ),
   );
   assert.match(worktreeTransaction, /--retained-by-github-pr origin "\$audited_gh_repo"/);
+  assert.match(worktreeTransaction, /--retained-by-remote-branch/);
+  assert.match(worktreeTransaction, /--expected-remote-oid/);
   assert.match(worktreeTransaction, /"\$audited_merged_pr_number"/);
   assert.match(worktreeTransaction, /--expected-base "\$audited_remote_main_branch"/);
   assert.match(worktreeTransaction, /queries\/fetches only the exact|queries\/fetches only|queries\/fetches/);

--- a/scripts/worktree-guard.mjs
+++ b/scripts/worktree-guard.mjs
@@ -398,6 +398,19 @@ function strictSingleExactBranch(output, remote, expectedRef, expectedOidWidth) 
   return { oid: match[1], ref: match[2], kind: "heads", name: match[3], peeled: false };
 }
 
+function strictExactBranchAdvertisement(target, remote, ref, expectedOidWidth, deadline) {
+  const probe = strictGitProbe(
+    ["-C", target, "ls-remote", "--exit-code", "--", remote, ref],
+    target,
+    deadline,
+  );
+  if (probe.status === 2 && probe.stdout === "") {
+    throw new Error(`remote ${remote} does not advertise exact branch ${ref}`);
+  }
+  if (probe.status !== 0) throw new Error(`exact branch advertisement probe exited ${probe.status}`);
+  return strictSingleExactBranch(probe.stdout, remote, ref, expectedOidWidth);
+}
+
 function strictValidateMergedGithubPr(pr, proof, head) {
   if (pr.number !== proof.number) throw new Error("GitHub PR number does not match requested proof");
   if (pr.state !== "closed" || pr.merged !== true || typeof pr.merged_at !== "string" || !Number.isFinite(Date.parse(pr.merged_at))) {
@@ -487,22 +500,24 @@ function strictRetainedByRemoteBranch(target, head, proof) {
   if (!remotes.includes(proof.remote)) throw new Error("remote-branch proof remote is not configured");
   strictGit(["-C", target, "check-ref-format", proof.ref], target, deadline);
 
-  const advertised = strictSingleExactBranch(
-    strictGit(["-C", target, "ls-remote", "--", proof.remote, proof.ref], target, deadline),
+  const advertised = strictExactBranchAdvertisement(
+    target,
     proof.remote,
     proof.ref,
     head.length,
+    deadline,
   );
   if (advertised.oid !== proof.oid) {
     throw new Error("advertised remote branch does not match expected OID");
   }
 
   strictFetchAdvertisedRefs(target, proof.remote, [proof.ref], deadline);
-  const refreshed = strictSingleExactBranch(
-    strictGit(["-C", target, "ls-remote", "--", proof.remote, proof.ref], target, deadline),
+  const refreshed = strictExactBranchAdvertisement(
+    target,
     proof.remote,
     proof.ref,
     head.length,
+    deadline,
   );
   if (refreshed.oid !== advertised.oid) {
     throw new Error(`remote ${proof.remote} changed ${proof.ref} during retention proof`);

--- a/scripts/worktree-guard.mjs
+++ b/scripts/worktree-guard.mjs
@@ -380,6 +380,24 @@ function strictSingleExactRef(output, remote, expectedRef, expectedOidWidth) {
   return { oid: match[1], ref: match[2], kind: "pull", name: match[3], peeled: false };
 }
 
+function strictSingleExactBranch(output, remote, expectedRef, expectedOidWidth) {
+  const lines = output.split("\n");
+  if (lines.length !== 2 || lines[1] !== "") {
+    throw new Error(`remote ${remote} returned malformed exact-branch output`);
+  }
+  const match = /^([0-9a-f]+)\t(refs\/heads\/(.+))$/.exec(lines[0]);
+  if (
+    !match ||
+    !FULL_OID.test(match[1]) ||
+    match[1].length !== expectedOidWidth ||
+    match[2] !== expectedRef ||
+    Buffer.byteLength(match[2], "utf8") > STRICT_MAX_REF_BYTES
+  ) {
+    throw new Error(`remote ${remote} returned a malformed exact branch`);
+  }
+  return { oid: match[1], ref: match[2], kind: "heads", name: match[3], peeled: false };
+}
+
 function strictValidateMergedGithubPr(pr, proof, head) {
   if (pr.number !== proof.number) throw new Error("GitHub PR number does not match requested proof");
   if (pr.state !== "closed" || pr.merged !== true || typeof pr.merged_at !== "string" || !Number.isFinite(Date.parse(pr.merged_at))) {
@@ -461,6 +479,49 @@ function strictRetainedByMergedGithubPr(target, head, proof) {
     deadline,
   );
   if (advertisedCommit !== head) throw new Error("fetched GitHub PR head does not match expected HEAD");
+}
+
+function strictRetainedByRemoteBranch(target, head, proof) {
+  const deadline = strictRetentionDeadline();
+  const remotes = strictRemoteNames(target, deadline);
+  if (!remotes.includes(proof.remote)) throw new Error("remote-branch proof remote is not configured");
+  strictGit(["-C", target, "check-ref-format", proof.ref], target, deadline);
+
+  const advertised = strictSingleExactBranch(
+    strictGit(["-C", target, "ls-remote", "--", proof.remote, proof.ref], target, deadline),
+    proof.remote,
+    proof.ref,
+    head.length,
+  );
+  if (advertised.oid !== proof.oid) {
+    throw new Error("advertised remote branch does not match expected OID");
+  }
+
+  strictFetchAdvertisedRefs(target, proof.remote, [proof.ref], deadline);
+  const refreshed = strictSingleExactBranch(
+    strictGit(["-C", target, "ls-remote", "--", proof.remote, proof.ref], target, deadline),
+    proof.remote,
+    proof.ref,
+    head.length,
+  );
+  if (refreshed.oid !== advertised.oid) {
+    throw new Error(`remote ${proof.remote} changed ${proof.ref} during retention proof`);
+  }
+  const advertisedCommit = strictResolveAdvertisedCommit(
+    target,
+    proof.remote,
+    advertised,
+    null,
+    deadline,
+  );
+  const ancestry = strictGitProbe(
+    ["-C", target, "merge-base", "--is-ancestor", head, advertisedCommit],
+    target,
+    deadline,
+  );
+  if (ancestry.stdout !== "") throw new Error("git ancestry probe returned unexpected output");
+  if (ancestry.status === 1) throw new Error("HEAD is not retained by the exact remote branch");
+  if (ancestry.status !== 0) throw new Error(`git ancestry probe exited ${ancestry.status}`);
 }
 
 function strictRetainedOnRemote(target, head) {
@@ -646,10 +707,17 @@ function runStrictWorktreeRemove(args) {
     args[2] === "--expected-head" &&
     args[4] === "--retained-by-github-pr" &&
     args[8] === "--expected-base";
-  if (!basicArgs && !githubPrArgs) {
+  const remoteBranchArgs =
+    args.length === 9 &&
+    args[0] === "--strict-worktree-remove" &&
+    args[2] === "--expected-head" &&
+    args[4] === "--retained-by-remote-branch" &&
+    args[7] === "--expected-remote-oid";
+  if (!basicArgs && !githubPrArgs && !remoteBranchArgs) {
     throw new Error(
       "expected --strict-worktree-remove <absolute-path> --expected-head <full-oid> " +
-        "[--retained-by-github-pr <remote> <owner/repo> <number> --expected-base <branch>]",
+        "[--retained-by-github-pr <remote> <owner/repo> <number> --expected-base <branch> | " +
+        "--retained-by-remote-branch <remote> <refs/heads/name> --expected-remote-oid <full-oid>]",
     );
   }
   const requestedPath = args[1];
@@ -657,6 +725,7 @@ function runStrictWorktreeRemove(args) {
   if (!path.isAbsolute(requestedPath)) throw new Error("target path must be absolute");
   if (!FULL_OID.test(expectedHead)) throw new Error("expected HEAD must be a full OID");
   let githubProof = null;
+  let remoteBranchProof = null;
   if (githubPrArgs) {
     const remote = args[5];
     const repo = args[6];
@@ -675,6 +744,18 @@ function runStrictWorktreeRemove(args) {
     const number = Number(numberText);
     if (!Number.isSafeInteger(number)) throw new Error("GitHub PR proof number is out of range");
     githubProof = { remote, repo, number, base };
+  } else if (remoteBranchArgs) {
+    const remote = args[5];
+    const ref = args[6];
+    const oid = args[8];
+    if (!remote || /\s/.test(remote)) throw new Error("remote-branch proof remote is malformed");
+    if (!ref.startsWith("refs/heads/") || Buffer.byteLength(ref, "utf8") > STRICT_MAX_REF_BYTES) {
+      throw new Error("remote-branch proof ref is malformed");
+    }
+    if (!FULL_OID.test(oid) || oid.length !== expectedHead.length) {
+      throw new Error("remote-branch proof OID is malformed");
+    }
+    remoteBranchProof = { remote, ref, oid };
   }
 
   let target;
@@ -708,6 +789,7 @@ function runStrictWorktreeRemove(args) {
   if (status !== "") throw new Error("target worktree is not clean");
 
   if (githubProof) strictRetainedByMergedGithubPr(target, actualHead, githubProof);
+  else if (remoteBranchProof) strictRetainedByRemoteBranch(target, actualHead, remoteBranchProof);
   else strictRetainedOnRemote(target, actualHead);
   strictLiveProcesses(target);
   process.stdout.write(`${JSON.stringify({

--- a/scripts/worktree-guard.test.mjs
+++ b/scripts/worktree-guard.test.mjs
@@ -166,6 +166,17 @@ function strictGithubPrArgs(wt, head, number = "4214") {
   ];
 }
 
+function strictRemoteBranchArgs(wt, head, ref, oid) {
+  return [
+    ...strictArgs(wt, head),
+    "--retained-by-remote-branch",
+    "origin",
+    ref,
+    "--expected-remote-oid",
+    oid,
+  ];
+}
+
 function strictEnv(executable = lsofStub()) {
   return { WT_GUARD_TEST_MODE: "1", WT_GUARD_TEST_LSOF_BIN: executable };
 }
@@ -834,6 +845,72 @@ await test("strict retention has a hard aggregate candidate bound", () => {
   assert.equal(result.status, 2, "more than 256 advertised candidate sources is refused before fetch");
   assert.equal(result.stdout, "");
   assert.deepEqual(gitMetadataSnapshot(excessive.dir), metadataBefore, "candidate overflow changes no refs or FETCH_HEAD");
+});
+
+await test("strict exact remote-branch proof avoids a large remote namespace", () => {
+  const fixture = repoWithMergedWorktreeAndAdvancedMain();
+  const remoteMain = sh("git", ["--git-dir", fixture.bare, "rev-parse", "refs/heads/main"], fixture.dir).trim();
+  for (let index = 0; index < 257; index += 1) {
+    sh(
+      "git",
+      ["--git-dir", fixture.bare, "update-ref", `refs/heads/generated-${String(index).padStart(3, "0")}`, remoteMain],
+      fixture.dir,
+    );
+  }
+
+  const logs = mkdtempSync(path.join(tmpdir(), "wt-guard-branch-proof-"));
+  const callLog = path.join(logs, "git.jsonl");
+  const fetchLog = path.join(logs, "fetch.jsonl");
+  writeFileSync(callLog, "");
+  writeFileSync(fetchLog, "");
+  const metadataBefore = gitMetadataSnapshot(fixture.dir);
+  const result = runStrict(
+    strictRemoteBranchArgs(fixture.wt, fixture.featureHead, "refs/heads/main", remoteMain),
+    fixture.dir,
+    {
+      ...strictEnv(),
+      PATH: gitWrapper({ callLog, fetchLog }),
+    },
+  );
+
+  assert.equal(result.status, 0, `exact remote branch retention succeeds without scanning 257 refs: ${result.stderr}`);
+  const calls = readFileSync(callLog, "utf8").trimEnd().split("\n").map((line) => JSON.parse(line));
+  const lsRemoteCalls = calls.filter((args) => args.includes("ls-remote"));
+  assert.equal(lsRemoteCalls.length, 2, "the exact remote branch is advertised and rechecked once");
+  for (const args of lsRemoteCalls) {
+    assert.equal(args.includes("--heads"), false, "exact branch proof never enumerates remote branches");
+    assert.equal(args.includes("--tags"), false, "exact branch proof never enumerates remote tags");
+    assert.deepEqual(args.slice(-3), ["--", "origin", "refs/heads/main"], "only the exact branch is queried");
+  }
+  const fetches = fetchCalls(fetchLog);
+  assert.equal(fetches.length, 1, "exact branch proof performs one source-only fetch");
+  assert.deepEqual(fetches[0].slice(-3), ["--", "origin", "refs/heads/main:"], "only the exact branch is fetched");
+  assert.deepEqual(gitMetadataSnapshot(fixture.dir), metadataBefore, "exact branch proof changes no refs or FETCH_HEAD");
+});
+
+await test("strict exact remote-branch proof fails closed on OID and ancestry drift", () => {
+  const fixture = repoWithWorktree({ push: true });
+  const head = sh("git", ["-C", fixture.wt, "rev-parse", "HEAD"], fixture.dir).trim();
+  const remoteMain = sh("git", ["--git-dir", fixture.bare, "rev-parse", "refs/heads/main"], fixture.dir).trim();
+  const wrongOid = "a".repeat(head.length);
+
+  let result = runStrict(
+    strictRemoteBranchArgs(fixture.wt, head, "refs/heads/main", wrongOid),
+    fixture.dir,
+    strictEnv(),
+  );
+  assert.equal(result.status, 2, "an unexpected advertised branch OID is refused");
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /does not match expected OID/);
+
+  result = runStrict(
+    strictRemoteBranchArgs(fixture.wt, head, "refs/heads/main", remoteMain),
+    fixture.dir,
+    strictEnv(),
+  );
+  assert.equal(result.status, 2, "a remote branch that does not retain HEAD is refused");
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /not retained by the exact remote branch/);
 });
 
 await test("strict retention fails closed when its aggregate deadline is exhausted", () => {

--- a/scripts/worktree-guard.test.mjs
+++ b/scripts/worktree-guard.test.mjs
@@ -904,6 +904,15 @@ await test("strict exact remote-branch proof fails closed on OID and ancestry dr
   assert.match(result.stderr, /does not match expected OID/);
 
   result = runStrict(
+    strictRemoteBranchArgs(fixture.wt, head, "refs/heads/missing", remoteMain),
+    fixture.dir,
+    strictEnv(),
+  );
+  assert.equal(result.status, 2, "a missing exact remote branch is refused");
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /does not advertise exact branch refs\/heads\/missing/);
+
+  result = runStrict(
     strictRemoteBranchArgs(fixture.wt, head, "refs/heads/main", remoteMain),
     fixture.dir,
     strictEnv(),


### PR DESCRIPTION
## Summary
- add a fail-closed strict guard mode for one exact retained remote branch
- query, fetch, and recheck only the named branch instead of scanning an oversized namespace
- preserve the existing 256-source cap for generic retention proofs
- document the exact-source mode in Branch Curator

## Verification
- `node --test --test-name-pattern="strict exact remote-branch|strict-worktree-remove is a fail-closed direct guard" scripts/worktree-guard.test.mjs`
- `node --test scripts/branch-curator-manual-cleanup-contract.test.mjs`
- `git diff --check`

Bead: cave-iqxuo