### PR TITLE
fix(client-v1): preserve standard-user discovery writes

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -244,7 +244,9 @@ if (-not (Test-Exclusive $state)) {
   $removed = @($state.aces | Where-Object { $trusted -notcontains $_.sid } |
     ForEach-Object { $_.sid } | Select-Object -Unique)
   $acl = $item.GetAccessControl('Access')
-  $acl.SetOwner($me)
+  if ($state.owner -ne $me.Value) {
+    $acl.SetOwner($me)
+  }
   $acl.SetAccessRuleProtection($true, $false)
   foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRule($rule) }
   $inheritance = if ($item.PSIsContainer) { 'ContainerInherit, ObjectInherit' } else { 'None' }

--- a/server.ts
+++ b/server.ts
@@ -413,7 +413,9 @@ if (-not (Test-Exclusive $state)) {
   $removed = @($state.aces | Where-Object { $trusted -notcontains $_.sid } |
     ForEach-Object { $_.sid } | Select-Object -Unique)
   $acl = $item.GetAccessControl('Access')
-  $acl.SetOwner($me)
+  if ($state.owner -ne $me.Value) {
+    $acl.SetOwner($me)
+  }
   $acl.SetAccessRuleProtection($true, $false)
   foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRule($rule) }
   $inheritance = if ($item.PSIsContainer) { 'ContainerInherit, ObjectInherit' } else { 'None' }

--- a/src/lib/server/client-v1/discovery.test.ts
+++ b/src/lib/server/client-v1/discovery.test.ts
@@ -599,10 +599,20 @@ test("the standalone server enforces ownership on Windows with this module's scr
       `${what} must stay identical to the module server.mjs cannot import`,
     );
   }
+  const windowsAclScript = region(
+    moduleSource,
+    "path-ownership.ts",
+    /const WINDOWS_ACL_SCRIPT = `([\s\S]*?)`;/,
+  );
   assert.match(
-    region(moduleSource, "path-ownership.ts", /const WINDOWS_ACL_SCRIPT = `([\s\S]*?)`;/),
-    /\$acl\.SetOwner\(\$me\)/,
-    "the Windows ACL repair must take ownership instead of leaving an Administrators-owned path unusable",
+    windowsAclScript,
+    /if \(\$state\.owner -ne \$me\.Value\) \{\s*\$acl\.SetOwner\(\$me\)\s*\}/,
+    "a current owner must be able to restrict an inherited DACL without WRITE_OWNER permission",
+  );
+  assert.equal(
+    windowsAclScript.match(/\$acl\.SetOwner\(\$me\)/g)?.length,
+    1,
+    "a foreign owner must still be taken exactly once before the DACL is repaired",
   );
   assert.equal(
     Number(region(moduleSource, "path-ownership.ts", /timeout:\s*([\d_]+),/).replaceAll("_", "")),

--- a/src/lib/server/client-v1/path-ownership.ts
+++ b/src/lib/server/client-v1/path-ownership.ts
@@ -205,9 +205,11 @@ export interface ClientV1PathOwnershipOptions {
  * Node reports `uid: 0` for every path on win32 and `chmod` there sets nothing
  * but the read-only bit, so neither half of the POSIX contract this module
  * enforces has a native equivalent. The repair takes ownership as the current
- * SID, then writes only the owner and DACL sections; `Set-Acl`, which also
- * carries the audit section, fails with `PrivilegeNotHeldException`
- * (SeSecurityPrivilege) against an already-protected path.
+ * SID only when ownership differs, then writes the DACL. Avoiding a redundant
+ * owner write lets an ordinary owner restrict an inherited DACL without
+ * requiring `WRITE_OWNER`; `Set-Acl`, which also carries the audit section,
+ * fails with `PrivilegeNotHeldException` (SeSecurityPrivilege) against an
+ * already-protected path.
  *
  * The resulting owner and DACL are re-read below. A repair that cannot make
  * both exclusive remains a finding and is refused rather than trusted.
@@ -254,7 +256,9 @@ if (-not (Test-Exclusive $state)) {
   $removed = @($state.aces | Where-Object { $trusted -notcontains $_.sid } |
     ForEach-Object { $_.sid } | Select-Object -Unique)
   $acl = $item.GetAccessControl('Access')
-  $acl.SetOwner($me)
+  if ($state.owner -ne $me.Value) {
+    $acl.SetOwner($me)
+  }
   $acl.SetAccessRuleProtection($true, $false)
   foreach ($rule in @($acl.Access)) { [void]$acl.RemoveAccessRule($rule) }
   $inheritance = if ($item.PSIsContainer) { 'ContainerInherit, ObjectInherit' } else { 'None' }


### PR DESCRIPTION
## Summary

Allow Cave's Windows client-v1 discovery publisher to restrict a directory it already owns when running as an ordinary user.

## Why

OpenCoven/chat protected conformance run 34675842331 reached a healthy Cave listener under its ephemeral standard account, but Cave never published `client-v1-discovery.json`. The ACL repair always called `SetOwner` whenever the inherited DACL needed repair. Windows requires `WRITE_OWNER` for that call even when the requested owner is unchanged; the restricted account has `WRITE_DAC` as owner but intentionally does not have `WRITE_OWNER` or take-ownership privileges.

## Changes

- Call `SetOwner` only when the observed owner differs from the current SID.
- Preserve the existing foreign-owner takeover attempt and fail-closed post-repair owner/DACL verification.
- Keep the standalone generated server byte-for-byte aligned with the source module.
- Add a source-contract regression that rejects an unconditional owner write.

## Verification

- `pnpm build`
- `pnpm typecheck`
- targeted ESLint for the changed source and test
- `node --experimental-strip-types --test src/lib/server/client-v1/discovery.test.ts src/lib/server/client-v1/path-ownership.test.ts`
- `pnpm check:tests-wired`

`pnpm test:api` also ran; unrelated `check-merge-tree-freshness` fixtures fail locally because this host sets `safe.bareRepository=explicit`.

## Risk + rollout notes

The change does not relax the accepted owner or ACE set. A foreign owner still triggers the same takeover attempt, and any failure to produce the exact current-user/SYSTEM/Administrators-only protected ACL remains terminal for discovery publication.
