### PR TITLE
fix(release): stabilize Windows candidate validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,15 +627,6 @@ jobs:
           IOS_RESULT: ${{ needs.ios.result }}
         run: |
           set -euo pipefail
-          if [ "$PATHS_RESULT" = "cancelled" ] \
-            && [ "$FRONTEND_VALIDATION_RESULT" = "cancelled" ] \
-            && [ "$FRONTEND_BUNDLE_RESULT" = "cancelled" ] \
-            && [ "$FRONTEND_E2E_RESULT" = "cancelled" ] \
-            && [ "$FRONTEND_E2E_AGENTIC_RESULT" = "cancelled" ] \
-            && [ "$IOS_RESULT" = "cancelled" ]; then
-            echo "Selected validation lanes were cancelled upstream; skipping aggregate assertions."
-            exit 0
-          fi
           test "$PATHS_RESULT" = "success"
           if [ "$FRONTEND_ENABLED" = "true" ]; then
             test "$FRONTEND_VALIDATION_RESULT" = "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,15 @@ jobs:
           IOS_RESULT: ${{ needs.ios.result }}
         run: |
           set -euo pipefail
+          if [ "$PATHS_RESULT" = "cancelled" ] \
+            && [ "$FRONTEND_VALIDATION_RESULT" = "cancelled" ] \
+            && [ "$FRONTEND_BUNDLE_RESULT" = "cancelled" ] \
+            && [ "$FRONTEND_E2E_RESULT" = "cancelled" ] \
+            && [ "$FRONTEND_E2E_AGENTIC_RESULT" = "cancelled" ] \
+            && [ "$IOS_RESULT" = "cancelled" ]; then
+            echo "Selected validation lanes were cancelled upstream; skipping aggregate assertions."
+            exit 0
+          fi
           test "$PATHS_RESULT" = "success"
           if [ "$FRONTEND_ENABLED" = "true" ]; then
             test "$FRONTEND_VALIDATION_RESULT" = "success"

--- a/scripts/client-v1-compatibility-control.integration.test.mjs
+++ b/scripts/client-v1-compatibility-control.integration.test.mjs
@@ -170,6 +170,7 @@ function isolatedEnvironment(root, port, selector) {
       || name === "USERPROFILE"
       || name === "HOMEDRIVE"
       || name === "HOMEPATH"
+      || name === "NODE_OPTIONS"
       || name.startsWith("COVEN_")
       || /(?:TOKEN|SECRET|PASSWORD|PRIVATE|API_KEY|CREDENTIAL)/i.test(name)
     ) {

--- a/scripts/client-v1-compatibility-control.integration.test.mjs
+++ b/scripts/client-v1-compatibility-control.integration.test.mjs
@@ -187,6 +187,8 @@ function isolatedEnvironment(root, port, selector) {
   env.XDG_CACHE_HOME = path.join(root, "cache");
   if (process.platform === "darwin") {
     env.NODE_OPTIONS = "--max-old-space-size=6144";
+  } else {
+    delete env.NODE_OPTIONS;
   }
   env.NODE_ENV = "production";
   env.COVEN_HOME = path.join(root, "coven");

--- a/scripts/client-v1-compatibility-control.integration.test.mjs
+++ b/scripts/client-v1-compatibility-control.integration.test.mjs
@@ -184,7 +184,9 @@ function isolatedEnvironment(root, port, selector) {
   env.TEMP = env.TMPDIR;
   env.XDG_CONFIG_HOME = path.join(root, "config");
   env.XDG_CACHE_HOME = path.join(root, "cache");
-  env.NODE_OPTIONS = "--max-old-space-size=6144";
+  if (process.platform === "darwin") {
+    env.NODE_OPTIONS = "--max-old-space-size=6144";
+  }
   env.NODE_ENV = "production";
   env.COVEN_HOME = path.join(root, "coven");
   env.COVEN_CAVE_HOME = path.join(root, "coven", "cave");
@@ -290,8 +292,18 @@ function assertSafeError(response, body) {
 
 async function removeTestBuildOutputs(root) {
   const removals = await Promise.allSettled([
-    rm(root, { recursive: true, force: true }),
-    rm(path.join(repositoryRoot, ".next"), { recursive: true, force: true }),
+    rm(root, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 100,
+    }),
+    rm(path.join(repositoryRoot, ".next"), {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 100,
+    }),
   ]);
   const failures = removals
     .filter((result) => result.status === "rejected")

--- a/src/lib/server/client-v1/conformance-compatibility.test.ts
+++ b/src/lib/server/client-v1/conformance-compatibility.test.ts
@@ -96,8 +96,13 @@ test("conformance builds keep Turbopack and start from a clean plugin runtime", 
   assert.match(script, /NODE_OPTIONS:\s*"--max-old-space-size=6144"/);
   assert.match(
     compatibilityHarness,
-    /env\.NODE_OPTIONS = "--max-old-space-size=6144"/,
-    "both packaged compatibility builds need the macOS runner's proven V8 heap ceiling",
+    /process\.platform === "darwin"[\s\S]*?env\.NODE_OPTIONS = "--max-old-space-size=6144"/,
+    "the packaged compatibility builds need the proven V8 heap ceiling only on macOS",
+  );
+  assert.match(
+    compatibilityHarness,
+    /rm\(root,\s*\{[\s\S]*?maxRetries:\s*10,[\s\S]*?retryDelay:\s*100,[\s\S]*?\}\)/,
+    "artifact cleanup must retry transient Windows file locks",
   );
   assert.match(
     script,

--- a/src/lib/server/client-v1/conformance-compatibility.test.ts
+++ b/src/lib/server/client-v1/conformance-compatibility.test.ts
@@ -101,6 +101,11 @@ test("conformance builds keep Turbopack and start from a clean plugin runtime", 
   );
   assert.match(
     compatibilityHarness,
+    /name === "NODE_OPTIONS"/,
+    "the isolated environment must not inherit a non-macOS heap override",
+  );
+  assert.match(
+    compatibilityHarness,
     /rm\(root,\s*\{[\s\S]*?maxRetries:\s*10,[\s\S]*?retryDelay:\s*100,[\s\S]*?\}\)/,
     "artifact cleanup must retry transient Windows file locks",
   );


### PR DESCRIPTION
## Summary

- keep the 6 GiB packaged-build heap override scoped to macOS, the platform whose release build exhausted its default V8 ceiling
- leave Windows on its previously passing default heap behavior
- retry recursive cleanup across transient Windows EBUSY locks after packaged server shutdown
- pin both release-harness guarantees in the existing conformance contract

## Root cause

v0.3.13-rc.2 passed the Windows packaged compatibility journey. The RC3 fix for a macOS build OOM added NODE_OPTIONS=--max-old-space-size=6144 to every platform; RC3 then repeatedly failed only on Windows. The first run missed the 45-second server readiness window while the process remained alive. A rerun completed the server journey but failed deleting the normal artifact with Windows EBUSY, proving cleanup also lacked the required retry window.

## Verification

- node --experimental-strip-types src/lib/server/client-v1/conformance-compatibility.test.ts
- pnpm test:client-v1:compatibility-control
- pnpm test:conformance
- pnpm typecheck
- pnpm lint
- pnpm check:tests-wired
- git diff --check

Failed candidate: https://github.com/OpenCoven/coven-cave/actions/runs/33605837132

Bead: cave-al7pr.1