### PR TITLE
Give desktop chat row controls 32px hit targets

### DIFF
--- a/src/components/chat-list-coarse-actions.test.ts
+++ b/src/components/chat-list-coarse-actions.test.ts
@@ -48,4 +48,9 @@ assert.match(src, /const togglePin = \(e: React\.MouseEvent \| null/, "togglePin
 assert.match(src, /const setSessionArchived = async \(e: React\.MouseEvent \| null/, "setSessionArchived accepts null event");
 assert.match(src, /const debugSession = \(e: React\.MouseEvent \| null/, "debugSession accepts null event");
 
+const desktopActions = src.slice(src.indexOf("/* Row actions — pin"), src.indexOf("{/* ── In conversations"));
+assert.equal((desktopActions.match(/h-8 w-8/g) ?? []).length, 4, "plain fine-pointer actions have 32px targets");
+assert.match(desktopActions, /ariaLabel=\{`Archive controls for chat \$\{rowName\}`\}[\s\S]*?size="lg"/, "the archive menu uses the primitive's 32px size rather than overriding its small size with utility classes");
+assert.equal((desktopActions.match(/focus-ring touch-always-visible/g) ?? []).length, 4, "plain action buttons opt into visible focus; OverflowMenu owns its focus ring");
+
 console.log("chat-list-coarse-actions.test.ts: ok");

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -335,10 +335,10 @@ assert.match(
   /\.ui-origin-chip\s*\{[\s\S]*?border-radius:\s*var\(--radius-pill\);[\s\S]*?\}/,
   "The origin pill keeps the signature pill radius",
 );
-// The three row action buttons (pin/archive/delete) must be uniform squares.
+// The plain row action buttons must be uniform 32px squares.
 {
-  const squares = source.match(/touch-always-visible inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md/g) ?? [];
-  assert.equal(squares.length, 4, "pin/archive/debug/delete must be uniform h-6 w-6 square icon buttons");
+  const squares = source.match(/focus-ring touch-always-visible inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md/g) ?? [];
+  assert.equal(squares.length, 4, "pin/archive/debug/delete must be uniform 32px square icon buttons with focus rings");
 }
 assert.match(
   source,

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -1839,7 +1839,7 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                                 aria-label={`${pinned ? "Unpin" : "Pin"} chat ${rowName}`}
                                 aria-pressed={pinned}
                                 className={[
-                                  "touch-always-visible inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] transition-all hover:border-[color-mix(in_oklch,var(--accent-presence)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_14%,transparent)] hover:text-[var(--accent-presence)] focus-visible:opacity-100 group-hover:opacity-100",
+                                  "focus-ring touch-always-visible inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] transition-all hover:border-[color-mix(in_oklch,var(--accent-presence)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_14%,transparent)] hover:text-[var(--accent-presence)] focus-visible:opacity-100 group-hover:opacity-100",
                                   pinned
                                     ? "text-[var(--accent-presence)] opacity-100"
                                     : "text-[var(--text-muted)] opacity-0",
@@ -1853,7 +1853,7 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                                 disabled={archivingId !== null}
                                 title={s.archived_at ? "Unarchive chat" : "Archive chat"}
                                 aria-label={`${s.archived_at ? "Unarchive" : "Archive"} chat ${rowName}`}
-                                className="touch-always-visible inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] opacity-0 transition-all hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-40"
+                                className="focus-ring touch-always-visible inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] opacity-0 transition-all hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-40"
                               >
                                 <Icon name={s.archived_at ? "ph:arrow-counter-clockwise" : "ph:archive"} width={12} aria-hidden />
                               </button>
@@ -1864,8 +1864,9 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                                 <OverflowMenu
                                   ariaLabel={`Archive controls for chat ${rowName}`}
                                   icon="ph:clock-counter-clockwise"
+                                  size="lg"
                                   disabled={archivingId !== null}
-                                  className="touch-always-visible h-6 w-6 shrink-0 rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] opacity-0 transition-all hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100"
+                                  className="touch-always-visible shrink-0 rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] opacity-0 transition-all hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100"
                                   minWidth={208}
                                 >
                                   <PopoverItem
@@ -1889,7 +1890,7 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                                 onClick={(e) => debugSession(e, s)}
                                 title="Debug chat"
                                 aria-label={`Debug chat ${rowName}`}
-                                className="touch-always-visible inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] opacity-0 transition-all hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100"
+                                className="focus-ring touch-always-visible inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] opacity-0 transition-all hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-secondary)] focus-visible:opacity-100 group-hover:opacity-100"
                               >
                                 <Icon name="ph:bug-bold" width={12} aria-hidden />
                               </button>
@@ -1898,7 +1899,7 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                                 onClick={(e) => { e.stopPropagation(); setConfirmDeleteId(s.id); }}
                                 title="Delete chat"
                                 aria-label={`Delete chat ${s.title || s.id}`}
-                                className="touch-always-visible inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] opacity-0 transition-all hover:border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-danger)_14%,transparent)] hover:text-[var(--color-danger)] focus-visible:opacity-100 group-hover:opacity-100"
+                                className="focus-ring touch-always-visible inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] opacity-0 transition-all hover:border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-danger)_14%,transparent)] hover:text-[var(--color-danger)] focus-visible:opacity-100 group-hover:opacity-100"
                               >
                                 <Icon name="ph:trash" width={12} aria-hidden />
                               </button>

--- a/src/styles/globals/shell-navigation.css
+++ b/src/styles/globals/shell-navigation.css
@@ -668,6 +668,16 @@
 .cnav__thread:hover .cnav__thread-main {
   padding-right: 76px;
 }
+@media (min-width: 1024px) {
+  .cnav__row-actions .cnav__icon-btn {
+    width: var(--space-8);
+    height: var(--space-8);
+  }
+  .cnav__thread:hover .cnav__thread-main,
+  .cnav__thread:has(.cnav__row-actions:focus-within) .cnav__thread-main {
+    padding-right: calc(3 * var(--space-8) + var(--space-3));
+  }
+}
 .cnav__thread:hover {
   background: color-mix(in oklch, var(--foreground) 5%, transparent);
   color: var(--text-primary);

--- a/src/styles/globals/shell-navigation.css
+++ b/src/styles/globals/shell-navigation.css
@@ -669,7 +669,7 @@
   padding-right: 76px;
 }
 @media (min-width: 1024px) {
-  .cnav__row-actions .cnav__icon-btn {
+  .cnav__thread .cnav__icon-btn {
     width: var(--space-8);
     height: var(--space-8);
   }

--- a/tests/chat-sidebar-nav.spec.ts
+++ b/tests/chat-sidebar-nav.spec.ts
@@ -246,6 +246,18 @@ test.describe("chat threads rail", () => {
       actionsLeft: element.querySelector(".cnav__row-actions")!.getBoundingClientRect().left,
     }));
     expect(titleAndActions.titleRight).toBeLessThanOrEqual(titleAndActions.actionsLeft);
+
+    await actions.first().click();
+    const pinnedUnpin = page.locator(RAIL).locator('button[title="Unpin chat"]')
+      .and(page.getByRole("button", { name: "Unpin Refactor auth flow", exact: true }));
+    await expect(pinnedUnpin).toBeVisible();
+    const pinnedBox = await renderedBox(pinnedUnpin);
+    expect(pinnedBox.width).toBeGreaterThanOrEqual(32);
+    expect(pinnedBox.height).toBeGreaterThanOrEqual(32);
+    await page.keyboard.press("Tab");
+    await pinnedUnpin.focus();
+    await expect(pinnedUnpin).toHaveCSS("outline-style", "solid");
+    await expect(pinnedUnpin).toHaveCSS("outline-width", "2px");
   });
 
   test("is docked in the chat surface, leaving the app sidebar unchanged", async ({ page }) => {

--- a/tests/chat-sidebar-nav.spec.ts
+++ b/tests/chat-sidebar-nav.spec.ts
@@ -180,6 +180,74 @@ async function gotoChat(page: Page, { expectRail = true } = {}) {
 }
 
 test.describe("chat threads rail", () => {
+  test("desktop session-list actions have 32px targets and keyboard focus rings", async ({ page }, testInfo) => {
+    await gotoChat(page);
+    await page.getByRole("tab", { name: "Projects", exact: true }).click();
+    await page.getByRole("tab", { name: "Sessions", exact: true }).click();
+    const row = page.locator(".chat-list-row").filter({ hasText: "Refactor auth flow" });
+    await row.hover();
+    const actions = row.locator(".chat-list-row-actions button");
+    await expect(actions).toHaveCount(5);
+    const boxes = await Promise.all((await actions.all()).map(renderedBox));
+    await testInfo.attach("session-list-target-boxes", { body: JSON.stringify(boxes), contentType: "application/json" });
+    for (const box of boxes) {
+      expect(box.width).toBeGreaterThanOrEqual(32);
+      expect(box.height).toBeGreaterThanOrEqual(32);
+    }
+    await page.mouse.move(0, 0);
+    for (const action of await actions.all()) {
+      await page.keyboard.press("Tab");
+      await action.focus();
+      await expect(action).toHaveCSS("opacity", "1");
+      await expect(action).toHaveCSS("outline-style", "solid");
+      await expect(action).toHaveCSS("outline-width", "2px");
+    }
+    await actions.first().click();
+    const sectionToggle = page.getByRole("button", { name: "Collapse Pinned", exact: true });
+    await expect(sectionToggle).toBeVisible();
+    const sectionBox = await renderedBox(sectionToggle);
+    expect(sectionBox.width).toBeGreaterThanOrEqual(32);
+    expect(sectionBox.height).toBeGreaterThanOrEqual(32);
+    await page.keyboard.press("Tab");
+    await sectionToggle.focus();
+    await expect(sectionToggle).toHaveCSS("outline-style", "solid");
+    await expect(sectionToggle).toHaveCSS("outline-width", "2px");
+  });
+
+  test("desktop row controls have 32px targets and visible keyboard focus", async ({ page }, testInfo) => {
+    await gotoChat(page);
+    const row = page.locator(RAIL).locator(".cnav__thread").filter({ hasText: "Refactor auth flow" });
+    await row.hover();
+    const actions = row.locator(".cnav__row-actions > button");
+    await expect(actions).toHaveCount(3);
+    const targets = [...await actions.all(), page.getByRole("button", { name: "Collapse chat list" })];
+    const boxes = await Promise.all(targets.map(renderedBox));
+    await testInfo.attach("desktop-target-boxes", { body: JSON.stringify(boxes), contentType: "application/json" });
+    for (const box of boxes) {
+      expect(box.width).toBeGreaterThanOrEqual(32);
+      expect(box.height).toBeGreaterThanOrEqual(32);
+    }
+    await page.mouse.move(0, 0);
+    await row.locator(".cnav__thread-main").focus();
+    await page.keyboard.press("Tab");
+    await expect(actions.first()).toBeFocused();
+    for (const [theme, mode] of [["coven", "dark"], ["coven", "light"], ["tide", "dark"]]) {
+      await page.evaluate(([theme, mode]) => {
+        document.documentElement.dataset.theme = theme;
+        document.documentElement.dataset.mode = mode;
+      }, [theme, mode]);
+      await expect(actions.first()).toHaveCSS("opacity", "1");
+      await expect(actions.first()).toHaveCSS("outline-style", "solid");
+      await expect(actions.first()).toHaveCSS("outline-width", "2px");
+    }
+    await narrowChatRail(page);
+    const titleAndActions = await row.evaluate((element) => ({
+      titleRight: element.querySelector(".cnav__thread-copy")!.getBoundingClientRect().right,
+      actionsLeft: element.querySelector(".cnav__row-actions")!.getBoundingClientRect().left,
+    }));
+    expect(titleAndActions.titleRight).toBeLessThanOrEqual(titleAndActions.actionsLeft);
+  });
+
   test("is docked in the chat surface, leaving the app sidebar unchanged", async ({ page }) => {
     await gotoChat(page);
     const nav = page.locator('aside[aria-label="Sidebar"]');


### PR DESCRIPTION
## Summary
Fix measured undersized desktop controls in both chat lists: the thread rail had 22px buttons, and the full session list had 24px buttons. Raise them to 32px using existing tokens and the OverflowMenu large size. Add missing focus rings to plain list actions and reserve matching rail title space on hover and keyboard focus. Leave already-adequate header/section toggles and mobile/coarse-pointer behavior intact.

Bead: cave-46ebz

## Evidence
Production browser baseline reproduced both 22px and 24px failures. Five targeted source-contract suites pass with the canonical CSS preload; typecheck, scoped ESLint, defined-token scan, and production build pass. All 13 rail browser cases pass, including existing mobile sheet coverage; final focused regressions also exercise all five list buttons, section chevrons, keyboard-only reveal, narrow rail title clearance, and Coven dark/light plus Tide focus rings. Screenshots inspected in the isolated production app; no live data seeded or modified.