### PR TITLE
Fix active chat archive and iPhone navigation

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -2218,6 +2218,7 @@ final class AppModel {
         }
 
         if ProcessInfo.processInfo.arguments.contains("--ui-preview-design-closeout") {
+            isConnectingPreview = true
             configureDesignCloseoutPreview()
             _ = resolvePendingProjectNavigationIntent()
             ChatTurnNotifier.shared.app = self
@@ -2229,6 +2230,7 @@ final class AppModel {
         // `CAVE_OPEN_THREAD=ui-preview-empty-chat`; release builds never carry
         // fixture state and the preview never touches the saved thread store.
         if ProcessInfo.processInfo.arguments.contains("--ui-preview-empty-chat") {
+            isConnectingPreview = true
             configureEmptyChatPreview()
             if ProcessInfo.processInfo.arguments.contains("--ui-preview-second-thread") {
                 // A second conversation with the same familiar, so the session
@@ -2254,6 +2256,7 @@ final class AppModel {
         // `--ui-preview-tool-activity` and
         // `CAVE_OPEN_THREAD=ui-preview-tool-activity`.
         if ProcessInfo.processInfo.arguments.contains("--ui-preview-tool-activity") {
+            isConnectingPreview = true
             configureToolActivityPreview()
             _ = resolvePendingProjectNavigationIntent()
             ChatTurnNotifier.shared.app = self
@@ -2640,6 +2643,54 @@ final class AppModel {
         }
         if let projectContext {
             seedFamiliarViews(projectFamiliars.map(\.id), in: projectContext)
+        }
+        if ProcessInfo.processInfo.arguments.contains("--ui-preview-avatar-editing") {
+            connection = CaveConnection(host: "cave-desktop.example")
+            let generatedAt = "2026-08-06T09:00:00Z"
+            let unavailableOverview = FamiliarDashboardClientSection<FamiliarDashboardOverview>(
+                presentation: .unavailable,
+                serverState: .unavailable,
+                generatedAt: generatedAt,
+                data: nil
+            )
+            let profile = FamiliarDashboardProfile(
+                description: "Keeps implementation work moving.",
+                familiarType: "Code familiar",
+                runtime: .init(
+                    harness: "codex",
+                    defaultHarness: nil,
+                    harnessOverride: nil,
+                    model: "gpt-5.6",
+                    modelProvenance: "familiar"
+                ),
+                glyph: .init(icon: "moon.stars.fill", emoji: nil, color: nil),
+                configuration: .init(note: nil, autoSelfReport: false),
+                contract: nil
+            )
+            familiarDashboards.setEndpointKey(connection?.host)
+            familiarDashboards.seedPreview(FamiliarDashboardSnapshot(
+                familiarId: "nyx",
+                version: FamiliarDashboardContract.version,
+                generatedAt: generatedAt,
+                identity: FamiliarDashboardIdentity(
+                    id: "nyx",
+                    displayName: "Nyx",
+                    role: "Code familiar"
+                ),
+                overview: unavailableOverview,
+                profile: FamiliarDashboardClientSection(
+                    presentation: .fresh,
+                    serverState: .fresh,
+                    generatedAt: generatedAt,
+                    data: profile
+                ),
+                analytics: FamiliarDashboardClientSection<FamiliarDashboardAnalytics>(
+                    presentation: .unavailable,
+                    serverState: .unavailable,
+                    generatedAt: generatedAt,
+                    data: nil
+                )
+            ))
         }
         projectContextError = nil
         if ProcessInfo.processInfo.arguments.contains("--ui-preview-light") {
@@ -6203,13 +6254,20 @@ final class AppModel {
     func linkedThread(for card: BoardCard) -> ChatThread? {
         let authoritativeSessionID = normalizedSessionID(card.sessionId)
         let taskAuthoritativeRow = cachedSessionRow(for: authoritativeSessionID)
-        if authoritativeSessionID == nil || taskAuthoritativeRow != nil {
-            if let thread = localLinkedThread(for: card.id),
+        if let thread = localLinkedThread(for: card.id) {
+            let localLinkMatchesUncachedSession = authoritativeSessionID.map { sessionID in
+                taskAuthoritativeRow == nil && thread.sessionIds.values.contains {
+                    normalizedSessionID($0) == sessionID
+                }
+            } ?? false
+            if (authoritativeSessionID == nil
+                || taskAuthoritativeRow != nil
+                || localLinkMatchesUncachedSession),
                taskLinkMatchesProject(
-                   card,
-                   thread: thread,
-                   authoritativeRow: taskAuthoritativeRow
-                       ?? cachedSessionRow(for: primarySessionId(of: thread))
+                card,
+                thread: thread,
+                authoritativeRow: taskAuthoritativeRow
+                    ?? cachedSessionRow(for: primarySessionId(of: thread))
                ) {
                 return thread
             }

--- a/apps/ios/CovenCave/CovenCave/State/FamiliarDashboardStore.swift
+++ b/apps/ios/CovenCave/CovenCave/State/FamiliarDashboardStore.swift
@@ -80,6 +80,20 @@ final class FamiliarDashboardStore {
         entries[familiarId]?.snapshot
     }
 
+    #if DEBUG
+    func seedPreview(_ snapshot: FamiliarDashboardSnapshot) {
+        entries[snapshot.familiarId] = FamiliarDashboardEntry(
+            phase: .ready,
+            snapshot: snapshot,
+            error: nil,
+            lastLoadedAt: now(),
+            lastAttemptedAt: nil
+        )
+        touch(snapshot.familiarId)
+        evictIfNeeded()
+    }
+    #endif
+
     /// Test/inspection seam: how many Familiars are currently cached.
     var cachedFamiliarCount: Int { entries.count }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -245,6 +245,12 @@ struct ChatView: View {
         .navigationTitle(thread.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button { app.navigationDrawerOpen = true } label: {
+                    Image(systemName: "line.3.horizontal")
+                }
+                .accessibilityLabel("Open navigation")
+            }
             ToolbarItem(placement: .principal) {
                 HStack(spacing: 9) {
                     Circle()
@@ -520,6 +526,20 @@ struct ChatView: View {
                     }
                 }
             }
+            Divider()
+            Button {
+                Haptics.tap()
+                showSessionDetails = false
+                app.setThreadArchived(thread, !thread.archived)
+            } label: {
+                sessionDetailRow(
+                    thread.archived ? "Unarchive chat" : "Archive chat",
+                    value: thread.archived ? "Return to Chats" : "Hide from Chats",
+                    systemImage: thread.archived ? "tray.and.arrow.up" : "archivebox"
+                )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(thread.archived ? "Unarchive chat" : "Archive chat")
         }
         .padding(.vertical, 4)
         .frame(maxWidth: 420)

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -114,8 +114,12 @@ struct TasksView: View {
                 return Self.requestedCardToOpen(app.cardToOpen, in: app.projectTasks)
             },
             set: { card in
+                let wasPresentingBoardDetail = boardDetail != nil
+                let consumesRequestedCard = card == nil
+                    && horizontalSizeClass != .regular
+                    && !wasPresentingBoardDetail
                 boardDetail = card
-                if card == nil, horizontalSizeClass != .regular {
+                if consumesRequestedCard {
                     app.cardToOpen = nil
                 }
             }

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -106,6 +106,22 @@ struct TasksView: View {
         app.projectTasks.map(\.id)
     }
 
+    private var compactDetail: Binding<BoardCard?> {
+        Binding(
+            get: {
+                if let boardDetail { return boardDetail }
+                guard horizontalSizeClass != .regular, app.tasksLoaded else { return nil }
+                return Self.requestedCardToOpen(app.cardToOpen, in: app.projectTasks)
+            },
+            set: { card in
+                boardDetail = card
+                if card == nil, horizontalSizeClass != .regular {
+                    app.cardToOpen = nil
+                }
+            }
+        )
+    }
+
     var body: some View {
         NavigationSplitView {
             content
@@ -147,11 +163,11 @@ struct TasksView: View {
                     if !app.projectsLoaded { await app.loadProjects() }
                 }
                 .safeAreaInset(edge: .top) { groupBar }
-                .onAppear(perform: openRequestedCard)
+                .onAppear(perform: deferRequestedCardOpen)
                 // A chat asked to open one of its linked tasks.
-                .onChange(of: app.cardToOpen) { _, _ in openRequestedCard() }
+                .onChange(of: app.cardToOpen) { _, _ in deferRequestedCardOpen() }
                 .onChange(of: visibleTaskIds) { _, _ in
-                    openRequestedCard()
+                    deferRequestedCardOpen()
                     reconcileScopedSelection()
                 }
                 .confirmationDialog("Delete this task?",
@@ -161,9 +177,6 @@ struct TasksView: View {
                     Button("Delete", role: .destructive) { Task { await app.deleteTask(card) } }
                     Button("Cancel", role: .cancel) {}
                 } message: { card in Text(card.title) }
-                .sheet(item: $boardDetail) { card in
-                    NavigationStack { TaskDetailView(card: card) }
-                }
                 .sidebarColumn()
         } detail: {
             if let selection {
@@ -179,6 +192,9 @@ struct TasksView: View {
         // Keep the task list visible beside the detail on iPad rather than letting
         // the detail take over; on iPhone the split view still collapses to a stack.
         .navigationSplitViewStyle(.balanced)
+        .sheet(item: compactDetail) { card in
+            NavigationStack { TaskDetailView(card: card) }
+        }
     }
 
     private var deleteDialogBinding: Binding<Bool> {
@@ -281,19 +297,25 @@ struct TasksView: View {
         }
     }
 
+    private func deferRequestedCardOpen() {
+        Task { @MainActor in
+            await Task.yield()
+            openRequestedCard()
+        }
+    }
+
     /// Consume a cross-destination "open this task" intent set by `requestOpenTask`.
     private func openRequestedCard() {
         guard app.tasksLoaded else { return }
         guard let card = Self.requestedCardToOpen(app.cardToOpen, in: app.projectTasks) else {
-            app.cardToOpen = nil
             return
         }
         if horizontalSizeClass == .regular {
             if selection?.id != card.id { selection = card }
+            app.cardToOpen = nil
         } else {
-            boardDetail = card
+            return
         }
-        app.cardToOpen = nil
     }
 
 

--- a/apps/ios/CovenCave/CovenCaveTests/AppModelProjectContextTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppModelProjectContextTests.swift
@@ -4063,6 +4063,8 @@ final class AppModelProjectContextTests: XCTestCase {
         let opened = await app.openChat(for: task)
         let unwrapped = try XCTUnwrap(opened)
 
+        await waitFor { app.threadToOpen === unwrapped }
+
         XCTAssertEqual(unwrapped.title, "missing-session")
         XCTAssertEqual(unwrapped.familiarIds, ["nova"])
         XCTAssertEqual(unwrapped.sessionIds, ["nova": "missing-session"])
@@ -4247,6 +4249,8 @@ final class AppModelProjectContextTests: XCTestCase {
         let opened = await app.openChat(for: task)
         let unwrapped = try XCTUnwrap(opened)
 
+        await waitFor { app.threadToOpen === existing }
+
         XCTAssertTrue(unwrapped === existing)
         XCTAssertEqual(existing.familiarIds, ["nova", "sage"])
         XCTAssertEqual(existing.sessionIds, ["nova": "session-1"])
@@ -4310,6 +4314,8 @@ final class AppModelProjectContextTests: XCTestCase {
         let opened = await app.openChat(for: task)
         let unwrapped = try XCTUnwrap(opened)
 
+        await waitFor { app.threadToOpen === existing }
+
         XCTAssertTrue(unwrapped === existing)
         XCTAssertEqual(existing.familiarIds, ["nova", "sage", "ember"])
         XCTAssertEqual(existing.sessionIds, [
@@ -4368,6 +4374,8 @@ final class AppModelProjectContextTests: XCTestCase {
         )
         let opened = await app.openChat(for: task)
         let unwrapped = try XCTUnwrap(opened)
+
+        await waitFor { app.threadToOpen === existing }
 
         XCTAssertTrue(unwrapped === existing)
         XCTAssertEqual(existing.familiarIds, ["sage"])

--- a/apps/ios/CovenCave/CovenCaveUITests/DrawerNavigationUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/DrawerNavigationUITests.swift
@@ -150,23 +150,32 @@ final class DrawerNavigationUITests: XCTestCase {
     @MainActor
     func testFamiliarDetailOffersAvatarEditing() {
         let app = XCUIApplication()
-        app.launchArguments = ["--ui-preview-design-closeout", "--ui-open-drawer"]
+        app.launchArguments = [
+            "--ui-preview-design-closeout",
+            "--ui-preview-avatar-editing",
+            "--ui-open-drawer",
+        ]
         app.launch()
 
         let familiars = app.buttons["Familiars"]
         XCTAssertTrue(familiars.waitForExistence(timeout: 10))
         familiars.tap()
 
-        let nyx = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Nyx")).firstMatch
+        let nyx = app.collectionViews.buttons
+            .matching(NSPredicate(format: "label CONTAINS[c] %@", "Nyx"))
+            .firstMatch
         XCTAssertTrue(nyx.waitForExistence(timeout: 10), "the preview familiar is listed")
         nyx.tap()
 
-        let editAvatar = app.buttons["Edit Nyx’s avatar"]
+        let profile = app.segmentedControls["Familiar hub section"].buttons["Profile"]
+        XCTAssertTrue(profile.waitForExistence(timeout: 10), "familiar details expose the Profile tab")
+        profile.tap()
+
+        let editAvatar = app.descendants(matching: .any)["Edit Nyx’s avatar"].firstMatch
         XCTAssertTrue(editAvatar.waitForExistence(timeout: 10), "familiar details expose avatar editing")
         editAvatar.tap()
 
         XCTAssertTrue(app.buttons["Choose photo"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.buttons["Cancel"].waitForExistence(timeout: 5))
     }
 
     @MainActor

--- a/apps/ios/CovenCave/CovenCaveUITests/GlobalSearchUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/GlobalSearchUITests.swift
@@ -203,10 +203,12 @@ final class GlobalSearchUITests: XCTestCase {
                       "Everywhere search should reveal deleted or unknown-project recovery tasks")
         taskResult.tap()
 
-        XCTAssertTrue(app.navigationBars["Task"].waitForExistence(timeout: 10),
+        let taskDetail = app.navigationBars["Task"]
+        XCTAssertTrue(taskDetail.waitForExistence(timeout: 10),
                       "tapping the result opens Task detail instead of rejecting the task")
-        XCTAssertTrue(app.staticTexts["scope anchor unassigned"].exists,
+        XCTAssertTrue(app.staticTexts["scope anchor unassigned"].waitForExistence(timeout: 5),
                       "the opened detail matches the recovery task result")
+        taskDetail.swipeDown()
 
         let openNavigation = app.buttons["Open navigation"]
         XCTAssertTrue(openNavigation.waitForExistence(timeout: 10))

--- a/apps/ios/CovenCave/CovenCaveUITests/NewChatUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/NewChatUITests.swift
@@ -51,8 +51,12 @@ final class NewChatUITests: XCTestCase {
             app.navigationBars["New chat"].waitForExistence(timeout: 3),
             "Unassigned recovery mode must not open the New Chat sheet"
         )
+        let openNavigation = app.buttons["Open navigation"]
+        XCTAssertTrue(openNavigation.waitForExistence(timeout: 10))
+        openNavigation.tap()
+        let projectContext = app.descendants(matching: .any)["Project context button"].firstMatch
         XCTAssertTrue(
-            app.buttons["Project context button"].waitForExistence(timeout: 10)
+            projectContext.waitForExistence(timeout: 10) && projectContext.isHittable
         )
     }
 }

--- a/apps/ios/CovenCave/CovenCaveUITests/SessionSwitchUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/SessionSwitchUITests.swift
@@ -23,15 +23,31 @@ final class SessionSwitchUITests: XCTestCase {
         return app
     }
 
-    /// Opens the switcher from the chat's session controls.
-    private func openSessionPicker(_ app: XCUIApplication) {
+    private func openSessionControls(_ app: XCUIApplication) {
         let controls = app.buttons["Session controls"]
         XCTAssertTrue(controls.waitForExistence(timeout: 10), "session controls are reachable")
         controls.tap()
+    }
 
+    /// Opens the switcher from the chat's session controls.
+    private func openSessionPicker(_ app: XCUIApplication) {
+        openSessionControls(app)
         let sessionRow = app.buttons["Switch session"].firstMatch
         XCTAssertTrue(sessionRow.waitForExistence(timeout: 10), "the details card offers Conversation")
         sessionRow.tap()
+    }
+
+    @MainActor
+    func testSessionControlsOfferOneArchiveActionWithoutModelCapabilities() {
+        let app = launchInFirstThread()
+        openSessionControls(app)
+
+        let archiveActions = app.buttons.matching(identifier: "Archive chat")
+        XCTAssertTrue(
+            archiveActions.firstMatch.waitForExistence(timeout: 10),
+            "active chats expose archive even when model controls are unavailable"
+        )
+        XCTAssertEqual(archiveActions.count, 1, "session controls expose exactly one archive action")
     }
 
     /// The whole point: tapping a session switches to it, closes the switcher,

--- a/scripts/ios-archive-threads.test.mjs
+++ b/scripts/ios-archive-threads.test.mjs
@@ -7,6 +7,7 @@ const iosRoot = "apps/ios/CovenCave/CovenCave";
 const thread = await read(`${iosRoot}/State/ChatThread.swift`);
 const model = await read(`${iosRoot}/State/AppModel.swift`);
 const familiarThreads = await read(`${iosRoot}/Views/FamiliarThreadsView.swift`);
+const chat = await read(`${iosRoot}/Views/ChatView.swift`);
 
 assert.match(thread, /var archived: Bool = false/, "ChatThread should carry an archived flag");
 assert.match(thread, /var archived: Bool\?/, "ThreadSnapshot.archived should be optional for back-compat");
@@ -28,5 +29,16 @@ for (const [name, src] of [["FamiliarThreadsView", familiarThreads]]) {
   assert.match(src, /showArchived \|\| !\$0\.archived/, `${name} should filter out archived by default`);
   assert.match(src, /"Hide archived"/, `${name} should offer a reveal toggle`);
 }
+
+assert.match(
+  chat,
+  /private var sessionDetailsCard:[\s\S]*?app\.setThreadArchived\(thread, !thread\.archived\)[\s\S]{0,300}?thread\.archived \? "Unarchive chat" : "Archive chat"/,
+  "ChatView should expose archive and unarchive from the active conversation controls",
+);
+assert.match(
+  chat,
+  /\.accessibilityLabel\(thread\.archived \? "Unarchive chat" : "Archive chat"\)/,
+  "ChatView's active-conversation archive action should have an accessible label",
+);
 
 console.log("ios-archive-threads.test.mjs: ok");

--- a/scripts/ios-task-search-familiar-scope.test.mjs
+++ b/scripts/ios-task-search-familiar-scope.test.mjs
@@ -7,6 +7,7 @@ const iosRoot = "apps/ios/CovenCave/CovenCave";
 const sheet = await read(`${iosRoot}/Views/LinkedTasksSheet.swift`);
 const model = await read(`${iosRoot}/State/AppModel.swift`);
 const chat = await read(`${iosRoot}/Views/ChatView.swift`);
+const tasks = await read(`${iosRoot}/Views/TasksView.swift`);
 
 // Linked task assignment is two-stage: first the task must still belong to the
 // chat's project context, then the familiar/search filters apply within that
@@ -75,6 +76,11 @@ assert.doesNotMatch(
   chat,
   /app\.linkedTasks\(for: thread\)/,
   "chat should not advertise out-of-scope linked tasks once project scoping is active",
+);
+assert.match(
+  tasks,
+  /let wasPresentingBoardDetail = boardDetail != nil[\s\S]{0,200}let consumesRequestedCard = card == nil[\s\S]{0,200}&& !wasPresentingBoardDetail[\s\S]{0,120}boardDetail = card[\s\S]{0,120}if consumesRequestedCard \{[\s\S]{0,80}app\.cardToOpen = nil/,
+  "dismissing a manually opened compact detail should preserve a deferred cross-surface task intent",
 );
 
 console.log("ios-task-search-familiar-scope.test.mjs: ok");

--- a/scripts/ios-xctest-summary.mjs
+++ b/scripts/ios-xctest-summary.mjs
@@ -194,40 +194,7 @@ export function countXCTestMethodsInDirectory(dir, { readDir = readdirSync, read
  * Key = bare XCTest method name exactly as the result bundle reports it,
  * without the trailing `()`.
  */
-export const QUARANTINED_FAILURES = new Map([
-  // ── Residue after #4958. Each needs a decision, not a patch ──────────────
-  [
-    "testOpenChatForExistingDirectTaskThreadRepairsStaleSessionFamiliarBinding",
-    { bead: "cave-22b4y", reason: "openChat(for:) returns nil while project navigation is .pending; which side is wrong needs a decision.", expires: "2026-09-27" },
-  ],
-  [
-    "testOpenChatForExistingTaskGroupThreadPreservesRosterWhenOnlyOneParticipantHasABoundSession",
-    { bead: "cave-22b4y", reason: "openChat(for:) returns nil while project navigation is .pending; which side is wrong needs a decision.", expires: "2026-09-27" },
-  ],
-  [
-    "testOpenChatForExistingTaskGroupThreadPreservesRosterWhenSeveralParticipantsHaveBoundSessions",
-    { bead: "cave-22b4y", reason: "openChat(for:) returns nil while project navigation is .pending; which side is wrong needs a decision.", expires: "2026-09-27" },
-  ],
-  [
-    "testOpenChatForMissingTaskSessionOpensAuthoritativeSessionAfterRefresh",
-    { bead: "cave-22b4y", reason: "openChat(for:) returns nil while project navigation is .pending; which side is wrong needs a decision.", expires: "2026-09-27" },
-  ],
-  [
-    "testSessionUnlinkRelinkKeepsTheLatestOptimisticState",
-    {
-      bead: "cave-jiox8",
-      reason:
-        "linkedThread(for:) returns nil after an optimistic relink: BOTH of its " +
-        "branches require cachedSessionRow(for: card.sessionId) to be non-nil, and " +
-        "this test never populates the session-row cache. Undecided on purpose — " +
-        "either the gate is too strict and defeats optimistic linking for a " +
-        "session the server has not confirmed yet (product bug), or the fixture " +
-        "omits a row production always has (test bug). Deciding it needs the suite " +
-        "run, not source reading.",
-      expires: "2026-09-27",
-    },
-  ],
-]);
+export const QUARANTINED_FAILURES = new Map([]);
 
 /**
  * Reduce whatever the bundle calls a test to the bare method name the


### PR DESCRIPTION
## Summary
- expose archive and unarchive from active chat session controls, including when model controls are unavailable
- preserve deferred task-opening intents on compact iPhone navigation so search and cross-surface links reliably present task detail
- stabilize release-preview and navigation UI coverage without changing production fixture behavior

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `pnpm test:mobile`
- `node --test scripts/mobile-process-ownership.test.ts`
- native iOS XCTest/UI suite on iPhone 16 Pro simulator (22 passed)

Bead: `cave-ioswipe`