### PR TITLE
Drop the session initiator chip from chat rows

### DIFF
--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -295,10 +295,24 @@ assert.doesNotMatch(
   "The old 40% muted-ink mix (~3:1 on dark, ~2.5:1 on light) must not return",
 );
 
+// The initiator pill left the chat row (cave-dkdev follow-up): session-list-merge
+// defaults every Cave conversation to {kind:"human", label:"Cave user"}, so the
+// chip read "Cave user" on every row — and "Unknown" wherever the field was
+// absent. A chip identical down the whole column spends horizontal budget to say
+// nothing, which is the critique this surface was rebuilt around. Origin stays,
+// because it actually varies. Not across the whole enum — CHAT_HIDDEN_ORIGINS
+// drops cron/heartbeat/canvas/journal/enhance from this list — but chat,
+// mention, board and call all reach a row, which is four more values than the
+// initiator chip ever showed.
+assert.doesNotMatch(
+  source,
+  /<SessionInitiatorChip/,
+  "the chat row must not reintroduce the constant initiator pill",
+);
 assert.match(
   source,
-  /<SessionInitiatorChip initiator=\{s\.initiator\} \/>/,
-  "Chat rows should render the session initiator attribution pill",
+  /\{s\.origin \? <OriginChip origin=\{s\.origin\} \/> : null\}/,
+  "…while the origin pill, which does vary between rows, stays",
 );
 assert.doesNotMatch(
   globals,

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -10,7 +10,6 @@ import { modelIcon, modelLabel } from "@/lib/model-label";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { useIsMobile, useIsCoarsePointer } from "@/lib/use-viewport";
 import { OriginChip } from "@/components/ui/origin-chip";
-import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
 import { SessionStatusPill } from "@/components/ui/session-status-pill";
 import { sessionPrStatus } from "@/lib/session-pr-status";
 import { requestDebugOpen } from "@/lib/chat-debug-store";
@@ -1695,8 +1694,23 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                                 {rowFamiliarName}
                                 {project ? ` · ${project}` : ""}
                               </span>
+                              {/* Origin stays; the initiator chip beside it went.
+                                  session-list-merge defaults every Cave
+                                  conversation to {kind:"human", label:"Cave
+                                  user"}, so the initiator read "Cave user" on
+                                  every row — and "Unknown" wherever the field
+                                  was absent. A chip identical down the whole
+                                  column is horizontal budget spent to say
+                                  nothing, which is the critique this surface was
+                                  rebuilt around.
+
+                                  Origin does vary, though NOT across the whole
+                                  enum: CHAT_HIDDEN_ORIGINS drops cron,
+                                  heartbeat, canvas, journal and enhance from
+                                  this list entirely, so what a row can actually
+                                  show is chat / mention / board / call. Four
+                                  values is still four more than one. */}
                               {s.origin ? <OriginChip origin={s.origin} /> : null}
-                              <SessionInitiatorChip initiator={s.initiator} />
                               {s.model ? (
                                 <span
                                   className="chat-list-row-model inline-flex shrink-0 items-center gap-0.5 rounded-[var(--radius-control)] bg-[var(--bg-raised)]/70 px-1 py-px text-[length:var(--text-2xs)] font-medium text-[var(--text-muted)]"

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -1694,22 +1694,10 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                                 {rowFamiliarName}
                                 {project ? ` · ${project}` : ""}
                               </span>
-                              {/* Origin stays; the initiator chip beside it went.
-                                  session-list-merge defaults every Cave
-                                  conversation to {kind:"human", label:"Cave
-                                  user"}, so the initiator read "Cave user" on
-                                  every row — and "Unknown" wherever the field
-                                  was absent. A chip identical down the whole
-                                  column is horizontal budget spent to say
-                                  nothing, which is the critique this surface was
-                                  rebuilt around.
-
-                                  Origin does vary, though NOT across the whole
-                                  enum: CHAT_HIDDEN_ORIGINS drops cron,
-                                  heartbeat, canvas, journal and enhance from
-                                  this list entirely, so what a row can actually
-                                  show is chat / mention / board / call. Four
-                                  values is still four more than one. */}
+                              {/* Origin only. The initiator chip that sat here
+                                  was constant down the whole column, so it cost
+                                  row width to say nothing; see
+                                  chat-list-delete.test.ts for the why. */}
                               {s.origin ? <OriginChip origin={s.origin} /> : null}
                               {s.model ? (
                                 <span


### PR DESCRIPTION
The session initiator chip said the same thing on every row.

`session-list-merge.ts:162` defaults every Cave conversation to `{kind:"human", label:"Cave user"}`, so in production the chip read **"Cave user" on every row** — and **"Unknown"** wherever the field was absent, which is how it appeared against seeded data. Either way it was identical down the whole column: horizontal budget spent to say nothing, on the surface [#5283](https://github.com/OpenCoven/coven-cave/pull/5283) rebuilt around exactly that critique. The interface study named this pair (`chat` / `Cave user / Cave`) as constant chrome to remove; #5283 dropped the absolute date and the duplicate timestamps but left this one.

## Origin stays

It genuinely varies — though **not across the whole enum**, and my first version of this comment claimed it did. `CHAT_HIDDEN_ORIGINS` drops `cron`, `heartbeat`, `canvas`, `journal` and `enhance` from this list entirely, so what a row can actually show is `chat` / `mention` / `board` / `call`. Four values, which is four more than the initiator chip ever had, and enough to tell a board-started run from a chat one.

No attribution is lost that the row was really carrying: the initiator's only non-constant states (`familiar`, `system`) correspond to origins this list already filters out.

## Verification

Driven in the running app with `initiator` populated the way the merge layer really populates it, rather than left absent — otherwise the check would only have proven the empty-field case:

- `initiatorChips: 0`
- `originChips: ["chat", "chat", "chat", "board"]` — still distinguishing
- row meta now reads `Running · open 40m 00s · +53 −6 · Nova · repo · chat · GPT-5`

`tsc` clean; the `chat-list-*` suites pass. The pin in `chat-list-delete.test.ts` that required the chip is inverted rather than deleted, so it now fails if the constant chip returns, and separately asserts the origin chip stays.
