### PR TITLE
chore(release): stamp v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-05
+
+> Starts the v0.4 release line from the fully validated v0.3.13 payload,
+> preserving GPT-6 Astra and the complete cross-platform release baseline.
+
+Minor release on top of v0.3.13. This stamp intentionally carries the
+validated v0.3.13 application payload forward without additional functional
+commits, establishing v0.4.0 as the baseline for the next minor series.
+
+### Changes
+- Advance the desktop, daemon, and iOS marketing version to v0.4.0.
+- Refresh the iOS App Store build number for a new TestFlight upload.
+- Preserve the validated v0.3.13 feature set, including Claude Fable 5.1 and
+  GPT-6 Astra, unchanged.
+
 ## [0.3.13] - 2026-09-01
 
 > Makes native iOS chat recovery more durable, introduces a review-first

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.3.13"
+    MARKETING_VERSION: "0.4.0"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026090117"
+    CURRENT_PROJECT_VERSION: "2026090517"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.3.13",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.3.13"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.13"
+version = "0.4.0"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.3.13",
+  "version": "0.4.0",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- stamp all canonical desktop, daemon, and iOS version sources to 0.4.0
- refresh the iOS App Store build number to 2026090517
- document that v0.4.0 establishes the next minor baseline from the fully validated v0.3.13 payload, retaining GPT-6 Astra

## Verification
- `pnpm release:preview --version 0.4.0`
- `pnpm release:verify --version 0.4.0`
- `node --test scripts/stamp-release.test.mjs scripts/ios-build-ci.test.mjs`
- `pnpm test:mobile` (100 files)
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`

Bead: `cave-752vu`
