### PR TITLE
fix(client-v1): isolate takeover fixture temp

### DIFF
--- a/scripts/client-v1-authority-takeover.mjs
+++ b/scripts/client-v1-authority-takeover.mjs
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,6 +29,7 @@ import { createClientV1HpkeTestClient } from "../src/lib/server/client-v1/testin
 import {
   ADMIN_TOKEN_HEADER,
   AUTHORITY_TAKEOVER_ASSERTION_IDS,
+  createConformanceFixtureRoot,
   freePort,
   requestOnce,
   seedIsolatedCaveHomes,
@@ -568,6 +569,10 @@ async function fixedAssertion(assertionId, reason, action) {
   }
 }
 
+export function createAuthorityTakeoverScratchRoot() {
+  return createConformanceFixtureRoot();
+}
+
 export async function runAuthorityTakeoverProof() {
   if (
     !existsSync(path.join(repositoryRoot, "server.mjs"))
@@ -579,12 +584,7 @@ export async function runAuthorityTakeoverProof() {
     );
   }
 
-  const scratchRoot = await mkdtemp(
-    path.join(
-      repositoryRoot,
-      ".scratch-client-v1-authority-takeover-",
-    ),
-  );
+  const scratchRoot = await createAuthorityTakeoverScratchRoot();
   let cave = null;
   let replacement = null;
   let cleanupFailed = false;

--- a/scripts/client-v1-authority-takeover.test.mjs
+++ b/scripts/client-v1-authority-takeover.test.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import { randomBytes } from "node:crypto";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -22,9 +25,43 @@ import {
   inspectCapturedBoundRequest,
   inspectCapturedPlaintextRequest,
 } from "./client-v1-authority-takeover.mjs";
+import * as authorityTakeover from "./client-v1-authority-takeover.mjs";
 
 const PAIRING_SECRET = base64UrlEncode(new Uint8Array(32).fill(0x31));
 const BEARER = "coven_test_bearer";
+
+test("authority takeover scratch data uses the supplied temp root", async () => {
+  assert.equal(
+    typeof authorityTakeover.createAuthorityTakeoverScratchRoot,
+    "function",
+  );
+  const parent = await mkdtemp(
+    path.join(tmpdir(), "cave-authority-takeover-parent-"),
+  );
+  const previousTmpdir = process.env.TMPDIR;
+  try {
+    const canonicalParent = await realpath(parent);
+    process.env.TMPDIR = canonicalParent;
+    const root = await authorityTakeover.createAuthorityTakeoverScratchRoot();
+    try {
+      assert.equal(root, await realpath(root));
+      assert.equal(path.dirname(root), canonicalParent);
+      assert.match(
+        path.basename(root),
+        /^cave-client-v1-conformance-/u,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  } finally {
+    if (previousTmpdir === undefined) {
+      delete process.env.TMPDIR;
+    } else {
+      process.env.TMPDIR = previousTmpdir;
+    }
+    await rm(parent, { recursive: true, force: true });
+  }
+});
 
 test("takeover credential kinds include pairing-secret and bearer", () => {
   assert.deepEqual(

--- a/scripts/client-v1-authority-takeover.test.mjs
+++ b/scripts/client-v1-authority-takeover.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { randomBytes } from "node:crypto";
-import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -38,10 +38,14 @@ test("authority takeover scratch data uses the supplied temp root", async () => 
   const parent = await mkdtemp(
     path.join(tmpdir(), "cave-authority-takeover-parent-"),
   );
-  const previousTmpdir = process.env.TMPDIR;
+  const previousTempEnvironment = Object.fromEntries(
+    ["TEMP", "TMP", "TMPDIR"].map((name) => [name, process.env[name]]),
+  );
   try {
     const canonicalParent = await realpath(parent);
-    process.env.TMPDIR = canonicalParent;
+    for (const name of Object.keys(previousTempEnvironment)) {
+      process.env[name] = canonicalParent;
+    }
     const root = await authorityTakeover.createAuthorityTakeoverScratchRoot();
     try {
       assert.equal(root, await realpath(root));
@@ -54,13 +58,27 @@ test("authority takeover scratch data uses the supplied temp root", async () => 
       await rm(root, { recursive: true, force: true });
     }
   } finally {
-    if (previousTmpdir === undefined) {
-      delete process.env.TMPDIR;
-    } else {
-      process.env.TMPDIR = previousTmpdir;
+    for (const [name, value] of Object.entries(previousTempEnvironment)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
     }
     await rm(parent, { recursive: true, force: true });
   }
+});
+
+test("authority takeover proof allocates scratch through the temp-root helper", async () => {
+  const source = await readFile(
+    new URL("./client-v1-authority-takeover.mjs", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /const scratchRoot = await createAuthorityTakeoverScratchRoot\(\);/u,
+  );
+  assert.doesNotMatch(
+    source,
+    /mkdtemp\(\s*path\.join\(\s*repositoryRoot,\s*["']\.scratch-client-v1-authority-takeover-/u,
+  );
 });
 
 test("takeover credential kinds include pairing-secret and bearer", () => {


### PR DESCRIPTION
## Summary
- allocate authority-takeover fixtures through the canonical OS temp helper
- honor the protected Windows Cave temp binding instead of writing under the restricted checkout
- add cross-platform environment and production call-site regression coverage

## Validation
- targeted authority and conformance tests: 84 passed
- full conformance suite: 15 test files passed
- typecheck and source lint passed