### PR TITLE
fix(release): bound packaged build heap on macOS

### DIFF
--- a/scripts/build-conformance.mjs
+++ b/scripts/build-conformance.mjs
@@ -11,8 +11,8 @@ const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url))
 const env = {
   ...process.env,
   COVEN_CAVE_CLIENT_V1_COMPATIBILITY_CONTROL: "1",
-  // The worker-thread plugin runtime shares one V8 heap. The bounded macOS
-  // authority runner needs an explicit ceiling above Node's default 4 GiB.
+  // Packaged compatibility builds exceed the bounded macOS runner's
+  // host-derived default during Next's TypeScript phase.
   NODE_OPTIONS: "--max-old-space-size=6144",
 };
 

--- a/scripts/client-v1-compatibility-control.integration.test.mjs
+++ b/scripts/client-v1-compatibility-control.integration.test.mjs
@@ -184,6 +184,7 @@ function isolatedEnvironment(root, port, selector) {
   env.TEMP = env.TMPDIR;
   env.XDG_CONFIG_HOME = path.join(root, "config");
   env.XDG_CACHE_HOME = path.join(root, "cache");
+  env.NODE_OPTIONS = "--max-old-space-size=6144";
   env.NODE_ENV = "production";
   env.COVEN_HOME = path.join(root, "coven");
   env.COVEN_CAVE_HOME = path.join(root, "coven", "cave");

--- a/scripts/client-v1-compatibility-control.integration.test.mjs
+++ b/scripts/client-v1-compatibility-control.integration.test.mjs
@@ -101,13 +101,13 @@ async function runBuild(label, args, env) {
       if (timedOut) {
         reject(
           new Error(
-            `${label} timed out after ${buildTimeoutMs} ms\n${output().slice(-4_000)}`,
+            `${label} timed out after ${buildTimeoutMs} ms\n${output()}`,
           ),
         );
       } else if (code !== 0) {
-        reject(new Error(`${label} exited with ${code ?? signal}\n${output().slice(-4_000)}`));
+        reject(new Error(`${label} exited with ${code ?? signal}\n${output()}`));
       } else if (output().includes(broadTraceWarning)) {
-        reject(new Error(`${label} emitted a broad filesystem trace warning\n${output().slice(-4_000)}`));
+        reject(new Error(`${label} emitted a broad filesystem trace warning\n${output()}`));
       } else {
         resolve();
       }

--- a/src/lib/server/client-v1/conformance-compatibility.test.ts
+++ b/src/lib/server/client-v1/conformance-compatibility.test.ts
@@ -80,6 +80,10 @@ test("conformance builds keep Turbopack and start from a clean plugin runtime", 
     path.join(process.cwd(), "scripts/build-conformance.mjs"),
     "utf8",
   );
+  const compatibilityHarness = readFileSync(
+    path.join(process.cwd(), "scripts/client-v1-compatibility-control.integration.test.mjs"),
+    "utf8",
+  );
   const manifest = JSON.parse(
     readFileSync(path.join(process.cwd(), "package.json"), "utf8"),
   ) as { scripts?: Record<string, string> };
@@ -90,6 +94,11 @@ test("conformance builds keep Turbopack and start from a clean plugin runtime", 
 
   assert.match(script, /\["pnpm@10\.34\.0", "build"\]/);
   assert.match(script, /NODE_OPTIONS:\s*"--max-old-space-size=6144"/);
+  assert.match(
+    compatibilityHarness,
+    /env\.NODE_OPTIONS = "--max-old-space-size=6144"/,
+    "both packaged compatibility builds need the macOS runner's proven V8 heap ceiling",
+  );
   assert.match(
     script,
     /rmSync\(path\.join\(repositoryRoot, "\.next"\), \{ recursive: true, force: true \}\)/,


### PR DESCRIPTION
## Summary
- apply the existing 6 GiB packaged-build V8 ceiling to the normal compatibility artifact as well as the conformance artifact
- retain the complete bounded build-output tail so V8 failures do not lose their diagnostic header
- pin the shared heap requirement in conformance regression coverage

## Root cause
The immutable `v0.3.13-rc.2` run failed twice only on `macos-15` while the normal packaged compatibility build entered Next.js TypeScript checking. That build bypassed both existing macOS heap protections: `scripts/build-conformance.mjs` pins 6 GiB and `scripts/sidecar-bundle.sh` pins 4 GiB, but the harness invoked ordinary `pnpm build` with the runner-derived default. The repository already records that this bounded runner default is insufficient for the TypeScript phase.

## Validation
- exact Node 24.18.0 arm64 packaged normal/conformance compatibility journey
- complete conformance suite
- focused regression test and syntax/diff checks
- clean code review

Failed candidate: https://github.com/OpenCoven/coven-cave/actions/runs/33596906601