### PR TITLE
Align native chat copy with Coven voice

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -326,7 +326,7 @@ struct ChatView: View {
             }
         }
         .sheet(item: $forwardingMessage) { message in
-            FamiliarPickerSheet(title: "Forward to Familiar") { familiar in
+            FamiliarPickerSheet(title: "Forward to familiar") { familiar in
                 forwardingMessage = nil
                 forward(message, to: familiar)
             }
@@ -2645,7 +2645,7 @@ struct ResponseReaderView: View {
                 UIPasteboard.general.string = item.markdown
                 Haptics.tap()
             } label: {
-                Label("Copy", systemImage: "doc.on.doc")
+                Label("Copy response", systemImage: "doc.on.doc")
             }
         }
         ToolbarItemGroup(placement: .primaryAction) {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -71,7 +71,7 @@ struct ChatView: View {
     @State private var photoItems: [PhotosPickerItem] = []
     @State private var pendingImages: [PendingImage] = []
     @State private var draftPersistenceTask: Task<Void, Never>?
-    /// "New Messages" divider: computed once per visit, *before*
+    /// "New messages" divider: computed once per visit, *before*
     /// `markFamiliarViewed` moves the seen boundary, then left in place for
     /// the whole visit (re-appears from pushes must not dissolve it).
     @State private var unreadDividerId: String?
@@ -394,7 +394,7 @@ struct ChatView: View {
             if draft.isEmpty, let saved = UserDefaults.standard.string(forKey: draftKey) {
                 draft = saved
             }
-            // Place the "New Messages" divider from the seen boundary BEFORE
+            // Place the "New messages" divider from the seen boundary BEFORE
             // marking viewed moves it.
             computeUnreadDividerIfNeeded()
             // Opening the chat clears the unread badge for its familiar(s) and
@@ -850,7 +850,7 @@ struct ChatView: View {
                             .foregroundStyle(.secondary)
                             .textCase(.uppercase)
                             .fixedSize(horizontal: false, vertical: true)
-                        Text(cards.first?.title ?? "Open Tasks")
+                        Text(cards.first?.title ?? "Open tasks")
                             .font(.subheadline.weight(.medium))
                             .foregroundStyle(.primary)
                             .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
@@ -1135,7 +1135,7 @@ struct ChatView: View {
 
     // MARK: - Empty state
 
-    /// Cold-start state per the design's "Start a new session" screen: a
+    /// Cold-start state per the design's "Start a chat" screen: a
     /// rotated-square sigil with a soft glow, serif headline, a short warded
     /// line, and "Conjure something" starter cards. Cards FILL the composer
     /// (focused, ready to tweak) rather than firing a send — same convention
@@ -1144,7 +1144,7 @@ struct ChatView: View {
         VStack(spacing: 18) {
             sigil
             VStack(spacing: 8) {
-                Text("Start a new session")
+                Text("Start a chat")
                     .font(.system(size: 26, weight: .medium, design: .serif))
                     .italic()
                     .foregroundStyle(.primary)
@@ -1157,7 +1157,7 @@ struct ChatView: View {
                     permissionsFamiliar = familiar
                 } label: {
                     (
-                        Text("Speak your intent — a familiar answers from the desktop. Repo access follows \(wardScope) active ")
+                        Text("Describe a task or choose a suggestion below. Your familiar works from the desktop. Project access follows \(wardScope) active ")
                             .foregroundStyle(.secondary)
                         + Text("ward.")
                             .foregroundStyle(chrome.accent)
@@ -1248,17 +1248,17 @@ struct ChatView: View {
             if $0.priority.rank != $1.priority.rank { return $0.priority.rank < $1.priority.rank }
             return (caveParseISO($0.updatedAt) ?? .distantPast) > (caveParseISO($1.updatedAt) ?? .distantPast)
         }.first
-        let nextLabel = next.map { "Chase the \($0.title)" } ?? "Chase the next priority"
+        let nextLabel = next.map { "Work on \($0.title)" } ?? "Work on the next priority"
         let nextHint = next.map {
             [$0.projectId, $0.githubLinks.first?.number.map { "#\($0)" }]
                 .compactMap { $0 }
                 .joined(separator: " · ")
         }.flatMap { $0.isEmpty ? nil : $0 } ?? "Ask your familiar to choose"
         let boardHint = app.tasksError != nil
-            ? "Board unavailable"
+            ? "Tasks unavailable — open Tasks to retry"
             : app.tasksLoaded
                 ? "\(running) running · \(blocked) blocked"
-                : "Load the live board"
+                : "Open Tasks to load tasks"
         let priorityHint = app.tasksError != nil && !app.tasks.isEmpty
             ? "Cached · \(nextHint)"
             : nextHint
@@ -1272,7 +1272,7 @@ struct ChatView: View {
                     : "\(openPullRequestURLs.count) open"),
             EmptyChatSuggestion(
                 icon: "checkmark.square",
-                label: "What's on the board?",
+                label: "What tasks need attention?",
                 hint: boardHint),
             EmptyChatSuggestion(
                 icon: "scope",
@@ -1475,7 +1475,8 @@ struct ChatView: View {
             .buttonStyle(.glassPress)
             .accessibilityLabel(showActionMenu ? "Close attach menu" : "Attach or run a tool")
 
-            TextField("Ask something…", text: $draft, axis: .vertical)
+            TextField("Write a message…", text: $draft, axis: .vertical)
+                .accessibilityLabel("Message")
                 .font(isEmptyThread ? .body : .callout)
                 .lineLimit(1...6)
                 .padding(.vertical, isEmptyThread ? 8 : 6)
@@ -2590,7 +2591,7 @@ private struct UnreadDividerView: View {
     var body: some View {
         HStack(spacing: 10) {
             hairline
-            Text("New Messages")
+            Text("New messages")
                 .font(.caption2.weight(.semibold))
                 .foregroundStyle(Color.accentColor)
                 .fixedSize()
@@ -2720,7 +2721,7 @@ struct FamiliarPickerSheet: View {
         NavigationStack {
             List {
                 if familiars.isEmpty {
-                    Text("No familiars found. Pull to refresh on the Chats screen.")
+                    Text("No familiars are available. Return to Chats and refresh, or check your connection.")
                         .font(.footnote).foregroundStyle(.secondary)
                 }
                 ForEach(familiars) { familiar in

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -64,7 +64,7 @@ struct MessageBubble: View {
                 UIPasteboard.general.string = parsed.visible
                 Haptics.tap()
             } label: {
-                Label("Copy", systemImage: "doc.on.doc")
+                Label("Copy message", systemImage: "doc.on.doc")
             }
         }
         if canOpenReader {
@@ -72,7 +72,7 @@ struct MessageBubble: View {
                 onOpenReader?(parsed.visible)
                 Haptics.tap()
             } label: {
-                Label("Open in Reader", systemImage: "text.page")
+                Label("Open in reader", systemImage: "text.page")
             }
         }
         if canReply {
@@ -90,17 +90,17 @@ struct MessageBubble: View {
                 onForward?(forwarded)
                 Haptics.tap()
             } label: {
-                Label("Forward to Familiar", systemImage: "arrowshape.turn.up.right")
+                Label("Forward to familiar", systemImage: "arrowshape.turn.up.right")
             }
         }
         if let onRetry {
             Button(action: onRetry) {
-                Label("Retry", systemImage: "arrow.clockwise")
+                Label(message.isError ? "Retry reply" : "Regenerate reply", systemImage: "arrow.clockwise")
             }
         }
         if let onDelete {
             Button(role: .destructive, action: onDelete) {
-                Label("Delete Message", systemImage: "trash")
+                Label("Delete message", systemImage: "trash")
             }
         }
     }
@@ -291,14 +291,14 @@ struct MessageBubble: View {
                 // red bubble. (Retry re-streams just this bubble's familiar.)
                 if !isUser, message.isError, let onRetry {
                     Button(action: onRetry) {
-                        Label("Retry", systemImage: "arrow.clockwise")
+                        Label("Retry reply", systemImage: "arrow.clockwise")
                             .font(.caption.weight(.semibold))
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                     .tint(.red)
                     .padding(.leading, 2)
-                    .accessibilityLabel("Retry sending this message")
+                    .accessibilityLabel("Retry generating this reply")
                 }
 
                 // Durable online sends remain replay-eligible until every

--- a/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
@@ -73,8 +73,9 @@ struct NewChatView: View {
                 }
 
                 if isGroup {
-                    Section("Group name (optional)") {
-                        TextField("e.g. Research crew", text: $groupName)
+                    Section("Group name (Optional)") {
+                        TextField("e.g., Research crew", text: $groupName)
+                            .accessibilityLabel("Group name")
                     }
                 }
 
@@ -90,7 +91,7 @@ struct NewChatView: View {
                         Text(blockedMessage.body)
                             .font(.footnote)
                             .foregroundStyle(.secondary)
-                        Button("Refresh Chats") {
+                        Button("Refresh chats") {
                             Task {
                                 await app.loadFamiliars()
                                 await app.loadSessions()
@@ -107,7 +108,7 @@ struct NewChatView: View {
                     Button("Cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(isGroup ? "Create" : "Start") { start() }
+                    Button(isGroup ? "Create group" : "Start chat") { start() }
                         .disabled(!canLaunchChat)
                 }
             }
@@ -130,7 +131,7 @@ struct NewChatView: View {
                 Text(activeProject.root)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
-                Text("New chats always start in the active project. Switch projects from Chats to use another root.")
+                Text("New chats start in the active project. Switch projects from Chats to use a different project.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             } else {
@@ -150,7 +151,7 @@ struct NewChatView: View {
         if fixedFamiliarId == nil {
             Section(selected.isEmpty ? "Choose familiars" : "\(selectedFamiliarIds.count) selected") {
                 if availableFamiliars.isEmpty {
-                    Text("No familiars are available in \(activeProject?.name ?? "the active project"). Refresh Chats or switch projects.")
+                    Text("No familiars are available in \(activeProject?.name ?? "the active project"). Refresh chats or switch projects.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
@@ -201,7 +202,7 @@ struct NewChatView: View {
            !availableFamiliarIDs.contains(fixedFamiliar.id) {
             return (
                 "This familiar is no longer in \(activeProject?.name ?? "the active project").",
-                "Refresh Chats or switch projects, then try again.",
+                "Refresh chats or switch projects, then try again.",
                 "person.crop.circle.badge.exclamationmark"
             )
         }
@@ -211,8 +212,8 @@ struct NewChatView: View {
                 ? "Selected familiar"
                 : "Selected familiars"
             return (
-                "\(noun) no longer belong to \(activeProject?.name ?? "the active project").",
-                "Refresh Chats or switch projects, then choose again. \(unavailableSelectedFamiliarNames)",
+                "\(noun) unavailable in \(activeProject?.name ?? "the active project").",
+                "Refresh chats or switch projects, then choose again. \(unavailableSelectedFamiliarNames)",
                 "person.crop.circle.badge.exclamationmark"
             )
         }
@@ -253,9 +254,9 @@ struct NewChatView: View {
             let projectName = activeProject?.name ?? "the active project"
             let message: String
             if revokedNames.count == 1, let revokedName = revokedNames.first {
-                message = "\(revokedName) can’t access \(projectName) anymore. Refresh Chats or switch projects, then choose again."
+                message = "\(revokedName) can’t access \(projectName) anymore. Refresh chats or switch projects, then choose again."
             } else {
-                message = "Some selected familiars can’t access \(projectName) anymore. Refresh Chats or switch projects, then choose again. \(revokedNames.joined(separator: ", "))"
+                message = "Some selected familiars can’t access \(projectName) anymore. Refresh chats or switch projects, then choose again. \(revokedNames.joined(separator: ", "))"
             }
             app.showToast(
                 message,

--- a/apps/ios/CovenCave/CovenCaveUITests/NewChatUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/NewChatUITests.swift
@@ -20,7 +20,7 @@ final class NewChatUITests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["Coven Cave"].waitForExistence(timeout: 10))
         XCTAssertFalse(app.buttons["New chat project"].exists)
-        XCTAssertTrue(app.buttons["Start"].isEnabled)
+        XCTAssertTrue(app.buttons["Start chat"].isEnabled)
     }
 
     @MainActor
@@ -33,7 +33,7 @@ final class NewChatUITests: XCTestCase {
             app.staticTexts["This familiar is no longer in Coven Cave."]
                 .waitForExistence(timeout: 10)
         )
-        XCTAssertFalse(app.buttons["Start"].isEnabled)
+        XCTAssertFalse(app.buttons["Start chat"].isEnabled)
         XCTAssertFalse(app.buttons["New chat project"].exists)
     }
 
@@ -58,5 +58,23 @@ final class NewChatUITests: XCTestCase {
         XCTAssertTrue(
             projectContext.waitForExistence(timeout: 10) && projectContext.isHittable
         )
+    }
+
+    @MainActor
+    func testEmptyChatUsesCanonicalCopyAndPersistentComposerLabel() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-preview-empty-chat"]
+        app.launchEnvironment["CAVE_OPEN_THREAD"] = "ui-preview-empty-chat"
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["Start a chat"].waitForExistence(timeout: 15))
+        XCTAssertFalse(app.staticTexts["Start a new session"].exists)
+        XCTAssertTrue(app.descendants(matching: .any)["Message"].firstMatch.exists)
+        XCTAssertTrue(app.buttons["Session controls"].exists,
+                      "execution controls retain their precise session terminology")
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "Native chat copy"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
     }
 }

--- a/scripts/ios-chat-project-contract.test.mjs
+++ b/scripts/ios-chat-project-contract.test.mjs
@@ -237,12 +237,12 @@ assert.match(
 );
 assert.match(
   newChat,
-  /Label\("Import from Markdown…", systemImage: "square\.and\.arrow\.down"\)[\s\S]*\.disabled\(!canLaunchChat\)[\s\S]*Button\(isGroup \? "Create" : "Start"\)\s*\{[\s\S]*\.disabled\(!canLaunchChat\)/,
+  /Label\("Import from Markdown…", systemImage: "square\.and\.arrow\.down"\)[\s\S]*\.disabled\(!canLaunchChat\)[\s\S]*Button\(isGroup \? "Create group" : "Start chat"\)\s*\{[\s\S]*\.disabled\(!canLaunchChat\)/,
   "Import and Start controls must stay disabled until launch is allowed",
 );
 assert.match(
   newChat,
-  /Section\("Project"\) \{[\s\S]*Label\(activeProject\.name, systemImage: "folder"\)[\s\S]*Switch projects from Chats to use another root\./,
+  /Section\("Project"\) \{[\s\S]*Label\(activeProject\.name, systemImage: "folder"\)[\s\S]*Switch projects from Chats to use a different project\./,
   "New Chat must describe the fixed active project instead of offering a picker",
 );
 assert.match(

--- a/scripts/ios-chat-restyle.test.mjs
+++ b/scripts/ios-chat-restyle.test.mjs
@@ -31,6 +31,8 @@ assert.match(newChat, /Section\("Group name \(Optional\)"\)/);
 assert.match(newChat, /TextField\("e\.g\., Research crew"[\s\S]{0,120}\.accessibilityLabel\("Group name"\)/);
 assert.match(bubble, /Label\("Open in reader",/);
 assert.match(bubble, /Label\("Forward to familiar",/);
+assert.match(chatView, /FamiliarPickerSheet\(title: "Forward to familiar"\)/);
+assert.match(chatView, /Label\("Copy response", systemImage: "doc\.on\.doc"\)/);
 assert.match(bubble, /Label\("Delete message",/);
 assert.match(bubble, /Label\(message\.isError \? "Retry reply" : "Regenerate reply",/);
 

--- a/scripts/ios-chat-restyle.test.mjs
+++ b/scripts/ios-chat-restyle.test.mjs
@@ -14,6 +14,25 @@ const chatView = await read("apps/ios/CovenCave/CovenCave/Views/ChatView.swift")
 const home = await read("apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift");
 const modelControl = await read("apps/ios/CovenCave/CovenCave/Views/ChatModelControl.swift");
 const camera = await read("apps/ios/CovenCave/CovenCave/Views/CameraPicker.swift");
+const newChat = await read("apps/ios/CovenCave/CovenCave/Views/NewChatView.swift");
+const bubble = await read("apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift");
+
+// Copy uses the live design-language contract, not the prototype's terminology.
+assert.match(chatView, /Text\("Start a chat"\)/);
+assert.match(chatView, /Describe a task or choose a suggestion below\./);
+assert.match(chatView, /"What tasks need attention\?"/);
+assert.match(chatView, /"Work on the next priority"/);
+assert.doesNotMatch(chatView, /"Board unavailable"|"Load the live board"|"New Messages"/);
+assert.match(chatView, /TextField\("Write a message…", text: \$draft, axis: \.vertical\)/);
+assert.match(chatView, /TextField\("Write a message…"[\s\S]{0,120}\.accessibilityLabel\("Message"\)/);
+assert.match(newChat, /Button\(isGroup \? "Create group" : "Start chat"\)/);
+assert.match(newChat, /Button\("Refresh chats"\)/);
+assert.match(newChat, /Section\("Group name \(Optional\)"\)/);
+assert.match(newChat, /TextField\("e\.g\., Research crew"[\s\S]{0,120}\.accessibilityLabel\("Group name"\)/);
+assert.match(bubble, /Label\("Open in reader",/);
+assert.match(bubble, /Label\("Forward to familiar",/);
+assert.match(bubble, /Label\("Delete message",/);
+assert.match(bubble, /Label\(message\.isError \? "Retry reply" : "Regenerate reply",/);
 
 // ── Reusable chrome: every icon-only control is labelled; accent is scarce ──
 assert.match(chrome, /struct CircularIconButton: View/, "circular icon button is a shared component");

--- a/scripts/ios-claude-design-fidelity.test.mjs
+++ b/scripts/ios-claude-design-fidelity.test.mjs
@@ -39,15 +39,15 @@ const globalSearch = await read(
 ).catch(() => "");
 
 // Supplied device reference: this is the canonical first empty conversation.
-assert.match(chat, /Text\("Start a new session"\)/, "empty chat keeps the authored serif heading");
+assert.match(chat, /Text\("Start a chat"\)/, "empty chat keeps its heading with canonical chat terminology");
 assert.match(
   chat,
-  /Speak your intent — a familiar answers from the desktop\./,
+  /Your familiar works from the desktop\./,
   "empty chat explains the desktop-backed familiar",
 );
 assert.match(
   chat,
-  /Repo access follows \\\(wardScope\) active/,
+  /Project access follows \\\(wardScope\) active/,
   "empty chat describes the real ward boundary without promising an unavailable mode",
 );
 assert.match(chat, /permissionsFamiliar = familiar/, "the ward copy opens the real permission controls");
@@ -65,8 +65,8 @@ assert.match(
   /Set\(app\.tasks\.flatMap\(\\\.githubLinks\)[\s\S]*?\$0\.state\?\.lowercased\(\) == "open"[\s\S]*?map \{ \$0\.url\.lowercased\(\) \}\)/,
   "the open-PR starter count is deduplicated and excludes closed or unknown links",
 );
-assert.match(chat, /"What's on the board\?"/, "second quick action follows the supplied start page");
-assert.match(chat, /"Chase the [^"]+"/, "third quick action is grounded in a real priority task");
+assert.match(chat, /"What tasks need attention\?"/, "second quick action uses the canonical Tasks vocabulary");
+assert.match(chat, /"Work on \\\(\$0\.title\)"/, "third quick action is grounded in a real priority task");
 assert.match(chat, /icon: "arrow\.triangle\.branch"/, "the PR starter uses a valid native branch glyph");
 assert.match(
   chat,
@@ -697,7 +697,7 @@ assert.match(
 );
 assert.match(
   chat,
-  /app\.tasksError != nil\s*\?\s*"Board unavailable"/,
+  /app\.tasksError != nil\s*\?\s*"Tasks unavailable — open Tasks to retry"/,
   "the start page does not report zero board work after a failed first load",
 );
 assert.match(

--- a/scripts/ios-message-forwarding.test.mjs
+++ b/scripts/ios-message-forwarding.test.mjs
@@ -20,8 +20,8 @@ assert.match(
 
 assert.match(
   bubble,
-  /Label\("Forward to Familiar", systemImage: "arrowshape\.turn\.up\.right"\)/,
-  "message context menu should offer Forward to Familiar",
+  /Label\("Forward to familiar", systemImage: "arrowshape\.turn\.up\.right"\)/,
+  "message context menu should offer Forward to familiar",
 );
 
 assert.match(

--- a/scripts/ios-message-reader.test.mjs
+++ b/scripts/ios-message-reader.test.mjs
@@ -24,7 +24,7 @@ assert.match(
 
 assert.match(
   messageBubble,
-  /Label\("Open in Reader", systemImage: "text\.page"\)/,
+  /Label\("Open in reader", systemImage: "text\.page"\)/,
   "reader action should be exposed from the message context menu",
 );
 

--- a/scripts/ios-message-retry.test.mjs
+++ b/scripts/ios-message-retry.test.mjs
@@ -16,12 +16,12 @@ const thread = await read(`${base}/State/ChatThread.swift`);
 // --- Visible retry button on error bubbles ----------------------------------
 assert.match(
   bubble,
-  /if !isUser, message\.isError, let onRetry \{[\s\S]*?Label\("Retry", systemImage: "arrow\.clockwise"\)/,
+  /if !isUser, message\.isError, let onRetry \{[\s\S]*?Label\("Retry reply", systemImage: "arrow\.clockwise"\)/,
   "MessageBubble should render a visible Retry button on a failed (isError) reply",
 );
 assert.match(
   bubble,
-  /\.accessibilityLabel\("Retry sending this message"\)/,
+  /\.accessibilityLabel\("Retry generating this reply"\)/,
   "the visible Retry button should carry an accessibility label",
 );
 


### PR DESCRIPTION
## Summary
- Normalize native chat/task terminology and sentence-case, object-specific actions across NewChatView, ChatView and MessageBubble.
- Add persistent native composer/group-name accessibility labels and concrete next steps while preserving all navigation, permissions and execution behavior.
- Update intentional copy contracts and native UI selectors; retain precise Session controls terminology.

## Evidence
- 12 focused source-contract tests passed; existing UI consistency baseline unchanged; test wiring passed.
- Native iOS Simulator build and 7 NewChat/SessionSwitch UI cases passed on a dedicated synthetic device; rendered screenshot inspected.
- Package resolution used system Git with a process-local exception scoped to the exact trusted WebRTC cache; global config and dependency pins unchanged.

Bead: cave-xd1b.3
Parent program remains separate: cave-xd1b.