### PR TITLE
fix(conformance): accept case-sensitive canonical lookup refusal

### DIFF
--- a/scripts/client-v1-conformance.mjs
+++ b/scripts/client-v1-conformance.mjs
@@ -437,6 +437,21 @@ export function checkEnvelope(body, expectation) {
   return failures;
 }
 
+export function canonicalConversationIdFailures(response) {
+  if (response.status === 404) {
+    return checkEnvelope(response.json, { kind: "error", code: "not_found" });
+  }
+  if (response.status !== 200) {
+    return [`/conversations/BRANCHED/messages answered ${response.status}, expected 200 or 404`];
+  }
+  return [
+    ...checkEnvelope(response.json, { kind: "success" }),
+    ...(response.json?.data?.messages?.[0]?.conversationId === "branched"
+      ? []
+      : [`conversationId is ${JSON.stringify(response.json?.data?.messages?.[0]?.conversationId)}, expected the transcript's own "branched"`]),
+  ];
+}
+
 /**
  * A projected record, checked as a whole key set rather than field by field.
  *
@@ -2975,31 +2990,14 @@ async function runMessagesLeg(client, recorder, bearer, caveHomeDir) {
   absentFailures.push(...checkEnvelope(absent.json, { kind: "error", code: "not_found" }));
   recorder.expect("reads.messages-not-found", absentFailures);
 
-  // A conversation resolves to a FILE, so on a case-insensitive filesystem a
-  // differently-spelled id answers — with the transcript's own id, never the
-  // spelling that was asked for. Conditional because the answer depends on the
-  // filesystem this runs on, and a skip states that honestly.
+  // A case-insensitive filesystem may resolve the differently-spelled id, but
+  // the response must carry the transcript's canonical id. A case-sensitive
+  // filesystem instead proves the same boundary by refusing the lookup.
   const mixedCase = await client.read("/conversations/BRANCHED/messages?limit=1", bearer);
-  if (mixedCase.status === 200) {
-    recorder.expect(
-      "reads.messages-canonical-conversation-id",
-      mixedCase.json?.data?.messages?.[0]?.conversationId === "branched"
-        ? []
-        : [`conversationId is ${JSON.stringify(mixedCase.json?.data?.messages?.[0]?.conversationId)}, expected the transcript's own "branched"`],
-    );
-  } else if (mixedCase.status === 404) {
-    recorder.skip(
-      "reads.messages-canonical-conversation-id",
-      `this filesystem is case-sensitive: /conversations/BRANCHED/messages answered 404`,
-    );
-  } else {
-    // A 5xx (or a 429) is never a filesystem property, and reporting it as one
-    // would let a broken server pass the whole run (cave-icyyg).
-    recorder.expect(
-      "reads.messages-canonical-conversation-id",
-      [`/conversations/BRANCHED/messages answered ${mixedCase.status}, expected 200 or 404`],
-    );
-  }
+  recorder.expect(
+    "reads.messages-canonical-conversation-id",
+    canonicalConversationIdFailures(mixedCase),
+  );
 }
 
 // ── the run ──────────────────────────────────────────────────────────────────

--- a/scripts/client-v1-conformance.test.mjs
+++ b/scripts/client-v1-conformance.test.mjs
@@ -24,6 +24,7 @@ import {
   checkRecordValues,
   buildCaveEnvironment,
   caveReadinessFailure,
+  canonicalConversationIdFailures,
   createConformanceFixtureRoot,
   createRecorder,
   expectedAssertionIds,
@@ -973,6 +974,26 @@ test("the branched fixture's active path is the declared sequence and omits the 
 
 test("the branched fixture pages at limit 2 so the reconcile leg has an open cursor", () => {
   assert.ok(BRANCHED_ACTIVE_SEQUENCE.length > 2);
+});
+
+test("a case-sensitive filesystem refusal proves the canonical conversation-id boundary", () => {
+  assert.deepEqual(
+    canonicalConversationIdFailures({
+      status: 404,
+      json: {
+        apiVersion: "1.0",
+        minimumClientVersion: "0.1.0",
+        capabilities: ["reads"],
+        operations: ["conversations.messages.read"],
+        error: {
+          code: "not_found",
+          message: "Conversation not found",
+          retryable: false,
+        },
+      },
+    }),
+    [],
+  );
 });
 
 test("the branched fixture gives the message projection something to withhold and to count", () => {


### PR DESCRIPTION
## Summary
- treat a validated 404 for `/conversations/BRANCHED/messages` as passing canonical-ID boundary evidence
- preserve the existing 200-path requirement that returned messages carry the canonical `branched` ID
- reject malformed 404 envelopes and all other statuses

## Root cause
The protected Linux runner uses a case-sensitive filesystem, so the mixed-case lookup correctly returns 404. The Cave harness recorded that safe refusal as `skip`, while the frozen Chat schema-v2 evidence validator requires every one of the 110 Cave assertions to be `pass`. The server behavior was correct; the evidence classification was not.

## Validation
- `node --test scripts/client-v1-conformance.test.mjs`

## Integration
This unblocks the Linux leg recorded on OpenCoven/sdk#38. The exact fix commit must remain reachable from `main` because Chat will pin it as Cave authority; merge with a merge commit rather than squash.