### PR TITLE
fix(worktrees): reconcile rerere retirement policy and guard

### DIFF
--- a/.agents/skills/branch-curator/references/deletion-proof.md
+++ b/.agents/skills/branch-curator/references/deletion-proof.md
@@ -725,6 +725,9 @@ EOF
 worktree_admin_safe=1
 while IFS= read -r -d '' admin_entry; do
   admin_name=${admin_entry##*/}
+  case "$admin_name" in
+    *.lock) worktree_admin_safe=0; break ;;
+  esac
   test ! -L "$admin_entry" ||
     { worktree_admin_safe=0; break; }
   case "$admin_name" in
@@ -735,8 +738,8 @@ while IFS= read -r -d '' admin_entry; do
       test -d "$admin_entry" || { worktree_admin_safe=0; break; }
       ;;
     MERGE_RR)
-      test -f "$admin_entry" && test -r "$admin_entry" &&
-        test ! -s "$admin_entry" || { worktree_admin_safe=0; break; }
+      node "$primary_checkout/scripts/worktree-rerere-state.mjs" "$admin_entry" ||
+        { worktree_admin_safe=0; break; }
       ;;
     ORIG_HEAD)
       test -f "$admin_entry" || { worktree_admin_safe=0; break; }

--- a/.agents/skills/branch-curator/references/deletion-proof.md
+++ b/.agents/skills/branch-curator/references/deletion-proof.md
@@ -683,7 +683,15 @@ test "$worktree_recovery_safe" -eq 1 ||
 
 Prove `ORIG_HEAD` and every first-field OID in `FETCH_HEAD`. Treat operation
 state, locked worktrees, and unknown top-level admin entries as live or
-uncertain:
+uncertain. The sole rerere exception is a readable, non-symbolic, zero-byte
+regular `MERGE_RR` file: Git's [rerere implementation](https://github.com/git/git/blob/master/rerere.c)
+writes a list of pending conflict paths and can leave an empty list after
+resolution. A nonempty file, directory, symlink (including dangling), unreadable
+file, or `MERGE_RR.lock` remains protected. Empty residue never overrides an
+unmerged index, operation marker, lock, ownership, recency, or retention check.
+Do not delete or rewrite the file to qualify a candidate. The strict guard
+checks this state before retention probes and again before its allow result;
+the complete recovery-OID and unknown-admin proof below remains mandatory.
 
 ```bash
 emit_plain_oids() {
@@ -725,6 +733,10 @@ while IFS= read -r -d '' admin_entry; do
       ;;
     logs|refs)
       test -d "$admin_entry" || { worktree_admin_safe=0; break; }
+      ;;
+    MERGE_RR)
+      test -f "$admin_entry" && test -r "$admin_entry" &&
+        test ! -s "$admin_entry" || { worktree_admin_safe=0; break; }
       ;;
     ORIG_HEAD)
       test -f "$admin_entry" || { worktree_admin_safe=0; break; }

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -551,3 +551,32 @@ test("evals cover every new authorization and race boundary", () => {
   assert.match(byId.get(59).expected_output, /destination or OID drift/i);
   assert.match(byId.get(59).expected_output, /status 2/i);
 });
+
+for (const state of ["empty", "nonempty", "directory", "symlink", "dangling", "lock", "merge"]) {
+  test(`documented MERGE_RR admin proof: ${state}`, {
+    skip: process.platform === "win32" && ["symlink", "dangling"].includes(state),
+  }, () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "curator-rerere-"));
+    const admin = path.join(dir, "admin");
+    fs.mkdirSync(admin);
+    const rr = path.join(admin, "MERGE_RR");
+    if (state === "directory") fs.mkdirSync(rr);
+    else if (state === "symlink" || state === "dangling") {
+      const target = path.join(dir, "empty");
+      if (state === "symlink") fs.writeFileSync(target, "");
+      fs.symlinkSync(target, rr);
+    } else {
+      fs.writeFileSync(rr, state === "nonempty" ? "pending" : "");
+      if (state === "lock") fs.writeFileSync(`${rr}.lock`, "");
+      if (state === "merge") fs.writeFileSync(path.join(admin, "MERGE_HEAD"), "");
+    }
+    const start = proof.indexOf("worktree_admin_safe=1");
+    const end = proof.indexOf("\n```", start);
+    assert.ok(start >= 0 && end > start);
+    const result = spawnSync("bash", ["-c",
+      `worktree_git_dir=$1\nfor candidate in one; do\n${proof.slice(start, end)}\nprintf 'SAFE\\n'\ndone`,
+      "admin-proof", admin], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), state === "empty" ? "SAFE" : "PRESERVE - worktree admin recovery state");
+  });
+}

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 function read(path) {
   return fs.readFileSync(path, "utf8");
@@ -579,7 +580,7 @@ for (const state of ["empty", "nonempty", "directory", "symlink", "dangling", "l
     assert.ok(start >= 0 && end > start);
     const result = spawnSync("bash", ["-c",
       `worktree_git_dir=$1\nprimary_checkout=$2\nfor candidate in one; do\n${proof.slice(start, end)}\nprintf 'SAFE\\n'\ndone`,
-      "admin-proof", admin, process.cwd()], { encoding: "utf8" });
+      "admin-proof", admin, fileURLToPath(new URL("..", import.meta.url))], { encoding: "utf8" });
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.stdout.trim(), state === "empty" ? "SAFE" : "PRESERVE - worktree admin recovery state");
   });

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -552,9 +552,9 @@ test("evals cover every new authorization and race boundary", () => {
   assert.match(byId.get(59).expected_output, /status 2/i);
 });
 
-for (const state of ["empty", "nonempty", "directory", "symlink", "dangling", "lock", "merge"]) {
+for (const state of ["empty", "nonempty", "directory", "symlink", "dangling", "lock", "merge", "unknown", "wrong-type", "admin-symlink", "shared-lock"]) {
   test(`documented MERGE_RR admin proof: ${state}`, {
-    skip: process.platform === "win32" && ["symlink", "dangling"].includes(state),
+    skip: process.platform === "win32" && ["symlink", "dangling", "admin-symlink"].includes(state),
   }, () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "curator-rerere-"));
     const admin = path.join(dir, "admin");
@@ -567,6 +567,10 @@ for (const state of ["empty", "nonempty", "directory", "symlink", "dangling", "l
       fs.symlinkSync(target, rr);
     } else {
       fs.writeFileSync(rr, state === "nonempty" ? "pending" : "");
+      if (state === "wrong-type") fs.mkdirSync(path.join(admin, "config.worktree"));
+      if (state === "admin-symlink") fs.symlinkSync(rr, path.join(admin, "config.worktree"));
+      if (state === "shared-lock") fs.writeFileSync(path.join(admin, "sharedindex.example.lock"), "");
+      if (state === "unknown") fs.writeFileSync(path.join(admin, "UNKNOWN_RECOVERY"), "");
       if (state === "lock") fs.writeFileSync(`${rr}.lock`, "");
       if (state === "merge") fs.writeFileSync(path.join(admin, "MERGE_HEAD"), "");
     }
@@ -574,8 +578,8 @@ for (const state of ["empty", "nonempty", "directory", "symlink", "dangling", "l
     const end = proof.indexOf("\n```", start);
     assert.ok(start >= 0 && end > start);
     const result = spawnSync("bash", ["-c",
-      `worktree_git_dir=$1\nfor candidate in one; do\n${proof.slice(start, end)}\nprintf 'SAFE\\n'\ndone`,
-      "admin-proof", admin], { encoding: "utf8" });
+      `worktree_git_dir=$1\nprimary_checkout=$2\nfor candidate in one; do\n${proof.slice(start, end)}\nprintf 'SAFE\\n'\ndone`,
+      "admin-proof", admin, process.cwd()], { encoding: "utf8" });
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.stdout.trim(), state === "empty" ? "SAFE" : "PRESERVE - worktree admin recovery state");
   });

--- a/scripts/worktree-guard.mjs
+++ b/scripts/worktree-guard.mjs
@@ -64,6 +64,7 @@
 
 import { appendFileSync, existsSync, lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
+import { assertEmptyRegularRerere } from "./worktree-rerere-state.mjs";
 import path from "node:path";
 import {
   createStrictRetentionDeadline,
@@ -235,20 +236,23 @@ function strictRecoveryState(target) {
     "git administrative directory",
   );
   for (const name of readdirSync(admin)) {
-    if (
-      name.endsWith(".lock") || name.startsWith("rebase-") ||
-      ["locked", "MERGE_HEAD", "REBASE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD",
-        "BISECT_HEAD", "AUTO_MERGE", "sequencer"].includes(name)
-    ) throw new Error(`target has recovery state: ${name}`);
+    if (name.endsWith(".lock")) throw new Error(`target has recovery state: ${name}`);
+    const entry = path.join(admin, name);
+    const stat = lstatSync(entry);
+    if (stat.isSymbolicLink()) throw new Error(`target has recovery state: symbolic ${name}`);
     if (name === "MERGE_RR") {
-      const entry = path.join(admin, name);
-      const stat = lstatSync(entry);
-      if (!stat.isFile() || stat.size !== 0) {
-        throw new Error("target has recovery state: MERGE_RR is not an empty regular file");
+      try {
+        assertEmptyRegularRerere(entry);
+      } catch (error) {
+        throw new Error(`target has recovery state: ${error}`);
       }
-      if (readFileSync(entry).length !== 0) {
-        throw new Error("target has recovery state: MERGE_RR changed during inspection");
-      }
+    } else if (["logs", "refs"].includes(name)) {
+      if (!stat.isDirectory()) throw new Error(`target has recovery state: non-directory ${name}`);
+    } else if (["HEAD", "commondir", "gitdir", "index", "config.worktree",
+      "COMMIT_EDITMSG", "ORIG_HEAD", "FETCH_HEAD"].includes(name) || name.startsWith("sharedindex.")) {
+      if (!stat.isFile()) throw new Error(`target has recovery state: non-file ${name}`);
+    } else {
+      throw new Error(`target has recovery state: ${name}`);
     }
   }
 }

--- a/scripts/worktree-guard.mjs
+++ b/scripts/worktree-guard.mjs
@@ -62,7 +62,7 @@
  * On any internal error the guard exits 0: a hook bug must never brick Bash.
  */
 
-import { appendFileSync, existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { appendFileSync, existsSync, lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import path from "node:path";
 import {
@@ -225,6 +225,32 @@ function strictRegisteredWorktree(target) {
     if (registeredPath === target) found = true;
   }
   if (!found) throw new Error("target is not an exactly registered worktree");
+}
+
+// MERGE_RR is rerere's pending-path list, not a commit/recovery OID.
+// An empty regular file is harmless residue; it never overrides operation state.
+function strictRecoveryState(target) {
+  const admin = strictSingleLine(
+    strictGit(["-C", target, "rev-parse", "--absolute-git-dir"]),
+    "git administrative directory",
+  );
+  for (const name of readdirSync(admin)) {
+    if (
+      name.endsWith(".lock") || name.startsWith("rebase-") ||
+      ["locked", "MERGE_HEAD", "REBASE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD",
+        "BISECT_HEAD", "AUTO_MERGE", "sequencer"].includes(name)
+    ) throw new Error(`target has recovery state: ${name}`);
+    if (name === "MERGE_RR") {
+      const entry = path.join(admin, name);
+      const stat = lstatSync(entry);
+      if (!stat.isFile() || stat.size !== 0) {
+        throw new Error("target has recovery state: MERGE_RR is not an empty regular file");
+      }
+      if (readFileSync(entry).length !== 0) {
+        throw new Error("target has recovery state: MERGE_RR changed during inspection");
+      }
+    }
+  }
 }
 
 function strictRemoteNames(target, deadline) {
@@ -781,6 +807,7 @@ function runStrictWorktreeRemove(args) {
   }
   if (!statSync(target).isDirectory()) throw new Error("target is not a directory");
   strictRegisteredWorktree(target);
+  strictRecoveryState(target);
 
   const actualHead = strictSingleOid(
     strictGit(["-C", target, "rev-parse", "--verify", "HEAD"]),
@@ -807,6 +834,7 @@ function runStrictWorktreeRemove(args) {
   else if (remoteBranchProof) strictRetainedByRemoteBranch(target, actualHead, remoteBranchProof);
   else strictRetainedOnRemote(target, actualHead);
   strictLiveProcesses(target);
+  strictRecoveryState(target);
   process.stdout.write(`${JSON.stringify({
     ok: true,
     mode: "strict-worktree-remove",

--- a/scripts/worktree-guard.test.mjs
+++ b/scripts/worktree-guard.test.mjs
@@ -6,7 +6,7 @@
 // garbage input. A guard bug must never brick Bash.
 
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync, chmodSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync, chmodSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -1398,3 +1398,28 @@ await test("strict-worktree-remove is a fail-closed direct guard", () => {
 });
 
 console.log("worktree-guard.test.mjs passed");
+
+for (const state of ["empty", "nonempty", "directory", "symlink", "dangling", "lock", "merge"]) {
+  await test(`strict MERGE_RR recovery state: ${state}`, {
+    skip: isWin && ["symlink", "dangling"].includes(state),
+  }, () => {
+    const fixture = repoWithWorktree({ push: true });
+    const head = sh("git", ["rev-parse", "HEAD"], fixture.wt).trim();
+    const admin = sh("git", ["rev-parse", "--absolute-git-dir"], fixture.wt).trim();
+    const rr = path.join(admin, "MERGE_RR");
+    if (state === "directory") mkdirSync(rr);
+    else if (state === "symlink" || state === "dangling") {
+      const target = path.join(fixture.dir, "empty-rerere");
+      if (state === "symlink") writeFileSync(target, "");
+      symlinkSync(target, rr);
+    } else {
+      writeFileSync(rr, state === "nonempty" ? `${"a".repeat(40)}\tfile\0` : "");
+      if (state === "lock") writeFileSync(`${rr}.lock`, "");
+      if (state === "merge") writeFileSync(path.join(admin, "MERGE_HEAD"), `${head}\n`);
+    }
+    const result = runStrict(strictArgs(fixture.wt, head), fixture.dir, strictEnv());
+    assert.equal(result.status, state === "empty" ? 0 : 2, result.stderr);
+    if (state !== "empty") assert.match(result.stderr, /recovery state/);
+    assert.ok(existsSync(fixture.wt), "probe does not mutate the candidate");
+  });
+}

--- a/scripts/worktree-guard.test.mjs
+++ b/scripts/worktree-guard.test.mjs
@@ -1399,9 +1399,9 @@ await test("strict-worktree-remove is a fail-closed direct guard", () => {
 
 console.log("worktree-guard.test.mjs passed");
 
-for (const state of ["empty", "nonempty", "directory", "symlink", "dangling", "lock", "merge"]) {
+for (const state of ["empty", "nonempty", "directory", "symlink", "dangling", "lock", "merge", "unknown", "wrong-type", "admin-symlink", "shared-lock"]) {
   await test(`strict MERGE_RR recovery state: ${state}`, {
-    skip: isWin && ["symlink", "dangling"].includes(state),
+    skip: isWin && ["symlink", "dangling", "admin-symlink"].includes(state),
   }, () => {
     const fixture = repoWithWorktree({ push: true });
     const head = sh("git", ["rev-parse", "HEAD"], fixture.wt).trim();
@@ -1414,6 +1414,10 @@ for (const state of ["empty", "nonempty", "directory", "symlink", "dangling", "l
       symlinkSync(target, rr);
     } else {
       writeFileSync(rr, state === "nonempty" ? `${"a".repeat(40)}\tfile\0` : "");
+      if (state === "wrong-type") mkdirSync(path.join(admin, "config.worktree"));
+      if (state === "admin-symlink") symlinkSync(rr, path.join(admin, "config.worktree"));
+      if (state === "shared-lock") writeFileSync(path.join(admin, "sharedindex.example.lock"), "");
+      if (state === "unknown") writeFileSync(path.join(admin, "UNKNOWN_RECOVERY"), "");
       if (state === "lock") writeFileSync(`${rr}.lock`, "");
       if (state === "merge") writeFileSync(path.join(admin, "MERGE_HEAD"), `${head}\n`);
     }
@@ -1421,5 +1425,35 @@ for (const state of ["empty", "nonempty", "directory", "symlink", "dangling", "l
     assert.equal(result.status, state === "empty" ? 0 : 2, result.stderr);
     if (state !== "empty") assert.match(result.stderr, /recovery state/);
     assert.ok(existsSync(fixture.wt), "probe does not mutate the candidate");
+  });
+}
+
+for (const replacement of ["symlink", "regular"]) {
+  await test(`rerere inspection rejects ${replacement} replacement after lstat`, {
+    skip: isWin && replacement === "symlink",
+  }, async () => {
+    const fs = await import("node:fs");
+    const { assertEmptyRegularRerere } = await import("./worktree-rerere-state.mjs");
+    const dir = fs.mkdtempSync(path.join(tmpdir(), "rerere-replacement-"));
+    const file = path.join(dir, "MERGE_RR");
+    fs.writeFileSync(file, "");
+    let replaced = false;
+    try {
+      assert.throws(() => assertEmptyRegularRerere(file, {
+        ...fs,
+        lstatSync(target) {
+          const stat = fs.lstatSync(target);
+          if (!replaced) {
+            replaced = true;
+            fs.renameSync(file, `${file}.original`);
+            if (replacement === "symlink") fs.symlinkSync(`${file}.original`, file);
+            else fs.writeFileSync(file, "");
+          }
+          return stat;
+        },
+      }));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 }

--- a/scripts/worktree-rerere-state.mjs
+++ b/scripts/worktree-rerere-state.mjs
@@ -1,0 +1,31 @@
+import * as fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+/** Validate one opened entry without following replacement symlinks or blocking on FIFOs. */
+export function assertEmptyRegularRerere(file, io = fs) {
+  const before = io.lstatSync(file);
+  const empty = (stat) => stat.isFile() && stat.size === 0;
+  if (!empty(before)) throw new Error("MERGE_RR is not an empty regular file");
+  const fd = io.openSync(file, fs.constants.O_RDONLY |
+    (fs.constants.O_NOFOLLOW ?? 0) | (fs.constants.O_NONBLOCK ?? 0));
+  try {
+    const opened = io.fstatSync(fd);
+    const sameEntry = (stat) => empty(stat) && stat.dev === before.dev && stat.ino === before.ino;
+    if (!sameEntry(opened) || io.readSync(fd, Buffer.alloc(1), 0, 1, 0) !== 0 ||
+        !sameEntry(io.fstatSync(fd)) || !sameEntry(io.lstatSync(file))) {
+      throw new Error("MERGE_RR changed during inspection");
+    }
+  } finally {
+    io.closeSync(fd);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    if (process.argv.length !== 3) throw new Error("expected one MERGE_RR path");
+    assertEmptyRegularRerere(process.argv[2]);
+  } catch (error) {
+    console.error(String(error));
+    process.exitCode = 2;
+  }
+}


### PR DESCRIPTION
## Summary

Align the branch-retirement proof and strict guard on safe empty MERGE_RR residue, unknown admin entries, and operation locks.

## Why

The documented cleanup proof classified an empty MERGE_RR file as unknown recovery state, preserving otherwise eligible merged worktrees. The strict guard did not inspect that state and could allow nonempty or symbolic rerere entries. Bead: cave-ylkts.

## Changes

- Permit only readable, non-symbolic, zero-byte regular MERGE_RR residue in the normative admin proof.
- Share a descriptor-based rerere validator between the normative shell proof and strict guard. Reject symlink or inode replacement and bound the read to one byte.
- Reject unknown, symbolic, wrongly typed admin entries and all locks, including shared-index locks, before retention probes and again before the strict guard returns an allow result.
- Exercise both the executable shell proof and strict guard with empty, nonempty, directory, symlink, dangling-symlink, lock, merge-marker, unknown-entry and wrong-type fixtures. Skip only symlink privilege-dependent fixtures on Windows.

## Verification

- 46 guard and policy tests passed, including deterministic replacement races and shared-index locks.
- pnpm typecheck and pnpm lint passed.
- pnpm test:api passed: 472 test files.
- pnpm test:app passed: 1420 test files (worktree-local frozen dependencies; system Git/Bash first on PATH).
- Test wiring passed: all 2008 files registered.
- git diff --check and node --check passed.
- Independent read-only review: no remaining important findings.
- Live non-destructive strict proof passed for fix/cave-12b6r-prompt-generation at 02c8b99b94bc8f873914886744f611f9957ed292 using its exact retained remote branch.

## Risk + rollout notes

The strict guard can now refuse active recovery markers it previously overlooked. Empty residue never overrides ownership, recency, unmerged-index, recovery-OID or retention checks. No admin residue, branch or worktree was removed during verification. After landing, begin a new bounded cleanup batch with fresh complete proof.
