### PR TITLE
chore(release): stamp v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-09-09
+
+> Reduces native iOS chat startup work and releases detached message renderers.
+
+Patch release on top of v0.4.1, focused on the urgent iOS responsiveness repair.
+
+### Fixed
+- Reduce ordinary iOS chat renderer startup JavaScript from 3.6 MB to about
+  160 KB by loading the bundled diagram engine only for completed diagrams
+  (#5350). This is a payload reduction, not a measured device-latency percentage.
+- Release detached iOS message renderers and ignore callbacks after teardown
+  while preserving streamed-response recovery (#5324).
+- Restore reliable chat prompt enhancement and make protocol conformance
+  probes portable across supported platforms.
+
+### Changed
+- Deliver visual comparisons without depending on session-owned servers.
+- Update Next.js, Sharp, and Vitest patch dependencies.
+- Advance release metadata to 0.4.2 and the iOS build to 2026090912.
+
 ## [0.4.1] - 2026-09-09
 
 > Makes assistant responses easier to read in native iOS chat.

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.4.1"
+    MARKETING_VERSION: "0.4.2"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026090901"
+    CURRENT_PROJECT_VERSION: "2026090912"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes-gcm",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.4.1"
+version = "0.4.2"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
Publish the authorized urgent iOS responsiveness update: 0.4.2 / 2026090912. Includes the chat startup payload fix in #5350 and renderer lifecycle repair in #5324. All five version locations and the finalized changelog are aligned; no additional product changes.

## Verification
- pnpm release:verify --version 0.4.2
- node scripts/stamp-release.test.mjs
- git diff --check
- Hotfix required CI passed on exact head before #5350 merged.

Bead: cave-d9clv (release transport for cave-g7zda).

Release remains incomplete until signed candidate promotion and matching iOS upload/processing receipts are available.