### PR TITLE
Retire unused session initiator exports

### DIFF
--- a/docs/specs/2026-06-29-telegram-channel-migration-plan.md
+++ b/docs/specs/2026-06-29-telegram-channel-migration-plan.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Treat OpenClaw's Telegram implementation as the compatibility reference, not the long-term runtime owner. First land an OpenCoven Telegram connector for safe outbound delivery; then add Cave docs/settings and a migration inventory; then move inbound/session handling only after outbound, auth, allowlists, and transcript compatibility are verified.
 
-**Tech Stack:** `@opencoven/channels` in `OpenCoven/coven`, Cave docs/settings in `coven-cave`, existing Cave OpenClaw session parsing (`src/lib/session-initiator.ts`), OpenClaw Telegram docs/extension as migration reference, 1Password refs for live tokens and chat IDs.
+**Tech Stack:** `@opencoven/channels` in `OpenCoven/coven`, Cave docs/settings in `coven-cave`, Cave session-key attribution (`src/lib/session-initiator.ts`), OpenClaw Telegram docs/extension as migration reference, 1Password refs for live tokens and chat IDs.
 
 ---
 
@@ -27,7 +27,7 @@ OpenClaw already has a mature Telegram stack:
 - Group policy and group sender allowlists.
 - Group/forum topic support and topic-aware session keys.
 - Message send/action paths and health/probe coverage.
-- Cave already parses OpenClaw Telegram transcript metadata into human initiators in `src/lib/session-initiator.ts`.
+- Cave's former OpenClaw transcript ingestion caller was removed with the Calls surface in PR #1858 (`7f2beed2e`); its unused parsing helpers were retired in `cave-ep9fb`. `src/lib/session-initiator.ts` now provides session-key attribution only. Its production caller, `src/lib/session-list-merge.ts`, preserves supplied initiators and otherwise uses an empty key with a familiar/harness fallback; it does not ingest OpenClaw sender metadata. Transcript attribution remains a migration requirement, not an already-wired capability.
 - Cave already treats `telegram` as a remote lane in `src/lib/presence.ts`.
 
 The OpenCoven target should preserve the parts Val relies on first, then graduate the richer group/topic behavior.
@@ -177,7 +177,7 @@ Do not copy raw IDs or real 1Password item titles.
 
 At minimum:
 
-- existing OpenClaw Telegram transcript metadata still renders as "Valentina / Telegram" in Cave;
+- migrated OpenClaw Telegram transcript metadata produces sanitized human attribution (for example, "Valentina / Telegram") in Cave; this requires an ingestion path and presentation coverage, not just session-key tests;
 - OpenCoven Telegram outbound messages can be attributed to a familiar;
 - session keys with group/topic shape parse without losing the familiar id;
 - missing or unresolved token refs fail closed;
@@ -227,7 +227,7 @@ Start with one-owner direct-message allowlist. Then add groups and topics after 
 
 - [ ] **Step 3: Preserve transcript attribution**
 
-Inbound events should carry sanitized sender metadata compatible with Cave's existing initiator parsing:
+Inbound events should carry sanitized sender metadata for a future wired Cave ingestion path, with compatibility coverage before cutover:
 
 ```ts
 {

--- a/docs/specs/2026-06-29-telegram-channel-migration-plan.md
+++ b/docs/specs/2026-06-29-telegram-channel-migration-plan.md
@@ -27,7 +27,7 @@ OpenClaw already has a mature Telegram stack:
 - Group policy and group sender allowlists.
 - Group/forum topic support and topic-aware session keys.
 - Message send/action paths and health/probe coverage.
-- Cave's former OpenClaw transcript ingestion caller was removed with the Calls surface in PR #1858 (`7f2beed2e`); its unused parsing helpers were retired in `cave-ep9fb`. `src/lib/session-initiator.ts` now provides session-key attribution only. Its production caller, `src/lib/session-list-merge.ts`, preserves supplied initiators and otherwise uses an empty key with a familiar/harness fallback; it does not ingest OpenClaw sender metadata. Transcript attribution remains a migration requirement, not an already-wired capability.
+- Cave's former OpenClaw transcript ingestion caller was removed with the Calls surface in PR #1858 (`7f2beed2e`); its unused parsing helpers were retired in `cave-ep9fb`. `src/lib/session-initiator.ts` now provides session-key attribution only. Its production caller, `src/lib/session-list-merge.ts`, preserves supplied initiators; daemon rows reaching the session-key fallback use an empty key with a familiar/harness fallback, while local conversations without supplied initiators default to the human "Cave user". Neither path ingests OpenClaw sender metadata. Transcript attribution remains a migration requirement, not an already-wired capability.
 - Cave already treats `telegram` as a remote lane in `src/lib/presence.ts`.
 
 The OpenCoven target should preserve the parts Val relies on first, then graduate the richer group/topic behavior.

--- a/src/lib/session-initiator.test.ts
+++ b/src/lib/session-initiator.test.ts
@@ -1,68 +1,75 @@
-// @ts-nocheck
 import assert from "node:assert/strict";
-import {
-  initiatorFromOpenClawMessages,
-  initiatorFromSessionKey,
-  labelFromAgentId,
-} from "./session-initiator.ts";
+import { initiatorFromSessionKey } from "./session-initiator.ts";
 
-assert.equal(labelFromAgentId("kitty"), "Kitty");
-assert.equal(labelFromAgentId("coven-code"), "Coven Code");
+for (const channel of ["cron", "heartbeat", "timer", "schedule"]) {
+  assert.deepEqual(
+    initiatorFromSessionKey(`agent:sage:${channel}:daily-brief`, "kitty"),
+    { kind: "system", label: channel, channel },
+    `${channel} sessions should be system-originated`,
+  );
+}
 
-assert.deepEqual(
-  initiatorFromOpenClawMessages(
-    [
-      {
-        role: "user",
-        senderName: "Valentina (❖,❖)",
-        senderUsername: "BunsDev",
-        sourceChannel: "telegram",
-      },
-    ],
-    "kitty",
-    "agent:kitty:telegram:direct:823292124",
-  ),
-  {
-    kind: "human",
-    label: "Valentina",
-    channel: "telegram",
-    username: "BunsDev",
-  },
-  "channel user metadata should win over the familiar whose transcript stored the session",
-);
+for (const channel of [
+  "telegram", "discord", "signal", "whatsapp", "imessage", "webchat", "slack",
+]) {
+  assert.deepEqual(
+    initiatorFromSessionKey(`agent:kitty:${channel}:group:example:topic:1`, "sage"),
+    {
+      kind: "human",
+      label: `Human via ${channel.charAt(0).toUpperCase()}${channel.slice(1)}`,
+      channel,
+    },
+    `${channel} sessions should retain human provenance with group/topic suffixes`,
+  );
+}
 
 assert.deepEqual(
-  initiatorFromOpenClawMessages(
-    [{ role: "user", content: "Remember this codeword: avocado." }],
-    "kitty",
-    "agent:kitty:cave-test-persist-1",
-  ),
-  {
-    kind: "familiar",
-    label: "Kitty",
-    agentId: "kitty",
-  },
-  "agent-keyed Cave persistence smoke sessions should show the familiar as initiator",
+  initiatorFromSessionKey("agent:kitty: TELEGRAM :direct:example", "sage"),
+  { kind: "human", label: "Human via Telegram", channel: "telegram" },
+  "channel recognition should trim whitespace and normalize case",
+);
+assert.deepEqual(
+  initiatorFromSessionKey("agent:sage: CRON :daily-brief", "kitty"),
+  { kind: "system", label: "cron", channel: "cron" },
+  "system channels should also be normalized",
 );
 
-assert.deepEqual(
-  initiatorFromSessionKey("agent:sage:cron:daily-brief", "sage"),
-  {
-    kind: "system",
-    label: "cron",
-    channel: "cron",
-  },
-  "cron session keys should be system-originated instead of familiar-originated",
-);
+for (const channel of [
+  "cave-test-persist-1", "unknown", "@telegram", "telegram/path", "tele gram",
+  "1telegram", "telegram\ninjected", "a".repeat(33),
+]) {
+  assert.deepEqual(
+    initiatorFromSessionKey(`agent:kitty:${channel}:example`, "sage"),
+    { kind: "familiar", label: "Kitty", agentId: "kitty" },
+    "unrecognized or invalid channels should fall back to the keyed familiar",
+  );
+}
+
+for (const [agentId, label] of [
+  ["kitty", "Kitty"],
+  ["coven-code", "Coven Code"],
+  ["__coven--code__", "Coven Code"],
+  ["", "Familiar"],
+  ["_-", "Familiar"],
+]) {
+  assert.deepEqual(
+    initiatorFromSessionKey("", agentId),
+    { kind: "familiar", label, agentId },
+    "missing keys should preserve fallback agent IDs and format their labels",
+  );
+}
 
 assert.deepEqual(
-  initiatorFromSessionKey("", "cody"),
-  {
-    kind: "familiar",
-    label: "Cody",
-    agentId: "cody",
-  },
-  "missing session keys should still fall back to the agent folder id",
+  initiatorFromSessionKey("agent:coven-code", "kitty"),
+  { kind: "familiar", label: "Coven Code", agentId: "coven-code" },
+  "the keyed agent should take precedence over the fallback without a channel",
 );
+for (const sessionKey of ["agent", "unscoped-session", "other:kitty:unknown"]) {
+  assert.deepEqual(
+    initiatorFromSessionKey(sessionKey, "cody"),
+    { kind: "familiar", label: "Cody", agentId: "cody" },
+    "keys without an agent identity should use the fallback",
+  );
+}
 
 console.log("session-initiator.test.ts: ok");

--- a/src/lib/session-initiator.ts
+++ b/src/lib/session-initiator.ts
@@ -1,13 +1,5 @@
 import type { SessionInitiator } from "./types.ts";
 
-type OpenClawMessageLike = {
-  role?: string;
-  senderName?: unknown;
-  senderUsername?: unknown;
-  sourceChannel?: unknown;
-  content?: unknown;
-};
-
 const SYSTEM_CHANNELS = new Set(["cron", "heartbeat", "timer", "schedule"]);
 const HUMAN_CHANNELS = new Set([
   "telegram",
@@ -19,31 +11,13 @@ const HUMAN_CHANNELS = new Set([
   "slack",
 ]);
 
-function cleanLabel(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-  const compact = value.replace(/\s+/g, " ").trim();
-  if (!compact) return null;
-  // Telegram display names sometimes carry decorative suffixes. Keep the
-  // person-readable part and avoid exposing raw IDs or styling glyphs.
-  return compact
-    .replace(/\s*\([^)]*\)\s*$/u, "")
-    .replace(/\s+id:\d+$/i, "")
-    .trim() || null;
-}
-
 function cleanChannel(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const normalized = value.trim().toLowerCase();
   return /^[a-z][a-z0-9_-]{0,31}$/.test(normalized) ? normalized : undefined;
 }
 
-function cleanUsername(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const username = value.replace(/^@/, "").trim();
-  return /^[A-Za-z0-9_]{1,32}$/.test(username) ? username : undefined;
-}
-
-export function labelFromAgentId(agentId: string): string {
+function labelFromAgentId(agentId: string): string {
   return agentId
     .split(/[-_]+/)
     .filter(Boolean)
@@ -72,46 +46,4 @@ export function initiatorFromSessionKey(
     label: labelFromAgentId(agentId),
     agentId,
   };
-}
-
-export function initiatorFromOpenClawMessages(
-  messages: OpenClawMessageLike[],
-  fallbackAgentId: string,
-  sessionKey = "",
-): SessionInitiator {
-  const firstUser = messages.find((message) => message.role === "user");
-  if (firstUser) {
-    const senderName = cleanLabel(firstUser.senderName);
-    const channel = cleanChannel(firstUser.sourceChannel);
-    const username = cleanUsername(firstUser.senderUsername);
-    if (senderName) {
-      return {
-        kind: "human",
-        label: senderName,
-        ...(channel ? { channel } : {}),
-        ...(username ? { username } : {}),
-      };
-    }
-  }
-
-  return initiatorFromSessionKey(sessionKey, fallbackAgentId);
-}
-
-export function openClawMessagesFromJsonlLines(lines: string[]): OpenClawMessageLike[] {
-  const messages: OpenClawMessageLike[] = [];
-  for (const line of lines) {
-    try {
-      const parsed = JSON.parse(line) as { type?: string; message?: OpenClawMessageLike };
-      if (parsed.type === "message" && parsed.message) messages.push(parsed.message);
-    } catch {
-      continue;
-    }
-  }
-  return messages;
-}
-
-export function sessionInitiatorLabel(initiator?: SessionInitiator): string {
-  if (!initiator) return "Unknown";
-  if (initiator.kind === "human" && initiator.channel) return `${initiator.label} / ${labelFromAgentId(initiator.channel)}`;
-  return initiator.label;
 }


### PR DESCRIPTION
## Summary
- Make the internally used agent-label helper private and remove the unused label formatter and OpenClaw transcript helpers. Keep the live session-key API unchanged.
- Confirm abandonment: PR #1858 (7f2beed2e) removed the Calls surface and the production transcript ingestion caller. Current session-list merging preserves supplied provenance or uses a familiar/harness fallback; no current ingestion consumer remains.
- Replace implementation-detail tests with live API coverage for human/system channels, normalization, invalid channels, keyed/fallback agents, and labels. Correct the historical Telegram plan while preserving its future compatibility requirements.

Bead: cave-ep9fb

## Verification
- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/session-initiator.test.ts src/lib/session-list-merge.test.ts` (2 files passed)
- `pnpm exec eslint src/lib/session-initiator.ts src/lib/session-initiator.test.ts`
- `pnpm typecheck`
- `git diff --check`