### PR TITLE
Add read-only TestFlight availability receipts

### DIFF
--- a/.github/workflows/testflight-receipt.yml
+++ b/.github/workflows/testflight-receipt.yml
@@ -1,0 +1,49 @@
+name: TestFlight availability receipt
+run-name: TestFlight receipt ${{ inputs.marketing_version }} (${{ inputs.build_number }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      marketing_version:
+        description: "Exact iOS marketing version (e.g. 0.4.2)"
+        type: string
+        required: true
+      build_number:
+        description: "Exact uploaded build number (e.g. 2026090912)"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  receipt:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+      - name: Verify read-only receipt contracts
+        run: node --test scripts/testflight-receipt.test.mjs
+      - name: Query Apple availability (GET only)
+        env:
+          TESTFLIGHT_MARKETING_VERSION: ${{ inputs.marketing_version }}
+          TESTFLIGHT_BUILD_NUMBER: ${{ inputs.build_number }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_SUBJECT: ${{ vars.APPLE_API_KEY_SUBJECT }}
+        run: node scripts/testflight-receipt.mjs
+      - name: Preserve sanitized receipt even when unavailable or denied
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: testflight-receipt
+          path: testflight-receipt.json
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/workflows/testflight-receipt.md
+++ b/docs/workflows/testflight-receipt.md
@@ -1,0 +1,62 @@
+# Read-only TestFlight availability receipt
+
+After the release workflow uploads an iOS build, dispatch from `main`:
+
+```bash
+gh workflow run testflight-receipt.yml --ref main \
+  -f marketing_version=0.4.2 -f build_number=2026090912
+gh run list --workflow testflight-receipt.yml --limit 5
+gh run download <run-id> --name testflight-receipt --dir <receipt-directory>
+```
+
+This is independent of release publication: it does not upload, tag, release,
+invite testers, assign groups, or change Apple distribution. It reads only
+`ai.opencoven.cave` on `IOS`, requiring an exact marketing version, build number,
+and matching app/pre-release-version relationships. No version stamps change.
+
+The manually dispatched workflow uses the same pinned actions and authorized
+`APPLE_API_KEY`, `APPLE_API_KEY_BASE64`, `APPLE_API_ISSUER` secrets as `release.yml`.
+`APPLE_API_KEY_SUBJECT=user` selects an individual key (`sub: user`, no `iss`);
+an unset subject selects a team key with an issuer. Private-key material stays
+in memory. Each five-minute ES256 JWT is scoped to one GET request. Neither
+tokens nor keys are printed, written to disk, or included in artifacts.
+Do not retrieve CI secrets or use local keys to work around authorization errors.
+
+The job summary and `testflight-receipt` JSON artifact (90-day retention) contain
+query timestamps, exact selectors, resource IDs, processing and beta states,
+assigned group IDs/types, and tester counts. Tester membership is read using the
+IDs-only relationship endpoint; tester IDs, names and emails are never emitted.
+Apple response bodies and arbitrary error messages are never logged.
+
+| Verdict | Meaning |
+| --- | --- |
+| `ABSENT` | No exact app, iOS pre-release version, or build is visible. |
+| `PROCESSING_PENDING` | Exact build is still processing; beta groups are not queried yet. |
+| `VALID_NOT_AVAILABLE` | Processing is `VALID`, but no populated assigned group has its matching lane `IN_BETA_TESTING`. `READY_FOR_BETA_TESTING` is insufficient. |
+| `TESTER_AVAILABLE` | Unexpired, `VALID` build has an assigned group with testers and matching internal/external state `IN_BETA_TESTING`. |
+| `BLOCKED` | Failed/invalid processing, expiration, or an assigned group's compliance/rejection state prevents availability. |
+| `UNKNOWN` | Unrecognized/missing state, inconsistent identity, bounded-query limit, configuration, transport or API error. |
+
+Only `TESTER_AVAILABLE` exits successfully. All other outcomes fail the job but
+preserve the receipt; a red job is not necessarily a tooling failure. A 401/403
+is recorded as `APPLE_AUTHORIZATION_DENIED` with the HTTP status and is not
+retried. Other transient HTTP failures have at most three attempts. Each response
+is limited to 1 MiB; queries have 15-second request timeouts, ten pages per list,
+100 total attempts and a four-minute query budget. Redirects are refused, the
+HTTPS host is fixed, and pagination must preserve the endpoint and selectors.
+
+This is a sequential API snapshot, not an atomic distribution transaction or
+proof of invitation acceptance, device eligibility, or user installation.
+No assigned group is inferred from processing alone. Rerun explicitly if Apple
+has not finished processing; this workflow does not poll indefinitely.
+
+## Apple API contract
+
+- [JWT signing and individual/team claims](https://developer.apple.com/documentation/appstoreconnectapi/generating-tokens-for-api-requests)
+- [Apps](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-apps)
+- [Pre-release versions](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-prereleaseversions)
+- [Builds](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds)
+- [Build beta detail](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-buildbetadetail)
+- [Internal states](https://developer.apple.com/documentation/appstoreconnectapi/internalbetastate) and [external states](https://developer.apple.com/documentation/appstoreconnectapi/externalbetastate)
+- [Beta groups filtered by app and build](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-betagroups)
+- [Tester relationship IDs](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-betagroups-_id_-relationships-betatesters)

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1825,6 +1825,7 @@ export const SUITES = {
     "src/lib/websocket-url.test.ts",
     "src/lib/familiar-liveness.test.ts",
     "scripts/app-store-connect.test.mjs",
+    "scripts/testflight-receipt.test.mjs",
     "scripts/release-macos-signing.test.mjs",
     "scripts/release-notes.test.mjs",
     "scripts/generate-latest-json.test.mjs",

--- a/scripts/testflight-receipt.mjs
+++ b/scripts/testflight-receipt.mjs
@@ -1,0 +1,293 @@
+import { createPrivateKey, sign } from "node:crypto";
+import { appendFileSync, writeFileSync } from "node:fs";
+import { setTimeout as sleep } from "node:timers/promises";
+import { isDirectRun } from "./direct-run.mjs";
+
+const ORIGIN = "https://api.appstoreconnect.apple.com";
+const BUNDLE_ID = "ai.opencoven.cave";
+const INTERNAL = [
+  "PROCESSING", "PROCESSING_EXCEPTION", "MISSING_EXPORT_COMPLIANCE",
+  "READY_FOR_BETA_TESTING", "IN_BETA_TESTING", "EXPIRED", "IN_EXPORT_COMPLIANCE_REVIEW",
+];
+const EXTERNAL = [
+  ...INTERNAL, "READY_FOR_BETA_SUBMISSION", "WAITING_FOR_BETA_REVIEW",
+  "IN_BETA_REVIEW", "BETA_REJECTED", "BETA_APPROVED", "NOT_APPLICABLE",
+];
+const BLOCKED = new Set([
+  "PROCESSING_EXCEPTION", "MISSING_EXPORT_COMPLIANCE", "EXPIRED",
+  "IN_EXPORT_COMPLIANCE_REVIEW", "BETA_REJECTED",
+]);
+
+export class ReceiptError extends Error {
+  constructor(code, status = null) {
+    super(code);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function requireValue(condition, code = "INVALID_RESPONSE") {
+  if (!condition) throw new ReceiptError(code);
+}
+
+export function selectors(version, build) {
+  requireValue(typeof version === "string" && /^\d{1,4}\.\d{1,4}\.\d{1,4}$/.test(version),
+    "INVALID_MARKETING_VERSION");
+  requireValue(typeof build === "string" && /^\d{1,18}(?:\.\d{1,4}){0,2}$/.test(build),
+    "INVALID_BUILD_NUMBER");
+  return { bundleId: BUNDLE_ID, marketingVersion: version, buildNumber: build, platform: "IOS" };
+}
+
+export function appleUrl(value) {
+  let url;
+  try {
+    url = new URL(value, ORIGIN);
+  } catch {
+    throw new ReceiptError("UNSAFE_API_URL");
+  }
+  requireValue(url.origin === ORIGIN && !url.username && !url.password && !url.hash
+    && /^\/v1\/(?:apps|preReleaseVersions|builds|betaGroups)(?:\/[A-Za-z0-9-]+(?:\/(?:buildBetaDetail|relationships\/betaTesters))?)?$/.test(url.pathname),
+  "UNSAFE_API_URL");
+  return url;
+}
+
+export function tokenSigner(env) {
+  const keyId = env.APPLE_API_KEY;
+  const subject = env.APPLE_API_KEY_SUBJECT || "";
+  requireValue(typeof keyId === "string" && /^[A-Z0-9]{10}$/.test(keyId), "INVALID_KEY_ID");
+  requireValue(subject === "" || subject === "user", "INVALID_KEY_SUBJECT");
+  requireValue(subject === "user" || /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(env.APPLE_API_ISSUER || ""),
+    "INVALID_TEAM_ISSUER");
+  const encoded = env.APPLE_API_KEY_BASE64;
+  requireValue(typeof encoded === "string" && encoded.length <= 16384
+    && /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(encoded)
+    && encoded.length > 0, "INVALID_PRIVATE_KEY");
+  const bytes = Buffer.from(encoded, "base64");
+  let key;
+  try {
+    key = createPrivateKey({ key: bytes, format: "pem" });
+  } catch {
+    throw new ReceiptError("INVALID_PRIVATE_KEY");
+  } finally {
+    bytes.fill(0);
+  }
+  requireValue(key.asymmetricKeyType === "ec"
+    && key.asymmetricKeyDetails?.namedCurve === "prime256v1", "INVALID_PRIVATE_KEY");
+  return (url, now = Math.floor(Date.now() / 1000)) => {
+    const checked = appleUrl(url);
+    const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+    const header = encode({ alg: "ES256", kid: keyId, typ: "JWT" });
+    const payload = encode({
+      ...(subject === "user" ? { sub: "user" } : { iss: env.APPLE_API_ISSUER }),
+      iat: now, exp: now + 300, aud: "appstoreconnect-v1",
+      scope: [`GET ${checked.pathname}${checked.search}`],
+    });
+    const input = `${header}.${payload}`;
+    const signature = sign("sha256", Buffer.from(input), { key, dsaEncoding: "ieee-p1363" });
+    return `${input}.${signature.toString("base64url")}`;
+  };
+}
+
+export function appleClient(signer, { fetchImpl = fetch, pause = sleep, now = Date.now } = {}) {
+  const deadline = now() + 240_000;
+  let requests = 0;
+  async function get(value) {
+    const url = appleUrl(value);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      requireValue(++requests <= 100 && now() < deadline, "REQUEST_BUDGET_EXCEEDED");
+      let response;
+      try {
+        response = await fetchImpl(url.href, {
+          method: "GET", redirect: "error",
+          headers: { Authorization: `Bearer ${signer(url.href)}`, Accept: "application/json" },
+          signal: AbortSignal.timeout(Math.max(1, Math.min(15_000, deadline - now()))),
+        });
+      } catch {
+        throw new ReceiptError("TRANSPORT_ERROR");
+      }
+      if (!response.ok) {
+        await response.body?.cancel();
+        if ([429, 500, 502, 503, 504].includes(response.status) && attempt < 2) {
+          await pause(1000 * (attempt + 1));
+          continue;
+        }
+        throw new ReceiptError(
+          [401, 403].includes(response.status) ? "APPLE_AUTHORIZATION_DENIED" : "APPLE_HTTP_ERROR",
+          response.status,
+        );
+      }
+      let text = "";
+      try {
+        requireValue(response.body, "INVALID_RESPONSE");
+        const decoder = new TextDecoder();
+        let size = 0;
+        for await (const chunk of response.body) {
+          size += chunk.byteLength;
+          requireValue(size <= 1_048_576, "RESPONSE_TOO_LARGE");
+          text += decoder.decode(chunk, { stream: true });
+        }
+        text += decoder.decode();
+      } catch (error) {
+        if (error instanceof ReceiptError) throw error;
+        throw new ReceiptError("TRANSPORT_ERROR");
+      }
+      try {
+        return JSON.parse(text);
+      } catch {
+        throw new ReceiptError("INVALID_JSON");
+      }
+    }
+    throw new ReceiptError("REQUEST_BUDGET_EXCEEDED");
+  }
+  async function list(path, params = {}) {
+    const first = appleUrl(path);
+    first.search = new URLSearchParams({ ...params, limit: "200" }).toString();
+    let next = first.href;
+    const seen = new Set();
+    const data = [];
+    while (next) {
+      requireValue(seen.size < 10 && !seen.has(next), "PAGINATION_LIMIT");
+      seen.add(next);
+      const url = appleUrl(next);
+      requireValue(url.pathname === first.pathname, "UNSAFE_PAGINATION");
+      // A next link may change only the cursor/limit, never our exact selectors.
+      const stable = (u) => [...u.searchParams].filter(([k]) => !["cursor", "limit"].includes(k))
+        .map(([k, v]) => `${k}=${v}`).sort();
+      requireValue(JSON.stringify(stable(url)) === JSON.stringify(stable(first)), "UNSAFE_PAGINATION");
+      const page = await get(url.href);
+      requireValue(Array.isArray(page?.data) && page.data.length <= 200, "INVALID_RESPONSE");
+      data.push(...page.data);
+      const link = page.links?.next;
+      requireValue(link === undefined || link === null || typeof link === "string", "INVALID_RESPONSE");
+      next = link ? appleUrl(link).href : null;
+    }
+    return data;
+  }
+  return { get, list };
+}
+
+function resource(value, type) {
+  requireValue(value?.type === type && typeof value.id === "string"
+    && /^[A-Za-z0-9-]{1,100}$/.test(value.id));
+  return value;
+}
+
+function relationship(value, name, type, id) {
+  requireValue(resource(value.relationships?.[name]?.data, type).id === id, "IDENTITY_MISMATCH");
+}
+
+function one(values, type) {
+  requireValue(values.length <= 1, "AMBIGUOUS_MATCH");
+  return values.length ? resource(values[0], type) : null;
+}
+
+function state(value, allowed) {
+  return allowed.includes(value) ? value : "UNKNOWN";
+}
+
+export async function collectReceipt(receipt, api) {
+  const target = receipt.target;
+  const app = one(await api.list("/v1/apps", {
+    "filter[bundleId]": BUNDLE_ID, "fields[apps]": "bundleId",
+  }), "apps");
+  if (!app) return "ABSENT";
+  requireValue(app.attributes?.bundleId === BUNDLE_ID, "IDENTITY_MISMATCH");
+  receipt.appId = app.id;
+  const version = one(await api.list("/v1/preReleaseVersions", {
+    "filter[app]": app.id, "filter[version]": target.marketingVersion, "filter[platform]": "IOS",
+    include: "app", "fields[preReleaseVersions]": "version,platform,app", "fields[apps]": "bundleId",
+  }), "preReleaseVersions");
+  if (!version) return "ABSENT";
+  requireValue(version.attributes?.version === target.marketingVersion
+    && version.attributes?.platform === "IOS", "IDENTITY_MISMATCH");
+  relationship(version, "app", "apps", app.id);
+  receipt.preReleaseVersionId = version.id;
+  const build = one(await api.list("/v1/builds", {
+    "filter[app]": app.id, "filter[preReleaseVersion]": version.id, "filter[version]": target.buildNumber,
+    include: "app,preReleaseVersion",
+    "fields[builds]": "version,processingState,expired,expirationDate,app,preReleaseVersion",
+    "fields[apps]": "bundleId", "fields[preReleaseVersions]": "version,platform",
+  }), "builds");
+  if (!build) return "ABSENT";
+  requireValue(build.attributes?.version === target.buildNumber, "IDENTITY_MISMATCH");
+  relationship(build, "app", "apps", app.id);
+  relationship(build, "preReleaseVersion", "preReleaseVersions", version.id);
+  receipt.buildId = build.id;
+  receipt.processingState = state(build.attributes.processingState, ["PROCESSING", "VALID", "FAILED", "INVALID"]);
+  if (receipt.processingState === "PROCESSING") return "PROCESSING_PENDING";
+  if (["FAILED", "INVALID"].includes(receipt.processingState)) return "BLOCKED";
+  if (receipt.processingState !== "VALID") return "UNKNOWN";
+  requireValue(typeof build.attributes.expired === "boolean", "INVALID_RESPONSE");
+  receipt.expired = build.attributes.expired;
+  const expiration = Date.parse(build.attributes.expirationDate);
+  requireValue(Number.isFinite(expiration), "INVALID_RESPONSE");
+  receipt.expirationDate = new Date(expiration).toISOString();
+  const detail = resource((await api.get(`/v1/builds/${build.id}/buildBetaDetail?${new URLSearchParams({
+    include: "build", "fields[buildBetaDetails]": "internalBuildState,externalBuildState,build",
+    "fields[builds]": "version",
+  })}`)).data, "buildBetaDetails");
+  relationship(detail, "build", "builds", build.id);
+  receipt.buildBetaDetailId = detail.id;
+  receipt.internalBuildState = state(detail.attributes?.internalBuildState, INTERNAL);
+  receipt.externalBuildState = state(detail.attributes?.externalBuildState, EXTERNAL);
+  const groups = await api.list("/v1/betaGroups", {
+    "filter[app]": app.id, "filter[builds]": build.id, include: "app",
+    "fields[betaGroups]": "isInternalGroup,app", "fields[apps]": "bundleId",
+  });
+  const groupIds = new Set();
+  for (const raw of groups) {
+    const group = resource(raw, "betaGroups");
+    requireValue(!groupIds.has(group.id), "INVALID_RESPONSE");
+    groupIds.add(group.id);
+    relationship(group, "app", "apps", app.id);
+    requireValue(typeof group.attributes?.isInternalGroup === "boolean", "INVALID_RESPONSE");
+    const testers = await api.list(`/v1/betaGroups/${group.id}/relationships/betaTesters`);
+    const testerIds = new Set(testers.map((tester) => resource(tester, "betaTesters").id));
+    const lane = group.attributes.isInternalGroup ? receipt.internalBuildState : receipt.externalBuildState;
+    receipt.groups.push({
+      id: group.id, isInternalGroup: group.attributes.isInternalGroup,
+      buildState: lane, testerCount: testerIds.size,
+      testerAvailable: lane === "IN_BETA_TESTING" && testerIds.size > 0
+        && !receipt.expired && expiration > Date.now(),
+    });
+  }
+  if (receipt.expired || expiration <= Date.now()) return "BLOCKED";
+  if (receipt.groups.some((group) => group.testerAvailable)) return "TESTER_AVAILABLE";
+  if (receipt.groups.some((group) => group.buildState === "UNKNOWN")
+    || (!receipt.groups.length && [receipt.internalBuildState, receipt.externalBuildState].includes("UNKNOWN"))) return "UNKNOWN";
+  if (receipt.groups.some((group) => BLOCKED.has(group.buildState))) return "BLOCKED";
+  return "VALID_NOT_AVAILABLE";
+}
+
+export async function runReceipt(env, dependencies = {}) {
+  const receipt = {
+    schemaVersion: 1, queryStartedAt: new Date().toISOString(), target: null,
+    verdict: "UNKNOWN", groups: [], error: null,
+    limitation: "Apple API snapshot only. Group membership is not proof of invitation acceptance, device eligibility, or installation.",
+  };
+  try {
+    receipt.target = selectors(env.TESTFLIGHT_MARKETING_VERSION, env.TESTFLIGHT_BUILD_NUMBER);
+    const api = dependencies.api ?? appleClient(tokenSigner(env));
+    receipt.verdict = await collectReceipt(receipt, api);
+  } catch (error) {
+    // The sole reporting boundary must never serialize arbitrary SDK/crypto/network errors.
+    receipt.error = error instanceof ReceiptError
+      ? { code: error.code, httpStatus: error.status }
+      : { code: "INTERNAL_ERROR", httpStatus: null };
+    receipt.verdict = "UNKNOWN";
+  }
+  receipt.queryCompletedAt = new Date().toISOString();
+  return receipt;
+}
+
+export function receiptSummary(receipt) {
+  return `## TestFlight availability receipt\n\n\`\`\`json\n${JSON.stringify(receipt, null, 2)}\n\`\`\`\n`;
+}
+
+if (isDirectRun(import.meta.url)) {
+  const receipt = await runReceipt(process.env);
+  writeFileSync("testflight-receipt.json", `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
+  if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, receiptSummary(receipt));
+  console.log(`TestFlight receipt: ${receipt.verdict}${receipt.error ? ` (${receipt.error.code})` : ""}`);
+  process.exitCode = receipt.verdict === "TESTER_AVAILABLE" ? 0 : 1;
+}

--- a/scripts/testflight-receipt.test.mjs
+++ b/scripts/testflight-receipt.test.mjs
@@ -1,0 +1,288 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync, verify } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import {
+  appleClient, appleUrl, ReceiptError, receiptSummary, runReceipt, selectors, tokenSigner,
+} from "./testflight-receipt.mjs";
+
+const env = { TESTFLIGHT_MARKETING_VERSION: "0.4.2", TESTFLIGHT_BUILD_NUMBER: "2026090912" };
+const relation = (type, id) => ({ data: { type, id } });
+const resource = (type, id, attributes = {}, relationships = {}) => ({ type, id, attributes, relationships });
+
+function fixture() {
+  const data = {
+    apps: [resource("apps", "app-1", { bundleId: "ai.opencoven.cave" })],
+    preReleaseVersions: [resource("preReleaseVersions", "version-1", { version: "0.4.2", platform: "IOS" },
+      { app: relation("apps", "app-1") })],
+    builds: [resource("builds", "build-1", {
+      version: "2026090912", processingState: "VALID", expired: false,
+      expirationDate: new Date(Date.now() + 86_400_000).toISOString(),
+    }, { app: relation("apps", "app-1"), preReleaseVersion: relation("preReleaseVersions", "version-1") })],
+    buildBetaDetail: resource("buildBetaDetails", "detail-1", {
+      internalBuildState: "IN_BETA_TESTING", externalBuildState: "READY_FOR_BETA_SUBMISSION",
+    }, { build: relation("builds", "build-1") }),
+    betaGroups: [resource("betaGroups", "group-1", { isInternalGroup: true, name: "PRIVATE GROUP NAME" },
+      { app: relation("apps", "app-1") })],
+    betaTesters: [{ type: "betaTesters", id: "private-tester-id" }],
+  };
+  const calls = [];
+  const api = appleClient(() => "private-token", {
+    fetchImpl: async (value, options) => {
+      const url = new URL(value);
+      calls.push({ url, options });
+      assert.equal(options.method, "GET");
+      assert.equal(options.redirect, "error");
+      assert.ok(options.signal instanceof AbortSignal);
+      const key = url.pathname.split("/").at(-1);
+      assert.ok(Object.hasOwn(data, key), `Unexpected endpoint ${key}`);
+      return Response.json({ data: data[key], links: { next: null } });
+    },
+    pause: async () => {},
+  });
+  return { data, calls, api };
+}
+
+test("JWTs are P-256 ES256, short-lived and GET-scoped for individual and team keys", () => {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  const base = {
+    APPLE_API_KEY: "TESTKEY123",
+    APPLE_API_KEY_BASE64: Buffer.from(privateKey.export({ type: "pkcs8", format: "pem" })).toString("base64"),
+    APPLE_API_ISSUER: "12345678-1234-1234-1234-123456789abc",
+  };
+  for (const subject of ["", "user"]) {
+    const token = tokenSigner({ ...base, APPLE_API_KEY_SUBJECT: subject })("/v1/apps?limit=200", 1000);
+    const [header, payload, signature] = token.split(".");
+    assert.deepEqual(JSON.parse(Buffer.from(header, "base64url")), { alg: "ES256", kid: base.APPLE_API_KEY, typ: "JWT" });
+    const claims = JSON.parse(Buffer.from(payload, "base64url"));
+    assert.equal(claims.aud, "appstoreconnect-v1");
+    assert.equal(claims.iat, 1000);
+    assert.equal(claims.exp, 1300);
+    assert.deepEqual(claims.scope, ["GET /v1/apps?limit=200"]);
+    assert.equal(claims.sub, subject ? "user" : undefined);
+    assert.equal(claims.iss, subject ? undefined : base.APPLE_API_ISSUER);
+    assert.equal(Buffer.from(signature, "base64url").length, 64);
+    assert.ok(verify("sha256", Buffer.from(`${header}.${payload}`),
+      { key: publicKey, dsaEncoding: "ieee-p1363" }, Buffer.from(signature, "base64url")));
+  }
+  assert.throws(() => tokenSigner({ ...base, APPLE_API_KEY_SUBJECT: "other" }), /INVALID_KEY_SUBJECT/);
+  assert.throws(() => tokenSigner({ ...base, APPLE_API_ISSUER: "" }), /INVALID_TEAM_ISSUER/);
+  assert.doesNotThrow(() => tokenSigner({ ...base, APPLE_API_KEY_SUBJECT: "user", APPLE_API_ISSUER: "" }));
+  assert.throws(() => tokenSigner({ ...base, APPLE_API_KEY_BASE64: "invalid" }), /INVALID_PRIVATE_KEY/);
+  const rsa = generateKeyPairSync("rsa", { modulusLength: 2048 }).privateKey;
+  assert.throws(() => tokenSigner({ ...base,
+    APPLE_API_KEY_BASE64: Buffer.from(rsa.export({ type: "pkcs8", format: "pem" })).toString("base64"),
+  }), /INVALID_PRIVATE_KEY/);
+});
+
+test("exact input validation does not echo arbitrary inputs", async () => {
+  assert.equal(selectors("0.4.2", "2026090912").bundleId, "ai.opencoven.cave");
+  for (const [version, build] of [["secret\nvalue", "1"], ["0.4.2", "1,2"], ["0.4.2", "$(write)"]]) {
+    const receipt = await runReceipt({ TESTFLIGHT_MARKETING_VERSION: version, TESTFLIGHT_BUILD_NUMBER: build });
+    assert.equal(receipt.verdict, "UNKNOWN");
+    assert.equal(receipt.target, null);
+    assert.ok(receipt.error);
+    assert.ok(!JSON.stringify(receipt).includes("secret"));
+  }
+});
+
+test("availability requires exact identity, matching beta lane and populated assigned group", async () => {
+  const f = fixture();
+  const receipt = await runReceipt(env, { api: f.api });
+  assert.equal(receipt.verdict, "TESTER_AVAILABLE");
+  assert.equal(receipt.buildId, "build-1");
+  assert.equal(receipt.processingState, "VALID");
+  assert.deepEqual(receipt.groups, [{
+    id: "group-1", isInternalGroup: true, buildState: "IN_BETA_TESTING", testerCount: 1, testerAvailable: true,
+  }]);
+  const builds = f.calls.find(({ url }) => url.pathname === "/v1/builds").url;
+  assert.equal(builds.searchParams.get("filter[app]"), "app-1");
+  assert.equal(builds.searchParams.get("filter[preReleaseVersion]"), "version-1");
+  assert.equal(builds.searchParams.get("filter[version]"), "2026090912");
+  const groups = f.calls.find(({ url }) => url.pathname === "/v1/betaGroups").url;
+  assert.equal(groups.searchParams.get("filter[app]"), "app-1");
+  assert.equal(groups.searchParams.get("filter[builds]"), "build-1");
+  assert.ok(f.calls.some(({ url }) => url.pathname === "/v1/betaGroups/group-1/relationships/betaTesters"));
+  assert.doesNotMatch(receiptSummary(receipt), /PRIVATE GROUP NAME|private-tester-id|private-token/);
+});
+
+test("processing, absent, blocked, unknown and merely ready states are not success", async () => {
+  const cases = [
+    ["PROCESSING_PENDING", (d) => { d.builds[0].attributes.processingState = "PROCESSING"; }],
+    ["BLOCKED", (d) => { d.builds[0].attributes.processingState = "INVALID"; }],
+    ["BLOCKED", (d) => { d.builds[0].attributes.expired = true; }],
+    ["BLOCKED", (d) => { d.builds[0].attributes.expirationDate = "2000-01-01T00:00:00Z"; }],
+    ["BLOCKED", (d) => { d.buildBetaDetail.attributes.internalBuildState = "MISSING_EXPORT_COMPLIANCE"; }],
+    ["UNKNOWN", (d) => { d.buildBetaDetail.attributes.internalBuildState = "NEW_STATE_WITH_PII"; }],
+    ["UNKNOWN", (d) => { delete d.builds[0].attributes.expired; }],
+    ["UNKNOWN", (d) => { d.builds[0].attributes.processingState = "SOMETHING_NEW"; }],
+    ["VALID_NOT_AVAILABLE", (d) => { d.buildBetaDetail.attributes.internalBuildState = "READY_FOR_BETA_TESTING"; }],
+    ["VALID_NOT_AVAILABLE", (d) => { d.betaGroups = []; }],
+    ["VALID_NOT_AVAILABLE", (d) => { d.betaTesters = []; }],
+    ["VALID_NOT_AVAILABLE", (d) => { d.betaGroups[0].attributes.isInternalGroup = false; }],
+    ["TESTER_AVAILABLE", (d) => {
+      d.betaGroups[0].attributes.isInternalGroup = false;
+      d.buildBetaDetail.attributes.externalBuildState = "IN_BETA_TESTING";
+    }],
+    ...["apps", "preReleaseVersions", "builds"].map((key) => ["ABSENT", (d) => { d[key] = []; }]),
+  ];
+  for (const [expected, change] of cases) {
+    const f = fixture();
+    change(f.data);
+    const receipt = await runReceipt(env, { api: f.api });
+    assert.equal(receipt.verdict, expected, change.toString());
+    assert.doesNotMatch(JSON.stringify(receipt), /NEW_STATE_WITH_PII/);
+  }
+});
+
+test("wrong app, marketing version, build, platform or linkage fails closed", async () => {
+  const mutations = [
+    (d) => { d.apps[0].attributes.bundleId = "wrong.bundle"; },
+    (d) => { d.preReleaseVersions[0].attributes.platform = "MAC_OS"; },
+    (d) => { d.preReleaseVersions[0].attributes.version = "0.4.1"; },
+    (d) => { d.preReleaseVersions[0].relationships.app.data.id = "wrong"; },
+    (d) => { d.builds[0].attributes.version = "other"; },
+    (d) => { d.builds[0].relationships.app.data.id = "wrong"; },
+    (d) => { d.builds[0].relationships.preReleaseVersion.data.id = "wrong"; },
+    (d) => { d.buildBetaDetail.relationships.build.data.id = "wrong"; },
+    (d) => { d.betaGroups[0].relationships.app.data.id = "wrong"; },
+    (d) => { d.betaGroups[0].attributes.isInternalGroup = "true"; },
+    (d) => { d.builds.push(d.builds[0]); },
+  ];
+  for (const change of mutations) {
+    const f = fixture();
+    change(f.data);
+    const receipt = await runReceipt(env, { api: f.api });
+    assert.equal(receipt.verdict, "UNKNOWN", change.toString());
+    assert.ok(receipt.error);
+  }
+});
+
+test("pagination collects tester counts without leaking identifiers", async () => {
+  let page = 0;
+  const client = appleClient(() => "token", {
+    fetchImpl: async () => Response.json({
+      data: [{ type: "betaTesters", id: `tester-${++page}` }],
+      links: { next: page === 1
+        ? "https://api.appstoreconnect.apple.com/v1/betaGroups/g/relationships/betaTesters?limit=200&cursor=next"
+        : null },
+    }),
+  });
+  assert.equal((await client.list("/v1/betaGroups/g/relationships/betaTesters")).length, 2);
+});
+
+test("requests refuse foreign origins, redirects and unsafe or unbounded pagination", async () => {
+  for (const url of [
+    "https://attacker.example/v1/apps", "http://api.appstoreconnect.apple.com/v1/apps",
+    "//attacker.example/v1/apps", "https://user:pass@api.appstoreconnect.apple.com/v1/apps",
+    "https://api.appstoreconnect.apple.com:444/v1/apps", "/v1/apps#fragment", "/v1/users",
+  ]) assert.throws(() => appleUrl(url), /UNSAFE_API_URL/);
+  for (const next of [
+    "https://attacker.example/v1/apps?limit=200",
+    "/v1/builds?limit=200", "/v1/apps?filter[bundleId]=other",
+    "/v1/apps?limit=200",
+  ]) {
+    let calls = 0;
+    const api = appleClient(() => "token", {
+      fetchImpl: async () => { calls += 1; return Response.json({ data: [], links: { next } }); },
+    });
+    await assert.rejects(api.list("/v1/apps"), ReceiptError);
+    assert.equal(calls, 1);
+  }
+  let pages = 0;
+  const api = appleClient(() => "token", {
+    fetchImpl: async () => Response.json({ data: [],
+      links: { next: `/v1/apps?limit=200&cursor=${++pages}` } }),
+  });
+  await assert.rejects(api.list("/v1/apps"), /PAGINATION_LIMIT/);
+  assert.equal(pages, 10);
+  const redirect = appleClient(() => "token", { fetchImpl: async (_url, options) => {
+    assert.equal(options.redirect, "error");
+    return new Response(null, { status: 302, headers: { Location: "https://attacker.example" } });
+  } });
+  await assert.rejects(redirect.get("/v1/apps"), /APPLE_HTTP_ERROR/);
+});
+
+test("401/403 never retry and failures never expose response bodies or thrown secrets", async () => {
+  for (const status of [401, 403, 429, 503]) {
+    let calls = 0;
+    const api = appleClient(() => "private-token", {
+      fetchImpl: async () => { calls += 1; return new Response("SECRET email@example.test", { status }); },
+      pause: async () => {},
+    });
+    const receipt = await runReceipt(env, { api });
+    assert.equal(calls, status === 401 || status === 403 ? 1 : 3);
+    assert.equal(receipt.verdict, "UNKNOWN");
+    assert.equal(receipt.error.httpStatus, status);
+    assert.doesNotMatch(receiptSummary(receipt), /SECRET|email@example|private-token/);
+  }
+  for (const fetchImpl of [
+    async () => { throw new Error("PRIVATE KEY SECRET"); },
+    async () => new Response("PRIVATE KEY SECRET"),
+    async () => new Response("x".repeat(1_048_577)),
+    async () => Response.json({ data: "not-a-list" }),
+  ]) {
+    const receipt = await runReceipt(env, { api: appleClient(() => "token", { fetchImpl }) });
+    assert.equal(receipt.verdict, "UNKNOWN");
+    assert.ok(receipt.error);
+    assert.doesNotMatch(receiptSummary(receipt), /PRIVATE KEY SECRET/);
+  }
+});
+
+test("retry recovery, total request budget and wall-clock deadline are bounded", async () => {
+  let requests = 0;
+  const api = appleClient(() => "token", { fetchImpl: async () => {
+    requests += 1;
+    return requests === 1 ? new Response(null, { status: 429 }) : Response.json({ data: [] });
+  }, pause: async () => {} });
+  assert.deepEqual(await api.list("/v1/apps"), []);
+  for (let i = 0; i < 98; i += 1) await api.get("/v1/apps");
+  await assert.rejects(api.get("/v1/apps"), /REQUEST_BUDGET_EXCEEDED/);
+  assert.equal(requests, 100);
+  let now = 0;
+  const timed = appleClient(() => "token", { now: () => now,
+    fetchImpl: async () => { throw new Error("must not request after deadline"); } });
+  now = 240_001;
+  await assert.rejects(timed.get("/v1/apps"), /REQUEST_BUDGET_EXCEEDED/);
+});
+
+test("CLI persists sanitized failure receipt and summary with a nonzero exit", () => {
+  const directory = mkdtempSync(join(process.cwd(), ".testflight-receipt-test-"));
+  try {
+    const summary = join(directory, "summary.txt");
+    const result = spawnSync(process.execPath, [resolve("scripts/testflight-receipt.mjs")], {
+      cwd: directory, encoding: "utf8",
+      env: { TESTFLIGHT_MARKETING_VERSION: "secret", TESTFLIGHT_BUILD_NUMBER: "1",
+        APPLE_API_KEY_BASE64: "SECRET CREDENTIAL", GITHUB_STEP_SUMMARY: summary },
+    });
+    assert.equal(result.status, 1);
+    const json = readFileSync(join(directory, "testflight-receipt.json"), "utf8");
+    assert.equal(JSON.parse(json).error.code, "INVALID_MARKETING_VERSION");
+    assert.doesNotMatch(json + readFileSync(summary, "utf8") + result.stdout + result.stderr, /SECRET CREDENTIAL|secret/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("workflow is main-only, manual, read-only, pinned and artifacts only sanitized JSON", () => {
+  const workflow = readFileSync(new URL("../.github/workflows/testflight-receipt.yml", import.meta.url), "utf8");
+  const release = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /^\s+(?:push|pull_request|schedule):/m);
+  assert.match(workflow, /if: github.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /permissions:\n  contents: read/);
+  assert.doesNotMatch(workflow, /: write|persist-credentials: true|continue-on-error/);
+  const actions = [...workflow.matchAll(/uses: (\S+)/g)].map((match) => match[1]);
+  assert.equal(actions.length, 3);
+  for (const action of actions) {
+    assert.match(action, /@[a-f0-9]{40}$/);
+    assert.ok(release.includes(action), action);
+  }
+  assert.match(workflow, /if: always\(\)/);
+  assert.match(workflow, /path: testflight-receipt\.json/);
+  assert.match(workflow, /if-no-files-found: error/);
+  for (const run of workflow.matchAll(/run: (.+)/g)) assert.doesNotMatch(run[1], /\$\{\{/);
+  assert.match(workflow, /APPLE_API_KEY_SUBJECT: \$\{\{ vars.APPLE_API_KEY_SUBJECT \}\}/);
+});


### PR DESCRIPTION
## Scope
Supports the authorized iOS release without changing its signed source, version stamps, tagging, upload, or Apple distribution. Bead: cave-o8mh7 (supporting cave-d9clv).

Adds a main-only manual workflow accepting exact marketing version/build for ai.opencoven.cave on IOS. Uses only existing release secrets, in-memory P-256 signing, five-minute per-request GET-scoped JWTs (individual sub:user/no iss or team issuer), fixed Apple HTTPS origin, refused redirects, bounded pagination/timeouts/retries and sanitized failure receipts. Apple 401/403 is never retried. Pinned checkout/setup-node/upload-artifact actions match release.yml; no dependencies added.

The artifact/job summary distinguishes absent/processing/VALID-but-unavailable/blocked/unknown from a populated assigned group whose matching internal/external lane is IN_BETA_TESTING. Tester relationship IDs are counted in memory; no tester PII, IDs, credentials, arbitrary response bodies or raw exception details are emitted. This is API availability evidence, never proof of user installation.

## Verification
- 33 targeted Node tests passed: receipt, existing altool wrapper, release-promotion workflow contracts.
- Existing test-wiring guard passed (2007 files); receipt tests wired into the release/mobile suite and executed by the manual workflow before secrets are provided.
- Targeted ESLint and git diff checks passed; docs index passed.
- Read-only independent review reported no significant issues.

After merge, dispatch testflight-receipt.yml from main for 0.4.2 / 2026090912; the parent release run 34357893342 has already completed its upload/processing step successfully.