### PR TITLE
Keep distinguishing chat title suffixes visible

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1757,6 +1757,7 @@ export const SUITES = {
     "src/lib/cave-conversations.test.ts",
     "src/lib/openclaw-conversation.test.ts",
     "src/lib/session-initiator.test.ts",
+    "src/lib/chat-title-parts.test.ts",
     "src/lib/chat-runtime-scope.test.ts",
     "src/lib/chat-boundary-sentinel.test.ts",
     "src/lib/chat-project-access.test.ts",

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -80,6 +80,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { ChatListSection, HighlightedSnippet, SortableChatListItem } from "./chat-list-primitives";
+import { ChatRowTitle } from "./chat-row-title";
 import { filterChatListRows, visibleChatSessions } from "@/lib/chat-list-model";
 import {
   CHAT_GROUP_BY_KEY,
@@ -1602,10 +1603,7 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                           {/* Content */}
                           <span className="chat-list-row-content flex min-w-0 flex-1 flex-col gap-0.5">
                             {/* Row 1: session title (bold subject line) + a
-                                neutral project tag + the relative-age column.
-                                Running sessions get full white; others are
-                                slightly muted — mirrors the unread/read
-                                convention in email clients. */}
+                                neutral project tag + the relative-age column. */}
                             <span className="chat-list-row-meta flex items-center justify-between gap-2">
                               <span className="chat-list-row-title flex min-w-0 flex-1 items-center gap-1.5">
                                 {pinned && (
@@ -1616,14 +1614,10 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                                     aria-hidden
                                   />
                                 )}
-                                <span className={[
-                                  "truncate text-[length:var(--text-md)] font-semibold",
-                                  s.status === "running"
-                                    ? "text-white"
-                                    : "text-[var(--text-primary)]",
-                                ].join(" ")}>
-                                  {stripLeadingTrailingEmoji((displayTitles.get(s.id) ?? s.title) || "(untitled chat)")}
-                                </span>
+                                <ChatRowTitle
+                                  className="text-[length:var(--text-md)] font-semibold text-[var(--text-primary)]"
+                                  title={stripLeadingTrailingEmoji((displayTitles.get(s.id) ?? s.title) || "(untitled chat)")}
+                                />
                               </span>
                               {workBranch ? (
                                 <span className="chat-session-branch hidden sm:inline-flex" title={`Branch ${workBranch}`}>
@@ -1956,9 +1950,10 @@ export function ChatList({ familiar, familiars = [], sessions, selection, onSele
                         className="focus-ring-inset group flex cursor-pointer flex-col gap-0.5 px-4 py-2.5 transition-colors hover:bg-[var(--bg-raised)]/50"
                       >
                         <span className="flex items-baseline justify-between gap-2">
-                          <span className="min-w-0 truncate text-[length:var(--text-base)] font-semibold text-[var(--text-primary)]">
-                            {stripLeadingTrailingEmoji(row.title || hit.title || "(untitled chat)")}
-                          </span>
+                          <ChatRowTitle
+                            className="text-[length:var(--text-base)] font-semibold text-[var(--text-primary)]"
+                            title={stripLeadingTrailingEmoji(row.title || hit.title || "(untitled chat)")}
+                          />
                           <span className="shrink-0 text-[length:var(--text-xs)] text-[var(--text-muted)]">
                             {hit.matchCount === 1 ? "1 match" : `${hit.matchCount} matches`}
                           </span>

--- a/src/components/chat-row-title.tsx
+++ b/src/components/chat-row-title.tsx
@@ -1,0 +1,13 @@
+import { chatTitleParts } from "@/lib/chat-title-parts";
+import "@/styles/chat-row-title.css";
+
+export function ChatRowTitle({ title, className = "" }: { title: string; className?: string }) {
+  const { head, tail } = chatTitleParts(title);
+  return (
+    <span className={`chat-row-title ${className}`} title={title}>
+      <span className="sr-only">{title}</span>
+      <span className="chat-row-title__head" aria-hidden="true">{head}</span>
+      <span className="chat-row-title__tail" aria-hidden="true"><span>{tail}</span></span>
+    </span>
+  );
+}

--- a/src/components/chat-sidebar-wiring.behavior.test.ts
+++ b/src/components/chat-sidebar-wiring.behavior.test.ts
@@ -122,7 +122,7 @@ function sectionByLabel(renderer: ReactTestRenderer, label: string) {
 
 function rowContainerFor(scope: ReturnType<typeof sectionByLabel>, title: string) {
   const titleNode = scope.find(
-    (node) => typeof node.type === "string" && node.props.className === "cnav__thread-title" && textContent(node.children) === title,
+    (node) => typeof node.type === "string" && node.props.className?.split(" ").includes("cnav__thread-title") && node.props.title === title,
   );
   let node = titleNode;
   while (

--- a/src/components/workspace-sidebar-attention.test.ts
+++ b/src/components/workspace-sidebar-attention.test.ts
@@ -353,8 +353,8 @@ function sectionCount(section: ReturnType<typeof sectionByLabel>) {
 
 function sectionThreadTitles(section: ReturnType<typeof sectionByLabel>) {
   return section
-    .findAll((node) => typeof node.type === "string" && node.props.className === "cnav__thread-title")
-    .map((node) => textContent(node.children));
+    .findAll((node) => typeof node.type === "string" && node.props.className?.split(" ").includes("cnav__thread-title"))
+    .map((node) => textContent(node.findByProps({ className: "sr-only" }).children));
 }
 
 function attentionCueLabels(section: ReturnType<typeof sectionByLabel>) {
@@ -429,7 +429,7 @@ test("legacy sessions without attention render as neutral rows", async () => {
 
   expect(
     renderer.root.findAll(
-      (node) => typeof node.type === "string" && node.props.className === "cnav__thread-title" && textContent(node.children) === "Legacy chat",
+      (node) => typeof node.type === "string" && node.props.className?.split(" ").includes("cnav__thread-title") && node.props.title === "Legacy chat",
     ),
   ).toHaveLength(1);
   expect(sectionsByLabel(renderer).some((section) => section.props["aria-label"] === "Awaiting you")).toBe(false);
@@ -705,7 +705,7 @@ test("attention show-more keeps the flat modifier, focus ring, and click handler
  *  renderer root) so duplicate titles across sections resolve unambiguously. */
 function rowContainerFor(scope: ReturnType<typeof sectionByLabel> | ReactTestRenderer["root"], title: string) {
   const titleNode = scope.find(
-    (node) => typeof node.type === "string" && node.props.className === "cnav__thread-title" && textContent(node.children) === title,
+    (node) => typeof node.type === "string" && node.props.className?.split(" ").includes("cnav__thread-title") && node.props.title === title,
   );
   let node = titleNode;
   while (
@@ -1015,8 +1015,8 @@ test("the embedded chat list never surfaces archived sessions", async () => {
   ).toHaveLength(0);
 
   const titles = renderer.root
-    .findAll((node) => typeof node.type === "string" && node.props.className === "cnav__thread-title")
-    .map((node) => textContent(node.children));
+    .findAll((node) => typeof node.type === "string" && node.props.className?.split(" ").includes("cnav__thread-title"))
+    .map((node) => textContent(node.findByProps({ className: "sr-only" }).children));
   expect(titles).not.toContain("Archived but pinned");
 
   await act(async () => renderer.unmount());

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -39,6 +39,7 @@ import {
   emitChatSessionDragStart,
 } from "@/lib/chat-split";
 import { requestChatRailToggle } from "@/lib/chat-rail-toggle";
+import { ChatRowTitle } from "@/components/chat-row-title";
 
 type Props = {
   sessions: SessionRow[];
@@ -330,7 +331,7 @@ function ThreadRow({
         {project ? <span className="sr-only">{`Project ${project.name} `}</span> : null}
         <span className="cnav__thread-copy">
           <span className="cnav__thread-line">
-            <span className="cnav__thread-title" title={title}>{title}</span>
+            <ChatRowTitle className="cnav__thread-title" title={title} />
             {/* Broadcast outcome replaces the timestamp while it shows: a
                 failed target must be visible on its own row, since a
                 broadcast that half-worked and said nothing is worse than one
@@ -453,7 +454,7 @@ function PinnedThreadRow({ session, active, now, onOpenUrl, onOpen, onTogglePin 
           <span className={`cnav__dot ${statusDotClass(session.status)}`} aria-hidden />
         )}
         <span className="cnav__thread-copy">
-          <span className="cnav__thread-title" title={title}>{title}</span>
+          <ChatRowTitle className="cnav__thread-title" title={title} />
           <ThreadAttentionCue label={attentionLabel} />
         </span>
       </button>

--- a/src/lib/chat-title-parts.test.ts
+++ b/src/lib/chat-title-parts.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { chatTitleParts } from "./chat-title-parts.ts";
+
+for (const title of ["", "A", "Short title", "a".repeat(52), "Words with  spaces"]) {
+  const { head, tail } = chatTitleParts(title);
+  assert.equal(head + tail, title, "short titles retain their entire text");
+}
+assert.deepEqual(chatTitleParts("a".repeat(35) + "b".repeat(18)), {
+  head: "a".repeat(28) + "…",
+  tail: "b".repeat(18),
+});
+for (const grapheme of ["👩🏽‍💻", "👨‍👩‍👧‍👦", "🇺🇦", "e\u0301"]) {
+  assert.deepEqual(chatTitleParts(grapheme.repeat(60)), {
+    head: grapheme.repeat(28) + "…",
+    tail: grapheme.repeat(18),
+  }, "middle shortening must not split a grapheme");
+  const title = grapheme.repeat(20);
+  const { head, tail } = chatTitleParts(title);
+  assert.equal(head + tail, title);
+  assert.equal(tail, grapheme.repeat(8));
+}
+console.log("chat-title-parts.test.ts: ok");

--- a/src/lib/chat-title-parts.ts
+++ b/src/lib/chat-title-parts.ts
@@ -1,0 +1,11 @@
+const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+export function chatTitleParts(title: string): { head: string; tail: string } {
+  const parts = Array.from(graphemes.segment(title), ({ segment }) => segment);
+  const tailLength = Math.min(18, Math.floor(parts.length * 0.4));
+  const split = parts.length - tailLength;
+  return {
+    head: parts.length > 52 ? `${parts.slice(0, 28).join("")}…` : parts.slice(0, split).join(""),
+    tail: parts.slice(split).join(""),
+  };
+}

--- a/src/styles/chat-row-title.css
+++ b/src/styles/chat-row-title.css
@@ -1,0 +1,27 @@
+.chat-row-title {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.chat-row-title__head {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+}
+
+/* Reserve the suffix even when the shortened title exceeds the row width. */
+.chat-row-title__tail {
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  max-width: 45%;
+  overflow: hidden;
+  white-space: pre;
+}
+
+.chat-row-title__tail > span {
+  flex-shrink: 0;
+}

--- a/tests/chat-sidebar-nav.spec.ts
+++ b/tests/chat-sidebar-nav.spec.ts
@@ -159,7 +159,7 @@ async function ensureChatSurface(page: Page, { expectRail = true } = {}) {
   if (expectRail) await page.waitForSelector(RAIL, { timeout: 30_000 });
 }
 
-async function gotoChat(page: Page, { expectRail = true } = {}) {
+async function gotoChat(page: Page, { expectRail = true, sessions = SESSIONS } = {}) {
   await page.addInitScript(() => {
     window.localStorage.setItem("cave:active-familiar", "nova");
     window.localStorage.setItem("cave:familiar:nova:last-surface", "chat");
@@ -170,7 +170,7 @@ async function gotoChat(page: Page, { expectRail = true } = {}) {
     route.fulfill({ json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" }] } }),
   );
   await page.route("**/api/sessions/list**", (route) =>
-    route.fulfill({ json: { ok: true, sessions: SESSIONS } }),
+    route.fulfill({ json: { ok: true, sessions } }),
   );
   await page.route("**/api/projects**", (route) =>
     route.fulfill({ json: { ok: true, projects: PROJECTS } }),
@@ -180,6 +180,72 @@ async function gotoChat(page: Page, { expectRail = true } = {}) {
 }
 
 test.describe("chat threads rail", () => {
+  test("middle ellipsis preserves title tails in narrow rail and session rows", async ({ page }) => {
+    const title = "Investigate a shared deployment prefix and keep the distinguishing release suffix";
+    const pinnedTitle = "Review a second shared deployment prefix and preserve the production suffix";
+    await page.addInitScript(() => {
+      localStorage.setItem("cave:chat:pinned-sessions", JSON.stringify(["s2"]));
+    });
+    await gotoChat(page, {
+      sessions: SESSIONS.map((session) => ({
+        ...session,
+        title: session.id === "s1" ? title : session.id === "s2" ? pinnedTitle : session.title,
+      })),
+    });
+    await narrowChatRail(page);
+
+    const assertTailVisible = async (root: Locator, fullTitle: string) => {
+      const renderer = root.locator(`.chat-row-title[title="${fullTitle}"]`).first();
+      await expect(renderer).toBeVisible();
+      await renderer.scrollIntoViewIfNeeded();
+      await expect(renderer.locator(".sr-only")).toHaveText(fullTitle);
+      await expect(renderer.locator(".chat-row-title__tail")).toHaveText(fullTitle.slice(-18));
+      const bounds = await renderer.evaluate((element) => {
+        const tail = element.querySelector(".chat-row-title__tail")!;
+        const text = tail.firstElementChild!.firstChild!;
+        const range = document.createRange();
+        range.setStart(text, text.textContent!.length - 6);
+        range.setEnd(text, text.textContent!.length);
+        const suffix = range.getBoundingClientRect();
+        const clip = tail.getBoundingClientRect();
+        const row = element.getBoundingClientRect();
+        const hit = document.elementFromPoint((suffix.left + suffix.right) / 2, (suffix.top + suffix.bottom) / 2);
+        return { suffixLeft: suffix.left, suffixRight: suffix.right, clipLeft: clip.left, clipRight: clip.right, rowRight: row.right, unobscured: hit !== null && tail.contains(hit) };
+      });
+      expect(bounds.suffixLeft).toBeGreaterThanOrEqual(bounds.clipLeft - 1);
+      expect(bounds.suffixRight).toBeLessThanOrEqual(bounds.clipRight + 1);
+      expect(bounds.clipRight).toBeLessThanOrEqual(bounds.rowRight + 1);
+      expect(bounds.unobscured).toBe(true);
+    };
+
+    for (const [theme, mode] of [["coven", "dark"], ["coven", "light"], ["tide", "dark"]]) {
+      await page.evaluate(([theme, mode]) => {
+        document.documentElement.dataset.theme = theme;
+        document.documentElement.dataset.mode = mode;
+      }, [theme, mode]);
+      await assertTailVisible(page.locator(RAIL), title);
+      await assertTailVisible(page.locator(RAIL), pinnedTitle);
+    }
+    await page.getByRole("tablist", { name: "Chat sections" }).getByRole("tab", { name: "Projects", exact: true }).click();
+    await page.getByRole("tablist", { name: "Chat sections" }).getByRole("tab", { name: "Sessions", exact: true }).click();
+    const list = page.getByTestId("chat-main").locator(".chat-list-surface");
+    await assertTailVisible(list, title);
+    await assertTailVisible(list, pinnedTitle);
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect.poll(async () => (await list.boundingBox())?.width ?? Infinity).toBeLessThanOrEqual(390);
+    for (const [theme, mode] of [["coven", "dark"], ["coven", "light"], ["tide", "dark"]]) {
+      await page.evaluate(([theme, mode]) => {
+        document.documentElement.dataset.theme = theme;
+        document.documentElement.dataset.mode = mode;
+      }, [theme, mode]);
+      await assertTailVisible(list, title);
+      await assertTailVisible(list, pinnedTitle);
+    }
+    await list.getByRole("textbox", { name: "Filter sessions", exact: true }).fill("distinguishing");
+    await assertTailVisible(list, title);
+    await expect(list.locator(`.chat-row-title[title="${pinnedTitle}"]`)).toHaveCount(0);
+  });
+
   test("is docked in the chat surface, leaving the app sidebar unchanged", async ({ page }) => {
     await gotoChat(page);
     const nav = page.locator('aside[aria-label="Sidebar"]');


### PR DESCRIPTION
## Summary
- Share a display-only middle-ellipsis title renderer across ordinary/pinned sidebar rows, full session rows, and content-search title rows. Keep persisted titles, filtering, sorting, action names, full accessible text, and hover tooltips unchanged.
- Split on grapheme boundaries (including joined emoji, flags, modifiers, and combining marks). Follow the existing compactPath 52-character threshold as prior art, with roughly 28 head / 18 tail for long titles; reserve suffix layout space so narrow rows do not end-clip the shortened string. Do not change the unrelated memory helper.
- Use the existing primary text token for running titles so light mode remains readable.
- Integrate landed #5368 and preserve both its action-target regressions and the new title regression.

Bead: cave-v37bw
Serial merge: parent confirmed #5368 landed and cleared this PR to merge.

## Verification
- Focused Node tests: grapheme/title helpers, existing session-rail-title and sidebar wiring/pinned contracts, chat-list action/delete/rendering contracts.
- Scoped ESLint; pnpm typecheck; token-reference scan; pnpm check:tests-wired; git diff --check.
- pnpm build, including bundle budgets.
- Production server on isolated port 3473 with canonical synthetic stores: all 14 tests in tests/chat-sidebar-nav.spec.ts passed. New test measures actual suffix Range bounds and hit-testing in a 200px rail and 390px full-list viewport, including pinned rows, full accessible title/tooltip, and filtering by hidden middle text. Coven dark/light and Tide dark screenshots inspected; capture hooks are not committed.
- No real user stores, foreign worktree, naming PR #5354, or sidechat PR #5355 changed.
