### PR TITLE
fix(conformance): classify bounded discovery readiness failures

### DIFF
--- a/docs/workflows/client-v1-conformance.md
+++ b/docs/workflows/client-v1-conformance.md
@@ -219,6 +219,44 @@ own diagnostic strings; if you add an assertion, keep secrets out of its detail
 text. Bearers and pairing secrets are 43 base64url characters and are trivially
 recognisable — but the rule is to not write them, not to scan for them.
 
+### Bounded startup discovery diagnostics
+
+A missing-discovery readiness outcome does not prove the file is absent.
+The startup reader distinguishes one filesystem read from JSON parsing and
+the existing object-shape check. Its final failure line is:
+
+```text
+client-v1-conformance: Client v1 discovery record is not published. [read=<READ>; publication=<PUBLICATION>]
+```
+
+`READ` is one of `not-found` (ENOENT), `access-denied` (EACCES),
+`operation-not-permitted` (EPERM), `not-directory` (ENOTDIR),
+`other-read-error`, `invalid-json`, or `invalid-shape`. Object records still
+pass through the existing endpoint and PID readiness checks; the diagnostic
+does not add or relax a discovery acceptance rule.
+
+The standalone publisher emits one fixed stderr line on refusal:
+`[cave] client-v1 discovery publication refused: <PUBLICATION>`.
+Its categories are `disabled-other`, `root-owner-unverified`,
+`root-owner-shared`, `target-owner-unverified`, `target-owner-shared`,
+`root-not-directory`, `root-symlink`, `target-not-file`, `endpoint-invalid`,
+and `authority-init`. These identify the refusal site, not its underlying
+Windows cause. Other filesystem or publication failures are `disabled-other`.
+Raw exception text and causes are not part of this line or the disabled banner.
+
+The harness observes at most 32 KiB of stderr, handles fragmented lines, and
+keeps the first complete recognized refusal. Without one, it reports
+`not-observed`, or `output-limit` if the observation budget is exhausted.
+It continues draining both output streams without forwarding raw output.
+The 120-second readiness deadline, polling, health/endpoint/PID precedence,
+and teardown are unchanged. Only the final missing-discovery outcome gains
+the suffix; there is no earlier generic missing line to mask it.
+
+These observations are diagnostic evidence only. They do not establish a
+repair, change ownership checks or waivers, infer reader/publisher path
+equality, or authorize publication. Coordinated consumers must bind reviewed
+Cave and Chat sources before the next protected OpenCoven/sdk#38 run.
+
 ## Findings a green run still reports
 
 The harness is written against what the wire does, not against what the

--- a/scripts/client-v1-conformance.mjs
+++ b/scripts/client-v1-conformance.mjs
@@ -794,6 +794,114 @@ export function buildCaveEnvironment({
   return env;
 }
 
+const CAVE_DISCOVERY_READ_FAILURES = new Set([
+  "not-found",
+  "access-denied",
+  "operation-not-permitted",
+  "not-directory",
+  "other-read-error",
+  "invalid-json",
+  "invalid-shape",
+]);
+const CAVE_DISCOVERY_PUBLICATION_FAILURES = new Set([
+  "not-observed",
+  "output-limit",
+  "disabled-other",
+  "root-owner-unverified",
+  "root-owner-shared",
+  "target-owner-unverified",
+  "target-owner-shared",
+  "root-not-directory",
+  "root-symlink",
+  "target-not-file",
+  "endpoint-invalid",
+  "authority-init",
+]);
+export const CAVE_DISCOVERY_PUBLICATION_OUTPUT_LIMIT = 32 * 1024;
+
+export async function readCaveDiscovery(discoveryPath, read = readFile) {
+  let text;
+  try {
+    text = await read(discoveryPath, "utf8");
+  } catch (error) {
+    const code = typeof error === "object" && error !== null
+      ? Object.getOwnPropertyDescriptor(error, "code")?.value
+      : undefined;
+    const readFailure = code === "ENOENT" ? "not-found"
+      : code === "EACCES" ? "access-denied"
+      : code === "EPERM" ? "operation-not-permitted"
+      : code === "ENOTDIR" ? "not-directory"
+      : "other-read-error";
+    return { discovery: null, readFailure };
+  }
+  let discovery;
+  try {
+    discovery = JSON.parse(text);
+  } catch {
+    return { discovery: null, readFailure: "invalid-json" };
+  }
+  if (!discovery || typeof discovery !== "object" || Array.isArray(discovery)) {
+    return { discovery: null, readFailure: "invalid-shape" };
+  }
+  return { discovery, readFailure: null };
+}
+
+export function createCaveDiscoveryPublicationObserver() {
+  let remaining = CAVE_DISCOVERY_PUBLICATION_OUTPUT_LIMIT;
+  let pending = "";
+  let category = "not-observed";
+  const acceptLine = (line) => {
+    const match = /^\[cave\] client-v1 discovery publication refused: ([a-z-]+)\r?$/u.exec(line);
+    if (
+      match
+      && CAVE_DISCOVERY_PUBLICATION_FAILURES.has(match[1])
+      && match[1] !== "not-observed"
+      && match[1] !== "output-limit"
+    ) {
+      category = match[1];
+    }
+  };
+  return {
+    observe(chunk) {
+      if (category !== "not-observed") return;
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      pending += bytes.subarray(0, remaining).toString("utf8");
+      remaining -= Math.min(bytes.length, remaining);
+      let newline;
+      while ((newline = pending.indexOf("\n")) !== -1) {
+        acceptLine(pending.slice(0, newline));
+        pending = pending.slice(newline + 1);
+        if (category !== "not-observed") {
+          pending = "";
+          return;
+        }
+      }
+      if (bytes.length > 0 && remaining === 0) {
+        pending = "";
+        category = "output-limit";
+      }
+    },
+    finish() {
+      if (category === "not-observed") acceptLine(pending);
+      pending = "";
+    },
+    category() {
+      return category;
+    },
+  };
+}
+
+export function caveDiscoveryReadinessDiagnostic(failure, readFailure, publicationFailure) {
+  if (
+    failure !== "Client v1 discovery record is not published."
+    || !CAVE_DISCOVERY_READ_FAILURES.has(readFailure)
+    || !CAVE_DISCOVERY_PUBLICATION_FAILURES.has(publicationFailure)
+  ) {
+    return failure;
+  }
+  return `${failure} [read=${readFailure}; publication=${publicationFailure}]`;
+}
+
 export async function startCave(input) {
   const { port } = input;
   const env = buildCaveEnvironment(input);
@@ -803,6 +911,9 @@ export async function startCave(input) {
     stdio: ["ignore", "pipe", "pipe"],
   });
   child.stdout.resume();
+  const publication = createCaveDiscoveryPublicationObserver();
+  child.stderr.on("data", publication.observe);
+  child.stderr.on("end", publication.finish);
   child.stderr.resume();
 
   const origin = `http://127.0.0.1:${port}`;
@@ -813,6 +924,7 @@ export async function startCave(input) {
     exited = true;
   });
   let failure = "Cave readiness timed out after 120 seconds.";
+  let readFailure = null;
   while (Date.now() < deadline) {
     if (exited) {
       failure = "Cave exited before readiness.";
@@ -823,12 +935,9 @@ export async function startCave(input) {
         path: `${CLIENT_V1_PREFIX}/health`,
         timeoutMs: Math.min(1_000, Math.max(1, deadline - Date.now())),
       });
-      let discovery = null;
-      try {
-        discovery = JSON.parse(await readFile(discoveryPath, "utf8"));
-      } catch {
-        // The listen callback may not have published the discovery record yet.
-      }
+      const readResult = await readCaveDiscovery(discoveryPath);
+      const { discovery } = readResult;
+      readFailure = readResult.readFailure;
       const readinessFailure = caveReadinessFailure({
         healthStatus: response.status,
         discovery,
@@ -843,7 +952,7 @@ export async function startCave(input) {
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   await stopCave({ child }, port).catch(() => {});
-  throw new Error(failure);
+  throw new Error(caveDiscoveryReadinessDiagnostic(failure, readFailure, publication.category()));
 }
 
 export function caveReadinessFailure({

--- a/scripts/client-v1-conformance.test.mjs
+++ b/scripts/client-v1-conformance.test.mjs
@@ -4,6 +4,7 @@ import { readFile, readdir, realpath, rm } from "node:fs/promises";
 import { createServer } from "node:http";
 import path from "node:path";
 import test from "node:test";
+import { runInNewContext } from "node:vm";
 
 import {
   AUTHORITY_TAKEOVER_ASSERTION_IDS,
@@ -24,7 +25,10 @@ import {
   checkRecordShape,
   checkRecordValues,
   buildCaveEnvironment,
+  CAVE_DISCOVERY_PUBLICATION_OUTPUT_LIMIT,
+  caveDiscoveryReadinessDiagnostic,
   caveReadinessFailure,
+  createCaveDiscoveryPublicationObserver,
   createConformanceFixtureRoot,
   createRecorder,
   expectedAssertionIds,
@@ -36,6 +40,7 @@ import {
   parseConformanceArgs,
   parseRawResponse,
   recordAuthorityTakeoverResult,
+  readCaveDiscovery,
   requestOnce,
   renderConformanceRecord,
   stopCave,
@@ -298,6 +303,223 @@ test("bounded readiness requests reject a stalled HTTP response", async () => {
     await new Promise((resolve, reject) =>
       server.close((error) => error ? reject(error) : resolve()),
     );
+  }
+});
+
+test("classifies discovery read failures without copying raw exceptions or causes", async () => {
+  for (const [code, readFailure] of [
+    ["ENOENT", "not-found"],
+    ["EACCES", "access-denied"],
+    ["EPERM", "operation-not-permitted"],
+    ["ENOTDIR", "not-directory"],
+    ["EIO", "other-read-error"],
+    ["private-code", "other-read-error"],
+  ]) {
+    const error = Object.assign(new Error("private path, secret, ACL and contents", {
+      cause: new Error("private cause"),
+    }), { code, stdout: "private stdout", stderr: "private stderr" });
+    let reads = 0;
+    assert.deepEqual(await readCaveDiscovery("private-path", async (file, encoding) => {
+      reads += 1;
+      assert.equal(file, "private-path");
+      assert.equal(encoding, "utf8");
+      throw error;
+    }), { discovery: null, readFailure });
+    assert.equal(reads, 1);
+  }
+  for (const error of [
+    "ENOENT private string",
+    null,
+    Object.create({ code: "ENOENT" }),
+    Object.defineProperty({}, "code", { get() { throw new Error("must not inspect getters"); } }),
+  ]) {
+    assert.deepEqual(
+      await readCaveDiscovery("unused", async () => { throw error; }),
+      { discovery: null, readFailure: "other-read-error" },
+    );
+  }
+});
+
+test("distinguishes invalid discovery JSON and shape without adding readiness gates", async () => {
+  assert.deepEqual(
+    await readCaveDiscovery("unused", async () => "{ private malformed JSON"),
+    { discovery: null, readFailure: "invalid-json" },
+  );
+  for (const text of ["null", "false", "42", '"private contents"', "[]"]) {
+    assert.deepEqual(
+      await readCaveDiscovery("unused", async () => text),
+      { discovery: null, readFailure: "invalid-shape" },
+    );
+  }
+  for (const discovery of [{}, { endpoint: "http://127.0.0.1:4310", pid: 4310 }]) {
+    assert.deepEqual(
+      await readCaveDiscovery("unused", async () => JSON.stringify(discovery)),
+      { discovery, readFailure: null },
+    );
+  }
+});
+
+test("observes only fixed publisher refusal lines across fragmented stderr", () => {
+  const line = "[cave] client-v1 discovery publication refused: root-owner-unverified\r\n";
+  for (let split = 0; split <= line.length; split += 1) {
+    const observer = createCaveDiscoveryPublicationObserver();
+    observer.observe(Buffer.from("private unrelated output\n"));
+    observer.observe(Buffer.from(line.slice(0, split)));
+    observer.observe(Buffer.from(line.slice(split)));
+    observer.observe(Buffer.from("[cave] client-v1 discovery publication refused: target-owner-shared\n"));
+    observer.finish();
+    assert.equal(observer.category(), "root-owner-unverified", `split ${split}`);
+  }
+  for (const invalid of [
+    "root-owner-unverified private-path",
+    "unknown",
+    "not-observed",
+    "output-limit",
+  ]) {
+    const observer = createCaveDiscoveryPublicationObserver();
+    observer.observe(`[cave] client-v1 discovery publication refused: ${invalid}\n`);
+    observer.observe("prefix [cave] client-v1 discovery publication refused: root-owner-shared\n");
+    observer.finish();
+    assert.equal(observer.category(), "not-observed");
+  }
+  const observer = createCaveDiscoveryPublicationObserver();
+  observer.observe("[cave] client-v1 discovery publication refused: disabled-other");
+  observer.finish();
+  assert.equal(observer.category(), "disabled-other");
+});
+
+test("caps publisher stderr observation and preserves the first complete refusal", () => {
+  const line = "[cave] client-v1 discovery publication refused: root-symlink\n";
+  const limited = createCaveDiscoveryPublicationObserver();
+  limited.observe(Buffer.alloc(CAVE_DISCOVERY_PUBLICATION_OUTPUT_LIMIT, 120));
+  limited.observe(line);
+  limited.observe(Buffer.alloc(CAVE_DISCOVERY_PUBLICATION_OUTPUT_LIMIT * 4));
+  limited.finish();
+  assert.equal(limited.category(), "output-limit");
+
+  const observed = createCaveDiscoveryPublicationObserver();
+  observed.observe(Buffer.concat([
+    Buffer.from(line),
+    Buffer.alloc(CAVE_DISCOVERY_PUBLICATION_OUTPUT_LIMIT * 2, 120),
+  ]));
+  observed.finish();
+  assert.equal(observed.category(), "root-symlink");
+
+  const truncated = createCaveDiscoveryPublicationObserver();
+  truncated.observe(Buffer.alloc(CAVE_DISCOVERY_PUBLICATION_OUTPUT_LIMIT - 8, 120));
+  truncated.observe(`\n${line}`);
+  truncated.finish();
+  assert.equal(truncated.category(), "output-limit");
+});
+
+test("formats exactly the coordinated finite read/publication contract", () => {
+  const missing = "Client v1 discovery record is not published.";
+  const reads = [
+    "not-found", "access-denied", "operation-not-permitted", "not-directory",
+    "other-read-error", "invalid-json", "invalid-shape",
+  ];
+  const publications = [
+    "not-observed", "output-limit", "disabled-other", "root-owner-unverified",
+    "root-owner-shared", "target-owner-unverified", "target-owner-shared",
+    "root-not-directory", "root-symlink", "target-not-file", "endpoint-invalid",
+    "authority-init",
+  ];
+  for (const read of reads) {
+    for (const publication of publications) {
+      assert.equal(
+        caveDiscoveryReadinessDiagnostic(missing, read, publication),
+        `${missing} [read=${read}; publication=${publication}]`,
+      );
+    }
+  }
+  for (const failure of [
+    "Cave readiness timed out after 120 seconds.",
+    "Cave exited before readiness.",
+    "Cave health is not ready.",
+    "Client v1 discovery endpoint does not match the listening Cave.",
+    "Client v1 discovery pid does not match the launched Cave.",
+    null,
+  ]) {
+    assert.equal(caveDiscoveryReadinessDiagnostic(failure, "not-found", "disabled-other"), failure);
+  }
+  assert.equal(caveDiscoveryReadinessDiagnostic(missing, "private", "disabled-other"), missing);
+  assert.equal(caveDiscoveryReadinessDiagnostic(missing, "not-found", "private"), missing);
+  assert.equal(caveDiscoveryReadinessDiagnostic(missing), missing);
+});
+
+test("startup drains stderr and emits only the final diagnostic after unchanged readiness gates and teardown", async () => {
+  const source = await readFile(new URL("./client-v1-conformance.mjs", import.meta.url), "utf8");
+  const startSource = /export async function startCave\(input\) \{[\s\S]*?\n\}/u.exec(source);
+  assert.ok(startSource);
+  const origin = "http://127.0.0.1:4310";
+  const missing = "Client v1 discovery record is not published.";
+  for (const [healthStatus, discovery, expected, requestFails, exits] of [
+    [200, null, `${missing} [read=access-denied; publication=root-owner-unverified]`],
+    [503, null, "Cave health is not ready."],
+    [200, { endpoint: "http://127.0.0.1:4311", pid: 4310 }, "Client v1 discovery endpoint does not match the listening Cave."],
+    [200, { endpoint: origin, pid: 9999 }, "Client v1 discovery pid does not match the launched Cave."],
+    [200, null, "Cave readiness timed out after 120 seconds.", true],
+    [200, null, "Cave exited before readiness.", true, true],
+    [200, { endpoint: origin, pid: 4310 }, null],
+  ]) {
+    const child = new EventEmitter();
+    child.pid = 4310;
+    let drains = 0;
+    let reads = 0;
+    let stops = 0;
+    let now = 0;
+    child.stdout = { resume() { drains += 1; } };
+    child.stderr = new EventEmitter();
+    child.stderr.resume = () => {
+      drains += 1;
+      child.stderr.emit("data", Buffer.from("private stderr\n[cave] client-v1 discovery publi"));
+      child.stderr.emit("data", Buffer.from("cation refused: root-owner-unverified\n"));
+      child.stderr.emit("data", Buffer.from("private late stderr\n"));
+      child.stderr.emit("end");
+    };
+    const start = runInNewContext(`(${startSource[0].replace(/^export /u, "")})`, {
+      buildCaveEnvironment: () => ({}),
+      spawn: () => child,
+      process: { execPath: "unused-node" },
+      repositoryRoot: "unused-root",
+      path,
+      CLIENT_V1_PREFIX: "/api/client/v1",
+      Date: { now: () => now },
+      setTimeout: (resolve, delay) => {
+        assert.equal(delay, 250);
+        now += exits ? delay : 120_000;
+        resolve();
+      },
+      requestOnce: async (_origin, options) => {
+        assert.equal(options.timeoutMs, 1_000);
+        if (exits) child.emit("exit");
+        if (requestFails) throw new Error("private HTTP failure");
+        return { status: healthStatus };
+      },
+      readCaveDiscovery: async () => {
+        reads += 1;
+        return { discovery, readFailure: discovery === null ? "access-denied" : null };
+      },
+      caveReadinessFailure,
+      caveDiscoveryReadinessDiagnostic,
+      createCaveDiscoveryPublicationObserver,
+      stopCave: async () => { stops += 1; },
+    });
+    if (expected === null) {
+      const result = await start({ port: 4310, caveHomeDir: "unused-home" });
+      assert.equal(result.child, child);
+      assert.equal(stops, 0);
+    } else {
+      await assert.rejects(start({ port: 4310, caveHomeDir: "unused-home" }), (error) => {
+        assert.equal(error.message, expected);
+        assert.equal(Object.hasOwn(error, "cause"), false);
+        assert.doesNotMatch(String(error), /private/);
+        return true;
+      });
+      assert.equal(stops, 1);
+    }
+    assert.equal(drains, 2);
+    assert.equal(reads, requestFails ? 0 : 1);
   }
 });
 

--- a/server.mjs
+++ b/server.mjs
@@ -270,6 +270,11 @@ if (-not (Test-Exclusive $state)) {
 `;
 const standaloneVerifiedWindowsPaths = /* @__PURE__ */ new Set();
 const standaloneWaivedWindowsPaths = /* @__PURE__ */ new Set();
+const standaloneDiscoveryPublicationFailures = /* @__PURE__ */ new WeakMap();
+function discoveryPublicationFailure(category, error) {
+  standaloneDiscoveryPublicationFailures.set(error, category);
+  return error;
+}
 function assertStandaloneWindowsExclusive(path, label) {
   if (standaloneVerifiedWindowsPaths.has(path)) return;
   if (standaloneWaivedWindowsPaths.has(path)) return;
@@ -315,10 +320,10 @@ function assertStandaloneWindowsExclusive(path, label) {
     }
   } catch (cause) {
     if (!waiver.granted) {
-      throw new Error(
+      throw discoveryPublicationFailure(`${label}-owner-unverified`, new Error(
         unverifiableOwnershipRefusal(subject, path, cause, waiver.note),
         { cause }
-      );
+      ));
     }
     standaloneWaivedWindowsPaths.add(path);
     console.warn(
@@ -337,7 +342,10 @@ function assertStandaloneWindowsExclusive(path, label) {
     findings.push(`access granted to ${[...new Set(foreign)].join(", ")}`);
   }
   if (findings.length > 0) {
-    throw new Error(sharedOwnershipRefusal(subject, path, findings, waiver));
+    throw discoveryPublicationFailure(
+      `${label}-owner-shared`,
+      new Error(sharedOwnershipRefusal(subject, path, findings, waiver))
+    );
   }
   if (report.repaired) {
     console.warn(
@@ -349,14 +357,17 @@ function assertStandaloneWindowsExclusive(path, label) {
 function requireStandaloneOwner(path, metadata, label) {
   if (typeof process.getuid === "function") {
     if (metadata.uid !== process.getuid()) {
-      throw new Error(`Client v1 discovery ${label} must be owned by the current user.`);
+      throw discoveryPublicationFailure(
+        `${label}-owner-shared`,
+        new Error(`Client v1 discovery ${label} must be owned by the current user.`)
+      );
     }
     return;
   }
   if (process.platform !== "win32") {
-    throw new Error(
+    throw discoveryPublicationFailure(`${label}-owner-unverified`, new Error(
       `Client v1 discovery ${label} ownership cannot be verified on ${process.platform}: this platform exposes neither a uid nor a Windows ACL, so ${path} is refused.`
-    );
+    ));
   }
   assertStandaloneWindowsExclusive(path, label);
 }
@@ -364,7 +375,10 @@ function assertStandaloneDiscoveryTarget(path) {
   try {
     const metadata = lstatSync(path);
     if (!metadata.isFile() || metadata.isSymbolicLink()) {
-      throw new Error(`Client v1 discovery target must be a regular file: ${path}.`);
+      throw discoveryPublicationFailure(
+        "target-not-file",
+        new Error(`Client v1 discovery target must be a regular file: ${path}.`)
+      );
     }
     requireStandaloneOwner(path, metadata, "target");
   } catch (error) {
@@ -377,18 +391,35 @@ function publishStandaloneClientV1DiscoveryRecord(endpoint) {
   mkdirSync(root, { recursive: true, mode: 448 });
   const rootMetadata = lstatSync(root);
   if (rootMetadata.isSymbolicLink() || !rootMetadata.isDirectory()) {
-    throw new Error("Client v1 discovery root must be a real directory.");
+    throw discoveryPublicationFailure(
+      rootMetadata.isSymbolicLink() ? "root-symlink" : "root-not-directory",
+      new Error("Client v1 discovery root must be a real directory.")
+    );
   }
   requireStandaloneOwner(root, rootMetadata, "root");
   const physicalRoot = realpathSync(root);
   if (physicalRoot !== root) {
-    throw new Error("Client v1 discovery root must not resolve through a symlink.");
+    throw discoveryPublicationFailure(
+      "root-symlink",
+      new Error("Client v1 discovery root must not resolve through a symlink.")
+    );
   }
   chmodSync(root, 448);
-  const url = new URL(endpoint);
+  let url;
+  try {
+    url = new URL(endpoint);
+  } catch (cause) {
+    throw discoveryPublicationFailure(
+      "endpoint-invalid",
+      new Error("Client v1 discovery endpoint must be a path-free loopback HTTP URL.", { cause })
+    );
+  }
   const loopback = url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]";
   if (url.protocol !== "http:" || !loopback || !url.port || url.username || url.password || url.pathname !== "/" || url.search || url.hash || /%(?:2f|5c)/i.test(endpoint)) {
-    throw new Error("Client v1 discovery endpoint must be a path-free loopback HTTP URL.");
+    throw discoveryPublicationFailure(
+      "endpoint-invalid",
+      new Error("Client v1 discovery endpoint must be a path-free loopback HTTP URL.")
+    );
   }
   const path = clientV1DiscoveryFile();
   assertStandaloneDiscoveryTarget(path);
@@ -403,10 +434,16 @@ function publishStandaloneClientV1DiscoveryRecord(endpoint) {
     };
   } else {
     if (CLIENT_V1_AUTHORITY_BOOTSTRAP === void 0) {
-      throw new Error("Client v1 HPKE authority initialization failed.");
+      throw discoveryPublicationFailure(
+        "authority-init",
+        new Error("Client v1 HPKE authority initialization failed.")
+      );
     }
     if ("unavailable" in CLIENT_V1_AUTHORITY_BOOTSTRAP) {
-      throw clientV1AuthorityInitializationError ?? new Error("Client v1 HPKE authority initialization failed.");
+      throw discoveryPublicationFailure(
+        "authority-init",
+        clientV1AuthorityInitializationError ?? new Error("Client v1 HPKE authority initialization failed.")
+      );
     }
     const bootstrap = CLIENT_V1_AUTHORITY_BOOTSTRAP;
     record = {
@@ -1248,9 +1285,9 @@ server.keepAliveTimeout = 75e3;
 server.headersTimeout = 8e4;
 function reportClientV1DiscoveryUnavailable(error) {
   clientV1DiscoveryPublished = false;
-  const detail = error instanceof Error ? error.message : String(error);
+  const category = typeof error === "object" && error !== null ? standaloneDiscoveryPublicationFailures.get(error) ?? "disabled-other" : "disabled-other";
   console.error("[cave] \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 CLIENT V1 DISABLED \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500");
-  console.error(`[cave] ${detail}`);
+  console.error(`[cave] client-v1 discovery publication refused: ${category}`);
   console.error(
     "[cave] The client v1 discovery record was NOT published, so paired clients cannot find this server and every client v1 request stays refused. Everything else on this server is running normally."
   );

--- a/server.ts
+++ b/server.ts
@@ -446,7 +446,30 @@ const standaloneVerifiedWindowsPaths = new Set<string>();
 // would then read.
 const standaloneWaivedWindowsPaths = new Set<string>();
 
-function assertStandaloneWindowsExclusive(path: string, label: string): void {
+type StandaloneDiscoveryPublicationFailure =
+  | "root-owner-unverified"
+  | "root-owner-shared"
+  | "target-owner-unverified"
+  | "target-owner-shared"
+  | "root-not-directory"
+  | "root-symlink"
+  | "target-not-file"
+  | "endpoint-invalid"
+  | "authority-init";
+
+// Keep diagnostic attribution separate from raw exception text and causes.
+const standaloneDiscoveryPublicationFailures =
+  new WeakMap<object, StandaloneDiscoveryPublicationFailure>();
+
+function discoveryPublicationFailure(
+  category: StandaloneDiscoveryPublicationFailure,
+  error: Error,
+): Error {
+  standaloneDiscoveryPublicationFailures.set(error, category);
+  return error;
+}
+
+function assertStandaloneWindowsExclusive(path: string, label: "root" | "target"): void {
   if (standaloneVerifiedWindowsPaths.has(path)) return;
   if (standaloneWaivedWindowsPaths.has(path)) return;
   const subject = `Client v1 discovery ${label}`;
@@ -521,10 +544,10 @@ function assertStandaloneWindowsExclusive(path: string, label: string): void {
     // The ONE condition the waiver covers: the host cannot answer the
     // question. Everything below this point had an answer.
     if (!waiver.granted) {
-      throw new Error(
+      throw discoveryPublicationFailure(`${label}-owner-unverified`, new Error(
         unverifiableOwnershipRefusal(subject, path, cause as Error, waiver.note),
         { cause },
-      );
+      ));
     }
     standaloneWaivedWindowsPaths.add(path);
     console.warn(
@@ -546,7 +569,10 @@ function assertStandaloneWindowsExclusive(path: string, label: string): void {
     findings.push(`access granted to ${[...new Set(foreign)].join(", ")}`);
   }
   if (findings.length > 0) {
-    throw new Error(sharedOwnershipRefusal(subject, path, findings, waiver));
+    throw discoveryPublicationFailure(
+      `${label}-owner-shared`,
+      new Error(sharedOwnershipRefusal(subject, path, findings, waiver)),
+    );
   }
   if (report.repaired) {
     console.warn(
@@ -561,7 +587,7 @@ function assertStandaloneWindowsExclusive(path: string, label: string): void {
 function requireStandaloneOwner(
   path: string,
   metadata: NonNullable<ReturnType<typeof lstatSync>>,
-  label: string,
+  label: "root" | "target",
 ): void {
   // The uid comparison alone was inert on win32 — `process.getuid` is undefined
   // there and `lstat` reports uid 0 for every path — so the discovery record
@@ -569,15 +595,18 @@ function requireStandaloneOwner(
   // that can answer neither question is refused rather than waved through.
   if (typeof process.getuid === "function") {
     if (metadata.uid !== process.getuid()) {
-      throw new Error(`Client v1 discovery ${label} must be owned by the current user.`);
+      throw discoveryPublicationFailure(
+        `${label}-owner-shared`,
+        new Error(`Client v1 discovery ${label} must be owned by the current user.`),
+      );
     }
     return;
   }
   if (process.platform !== "win32") {
-    throw new Error(
+    throw discoveryPublicationFailure(`${label}-owner-unverified`, new Error(
       `Client v1 discovery ${label} ownership cannot be verified on ${process.platform}: `
       + `this platform exposes neither a uid nor a Windows ACL, so ${path} is refused.`,
-    );
+    ));
   }
   assertStandaloneWindowsExclusive(path, label);
 }
@@ -586,7 +615,10 @@ function assertStandaloneDiscoveryTarget(path: string): void {
   try {
     const metadata = lstatSync(path);
     if (!metadata.isFile() || metadata.isSymbolicLink()) {
-      throw new Error(`Client v1 discovery target must be a regular file: ${path}.`);
+      throw discoveryPublicationFailure(
+        "target-not-file",
+        new Error(`Client v1 discovery target must be a regular file: ${path}.`),
+      );
     }
     requireStandaloneOwner(path, metadata, "target");
   } catch (error) {
@@ -600,16 +632,30 @@ function publishStandaloneClientV1DiscoveryRecord(endpoint: string): void {
   mkdirSync(root, { recursive: true, mode: 0o700 });
   const rootMetadata = lstatSync(root);
   if (rootMetadata.isSymbolicLink() || !rootMetadata.isDirectory()) {
-    throw new Error("Client v1 discovery root must be a real directory.");
+    throw discoveryPublicationFailure(
+      rootMetadata.isSymbolicLink() ? "root-symlink" : "root-not-directory",
+      new Error("Client v1 discovery root must be a real directory."),
+    );
   }
   requireStandaloneOwner(root, rootMetadata, "root");
   const physicalRoot = realpathSync(root);
   if (physicalRoot !== root) {
-    throw new Error("Client v1 discovery root must not resolve through a symlink.");
+    throw discoveryPublicationFailure(
+      "root-symlink",
+      new Error("Client v1 discovery root must not resolve through a symlink."),
+    );
   }
   chmodSync(root, 0o700);
 
-  const url = new URL(endpoint);
+  let url: URL;
+  try {
+    url = new URL(endpoint);
+  } catch (cause) {
+    throw discoveryPublicationFailure(
+      "endpoint-invalid",
+      new Error("Client v1 discovery endpoint must be a path-free loopback HTTP URL.", { cause }),
+    );
+  }
   const loopback = url.hostname === "127.0.0.1"
     || url.hostname === "localhost"
     || url.hostname === "[::1]";
@@ -624,7 +670,10 @@ function publishStandaloneClientV1DiscoveryRecord(endpoint: string): void {
     || url.hash
     || /%(?:2f|5c)/i.test(endpoint)
   ) {
-    throw new Error("Client v1 discovery endpoint must be a path-free loopback HTTP URL.");
+    throw discoveryPublicationFailure(
+      "endpoint-invalid",
+      new Error("Client v1 discovery endpoint must be a path-free loopback HTTP URL."),
+    );
   }
 
   const path = clientV1DiscoveryFile();
@@ -661,11 +710,17 @@ function publishStandaloneClientV1DiscoveryRecord(endpoint: string): void {
     };
   } else {
     if (CLIENT_V1_AUTHORITY_BOOTSTRAP === undefined) {
-      throw new Error("Client v1 HPKE authority initialization failed.");
+      throw discoveryPublicationFailure(
+        "authority-init",
+        new Error("Client v1 HPKE authority initialization failed."),
+      );
     }
     if ("unavailable" in CLIENT_V1_AUTHORITY_BOOTSTRAP) {
-      throw clientV1AuthorityInitializationError
-        ?? new Error("Client v1 HPKE authority initialization failed.");
+      throw discoveryPublicationFailure(
+        "authority-init",
+        clientV1AuthorityInitializationError
+          ?? new Error("Client v1 HPKE authority initialization failed."),
+      );
     }
     const bootstrap = CLIENT_V1_AUTHORITY_BOOTSTRAP;
     record = {
@@ -1960,9 +2015,11 @@ server.headersTimeout = 80_000;
  */
 function reportClientV1DiscoveryUnavailable(error: unknown): void {
   clientV1DiscoveryPublished = false;
-  const detail = error instanceof Error ? error.message : String(error);
+  const category = typeof error === "object" && error !== null
+    ? standaloneDiscoveryPublicationFailures.get(error) ?? "disabled-other"
+    : "disabled-other";
   console.error("[cave] ─────────────── CLIENT V1 DISABLED ───────────────");
-  console.error(`[cave] ${detail}`);
+  console.error(`[cave] client-v1 discovery publication refused: ${category}`);
   console.error(
     "[cave] The client v1 discovery record was NOT published, so paired clients"
     + " cannot find this server and every client v1 request stays refused."

--- a/src/lib/server/client-v1/discovery.test.ts
+++ b/src/lib/server/client-v1/discovery.test.ts
@@ -10,7 +10,9 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { stripTypeScriptTypes } from "node:module";
 import test, { type TestContext } from "node:test";
+import { runInNewContext } from "node:vm";
 
 import {
   CLIENT_V1_DISCOVERY_FILE,
@@ -507,7 +509,7 @@ test("standalone authority boot is default-off, one-key, public-only, and fail-c
   );
   assert.match(
     source,
-    /if \("unavailable" in CLIENT_V1_AUTHORITY_BOOTSTRAP\) \{\s*throw clientV1AuthorityInitializationError/,
+    /if \("unavailable" in CLIENT_V1_AUTHORITY_BOOTSTRAP\) \{\s*throw discoveryPublicationFailure\(\s*"authority-init",\s*clientV1AuthorityInitializationError/,
     "unavailable active mode publishes no record through the existing loud failure path",
   );
 
@@ -621,7 +623,7 @@ test("the standalone server enforces ownership on Windows with this module's scr
   );
   assert.match(
     source,
-    /if \(findings\.length > 0\) \{\s*throw new Error\(/,
+    /if \(findings\.length > 0\) \{\s*throw discoveryPublicationFailure\(\s*`\$\{label\}-owner-shared`,\s*new Error\(/,
     "the standalone server must refuse on any finding, not merely collect them",
   );
 });
@@ -683,4 +685,182 @@ test("a client-v1 discovery failure degrades that surface instead of killing the
     /UNVERIFIED_OWNERSHIP_ENV/,
     "the banner must name the waiver, which is the only remedy on a host that cannot read a DACL",
   );
+});
+
+async function standalonePublisher(overrides: Record<string, unknown> = {}) {
+  const source = await readFile(resolve(process.cwd(), "server.ts"), "utf8");
+  const start = source.indexOf("const standaloneVerifiedWindowsPaths");
+  const end = source.indexOf("function removeStandaloneClientV1DiscoveryRecord");
+  const reporter = /function reportClientV1DiscoveryUnavailable\([\s\S]*?\n\}/.exec(source);
+  assert.ok(start > 0 && end > start && reporter);
+  const messages: string[] = [];
+  const writes: string[] = [];
+  const root = resolve("private-discovery-root");
+  const target = join(root, CLIENT_V1_DISCOVERY_FILE);
+  const metadata = (file: string) => ({
+    uid: 1001,
+    isSymbolicLink: () => false,
+    isDirectory: () => file === root,
+    isFile: () => file !== root,
+  });
+  const runtime = runInNewContext(stripTypeScriptTypes(`
+    let clientV1DiscoveryPublished = false;
+    ${source.slice(start, end)}
+    ${reporter![0]}
+    ({
+      publish: publishStandaloneClientV1DiscoveryRecord,
+      report: reportClientV1DiscoveryUnavailable,
+      published: () => clientV1DiscoveryPublished,
+    });
+  `), {
+    Error, URL, Buffer, join,
+    process: { pid: 4310, getuid: () => 1001, platform: "linux", env: {} },
+    console: {
+      error: (...args: unknown[]) => messages.push(args.join(" ")),
+      warn: (...args: unknown[]) => messages.push(args.join(" ")),
+    },
+    clientV1DiscoveryFile: () => target,
+    mkdirSync: () => {},
+    lstatSync: metadata,
+    realpathSync: () => root,
+    chmodSync: () => {},
+    openSync: () => { writes.push("open"); return 1; },
+    writeFileSync: () => { writes.push("write"); },
+    fsyncSync: () => {},
+    closeSync: () => {},
+    renameSync: () => { writes.push("rename"); },
+    rmSync: () => {},
+    randomUUID: () => "fixed-test-nonce",
+    CLIENT_V1_AUTHORITY_MODE: "off",
+    CLIENT_V1_AUTHORITY_BOOTSTRAP: undefined,
+    CLIENT_V1_DISCOVERY_NONCE: "fixed-test-nonce",
+    CLIENT_V1_DISCOVERY_STARTED_AT: "2026-09-12T00:00:00.000Z",
+    clientV1AuthorityInitializationError: null,
+    resolveUnverifiedOwnershipWaiver: () => ({ granted: false }),
+    unverifiableOwnershipRefusal: () => "private path, ACL and exception",
+    sharedOwnershipRefusal: () => "private path, ACL and principal",
+    WINDOWS_ACL_SCRIPT: "unused-test-probe",
+    WINDOWS_SYSTEM_SID: "system",
+    WINDOWS_ADMINISTRATORS_SID: "admins",
+    UNVERIFIED_OWNERSHIP_ENV: "COVEN_CAVE_ALLOW_UNVERIFIED_CLIENT_V1_OWNERSHIP",
+    UNVERIFIED_OWNERSHIP_TOKEN: "test-waiver-token",
+    UNVERIFIED_OWNERSHIP_REASON_ENV: "COVEN_CAVE_UNVERIFIED_CLIENT_V1_OWNERSHIP_REASON",
+    ...overrides,
+  }) as {
+    publish: (endpoint: string) => void;
+    report: (error: unknown) => void;
+    published: () => boolean;
+  };
+  return { ...runtime, messages, writes, root, target };
+}
+
+test("standalone publication reports fixed refusal categories without raw cause leakage", async () => {
+  const root = resolve("private-discovery-root");
+  const cases: [string, Record<string, unknown>, string?][] = [
+    ["root-not-directory", {
+      lstatSync: () => ({ isSymbolicLink: () => false, isDirectory: () => false }),
+    }],
+    ["root-symlink", {
+      lstatSync: () => ({ isSymbolicLink: () => true, isDirectory: () => true }),
+    }],
+    ["root-symlink", { realpathSync: () => "private-symlink-target" }],
+    ["root-owner-shared", {
+      lstatSync: () => ({ uid: 9999, isSymbolicLink: () => false, isDirectory: () => true }),
+    }],
+    ["target-owner-shared", {
+      lstatSync: (file: string) => ({
+        uid: file === root ? 1001 : 9999,
+        isSymbolicLink: () => false,
+        isDirectory: () => true,
+        isFile: () => true,
+      }),
+    }],
+    ["target-not-file", {
+      lstatSync: () => ({
+        uid: 1001, isSymbolicLink: () => false, isDirectory: () => true, isFile: () => false,
+      }),
+    }],
+    ["endpoint-invalid", {}, "https://private-host:4310/private"],
+    ["endpoint-invalid", {}, "private-invalid-url"],
+    ["authority-init", { CLIENT_V1_AUTHORITY_MODE: "enforce" }],
+    ["authority-init", {
+      CLIENT_V1_AUTHORITY_MODE: "enforce",
+      CLIENT_V1_AUTHORITY_BOOTSTRAP: { unavailable: true },
+      clientV1AuthorityInitializationError: new Error("private init cause"),
+    }],
+    ["disabled-other", {
+      mkdirSync: () => { throw new Error("private mkdir path", { cause: "private secret" }); },
+    }],
+  ];
+  for (const [category, overrides, endpoint] of cases) {
+    const runtime = await standalonePublisher(overrides);
+    let failed = false;
+    try {
+      runtime.publish(endpoint ?? "http://127.0.0.1:4310");
+    } catch (error) {
+      failed = true;
+      runtime.report(error);
+    }
+    assert.equal(failed, true, category);
+    assert.equal(runtime.published(), false, category);
+    assert.deepEqual(runtime.writes, [], category);
+    assert.equal(
+      runtime.messages.filter((line) => line.includes("publication refused:")).join("\n"),
+      `[cave] client-v1 discovery publication refused: ${category}`,
+    );
+    assert.doesNotMatch(runtime.messages.join("\n"), /private/i);
+    assert.match(runtime.messages.join("\n"), /CLIENT V1 DISABLED/);
+    assert.match(runtime.messages.join("\n"), /Everything else on this server is running normally/);
+  }
+});
+
+test("standalone Windows owner observations distinguish unreadable and shared without disarming gates", async () => {
+  for (const label of ["root", "target"]) {
+    for (const verdict of ["unverified", "shared"]) {
+      const root = resolve("private-discovery-root");
+      const runtime = await standalonePublisher({
+        process: { pid: 4310, platform: "win32", env: {} },
+        execFileSync: (_exe: string, _args: string[], options: { env: Record<string, string> }) => {
+          const atRoot = options.env.COVEN_CAVE_CLIENT_V1_ACL_PATH === root;
+          const selected = atRoot === (label === "root");
+          if (selected && verdict === "unverified") {
+            throw Object.assign(new Error("private ACL exception", { cause: "private cause" }), {
+              stderr: "private ACL stderr", stdout: "private ACL stdout",
+            });
+          }
+          return JSON.stringify({
+            self: "self", owner: selected && verdict === "shared" ? "foreign" : "self",
+            protected: true, repaired: false, removed: [], aces: [],
+          });
+        },
+      });
+      assert.throws(() => runtime.publish("http://127.0.0.1:4310"), (error) => {
+        runtime.report(error);
+        return true;
+      });
+      assert.equal(runtime.published(), false);
+      assert.deepEqual(runtime.writes, []);
+      assert.ok(runtime.messages.includes(
+        `[cave] client-v1 discovery publication refused: ${label}-owner-${verdict}`,
+      ));
+      assert.doesNotMatch(runtime.messages.join("\n"), /private|foreign/);
+    }
+  }
+});
+
+test("standalone diagnostic reporter never coerces unknown errors and successful publication stays silent", async () => {
+  const runtime = await standalonePublisher();
+  runtime.publish("http://127.0.0.1:4310");
+  assert.equal(runtime.published(), true);
+  assert.deepEqual(runtime.writes, ["open", "write", "rename"]);
+  assert.equal(runtime.messages.length, 0);
+  const hostile = {
+    toString() { throw new Error("must not stringify errors"); },
+    get message() { throw new Error("must not read message"); },
+    get cause() { throw new Error("must not read cause"); },
+    category: "root-owner-shared",
+  };
+  runtime.report(hostile);
+  assert.equal(runtime.published(), false);
+  assert.ok(runtime.messages.includes("[cave] client-v1 discovery publication refused: disabled-other"));
 });


### PR DESCRIPTION
## Purpose
Diagnose the unresolved Windows discovery readiness failure blocking OpenCoven/sdk#38. The generic missing label does not distinguish absence, access denial, malformed JSON or publication refusal.

## Changes
- Attribute finite publication-refusal categories at the actual source without parsing or logging raw exception text.
- Observe complete fixed stderr lines with a32KiB cap, fragmented-line support, first-recognized precedence and continuous draining.
- Add finite read/publication detail only to the existing final missing-discovery outcome; preserve readiness deadline, health/endpoint/PID validation, ACLs, cleanup and degraded behavior.
- Regenerate server.mjs with the existing standalone build and cover formatting, bounded observation, source attribution, precedence and nonleakage.

## Validation
99 focused cases, typecheck, configured targeted lint and standalone build passed. Independent code review found no significant issue. Focused cases rerun after advancing to current main.

## Dependencies and limits
Matches the existing unpublished Chat decoder in diag/cave-discovery-read-publication; that worktree is untouched. Coordinated reviewed source/producer/SDK validator bindings are needed before the next protected run. No real Windows read/publication pair is yet observed, no root-cause repair is claimed, and this does not authorize OpenCoven/sdk#40 SHIP.