### PR TITLE
Isolate lifecycle fixtures from host startup discovery

### DIFF
--- a/scripts/lifecycle-fixture-env.mjs
+++ b/scripts/lifecycle-fixture-env.mjs
@@ -1,11 +1,29 @@
 // Import before production modules: coven-bin captures homedir at module load.
 // These suites test real Git and maintenance protocols against fixture CLIs,
 // not the developer's login profile, version managers, or managed toolchain.
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 const home = mkdtempSync(path.join(tmpdir(), "cave-lifecycle-home-"));
+// Register cleanup before creating anything else, including on setup failure.
+process.once("exit", () => {
+  rmSync(home, { recursive: true, force: true, maxRetries: 8, retryDelay: 100 });
+});
+
+if (process.platform !== "win32") {
+  const git = (process.env.PATH ?? "").split(path.delimiter)
+    .map((entry) => path.join(entry, "git"))
+    .find((candidate) => existsSync(candidate));
+  if (!git) throw new Error("lifecycle fixtures require git on PATH");
+  const bin = path.join(home, "bin");
+  mkdirSync(bin);
+  // Retain the selected runtimes, not their host manager's entire bin directory.
+  symlinkSync(process.execPath, path.join(bin, "node"));
+  symlinkSync(git, path.join(bin, "git"));
+  process.env.PATH = [bin, "/usr/bin", "/bin"].join(path.delimiter);
+}
+
 const shell = path.join(home, "login-shell");
 writeFileSync(shell, `#!/bin/sh
 if [ "$#" -ne 2 ] || [ "$1" != "-ilc" ] || [ "$2" != 'echo $PATH' ]; then
@@ -20,13 +38,12 @@ Object.assign(process.env, {
   HOME: home,
   USERPROFILE: home,
   COVEN_HOME: path.join(home, ".coven"),
+  COVEN_VAULT_FILE: path.join(home, "missing-vault.yaml"),
+  // Individual protocol fixtures override this; idle cache resets must not
+  // resolve a real Coven installation from a system-wide candidate directory.
+  COVEN_BIN: process.execPath,
   XDG_DATA_HOME: path.join(home, ".local", "share"),
   LOCALAPPDATA: path.join(home, "AppData", "Local"),
   APPDATA: path.join(home, "AppData", "Roaming"),
   SHELL: shell,
-});
-
-// The suite owns this directory; its CLI children inherit it, never remove it.
-process.once("exit", () => {
-  rmSync(home, { recursive: true, force: true, maxRetries: 8, retryDelay: 100 });
 });

--- a/scripts/lifecycle-fixture-env.mjs
+++ b/scripts/lifecycle-fixture-env.mjs
@@ -1,0 +1,32 @@
+// Import before production modules: coven-bin captures homedir at module load.
+// These suites test real Git and maintenance protocols against fixture CLIs,
+// not the developer's login profile, version managers, or managed toolchain.
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const home = mkdtempSync(path.join(tmpdir(), "cave-lifecycle-home-"));
+const shell = path.join(home, "login-shell");
+writeFileSync(shell, `#!/bin/sh
+if [ "$#" -ne 2 ] || [ "$1" != "-ilc" ] || [ "$2" != 'echo $PATH' ]; then
+  echo 'unexpected lifecycle fixture shell invocation' >&2
+  exit 2
+fi
+printf '%s\\n' "$PATH"
+`);
+chmodSync(shell, 0o755);
+
+Object.assign(process.env, {
+  HOME: home,
+  USERPROFILE: home,
+  COVEN_HOME: path.join(home, ".coven"),
+  XDG_DATA_HOME: path.join(home, ".local", "share"),
+  LOCALAPPDATA: path.join(home, "AppData", "Local"),
+  APPDATA: path.join(home, "AppData", "Roaming"),
+  SHELL: shell,
+});
+
+// The suite owns this directory; its CLI children inherit it, never remove it.
+process.once("exit", () => {
+  rmSync(home, { recursive: true, force: true, maxRetries: 8, retryDelay: 100 });
+});

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -319,6 +319,8 @@ test("lifecycle fixtures replace host discovery inputs before importing producti
     );
   }
   const hostileHome = mkdtempSync(path.join(tmpdir(), "cave-host-profile-"));
+  const hostileVault = path.join(hostileHome, "vault.yaml");
+  writeFileSync(hostileVault, "HOST_FIXTURE_SENTINEL:\n  ref: op://fixture/host/secret\n");
   try {
     runIsolatedDiscovery(`
       import assert from "node:assert/strict";
@@ -337,22 +339,34 @@ test("lifecycle fixtures replace host discovery inputs before importing producti
       };
       syncBuiltinESMExports();
       assert.notEqual(homedir(), hostile);
-      for (const key of ["COVEN_HOME", "XDG_DATA_HOME", "LOCALAPPDATA", "APPDATA", "SHELL"]) {
+      for (const key of ["COVEN_HOME", "COVEN_VAULT_FILE", "XDG_DATA_HOME", "LOCALAPPDATA", "APPDATA", "SHELL"]) {
         assert.equal(process.env[key].startsWith(homedir() + path.sep), true, key);
       }
       assert.equal(process.env.USERPROFILE, homedir());
+      assert.deepEqual(process.env.PATH.split(path.delimiter), [
+        path.join(homedir(), "bin"), "/usr/bin", "/bin",
+      ]);
       // If coven-bin captured the host home before isolation, this candidate
       // would be probed even though HOME now names the fixture.
       const nvm = path.join(hostile, ".nvm", "versions", "node", "v99.0.0", "bin");
       mkdirSync(nvm, { recursive: true });
       for (const name of ["node", "npm"]) writeFileSync(path.join(nvm, name), "");
-      const { covenSpawnEnv } = await import("./src/lib/coven-bin.ts");
+      const { covenBin, covenSpawnEnv } = await import("./src/lib/coven-bin.ts");
+      const { loadVaultMap } = await import("./src/lib/vault.ts");
+      assert.deepEqual(loadVaultMap(true), {}, "inherited vault configuration is not loaded");
+      assert.equal(covenBin(), process.execPath, "idle resolver cannot select a host Coven");
       const env = covenSpawnEnv();
       assert.ok(env.PATH);
+      assert.equal(env.PATH.includes(hostile), false);
       assert.deepEqual(calls, [{ command: process.env.SHELL, args: ["-ilc", "echo $PATH"] }]);
-    `, Object.fromEntries([
-      "HOME", "USERPROFILE", "COVEN_HOME", "XDG_DATA_HOME", "LOCALAPPDATA", "APPDATA", "SHELL",
-    ].map((key) => [key, hostileHome])));
+    `, {
+      ...Object.fromEntries([
+        "HOME", "USERPROFILE", "COVEN_HOME", "XDG_DATA_HOME", "LOCALAPPDATA", "APPDATA", "SHELL",
+      ].map((key) => [key, hostileHome])),
+      COVEN_VAULT_FILE: hostileVault,
+      COVEN_BIN: path.join(hostileHome, "coven"),
+      PATH: [hostileHome, process.env.PATH].join(path.delimiter),
+    });
   } finally {
     rmSync(hostileHome, { recursive: true, force: true });
   }

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
   COVEN_MAINTENANCE_MINIMUM_VERSION,
   COVEN_OWNER_LEASE_MS,
   createCovenMaintenanceClient,
-  defaultRunCoven,
   createRepositoryMaintenanceCoordinator,
   MAX_FENCED_MUTATION_TIMEOUT_MS,
   repositoryMaintenanceCapabilities,
@@ -272,21 +276,148 @@ test("Coven client rejects maintenance protocols below the reviewed release", ()
   assert.equal(noBinary.covenMinimumVersion, COVEN_MAINTENANCE_MINIMUM_VERSION);
 });
 
-// Every other test in this file injects `run`, so the one runner that actually
-// spawns Coven is the one place the reported binary could quietly go missing —
-// and then every downstream assertion below would still pass while the real
-// refusal named nothing. Resolution may legitimately fail (no CLI installed,
-// as on CI); what must never happen is a successful spawn that does not say
-// what it spawned.
+const sourceRoot = fileURLToPath(new URL("../", import.meta.url));
+
+function runIsolatedDiscovery(source, env = {}) {
+  const result = spawnSync(process.execPath, [
+    "--experimental-strip-types",
+    "--import", "./scripts/lifecycle-fixture-env.mjs",
+    "--input-type=module",
+    "--eval", source,
+  ], {
+    cwd: sourceRoot,
+    env: { ...process.env, COVEN_BIN: process.execPath, ...env },
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  assert.equal(result.status, 0, result.stderr || result.error?.message);
+  return result.stdout;
+}
+
 test("the real runner reports the argv it executed", () => {
-  let result;
-  try {
-    result = defaultRunCoven({ args: ["--version"], cwd: process.cwd() });
-  } catch {
-    return; // no resolvable Coven CLI on this host; nothing was executed
+  const stdout = runIsolatedDiscovery(`
+    import assert from "node:assert/strict";
+    import { realpathSync } from "node:fs";
+    import { defaultRunCoven } from "./scripts/maintenance-gate.mjs";
+    const result = defaultRunCoven({ args: ["--version"], cwd: process.cwd() });
+    assert.equal(result.ok, true);
+    assert.equal(result.binary, realpathSync(process.execPath));
+    assert.equal(result.stdout.trim(), process.version);
+    console.log(process.env.HOME);
+  `);
+  assert.equal(existsSync(stdout.trim()), false, "the fixture home is removed on exit");
+});
+
+test("lifecycle fixtures replace host discovery inputs before importing production modules", {
+  skip: process.platform === "win32",
+}, () => {
+  for (const suite of ["create", "patrol", "retirement"]) {
+    assert.match(
+      readFileSync(path.join(sourceRoot, "scripts", `worktree-lifecycle-${suite}.test.mjs`), "utf8"),
+      /^import "\.\/lifecycle-fixture-env\.mjs";/,
+      `${suite} must isolate HOME before coven-bin captures it`,
+    );
   }
-  assert.equal(typeof result.binary, "string");
-  assert.ok(result.binary.length > 0, "a spawn attempt always names its command");
+  const hostileHome = mkdtempSync(path.join(tmpdir(), "cave-host-profile-"));
+  try {
+    runIsolatedDiscovery(`
+      import assert from "node:assert/strict";
+      import cp from "node:child_process";
+      import { mkdirSync, writeFileSync } from "node:fs";
+      import { syncBuiltinESMExports } from "node:module";
+      import { homedir } from "node:os";
+      import path from "node:path";
+      const hostile = ${JSON.stringify(hostileHome)};
+      const originalExec = cp.execFileSync;
+      const calls = [];
+      cp.execFileSync = (command, args, options) => {
+        calls.push({ command, args });
+        assert.equal(command.startsWith(hostile), false, "host helper must never execute");
+        return originalExec(command, args, options);
+      };
+      syncBuiltinESMExports();
+      assert.notEqual(homedir(), hostile);
+      for (const key of ["COVEN_HOME", "XDG_DATA_HOME", "LOCALAPPDATA", "APPDATA", "SHELL"]) {
+        assert.equal(process.env[key].startsWith(homedir() + path.sep), true, key);
+      }
+      assert.equal(process.env.USERPROFILE, homedir());
+      // If coven-bin captured the host home before isolation, this candidate
+      // would be probed even though HOME now names the fixture.
+      const nvm = path.join(hostile, ".nvm", "versions", "node", "v99.0.0", "bin");
+      mkdirSync(nvm, { recursive: true });
+      for (const name of ["node", "npm"]) writeFileSync(path.join(nvm, name), "");
+      const { covenSpawnEnv } = await import("./src/lib/coven-bin.ts");
+      const env = covenSpawnEnv();
+      assert.ok(env.PATH);
+      assert.deepEqual(calls, [{ command: process.env.SHELL, args: ["-ilc", "echo $PATH"] }]);
+    `, Object.fromEntries([
+      "HOME", "USERPROFILE", "COVEN_HOME", "XDG_DATA_HOME", "LOCALAPPDATA", "APPDATA", "SHELL",
+    ].map((key) => [key, hostileHome])));
+  } finally {
+    rmSync(hostileHome, { recursive: true, force: true });
+  }
+});
+
+test("production discovery retains success, failure, cache recovery, and deadline controls", {
+  skip: process.platform === "win32",
+}, () => {
+  runIsolatedDiscovery(`
+    import assert from "node:assert/strict";
+    import cp from "node:child_process";
+    import { syncBuiltinESMExports } from "node:module";
+    const calls = [];
+    let failure;
+    cp.execFileSync = (command, args, options) => {
+      assert.equal(command, process.env.SHELL);
+      assert.deepEqual(args, ["-ilc", "echo $PATH"]);
+      calls.push(options.timeout);
+      if (failure) throw Object.assign(new Error("fixture discovery failure"), { code: failure });
+      return "/fixture/discovered";
+    };
+    syncBuiltinESMExports();
+    const { covenSpawnEnv, refreshCovenSpawnEnv, refreshCovenBin } =
+      await import("./src/lib/coven-bin.ts");
+    let clock = 1000;
+    const options = { discoveryDeadline: 1250, now: () => clock };
+    assert.ok(covenSpawnEnv(options).PATH.includes("/fixture/discovered"));
+    assert.deepEqual(calls, [250], "shell receives only the remaining discovery budget");
+    covenSpawnEnv(options);
+    assert.equal(calls.length, 1, "healthy discovery is cached");
+    clock = 1250;
+    refreshCovenSpawnEnv(options);
+    assert.equal(calls.length, 1, "expired discovery starts no subprocess");
+    clock = 1000;
+    covenSpawnEnv(options);
+    assert.equal(calls.length, 2, "expired discovery did not poison the cache");
+    for (failure of ["EACCES", "ETIMEDOUT"]) {
+      assert.equal(refreshCovenSpawnEnv(options).PATH.includes("/fixture/discovered"), false);
+    }
+    failure = undefined;
+    assert.ok(refreshCovenSpawnEnv(options).PATH.includes("/fixture/discovered"));
+
+    const { defaultRunCoven } = await import("./scripts/maintenance-gate.mjs");
+    const spawns = [];
+    cp.spawnSync = (command, args, options) => {
+      spawns.push({ command, args, options });
+      return { status: null, error: Object.assign(new Error("fixture spawn failure"), { code: failure }) };
+    };
+    syncBuiltinESMExports();
+    // 4500ms of the runner's 5000ms env budget has elapsed before discovery.
+    Date.now = () => 5500;
+    for (failure of ["ETIMEDOUT", "EACCES"]) {
+      refreshCovenBin();
+      const result = defaultRunCoven({ args: ["--version"], cwd: process.cwd(), now: () => 1000 });
+      assert.equal(calls.at(-1), 500, "runner still imposes its absolute env deadline");
+      assert.equal(result.ok, false);
+      assert.equal(result.spawnFailure.kind, failure === "ETIMEDOUT" ? "timeout" : "spawn-error");
+      assert.equal(result.spawnFailure.code, failure);
+      assert.equal(result.spawnFailure.timeoutMs, 35000);
+      assert.equal(result.binary, spawns.at(-1).command);
+      assert.deepEqual(spawns.at(-1).args, ["--version"]);
+      assert.equal(spawns.at(-1).options.timeout, 35000);
+      assert.equal(spawns.at(-1).options.shell, false);
+    }
+  `);
 });
 
 // The composite coordinator prefixes the Coven reason and used to interpolate

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1,3 +1,4 @@
+import "./lifecycle-fixture-env.mjs";
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
 import {

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1,3 +1,4 @@
+import "./lifecycle-fixture-env.mjs";
 import assert from "node:assert/strict";
 import {
   chmodSync,
@@ -3190,12 +3191,9 @@ exit 0
   );
   let patrolInvocation = 0;
   let lastPatrolInvocation = "";
-  // This file spawns the patrol ~140 times at ~4.5s apiece (measured: 5.15s
-  // mean over the first ten, 3.75s over the last ten — flat, not degrading), so
-  // it produces no output for roughly ten minutes. That silence is
-  // indistinguishable from a hang and has been mistaken for one. Emit a
-  // heartbeat per spawn — cheap, and it names the exact invocation to look at
-  // when something does wedge.
+  // Real Git inventory still makes these ~140 patrol spawns substantial even
+  // with host-profile discovery isolated. Keep a heartbeat naming the exact
+  // invocation so slow progress can be distinguished from a wedged child.
   const startedAt = Date.now();
   const heartbeat = (label) => {
     if (process.env.LIFECYCLE_TEST_QUIET) return;

--- a/scripts/worktree-lifecycle-retirement.test.mjs
+++ b/scripts/worktree-lifecycle-retirement.test.mjs
@@ -1,3 +1,4 @@
+import "./lifecycle-fixture-env.mjs";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import {


### PR DESCRIPTION
## Summary

Bead: `cave-b0gsf`

- Isolate creation, patrol, and retirement fixtures from the host login shell, home-directory version managers, and managed-toolchain homes before production modules capture `homedir()`. Each suite owns and removes its temporary home; its real CLI children inherit it.
- Keep all existing real Git operations, fixture CLI protocols, scenarios, failure controls, and child timeouts. No production file or maintenance gate changes.
- Replace the real-runner assertion that silently returned on unresolved host installations with an unconditional, controlled executable assertion. Add hostile-home/import-order regression coverage and explicit production discovery success, failure, deadline, cache-recovery, and spawn-failure controls.

## Full-fixture measurements

Same shared macOS host, Node v24.18.1, same subprocess instrumentation, and `--test-concurrency=1`. The runs overlapped on a busy shared host, so wall times are indicative observations, not an isolated performance benchmark or a CI speed threshold.

| Full fixture suite | Before | After |
| --- | ---: | ---: |
| Creation | 1016.07s | 312.05s |
| Patrol | 447.75s | 375.25s |
| Retirement | 106.54s | 18.76s |
| Total wall clock | 1570.45s | 706.19s |

Observed total reduction: **55%**, approximately **14m24s**.

Profiling began before choosing the change. A preload measured synchronous subprocess calls separately from whole CLI runtime:

| Category | Before calls / cumulative time | After calls / cumulative time |
| --- | ---: | ---: |
| Git | 21,749 / 458.57s | 21,749 / 428.67s |
| Coven/GitHub/Beads fixture stubs | 5,414 / 151.89s | 5,414 / 199.94s |
| Lifecycle CLI subprocesses (inclusive) | 231 / 1359.02s | 231 / 637.01s |
| Login PATH discovery | 170 / 796.77s | 97 / 1.48s |
| Host Node/npm discovery | 911 / 82.48s | 0 / 0s |

The inclusive CLI row overlaps its nested calls; these rows must not be summed. The after run invokes only the fixture login shell, not the host's zsh. Successful bounded discovery also allows the existing production cache to work rather than repeatedly retrying expired discovery. Git, fixture-stub, and lifecycle-CLI counts are **identical**: the speedup did not come from skipping safety work.

This is not a claim that all patrol latency was shell startup. Patrol still performs substantial real Git inventory, and its improvement is much smaller than creation/retirement.

## Verification

Both complete before/after fixture runs passed with the same scenarios:

```sh
node --experimental-strip-types --test --test-concurrency=1 \
  scripts/worktree-lifecycle-patrol.test.mjs \
  scripts/worktree-lifecycle-retirement.test.mjs \
  scripts/worktree-lifecycle-create.test.mjs
```

Also passed:

- `scripts/maintenance-gate.test.mjs`: 23 tests, including real executable identity, hostile-home isolation, remaining/expired discovery deadlines, healthy-cache behavior, failed/timeout discovery fallback, recovery, 5s environment budget, 35s spawn timeout, and fail-closed maintenance ownership.
- Existing `src/lib/coven-bin.test.ts`, `src/lib/login-shell-win32-guard.test.ts`, `scripts/worktree-lifecycle-fence-renewal.test.mjs`, and `scripts/local-maintenance-gate.test.mjs`: 40 runner tests.
- Scoped ESLint for all five changed files; `pnpm check:tests-wired`; `git diff --check`.

Existing retirement coverage still includes retention failures, exact OID checks, dirty paths, gate/generation loss, partial failure reporting, recovery ownership, symlink boundaries, foreign locks, and scoped cooldown admission.

No merge is requested until the coordinated merge handoff is approved.
