### PR TITLE
[Withdrawn] feat(cave): add Salem Quick Answer macOS menu-bar shell

### DIFF
--- a/apps/macos/SalemQuickAnswer/README.md
+++ b/apps/macos/SalemQuickAnswer/README.md
@@ -1,0 +1,71 @@
+# Salem Quick Answer for macOS
+
+Tracking: OpenCoven/coven-cave#5329 under #5323.
+
+This is the native Cave-owned menu-bar shell for Salem Quick Answer. The #5329 slice is deliberately fixture-only: it contains no live Salem networking, Keychain credential, model/provider secret, familiar runtime, Psyche/Threads/Coven mutation path, chat history, or voice input.
+
+## What works in this slice
+
+- menu-bar status item with a SwiftUI popover;
+- global `⌥ Space` toggle without an Accessibility permission dependency;
+- question field focused when the popover appears;
+- Anyone / AI user / Creator / Developer / Security / Partner audience selector;
+- Quick / Conversation / Deep / Technical depth selector;
+- explicit answered, low-confidence, stale, offline, unauthorized, rate-limited, and failed states;
+- claim status and confidence rendered separately;
+- caveat and evidence disclosure;
+- versioned offline pitch cards clearly labeled as reference language, not live implementation status;
+- deterministic fixture service implementing the `opencoven.salem-brief/v1` client shape;
+- XCTest state coverage plus a portable source-contract verifier.
+
+## Generate and run
+
+Requires macOS, Xcode 16+, and XcodeGen.
+
+```sh
+cd apps/macos/SalemQuickAnswer
+xcodegen generate
+open SalemQuickAnswer.xcodeproj
+```
+
+Or build/test from the command line:
+
+```sh
+cd apps/macos/SalemQuickAnswer
+xcodegen generate
+xcodebuild test \
+  -project SalemQuickAnswer.xcodeproj \
+  -scheme SalemQuickAnswer \
+  -destination 'platform=macOS'
+```
+
+The generated `.xcodeproj` is not the source of truth and should not be committed unless Cave later standardizes a different Apple-project policy. `project.yml` is canonical, matching the existing native iOS convention.
+
+## Portable source check
+
+From the repository root:
+
+```sh
+node scripts/verify-quick-answer-macos.mjs
+```
+
+This is not a substitute for Xcode compilation. It verifies the principal product boundary in CI/dev environments that cannot build macOS: LSUIElement/menu-bar wiring, ⌥Space registration, explicit failure states, offline pitch language, fixture schema version, and absence of live-network/provider-secret wiring.
+
+## Fixture paths
+
+Normal questions return a synthetic `specified` answer. These phrases exercise failures without network access:
+
+```text
+fixture:unknown
+fixture:stale
+fixture:offline
+fixture:unauthorized
+fixture:rate
+fixture:failed
+```
+
+Questions containing `every model` also exercise the low-confidence “I wouldn't claim that yet” path.
+
+## Trust boundary
+
+The bundled pitches are reference language only. They are not evidence that a feature is currently implemented, verified, released, private, secure, or universally compatible. The next live-integration slice (#5330) must decode the server's structured Brief response and preserve its explicit evidence/freshness/failure states instead of turning the offline library into a cache of current truth.

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswer/FixtureBriefService.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswer/FixtureBriefService.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+protocol BriefServing {
+    func answer(question: String, audience: AnswerAudience, depth: AnswerDepth) async throws -> BriefResponse
+}
+
+enum FixtureBriefError: Error {
+    case offline
+    case unauthorized
+    case rateLimited
+    case failed
+}
+
+struct FixtureBriefService: BriefServing {
+    func answer(question: String, audience: AnswerAudience, depth: AnswerDepth) async throws -> BriefResponse {
+        try await Task.sleep(for: .milliseconds(180))
+        let normalized = question.lowercased()
+
+        if normalized.contains("fixture:offline") { throw FixtureBriefError.offline }
+        if normalized.contains("fixture:unauthorized") { throw FixtureBriefError.unauthorized }
+        if normalized.contains("fixture:rate") { throw FixtureBriefError.rateLimited }
+        if normalized.contains("fixture:failed") { throw FixtureBriefError.failed }
+
+        let unknown = normalized.contains("every model") || normalized.contains("fixture:unknown")
+        let stale = normalized.contains("fixture:stale")
+        let answer = unknown
+            ? "I wouldn't claim that yet."
+            : "OpenCoven is building a personal AI assistant you can keep as the technology behind it changes."
+
+        return BriefResponse(
+            schemaVersion: "opencoven.salem-brief/v1",
+            queryId: "fixture-\(UUID().uuidString.lowercased())",
+            question: question,
+            answer: .init(
+                sayThis: answer,
+                followUp: unknown
+                    ? "Universal support still has to be implemented and verified for specific environments."
+                    : "We call that ongoing assistant a familiar, with continuity and authority kept distinct.",
+                caveats: unknown ? ["Reference fixture: not live release-status evidence."] : []
+            ),
+            classification: .init(
+                claimStatus: unknown ? .unknown : .specified,
+                confidence: unknown ? .low : .high,
+                safeToGeneralize: false
+            ),
+            evidence: unknown ? [] : [
+                .init(
+                    id: "fixture-docs-1",
+                    title: "OpenCoven canonical pitch reference",
+                    url: nil,
+                    summary: "Synthetic fixture used only for deterministic client development.",
+                    sourceAuthority: "canonical_docs",
+                    lifecycle: "current",
+                    repository: nil,
+                    path: nil,
+                    revision: nil,
+                    sourceHash: nil
+                )
+            ],
+            knowledge: .init(
+                sourceRevision: nil,
+                sourceHash: stale ? String(repeating: "a", count: 64) : nil,
+                indexedAt: stale ? "2026-09-01T00:00:00.000Z" : nil,
+                checkedAt: stale ? "2026-09-08T00:00:00.000Z" : nil,
+                freshness: stale ? .stale : .unknown
+            )
+        )
+    }
+}

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswer/FixtureBriefService.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswer/FixtureBriefService.swift
@@ -4,7 +4,7 @@ protocol BriefServing {
     func answer(question: String, audience: AnswerAudience, depth: AnswerDepth) async throws -> BriefResponse
 }
 
-enum FixtureBriefError: Error {
+enum BriefServiceError: Error {
     case offline
     case unauthorized
     case rateLimited
@@ -16,10 +16,10 @@ struct FixtureBriefService: BriefServing {
         try await Task.sleep(for: .milliseconds(180))
         let normalized = question.lowercased()
 
-        if normalized.contains("fixture:offline") { throw FixtureBriefError.offline }
-        if normalized.contains("fixture:unauthorized") { throw FixtureBriefError.unauthorized }
-        if normalized.contains("fixture:rate") { throw FixtureBriefError.rateLimited }
-        if normalized.contains("fixture:failed") { throw FixtureBriefError.failed }
+        if normalized.contains("fixture:offline") { throw BriefServiceError.offline }
+        if normalized.contains("fixture:unauthorized") { throw BriefServiceError.unauthorized }
+        if normalized.contains("fixture:rate") { throw BriefServiceError.rateLimited }
+        if normalized.contains("fixture:failed") { throw BriefServiceError.failed }
 
         let unknown = normalized.contains("every model") || normalized.contains("fixture:unknown")
         let stale = normalized.contains("fixture:stale")

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswer/GlobalHotKeyController.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswer/GlobalHotKeyController.swift
@@ -1,0 +1,66 @@
+import Carbon.HIToolbox
+import Foundation
+
+final class GlobalHotKeyController {
+    private var hotKeyRef: EventHotKeyRef?
+    private var eventHandler: EventHandlerRef?
+    private let action: () -> Void
+
+    init(action: @escaping () -> Void) {
+        self.action = action
+    }
+
+    func register() {
+        unregister()
+
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+
+        let opaqueSelf = Unmanaged.passUnretained(self).toOpaque()
+        InstallEventHandler(
+            GetApplicationEventTarget(),
+            { _, _, userData in
+                guard let userData else { return noErr }
+                let controller = Unmanaged<GlobalHotKeyController>
+                    .fromOpaque(userData)
+                    .takeUnretainedValue()
+                DispatchQueue.main.async { controller.action() }
+                return noErr
+            },
+            1,
+            &eventType,
+            opaqueSelf,
+            &eventHandler
+        )
+
+        let identifier = EventHotKeyID(
+            signature: OSType(0x4F435141), // OCQA
+            id: 1
+        )
+        RegisterEventHotKey(
+            UInt32(kVK_Space),
+            UInt32(optionKey),
+            identifier,
+            GetApplicationEventTarget(),
+            0,
+            &hotKeyRef
+        )
+    }
+
+    func unregister() {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+            self.hotKeyRef = nil
+        }
+        if let eventHandler {
+            RemoveEventHandler(eventHandler)
+            self.eventHandler = nil
+        }
+    }
+
+    deinit {
+        unregister()
+    }
+}

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswer/Models.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswer/Models.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+enum ClaimStatus: String, Codable, CaseIterable {
+    case verified
+    case implemented
+    case specified
+    case approvedDesign = "approved_design"
+    case proposed
+    case experimental
+    case deprecated
+    case unknown
+
+    var label: String {
+        switch self {
+        case .verified: "Verified"
+        case .implemented: "Implemented"
+        case .specified: "Specified"
+        case .approvedDesign: "Approved design"
+        case .proposed: "Proposed"
+        case .experimental: "Experimental"
+        case .deprecated: "Deprecated"
+        case .unknown: "Unknown"
+        }
+    }
+}
+
+enum BriefConfidence: String, Codable {
+    case high
+    case medium
+    case low
+
+    var label: String { rawValue.capitalized }
+}
+
+enum KnowledgeFreshness: String, Codable {
+    case fresh
+    case aging
+    case stale
+    case unknown
+}
+
+struct BriefEvidence: Codable, Identifiable, Equatable {
+    let id: String
+    let title: String
+    let url: String?
+    let summary: String
+    let sourceAuthority: String
+    let lifecycle: String
+    let repository: String?
+    let path: String?
+    let revision: String?
+    let sourceHash: String?
+}
+
+struct BriefResponse: Codable, Equatable {
+    struct Answer: Codable, Equatable {
+        let sayThis: String
+        let followUp: String?
+        let caveats: [String]
+    }
+
+    struct Classification: Codable, Equatable {
+        let claimStatus: ClaimStatus
+        let confidence: BriefConfidence
+        let safeToGeneralize: Bool
+    }
+
+    struct Knowledge: Codable, Equatable {
+        let sourceRevision: String?
+        let sourceHash: String?
+        let indexedAt: String?
+        let checkedAt: String?
+        let freshness: KnowledgeFreshness
+    }
+
+    let schemaVersion: String
+    let queryId: String
+    let question: String
+    let answer: Answer
+    let classification: Classification
+    let evidence: [BriefEvidence]
+    let knowledge: Knowledge
+}
+
+enum QuickAnswerState: Equatable {
+    case idle
+    case querying
+    case answered(BriefResponse)
+    case lowConfidence(BriefResponse)
+    case stale(BriefResponse)
+    case offline
+    case unauthorized
+    case rateLimited
+    case failed(String)
+}
+
+enum AnswerDepth: String, CaseIterable, Identifiable {
+    case quick
+    case conversation
+    case deep
+    case technical
+
+    var id: Self { self }
+    var label: String { rawValue.capitalized }
+}
+
+enum AnswerAudience: String, CaseIterable, Identifiable {
+    case anyone
+    case aiUser = "ai_user"
+    case creator
+    case developer
+    case security
+    case partner
+
+    var id: Self { self }
+    var label: String {
+        switch self {
+        case .anyone: "Anyone"
+        case .aiUser: "AI user"
+        case .creator: "Creator"
+        case .developer: "Developer"
+        case .security: "Security"
+        case .partner: "Partner / investor"
+        }
+    }
+}

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswer/PitchLibrary.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswer/PitchLibrary.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct PitchCard: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let text: String
+}
+
+enum PitchLibrary {
+    static let version = "2026-09-08"
+
+    static let cards: [PitchCard] = [
+        .init(id: "general-10", title: "10 seconds", text: "OpenCoven is building a personal AI assistant you can keep as your devices and AI tools change."),
+        .init(id: "general-30", title: "30 seconds", text: "OpenCoven is about having a personal AI assistant you don't have to start over with. We're building it so the things you choose to save—your preferences, ongoing work, and the limits you set—can stay with your assistant as you change devices or AI systems. We call that assistant a familiar. AI that can stay."),
+        .init(id: "general-60", title: "60 seconds", text: "OpenCoven is about having a personal AI assistant you don't have to start over with. If you've already taught an AI how you like to work, what you've decided, and what matters to you, changing the technology underneath shouldn't force you to rebuild everything from zero. We call your ongoing assistant a familiar. The goal is to carry forward its identity, the information you choose to save, and the limits you set across supported environments. AI that can stay."),
+        .init(id: "developer", title: "Developer", text: "OpenCoven treats the familiar as the durable identity rather than the model or runtime. Identity, continuity, authorization, orchestration, and execution stay distinct, so portability doesn't silently grant new authority."),
+        .init(id: "security", title: "Security", text: "OpenCoven separates what an assistant knows from what it's allowed to do. Memory or context can't grant itself protected authority; those boundaries stay explicit and separately governed."),
+        .init(id: "partner", title: "Partner / investor", text: "OpenCoven is building the identity and continuity layer for personal AI assistants that can persist beyond any single model or provider, while keeping human-defined authority boundaries explicit."),
+        .init(id: "creator", title: "Creator", text: "If you've spent months building context around a book, codebase, design practice, or research project, changing AI tools shouldn't mean rebuilding that working relationship from scratch."),
+        .init(id: "familiar", title: "What is a familiar?", text: "A familiar is OpenCoven's name for an ongoing personal AI assistant—AI software whose identity and selected continuity can persist across supported environments."),
+        .init(id: "memory", title: "Is this just memory?", text: "Memory is part of it, but OpenCoven is also about which assistant you're continuing with and what it's allowed to do. Remembering information is not the same as preserving identity or granting permission."),
+        .init(id: "everywhere", title: "Does it work everywhere?", text: "I wouldn't claim universal compatibility today. Portability is a core goal, but each runtime, model, and integration still has to be implemented and verified."),
+        .init(id: "personhood", title: "Is a familiar alive?", text: "Familiar is our name for an ongoing AI assistant. It's AI software, not a claim of consciousness, personhood, or legal agency."),
+        .init(id: "why", title: "Why OpenCoven?", text: "Because the effort you put into an AI assistant shouldn't belong permanently to one model, app, device, or provider. Keep the assistant; change the tools; keep the limits clear.")
+    ]
+}

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswer/QuickAnswerView.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswer/QuickAnswerView.swift
@@ -1,0 +1,262 @@
+import SwiftUI
+
+struct QuickAnswerView: View {
+    @ObservedObject var model: QuickAnswerViewModel
+    @FocusState private var questionFocused: Bool
+    let dismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if model.showingPitches {
+                pitchLibrary
+            } else {
+                askSurface
+            }
+        }
+        .frame(width: 480, minHeight: 310)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .onAppear { questionFocused = true }
+        .onExitCommand { dismiss() }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "sparkles")
+                .foregroundStyle(Color.accentColor)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Salem Quick Answer")
+                    .font(.headline)
+                Text(model.showingPitches ? "Reference pitches — not live status" : "Ask about OpenCoven")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button(model.showingPitches ? "Ask" : "Pitches") {
+                model.showingPitches.toggle()
+                if !model.showingPitches { questionFocused = true }
+            }
+            .buttonStyle(.borderless)
+            .accessibilityHint("Switches between live-answer fixtures and offline reference pitches")
+        }
+        .padding(16)
+    }
+
+    private var askSurface: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 8) {
+                TextField("Ask about OpenCoven…", text: $model.question)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($questionFocused)
+                    .onSubmit { model.submit() }
+                    .accessibilityLabel("OpenCoven question")
+
+                Button("Ask") { model.submit() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!model.canSubmit)
+                    .keyboardShortcut(.return, modifiers: [.command])
+            }
+
+            HStack(spacing: 12) {
+                Picker("Audience", selection: $model.audience) {
+                    ForEach(AnswerAudience.allCases) { audience in
+                        Text(audience.label).tag(audience)
+                    }
+                }
+                .labelsHidden()
+                .accessibilityLabel("Audience")
+
+                Picker("Depth", selection: $model.depth) {
+                    ForEach(AnswerDepth.allCases) { depth in
+                        Text(depth.label).tag(depth)
+                    }
+                }
+                .labelsHidden()
+                .accessibilityLabel("Answer depth")
+
+                Spacer()
+
+                if case .querying = model.state {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel("Getting answer")
+                }
+            }
+
+            stateContent
+        }
+        .padding(16)
+    }
+
+    @ViewBuilder
+    private var stateContent: some View {
+        switch model.state {
+        case .idle:
+            helper("Ask a question. Fixture commands: fixture:stale, fixture:offline, fixture:unauthorized, fixture:rate.")
+        case .querying:
+            helper("Checking the available OpenCoven evidence…")
+        case .answered(let brief):
+            answerCard(brief, notice: nil)
+        case .lowConfidence(let brief):
+            answerCard(brief, notice: "Low confidence — verify before saying this as a current fact.")
+        case .stale(let brief):
+            answerCard(brief, notice: "Stale knowledge — don't use this as current release-status authority.")
+        case .offline:
+            failureState("Salem is offline.", detail: "Use Pitches for versioned reference language.")
+        case .unauthorized:
+            failureState("Quick Answer isn't authorized.", detail: "The live client credential will be added in the next integration slice.")
+        case .rateLimited:
+            failureState("Too many requests.", detail: "Use a reference pitch or try again after the rate-limit window resets.")
+        case .failed(let message):
+            failureState(message, detail: "No answer was substituted for the failed request.")
+        }
+    }
+
+    private func answerCard(_ brief: BriefResponse, notice: String?) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let notice {
+                Label(notice, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(notice)
+            }
+
+            Text("SAY THIS")
+                .font(.caption2.weight(.semibold))
+                .tracking(0.8)
+                .foregroundStyle(.secondary)
+            Text(brief.answer.sayThis)
+                .font(.body)
+                .textSelection(.enabled)
+
+            HStack(spacing: 8) {
+                statusPill(brief.classification.claimStatus.label)
+                statusPill("Confidence: \(brief.classification.confidence.label)")
+                if brief.knowledge.freshness != .unknown {
+                    statusPill("Knowledge: \(brief.knowledge.freshness.rawValue.capitalized)")
+                }
+            }
+
+            if let followUp = brief.answer.followUp {
+                DisclosureGroup("More detail") {
+                    Text(followUp)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 4)
+                }
+            }
+
+            HStack(spacing: 14) {
+                if !brief.answer.caveats.isEmpty {
+                    Button("Caveats") { model.showingCaveats.toggle() }
+                        .buttonStyle(.link)
+                }
+                if !brief.evidence.isEmpty {
+                    Button("Evidence") { model.showingEvidence.toggle() }
+                        .buttonStyle(.link)
+                }
+                Spacer()
+                Button("Clear") {
+                    model.reset()
+                    questionFocused = true
+                }
+                .buttonStyle(.link)
+            }
+
+            if model.showingCaveats {
+                VStack(alignment: .leading, spacing: 5) {
+                    ForEach(brief.answer.caveats, id: \.self) { caveat in
+                        Text("• \(caveat)").font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                .accessibilityElement(children: .combine)
+            }
+
+            if model.showingEvidence {
+                VStack(alignment: .leading, spacing: 7) {
+                    ForEach(brief.evidence) { evidence in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(evidence.title).font(.caption.weight(.semibold))
+                            Text(evidence.sourceAuthority.replacingOccurrences(of: "_", with: " "))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(14)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+    }
+
+    private var pitchLibrary: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text("Reference version \(PitchLibrary.version)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text("Not live implementation status")
+                        .font(.caption.weight(.semibold))
+                }
+                ForEach(PitchLibrary.cards) { pitch in
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text(pitch.title).font(.caption.weight(.semibold))
+                        Text(pitch.text).font(.callout).textSelection(.enabled)
+                    }
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color(nsColor: .controlBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                    )
+                }
+            }
+            .padding(16)
+        }
+        .frame(maxHeight: 520)
+    }
+
+    private func statusPill(_ text: String) -> some View {
+        Text(text)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Color(nsColor: .quaternaryLabelColor).opacity(0.12))
+            .clipShape(Capsule())
+    }
+
+    private func helper(_ text: String) -> some View {
+        Text(text)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityLabel(text)
+    }
+
+    private func failureState(_ title: String, detail: String) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Label(title, systemImage: "exclamationmark.circle")
+                .font(.callout.weight(.semibold))
+            Text(detail).font(.caption).foregroundStyle(.secondary)
+            Button("Open reference pitches") { model.showingPitches = true }
+                .buttonStyle(.link)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .contain)
+    }
+}

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswer/QuickAnswerViewModel.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswer/QuickAnswerViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 @MainActor

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswer/QuickAnswerViewModel.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswer/QuickAnswerViewModel.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+@MainActor
+final class QuickAnswerViewModel: ObservableObject {
+    @Published var question = ""
+    @Published var audience: AnswerAudience = .anyone
+    @Published var depth: AnswerDepth = .conversation
+    @Published private(set) var state: QuickAnswerState = .idle
+    @Published var showingPitches = false
+    @Published var showingEvidence = false
+    @Published var showingCaveats = false
+
+    private let service: BriefServing
+
+    init(service: BriefServing = FixtureBriefService()) {
+        self.service = service
+    }
+
+    var canSubmit: Bool {
+        !question.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && state != .querying
+    }
+
+    func submit() {
+        let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, state != .querying else { return }
+
+        state = .querying
+        showingEvidence = false
+        showingCaveats = false
+
+        Task {
+            do {
+                let response = try await service.answer(
+                    question: trimmed,
+                    audience: audience,
+                    depth: depth
+                )
+                if response.knowledge.freshness == .stale {
+                    state = .stale(response)
+                } else if response.classification.confidence == .low {
+                    state = .lowConfidence(response)
+                } else {
+                    state = .answered(response)
+                }
+            } catch FixtureBriefError.offline {
+                state = .offline
+            } catch FixtureBriefError.unauthorized {
+                state = .unauthorized
+            } catch FixtureBriefError.rateLimited {
+                state = .rateLimited
+            } catch {
+                state = .failed("Couldn't get an answer. Try again.")
+            }
+        }
+    }
+
+    func reset() {
+        question = ""
+        state = .idle
+        showingEvidence = false
+        showingCaveats = false
+    }
+
+    var currentBrief: BriefResponse? {
+        switch state {
+        case .answered(let brief), .lowConfidence(let brief), .stale(let brief): brief
+        default: nil
+        }
+    }
+}

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswer/QuickAnswerViewModel.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswer/QuickAnswerViewModel.swift
@@ -43,11 +43,11 @@ final class QuickAnswerViewModel: ObservableObject {
                 } else {
                     state = .answered(response)
                 }
-            } catch FixtureBriefError.offline {
+            } catch BriefServiceError.offline {
                 state = .offline
-            } catch FixtureBriefError.unauthorized {
+            } catch BriefServiceError.unauthorized {
                 state = .unauthorized
-            } catch FixtureBriefError.rateLimited {
+            } catch BriefServiceError.rateLimited {
                 state = .rateLimited
             } catch {
                 state = .failed("Couldn't get an answer. Try again.")

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswer/SalemQuickAnswerApp.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswer/SalemQuickAnswerApp.swift
@@ -1,0 +1,66 @@
+import AppKit
+import SwiftUI
+
+@main
+struct SalemQuickAnswerApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
+    var body: some Scene {
+        Settings {
+            EmptyView()
+        }
+    }
+}
+
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
+    private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+    private let popover = NSPopover()
+    private let model = QuickAnswerViewModel()
+    private var hotKeyController: GlobalHotKeyController?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+
+        if let button = statusItem.button {
+            button.image = NSImage(systemSymbolName: "sparkles", accessibilityDescription: "Salem Quick Answer")
+            button.toolTip = "Salem Quick Answer — ⌥Space"
+            button.target = self
+            button.action = #selector(togglePopover)
+        }
+
+        popover.behavior = .transient
+        popover.animates = false
+        popover.delegate = self
+        popover.contentSize = NSSize(width: 480, height: 420)
+        popover.contentViewController = NSHostingController(
+            rootView: QuickAnswerView(model: model) { [weak self] in
+                self?.closePopover()
+            }
+        )
+
+        hotKeyController = GlobalHotKeyController { [weak self] in
+            self?.togglePopover()
+        }
+        hotKeyController?.register()
+    }
+
+    @objc func togglePopover() {
+        if popover.isShown {
+            closePopover()
+        } else {
+            showPopover()
+        }
+    }
+
+    private func showPopover() {
+        guard let button = statusItem.button else { return }
+        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        NSApp.activate(ignoringOtherApps: true)
+        popover.contentViewController?.view.window?.makeKey()
+    }
+
+    private func closePopover() {
+        popover.performClose(nil)
+    }
+}

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswerTests/QuickAnswerStateTests.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswerTests/QuickAnswerStateTests.swift
@@ -88,11 +88,11 @@ final class QuickAnswerStateTests: XCTestCase {
     }
 
     @MainActor
-    func testFixtureFailuresRemainDistinct() async throws {
+    func testServiceFailuresRemainDistinct() async throws {
         for (error, assertion) in [
-            (FixtureBriefError.offline, "offline"),
-            (FixtureBriefError.unauthorized, "unauthorized"),
-            (FixtureBriefError.rateLimited, "rateLimited"),
+            (BriefServiceError.offline, "offline"),
+            (BriefServiceError.unauthorized, "unauthorized"),
+            (BriefServiceError.rateLimited, "rateLimited"),
         ] {
             let model = QuickAnswerViewModel(service: MockBriefService(result: .failure(error)))
             model.question = "fixture"

--- a/apps/macos/SalemQuickAnswer/SalemQuickAnswerTests/QuickAnswerStateTests.swift
+++ b/apps/macos/SalemQuickAnswer/SalemQuickAnswerTests/QuickAnswerStateTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import SalemQuickAnswer
+
+private struct MockBriefService: BriefServing {
+    let result: Result<BriefResponse, Error>
+
+    func answer(question: String, audience: AnswerAudience, depth: AnswerDepth) async throws -> BriefResponse {
+        try result.get()
+    }
+}
+
+final class QuickAnswerStateTests: XCTestCase {
+    private func brief(
+        confidence: BriefConfidence = .high,
+        freshness: KnowledgeFreshness = .unknown
+    ) -> BriefResponse {
+        BriefResponse(
+            schemaVersion: "opencoven.salem-brief/v1",
+            queryId: "test-query",
+            question: "What is OpenCoven?",
+            answer: .init(
+                sayThis: "A grounded answer.",
+                followUp: nil,
+                caveats: []
+            ),
+            classification: .init(
+                claimStatus: confidence == .low ? .unknown : .specified,
+                confidence: confidence,
+                safeToGeneralize: false
+            ),
+            evidence: confidence == .low ? [] : [
+                .init(
+                    id: "evidence-1",
+                    title: "Fixture",
+                    url: nil,
+                    summary: "Fixture evidence",
+                    sourceAuthority: "canonical_docs",
+                    lifecycle: "current",
+                    repository: nil,
+                    path: nil,
+                    revision: nil,
+                    sourceHash: nil
+                )
+            ],
+            knowledge: .init(
+                sourceRevision: nil,
+                sourceHash: freshness == .stale ? String(repeating: "a", count: 64) : nil,
+                indexedAt: freshness == .stale ? "2026-09-01T00:00:00.000Z" : nil,
+                checkedAt: freshness == .stale ? "2026-09-08T00:00:00.000Z" : nil,
+                freshness: freshness
+            )
+        )
+    }
+
+    @MainActor
+    func testSuccessfulAnswerBecomesAnswered() async throws {
+        let model = QuickAnswerViewModel(service: MockBriefService(result: .success(brief())))
+        model.question = "What is OpenCoven?"
+        model.submit()
+        await Task.yield()
+        try await Task.sleep(for: .milliseconds(10))
+
+        guard case .answered(let response) = model.state else {
+            return XCTFail("Expected answered state")
+        }
+        XCTAssertEqual(response.answer.sayThis, "A grounded answer.")
+    }
+
+    @MainActor
+    func testLowConfidenceAndStaleAreExplicitStates() async throws {
+        let low = QuickAnswerViewModel(
+            service: MockBriefService(result: .success(brief(confidence: .low)))
+        )
+        low.question = "Does it support every model?"
+        low.submit()
+        await Task.yield()
+        try await Task.sleep(for: .milliseconds(10))
+        if case .lowConfidence = low.state {} else { XCTFail("Expected low-confidence state") }
+
+        let stale = QuickAnswerViewModel(
+            service: MockBriefService(result: .success(brief(freshness: .stale)))
+        )
+        stale.question = "What is current?"
+        stale.submit()
+        await Task.yield()
+        try await Task.sleep(for: .milliseconds(10))
+        if case .stale = stale.state {} else { XCTFail("Expected stale state") }
+    }
+
+    @MainActor
+    func testFixtureFailuresRemainDistinct() async throws {
+        for (error, assertion) in [
+            (FixtureBriefError.offline, "offline"),
+            (FixtureBriefError.unauthorized, "unauthorized"),
+            (FixtureBriefError.rateLimited, "rateLimited"),
+        ] {
+            let model = QuickAnswerViewModel(service: MockBriefService(result: .failure(error)))
+            model.question = "fixture"
+            model.submit()
+            await Task.yield()
+            try await Task.sleep(for: .milliseconds(10))
+
+            switch (assertion, model.state) {
+            case ("offline", .offline), ("unauthorized", .unauthorized), ("rateLimited", .rateLimited):
+                break
+            default:
+                XCTFail("Expected \(assertion) state")
+            }
+        }
+    }
+
+    func testOfflinePitchLibraryIsVersionedAndComplete() {
+        XCTAssertEqual(PitchLibrary.version, "2026-09-08")
+        XCTAssertGreaterThanOrEqual(PitchLibrary.cards.count, 12)
+        XCTAssertTrue(PitchLibrary.cards.contains { $0.id == "memory" })
+        XCTAssertTrue(PitchLibrary.cards.contains { $0.id == "everywhere" })
+        XCTAssertTrue(PitchLibrary.cards.contains { $0.id == "personhood" })
+    }
+}

--- a/apps/macos/SalemQuickAnswer/project.yml
+++ b/apps/macos/SalemQuickAnswer/project.yml
@@ -1,0 +1,47 @@
+name: SalemQuickAnswer
+options:
+  bundleIdPrefix: ai.opencoven
+  deploymentTarget:
+    macOS: "15.0"
+  createIntermediateGroups: true
+settings:
+  base:
+    SWIFT_VERSION: "5.0"
+    MACOSX_DEPLOYMENT_TARGET: "15.0"
+    GENERATE_INFOPLIST_FILE: YES
+    CODE_SIGN_STYLE: Automatic
+    DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
+targets:
+  SalemQuickAnswer:
+    type: application
+    platform: macOS
+    sources:
+      - path: SalemQuickAnswer
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: ai.opencoven.cave.quickanswer
+        PRODUCT_NAME: Salem Quick Answer
+        INFOPLIST_KEY_LSUIElement: YES
+        ENABLE_PREVIEWS: YES
+        SWIFT_EMIT_LOC_STRINGS: YES
+  SalemQuickAnswerTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: SalemQuickAnswerTests
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: ai.opencoven.cave.quickanswer.tests
+        GENERATE_INFOPLIST_FILE: YES
+    dependencies:
+      - target: SalemQuickAnswer
+schemes:
+  SalemQuickAnswer:
+    build:
+      targets:
+        SalemQuickAnswer: all
+    test:
+      targets:
+        - SalemQuickAnswerTests
+    run:
+      config: Debug

--- a/scripts/verify-quick-answer-macos.mjs
+++ b/scripts/verify-quick-answer-macos.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (path) => readFileSync(path, "utf8");
+const root = "apps/macos/SalemQuickAnswer";
+
+const project = read(`${root}/project.yml`);
+const app = read(`${root}/SalemQuickAnswer/SalemQuickAnswerApp.swift`);
+const hotkey = read(`${root}/SalemQuickAnswer/GlobalHotKeyController.swift`);
+const view = read(`${root}/SalemQuickAnswer/QuickAnswerView.swift`);
+const model = read(`${root}/SalemQuickAnswer/Models.swift`);
+const pitches = read(`${root}/SalemQuickAnswer/PitchLibrary.swift`);
+const fixture = read(`${root}/SalemQuickAnswer/FixtureBriefService.swift`);
+
+assert.match(project, /platform: macOS/);
+assert.match(project, /INFOPLIST_KEY_LSUIElement: YES/);
+assert.match(project, /SalemQuickAnswerTests/);
+assert.match(app, /NSStatusBar\.system\.statusItem/);
+assert.match(app, /NSPopover/);
+assert.match(hotkey, /kVK_Space/);
+assert.match(hotkey, /optionKey/);
+assert.match(view, /SAY THIS/);
+assert.match(view, /Confidence:/);
+assert.match(view, /Stale knowledge/);
+assert.match(view, /Open reference pitches/);
+assert.match(model, /case lowConfidence/);
+assert.match(model, /case stale/);
+assert.match(model, /case offline/);
+assert.match(model, /case unauthorized/);
+assert.match(model, /case rateLimited/);
+assert.match(model, /case failed/);
+assert.match(pitches, /Reference|version/);
+assert.match(pitches, /I wouldn't claim universal compatibility today/);
+assert.match(pitches, /not a claim of consciousness, personhood, or legal agency/);
+assert.match(fixture, /opencoven\.salem-brief\/v1/);
+assert.doesNotMatch(fixture, /URLSession|https:\/\//);
+assert.doesNotMatch(app + view + fixture, /OPENAI_API_KEY|SALEM_ADMIN_PASSWORD|UPSTASH_/);
+
+console.log("quick-answer-macos-source: ok");


### PR DESCRIPTION
## Scope

Closes no issue; refs #5329 under epic #5323. This is the **fixture-only native shell**. Keep #5329 open until real Xcode/macOS verification is recorded.

Base: `9366009e028ff10e7130c3d7824fe8d55e15323f`
Head branch: `feat/salem-quick-answer-shell-5329`

## What changed

Added `apps/macos/SalemQuickAnswer`, following Cave's existing native Apple/XcodeGen convention:

- XcodeGen macOS application + XCTest target;
- LSUIElement menu-bar utility hosted by `NSStatusItem` + `NSPopover` with SwiftUI content;
- global `⌥ Space` registration using the macOS hot-key API, avoiding an Accessibility-permission dependency;
- question composer with immediate focus, audience/depth controls, speakable answer card, separate claim-status/confidence labels, evidence/caveat disclosure, and Escape dismissal;
- explicit idle/querying/answered/low-confidence/stale/offline/unauthorized/rate-limited/failed states;
- versioned offline reference pitch library covering the required general/audience/common-question cases;
- deterministic `opencoven.salem-brief/v1` fixture service with no network use;
- XCTest state-machine/pitch coverage;
- portable `node scripts/verify-quick-answer-macos.mjs` source-contract verifier for non-macOS environments;
- scoped README with generation/test commands and trust boundary.

## Product / authority boundary

This slice contains **no live Salem networking, Keychain credential, provider/infrastructure secret, persistent question history, voice input, familiar runtime, Psyche task, Threads proposal, Coven execution, memory mutation, GitHub write, release, or publication path**.

Offline pitch cards are visibly labeled reference material and are not presented as current implementation/release evidence.

## Design contract

Reviewed `docs/coven-design-language.md` before implementation. The surface uses native semantic system surfaces/text, Cave-style hairline cards/pills, sparse accent usage, terse utility copy, explicit text alongside status, keyboard access, and no hard-coded product palette. No parallel Cave web primitive system is introduced.

## Deterministic fixture paths

- normal question → synthetic specified/high answer
- `every model` or `fixture:unknown` → low-confidence “I wouldn't claim that yet”
- `fixture:stale`
- `fixture:offline`
- `fixture:unauthorized`
- `fixture:rate`
- `fixture:failed`

The service error contract is domain-level (`BriefServiceError`) rather than fixture-specific so #5330 can replace the fixture service with URLSession without rewriting the UI state machine.

## Verification status

Repository tree inspection confirms exactly 11 new paths under the Quick Answer app/script boundary and no unrelated Cave files changed.

The current execution environment does **not** provide Xcode/XcodeGen or a mounted Cave checkout, so I am **not claiming** Swift compilation, XCTest execution, menu-bar launch, or global-shortcut acceptance yet. This PR must remain draft until a real macOS checkout runs:

```sh
node scripts/verify-quick-answer-macos.mjs
cd apps/macos/SalemQuickAnswer
xcodegen generate
xcodebuild test \
  -project SalemQuickAnswer.xcodeproj \
  -scheme SalemQuickAnswer \
  -destination 'platform=macOS'
```

Then perform an operator check with another app foreground to prove menu-bar presence, `⌥ Space` invocation/focus, Escape dismissal, and offline fixture states.

## Review focus

1. native app placement/ownership under Cave;
2. AppKit status-item/popover + SwiftUI lifecycle;
3. global hot-key registration and cleanup;
4. explicit stale/failure semantics;
5. offline pitch wording and “reference, not live status” labeling;
6. accessibility and status-vs-confidence distinction;
7. absence of live networking/secrets in this slice.

## Non-goals

Live `/api/brief` integration and Keychain belong to #5330. Audience/depth server transforms and packaged acceptance belong to #5331. No merge, release, deployment, or publication authorization is implied by this draft.