### PR TITLE
chore(release): stamp v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-09
+
+> Makes assistant responses easier to read in native iOS chat.
+
+Patch release on top of v0.4.0, carrying the iOS assistant response formatting repair.
+
+### Fixed
+- Normalize assistant protocol markers and citations before native rendering.
+- Preserve Markdown code examples and improve inline-code wrapping.
+- Bound automatic link previews and hide empty control-only message bubbles.
+
+### Changed
+- Advance desktop and iOS release metadata to 0.4.1 and refresh the TestFlight build number.
+- Remove the temporary August worktree recovery notice from the tracked tree.
+
 ## [0.4.0] - 2026-09-05
 
 > Starts the v0.4 release line from the fully validated v0.3.13 payload,

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.4.0"
+    MARKETING_VERSION: "0.4.1"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026090517"
+    CURRENT_PROJECT_VERSION: "2026090901"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.4.0"
+version = "0.4.1"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Prepare v0.4.1 from main at 2106e49a14182b39e6072aaf2ae4e89f04d4427c. This patch delivers the native iOS assistant response-formatting fix: protocol/citation normalization, preserved Markdown code examples, improved inline-code wrapping, bounded link previews, and suppression of empty control-only bubbles.

Updates all five release manifests and finalizes CHANGELOG.md. iOS marketing version is 0.4.1 and build number is 2026090901. Draft renderer lifecycle and physical-performance baseline PRs are not included.

Validation passed locally:
- release:verify and git diff --check
- typecheck, lint, and check:tests-wired (2,004 files)
- test:app (1,418 files), test:api (471 files), test:mobile (100 files)
- 67 release-stamp, promotion, and App Store Connect contract tests

Local fixture requirements: app/API tests used an external TMPDIR; app tests put system Git before Homebrew on PATH because the hook-installer test requires Git and Node in separate directories. No tests were skipped or source guards changed.

Bead: cave-at391. After merge, validate a signed immutable v0.4.1-rc.1 candidate before promoting the same commit to v0.4.1 and confirming TestFlight processing.
