### PR TITLE
Fix iOS assistant response formatting

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/AssistantResponseProjection.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/AssistantResponseProjection.swift
@@ -1,0 +1,588 @@
+import Foundation
+
+struct AssistantResponseProjection: Equatable {
+    let visible: String
+    let suggestions: [String]
+    let previewURLs: [URL]
+
+    private final class CacheEntry: NSObject {
+        let projection: AssistantResponseProjection
+
+        init(_ projection: AssistantResponseProjection) {
+            self.projection = projection
+        }
+    }
+
+    private static let cache: NSCache<NSString, CacheEntry> = {
+        let cache = NSCache<NSString, CacheEntry>()
+        cache.countLimit = 128
+        cache.totalCostLimit = 2_000_000
+        return cache
+    }()
+
+    private static let githubMarkerExpression = try! NSRegularExpression(
+        pattern: #"<coven:github(?!-)\b((?:[^">]|"[^"]*")*?)/?>"#
+    )
+    private static let genericControlExpression = try! NSRegularExpression(
+        pattern: #"</?coven:[A-Za-z0-9-]+\b(?:[^">]|"[^"]*")*?/?>"#
+    )
+    private static let attributeExpression = try! NSRegularExpression(
+        pattern: #"([A-Za-z-]+)="([^"]*)""#
+    )
+    private static let angleCitationExpression = try! NSRegularExpression(
+        pattern: #"^<(https?://[^\s>]+)>"#
+    )
+    private static let plainCitationExpression = try! NSRegularExpression(
+        pattern: #"^(https?://[^\s]+)"#
+    )
+    private static let citationReferenceExpression = try! NSRegularExpression(
+        pattern: #"\[\^([^\]]+)\]"#
+    )
+    static func parse(_ raw: String, streaming: Bool = false) -> AssistantResponseProjection {
+        let cacheKey = "\(streaming ? 1 : 0):\(raw)" as NSString
+        if let cached = cache.object(forKey: cacheKey) {
+            return cached.projection
+        }
+
+        let protected = protectMarkdownCode(in: raw)
+        let nextPaths = NextPaths.extract(protected.text)
+        let controls = extractControls(from: nextPaths.visible)
+        let cited = streaming ? controls.visible : renderCitations(in: controls.visible)
+        let bareURLs = bareLineURLs(in: cited)
+        let previews = Array(deduplicated(controls.githubURLs + bareURLs).prefix(2))
+
+        let projection = AssistantResponseProjection(
+            visible: protected.restore(in: normalize(cited)),
+            suggestions: nextPaths.suggestions.map { protected.restore(in: $0) },
+            previewURLs: previews
+        )
+        cache.setObject(CacheEntry(projection), forKey: cacheKey, cost: raw.utf8.count)
+        return projection
+    }
+
+    private struct ControlExtraction {
+        let visible: String
+        let githubURLs: [URL]
+    }
+
+    private struct Citation {
+        let label: String
+        let url: URL
+    }
+
+    private static func extractControls(from text: String) -> ControlExtraction {
+        var urls: [URL] = []
+        let visible = text
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line in
+                extractControls(from: String(line), githubURLs: &urls)
+            }
+            .joined(separator: "\n")
+
+        return ControlExtraction(visible: visible, githubURLs: urls)
+    }
+
+    private static func extractControls(from prose: String, githubURLs: inout [URL]) -> String {
+        var rendered = prose
+
+        let matches = githubMarkerExpression.matches(
+            in: prose,
+            range: NSRange(prose.startIndex..., in: prose)
+        )
+        for match in matches {
+            if match.numberOfRanges > 1,
+               let attrsRange = Range(match.range(at: 1), in: prose),
+               let url = githubURL(from: parseAttributes(String(prose[attrsRange]))) {
+                githubURLs.append(url)
+            }
+        }
+        rendered = githubMarkerExpression.stringByReplacingMatches(
+            in: rendered,
+            range: NSRange(rendered.startIndex..., in: rendered),
+            withTemplate: ""
+        )
+
+        rendered = genericControlExpression.stringByReplacingMatches(
+            in: rendered,
+            range: NSRange(rendered.startIndex..., in: rendered),
+            withTemplate: ""
+        )
+
+        if let incomplete = rendered.range(of: "<coven:", options: .caseInsensitive) {
+            rendered.removeSubrange(incomplete.lowerBound...)
+        }
+        return rendered
+    }
+
+    private static func parseAttributes(_ raw: String) -> [String: String] {
+        var attributes: [String: String] = [:]
+        for match in attributeExpression.matches(
+            in: raw,
+            range: NSRange(raw.startIndex..., in: raw)
+        ) {
+            guard match.numberOfRanges == 3,
+                  let keyRange = Range(match.range(at: 1), in: raw),
+                  let valueRange = Range(match.range(at: 2), in: raw) else { continue }
+            attributes[String(raw[keyRange])] = String(raw[valueRange])
+        }
+        return attributes
+    }
+
+    private static func githubURL(from attributes: [String: String]) -> URL? {
+        guard let kind = attributes["kind"],
+              let repo = attributes["repo"],
+              repo.range(
+                  of: #"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?/[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$"#,
+                  options: .regularExpression
+              ) != nil else { return nil }
+
+        let base = "https://github.com/\(repo)"
+        let destination: String?
+        switch kind {
+        case "pr", "issue", "review-thread":
+            guard let number = positiveInteger(attributes["number"]) else { return nil }
+            let path = kind == "issue" ? "issues" : "pull"
+            if kind == "review-thread", let thread = positiveInteger(attributes["thread"]) {
+                destination = "\(base)/\(path)/\(number)#discussion_r\(thread)"
+            } else {
+                destination = "\(base)/\(path)/\(number)"
+            }
+        case "commit":
+            guard let sha = attributes["sha"],
+                  sha.range(of: #"^[0-9a-fA-F]{7,40}$"#, options: .regularExpression) != nil else {
+                return nil
+            }
+            destination = "\(base)/commit/\(sha)"
+        case "run":
+            guard let run = positiveInteger(attributes["run"]) else { return nil }
+            destination = "\(base)/actions/runs/\(run)"
+        default:
+            destination = nil
+        }
+        return destination.flatMap(URL.init(string:))
+    }
+
+    private static func positiveInteger(_ raw: String?) -> Int? {
+        guard let raw, raw.range(of: #"^\d+$"#, options: .regularExpression) != nil,
+              let value = Int(raw), value > 0 else { return nil }
+        return value
+    }
+
+    private static func renderCitations(in text: String) -> String {
+        var definitions: [String: Citation] = [:]
+        let withoutDefinitions = text
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line -> String in
+                let line = String(line)
+                guard let definition = citationDefinition(from: line) else { return line }
+                if let citation = definition.citation {
+                    definitions[definition.key] = citation
+                    return ""
+                }
+                return line
+            }
+            .joined(separator: "\n")
+
+        return withoutDefinitions
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line in
+                replaceCitationReferences(in: String(line), definitions: definitions)
+            }
+            .joined(separator: "\n")
+    }
+
+    private static func citationDefinition(
+        from line: String
+    ) -> (key: String, citation: Citation?)? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("[^"),
+              let closing = trimmed.firstIndex(of: "]"),
+              trimmed.index(after: closing) < trimmed.endIndex,
+              trimmed[trimmed.index(after: closing)] == ":" else { return nil }
+
+        let keyStart = trimmed.index(trimmed.startIndex, offsetBy: 2)
+        let key = String(trimmed[keyStart..<closing])
+        guard !key.isEmpty else { return nil }
+
+        let contentStart = trimmed.index(closing, offsetBy: 2)
+        let content = trimmed[contentStart...].trimmingCharacters(in: .whitespaces)
+        guard let parsed = citationContent(String(content)) else {
+            return (key, nil)
+        }
+        return (key, Citation(label: parsed.label, url: parsed.url))
+    }
+
+    private static func citationContent(_ raw: String) -> (label: String, url: URL)? {
+        if let destination = markdownLinkDestination(in: raw),
+           let url = URL(string: destination) {
+            return (providerLabel(for: url), url)
+        }
+
+        if let match = firstMatch(
+            expression: angleCitationExpression,
+            in: raw
+        ), let url = URL(string: match[1]) {
+            return (providerLabel(for: url), url)
+        }
+
+        if let match = firstMatch(
+            expression: plainCitationExpression,
+            in: raw
+        ), let url = URL(string: match[1]) {
+            return (providerLabel(for: url), url)
+        }
+        return nil
+    }
+
+    private static func markdownLinkDestination(in raw: String) -> String? {
+        guard raw.first == "[",
+              let labelEnd = raw.firstIndex(of: "]") else { return nil }
+        let open = raw.index(after: labelEnd)
+        guard open < raw.endIndex, raw[open] == "(" else { return nil }
+
+        var depth = 1
+        var escaped = false
+        var cursor = raw.index(after: open)
+        let destinationStart = cursor
+        while cursor < raw.endIndex {
+            let character = raw[cursor]
+            if escaped {
+                escaped = false
+            } else if character == "\\" {
+                escaped = true
+            } else if character == "(" {
+                depth += 1
+            } else if character == ")" {
+                depth -= 1
+                if depth == 0 {
+                    let destination = String(raw[destinationStart..<cursor])
+                        .trimmingCharacters(in: .whitespaces)
+                    return destination.isEmpty ? nil : destination
+                }
+            }
+            cursor = raw.index(after: cursor)
+        }
+        return nil
+    }
+
+    private static func firstMatch(
+        expression: NSRegularExpression,
+        in text: String
+    ) -> [String]? {
+        guard let match = expression.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ) else { return nil }
+
+        return (0..<match.numberOfRanges).map { index in
+            guard let range = Range(match.range(at: index), in: text) else { return "" }
+            return String(text[range])
+        }
+    }
+
+    private static func providerLabel(for url: URL) -> String {
+        var host = (url.host ?? url.absoluteString).lowercased()
+        if host.hasPrefix("www.") {
+            host.removeFirst(4)
+        }
+        switch host {
+        case "github.com":
+            return "GitHub"
+        case "quickbooks.intuit.com":
+            return "QuickBooks"
+        case "youtube.com", "m.youtube.com", "youtu.be":
+            return "YouTube"
+        default:
+            return host
+        }
+    }
+
+    private static func replaceCitationReferences(
+        in text: String,
+        definitions: [String: Citation]
+    ) -> String {
+        let source = text as NSString
+        let matches = citationReferenceExpression.matches(
+            in: text,
+            range: NSRange(location: 0, length: source.length)
+        )
+        let rendered = NSMutableString(string: text)
+        for match in matches.reversed() {
+            guard match.numberOfRanges == 2 else { continue }
+            let key = source.substring(with: match.range(at: 1))
+            let replacement: String
+            if let citation = definitions[key] {
+                let escapedLabel = citation.label.replacingOccurrences(of: "]", with: #"\]"#)
+                let link = "[\(escapedLabel)](\(citation.url.absoluteString))"
+                let needsSpace = match.range.location > 0
+                    && !(source.substring(with: NSRange(
+                        location: match.range.location - 1,
+                        length: 1
+                    )).rangeOfCharacter(from: .whitespacesAndNewlines) != nil)
+                replacement = needsSpace ? " \(link)" : link
+            } else {
+                continue
+            }
+            rendered.replaceCharacters(in: match.range, with: replacement)
+        }
+        return rendered as String
+    }
+
+    private static func bareLineURLs(in text: String) -> [URL] {
+        var urls: [URL] = []
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let candidate = line.trimmingCharacters(in: .whitespaces)
+            if let url = URL(string: candidate),
+               url.scheme == "http" || url.scheme == "https",
+               !candidate.contains(where: \.isWhitespace) {
+                urls.append(url)
+            }
+        }
+        return urls
+    }
+
+    private struct ProtectedMarkdownCode {
+        let text: String
+        let fragments: [(token: String, source: String)]
+
+        func restore(in value: String) -> String {
+            fragments.reduce(value) { result, fragment in
+                result.replacingOccurrences(of: fragment.token, with: fragment.source)
+            }
+        }
+    }
+
+    private struct MarkdownLine {
+        let range: Range<String.Index>
+        let contentRange: Range<String.Index>
+        let content: Substring
+        let isBlank: Bool
+        let isIndentedCode: Bool
+    }
+
+    private struct FenceMarker {
+        let character: Character
+        let length: Int
+    }
+
+    private static func protectMarkdownCode(in text: String) -> ProtectedMarkdownCode {
+        guard !text.isEmpty else {
+            return ProtectedMarkdownCode(text: text, fragments: [])
+        }
+
+        let lines = markdownLines(in: text)
+        var ranges: [Range<String.Index>] = []
+        var lineIndex = 0
+        while lineIndex < lines.count {
+            let line = lines[lineIndex]
+            if let opening = fenceMarker(in: line.content) {
+                var closingIndex = lineIndex + 1
+                while closingIndex < lines.count {
+                    if isClosingFence(lines[closingIndex].content, for: opening) {
+                        break
+                    }
+                    closingIndex += 1
+                }
+                let endIndex = closingIndex < lines.count ? closingIndex : lines.count - 1
+                ranges.append(line.range.lowerBound..<lines[endIndex].range.upperBound)
+                lineIndex = endIndex + 1
+                continue
+            }
+
+            if line.isIndentedCode {
+                var endIndex = lineIndex
+                var candidate = lineIndex + 1
+                while candidate < lines.count {
+                    let next = lines[candidate]
+                    guard next.isIndentedCode || next.isBlank else { break }
+                    endIndex = candidate
+                    candidate += 1
+                }
+                while endIndex > lineIndex, lines[endIndex].isBlank {
+                    endIndex -= 1
+                }
+                ranges.append(line.range.lowerBound..<lines[endIndex].range.upperBound)
+                lineIndex = endIndex + 1
+                continue
+            }
+
+            ranges.append(contentsOf: inlineCodeRanges(in: text, range: line.contentRange))
+            lineIndex += 1
+        }
+
+        var markerPrefix = "\u{E000}COVEN-CODE-"
+        while text.contains(markerPrefix) {
+            markerPrefix += "-"
+        }
+        var protectedText = ""
+        var fragments: [(token: String, source: String)] = []
+        var cursor = text.startIndex
+        for (index, range) in ranges.enumerated() {
+            let token = "\(markerPrefix)\(index)\u{E001}"
+            protectedText += text[cursor..<range.lowerBound]
+            protectedText += token
+            let source = String(text[range])
+            fragments.append((token, source))
+            cursor = range.upperBound
+        }
+        protectedText += text[cursor...]
+        return ProtectedMarkdownCode(text: protectedText, fragments: fragments)
+    }
+
+    private static func markdownLines(in text: String) -> [MarkdownLine] {
+        var lines: [MarkdownLine] = []
+        var cursor = text.startIndex
+        while cursor < text.endIndex {
+            let newline = text[cursor...].firstIndex(of: "\n")
+            let contentEnd = newline ?? text.endIndex
+            let lineEnd = newline.map { text.index(after: $0) } ?? text.endIndex
+            let contentRange = cursor..<contentEnd
+            let content = text[contentRange]
+            let leadingSpaces = content.prefix(while: { $0 == " " }).count
+            lines.append(MarkdownLine(
+                range: cursor..<lineEnd,
+                contentRange: contentRange,
+                content: content,
+                isBlank: content.allSatisfy(\.isWhitespace),
+                isIndentedCode: content.hasPrefix("\t") || leadingSpaces >= 4
+            ))
+            cursor = lineEnd
+        }
+        return lines
+    }
+
+    private static func fenceMarker(in line: Substring) -> FenceMarker? {
+        let leadingSpaces = line.prefix(while: { $0 == " " }).count
+        guard leadingSpaces <= 3 else { return nil }
+        let trimmed = line.dropFirst(leadingSpaces)
+        guard let character = trimmed.first, character == "`" || character == "~" else {
+            return nil
+        }
+        let length = trimmed.prefix(while: { $0 == character }).count
+        guard length >= 3 else { return nil }
+        return FenceMarker(character: character, length: length)
+    }
+
+    private static func isClosingFence(_ line: Substring, for opening: FenceMarker) -> Bool {
+        let leadingSpaces = line.prefix(while: { $0 == " " }).count
+        guard leadingSpaces <= 3 else { return false }
+        let trimmed = line.dropFirst(leadingSpaces)
+        let length = trimmed.prefix(while: { $0 == opening.character }).count
+        guard length >= opening.length else { return false }
+        return trimmed.dropFirst(length).allSatisfy(\.isWhitespace)
+    }
+
+    private static func inlineCodeRanges(
+        in text: String,
+        range: Range<String.Index>
+    ) -> [Range<String.Index>] {
+        var ranges: [Range<String.Index>] = []
+        var cursor = range.lowerBound
+        while cursor < range.upperBound {
+            guard text[cursor] == "`" else {
+                cursor = text.index(after: cursor)
+                continue
+            }
+            let openingStart = cursor
+            let openingEnd = backtickRunEnd(in: text, from: cursor, limit: range.upperBound)
+            let length = text.distance(from: openingStart, to: openingEnd)
+            var search = openingEnd
+            var closingEnd: String.Index?
+            while search < range.upperBound {
+                guard text[search] == "`" else {
+                    search = text.index(after: search)
+                    continue
+                }
+                let candidateEnd = backtickRunEnd(in: text, from: search, limit: range.upperBound)
+                if text.distance(from: search, to: candidateEnd) == length {
+                    closingEnd = candidateEnd
+                    break
+                }
+                search = candidateEnd
+            }
+            guard let closingEnd else {
+                cursor = openingEnd
+                continue
+            }
+            ranges.append(openingStart..<closingEnd)
+            cursor = closingEnd
+        }
+        return ranges
+    }
+
+    private static func backtickRunEnd(
+        in text: String,
+        from start: String.Index,
+        limit: String.Index
+    ) -> String.Index {
+        var cursor = start
+        while cursor < limit, text[cursor] == "`" {
+            cursor = text.index(after: cursor)
+        }
+        return cursor
+    }
+
+    private static func deduplicated(_ urls: [URL]) -> [URL] {
+        var seen: Set<String> = []
+        return urls.filter { seen.insert($0.absoluteString).inserted }
+    }
+
+    private static func normalize(_ text: String) -> String {
+        var inFence = false
+        var inIndentedCode = false
+        var previousProseLineWasBlank = false
+        var output: [String] = []
+
+        for substring in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(substring)
+            let leadingSpaces = line.prefix(while: { $0 == " " }).count
+            let trimmed = line.dropFirst(leadingSpaces)
+            let isFence = leadingSpaces <= 3
+                && (trimmed.hasPrefix("```") || trimmed.hasPrefix("~~~"))
+            let isIndentedLine = line.hasPrefix("\t") || leadingSpaces >= 4
+
+            if isFence {
+                output.append(line)
+                inFence.toggle()
+                inIndentedCode = false
+                previousProseLineWasBlank = false
+                continue
+            }
+            if inFence {
+                output.append(line)
+                previousProseLineWasBlank = false
+                continue
+            }
+            if isIndentedLine {
+                output.append(line)
+                inIndentedCode = true
+                previousProseLineWasBlank = false
+                continue
+            }
+            if inIndentedCode && line.isEmpty {
+                output.append(line)
+                continue
+            }
+            inIndentedCode = false
+
+            let cleaned = line.replacingOccurrences(
+                of: #"[ \t]+$"#,
+                with: "",
+                options: .regularExpression
+            )
+            if cleaned.isEmpty {
+                if !previousProseLineWasBlank {
+                    output.append(cleaned)
+                }
+                previousProseLineWasBlank = true
+                continue
+            }
+            previousProseLineWasBlank = false
+            output.append(cleaned)
+        }
+
+        return output
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .newlines)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Models/AssistantResponseProjection.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/AssistantResponseProjection.swift
@@ -346,9 +346,32 @@ struct AssistantResponseProjection: Equatable {
         let fragments: [(token: String, source: String)]
 
         func restore(in value: String) -> String {
-            fragments.reduce(value) { result, fragment in
-                result.replacingOccurrences(of: fragment.token, with: fragment.source)
+            guard !fragments.isEmpty else { return value }
+            let sourcesByToken = Dictionary(
+                uniqueKeysWithValues: fragments.map { ($0.token, $0.source) }
+            )
+            var output = ""
+            output.reserveCapacity(value.count)
+            var cursor = value.startIndex
+            while cursor < value.endIndex,
+                  let tokenStart = value[cursor...].firstIndex(of: "\u{E000}") {
+                output += value[cursor..<tokenStart]
+                guard let terminator = value[tokenStart...].firstIndex(of: "\u{E001}") else {
+                    output += value[tokenStart...]
+                    return output
+                }
+                let tokenEnd = value.index(after: terminator)
+                let token = String(value[tokenStart..<tokenEnd])
+                if let source = sourcesByToken[token] {
+                    output += source
+                    cursor = tokenEnd
+                } else {
+                    output.append(value[tokenStart])
+                    cursor = value.index(after: tokenStart)
+                }
             }
+            output += value[cursor...]
+            return output
         }
     }
 
@@ -384,7 +407,7 @@ struct AssistantResponseProjection: Equatable {
                     closingIndex += 1
                 }
                 let endIndex = closingIndex < lines.count ? closingIndex : lines.count - 1
-                ranges.append(line.range.lowerBound..<lines[endIndex].range.upperBound)
+                ranges.append(line.range.lowerBound..<lines[endIndex].contentRange.upperBound)
                 lineIndex = endIndex + 1
                 continue
             }
@@ -401,7 +424,7 @@ struct AssistantResponseProjection: Equatable {
                 while endIndex > lineIndex, lines[endIndex].isBlank {
                     endIndex -= 1
                 }
-                ranges.append(line.range.lowerBound..<lines[endIndex].range.upperBound)
+                ranges.append(line.range.lowerBound..<lines[endIndex].contentRange.upperBound)
                 lineIndex = endIndex + 1
                 continue
             }
@@ -431,6 +454,7 @@ struct AssistantResponseProjection: Equatable {
 
     private static func markdownLines(in text: String) -> [MarkdownLine] {
         var lines: [MarkdownLine] = []
+        var activeListContentIndent: Int?
         var cursor = text.startIndex
         while cursor < text.endIndex {
             let newline = text[cursor...].firstIndex(of: "\n")
@@ -439,16 +463,63 @@ struct AssistantResponseProjection: Equatable {
             let contentRange = cursor..<contentEnd
             let content = text[contentRange]
             let leadingSpaces = content.prefix(while: { $0 == " " }).count
+            let isBlank = content.allSatisfy(\.isWhitespace)
+            let listContentIndent = listItemContentIndent(in: content)
+            let isIndentedCode: Bool
+            if isBlank {
+                isIndentedCode = false
+            } else if let listContentIndent {
+                activeListContentIndent = listContentIndent
+                isIndentedCode = false
+            } else if let activeIndent = activeListContentIndent,
+                      leadingSpaces >= activeIndent {
+                isIndentedCode = content.hasPrefix("\t")
+                    || leadingSpaces >= activeIndent + 4
+            } else {
+                activeListContentIndent = nil
+                isIndentedCode = content.hasPrefix("\t") || leadingSpaces >= 4
+            }
             lines.append(MarkdownLine(
                 range: cursor..<lineEnd,
                 contentRange: contentRange,
                 content: content,
-                isBlank: content.allSatisfy(\.isWhitespace),
-                isIndentedCode: content.hasPrefix("\t") || leadingSpaces >= 4
+                isBlank: isBlank,
+                isIndentedCode: isIndentedCode
             ))
             cursor = lineEnd
         }
         return lines
+    }
+
+    private static func listItemContentIndent(in line: Substring) -> Int? {
+        let leadingSpaces = line.prefix(while: { $0 == " " }).count
+        let markerStart = line.index(line.startIndex, offsetBy: leadingSpaces)
+        guard markerStart < line.endIndex else { return nil }
+
+        var cursor = markerStart
+        let first = line[cursor]
+        if first == "-" || first == "+" || first == "*" {
+            cursor = line.index(after: cursor)
+        } else if first.isNumber {
+            var digitCount = 0
+            while cursor < line.endIndex, line[cursor].isNumber, digitCount < 9 {
+                cursor = line.index(after: cursor)
+                digitCount += 1
+            }
+            guard digitCount > 0, cursor < line.endIndex,
+                  line[cursor] == "." || line[cursor] == ")" else { return nil }
+            cursor = line.index(after: cursor)
+        } else {
+            return nil
+        }
+
+        guard cursor < line.endIndex, line[cursor].isWhitespace else { return nil }
+        let whitespaceStart = cursor
+        while cursor < line.endIndex, line[cursor] == " " {
+            cursor = line.index(after: cursor)
+        }
+        let padding = max(1, line.distance(from: whitespaceStart, to: cursor))
+        return leadingSpaces + line.distance(from: markerStart, to: whitespaceStart) + padding
     }
 
     private static func fenceMarker(in line: Substring) -> FenceMarker? {

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -59,9 +59,9 @@ struct MessageBubble: View {
     /// Long-press actions shared by the bubble and the system note: copy the
     /// text, optionally retry (regenerate), and delete.
     @ViewBuilder private var messageActions: some View {
-        if !message.text.isEmpty {
+        if !parsed.visible.isEmpty {
             Button {
-                UIPasteboard.general.string = message.text
+                UIPasteboard.general.string = parsed.visible
                 Haptics.tap()
             } label: {
                 Label("Copy", systemImage: "doc.on.doc")
@@ -103,23 +103,35 @@ struct MessageBubble: View {
         }
     }
 
-    /// Assistant text minus the `<coven:next-paths>` block (parsed into chips).
-    private var parsed: (visible: String, suggestions: [String]) {
-        isUser ? (message.text, []) : NextPaths.extract(message.text)
+    /// Assistant prose and native presentation metadata, with protocol controls
+    /// removed before rendering, copying, forwarding, or quoting.
+    private var parsed: AssistantResponseProjection {
+        if message.role != .assistant {
+            return AssistantResponseProjection(
+                visible: message.text,
+                suggestions: [],
+                previewURLs: isUser ? firstLink(in: message.text).map { [$0] } ?? [] : []
+            )
+        }
+        return AssistantResponseProjection.parse(message.text, streaming: message.streaming)
     }
 
     /// Render the desktop-parity markdown WebView. Assistant replies always do —
     /// now including while streaming (the WebView renders live, throttled). A
     /// *user* message only renders markdown when it actually contains some, so
     /// plain chatter stays fast native Text. Error messages stay native Text.
-    private var rendersMarkdown: Bool {
-        guard !message.isError, !parsed.visible.isEmpty, !markdownFailed else { return false }
+    private func rendersMarkdown(_ projection: AssistantResponseProjection) -> Bool {
+        guard !message.isError, !projection.visible.isEmpty, !markdownFailed else { return false }
         if isUser { return MarkdownDetect.hasMarkdown(message.text) }
         return true
     }
 
     private var canOpenReader: Bool {
-        !isUser && !message.streaming && !message.isError && !parsed.visible.isEmpty && onOpenReader != nil
+        canOpenReader(parsed)
+    }
+
+    private func canOpenReader(_ projection: AssistantResponseProjection) -> Bool {
+        !isUser && !message.streaming && !message.isError && !projection.visible.isEmpty && onOpenReader != nil
     }
 
     private var canForward: Bool {
@@ -137,8 +149,9 @@ struct MessageBubble: View {
     private var replySwipe: some Gesture {
         DragGesture(minimumDistance: 24)
             .onChanged { value in
-                guard canReply, value.translation.width > 0,
-                      abs(value.translation.width) > abs(value.translation.height) else { return }
+                guard value.translation.width > 0,
+                      abs(value.translation.width) > abs(value.translation.height),
+                      canReply else { return }
                 replyDrag = min(value.translation.width, 64)
             }
             .onEnded { _ in
@@ -216,7 +229,8 @@ struct MessageBubble: View {
     }
 
     private var chatBubble: some View {
-        HStack(alignment: .bottom, spacing: 8) {
+        let projection = parsed
+        return HStack(alignment: .bottom, spacing: 8) {
             if isUser { Spacer(minLength: 48) }
 
             if !isUser, isGroup {
@@ -252,8 +266,8 @@ struct MessageBubble: View {
                         .padding(.leading, 2)
                 }
                 // Hide the (empty) text bubble for image-only messages.
-                if !parsed.visible.isEmpty || message.attachmentDataUrls.isEmpty {
-                    bubble
+                if !projection.visible.isEmpty || (message.streaming && message.attachmentDataUrls.isEmpty) {
+                    bubble(projection)
                         .contextMenu { messageActions }
                 }
                 if !isUser {
@@ -261,9 +275,12 @@ struct MessageBubble: View {
                     responseControlStatus
                 }
 
-                // Rich preview card for the first link in a finished message.
-                if !message.streaming, let link = firstLink(in: parsed.visible) {
-                    LinkPreviewCard(url: link)
+                // Protocol cards and explicit bare-line links can unfurl. Inline
+                // citations remain compact links instead of duplicate cards.
+                if !message.streaming {
+                    ForEach(projection.previewURLs, id: \.absoluteString) { link in
+                        LinkPreviewCard(url: link)
+                    }
                 }
 
                 // A failed reply gets a visible Retry button, not just the
@@ -312,12 +329,12 @@ struct MessageBubble: View {
                 // Design's persistent action row under the latest settled
                 // reply — copy (flips to a check) and regenerate — so the two
                 // most common actions don't hide behind a long-press.
-                if !isUser, isLast, !message.streaming, !message.isError, !parsed.visible.isEmpty {
+                if !isUser, isLast, !message.streaming, !message.isError, !projection.visible.isEmpty {
                     actionRow
                 }
 
-                if !isUser, isLast, !message.streaming, !parsed.suggestions.isEmpty {
-                    SuggestionPills(suggestions: parsed.suggestions, onTap: onSuggestion)
+                if !isUser, isLast, !message.streaming, !projection.suggestions.isEmpty {
+                    SuggestionPills(suggestions: projection.suggestions, onTap: onSuggestion)
                 }
             }
 
@@ -456,7 +473,7 @@ struct MessageBubble: View {
         }
     }
 
-    @ViewBuilder private var bubble: some View {
+    @ViewBuilder private func bubble(_ projection: AssistantResponseProjection) -> some View {
         if message.text.isEmpty && message.streaming {
             VStack(alignment: .leading, spacing: 8) {
                 TypingIndicator()
@@ -468,8 +485,8 @@ struct MessageBubble: View {
                     GrimoireHintCard()
                 }
             }
-        } else if rendersMarkdown {
-            MarkdownWebView(markdown: parsed.visible, height: $mdHeight,
+        } else if rendersMarkdown(projection) {
+            MarkdownWebView(markdown: projection.visible, height: $mdHeight,
                             streaming: message.streaming && !isUser,
                             theme: colorScheme == .light ? .light : .dark,
                             accentHex: chrome.accentHex,
@@ -478,9 +495,9 @@ struct MessageBubble: View {
                 .padding(.horizontal, 14).padding(.vertical, 10)
                 .background(bubbleBackground, in: bubbleShape)
                 .overlay(alignment: .topTrailing) {
-                    if canOpenReader {
+                    if canOpenReader(projection) {
                         Button {
-                            onOpenReader?(parsed.visible)
+                            onOpenReader?(projection.visible)
                             Haptics.tap()
                         } label: {
                             Image(systemName: "arrow.up.left.and.arrow.down.right")
@@ -498,7 +515,7 @@ struct MessageBubble: View {
                     if message.streaming && !isUser { StreamingDot().padding(6) }
                 }
         } else {
-            Text(parsed.visible.isEmpty ? " " : parsed.visible)
+            Text(projection.visible.isEmpty ? " " : projection.visible)
                 .textSelection(.enabled)
                 .foregroundStyle(isUser ? chrome.accentForeground : Color.primary)
                 .padding(.horizontal, 14).padding(.vertical, 9)

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -265,7 +265,8 @@ struct MessageBubble: View {
                                       messageId: message.id)
                         .padding(.leading, 2)
                 }
-                // Hide the (empty) text bubble for image-only messages.
+                // Hide empty settled bubbles, including image-only and
+                // control-only assistant responses.
                 if !projection.visible.isEmpty || (message.streaming && message.attachmentDataUrls.isEmpty) {
                     bubble(projection)
                         .contextMenu { messageActions }

--- a/apps/ios/CovenCave/CovenCaveTests/AssistantResponseProjectionTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AssistantResponseProjectionTests.swift
@@ -213,4 +213,49 @@ final class AssistantResponseProjectionTests: XCTestCase {
             "Source [docs.www.example.com](https://docs.www.example.com/report)."
         )
     }
+
+    func testListContinuationStillProcessesControlsAndCitations() {
+        let response = AssistantResponseProjection.parse(
+            """
+            Findings:
+
+            - Top level
+
+                Continue here <coven:github kind="pr" repo="owner/repo" number="7" /> with a source[^1].
+
+            [^1]: https://example.com/source
+            """
+        )
+
+        XCTAssertFalse(response.visible.contains("<coven:"))
+        XCTAssertTrue(
+            response.visible.contains(
+                "Continue here  with a source [example.com](https://example.com/source)."
+            )
+        )
+        XCTAssertEqual(
+            response.previewURLs.map(\.absoluteString),
+            ["https://github.com/owner/repo/pull/7"]
+        )
+    }
+
+    func testCitationImmediatelyAfterFenceIsProcessed() {
+        let response = AssistantResponseProjection.parse(
+            """
+            Cite this[^1].
+
+            ```
+            code
+            ```
+            [^1]: https://example.com/source
+            """
+        )
+
+        XCTAssertTrue(
+            response.visible.contains(
+                "Cite this [example.com](https://example.com/source)."
+            )
+        )
+        XCTAssertFalse(response.visible.contains("[^1]:"))
+    }
 }

--- a/apps/ios/CovenCave/CovenCaveTests/AssistantResponseProjectionTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AssistantResponseProjectionTests.swift
@@ -1,0 +1,216 @@
+import XCTest
+@testable import CovenCave
+
+final class AssistantResponseProjectionTests: XCTestCase {
+    func testControlMarkersAndFootnotesBecomeNativeResponseMetadata() {
+        let response = AssistantResponseProjection.parse(
+            """
+            The release is live[^release].
+
+            <coven:github kind="run" repo="OpenCoven/coven-cave" run="33080679864" title="Release" />
+
+            [^release]: https://github.com/OpenCoven/coven-cave/actions/runs/33080679864 "Release workflow"
+
+            <coven:next-paths>
+            - [reply:recommended] Open the release
+            </coven:next-paths>
+            """
+        )
+
+        XCTAssertEqual(
+            response.visible,
+            "The release is live [GitHub](https://github.com/OpenCoven/coven-cave/actions/runs/33080679864)."
+        )
+        XCTAssertEqual(response.suggestions, ["Open the release"])
+        XCTAssertEqual(
+            response.previewURLs.map(\.absoluteString),
+            ["https://github.com/OpenCoven/coven-cave/actions/runs/33080679864"]
+        )
+        XCTAssertFalse(response.visible.contains("<coven:"))
+        XCTAssertFalse(response.visible.contains("[^release]"))
+    }
+
+    func testScreenshotStyleCitationsStayUsefulWithoutRawDefinitionLines() {
+        let response = AssistantResponseProjection.parse(
+            """
+            FreshBooks reports a payment delay[^1], while QuickBooks describes the same pattern[^2].
+
+            [^1]: <https://www.freshbooks.com/hub/reports/payments> — Invoice payment analysis
+            [^2]: [QuickBooks report](https://quickbooks.intuit.com/r/reports/payment-times/)
+            """
+        )
+
+        XCTAssertEqual(
+            response.visible,
+            "FreshBooks reports a payment delay [freshbooks.com](https://www.freshbooks.com/hub/reports/payments), while QuickBooks describes the same pattern [QuickBooks](https://quickbooks.intuit.com/r/reports/payment-times/)."
+        )
+        XCTAssertTrue(response.previewURLs.isEmpty, "inline citations must not create a duplicate preview card")
+        XCTAssertFalse(response.visible.contains("[^"))
+    }
+
+    func testProtocolExamplesInsideCodeRemainLiteral() {
+        let response = AssistantResponseProjection.parse(
+            """
+            Use `<coven:github kind="issue" repo="owner/repo" number="7" />`.
+
+            ```xml
+            <coven:github kind="pr" repo="owner/repo" number="42" />
+            [^1]: https://example.com/source
+            ```
+            """
+        )
+
+        XCTAssertTrue(response.visible.contains("`<coven:github kind=\"issue\""))
+        XCTAssertTrue(response.visible.contains("<coven:github"))
+        XCTAssertTrue(response.visible.contains("[^1]:"))
+        XCTAssertTrue(response.previewURLs.isEmpty)
+    }
+
+    func testVariableLengthMarkdownCodeDelimitersRemainLiteral() {
+        let response = AssistantResponseProjection.parse(
+            """
+            ``Use `<coven:github kind="issue" repo="owner/repo" number="7" />` literally.``
+
+            ````markdown
+            ```xml
+            <coven:github kind="pr" repo="owner/repo" number="42" />
+            ```
+            <coven:next-paths>
+            - literal
+            </coven:next-paths>
+            ````
+            """
+        )
+
+        XCTAssertTrue(response.visible.contains("<coven:github kind=\"issue\""))
+        XCTAssertTrue(response.visible.contains("<coven:github kind=\"pr\""))
+        XCTAssertTrue(response.visible.contains("<coven:next-paths>"))
+        XCTAssertTrue(response.suggestions.isEmpty)
+        XCTAssertTrue(response.previewURLs.isEmpty)
+    }
+
+    func testUnsupportedAndIncompleteControlsNeverLeakIntoProse() {
+        let response = AssistantResponseProjection.parse(
+            """
+            Before.
+            <coven:preview url="http://127.0.0.1:3000/demo" title="Demo" />
+            <coven:github kind="pr" repo="OpenCoven/coven-cave"
+            """
+        )
+
+        XCTAssertEqual(response.visible, "Before.")
+        XCTAssertTrue(response.previewURLs.isEmpty)
+    }
+
+    func testBareLineLinksStillCreateOnePreview() {
+        let response = AssistantResponseProjection.parse(
+            """
+            Details:
+
+            https://example.com/report
+            """
+        )
+
+        XCTAssertEqual(response.previewURLs.map(\.absoluteString), ["https://example.com/report"])
+    }
+
+    func testPreviewCardsAreBounded() {
+        let response = AssistantResponseProjection.parse(
+            """
+            https://example.com/one
+            https://example.com/two
+            https://example.com/three
+            """
+        )
+
+        XCTAssertEqual(
+            response.previewURLs.map(\.absoluteString),
+            ["https://example.com/one", "https://example.com/two"]
+        )
+    }
+
+    func testFencedAndIndentedCodeRemainLiteral() {
+        let raw = "```text\nalpha   \n\n\nbeta\n```\n\n"
+            + "    <coven:github kind=\"pr\" repo=\"owner/repo\" number=\"42\" />\n"
+            + "    [^1]: https://example.com/source"
+        let response = AssistantResponseProjection.parse(raw)
+
+        XCTAssertTrue(response.visible.contains("alpha   \n\n\nbeta"))
+        XCTAssertTrue(response.visible.contains("    <coven:github"))
+        XCTAssertTrue(response.visible.contains("    [^1]:"))
+        XCTAssertTrue(response.previewURLs.isEmpty)
+    }
+
+    func testUnmatchedNumericReferenceRemainsVisible() {
+        let response = AssistantResponseProjection.parse(
+            "Match with [^0-9] and keep [^1] until its definition arrives."
+        )
+
+        XCTAssertEqual(
+            response.visible,
+            "Match with [^0-9] and keep [^1] until its definition arrives."
+        )
+    }
+
+    func testUnsupportedCitationDefinitionRemainsVisible() {
+        let response = AssistantResponseProjection.parse(
+            """
+            See the implementation[^src].
+
+            [^src]: src/lib/citations.ts#L303-L326
+            """
+        )
+
+        XCTAssertEqual(
+            response.visible,
+            "See the implementation[^src].\n\n[^src]: src/lib/citations.ts#L303-L326"
+        )
+    }
+
+    func testMarkdownCitationAllowsBalancedParenthesesInURL() {
+        let response = AssistantResponseProjection.parse(
+            """
+            Background[^wiki].
+
+            [^wiki]: [Wiki](https://en.wikipedia.org/wiki/Foo_(bar))
+            """
+        )
+
+        XCTAssertEqual(
+            response.visible,
+            "Background [en.wikipedia.org](https://en.wikipedia.org/wiki/Foo_(bar))."
+        )
+    }
+
+    func testStreamingCitationWaitsForSettledResponse() {
+        let response = AssistantResponseProjection.parse(
+            """
+            Live[^release]
+
+            [^release]: https://gith
+            """,
+            streaming: true
+        )
+
+        XCTAssertEqual(
+            response.visible,
+            "Live[^release]\n\n[^release]: https://gith"
+        )
+        XCTAssertTrue(response.previewURLs.isEmpty)
+    }
+
+    func testProviderPrefixNormalizationDoesNotAlterInteriorWWW() {
+        let response = AssistantResponseProjection.parse(
+            """
+            Source[^1].
+
+            [^1]: https://docs.www.example.com/report
+            """
+        )
+
+        XCTAssertEqual(
+            response.visible,
+            "Source [docs.www.example.com](https://docs.www.example.com/report)."
+        )
+    }
+}

--- a/apps/ios/markdown/entry.mjs
+++ b/apps/ios/markdown/entry.mjs
@@ -136,6 +136,15 @@ async function renderMarkdown(md, { streaming = false } = {}) {
   return html;
 }
 
+function classifyInlineTokens(root) {
+  root.querySelectorAll("code:not(pre code)").forEach((element) => {
+    const text = (element.textContent || "").trim();
+    if (text && text.length <= 28 && !/\s/.test(text)) {
+      element.classList.add("inline-token");
+    }
+  });
+}
+
 // Reader theming: override the prose-level CSS variables (declared on :root in
 // markdown.css) so the same bundle can render dark / light / sepia. Code blocks
 // keep their dark card (we deliberately DON'T touch --code-bg / hljs colours) —
@@ -147,8 +156,8 @@ async function renderMarkdown(md, { streaming = false } = {}) {
 // it stays legible on a light bubble.
 const THEME_VARS = {
   dark: null,
-  light: { "--txt": "#1c1c22", "--txt-muted": "#5b5b66", "--accent": "#5a51d6", "--hairline": "rgba(0,0,0,0.14)", "--code-inline-bg": "color-mix(in srgb, var(--accent) 13%, transparent)", "--code-inline-fg": "color-mix(in srgb, var(--accent), #000000 14%)", "--th-bg": "rgba(0,0,0,0.04)", bg: "#ffffff" },
-  sepia: { "--txt": "#43382a", "--txt-muted": "#7a6a55", "--accent": "#9a5a2a", "--hairline": "rgba(0,0,0,0.16)", "--code-inline-bg": "color-mix(in srgb, var(--accent) 15%, transparent)", "--code-inline-fg": "color-mix(in srgb, var(--accent), #000000 22%)", "--th-bg": "rgba(0,0,0,0.05)", bg: "#f4ecd8" },
+  light: { "--txt": "#1c1c22", "--txt-muted": "#5b5b66", "--accent": "#5a51d6", "--hairline": "rgba(0,0,0,0.14)", "--code-inline-bg": "color-mix(in srgb, var(--accent) 9%, transparent)", "--code-inline-fg": "color-mix(in srgb, var(--accent), #000000 18%)", "--th-bg": "rgba(0,0,0,0.04)", bg: "#ffffff" },
+  sepia: { "--txt": "#43382a", "--txt-muted": "#7a6a55", "--accent": "#9a5a2a", "--hairline": "rgba(0,0,0,0.16)", "--code-inline-bg": "color-mix(in srgb, var(--accent) 10%, transparent)", "--code-inline-fg": "color-mix(in srgb, var(--accent), #000000 20%)", "--th-bg": "rgba(0,0,0,0.05)", bg: "#f4ecd8" },
 };
 const THEME_KEYS = ["--txt", "--txt-muted", "--accent", "--hairline", "--code-inline-bg", "--code-inline-fg", "--th-bg"];
 function applyTheme(name) {
@@ -206,6 +215,7 @@ window.caveRender = async (md, opts = {}) => {
   applyStyle(opts);
   try {
     root.innerHTML = await renderMarkdown(md, { streaming: !!opts.streaming });
+    classifyInlineTokens(root);
   } catch (err) {
     root.textContent = String(md || "");
     window.webkit?.messageHandlers?.cave?.postMessage({ type: "error", message: String(err) });

--- a/apps/ios/markdown/markdown.css
+++ b/apps/ios/markdown/markdown.css
@@ -12,11 +12,11 @@
   --hairline: rgba(255,255,255,0.10);
   /* Inline code + links follow --accent so they match the selected desktop
      theme (the renderer overrides --accent with the published accent). Derived
-     via color-mix off --accent: a translucent pill, with the text lifted toward
+     via color-mix off --accent: a quiet tint, with the text lifted toward
      white on the dark default for contrast. THEME_VARS re-points the text mix
      toward black on the light/sepia reader pages. */
-  --code-inline-bg: color-mix(in srgb, var(--accent) 18%, transparent);
-  --code-inline-fg: color-mix(in srgb, var(--accent), #ffffff 34%);
+  --code-inline-bg: color-mix(in srgb, var(--accent) 11%, transparent);
+  --code-inline-fg: color-mix(in srgb, var(--accent), #ffffff 22%);
   --th-bg: rgba(255,255,255,0.04);
 }
 
@@ -53,15 +53,16 @@ blockquote {
 
 hr { border: 0; border-top: 1px solid var(--hairline); margin: 1em 0; }
 
-/* inline code — lavender pill */
+/* Inline code stays distinct without turning every identifier into a badge. */
 code {
   font-family: "SF Mono", ui-monospace, Menlo, monospace;
-  font-size: 0.88em;
+  font-size: 0.86em;
   background: var(--code-inline-bg);
   color: var(--code-inline-fg);
-  padding: 0.12em 0.4em;
-  border-radius: 5px;
+  padding: 0.06em 0.24em;
+  border-radius: 4px;
 }
+code.inline-token { white-space: nowrap; }
 
 /* fenced code block — the .code-block container owns the frame (border/radius/
    background) so the header bar and <pre> share one rounded card. */

--- a/scripts/ios-link-previews.test.mjs
+++ b/scripts/ios-link-previews.test.mjs
@@ -22,8 +22,23 @@ assert.match(lp, /Text\(m\.title \?\? url\.host/, "the card should show the titl
 const bubble = await read("MessageBubble.swift");
 assert.match(
   bubble,
-  /if !message\.streaming, let link = firstLink\(in: parsed\.visible\) \{\s*LinkPreviewCard\(url: link\)/,
-  "MessageBubble should show a LinkPreviewCard for the first link in a finished message",
+  /ForEach\(projection\.previewURLs, id: \\\.\absoluteString\) \{ link in\s*LinkPreviewCard\(url: link\)/,
+  "MessageBubble should render only the response projection's deliberate previews",
+);
+assert.match(
+  bubble,
+  /if message\.role != \.assistant \{[\s\S]*visible: message\.text,[\s\S]*previewURLs: isUser \? firstLink/,
+  "protocol cleanup should not alter system messages while user messages keep link previews",
+);
+
+const projection = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/Models/AssistantResponseProjection.swift", import.meta.url),
+  "utf8",
+);
+assert.match(
+  projection,
+  /AssistantResponseProjection[\s\S]*extractControls[\s\S]*renderCitations[\s\S]*bareLineURLs/,
+  "assistant response projection should strip controls and classify links before presentation",
 );
 
 console.log("ios-link-previews: ok");

--- a/scripts/ios-markdown-accent.test.mjs
+++ b/scripts/ios-markdown-accent.test.mjs
@@ -97,6 +97,16 @@ assert.match(
   "inline code background should be color-mixed off var(--accent)",
 );
 assert.match(
+  entry,
+  /function classifyInlineTokens[\s\S]*code:not\(pre code\)[\s\S]*text\.length <= 28[\s\S]*classList\.add\("inline-token"\)/,
+  "short metadata tokens should be classified after markdown rendering",
+);
+assert.match(
+  css,
+  /code\.inline-token\s*\{\s*white-space:\s*nowrap;/,
+  "classified metadata tokens should move as a unit instead of breaking mid-identifier",
+);
+assert.match(
   css,
   /--code-inline-fg: color-mix\(in srgb, var\(--accent\)/,
   "inline code text should be color-mixed off var(--accent)",

--- a/scripts/ios-message-reader.test.mjs
+++ b/scripts/ios-message-reader.test.mjs
@@ -18,7 +18,7 @@ assert.match(
 
 assert.match(
   messageBubble,
-  /private var canOpenReader: Bool \{[\s\S]*!isUser[\s\S]*!message\.streaming[\s\S]*!message\.isError[\s\S]*!parsed\.visible\.isEmpty[\s\S]*onOpenReader != nil/,
+  /private var canOpenReader: Bool \{\s*canOpenReader\(parsed\)\s*\}[\s\S]*private func canOpenReader\(_ projection: AssistantResponseProjection\) -> Bool \{[\s\S]*!isUser[\s\S]*!message\.streaming[\s\S]*!message\.isError[\s\S]*!projection\.visible\.isEmpty[\s\S]*onOpenReader != nil/,
   "reader action should only be available for settled non-error assistant responses",
 );
 
@@ -32,6 +32,12 @@ assert.match(
   messageBubble,
   /\.accessibilityLabel\("Open response in reader"\)/,
   "reader expand button should be directly accessible from the assistant bubble",
+);
+
+assert.match(
+  messageBubble,
+  /if !projection\.visible\.isEmpty \|\| \(message\.streaming && message\.attachmentDataUrls\.isEmpty\)/,
+  "settled control-only responses should not render an empty text bubble",
 );
 
 assert.match(


### PR DESCRIPTION
## Summary
- normalize assistant protocol markers and citations before native rendering
- preserve Markdown code examples and bound automatic link previews
- align inline-code wrapping and hide empty control-only bubbles

## Verification
- `TMPDIR=$PWD/.tmp pnpm test:mobile`
- focused `AssistantResponseProjectionTests` XCTest run
- iOS `xcodebuild build-for-testing`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`

Bead: `cave-o8kh3`