### PR TITLE
docs(plans): reconcile live program status

### DIFF
--- a/docs/roadmaps/coven-automations-v1.mapping.json
+++ b/docs/roadmaps/coven-automations-v1.mapping.json
@@ -1,8 +1,9 @@
 {
   "schemaVersion": "opencoven.automation-program-map/v1",
   "programId": "coven-automations-v1",
-  "generatedAt": "2026-09-01T20:56:00Z",
-  "status": "live-beads-seeded; remote-synchronized; verified",
+  "generatedAt": "2026-09-04T04:39:00Z",
+  "status": "live-state-audited; seed-sync-evidence-historical",
+  "lastLiveAudit": "2026-09-04T04:39:00Z",
   "program": {
     "github": "OpenCoven/coven#854",
     "beadId": "cave-hlv.9",
@@ -22,6 +23,7 @@
     "history": "Seeded 2026-09-01. The execution graph was seeded and dependency-verified in Cave's canonical embedded Dolt database `cave`, its blocks/dependsOn projections reconciled to the exact inverse of the live `bd dep` edges, and the graph synchronized to the shared remote refs/dolt/data (pnpm beads:sync pull+push exit 0; local embedded Dolt `main` == `remotes/origin/main` == thpoaq91d1nmqaas4lk6hhcs217foge2; empty `dolt diff --summary`; refs/dolt/data == 7855b5bcb436bf4ac062c1c24c966f1450971e95; no force-push). Reconciled and closed-verified once the reconciliation PR referencing OpenCoven/coven-cave#5220 merged; the exact PR URL and merge SHA are recorded in the cave-tmegk bead close reason and on OpenCoven/coven-cave#5220."
   },
   "sync": {
+    "snapshotAt": "2026-09-01T20:56:00Z",
     "beadsTool": "bd 1.3.0-rc.1 (schema v66 capable)",
     "beadSchemaVersion": 1,
     "doltSchemaVersion": 66,
@@ -33,8 +35,9 @@
     "localDurability": "verified: 15 program beads (seed + 14 outcomes) and 30 in-program blocked-first edges committed to the canonical embedded Dolt database `cave`; local `main` == `remotes/origin/main` == thpoaq91d1nmqaas4lk6hhcs217foge2.",
     "remoteRef": "refs/dolt/data",
     "remoteOid": "7855b5bcb436bf4ac062c1c24c966f1450971e95",
-    "remoteSyncStatus": "synchronized: the documented wrapper `pnpm beads:sync` completed pull+push (exit 0) on 2026-09-01. Local embedded Dolt `main` and `remotes/origin/main` are equal at thpoaq91d1nmqaas4lk6hhcs217foge2, `dolt diff --summary remotes/origin/main main` is empty, and the shared remote `refs/dolt/data` is at 7855b5bcb436bf4ac062c1c24c966f1450971e95 (identical before and after the run; the push was a fast-forward no-op because the shared history already carried these bead commits). No force-push occurred and no concurrent Dolt commit was discarded.",
-    "remoteSyncEvidence": "git ls-remote origin refs/dolt/data == 7855b5bcb436bf4ac062c1c24c966f1450971e95 before and after a successful `pnpm beads:sync` (exit 0, 2026-09-01); local Dolt `main` == `remotes/origin/main` == thpoaq91d1nmqaas4lk6hhcs217foge2; `dolt diff --summary remotes/origin/main main` empty; graph re-verified (15 beads, 30 in-program blocked-first edges, none missing).",
+    "remoteSyncStatus": "historical snapshot: the documented wrapper `pnpm beads:sync` completed pull+push (exit 0) on 2026-09-01. Local embedded Dolt `main` and `remotes/origin/main` were equal at thpoaq91d1nmqaas4lk6hhcs217foge2, `dolt diff --summary remotes/origin/main main` was empty, and the shared remote `refs/dolt/data` was at 7855b5bcb436bf4ac062c1c24c966f1450971e95. No force-push occurred and no concurrent Dolt commit was discarded.",
+    "remoteSyncEvidence": "Historical 2026-09-01 evidence: git ls-remote origin refs/dolt/data == 7855b5bcb436bf4ac062c1c24c966f1450971e95 before and after a successful `pnpm beads:sync` (exit 0); local Dolt `main` == `remotes/origin/main` == thpoaq91d1nmqaas4lk6hhcs217foge2; `dolt diff --summary remotes/origin/main main` empty; graph re-verified (15 beads, 30 in-program blocked-first edges, none missing).",
+    "currentRemoteObservation": "Read-only audit on 2026-09-04 observed refs/dolt/data at 11c53114f4e6b79029f806ea88e57db01a13585b. No sync or current local/remote equality check was performed.",
     "knownToolingLimitations": [
       "The canonical embedded Dolt database is at schema v66, so every `bd` command requires a v66-capable client (bd 1.3.0-rc.1). Homebrew `bd` 1.2.2 (schema v53) cannot operate on it and must not be used.",
       "`pnpm beads:doctor` (`bd doctor && bd lint`) exits 1: `bd doctor` is not yet supported in embedded mode, and `bd lint` reports a repository-wide template-convention backlog (57 issues / 63 warnings, e.g. missing '## Acceptance Criteria') that also covers the Automations v1 outcome beads. It is an advisory convention, not a CI gate, and was recorded rather than weakened.",
@@ -71,7 +74,12 @@
       "priority": "P0",
       "github": "OpenCoven/coven#859",
       "beadId": "cave-hlv.10",
-      "state": "open",
+      "state": "closed-verified",
+      "evidence": [
+        "OpenCoven/coven#859 closed 2026-09-03",
+        "Bead cave-hlv.10 closed after program-control acceptance",
+        "OpenCoven/coven#910 merged as 329717d8d9edcfca4ea98800392fbf683613ec92"
+      ],
       "dependsOn": [],
       "blocks": [
         "release-go-no-go",
@@ -103,7 +111,7 @@
       "priority": "P0",
       "github": "OpenCoven/coven#855",
       "beadId": "cave-tm1y0",
-      "state": "open",
+      "state": "in_progress",
       "dependsOn": [
         "foundation"
       ],
@@ -134,7 +142,12 @@
       "priority": "P0",
       "github": "OpenCoven/familiar-contract#17",
       "beadId": "cave-6jswi",
-      "state": "open",
+      "state": "closed-verified",
+      "evidence": [
+        "OpenCoven/familiar-contract#17 closed 2026-09-03",
+        "OpenCoven/familiar-contract#19 merged as 13d150a32a817da19bb4e5053f2205b15db0bb0a",
+        "Bead cave-6jswi closed with immutable merge evidence"
+      ],
       "dependsOn": [
         "foundation"
       ],
@@ -149,7 +162,12 @@
       "priority": "P0",
       "github": "OpenCoven/coven-threads#29",
       "beadId": "cave-m9tw3",
-      "state": "open",
+      "state": "closed-verified",
+      "evidence": [
+        "OpenCoven/coven-threads#29 closed 2026-09-03",
+        "OpenCoven/coven-threads#35 merged as c3bd46bcadb6396db8436c47411a4d0eac17192b",
+        "Bead cave-m9tw3 closed after authority-profile conformance"
+      ],
       "dependsOn": [
         "familiar-embodiment"
       ],
@@ -265,7 +283,8 @@
       "priority": "P0",
       "github": "OpenCoven/coven#854",
       "beadId": "cave-hlv.9",
-      "state": "blocked",
+      "state": "open",
+      "disposition": "blocked-by-open-dependencies",
       "dependsOn": [
         "program-control",
         "foundation",
@@ -289,7 +308,7 @@
     "method": "bd dep list <id> --direction down --json across all 15 program beads; the blocks projections in this file are the exact inverse of those live edges, and every outcome's dependsOn equals its live down-edges.",
     "cycles": "none (bd dep cycles -> 'No dependency cycles detected')",
     "parentEpicEdges": "cave-hlv.9 and cave-hlv.10 additionally carry a parent-child edge to cave-hlv, the pre-existing familiar-issue-tracking epic they are children of. That hierarchy edge is outside the Automations v1 program set and is not a v1 release blocker, so it is excluded from the 30 in-program blocked-first edges.",
-    "verifiedAt": "2026-09-01T20:56:00Z"
+    "verifiedAt": "2026-09-04T04:39:00Z"
   },
   "releaseGates": {
     "A": "durable-local-scheduler",
@@ -299,9 +318,8 @@
   },
   "nextAction": {
     "github": [
-      "OpenCoven/coven#855",
-      "OpenCoven/familiar-contract#17"
+      "OpenCoven/coven#855"
     ],
-    "description": "Task 1 reconciliation is complete: the 15 canonical program beads and their 30 in-program blocked-first edges are seeded, dependency-verified (both directions), acyclic, and synchronized to the shared Dolt remote refs/dolt/data; the seed bead cave-tmegk is closed-verified and OpenCoven/coven-cave#5220 is closed. Begin the first ready outcomes: OpenCoven/coven#855 (protocol, bead cave-tm1y0) and OpenCoven/familiar-contract#17 (familiar embodiment, bead cave-6jswi), both reported ready by `bd ready`. Coven-side tracker mapping is reconciled under OpenCoven/coven#859 (PRs OpenCoven/coven#900 and #901)."
+    "description": "Task 1 and program control are closed. Continue OpenCoven/coven#855 (Bead cave-tm1y0), currently in progress. Familiar embodiment OpenCoven/familiar-contract#17 / cave-6jswi and automation authority OpenCoven/coven-threads#29 / cave-m9tw3 are closed-verified. OpenCoven/coven#856 remains open and dependency-blocked while protocol work continues; OpenCoven/coven#922 is active work, not terminal evidence."
   }
 }

--- a/docs/roadmaps/coven-automations-v1.md
+++ b/docs/roadmaps/coven-automations-v1.md
@@ -1,7 +1,9 @@
 # Coven Automations v1 operational roadmap
 
 **Status:** Approved for execution  
-**Last reconciled:** 2026-09-01  
+**Last live-state audit:** 2026-09-04
+
+**Seed reconciliation:** 2026-09-01
 **Program outcome:** `OpenCoven/coven#854` (Bead `cave-hlv.9`)  
 **Seed task:** `OpenCoven/coven-cave#5220` (Bead `cave-tmegk`)  
 **Execution queue:** Cave's embedded-Dolt Beads graph — seeded and dependency-verified (15 beads)  
@@ -47,9 +49,9 @@ That foundation is not yet a certified automation protocol. The remaining releas
 
 | Priority | Outcome | GitHub | Bead | Current disposition |
 | --- | --- | --- | --- | --- |
-| P0 | Coven Automations v1 program and release rollup | `OpenCoven/coven#854` | `cave-hlv.9` | Open; canonical program/release-gate outcome (rollup only, not catch-all implementation) |
+| P0 | Coven Automations v1 program and release rollup | `OpenCoven/coven#854` | `cave-hlv.9` | Open and dependency-blocked by remaining outcomes; canonical program/release-gate rollup (not catch-all implementation) |
 | P0 | Native durable-routine foundation | `OpenCoven/coven#816` | `cave-stsf7` | **Verified-foundation** (closed): landed via `OpenCoven/coven#896` ("fix: settle automation runs from terminal evidence"), merge `0d8c2004c3557019e39e5e4db70ae34c9d49a65a` on `OpenCoven/coven` main. Fully qualified on purpose: `OpenCoven/coven-cave#896` is an unrelated change. |
-| P0 | Beads/GitHub operational graph and drift control | `OpenCoven/coven#859` | `cave-hlv.10` | Open; canonical Dolt graph seeded |
+| P0 | Beads/GitHub operational graph and drift control | `OpenCoven/coven#859` | `cave-hlv.10` | **Closed-verified** 2026-09-03; program-control acceptance complete |
 
 ### P0 protocol and safety train
 
@@ -113,14 +115,13 @@ all required P0 + supported P1 canaries
 
 ### Execution order
 
-1. **Operationalize the graph.** Complete `coven#859`, reuse Cave's existing Beads infrastructure, map every public outcome exactly once, and establish drift reporting.
-2. **Reconcile the foundation.** Close `coven#816` only after clean-clone, migration, daemon wiring, restart, stale-lease, shared-path, and delivery evidence is attached.
-3. **Ratify the public protocol.** Complete `coven#855` before clients harden hand-authored JSON shapes.
-4. **Parallelize independent foundations.** Progress `coven#856`, `familiar-contract#17`, and `coven-threads#29` against pinned draft artifacts.
-5. **Integrate trust at dispatch.** Complete `coven#857`; do not retain a string-only fallback.
-6. **Certify the core.** Complete `coven#858` against packed/exact artifacts under deterministic, crash, duplicate, security, privacy, and load tests.
-7. **Graduate clients and orchestration.** Land SDK read/verify/subscribe, Cave oversight, and the Psyche adapter against immutable canaries.
-8. **Publish and enforce.** Complete Docs and organization workflows, then produce one exact-release go/no-go evidence packet under `coven#854`.
+1. **Preserve the completed control plane.** `coven#859`, `coven#816`, `familiar-contract#17`, and `coven-threads#29` are closed-verified; do not reopen them absent evidence of new drift.
+2. **Continue the active public protocol work.** `coven#855` / `cave-tm1y0` is claimed and in progress. Complete it before clients harden hand-authored JSON shapes.
+3. **Advance scheduler reliability when its protocol dependency clears.** `coven#856` remains open and dependency-blocked while protocol work continues.
+4. **Integrate trust at dispatch.** Complete `coven#857`; its embodiment and authority prerequisites are closed, while protocol remains open.
+5. **Certify the core.** Complete `coven#858` against packed/exact artifacts under deterministic, crash, duplicate, security, privacy, and load tests.
+6. **Graduate clients and orchestration.** Land SDK read/verify/subscribe, Cave oversight, and the Psyche adapter against immutable canaries.
+7. **Publish and enforce.** Complete Docs and organization workflows, then produce one exact-release go/no-go evidence packet under `coven#854`.
 
 ## 5. Beads operating model
 
@@ -144,12 +145,12 @@ below are confirmed from live Dolt state (`bd show` / `bd dep list`):
 
 ```text
 Coven Automations v1 (release rollup) -> coven#854   = cave-hlv.9   (task, parent cave-hlv)
-Program control / drift               -> coven#859   = cave-hlv.10  (task, parent cave-hlv)
+Program control / drift (closed)      -> coven#859   = cave-hlv.10  (task, parent cave-hlv)
   ├── Foundation (verified, closed)                  -> coven#816              = cave-stsf7
-  ├── Protocol contract                              -> coven#855              = cave-tm1y0
+  ├── Protocol contract (in progress)                -> coven#855              = cave-tm1y0
   ├── Scheduler reliability                          -> coven#856              = cave-1sh6p
-  ├── Familiar embodiment profile                    -> familiar-contract#17   = cave-6jswi
-  ├── Automation authority profile                   -> coven-threads#29       = cave-m9tw3
+  ├── Familiar embodiment profile (closed)           -> familiar-contract#17   = cave-6jswi
+  ├── Automation authority profile (closed)          -> coven-threads#29       = cave-m9tw3
   ├── Coven dispatch/receipt integration             -> coven#857              = cave-dbkng
   ├── Conformance and diagnostics                    -> coven#858              = cave-x28j6
   ├── SDK                                            -> sdk#80                 = cave-90hwl
@@ -269,7 +270,7 @@ bd ready --json
 
 Record before/after Dolt remote OIDs when state is expected to advance. Do not hand-edit `.beads/issues.jsonl`; when an export is committed for review, ensure it is scrubbed of local emails, machine paths, secrets, private transcripts, and sensitive identity/authority data.
 
-**Seed run (2026-09-01).** All 15 program beads (seed `cave-tmegk` plus 14
+**Historical seed run (2026-09-01).** All 15 program beads (seed `cave-tmegk` plus 14
 outcomes) are committed to the canonical embedded Dolt database `cave` and carry
 30 in-program blocked-first edges. The `blocks` projections in the mapping file
 are the exact inverse of the live `bd dep list --direction down` output for all
@@ -278,8 +279,8 @@ cycles` reports no cycles. The two `cave-hlv.9`/`cave-hlv.10` -> `cave-hlv`
 parent-child edges are pre-existing epic hierarchy outside the program set and
 are excluded from the 30.
 
-**Remote propagation is synchronized.** `pnpm beads:sync` — the documented
-wrapper — completed both its pull and push phases and exited 0:
+**Historical remote-propagation evidence (2026-09-01).** `pnpm beads:sync` —
+the documented wrapper — completed both its pull and push phases and exited 0:
 
 ```text
 [beads:sync] pull  -> Pull complete.
@@ -296,7 +297,13 @@ no-op — the shared history already carried these bead commits). The remote was
 re-verified afterward: all 15 beads present, 30 in-program blocked-first edges,
 none missing.
 
-**Known tooling limitations (external, recorded rather than worked around).**
+The 2026-09-04 read-only audit observed `refs/dolt/data` at
+`11c53114f4e6b79029f806ea88e57db01a13585b`. It did not run a sync or compare
+the current local and remote Dolt branches, so the 2026-09-01 equality claim
+above is historical evidence, not a claim about current synchronization.
+
+**Historical tooling observations from 2026-09-01 (external, recorded rather
+than worked around).**
 The canonical embedded Dolt database is at schema v66, so every `bd` command
 requires a v66-capable client (`bd` 1.3.0-rc.1); Homebrew `bd` 1.2.2 (schema
 v53) cannot operate on it. `pnpm beads:doctor` (`bd doctor && bd lint`) exits 1:
@@ -309,14 +316,18 @@ beads missing shared-ownership labels; none of the 15 Automations v1 beads
 appears in that list and each carries exactly one `surface:shared` label.
 
 **Task 1 is reconciled and closed.** The seed bead `cave-tmegk` is
-closed-verified and `OpenCoven/coven-cave#5220` is closed. The next action is to
-start the first ready outcomes — `OpenCoven/coven#855` (protocol, `cave-tm1y0`)
-and `OpenCoven/familiar-contract#17` (familiar embodiment, `cave-6jswi`) — not
-further Task 1 reconciliation.
+closed-verified and `OpenCoven/coven-cave#5220` is closed. Continue the claimed
+protocol outcome `OpenCoven/coven#855` (Bead `cave-tm1y0`), which is in progress.
+Familiar embodiment (`OpenCoven/familiar-contract#17`, `cave-6jswi`) and
+automation authority (`OpenCoven/coven-threads#29`, `cave-m9tw3`) are now
+closed-verified. Scheduler reliability remains open behind the protocol
+dependency.
 
 ## 6. Drift contract
 
-The tracker-control work under `coven#859` and `.github#2` must report at least:
+The completed tracker-control outcome under `coven#859`, together with the
+still-open organization-canaries outcome under `.github#2`, must report at
+least:
 
 - GitHub outcome without exactly one Bead mapping;
 - Bead mapped to multiple public outcomes;

--- a/docs/superpowers/plans/2026-08-30-chat-v1-phase-1-gate-status.md
+++ b/docs/superpowers/plans/2026-08-30-chat-v1-phase-1-gate-status.md
@@ -1,5 +1,18 @@
 # Chat v1 Phase 1 Gate — Working Record Re-Verification (2026-08-30)
 
+> **Current refresh — 2026-09-04:** Phase 1 is closed in canonical Beads:
+> `cave-23nmv` closed on 2026-08-29 with OpenCoven/chat#31,
+> OpenCoven/chat#30, and 15/15
+> real-authority assertions recorded as evidence. GitHub #4833 remains an
+> unrefreshed open mirror; #4780 and #4830 are closed. Actions run
+> `33250233035` succeeded and its secret-scanned report artifact is retained
+> through 2026-09-12. A newer OpenCoven/chat `main` CI run,
+> `33853544991` at `1e8597d3a6195fcce2fa8f76b28dc9bdd9bec985`, also passed
+> the Phase 1 real-authority job and retains its report through 2026-09-18.
+> Chat `main` has advanced again and its newest run is still in progress, so
+> neither result is represented as verification of the current tip. The dated
+> body below is retained as the 2026-08-30 audit record.
+
 Bead `cave-23nmv` · Phase 1 gate · owner Cross-repo ·
 [#4833](https://github.com/OpenCoven/coven-cave/issues/4833).
 

--- a/docs/superpowers/plans/2026-08-30-chat-v1-phase-1-native-discovery-status.md
+++ b/docs/superpowers/plans/2026-08-30-chat-v1-phase-1-native-discovery-status.md
@@ -1,5 +1,15 @@
 # Chat v1 P1 — Native Discovery, Launch, Keychain, and Connection State: Working Record and Claimable Scope
 
+> **Current refresh — 2026-09-04:** Implementation and canonical Phase 1 gate
+> closure are complete. OpenCoven/chat#41 merged on 2026-08-30 and later
+> hardening continued through OpenCoven/chat#55. GitHub #4780 and #4830 are
+> closed, while #4830
+> still lacks an on-issue closure-evidence comment. Treat that as mirror
+> hygiene, not an implementation blocker. OpenCoven/chat CI run `33853544991`
+> at `1e8597d3a6195fcce2fa8f76b28dc9bdd9bec985` passed the Phase 1
+> real-authority job and retains its report through 2026-09-18. Chat `main` has
+> advanced again and its newest run is still in progress.
+
 Bead `cave-tsvfj` · Issue [#4830](https://github.com/OpenCoven/coven-cave/issues/4830) · Phase 1 · owner **Chat** · surface `desktop`
 
 **Verified 2026-08-30.** Every claim below was re-checked read-only against the GitHub API on 2026-08-30. Evidence links carry their own dates. This record supersedes the state line in the #4830 issue body (verified 2026-08-22) and refines the 2026-08-24 reassessment comment ([#4830 comment](https://github.com/OpenCoven/coven-cave/issues/4830#issuecomment-5394655968)).

--- a/docs/superpowers/plans/2026-08-30-chat-v1-phase-1-program-status.md
+++ b/docs/superpowers/plans/2026-08-30-chat-v1-phase-1-program-status.md
@@ -1,5 +1,12 @@
 # Chat v1 Phase 1 — Verified Program Status (Discovery, Pairing, Health, Revocation)
 
+> **Current refresh — 2026-09-04:** Phase 1 is complete in canonical Beads:
+> the implementation beads, `cave-23nmv` gate, and `cave-fz01p` epic are
+> closed with named successful gate evidence. GitHub #4818 and #4833 remain
+> stale open mirrors even though #4780 and #4830 are closed. Remaining work is
+> evidence preservation and mirror reconciliation, not Phase 1 implementation.
+> The 2026-08-30 body below remains the dated audit trail.
+
 **Date of verification:** 2026-08-30 (read-only, all checks against `main` heads and issue state at that date)
 **Refresh:** second pass appended below (2026-08-30T15:00Z) — `cave-tsvfj`/#4830 closed without on-issue evidence; this record set synced upstream via #5211. Verdict unchanged: still NOT MET.
 **Tracker issue:** OpenCoven/coven-cave#4818 · Bead `cave-fz01p` · Phase 1 epic · lane `program-coordination`

--- a/docs/superpowers/plans/2026-08-30-chat-v1-phase-1-sdk-ipc-status.md
+++ b/docs/superpowers/plans/2026-08-30-chat-v1-phase-1-sdk-ipc-status.md
@@ -1,5 +1,12 @@
 # [Chat v1 P1] TypeScript Coven IPC discovery and health — verified status + implementation contract handoff
 
+> **Current refresh — 2026-09-04:** The SDK IPC implementation remains landed,
+> and `cave-p8qkk`, implementation child `cave-p8qkk.1`, Phase 0 prerequisite
+> `cave-bt9wx`, Phase 1 gate `cave-23nmv`, and Phase 1 epic `cave-fz01p` are
+> closed in canonical Beads. GitHub #4780 is closed; #4818 and #4833 remain
+> stale open mirrors. Those mirror records are reconciliation debt, not
+> execution blockers.
+
 **Date:** 2026-08-30 (all evidence below was fetched on this date)
 **Bead:** `cave-p8qkk` · Phase 1 · P0 · lane `typescript-sdk-cli` · owner repo **OpenCoven/sdk**
 **Issue:** [OpenCoven/coven-cave#4780](https://github.com/OpenCoven/coven-cave/issues/4780) (GitHub Teamwork visibility mirror; Beads is authoritative)

--- a/docs/superpowers/plans/2026-08-30-chat-v1-phase-2-canonical-read-conformance-status.md
+++ b/docs/superpowers/plans/2026-08-30-chat-v1-phase-2-canonical-read-conformance-status.md
@@ -1,5 +1,12 @@
 # Chat v1 Phase 2 — real-authority canonical read conformance: re-verified working record
 
+> **Current refresh — 2026-09-04:** The operative conclusion is unchanged.
+> GitHub #4838 remains open and canonical Bead `cave-hjy2f` is blocked. The SDK
+> results directory still states that no passing three-platform aggregate
+> exists, and the Chat canonical-read journey remains dependent on the blocked
+> shell lane. The dated body below should not be read as saying the Bead is
+> currently ready.
+
 > Issue [#4838](https://github.com/OpenCoven/coven-cave/issues/4838) · bead `cave-hjy2f` · Phase 2 · owner **Cross-repo** ·
 > Re-verified **2026-08-30**, read-only (GitHub API over `OpenCoven/coven-cave`, `OpenCoven/sdk`, `OpenCoven/chat`, `OpenCoven/coven`, plus a fresh clone of `OpenCoven/coven-cave` at `origin/main`) ·
 > Supersedes the **Blocked** state recorded on 2026-08-22 in the issue body ·

--- a/docs/superpowers/plans/2026-08-30-chat-v1-phase-2-chat-shell-status.md
+++ b/docs/superpowers/plans/2026-08-30-chat-v1-phase-2-chat-shell-status.md
@@ -1,5 +1,12 @@
 # Chat v1 Phase 2 — Chat shell working record and claimable scope (verified 2026-08-30)
 
+> **Current refresh — 2026-09-04:** OpenCoven/chat#41-#45, #47-#51, #53, and
+> #55 merged as conformance and harness hardening; #46, #52, and #54 closed
+> unmerged. This work did not complete the canonical Phase 2 shell.
+> GitHub #4837 remains open and canonical Bead `cave-ff3j6` remains blocked.
+> Search, grouping, degraded-state handling, and real-authority canonical-read
+> journeys remain the critical work.
+
 > Working record for [OpenCoven/coven-cave#4837](https://github.com/OpenCoven/coven-cave/issues/4837)
 > (bead `cave-ff3j6` · Phase 2 · owner Chat · surface desktop). Register:
 > [`2026-08-15-opencoven-chat-program-tracking.md`](https://github.com/OpenCoven/chat/blob/main/docs/superpowers/plans/2026-08-15-opencoven-chat-program-tracking.md)

--- a/docs/superpowers/plans/2026-08-30-chat-v1-phase-2-gate-status.md
+++ b/docs/superpowers/plans/2026-08-30-chat-v1-phase-2-gate-status.md
@@ -1,5 +1,11 @@
 # Chat v1 Phase 2 gate — canonical reads: re-verified working record (2026-08-30)
 
+> **Current refresh — 2026-09-04:** The Phase 2 gate remains blocked by the
+> Chat shell and the missing accepted three-platform real-authority aggregate.
+> Canonical Beads `cave-ff3j6`, `cave-hjy2f`, and `cave-8ywi2` are blocked;
+> GitHub #4837, #4838, and #4839 remain open mirrors. Phase 1 is closed in
+> Beads even though GitHub #4833 remains unrefreshed and open.
+
 Gate issue: [#4839](https://github.com/OpenCoven/coven-cave/issues/4839) · bead `cave-8ywi2` ·
 Phase 2 · owner Cross-repo (mirrored as [#4906](https://github.com/OpenCoven/coven-cave/issues/4906),
 closed 2026-08-24 as a duplicate visibility mirror — evidence stays on #4839).

--- a/docs/superpowers/plans/2026-08-30-chat-v1-phase-7-acceptance-status.md
+++ b/docs/superpowers/plans/2026-08-30-chat-v1-phase-7-acceptance-status.md
@@ -1,5 +1,13 @@
 # Chat v1 Phase 7 — OS acceptance, staged rollout, and rollback drill: verified status + acceptance evidence runbook
 
+> **Current refresh — 2026-09-04:** Phase 7 remains blocked in canonical
+> Beads. Chat now has the `v0.0.1-demo.1` macOS-arm64 prerelease, but it is not
+> a signed cross-platform production candidate and updater artifacts remain
+> disabled. Published npm/crate artifacts, compatibility canaries, three-OS
+> acceptance, rollout/rollback evidence, and gate evidence are still missing.
+> Bead `cave-as76u` and the other Phase 7 records are now directly queryable as
+> blocked rather than tracker-unverifiable.
+
 Bead `cave-udcn7` (issue [#4781](https://github.com/OpenCoven/coven-cave/issues/4781)), Phase 7, P0, lane `release-acceptance`.
 
 **Verification date: 2026-08-30.** Everything under "Verified" below was checked against live state on that date unless a date is attached to the specific claim. Verifier: agent session authenticated as `CompleteDotTech` (push access to OpenCoven/coven-cave only; `OpenCoven/chat`, `OpenCoven/sdk`, and `OpenCoven/coven` were read as read-only sources).

--- a/docs/superpowers/plans/2026-08-30-chat-v1-phase-7-rollout-status.md
+++ b/docs/superpowers/plans/2026-08-30-chat-v1-phase-7-rollout-status.md
@@ -1,5 +1,13 @@
 # Chat v1 Phase 7 — Packaging, Compatibility, Publishing, and Rollout: Verified Program Status
 
+> **Current refresh — 2026-09-04:** Phase 7 remains blocked in canonical
+> Beads; it is no longer tracker-unverifiable. Chat's `v0.0.1-demo.1`
+> prerelease is macOS-arm64 demo evidence, not the signed cross-platform
+> production/updater candidate required by this program. Coven has advanced to
+> v0.4.3, but the planned client crate publication remains absent. Phase 1 is
+> closed canonically; GitHub #4833 is only a stale open mirror. The missing
+> acceptance record and Phase 7 gate evidence remain real blockers.
+
 Issue: [OpenCoven/coven-cave#4820](https://github.com/OpenCoven/coven-cave/issues/4820) · Bead `cave-j65ie` · Lane `program-coordination`
 
 **Verified: 2026-08-30.** Read-only verification. This document records verified program status only; it closes nothing and changes no bead.

--- a/docs/superpowers/plans/2026-09-01-research-github-resource-viewer.md
+++ b/docs/superpowers/plans/2026-09-01-research-github-resource-viewer.md
@@ -1,5 +1,9 @@
 # Saved GitHub resource viewer implementation plan
 
+> **Status: Shipped.** Merged in [#5287](https://github.com/OpenCoven/coven-cave/pull/5287)
+> on 2026-09-02 as `6a457a82fb3832224b11f16c5531ac413ae38fa6`.
+> Checkbox state is not used; the completion evidence below is authoritative.
+
 **Goal:** Make a saved GitHub repository URL ingest and open like a
 source-native Research Desk resource.
 
@@ -43,3 +47,21 @@ source-native Research Desk resource.
 - Exercise a production-path save/detail/blob/view flow with mocked GitHub
   transport and persisted snapshot evidence.
 - Inspect the final diff and classify every requested deliverable.
+
+## Completion evidence
+
+- Bead `cave-zl52y` is closed with the PR head
+  `d09c893748b2b9f4c8847c1d9199490ae77fac07` and merge commit above recorded
+  in its closure evidence.
+- The shipped flow persists exact commit and blob provenance, projects a
+  list-safe summary, enriches at most five repositories serially, preserves the
+  compatibility extension channel, and opens the saved resource directly in
+  the two-pane viewer.
+- Focused evidence lives in
+  `src/lib/research-github-repo.test.ts`,
+  `src/lib/server/research-github-repo.test.ts`,
+  `src/components/role-surfaces/research-github-repo-viewer.test.tsx`, and
+  `tests/research-github-resource-viewer.spec.ts`.
+- Review hardening added anonymous fallback for public GitHub reads when
+  credential resolution fails and fixed commit-aware markdown-link handling;
+  neither changed the plan's product scope.

--- a/docs/superpowers/plans/2026-09-01-review-first-coding-desk.md
+++ b/docs/superpowers/plans/2026-09-01-review-first-coding-desk.md
@@ -1,5 +1,10 @@
 # Review-First Coding Desk Implementation Plan
 
+> **Status: Shipped.** Merged in [#5276](https://github.com/OpenCoven/coven-cave/pull/5276)
+> on 2026-09-02 as `ecd8b1a5efac82d133745a403856ce202bb91d68`.
+> The historical checkboxes remain unchanged; completion is established by the
+> merge and evidence appendix below.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. **Checkbox state in this document is not evidence of completion. Verify what has shipped against code and merged PRs.**
 
 **Goal:** Make the Coding Desk default to a minimal, actionable queue of human-created sessions in verified GitHub repositories outside familiar workspaces, while preserving explicit access to every other local session.
@@ -1026,3 +1031,24 @@ git commit -m "test(code): verify review-first Coding Desk"
 - Empty panels do not consume full-width space by default.
 - Queue shortcuts never capture text-entry or terminal keystrokes.
 - Focused unit, E2E, lint, typecheck, and build gates pass.
+
+## Completion evidence
+
+- PR #5276 shipped from head
+  `d34b11df7b9dad419175309d10d44f6ea0b40f7c` and merged as
+  `ecd8b1a5efac82d133745a403856ce202bb91d68`.
+- `src/lib/code-review-queue.ts` is the shared eligibility, ordering, grouping,
+  count, and selected-session-override authority consumed by the rail and
+  picker.
+- `src/lib/session-git-enrich.ts` and
+  `src/lib/familiar-workspace-sessions.ts` provide the trusted GitHub-origin
+  and familiar-workspace classifications. The final implementation fails
+  closed when workspace trust cannot be established.
+- Focused evidence lives in `src/lib/code-review-queue.test.ts`,
+  `src/components/code-review-queue-controls.test.tsx`,
+  `tests/code-surface.spec.ts`, and
+  `tests/mobile/code-surface-drill-in.spec.ts`.
+- Review hardening normalized whitespace-only pull-request state and expanded
+  supporting strict configuration, session-merge, shortcut, and mobile
+  coverage. Those changes refined the implementation without changing the
+  completion criteria.


### PR DESCRIPTION
## Summary
- reconcile the Coven Automations v1 roadmap and mapping with current GitHub and canonical Beads state
- preserve historical seed-sync evidence while separating it from current live-state claims
- mark the Research GitHub viewer and Review-First Coding Desk plans as shipped with completion evidence
- add current refresh banners to the Chat v1 Phase 1, Phase 2, and Phase 7 status records

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `SHELL=/bin/sh GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all pnpm test:api`
- `pnpm check:tests-wired`
- `node scripts/docs-index.test.mjs`
- `node --test scripts/plan-doc-checkbox-hygiene.test.mjs`
- mapping JSON parse and `git diff --check`

Bead: `cave-h5o17`