### PR TITLE
Keep completed-chat archive guidance visible above the composer

### DIFF
--- a/src/components/chat-archive-nudge.test.ts
+++ b/src/components/chat-archive-nudge.test.ts
@@ -48,12 +48,25 @@ assert.match(
   /Archive chat/,
   "primary CTA reads 'Archive chat'",
 );
-// X-close + secondary Dismiss both wired to onDismiss so the user can quit
-// from either affordance.
 assert.match(
   componentSrc,
-  /aria-label="Dismiss archive nudge"[\s\S]*onClick=\{onDismiss\}/,
-  "header close button is wired to onDismiss",
+  /onClick=\{onDismiss\}[\s\S]*Keep chat open/,
+  "secondary action clearly keeps the chat open",
+);
+assert.match(
+  componentSrc,
+  /Task complete\. Ready to archive\?/,
+  "the heading explains why archiving is being suggested without claiming the chat is finished",
+);
+assert.match(
+  componentSrc,
+  /finished with this topic[\s\S]*history[\s\S]*Show archived/,
+  "guidance explains when to archive, preserved history and where to find it",
+);
+assert.match(
+  componentSrc,
+  /<Button\s+variant="primary"[\s\S]*onClick=\{onArchive\}[\s\S]*loading=\{archiving\}/,
+  "archive uses the prominent shared primary button with loading semantics",
 );
 // Disabled state during the archive request.
 assert.match(
@@ -122,11 +135,19 @@ assert.match(
   /const dismissArchiveNudge = useCallback\([\s\S]*markChatArchiveNudgeDismissed\(sessionId, window\.localStorage\)/,
   "dismissArchiveNudge persists the per-session flag to localStorage",
 );
-// Banner is mounted inside the chat thread, just before tailRef so the new
-// turn appears below it visually.
+// The prompt stays outside the transcript scroller, directly above the composer.
+assert.ok(
+  chatViewSrc.indexOf("<ChatArchiveNudge") > chatViewSrc.indexOf("</ToolProjectRootContext.Provider>"),
+  "the archive prompt is not buried inside the scrollable transcript",
+);
 assert.match(
   chatViewSrc,
-  /shouldShowChatArchiveNudge\(\{\s*taskLifecycle: linkedContext\?\.task\?\.lifecycle \?\? null,\s*sessionArchived: Boolean\(session\?\.archived_at\),\s*dismissed: archiveNudgeDismissed,\s*\}\) \? \(\s*<ChatArchiveNudge[\s\S]*taskTitle=\{linkedContext\?\.task\?\.title \?\? ""\}[\s\S]*onArchive=\{\(\) => void setChatArchived\(true\)\}[\s\S]*onDismiss=\{dismissArchiveNudge\}[\s\S]*archiving=\{archiving\}/,
+  /<ChatArchiveNudge[\s\S]*?\/>\s*\) : null\}\s*\{inlineComposer \? null : showDockedComposer \? composerNode : null\}/,
+  "archive guidance is adjacent to the composer",
+);
+assert.match(
+  chatViewSrc,
+  /shouldShowChatArchiveNudge\(\{\s*taskLifecycle: linkedContext\?\.task\?\.lifecycle \?\? null,\s*sessionArchived: Boolean\(session\?\.archived_at\),\s*dismissed: archiveNudgeDismissed,\s*sessionBusy: busy \|\| autoMissionActive \|\| voiceCallOpen \|\| session\?\.status === "running",\s*\}\) \? \(\s*<ChatArchiveNudge[\s\S]*taskTitle=\{linkedContext\?\.task\?\.title \?\? ""\}[\s\S]*onArchive=\{\(\) => void setChatArchived\(true\)\}[\s\S]*onDismiss=\{dismissArchiveNudge\}[\s\S]*archiving=\{archiving\}/,
   "the nudge and header button share the same archive mutation and busy state",
 );
 

--- a/src/components/chat-archive-nudge.tsx
+++ b/src/components/chat-archive-nudge.tsx
@@ -3,8 +3,8 @@
 import "@/styles/cave-chat.css";
 
 /**
- * ChatArchiveNudge — the inline "final nudge" rendered at the bottom of a
- * chat transcript when the chat is tied to a task whose execution lifecycle
+ * ChatArchiveNudge — persistent guidance above the composer, outside the
+ * transcript scroller, when the chat is tied to a task whose execution lifecycle
  * has reached `completed`. Companion to the global inbox toast (see
  * `task-archive-nudge.ts`): the toast catches the user wherever they are, this
  * banner persists inside the chat itself so it's still here when they come
@@ -15,6 +15,7 @@ import "@/styles/cave-chat.css";
  */
 
 import { Icon } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
 
 export type ChatArchiveNudgeProps = {
   /** Title of the linked task — surfaced in the nudge body for context. */
@@ -39,52 +40,46 @@ export function ChatArchiveNudge({
       role="status"
       aria-live="polite"
       aria-label={`Ready to archive: ${title}`}
-      className="cave-chat-archive-nudge focus-ring relative mx-auto my-4 flex w-full max-w-[42rem] items-start gap-3 rounded-xl border border-[color-mix(in_oklch,var(--accent-presence)_38%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_10%,var(--bg-raised))] px-4 py-3 text-[length:var(--text-base)] text-[var(--text-primary)] shadow-[0_1px_0_color-mix(in_oklch,var(--accent-presence)_20%,transparent)]"
+      className="cave-chat-archive-nudge mx-4 mb-2 flex shrink-0 items-start gap-3 rounded-[var(--radius-card)] border border-[var(--border-strong)] bg-[var(--bg-raised)] p-4 text-[length:var(--text-base)] text-[var(--text-primary)]"
       data-testid="chat-archive-nudge"
     >
       <Icon
         name="ph:archive"
         width={18}
-        className="mt-0.5 shrink-0 text-[var(--accent-presence)]"
+        className="shrink-0 text-[var(--text-secondary)]"
         aria-hidden
       />
       <div className="min-w-0 flex-1">
-        <div className="font-medium text-[var(--text-primary)]">
-          Ready to archive
-        </div>
-        <p className="mt-0.5 text-[length:var(--text-sm)] text-[var(--text-secondary)]">
+        <h2 className="text-[length:var(--text-md)] font-semibold text-[var(--text-primary)]">
+          Task complete. Ready to archive?
+        </h2>
+        <p className="mt-1 break-words text-[length:var(--text-sm)] text-[var(--text-secondary)]">
           <span className="font-medium text-[var(--text-primary)]">{title}</span>
-          {" is complete. Archive this chat to clear it from your active sessions."}
+          {" is complete. Archive when you're finished with this topic."}
         </p>
-        <div className="mt-2 flex flex-wrap items-center gap-2">
-          <button
-            type="button"
+        <p className="mt-1 text-[length:var(--text-sm)] text-[var(--text-secondary)]">
+          This clears the chat from active chats, not its history. Find it again with Show archived.
+        </p>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <Button
+            variant="primary"
             onClick={onArchive}
-            disabled={archiving}
-            className="focus-ring inline-flex items-center gap-1.5 rounded-md border border-[color-mix(in_oklch,var(--accent-presence)_55%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_18%,transparent)] px-2.5 py-1 text-[length:var(--text-xs)] font-medium text-[var(--text-primary)] transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_28%,transparent)] disabled:opacity-50"
+            loading={archiving}
+            leadingIcon="ph:archive"
+            className="focus-ring"
           >
-            <Icon name="ph:archive" width={12} aria-hidden />
             {archiving ? "Archiving…" : "Archive chat"}
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="ghost"
             onClick={onDismiss}
             disabled={archiving}
-            className="focus-ring inline-flex items-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-[length:var(--text-xs)] font-medium text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)] disabled:opacity-50"
+            className="focus-ring"
           >
-            Dismiss
-          </button>
+            Keep chat open
+          </Button>
         </div>
       </div>
-      <button
-        type="button"
-        aria-label="Dismiss archive nudge"
-        onClick={onDismiss}
-        disabled={archiving}
-        className="focus-ring absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] disabled:opacity-50"
-      >
-        <Icon name="ph:x" width={12} aria-hidden />
-      </button>
     </div>
   );
 }

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -8286,18 +8286,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             onOpenPreview={onOpenPreview}
             handlersRef={transcriptHandlersRef}
           />
-          {!offlineReadOnly && shouldShowChatArchiveNudge({
-            taskLifecycle: linkedContext?.task?.lifecycle ?? null,
-            sessionArchived: Boolean(session?.archived_at),
-            dismissed: archiveNudgeDismissed,
-          }) ? (
-            <ChatArchiveNudge
-              taskTitle={linkedContext?.task?.title ?? ""}
-              onArchive={() => void setChatArchived(true)}
-              onDismiss={dismissArchiveNudge}
-              archiving={archiving}
-            />
-          ) : null}
           <div ref={tailRef} />
         </div>
 
@@ -8463,6 +8451,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         />
       ) : null}
 
+      {!offlineReadOnly && shouldShowChatArchiveNudge({
+        taskLifecycle: linkedContext?.task?.lifecycle ?? null,
+        sessionArchived: Boolean(session?.archived_at),
+        dismissed: archiveNudgeDismissed,
+        sessionBusy: busy || autoMissionActive || voiceCallOpen || session?.status === "running",
+      }) ? (
+        <ChatArchiveNudge
+          taskTitle={linkedContext?.task?.title ?? ""}
+          onArchive={() => void setChatArchived(true)}
+          onDismiss={dismissArchiveNudge}
+          archiving={archiving}
+        />
+      ) : null}
       {inlineComposer ? null : showDockedComposer ? composerNode : null}
       {voiceCallOpen && sessionId && !offlineReadOnly && (
         <VoiceCallOverlay

--- a/src/lib/chat-archive-nudge.test.ts
+++ b/src/lib/chat-archive-nudge.test.ts
@@ -154,4 +154,26 @@ for (const lifecycle of [null, undefined, ""]) {
   clearChatArchiveNudgeDismissed("s-3", hostile);
 }
 
+assert.equal(
+  shouldShowChatArchiveNudge({
+    taskLifecycle: "completed",
+    sessionArchived: false,
+    dismissed: false,
+    sessionBusy: true,
+  }),
+  false,
+  "does not recommend archiving while the familiar is still working",
+);
+
+assert.equal(
+  shouldShowChatArchiveNudge({
+    taskLifecycle: "completed",
+    sessionArchived: false,
+    dismissed: false,
+    sessionBusy: false,
+  }),
+  true,
+  "returns after work settles without dismissing the recommendation",
+);
+
 console.log("chat-archive-nudge.test.ts ok");

--- a/src/lib/chat-archive-nudge.ts
+++ b/src/lib/chat-archive-nudge.ts
@@ -1,6 +1,6 @@
 /**
- * In-chat archive nudge — the "final nudge" surfaced inline at the end of a
- * chat transcript when the linked task has reached the end of its execution
+ * In-chat archive nudge — persistent guidance above the composer
+ * when the linked task has reached the end of its execution
  * lifecycle (card lifecycle → `completed`) and the chat is ready to archive.
  *
  * The toast variant (see {@link ./task-archive-nudge}) lives in the global
@@ -79,6 +79,8 @@ export type ChatArchiveNudgeInputs = {
   sessionArchived: boolean;
   /** Whether the user has dismissed the nudge for this session. */
   dismissed: boolean;
+  /** Active work must settle before suggesting that the chat be put away. */
+  sessionBusy?: boolean;
 };
 
 /**
@@ -87,6 +89,7 @@ export type ChatArchiveNudgeInputs = {
  * session is still active, and the user hasn't already dismissed it.
  */
 export function shouldShowChatArchiveNudge(inputs: ChatArchiveNudgeInputs): boolean {
+  if (inputs.sessionBusy) return false;
   if (inputs.sessionArchived) return false;
   if (inputs.dismissed) return false;
   if (!inputs.taskLifecycle) return false;

--- a/tests/chat-archive-nudge.spec.ts
+++ b/tests/chat-archive-nudge.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const SESSION_ID = "archive-guidance";
+const ISO = "2026-09-09T10:00:00.000Z";
+const PROJECT_ROOT = "/repo";
+
+async function openChat(
+  page: Page,
+  options: { lifecycle?: string | null; running?: boolean; failArchive?: boolean } = {},
+) {
+  const mutations: unknown[] = [];
+  let failArchive = options.failArchive ?? false;
+  let archived = false;
+  const task = options.lifecycle === null ? null : {
+    id: "archive-task",
+    title: "Polish archive guidance",
+    status: "done",
+    lifecycle: options.lifecycle ?? "completed",
+    priority: "medium",
+    labels: [],
+    cwd: PROJECT_ROOT,
+    projectId: "p1",
+    notes: null,
+  };
+  await page.addInitScript(() => {
+    localStorage.setItem("cave:onboarding:dismissed", "1");
+    localStorage.setItem("cave:active-familiar", "nova");
+    localStorage.setItem("cave:familiar:nova:last-surface", "chat");
+  });
+  await page.route("**/api/familiars**", (route) => route.fulfill({
+    json: { ok: true, familiars: [{
+      id: "nova", display_name: "Nova", role: "Orchestrator",
+      status: "active", icon: "ph:sparkle-fill",
+    }] },
+  }));
+  await page.route("**/api/projects**", (route) => route.fulfill({
+    json: { ok: true, projects: [{ id: "p1", name: "Cave", root: PROJECT_ROOT, access: "write" }] },
+  }));
+  await page.route("**/api/sessions/list**", (route) => route.fulfill({
+    json: { ok: true, sessions: archived ? [] : [{
+      id: SESSION_ID, title: "Archive guidance", familiarId: "nova",
+      status: options.running ? "running" : "idle",
+      project_root: PROJECT_ROOT, harness: "claude", model: "test",
+      runtime: `local:${PROJECT_ROOT}`, exit_code: null, archived_at: null,
+      created_at: ISO, updated_at: ISO,
+    }] },
+  }));
+  await page.route("**/api/chat/conversation/**", (route) => route.fulfill({
+    json: {
+      ok: true,
+      context: { task, tasks: task ? [task] : [], github: [] },
+      conversation: {
+        activeLeafId: "turn-39",
+        turns: Array.from({ length: 40 }, (_, index) => ({
+          id: `turn-${index}`,
+          parentId: index === 0 ? null : `turn-${index - 1}`,
+          role: index % 2 === 0 ? "user" : "assistant",
+          text: `Message ${index + 1}. ${"Review the completed work and keep its history. ".repeat(12)}`,
+          createdAt: ISO,
+        })),
+      },
+    },
+  }));
+  await page.route(`**/api/sessions/${SESSION_ID}`, (route) => {
+    mutations.push(route.request().postDataJSON());
+    if (failArchive) {
+      failArchive = false;
+      return route.fulfill({ status: 500, json: { ok: false, error: "Archive unavailable. Try again." } });
+    }
+    archived = true;
+    return route.fulfill({ json: { ok: true } });
+  });
+  await page.goto(`/?mode=chat#chat-${SESSION_ID}`, { waitUntil: "domcontentloaded" });
+  await expect(page.locator(".cave-chat-transcript").first()).toBeVisible({ timeout: 45_000 });
+  return mutations;
+}
+
+test("archive guidance stays visible above the composer, including while reading older messages", async ({ page }) => {
+  await openChat(page);
+  const nudge = page.getByTestId("chat-archive-nudge");
+  await expect(nudge.getByRole("heading", { name: "Task complete. Ready to archive?" })).toBeVisible();
+  await expect(nudge).toContainText("finished with this topic");
+  await expect(nudge).toContainText("not its history");
+  await expect(nudge).toContainText("Show archived");
+  await expect(nudge.getByRole("button", { name: "Archive chat" })).toHaveClass(/ui-btn--primary/);
+  expect(await nudge.evaluate((element) => element.closest(".cave-chat-transcript") === null)).toBe(true);
+
+  const composer = page.locator(".cave-composer-dock").first();
+  const nudgeBox = await nudge.boundingBox();
+  const composerBox = await composer.boundingBox();
+  expect(nudgeBox).not.toBeNull();
+  expect(composerBox).not.toBeNull();
+  expect(nudgeBox!.y + nudgeBox!.height).toBeLessThanOrEqual(composerBox!.y + 1);
+
+  await page.locator(".cave-chat-transcript").first().evaluate((element) => {
+    element.scrollTop = 0;
+    element.dispatchEvent(new Event("scroll"));
+  });
+  await expect(nudge).toBeInViewport({ ratio: 1 });
+  for (const [theme, mode] of [["coven", "dark"], ["coven", "light"], ["tide", "dark"]]) {
+    await page.evaluate(({ theme, mode }) => {
+      document.documentElement.dataset.theme = theme;
+      document.documentElement.dataset.mode = mode;
+    }, { theme, mode });
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(nudge).toBeInViewport({ ratio: 1 });
+    expect(await nudge.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+    await expect(nudge.getByRole("button", { name: "Keep chat open" })).toBeVisible();
+  }
+});
+
+test("keeping a chat open dismisses only the prompt and survives reload", async ({ page }) => {
+  const mutations = await openChat(page);
+  const nudge = page.getByTestId("chat-archive-nudge");
+  const keepOpen = nudge.getByRole("button", { name: "Keep chat open" });
+  await keepOpen.focus();
+  await page.keyboard.press("Enter");
+  await expect(nudge).toHaveCount(0);
+  expect(mutations).toEqual([]);
+  expect(await page.evaluate((id) => localStorage.getItem(`cave:chat-archive-nudge-dismissed:${id}`), SESSION_ID))
+    .toBe("1");
+  await page.reload();
+  await expect(page.locator(".cave-composer-input").first()).toBeVisible();
+  await expect(nudge).toHaveCount(0);
+});
+
+test("failed archive stays actionable and a retry uses the existing archive endpoint", async ({ page }) => {
+  const mutations = await openChat(page, { failArchive: true });
+  const nudge = page.getByTestId("chat-archive-nudge");
+  await nudge.getByRole("button", { name: "Archive chat" }).click();
+  await expect(page.getByText("Archive unavailable. Try again.", { exact: true })).toBeVisible();
+  await expect(nudge.getByRole("button", { name: "Archive chat" })).toBeEnabled();
+  await nudge.getByRole("button", { name: "Archive chat" }).click();
+  await expect(nudge).toHaveCount(0);
+  expect(mutations).toEqual([{ archived: true }, { archived: true }]);
+});
+
+for (const [label, options] of [
+  ["active work", { running: true }],
+  ["unfinished task", { lifecycle: "running" }],
+  ["unlinked chat", { lifecycle: null }],
+] as const) {
+  test(`does not imply ${label} is ready to archive`, async ({ page }) => {
+    await openChat(page, options);
+    await expect(page.locator(".cave-composer-input").first()).toBeVisible();
+    await expect(page.getByTestId("chat-archive-nudge")).toHaveCount(0);
+  });
+}


### PR DESCRIPTION
## Summary

Keep completed-task archive guidance visible above the Chat composer instead of burying it in the transcript scroller. Explain that archiving removes a chat from active chats, preserves its history, and leaves it accessible through Show archived.

Use the shared primary Archive chat action and an explicit Keep chat open action. Preserve dismissal persistence and archive-error retry behavior; suppress the recommendation while the familiar, an autonomous mission, or a voice call is active.

Bead: `cave-rfxm8`

## Evidence

- Focused helper and component source-contract tests passed after integration onto current main.
- Typecheck, lint, test wiring and production build passed.
- Six route-mocked Playwright cases passed against an isolated production server: persistent placement while reading older messages; narrow Coven dark/light and Tide dark layouts; keyboard dismissal and reload persistence; archive failure/retry; busy, unfinished and unlinked suppression.
- Inspected the resulting narrow-screen capture; both actions remain visible above the composer.

No data migration, release or deletion actions.
