### PR TITLE
Align Windows candidate startup timeout

### DIFF
--- a/scripts/client-v1-compatibility-control.integration.test.mjs
+++ b/scripts/client-v1-compatibility-control.integration.test.mjs
@@ -22,7 +22,7 @@ import { resolveCorepackLaunch } from "./corepack-launch.mjs";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const buildTimeoutMs = 20 * 60_000;
-const startupTimeoutMs = 45_000;
+const startupTimeoutMs = process.platform === "win32" ? 90_000 : 45_000;
 const requestTimeoutMs = 3_000;
 const shutdownTimeoutMs = 8_000;
 const maxOutputBytes = 32_000;

--- a/src/lib/server/client-v1/conformance-compatibility.test.ts
+++ b/src/lib/server/client-v1/conformance-compatibility.test.ts
@@ -106,6 +106,11 @@ test("conformance builds keep Turbopack and start from a clean plugin runtime", 
   );
   assert.match(
     compatibilityHarness,
+    /process\.platform === "win32" \? 90_000 : 45_000/,
+    "Windows packaged startup must use the production sidecar's 90-second readiness budget",
+  );
+  assert.match(
+    compatibilityHarness,
     /rm\(root,\s*\{[\s\S]*?maxRetries:\s*10,[\s\S]*?retryDelay:\s*100,[\s\S]*?\}\)/,
     "artifact cleanup must retry transient Windows file locks",
   );

--- a/src/lib/server/client-v1/conformance-compatibility.test.ts
+++ b/src/lib/server/client-v1/conformance-compatibility.test.ts
@@ -106,7 +106,7 @@ test("conformance builds keep Turbopack and start from a clean plugin runtime", 
   );
   assert.match(
     compatibilityHarness,
-    /process\.platform === "win32" \? 90_000 : 45_000/,
+    /process\.platform\s*===\s*["']win32["']\s*\?\s*90_000\s*:\s*45_000/,
     "Windows packaged startup must use the production sidecar's 90-second readiness budget",
   );
   assert.match(


### PR DESCRIPTION
## Summary
- align the Windows packaged compatibility startup deadline with the production sidecar 90-second cold-start budget
- preserve the existing 45-second deadline on Linux and macOS
- pin the platform-specific contract in the conformance source test

## Verification
- `node --experimental-strip-types src/lib/server/client-v1/conformance-compatibility.test.ts`
- `pnpm test:client-v1:compatibility-control`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`

Bead: `cave-al7pr.1`
