### PR TITLE
Prevent exponential findings prefix parsing

### DIFF
--- a/src/lib/research-findings-doc.test.ts
+++ b/src/lib/research-findings-doc.test.ts
@@ -166,6 +166,19 @@ and URL https://x.test/[S95] stay distinct.
   assert.deepEqual(doc.refIds, ["S99"]);
 });
 
+test("malformed nested quote prefixes are rejected without exponential backtracking", () => {
+  const input = `${"> ".repeat(26)}x\`\`\` [S1]`;
+  const startedAt = performance.now();
+  const spans = parseInline(input, SOURCES);
+  const elapsedMs = performance.now() - startedAt;
+
+  assert.deepEqual(refIds(spans), ["S1"]);
+  assert.ok(
+    elapsedMs < 150,
+    `malformed container prefix took ${elapsedMs.toFixed(1)}ms to reject`,
+  );
+});
+
 test("conflicting/rejected source refs carry warn/muted tones", () => {
   const spans = parseInline("see S6 and R1 and S14", SOURCES);
   const byId = new Map(

--- a/src/lib/research-findings-doc.ts
+++ b/src/lib/research-findings-doc.ts
@@ -145,6 +145,59 @@ function backtickRunLength(input: string, index: number): number {
   return length;
 }
 
+function isUnsupportedContainerPrefix(prefix: string): boolean {
+  let cursor = 0;
+  let foundMarker = false;
+  const skipHorizontalWhitespace = () => {
+    while (prefix[cursor] === " " || prefix[cursor] === "\t") cursor += 1;
+  };
+
+  while (cursor < prefix.length) {
+    skipHorizontalWhitespace();
+    if (cursor === prefix.length) return foundMarker;
+
+    if (prefix[cursor] === ">") {
+      foundMarker = true;
+      cursor += 1;
+      skipHorizontalWhitespace();
+      continue;
+    }
+
+    if (
+      prefix[cursor] === "-" ||
+      prefix[cursor] === "+" ||
+      prefix[cursor] === "*"
+    ) {
+      cursor += 1;
+      if (prefix[cursor] !== " " && prefix[cursor] !== "\t") return false;
+      foundMarker = true;
+      skipHorizontalWhitespace();
+      continue;
+    }
+
+    const digitStart = cursor;
+    while (
+      cursor - digitStart < 9 &&
+      prefix[cursor] >= "0" &&
+      prefix[cursor] <= "9"
+    ) {
+      cursor += 1;
+    }
+    if (
+      cursor === digitStart ||
+      (prefix[cursor] !== "." && prefix[cursor] !== ")")
+    ) {
+      return false;
+    }
+    cursor += 1;
+    if (prefix[cursor] !== " " && prefix[cursor] !== "\t") return false;
+    foundMarker = true;
+    skipHorizontalWhitespace();
+  }
+
+  return foundMarker;
+}
+
 function isUnsupportedContainerFenceRun(
   input: string,
   index: number,
@@ -157,9 +210,7 @@ function isUnsupportedContainerFenceRun(
   return (
     (index === lineStart && /\s/.test(input[index + runLength] ?? "")) ||
     /^[ \t]+$/.test(prefix) ||
-    /^(?:[ \t]*(?:>[ \t]?|(?:[-+*]|\d{1,9}[.)])[ \t]+))+[ \t]*$/.test(
-      prefix,
-    )
+    isUnsupportedContainerPrefix(prefix)
   );
 }
 


### PR DESCRIPTION
## Summary
- replace the ambiguous container-prefix regex with a linear scanner
- preserve quote, bullet, ordered-list, and whitespace prefix behavior
- add an adversarial runtime regression that keeps following references visible

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` (1,418 files)
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all pnpm test:api` (471 files)
- `pnpm check:tests-wired` (2,004 files)
- scanner/regex equivalence probe over 500,000 generated prefixes plus edge cases

Bead: `cave-p9ecg`