### PR TITLE
fix(release): unblock v0.3.13 candidate validation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,8 +8,6 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "1" || process.env.ANALYZE === "true",
 });
 
-const conformanceBuild =
-  process.env.COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL === "1";
 const daemonlessE2E = process.env.COVEN_CAVE_E2E === "1";
 
 const nextConfig: NextConfig = {
@@ -113,12 +111,6 @@ const nextConfig: NextConfig = {
   // bundle-budget postbuild gate and the e2e suite guard the output.
   reactCompiler: true,
   experimental: {
-    // The conformance artifact is built inside Chat's bounded macOS authority
-    // runner. Keep the production Turbopack compiler, but avoid the PostCSS
-    // child-process IPC path that can time out under that runner's contention.
-    turbopackPluginRuntimeStrategy: conformanceBuild
-      ? "workerThreads"
-      : undefined,
     // Next 16.2 enables Turbopack's persistent dev cache by default. In a
     // long-lived desktop session the cache reaches multiple gigabytes, then
     // its SST compaction can starve the PostCSS child-process IPC until

--- a/scripts/build-conformance.mjs
+++ b/scripts/build-conformance.mjs
@@ -1,15 +1,34 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const result = spawnSync("corepack", ["pnpm@10.34.0", "build"], {
-  env: {
-    ...process.env,
-    COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL: "1",
-    // The worker-thread plugin runtime shares one V8 heap. The bounded macOS
-    // authority runner needs an explicit ceiling above Node's default 4 GiB.
-    NODE_OPTIONS: "--max-old-space-size=6144",
-  },
+import { resolveCorepackLaunch } from "./corepack-launch.mjs";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const env = {
+  ...process.env,
+  COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL: "1",
+  // The worker-thread plugin runtime shares one V8 heap. The bounded macOS
+  // authority runner needs an explicit ceiling above Node's default 4 GiB.
+  NODE_OPTIONS: "--max-old-space-size=6144",
+};
+
+rmSync(path.join(repositoryRoot, ".next"), { recursive: true, force: true });
+
+let launch;
+try {
+  launch = resolveCorepackLaunch(["pnpm@10.34.0", "build"], { env });
+} catch (error) {
+  console.error(`build:conformance failed to start: ${error.message}`);
+  process.exit(1);
+}
+
+const result = spawnSync(launch.command, launch.args, {
+  cwd: repositoryRoot,
+  env,
   stdio: "inherit",
 });
 

--- a/scripts/client-v1-compatibility-control.integration.test.mjs
+++ b/scripts/client-v1-compatibility-control.integration.test.mjs
@@ -18,12 +18,15 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { resolveCorepackLaunch } from "./corepack-launch.mjs";
+
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const buildTimeoutMs = 10 * 60_000;
+const buildTimeoutMs = 20 * 60_000;
 const startupTimeoutMs = 45_000;
 const requestTimeoutMs = 3_000;
 const shutdownTimeoutMs = 8_000;
 const maxOutputBytes = 32_000;
+const broadTraceWarning = "Dynamic filesystem access causes tracing of the whole project";
 const healthPath = "/api/client/v1/health";
 const successMetadata = {
   apiVersion: "1.0",
@@ -59,8 +62,10 @@ async function stopChild(child) {
 function collectOutput(child) {
   let output = "";
   const append = (chunk) => {
-    if (output.length >= maxOutputBytes) return;
-    output += chunk.toString("utf8").slice(0, maxOutputBytes - output.length);
+    output += chunk.toString("utf8");
+    if (output.length > maxOutputBytes) {
+      output = output.slice(-maxOutputBytes);
+    }
   };
   child.stdout?.on("data", append);
   child.stderr?.on("data", append);
@@ -68,7 +73,13 @@ function collectOutput(child) {
 }
 
 async function runBuild(label, args, env) {
-  const child = spawn("corepack", ["pnpm@10.34.0", ...args], {
+  let launch;
+  try {
+    launch = resolveCorepackLaunch(["pnpm@10.34.0", ...args], { env });
+  } catch (error) {
+    throw new Error(`${label} failed to start: ${error.message}`, { cause: error });
+  }
+  const child = spawn(launch.command, launch.args, {
     cwd: repositoryRoot,
     env,
     stdio: ["ignore", "pipe", "pipe"],
@@ -88,9 +99,15 @@ async function runBuild(label, args, env) {
     child.once("close", (code, signal) => {
       clearTimeout(timer);
       if (timedOut) {
-        reject(new Error(`${label} timed out after ${buildTimeoutMs} ms`));
+        reject(
+          new Error(
+            `${label} timed out after ${buildTimeoutMs} ms\n${output().slice(-4_000)}`,
+          ),
+        );
       } else if (code !== 0) {
         reject(new Error(`${label} exited with ${code ?? signal}\n${output().slice(-4_000)}`));
+      } else if (output().includes(broadTraceWarning)) {
+        reject(new Error(`${label} emitted a broad filesystem trace warning\n${output().slice(-4_000)}`));
       } else {
         resolve();
       }

--- a/scripts/corepack-launch.mjs
+++ b/scripts/corepack-launch.mjs
@@ -1,0 +1,75 @@
+import { statSync } from "node:fs";
+import path from "node:path";
+
+function environmentValue(env, key, platform) {
+  if (platform !== "win32") return env[key];
+  const wanted = key.toUpperCase();
+  return Object.entries(env).find(([name]) => name.toUpperCase() === wanted)?.[1];
+}
+
+function defaultIsFile(candidate) {
+  try {
+    const metadata = statSync(candidate);
+    return metadata.isFile() || metadata.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+export function resolveCorepackLaunch(
+  args,
+  {
+    platform = process.platform,
+    env = process.env,
+    nodePath = process.execPath,
+    isFile = defaultIsFile,
+  } = {},
+) {
+  if (platform !== "win32") {
+    return { command: "corepack", args: [...args] };
+  }
+
+  const pathApi = path.win32;
+  const searchPath = environmentValue(env, "PATH", platform) ?? "";
+  const directories = [
+    pathApi.dirname(nodePath),
+    ...searchPath.split(pathApi.delimiter),
+  ];
+  const seen = new Set();
+
+  for (const rawDirectory of directories) {
+    const directory = rawDirectory.trim();
+    if (!directory || seen.has(directory.toLowerCase())) continue;
+    seen.add(directory.toLowerCase());
+
+    for (const name of ["corepack.exe", "corepack.com"]) {
+      const executable = pathApi.join(directory, name);
+      if (isFile(executable)) {
+        return { command: executable, args: [...args] };
+      }
+    }
+
+    const entry = pathApi.join(
+      directory,
+      "node_modules",
+      "corepack",
+      "dist",
+      "corepack.js",
+    );
+    if (!isFile(entry)) continue;
+    if (
+      !isFile(pathApi.join(directory, "corepack.cmd"))
+      && !isFile(pathApi.join(directory, "corepack.bat"))
+    ) {
+      continue;
+    }
+    return {
+      command: nodePath,
+      args: [entry, ...args],
+    };
+  }
+
+  throw new Error(
+    "Windows PATH does not contain a spawn-safe Corepack launcher; expected corepack.exe or a Corepack npm shim beside node_modules/corepack/dist/corepack.js.",
+  );
+}

--- a/scripts/corepack-launch.test.mjs
+++ b/scripts/corepack-launch.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveCorepackLaunch } from "./corepack-launch.mjs";
+
+test("keeps the ordinary Corepack launch on POSIX", () => {
+  assert.deepEqual(
+    resolveCorepackLaunch(["pnpm@10.34.0", "build"], {
+      platform: "darwin",
+      env: { PATH: "/usr/local/bin:/usr/bin" },
+      nodePath: "/usr/local/bin/node",
+    }),
+    {
+      command: "corepack",
+      args: ["pnpm@10.34.0", "build"],
+    },
+  );
+});
+
+test("runs the Windows Corepack shim target directly through Node", () => {
+  const nodePath = String.raw`C:\hostedtoolcache\windows\node\24.18.1\x64\node.exe`;
+  const corepackRoot = path.win32.dirname(nodePath);
+  const corepackShim = path.win32.join(corepackRoot, "corepack.cmd");
+  const corepackEntry = path.win32.join(
+    corepackRoot,
+    "node_modules",
+    "corepack",
+    "dist",
+    "corepack.js",
+  );
+  const files = new Set([corepackShim, corepackEntry]);
+
+  assert.deepEqual(
+    resolveCorepackLaunch(["pnpm@10.34.0", "build"], {
+      platform: "win32",
+      env: { Path: `${corepackRoot};C:\\Windows\\System32` },
+      nodePath,
+      isFile: (candidate) => files.has(candidate),
+    }),
+    {
+      command: nodePath,
+      args: [corepackEntry, "pnpm@10.34.0", "build"],
+    },
+  );
+});
+
+test("prefers a directly executable Windows Corepack binary", () => {
+  const corepackRoot = String.raw`C:\tools`;
+  const executable = path.win32.join(corepackRoot, "corepack.exe");
+
+  assert.deepEqual(
+    resolveCorepackLaunch(["pnpm@10.34.0", "build"], {
+      platform: "win32",
+      env: { PATH: corepackRoot },
+      nodePath: String.raw`C:\node\node.exe`,
+      isFile: (candidate) => candidate === executable,
+    }),
+    {
+      command: executable,
+      args: ["pnpm@10.34.0", "build"],
+    },
+  );
+});
+
+test("fails clearly when Windows exposes no spawn-safe Corepack launcher", () => {
+  assert.throws(
+    () =>
+      resolveCorepackLaunch(["pnpm@10.34.0", "build"], {
+        platform: "win32",
+        env: { Path: String.raw`C:\Windows\System32` },
+        nodePath: String.raw`C:\node\node.exe`,
+        isFile: () => false,
+      }),
+    /spawn-safe Corepack launcher/,
+  );
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -270,6 +270,8 @@ export const SUITES = {
     "src-tauri/notch-window-chrome.test.mjs",
     "scripts/react-compiler-config.test.mjs",
     "scripts/turbopack-dev-cache.test.mjs",
+    "scripts/turbopack-runtime-boundaries.test.mjs",
+    "scripts/corepack-launch.test.mjs",
     "scripts/codemods/tokenize-tsx-design.test.mjs",
     "scripts/eslint/design-system-plugin.test.mjs",
     "scripts/bundle-budget.test.mjs",

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -157,11 +157,11 @@ assert.ok(
 );
 const sidecarMeasurement = declaredSidecarBudget.measurement;
 const measuredPlatforms = ["windows", "ubuntu", "macos"];
-assert.equal(sidecarMeasurement.on, "2026-08-25", "the Task9 HPKE budget review date must not drift");
+assert.equal(sidecarMeasurement.on, "2026-09-02", "the release-candidate budget review date must not drift");
 assert.equal(
   sidecarMeasurement.reference,
-  "OpenCoven/coven-cave#4996",
-  "the Task9 HPKE budget must retain its governing issue reference",
+  "v0.3.13-rc.1 / GitHub Actions run 33587097523",
+  "the release-candidate budget must retain its governing evidence reference",
 );
 const governingMeasurement = Math.max(
   ...measuredPlatforms.map((platform) => sidecarMeasurement[platform]),
@@ -179,7 +179,7 @@ assert.equal(
 assert.equal(
   sidecarMeasurement.headroom,
   150,
-  "the HPKE feature delta must preserve the established 150-file headroom",
+  "the release budget must preserve the established 150-file headroom",
 );
 assert.ok(
   sidecarMeasurement.featureDelta
@@ -204,9 +204,32 @@ assert.equal(
 );
 for (const platform of measuredPlatforms) {
   assert.equal(
-    sidecarMeasurement[platform] - sidecarMeasurement.featureDelta.baseline[platform],
+    sidecarMeasurement.featureDelta.measured[platform]
+      - sidecarMeasurement.featureDelta.baseline[platform],
     sidecarMeasurement.featureDelta.fileCount,
     `${platform} must move by exactly the reviewed feature delta`,
+  );
+}
+assert.equal(
+  sidecarMeasurement.windowsObserved,
+  false,
+  "the failed rc.1 Windows runtime leg must remain explicitly identified as projected evidence",
+);
+assert.equal(
+  sidecarMeasurement.releaseDelta.nextTraceFileCount,
+  18,
+  "the release delta must retain the measured Next trace growth",
+);
+assert.equal(
+  sidecarMeasurement.releaseDelta.tracedPackageCountChanged,
+  false,
+  "the release delta must not be reclassified as dependency-subtree growth",
+);
+for (const platform of measuredPlatforms) {
+  assert.equal(
+    sidecarMeasurement[platform] - sidecarMeasurement.releaseDelta.baseline[platform],
+    sidecarMeasurement.releaseDelta.fileCount,
+    `${platform} must move by exactly the reviewed v0.3.13 release delta`,
   );
 }
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");

--- a/scripts/sidecar-runtime-budget.json
+++ b/scripts/sidecar-runtime-budget.json
@@ -1,14 +1,15 @@
 {
   "note": "Single source of truth for the sidecar runtime file-count budget. Edit fileCount HERE and nowhere else: scripts/sidecar-runtime-closure.mjs reads this file, scripts/sidecar-runtime-smoke.mjs derives from that, and src-tauri/build.rs generates the Rust MAX_FILE_COUNT const from it. Before cave-0ia8h the same number was hand-synced across six places and drifted; sidecar-bundle-deps.test.mjs now fails if a literal reappears.",
   "raising": "Raising this is a deliberate, reviewed act, not a reflex when CI goes red. Set it from the GOVERNING platform measurement (Windows runs a few files above Ubuntu; a budget set from an Ubuntu-only figure has reddened windows-latest more than once) and record that measurement below. The reasoning history lives beside SIDECAR_RUNTIME_BUDGETS in scripts/sidecar-runtime-closure.mjs.",
-  "fileCount": 6924,
+  "fileCount": 7351,
   "measurement": {
-    "on": "2026-08-25",
-    "reference": "OpenCoven/coven-cave#4996",
+    "on": "2026-09-02",
+    "reference": "v0.3.13-rc.1 / GitHub Actions run 33587097523",
     "governingPlatform": "windows",
-    "windows": 6774,
-    "ubuntu": 6770,
-    "macos": 6766,
+    "windows": 7201,
+    "windowsObserved": false,
+    "ubuntu": 7198,
+    "macos": 7194,
     "headroom": 150,
     "featureDelta": {
       "fileCount": 139,
@@ -25,8 +26,27 @@
         "windows": 6635,
         "ubuntu": 6631,
         "macos": 6627
+      },
+      "measured": {
+        "windows": 6774,
+        "ubuntu": 6770,
+        "macos": 6766
       }
     },
-    "headroomRationale": "OpenCoven/coven-cave#4996 adds the pinned pure-JS @hpke/common, @hpke/core, and @hpke/dhkem-x25519 dynamic runtime closure: exactly 139 packaged files in 42 directories, approximately 868 KiB on disk, with no native or platform subtree. Each reviewed platform measurement moves by exactly that feature delta from the 2026-08-24 baseline: macOS 6,766, Ubuntu 6,770, and Windows 6,774. Preserve the established 150-file headroom from the governing Windows measurement, yielding 6,924 files. Unrelated current-main drift remains inside that headroom; the expanded-byte ceiling and directory budgets are unchanged."
+    "releaseDelta": {
+      "fileCount": 327,
+      "nextTraceFileCount": 18,
+      "changedAppFileCount": 64,
+      "addedRouteCount": 18,
+      "runtimeKind": "generated-next-output",
+      "nativeOrPlatformSubtree": false,
+      "tracedPackageCountChanged": false,
+      "baseline": {
+        "windows": 6874,
+        "ubuntu": 6871,
+        "macos": 6867
+      }
+    },
+    "headroomRationale": "v0.3.13-rc.1 measured 7,194 files on macOS and 7,198 on Ubuntu after 140 mainline commits. Both platforms increased by exactly 327 files over the last successful candidate (6,867 and 6,871), while Next trace files increased from 335 to 353 and traced package counts remained unchanged. The delta is generated .next server/static output from 64 changed src/app files, including 18 added routes; no forbidden root, dependency subtree, native subtree, source map, or test tree entered the closure. The Windows job failed before assembly, so its 7,201 baseline is the prior measured 6,874 plus the identical 327-file cross-platform delta. Preserve the established 150-file headroom from that conservative Windows projection, yielding 7,351. A clean zero-warning Turbopack build still measured 7,194 files on macOS, independently proving the sidecar increase is ordinary generated application output rather than broad filesystem tracing. The expanded-byte ceiling remains unchanged."
   }
 }

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -290,6 +290,18 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // dependency subtree, source maps, tests, or duplicate package tree entered
   // the closure. Keep the established 150-file headroom from the governing
   // Windows measurement without relaxing the expanded-byte ceiling.
+  //
+  // 2026-09-02 (v0.3.13-rc.1): macOS measured 7,194 files and Ubuntu
+  // measured 7,198, exactly +327 on both platforms from the last successful
+  // candidate's 6,867/6,871. The tree added 18 Next traces (335 -> 353) and
+  // 64 changed src/app files, including 18 new routes, while traced package
+  // counts stayed unchanged. No forbidden root, dependency/native subtree,
+  // source map, or test tree entered the closure. The Windows leg failed
+  // before assembly, so project its governing count as its measured 6,874
+  // baseline plus the identical 327-file delta: 7,201. Preserve the established
+  // 150-file headroom. A separate zero-warning Turbopack build still measured
+  // 7,194 on macOS, proving the increase is generated application output rather
+  // than broad filesystem tracing; leave the expanded-byte ceiling unchanged.
   fileCount: readSidecarFileCountBudget(),
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });

--- a/scripts/turbopack-runtime-boundaries.test.mjs
+++ b/scripts/turbopack-runtime-boundaries.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const expectedBoundaries = new Map([
+  ["../src/lib/mobile-handoff.ts", [
+    ["spawn(/* turbopackIgnore: true */ bin, args", 1],
+  ]],
+  ["../src/lib/server/backup-archive.ts", [
+    ["path.join(/* turbopackIgnore: true */ researchRoot, relativeDirectory)", 1],
+  ]],
+  ["../src/lib/server/research-context-pack-store.ts", [
+    ["readdir(/* turbopackIgnore: true */ layout.manifestsDir)", 2],
+  ]],
+  ["../src/lib/server/research-resource-lexical-index.ts", [
+    ["existsSync(/* turbopackIgnore: true */ candidate)", 1],
+    ["path.resolve(/* turbopackIgnore: true */ options.file ?? lexicalIndexPath())", 2],
+    ["existsSync(/* turbopackIgnore: true */ file)", 2],
+    ["existsSync(/* turbopackIgnore: true */ `${file}${suffix}`)", 1],
+  ]],
+  ["../src/lib/server/research-resource-semantic-index.ts", [
+    ["existsSync(/* turbopackIgnore: true */ candidate)", 2],
+    ["readdirSync(/* turbopackIgnore: true */ directory)", 1],
+    ["path.resolve(/* turbopackIgnore: true */ options.file ?? semanticIndexPath())", 2],
+    ["existsSync(/* turbopackIgnore: true */ candidate.file)", 1],
+    ["existsSync(/* turbopackIgnore: true */ file)", 5],
+    ["existsSync(/* turbopackIgnore: true */ `${file}${suffix}`)", 1],
+  ]],
+  ["../src/lib/server/research-topic-discovery-store.ts", [
+    ["readdir(/* turbopackIgnore: true */ layout.jobsDir)", 2],
+    ["readdir(/* turbopackIgnore: true */ layout.proposalsDir)", 1],
+  ]],
+  ["../src/lib/server/skill-scan.ts", [
+    ["realpath(/* turbopackIgnore: true */ candidate)", 2],
+  ]],
+]);
+
+test("runtime-owned paths stay outside Turbopack's packaged filesystem trace", async () => {
+  for (const [relativePath, boundaries] of expectedBoundaries) {
+    const source = await readFile(new URL(relativePath, import.meta.url), "utf8");
+    for (const [boundary, expected] of boundaries) {
+      const actual = source.split(boundary).length - 1;
+      assert.equal(
+        actual,
+        expected,
+        `${relativePath} must retain the reviewed boundary ${boundary}`,
+      );
+    }
+  }
+});

--- a/src-tauri/src/sidecar_startup.rs
+++ b/src-tauri/src/sidecar_startup.rs
@@ -1559,7 +1559,7 @@ pub(super) fn spawn_sidecar_startup(
                     }
                 }
                 let status = SidecarStartupStatus::failed(
-                    "Sidecar startup worker terminated unexpectedly. Please retry.",
+                    "Sidecar startup worker terminated unexpectedly. Please retry.".to_string(),
                 );
                 if let Err(error) = publish_sidecar_startup_status(
                     &app,

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -403,7 +403,7 @@ function runTailscaleCommandOnce(
 ): Promise<TailscaleServeCommandResult> {
   return new Promise((resolve) => {
     const bin = tailscaleBin();
-    const child = spawn(bin, args, {
+    const child = spawn(/* turbopackIgnore: true */ bin, args, {
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
       env: tailscaleSpawnEnv(),

--- a/src/lib/server/backup-archive.ts
+++ b/src/lib/server/backup-archive.ts
@@ -193,7 +193,7 @@ async function pruneResearchAuthority(
     path.join(researchRoot, "blobs", "sha256"),
   ]);
   for (const relativeDirectory of RESEARCH_AUTHORITATIVE_DIRECTORIES) {
-    const directory = path.join(researchRoot, relativeDirectory);
+    const directory = path.join(/* turbopackIgnore: true */ researchRoot, relativeDirectory);
     await prepareResearchRestorePath(
       path.join(directory, ".restore-placeholder"),
       researchRoot,

--- a/src/lib/server/client-v1/conformance-compatibility.test.ts
+++ b/src/lib/server/client-v1/conformance-compatibility.test.ts
@@ -75,7 +75,7 @@ test("normal builds compile the compatibility control disabled", () => {
   );
 });
 
-test("conformance builds keep Turbopack while avoiding plugin process IPC", () => {
+test("conformance builds keep Turbopack and start from a clean plugin runtime", () => {
   const script = readFileSync(
     path.join(process.cwd(), "scripts/build-conformance.mjs"),
     "utf8",
@@ -90,11 +90,17 @@ test("conformance builds keep Turbopack while avoiding plugin process IPC", () =
 
   assert.match(script, /\["pnpm@10\.34\.0", "build"\]/);
   assert.match(script, /NODE_OPTIONS:\s*"--max-old-space-size=6144"/);
+  assert.match(
+    script,
+    /rmSync\(path\.join\(repositoryRoot, "\.next"\), \{ recursive: true, force: true \}\)/,
+    "the compatibility-mode build must not reuse the normal build's Turbopack state",
+  );
   assert.equal(manifest.scripts?.["build:conformance"], "node scripts/build-conformance.mjs");
   assert.match(manifest.scripts?.build ?? "", /^next build(?:\s|$)/);
   assert.doesNotMatch(manifest.scripts?.build ?? "", /--webpack/);
-  assert.match(
+  assert.doesNotMatch(
     config,
-    /COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL === "1"[\s\S]*?turbopackPluginRuntimeStrategy:\s*conformanceBuild\s*\?\s*"workerThreads"\s*:\s*undefined/,
+    /turbopackPluginRuntimeStrategy/,
+    "the worker-thread PostCSS runtime corrupts concurrent stylesheet transforms",
   );
 });

--- a/src/lib/server/research-context-pack-store.ts
+++ b/src/lib/server/research-context-pack-store.ts
@@ -534,7 +534,7 @@ export function createContextPackStore(options: { root?: string } = {}): Context
       const layout = await openLayout(root);
       let entries: string[];
       try {
-        entries = await readdir(layout.manifestsDir);
+        entries = await readdir(/* turbopackIgnore: true */ layout.manifestsDir);
       } catch {
         return [];
       }
@@ -623,7 +623,7 @@ export async function reconcileRestoredContextPacks(options: {
   const layout = await openLayout(options.root ?? path.join(caveHome(), "research-context-packs"));
   let entries: string[] = [];
   try {
-    entries = await readdir(layout.manifestsDir);
+    entries = await readdir(/* turbopackIgnore: true */ layout.manifestsDir);
   } catch {
     return { validated: 0, invalid: 0 };
   }

--- a/src/lib/server/research-resource-lexical-index.ts
+++ b/src/lib/server/research-resource-lexical-index.ts
@@ -294,7 +294,7 @@ export function closeCanonicalResearchResourceLexicalHandlesForRestore(fileInput
 
 function hardenSqliteFiles(file: string): void {
   for (const candidate of [file, `${file}-wal`, `${file}-shm`]) {
-    if (!existsSync(candidate)) continue;
+    if (!existsSync(/* turbopackIgnore: true */ candidate)) continue;
     const metadata = lstatSync(candidate);
     if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1) {
       throw new ResearchResourceLexicalIndexError("unsafe-path", "lexical SQLite sidecar is unsafe");
@@ -710,7 +710,7 @@ async function openAt(
 export async function openResearchResourceLexicalIndex(
   options: { file?: string } = {},
 ): Promise<ResearchResourceLexicalIndex> {
-  const file = path.resolve(options.file ?? lexicalIndexPath());
+  const file = path.resolve(/* turbopackIgnore: true */ options.file ?? lexicalIndexPath());
   const marker = canonicalRestoreMarker(file);
   if (marker && existsSync(marker)) throw unavailableDuringRestore();
   return openAt(file, { observeRestoreMarker: marker !== null });
@@ -720,7 +720,7 @@ export async function rebuildResearchResourceLexicalIndex(
   options: { file?: string },
   populateFromVerifiedSnapshots: (index: ResearchResourceLexicalIndex) => void | Promise<void>,
 ): Promise<{ index: ResearchResourceLexicalIndex; quarantinePath: string | null }> {
-  const file = path.resolve(options.file ?? lexicalIndexPath());
+  const file = path.resolve(/* turbopackIgnore: true */ options.file ?? lexicalIndexPath());
   ensureDirectory(path.dirname(file));
   const temporary = path.join(
     path.dirname(file),
@@ -742,13 +742,15 @@ export async function rebuildResearchResourceLexicalIndex(
     throw error;
   }
 
-  const quarantinePath = existsSync(file)
+  const quarantinePath = existsSync(/* turbopackIgnore: true */ file)
     ? `${file}.corrupt-${Date.now()}-${randomBytes(4).toString("hex")}`
     : null;
   if (quarantinePath) {
     renameSync(file, quarantinePath);
     for (const suffix of ["-wal", "-shm"]) {
-      if (existsSync(`${file}${suffix}`)) renameSync(`${file}${suffix}`, `${quarantinePath}${suffix}`);
+      if (existsSync(/* turbopackIgnore: true */ `${file}${suffix}`)) {
+        renameSync(`${file}${suffix}`, `${quarantinePath}${suffix}`);
+      }
     }
     syncDirectory(path.dirname(file));
   }
@@ -756,7 +758,7 @@ export async function rebuildResearchResourceLexicalIndex(
     renameSync(temporary, file);
     syncDirectory(path.dirname(file));
   } catch (error) {
-    if (quarantinePath && !existsSync(file)) {
+    if (quarantinePath && !existsSync(/* turbopackIgnore: true */ file)) {
       renameSync(quarantinePath, file);
       syncDirectory(path.dirname(file));
     }

--- a/src/lib/server/research-resource-semantic-index.ts
+++ b/src/lib/server/research-resource-semantic-index.ts
@@ -342,7 +342,7 @@ function ensurePrivateFile(file: string): boolean {
 function hardenSqliteFiles(file: string, safetyCheck: () => void = () => {}): void {
   for (const candidate of [file, `${file}-wal`, `${file}-shm`]) {
     safetyCheck();
-    if (!existsSync(candidate)) continue;
+    if (!existsSync(/* turbopackIgnore: true */ candidate)) continue;
     const metadata = lstatSync(candidate);
     if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1) {
       throw new ResearchResourceSemanticIndexError("unsafe-path", "semantic SQLite sidecar is unsafe");
@@ -459,7 +459,7 @@ function purgeResidualFiles(
   const residual = new RegExp(`^(?:${base}\\.corrupt-[0-9]+-[a-f0-9]{8}|\\.research-semantic-[0-9]+-[a-f0-9]{24}\\.sqlite)(?:-wal|-shm)?$`);
   let removed = false;
   safetyCheck();
-  for (const name of readdirSync(directory).sort()) {
+  for (const name of readdirSync(/* turbopackIgnore: true */ directory).sort()) {
     if (!residual.test(name)) continue;
     safetyCheck();
     const candidate = path.join(directory, name);
@@ -487,7 +487,7 @@ function purgeOrphanedCanonicalSidecars(
   let removed = false;
   for (const candidate of [`${file}-wal`, `${file}-shm`]) {
     safetyCheck();
-    if (!existsSync(candidate)) continue;
+    if (!existsSync(/* turbopackIgnore: true */ candidate)) continue;
     const metadata = lstatSync(candidate);
     if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1) {
       throw new ResearchResourceSemanticIndexError("unsafe-path", "orphaned semantic SQLite sidecar is unsafe");
@@ -622,7 +622,7 @@ function cosine(left: readonly number[], right: readonly number[]): number {
 export async function openResearchResourceSemanticIndex(
   options: { file?: string; beforeFinalSafetyCheck?: () => void } = {},
 ): Promise<ResearchResourceSemanticIndex> {
-  const file = path.resolve(options.file ?? semanticIndexPath());
+  const file = path.resolve(/* turbopackIgnore: true */ options.file ?? semanticIndexPath());
   if (!path.isAbsolute(file)) {
     throw new ResearchResourceSemanticIndexError("unsafe-path", "semantic index path must be absolute");
   }
@@ -1005,7 +1005,7 @@ export async function removeResearchResourceSemanticPublication(input: {
     for (const candidate of canonicalCandidates) {
       input.beforeCorruptCanonicalSafetyCheck?.(candidate.boundary);
       assertStableDeletionLayout(deletionLayout);
-      if (!existsSync(candidate.file)) continue;
+      if (!existsSync(/* turbopackIgnore: true */ candidate.file)) continue;
       const metadata = lstatSync(candidate.file);
       if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1) {
         throw new ResearchResourceSemanticIndexError("unsafe-path", "corrupt semantic database path is unsafe");
@@ -1027,10 +1027,10 @@ export async function removeResearchResourceSemanticPublication(input: {
 export async function rebuildResearchResourceSemanticIndex(
   options: { file?: string } = {},
 ): Promise<{ index: ResearchResourceSemanticIndex; quarantinePath: string | null }> {
-  const file = path.resolve(options.file ?? semanticIndexPath());
+  const file = path.resolve(/* turbopackIgnore: true */ options.file ?? semanticIndexPath());
   ensureDirectory(path.dirname(file));
-  if (existsSync(file)) hardenSqliteFiles(file);
-  const expectedIdentity = existsSync(file) ? lstatSync(file) : null;
+  if (existsSync(/* turbopackIgnore: true */ file)) hardenSqliteFiles(file);
+  const expectedIdentity = existsSync(/* turbopackIgnore: true */ file) ? lstatSync(file) : null;
   const temporary = path.join(
     path.dirname(file),
     `.research-semantic-${process.pid}-${randomBytes(12).toString("hex")}.sqlite`,
@@ -1073,7 +1073,9 @@ export async function rebuildResearchResourceSemanticIndex(
       if (quarantinePath) {
         await renameWithRetry(file, quarantinePath);
         for (const suffix of ["-wal", "-shm"]) {
-          if (existsSync(`${file}${suffix}`)) await renameWithRetry(`${file}${suffix}`, `${quarantinePath}${suffix}`);
+          if (existsSync(/* turbopackIgnore: true */ `${file}${suffix}`)) {
+            await renameWithRetry(`${file}${suffix}`, `${quarantinePath}${suffix}`);
+          }
         }
         syncDirectory(path.dirname(file));
       }
@@ -1081,7 +1083,7 @@ export async function rebuildResearchResourceSemanticIndex(
         await renameWithRetry(temporary, file);
         syncDirectory(path.dirname(file));
       } catch (error) {
-        if (quarantinePath && !existsSync(file)) {
+        if (quarantinePath && !existsSync(/* turbopackIgnore: true */ file)) {
           await renameWithRetry(quarantinePath, file);
           syncDirectory(path.dirname(file));
         }

--- a/src/lib/server/research-topic-discovery-store.ts
+++ b/src/lib/server/research-topic-discovery-store.ts
@@ -448,7 +448,7 @@ export function createTopicDiscoveryStore(options: { root?: string } = {}): Topi
       const layout = await openLayout(root);
       let entries: string[];
       try {
-        entries = await readdir(layout.jobsDir);
+        entries = await readdir(/* turbopackIgnore: true */ layout.jobsDir);
       } catch {
         return [];
       }
@@ -556,7 +556,7 @@ export function createTopicDiscoveryStore(options: { root?: string } = {}): Topi
       const layout = await openLayout(root);
       let entries: string[];
       try {
-        entries = await readdir(layout.proposalsDir);
+        entries = await readdir(/* turbopackIgnore: true */ layout.proposalsDir);
       } catch {
         return [];
       }
@@ -581,7 +581,7 @@ export function createTopicDiscoveryStore(options: { root?: string } = {}): Topi
       const layout = await openLayout(root);
       let entries: string[];
       try {
-        entries = await readdir(layout.jobsDir);
+        entries = await readdir(/* turbopackIgnore: true */ layout.jobsDir);
       } catch {
         return [];
       }

--- a/src/lib/server/skill-scan.ts
+++ b/src/lib/server/skill-scan.ts
@@ -84,7 +84,7 @@ export async function resolveRuntimeSkillRoots(
   const roots: string[] = [];
   for (const candidate of candidates) {
     try {
-      const resolved = await realpath(candidate);
+      const resolved = await realpath(/* turbopackIgnore: true */ candidate);
       if (!(await stat(resolved)).isDirectory()) continue;
       if (covered.some((root) => isWithinRoot(resolved, root))) continue;
       if (!roots.includes(resolved)) roots.push(resolved);
@@ -118,7 +118,7 @@ export async function resolveRuntimeResourceRoots(
   );
   for (const candidate of candidates) {
     try {
-      const resolved = await realpath(candidate);
+      const resolved = await realpath(/* turbopackIgnore: true */ candidate);
       if (!(await stat(resolved)).isDirectory()) continue;
       if (covered.some((root) => isWithinRoot(resolved, root))) continue;
       if (!roots.includes(resolved)) roots.push(resolved);


### PR DESCRIPTION
## Summary
- repair the Windows-only Rust startup-status compile mismatch and launch Corepack through a shell-free Windows resolver
- eliminate broad Turbopack filesystem traces, restore stable clean conformance builds, and retain the real build-output tail
- document the deterministic v0.3.13 sidecar closure increase and restore the established 150-file cross-platform budget headroom

## RC1 failures addressed
- Windows native Rust compile: `SidecarStartupStatus::failed` now receives an owned `String`
- Windows packaged Client v1: `corepack.cmd` resolves to `node <corepack.js>` without `cmd.exe`
- macOS packaged Client v1: runtime-owned filesystem paths no longer trace the checkout; conformance builds start from a clean `.next` and avoid the corrupting worker-thread PostCSS runtime
- Linux sidecar budget: macOS and Ubuntu both measured an exact +327-file delta from 18 additional Next traces, with unchanged traced package counts and no forbidden/dependency/native subtree

## Validation
- `pnpm test:client-v1:compatibility-control`
- `pnpm test:conformance`
- `pnpm test:sidecar-runtime`
- `pnpm typecheck`
- `pnpm lint`
- `cargo check --manifest-path src-tauri/Cargo.toml --locked`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked --lib`
- focused runtime-path, Corepack, sidecar-budget, and Client v1 tests
- clean zero-warning production build: 7m55s, 7,657 standalone files, 440,456,845 bytes
- assembled macOS sidecar: 7,194 files, 122,495,920 bytes

The local Windows cross-target check reached native C dependencies but cannot complete on macOS without the Windows SDK headers; the release matrix's native Windows job remains the authoritative compile proof.
