### PR TITLE
fix(ios): reduce chat renderer startup payload by 95%

### DIFF
--- a/apps/ios/CovenCave/.gitignore
+++ b/apps/ios/CovenCave/.gitignore
@@ -14,3 +14,4 @@ DerivedData/
 # + the standalone CSS the full-screen zoom view restyles lifted content with)
 CovenCave/Resources/markdown.html
 CovenCave/Resources/markdown.css
+CovenCave/Resources/markdown-mermaid.js

--- a/apps/ios/CovenCave/CovenCaveTests/MarkdownBundleLoadingTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/MarkdownBundleLoadingTests.swift
@@ -1,0 +1,121 @@
+import UIKit
+import WebKit
+import XCTest
+@testable import CovenCave
+
+final class MarkdownBundleLoadingTests: XCTestCase {
+    func testPackagedStartupBundleExcludesDiagramPayload() throws {
+        let html = try XCTUnwrap(Bundle.main.url(forResource: "markdown", withExtension: "html"))
+        let bytes = try Data(contentsOf: html).count
+        XCTAssertLessThan(bytes, 512 * 1024)
+        let diagram = try XCTUnwrap(Bundle.main.url(forResource: "markdown-mermaid", withExtension: "js"))
+        XCTAssertGreaterThan(try Data(contentsOf: diagram).count, 0)
+    }
+
+    @MainActor
+    func testDiagramEngineLoadsOnlyForSettledDiagramsAndIsReused() async throws {
+        let coordinator = MarkdownWebView.Coordinator()
+        let window = mount(coordinator.webView)
+        defer { unmount(window, coordinator: coordinator) }
+        try await waitUntilReady(coordinator.webView)
+
+        let webView = coordinator.webView
+        let prose = try await webView.callAsyncJavaScript("""
+            await window.caveRender('**Hello**\\n\\n```swift\\nlet value = 1\\n```');
+            return !!document.querySelector('strong') &&
+                !!document.querySelector('code .hljs-keyword') &&
+                typeof window.caveMermaid === 'undefined' &&
+                document.querySelectorAll('script[src]').length === 0;
+            """, arguments: [:], contentWorld: .page)
+        XCTAssertEqual(prose as? Bool, true, "Ordinary formatted replies must not load diagram code")
+
+        let diagram = "```mermaid\nflowchart LR\nA --> B\n```"
+        let streaming = try await webView.callAsyncJavaScript("""
+            await window.caveRender(md, {streaming: true});
+            return document.getElementById('root').textContent.includes('rendering on completion') &&
+                typeof window.caveMermaid === 'undefined' &&
+                document.querySelectorAll('script[src]').length === 0;
+            """, arguments: ["md": diagram], contentWorld: .page)
+        XCTAssertEqual(streaming as? Bool, true, "Incomplete diagrams must remain lightweight")
+
+        let settled = try await webView.callAsyncJavaScript("""
+            await window.caveRender(md, {streaming: false});
+            return !!document.querySelector('.cm-mermaid-diagram svg') &&
+                document.querySelectorAll('script[src$="markdown-mermaid.js"]').length === 1;
+            """, arguments: ["md": diagram], contentWorld: .page)
+        XCTAssertEqual(settled as? Bool, true, "The bundled local script must render a real SVG")
+
+        let repeated = try await webView.callAsyncJavaScript("""
+            const plugin = window.caveMermaid;
+            await window.caveRender(md, {reader: true, theme: 'sepia'});
+            return plugin === window.caveMermaid &&
+                !!document.querySelector('.cm-mermaid-diagram svg') &&
+                document.querySelectorAll('script[src$="markdown-mermaid.js"]').length === 1;
+            """, arguments: ["md": diagram], contentWorld: .page)
+        XCTAssertEqual(repeated as? Bool, true, "Reader rerenders must reuse the loaded engine")
+    }
+
+    @MainActor
+    func testMissingDiagramResourceReportsFailureAndPreservesReadableSource() async throws {
+        let coordinator = MarkdownWebView.Coordinator()
+        let window = mount(coordinator.webView)
+        defer { unmount(window, coordinator: coordinator) }
+        try await waitUntilReady(coordinator.webView)
+
+        _ = try await coordinator.webView.evaluateJavaScript("""
+            const append = document.head.appendChild.bind(document.head);
+            document.head.appendChild = function(node) {
+                if (node.tagName === 'SCRIPT') node.src = 'missing-diagram-test.js';
+                return append(node);
+            }; true;
+            """)
+        var failures = 0
+        coordinator.onFailure = { failures += 1 }
+        let markdown = "```mermaid\nflowchart LR\nA --> B\n```"
+        coordinator.apply(markdown: markdown, streaming: false,
+                          fontScale: 1, theme: .dark, accentHex: nil, reader: false)
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(5))
+        while failures == 0, clock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(failures, 1, "Resource failure must reach the native readable fallback")
+        let visible = try await coordinator.webView.evaluateJavaScript(
+            "document.getElementById('root').textContent"
+        )
+        XCTAssertEqual(visible as? String, markdown)
+    }
+
+    @MainActor
+    private func mount(_ webView: WKWebView) -> UIWindow {
+        let host = UIViewController()
+        host.view = webView
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 700))
+        window.rootViewController = host
+        window.isHidden = false
+        host.view.layoutIfNeeded()
+        return window
+    }
+
+    @MainActor
+    private func unmount(_ window: UIWindow, coordinator: MarkdownWebView.Coordinator) {
+        coordinator.invalidate()
+        window.isHidden = true
+        window.rootViewController = nil
+    }
+
+    @MainActor
+    private func waitUntilReady(_ webView: WKWebView) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(30))
+        while clock.now < deadline {
+            if (try? await webView.evaluateJavaScript("typeof window.caveRender === 'function'")) as? Bool == true {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail("The packaged markdown renderer did not become ready")
+        throw NSError(domain: "MarkdownBundleLoadingTests", code: 1)
+    }
+}

--- a/apps/ios/CovenCave/README.md
+++ b/apps/ios/CovenCave/README.md
@@ -46,6 +46,11 @@ xcodebuild -project CovenCave.xcodeproj -scheme CovenCave \
   -derivedDataPath build CODE_SIGNING_ALLOWED=NO build
 ```
 
+Markdown resources include `markdown.html`, `markdown.css`, and the lazy
+`markdown-mermaid.js` diagram engine. All three are packaged locally; ordinary
+replies and streaming diagram placeholders do not load the diagram engine.
+Settled diagrams load it once per renderer without requiring a network connection.
+
 ⚠️ **`cannot find type <Something> in scope` means a stale `.xcodeproj`, not a
 code bug.** `xcodegen` SCANS the source directory, so a project generated before
 a Swift file was added simply does not contain it — the file is on disk, in git,

--- a/apps/ios/markdown/entry.mjs
+++ b/apps/ios/markdown/entry.mjs
@@ -2,11 +2,10 @@
 // Same @create-markdown/* + mermaid pipeline as the desktop chat, with
 // highlight.js for code syntax colours (shiki doesn't bundle into a browser
 // IIFE via esbuild — @shikijs/vscode-textmate's Resolver breaks). Bundled to a
-// self-contained HTML by scripts/build-ios-markdown.mjs.
+// local resources by scripts/build-ios-markdown.mjs.
 
 import { parse } from "@create-markdown/core";
 import { renderAsync } from "@create-markdown/preview";
-import { mermaidPlugin } from "@create-markdown/preview-mermaid";
 import { renderTableReplacements } from "../../../src/lib/markdown-table-cells.ts";
 import hljs from "highlight.js/lib/core";
 
@@ -49,10 +48,26 @@ hljs.configure({ classPrefix: "hljs-" });
 // a few extras it doesn't infer from our registered set:
 const ALIASES = { sh: "bash", shell: "bash", zsh: "bash", html: "xml", "objective-c": "c" };
 
-const mermaid = mermaidPlugin({ theme: "dark", config: { securityLevel: "strict" } });
 let mermaidReady = null;
 function initMermaid() {
-  if (!mermaidReady) mermaidReady = Promise.resolve(mermaid.init?.());
+  // A dynamic import inside the old IIFE still bundled the entire diagram
+  // engine into every message. Load a separate local script only on settle.
+  if (!mermaidReady) {
+    mermaidReady = new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = "markdown-mermaid.js";
+      script.onload = () => {
+        const plugin = window.caveMermaid;
+        if (!plugin) {
+          reject(new Error("Bundled Mermaid renderer unavailable"));
+          return;
+        }
+        Promise.resolve(plugin.init?.()).then(() => resolve(plugin), reject);
+      };
+      script.onerror = () => reject(new Error("Could not load bundled Mermaid renderer"));
+      document.head.appendChild(script);
+    });
+  }
   return mermaidReady;
 }
 
@@ -104,7 +119,7 @@ async function renderMarkdown(md, { streaming = false } = {}) {
   const blocks = parse(md || "");
   const codeBlocks = blocks.filter((b) => b.type === "codeBlock");
   const hasMermaid = !streaming && codeBlocks.some(isMermaid);
-  if (hasMermaid) await initMermaid();
+  const mermaid = hasMermaid ? await initMermaid() : null;
 
   const replacements = new Array(codeBlocks.length);
   codeBlocks.forEach((block, i) => {
@@ -219,8 +234,10 @@ window.caveRender = async (md, opts = {}) => {
   } catch (err) {
     root.textContent = String(md || "");
     window.webkit?.messageHandlers?.cave?.postMessage({ type: "error", message: String(err) });
+    throw err;
+  } finally {
+    reportLayout();
   }
-  reportLayout();
 };
 
 // Re-style without re-rendering markdown — used when the reader's font size or

--- a/apps/ios/markdown/mermaid.mjs
+++ b/apps/ios/markdown/mermaid.mjs
@@ -1,0 +1,6 @@
+import { mermaidPlugin } from "@create-markdown/preview-mermaid";
+
+window.caveMermaid = mermaidPlugin({
+  theme: "dark",
+  config: { securityLevel: "strict" },
+});

--- a/docs/performance/ios-performance-audit.md
+++ b/docs/performance/ios-performance-audit.md
@@ -8,6 +8,31 @@ rendering. The first six implementation tasks landed in PR #3623; this closeout
 adds typed markdown signatures, renderer instrumentation, the final simulator
 validation, and the physical-device handoff.
 
+## September 9 responsiveness hotfix
+
+The renderer's single-file IIFE included the entire Mermaid dependency graph
+even though diagram initialization was deferred. Every assistant message
+therefore loaded that JavaScript payload, including messages without diagrams.
+The diagram engine now lives in a separately bundled local
+`markdown-mermaid.js`, loaded only for a settled Mermaid block. Streaming
+placeholders, ordinary markdown, code highlighting, and tables keep the small
+core renderer; the reader reuses the same lazy engine.
+
+The minified startup JavaScript fell from 3,620,968 bytes to approximately
+160 KB (about 95.6% less). This measures per-renderer payload, not total app
+download size or a claimed device-latency percentile. The remaining diagram
+payload is still packaged offline. `ios-markdown-bundle.test.mjs` enforces a
+512 KiB startup ceiling and excludes Mermaid dependencies from the core graph.
+
+`MarkdownBundleLoadingTests` exercises the packaged files in real WKWebView:
+ordinary markdown and streaming placeholders load no diagram script; settled
+diagrams produce SVG and reuse one script; a missing diagram resource preserves
+readable source and rejects the render so native fallback can handle it.
+The focused Release simulator run passed these three tests plus the fifteen
+existing renderer lifecycle/signature tests. The previously merged renderer
+teardown repair remains intact. No new physical-device latency or thermal
+claim is made by this hotfix.
+
 ## Before/after metrics
 
 The request/work-count evidence is deterministic rather than a claim about

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3002,10 +3002,6 @@ packages:
     resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
 
-  picomatch@4.0.7:
-    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
-    engines: {node: '>=12'}
-
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -6817,8 +6813,6 @@ snapshots:
       '@napi-rs/canvas': 1.0.7
 
   picocolors@1.1.1: {}
-
-  picomatch@4.0.7: {}
 
   picomatch@4.0.7: {}
 

--- a/scripts/build-ios-markdown.mjs
+++ b/scripts/build-ios-markdown.mjs
@@ -1,9 +1,9 @@
 // Bundles the native iOS app's markdown renderer into a single self-contained
-// HTML file (apps/ios/CovenCave/CovenCave/Resources/markdown.html) that the
-// SwiftUI MarkdownWebView loads. Uses the SAME @create-markdown + mermaid
-// packages as the desktop chat, so rendering matches.
+// HTML file and a lazy local diagram script in CovenCave/Resources. Uses the
+// SAME @create-markdown + mermaid packages as desktop, without making ordinary
+// messages load and parse the diagram engine.
 //
-// Run: node scripts/build-ios-markdown.mjs   (commit the generated markdown.html)
+// Run: node scripts/build-ios-markdown.mjs (generated resources are gitignored)
 
 import { build } from "esbuild";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
@@ -17,6 +17,7 @@ const outHtml = resolve(root, "apps/ios/CovenCave/CovenCave/Resources/markdown.h
 // The CSS is also emitted standalone so the native full-screen zoom view
 // (ContentZoom.swift) can restyle a lifted table/diagram to match the chat.
 const outCss = resolve(root, "apps/ios/CovenCave/CovenCave/Resources/markdown.css");
+const outMermaid = resolve(dirname(outHtml), "markdown-mermaid.js");
 
 const result = await build({
   entryPoints: [resolve(srcDir, "entry.mjs")],
@@ -29,6 +30,16 @@ const result = await build({
   legalComments: "none",
 });
 const js = result.outputFiles[0].text;
+const diagramResult = await build({
+  entryPoints: [resolve(srcDir, "mermaid.mjs")],
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  target: "safari16",
+  minify: true,
+  write: false,
+  legalComments: "none",
+});
 const css = readFileSync(resolve(srcDir, "markdown.css"), "utf8");
 
 const html = `<!doctype html>
@@ -45,3 +56,5 @@ writeFileSync(outHtml, html);
 console.log(`wrote ${outHtml} (${(html.length / 1024).toFixed(0)} KB)`);
 writeFileSync(outCss, css);
 console.log(`wrote ${outCss} (${(css.length / 1024).toFixed(0)} KB)`);
+writeFileSync(outMermaid, diagramResult.outputFiles[0].contents);
+console.log(`wrote ${outMermaid} (${(diagramResult.outputFiles[0].contents.byteLength / 1024).toFixed(0)} KB, lazy)`);

--- a/scripts/ios-markdown-bundle.test.mjs
+++ b/scripts/ios-markdown-bundle.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+const result = await build({
+  absWorkingDir: root,
+  entryPoints: ["apps/ios/markdown/entry.mjs"],
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  target: "safari16",
+  minify: true,
+  write: false,
+  metafile: true,
+  legalComments: "none",
+});
+
+const bytes = result.outputFiles[0].contents.byteLength;
+assert.ok(
+  bytes < 512 * 1024,
+  `Every chat renderer loads the core bundle: ${bytes} bytes exceeds the 512 KiB startup budget`,
+);
+assert.deepEqual(
+  Object.keys(result.metafile.inputs).filter((name) => /node_modules\/(?:\.pnpm\/)?(?:@create-markdown\/preview-mermaid|mermaid)[/@]/.test(name)),
+  [],
+  "Diagram-only dependencies must not be parsed when opening ordinary chat messages",
+);
+
+console.log(`ios-markdown-bundle.test.mjs: ok (${bytes} startup bytes)`);

--- a/scripts/ios-project-generation.test.mjs
+++ b/scripts/ios-project-generation.test.mjs
@@ -53,7 +53,7 @@ assert.match(
 // full-text search passes even when the check loop does not mention them. This
 // is the third assertion in this file to have that shape — see the two notes
 // above. Search executable lines only.
-for (const resource of ["markdown.html", "markdown.css"]) {
+for (const resource of ["markdown.html", "markdown.css", "markdown-mermaid.js"]) {
   assert.ok(
     wrapperCode.includes(resource),
     `the wrapper should assert ${resource} exists before generating the project`,

--- a/scripts/ios-xcodegen.sh
+++ b/scripts/ios-xcodegen.sh
@@ -56,7 +56,7 @@ fi
 # The generators can succeed while writing nothing useful; check the artifacts
 # themselves, not the exit code, since the exit code is what fooled us before.
 missing=()
-for resource in markdown.html markdown.css; do
+for resource in markdown.html markdown.css markdown-mermaid.js; do
   [ -s "$RESOURCES/$resource" ] || missing+=("$resource")
 done
 if [ ${#missing[@]} -gt 0 ]; then

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1939,6 +1939,7 @@ export const SUITES = {
     "scripts/ios-chat-familiars-home.test.mjs",
     "scripts/ios-familiar-profile.test.mjs",
     "scripts/ios-project-generation.test.mjs",
+    "scripts/ios-markdown-bundle.test.mjs",
     "scripts/ios-chat-restyle.test.mjs",
     "scripts/ios-claude-design-fidelity.test.mjs",
     "scripts/ios-modern-polish.test.mjs",


### PR DESCRIPTION
## Summary
- Remove the diagram engine from every chat renderer's startup payload: 3,620,968 bytes to about 160,200 bytes (95.6% less JavaScript).
- Load one packaged, offline Mermaid script only for settled diagrams; preserve streaming placeholders, highlighting, reader rendering, and readable error fallback.
- Keep the existing renderer teardown fix from #5324 and remove two identical lockfile mappings that blocked frozen installs.

## Evidence
- Exact-base Release renderer suite: 15/15 passed.
- Patched native Release suite: 18/18 passed, including real SVG rendering, one-time loading, and missing-resource fallback.
- Mobile: 101 test files passed; all 2,006 tests wired; frozen install and diff checks passed.
- Independent read-only review found no significant defects.
- Payload reduction is not a claim of measured physical-device latency or thermal improvement.

Bead: cave-g7zda. User authorized urgent iOS patch and republication; TestFlight delivery follows protected-main integration.