### PR TITLE
Ship chat-only iOS with persistent conversations

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Intents/CaveAppIntents.swift
+++ b/apps/ios/CovenCave/CovenCave/Intents/CaveAppIntents.swift
@@ -1,11 +1,12 @@
 import AppIntents
 import Foundation
 
-/// Create a reminder by voice / Spotlight / Shortcuts — e.g. "New Coven reminder".
-/// Requires local device authentication, then uses the saved connection directly.
+/// Retained only so a saved shortcut explains the retirement without writing
+/// reminders or reopening a retired destination.
 struct NewReminderIntent: AppIntent {
     static var title: LocalizedStringResource = "New Reminder"
-    static var description = IntentDescription("Create a reminder in Coven Cave.")
+    static var description = IntentDescription("Reminders are available on desktop.")
+    static var isDiscoverable: Bool = false
     static var authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     @Parameter(title: "Reminder", requestValueDialog: "What's the reminder?")
@@ -20,63 +21,45 @@ struct NewReminderIntent: AppIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        guard let connection = CaveConnection.load() else {
-            return .result(dialog: "Open Coven Cave and connect to your desktop first.")
-        }
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return .result(dialog: "I need something to remind you about.") }
-        let fireAt = when ?? Date().addingTimeInterval(3600)
-        do {
-            try await CaveClient(connection: connection).createReminder(title: trimmed, fireAt: fireAt)
-            return .result(dialog: "Reminder set: \(trimmed)")
-        } catch {
-            return .result(dialog: "Couldn't reach your desktop to set that reminder.")
-        }
+        .result(dialog: "Reminders are available in Coven Cave on your desktop.")
     }
 }
 
-/// Authenticated task summary — e.g. "What's running in Coven Cave".
+/// A compatibility response for previously saved task-summary shortcuts.
 struct RunningTasksIntent: AppIntent {
     static var title: LocalizedStringResource = "Running Tasks"
-    static var description = IntentDescription("Summarize the tasks currently running.")
+    static var description = IntentDescription("Tasks are available on desktop.")
+    static var isDiscoverable: Bool = false
     static var authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     @MainActor
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        guard let connection = CaveConnection.load() else {
-            return .result(dialog: "Open Coven Cave and connect to your desktop first.")
-        }
-        let running = ((try? await CaveClient(connection: connection).tasks()) ?? [])
-            .filter { $0.status == .running }
-        guard !running.isEmpty else { return .result(dialog: "Nothing is running right now.") }
-        let names = running.prefix(3).map(\.title).joined(separator: ", ")
-        let more = running.count > 3 ? ", and \(running.count - 3) more" : ""
-        let count = running.count
-        return .result(dialog: "\(count) task\(count == 1 ? "" : "s") running: \(names)\(more).")
+        .result(dialog: "Tasks are available in Coven Cave on your desktop.")
     }
 }
 
-/// Surfaces the intents to Siri, Spotlight, and the Shortcuts app with spoken
-/// phrases. Discovered automatically once the app has launched at least once.
+struct OpenChatsIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Chats"
+    static var description = IntentDescription("Open your Coven Cave conversations.")
+    static var openAppWhenRun: Bool = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult & OpensIntent {
+        .result(opensIntent: OpenURLIntent(URL(string: "covencave://chats")!))
+    }
+}
+
+/// Only chat is offered to Siri, Spotlight, and the Shortcuts app.
 struct CaveShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
         AppShortcut(
-            intent: NewReminderIntent(),
+            intent: OpenChatsIntent(),
             phrases: [
-                "New \(.applicationName) reminder",
-                "Set a reminder in \(.applicationName)",
+                "Open \(.applicationName) chats",
+                "Open chats in \(.applicationName)",
             ],
-            shortTitle: "New Reminder",
-            systemImageName: "bell.badge"
-        )
-        AppShortcut(
-            intent: RunningTasksIntent(),
-            phrases: [
-                "What's running in \(.applicationName)",
-                "\(.applicationName) running tasks",
-            ],
-            shortTitle: "Running Tasks",
-            systemImageName: "play.circle"
+            shortTitle: "Open Chats",
+            systemImageName: "bubble.left.and.bubble.right"
         )
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Models/ChatDispatchBinding.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/ChatDispatchBinding.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// The caller's intended target, captured before any dispatch suspension.
+struct ChatDispatchBinding: Equatable {
+    let threadId: String
+    let projectRoot: String?
+    let familiarIds: [String]
+    private let roster: [String]
+    private let sessionIds: [String: String]
+
+    @MainActor
+    init(thread: ChatThread, familiarIds: [String]? = nil) {
+        threadId = thread.id
+        projectRoot = thread.projectRoot
+        let recipients = familiarIds ?? thread.familiarIds
+        self.familiarIds = recipients
+        roster = thread.familiarIds
+        sessionIds = thread.sessionIds.filter { recipients.contains($0.key) }
+    }
+
+    @MainActor
+    func matches(_ thread: ChatThread, includingSessions: Bool = false) -> Bool {
+        thread.id == threadId
+            && thread.projectRoot == projectRoot
+            && thread.familiarIds == roster
+            && familiarIds.allSatisfy { roster.contains($0) }
+            && sessionIds.allSatisfy { thread.sessionIds[$0.key] == $0.value }
+            && (!includingSessions || familiarIds.allSatisfy {
+                thread.sessionIds[$0] == sessionIds[$0]
+            })
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Models/NewChatImportLaunchContext.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/NewChatImportLaunchContext.swift
@@ -3,7 +3,7 @@ import Foundation
 struct NewChatImportLaunchContext: Equatable, Sendable {
     enum ValidationResult: Equatable, Sendable {
         case valid
-        case unassigned
+        case accessUnavailable
         case projectChanged
         case familiarAccessRevoked([String])
     }
@@ -13,15 +13,18 @@ struct NewChatImportLaunchContext: Equatable, Sendable {
     let familiarIds: [String]
 
     init?(
-        activeProject: ProjectInfo?,
+        selectedProject: ProjectInfo?,
         selectedFamiliarIds: [String]
     ) {
-        guard let activeProject else { return nil }
-        let projectId = Self.normalized(activeProject.id)
-        let projectRoot = Self.normalized(activeProject.root)
+        guard let selectedProject else { return nil }
+        let projectId = Self.normalized(selectedProject.id)
+        let projectRoot = Self.normalized(selectedProject.root)
         let familiarIds = ChatProjectSelection.familiarKey(selectedFamiliarIds)
         guard !projectId.isEmpty,
               !projectRoot.isEmpty,
+              projectId == selectedProject.id,
+              projectRoot == selectedProject.root,
+              ProjectContext.openContext(for: projectRoot, in: []) != nil,
               !familiarIds.isEmpty else { return nil }
         self.projectId = projectId
         self.projectRoot = projectRoot
@@ -29,28 +32,28 @@ struct NewChatImportLaunchContext: Equatable, Sendable {
     }
 
     func validate(
-        projectContext: ProjectContext?,
-        activeProject: ProjectInfo?,
-        projectMembership: ProjectMembershipIndex
+        registeredProjects: [ProjectInfo],
+        accessibleProjects: [ProjectInfo],
+        projectMembership: ProjectMembershipIndex,
+        membershipLoaded: Bool
     ) -> ValidationResult {
-        if projectContext == .unassigned {
-            return .unassigned
-        }
-
-        guard let activeProject else { return .projectChanged }
-        let activeProjectId = Self.normalized(activeProject.id)
-        let activeProjectRoot = Self.normalized(activeProject.root)
-        guard activeProjectId == projectId,
-              activeProjectRoot == projectRoot else {
+        guard membershipLoaded else { return .accessUnavailable }
+        guard registeredProjects.contains(where: {
+            $0.id == projectId && $0.root == projectRoot
+        }) else {
             return .projectChanged
         }
 
         let revokedFamiliarIds = familiarIds.filter {
-            !projectMembership.contains($0, inProjectID: activeProjectId)
+            !projectMembership.contains($0, inProjectID: projectId)
         }
-        return revokedFamiliarIds.isEmpty
-            ? .valid
-            : .familiarAccessRevoked(revokedFamiliarIds)
+        guard revokedFamiliarIds.isEmpty else {
+            return .familiarAccessRevoked(revokedFamiliarIds)
+        }
+        guard accessibleProjects.contains(where: {
+            $0.id == projectId && $0.root == projectRoot
+        }) else { return .accessUnavailable }
+        return .valid
     }
 
     private static func normalized(_ value: String) -> String {

--- a/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// Mirrors the applicable web/TUI vocabulary (`src/lib/slash-commands.ts` →
 /// `coven/crates/coven-cli/src/tui/chat/app.rs`) so a muscle-memory `/clear`
-/// or `/board` does the same thing on the phone as on the desktop. Terminal
+/// does the same thing on the phone as on the desktop. Terminal
 /// commands are intentionally absent because iOS has no terminal surface.
 /// Aliases are first-class: `/h`, `/cls`, `/q` resolve to their canonical command.
 ///
@@ -38,7 +38,6 @@ struct SlashCommand: Identifiable, Hashable {
         case newChat               // start a fresh chat with the same familiar(s)
         case familiarPicker        // switch familiar (arg = name) or open the picker
         case openSessions          // jump to the Chats list
-        case openBoard             // switch to the Tasks destination
         case sendAsPrompt          // /run /codex /claude — send the args as a message
         case daemonStatus          // /daemon — fetch + show status inline
         case doctor                // /doctor — run `coven doctor` inline
@@ -57,6 +56,13 @@ struct SlashCommand: Identifiable, Hashable {
     let action: Action
 
     var id: String { name }
+
+    var sendsChatMessage: Bool {
+        switch action {
+        case .sendAsPrompt, .startDiagram: return true
+        default: return false
+        }
+    }
 
     /// Every typeable token for this command (canonical name + aliases).
     var tokens: [String] { [name] + aliases }
@@ -135,9 +141,9 @@ enum SlashCatalog {
         SlashCommand(name: "/chats", aliases: ["/agents", "/chat"], hint: "Chats",
                      description: "Switch back to the Chats view.",
                      section: .view, availability: .native, action: .openSessions),
-        SlashCommand(name: "/board", hint: "Tasks",
-                     description: "Open the Tasks board.",
-                     section: .view, availability: .native, action: .openBoard),
+        SlashCommand(name: "/board", aliases: ["/tasks", "/task"], hint: "Tasks",
+                     description: "Manage tasks on the desktop.",
+                     section: .view, availability: .desktopOnly, action: .desktopOnly("Tasks")),
         SlashCommand(name: "/journal", hint: "Journal",
                      description: "Your daily journal — open it on the desktop.",
                      section: .view, availability: .desktopOnly, action: .desktopOnly("Journal")),
@@ -168,17 +174,17 @@ enum SlashCatalog {
                      section: .view, availability: .desktopOnly, action: .desktopOnly("Eval Loops")),
 
         // MARK: Launch
-        SlashCommand(name: "/run", hint: "run task",
-                     description: "Run a task through the active familiar.",
-                     argPlaceholder: "task…", section: .launch,
+        SlashCommand(name: "/run", hint: "send a prompt",
+                     description: "Send a prompt to the active familiar.",
+                     argPlaceholder: "message…", section: .launch,
                      availability: .native, action: .sendAsPrompt),
         SlashCommand(name: "/codex", hint: "codex runtime",
-                     description: "Send a task (runs through the active familiar on mobile).",
-                     argPlaceholder: "task…", section: .launch,
+                     description: "Send a prompt through the active familiar on mobile.",
+                     argPlaceholder: "message…", section: .launch,
                      availability: .native, action: .sendAsPrompt),
         SlashCommand(name: "/claude", hint: "claude runtime",
-                     description: "Send a task (runs through the active familiar on mobile).",
-                     argPlaceholder: "task…", section: .launch,
+                     description: "Send a prompt through the active familiar on mobile.",
+                     argPlaceholder: "message…", section: .launch,
                      availability: .native, action: .sendAsPrompt),
     ]
 

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -1030,7 +1030,7 @@ struct CaveClient {
                     req.timeoutInterval = 600
 
                     onRequestStarted()
-                    let (bytes, resp) = try await Self.streamSession.bytes(for: req)
+                    let (bytes, resp) = try await (injectedSession ?? Self.streamSession).bytes(for: req)
                     if let http = resp as? HTTPURLResponse,
                        !(200..<300).contains(http.statusCode) {
                         let data = try await Self.readServerErrorBody(from: bytes)
@@ -1076,7 +1076,7 @@ struct CaveClient {
                     req.setValue("text/event-stream", forHTTPHeaderField: "Accept")
                     req.timeoutInterval = 600
 
-                    let (bytes, resp) = try await Self.streamSession.bytes(for: req)
+                    let (bytes, resp) = try await (injectedSession ?? Self.streamSession).bytes(for: req)
                     if (resp as? HTTPURLResponse)?.statusCode == 404 {
                         throw NoResumableRun()
                     }

--- a/apps/ios/CovenCave/CovenCave/Notifications/ReminderNotifications.swift
+++ b/apps/ios/CovenCave/CovenCave/Notifications/ReminderNotifications.swift
@@ -1,29 +1,14 @@
 import Foundation
 import UserNotifications
 
-/// Schedules on-device notifications for upcoming reminders so the phone buzzes
-/// when one is due — even when the desktop is asleep or off the tailnet. Today
-/// the phone only *lists* reminders; this makes them actionable away from the desk.
-///
-/// Idempotent: each `sync` clears our previously-scheduled reminders and re-adds
-/// the current upcoming set, so edits/completions on the desktop are reflected on
-/// the next refresh. We own only identifiers prefixed with `idPrefix`, so other
-/// notifications (if any are ever added) are left untouched.
+/// Removes local alerts left by the retired reminders surface. Backend
+/// reminders and chat notifications are never changed by this migration.
 @MainActor
 enum ReminderNotifications {
-    private static let idPrefix = "cave.reminder."
-    /// iOS keeps at most 64 pending requests per app; stay comfortably under.
-    private static let maxScheduled = 60
+    private nonisolated static let idPrefix = "cave.reminder."
 
     nonisolated static func deepLinkURL(taskId: String? = nil) -> URL? {
-        if let taskId = taskId?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !taskId.isEmpty {
-            return ProjectNavigationIntent(
-                entity: .task(id: taskId),
-                destination: .tasks
-            ).url
-        }
-        return ProjectNavigationIntent(destination: .tasks).url
+        nil
     }
 
     nonisolated static func deepLinkURL(for reminder: Reminder) -> URL? {
@@ -33,73 +18,44 @@ enum ReminderNotifications {
                 destination: .chats
             ).url
         }
-        if let taskId = reminder.link?.resolvedTaskID {
-            return deepLinkURL(taskId: taskId)
-        }
-        return deepLinkURL()
+        return nil
     }
 
-    /// Ask once. Safe to call repeatedly — the system only prompts while the
-    /// status is undetermined; afterwards this is a cheap no-op.
+    nonisolated static func isRetiredRequest(identifier: String) -> Bool {
+        identifier.hasPrefix(idPrefix)
+    }
+
+    /// Legacy callers may still request reconciliation; only chat owns new
+    /// notification permission prompts.
     static func requestAuthorizationIfNeeded() async {
-        let center = UNUserNotificationCenter.current()
-        let settings = await center.notificationSettings()
-        guard settings.authorizationStatus == .notDetermined else { return }
-        _ = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
-    }
-
-    /// Reschedule local notifications to match `reminders`. Only pending reminders
-    /// with a future fire time are scheduled; the soonest `maxScheduled` win.
-    static func sync(_ reminders: [Reminder]) async {
-        let center = UNUserNotificationCenter.current()
-        let settings = await center.notificationSettings()
-        guard settings.authorizationStatus == .authorized
-                || settings.authorizationStatus == .provisional else {
-            await clear()
-            return
-        }
-
         await clear()
-
-        let now = Date()
-        let upcoming = reminders
-            .filter { $0.status == "pending" }
-            .compactMap { r -> (Reminder, Date)? in
-                guard let iso = r.fireAt, let date = caveParseISO(iso), date > now else { return nil }
-                return (r, date)
-            }
-            .sorted { $0.1 < $1.1 }
-            .prefix(maxScheduled)
-
-        for (reminder, fireDate) in upcoming {
-            let content = UNMutableNotificationContent()
-            content.title = "Reminder"
-            content.body = reminder.title
-            content.sound = .default
-            if let url = deepLinkURL(for: reminder) {
-                content.userInfo = ["deepLink": url.absoluteString]
-            }
-            let comps = Calendar.current.dateComponents(
-                [.year, .month, .day, .hour, .minute, .second], from: fireDate)
-            let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: false)
-            let request = UNNotificationRequest(
-                identifier: idPrefix + reminder.id, content: content, trigger: trigger)
-            try? await center.add(request)
-        }
     }
 
-    /// Remove every notification we scheduled that is still pending.
+    /// Kept for legacy reminder mutations, but never schedules new alerts.
+    static func sync(_: [Reminder]) async {
+        await clear()
+    }
+
+    /// Clear only alerts issued by the retired reminder scheduler.
     static func clear() async {
         let center = UNUserNotificationCenter.current()
         let pending = await center.pendingNotificationRequests()
-        let ours = pending.map(\.identifier).filter { $0.hasPrefix(idPrefix) }
+        let ours = pending.map(\.identifier).filter { isRetiredRequest(identifier: $0) }
         center.removePendingNotificationRequests(withIdentifiers: ours)
+        let delivered = await center.deliveredNotifications()
+        let retired = delivered.map(\.request.identifier).filter { isRetiredRequest(identifier: $0) }
+        center.removeDeliveredNotifications(withIdentifiers: retired)
     }
 }
 
 /// Bridges notification taps (and foreground presentation) back to the app's
 /// deep-link router. Set as the notification-center delegate at launch.
 final class CaveNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+    override init() {
+        super.init()
+        Task { await ReminderNotifications.clear() }
+    }
+
     @MainActor private var pendingOpen: URL?
     @MainActor var onOpen: ((URL) -> Void)? {
         didSet {
@@ -119,15 +75,18 @@ final class CaveNotificationDelegate: NSObject, UNUserNotificationCenterDelegate
         onOpen(url)
     }
 
-    /// Show reminder banners even while the app is in the foreground.
+    /// A reminder already being delivered during migration stays silent.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        [.banner, .sound]
+        guard !ReminderNotifications.isRetiredRequest(identifier: notification.request.identifier) else {
+            return []
+        }
+        return [.banner, .sound]
     }
 
-    /// A tapped reminder re-enters the linked chat/task when one is known.
+    /// Taps use the shared router, which also rejects retired destinations.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -6,24 +6,16 @@ import UIKit
 #endif
 import WidgetKit
 
-/// The application destinations. Lifted out of the drawer shell so slash commands
-/// (`/board`, `/chats`) can drive selection from anywhere.
+/// Tasks remains decodable for legacy links, but is not a native destination.
 enum AppTab: String, CaseIterable, Sendable { case chats, tasks, settings }
 
 extension AppTab {
-    static let drawerDestinations: [AppTab] = [.chats, .tasks]
-    static let shortcutOrder: [AppTab] = [.chats, .tasks, .settings]
+    static let drawerDestinations: [AppTab] = [.chats, .settings]
+    static let shortcutOrder: [AppTab] = [.chats, .settings]
 
-    /// Project search returns to the active project-scoped destination when it
-    /// has one; settings falls back to Chats because it does not render
-    /// project-scoped content of its own.
+    /// Retained for legacy search callers; project navigation is rejected below.
     var projectSearchReturnDestination: AppTab {
-        switch self {
-        case .settings:
-            return .chats
-        case .chats, .tasks:
-            return self
-        }
+        .chats
     }
 }
 
@@ -1153,12 +1145,11 @@ final class AppModel {
         for intent: ProjectNavigationIntent
     ) -> Bool {
         switch surface {
-        case .projects:
-            return intent.projectId != nil || intent.entity != nil
+        case .projects, .tasks:
+            return false
         case .sessions:
-            return intent.threadId != nil
-        case .tasks:
-            return intent.taskId != nil
+            guard let id = intent.threadId else { return false }
+            return !threads.contains { $0.id == id }
         }
     }
 
@@ -1215,6 +1206,9 @@ final class AppModel {
             !projectRoot.isEmpty else {
             return .success(.unassigned)
         }
+        guard ProjectContext.openContext(for: projectRoot, in: []) != nil else {
+            return .failure(.invalidProjectMetadata)
+        }
         guard projectsLoaded || !projects.isEmpty else {
             return .failure(.projectCatalogUnavailable)
         }
@@ -1268,12 +1262,15 @@ final class AppModel {
     }
 
     func canOpen(_ thread: ChatThread) -> Bool {
-        validatedOpenContext(for: thread) != nil
+        threadOpenFailure(for: thread) == nil
     }
 
     func threadOpenFailure(for thread: ChatThread) -> ThreadOpenFailure? {
         switch requestOpenContext(for: thread) {
         case .success:
+            return nil
+        case .failure(.projectCatalogUnavailable):
+            // Cached history stays readable; dispatch has a separate access gate.
             return nil
         case .failure(let failure):
             return failure
@@ -1305,18 +1302,9 @@ final class AppModel {
     }
 
     private func hydrateProjectNavigationIfNeeded(for intent: ProjectNavigationIntent) {
+        guard intent.resolvedDestination != .tasks else { return }
         let generation = currentProjectNavigationConnectionGeneration()
         let canHydrateRemotely = isProjectNavigationConnectionKnownGood(generation: generation)
-
-        if canHydrateRemotely,
-           projectNavigationIntentNeedsHydration(.projects, for: intent),
-           !projectNavigationSurfaceAttemptedCurrentGeneration(.projects, generation: generation),
-           !projectNavigationSurfaceHydratingCurrentGeneration(.projects, generation: generation),
-           coreResourceClient != nil {
-            launchProjectNavigationHydration(.projects, generation: generation) { app in
-                await app.loadProjects()
-            }
-        }
 
         if canHydrateRemotely,
            projectNavigationIntentNeedsHydration(.sessions, for: intent),
@@ -1324,17 +1312,7 @@ final class AppModel {
            !projectNavigationSurfaceHydratingCurrentGeneration(.sessions, generation: generation),
            sessionLoadingClient != nil {
             launchProjectNavigationHydration(.sessions, generation: generation) { app in
-                await app.loadSessions()
-            }
-        }
-
-        if canHydrateRemotely,
-           projectNavigationIntentNeedsHydration(.tasks, for: intent),
-           !projectNavigationSurfaceAttemptedCurrentGeneration(.tasks, generation: generation),
-           !projectNavigationSurfaceHydratingCurrentGeneration(.tasks, generation: generation),
-           taskLoadingClient != nil {
-            launchProjectNavigationHydration(.tasks, generation: generation) { app in
-                await app.loadTasks()
+                await app.loadSessions(preservingSelection: true)
             }
         }
     }
@@ -1353,6 +1331,17 @@ final class AppModel {
         attemptHydrationIfNeeded: Bool = false
     ) -> Bool {
         guard let intent = pendingProjectNavigationIntent else { return false }
+        guard intent.resolvedDestination != .tasks else {
+            pendingProjectNavigationIntent = nil
+            cardToOpen = nil
+            showDesktopOnlyDestination()
+            return false
+        }
+        if intent.entity == nil, intent.projectId != nil {
+            pendingProjectNavigationIntent = nil
+            showDesktopOnlyDestination("Project navigation")
+            return false
+        }
         if attemptHydrationIfNeeded {
             hydrateProjectNavigationIfNeeded(for: intent)
         }
@@ -1406,28 +1395,14 @@ final class AppModel {
                 }
                 return threadsHydrated ? .failed(.threadUnavailable) : .pending
             }
-            if navigationGeneration != nil,
-               thread.projectRoot?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
-               projectNavigationSurfaceFailedCurrentGeneration(
-                .projects,
-                generation: navigationGeneration
-               ) {
-                return .failed(projectNavigationHydrationFailure(.projects, for: intent))
-            }
-            if navigationGeneration != nil,
-               thread.projectRoot?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
-               !projectNavigationSurfaceSucceededCurrentGeneration(
-                .projects,
-                generation: navigationGeneration
-               ) {
-                return .pending
-            }
             switch requestOpenContext(for: thread) {
             case .success(let context):
                 completeProjectNavigation(intent, context: context, thread: thread)
                 return .resolved
             case .failure(.projectCatalogUnavailable):
-                return .pending
+                // Reading a cached transcript is not send authorization.
+                completeProjectNavigation(intent, context: nil, thread: thread)
+                return .resolved
             case .failure(let failure):
                 return .failed(ProjectNavigationFailure(
                     toastText: failure.toastText,
@@ -1489,32 +1464,8 @@ final class AppModel {
             }
 
         case nil:
-            if navigationGeneration != nil,
-               projectNavigationSurfaceFailedCurrentGeneration(
-                .projects,
-                generation: navigationGeneration
-               ) {
-                return .failed(projectNavigationHydrationFailure(.projects, for: intent))
-            }
-            if navigationGeneration != nil,
-               !projectNavigationSurfaceSucceededCurrentGeneration(
-                .projects,
-                generation: navigationGeneration
-               ) {
-                return .pending
-            }
-            switch requestOpenContext(forProjectID: intent.projectId) {
-            case .success(let context):
-                completeProjectNavigation(intent, context: context)
-                return .resolved
-            case .failure(.projectCatalogUnavailable):
-                return .pending
-            case .failure(let failure):
-                return .failed(ProjectNavigationFailure(
-                    toastText: failure.toastText,
-                    systemImage: failure.systemImage
-                ))
-            }
+            completeProjectNavigation(intent, context: nil)
+            return .resolved
         }
     }
 
@@ -1524,19 +1475,12 @@ final class AppModel {
         thread: ChatThread? = nil,
         card: BoardCard? = nil
     ) {
-        let didSwitchProject = context.map { $0.id != projectContext?.id } ?? false
-        if let context, didSwitchProject {
-            switchProject(to: context)
-        }
         selectedTab = intent.resolvedDestination
         if let thread {
             threadToOpen = thread
         }
         if let card {
             cardToOpen = card
-        }
-        if didSwitchProject, let context {
-            announceProjectNavigationSwitch(to: context, for: intent)
         }
     }
 
@@ -1558,8 +1502,7 @@ final class AppModel {
 #endif
     }
 
-    /// Ask the chat list to open a thread, first aligning the canonical app
-    /// project context that owns it.
+    /// Open the bound object without changing the ambient legacy project filter.
     @discardableResult
     func requestOpen(_ thread: ChatThread) -> Bool {
         beginProjectNavigation(ProjectNavigationIntent(
@@ -1604,6 +1547,14 @@ final class AppModel {
             destination: destination,
             projectId: projectId
         ))
+    }
+
+    func showDesktopOnlyDestination(_ destination: String = "Tasks") {
+        showToast(
+            "\(destination) is desktop-only. Open Coven Cave on your desktop; iOS supports Chats and Settings.",
+            systemImage: "desktopcomputer",
+            style: .warning
+        )
     }
 
     @discardableResult
@@ -1671,6 +1622,50 @@ final class AppModel {
     var projectMembershipLoaded = false
     @ObservationIgnored private var projectContextSelectionSource: ProjectContextSelectionSource?
 
+    var chatAccessIsCurrent: Bool {
+        projectsLoaded && projectMembershipLoaded && projectContextError == nil
+    }
+
+    func chatAccessIsCurrent(projectRoot: String?, familiarIds: [String]) -> Bool {
+        let targets = Set(familiarIds)
+        guard chatAccessIsCurrent,
+              let projectRoot,
+              projectRoot == projectRoot.trimmingCharacters(in: .whitespacesAndNewlines),
+              !targets.isEmpty,
+              targets.allSatisfy({ !$0.isEmpty && $0 == $0.trimmingCharacters(in: .whitespacesAndNewlines) }),
+              case .project(let project)? = ProjectContext.openContext(for: projectRoot, in: projects),
+              project.root == projectRoot
+        else { return false }
+        return targets.allSatisfy { projectMembership.contains($0, in: project) }
+    }
+
+    @discardableResult
+    func requireCurrentChatAccess() -> Bool {
+        guard chatAccessIsCurrent else {
+            showToast(
+                "Chat access is unavailable. Refresh Chats to verify project access, then try again.",
+                systemImage: "arrow.clockwise",
+                style: .warning
+            )
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
+    func requireCurrentChatAccess(projectRoot: String?, familiarIds: [String]) -> Bool {
+        guard requireCurrentChatAccess() else { return false }
+        guard chatAccessIsCurrent(projectRoot: projectRoot, familiarIds: familiarIds) else {
+            showToast(
+                "This chat's project access could not be verified for every participant. Refresh access or open New chat to choose a project.",
+                systemImage: "lock.shield",
+                style: .warning
+            )
+            return false
+        }
+        return true
+    }
+
     var activeProject: ProjectInfo? {
         guard case .project(let selected)? = projectContext else { return nil }
         return projects.first { $0.id == selected.id } ?? selected
@@ -1681,7 +1676,8 @@ final class AppModel {
     }
 
     var canStartProjectChats: Bool {
-        activeProjectRoot != nil
+        // Presentation is always available; New Chat verifies its own access.
+        true
     }
 
     func projectContext(for thread: ChatThread) -> ProjectContext {
@@ -2162,6 +2158,7 @@ final class AppModel {
     /// familiarId → when its chats were last viewed. A familiar reads as
     /// "unread" when its latest activity is newer than this. Persisted.
     var familiarViews: [String: Date] = [:]
+    var threadViews: [String: Date] = [:]
 
     private func familiarViewKey(for familiarId: String, in context: ProjectContext?) -> String {
         guard let context else { return familiarId }
@@ -3904,19 +3901,6 @@ final class AppModel {
         }
     }
 
-    private func shouldFetchTaskHistoryForProjectContextSelection(
-        _ decision: ProjectContext.SelectionDecision,
-        hasUsableTasks: Bool
-    ) -> Bool {
-        guard !hasUsableTasks else { return false }
-        switch decision.reason {
-        case .suppliedSelection, .localThread, .serverSession, .taskHistory:
-            return false
-        case .alphabeticalFallback, .unassignedFallback, .none:
-            return true
-        }
-    }
-
     private func needsAuthoritativeSessionHistoryForProjectContextSelection(
         explicitSelection: (context: ProjectContext?, source: ProjectContextSelectionSource?),
         projects: [ProjectInfo]
@@ -3946,7 +3930,7 @@ final class AppModel {
         let haveUsableSessions = sessionsLoaded && sessionsError == nil
         let haveUsableTasks = tasksLoaded && tasksError == nil
         var resolvedSessions = haveUsableSessions ? serverSessions : []
-        var resolvedTasks = haveUsableTasks ? tasks : []
+        let resolvedTasks = haveUsableTasks ? tasks : []
         var explicitSelection = explicitProjectContextSelectionCandidate(in: nextProjects)
         let needsAuthoritativeSessionHistory = !haveUsableSessions
             && needsAuthoritativeSessionHistoryForProjectContextSelection(
@@ -3981,9 +3965,7 @@ final class AppModel {
             )
         }
 
-        // Cold/default selection is intentionally staged: local threads first,
-        // then eligible server sessions, then task history only if sessions
-        // succeeded without identifying a registered project.
+        // Legacy default selection may consult chat history, never task APIs.
         var fetchedSessions: [SessionRow]?
         var sessionsError: String?
         var sessionsLoadToken: CoordinatedLoadToken?
@@ -4030,39 +4012,6 @@ final class AppModel {
             )
         }
 
-        let postSessionDecision = resolvedProjectContextSelectionDecision(
-            explicitSelection: explicitSelection,
-            projects: nextProjects,
-            threads: postSessionThreads,
-            sessions: resolvedSessions,
-            tasks: [],
-            allowAlphabeticalFallback: false
-        )
-
-        var fetchedTasks: [BoardCard]?
-        var tasksError: String?
-        var tasksLoadToken: CoordinatedLoadToken?
-        if shouldFetchTaskHistoryForProjectContextSelection(
-            postSessionDecision,
-            hasUsableTasks: haveUsableTasks
-        ) {
-            let loadedTasks = await coordinatedTasksLoad(
-                using: client,
-                generation: navigationGeneration,
-                scope: .projectContext
-            )
-            guard !Task.isCancelled, loadNonce == projectContextLoadNonce else {
-                throw CancellationError()
-            }
-            tasksLoadToken = loadedTasks.token
-            switch loadedTasks.result {
-            case .success(let nextTasks):
-                resolvedTasks = nextTasks
-                fetchedTasks = nextTasks
-            case .failure(let error):
-                tasksError = handleSurfaceError(error)
-            }
-        }
         guard !Task.isCancelled, loadNonce == projectContextLoadNonce else {
             throw CancellationError()
         }
@@ -4079,10 +4028,7 @@ final class AppModel {
             sessions: resolvedSessions,
             tasks: resolvedTasks,
             fetchedSessions: fetchedSessions,
-            fetchedTasks: fetchedTasks,
-            tasksError: tasksError,
-            sessionsLoadToken: sessionsLoadToken,
-            tasksLoadToken: tasksLoadToken
+            sessionsLoadToken: sessionsLoadToken
         )
     }
 
@@ -4141,6 +4087,11 @@ final class AppModel {
         await loadProjectContext(using: client)
     }
 
+    func refreshChatAccess() async {
+        guard let client = coreResourceClient else { return }
+        await loadProjectContext(using: client, preservingSelection: true)
+    }
+
     func loadProjects() async {
         guard let client = coreResourceClient else { return }
         await loadProjectContext(using: client, mirrorFailuresTo: [.projects])
@@ -4148,13 +4099,15 @@ final class AppModel {
 
     func loadProjectContext(
         using client: any ProjectContextLoadingClient,
-        mirrorFailuresTo mirroredSurfaces: ProjectContextFailureSurfaces = []
+        mirrorFailuresTo mirroredSurfaces: ProjectContextFailureSurfaces = [],
+        preservingSelection: Bool = false
     ) async {
         let navigationGeneration = currentProjectNavigationConnectionGeneration()
         noteProjectNavigationSurfaceAttempt(.projects, generation: navigationGeneration)
         projectContextLoadNonce &+= 1
         let loadNonce = projectContextLoadNonce
-        let hadMembership = projectMembershipLoaded
+        let hadMembership = projectMembershipLoaded || projectsLoaded
+        projectMembershipLoaded = false
 
         do {
             async let loadedProjects = client.projects()
@@ -4245,7 +4198,8 @@ final class AppModel {
                 state: tasksLoadState
             )
 
-            if selectionResolution.usedHistoryFallback
+            if !preservingSelection,
+                selectionResolution.usedHistoryFallback
                 && canUseSessionsFallbackSelection
                 && canUseTasksFallbackSelection {
                 applyProjectContextSelection(
@@ -4255,7 +4209,7 @@ final class AppModel {
                 if selectionResolution.persistSelection {
                     persistProjectContextSelection(selectionResolution.context)
                 }
-            } else {
+            } else if !preservingSelection {
                 refreshProjectContextSelectionFromCurrentData()
             }
             projectContextError = nil
@@ -4266,13 +4220,14 @@ final class AppModel {
             let message = handleSurfaceError(error)
             noteProjectNavigationSurfaceFailure(.projects, generation: navigationGeneration)
             projectContextError = message
+            projectMembershipLoaded = false
             if mirroredSurfaces.contains(.projects) {
                 projectsError = message
             }
             if mirroredSurfaces.contains(.familiars) {
                 familiarsError = message
             }
-            if !hadMembership {
+            if !hadMembership && !preservingSelection {
                 applyProjectContextSelection(nil, source: nil)
                 if projects.isEmpty { projectsError = message }
                 if familiars.isEmpty { familiarsError = message }
@@ -4909,9 +4864,10 @@ final class AppModel {
     /// Rollback persistence deliberately uses `flushThreadsAndWait()` directly
     /// instead, because it must still land after this lease is revoked.
     func persistThreadsBeforeDispatch(for lease: ConnectionDispatchLease) async -> Bool {
-        guard connectionDispatchLeaseIsCurrent(lease) else { return false }
+        guard connectionDispatchLeaseIsCurrent(lease),
+              requireCurrentChatAccess() else { return false }
         let persisted = await flushThreadsAndWait()
-        return persisted && connectionDispatchLeaseIsCurrent(lease)
+        return persisted && connectionDispatchLeaseIsCurrent(lease) && requireCurrentChatAccess()
     }
 
     private func refreshLeaseIsCurrent(
@@ -5036,12 +4992,11 @@ final class AppModel {
         await refreshConnection(reloadLoadedSurfaces: true, quiet: true)
     }
 
-    /// Any surface has completed a load — real data or an intentional empty
-    /// state — so the primary shell is worth keeping mounted through a
-    /// connection drop (RootView shows the reconnect pill over it instead of
-    /// tearing down to the Connect screen).
+    /// Restored conversations are readable without a live catalog. This is
+    /// shell readiness only; chatAccessIsCurrent separately gates dispatch.
     var hasLoadedSurfaces: Bool {
-        familiarsLoaded || sessionsLoaded || tasksLoaded || remindersLoaded || projectsLoaded
+        !chatThreads.isEmpty || !chatServerSessions.isEmpty
+            || familiarsLoaded || sessionsLoaded || projectsLoaded
     }
 
     private var shouldReloadLoadedSurfaces: Bool { hasLoadedSurfaces }
@@ -5055,14 +5010,6 @@ final class AppModel {
         }
         return surfaces
     }
-    /// A first shell mount waits for a successfully loaded membership snapshot
-    /// plus either a concrete selection or the intentional "no projects yet"
-    /// empty state (`projectsLoaded && projects.isEmpty`).
-    private var isProjectContextReadyForShellGate: Bool {
-        guard projectMembershipLoaded else { return false }
-        return projectContext != nil || (projectsLoaded && projects.isEmpty)
-    }
-
     private func pairingMessage() -> String {
         CaveConnection.accessToken == nil
             ? "This desktop requires pairing. Open Cave on the desktop → “Open on phone”, then scan the QR code or paste the invite link here."
@@ -5173,8 +5120,6 @@ final class AppModel {
                 )
             }
             if sessionsLoaded { group.addTask { await self.loadSessions() } }
-            if tasksLoaded { group.addTask { await self.loadTasks() } }
-            if remindersLoaded { group.addTask { await self.loadReminders() } }
         }
     }
 
@@ -5281,8 +5226,8 @@ final class AppModel {
             markProjectNavigationConnectionKnownGood(
                 generation: currentProjectNavigationConnectionGeneration()
             )
-            let shouldGateShell = !hasLoadedSurfaces
-            if shouldGateShell {
+            let shouldLoadCoreBeforeDispatch = !chatAccessIsCurrent
+            if shouldLoadCoreBeforeDispatch {
                 if refresh.surfaceReloadRequested {
                     await refreshLoadedSurfaces(
                         configurationGeneration: configurationGeneration
@@ -5297,12 +5242,6 @@ final class AppModel {
                     configurationGeneration: configurationGeneration
                 ) else { return }
                 if case .needsAuth = connectionState {
-                    return
-                }
-                guard isProjectContextReadyForShellGate else {
-                    if projectContextError != nil {
-                        connectionState = .projectContextRequired
-                    }
                     return
                 }
             }
@@ -5322,7 +5261,7 @@ final class AppModel {
                 configurationGeneration: configurationGeneration
             ) else { return }
             flushQueuedMessages()
-            if !shouldGateShell {
+            if !shouldLoadCoreBeforeDispatch {
                 guard refreshLeaseIsCurrent(
                     supervisorGeneration,
                     configurationGeneration: configurationGeneration
@@ -5372,6 +5311,7 @@ final class AppModel {
         guard let client, !flushingQueued else { return }
         let pending = threads.filter { thread in thread.messages.contains { $0.isQueued } }
         guard !pending.isEmpty else { return }
+        guard requireCurrentChatAccess() else { return }
         let configurationGeneration = connectionConfigurationGeneration
         let dispatchLease = captureConnectionDispatchLease()
         let flushID = UUID()
@@ -5389,8 +5329,10 @@ final class AppModel {
             for thread in pending {
                 guard self.queuedMessageFlushID == flushID,
                       self.connectionConfigurationLeaseIsCurrent(configurationGeneration),
-                      self.connectionDispatchLeaseIsCurrent(dispatchLease)
+                      self.connectionDispatchLeaseIsCurrent(dispatchLease),
+                      self.requireCurrentChatAccess()
                 else { return }
+                let binding = ChatDispatchBinding(thread: thread)
                 await thread.replayQueued(
                     client: client,
                     onConnectionFailure: { [weak self] error in
@@ -5405,6 +5347,23 @@ final class AppModel {
                         guard let self else { return false }
                         return self.queuedMessageFlushID == flushID
                             && self.connectionDispatchLeaseIsCurrent(dispatchLease)
+                            && binding.matches(thread)
+                            && self.chatAccessIsCurrent
+                    },
+                    targetAccessIsCurrent: { [weak self] projectRoot, familiarId in
+                        self?.chatAccessIsCurrent(
+                            projectRoot: projectRoot,
+                            familiarIds: [familiarId]
+                        ) ?? false
+                    },
+                    onAccessRefused: { [weak self] familiarId in
+                        self?.showToast(
+                            familiarId == nil
+                                ? "Queued messages kept: their original chat could not be verified. Copy the message into a new chat to choose a different project or conversation."
+                                : "Queued chat access could not be verified. Refresh access before retrying; the original recipients have been kept.",
+                            systemImage: "lock.shield",
+                            style: .warning
+                        )
                     },
                     persistBeforeDispatch: { [weak self] in
                         // Stable queued run identity must reach the atomic
@@ -5413,13 +5372,17 @@ final class AppModel {
                         guard let self,
                               self.queuedMessageFlushID == flushID,
                               self.connectionConfigurationLeaseIsCurrent(configurationGeneration),
-                              self.connectionDispatchLeaseIsCurrent(dispatchLease)
+                              self.connectionDispatchLeaseIsCurrent(dispatchLease),
+                              self.requireCurrentChatAccess(),
+                              binding.matches(thread)
                         else { return false }
                         let persisted = await self.flushThreadsAndWait()
                         return persisted
                             && self.queuedMessageFlushID == flushID
                             && self.connectionConfigurationLeaseIsCurrent(configurationGeneration)
                             && self.connectionDispatchLeaseIsCurrent(dispatchLease)
+                            && self.requireCurrentChatAccess()
+                            && binding.matches(thread)
                     },
                     persistAfterRollback: { [weak self] in
                         // Deliberately endpoint-unfenced: replay has already
@@ -5708,16 +5671,29 @@ final class AppModel {
         return activity > seen
     }
 
-    /// Earliest "last viewed" date across a thread's familiars — the boundary
-    /// the "New Messages" divider is placed against. nil when untracked.
+    /// A conversation's read acknowledgement, with the old familiar-wide
+    /// boundary retained only for history that predates per-chat tracking.
     func seenBoundary(for thread: ChatThread) -> Date? {
+        if let seen = threadViews[thread.id]
+            ?? (projectContextDefaults.object(forKey: Self.threadViewKey(thread.id)) as? Date) {
+            return seen
+        }
         let context = projectContext(for: thread)
         return thread.familiarIds.compactMap {
             familiarViewDate(for: $0, in: context)
         }.min()
     }
 
-    /// Mark a familiar's chats as read (call when opening them).
+    static func threadViewKey(_ threadId: String) -> String { "cave.chat.viewed.\(threadId)" }
+
+    func markThreadViewed(_ thread: ChatThread, through activityAt: Date? = nil) {
+        let seen = max(Date(), max(thread.updatedAt, activityAt ?? thread.updatedAt))
+        threadViews[thread.id] = seen
+        projectContextDefaults.set(seen, forKey: Self.threadViewKey(thread.id))
+    }
+
+    /// Legacy familiar-wide acknowledgement. Conversation surfaces use
+    /// `markThreadViewed` so opening one chat cannot clear a sibling's unread state.
     func markFamiliarViewed(_ ids: [String]) {
         markFamiliarViewed(ids, in: projectContext)
     }
@@ -5779,12 +5755,15 @@ final class AppModel {
     var sessionsError: String?
     var sessionsLoaded = false
 
-    func loadSessions() async {
+    func loadSessions(preservingSelection: Bool = false) async {
         guard let client = sessionLoadingClient else { return }
-        await loadSessions(using: client)
+        await loadSessions(using: client, preservingSelection: preservingSelection)
     }
 
-    func loadSessions(using client: any ProjectContextLoadingClient) async {
+    func loadSessions(
+        using client: any ProjectContextLoadingClient,
+        preservingSelection: Bool = false
+    ) async {
         let navigationGeneration = currentProjectNavigationConnectionGeneration()
         noteProjectNavigationSurfaceAttempt(.sessions, generation: navigationGeneration)
         let load = await coordinatedSessionsLoad(
@@ -5797,7 +5776,7 @@ final class AppModel {
 
         switch load.result {
         case .success(let sessions):
-            applyLoadedSessions(sessions)
+            applyLoadedSessions(sessions, refreshProjectContextSelection: !preservingSelection)
             noteProjectNavigationSurfaceSuccess(.sessions, generation: navigationGeneration)
             _ = resolvePendingProjectNavigationIntent(attemptHydrationIfNeeded: true)
         case .failure(let error):
@@ -6232,23 +6211,17 @@ final class AppModel {
         familiarId: String,
         loadHistory shouldLoadHistory: Bool = true
     ) -> ChatThread {
-        let changed = backfillThreadProjectRoots(from: [row])
+        _ = backfillThreadProjectRoots(from: [row])
         if let existing = threads.first(where: { $0.sessionIds.values.contains(row.id) }) {
             if row.isFlowRun && existing.flowSessionIds.insert(row.id).inserted {
                 persistThreads()
             }
-            let repair = repairThreadSessionBinding(
+            _ = repairThreadSessionBinding(
                 existing,
                 with: row,
                 fallbackFamiliarID: familiarId
             )
-            if changed || repair.changed {
-                refreshProjectContextSelectionFromCurrentData()
-            }
             return existing
-        }
-        if changed {
-            refreshProjectContextSelectionFromCurrentData()
         }
         let resolvedFamiliarID = authoritativeFamiliarID(from: row, fallback: familiarId) ?? familiarId
         let title = row.title.isEmpty
@@ -6882,7 +6855,16 @@ final class AppModel {
         switch context {
         case .project(let project):
             let allowed = projectMembership.familiarIDs(forProjectID: project.id)
-            guard allowed.contains(familiarId) else { return nil }
+            guard projectMembershipLoaded, projectContextError == nil,
+                  projects.contains(where: { $0.id == project.id && $0.root == project.root }),
+                  allowed.contains(familiarId) else {
+                showToast(
+                    "Could not verify this chat's project access. Refresh access in New chat and try again.",
+                    systemImage: "folder.badge.questionmark",
+                    style: .warning
+                )
+                return nil
+            }
             let name = familiar(familiarId)?.displayName ?? familiarId
             let thread = ChatThread(
                 title: name,
@@ -6980,9 +6962,7 @@ final class AppModel {
         )
     }
 
-    /// Global familiar opens prefer the latest local landing chat across all
-    /// contexts, then any unmaterialized server session, and only then a fresh
-    /// active-project chat when that familiar is available there.
+    /// Global familiar opens reuse history; fresh chats require local configuration.
     @discardableResult
     func requestOpenGlobalFamiliarLandingThread(for familiarId: String) -> Bool {
         if let existing = globalLandingDirectThread(for: familiarId) {
@@ -6994,24 +6974,38 @@ final class AppModel {
             return requestOpen(thread)
         }
 
-        guard let activeProject,
-              projectMembershipLoaded,
-              projectMembership.contains(familiarId, in: activeProject),
-              let fresh = directThread(for: familiarId, in: .project(activeProject))
-        else {
-            reportGlobalFamiliarOpenFailure(for: familiarId)
-            return false
-        }
-
-        return requestOpen(fresh)
+        showToast(
+            "Open New chat to choose this familiar and its project access.",
+            systemImage: "bubble.left.and.bubble.right",
+            style: .warning
+        )
+        return false
     }
 
     func startFreshThreadInActiveProject(
         familiarIds: [String],
         title: String? = nil
     ) -> ChatThread? {
-        guard let activeProject, let activeProjectRoot else { return nil }
-        guard projectMembershipLoaded else {
+        startFreshThread(in: projectContext, familiarIds: familiarIds, title: title)
+    }
+
+    func startFreshThread(
+        in context: ProjectContext?,
+        familiarIds: [String],
+        title: String? = nil
+    ) -> ChatThread? {
+        guard case .project(let boundProject)? = context,
+              let boundProject = projects.first(where: {
+                  $0.id == boundProject.id && $0.root == boundProject.root
+              }) else {
+            showToast(
+                "Choose a registered project in New chat to start a replacement chat.",
+                systemImage: "folder.badge.questionmark",
+                style: .warning
+            )
+            return nil
+        }
+        guard projectMembershipLoaded, projectContextError == nil else {
             showToast(
                 "Refresh Chats to load project access, then try again.",
                 systemImage: "arrow.clockwise",
@@ -7019,8 +7013,12 @@ final class AppModel {
             )
             return nil
         }
+        guard !familiarIds.isEmpty else {
+            showToast("Choose a familiar in New chat.", style: .warning)
+            return nil
+        }
         let invalidFamiliarIDs = familiarIds.filter {
-            !projectMembership.contains($0, in: activeProject)
+            !projectMembership.contains($0, in: boundProject)
         }
         guard invalidFamiliarIDs.isEmpty else {
             let invalidNames = invalidFamiliarIDs.map {
@@ -7030,7 +7028,7 @@ final class AppModel {
                 ? invalidNames[0]
                 : "Some participants"
             showToast(
-                "\(subject) can’t access \(activeProject.name). Open New Chat to choose a valid roster or switch projects, then try again.",
+                "\(subject) can’t access \(boundProject.name). Open New chat to choose a project and valid roster, then try again.",
                 systemImage: "person.crop.circle.badge.exclamationmark",
                 style: .warning
             )
@@ -7039,7 +7037,7 @@ final class AppModel {
         return startFreshThread(
             familiarIds: familiarIds,
             title: title,
-            projectRoot: activeProjectRoot
+            projectRoot: boundProject.root
         )
     }
 

--- a/apps/ios/CovenCave/CovenCave/State/ChatListSnapshot.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatListSnapshot.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Disposable list organization, never a source of send authority. It reads no
+/// transcript text, so streamed tokens do not re-sort the entire home.
+@MainActor
+struct ChatListSnapshot {
+    struct Entry: Identifiable {
+        enum Conversation {
+            case local(ChatThread)
+            case server(SessionRow)
+        }
+
+        let id: String
+        let conversation: Conversation
+        let updatedAt: Date
+        let pinned: Bool
+        let archived: Bool
+        let searchText: String
+    }
+
+    private struct SessionIdentity: Hashable {
+        let familiarId: String
+        let sessionId: String
+    }
+
+    let entries: [Entry]
+    let archivedCount: Int
+
+    init(
+        threads: [ChatThread],
+        sessions: [SessionRow],
+        familiars: [Familiar],
+        query: String = "",
+        includeArchived: Bool = false
+    ) {
+        var names: [String: String] = [:]
+        for familiar in familiars {
+            names[familiar.id] = familiar.displayName
+        }
+        var serverMetadata: [SessionIdentity: (title: String, activity: Date)] = [:]
+        for session in sessions where !session.isGeneratedRun {
+            if let familiarId = session.familiarId {
+                serverMetadata[SessionIdentity(familiarId: familiarId, sessionId: session.id)] = (
+                    session.title,
+                    caveParseISO(session.updatedAt) ?? caveParseISO(session.createdAt) ?? .distantPast
+                )
+            }
+        }
+        var represented = Set<SessionIdentity>()
+        var all: [Entry] = []
+        all.reserveCapacity(threads.count + sessions.count)
+        for thread in threads where !thread.isFlowRun {
+            var titles = [thread.title]
+            var activity = thread.updatedAt
+            for (familiarId, sessionId) in thread.sessionIds
+            where thread.familiarIds.contains(familiarId) {
+                let identity = SessionIdentity(familiarId: familiarId, sessionId: sessionId)
+                represented.insert(identity)
+                if let metadata = serverMetadata[identity] {
+                    titles.append(metadata.title)
+                    activity = max(activity, metadata.activity)
+                }
+            }
+            all.append(Entry(
+                id: "local:\(thread.id)",
+                conversation: .local(thread),
+                updatedAt: activity,
+                pinned: thread.pinned,
+                archived: thread.archived,
+                searchText: (titles + thread.familiarIds.compactMap { names[$0] })
+                    .joined(separator: " ").lowercased()
+            ))
+        }
+        for session in sessions where !session.isGeneratedRun {
+            if let familiarId = session.familiarId,
+               represented.contains(SessionIdentity(familiarId: familiarId, sessionId: session.id)) {
+                continue
+            }
+            all.append(Entry(
+                id: "server:\(session.id)",
+                conversation: .server(session),
+                updatedAt: caveParseISO(session.updatedAt) ?? caveParseISO(session.createdAt) ?? .distantPast,
+                pinned: session.pinned == true,
+                archived: session.archivedAt != nil,
+                searchText: [session.title, session.familiarId.flatMap { names[$0] } ?? ""]
+                    .joined(separator: " ").lowercased()
+            ))
+        }
+        archivedCount = all.lazy.filter(\.archived).count
+        let search = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        entries = all.filter {
+            (includeArchived || !$0.archived) && (search.isEmpty || $0.searchText.contains(search))
+        }.sorted {
+            if $0.pinned != $1.pinned { return $0.pinned }
+            if $0.updatedAt != $1.updatedAt { return $0.updatedAt > $1.updatedAt }
+            return $0.id < $1.id
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -4,6 +4,13 @@ import Observation
 /// A message as shown in the thread UI. For group threads, assistant messages
 /// carry the `familiarId` that produced them so we can attribute + colour them.
 struct DisplayMessage: Identifiable, Codable, Hashable {
+    /// An absent context is legacy; a captured nil root is unknown provenance
+    /// and must not inherit a project recovered later from server metadata.
+    struct QueuedContext: Codable, Hashable {
+        let projectRoot: String?
+        let sessionIds: [String: String]
+    }
+
     /// `system` carries inline slash-command output (help, `/daemon`,
     /// results) — rendered as a centred note, never sent to a familiar.
     enum Role: String, Codable { case user, assistant, system }
@@ -55,6 +62,7 @@ struct DisplayMessage: Identifiable, Codable, Hashable {
     /// live thread membership would skip an original target or send to a new
     /// one the user never selected. Optional for pre-migration snapshots.
     var queuedTargetFamiliarIds: [String]?
+    var queuedContext: QueuedContext?
     /// Per-send response controls. Optional so snapshots written before the
     /// controls shipped remain decodable and replay with current defaults.
     var reasoningEffort: ChatThinkingEffort?
@@ -324,7 +332,18 @@ final class ChatThread: Identifiable, Hashable {
         self.familiarIds = familiarIds
         self.sessionIds = sessionIds
         self.projectRoot = projectRoot
-        self.messages = messages
+        self.messages = messages.map { message in
+            guard message.isQueued else { return message }
+            var migrated = message
+            if migrated.queuedContext == nil {
+                migrated.queuedContext = .init(projectRoot: projectRoot, sessionIds: sessionIds)
+            }
+            if migrated.queuedTargetFamiliarIds == nil {
+                migrated.queuedTargetFamiliarIds = message.queuedRunIdsByFamiliarId
+                    .map { Array($0.keys).sorted() } ?? familiarIds
+            }
+            return migrated
+        }
         self.pendingModelOverride = pendingModelOverride
         self.updatedAt = Date()
         rebuildTranscript()  // didSet doesn't fire during init
@@ -390,6 +409,7 @@ final class ChatThread: Identifiable, Hashable {
             queuedRunIdsByFamiliarId: deliveryRunIds,
             queuedAttemptedFamiliarIds: familiarIds,
             queuedTargetFamiliarIds: familiarIds,
+            queuedContext: .init(projectRoot: projectRoot, sessionIds: sessionIds),
             reasoningEffort: reasoningEffort, responseSpeed: responseSpeed,
             modelControls: modelControls.isEmpty ? nil : modelControls,
             modelOverride: modelOverride,
@@ -496,6 +516,7 @@ final class ChatThread: Identifiable, Hashable {
             role: .user, familiarId: nil, text: trimmed,
             attachmentDataUrls: attachments.map(\.dataUrl),
             queuedTargetFamiliarIds: familiarIds,
+            queuedContext: .init(projectRoot: projectRoot, sessionIds: sessionIds),
             reasoningEffort: reasoningEffort, responseSpeed: responseSpeed,
             modelControls: modelControls.isEmpty ? nil : modelControls,
             modelOverride: modelOverride,
@@ -516,6 +537,8 @@ final class ChatThread: Identifiable, Hashable {
     func replayQueued(client: CaveClient,
                       onConnectionFailure: ((Error) -> Void)? = nil,
                       dispatchLeaseIsCurrent: @escaping () -> Bool,
+                      targetAccessIsCurrent: @escaping (String?, String) -> Bool,
+                      onAccessRefused: @escaping (String?) -> Void,
                       persistBeforeDispatch: @escaping () async -> Bool,
                       persistAfterRollback: @escaping () async -> Bool,
                       onChange: @escaping () -> Void) async {
@@ -527,7 +550,13 @@ final class ChatThread: Identifiable, Hashable {
             let targets = queuedMessage.queuedTargetFamiliarIds
                 ?? queuedMessage.queuedRunIdsByFamiliarId.map { Array($0.keys).sorted() }
                 ?? familiarIds
-            guard requireSendProvenance(to: targets) else { return }
+            guard !targets.isEmpty,
+                  let queuedContext = queuedMessage.queuedContext,
+                  let queuedProjectRoot = queuedContext.projectRoot,
+                  queuedProjectRoot == projectRoot else {
+                onAccessRefused(nil)
+                return
+            }
             let queuedId = queuedMessage.id
             let prompt = queuedMessage.sendPrompt ?? queuedMessage.text
             let attachments = Self.attachments(fromDataUrls: queuedMessage.attachmentDataUrls)
@@ -536,7 +565,29 @@ final class ChatThread: Identifiable, Hashable {
             let modelControls = queuedMessage.modelControls ?? [:]
             var completed = Set(queuedMessage.queuedCompletedFamiliarIds ?? [])
             for familiarId in targets where !completed.contains(familiarId) {
-                guard !Task.isCancelled else { return }
+                guard !Task.isCancelled, dispatchLeaseIsCurrent() else { return }
+                let queuedSessionId = queuedContext.sessionIds[familiarId] ?? sessionIds[familiarId]
+                var targetWasRefused = false
+                let mayDispatchTarget: () -> Bool = {
+                    guard dispatchLeaseIsCurrent() else { return false }
+                    guard self.projectRoot == queuedProjectRoot,
+                          self.sessionIds[familiarId] == queuedSessionId else {
+                        targetWasRefused = true
+                        onAccessRefused(nil)
+                        return false
+                    }
+                    guard targetAccessIsCurrent(queuedProjectRoot, familiarId) else {
+                        targetWasRefused = true
+                        onAccessRefused(familiarId)
+                        return false
+                    }
+                    return true
+                }
+                guard mayDispatchTarget() else { continue }
+                guard requireSendProvenance(to: [familiarId]) else {
+                    onAccessRefused(familiarId)
+                    continue
+                }
                 // A sibling from the original concurrent fan-out can still be
                 // streaming when another leg proves offline and queues their
                 // shared user bubble. Never start a second request for it.
@@ -702,7 +753,7 @@ final class ChatThread: Identifiable, Hashable {
                 // Cancellation after the checkpoint but before `stream` begins
                 // proves this leg never left the phone. Roll its boundary back so
                 // an endpoint re-pair can safely deliver it to the replacement.
-                guard !Task.isCancelled, dispatchLeaseIsCurrent() else {
+                guard !Task.isCancelled, dispatchLeaseIsCurrent(), mayDispatchTarget() else {
                     mutate(queuedId) {
                         var attemptedIds = Set($0.queuedAttemptedFamiliarIds ?? [])
                         attemptedIds.remove(familiarId)
@@ -726,6 +777,7 @@ final class ChatThread: Identifiable, Hashable {
                     // the superseded endpoint/flush id.
                     _ = await persistAfterRollback()
                     onChange()
+                    if !Task.isCancelled, dispatchLeaseIsCurrent() { continue }
                     return
                 }
 
@@ -741,12 +793,17 @@ final class ChatThread: Identifiable, Hashable {
                     modelOverride: queuedMessage.modelOverride,
                     modelOverrideScope: queuedMessage.modelOverrideScope ?? (queuedMessage.modelOverride == nil ? nil : .session),
                     runId: runId,
-                    liveDispatchLeaseIsCurrent: dispatchLeaseIsCurrent,
+                    liveDispatchLeaseIsCurrent: mayDispatchTarget,
                     persistAfterProvablyUnsentRollback: persistAfterRollback,
                     client: client,
                     onChange: onChange,
                     onConnectionFailure: onConnectionFailure
                 )
+                // A pre-POST target refusal must not hold back permitted siblings.
+                if streamOutcome == .queued, targetWasRefused,
+                   !Task.isCancelled, dispatchLeaseIsCurrent() {
+                    continue
+                }
                 // A provably-unsent reconnect failure removes its placeholder
                 // and leaves the durable queue bit set. Stop without spinning;
                 // the next supervisor success resumes this familiar only.
@@ -760,6 +817,7 @@ final class ChatThread: Identifiable, Hashable {
                 updatedAt = Date()
                 onChange()
             }
+            guard targets.allSatisfy({ completed.contains($0) }) else { return }
             mutate(queuedId) {
                 $0.queued = false
                 $0.queuedDispatchInFlight = nil
@@ -767,6 +825,7 @@ final class ChatThread: Identifiable, Hashable {
                 $0.queuedRunIdsByFamiliarId = nil
                 $0.queuedAttemptedFamiliarIds = nil
                 $0.queuedTargetFamiliarIds = nil
+                $0.queuedContext = nil
             }
             updatedAt = Date()
             onChange()
@@ -1391,12 +1450,17 @@ final class ChatThread: Identifiable, Hashable {
     /// reply on screen stayed. Nil is the honest state: the server has never
     /// named THIS reply to us, so a delete goes through the transcript matcher
     /// like any other unnamed message.
+    @discardableResult
     func retry(_ messageId: String, client: CaveClient,
+               liveDispatchLeaseIsCurrent: @escaping () -> Bool,
+               persistAfterRefusal: @escaping () async -> Bool,
+               onRefusal: @escaping () -> Void,
                onConnectionFailure: ((Error) -> Void)? = nil,
-               onChange: @escaping () -> Void) {
+               onChange: @escaping () -> Void) -> Task<Void, Never>? {
         guard let idx = messages.firstIndex(where: { $0.id == messageId }),
               messages[idx].role == .assistant,
-              let familiarId = messages[idx].familiarId else { return }
+              !messages[idx].streaming,
+              let familiarId = messages[idx].familiarId else { return nil }
         let source = messages[..<idx].last(where: { $0.role == .user })
         let prompt = source?.sendPrompt ?? source?.text ?? ""
         let retryModel = source?.retryModel(for: familiarId)
@@ -1404,23 +1468,56 @@ final class ChatThread: Identifiable, Hashable {
             retryModel: retryModel,
             originalScope: source?.modelOverrideScope
         )
-        guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        guard requireSendProvenance(to: [familiarId]) else { return }
+        guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        guard requireSendProvenance(to: [familiarId]) else { return nil }
+        let binding = ChatDispatchBinding(thread: self, familiarIds: [familiarId])
+        let previousReply = messages[idx]
         mutate(messageId) {
             $0.serverTurnId = nil
             $0.text = ""; $0.isError = false; $0.streaming = true; $0.activity = nil
         }
+        let retryPlaceholder = messages[idx]
         updatedAt = Date()
         onChange()
-        Task { await self.stream(familiarId: familiarId, prompt: prompt,
-                                 into: messageId,
-                                 reasoningEffort: source?.reasoningEffort,
-                                 responseSpeed: source?.responseSpeed,
-                                 modelControls: source?.modelControls ?? [:],
-                                 modelOverride: modelBinding.modelOverride,
-                                 modelOverrideScope: modelBinding.scope,
-                                 client: client, onChange: onChange,
-                                 onConnectionFailure: onConnectionFailure) }
+        return Task {
+            var refusedBeforeDispatch = Task.isCancelled
+            let mayDispatch = {
+                guard !Task.isCancelled,
+                      binding.matches(self, includingSessions: true),
+                      liveDispatchLeaseIsCurrent() else {
+                    refusedBeforeDispatch = true
+                    return false
+                }
+                return true
+            }
+            if !refusedBeforeDispatch {
+                await self.stream(
+                    familiarId: familiarId,
+                    prompt: prompt,
+                    into: messageId,
+                    reasoningEffort: source?.reasoningEffort,
+                    responseSpeed: source?.responseSpeed,
+                    modelControls: source?.modelControls ?? [:],
+                    modelOverride: modelBinding.modelOverride,
+                    modelOverrideScope: modelBinding.scope,
+                    liveDispatchLeaseIsCurrent: mayDispatch,
+                    client: client,
+                    onChange: onChange,
+                    onConnectionFailure: onConnectionFailure
+                )
+            }
+            // A failed authority preflight proves no POST started. Do not
+            // restore on ambiguous transport failures or overwrite a newer edit.
+            guard refusedBeforeDispatch else { return }
+            if let current = messages.firstIndex(where: { $0.id == messageId }),
+               messages[current] == retryPlaceholder {
+                messages[current] = previousReply
+                updatedAt = Date()
+                onChange()
+                _ = await persistAfterRefusal()
+            }
+            onRefusal()
+        }
     }
 
     /// Append an inline system note (slash-command output) and return its id so
@@ -2657,6 +2754,7 @@ final class ChatThread: Identifiable, Hashable {
             $0.queuedRunIdsByFamiliarId = nil
             $0.queuedAttemptedFamiliarIds = nil
             $0.queuedTargetFamiliarIds = nil
+            $0.queuedContext = nil
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/State/UnreadMarker.swift
+++ b/apps/ios/CovenCave/CovenCave/State/UnreadMarker.swift
@@ -2,11 +2,11 @@ import Foundation
 
 /// Placement logic for the transcript's "New Messages" divider — the
 /// iMessage/Telegram-style marker above the first reply that arrived since
-/// the operator last viewed this familiar's chats. Pure functions so the
+/// the operator last viewed this conversation. Pure functions so the
 /// placement rules are unit-testable.
 enum UnreadMarker {
     /// The id of the first unseen message: the earliest assistant reply
-    /// created strictly after `seenBoundary`. A nil boundary (familiar not
+    /// created strictly after `seenBoundary`. A nil boundary (history not
     /// tracked yet) means no divider — new familiars are seeded as "seen
     /// now", so the whole backlog never reads as unread. The operator's own
     /// sends and local system notes never count as unseen.

--- a/apps/ios/CovenCave/CovenCave/Views/ChatProjectPicker.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatProjectPicker.swift
@@ -17,6 +17,7 @@ struct ChatProjectPicker: View {
     var requiresExplicitSelection = false
     var onResolved: (() -> Void)?
     var onManageAccess: (() -> Void)?
+    var onSelection: ((ProjectInfo?) -> Void)?
 
     @State private var projects: [ProjectInfo] = []
     @State private var isLoading = false
@@ -83,6 +84,7 @@ struct ChatProjectPicker: View {
                     Label(errorMessage, systemImage: "exclamationmark.triangle")
                         .foregroundStyle(.secondary)
                     Button("Retry") { reloadToken += 1 }
+                        .frame(minHeight: 44)
                 }
             } else if projects.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
@@ -95,8 +97,10 @@ struct ChatProjectPicker: View {
                     .foregroundStyle(.secondary)
                     HStack(spacing: 12) {
                         Button("Retry") { reloadToken += 1 }
+                            .frame(minHeight: 44)
                         if let onManageAccess {
                             Button("Project access", action: onManageAccess)
+                                .frame(minHeight: 44)
                         }
                     }
                 }
@@ -117,12 +121,17 @@ struct ChatProjectPicker: View {
                 get: { selectedRoot },
                 set: { root in
                     selectedRoot = root
-                    isResolved = root != nil
-                    if root != nil { onResolved?() }
+                    let project = projects.first { $0.root == root }
+                    isResolved = project != nil
+                    onSelection?(project)
+                    if isResolved { onResolved?() }
                 }
             )
         ) {
             Text("Choose a project").tag(String?.none)
+            if let selectedRoot, !projects.contains(where: { $0.root == selectedRoot }) {
+                Text("Selected project unavailable").tag(Optional(selectedRoot))
+            }
             ForEach(projects) { project in
                 Text(projectOptionLabel(project))
                     .tag(Optional(project.root))
@@ -130,6 +139,7 @@ struct ChatProjectPicker: View {
             }
         }
         .pickerStyle(.menu)
+        .frame(minHeight: 44)
         .accessibilityIdentifier("New chat project")
         .accessibilityHint("Chooses where this chat can work")
     }
@@ -211,14 +221,16 @@ struct ChatProjectPicker: View {
             }
             isLoading = false
             projects = loaded
-            selectedRoot = requiresExplicitSelection
-                ? nil
-                : ChatProjectSelection.resolvedRoot(
-                    current: selectedRoot,
+            // A refresh may invalidate a choice, but must never replace it.
+            if selectedRoot == nil, !requiresExplicitSelection {
+                selectedRoot = ChatProjectSelection.resolvedRoot(
+                    current: nil,
                     recent: recentRoots,
                     projects: loaded
                 )
-            isResolved = selectedRoot != nil
+                onSelection?(loaded.first { $0.root == selectedRoot })
+            }
+            isResolved = loaded.contains { $0.root == selectedRoot }
             resolvedLoadKey = identity.key
             if isResolved { onResolved?() }
         } catch is CancellationError {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -29,13 +29,13 @@ struct ChatView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.chrome) private var chrome
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Bindable var thread: ChatThread
     @State private var draft: String = ""
     /// The message being quoted in the next send, if any (swipe-to-reply).
     @State private var replyingTo: DisplayMessage?
     @FocusState private var composerFocused: Bool
     @State private var showCommands = false
+    @State private var showNewChat = false
     @State private var showFamiliarPicker = false
     @State private var forwardingMessage: DisplayMessage?
     @State private var showModelPicker = false
@@ -50,12 +50,11 @@ struct ChatView: View {
     @State private var modelPresentationScope = ChatModelPresentationScope()
     @State private var modelRequests = ChatModelRequestCoordinator()
     @State private var modelMutationQueue = ChatModelMutationQueue()
-    @State private var showTasks = false
     @State private var permissionsFamiliar: Familiar?
     @State private var showPermissionFamiliarPicker = false
     @State private var showSessionDetails = false
     @State private var showSessionPicker = false
-    @State private var showVoiceCall = false
+    @State private var voiceCall: LiveVoiceCallModel?
     /// Inert navigation path handed to the session picker to satisfy its
     /// binding. The picker runs in `onSelect` mode, so it never pushes — a
     /// chosen session is switched to via `switchToSession` instead. Pushing
@@ -72,7 +71,7 @@ struct ChatView: View {
     @State private var pendingImages: [PendingImage] = []
     @State private var draftPersistenceTask: Task<Void, Never>?
     /// "New messages" divider: computed once per visit, *before*
-    /// `markFamiliarViewed` moves the seen boundary, then left in place for
+    /// `markThreadViewed` moves the seen boundary, then left in place for
     /// the whole visit (re-appears from pushes must not dissolve it).
     @State private var unreadDividerId: String?
     @State private var unreadRunLength = 0
@@ -92,7 +91,6 @@ struct ChatView: View {
     @State private var showPhotosPicker = false
     @State private var showCamera = false
     @State private var showFileImporter = false
-    @State private var showPlugins = false
     @State private var responseReader: ResponseReaderItem?
     @State private var projectResolved = false
     // Tap-to-enlarge target (image attachment, or a table/diagram/image lifted
@@ -151,6 +149,7 @@ struct ChatView: View {
         guard !thread.isFlowRun else { return nil }
         guard let familiar = voiceCallFamiliar else { return nil }
         guard !isRecoveryOnlyThread else { return nil }
+        guard chatAccessLoaded else { return nil }
         guard app.threadOpenFailure(for: thread) == nil else { return nil }
         guard visibleThreadContext != .unassigned else { return nil }
         guard let projectRoot = thread.projectRoot?
@@ -170,6 +169,24 @@ struct ChatView: View {
 
     private var visibleThreadContext: ProjectContext {
         app.projectContext(for: thread)
+    }
+
+    private var chatAccessLoaded: Bool {
+        app.chatAccessIsCurrent(projectRoot: thread.projectRoot, familiarIds: thread.familiarIds)
+    }
+
+    private func requireChatAccess() -> Bool {
+        app.requireCurrentChatAccess(projectRoot: thread.projectRoot, familiarIds: thread.familiarIds)
+    }
+
+    private func dispatchIsCurrent(
+        _ binding: ChatDispatchBinding,
+        in target: ChatThread,
+        lease: AppModel.ConnectionDispatchLease
+    ) -> Bool {
+        app.connectionDispatchLeaseIsCurrent(lease)
+            && binding.matches(target)
+            && app.chatAccessIsCurrent(projectRoot: binding.projectRoot, familiarIds: binding.familiarIds)
     }
 
     private func writeDraftPersistence(_ value: String, key: String) {
@@ -211,9 +228,6 @@ struct ChatView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if !app.projectLinkedTasks(for: thread).isEmpty {
-                linkedContextStrip
-            }
             messageScroll
                 // While the "+" menu is up, the transcript becomes its scrim:
                 // a light dim signals the mode and any outside tap dismisses.
@@ -270,7 +284,7 @@ struct ChatView: View {
                 if let voiceCallLaunch, app.client != nil {
                     Button {
                         Haptics.tap()
-                        showVoiceCall = true
+                        beginVoiceCall()
                     } label: {
                         Image(systemName: "phone.fill")
                     }
@@ -303,9 +317,11 @@ struct ChatView: View {
         .sheet(isPresented: $showCommands) {
             CommandsSheet { command in prefill(command) }
         }
-        .fullScreenCover(isPresented: $showPlugins) {
-            PluginsPanel { plugin in
-                prefillPlugin(plugin)
+        .sheet(isPresented: $showNewChat) {
+            NewChatView(initialFamiliarIds: thread.familiarIds) { fresh in
+                showNewChat = false
+                flushDraftPersistence()
+                _ = app.requestOpen(fresh)
             }
         }
         .sheet(isPresented: $showModelPicker) {
@@ -331,9 +347,6 @@ struct ChatView: View {
                 forward(message, to: familiar)
             }
         }
-        .sheet(isPresented: $showTasks) {
-            LinkedTasksSheet(thread: thread)
-        }
         .sheet(item: $permissionsFamiliar) { familiar in
             FamiliarPermissionsSheet(familiar: familiar)
         }
@@ -349,29 +362,9 @@ struct ChatView: View {
         .sheet(item: $responseReader) { item in
             ResponseReaderView(item: item)
         }
-        .fullScreenCover(isPresented: $showVoiceCall) {
-            if let voiceCallLaunch {
-                LiveVoiceCallView(
-                    familiar: voiceCallLaunch.familiar,
-                    sessionId: voiceCallLaunch.sessionId,
-                    projectRoot: voiceCallLaunch.projectRoot,
-                    client: app.client,
-                    onSessionEstablished: { sessionId in
-                        bindVoiceCallSession(sessionId, for: voiceCallLaunch.familiar.id)
-                    },
-                    onSessionDiscarded: { sessionId in
-                        unbindVoiceCallSession(sessionId, for: voiceCallLaunch.familiar.id)
-                    },
-                    onCleanupWarning: { message in
-                        app.showToast(message,
-                                      systemImage: "exclamationmark.triangle.fill",
-                                      style: .warning)
-                    }
-                )
-            }
+        .fullScreenCover(item: $voiceCall) { model in
+            LiveVoiceCallView(model: model)
         }
-        // A new chat linked to a task acquires its server session only after the
-        // first reply; once streaming stops, push that sessionId onto the card.
         .onChange(of: thread.isStreaming) { _, streaming in
             if !streaming {
                 // A reply just finished streaming — a subtle "done" haptic so you
@@ -382,7 +375,6 @@ struct ChatView: View {
                     Haptics.success()
                 }
                 Task {
-                    await app.reconcileCardLinks(for: thread)
                     _ = await loadSessionModelState()
                 }
             }
@@ -397,19 +389,13 @@ struct ChatView: View {
             // Place the "New messages" divider from the seen boundary BEFORE
             // marking viewed moves it.
             computeUnreadDividerIfNeeded()
-            // Opening the chat clears the unread badge for its familiar(s) and
-            // any delivered reply banner for this thread.
-            app.markFamiliarViewed(
-                thread.familiarIds,
-                in: app.projectContext(for: thread)
-            )
+            // Opening the chat clears only this thread's unread state and
+            // delivered reply banners, not other chats with these participants.
+            app.markThreadViewed(thread)
             ChatNotifications.removeDelivered(threadId: thread.id)
         }
         .task(id: modelStateLoadKey) {
             await loadSessionModelState()
-        }
-        .task {
-            if !app.tasksLoaded { await app.loadTasks() }
         }
         // Persist every edit per-thread; send() clears the draft, which removes
         // the stored copy here so a sent message leaves nothing behind. Debounce
@@ -597,10 +583,8 @@ struct ChatView: View {
                 .font(.footnote)
                 .foregroundStyle(.secondary)
 
-            if app.canStartProjectChats {
-                Button("Start replacement chat", action: startReplacementChat)
-                    .buttonStyle(.borderedProminent)
-            }
+            Button("Start replacement chat", action: startReplacementChat)
+                .buttonStyle(.borderedProminent)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
@@ -609,10 +593,7 @@ struct ChatView: View {
     }
 
     private var recoveryOnlyCopy: String {
-        if let activeProject = app.activeProject {
-            return "This conversation was created without a registered project. Inspect, export, or delete it here, or start a replacement chat in \(activeProject.name)."
-        }
-        return "This conversation was created without a registered project. Switch to a registered project in Chats to start a replacement chat."
+        "This conversation has no registered project access. Inspect, export, or delete it here, or choose access for a replacement chat in New chat."
     }
 
     private func sessionControlRow<Control: View>(
@@ -769,113 +750,6 @@ struct ChatView: View {
 
     private func conciseModelName(_ id: String) -> String {
         id.split(separator: "/").last.map(String.init) ?? id
-    }
-
-    private var linkedGitHubContext: (link: CardGitHubLink, url: URL)? {
-        app.projectLinkedTasks(for: thread)
-            .flatMap(\.githubLinks)
-            .compactMap { link in
-                validGitHubURL(for: link).map { (link, $0) }
-            }
-            .first
-    }
-
-    private func validGitHubURL(for link: CardGitHubLink) -> URL? {
-        let kind = link.kind.lowercased()
-        guard ["pr", "review_request", "issue"].contains(kind),
-              let number = link.number,
-              let url = URL(string: link.url),
-              url.scheme?.lowercased() == "https",
-              url.host?.lowercased() == "github.com",
-              url.user == nil,
-              url.password == nil,
-              url.port == nil
-        else { return nil }
-
-        let repo = link.repo.split(separator: "/", omittingEmptySubsequences: true)
-        let path = url.pathComponents.filter { $0 != "/" }
-        let expectedKind = kind == "issue" ? "issues" : "pull"
-        guard repo.count == 2,
-              path.count >= 4,
-              path[0].caseInsensitiveCompare(String(repo[0])) == .orderedSame,
-              path[1].caseInsensitiveCompare(String(repo[1])) == .orderedSame,
-              path[2].lowercased() == expectedKind,
-              path[3] == String(number)
-        else { return nil }
-        return url
-    }
-
-    private func githubContextLabel(_ link: CardGitHubLink) -> String {
-        let kind = link.kind.lowercased() == "issue" ? "Issue" : "PR"
-        guard let number = link.number else { return kind }
-        return "\(kind) #\(number)"
-    }
-
-    private var linkedContextStrip: some View {
-        let cards = app.projectLinkedTasks(for: thread)
-        let layout = dynamicTypeSize.isAccessibilitySize
-            ? AnyLayout(VStackLayout(alignment: .leading, spacing: 8))
-            : AnyLayout(HStackLayout(spacing: 8))
-        return layout {
-            if let context = linkedGitHubContext {
-                Link(destination: context.url) {
-                    HStack(spacing: 6) {
-                        Image(systemName: context.link.kind.lowercased() == "issue"
-                              ? "smallcircle.filled.circle" : "arrow.triangle.branch")
-                        Text(githubContextLabel(context.link))
-                            .lineLimit(1)
-                        Image(systemName: "arrow.up.right")
-                            .font(.caption2.weight(.bold))
-                    }
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(chrome.accent)
-                    .padding(.horizontal, 10)
-                    .frame(minHeight: 36)
-                    .background(chrome.accent.opacity(0.12), in: Capsule())
-                    .overlay(Capsule().stroke(chrome.accent.opacity(0.35), lineWidth: 1))
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Open \(githubContextLabel(context.link)) on GitHub")
-            }
-
-            Button {
-                showTasks = true
-            } label: {
-                HStack(spacing: 10) {
-                    Image(systemName: "checklist")
-                        .foregroundStyle(chrome.accent)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(cards.count == 1 ? "Linked task" : "\(cards.count) linked tasks")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                            .textCase(.uppercase)
-                            .fixedSize(horizontal: false, vertical: true)
-                        Text(cards.first?.title ?? "Open tasks")
-                            .font(.subheadline.weight(.medium))
-                            .foregroundStyle(.primary)
-                            .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(.tertiary)
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .accessibilityHint("Opens tasks linked to this conversation")
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, dynamicTypeSize.isAccessibilitySize ? 8 : 0)
-        .padding(.top, dynamicTypeSize.isAccessibilitySize ? 16 : 0)
-        .padding(.bottom, dynamicTypeSize.isAccessibilitySize ? 16 : 0)
-        .frame(minHeight: 52)
-        .background(chrome.bgRaised)
-        .overlay(alignment: .bottom) {
-            Rectangle().fill(chrome.border).frame(height: 1)
-        }
     }
 
     private func sessionDetailRow(
@@ -1157,7 +1031,7 @@ struct ChatView: View {
                     permissionsFamiliar = familiar
                 } label: {
                     (
-                        Text("Describe a task or choose a suggestion below. Your familiar works from the desktop. Project access follows \(wardScope) active ")
+                        Text("Write a message or choose a suggestion below. Your familiar works from the desktop. Project access follows \(wardScope) active ")
                             .foregroundStyle(.secondary)
                         + Text("ward.")
                             .foregroundStyle(chrome.accent)
@@ -1235,49 +1109,19 @@ struct ChatView: View {
     }
 
     private var emptySuggestions: [EmptyChatSuggestion] {
-        let openPullRequestURLs = Set(app.tasks.flatMap(\.githubLinks)
-            .filter {
-                ($0.kind == "pr" || $0.kind == "review_request")
-                    && $0.state?.lowercased() == "open"
-            }
-            .map { $0.url.lowercased() })
-        let active = app.tasks.filter { $0.status.isActive }
-        let running = active.filter { $0.status == .running }.count
-        let blocked = active.filter { $0.status == .blocked }.count
-        let next = active.sorted {
-            if $0.priority.rank != $1.priority.rank { return $0.priority.rank < $1.priority.rank }
-            return (caveParseISO($0.updatedAt) ?? .distantPast) > (caveParseISO($1.updatedAt) ?? .distantPast)
-        }.first
-        let nextLabel = next.map { "Work on \($0.title)" } ?? "Work on the next priority"
-        let nextHint = next.map {
-            [$0.projectId, $0.githubLinks.first?.number.map { "#\($0)" }]
-                .compactMap { $0 }
-                .joined(separator: " · ")
-        }.flatMap { $0.isEmpty ? nil : $0 } ?? "Ask your familiar to choose"
-        let boardHint = app.tasksError != nil
-            ? "Tasks unavailable — open Tasks to retry"
-            : app.tasksLoaded
-                ? "\(running) running · \(blocked) blocked"
-                : "Open Tasks to load tasks"
-        let priorityHint = app.tasksError != nil && !app.tasks.isEmpty
-            ? "Cached · \(nextHint)"
-            : nextHint
-
-        return [
+        [
             EmptyChatSuggestion(
-                icon: "arrow.triangle.branch",
-                label: "Review my open PRs",
-                hint: openPullRequestURLs.isEmpty
-                    ? "Ask GitHub through your familiar"
-                    : "\(openPullRequestURLs.count) open"),
+                icon: "lightbulb",
+                label: "Help me explore an idea",
+                hint: "Think it through together"),
             EmptyChatSuggestion(
-                icon: "checkmark.square",
-                label: "What tasks need attention?",
-                hint: boardHint),
+                icon: "text.bubble",
+                label: "Explain something to me",
+                hint: "Bring a question or some context"),
             EmptyChatSuggestion(
-                icon: "scope",
-                label: nextLabel,
-                hint: priorityHint),
+                icon: "pencil",
+                label: "Help me draft a message",
+                hint: "Find the words you need"),
         ]
     }
 
@@ -1301,6 +1145,21 @@ struct ChatView: View {
 
     private var composer: some View {
         VStack(spacing: 8) {
+            if !chatAccessLoaded {
+                HStack(spacing: 12) {
+                    Label("Chat access unavailable", systemImage: "lock.shield")
+                        .font(.footnote)
+                    Spacer(minLength: 8)
+                    Button("Refresh access") {
+                        Task { await app.refreshChatAccess() }
+                    }
+                    .font(.footnote.weight(.semibold))
+                    .frame(minHeight: 44)
+                }
+                .foregroundStyle(chrome.textSecondary)
+                .padding(.horizontal, 16)
+                .background(chrome.bgRaised)
+            }
             if showActionMenu {
                 FloatingActionMenu(actions: composerActions) { showActionMenu = false }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -1372,8 +1231,6 @@ struct ChatView: View {
             FloatingAction(id: "camera", systemImage: "camera", label: "Camera") { showCamera = true },
             FloatingAction(id: "photos", systemImage: "photo.on.rectangle", label: "Photos") { showPhotosPicker = true },
             FloatingAction(id: "files", systemImage: "folder", label: "Files") { showFileImporter = true },
-            FloatingAction(id: "tasks", systemImage: "checklist", label: "Link a task") { showTasks = true },
-            FloatingAction(id: "plugins", systemImage: "puzzlepiece.extension", label: "Plugins") { showPlugins = true },
             FloatingAction(id: "dictation", systemImage: "mic.fill", label: "Dictate") { startDictation() },
             FloatingAction(id: "commands", systemImage: "command", label: "Commands") { showCommands = true },
         ]
@@ -1567,7 +1424,11 @@ struct ChatView: View {
     private var canSend: Bool {
         let hasContent = !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             || !pendingImages.isEmpty
-        return !thread.isFlowRun && !isRecoveryOnlyThread && hasContent && (isCommand || thread.canSendMessages)
+        guard !thread.isFlowRun, !isRecoveryOnlyThread, hasContent else { return false }
+        if case .command(let command, _) = SlashInput.parse(draft), !command.sendsChatMessage {
+            return true
+        }
+        return chatAccessLoaded && thread.canSendMessages
     }
 
     /// True when the draft is a recognised command — tints the send affordance
@@ -1593,10 +1454,12 @@ struct ChatView: View {
         let raw = draft
         switch SlashInput.parse(raw) {
         case .command(let command, let args):
-            if case .sendAsPrompt = command.action,
-               !thread.canSendMessages {
-                thread.needsProjectSelection = true
-                return
+            if command.sendsChatMessage {
+                guard requireChatAccess() else { return }
+                guard thread.canSendMessages else {
+                    thread.needsProjectSelection = true
+                    return
+                }
             }
             draft = ""
             dispatch(command, args: args)
@@ -1607,6 +1470,7 @@ struct ChatView: View {
             app.touch(thread)
         case .prose(let text):
             guard let client = app.client else { return }
+            guard requireChatAccess() else { return }
             guard thread.canSendMessages else {
                 thread.needsProjectSelection = true
                 return
@@ -1636,13 +1500,14 @@ struct ChatView: View {
                 return
             }
             let dispatchLease = app.captureConnectionDispatchLease()
+            let dispatchBinding = ChatDispatchBinding(thread: thread)
             thread.send(outgoing, attachments: attachments,
                         modelControls: modelControlValues,
                         modelOverride: modelBinding.modelOverride,
                         modelOverrideScope: modelBinding.scope,
                         onConnectionFailure: { app.noteConnectionFailure($0) },
                         liveDispatchLeaseIsCurrent: {
-                            app.connectionDispatchLeaseIsCurrent(dispatchLease)
+                            dispatchIsCurrent(dispatchBinding, in: thread, lease: dispatchLease)
                         },
                         persistBeforeDispatch: {
                             await app.persistThreadsBeforeDispatch(for: dispatchLease)
@@ -1660,6 +1525,7 @@ struct ChatView: View {
             return
         }
         guard let client = app.client else { return }
+        guard requireChatAccess() else { return }
         guard thread.canSendMessages else {
             thread.needsProjectSelection = true
             return
@@ -1674,12 +1540,13 @@ struct ChatView: View {
             return
         }
         let dispatchLease = app.captureConnectionDispatchLease()
+        let dispatchBinding = ChatDispatchBinding(thread: thread)
         thread.send(text, modelControls: modelControlValues,
                     modelOverride: modelBinding.modelOverride,
                     modelOverrideScope: modelBinding.scope,
                     onConnectionFailure: { app.noteConnectionFailure($0) },
                     liveDispatchLeaseIsCurrent: {
-                        app.connectionDispatchLeaseIsCurrent(dispatchLease)
+                        dispatchIsCurrent(dispatchBinding, in: thread, lease: dispatchLease)
                     },
                     persistBeforeDispatch: {
                         await app.persistThreadsBeforeDispatch(for: dispatchLease)
@@ -1708,14 +1575,27 @@ struct ChatView: View {
             return
         }
         guard let client = app.client else { return }
+        guard let familiarId = assistant.familiarId,
+              app.requireCurrentChatAccess(projectRoot: thread.projectRoot, familiarIds: [familiarId])
+        else { return }
         guard thread.canSendMessages else {
             thread.needsProjectSelection = true
             return
         }
         Haptics.tap()
+        let dispatchLease = app.captureConnectionDispatchLease()
+        let dispatchBinding = ChatDispatchBinding(thread: thread, familiarIds: [familiarId])
         thread.retry(
             assistant.id,
             client: client,
+            liveDispatchLeaseIsCurrent: {
+                dispatchIsCurrent(dispatchBinding, in: thread, lease: dispatchLease)
+            },
+            persistAfterRefusal: { await app.flushThreadsAndWait() },
+            onRefusal: {
+                app.showToast("Retry was not sent because chat access or the connection changed.",
+                              systemImage: "lock.shield", style: .warning)
+            },
             onConnectionFailure: { app.noteConnectionFailure($0) }
         ) { app.touch(thread) }
     }
@@ -1739,13 +1619,6 @@ struct ChatView: View {
         composerFocused = true
     }
 
-    private func prefillPlugin(_ plugin: MarketplacePlugin) {
-        let prompt = "Use \(plugin.displayName) to "
-        draft = draft.isEmpty ? prompt : "\(draft)\n\(prompt)"
-        showPlugins = false
-        composerFocused = true
-    }
-
     private func dispatch(_ command: SlashCommand, args: String) {
         switch command.action {
         case .help:
@@ -1757,17 +1630,7 @@ struct ChatView: View {
         case .quitToList:
             dismiss()
         case .newChat:
-            guard let fresh = app.startFreshThreadInActiveProject(
-                familiarIds: thread.familiarIds,
-                title: thread.isGroup ? thread.title : nil
-            ) else {
-                if !app.canStartProjectChats {
-                    showRecoveryOnlyChatGuidance()
-                }
-                return
-            }
-            _ = app.requestOpen(fresh)
-            app.showToast("Started a new chat", systemImage: "square.and.pencil", style: .info)
+            showNewChat = true
         case .familiarPicker:
             if args.isEmpty {
                 showFamiliarPicker = true
@@ -1781,9 +1644,6 @@ struct ChatView: View {
         case .openSessions:
             app.selectedTab = .chats
             dismiss()
-        case .openBoard:
-            app.selectedTab = .tasks
-            app.showToast("Opened Tasks", systemImage: "checklist", style: .info)
         case .sendAsPrompt:
             sendPrompt(args, command: command)
         case .daemonStatus:
@@ -1804,6 +1664,7 @@ struct ChatView: View {
 
     private func startDiagram(_ args: String) {
         guard let client = app.client else { return }
+        guard requireChatAccess() else { return }
         guard thread.canSendMessages else {
             thread.needsProjectSelection = true
             return
@@ -1811,6 +1672,7 @@ struct ChatView: View {
         let brief = args.trimmingCharacters(in: .whitespacesAndNewlines)
         let modelBinding = turnModelBinding
         let dispatchLease = app.captureConnectionDispatchLease()
+        let dispatchBinding = ChatDispatchBinding(thread: thread)
         thread.send(DiagramCommandPrompt.build(brief),
                     displayText: brief.isEmpty ? DiagramCommandPrompt.start : brief,
                     modelControls: modelControlValues,
@@ -1818,7 +1680,7 @@ struct ChatView: View {
                     modelOverrideScope: modelBinding.scope,
                     onConnectionFailure: { app.noteConnectionFailure($0) },
                     liveDispatchLeaseIsCurrent: {
-                        app.connectionDispatchLeaseIsCurrent(dispatchLease)
+                        dispatchIsCurrent(dispatchBinding, in: thread, lease: dispatchLease)
                     },
                     persistBeforeDispatch: {
                         await app.persistThreadsBeforeDispatch(for: dispatchLease)
@@ -2167,24 +2029,26 @@ struct ChatView: View {
         }
         let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
-            thread.appendSystem("\(command.name) needs a task — e.g. \(command.name) fix the build",
+            thread.appendSystem("\(command.name) needs a prompt — e.g. \(command.name) explain this code",
                                 isError: true)
             app.touch(thread)
             return
         }
         guard let client = app.client else { return }
+        guard requireChatAccess() else { return }
         guard thread.canSendMessages else {
             thread.needsProjectSelection = true
             return
         }
         let modelBinding = turnModelBinding
         let dispatchLease = app.captureConnectionDispatchLease()
+        let dispatchBinding = ChatDispatchBinding(thread: thread)
         thread.send(trimmed, modelControls: modelControlValues,
                     modelOverride: modelBinding.modelOverride,
                     modelOverrideScope: modelBinding.scope,
                     onConnectionFailure: { app.noteConnectionFailure($0) },
                     liveDispatchLeaseIsCurrent: {
-                        app.connectionDispatchLeaseIsCurrent(dispatchLease)
+                        dispatchIsCurrent(dispatchBinding, in: thread, lease: dispatchLease)
                     },
                     persistBeforeDispatch: {
                         await app.persistThreadsBeforeDispatch(for: dispatchLease)
@@ -2338,7 +2202,11 @@ struct ChatView: View {
             return
         }
         guard let client = app.client else { return }
+        guard requireChatAccess() else { return }
+        guard app.requireCurrentChatAccess(projectRoot: thread.projectRoot, familiarIds: [familiar.id])
+        else { return }
         let dispatchLease = app.captureConnectionDispatchLease()
+        let sourceBinding = ChatDispatchBinding(thread: thread)
         let activeContext = visibleThreadContext
         let needsDeferredHistoryHydration =
             app.landingDirectThread(for: familiar.id, in: activeContext) == nil
@@ -2349,15 +2217,27 @@ struct ChatView: View {
             loadHistory: false
         ) else {
             app.showToast(
-                "Switch to a registered project before forwarding",
+                "Open New chat to choose project access for this familiar before forwarding",
                 systemImage: "folder.badge.questionmark",
                 style: .warning
             )
             return
         }
+        let destinationBinding = ChatDispatchBinding(thread: destination)
+        guard app.requireCurrentChatAccess(
+            projectRoot: destinationBinding.projectRoot,
+            familiarIds: destinationBinding.familiarIds
+        ) else { return }
         let prompt = forwardPrompt(for: message, to: familiar)
         let displayText = forwardDisplayText(for: message)
         Task { @MainActor in
+            guard sourceBinding.matches(thread),
+                  dispatchIsCurrent(destinationBinding, in: destination, lease: dispatchLease)
+            else {
+                app.showToast("Forward was not sent because chat access or the connection changed.",
+                              systemImage: "lock.shield", style: .warning)
+                return
+            }
             switch app.forwardingRouteDisposition(from: thread, to: destination) {
             case .allowed:
                 break
@@ -2397,7 +2277,7 @@ struct ChatView: View {
                     : nil,
                 onConnectionFailure: { app.noteConnectionFailure($0) },
                 liveDispatchLeaseIsCurrent: {
-                    app.connectionDispatchLeaseIsCurrent(dispatchLease)
+                    dispatchIsCurrent(destinationBinding, in: destination, lease: dispatchLease)
                 },
                 persistBeforeDispatch: {
                     await app.persistThreadsBeforeDispatch(for: dispatchLease)
@@ -2438,44 +2318,53 @@ struct ChatView: View {
     }
 
     private func startReplacementChat() {
-        guard let replacement = app.startFreshThreadInActiveProject(
-            familiarIds: thread.familiarIds,
-            title: thread.isGroup ? thread.title : nil
-        ) else {
-            if !app.canStartProjectChats {
-                showRecoveryOnlyChatGuidance()
-            }
-            return
-        }
-        _ = app.requestOpen(replacement)
-        app.showToast(
-            "Started a replacement chat",
-            systemImage: "square.and.pencil",
-            style: .info
-        )
+        showNewChat = true
     }
 
     private func showRecoveryOnlyChatGuidance() {
         app.showToast(
-            app.canStartProjectChats
-                ? "Start a replacement chat in the active project"
-                : "Switch to a registered project to start a replacement chat",
+            "Open New chat to choose project access for a replacement chat",
             systemImage: "folder.badge.questionmark",
             style: .warning
         )
     }
 
-    private func bindVoiceCallSession(_ sessionId: String, for familiarId: String) {
-        app.bindThreadSession(sessionId, to: thread, for: familiarId)
-    }
-
-    private func unbindVoiceCallSession(_ sessionId: String, for familiarId: String) {
-        let trimmed = sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty,
-              thread.sessionIds[familiarId] == trimmed
-        else { return }
-        thread.sessionIds.removeValue(forKey: familiarId)
-        app.touch(thread)
+    private func beginVoiceCall() {
+        guard voiceCall == nil, let client = app.client, requireChatAccess(),
+              let launch = voiceCallLaunch else { return }
+        let callThread = thread
+        let familiarId = launch.familiar.id
+        let dispatchLease = app.captureConnectionDispatchLease()
+        var binding = ChatDispatchBinding(thread: callThread, familiarIds: [familiarId])
+        voiceCall = LiveVoiceCallModel(
+            familiar: launch.familiar,
+            sessionId: launch.sessionId,
+            projectRoot: launch.projectRoot,
+            client: client,
+            authorityIsCurrent: {
+                dispatchIsCurrent(binding, in: callThread, lease: dispatchLease)
+                    && binding.matches(callThread, includingSessions: true)
+            },
+            onSessionEstablished: { sessionId in
+                // Accepted first turns can bind after hangup. Only this call
+                // may advance its captured session, never a replacement endpoint.
+                guard app.connectionDispatchLeaseIsCurrent(dispatchLease),
+                      binding.matches(callThread, includingSessions: true) else { return }
+                app.bindThreadSession(sessionId, to: callThread, for: familiarId)
+                binding = ChatDispatchBinding(thread: callThread, familiarIds: [familiarId])
+            },
+            onSessionDiscarded: { sessionId in
+                guard app.connectionDispatchLeaseIsCurrent(dispatchLease),
+                      binding.matches(callThread, includingSessions: true),
+                      callThread.sessionIds[familiarId] == sessionId else { return }
+                callThread.sessionIds.removeValue(forKey: familiarId)
+                binding = ChatDispatchBinding(thread: callThread, familiarIds: [familiarId])
+                app.touch(callThread)
+            },
+            onCleanupWarning: { message in
+                app.showToast(message, systemImage: "exclamationmark.triangle.fill", style: .warning)
+            }
+        )
     }
 
     private func forwardSenderName(for message: DisplayMessage) -> String {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -25,15 +25,14 @@ enum ChatNewConversationContext {
     }
 }
 
-/// The Chats destination, shaped like Messages: one vertical list of
-/// *familiars*, each row previewing the last thing said in that familiar's
-/// landing chat. There is no cross-familiar "Recent" list — a familiar is the
-/// conversation, and its other sessions live one level down.
+/// Global, resumable conversations. A chat owns its project binding; the
+/// sidebar's search, archive filter, and selection never change that binding.
 struct ChatsHomeView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.chrome) private var chrome
     @Environment(\.horizontalSizeClass) private var sizeClass
     @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var showNewChat = false
     @State private var fixedNewChatFamiliarId: String?
     @State private var query = ""
@@ -44,37 +43,52 @@ struct ChatsHomeView: View {
     /// fills the pane beside the list; on iPhone `NavigationSplitView` collapses
     /// and selecting pushes, so the drill-down behaviour is unchanged.
     @State private var selection: ChatRoute?
+    @State private var preferredCompactColumn: NavigationSplitViewColumn = .sidebar
     /// Navigation *within* the detail column — e.g. a familiar's thread list
     /// pushing a conversation. Reset whenever the sidebar selection changes.
     @State private var detailPath: [ChatRoute] = []
-    /// All-familiars roster sheet.
-    @State private var showFamiliars = false
+    @State private var showArchived = false
+    @State private var renamingThread: ChatThread?
+    @State private var pendingDelete: ChatThread?
+    @State private var exportArchive: ExportArchive?
     @State private var appliedPreviewLaunchIntent = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// Anchors the iOS 18 zoom transition: thread rows mark themselves as
     /// sources; the pushed conversation zooms out of its row.
     @Namespace private var zoomNamespace
 
-    private var activeProjectContext: ProjectContext {
-        app.projectContext ?? .unassigned
-    }
-
     var body: some View {
         splitView
-        .sheet(isPresented: $showFamiliars) {
-            FamiliarsListView { familiar in
-                showFamiliars = false
-                fixedNewChatFamiliarId = familiar.id
-                Task { @MainActor in
-                    await Task.yield()
-                    showNewChat = true
+        .threadRenameAlert($renamingThread) { thread, name in
+            app.renameThread(thread, to: name)
+        }
+        .confirmationDialog(
+            "Delete this chat?",
+            isPresented: Binding(
+                get: { pendingDelete != nil },
+                set: { if !$0 { pendingDelete = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: pendingDelete
+        ) { thread in
+            Button("Delete", role: .destructive) {
+                if lastThreadId == thread.id {
+                    detailPath = []
+                    selection = nil
                 }
+                app.deleteThread(thread)
             }
+            Button("Cancel", role: .cancel) {}
+        } message: { thread in
+            Text(thread.title)
+        }
+        .sheet(item: $exportArchive) { archive in
+            ActivityView(items: [archive.url])
         }
         .onAppear {
             #if DEBUG
             if ProcessInfo.processInfo.arguments.contains("--ui-open-familiars") {
-                showFamiliars = true
+                presentGeneralNewChat()
             }
             applyPreviewLaunchIntent()
             #endif
@@ -82,29 +96,34 @@ struct ChatsHomeView: View {
     }
 
     private var splitView: some View {
-        NavigationSplitView {
+        let snapshot = ChatListSnapshot(
+            threads: app.chatThreads,
+            sessions: app.chatServerSessions,
+            familiars: app.familiars,
+            query: query,
+            includeArchived: showArchived
+        )
+        return NavigationSplitView(preferredCompactColumn: $preferredCompactColumn) {
             Group {
-                if app.projectFamiliars.isEmpty
-                    && app.projectThreads.isEmpty
-                    && app.projectServerSessions.isEmpty
-                {
+                if snapshot.entries.isEmpty && query.isEmpty && snapshot.archivedCount == 0 {
                     if let error = app.familiarsError ?? app.sessionsError {
                         loadFailure(error)
                     } else {
                         emptyState
                     }
-                } else if filteredFamiliars.isEmpty {
+                } else if snapshot.entries.isEmpty && !query.isEmpty {
                     ContentUnavailableView.search(text: query)
                 } else {
-                    homeList
+                    homeList(snapshot)
                 }
             }
-            // Flush large-title header at the very top, matching Read / Tasks
-            // (which hide the nav bar and supply their own top inset) so
-            // every destination's header aligns. Search + compose stay in the bottom bar.
             .toolbar(.hidden, for: .navigationBar)
-            .safeAreaInset(edge: .top, spacing: 0) { header }
-            .safeAreaInset(edge: .bottom, spacing: 0) { homeSearchBar }
+            .safeAreaInset(edge: .top, spacing: 0) {
+                if app.selectedTab != .settings { header(snapshot) }
+            }
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                if app.selectedTab != .settings { homeSearchBar }
+            }
             .sheet(
                 isPresented: $showNewChat,
                 onDismiss: {
@@ -134,7 +153,7 @@ struct ChatsHomeView: View {
                 _ = app.resolvePendingProjectNavigationIntent()
                 selectMostRecentThreadIfNeeded()
             }
-            // A slash command (`/new`, `/familiar <name>`) or a task link asked to
+            // A slash command (`/new`, `/familiar <name>`) or a chat link asked to
             // open a specific thread — surface it in the detail column.
             .onChange(of: app.threadToOpen) { _, thread in
                 consumeThreadRequest(thread)
@@ -146,8 +165,7 @@ struct ChatsHomeView: View {
             }
             .onChange(of: app.chatSearchRequested) { _, requested in
                 guard requested else { return }
-                searchFocused = true
-                app.chatSearchRequested = false
+                revealChatSearch()
             }
             .sidebarColumn()
         } detail: {
@@ -158,10 +176,9 @@ struct ChatsHomeView: View {
         .navigationSplitViewStyle(.balanced)
         // A new sidebar selection starts a fresh detail navigation (so a familiar
         // opens at its thread list, not a stale pushed conversation).
-        .onChange(of: selection) { _, _ in detailPath = [] }
-        .onChange(of: activeProjectContext.id) { oldID, newID in
-            guard oldID != newID else { return }
-            handleProjectContextChange()
+        .onChange(of: selection) { _, selected in
+            detailPath = []
+            preferredCompactColumn = selected == nil ? .sidebar : .detail
         }
     }
 
@@ -180,17 +197,14 @@ struct ChatsHomeView: View {
                     ContentUnavailableView {
                         Label("Select a chat", systemImage: "bubble.left.and.bubble.right")
                     } description: {
-                        Text("Pick a familiar or conversation to start.")
+                        Text("Choose a conversation, or start a new chat.")
                     }
                 }
             }
             .navigationDestination(for: ChatRoute.self) { route in
                 switch route {
                 case .familiar(let familiar):
-                    FamiliarThreadsView(familiar: familiar,
-                                        projectContext: activeProjectContext,
-                                        path: $detailPath,
-                                        zoomNamespace: zoomNamespace)
+                    familiarChat(familiar)
                 case .thread(let thread):
                     chatDestination(thread)
                 }
@@ -219,10 +233,13 @@ struct ChatsHomeView: View {
         case nil:
             if !applyZoom {
                 ChatView(thread: thread)
+                    .id(thread.id)
             } else if reduceMotion {
                 ChatView(thread: thread)
+                    .id(thread.id)
             } else {
                 ChatView(thread: thread)
+                    .id(thread.id)
                     .navigationTransition(.zoom(sourceID: thread.id, in: zoomNamespace))
             }
         case .projectCatalogUnavailable?:
@@ -240,13 +257,13 @@ struct ChatsHomeView: View {
     /// one. Session switching happens in ChatView's config card, not here.
     @ViewBuilder
     private func familiarChat(_ familiar: Familiar) -> some View {
-        if let thread = app.projectLandingDirectThread(for: familiar.id) {
+        if let thread = app.globalLandingDirectThread(for: familiar.id) {
             chatDestination(
                 thread,
                 applyZoom: false,
                 recoveryAction: { detailPath = [.familiar(familiar)] }
             )
-        } else if let session = app.projectServerOnlySessions(for: familiar.id).first {
+        } else if let session = app.globalServerOnlySessions(for: familiar.id).first {
             FamiliarServerLandingView(
                 familiar: familiar,
                 session: session,
@@ -256,15 +273,9 @@ struct ChatsHomeView: View {
             ContentUnavailableView {
                 Label("No chats with \(familiar.displayName)", systemImage: "bubble.left.and.bubble.right")
             } description: {
-                if app.canStartProjectChats {
-                    Text("Start one to begin.")
-                } else {
-                    Text("Unassigned chats are recovery-only. Switch to a registered project to start a replacement chat.")
-                }
+                Text("Choose this familiar and its chat access to begin.")
             } actions: {
-                if app.canStartProjectChats {
-                    Button("New chat") { startNewChat(with: familiar) }
-                }
+                Button("New chat") { startNewChat(with: familiar) }
             }
         }
     }
@@ -291,14 +302,6 @@ struct ChatsHomeView: View {
     }
 
     private func presentNewChat(fixedFamiliarId: String? = nil) {
-        guard app.canStartProjectChats else {
-            app.showToast(
-                "Unassigned chats are recovery-only. Switch to a registered project to start a replacement chat.",
-                systemImage: "folder.badge.questionmark",
-                style: .warning
-            )
-            return
-        }
         self.fixedNewChatFamiliarId = fixedFamiliarId
         showNewChat = true
     }
@@ -316,20 +319,48 @@ struct ChatsHomeView: View {
         presentNewChat()
     }
 
-    /// Large-title header pinned to the top, mirroring the Read / Tasks
-    /// destinations so every destination title aligns at the same flush position.
-    private var header: some View {
-        HStack(spacing: 12) {
-            CircularIconButton(systemImage: "line.3.horizontal",
-                               label: "Open navigation") {
-                app.navigationDrawerOpen = true
+    private func header(_ snapshot: ChatListSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 12) {
+                CircularIconButton(systemImage: "line.3.horizontal",
+                                   label: "Open navigation") {
+                    app.navigationDrawerOpen = true
+                }
+                if dynamicTypeSize.isAccessibilitySize {
+                    Text("Chats")
+                        .font(.system(.title2, design: .serif).weight(.semibold))
+                        .accessibilityAddTraits(.isHeader)
+                } else if sizeClass == .regular {
+                    EditorialSurfaceTitle(title: "Chats", large: true)
+                } else {
+                    EditorialSurfaceTitle(
+                        title: "Chats",
+                        detail: visibleConversationLabel(snapshot.entries.count),
+                        large: true
+                    )
+                }
+                Spacer(minLength: 0)
+                Menu {
+                    Button { showArchived.toggle() } label: {
+                        Label(
+                            showArchived ? "Hide archived" : "Show archived (\(snapshot.archivedCount))",
+                            systemImage: "archivebox"
+                        )
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 18, weight: .semibold))
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel("Chat list options")
             }
-            EditorialSurfaceTitle(
-                title: "Chats",
-                detail: visibleConversationLabel,
-                large: true
-            )
-            Spacer()
+            if dynamicTypeSize.isAccessibilitySize || sizeClass == .regular,
+               let detail = visibleConversationLabel(snapshot.entries.count) {
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(chrome.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .padding(.horizontal, 14)
         .padding(.top, 6)
@@ -341,6 +372,7 @@ struct ChatsHomeView: View {
         HStack(spacing: 8) {
             HStack(spacing: 8) {
                 Image(systemName: "magnifyingglass")
+                    .font(.system(size: 18))
                     .foregroundStyle(searchFocused ? chrome.accent : chrome.textSecondary)
                 TextField("Search chats…", text: $query)
                     .textInputAutocapitalization(.never)
@@ -350,7 +382,10 @@ struct ChatsHomeView: View {
                     Button {
                         query = ""
                     } label: {
-                        Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 18))
+                            .foregroundStyle(.secondary)
+                            .frame(minWidth: 44, minHeight: 44)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Clear search")
@@ -384,15 +419,11 @@ struct ChatsHomeView: View {
         .frame(maxWidth: .infinity)
     }
 
-    private var visibleConversationCount: Int {
-        app.chatThreads.lazy.filter { !$0.archived }.count
-    }
-
-    private var visibleConversationLabel: String? {
-        guard visibleConversationCount > 0 else { return nil }
-        return visibleConversationCount == 1
+    private func visibleConversationLabel(_ count: Int) -> String? {
+        guard count > 0 else { return nil }
+        return count == 1
             ? "1 conversation"
-            : "\(visibleConversationCount) conversations"
+            : "\(count) conversations"
     }
 
     private var dockControlSize: CGFloat {
@@ -403,83 +434,94 @@ struct ChatsHomeView: View {
         verticalSizeClass == .compact ? 14 : 16
     }
 
-    private var homeList: some View {
+    private func homeList(_ snapshot: ChatListSnapshot) -> some View {
         List(selection: $selection) {
-            ForEach(filteredFamiliars) { familiar in
-                FamiliarConversationRow(familiar: familiar)
-                    .tag(ChatRoute.familiar(familiar))
-                    .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
-                    // Rows sit flush on the themed floor (design 1a); iPad keeps
-                    // the default cell background so the sidebar selection
-                    // highlight stays visible.
-                    .listRowBackground(sizeClass == .compact ? Color.clear : nil)
-                    .swipeActions(edge: .leading) {
-                        Button { startNewChat(with: familiar) } label: {
-                            Label("New chat", systemImage: "square.and.pencil")
-                        }
-                        .tint(.accentColor)
-                    }
-                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                        if app.projectHasUnread(familiar.id) {
-                            Button { app.markFamiliarViewed([familiar.id]) } label: {
-                                Label("Mark all read", systemImage: "checkmark.circle")
+            ForEach(snapshot.entries) { entry in
+                Group {
+                    switch entry.conversation {
+                    case .local(let thread):
+                        ThreadRow(
+                            thread: thread,
+                            activityAt: entry.updatedAt,
+                            isSelected: sizeClass == .regular && selection == .thread(thread)
+                        )
+                            .tag(ChatRoute.thread(thread))
+                            .matchedTransitionSource(id: thread.id, in: zoomNamespace)
+                            .contextMenu { threadActions(thread, activityAt: entry.updatedAt) }
+                            .swipeActions(edge: .leading) {
+                                Button { app.setThreadPinned(thread, !thread.pinned) } label: {
+                                    Label(thread.pinned ? "Unpin" : "Pin", systemImage: "pin")
+                                }
+                                .tint(chrome.accent)
                             }
-                            .tint(.indigo)
-                        }
-                    }
-                    .contextMenu {
-                        Button { startNewChat(with: familiar) } label: {
-                            Label("New chat", systemImage: "square.and.pencil")
-                        }
-                        if app.projectHasUnread(familiar.id) {
-                            Button { app.markFamiliarViewed([familiar.id]) } label: {
-                                Label("Mark all read", systemImage: "checkmark.circle")
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) { pendingDelete = thread } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                                Button { app.setThreadArchived(thread, !thread.archived) } label: {
+                                    Label(thread.archived ? "Unarchive" : "Archive", systemImage: "archivebox")
+                                }
+                                .tint(chrome.accent)
                             }
+                    case .server(let session):
+                        Button {
+                            _ = app.requestOpenServerSession(session, fallbackFamiliarId: session.familiarId)
+                        } label: {
+                            ServerSessionRow(session: session)
                         }
+                        .buttonStyle(.plain)
                     }
+                }
+                .accessibilityIdentifier("Chat row \(entry.id)")
+                .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                .listRowBackground(sizeClass == .compact ? Color.clear : nil)
             }
-            if showsLowDensityActions {
-                lowDensityActions
-                    .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
+            if snapshot.entries.isEmpty && snapshot.archivedCount > 0 {
+                Button("Show archived chats (\(snapshot.archivedCount))") { showArchived = true }
+                    .frame(minHeight: 44)
             }
         }
         .listStyle(.plain)
         .themedListBackground()
     }
 
-    private var showsLowDensityActions: Bool {
-        query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && filteredFamiliars.count <= 2
-    }
-
-    private var lowDensityActions: some View {
-        HStack(spacing: 10) {
-            lowDensityAction("New chat", systemImage: "square.and.pencil") {
-                presentContextualNewChat()
-            }
-            lowDensityAction("All familiars", systemImage: "person.2") {
-                showFamiliars = true
+    @ViewBuilder
+    private func threadActions(_ thread: ChatThread, activityAt: Date) -> some View {
+        Button { renamingThread = thread } label: {
+            Label("Rename", systemImage: "pencil")
+        }
+        if !app.isRecoveryOnlyThread(thread) {
+            Button { _ = app.duplicateThread(thread) } label: {
+                Label("Duplicate", systemImage: "plus.square.on.square")
             }
         }
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Chat shortcuts")
-    }
-
-    private func lowDensityAction(
-        _ label: String,
-        systemImage: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Label(label, systemImage: systemImage)
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(chrome.textPrimary)
-                .frame(maxWidth: .infinity, minHeight: 44)
-                .glass(.raised, cornerRadius: 14)
+        Button { app.setThreadPinned(thread, !thread.pinned) } label: {
+            Label(thread.pinned ? "Unpin" : "Pin", systemImage: "pin")
         }
-        .buttonStyle(.glassPress)
+        Button { app.setThreadMuted(thread, !thread.muted) } label: {
+            Label(thread.muted ? "Unmute" : "Mute", systemImage: "bell")
+        }
+        Button { app.setThreadArchived(thread, !thread.archived) } label: {
+            Label(thread.archived ? "Unarchive" : "Archive", systemImage: "archivebox")
+        }
+        Button {
+            app.markThreadViewed(thread, through: activityAt)
+        } label: {
+            Label("Mark read", systemImage: "checkmark.circle")
+        }
+        Button {
+            do {
+                exportArchive = ExportArchive(url: try app.exportThreadsZip([thread]))
+            } catch {
+                app.showToast("Could not export chat: \(error.localizedDescription)",
+                              systemImage: "exclamationmark.triangle", style: .warning)
+            }
+        } label: {
+            Label("Export chat", systemImage: "square.and.arrow.up")
+        }
+        Button(role: .destructive) { pendingDelete = thread } label: {
+            Label("Delete", systemImage: "trash")
+        }
     }
 
     private func consumeGlobalRequests() {
@@ -489,54 +531,36 @@ struct ChatsHomeView: View {
             app.newChatRequested = false
         }
         if app.chatSearchRequested {
-            searchFocused = true
-            app.chatSearchRequested = false
+            revealChatSearch()
         }
     }
 
-    private func handleProjectContextChange() {
-        detailPath = []
-        selection = nil
-        _ = app.resolvePendingProjectNavigationIntent()
-        consumeGlobalRequests()
-        selectMostRecentThreadIfNeeded()
+    private func revealChatSearch() {
+        if sizeClass == .compact {
+            detailPath = []
+            selection = nil
+            preferredCompactColumn = .sidebar
+        }
+        searchFocused = true
+        app.chatSearchRequested = false
     }
 
-    /// Open Chats at the latest active conversation without stealing focus from
-    /// a deep link, cross-view handoff, New Chat, or an existing selection.
+    /// Fill an empty iPad detail without stealing the iPhone's conversation list.
     private func selectMostRecentThreadIfNeeded() {
         #if DEBUG
         guard !ProcessInfo.processInfo.arguments.contains("--ui-preview-chats-home") else { return }
         #endif
-        guard selection == nil,
+        guard sizeClass == .regular,
+              selection == nil,
               !showNewChat,
               app.threadToOpen == nil,
               app.pendingProjectNavigationIntent == nil,
               !app.newChatRequested
         else { return }
 
-        let mostRecentGroupThread = app.projectThreads
-            .filter(\.isGroup)
-            .filter { !$0.archived }
-            .max { $0.updatedAt < $1.updatedAt }
-        let mostRecentFamiliar = app.projectFamiliars.max { lhs, rhs in
-            let leftActivity = app.projectLastActivity(for: lhs.id) ?? .distantPast
-            let rightActivity = app.projectLastActivity(for: rhs.id) ?? .distantPast
-            if leftActivity == rightActivity {
-                return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
-                    == .orderedAscending
-            }
-            return leftActivity < rightActivity
-        }
-
-        if let familiar = mostRecentFamiliar,
-           let familiarActivity = app.projectLastActivity(for: familiar.id),
-           familiarActivity > (mostRecentGroupThread?.updatedAt ?? .distantPast) {
-            open(.familiar(familiar))
-        } else if let mostRecentGroupThread {
-            open(.thread(mostRecentGroupThread))
-        } else if let familiar = mostRecentFamiliar {
-            open(.familiar(familiar))
+        if let thread = app.chatThreads.filter({ !$0.archived })
+            .max(by: { $0.updatedAt < $1.updatedAt }) {
+            open(.thread(thread))
         }
     }
 
@@ -546,32 +570,18 @@ struct ChatsHomeView: View {
     private func consumeThreadRequest(_ thread: ChatThread?) {
         guard let thread else { return }
         if lastThreadId != thread.id { open(.thread(thread)) }
+        preferredCompactColumn = .detail
         app.threadToOpen = nil
-    }
-
-    /// Familiars matching the search query (name or role). Empty query → all.
-    private var filteredFamiliars: [Familiar] {
-        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !q.isEmpty else { return app.projectFamiliars }
-        return app.projectFamiliars.filter {
-            $0.displayName.lowercased().contains(q) || ($0.role?.lowercased().contains(q) ?? false)
-        }
     }
 
     private var emptyState: some View {
         ContentUnavailableView {
-            Label("No familiars yet", systemImage: "bubble.left.and.bubble.right")
+            Label("Start a conversation", systemImage: "bubble.left.and.bubble.right")
         } description: {
-            if app.canStartProjectChats {
-                Text("Pull to refresh once your desktop is connected, or start a group chat.")
-            } else {
-                Text("Unassigned chats are recovery-only. Switch to a registered project to start a replacement chat.")
-            }
+            Text("Choose a familiar for a new chat. Your conversations will stay here.")
         } actions: {
-            if app.canStartProjectChats {
-                Button("New chat") { presentGeneralNewChat() }
-                    .buttonStyle(.borderedProminent)
-            }
+            Button("New chat") { presentGeneralNewChat() }
+                .buttonStyle(.borderedProminent)
         }
     }
 
@@ -583,7 +593,8 @@ struct ChatsHomeView: View {
         else { return }
 
         appliedPreviewLaunchIntent = true
-        if let thread = app.projectMostRecentThread {
+        if let thread = app.chatThreads.filter({ !$0.archived })
+            .max(by: { $0.updatedAt < $1.updatedAt }) {
             selection = .thread(thread)
         }
         presentContextualNewChat()
@@ -607,112 +618,6 @@ struct ChatsHomeView: View {
     }
 }
 
-/// One familiar as an iMessage-style conversation row: avatar, name, a preview
-/// of the last thing said in its landing chat, and when. Selection is driven by
-/// the enclosing `List` tag, so the row itself is not a Button — that would
-/// swallow the sidebar selection on iPad.
-struct FamiliarConversationRow: View {
-    @Environment(AppModel.self) private var app
-    @Environment(\.chrome) private var chrome
-    let familiar: Familiar
-
-    private var thread: ChatThread? { app.projectLandingDirectThread(for: familiar.id) }
-    private var serverSession: SessionRow? { app.projectServerOnlySessions(for: familiar.id).first }
-
-    private enum ActivitySource {
-        case local(ChatThread)
-        case server(SessionRow)
-        case none
-    }
-
-    private var activitySource: ActivitySource {
-        let localDate = thread?.updatedAt ?? .distantPast
-        let serverDate = serverSession.flatMap { caveParseISO($0.updatedAt) } ?? .distantPast
-        if let thread, localDate >= serverDate { return .local(thread) }
-        if let serverSession { return .server(serverSession) }
-        return .none
-    }
-
-    private var preview: String {
-        switch activitySource {
-        case .local(let thread):
-            guard let text = thread.messages.last?.text, !text.isEmpty else {
-                return "No messages yet"
-            }
-            return text.replacingOccurrences(of: "\n", with: " ")
-        case .server(let session):
-            let title = session.title.trimmingCharacters(in: .whitespacesAndNewlines)
-            return title.isEmpty ? "Chat available on another device" : title
-        case .none:
-            return "No messages yet"
-        }
-    }
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            AvatarView(familiar: familiar,
-                       url: app.client?.avatarURL(for: familiar),
-                       size: 52, showStatus: true)
-                .padding(.top, 2)
-            VStack(alignment: .leading, spacing: 4) {
-                ViewThatFits(in: .horizontal) {
-                    HStack(alignment: .firstTextBaseline, spacing: 6) {
-                        familiarName
-                        Spacer(minLength: 8)
-                        relativeTime
-                    }
-                    VStack(alignment: .leading, spacing: 2) {
-                        familiarName
-                        relativeTime
-                    }
-                }
-                Text(preview)
-                    .font(.subheadline)
-                    .foregroundStyle(chrome.textSecondary)
-                    .lineLimit(2)
-                    .lineSpacing(2)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .padding(.vertical, 6)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityText)
-    }
-
-    private var familiarName: some View {
-        HStack(spacing: 6) {
-            Text(familiar.displayName)
-                .font(.body.weight(.semibold))
-                .foregroundStyle(chrome.textPrimary)
-                .lineLimit(1)
-                .layoutPriority(1)
-            if app.projectHasUnread(familiar.id) {
-                Circle().fill(chrome.accent).frame(width: 8, height: 8)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var relativeTime: some View {
-        if let updated = app.projectLastActivity(for: familiar.id) {
-            Text(updated, format: .relative(presentation: .numeric))
-                .font(.caption2)
-                .foregroundStyle(chrome.textMuted)
-                .lineLimit(1)
-                .minimumScaleFactor(0.82)
-        }
-    }
-
-    /// VoiceOver hears the name, whether anything is unread, and the preview —
-    /// the unread state is a coloured dot otherwise, which announces nothing.
-    private var accessibilityText: String {
-        var parts: [String] = [familiar.displayName]
-        if app.projectHasUnread(familiar.id) { parts.append("unread") }
-        parts.append(preview)
-        return parts.joined(separator: ". ")
-    }
-}
-
 private struct FamiliarServerLandingView: View {
     @Environment(AppModel.self) private var app
     let familiar: Familiar
@@ -727,6 +632,7 @@ private struct FamiliarServerLandingView: View {
                 switch app.threadOpenFailure(for: thread) {
                 case nil:
                     ChatView(thread: thread)
+                        .id(thread.id)
                 case .projectCatalogUnavailable?:
                     ProgressView("Loading project context…")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -757,7 +663,7 @@ private struct ThreadOpenRecoveryView: View {
             Label("This chat needs recovery", systemImage: "folder.badge.questionmark")
         } description: {
             Text(
-                "Its project metadata could not be resolved. It stays visible in Unassigned so you can inspect, export, or delete it, but it can’t open as a sendable chat."
+                "Its project metadata could not be resolved. It stays in your chat list so you can export or delete it, but sending is unavailable."
             )
         } actions: {
             if let actionTitle, let action {
@@ -770,60 +676,67 @@ private struct ThreadOpenRecoveryView: View {
 
 struct ThreadRow: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     let thread: ChatThread
+    var activityAt: Date? = nil
+    var isSelected = false
 
     private var familiars: [Familiar] { thread.familiarIds.compactMap(app.familiar) }
     private var lastMessage: DisplayMessage? { thread.messages.last }
+    private var activityDate: Date { max(activityAt ?? thread.updatedAt, thread.updatedAt) }
+    private var primaryColor: Color { isSelected ? chrome.accentForeground : chrome.textPrimary }
+    private var secondaryColor: Color { isSelected ? chrome.accentForeground : chrome.textSecondary }
+    private var accentColor: Color { isSelected ? chrome.accentForeground : chrome.accent }
+    private var hasUnread: Bool {
+        guard let seen = app.seenBoundary(for: thread) else { return false }
+        return activityDate > seen
+    }
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             if thread.isGroup {
                 AvatarClusterView(familiars: familiars, size: 48)
             } else {
                 AvatarView(familiar: familiars.first,
                            url: familiars.first.flatMap { app.client?.avatarURL(for: $0) },
-                           size: 48)
+                           size: 48, showStatus: true)
             }
             VStack(alignment: .leading, spacing: 3) {
-                HStack {
-                    Text(thread.title).font(.headline).lineLimit(1)
-                    if thread.pinned {
-                        Image(systemName: "pin.fill")
-                            .font(.caption2).foregroundStyle(.orange)
-                            .accessibilityLabel("Pinned")
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        title
+                        Spacer(minLength: 8)
+                        relativeTime
                     }
-                    if thread.muted {
-                        Image(systemName: "bell.slash.fill")
-                            .font(.caption2).foregroundStyle(.secondary)
-                            .accessibilityLabel("Muted")
+                    VStack(alignment: .leading, spacing: 2) {
+                        title
+                        relativeTime
                     }
-                    if thread.isGroup {
-                        Image(systemName: "person.2.fill")
-                            .font(.caption2).foregroundStyle(.secondary)
-                            .accessibilityLabel("Group chat")
-                    }
-                    Spacer()
-                    Text(thread.updatedAt, format: .relative(presentation: .numeric))
-                        .font(.caption).foregroundStyle(.tertiary)
                 }
+                Text(familiars.map(\.displayName).joined(separator: ", "))
+                    .font(.caption)
+                    .foregroundStyle(secondaryColor)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
                 if let draftText = app.threadDrafts[thread.id] {
                     // A persisted unsent draft outranks the last-message
                     // preview (standard messenger affordance — makes drafts
                     // discoverable from the list).
-                    (Text("Draft: ").foregroundStyle(Color.accentColor)
+                    (Text("Draft: ").foregroundStyle(accentColor)
                         + Text(draftText.replacingOccurrences(of: "\n", with: " ")))
                         .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(secondaryColor)
                         .lineLimit(2)
                 } else {
                     Text(previewText)
                         .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(secondaryColor)
                         .lineLimit(2)
                 }
             }
         }
-        .padding(.vertical, 2)
+        .frame(minHeight: 44)
+        .padding(.vertical, 4)
         .contentShape(Rectangle())
         // Collapse title, status glyphs, time, and preview into one spoken element.
         .accessibilityElement(children: .combine)
@@ -833,10 +746,13 @@ struct ThreadRow: View {
     /// One spoken summary of the row: title, status, last activity, preview.
     private var accessibilityText: String {
         var parts: [String] = [thread.title]
+        parts.append(contentsOf: familiars.map(\.displayName))
+        if hasUnread { parts.append("unread") }
+        if thread.archived { parts.append("archived") }
         if thread.isGroup { parts.append("group chat") }
         if thread.pinned { parts.append("pinned") }
         if thread.muted { parts.append("muted") }
-        parts.append("last active " + Self.relativeFormatter.localizedString(for: thread.updatedAt, relativeTo: Date()))
+        parts.append("last active " + Self.relativeFormatter.localizedString(for: activityDate, relativeTo: Date()))
         if let draftText = app.threadDrafts[thread.id] {
             parts.append("draft: " + draftText)
         } else {
@@ -847,7 +763,41 @@ struct ThreadRow: View {
 
     private static let relativeFormatter = RelativeDateTimeFormatter()
 
+    private var title: some View {
+        HStack(spacing: 6) {
+            Text(thread.title)
+                .font(.headline)
+                .foregroundStyle(primaryColor)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+                .layoutPriority(1)
+            if hasUnread {
+                Circle().fill(accentColor).frame(width: 8, height: 8)
+            }
+            if thread.pinned {
+                Image(systemName: "pin.fill").foregroundStyle(accentColor)
+            }
+            if thread.muted {
+                Image(systemName: "bell.slash.fill").foregroundStyle(secondaryColor)
+            }
+            if thread.isGroup {
+                Image(systemName: "person.2.fill").foregroundStyle(secondaryColor)
+            }
+            if thread.archived {
+                Image(systemName: "archivebox").foregroundStyle(secondaryColor)
+            }
+        }
+        .font(.caption2)
+    }
+
+    private var relativeTime: some View {
+        Text(activityDate, format: .relative(presentation: .numeric))
+            .font(.caption)
+            .foregroundStyle(secondaryColor)
+            .lineLimit(1)
+    }
+
     private var previewText: String {
+        if activityDate > thread.updatedAt { return "New activity on another device" }
         guard let last = lastMessage else { return "Tap to start chatting" }
         if last.streaming && last.text.isEmpty { return "…" }
         let prefix = last.role == .user ? "\(app.operatorDisplayName): " : ""

--- a/apps/ios/CovenCave/CovenCave/Views/CommandsSheet.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CommandsSheet.swift
@@ -45,7 +45,7 @@ struct CommandsSheet: View {
             .navigationTitle("Commands")
             .navigationBarTitleDisplayMode(.inline)
             .searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always),
-                        prompt: "Search commands")
+                        prompt: "Search commands…")
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -153,7 +153,6 @@ struct FamiliarThreadsView: View {
         .refreshable { await app.loadSessions() }
         // Re-appearance is not: reuse a list fetched moments ago (cave-ioswipe.5).
         .task { await app.loadSessionsIfStale() }
-        .onAppear { app.markFamiliarViewed([familiar.id], in: projectContext) }
         .safeAreaInset(edge: .bottom) {
             if selectMode {
                 HStack {
@@ -326,11 +325,7 @@ struct FamiliarThreadsView: View {
             return nil
         }
     }
-    private var hasLocalThreads: Bool { !app.projectDirectThreads(for: familiar.id).isEmpty }
-    private var canStartChatsInContext: Bool {
-        if case .project = projectContext { return true }
-        return false
-    }
+    private var hasLocalThreads: Bool { !localThreads.isEmpty }
     private var allLocalSelected: Bool {
         !visibleLocalThreads.isEmpty && Set(visibleLocalThreads.map(\.id)).isSubset(of: selectedIds)
     }
@@ -453,19 +448,6 @@ struct FamiliarThreadsView: View {
     }
 
     private func startNewChat() {
-        guard canStartChatsInContext else {
-            app.showToast(
-                "Unassigned chats are recovery-only. Switch to a registered project to start a replacement chat.",
-                systemImage: "folder.badge.questionmark",
-                style: .warning
-            )
-            return
-        }
-        if app.projectContext?.id != projectContext.id {
-            guard app.requestOpenDestination(.chats, projectId: projectContext.projectId) else {
-                return
-            }
-        }
         showNewChat = true
     }
 
@@ -473,48 +455,83 @@ struct FamiliarThreadsView: View {
         ContentUnavailableView {
             Label("No chats with \(familiar.displayName)", systemImage: "bubble.left")
         } description: {
-            if canStartChatsInContext {
-                Text("Start a conversation — it'll appear here and stay separate from your other chats.")
-            } else {
-                Text("Unassigned chats are recovery-only. Switch to a registered project to start a replacement chat.")
-            }
+            Text("Start a separate conversation with this familiar. Choose its access in New chat.")
         } actions: {
-            if canStartChatsInContext {
-                Button("New chat", action: startNewChat)
-                    .buttonStyle(.borderedProminent)
-            }
+            Button("New chat", action: startNewChat)
+                .buttonStyle(.borderedProminent)
         }
     }
 }
 
 /// A server-side session not yet materialised on this device — tapping it pulls
 /// the conversation down. Mirrors `ThreadRow`'s layout with a synced-elsewhere hint.
-private struct ServerSessionRow: View {
+struct ServerSessionRow: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     let session: SessionRow
+    private var familiar: Familiar? { session.familiarId.flatMap(app.familiar) }
 
     var body: some View {
-        HStack(spacing: 12) {
-            AvatarView(familiar: session.familiarId.flatMap(app.familiar),
-                       url: session.familiarId.flatMap(app.familiar).flatMap { app.client?.avatarURL(for: $0) },
-                       size: 48)
+        HStack(alignment: .top, spacing: 12) {
+            AvatarView(familiar: familiar,
+                       url: familiar.flatMap { app.client?.avatarURL(for: $0) },
+                       size: 48, showStatus: true)
             VStack(alignment: .leading, spacing: 3) {
-                HStack {
-                    Text(session.title.isEmpty ? "Untitled chat" : session.title)
-                        .font(.headline).lineLimit(1)
-                    Spacer()
-                    if let date = caveParseISO(session.updatedAt) {
-                        Text(date, format: .relative(presentation: .numeric))
-                            .font(.caption).foregroundStyle(.tertiary)
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        title
+                        Spacer(minLength: 8)
+                        relativeTime
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        title
+                        relativeTime
                     }
                 }
-                Label("Synced from another device", systemImage: "desktopcomputer")
+                if let familiar {
+                    Text(familiar.displayName)
+                        .font(.caption)
+                        .foregroundStyle(chrome.textSecondary)
+                }
+                Label("On another device", systemImage: "desktopcomputer")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
             }
         }
-        .padding(.vertical, 2)
+        .frame(minHeight: 44)
+        .padding(.vertical, 4)
         .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+    }
+
+    private var title: some View {
+        HStack(spacing: 6) {
+            Text(session.title.isEmpty ? "Untitled chat" : session.title)
+                .font(.headline)
+                .foregroundStyle(chrome.textPrimary)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+                .layoutPriority(1)
+            if session.pinned == true {
+                Image(systemName: "pin.fill").foregroundStyle(chrome.accent)
+                    .accessibilityLabel("Pinned")
+            }
+            if session.archivedAt != nil {
+                Image(systemName: "archivebox").foregroundStyle(.secondary)
+                    .accessibilityLabel("Archived")
+            }
+        }
+        .font(.caption2)
+    }
+
+    @ViewBuilder
+    private var relativeTime: some View {
+        if let date = caveParseISO(session.updatedAt) ?? caveParseISO(session.createdAt) {
+            Text(date, format: .relative(presentation: .numeric))
+                .font(.caption)
+                .foregroundStyle(chrome.textSecondary)
+                .lineLimit(1)
+        }
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarsListView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarsListView.swift
@@ -3,21 +3,9 @@ import PhotosUI
 import UIKit
 
 enum FamiliarsListCopy {
-    static let cachedAccessBanner = "Showing cached familiar access"
-
-    static func emptyState(for context: ProjectContext?) -> (title: String, message: String) {
-        switch context {
-        case .project(let project):
-            return (
-                "No familiars have access",
-                "No familiars have access to \(project.name) yet."
-            )
-        case .unassigned:
-            return ("No recovery familiars", ProjectContextCopy.unassignedRecovery)
-        case nil:
-            return ("Choose a project", "Choose a project in Chats to see its familiar roster.")
-        }
-    }
+    static let cachedAccessBanner = "Showing cached familiars"
+    static let emptyTitle = "No familiars available"
+    static let emptyMessage = "Connect to your Cave in Settings, then refresh familiars."
 }
 
 @MainActor
@@ -34,10 +22,10 @@ struct FamiliarsListPresentation {
     let mode: Mode
 
     init(app: AppModel) {
-        visibleFamiliars = app.projectFamiliars
-        showsCachedAccessBanner = app.projectMembershipLoaded && app.familiarsError != nil
+        visibleFamiliars = app.familiars
+        showsCachedAccessBanner = app.familiarsLoaded && app.familiarsError != nil && !app.familiars.isEmpty
 
-        guard app.projectMembershipLoaded else {
+        guard app.familiarsLoaded else {
             if let error = app.familiarsError {
                 mode = .firstLoadError(error)
             } else {
@@ -47,61 +35,25 @@ struct FamiliarsListPresentation {
         }
 
         if visibleFamiliars.isEmpty {
-            let copy = FamiliarsListCopy.emptyState(for: app.projectContext)
-            mode = .empty(title: copy.title, message: copy.message)
+            if let error = app.familiarsError {
+                mode = .firstLoadError(error)
+            } else {
+                mode = .empty(title: FamiliarsListCopy.emptyTitle, message: FamiliarsListCopy.emptyMessage)
+            }
         } else {
             mode = .list
         }
     }
 }
 
-@MainActor
-struct FamiliarDetailStatsModel {
-    let chats: String
-    let activity: String
-    let tasks: String
-    let memory: String
-
-    static func make(
-        app: AppModel,
-        familiar: Familiar,
-        context: ProjectContext?
-    ) -> FamiliarDetailStatsModel {
-        let chatCount = context.map { app.threadCount(for: familiar.id, in: $0) } ?? 0
-        let assignedTasks = context.map { scopedContext in
-            app.tasks.filter {
-                scopedContext.matches(task: $0, registeredProjects: app.projects)
-                    && $0.familiarId == familiar.id
-                    && $0.status.isActive
-            }
-        } ?? []
-        let taskValue = app.tasksError == nil
-            ? "\(assignedTasks.count)"
-            : app.tasks.isEmpty ? "Unknown" : "\(assignedTasks.count) cached"
-
-        return FamiliarDetailStatsModel(
-            chats: "\(chatCount)",
-            activity: activityValue(for: context.flatMap { app.lastActivity(for: familiar.id, in: $0) }),
-            tasks: taskValue,
-            memory: familiar.memoryFreshness ?? "Unknown"
-        )
-    }
-
-    static func activityValue(for lastActivity: Date?) -> String {
-        guard let lastActivity else { return "No activity yet" }
-        return lastActivity.formatted(date: .abbreviated, time: .shortened)
-    }
-}
-
-/// The all-familiars roster (design: "Familiars" drawer destination): every
-/// summoned familiar with its avatar, role, and live presence. Tapping one
-/// dismisses the sheet and routes to that familiar's threads.
+/// A participant picker for New chat, not a familiar dashboard.
 struct FamiliarsListView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.chrome) private var chrome
     @Environment(\.dismiss) private var dismiss
+    @State private var permissionsFamiliar: Familiar?
 
-    /// Host-supplied: route to the familiar's surface after dismissal.
+    /// Host-supplied: select this chat participant after dismissal.
     var openFamiliar: (Familiar) -> Void
 
     var body: some View {
@@ -124,23 +76,29 @@ struct FamiliarsListView: View {
                     }
                 case .empty(let title, let message):
                     ContentUnavailableView {
-                        Label(title, systemImage: app.projectContext == .unassigned ? "tray.full" : "cat")
+                        Label(title, systemImage: "cat")
                     } description: {
                         Text(message)
+                    } actions: {
+                        Button("Refresh familiars") { Task { await app.loadFamiliars() } }
+                            .buttonStyle(.bordered)
                     }
                 case .list:
                     List(presentation.visibleFamiliars) { familiar in
-                        NavigationLink {
-                            // The roster opens the unified hub (cave-9rwd.2).
-                            // The Chats hand-off is unchanged: the hub's Chat
-                            // action runs the exact same closure the detail
-                            // page's button used to.
-                            FamiliarHubView(familiar: familiar) {
-                                dismiss()
-                                openFamiliar(familiar)
-                            }
+                        Button {
+                            dismiss()
+                            openFamiliar(familiar)
                         } label: {
                             FamiliarRosterRow(familiar: familiar)
+                        }
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            Button("Permissions", systemImage: "lock.shield") {
+                                permissionsFamiliar = familiar
+                            }
+                        }
+                        .accessibilityAction(named: Text("Permissions")) {
+                            permissionsFamiliar = familiar
                         }
                         .listRowBackground(Color.clear)
                         .listRowSeparatorTint(chrome.border.opacity(0.6))
@@ -167,7 +125,7 @@ struct FamiliarsListView: View {
                     .background(chrome.bgRaised)
                 }
             }
-            .navigationTitle("Familiars")
+            .navigationTitle("Choose a familiar")
             .navigationBarTitleDisplayMode(.large)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -176,6 +134,13 @@ struct FamiliarsListView: View {
             }
         }
         .themedSheetBackground()
+        .task {
+            if !app.familiarsLoaded { await app.loadFamiliars() }
+        }
+        .refreshable { await app.loadFamiliars() }
+        .sheet(item: $permissionsFamiliar) { familiar in
+            FamiliarPermissionsSheet(familiar: familiar)
+        }
     }
 }
 
@@ -222,7 +187,7 @@ private struct FamiliarRosterRow: View {
         .padding(.vertical, 6)
         .contentShape(Rectangle())
         .accessibilityLabel("\(familiar.displayName), \(presenceLabel)")
-        .accessibilityHint(Text("Opens this familiar's details."))
+        .accessibilityHint("Selects this familiar for chat.")
     }
 }
 
@@ -320,7 +285,6 @@ struct FamiliarDetailView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .task(id: modelLoadTarget) {
-            if !app.tasksLoaded { await app.loadTasks() }
             await loadModel()
         }
         .sheet(isPresented: $showModelPicker) {

--- a/apps/ios/CovenCave/CovenCave/Views/NavigationDrawer.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/NavigationDrawer.swift
@@ -9,8 +9,6 @@ struct CaveNavigationDrawer: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @Binding var isOpen: Bool
-    var openProjectSwitcher: () -> Void
-    var openFamiliars: () -> Void
     var openThread: (ChatThread) -> Void
     var newChat: () -> Void
     var openSearch: () -> Void
@@ -18,7 +16,10 @@ struct CaveNavigationDrawer: View {
     @State private var recentsExpanded = true
 
     private var recentThreads: [ChatThread] {
-        app.projectRecentThreads(limit: 5)
+        Array(app.chatThreads.filter { !$0.archived }.sorted {
+            if $0.pinned != $1.pinned { return $0.pinned }
+            return $0.updatedAt > $1.updatedAt
+        }.prefix(5))
     }
 
     var body: some View {
@@ -51,20 +52,6 @@ struct CaveNavigationDrawer: View {
                 VStack(alignment: .leading, spacing: 4) {
                     DrawerNavRow(systemImage: "bubble.left", label: "Chats",
                                  active: app.selectedTab == .chats) { go(.chats) }
-                    DrawerNavRow(systemImage: "checkmark.square", label: "Tasks",
-                                 active: app.selectedTab == .tasks) { go(.tasks) }
-
-                    sectionLabel("Workspace")
-
-                    ProjectContextButton {
-                        close()
-                        openProjectSwitcher()
-                    }
-
-                    DrawerNavRow(systemImage: "cat", label: "Familiars") {
-                        close()
-                        openFamiliars()
-                    }
 
                     if !recentThreads.isEmpty {
                         Button {
@@ -73,7 +60,7 @@ struct CaveNavigationDrawer: View {
                             }
                         } label: {
                             HStack(spacing: 6) {
-                                Text("Recent Chats")
+                                Text("Recent chats")
                                     .font(.subheadline.weight(.semibold))
                                 Image(systemName: "chevron.down")
                                     .font(.caption2.weight(.semibold))
@@ -105,7 +92,7 @@ struct CaveNavigationDrawer: View {
                                         Spacer(minLength: 0)
                                     }
                                     .padding(.horizontal, 14)
-                                    .frame(minHeight: 42)
+                                    .frame(minHeight: 44)
                                     .contentShape(Rectangle())
                                 }
                                 .buttonStyle(.glassPress)
@@ -132,13 +119,6 @@ struct CaveNavigationDrawer: View {
         .overlay(alignment: .trailing) {
             Rectangle().fill(chrome.border.opacity(0.7)).frame(width: 1).ignoresSafeArea()
         }
-        .task {
-            if !app.projectMembershipLoaded {
-                await app.retryProjectContextLoad()
-            } else if !app.projectsLoaded {
-                await app.loadProjects()
-            }
-        }
         .gesture(
             DragGesture(minimumDistance: 24).onEnded { value in
                 if value.translation.width < -40 { close() }
@@ -162,7 +142,7 @@ struct CaveNavigationDrawer: View {
                     .contentShape(Circle())
             }
             .buttonStyle(.glassPress)
-            .accessibilityLabel("Search everything")
+            .accessibilityLabel("Search chats")
         }
         .padding(.horizontal, 20)
     }
@@ -173,7 +153,7 @@ struct CaveNavigationDrawer: View {
                 close()
                 newChat()
             } label: {
-                Label("New Chat", systemImage: "square.and.pencil")
+                Label("New chat", systemImage: "square.and.pencil")
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(chrome.bgBase)
                     .frame(minHeight: 44)
@@ -204,16 +184,6 @@ struct CaveNavigationDrawer: View {
         .overlay(alignment: .top) {
             Rectangle().fill(chrome.border.opacity(0.6)).frame(height: 1)
         }
-    }
-
-    private func sectionLabel(_ title: String) -> some View {
-        Text(title)
-            .font(.subheadline.weight(.semibold))
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 14)
-            .padding(.top, 18)
-            .padding(.bottom, 6)
-            .accessibilityAddTraits(.isHeader)
     }
 
     private func close() { isOpen = false }

--- a/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
@@ -1,54 +1,35 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
-/// Pick one familiar (direct chat) or several (group). Mirrors the Telegram
-/// "new message → new group" flow while fixing every new chat to the active
-/// registered project.
+/// Familiar and access selection belong to this launch, not the shell.
 struct NewChatView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.chrome) private var chrome
     let fixedFamiliarId: String?
     var onStart: (ChatThread) -> Void
 
     @State private var selected: Set<String>
-    @State private var groupName: String = ""
+    @State private var groupName = ""
+    @State private var selectedProject: ProjectInfo?
+    @State private var selectedRoot: String?
+    @State private var projectResolved = false
+    @State private var projectRefreshToken = 0
+    @State private var isLaunching = false
+    @State private var launchError: String?
     @State private var importingFile = false
     @State private var importLaunchContext: NewChatImportLaunchContext?
+    @State private var importConnectionLease: AppModel.ConnectionDispatchLease?
 
-    private var activeProject: ProjectInfo? { app.activeProject }
-    private var activeProjectRoot: String? { activeProject?.root }
-    private var availableFamiliars: [Familiar] {
-        guard activeProject != nil else { return [] }
-        return app.projectFamiliars
-    }
-    private var availableFamiliarIDs: Set<String> {
-        Set(availableFamiliars.map(\.id))
-    }
-    private var isGroup: Bool { selectedFamiliarIds.count > 1 }
-    private var fixedFamiliar: Familiar? {
-        guard let fixedFamiliarId else { return nil }
-        return app.familiar(fixedFamiliarId)
-    }
     private var selectedFamiliarIds: [String] {
-        availableFamiliars.map(\.id).filter { selected.contains($0) }
+        ChatProjectSelection.familiarKey(Array(selected))
     }
-    private var unavailableSelectedFamiliarIDs: [String] {
-        selected
-            .filter { !availableFamiliarIDs.contains($0) }
-            .sorted()
-    }
-    private var unavailableSelectedFamiliarNames: String {
-        unavailableSelectedFamiliarIDs
-            .map { app.familiar($0)?.displayName ?? $0 }
-            .joined(separator: ", ")
-    }
-    private var isRecoveryOnlyContext: Bool {
-        app.projectContext == .unassigned || activeProjectRoot == nil
-    }
+    private var availableFamiliars: [Familiar] { app.familiars }
+    private var isGroup: Bool { selectedFamiliarIds.count > 1 }
     private var canLaunchChat: Bool {
-        activeProjectRoot != nil
-            && !selectedFamiliarIds.isEmpty
-            && unavailableSelectedFamiliarIDs.isEmpty
+        projectResolved && selectedProject != nil
+            && !selectedFamiliarIds.isEmpty && !isLaunching
+            && selectedFamiliarIds.allSatisfy { id in availableFamiliars.contains { $0.id == id } }
     }
 
     init(
@@ -68,250 +49,253 @@ struct NewChatView: View {
                 Section {
                     Button { beginImport() } label: {
                         Label("Import from Markdown…", systemImage: "square.and.arrow.down")
+                            .frame(minHeight: 44)
                     }
                     .disabled(!canLaunchChat)
                 }
-
                 if isGroup {
                     Section("Group name (Optional)") {
                         TextField("e.g., Research crew", text: $groupName)
                             .accessibilityLabel("Group name")
                     }
                 }
-
-                projectSection
-
-                if !isRecoveryOnlyContext {
-                    familiarSection
-                }
-
-                if let blockedMessage = blockedMessage {
-                    Section {
-                        Label(blockedMessage.title, systemImage: blockedMessage.systemImage)
-                        Text(blockedMessage.body)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                        Button("Refresh chats") {
-                            Task {
-                                await app.loadFamiliars()
-                                await app.loadSessions()
-                            }
+                familiarSection
+                Section("Chat access") {
+                    ChatProjectPicker(
+                        familiarIds: selectedFamiliarIds,
+                        recentRoots: [],
+                        selectedRoot: $selectedRoot,
+                        isResolved: $projectResolved,
+                        refreshToken: projectRefreshToken,
+                        requiresExplicitSelection: true,
+                        onSelection: { project in
+                            selectedProject = project
+                            launchError = nil
+                        }
+                    )
+                    Text("Choose a registered project for this chat. This does not change other chats. Manage familiar access on your desktop, then refresh.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Button("Refresh access") {
+                        Task {
+                            await app.refreshChatAccess()
+                            projectRefreshToken += 1
                         }
                     }
+                    .frame(minHeight: 44)
+                }
+                if let launchError {
+                    Section {
+                        Label(launchError, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.secondary)
+                            .accessibilityAddTraits(.updatesFrequently)
+                    }
+                }
+                if isLaunching {
+                    Section { ProgressView("Checking chat access…") }
                 }
             }
+            .disabled(isLaunching)
             .themedListBackground()
             .navigationTitle("New chat")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
+                        .disabled(isLaunching)
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button(isGroup ? "Create group" : "Start chat") { start() }
                         .disabled(!canLaunchChat)
                 }
             }
+            .task {
+                if !app.familiarsLoaded { await app.refreshChatAccess() }
+            }
             .fileImporter(
                 isPresented: $importingFile,
                 allowedContentTypes: [.plainText, .text],
-                allowsMultipleSelection: false
-            ) { result in
-                importFromFile(result)
-            }
+                allowsMultipleSelection: false,
+                onCompletion: importFromFile
+            )
         }
         .themedSheetBackground()
-    }
-
-    @ViewBuilder
-    private var projectSection: some View {
-        Section("Project") {
-            if let activeProject {
-                Label(activeProject.name, systemImage: "folder")
-                Text(activeProject.root)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                Text("New chats start in the active project. Switch projects from Chats to use a different project.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            } else {
-                Label(
-                    "Unassigned chats are recovery-only.",
-                    systemImage: "folder.badge.questionmark"
-                )
-                Text("Switch to a registered project in Chats to start a replacement chat.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
-        }
+        .interactiveDismissDisabled(isLaunching)
     }
 
     @ViewBuilder
     private var familiarSection: some View {
-        if fixedFamiliarId == nil {
-            Section(selected.isEmpty ? "Choose familiars" : "\(selectedFamiliarIds.count) selected") {
-                if availableFamiliars.isEmpty {
-                    Text("No familiars are available in \(activeProject?.name ?? "the active project"). Refresh chats or switch projects.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-                ForEach(availableFamiliars) { familiar in
-                    Button { toggle(familiar.id) } label: {
-                        HStack(spacing: 12) {
-                            AvatarView(
-                                familiar: familiar,
-                                url: app.client?.avatarURL(for: familiar),
-                                size: 40,
-                                showStatus: true
-                            )
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(familiar.displayName)
-                                    .font(.body)
-                                    .foregroundStyle(.primary)
-                                if let role = familiar.role, !role.isEmpty {
-                                    Text(role)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
+        Section(fixedFamiliarId == nil ? "Choose familiars" : "Familiar") {
+            if app.canLoadChatProjects && !app.familiarsLoaded && app.familiarsError == nil {
+                ProgressView("Loading familiars…")
+            }
+            if let error = app.familiarsError {
+                Label(error, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.secondary)
+            }
+            if availableFamiliars.isEmpty {
+                Text("No familiars available. Connect to your Cave in Settings, then refresh access.")
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(availableFamiliars.filter { fixedFamiliarId == nil || $0.id == fixedFamiliarId }) { familiar in
+                Button { toggle(familiar.id) } label: {
+                    HStack(spacing: 12) {
+                        AvatarView(
+                            familiar: familiar,
+                            url: app.client?.avatarURL(for: familiar),
+                            size: 40,
+                            showStatus: true
+                        )
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(familiar.displayName).font(.body).foregroundStyle(.primary)
+                            if let role = familiar.role, !role.isEmpty {
+                                Text(role).font(.caption).foregroundStyle(.secondary)
                             }
-                            Spacer()
-                            Image(systemName: selected.contains(familiar.id) ? "checkmark.circle.fill" : "circle")
-                                .foregroundStyle(
-                                    selected.contains(familiar.id)
-                                        ? Color.accentColor
-                                        : Color.secondary
-                                )
                         }
+                        Spacer()
+                        Image(systemName: selected.contains(familiar.id) ? "checkmark.circle.fill" : "circle")
+                            .foregroundStyle(selected.contains(familiar.id) ? chrome.accent : chrome.textSecondary)
                     }
-                    .buttonStyle(.plain)
+                    .frame(minHeight: 44)
+                }
+                .buttonStyle(.plain)
+                .disabled(fixedFamiliarId != nil)
+                .accessibilityAddTraits(selected.contains(familiar.id) ? [.isSelected] : [])
+            }
+            ForEach(selectedFamiliarIds.filter { id in !availableFamiliars.contains { $0.id == id } }, id: \.self) { id in
+                Label("\(id) is unavailable. Refresh access or choose another familiar.", systemImage: "person.crop.circle.badge.exclamationmark")
+                if fixedFamiliarId == nil {
+                    Button("Remove \(id)") { toggle(id) }.frame(minHeight: 44)
                 }
             }
         }
-    }
-
-    private var blockedMessage: (title: String, body: String, systemImage: String)? {
-        if isRecoveryOnlyContext {
-            return (
-                "Unassigned chats are recovery-only.",
-                "Switch to a registered project in Chats to start a replacement chat.",
-                "folder.badge.questionmark"
-            )
-        }
-
-        if let fixedFamiliar,
-           !availableFamiliarIDs.contains(fixedFamiliar.id) {
-            return (
-                "This familiar is no longer in \(activeProject?.name ?? "the active project").",
-                "Refresh chats or switch projects, then try again.",
-                "person.crop.circle.badge.exclamationmark"
-            )
-        }
-
-        if !unavailableSelectedFamiliarIDs.isEmpty {
-            let noun = unavailableSelectedFamiliarIDs.count == 1
-                ? "Selected familiar"
-                : "Selected familiars"
-            return (
-                "\(noun) unavailable in \(activeProject?.name ?? "the active project").",
-                "Refresh chats or switch projects, then choose again. \(unavailableSelectedFamiliarNames)",
-                "person.crop.circle.badge.exclamationmark"
-            )
-        }
-
-        return nil
-    }
-
-    /// Read the picked Markdown file into a new thread and open it.
-    private func importFromFile(_ result: Result<[URL], Error>) {
-        defer { importLaunchContext = nil }
-        guard case .success(let urls) = result,
-              let url = urls.first,
-              let launchContext = importLaunchContext
-        else { return }
-        switch launchContext.validate(
-            projectContext: app.projectContext,
-            activeProject: activeProject,
-            projectMembership: app.projectMembership
-        ) {
-        case .valid:
-            break
-        case .unassigned:
-            app.showToast(
-                "Import cancelled. Unassigned chats are recovery-only. Switch to a registered project in Chats, then try again.",
-                systemImage: "folder.badge.questionmark",
-                style: .warning
-            )
-            return
-        case .projectChanged:
-            app.showToast(
-                "Import cancelled. The active project changed while the picker was open. Reopen Import from Markdown for the current project or switch back, then try again.",
-                systemImage: "arrow.trianglehead.swap",
-                style: .warning
-            )
-            return
-        case .familiarAccessRevoked(let revokedFamiliarIds):
-            let revokedNames = revokedFamiliarIds.map { app.familiar($0)?.displayName ?? $0 }
-            let projectName = activeProject?.name ?? "the active project"
-            let message: String
-            if revokedNames.count == 1, let revokedName = revokedNames.first {
-                message = "\(revokedName) can’t access \(projectName) anymore. Refresh chats or switch projects, then choose again."
-            } else {
-                message = "Some selected familiars can’t access \(projectName) anymore. Refresh chats or switch projects, then choose again. \(revokedNames.joined(separator: ", "))"
-            }
-            app.showToast(
-                message,
-                systemImage: "person.crop.circle.badge.exclamationmark",
-                style: .warning
-            )
-            return
-        }
-        let scoped = url.startAccessingSecurityScopedResource()
-        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
-        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return }
-        let fallback = url.deletingPathExtension().lastPathComponent
-        onStart(
-            app.importMarkdown(
-                text,
-                fallbackTitle: fallback,
-                familiarIds: launchContext.familiarIds,
-                projectRoot: launchContext.projectRoot
-            )
-        )
-    }
-
-    private func beginImport() {
-        guard let launchContext = NewChatImportLaunchContext(
-            activeProject: activeProject,
-            selectedFamiliarIds: selectedFamiliarIds
-        ) else { return }
-        importLaunchContext = launchContext
-        importingFile = true
     }
 
     private func toggle(_ id: String) {
-        if selected.contains(id) {
-            selected.remove(id)
-        } else {
-            selected.insert(id)
+        if selected.contains(id) { selected.remove(id) } else { selected.insert(id) }
+        projectResolved = false
+        launchError = nil
+    }
+
+    private func reportLaunchError(_ message: String) {
+        launchError = message
+        app.showToast(message, systemImage: "exclamationmark.triangle", style: .warning)
+    }
+
+    private func beginImport() {
+        guard canLaunchChat,
+              let context = NewChatImportLaunchContext(
+                selectedProject: selectedProject,
+                selectedFamiliarIds: selectedFamiliarIds
+              ) else {
+            reportLaunchError("Choose familiars and a registered project before importing.")
+            return
+        }
+        importLaunchContext = context
+        importConnectionLease = app.captureConnectionDispatchLease()
+        importingFile = true
+    }
+
+    private func importFromFile(_ result: Result<[URL], Error>) {
+        let context = importLaunchContext
+        let lease = importConnectionLease
+        importLaunchContext = nil
+        importConnectionLease = nil
+        do {
+            guard let url = try result.get().first else { return }
+            guard let context, let lease else {
+                reportLaunchError("Import access expired. Choose a project and import again.")
+                return
+            }
+            isLaunching = true
+            Task { @MainActor in
+                defer { isLaunching = false }
+                guard await validate(context, lease: lease) else { return }
+                let scoped = url.startAccessingSecurityScopedResource()
+                defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+                do {
+                    let text = try String(contentsOf: url, encoding: .utf8)
+                    onStart(app.importMarkdown(
+                        text,
+                        fallbackTitle: url.deletingPathExtension().lastPathComponent,
+                        familiarIds: context.familiarIds,
+                        projectRoot: context.projectRoot
+                    ))
+                } catch {
+                    reportLaunchError("Could not read the Markdown file: \(error.localizedDescription)")
+                }
+            }
+        } catch {
+            if (error as NSError).code != CocoaError.userCancelled.rawValue {
+                reportLaunchError("Could not import the chat: \(error.localizedDescription)")
+            }
         }
     }
 
     private func start() {
-        let ids = selectedFamiliarIds
         guard canLaunchChat,
-              !ids.isEmpty,
-              let activeProjectRoot
-        else { return }
-        let thread = ids.count == 1
-            ? app.startFreshThread(
-                familiarIds: ids,
-                projectRoot: activeProjectRoot
-            )
-            : app.createGroup(
-                familiarIds: ids,
-                title: groupName,
-                projectRoot: activeProjectRoot
-            )
-        onStart(thread)
+              let context = NewChatImportLaunchContext(
+                selectedProject: selectedProject,
+                selectedFamiliarIds: selectedFamiliarIds
+              ) else {
+            reportLaunchError("Choose familiars and a registered project before starting.")
+            return
+        }
+        let lease = app.captureConnectionDispatchLease()
+        let title = groupName
+        isLaunching = true
+        Task { @MainActor in
+            defer { isLaunching = false }
+            guard await validate(context, lease: lease) else { return }
+            let thread = context.familiarIds.count == 1
+                ? app.startFreshThread(familiarIds: context.familiarIds, projectRoot: context.projectRoot)
+                : app.createGroup(familiarIds: context.familiarIds, title: title, projectRoot: context.projectRoot)
+            onStart(thread)
+        }
+    }
+
+    @MainActor
+    private func validate(
+        _ context: NewChatImportLaunchContext,
+        lease: AppModel.ConnectionDispatchLease
+    ) async -> Bool {
+        guard app.connectionDispatchLeaseIsCurrent(lease) else {
+            reportLaunchError("Your Cave connection changed. Reopen New chat and try again.")
+            return false
+        }
+        await app.refreshChatAccess()
+        guard app.connectionDispatchLeaseIsCurrent(lease) else {
+            reportLaunchError("Your Cave connection changed. Reopen New chat and try again.")
+            return false
+        }
+        do {
+            let accessible = try await app.loadChatProjects(familiarIds: context.familiarIds)
+            try Task.checkCancellation()
+            guard app.connectionDispatchLeaseIsCurrent(lease) else {
+                reportLaunchError("Your Cave connection changed. Reopen New chat and try again.")
+                return false
+            }
+            switch context.validate(
+                registeredProjects: app.projects,
+                accessibleProjects: accessible,
+                projectMembership: app.projectMembership,
+                membershipLoaded: app.projectMembershipLoaded && app.projectContextError == nil
+            ) {
+            case .valid:
+                return true
+            case .accessUnavailable:
+                reportLaunchError("Could not verify access to the selected project. Refresh access or manage grants on your desktop.")
+            case .projectChanged:
+                reportLaunchError("The selected project changed or was removed. Refresh access and choose a project again.")
+            case .familiarAccessRevoked(let ids):
+                let names = ids.map { app.familiar($0)?.displayName ?? $0 }.joined(separator: ", ")
+                reportLaunchError("Project access was revoked for \(names). Refresh access and choose again.")
+            }
+        } catch is CancellationError {
+            return false
+        } catch {
+            reportLaunchError("Could not verify chat access: \(error.localizedDescription)")
+        }
+        return false
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -14,12 +14,6 @@ struct RootView: View {
                     ConnectionView()
                 case .checking where app.connection != nil && !app.hasLoadedSurfaces:
                     ConnectingView()
-                case .projectContextRequired where !app.hasLoadedSurfaces:
-                    // The desktop is reachable, but project context is still
-                    // unresolved. Keep destinations unmounted and offer the
-                    // dedicated context gate instead of mislabeling this as
-                    // offline or pairing.
-                    ProjectContextGateView()
                 case .unreachable where !app.hasLoadedSurfaces:
                     // Never got in this session — nothing to keep on screen.
                     ConnectionView()
@@ -152,18 +146,6 @@ private struct ReconnectPill: View {
 struct MainShellView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.scenePhase) private var scenePhase
-    @State private var presentedOverlay: MainOverlay? = {
-        #if DEBUG
-        if ProcessInfo.processInfo.arguments.contains("--ui-open-search") {
-            return .search
-        }
-        if ProcessInfo.processInfo.arguments.contains("--ui-open-projects") {
-            return .projectSwitcher
-        }
-        #endif
-        return nil
-    }()
-    @State private var overlayDismissalAction: (() -> Void)?
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .leading) {
@@ -181,71 +163,27 @@ struct MainShellView: View {
                         get: { app.navigationDrawerOpen },
                         set: { app.navigationDrawerOpen = $0 }
                     ),
-                    openProjectSwitcher: { presentedOverlay = .projectSwitcher },
-                    openFamiliars: { presentedOverlay = .familiars },
                     openThread: { _ = app.requestOpen($0) },
                     newChat: {
                         app.selectedTab = .chats
                         app.newChatRequested = true
                     },
-                    openSearch: { presentedOverlay = .search }
+                    openSearch: {
+                        app.selectedTab = .chats
+                        app.chatSearchRequested = true
+                    }
                 )
                 .zIndex(100)
             }
         }
-        .fullScreenCover(item: $presentedOverlay, onDismiss: runOverlayDismissalAction) { overlay in
-            switch overlay {
-            case .projectSwitcher:
-                ProjectSwitcherView()
-            case .familiars: FamiliarsListView { familiar in
-                dismissOverlay {
-                    if let thread = app.openFamiliarLandingThread(
-                        for: familiar.id,
-                        in: app.projectContext
-                    ) {
-                        _ = app.requestOpen(thread)
-                    } else {
-                        app.showToast(
-                            "Switch to a registered project to start a new chat.",
-                            systemImage: "folder.badge.questionmark",
-                            style: .warning
-                        )
-                    }
-                }
-            }
-            case .search:
-                GlobalSearchView(
-                    dismiss: { presentedOverlay = nil },
-                    openThread: { thread in
-                        dismissOverlay { _ = app.requestOpen(thread) }
-                    },
-                    openServerSession: { session, familiarId in
-                        dismissOverlay {
-                            _ = app.requestOpenServerSession(
-                                session,
-                                fallbackFamiliarId: familiarId
-                            )
-                        }
-                    },
-                    openProject: { project in
-                        dismissOverlay { _ = app.requestOpenProjectSearchResult(project) }
-                    },
-                    openFamiliar: { familiar in
-                        dismissOverlay {
-                            _ = app.requestOpenGlobalFamiliarLandingThread(for: familiar.id)
-                        }
-                    },
-                    openTask: { card in
-                        dismissOverlay { app.requestOpenTask(card) }
-                    }
-                )
-            }
-        }
-        // Command confirmations float above the whole shell so they're visible
-        // whether a command stays in chat or jumps to the Tasks destination.
         .toast(Binding(get: { app.toast }, set: { app.toast = $0 }))
-        // Hardware-keyboard destination switching (iPad / Mac over Tailscale): ⌘1–3.
-        // Hidden buttons keep the shortcuts active without affecting layout.
+        .onAppear {
+            #if DEBUG
+            if ProcessInfo.processInfo.arguments.contains("--ui-open-search") {
+                app.chatSearchRequested = true
+            }
+            #endif
+        }
         .background {
             ForEach(Array(AppTab.shortcutOrder.enumerated()), id: \.element) { index, tab in
                 Button {
@@ -276,44 +214,17 @@ struct MainShellView: View {
         }
     }
 
-    private func dismissOverlay(then action: @escaping () -> Void) {
-        overlayDismissalAction = action
-        presentedOverlay = nil
-    }
-
-    private func runOverlayDismissalAction() {
-        let action = overlayDismissalAction
-        overlayDismissalAction = nil
-        Task { @MainActor in
-            await Task.yield()
-            action?()
-        }
-    }
-
-    @ViewBuilder
     private var shellContent: some View {
-        if app.selectedTab == .settings {
-            SettingsView()
-        } else {
-            switch app.projectContextGateState {
-            case .ready:
-                selectedDestination
-                    .id(app.projectContext?.id ?? "__project-context-unset__")
-            case .loading, .retryableError, .noProjects:
-                ProjectContextGateView()
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var selectedDestination: some View {
-        switch app.selectedTab {
-        case .chats:
+        ZStack {
+            // Settings and access refreshes must not discard the active draft,
+            // conversation selection, or scroll position.
             ChatsHomeView()
-        case .tasks:
-            TasksView()
-        case .settings:
-            SettingsView()
+                .opacity(app.selectedTab == .settings ? 0 : 1)
+                .allowsHitTesting(app.selectedTab != .settings)
+                .accessibilityHidden(app.selectedTab == .settings)
+            if app.selectedTab == .settings {
+                SettingsView()
+            }
         }
     }
 }
@@ -351,20 +262,6 @@ private struct DrawerDestinationStage: ViewModifier {
             .allowsHitTesting(!isOpen)
             .accessibilityHidden(isOpen)
             .animation(reduceMotion ? nil : .snappy(duration: 0.26), value: isOpen)
-    }
-}
-
-private enum MainOverlay: Identifiable {
-    case projectSwitcher
-    case familiars
-    case search
-
-    var id: String {
-        switch self {
-        case .projectSwitcher: "project-switcher"
-        case .familiars: "familiars"
-        case .search: "search"
-        }
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -30,7 +30,7 @@ struct SettingsView: View {
     }
 
     /// Top level mirrors the design handoff's settings IA: profile hero, then
-    /// Appearance / Wards / Chats / Community / Legal groups and a centered
+    /// Appearance / Wards / Chats / Legal groups and a centered
     /// mono brand footer. Connection plumbing (address, re-check, disconnect)
     /// lives one level down behind the hero.
     var body: some View {
@@ -41,7 +41,6 @@ struct SettingsView: View {
                 wardsSection
                 securitySection
                 chatsSection
-                communitySection
                 legalSection
             }
             .themedListBackground()
@@ -342,25 +341,7 @@ struct SettingsView: View {
         }
     }
 
-    // MARK: - Community & Legal
-
-    private var communitySection: some View {
-        Section("Community") {
-            HStack(spacing: 0) {
-                iconShelfLink(
-                    "Discord",
-                    systemImage: "bubble.left.and.bubble.right.fill",
-                    url: "https://discord.gg/opencoven"
-                )
-                iconShelfLink("X", systemImage: "at", url: "https://x.com/OpenCvn")
-                iconShelfLink("Docs", systemImage: "book.closed.fill", url: "https://docs.opencoven.ai")
-                iconShelfLink("Podcast", systemImage: "waveform", url: "https://pod.opencoven.ai")
-                iconShelfLink("Blog", systemImage: "text.page.fill", url: "https://mind.opencoven.ai")
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 4)
-        }
-    }
+    // MARK: - Legal
 
     private var legalSection: some View {
         Section {
@@ -396,7 +377,7 @@ struct SettingsView: View {
                 Image(systemName: systemImage)
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundStyle(chrome.textPrimary)
-                    .frame(width: 42, height: 42)
+                    .frame(width: 44, height: 44)
                     .background(
                         chrome.bgElevated,
                         in: RoundedRectangle(cornerRadius: 13, style: .continuous)

--- a/apps/ios/CovenCave/CovenCave/Views/Voice/CaveVoiceTurnSender.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/Voice/CaveVoiceTurnSender.swift
@@ -20,8 +20,14 @@ enum VoiceTurnSendError: LocalizedError {
 final class CaveVoiceTurnSender: VoiceTurnSending {
     private let sendStream: (CaveClient.SendBody) -> AsyncThrowingStream<CaveClient.StreamFrame, Error>
 
-    init(client: CaveClient) {
-        self.sendStream = client.sendStream
+    init(client: CaveClient, liveDispatchLeaseIsCurrent: @escaping () -> Bool) {
+        self.sendStream = { body in
+            client.sendStream(
+                body,
+                preflight: liveDispatchLeaseIsCurrent,
+                onRequestStarted: {}
+            )
+        }
     }
 
     init(

--- a/apps/ios/CovenCave/CovenCave/Views/Voice/LiveVoiceCallModel.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/Voice/LiveVoiceCallModel.swift
@@ -12,7 +12,8 @@ import Observation
 /// engine and the network.
 @MainActor
 @Observable
-final class LiveVoiceCallModel {
+final class LiveVoiceCallModel: Identifiable {
+    let id = UUID()
     /// The pre-call / call lifecycle the surface renders around the engine's
     /// own `VoiceCallState`.
     enum Launch: Equatable {
@@ -35,25 +36,33 @@ final class LiveVoiceCallModel {
 
     private(set) var launch: Launch = .idle
     private(set) var state: VoiceCallState
+    private(set) var authorityRevoked = false
 
     private let onSessionEstablished: ((String) -> Void)?
     private let onSessionDiscarded: ((String) -> Void)?
     private let onCleanupWarning: ((String) -> Void)?
     private let client: CaveClient?
-    private let makeRealtimeTransport: () -> any VoiceCallTransport
-    private let makeNativeTransport: (CaveClient) -> any VoiceCallTransport
+    private let authorityValidator: () -> Bool
+    private let makeRealtimeTransport: (() -> any VoiceCallTransport)?
+    private let makeNativeTransport: ((CaveClient) -> any VoiceCallTransport)?
     private let makeMediaSession: () -> any VoiceMediaSessionManaging
     private var coordinator: VoiceCallCoordinator?
     private var didBindThreadSession = false
     private var autoCreatedSessionId: String?
     private var hasCommittedConversationContent = false
     @ObservationIgnored private var cleanupTask: Task<Void, Never>?
+    @ObservationIgnored private var startupTask: Task<Void, Never>?
+    private var hasStarted = false
+    private var hasEnded = false
+    private var launchGeneration = 0
+    private var restartInFlight = false
 
     init(
         familiar: Familiar,
         sessionId: String?,
         projectRoot: String?,
         client: CaveClient?,
+        authorityIsCurrent: @escaping () -> Bool = { true },
         onSessionEstablished: ((String) -> Void)? = nil,
         onSessionDiscarded: ((String) -> Void)? = nil,
         onCleanupWarning: ((String) -> Void)? = nil,
@@ -66,10 +75,9 @@ final class LiveVoiceCallModel {
         self.onSessionDiscarded = onSessionDiscarded
         self.onCleanupWarning = onCleanupWarning
         self.client = client
-        self.makeRealtimeTransport = makeRealtimeTransport ?? { OpenAIRealtimeTransport() }
-        self.makeNativeTransport = makeNativeTransport ?? {
-            AppleVoiceTransport(turnSender: CaveVoiceTurnSender(client: $0))
-        }
+        self.authorityValidator = authorityIsCurrent
+        self.makeRealtimeTransport = makeRealtimeTransport
+        self.makeNativeTransport = makeNativeTransport
         self.makeMediaSession = makeMediaSession ?? { VoiceMediaSession() }
         let mode = VoiceTransportPlanner.plan(for: familiar)
         self.plannedMode = mode
@@ -85,20 +93,23 @@ final class LiveVoiceCallModel {
     var activeMode: VoiceCallMode { state.mode }
 
     var isMuted: Bool { state.isMuted }
+    var authorityIsCurrent: Bool { authorityValidator() }
 
     func start() async {
-        switch plannedMode {
-        case .realtime: await startRealtime()
-        case .native: await startOnDevice()
-        }
+        guard !hasStarted, !hasEnded, refreshAuthority() else { return }
+        hasStarted = true
+        await runStartup(mode: plannedMode)
     }
 
     func toggleMute() {
-        guard let coordinator, !state.phase.isTerminal else { return }
+        guard refreshAuthority(), let coordinator, !state.phase.isTerminal else { return }
         coordinator.setMuted(!state.isMuted)
     }
 
     func end() {
+        launchGeneration += 1
+        guard !hasEnded else { return }
+        hasEnded = true
         if let coordinator {
             coordinator.end()
         } else if !state.phase.isTerminal {
@@ -107,22 +118,43 @@ final class LiveVoiceCallModel {
         scheduleAutoCreatedSessionCleanupIfNeeded()
     }
 
+    @discardableResult
+    func refreshAuthority() -> Bool {
+        guard !authorityRevoked else { return false }
+        guard authorityIsCurrent else {
+            authorityRevoked = true
+            end()
+            launch = .unavailable(VoiceCallCopy.authorityChanged)
+            return false
+        }
+        return true
+    }
+
     /// Rebuild a fresh coordinator and retry the transport that just failed.
     func retry() async {
+        guard !restartInFlight, refreshAuthority() else { return }
+        restartInFlight = true
+        defer { restartInFlight = false }
+        let requestedGeneration = launchGeneration
+        await startupTask?.value
         await waitForPendingCleanup()
+        guard launchGeneration == requestedGeneration, refreshAuthority() else { return }
         let mode = state.mode
         resetForRestart(mode: mode)
-        switch mode {
-        case .realtime: await startRealtime()
-        case .native: await startOnDevice()
-        }
+        await runStartup(mode: mode)
     }
 
     /// Accept the on-device fallback after a Realtime grant couldn't be minted.
     func acceptOnDeviceFallback() async {
+        guard !restartInFlight, refreshAuthority() else { return }
+        restartInFlight = true
+        defer { restartInFlight = false }
+        let requestedGeneration = launchGeneration
+        await startupTask?.value
         await waitForPendingCleanup()
+        guard launchGeneration == requestedGeneration, refreshAuthority() else { return }
         resetForRestart(mode: .native)
-        await startOnDevice()
+        await runStartup(mode: .native)
     }
 
     func waitForPendingCleanup() async {
@@ -131,7 +163,30 @@ final class LiveVoiceCallModel {
 
     // MARK: - Transport startup
 
-    private func startRealtime() async {
+    private func runStartup(mode: VoiceCallMode) async {
+        let generation = launchGeneration
+        let task = Task {
+            switch mode {
+            case .realtime: await startRealtime(generation: generation)
+            case .native: await startOnDevice(generation: generation)
+            }
+        }
+        startupTask = task
+        await task.value
+        if launchGeneration == generation { startupTask = nil }
+    }
+
+    private func canContinueLaunch(_ generation: Int) -> Bool {
+        guard !hasEnded, launchGeneration == generation, !Task.isCancelled,
+              refreshAuthority() else {
+            scheduleAutoCreatedSessionCleanupIfNeeded()
+            return false
+        }
+        return true
+    }
+
+    private func startRealtime(generation: Int) async {
+        guard canContinueLaunch(generation) else { return }
         guard let client else {
             launch = .unavailable(disconnectedCopy)
             return
@@ -143,9 +198,11 @@ final class LiveVoiceCallModel {
         launch = .minting
         do {
             let sessionId = try await realtimeSessionID(client: client, projectRoot: projectRoot)
+            guard canContinueLaunch(generation) else { return }
             let response = try await client.mintVoiceSession(
                 familiarId: familiar.id, sessionId: sessionId
             )
+            guard canContinueLaunch(generation) else { return }
             let context = VoiceCallTransportContext(
                 familiarId: familiar.id,
                 sessionId: sessionId,
@@ -154,21 +211,29 @@ final class LiveVoiceCallModel {
             )
             await launchCoordinator(
                 mode: .realtime,
-                transport: makeRealtimeTransport(),
+                transport: makeRealtimeTransport?() ?? OpenAIRealtimeTransport(
+                    liveAuthorityIsCurrent: { [weak self] in
+                        self?.canContinueLaunch(generation) ?? false
+                    }
+                ),
                 mediaSession: makeMediaSession(),
-                context: context
+                context: context,
+                generation: generation
             )
         } catch let error as CaveError where error.requiresProjectSelection {
+            guard canContinueLaunch(generation) else { return }
             launch = .unavailable(projectRequiredCopy)
             scheduleAutoCreatedSessionCleanupIfNeeded()
         } catch {
+            guard canContinueLaunch(generation) else { return }
             // A grant we couldn't mint is the fallback trigger, not a dead end.
             launch = .fallbackOffer(VoiceCallCopy.mintFailureFallback(error.localizedDescription))
             scheduleAutoCreatedSessionCleanupIfNeeded()
         }
     }
 
-    private func startOnDevice() async {
+    private func startOnDevice(generation: Int) async {
+        guard canContinueLaunch(generation) else { return }
         guard let client else {
             launch = .unavailable(disconnectedCopy)
             return
@@ -185,17 +250,28 @@ final class LiveVoiceCallModel {
         )
         await launchCoordinator(
             mode: .native,
-            transport: makeNativeTransport(client),
+            transport: makeNativeTransport?(client) ?? AppleVoiceTransport(
+                turnSender: CaveVoiceTurnSender(
+                    client: client,
+                    liveDispatchLeaseIsCurrent: { [weak self] in
+                        self?.canContinueLaunch(generation) ?? false
+                    }
+                )
+            ),
             mediaSession: makeMediaSession(),
-            context: context
+            context: context,
+            generation: generation
         )
     }
 
     private func launchCoordinator(mode: VoiceCallMode, transport: VoiceCallTransport,
                                    mediaSession: VoiceMediaSessionManaging,
-                                   context: VoiceCallTransportContext) async {
+                                   context: VoiceCallTransportContext, generation: Int) async {
         let coordinator = VoiceCallCoordinator(
-            mode: mode, transport: transport, mediaSession: mediaSession, context: context
+            mode: mode, transport: transport, mediaSession: mediaSession, context: context,
+            liveAuthorityIsCurrent: { [weak self] in
+                self?.canContinueLaunch(generation) ?? false
+            }
         )
         coordinator.onStateChange = { [weak self] state in
             self?.handleCoordinatorStateChange(state)
@@ -208,7 +284,11 @@ final class LiveVoiceCallModel {
 
     private func resetForRestart(mode: VoiceCallMode) {
         let retryableAutoCreatedSessionId = pendingAutoCreatedSessionIdForRestart()
+        coordinator?.end()
         coordinator = nil
+        hasStarted = true
+        hasEnded = false
+        launchGeneration += 1
         didBindThreadSession = false
         hasCommittedConversationContent = false
         autoCreatedSessionId = retryableAutoCreatedSessionId

--- a/apps/ios/CovenCave/CovenCave/Views/Voice/LiveVoiceCallView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/Voice/LiveVoiceCallView.swift
@@ -13,24 +13,8 @@ struct LiveVoiceCallView: View {
 
     @State private var model: LiveVoiceCallModel
 
-    init(
-        familiar: Familiar,
-        sessionId: String?,
-        projectRoot: String?,
-        client: CaveClient?,
-        onSessionEstablished: ((String) -> Void)? = nil,
-        onSessionDiscarded: ((String) -> Void)? = nil,
-        onCleanupWarning: ((String) -> Void)? = nil
-    ) {
-        _model = State(initialValue: LiveVoiceCallModel(
-            familiar: familiar,
-            sessionId: sessionId,
-            projectRoot: projectRoot,
-            client: client,
-            onSessionEstablished: onSessionEstablished,
-            onSessionDiscarded: onSessionDiscarded,
-            onCleanupWarning: onCleanupWarning
-        ))
+    init(model: LiveVoiceCallModel) {
+        _model = State(initialValue: model)
     }
 
     var body: some View {
@@ -44,9 +28,13 @@ struct LiveVoiceCallView: View {
             .padding(20)
         }
         .task { await model.start() }
-        .onChange(of: model.state.phase) { _, phase in
-            if phase == .ended { dismiss() }
+        .onChange(of: model.authorityIsCurrent, initial: true) { _, _ in
+            model.refreshAuthority()
         }
+        .onChange(of: model.state.phase) { _, phase in
+            if phase == .ended, !model.authorityRevoked { dismiss() }
+        }
+        .onDisappear { model.end() }
     }
 
     // MARK: - Header

--- a/apps/ios/CovenCave/CovenCave/Views/Voice/VoiceCallPresentation.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/Voice/VoiceCallPresentation.swift
@@ -53,6 +53,15 @@ enum VoiceTransportPlanner {
 }
 
 enum VoiceCallCopy {
+    static var authorityChanged: VoiceCallErrorCopy {
+        VoiceCallErrorCopy(
+            title: "Voice call ended",
+            message: "Chat access or the desktop connection changed. Close this call and start a new one when access is available.",
+            recovery: .dismiss,
+            offersOnDeviceFallback: false
+        )
+    }
+
     static func modeLabel(_ mode: VoiceCallMode) -> String {
         switch mode {
         case .realtime: "Live voice"

--- a/apps/ios/CovenCave/CovenCave/Voice/OpenAIRealtimeTransport.swift
+++ b/apps/ios/CovenCave/CovenCave/Voice/OpenAIRealtimeTransport.swift
@@ -26,6 +26,7 @@ final class OpenAIRealtimeTransport: NSObject, VoiceCallTransport {
 
     private let factory = RTCPeerConnectionFactory()
     private let urlSession: URLSession
+    private let liveAuthorityIsCurrent: () -> Bool
     private var peerConnection: RTCPeerConnection?
     private var dataChannel: RTCDataChannel?
     private var localAudioSource: RTCAudioSource?
@@ -33,13 +34,14 @@ final class OpenAIRealtimeTransport: NSObject, VoiceCallTransport {
     private var decoder = OpenAIRealtimeEventDecoder()
     private var stopped = false
 
-    init(urlSession: URLSession = .shared) {
+    init(urlSession: URLSession = .shared, liveAuthorityIsCurrent: @escaping () -> Bool = { true }) {
         self.urlSession = urlSession
+        self.liveAuthorityIsCurrent = liveAuthorityIsCurrent
         super.init()
     }
 
     func start(with context: VoiceCallTransportContext) async throws {
-        guard !stopped else { return }
+        try requireActiveAuthority()
         guard let grant = context.grant, grant.provider == "openai" else {
             throw OpenAIRealtimeTransportError.missingGrant
         }
@@ -67,11 +69,14 @@ final class OpenAIRealtimeTransport: NSObject, VoiceCallTransport {
         dataChannel = channel
 
         let offer = try await createOffer(connection: connection, constraints: constraints)
+        try requireActiveAuthority()
         try await setLocalDescription(offer, on: connection)
+        try requireActiveAuthority()
         let answerSDP = try await sendOffer(offer.sdp, to: url, clientSecret: grant.clientSecret)
+        try requireActiveAuthority()
         guard !answerSDP.isEmpty else { throw OpenAIRealtimeTransportError.emptyAnswer }
         try await setRemoteDescription(RTCSessionDescription(type: .answer, sdp: answerSDP), on: connection)
-        guard !stopped else { return }
+        try requireActiveAuthority()
         onEvent?(.connected)
     }
 
@@ -119,6 +124,7 @@ final class OpenAIRealtimeTransport: NSObject, VoiceCallTransport {
     }
 
     private func sendOffer(_ sdp: String, to url: URL, clientSecret: String) async throws -> String {
+        try requireActiveAuthority()
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.httpBody = Data(sdp.utf8)
@@ -130,6 +136,13 @@ final class OpenAIRealtimeTransport: NSObject, VoiceCallTransport {
             throw OpenAIRealtimeTransportError.signalingFailed((response as? HTTPURLResponse)?.statusCode ?? 0)
         }
         return String(decoding: data, as: UTF8.self)
+    }
+
+    private func requireActiveAuthority() throws {
+        guard !stopped, !Task.isCancelled, liveAuthorityIsCurrent() else {
+            stop()
+            throw CancellationError()
+        }
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Voice/VoiceCallCoordinator.swift
+++ b/apps/ios/CovenCave/CovenCave/Voice/VoiceCallCoordinator.swift
@@ -35,11 +35,13 @@ final class VoiceCallCoordinator {
     private let transport: VoiceCallTransport
     private let mediaSession: VoiceMediaSessionManaging
     private let context: VoiceCallTransportContext
+    private let liveAuthorityIsCurrent: () -> Bool
     private var didCleanUp = false
 
     init(mode: VoiceCallMode, transport: VoiceCallTransport,
          mediaSession: VoiceMediaSessionManaging,
-         context: VoiceCallTransportContext) {
+         context: VoiceCallTransportContext,
+         liveAuthorityIsCurrent: @escaping () -> Bool = { true }) {
         state = VoiceCallState(
             mode: mode,
             sessionId: context.sessionId,
@@ -48,27 +50,34 @@ final class VoiceCallCoordinator {
         self.transport = transport
         self.mediaSession = mediaSession
         self.context = context
+        self.liveAuthorityIsCurrent = liveAuthorityIsCurrent
         transport.onEvent = { [weak self] event in self?.receive(event) }
         mediaSession.onInterruption = { [weak self] in self?.receive(.failed("audio_interrupted")) }
         mediaSession.onRouteChange = { [weak self] in self?.receive(.failed("audio_route_changed")) }
     }
 
     func start() async {
-        guard state.phase == .idle else { return }
+        guard state.phase == .idle, liveAuthorityIsCurrent() else { return }
         state.send(.start)
         publish()
         do {
             try await mediaSession.prepare(mode: state.mode, needsSpeechRecognition: state.mode == .native)
-            guard !state.phase.isTerminal else {
+            guard liveAuthorityIsCurrent(), !state.phase.isTerminal else {
                 // `end()` may have run while permission was pending. A real
                 // media session can become active immediately before its async
                 // prepare returns, so deactivate it again after that late return.
+                end()
                 mediaSession.stop()
                 return
             }
             state.receive(.permissionGranted)
             publish()
             try await transport.start(with: context)
+            if !liveAuthorityIsCurrent() || state.phase.isTerminal {
+                end()
+                transport.stop()
+                mediaSession.stop()
+            }
         } catch {
             if state.phase.isTerminal {
                 mediaSession.stop()

--- a/apps/ios/CovenCave/CovenCaveTests/AppModelProjectContextTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppModelProjectContextTests.swift
@@ -1,6 +1,52 @@
 import XCTest
 @testable import CovenCave
 
+private final class QueuedAccessURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var capturedRequests: [URLRequest] = []
+
+    static var requests: [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return capturedRequests
+    }
+
+    static func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        capturedRequests = []
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "queue-authorization.cave.test"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock()
+        Self.capturedRequests.append(request)
+        Self.lock.unlock()
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/event-stream"]
+              ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        let events = "data: {\"kind\":\"assistant_chunk\",\"text\":\"Allowed reply\"}\n\n"
+            + "data: {\"kind\":\"done\",\"isError\":false}\n\n"
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(events.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
 private struct StubProjectContextClient: ProjectContextLoadingClient, @unchecked Sendable {
     var projectsResult: Result<[ProjectInfo], Error>
     var grantsResult: Result<ProjectGrantsResponse, Error>
@@ -1136,6 +1182,42 @@ final class AppModelProjectContextTests: XCTestCase {
         )
     }
 
+    private func queuedAccessClient() -> CaveClient {
+        QueuedAccessURLProtocol.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [QueuedAccessURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        addTeardownBlock {
+            session.invalidateAndCancel()
+        }
+        return CaveClient(
+            connection: CaveConnection(host: "https://queue-authorization.cave.test"),
+            session: session
+        )
+    }
+
+    @MainActor
+    private func replayQueue(
+        _ thread: ChatThread,
+        app: AppModel,
+        client: CaveClient,
+        persistBeforeDispatch: @escaping () async -> Bool = { true },
+        persistAfterRollback: @escaping () async -> Bool = { true },
+        onAccessRefused: @escaping (String?) -> Void = { _ in }
+    ) async {
+        await thread.replayQueued(
+            client: client,
+            dispatchLeaseIsCurrent: { true },
+            targetAccessIsCurrent: { root, familiarId in
+                app.chatAccessIsCurrent(projectRoot: root, familiarIds: [familiarId])
+            },
+            onAccessRefused: onAccessRefused,
+            persistBeforeDispatch: persistBeforeDispatch,
+            persistAfterRollback: persistAfterRollback,
+            onChange: {}
+        )
+    }
+
     private func projectAccessDeniedError(_ message: String) -> CaveError {
         .serverResponse(status: 403, code: "project_access_denied", message: message)
     }
@@ -1437,6 +1519,48 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertTrue(app.projectFamiliars.isEmpty)
     }
 
+    func testRestoredChatHistoryKeepsColdUnreachableShellReadable() async {
+        let snapshot = thread(
+            "offline-history",
+            familiarIds: ["nova"],
+            projectRoot: "/repos/alpha"
+        ).snapshot
+        let app = makeApp(
+            restoreLocalState: true,
+            threadSnapshotLoader: { [snapshot] },
+            baseURLDiscoverer: { _ in .unreachable(nil) }
+        )
+        _ = connect(app)
+        await waitFor { app.threads.contains { $0.id == snapshot.id } }
+
+        await app.refreshConnection()
+
+        XCTAssertTrue(app.hasLoadedSurfaces)
+        XCTAssertFalse(app.projectsLoaded)
+        XCTAssertFalse(app.projectMembershipLoaded)
+        XCTAssertFalse(app.chatAccessIsCurrent)
+        XCTAssertNil(app.projectContext)
+        let restored = app.threads.first { $0.id == snapshot.id }
+        XCTAssertNotNil(restored)
+        if let restored {
+            XCTAssertTrue(app.requestOpen(restored))
+            XCTAssertTrue(app.threadToOpen === restored)
+        }
+        if case .unreachable = app.connectionState {} else {
+            XCTFail("The unreachable desktop must not be reported as connected")
+        }
+    }
+
+    func testRetiredTaskDataAloneDoesNotMakeChatShellReady() {
+        let app = makeApp()
+        app.tasksLoaded = true
+        app.remindersLoaded = true
+        XCTAssertFalse(app.hasLoadedSurfaces)
+        app.sessionsLoaded = true
+        XCTAssertTrue(app.hasLoadedSurfaces)
+        XCTAssertFalse(app.chatAccessIsCurrent)
+    }
+
     func testTransientProjectContextFailureKeepsCachedScopeAndGlobalData() async {
         let app = makeApp()
         let connection = connect(app)
@@ -1468,7 +1592,7 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertEqual(app.projectContext, .project(project("alpha", "Alpha")))
         XCTAssertEqual(app.projectContextError, "Grant refresh failed")
-        XCTAssertTrue(app.projectMembershipLoaded)
+        XCTAssertFalse(app.projectMembershipLoaded)
         XCTAssertEqual(app.projects.map(\.id), ["alpha"])
         XCTAssertEqual(app.familiars.map(\.id), ["nova"])
         XCTAssertEqual(app.projectMembership.familiarIDs(forProjectID: "alpha"), Set(["nova"]))
@@ -1559,7 +1683,7 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(app.pendingProjectNavigationIntent, expectedIntent)
     }
 
-    func testRequestOpenSwitchesToThreadProjectBeforeOpening() {
+    func testRequestOpenPreservesAmbientProjectBeforeOpening() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         let beta = project("beta", "Beta")
@@ -1579,13 +1703,14 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertTrue(app.requestOpen(destination))
 
-        XCTAssertEqual(app.projectContext, .project(beta))
+        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.projectContext(for: destination), .project(beta))
         XCTAssertEqual(app.selectedTab, .chats)
         XCTAssertTrue(app.threadToOpen === destination)
         XCTAssertNil(app.toast)
     }
 
-    func testRequestOpenSwitchesToUnassignedForProjectlessThread() {
+    func testRequestOpenPreservesAmbientProjectForProjectlessThread() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         let destination = thread("legacy-thread", familiarIds: ["nova"], projectRoot: nil)
@@ -1596,7 +1721,8 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertTrue(app.requestOpen(destination))
 
-        XCTAssertEqual(app.projectContext, .unassigned)
+        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.projectContext(for: destination), .unassigned)
         XCTAssertEqual(app.selectedTab, .chats)
         XCTAssertTrue(app.threadToOpen === destination)
         XCTAssertNil(app.toast)
@@ -1618,7 +1744,8 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertTrue(app.requestOpen(destination))
 
-        XCTAssertEqual(app.projectContext, .project(nested))
+        XCTAssertEqual(app.projectContext, .project(parent))
+        XCTAssertEqual(app.projectContext(for: destination), .project(nested))
         XCTAssertTrue(app.threadToOpen === destination)
         XCTAssertNil(app.toast)
     }
@@ -1637,7 +1764,8 @@ final class AppModelProjectContextTests: XCTestCase {
             app.threads = [destination]
 
             XCTAssertTrue(app.requestOpen(destination))
-            XCTAssertEqual(app.projectContext, .unassigned)
+            XCTAssertEqual(app.projectContext, .project(alpha))
+            XCTAssertEqual(app.projectContext(for: destination), .unassigned)
             XCTAssertTrue(app.threadToOpen === destination)
             XCTAssertNil(app.toast)
 
@@ -1645,7 +1773,7 @@ final class AppModelProjectContextTests: XCTestCase {
         }
     }
 
-    func testRequestOpenTaskSwitchesToTaskProjectBeforeOpening() {
+    func testRequestOpenTaskRejectsDesktopOnlyDestination() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         let beta = project("beta", "Beta")
@@ -1657,16 +1785,16 @@ final class AppModelProjectContextTests: XCTestCase {
         app.projectContext = .project(alpha)
         app.selectedTab = .settings
 
-        XCTAssertTrue(app.requestOpenTask(destination))
+        XCTAssertFalse(app.requestOpenTask(destination))
 
-        XCTAssertEqual(app.projectContext, .project(beta))
-        XCTAssertEqual(app.selectedTab, .tasks)
-        XCTAssertEqual(app.cardToOpen?.id, destination.id)
+        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.selectedTab, .settings)
+        XCTAssertNil(app.cardToOpen)
         XCTAssertNil(app.pendingProjectNavigationIntent)
-        XCTAssertNil(app.toast)
+        XCTAssertTrue(app.toast?.text.contains("desktop-only") == true)
     }
 
-    func testRequestOpenTaskSwitchesToUnassignedForProjectlessTask() {
+    func testRequestOpenProjectlessTaskDoesNotRescope() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         let destination = card("legacy-task", familiarId: "nova", projectId: nil)
@@ -1676,16 +1804,16 @@ final class AppModelProjectContextTests: XCTestCase {
         app.tasksLoaded = true
         app.projectContext = .project(alpha)
 
-        XCTAssertTrue(app.requestOpenTask(destination))
+        XCTAssertFalse(app.requestOpenTask(destination))
 
-        XCTAssertEqual(app.projectContext, .unassigned)
-        XCTAssertEqual(app.selectedTab, .tasks)
-        XCTAssertEqual(app.cardToOpen?.id, destination.id)
+        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.selectedTab, .chats)
+        XCTAssertNil(app.cardToOpen)
         XCTAssertNil(app.pendingProjectNavigationIntent)
-        XCTAssertNil(app.toast)
+        XCTAssertTrue(app.toast?.text.contains("desktop-only") == true)
     }
 
-    func testRequestOpenProjectSearchResultKeepsProjectScopedDestination() {
+    func testRetiredProjectSearchResultDoesNotRescopeDestination() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         let beta = project("beta", "Beta")
@@ -1694,15 +1822,15 @@ final class AppModelProjectContextTests: XCTestCase {
         app.projectContext = .project(alpha)
         app.selectedTab = .tasks
 
-        XCTAssertTrue(app.requestOpenProjectSearchResult(beta))
+        XCTAssertFalse(app.requestOpenProjectSearchResult(beta))
 
-        XCTAssertEqual(app.projectContext, .project(beta))
+        XCTAssertEqual(app.projectContext, .project(alpha))
         XCTAssertEqual(app.selectedTab, .tasks)
         XCTAssertNil(app.pendingProjectNavigationIntent)
-        XCTAssertNil(app.toast)
+        XCTAssertTrue(app.toast?.text.contains("desktop-only") == true)
     }
 
-    func testRequestOpenProjectSearchResultFallsBackToChatsFromSettings() {
+    func testRetiredProjectSearchResultPreservesSettings() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         let beta = project("beta", "Beta")
@@ -1711,15 +1839,15 @@ final class AppModelProjectContextTests: XCTestCase {
         app.projectContext = .project(alpha)
         app.selectedTab = .settings
 
-        XCTAssertTrue(app.requestOpenProjectSearchResult(beta))
+        XCTAssertFalse(app.requestOpenProjectSearchResult(beta))
 
-        XCTAssertEqual(app.projectContext, .project(beta))
-        XCTAssertEqual(app.selectedTab, .chats)
+        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.selectedTab, .settings)
         XCTAssertNil(app.pendingProjectNavigationIntent)
-        XCTAssertNil(app.toast)
+        XCTAssertTrue(app.toast?.text.contains("desktop-only") == true)
     }
 
-    func testRequestOpenServerSessionSwitchesToSessionProjectBeforeOpening() {
+    func testRequestOpenServerSessionPreservesAmbientProjectBeforeOpening() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         let beta = project("beta", "Beta")
@@ -1732,7 +1860,7 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertTrue(app.requestOpenServerSession(destination, fallbackFamiliarId: "nova"))
 
-        XCTAssertEqual(app.projectContext, .project(beta))
+        XCTAssertEqual(app.projectContext, .project(alpha))
         XCTAssertEqual(app.selectedTab, .chats)
         XCTAssertEqual(app.threadToOpen?.sessionIds, ["nova": destination.id])
         XCTAssertEqual(app.threadToOpen?.projectRoot, beta.root)
@@ -1740,7 +1868,7 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertNil(app.toast)
     }
 
-    func testRequestOpenTaskTreatsUnknownProjectAsUnassignedRecovery() {
+    func testRequestOpenTaskRejectsUnknownProjectWithoutRecoveryNavigation() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         let destination = card("ghost-task", familiarId: "nova", projectId: "ghost")
@@ -1751,13 +1879,13 @@ final class AppModelProjectContextTests: XCTestCase {
         app.projectContext = .project(alpha)
         app.selectedTab = .settings
 
-        XCTAssertTrue(app.requestOpenTask(destination))
+        XCTAssertFalse(app.requestOpenTask(destination))
 
-        XCTAssertEqual(app.selectedTab, .tasks)
-        XCTAssertEqual(app.projectContext, .unassigned)
-        XCTAssertEqual(app.cardToOpen?.id, destination.id)
+        XCTAssertEqual(app.selectedTab, .settings)
+        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertNil(app.cardToOpen)
         XCTAssertNil(app.pendingProjectNavigationIntent)
-        XCTAssertNil(app.toast)
+        XCTAssertTrue(app.toast?.text.contains("desktop-only") == true)
     }
 
     func testRequestOpenTaskFailsExplicitlyWhenProjectIDIsMalformed() {
@@ -1776,16 +1904,16 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(app.selectedTab, .settings)
         XCTAssertEqual(app.projectContext, .project(alpha))
         XCTAssertNil(app.cardToOpen)
-        XCTAssertEqual(app.pendingProjectNavigationIntent?.taskId, destination.id)
+        XCTAssertNil(app.pendingProjectNavigationIntent)
         assertToast(
             app,
-            text: "This task is no longer linked to a registered project. Refresh Tasks or reassign it on your desktop, then try again.",
-            systemImage: "folder.badge.questionmark"
+            text: "Tasks is desktop-only. Open Coven Cave on your desktop; iOS supports Chats and Settings.",
+            systemImage: "desktopcomputer"
         )
     }
 
     @MainActor
-    func testMoveTaskToProjectSwitchesToDestinationTaskContextOnSuccess() async {
+    func testLegacyTaskMovePreservesNavigationWhileUpdatingBackendOwnership() async {
         let alpha = project("alpha", "Alpha")
         let task = card("recover-task", familiarId: "nova", projectId: nil)
         let controlledClient = ControlledCoreClient(
@@ -1806,10 +1934,10 @@ final class AppModelProjectContextTests: XCTestCase {
         await app.moveTaskToProject(task, project: alpha)
 
         XCTAssertEqual(app.tasks.first?.projectId, alpha.id)
-        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.projectContext, .unassigned)
         XCTAssertEqual(app.selectedTab, .tasks)
         XCTAssertEqual(app.cardToOpen?.id, task.id)
-        XCTAssertEqual(app.projectTasks.map(\.id), [task.id])
+        XCTAssertTrue(app.projectTasks.isEmpty)
         XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertNil(app.tasksError)
         assertToast(app, text: "Moved to Alpha", systemImage: "folder.badge.plus")
@@ -1929,7 +2057,7 @@ final class AppModelProjectContextTests: XCTestCase {
 
         let moved = try XCTUnwrap(app.tasks.first)
         XCTAssertEqual(moved.projectId, alpha.id)
-        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.projectContext, .unassigned)
         XCTAssertEqual(app.selectedTab, .tasks)
         XCTAssertEqual(app.cardToOpen?.id, task.id)
         XCTAssertNil(app.cardThreadLinks[task.id])
@@ -1938,11 +2066,9 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertNil(app.tasksError)
 
         let opened = await app.openChat(for: moved)
-        let unwrapped = try XCTUnwrap(opened)
-        XCTAssertFalse(unwrapped === legacyThread)
-        XCTAssertEqual(unwrapped.projectRoot, alpha.root)
-        XCTAssertEqual(app.cardThreadLinks[task.id], unwrapped.id)
-        XCTAssertTrue(app.linkedThread(for: moved) === unwrapped)
+        XCTAssertNil(opened, "legacy task mutation cannot implicitly select new-chat access")
+        XCTAssertNil(app.cardThreadLinks[task.id])
+        XCTAssertEqual(app.threads.map(\.id), [legacyThread.id])
     }
 
     @MainActor
@@ -1979,7 +2105,7 @@ final class AppModelProjectContextTests: XCTestCase {
 
         let moved = try XCTUnwrap(app.tasks.first)
         XCTAssertEqual(moved.projectId, alpha.id)
-        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.projectContext, .unassigned)
         XCTAssertEqual(app.selectedTab, .tasks)
         XCTAssertEqual(app.cardToOpen?.id, task.id)
         XCTAssertEqual(app.cardThreadLinks[task.id], linked.id)
@@ -2030,7 +2156,7 @@ final class AppModelProjectContextTests: XCTestCase {
 
         let moved = try XCTUnwrap(app.tasks.first)
         XCTAssertEqual(moved.projectId, alpha.id)
-        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.projectContext, .unassigned)
         XCTAssertEqual(app.selectedTab, .tasks)
         XCTAssertEqual(app.cardToOpen?.id, task.id)
         XCTAssertNil(moved.sessionId)
@@ -2045,11 +2171,9 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertNil(sessionUpdates.first?.sessionId)
 
         let opened = await app.openChat(for: moved)
-        let unwrapped = try XCTUnwrap(opened)
-        XCTAssertFalse(unwrapped === legacyThread)
-        XCTAssertEqual(unwrapped.projectRoot, alpha.root)
-        XCTAssertEqual(app.cardThreadLinks[task.id], unwrapped.id)
-        XCTAssertTrue(app.linkedThread(for: moved) === unwrapped)
+        XCTAssertNil(opened, "a task move must not silently create a conversation in another project")
+        XCTAssertNil(app.cardThreadLinks[task.id])
+        XCTAssertEqual(app.threads.map(\.id), [legacyThread.id])
     }
 
     @MainActor
@@ -2118,7 +2242,7 @@ final class AppModelProjectContextTests: XCTestCase {
     }
 
     @MainActor
-    func testMoveTaskToProjectAllowsImmediateChatOpenAfterSwitchingContext() async throws {
+    func testLegacyTaskMoveDoesNotImplicitlyAuthorizeANewChat() async throws {
         let alpha = project("alpha", "Alpha")
         let task = card("recover-task", familiarId: "nova", projectId: nil)
         let controlledClient = ControlledCoreClient(
@@ -2145,16 +2269,16 @@ final class AppModelProjectContextTests: XCTestCase {
         await app.moveTaskToProject(task, project: alpha)
 
         let moved = try XCTUnwrap(app.tasks.first)
-        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.projectContext, .unassigned)
         XCTAssertEqual(app.selectedTab, .tasks)
         XCTAssertEqual(app.cardToOpen?.id, task.id)
 
         let opened = await app.openChat(for: moved)
-        let unwrapped = try XCTUnwrap(opened)
-        XCTAssertEqual(unwrapped.projectRoot, alpha.root)
-        XCTAssertEqual(app.cardThreadLinks[task.id], unwrapped.id)
-        XCTAssertTrue(app.threadToOpen === unwrapped)
-        XCTAssertEqual(app.selectedTab, .chats)
+        XCTAssertNil(opened)
+        XCTAssertNil(app.cardThreadLinks[task.id])
+        XCTAssertNil(app.threadToOpen)
+        XCTAssertTrue(app.threads.isEmpty)
+        XCTAssertEqual(app.projectContext, .unassigned)
     }
 
     @MainActor
@@ -2528,11 +2652,13 @@ final class AppModelProjectContextTests: XCTestCase {
         let destination = thread("alpha-thread", familiarIds: ["nova"], projectRoot: "/repos/alpha")
 
         XCTAssertNil(app.validatedOpenContext(for: destination))
-        XCTAssertFalse(app.canOpen(destination))
-        XCTAssertEqual(
-            app.threadOpenFailure(for: destination),
-            AppModel.ThreadOpenFailure.projectCatalogUnavailable
-        )
+        XCTAssertTrue(app.canOpen(destination))
+        XCTAssertNil(app.threadOpenFailure(for: destination))
+        app.threads = [destination]
+        XCTAssertTrue(app.requestOpen(destination))
+        XCTAssertTrue(app.threadToOpen === destination)
+        XCTAssertNil(app.projectContext)
+        XCTAssertFalse(app.projectMembershipLoaded)
     }
 
     func testValidatedOpenContextRejectsMalformedDotSegmentRoots() {
@@ -2606,23 +2732,23 @@ final class AppModelProjectContextTests: XCTestCase {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         let beta = project("beta", "Beta")
-        let destination = card("beta-task", familiarId: "nova", projectId: beta.id)
+        let destination = thread("beta-thread", familiarIds: ["nova"], projectRoot: beta.root)
         app.projects = [alpha, beta]
         app.projectsLoaded = true
-        app.tasks = [destination]
-        app.tasksLoaded = true
+        app.threads = [destination]
         app.projectContext = .project(alpha)
         app.pendingProjectNavigationIntent = ProjectNavigationIntent(
-            entity: .task(id: destination.id),
-            destination: .tasks,
+            entity: .thread(id: destination.id),
+            destination: .chats,
             projectId: alpha.id
         )
 
         XCTAssertTrue(app.resolvePendingProjectNavigationIntent())
 
-        XCTAssertEqual(app.projectContext, .project(beta))
-        XCTAssertEqual(app.selectedTab, .tasks)
-        XCTAssertEqual(app.cardToOpen?.id, destination.id)
+        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.selectedTab, .chats)
+        XCTAssertTrue(app.threadToOpen === destination)
+        XCTAssertEqual(destination.projectRoot, beta.root)
         XCTAssertNil(app.pendingProjectNavigationIntent)
     }
 
@@ -2638,19 +2764,16 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertEqual(app.selectedTab, .settings)
         XCTAssertEqual(app.deepLink, .tasks)
-        XCTAssertEqual(
-            app.pendingProjectNavigationIntent,
-            ProjectNavigationIntent(destination: .tasks, projectId: "ghost")
-        )
+        XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertNil(app.cardToOpen)
         assertToast(
             app,
-            text: "This project is no longer registered on this device. Refresh Chats or choose another project, then try again.",
-            systemImage: "folder.badge.questionmark"
+            text: "Tasks is desktop-only. Open Coven Cave on your desktop; iOS supports Chats and Settings.",
+            systemImage: "desktopcomputer"
         )
     }
 
-    func testProjectChatsDeepLinkSwitchesProjectAndPreservesDestination() throws {
+    func testRetiredProjectChatsDeepLinkDoesNotSwitchProjectOrDestination() throws {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         let beta = project("beta", "Beta")
@@ -2662,13 +2785,13 @@ final class AppModelProjectContextTests: XCTestCase {
 
         app.handleDeepLink(url)
 
-        XCTAssertEqual(app.projectContext, .project(beta))
-        XCTAssertEqual(app.selectedTab, .chats)
+        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.selectedTab, .settings)
         XCTAssertNil(app.pendingProjectNavigationIntent)
-        XCTAssertNil(app.toast)
+        XCTAssertTrue(app.toast?.text.contains("desktop-only") == true)
     }
 
-    func testPendingTaskNavigationSurvivesFailedHydration() {
+    func testPendingTaskNavigationIsRejectedBeforeHydration() {
         let app = makeApp()
         let expectedIntent = ProjectNavigationIntent(
             entity: .task(id: "missing-task"),
@@ -2679,12 +2802,12 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertFalse(app.resolvePendingProjectNavigationIntent())
 
-        XCTAssertEqual(app.pendingProjectNavigationIntent, expectedIntent)
+        XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertNil(app.cardToOpen)
         assertToast(
             app,
-            text: "This task is not available on this device yet. Refresh Tasks and try again.",
-            systemImage: "checklist"
+            text: "Tasks is desktop-only. Open Coven Cave on your desktop; iOS supports Chats and Settings.",
+            systemImage: "desktopcomputer"
         )
     }
 
@@ -2718,7 +2841,7 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertTrue(app.requestOpenGlobalFamiliarLandingThread(for: "nova"))
 
-        XCTAssertEqual(app.projectContext, .project(beta))
+        XCTAssertEqual(app.projectContext, .project(alpha))
         XCTAssertTrue(app.threadToOpen === betaLanding)
         XCTAssertNil(app.toast)
     }
@@ -2751,13 +2874,13 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertTrue(app.requestOpenGlobalFamiliarLandingThread(for: "nova"))
 
-        XCTAssertEqual(app.projectContext, .project(beta))
+        XCTAssertEqual(app.projectContext, .project(alpha))
         XCTAssertEqual(app.threadToOpen?.sessionIds, ["nova": "beta-server"])
         XCTAssertEqual(app.threadToOpen?.projectRoot, beta.root)
         XCTAssertNil(app.toast)
     }
 
-    func testRequestOpenGlobalFamiliarLandingThreadCreatesFreshChatInActiveProjectWhenNoHistoryExists() {
+    func testGlobalFamiliarWithoutHistoryRequiresChatLocalConfiguration() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         app.projects = [alpha]
@@ -2769,12 +2892,12 @@ final class AppModelProjectContextTests: XCTestCase {
         app.projectMembershipLoaded = true
         app.projectContext = .project(alpha)
 
-        XCTAssertTrue(app.requestOpenGlobalFamiliarLandingThread(for: "nova"))
+        XCTAssertFalse(app.requestOpenGlobalFamiliarLandingThread(for: "nova"))
 
         XCTAssertEqual(app.projectContext, .project(alpha))
-        XCTAssertEqual(app.threadToOpen?.projectRoot, alpha.root)
-        XCTAssertEqual(app.threadToOpen?.familiarIds, ["nova"])
-        XCTAssertNil(app.toast)
+        XCTAssertNil(app.threadToOpen)
+        XCTAssertTrue(app.threads.isEmpty)
+        XCTAssertTrue(app.toast?.text.contains("New chat") == true)
     }
 
     func testRequestOpenGlobalFamiliarLandingThreadShowsGuidanceWhenFamiliarBelongsToDifferentProject() {
@@ -2796,8 +2919,8 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertNil(app.threadToOpen)
         assertToast(
             app,
-            text: "Nova has no chats in Alpha. Switch to Beta in Chats to start one.",
-            systemImage: "folder.badge.questionmark"
+            text: "Open New chat to choose this familiar and its project access.",
+            systemImage: "bubble.left.and.bubble.right"
         )
     }
 
@@ -3050,7 +3173,7 @@ final class AppModelProjectContextTests: XCTestCase {
     }
 
     @MainActor
-    func testFamiliarsListPresentationKeepsAccessScopedRosterDuringCachedRefreshFailure() {
+    func testFamiliarsListPresentationKeepsGlobalRosterWithoutImplyingAccess() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         app.projects = [alpha]
@@ -3064,18 +3187,20 @@ final class AppModelProjectContextTests: XCTestCase {
         app.projectMembership = ProjectMembershipIndex(
             familiarIDsByProjectID: ["alpha": Set(["nova"])]
         )
-        app.projectMembershipLoaded = true
+        app.projectMembershipLoaded = false
+        app.projectContextError = "Grant refresh failed"
         app.familiarsError = "Grant refresh failed"
 
         let presentation = FamiliarsListPresentation(app: app)
 
-        XCTAssertEqual(presentation.visibleFamiliars.map(\.id), ["nova"])
+        XCTAssertEqual(presentation.visibleFamiliars.map(\.id), ["nova", "sage"])
         XCTAssertTrue(presentation.showsCachedAccessBanner)
         XCTAssertEqual(presentation.mode, .list)
+        XCTAssertFalse(app.chatAccessIsCurrent)
     }
 
     @MainActor
-    func testFamiliarsListPresentationUsesRecoveryCopyWhenCachedScopeIsEmpty() {
+    func testFamiliarsListPresentationShowsLoadErrorWithoutAnAmbientScope() {
         let app = makeApp()
         app.projectContext = .unassigned
         app.projectMembershipLoaded = true
@@ -3084,15 +3209,15 @@ final class AppModelProjectContextTests: XCTestCase {
         let presentation = FamiliarsListPresentation(app: app)
 
         XCTAssertTrue(presentation.visibleFamiliars.isEmpty)
-        XCTAssertTrue(presentation.showsCachedAccessBanner)
+        XCTAssertFalse(presentation.showsCachedAccessBanner)
         XCTAssertEqual(
             presentation.mode,
-            .empty(title: "No recovery familiars", message: ProjectContextCopy.unassignedRecovery)
+            .firstLoadError("Grant refresh failed")
         )
     }
 
     @MainActor
-    func testFamiliarDetailStatsStayScopedAndUseNoActivityFallback() {
+    func testFamiliarChatHistoryIgnoresLegacyTaskAnalyticsAndAmbientProject() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
         let beta = project("beta", "Beta")
@@ -3121,15 +3246,14 @@ final class AppModelProjectContextTests: XCTestCase {
             ),
         ]
 
-        let alphaStats = FamiliarDetailStatsModel.make(app: app, familiar: shared, context: .project(alpha))
-        let quietStats = FamiliarDetailStatsModel.make(app: app, familiar: quiet, context: .project(alpha))
-
-        XCTAssertEqual(alphaStats.chats, "1")
-        XCTAssertEqual(alphaStats.tasks, "1")
-        XCTAssertNotEqual(alphaStats.activity, "No activity yet")
-        XCTAssertEqual(quietStats.chats, "0")
-        XCTAssertEqual(quietStats.tasks, "0")
-        XCTAssertEqual(quietStats.activity, "No activity yet")
+        app.projectContext = .project(alpha)
+        XCTAssertEqual(app.globalThreadCount(for: shared.id), 2)
+        XCTAssertEqual(app.globalLastActivity(for: shared.id), Date(timeIntervalSince1970: 80))
+        XCTAssertEqual(app.globalThreadCount(for: quiet.id), 0)
+        XCTAssertNil(app.globalLastActivity(for: quiet.id))
+        app.projectContext = .project(beta)
+        XCTAssertEqual(app.globalThreadCount(for: shared.id), 2)
+        XCTAssertEqual(app.globalLastActivity(for: shared.id), Date(timeIntervalSince1970: 80))
     }
 
     func testTasksViewDropsLegacyProjectGroupingAndScopesPendingOpenCards() {
@@ -3507,7 +3631,7 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertEqual(unwrapped.projectRoot, alpha.root)
         XCTAssertEqual(unwrapped.familiarIds, ["nova"])
-        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(app.projectContext, .project(beta))
         XCTAssertEqual(app.cardThreadLinks[task.id], unwrapped.id)
         XCTAssertTrue(app.threadToOpen === unwrapped)
         XCTAssertEqual(app.selectedTab, .chats)
@@ -3699,7 +3823,7 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertEqual(unwrapped.sessionIds["nova"], "session-1")
         XCTAssertEqual(unwrapped.projectRoot, beta.root)
-        XCTAssertEqual(app.projectContext, .project(beta))
+        XCTAssertEqual(app.projectContext, .project(alpha))
         XCTAssertNil(app.cardThreadLinks[task.id])
         XCTAssertNil(app.linkedThread(for: task))
         assertToast(
@@ -3756,7 +3880,7 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertFalse(unwrapped === staleLocal)
         XCTAssertEqual(unwrapped.sessionIds["nova"], "session-1")
         XCTAssertEqual(unwrapped.projectRoot, beta.root)
-        XCTAssertEqual(app.projectContext, .project(beta))
+        XCTAssertEqual(app.projectContext, .project(alpha))
         XCTAssertEqual(app.cardThreadLinks[task.id], staleLocal.id)
         XCTAssertNil(app.linkedThread(for: task))
     }
@@ -4629,6 +4753,455 @@ final class AppModelProjectContextTests: XCTestCase {
     }
 
     @MainActor
+    func testChatLocalLaunchSurvivesAmbientChangeAndAccessRefresh() async throws {
+        let app = makeApp()
+        let alpha = project("alpha", "Alpha")
+        let beta = project("beta", "Beta")
+        let launch = try XCTUnwrap(NewChatImportLaunchContext(
+            selectedProject: alpha,
+            selectedFamiliarIds: ["nova"]
+        ))
+        app.projectContext = .project(beta)
+        let accessClient = ControlledCoreClient(
+            projects: [alpha, beta],
+            grants: grants(grants: [
+                ProjectGrant(familiarId: "nova", projectId: alpha.id, access: .write),
+            ]),
+            familiars: [familiar("nova", "Nova")]
+        )
+
+        await app.loadProjectContext(using: accessClient, preservingSelection: true)
+
+        XCTAssertEqual(app.projectContext, .project(beta))
+        XCTAssertEqual(launch.validate(
+            registeredProjects: app.projects,
+            accessibleProjects: [alpha],
+            projectMembership: app.projectMembership,
+            membershipLoaded: app.projectMembershipLoaded
+        ), .valid)
+        let created = try XCTUnwrap(app.startFreshThread(
+            in: .project(alpha), familiarIds: launch.familiarIds
+        ))
+        XCTAssertEqual(created.projectRoot, alpha.root)
+        XCTAssertEqual(app.projectContext, .project(beta))
+        XCTAssertTrue(app.requestOpen(created))
+        XCTAssertEqual(app.projectContext, .project(beta))
+        let calls = await accessClient.callLog.snapshot()
+        XCTAssertEqual(calls.tasks, 0)
+    }
+
+    @MainActor
+    func testBoundThreadLaunchFailsClosedAfterGrantRefreshFailure() async {
+        let app = makeApp()
+        let alpha = project("alpha", "Alpha")
+        app.projects = [alpha]
+        app.projectsLoaded = true
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova"]])
+        app.projectMembershipLoaded = true
+        await app.loadProjectContext(
+            using: failingClient(message: "Grant refresh failed"),
+            preservingSelection: true
+        )
+        XCTAssertFalse(app.projectMembershipLoaded)
+        XCTAssertNil(app.startFreshThread(in: .project(alpha), familiarIds: ["nova"]))
+        XCTAssertTrue(app.threads.isEmpty)
+        XCTAssertTrue(app.toast?.text.contains("project access") == true)
+    }
+
+    @MainActor
+    func testChatWriteAccessUsesBoundProjectAndExactRosterNotReadability() {
+        let app = makeApp()
+        let alpha = project("alpha", "Alpha")
+        let beta = project("beta", "Beta")
+        let cached = thread("cached-access", familiarIds: ["nova"], projectRoot: alpha.root)
+        XCTAssertNil(app.threadOpenFailure(for: cached))
+        XCTAssertFalse(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: ["nova"]))
+
+        app.projects = [alpha, beta]
+        app.projectsLoaded = true
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: [
+            "alpha": ["nova", "sage"],
+            "beta": ["sage"],
+        ])
+        app.projectMembershipLoaded = true
+        app.projectContext = .project(beta)
+        XCTAssertTrue(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: ["nova", "sage"]))
+        XCTAssertFalse(app.chatAccessIsCurrent(projectRoot: beta.root, familiarIds: ["nova"]))
+        app.projectContext = nil
+        XCTAssertTrue(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: ["nova"]))
+        XCTAssertTrue(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: ["nova", "nova"]))
+        XCTAssertFalse(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: []))
+        XCTAssertFalse(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: [""]))
+        XCTAssertFalse(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: [" nova"]))
+        XCTAssertFalse(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: ["nova", "missing"]))
+        let invalidRoots: [String?] = [
+            nil, "", "relative/project", "/repos/unknown",
+            "\(alpha.root)/.worktrees/branch", " \(alpha.root)", "\(alpha.root)/",
+        ]
+        for root in invalidRoots {
+            XCTAssertFalse(app.chatAccessIsCurrent(projectRoot: root, familiarIds: ["nova"]))
+        }
+
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova"]])
+        XCTAssertTrue(app.chatAccessIsCurrent)
+        XCTAssertFalse(app.requireCurrentChatAccess(projectRoot: alpha.root, familiarIds: ["nova", "sage"]))
+        XCTAssertTrue(app.toast?.text.contains("every participant") == true)
+        XCTAssertNil(app.threadOpenFailure(for: cached))
+        app.projectContextError = "Refresh failed"
+        XCTAssertFalse(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: ["nova"]))
+        app.projectContextError = nil
+        app.projectMembershipLoaded = false
+        XCTAssertFalse(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: ["nova"]))
+    }
+
+    @MainActor
+    func testRevokedQueuedRecipientCannotBeReplacedByCurrentRosterAccess() async {
+        let app = makeApp()
+        _ = connect(app)
+        app.connectionState = .connected
+        let alpha = project("alpha", "Alpha")
+        let pending = thread("revoked-queue", familiarIds: ["nova"], projectRoot: alpha.root)
+        pending.enqueue("Keep the original recipient")
+        pending.familiarIds = ["sage"]
+        app.threads = [pending]
+        app.threadDrafts[pending.id] = "Keep this draft"
+        app.projects = [alpha]
+        app.projectsLoaded = true
+        app.projectMembershipLoaded = true
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["sage"]])
+        XCTAssertTrue(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: pending.familiarIds))
+        XCTAssertFalse(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: ["nova"]))
+
+        app.flushQueuedMessages()
+        await waitFor { app.toast?.text.contains("Queued chat access") == true }
+
+        XCTAssertEqual(pending.messages.count, 1)
+        XCTAssertTrue(pending.messages.first?.isQueued == true)
+        XCTAssertEqual(pending.messages.first?.queuedTargetFamiliarIds, ["nova"])
+        XCTAssertNil(pending.messages.first?.queuedAttemptedFamiliarIds)
+        XCTAssertEqual(pending.projectRoot, alpha.root)
+        XCTAssertEqual(app.threadDrafts[pending.id], "Keep this draft")
+
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova"]])
+        XCTAssertTrue(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: ["nova"]),
+                      "restored access is evaluated against the original queued recipient")
+    }
+
+    @MainActor
+    func testQueuedAccessPreservesLegacyRunRecipientFallback() async {
+        let app = makeApp()
+        let alpha = project("alpha", "Alpha")
+        app.projects = [alpha]
+        app.projectsLoaded = true
+        app.projectMembershipLoaded = true
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["sage"]])
+        let pending = thread("legacy-queue", familiarIds: ["sage"], projectRoot: alpha.root)
+        pending.enqueue("Legacy delivery")
+        pending.messages[0].queuedTargetFamiliarIds = nil
+        pending.messages[0].queuedRunIdsByFamiliarId = ["nova": "original-run"]
+        let transport = queuedAccessClient()
+        let before = pending.messages
+        var refused: [String?] = []
+        await replayQueue(pending, app: app, client: transport, onAccessRefused: { refused.append($0) })
+        XCTAssertEqual(refused, ["nova"])
+        XCTAssertEqual(pending.messages, before)
+        XCTAssertTrue(QueuedAccessURLProtocol.requests.isEmpty)
+    }
+
+    @MainActor
+    func testSuccessfulGrantRefreshRevocationLeavesQueuedRecipientUnsent() async {
+        let app = makeApp()
+        let alpha = project("alpha", "Alpha")
+        app.projects = [alpha]
+        app.projectsLoaded = true
+        app.projectMembershipLoaded = true
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova", "sage"]])
+        let pending = thread("refresh-revoked", familiarIds: ["nova"], projectRoot: alpha.root)
+        pending.enqueue("Never replace Nova with Sage")
+        let before = pending.messages
+        let transport = queuedAccessClient()
+        await app.loadProjectContext(using: client(
+            projects: [alpha],
+            grants: grants(grants: [ProjectGrant(familiarId: "sage", projectId: alpha.id, access: .write)]),
+            familiars: [familiar("nova", "Nova"), familiar("sage", "Sage")]
+        ), preservingSelection: true)
+        XCTAssertTrue(app.chatAccessIsCurrent)
+        XCTAssertTrue(app.chatAccessIsCurrent(projectRoot: alpha.root, familiarIds: ["sage"]))
+        var checkpoints = 0
+        var refused: [String?] = []
+        await replayQueue(pending, app: app, client: transport, persistBeforeDispatch: {
+            checkpoints += 1
+            return true
+        }, onAccessRefused: { refused.append($0) })
+        XCTAssertEqual(refused, ["nova"])
+        XCTAssertEqual(checkpoints, 0)
+        XCTAssertTrue(QueuedAccessURLProtocol.requests.isEmpty)
+        XCTAssertEqual(pending.messages, before)
+    }
+
+    @MainActor
+    func testFrozenQueuedGroupSkipsRevokedTargetWithoutStarvingAllowedRecipient() async {
+        let app = makeApp()
+        let alpha = project("alpha", "Alpha")
+        app.projects = [alpha]
+        app.projectsLoaded = true
+        app.projectMembershipLoaded = true
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["sage", "new-member"]])
+        let pending = thread("partial-queue", familiarIds: ["nova", "sage"], projectRoot: alpha.root)
+        pending.enqueue("Only original recipients")
+        pending.familiarIds = ["new-member"]
+        let transport = queuedAccessClient()
+        var refused: [String?] = []
+        await replayQueue(pending, app: app, client: transport, onAccessRefused: { refused.append($0) })
+        XCTAssertEqual(refused, ["nova"])
+        XCTAssertEqual(QueuedAccessURLProtocol.requests.filter { $0.httpMethod == "POST" }.count, 1)
+        XCTAssertEqual(pending.messages.first?.queuedTargetFamiliarIds, ["nova", "sage"])
+        XCTAssertEqual(pending.messages.first?.queuedCompletedFamiliarIds, ["sage"])
+        XCTAssertTrue(pending.messages.first?.isQueued == true)
+        XCTAssertEqual(pending.messages.first?.queuedContext?.projectRoot, alpha.root)
+        XCTAssertEqual(pending.messages.filter { $0.role == .assistant }.map(\.familiarId), ["sage"])
+        XCTAssertEqual(pending.messages.last?.text, "Allowed reply")
+        XCTAssertFalse(pending.messages.last?.isError == true)
+        XCTAssertEqual(pending.familiarIds, ["new-member"])
+    }
+
+    @MainActor
+    func testCompletedQueuedDeliveryClearsItsOriginalContext() async {
+        let app = makeApp()
+        let alpha = project("alpha", "Alpha")
+        app.projects = [alpha]
+        app.projectsLoaded = true
+        app.projectMembershipLoaded = true
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova"]])
+        let pending = thread("complete-queue", familiarIds: ["nova"], projectRoot: alpha.root)
+        pending.enqueue("Deliver to the original chat")
+        let transport = queuedAccessClient()
+
+        await replayQueue(pending, app: app, client: transport)
+
+        XCTAssertEqual(QueuedAccessURLProtocol.requests.filter { $0.httpMethod == "POST" }.count, 1)
+        XCTAssertFalse(pending.messages.first?.isQueued == true)
+        XCTAssertNil(pending.messages.first?.queuedContext)
+        XCTAssertNil(pending.messages.first?.queuedTargetFamiliarIds)
+        XCTAssertEqual(pending.messages.last?.text, "Allowed reply")
+        XCTAssertFalse(pending.messages.last?.isError == true)
+    }
+
+    @MainActor
+    func testQueuedStreamResumeUsesTheSameInjectedTransport() async throws {
+        let transport = queuedAccessClient()
+        var reply = ""
+        for try await frame in transport.resumeStream(runId: "original-run", cursor: 7) {
+            if case .assistantChunk(let text) = frame.event { reply += text }
+        }
+
+        XCTAssertEqual(reply, "Allowed reply")
+        XCTAssertEqual(QueuedAccessURLProtocol.requests.count, 1)
+        XCTAssertEqual(QueuedAccessURLProtocol.requests.first?.httpMethod, "GET")
+        XCTAssertEqual(QueuedAccessURLProtocol.requests.first?.url?.path, "/api/chat/stream")
+        XCTAssertEqual(
+            QueuedAccessURLProtocol.requests.first?.url?.query,
+            "runId=original-run&cursor=7"
+        )
+    }
+
+    @MainActor
+    func testGrantRevocationDuringQueuedPersistenceRollsBackWithoutPost() async {
+        let app = makeApp()
+        let alpha = project("alpha", "Alpha")
+        app.projects = [alpha]
+        app.projectsLoaded = true
+        app.projectMembershipLoaded = true
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova"]])
+        let pending = thread("checkpoint-revoked", familiarIds: ["nova"], projectRoot: alpha.root)
+        pending.enqueue("Keep pending")
+        let before = pending.messages
+        let transport = queuedAccessClient()
+        var rollbacks = 0
+        var refused: [String?] = []
+        await replayQueue(pending, app: app, client: transport, persistBeforeDispatch: {
+            await app.loadProjectContext(using: self.client(
+                projects: [alpha],
+                grants: self.grants(),
+                familiars: [self.familiar("nova", "Nova")]
+            ), preservingSelection: true)
+            return true
+        }, persistAfterRollback: {
+            rollbacks += 1
+            return true
+        }, onAccessRefused: { refused.append($0) })
+        XCTAssertTrue(app.chatAccessIsCurrent)
+        XCTAssertEqual(refused, ["nova"])
+        XCTAssertEqual(rollbacks, 1)
+        XCTAssertTrue(QueuedAccessURLProtocol.requests.isEmpty)
+        XCTAssertEqual(pending.messages, before)
+    }
+
+    @MainActor
+    func testQueuedGrantRevocationAtNetworkPreflightPreservesPendingLeg() async {
+        let app = makeApp()
+        let alpha = project("alpha", "Alpha")
+        app.projects = [alpha]
+        app.projectsLoaded = true
+        app.projectMembershipLoaded = true
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova"]])
+        let pending = thread("late-revoked", familiarIds: ["nova"], projectRoot: alpha.root)
+        pending.enqueue("Keep pending at the last boundary")
+        let transport = queuedAccessClient()
+        var accessProbes = 0
+        var refused: [String?] = []
+        await pending.replayQueued(
+            client: transport,
+            dispatchLeaseIsCurrent: { true },
+            targetAccessIsCurrent: { root, recipient in
+                XCTAssertEqual(root, alpha.root)
+                XCTAssertEqual(recipient, "nova")
+                accessProbes += 1
+                // Leg admission, checkpoint, stream entry, then URLSession preflight.
+                if accessProbes == 4 {
+                    app.projectMembership = ProjectMembershipIndex()
+                }
+                return app.chatAccessIsCurrent(projectRoot: root, familiarIds: [recipient])
+            },
+            onAccessRefused: { refused.append($0) },
+            persistBeforeDispatch: { true },
+            persistAfterRollback: { true },
+            onChange: {}
+        )
+        XCTAssertEqual(accessProbes, 4)
+        XCTAssertEqual(refused, ["nova"])
+        XCTAssertTrue(QueuedAccessURLProtocol.requests.isEmpty)
+        XCTAssertTrue(pending.messages.first?.isQueued == true)
+        XCTAssertNil(pending.messages.first?.queuedAttemptedFamiliarIds)
+        XCTAssertNil(pending.messages.first?.queuedRunIdsByFamiliarId)
+        XCTAssertEqual(pending.messages.first?.queuedTargetFamiliarIds, ["nova"])
+    }
+
+    @MainActor
+    func testQueuedFinalPreflightRefusalDoesNotStarveAllowedSibling() async {
+        let app = makeApp()
+        let alpha = project("alpha", "Alpha")
+        app.projects = [alpha]
+        app.projectsLoaded = true
+        app.projectMembershipLoaded = true
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova", "sage"]])
+        let pending = thread("late-group-revocation", familiarIds: ["nova", "sage"], projectRoot: alpha.root)
+        pending.enqueue("Keep both original recipients")
+        let transport = queuedAccessClient()
+        var novaProbes = 0
+        var refused: [String?] = []
+        await pending.replayQueued(
+            client: transport,
+            dispatchLeaseIsCurrent: { true },
+            targetAccessIsCurrent: { root, recipient in
+                if recipient == "nova" {
+                    novaProbes += 1
+                    if novaProbes == 4 {
+                        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["sage"]])
+                    }
+                }
+                return app.chatAccessIsCurrent(projectRoot: root, familiarIds: [recipient])
+            },
+            onAccessRefused: { refused.append($0) },
+            persistBeforeDispatch: { true },
+            persistAfterRollback: { true },
+            onChange: {}
+        )
+
+        XCTAssertEqual(novaProbes, 4)
+        XCTAssertEqual(refused, ["nova"])
+        XCTAssertEqual(QueuedAccessURLProtocol.requests.filter { $0.httpMethod == "POST" }.count, 1)
+        XCTAssertEqual(pending.messages.first?.queuedCompletedFamiliarIds, ["sage"])
+        XCTAssertTrue(pending.messages.first?.isQueued == true)
+        XCTAssertFalse(pending.messages.first?.queuedAttemptedFamiliarIds?.contains("nova") == true)
+        XCTAssertEqual(pending.messages.last?.familiarId, "sage")
+        XCTAssertEqual(pending.messages.last?.text, "Allowed reply")
+    }
+
+    @MainActor
+    func testQueuedCheckpointRefusalDoesNotStarveAllowedSibling() async {
+        let app = makeApp()
+        let alpha = project("alpha", "Alpha")
+        app.projects = [alpha]
+        app.projectsLoaded = true
+        app.projectMembershipLoaded = true
+        app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova", "sage"]])
+        let pending = thread("checkpoint-group-revocation", familiarIds: ["nova", "sage"], projectRoot: alpha.root)
+        pending.enqueue("Keep both original recipients")
+        let transport = queuedAccessClient()
+        var checkpoints = 0
+        var rollbacks = 0
+        await replayQueue(pending, app: app, client: transport, persistBeforeDispatch: {
+            checkpoints += 1
+            app.projectMembership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["sage"]])
+            return true
+        }, persistAfterRollback: {
+            rollbacks += 1
+            return true
+        })
+
+        XCTAssertEqual(checkpoints, 2)
+        XCTAssertEqual(rollbacks, 1)
+        XCTAssertEqual(QueuedAccessURLProtocol.requests.filter { $0.httpMethod == "POST" }.count, 1)
+        XCTAssertEqual(pending.messages.first?.queuedCompletedFamiliarIds, ["sage"])
+        XCTAssertTrue(pending.messages.first?.isQueued == true)
+        XCTAssertEqual(pending.messages.last?.familiarId, "sage")
+        XCTAssertEqual(pending.messages.last?.text, "Allowed reply")
+    }
+
+    @MainActor
+    func testQueuedConnectionRevocationStillStopsAllRecipients() async {
+        let alpha = project("alpha", "Alpha")
+        let pending = thread("connection-revoked-group", familiarIds: ["nova", "sage"], projectRoot: alpha.root)
+        pending.enqueue("Wait for the original connection")
+        let transport = queuedAccessClient()
+        var connectionIsCurrent = true
+        var considered: [String] = []
+        await pending.replayQueued(
+            client: transport,
+            dispatchLeaseIsCurrent: { connectionIsCurrent },
+            targetAccessIsCurrent: { _, recipient in
+                considered.append(recipient)
+                return true
+            },
+            onAccessRefused: { _ in XCTFail("The endpoint, not a target grant, was revoked.") },
+            persistBeforeDispatch: { connectionIsCurrent = false; return true },
+            persistAfterRollback: { true },
+            onChange: {}
+        )
+
+        XCTAssertEqual(considered, ["nova"])
+        XCTAssertTrue(QueuedAccessURLProtocol.requests.isEmpty)
+        XCTAssertTrue(pending.messages.first?.isQueued == true)
+        XCTAssertEqual(pending.messages.first?.queuedTargetFamiliarIds, ["nova", "sage"])
+        XCTAssertNil(pending.messages.first?.queuedCompletedFamiliarIds)
+    }
+
+    @MainActor
+    func testUnavailableChatAccessPreservesQueuedTargetAndDraft() async {
+        let app = makeApp()
+        _ = connect(app)
+        app.connectionState = .connected
+        let pending = thread("queued", familiarIds: ["nova"], projectRoot: "/repos/alpha")
+        pending.enqueue("Keep this exact target")
+        app.threads = [pending]
+        app.threadDrafts[pending.id] = "Unsent draft"
+        let targets = pending.messages.first?.queuedTargetFamiliarIds
+        let lease = app.captureConnectionDispatchLease()
+
+        app.flushQueuedMessages()
+        let checkpointAccepted = await app.persistThreadsBeforeDispatch(for: lease)
+
+        XCTAssertFalse(checkpointAccepted)
+        XCTAssertEqual(pending.messages.count, 1)
+        XCTAssertTrue(pending.messages.first?.isQueued == true)
+        XCTAssertEqual(pending.messages.first?.queuedTargetFamiliarIds, targets)
+        XCTAssertEqual(pending.projectRoot, "/repos/alpha")
+        XCTAssertEqual(app.threadDrafts[pending.id], "Unsent draft")
+        XCTAssertTrue(app.toast?.text.contains("Chat access is unavailable") == true)
+    }
+
+    @MainActor
     func testStartFreshThreadInActiveProjectBlocksRosterOutsideActiveProject() {
         let app = makeApp()
         let alpha = project("alpha", "Alpha")
@@ -4651,7 +5224,7 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertTrue(app.threads.isEmpty)
         assertToast(
             app,
-            text: "Sage can’t access Alpha. Open New Chat to choose a valid roster or switch projects, then try again.",
+            text: "Sage can’t access Alpha. Open New chat to choose a project and valid roster, then try again.",
             systemImage: "person.crop.circle.badge.exclamationmark"
         )
     }
@@ -4755,7 +5328,7 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(app.projectSwitcherState, .emptyNoProjects)
     }
 
-    func testRefreshConnectionFailedInitialProjectContextLoadUsesProjectContextRequiredState() async {
+    func testRefreshConnectionKeepsChatShellAvailableWhenInitialCatalogFails() async {
         let message = "Choose a project in Cave before opening it on this device."
         let foundURL = URL(string: "http://cave.test:3000")!
         let retryingClient = RetryingProjectContextCoreClient(
@@ -4775,7 +5348,7 @@ final class AppModelProjectContextTests: XCTestCase {
 
         await app.refreshConnection()
 
-        XCTAssertEqual(app.connectionState, .projectContextRequired)
+        XCTAssertEqual(app.connectionState, .connected)
         XCTAssertNil(app.projectContext)
         XCTAssertFalse(app.projectMembershipLoaded)
         XCTAssertEqual(app.projectContextError, message)
@@ -4800,7 +5373,7 @@ final class AppModelProjectContextTests: XCTestCase {
         app.connection = CaveConnection(host: foundURL.absoluteString)
 
         await app.connectWithRetry()
-        XCTAssertEqual(app.connectionState, .projectContextRequired)
+        XCTAssertEqual(app.connectionState, .connected)
         XCTAssertEqual(app.projectContextError, message)
 
         await app.connectWithRetry()
@@ -4847,17 +5420,7 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(calls.grants, 1)
         XCTAssertEqual(calls.familiars, 1)
         XCTAssertEqual(calls.sessions, 1)
-        // Task history IS consulted here, and one fetch is correct. The cold
-        // selection is staged local threads -> server sessions -> task history
-        // -> alphabetical, and `shouldFetchTaskHistoryForProjectContextSelection`
-        // fetches whenever the decision would otherwise land on the alphabetical
-        // or unassigned fallback. This client serves an EMPTY session list, so
-        // sessions succeed without identifying a registered project and the
-        // task-history stage runs — which is the point of that stage: it picks
-        // the project the operator actually worked in instead of the one that
-        // happens to sort first. Asserting 0 here asserted that the fallback
-        // never runs, which was never true; it had simply never executed.
-        XCTAssertEqual(calls.tasks, 1)
+        XCTAssertEqual(calls.tasks, 0)
     }
 
     func testColdLaunchChoosesMostRecentHydratedLocalThreadProjectBeforeServerHistory() async {
@@ -5010,7 +5573,7 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(historyOrder, [.sessions])
     }
 
-    func testColdLaunchUsesRecentTaskProjectBeforeAlphabeticalFallback() async {
+    func testColdLaunchNeverHydratesTasksForChatBrowsing() async {
         let foundURL = URL(string: "http://cave.test:3000")!
         let controlledClient = ControlledCoreClient(
             projects: [
@@ -5039,19 +5602,19 @@ final class AppModelProjectContextTests: XCTestCase {
         await app.refreshConnection()
 
         XCTAssertEqual(app.connectionState, .connected)
-        XCTAssertEqual(app.projectContext, .project(project("zulu", "Zulu")))
+        XCTAssertEqual(app.projectContext, .project(project("alpha", "Alpha")))
         XCTAssertTrue(app.sessionsLoaded)
-        XCTAssertTrue(app.tasksLoaded)
+        XCTAssertFalse(app.tasksLoaded)
         XCTAssertEqual(app.serverSessions, [])
-        XCTAssertEqual(app.tasks.map(\.id), ["alpha-task", "zulu-task"])
+        XCTAssertTrue(app.tasks.isEmpty)
         let calls = await controlledClient.callLog.snapshot()
         XCTAssertEqual(calls.sessions, 1)
-        XCTAssertEqual(calls.tasks, 1)
+        XCTAssertEqual(calls.tasks, 0)
         let historyOrder = await controlledClient.callLog.historyOrderSnapshot()
-        XCTAssertEqual(historyOrder, [.sessions, .tasks])
+        XCTAssertEqual(historyOrder, [.sessions])
     }
 
-    func testLoadProjectContextWaitsForSuccessfulSessionHistoryBeforeFetchingTasks() async {
+    func testLoadProjectContextLoadsSessionHistoryWithoutFetchingTasks() async {
         let sessionStarted = Gate()
         let sessionRelease = Gate()
         let controlledClient = ControlledCoreClient(
@@ -5086,9 +5649,9 @@ final class AppModelProjectContextTests: XCTestCase {
         await sessionRelease.open()
         await loadTask.value
 
-        XCTAssertEqual(app.projectContext, .project(project("zulu", "Zulu")))
+        XCTAssertEqual(app.projectContext, .project(project("alpha", "Alpha")))
         let historyOrder = await controlledClient.callLog.historyOrderSnapshot()
-        XCTAssertEqual(historyOrder, [.sessions, .tasks])
+        XCTAssertEqual(historyOrder, [.sessions])
     }
 
     func testLoadProjectContextSkipsTaskHistoryWhenLocalThreadAlreadyDeterminesContext() async {
@@ -5126,7 +5689,7 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(calls.tasks, 0)
     }
 
-    func testColdLaunchFallsBackToAlphabeticalProjectWhenTaskHistoryFails() async {
+    func testChatBootstrapDoesNotConsultFailingTaskHistory() async {
         let message = "Recent tasks unavailable"
         let foundURL = URL(string: "http://cave.test:3000")!
         let controlledClient = ControlledCoreClient(
@@ -5163,13 +5726,13 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertTrue(app.sessionsLoaded)
         XCTAssertTrue(app.serverSessions.isEmpty)
         XCTAssertFalse(app.tasksLoaded)
-        XCTAssertEqual(app.tasksError, message)
+        XCTAssertNil(app.tasksError)
         XCTAssertNil(app.projectContextError)
         let calls = await controlledClient.callLog.snapshot()
         XCTAssertEqual(calls.sessions, 1)
-        XCTAssertEqual(calls.tasks, 1)
+        XCTAssertEqual(calls.tasks, 0)
         let historyOrder = await controlledClient.callLog.historyOrderSnapshot()
-        XCTAssertEqual(historyOrder, [.sessions, .tasks])
+        XCTAssertEqual(historyOrder, [.sessions])
     }
 
     func testUserSwitchDuringHistoryBootstrapIsNotOverwritten() async {
@@ -5299,7 +5862,7 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(app.familiarsError, message)
         XCTAssertEqual(app.projects.map(\.id), ["alpha"])
         XCTAssertEqual(app.familiars.map(\.id), ["nova"])
-        XCTAssertTrue(app.projectMembershipLoaded)
+        XCTAssertFalse(app.projectMembershipLoaded)
     }
 
     func testReconnectRefreshFailureMirrorsCachedProjectContextErrorToEmptyProjectsAndRetryClearsIt() async {
@@ -5406,7 +5969,7 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(app.projectContext, .project(project("alpha", "Alpha")))
     }
 
-    func testPendingTaskIntentWaitsForRelocatedBootstrapBeforeHydrating() async throws {
+    func testRetiredTaskIntentIsRejectedBeforeRelocatedBootstrap() async throws {
         let alpha = project("alpha", "Alpha")
         let target = card("relocated-task", familiarId: "nova", projectId: alpha.id)
         let historyStarted = Gate()
@@ -5433,9 +5996,9 @@ final class AppModelProjectContextTests: XCTestCase {
 
         let preBootstrapCalls = await controlledClient.callLog.snapshot()
         XCTAssertEqual(preBootstrapCalls.tasks, 0)
-        XCTAssertEqual(app.pendingProjectNavigationIntent?.taskId, target.id)
+        XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertNil(app.cardToOpen)
-        XCTAssertNil(app.toast)
+        XCTAssertTrue(app.toast?.text.contains("desktop-only") == true)
 
         let refreshTask = Task { await app.refreshConnection() }
         let started = expectation(description: "post-bootstrap task hydration started")
@@ -5452,27 +6015,24 @@ final class AppModelProjectContextTests: XCTestCase {
         let postBootstrapCalls = await controlledClient.callLog.snapshot()
         XCTAssertEqual(postBootstrapCalls.sessions, 1)
         XCTAssertEqual(postBootstrapCalls.tasks, 0)
-        XCTAssertEqual(app.pendingProjectNavigationIntent?.taskId, target.id)
+        XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertNil(app.cardToOpen)
         assertOnlyPortRelocationNoticeToast(app, port: 4000)
 
         await historyRelease.open()
         await refreshTask.value
-        await waitFor { app.cardToOpen?.id == target.id }
+        XCTAssertNil(app.cardToOpen)
 
         XCTAssertEqual(app.connection?.baseURL, foundURL)
         XCTAssertEqual(app.projectContext, .project(alpha))
-        XCTAssertEqual(app.selectedTab, .tasks)
+        XCTAssertEqual(app.selectedTab, .chats)
         XCTAssertNil(app.pendingProjectNavigationIntent)
         assertOnlyPortRelocationNoticeToast(app, port: 4000)
-        // The hydration the mid-flight snapshot was too early to see: once the
-        // release gate opens, the staged task fetch does run, and it is what
-        // resolves `cardToOpen` above.
         let hydratedCalls = await controlledClient.callLog.snapshot()
-        XCTAssertEqual(hydratedCalls.tasks, 1)
+        XCTAssertEqual(hydratedCalls.tasks, 0)
     }
 
-    func testPendingTaskIntentFailsOnlyAfterSuccessfulCurrentGenerationTaskLoad() async throws {
+    func testRetiredTaskIntentFailsWithoutWaitingForCurrentGenerationLoad() async throws {
         let alpha = project("alpha", "Alpha")
         let historyStarted = Gate()
         let historyRelease = Gate()
@@ -5495,32 +6055,32 @@ final class AppModelProjectContextTests: XCTestCase {
 
         app.handleDeepLink(try XCTUnwrap(URL(string: "covencave://task/missing-task")))
         await Task.yield()
-        XCTAssertNil(app.toast)
+        XCTAssertTrue(app.toast?.text.contains("desktop-only") == true)
 
         let refreshTask = Task { await app.refreshConnection() }
         let started = expectation(description: "missing-task hydration started")
         Task { await historyStarted.wait(); started.fulfill() }
         await fulfillment(of: [started], timeout: 1)
 
-        XCTAssertEqual(app.pendingProjectNavigationIntent?.taskId, "missing-task")
+        XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertNil(app.cardToOpen)
-        XCTAssertNil(app.toast)
+        XCTAssertTrue(app.toast?.text.contains("desktop-only") == true)
 
         await historyRelease.open()
         await refreshTask.value
         await waitFor { app.toast != nil }
 
-        XCTAssertEqual(app.pendingProjectNavigationIntent?.taskId, "missing-task")
+        XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertNil(app.cardToOpen)
         assertToast(
             app,
-            text: "This task is not available on this device yet. Refresh Tasks and try again.",
-            systemImage: "checklist"
+            text: "Tasks is desktop-only. Open Coven Cave on your desktop; iOS supports Chats and Settings.",
+            systemImage: "desktopcomputer"
         )
     }
 
     @MainActor
-    func testPendingTaskHydrationFailureRetainsIntentUntilExplicitRetrySucceeds() async throws {
+    func testLegacyTaskRefreshCannotReviveRetiredNavigation() async throws {
         let failingClient = ControlledCoreClient(
             projects: [],
             grants: grants(),
@@ -5547,13 +6107,13 @@ final class AppModelProjectContextTests: XCTestCase {
 
         await app.loadTasks(using: failingClient)
 
-        XCTAssertEqual(app.pendingProjectNavigationIntent?.taskId, recoveredTask.id)
+        XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertEqual(app.tasksError, "Task history is offline")
         XCTAssertNil(app.cardToOpen)
         assertToast(
             app,
-            text: "Couldn’t load Tasks while opening task retry-task. Refresh Tasks or reconnect, then try again.",
-            systemImage: "checklist"
+            text: "Tasks is desktop-only. Open Coven Cave on your desktop; iOS supports Chats and Settings.",
+            systemImage: "desktopcomputer"
         )
         let firstToastID = try XCTUnwrap(app.toast?.id)
 
@@ -5567,10 +6127,10 @@ final class AppModelProjectContextTests: XCTestCase {
         await app.loadTasks(using: retryClient)
 
         XCTAssertNil(app.pendingProjectNavigationIntent)
-        XCTAssertEqual(app.cardToOpen?.id, recoveredTask.id)
-        XCTAssertEqual(app.selectedTab, .tasks)
+        XCTAssertNil(app.cardToOpen)
+        XCTAssertEqual(app.selectedTab, .chats)
         XCTAssertNil(app.tasksError)
-        XCTAssertNil(app.toast)
+        XCTAssertEqual(app.toast?.id, firstToastID)
         let retryCalls = await retryClient.callLog.snapshot()
         XCTAssertEqual(retryCalls.tasks, 1)
     }
@@ -5708,7 +6268,7 @@ final class AppModelProjectContextTests: XCTestCase {
     }
 
     @MainActor
-    func testReconnectPendingTaskHydrationSupersedesStaleGenerationWithoutRetryLoop() async throws {
+    func testReconnectDoesNotHydrateOrReopenRetiredTaskIntent() async throws {
         let alpha = project("alpha", "Alpha")
         let staleStarted = Gate()
         let staleRelease = Gate()
@@ -5753,10 +6313,10 @@ final class AppModelProjectContextTests: XCTestCase {
             destination: .tasks
         )
         XCTAssertFalse(app.resolvePendingProjectNavigationIntent(attemptHydrationIfNeeded: true))
-        await staleStarted.wait()
+        XCTAssertNil(app.pendingProjectNavigationIntent)
+        XCTAssertTrue(app.toast?.text.contains("desktop-only") == true)
 
         let reconnect = Task { await app.configure(host: foundURL.absoluteString) }
-        await currentStarted.wait()
         await reconnect.value
 
         await staleRelease.open()
@@ -5764,27 +6324,25 @@ final class AppModelProjectContextTests: XCTestCase {
         await Task.yield()
 
         let midCalls = await client.callLog.snapshot()
-        XCTAssertEqual(midCalls.tasks, 2)
-        XCTAssertEqual(app.pendingProjectNavigationIntent?.taskId, reopened.id)
+        XCTAssertEqual(midCalls.tasks, 0)
+        XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertTrue(app.tasks.isEmpty)
         XCTAssertNil(app.cardToOpen)
-        assertOnlyReconnectNoticeToast(app)
 
         await currentRelease.open()
-        await waitFor { app.cardToOpen?.id == reopened.id }
+        XCTAssertNil(app.cardToOpen)
 
         let finalCalls = await client.callLog.snapshot()
-        XCTAssertEqual(finalCalls.tasks, 2)
-        XCTAssertEqual(app.tasks.map(\.id), [reopened.id])
+        XCTAssertEqual(finalCalls.tasks, 0)
+        XCTAssertTrue(app.tasks.isEmpty)
         XCTAssertEqual(app.projectContext, .project(alpha))
-        XCTAssertEqual(app.selectedTab, .tasks)
+        XCTAssertEqual(app.selectedTab, .chats)
         XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertNil(app.tasksError)
-        assertOnlyReconnectNoticeToast(app)
     }
 
     @MainActor
-    func testPendingProjectHydrationFailureRetainsIntentUntilExplicitRetrySucceeds() async throws {
+    func testCachedChatCanOpenWhenProjectHydrationFailsWithoutRescoping() async throws {
         let alpha = project("alpha", "Alpha")
         let failingClient = ControlledCoreClient(
             projects: [],
@@ -5803,22 +6361,22 @@ final class AppModelProjectContextTests: XCTestCase {
         )
         let app = makeApp()
         _ = connect(app, host: "http://127.0.0.1:1")
+        let cached = thread("cached", familiarIds: ["nova"], projectRoot: alpha.root)
+        app.threads = [cached]
         app.pendingProjectNavigationIntent = ProjectNavigationIntent(
-            destination: .tasks,
+            entity: .thread(id: cached.id),
+            destination: .chats,
             projectId: alpha.id
         )
 
         await app.loadProjectContext(using: failingClient)
 
-        XCTAssertEqual(app.pendingProjectNavigationIntent?.projectId, alpha.id)
+        XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertEqual(app.projectContextError, "Project context is offline")
         XCTAssertNil(app.projectContext)
-        assertToast(
-            app,
-            text: "Couldn’t load project context while opening project alpha. Refresh Chats or reconnect, then try again.",
-            systemImage: "folder.badge.questionmark"
-        )
-        let firstToastID = try XCTUnwrap(app.toast?.id)
+        XCTAssertTrue(app.threadToOpen === cached)
+        XCTAssertFalse(app.projectMembershipLoaded)
+        XCTAssertNil(app.toast)
 
         XCTAssertFalse(app.resolvePendingProjectNavigationIntent())
         XCTAssertFalse(app.resolvePendingProjectNavigationIntent())
@@ -5827,13 +6385,14 @@ final class AppModelProjectContextTests: XCTestCase {
         XCTAssertEqual(failedCalls.projects, 1)
         XCTAssertEqual(failedCalls.grants, 1)
         XCTAssertEqual(failedCalls.familiars, 1)
-        XCTAssertEqual(app.toast?.id, firstToastID)
+        XCTAssertNil(app.toast)
 
-        await app.loadProjectContext(using: retryClient)
+        await app.loadProjectContext(using: retryClient, preservingSelection: true)
 
         XCTAssertNil(app.pendingProjectNavigationIntent)
-        XCTAssertEqual(app.projectContext, .project(alpha))
-        XCTAssertEqual(app.selectedTab, .tasks)
+        XCTAssertNil(app.projectContext)
+        XCTAssertTrue(app.threadToOpen === cached)
+        XCTAssertEqual(app.selectedTab, .chats)
         XCTAssertNil(app.projectContextError)
         XCTAssertNil(app.projectsError)
         XCTAssertNil(app.toast)
@@ -6032,8 +6591,8 @@ final class AppModelProjectContextTests: XCTestCase {
             familiars: [familiar("nova", "Nova")],
             sessions: [],
             tasks: [card("context-task", familiarId: "nova", projectId: alpha.id)],
-            taskStarted: contextStarted,
-            taskRelease: contextRelease
+            contextStarted: contextStarted,
+            contextRelease: contextRelease
         )
         let app = makeApp(coreResourceClientFactory: { _ in standaloneClient })
         _ = connect(app, host: "http://127.0.0.1:1")
@@ -6081,8 +6640,8 @@ final class AppModelProjectContextTests: XCTestCase {
                 code: 81,
                 userInfo: [NSLocalizedDescriptionKey: "Task history is offline"]
             )),
-            taskStarted: taskStarted,
-            taskRelease: taskRelease
+            sessionStarted: taskStarted,
+            sessionRelease: taskRelease
         )
         let app = makeApp(coreResourceClientFactory: { _ in staleLoad })
         _ = connect(app, host: "http://127.0.0.1:1")
@@ -6105,7 +6664,7 @@ final class AppModelProjectContextTests: XCTestCase {
 
         XCTAssertEqual(app.serverSessions.map(\.id), ["beta-session"])
         XCTAssertEqual(app.projectContext, .project(beta))
-        XCTAssertEqual(app.tasksError, "Task history is offline")
+        XCTAssertNil(app.tasksError)
     }
 
     @MainActor
@@ -6123,8 +6682,8 @@ final class AppModelProjectContextTests: XCTestCase {
             familiars: [familiar("nova", "Nova")],
             sessions: [],
             tasks: [card("alpha-task", familiarId: "nova", projectId: alpha.id)],
-            taskStarted: taskStarted,
-            taskRelease: taskRelease
+            sessionStarted: taskStarted,
+            sessionRelease: taskRelease
         )
         let app = makeApp(coreResourceClientFactory: { _ in staleLoad })
         _ = connect(app, host: "http://127.0.0.1:1")
@@ -6149,12 +6708,10 @@ final class AppModelProjectContextTests: XCTestCase {
     }
 
     @MainActor
-    func testNewerStandaloneTasksLoadWinsOverOlderSuccessfulTaskSnapshot() async {
+    func testProjectBootstrapNeverFetchesLegacyTaskSnapshots() async {
         let alpha = project("alpha", "Alpha")
         let beta = project("beta", "Beta")
-        let taskStarted = Gate()
-        let taskRelease = Gate()
-        let staleLoad = ControlledCoreClient(
+        let bootstrap = ControlledCoreClient(
             projects: [alpha, beta],
             grants: grants(grants: [
                 ProjectGrant(familiarId: "nova", projectId: alpha.id, access: .write),
@@ -6162,31 +6719,20 @@ final class AppModelProjectContextTests: XCTestCase {
             ]),
             familiars: [familiar("nova", "Nova")],
             sessions: [],
-            tasks: [card("alpha-task", familiarId: "nova", projectId: alpha.id)],
-            taskStarted: taskStarted,
-            taskRelease: taskRelease
+            tasks: [card("alpha-task", familiarId: "nova", projectId: alpha.id)]
         )
-        let app = makeApp(coreResourceClientFactory: { _ in staleLoad })
+        let app = makeApp(coreResourceClientFactory: { _ in bootstrap })
         _ = connect(app, host: "http://127.0.0.1:1")
 
-        let staleTask = Task { await app.loadProjectContext(using: staleLoad) }
-        await taskStarted.wait()
+        await app.loadProjectContext(using: bootstrap)
 
-        await app.loadTasks(using: client(
-            projects: [alpha, beta],
-            grants: grants(),
-            familiars: [familiar("nova", "Nova")],
-            tasks: [card("beta-task", familiarId: "nova", projectId: beta.id)]
-        ))
-
-        XCTAssertEqual(app.tasks.map(\.id), ["beta-task"])
-        XCTAssertNil(app.projectContext)
-
-        await taskRelease.open()
-        await staleTask.value
-
-        XCTAssertEqual(app.tasks.map(\.id), ["beta-task"])
-        XCTAssertEqual(app.projectContext, .project(beta))
+        let calls = await bootstrap.callLog.snapshot()
+        XCTAssertEqual(calls.tasks, 0)
+        XCTAssertTrue(app.tasks.isEmpty)
+        XCTAssertFalse(app.tasksLoaded)
+        XCTAssertTrue(app.projectsLoaded)
+        XCTAssertTrue(app.familiarsLoaded)
+        XCTAssertTrue(app.sessionsLoaded)
     }
 
     @MainActor

--- a/apps/ios/CovenCave/CovenCaveTests/CaveVoiceTurnSenderTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/CaveVoiceTurnSenderTests.swift
@@ -3,6 +3,28 @@ import XCTest
 
 @MainActor
 final class CaveVoiceTurnSenderTests: XCTestCase {
+    func testRealClientRechecksVoiceAuthorityAtDeferredPOSTPreflight() async {
+        var preflights = 0
+        let sender = CaveVoiceTurnSender(
+            client: CaveClient(connection: CaveConnection(host: "http://127.0.0.1:9")),
+            liveDispatchLeaseIsCurrent: {
+                preflights += 1
+                return false
+            }
+        )
+        do {
+            _ = try await sender.sendRecognizedTurn(
+                "Do not send", familiarId: "nova",
+                sessionId: "captured-session", projectRoot: "/repos/cave"
+            )
+            XCTFail("Revoked voice authority must refuse before a POST.")
+        } catch is CaveClient.SendPreflightRevoked {
+            XCTAssertEqual(preflights, 1)
+        } catch {
+            XCTFail("Expected a provably-unsent preflight refusal, got \(error)")
+        }
+    }
+
     func testFreshRegisteredProjectTurnSendsProjectRootAndBindsReturnedSession() async throws {
         var sentBody: CaveClient.SendBody?
         let sender = CaveVoiceTurnSender { body in

--- a/apps/ios/CovenCave/CovenCaveTests/ChatListSnapshotTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ChatListSnapshotTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import CovenCave
+
+@MainActor
+final class ChatListSnapshotTests: XCTestCase {
+    func testGlobalListIncludesDirectAndGroupChatsAcrossProjects() {
+        let first = chat("alpha", root: "/repos/alpha")
+        let second = chat("beta", root: "/repos/beta", familiars: ["nyx", "lyra"])
+        let snapshot = ChatListSnapshot(threads: [first, second], sessions: [], familiars: [])
+
+        XCTAssertEqual(Set(snapshot.entries.map(\.id)), ["local:alpha", "local:beta"])
+    }
+
+    func testServerConversationIsNotDuplicatedAfterLocalHydration() {
+        let local = chat("phone", root: "/repos/alpha")
+        local.sessionIds = ["nyx": "server-1"]
+        let server = SessionRow(id: "server-1", title: "Desktop title", familiarId: "nyx")
+        let snapshot = ChatListSnapshot(threads: [local], sessions: [server], familiars: [])
+
+        XCTAssertEqual(snapshot.entries.map(\.id), ["local:phone"])
+    }
+
+    func testDifferentFamiliarDoesNotDisappearBecauseOfAnUnmatchedBinding() {
+        let local = chat("phone", root: "/repos/alpha")
+        local.sessionIds = ["lyra": "server-1"]
+        let server = SessionRow(id: "server-1", title: "Other chat", familiarId: "nyx")
+        let snapshot = ChatListSnapshot(threads: [local], sessions: [server], familiars: [])
+
+        XCTAssertEqual(snapshot.entries.count, 2)
+    }
+
+    func testArchivedLocalDoesNotReappearAsAServerOnlyChat() {
+        let local = chat("archived", root: "/repos/alpha")
+        local.archived = true
+        local.sessionIds = ["nyx": "server-1"]
+        let server = SessionRow(id: "server-1", title: "Archived", familiarId: "nyx")
+
+        let hidden = ChatListSnapshot(threads: [local], sessions: [server], familiars: [])
+        XCTAssertTrue(hidden.entries.isEmpty)
+        XCTAssertEqual(hidden.archivedCount, 1)
+        let visible = ChatListSnapshot(
+            threads: [local], sessions: [server], familiars: [], includeArchived: true
+        )
+        XCTAssertEqual(visible.entries.map(\.id), ["local:archived"])
+    }
+
+    func testGroupFanOutSessionsAppearOnlyAsTheGroupConversation() {
+        let group = chat("group", root: "/repos/alpha", familiars: ["nyx", "lyra"])
+        group.sessionIds = ["nyx": "nyx-session", "lyra": "lyra-session"]
+        let sessions = [
+            SessionRow(id: "nyx-session", title: "Nyx turn", familiarId: "nyx"),
+            SessionRow(id: "lyra-session", title: "Lyra turn", familiarId: "lyra"),
+        ]
+        let snapshot = ChatListSnapshot(threads: [group], sessions: sessions, familiars: [])
+        XCTAssertEqual(snapshot.entries.map(\.id), ["local:group"])
+    }
+
+    func testRenamedLocalChatStillMatchesItsAuthoritativeServerTitle() {
+        let local = chat("Phone name", root: "/repos/alpha")
+        local.sessionIds = ["nyx": "server-1"]
+        let server = SessionRow(id: "server-1", title: "Desktop handoff", familiarId: "nyx")
+        let snapshot = ChatListSnapshot(
+            threads: [local], sessions: [server], familiars: [], query: "desktop"
+        )
+        XCTAssertEqual(snapshot.entries.map(\.id), ["local:Phone name"])
+        XCTAssertEqual(local.title, "Phone name", "search must not rename or rebind the conversation")
+    }
+
+    func testBoundServerActivityOrdersCachedChatsWithoutMutatingTheirHistory() {
+        let local = chat("phone", root: "/repos/alpha")
+        local.sessionIds = ["nyx": "server-1"]
+        local.updatedAt = Date(timeIntervalSince1970: 1)
+        let other = chat("other", root: "/repos/beta")
+        other.updatedAt = Date(timeIntervalSince1970: 2)
+        let server = SessionRow(
+            id: "server-1", title: "Desktop update", familiarId: "nyx",
+            updatedAt: "2026-09-12T10:00:00Z"
+        )
+        let snapshot = ChatListSnapshot(
+            threads: [other, local], sessions: [server], familiars: []
+        )
+        XCTAssertEqual(snapshot.entries.map(\.id), ["local:phone", "local:other"])
+        XCTAssertEqual(snapshot.entries.first?.updatedAt, caveParseISO(server.updatedAt))
+        XCTAssertEqual(local.updatedAt, Date(timeIntervalSince1970: 1))
+    }
+
+    func testPinsSortFirstThenRecentActivityWithDeterministicTies() {
+        let pinned = chat("pinned", root: nil)
+        pinned.pinned = true
+        pinned.updatedAt = Date(timeIntervalSince1970: 1)
+        let first = chat("a", root: nil)
+        let second = chat("b", root: nil)
+        first.updatedAt = Date(timeIntervalSince1970: 100)
+        second.updatedAt = first.updatedAt
+
+        let snapshot = ChatListSnapshot(
+            threads: [second, pinned, first], sessions: [], familiars: []
+        )
+        XCTAssertEqual(snapshot.entries.map(\.id), ["local:pinned", "local:a", "local:b"])
+    }
+
+    func testSearchMatchesChatTitlesAndExactParticipantDisplayNames() {
+        let local = chat("Build review", root: nil)
+        let familiar = Familiar(id: "nyx", displayName: "Night Owl")
+        XCTAssertEqual(ChatListSnapshot(
+            threads: [local], sessions: [], familiars: [familiar], query: " night "
+        ).entries.count, 1)
+        XCTAssertEqual(ChatListSnapshot(
+            threads: [local], sessions: [], familiars: [familiar], query: "BUILD"
+        ).entries.count, 1)
+        XCTAssertTrue(ChatListSnapshot(
+            threads: [local], sessions: [], familiars: [familiar], query: "other"
+        ).entries.isEmpty)
+    }
+
+    func testGeneratedSessionsNeverBecomeConversations() {
+        let generated = SessionRow(id: "generated", title: "Background run", generated: true)
+        let chat = SessionRow(id: "chat", title: "Real chat", familiarId: "nyx")
+        let snapshot = ChatListSnapshot(
+            threads: [], sessions: [generated, chat], familiars: []
+        )
+        XCTAssertEqual(snapshot.entries.map(\.id), ["server:chat"])
+    }
+
+    private func chat(
+        _ id: String,
+        root: String?,
+        familiars: [String] = ["nyx"]
+    ) -> ChatThread {
+        ChatThread(id: id, title: id, familiarIds: familiars, projectRoot: root)
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/ChatNotificationsTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ChatNotificationsTests.swift
@@ -85,9 +85,8 @@ final class ChatNotificationsTests: XCTestCase {
         }
     }
 
-    func testReminderDeepLinkUsesTaskEntityWhenIDExists() throws {
-        let url = try XCTUnwrap(ReminderNotifications.deepLinkURL(taskId: "card-123"))
-        XCTAssertEqual(url.absoluteString, "covencave://task/card-123")
+    func testReminderDeepLinkDoesNotOfferRetiredTaskEntity() {
+        XCTAssertNil(ReminderNotifications.deepLinkURL(taskId: "card-123"))
     }
 
     func testReminderDeepLinkUsesThreadEntityForLinkedSessionOrThread() throws {
@@ -101,19 +100,25 @@ final class ChatNotificationsTests: XCTestCase {
         XCTAssertEqual(url.absoluteString, "covencave://thread/thread-123")
     }
 
-    func testReminderDeepLinkUsesTaskEntityForLinkedCard() throws {
-        let url = try XCTUnwrap(
+    func testReminderDeepLinkDoesNotOfferLinkedCard() {
+        XCTAssertNil(
             ReminderNotifications.deepLinkURL(for: reminder(link: Reminder.Link(
                 kind: .card,
                 taskId: "card-123"
             )))
         )
-        XCTAssertEqual(url.absoluteString, "covencave://task/card-123")
     }
 
-    func testReminderDeepLinkFallsBackToGenericTasksDestination() throws {
-        let url = try XCTUnwrap(ReminderNotifications.deepLinkURL(for: reminder()))
-        XCTAssertEqual(url.absoluteString, "covencave://tasks")
+    func testReminderDeepLinkDoesNotFallBackToTasks() {
+        XCTAssertNil(ReminderNotifications.deepLinkURL(for: reminder()))
+        XCTAssertNil(ReminderNotifications.deepLinkURL())
+    }
+
+    func testRetirementOnlyMatchesReminderNotificationIdentifiers() {
+        XCTAssertTrue(ReminderNotifications.isRetiredRequest(identifier: "cave.reminder.rem-1"))
+        for identifier in ["cave.chat.thread-1", "cave.connection.reconnected", "other.reminder.1"] {
+            XCTAssertFalse(ReminderNotifications.isRetiredRequest(identifier: identifier), identifier)
+        }
     }
 
     @MainActor

--- a/apps/ios/CovenCave/CovenCaveTests/ChatReadStateTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ChatReadStateTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import CovenCave
+
+final class ChatReadStateTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "ChatReadStateTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    @MainActor
+    func testMarkingOneConversationReadDoesNotClearItsSiblings() throws {
+        let app = model()
+        let first = thread("first")
+        let second = thread("second")
+        let key = "\(app.projectContext(for: first).id)|nyx"
+        app.familiarViews[key] = Date(timeIntervalSince1970: 1)
+        let siblingBoundary = try XCTUnwrap(app.seenBoundary(for: second))
+
+        app.markThreadViewed(first)
+
+        XCTAssertGreaterThan(try XCTUnwrap(app.seenBoundary(for: first)), siblingBoundary)
+        XCTAssertEqual(app.seenBoundary(for: second), siblingBoundary)
+        XCTAssertEqual(app.familiarViews[key], Date(timeIntervalSince1970: 1))
+    }
+
+    @MainActor
+    func testReadBoundarySurvivesModelRecreationWithTheSameDefaults() {
+        let first = model()
+        let chat = thread("persisted")
+        first.markThreadViewed(chat)
+
+        let restored = model()
+        XCTAssertEqual(restored.seenBoundary(for: chat), first.seenBoundary(for: chat))
+        XCTAssertNil(restored.seenBoundary(for: thread("different")))
+    }
+
+    @MainActor
+    func testGroupReadDoesNotMarkItsDirectConversationRead() throws {
+        let app = model()
+        let group = ChatThread(id: "group", title: "Group", familiarIds: ["nyx", "lyra"])
+        let direct = thread("direct")
+        let context = app.projectContext(for: group)
+        app.familiarViews["\(context.id)|nyx"] = Date(timeIntervalSince1970: 1)
+        app.familiarViews["\(context.id)|lyra"] = Date(timeIntervalSince1970: 2)
+
+        app.markThreadViewed(group)
+
+        XCTAssertEqual(app.seenBoundary(for: direct), Date(timeIntervalSince1970: 1))
+        XCTAssertGreaterThan(try XCTUnwrap(app.seenBoundary(for: group)), Date(timeIntervalSince1970: 2))
+    }
+
+    @MainActor
+    func testReadAcknowledgesDisplayedServerActivityDespiteClockSkew() {
+        let app = model()
+        let chat = thread("server-backed")
+        let displayedActivity = Date().addingTimeInterval(60)
+
+        app.markThreadViewed(chat, through: displayedActivity)
+
+        XCTAssertEqual(app.seenBoundary(for: chat), displayedActivity)
+    }
+
+    @MainActor
+    private func model() -> AppModel {
+        AppModel(defaults: defaults, restoreLocalState: false, widgetSnapshotDefaults: defaults)
+    }
+
+    @MainActor
+    private func thread(_ id: String) -> ChatThread {
+        ChatThread(id: id, title: id, familiarIds: ["nyx"])
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/ChatRetryDispatchTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ChatRetryDispatchTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import CovenCave
+
+@MainActor
+final class ChatRetryDispatchTests: XCTestCase {
+    private func thread() -> ChatThread {
+        ChatThread(
+            title: "Retry",
+            familiarIds: ["nova", "ember"],
+            sessionIds: ["nova": "session-nova"],
+            projectRoot: "/repos/cave",
+            messages: [
+                DisplayMessage(role: .user, text: "Original prompt", sendPrompt: "Exact wire prompt"),
+                DisplayMessage(
+                    serverTurnId: "server-original",
+                    role: .assistant,
+                    familiarId: "nova",
+                    text: "The original reply",
+                    isError: true,
+                    requestedModel: "chosen-model"
+                ),
+            ]
+        )
+    }
+
+    private var client: CaveClient {
+        CaveClient(connection: CaveConnection(host: "http://127.0.0.1:9"))
+    }
+
+    func testRevocationAfterRetryReturnsRestoresAndPersistsOriginalReply() async throws {
+        let thread = thread()
+        let original = thread.messages
+        var current = true
+        var persisted = 0
+        var refusals = 0
+        let task = try XCTUnwrap(thread.retry(
+            original[1].id,
+            client: client,
+            liveDispatchLeaseIsCurrent: { current },
+            persistAfterRefusal: { persisted += 1; return true },
+            onRefusal: { refusals += 1 },
+            onChange: {}
+        ))
+        XCTAssertTrue(thread.messages[1].streaming)
+        current = false
+        await task.value
+        XCTAssertEqual(thread.messages, original)
+        XCTAssertEqual(persisted, 1)
+        XCTAssertEqual(refusals, 1)
+    }
+
+    func testDeferredNetworkPreflightRechecksAuthorityAndRestoresOriginalReply() async throws {
+        let thread = thread()
+        let original = thread.messages
+        var preflights = 0
+        var refusals = 0
+        let task = try XCTUnwrap(thread.retry(
+            original[1].id,
+            client: client,
+            liveDispatchLeaseIsCurrent: {
+                preflights += 1
+                // The stream-entry check succeeds; the separate MainActor task
+                // immediately before CaveClient constructs its POST refuses.
+                return preflights == 1
+            },
+            persistAfterRefusal: { true },
+            onRefusal: { refusals += 1 },
+            onChange: {}
+        ))
+        await task.value
+        XCTAssertEqual(preflights, 2)
+        XCTAssertEqual(refusals, 1)
+        XCTAssertEqual(thread.messages, original)
+    }
+
+    func testRootSessionAndRosterDriftBeforeDeferredPOSTFailClosed() async throws {
+        let mutations: [(ChatThread) -> Void] = [
+            { $0.projectRoot = "/repos/replacement" },
+            { $0.sessionIds["nova"] = "replacement-session" },
+            { $0.familiarIds = ["nova", "other"] },
+        ]
+        for mutate in mutations {
+            let thread = thread()
+            let original = thread.messages
+            var preflights = 0
+            var refusals = 0
+            let task = try XCTUnwrap(thread.retry(
+                original[1].id,
+                client: client,
+                liveDispatchLeaseIsCurrent: {
+                    preflights += 1
+                    mutate(thread)
+                    return true
+                },
+                persistAfterRefusal: { true },
+                onRefusal: { refusals += 1 },
+                onChange: {}
+            ))
+            await task.value
+            XCTAssertEqual(preflights, 1, "The frozen binding must reject before calling external authority again.")
+            XCTAssertEqual(refusals, 1)
+            XCTAssertEqual(thread.messages, original)
+        }
+    }
+
+    func testRefusalDoesNotOverwriteANewerTranscriptEdit() async throws {
+        let thread = thread()
+        let messageId = thread.messages[1].id
+        var refusals = 0
+        let task = try XCTUnwrap(thread.retry(
+            messageId,
+            client: client,
+            liveDispatchLeaseIsCurrent: {
+                thread.updateText(messageId, "Newer transcript")
+                return false
+            },
+            persistAfterRefusal: { XCTFail("No rollback should be persisted over a newer edit."); return false },
+            onRefusal: { refusals += 1 },
+            onChange: {}
+        ))
+        await task.value
+        XCTAssertEqual(thread.messages[1].text, "Newer transcript")
+        XCTAssertEqual(refusals, 1)
+    }
+
+    func testFrozenSendBindingAllowsSiblingSessionEstablishmentButNotRetargeting() {
+        let thread = thread()
+        let send = ChatDispatchBinding(thread: thread)
+        let retry = ChatDispatchBinding(thread: thread, familiarIds: ["nova"])
+        thread.sessionIds["ember"] = "newly-established-sibling"
+        XCTAssertTrue(send.matches(thread))
+        XCTAssertTrue(retry.matches(thread, includingSessions: true))
+        thread.sessionIds["nova"] = "replacement"
+        XCTAssertFalse(send.matches(thread), "an established send target must not switch sessions")
+        XCTAssertFalse(retry.matches(thread, includingSessions: true))
+        thread.projectRoot = "/repos/replacement"
+        XCTAssertFalse(send.matches(thread))
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/DrawerDestinationOrderTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/DrawerDestinationOrderTests.swift
@@ -4,23 +4,27 @@ import XCTest
 /// The focused drawer hierarchy and its broader keyboard destination order.
 final class DrawerDestinationOrderTests: XCTestCase {
 
-    func testDrawerKeepsOnlyChatsAndTasksAsPrimaryDestinations() {
-        XCTAssertEqual(AppTab.drawerDestinations, [.chats, .tasks])
+    func testDrawerKeepsOnlyChatsAndSettingsAsPrimaryDestinations() {
+        XCTAssertEqual(AppTab.drawerDestinations, [.chats, .settings])
         XCTAssertEqual(AppTab.drawerDestinations.count, Set(AppTab.drawerDestinations).count,
                        "a drawer destination is placed twice")
-        XCTAssertFalse(AppTab.drawerDestinations.contains(.settings),
-                       "Settings is reached from the profile avatar, not a primary row")
+        XCTAssertFalse(AppTab.drawerDestinations.contains(.tasks),
+                       "Tasks is not a native iOS destination; chat-only omits it entirely")
     }
 
-    /// ⌘1–3 must cover every destination exactly once so every application surface
-    /// remains keyboard-reachable.
-    func testShortcutOrderCoversAllDestinationsExactlyOnce() {
-        XCTAssertEqual(AppTab.shortcutOrder.count, AppTab.allCases.count)
-        XCTAssertEqual(Set(AppTab.shortcutOrder), Set(AppTab.allCases))
+    /// ⌘1–2 must cover every REACHABLE destination exactly once. `.tasks` is
+    /// retained on `AppTab` only for legacy deep-link decoding (see the enum's
+    /// doc comment) and is deliberately excluded from both `drawerDestinations`
+    /// and `shortcutOrder` — it has no UI surface to shortcut into.
+    func testShortcutOrderCoversAllReachableDestinationsExactlyOnce() {
+        XCTAssertEqual(AppTab.shortcutOrder.count, AppTab.drawerDestinations.count)
+        XCTAssertEqual(Set(AppTab.shortcutOrder), Set(AppTab.drawerDestinations))
+        XCTAssertFalse(AppTab.shortcutOrder.contains(.tasks),
+                       "Tasks has no UI surface, so it must not receive a keyboard shortcut")
     }
 
     func testShortcutOrderKeepsSettingsReachable() {
-        XCTAssertEqual(AppTab.shortcutOrder, [.chats, .tasks, .settings])
+        XCTAssertEqual(AppTab.shortcutOrder, [.chats, .settings])
     }
 
     /// Raw values are persisted and used by deterministic launch selectors.

--- a/apps/ios/CovenCave/CovenCaveTests/LaunchThreadIntentTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/LaunchThreadIntentTests.swift
@@ -74,7 +74,7 @@ final class LaunchThreadIntentTests: XCTestCase {
         XCTAssertNil(app.pendingProjectNavigationIntent)
     }
 
-    func testWarmTaskDeepLinkOpensImmediatelyWhenTaskAndProjectAreHydrated() throws {
+    func testWarmTaskDeepLinkIsRejectedAsDesktopOnlyEvenWhenHydrated() throws {
         let app = makeApp()
         app.selectedTab = .settings
         let alpha = project("alpha", "Alpha")
@@ -105,10 +105,13 @@ final class LaunchThreadIntentTests: XCTestCase {
 
         app.handleDeepLink(url)
 
+        // Tasks has no native destination on chat-only iOS, so a task deep
+        // link is rejected outright — even when the task/project catalogs are
+        // already hydrated — rather than opening the card.
         XCTAssertEqual(app.deepLink, .tasks)
-        XCTAssertEqual(app.selectedTab, .tasks)
-        XCTAssertEqual(app.projectContext, .project(alpha))
-        XCTAssertEqual(app.cardToOpen?.id, target.id)
+        XCTAssertEqual(app.selectedTab, .settings)
+        XCTAssertNil(app.projectContext)
+        XCTAssertNil(app.cardToOpen)
         XCTAssertNil(app.pendingProjectNavigationIntent)
     }
 

--- a/apps/ios/CovenCave/CovenCaveTests/LiveVoiceCallModelTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/LiveVoiceCallModelTests.swift
@@ -4,11 +4,17 @@ import XCTest
 
 private final class LiveVoiceCallModelURLProtocol: URLProtocol {
     static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    static var pause: ((LiveVoiceCallModelURLProtocol) -> Bool)?
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
+        if Self.pause?(self) == true { return }
+        resumeResponse()
+    }
+
+    func resumeResponse() {
         do {
             let handler = try XCTUnwrap(Self.handler)
             let (response, data) = try handler(request)
@@ -27,6 +33,7 @@ private final class LiveVoiceCallModelURLProtocol: URLProtocol {
 final class LiveVoiceCallModelTests: XCTestCase {
     override func tearDown() {
         LiveVoiceCallModelURLProtocol.handler = nil
+        LiveVoiceCallModelURLProtocol.pause = nil
         super.tearDown()
     }
 
@@ -79,6 +86,193 @@ final class LiveVoiceCallModelTests: XCTestCase {
           }
         }
         """
+    }
+
+    func testStablePresentationStartsOnceAndDismissalCleansUpIdempotently() async {
+        let transport = RecordingVoiceTransport()
+        let media = RecordingVoiceMediaSession()
+        let model = LiveVoiceCallModel(
+            familiar: familiar(voiceProvider: "anthropic"),
+            sessionId: "existing",
+            projectRoot: "/repos/cave",
+            client: CaveClient(connection: CaveConnection(host: "http://cave.test:3000")),
+            makeNativeTransport: { _ in transport },
+            makeMediaSession: { media }
+        )
+        let presentationId = model.id
+        await model.start()
+        await model.start()
+        XCTAssertEqual(transport.startCalls, 1)
+        model.end()
+        model.end()
+        await model.start()
+        XCTAssertEqual(model.id, presentationId)
+        XCTAssertEqual(transport.startCalls, 1)
+        XCTAssertEqual(transport.stopCalls, 1)
+        XCTAssertEqual(media.stopCalls, 1)
+    }
+
+    func testAuthorityRecoveryNeverRestartsARevokedPresentation() async {
+        let transport = RecordingVoiceTransport()
+        let media = RecordingVoiceMediaSession()
+        var authorized = true
+        let model = LiveVoiceCallModel(
+            familiar: familiar(voiceProvider: "anthropic"),
+            sessionId: "existing",
+            projectRoot: "/repos/cave",
+            client: CaveClient(connection: CaveConnection(host: "http://cave.test:3000")),
+            authorityIsCurrent: { authorized },
+            makeNativeTransport: { _ in transport },
+            makeMediaSession: { media }
+        )
+        await model.start()
+        authorized = false
+        XCTAssertFalse(model.refreshAuthority())
+        XCTAssertEqual(model.state.phase, .ended)
+        XCTAssertEqual(transport.stopCalls, 1)
+        XCTAssertEqual(media.stopCalls, 1)
+        authorized = true
+        XCTAssertFalse(model.refreshAuthority())
+        await model.start()
+        await model.retry()
+        await model.acceptOnDeviceFallback()
+        XCTAssertEqual(transport.startCalls, 1)
+        XCTAssertTrue(model.authorityRevoked)
+        XCTAssertEqual(model.launch, .unavailable(VoiceCallCopy.authorityChanged))
+    }
+
+    func testAuthorityIsRecheckedAfterSuspendedMicrophonePermission() async throws {
+        let permissionRequested = expectation(description: "permission requested")
+        var permission: CheckedContinuation<Void, Never>?
+        let transport = RecordingVoiceTransport()
+        let media = RecordingVoiceMediaSession()
+        media.prepareHook = {
+            await withCheckedContinuation { continuation in
+                permission = continuation
+                permissionRequested.fulfill()
+            }
+        }
+        var authorized = true
+        let model = LiveVoiceCallModel(
+            familiar: familiar(voiceProvider: "anthropic"),
+            sessionId: "existing",
+            projectRoot: "/repos/cave",
+            client: CaveClient(connection: CaveConnection(host: "http://cave.test:3000")),
+            authorityIsCurrent: { authorized },
+            makeNativeTransport: { _ in transport },
+            makeMediaSession: { media }
+        )
+        let start = Task { await model.start() }
+        await fulfillment(of: [permissionRequested], timeout: 3)
+        authorized = false
+        try XCTUnwrap(permission).resume()
+        await start.value
+        XCTAssertTrue(model.authorityRevoked)
+        XCTAssertEqual(model.state.phase, .ended)
+        XCTAssertEqual(transport.startCalls, 0)
+        XCTAssertGreaterThanOrEqual(media.stopCalls, 1)
+    }
+
+    func testDismissalDuringTransportStartupStopsLateActivation() async throws {
+        let transportStarting = expectation(description: "transport starting")
+        var ready: CheckedContinuation<Void, Never>?
+        let transport = RecordingVoiceTransport()
+        transport.startHook = {
+            await withCheckedContinuation { continuation in
+                ready = continuation
+                transportStarting.fulfill()
+            }
+        }
+        let media = RecordingVoiceMediaSession()
+        let model = LiveVoiceCallModel(
+            familiar: familiar(voiceProvider: "anthropic"),
+            sessionId: "existing",
+            projectRoot: "/repos/cave",
+            client: CaveClient(connection: CaveConnection(host: "http://cave.test:3000")),
+            makeNativeTransport: { _ in transport },
+            makeMediaSession: { media }
+        )
+        let start = Task { await model.start() }
+        await fulfillment(of: [transportStarting], timeout: 3)
+        model.end()
+        try XCTUnwrap(ready).resume()
+        await start.value
+        XCTAssertEqual(model.state.phase, .ended)
+        XCTAssertFalse(transport.active)
+        XCTAssertGreaterThanOrEqual(transport.stopCalls, 2)
+    }
+
+    func testRevocationDuringSessionCreationCleansUpWithoutMintingOrStarting() async throws {
+        let creationStarted = expectation(description: "session creation started")
+        var pending: LiveVoiceCallModelURLProtocol?
+        LiveVoiceCallModelURLProtocol.pause = { request in
+            guard request.request.url?.path == "/api/chat/conversation" else { return false }
+            pending = request
+            creationStarted.fulfill()
+            return true
+        }
+        var requests: [String] = []
+        let client = client { [self] request in
+            let path = request.url?.path ?? ""
+            requests.append(path)
+            switch path {
+            case "/api/chat/conversation":
+                return try response(for: request, status: 200, body: #"{"ok":true,"sessionId":"late-empty"}"#)
+            case "/api/chat/conversation/late-empty":
+                return try response(for: request, status: 200, body: #"{"ok":true,"deleted":true}"#)
+            default:
+                XCTFail("A revoked call must not mint a grant: \(path)")
+                return try response(for: request, status: 500, body: #"{"ok":false}"#)
+            }
+        }
+        let transport = RecordingVoiceTransport()
+        var authorized = true
+        let model = LiveVoiceCallModel(
+            familiar: familiar(), sessionId: nil, projectRoot: "/repos/cave",
+            client: client,
+            authorityIsCurrent: { authorized },
+            makeRealtimeTransport: { transport },
+            makeMediaSession: { RecordingVoiceMediaSession() }
+        )
+        let start = Task { await model.start() }
+        await fulfillment(of: [creationStarted], timeout: 3)
+        authorized = false
+        model.refreshAuthority()
+        try XCTUnwrap(pending).resumeResponse()
+        await start.value
+        await model.waitForPendingCleanup()
+        XCTAssertEqual(requests, ["/api/chat/conversation", "/api/chat/conversation/late-empty"])
+        XCTAssertEqual(transport.startCalls, 0)
+        XCTAssertNil(model.state.sessionId)
+        XCTAssertEqual(model.launch, .unavailable(VoiceCallCopy.authorityChanged))
+    }
+
+    func testEndDuringGrantMintingCannotStartALateTransport() async throws {
+        let mintStarted = expectation(description: "grant mint started")
+        var pending: LiveVoiceCallModelURLProtocol?
+        LiveVoiceCallModelURLProtocol.pause = { request in
+            guard request.request.url?.path == "/api/voice/session" else { return false }
+            pending = request
+            mintStarted.fulfill()
+            return true
+        }
+        let client = client { [self] request in
+            try response(for: request, status: 200, body: grantResponseBody)
+        }
+        let transport = RecordingVoiceTransport()
+        let model = LiveVoiceCallModel(
+            familiar: familiar(), sessionId: "existing", projectRoot: "/repos/cave",
+            client: client,
+            makeRealtimeTransport: { transport },
+            makeMediaSession: { RecordingVoiceMediaSession() }
+        )
+        let start = Task { await model.start() }
+        await fulfillment(of: [mintStarted], timeout: 3)
+        model.end()
+        try XCTUnwrap(pending).resumeResponse()
+        await start.value
+        XCTAssertEqual(transport.startCalls, 0)
+        XCTAssertEqual(model.state.phase, .ended)
     }
 
     func testEndingAnAutoCreatedCallWithoutTranscriptDiscardsTheEmptySession() async throws {
@@ -457,15 +651,23 @@ private final class RecordingVoiceTransport: VoiceCallTransport {
     var onEvent: (@MainActor (VoiceCallEvent) -> Void)?
     private(set) var startCalls = 0
     private(set) var startedContexts: [VoiceCallTransportContext] = []
+    private(set) var stopCalls = 0
+    private(set) var active = false
+    var startHook: (() async -> Void)?
 
     func start(with context: VoiceCallTransportContext) async throws {
         startCalls += 1
         startedContexts.append(context)
+        await startHook?()
+        active = true
     }
 
     func setMuted(_ muted: Bool) {}
 
-    func stop() {}
+    func stop() {
+        stopCalls += 1
+        active = false
+    }
 
     func emit(_ event: VoiceCallEvent) {
         onEvent?(event)
@@ -477,10 +679,13 @@ private final class RecordingVoiceMediaSession: VoiceMediaSessionManaging {
     var onInterruption: (@MainActor () -> Void)?
     var onRouteChange: (@MainActor () -> Void)?
     var prepareError: Error?
+    var prepareHook: (() async -> Void)?
+    private(set) var stopCalls = 0
 
     func prepare(mode: VoiceCallMode, needsSpeechRecognition: Bool) async throws {
+        await prepareHook?()
         if let prepareError { throw prepareError }
     }
 
-    func stop() {}
+    func stop() { stopCalls += 1 }
 }

--- a/apps/ios/CovenCave/CovenCaveTests/NewChatImportLaunchContextTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/NewChatImportLaunchContextTests.swift
@@ -2,150 +2,88 @@ import XCTest
 @testable import CovenCave
 
 final class NewChatImportLaunchContextTests: XCTestCase {
-    private func project(
-        _ id: String,
-        _ name: String,
-        root: String? = nil
-    ) -> ProjectInfo {
-        ProjectInfo(
-            id: id,
-            name: name,
-            root: root ?? "/repos/\(id)",
-            color: nil,
-            updatedAt: nil,
-            access: nil
-        )
+    private func project(_ id: String, root: String? = nil) -> ProjectInfo {
+        ProjectInfo(id: id, name: id, root: root ?? "/repos/\(id)", color: nil, updatedAt: nil, access: .write)
     }
 
-    private func membership(_ rows: [String: Set<String>]) -> ProjectMembershipIndex {
-        ProjectMembershipIndex(familiarIDsByProjectID: rows)
+    private func context() throws -> NewChatImportLaunchContext {
+        try XCTUnwrap(NewChatImportLaunchContext(
+            selectedProject: project("alpha"),
+            selectedFamiliarIds: ["sage", "nova", "sage", ""]
+        ))
     }
 
-    func testCaptureRequiresActiveProjectAndNonEmptyRoster() {
-        let alpha = project("alpha", "Alpha")
-
-        XCTAssertNil(
-            NewChatImportLaunchContext(
-                activeProject: nil,
-                selectedFamiliarIds: ["nova"]
-            )
-        )
-        XCTAssertNil(
-            NewChatImportLaunchContext(
-                activeProject: alpha,
-                selectedFamiliarIds: []
-            )
-        )
+    func testCaptureRequiresLocalProjectAndNonEmptyRoster() {
+        XCTAssertNil(NewChatImportLaunchContext(selectedProject: nil, selectedFamiliarIds: ["nova"]))
+        XCTAssertNil(NewChatImportLaunchContext(selectedProject: project("alpha"), selectedFamiliarIds: []))
+        XCTAssertNil(NewChatImportLaunchContext(
+            selectedProject: project("alpha", root: "/repos/../alpha"),
+            selectedFamiliarIds: ["nova"]
+        ))
     }
 
-    func testCaptureNormalizesStablePreferredRoster() throws {
-        let alpha = project("alpha", "Alpha")
-        let context = try XCTUnwrap(
-            NewChatImportLaunchContext(
-                activeProject: alpha,
-                selectedFamiliarIds: ["sage", "nova", "sage", ""]
-            )
-        )
-
-        XCTAssertEqual(context.projectId, "alpha")
-        XCTAssertEqual(context.projectRoot, "/repos/alpha")
-        XCTAssertEqual(context.familiarIds, ["nova", "sage"])
+    func testCaptureKeepsStablePreferredRoster() throws {
+        let captured = try context()
+        XCTAssertEqual(captured.projectId, "alpha")
+        XCTAssertEqual(captured.projectRoot, "/repos/alpha")
+        XCTAssertEqual(captured.familiarIds, ["nova", "sage"])
     }
 
-    func testValidationSucceedsWhenProjectAndRosterStayActive() throws {
-        let alpha = project("alpha", "Alpha")
-        let context = try XCTUnwrap(
-            NewChatImportLaunchContext(
-                activeProject: alpha,
-                selectedFamiliarIds: ["nova", "sage"]
-            )
-        )
-
-        XCTAssertEqual(
-            context.validate(
-                projectContext: .project(alpha),
-                activeProject: alpha,
-                projectMembership: membership(["alpha": Set(["nova", "sage"])])
-            ),
-            .valid
-        )
-    }
-
-    func testValidationRejectsProjectSwitchWhilePickerIsOpen() throws {
-        let alpha = project("alpha", "Alpha")
-        let beta = project("beta", "Beta")
-        let context = try XCTUnwrap(
-            NewChatImportLaunchContext(
-                activeProject: alpha,
-                selectedFamiliarIds: ["nova"]
-            )
-        )
-
-        XCTAssertEqual(
-            context.validate(
-                projectContext: .project(beta),
-                activeProject: beta,
-                projectMembership: membership(["beta": Set(["nova"])])
-            ),
-            .projectChanged
-        )
+    func testLocalSelectionSurvivesAmbientProjectChangesAndGrantReordering() throws {
+        let captured = try context()
+        let membership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova", "sage"]])
+        for catalog in [[project("beta"), project("alpha")], [project("alpha"), project("beta")]] {
+            XCTAssertEqual(captured.validate(
+                registeredProjects: catalog,
+                accessibleProjects: catalog,
+                projectMembership: membership,
+                membershipLoaded: true
+            ), .valid)
+            XCTAssertEqual(captured.projectId, "alpha")
+        }
     }
 
     func testValidationRejectsProjectRootChangesForSameProjectID() throws {
-        let alpha = project("alpha", "Alpha", root: "/repos/alpha")
-        let movedAlpha = project("alpha", "Alpha", root: "/repos/alpha-renamed")
-        let context = try XCTUnwrap(
-            NewChatImportLaunchContext(
-                activeProject: alpha,
-                selectedFamiliarIds: ["nova"]
-            )
-        )
-
-        XCTAssertEqual(
-            context.validate(
-                projectContext: .project(movedAlpha),
-                activeProject: movedAlpha,
-                projectMembership: membership(["alpha": Set(["nova"])])
-            ),
-            .projectChanged
-        )
+        XCTAssertEqual(try context().validate(
+            registeredProjects: [project("alpha", root: "/repos/renamed")],
+            accessibleProjects: [project("alpha", root: "/repos/renamed")],
+            projectMembership: ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova", "sage"]]),
+            membershipLoaded: true
+        ), .projectChanged)
     }
 
-    func testValidationRejectsUnassignedWhilePickerIsOpen() throws {
-        let alpha = project("alpha", "Alpha")
-        let context = try XCTUnwrap(
-            NewChatImportLaunchContext(
-                activeProject: alpha,
-                selectedFamiliarIds: ["nova"]
-            )
-        )
-
-        XCTAssertEqual(
-            context.validate(
-                projectContext: .unassigned,
-                activeProject: nil,
-                projectMembership: membership(["alpha": Set(["nova"])])
-            ),
-            .unassigned
-        )
+    func testValidationRejectsRemovedProjectWithoutSelectingAnother() throws {
+        XCTAssertEqual(try context().validate(
+            registeredProjects: [project("beta")],
+            accessibleProjects: [project("beta")],
+            projectMembership: ProjectMembershipIndex(familiarIDsByProjectID: ["beta": ["nova", "sage"]]),
+            membershipLoaded: true
+        ), .projectChanged)
     }
 
     func testValidationRejectsAccessRevocationWhilePickerIsOpen() throws {
-        let alpha = project("alpha", "Alpha")
-        let context = try XCTUnwrap(
-            NewChatImportLaunchContext(
-                activeProject: alpha,
-                selectedFamiliarIds: ["nova", "sage"]
-            )
-        )
+        XCTAssertEqual(try context().validate(
+            registeredProjects: [project("alpha")],
+            accessibleProjects: [project("alpha")],
+            projectMembership: ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova"]]),
+            membershipLoaded: true
+        ), .familiarAccessRevoked(["sage"]))
+    }
 
-        XCTAssertEqual(
-            context.validate(
-                projectContext: .project(alpha),
-                activeProject: alpha,
-                projectMembership: membership(["alpha": Set(["nova"])])
-            ),
-            .familiarAccessRevoked(["sage"])
-        )
+    func testValidationRejectsMissingOrStaleGrantsEvenWithCachedMembership() throws {
+        let captured = try context()
+        let membership = ProjectMembershipIndex(familiarIDsByProjectID: ["alpha": ["nova", "sage"]])
+        XCTAssertEqual(captured.validate(
+            registeredProjects: [project("alpha")],
+            accessibleProjects: [],
+            projectMembership: membership,
+            membershipLoaded: true
+        ), .accessUnavailable)
+        XCTAssertEqual(captured.validate(
+            registeredProjects: [project("alpha")],
+            accessibleProjects: [project("alpha")],
+            projectMembership: membership,
+            membershipLoaded: false
+        ), .accessUnavailable)
     }
 }

--- a/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
@@ -162,11 +162,15 @@ final class PairingIntentTests: XCTestCase {
         app.handleDeepLink(tasksURL)
         app.connectionState = .connected
 
-        XCTAssertEqual(
-            app.pendingProjectNavigationIntent,
-            ProjectNavigationIntent(destination: .tasks)
-        )
-        XCTAssertNotEqual(app.pendingProjectNavigationIntent?.threadId, intent.threadId)
+        // Tasks is desktop-only: the newer navigation is rejected outright
+        // rather than staged, so nothing pending survives it.
+        XCTAssertNil(app.pendingProjectNavigationIntent)
+        // The essential property under test: the newer navigation must have
+        // cancelled the staged pairing destination, not merely left it
+        // unresolved. Prove it directly — resuming the original pairing
+        // intent must no longer produce its thread navigation.
+        app.resumePairingDestination(intent)
+        XCTAssertNil(app.pendingProjectNavigationIntent)
     }
 
     func testPairingWithoutDestinationPreservesPendingProjectNavigation() {
@@ -193,7 +197,10 @@ final class PairingIntentTests: XCTestCase {
 
         app.handleDeepLink(url)
 
-        XCTAssertEqual(app.selectedTab, .tasks)
+        // Tasks is desktop-only on chat-only iOS: the deep link is decoded
+        // (so `deepLink` still records the legacy signal) but rejected before
+        // it can change the selected tab.
+        XCTAssertEqual(app.selectedTab, .settings)
         XCTAssertEqual(app.deepLink, .tasks)
         XCTAssertNil(app.pendingProjectNavigationIntent)
         XCTAssertNil(app.pendingPairingIntent)

--- a/apps/ios/CovenCave/CovenCaveTests/QueuedChatContextTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/QueuedChatContextTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import CovenCave
+
+@MainActor
+final class QueuedChatContextTests: XCTestCase {
+    private let originalRoot = "/repos/original"
+    private let replacementRoot = "/repos/replacement"
+
+    func testOfflineQueueCannotAdoptAReplacementRootBeforeReplay() async {
+        let chat = ChatThread(title: "Offline", familiarIds: ["nova"], projectRoot: originalRoot)
+        chat.enqueue("Keep my original project")
+        chat.projectRoot = replacementRoot
+
+        await assertReplayRequiresOriginalBinding(chat)
+    }
+
+    func testOriginalQueueRootSurvivesSnapshotRoundTripAfterRetargeting() async throws {
+        let chat = ChatThread(title: "Offline", familiarIds: ["nova"], projectRoot: originalRoot)
+        chat.enqueue("Keep this across a restart")
+        chat.projectRoot = replacementRoot
+        let data = try JSONEncoder().encode(chat.snapshot)
+        let restored = ChatThread(snapshot: try JSONDecoder().decode(ThreadSnapshot.self, from: data))
+
+        await assertReplayRequiresOriginalBinding(restored)
+    }
+
+    func testFailedLiveCheckpointCannotRequeueIntoAReplacementRoot() async throws {
+        let chat = ChatThread(title: "Live", familiarIds: ["nova"], projectRoot: originalRoot)
+        let rolledBack = expectation(description: "the unsent turn is durable")
+        chat.send(
+            "Preserve this send's project",
+            liveDispatchLeaseIsCurrent: { false },
+            persistBeforeDispatch: {
+                chat.projectRoot = self.replacementRoot
+                return false
+            },
+            persistAfterRollback: { rolledBack.fulfill(); return true },
+            client: client,
+            onChange: {}
+        )
+        await fulfillment(of: [rolledBack], timeout: 3)
+        let data = try JSONEncoder().encode(chat.snapshot)
+        let restored = ChatThread(snapshot: try JSONDecoder().decode(ThreadSnapshot.self, from: data))
+
+        await assertReplayRequiresOriginalBinding(restored)
+    }
+
+    func testLegacyQueueCapturesItsSavedRootBeforeHistoryReconciliation() async {
+        let restored = legacyQueue(root: originalRoot)
+        restored.projectRoot = replacementRoot
+
+        await assertReplayRequiresOriginalBinding(restored)
+    }
+
+    func testLegacyQueueWithoutARootCannotAdoptLaterRecoveredMetadata() async {
+        let restored = legacyQueue(root: nil)
+        restored.projectRoot = replacementRoot
+
+        await assertReplayRequiresOriginalBinding(restored)
+    }
+
+    func testLegacyQueueFreezesRecipientFallbackAndPreservesExplicitTargets() {
+        var saved = ChatThread(title: "Legacy", familiarIds: ["nova"], projectRoot: originalRoot).snapshot
+        saved.messages = [
+            DisplayMessage(role: .user, text: "Saved roster", queued: true),
+            DisplayMessage(
+                role: .user, text: "Saved delivery", queued: true,
+                queuedRunIdsByFamiliarId: ["sage": "saved-run"]
+            ),
+            DisplayMessage(
+                role: .user, text: "Explicit recipients", queued: true,
+                queuedRunIdsByFamiliarId: ["sage": "saved-run"],
+                queuedTargetFamiliarIds: ["ember"]
+            ),
+        ]
+        let restored = ChatThread(snapshot: saved)
+
+        XCTAssertEqual(restored.messages.map(\.queuedTargetFamiliarIds), [["nova"], ["sage"], ["ember"]])
+    }
+
+    func testLegacyQueuedRecipientCannotBeReplacedBySessionRepair() async {
+        var saved = ChatThread(
+            title: "Legacy", familiarIds: ["nova"],
+            sessionIds: ["nova": "saved-session"], projectRoot: originalRoot
+        ).snapshot
+        saved.messages = [DisplayMessage(role: .user, text: "Keep the saved recipient", queued: true)]
+        let restored = ChatThread(snapshot: saved)
+        restored.familiarIds = ["sage"]
+        restored.sessionIds = ["sage": "saved-session"]
+
+        await assertReplayRequiresOriginalBinding(restored)
+    }
+
+    func testQueuedEstablishedSessionCannotBeReplacedBeforeReplay() async {
+        let chat = ChatThread(
+            title: "Existing chat", familiarIds: ["nova"],
+            sessionIds: ["nova": "original-session"], projectRoot: originalRoot
+        )
+        chat.enqueue("Keep my original conversation")
+        chat.sessionIds["nova"] = "replacement-session"
+
+        await assertReplayRequiresOriginalBinding(chat)
+    }
+
+    func testQueuedSessionIdentitySurvivesSnapshotRoundTrip() async throws {
+        let chat = ChatThread(
+            title: "Existing chat", familiarIds: ["nova"],
+            sessionIds: ["nova": "original-session"], projectRoot: originalRoot
+        )
+        chat.enqueue("Keep this conversation across a restart")
+        chat.sessionIds["nova"] = "replacement-session"
+        let data = try JSONEncoder().encode(chat.snapshot)
+        let restored = ChatThread(snapshot: try JSONDecoder().decode(ThreadSnapshot.self, from: data))
+
+        await assertReplayRequiresOriginalBinding(restored)
+    }
+
+    func testInitiallyUnboundQueuedSessionCanBecomeEstablished() async {
+        let chat = ChatThread(title: "New chat", familiarIds: ["nova"], projectRoot: originalRoot)
+        chat.enqueue("Follow the session established for this chat")
+        chat.sessionIds["nova"] = "newly-established-session"
+        var authorizedTargets: [String] = []
+        var refusedTargets: [String?] = []
+        await chat.replayQueued(
+            client: client,
+            dispatchLeaseIsCurrent: { true },
+            targetAccessIsCurrent: { root, target in
+                XCTAssertEqual(root, self.originalRoot)
+                authorizedTargets.append(target)
+                return false
+            },
+            onAccessRefused: { refusedTargets.append($0) },
+            persistBeforeDispatch: { false },
+            persistAfterRollback: { true },
+            onChange: {}
+        )
+
+        XCTAssertEqual(authorizedTargets, ["nova"])
+        XCTAssertEqual(refusedTargets, ["nova"])
+        XCTAssertTrue(chat.messages.first?.isQueued == true)
+    }
+
+    private var client: CaveClient {
+        CaveClient(connection: CaveConnection(host: "https://unused.invalid"))
+    }
+
+    private func legacyQueue(root: String?) -> ChatThread {
+        var saved = ChatThread(title: "Legacy", familiarIds: ["nova"], projectRoot: root).snapshot
+        saved.messages = [DisplayMessage(role: .user, text: "Legacy queued message", queued: true)]
+        return ChatThread(snapshot: saved)
+    }
+
+    private func assertReplayRequiresOriginalBinding(
+        _ chat: ChatThread,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let before = chat.snapshot
+        var bindingRefusals = 0
+        await chat.replayQueued(
+            client: client,
+            dispatchLeaseIsCurrent: { true },
+            targetAccessIsCurrent: { _, _ in
+                XCTFail("A replacement chat binding must be refused before checking its grants.", file: file, line: line)
+                return false
+            },
+            onAccessRefused: { target in
+                if target == nil { bindingRefusals += 1 }
+            },
+            persistBeforeDispatch: {
+                XCTFail("A retargeted queued turn must not reach a delivery checkpoint.", file: file, line: line)
+                return false
+            },
+            persistAfterRollback: { true },
+            onChange: {}
+        )
+        XCTAssertEqual(bindingRefusals, 1, file: file, line: line)
+        XCTAssertEqual(chat.snapshot, before, file: file, line: line)
+        XCTAssertTrue(chat.messages.first?.isQueued == true, file: file, line: line)
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/SessionSwitchTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/SessionSwitchTests.swift
@@ -80,8 +80,8 @@ final class SessionSwitchTests: XCTestCase {
         XCTAssertNil(app.pendingProjectNavigationIntent)
     }
 
-    /// Switching sessions must also land in the chosen thread's owning project.
-    func testSwitchingSessionAlignsProjectContext() {
+    /// Switching sessions follows the object without rescoping the shell.
+    func testSwitchingSessionPreservesAmbientProjectContext() {
         let app = makeApp()
         let alpha = project("alpha")
         let beta = project("beta")
@@ -98,7 +98,8 @@ final class SessionSwitchTests: XCTestCase {
 
         XCTAssertTrue(app.switchConversation(to: chosen, currentThreadId: "alpha-session"))
 
-        XCTAssertEqual(app.projectContext, .project(beta))
+        XCTAssertEqual(app.projectContext, .project(alpha))
+        XCTAssertEqual(chosen.projectRoot, beta.root)
         XCTAssertTrue(app.threadToOpen === chosen)
         XCTAssertNil(app.pendingProjectNavigationIntent)
     }

--- a/apps/ios/CovenCave/CovenCaveTests/SlashCommandTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/SlashCommandTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import CovenCave
+
+final class SlashCommandTests: XCTestCase {
+    func testTaskCommandsStayRecognizedButDesktopOnly() {
+        for token in ["/board", "/tasks", "/task"] {
+            guard case .command(let command, let args) = SlashInput.parse("\(token) legacy-id") else {
+                return XCTFail("Expected a recognized legacy command: \(token)")
+            }
+            XCTAssertEqual(args, "legacy-id")
+            XCTAssertEqual(command.action, .desktopOnly("Tasks"))
+            XCTAssertTrue(command.availability == .desktopOnly)
+            XCTAssertFalse(SlashCatalog.available.contains(command))
+            XCTAssertTrue(SlashCatalog.matches(token).isEmpty)
+        }
+    }
+
+    func testAutocompleteExcludesRetiredOperationalSurfaces() {
+        let offered = SlashCatalog.matches("/")
+        XCTAssertEqual(offered, SlashCatalog.available)
+        for token in ["/board", "/tasks", "/task", "/remind", "/automations"] {
+            XCTAssertFalse(offered.contains { $0.tokens.contains(token) }, token)
+        }
+    }
+
+    func testChatCommandsKeepTheirActualActions() {
+        XCTAssertEqual(SlashCatalog.command(for: "/model")?.action, .switchModel)
+        XCTAssertEqual(SlashCatalog.command(for: "/familiar")?.action, .familiarPicker)
+        XCTAssertEqual(SlashCatalog.command(for: "/sessions")?.action, .openSessions)
+        for token in ["/run", "/codex", "/claude"] {
+            XCTAssertEqual(SlashCatalog.command(for: token)?.action, .sendAsPrompt)
+        }
+    }
+
+    func testOnlyMessageCommandsRequireSendAuthorization() {
+        for token in ["/run", "/codex", "/claude", "/diagram"] {
+            XCTAssertEqual(SlashCatalog.command(for: token)?.sendsChatMessage, true, token)
+        }
+        for token in ["/help", "/board", "/tasks", "/new", "/model", "/sessions"] {
+            XCTAssertEqual(SlashCatalog.command(for: token)?.sendsChatMessage, false, token)
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/VoiceCallPresentationTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/VoiceCallPresentationTests.swift
@@ -37,6 +37,13 @@ final class VoiceCallPresentationTests: XCTestCase {
 
     // MARK: - Error → recovery mapping
 
+    func testAuthorityLossRequiresClosingThePresentationWithoutRetryOrFallback() {
+        let copy = VoiceCallCopy.authorityChanged
+        XCTAssertEqual(copy.recovery, .dismiss)
+        XCTAssertFalse(copy.offersOnDeviceFallback)
+        XCTAssertTrue(copy.message.contains("start a new one"))
+    }
+
     func testDeniedPermissionsRouteToSettingsWithNoFallback() {
         let mic = VoiceCallCopy.error(for: "microphone_denied", mode: .realtime)
         XCTAssertEqual(mic.recovery, .openSettings)

--- a/apps/ios/CovenCave/CovenCaveUITests/DrawerNavigationUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/DrawerNavigationUITests.swift
@@ -3,27 +3,19 @@ import XCTest
 final class DrawerNavigationUITests: XCTestCase {
 
     @MainActor
-    func testLaunchThreadIntentDoesNotReopenAfterChatsRemounts() {
+    func testSettingsRoundTripPreservesSelectedConversation() {
         let app = XCUIApplication()
         app.launchArguments = ["--ui-preview-empty-chat", "--ui-preview-second-thread"]
         app.launchEnvironment["CAVE_OPEN_THREAD"] = "ui-preview-empty-chat"
         app.launch()
 
         let launchThreadTitle = "Chat with Nyx on Jul 26"
-        let newestThreadTitle = "Chat with Nyx on Jul 27"
         XCTAssertTrue(app.navigationBars[launchThreadTitle].waitForExistence(timeout: 10),
                       "the launch thread opens on the first Chats mount")
 
-        let back = app.navigationBars.buttons["BackButton"].firstMatch
-        if back.waitForExistence(timeout: 3) {
-            back.tap()
-        } else {
-            app.swipeRight()
-        }
-
         let openNavigation = app.buttons["Open navigation"]
         XCTAssertTrue(openNavigation.waitForExistence(timeout: 10),
-                      "leaving the launch thread returns to Chats home")
+                      "the conversation exposes navigation")
         openNavigation.tap()
         app.buttons["Profile and settings"].tap()
 
@@ -32,21 +24,19 @@ final class DrawerNavigationUITests: XCTestCase {
         openNavigation.tap()
         app.buttons["Chats"].tap()
 
-        XCTAssertTrue(app.navigationBars[newestThreadTitle].waitForExistence(timeout: 10),
-                      "remounted Chats selects the current default conversation")
-        XCTAssertFalse(app.navigationBars[launchThreadTitle].exists,
-                       "the consumed launch thread does not override the newer default")
+        XCTAssertTrue(app.navigationBars[launchThreadTitle].waitForExistence(timeout: 10),
+                      "Settings does not remount Chats or select a different conversation")
     }
 
     @MainActor
     func testDrawerRecentThreadOpensAfterChatsIsMounted() {
         let app = XCUIApplication()
-        app.launchArguments = ["--ui-preview-empty-chat", "--ui-tab", "tasks"]
+        app.launchArguments = ["--ui-preview-empty-chat", "--ui-tab", "settings"]
         app.launch()
 
         let openNavigation = app.buttons["Open navigation"]
         XCTAssertTrue(openNavigation.waitForExistence(timeout: 10),
-                      "Tasks exposes the navigation drawer")
+                      "Settings exposes the navigation drawer")
         openNavigation.tap()
 
         let recentThread = app.buttons["Chat with Nyx on Jul 26"]
@@ -61,7 +51,7 @@ final class DrawerNavigationUITests: XCTestCase {
     @MainActor
     func testDrawerRoutesBetweenPrimaryDestinationsWithoutATabBar() {
         let app = XCUIApplication()
-        app.launchArguments = ["--ui-preview-empty-chat", "--ui-tab", "tasks"]
+        app.launchArguments = ["--ui-preview-empty-chat", "--ui-preview-chats-home"]
         app.launch()
 
         XCTAssertFalse(app.tabBars.firstMatch.exists, "the app has no native tab bar")
@@ -71,34 +61,20 @@ final class DrawerNavigationUITests: XCTestCase {
                       "a primary destination exposes the navigation drawer")
         openNavigation.tap()
 
-        for destination in ["Chats", "Tasks"] {
+        for destination in ["Chats", "Search chats"] {
             XCTAssertTrue(app.buttons[destination].waitForExistence(timeout: 5),
                           "drawer includes primary destination \(destination)")
         }
-        for resource in ["Projects", "Familiars"] {
-            XCTAssertTrue(app.buttons[resource].waitForExistence(timeout: 5),
-                          "drawer includes contextual resource \(resource)")
+        for retired in ["Tasks", "Projects", "Familiars", "Automations", "Terminal", "Project context button"] {
+            XCTAssertFalse(app.buttons[retired].exists,
+                           "chat-only navigation must not expose \(retired)")
         }
-        XCTAssertTrue(app.staticTexts["Workspace"].waitForExistence(timeout: 5),
-                      "drawer groups contextual resources below primary navigation")
+        XCTAssertFalse(app.staticTexts["Workspace"].exists)
         XCTAssertTrue(app.buttons["Profile and settings"].waitForExistence(timeout: 5),
                       "the profile avatar is the Settings entry point")
         XCTAssertFalse(app.buttons["Settings"].exists,
                        "Settings is not duplicated as a primary drawer row")
         XCTAssertFalse(app.buttons["Terminal"].exists, "the retired iOS terminal stays out of the drawer")
-
-        let projectContext = app.buttons["Project context button"]
-        XCTAssertTrue(projectContext.waitForExistence(timeout: 5),
-                      "drawer exposes the active project switcher")
-        projectContext.tap()
-
-        XCTAssertTrue(app.navigationBars["Switch project"].waitForExistence(timeout: 10),
-                      "the drawer project control opens the switcher")
-        app.buttons["Done"].tap()
-
-        XCTAssertTrue(openNavigation.waitForExistence(timeout: 10),
-                      "closing the switcher returns to the current destination")
-        openNavigation.tap()
 
         app.buttons["Profile and settings"].tap()
         XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 10),
@@ -111,98 +87,136 @@ final class DrawerNavigationUITests: XCTestCase {
         XCTAssertTrue(openNavigation.waitForExistence(timeout: 10),
                       "Chats is mounted after drawer routing")
 
-        openNavigation.tap()
-        app.buttons["Tasks"].tap()
-        XCTAssertTrue(app.navigationBars["Tasks"].waitForExistence(timeout: 10),
-                      "Tasks is mounted after drawer routing")
         XCTAssertFalse(app.tabBars.firstMatch.exists, "routing does not introduce a native tab bar")
     }
 
     @MainActor
-    func testSwitchingProjectsClearsStaleChatDetail() {
+    func testChatsIncludesBothProjectsWithoutAGlobalFilter() {
         let app = XCUIApplication()
-        app.launchArguments = ["--ui-preview-design-closeout"]
+        app.launchArguments = ["--ui-preview-design-closeout", "--ui-preview-chats-home"]
         app.launch()
 
-        XCTAssertTrue(app.navigationBars["Chat with Nyx on Jul 26"].waitForExistence(timeout: 10),
-                      "the current project's default chat opens first")
-
-        let openNavigation = app.buttons["Open navigation"]
-        XCTAssertTrue(openNavigation.waitForExistence(timeout: 10))
-        openNavigation.tap()
-
-        let projectContext = app.buttons["Project context button"]
-        XCTAssertTrue(projectContext.waitForExistence(timeout: 5),
-                      "drawer exposes the shared project switcher")
-        projectContext.tap()
-
-        let designLibrary = app.descendants(matching: .any)["Project row project:design-library"].firstMatch
-        XCTAssertTrue(designLibrary.waitForExistence(timeout: 10),
-                      "the alternate project is listed in the switcher")
-        designLibrary.tap()
-
-        XCTAssertTrue(app.navigationBars["Lyra design review"].waitForExistence(timeout: 10),
-                      "changing projects reseeds Chats with the new project's detail")
-        XCTAssertFalse(app.navigationBars["Chat with Nyx on Jul 26"].exists,
-                       "the previous project's detail cannot survive the context switch")
+        let nyx = app.descendants(matching: .any)["Chat row local:ui-preview-empty-chat"].firstMatch
+        let lyra = app.descendants(matching: .any)["Chat row local:ui-preview-lyra-chat"].firstMatch
+        XCTAssertTrue(nyx.waitForExistence(timeout: 10))
+        XCTAssertTrue(lyra.waitForExistence(timeout: 10),
+                      "a different project's chat is visible without switching global context")
+        lyra.tap()
+        XCTAssertTrue(app.navigationBars["Lyra design review"].waitForExistence(timeout: 10))
     }
 
     @MainActor
-    func testFamiliarDetailOffersAvatarEditing() {
+    func testDrawerSearchSearchesChatsOnly() {
         let app = XCUIApplication()
         app.launchArguments = [
             "--ui-preview-design-closeout",
-            "--ui-preview-avatar-editing",
+            "--ui-preview-chats-home",
             "--ui-open-drawer",
         ]
         app.launch()
 
-        let familiars = app.buttons["Familiars"]
-        XCTAssertTrue(familiars.waitForExistence(timeout: 10))
-        familiars.tap()
-
-        let nyx = app.collectionViews.buttons
-            .matching(NSPredicate(format: "label CONTAINS[c] %@", "Nyx"))
-            .firstMatch
-        XCTAssertTrue(nyx.waitForExistence(timeout: 10), "the preview familiar is listed")
-        nyx.tap()
-
-        let profile = app.segmentedControls["Familiar hub section"].buttons["Profile"]
-        XCTAssertTrue(profile.waitForExistence(timeout: 10), "familiar details expose the Profile tab")
-        profile.tap()
-
-        let editAvatar = app.descendants(matching: .any)["Edit Nyx’s avatar"].firstMatch
-        XCTAssertTrue(editAvatar.waitForExistence(timeout: 10), "familiar details expose avatar editing")
-        editAvatar.tap()
-
-        XCTAssertTrue(app.buttons["Choose photo"].waitForExistence(timeout: 5))
+        let search = app.buttons["Search chats"]
+        XCTAssertTrue(search.waitForExistence(timeout: 10))
+        search.tap()
+        let field = app.textFields["Search chats…"]
+        XCTAssertTrue(field.waitForExistence(timeout: 10))
+        field.tap()
+        field.typeText("Lyra")
+        XCTAssertTrue(app.descendants(matching: .any)["Chat row local:ui-preview-lyra-chat"].firstMatch
+            .waitForExistence(timeout: 5))
+        XCTAssertFalse(app.descendants(matching: .any)["Chat row local:ui-preview-empty-chat"].firstMatch.exists)
+        XCTAssertFalse(app.buttons["Tasks"].exists)
+        XCTAssertFalse(app.buttons["Projects"].exists)
     }
 
     @MainActor
-    func testProjectContextGateOffersSettingsEscapeBeforeShellMounts() {
+    func testDrawerSearchRevealsTheListFromAnOpenConversation() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-preview-design-closeout"]
+        app.launchEnvironment["CAVE_OPEN_THREAD"] = "ui-preview-empty-chat"
+        app.launch()
+
+        XCTAssertTrue(app.navigationBars["Chat with Nyx on Jul 26"].waitForExistence(timeout: 10))
+        app.buttons["Open navigation"].tap()
+        app.buttons["Search chats"].tap()
+
+        let field = app.textFields["Search chats…"]
+        XCTAssertTrue(field.waitForExistence(timeout: 10))
+        let visible = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "hittable == true"), object: field
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [visible], timeout: 5), .completed,
+                       "search must leave the collapsed conversation detail")
+        field.tap()
+        field.typeText("Lyra")
+        XCTAssertTrue(app.descendants(matching: .any)["Chat row local:ui-preview-lyra-chat"]
+            .firstMatch.waitForExistence(timeout: 5))
+    }
+
+    @MainActor
+    func testRecentChatReopensTheSameConversationAfterDrawerSearch() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-preview-empty-chat"]
+        app.launchEnvironment["CAVE_OPEN_THREAD"] = "ui-preview-empty-chat"
+        app.launch()
+
+        XCTAssertTrue(app.navigationBars["Chat with Nyx on Jul 26"].waitForExistence(timeout: 10))
+        app.buttons["Open navigation"].tap()
+        app.buttons["Search chats"].tap()
+        XCTAssertTrue(app.textFields["Search chats…"].waitForExistence(timeout: 10))
+
+        app.buttons["Open navigation"].tap()
+        app.buttons["Chat with Nyx on Jul 26"].tap()
+        let composer = app.descendants(matching: .any)["Message"].firstMatch
+        let visible = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "hittable == true"), object: composer
+        )
+        XCTAssertEqual(XCTWaiter.wait(for: [visible], timeout: 5), .completed,
+                       "an explicit same-chat open must reveal detail without resetting its state")
+    }
+
+    @MainActor
+    func testSwitchingProjectsKeepsEachConversationsDraftSeparate() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-preview-design-closeout"]
+        app.launchEnvironment["CAVE_OPEN_THREAD"] = "ui-preview-empty-chat"
+        app.launch()
+
+        XCTAssertTrue(app.navigationBars["Chat with Nyx on Jul 26"].waitForExistence(timeout: 10))
+        let composer = app.descendants(matching: .any)["Message"].firstMatch
+        XCTAssertTrue(composer.waitForExistence(timeout: 5))
+        composer.tap()
+        composer.typeText("Draft only for Nyx")
+
+        app.buttons["Open navigation"].tap()
+        app.buttons["Lyra design review"].tap()
+        XCTAssertTrue(app.navigationBars["Lyra design review"].waitForExistence(timeout: 10))
+        XCTAssertFalse((composer.value as? String ?? "").contains("Draft only for Nyx"))
+        composer.tap()
+        composer.typeText("Draft only for Lyra")
+
+        app.buttons["Open navigation"].tap()
+        app.buttons["Chat with Nyx on Jul 26"].tap()
+        XCTAssertTrue(app.navigationBars["Chat with Nyx on Jul 26"].waitForExistence(timeout: 10))
+        XCTAssertTrue((composer.value as? String ?? "").contains("Draft only for Nyx"))
+        XCTAssertFalse((composer.value as? String ?? "").contains("Draft only for Lyra"),
+                       "a different project's composer must never overwrite or inherit this draft")
+    }
+
+    @MainActor
+    func testMissingProjectCatalogDoesNotHideChatOrSettings() {
         let app = XCUIApplication()
         app.launchArguments = ["--ui-preview-project-context-gate"]
         app.launch()
 
-        XCTAssertTrue(app.staticTexts["Couldn’t load project access"].waitForExistence(timeout: 10),
-                      "the cold project-context gate is visible")
-        XCTAssertFalse(app.buttons["Open navigation"].exists,
-                       "the cold gate does not mount the primary shell")
-
-        let settings = app.buttons["Settings"]
-        XCTAssertTrue(settings.waitForExistence(timeout: 5),
-                      "the gate exposes a settings escape hatch")
-        settings.tap()
+        let navigation = app.buttons["Open navigation"]
+        XCTAssertTrue(navigation.waitForExistence(timeout: 10),
+                      "access failure must not replace the chat shell with a global project gate")
+        navigation.tap()
+        app.buttons["Profile and settings"].tap()
 
         XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 10),
-                      "the escape hatch opens settings recovery")
-
-        let close = app.buttons["Close"]
-        XCTAssertTrue(close.waitForExistence(timeout: 5),
-                      "modal settings expose a close control")
-        close.tap()
-
-        XCTAssertTrue(app.buttons["Retry"].waitForExistence(timeout: 10),
-                      "dismissing settings returns to the gate retry state")
+                      "Settings remains reachable for permission and connection recovery")
+        XCTAssertFalse(app.staticTexts["Community"].exists)
     }
 }

--- a/apps/ios/CovenCave/CovenCaveUITests/GlobalSearchUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/GlobalSearchUITests.swift
@@ -1,282 +1,63 @@
 import XCTest
 
+/// Global search is now conversation search: no scope selector or other
+/// surface's results, while local and desktop conversations remain discoverable.
 final class GlobalSearchUITests: XCTestCase {
-
     @MainActor
-    func testProjectResultSwitchesContextWithoutLeavingCurrentDestination() {
-        let app = XCUIApplication()
-        app.launchArguments = [
-            "--ui-preview-design-closeout",
-            "--ui-tab", "tasks",
-            "--ui-open-search",
-            "--ui-search-query", "Design Library",
-        ]
-        app.launch()
-
-        toggleEverywhere(in: app)
-
-        let projectResult = app.buttons["Global search project design-library"]
-        XCTAssertTrue(projectResult.waitForExistence(timeout: 10),
-                      "global search finds the loaded project")
-        projectResult.tap()
-
-        XCTAssertTrue(app.navigationBars["Tasks"].waitForExistence(timeout: 10),
-                      "choosing a project keeps the current destination mounted")
-
-        let openNavigation = app.buttons["Open navigation"]
-        XCTAssertTrue(openNavigation.waitForExistence(timeout: 10))
-        openNavigation.tap()
-
-        let projectContext = app.buttons["Project context button"]
-        XCTAssertTrue(projectContext.waitForExistence(timeout: 5),
-                      "the switched context is reflected in shared app chrome")
-        XCTAssertEqual(projectContext.value as? String, "Design Library")
-    }
-
-    @MainActor
-    func testDrawerSearchRoutesATaskResultToItsDetail() {
-        let app = XCUIApplication()
-        app.launchArguments = ["--ui-preview-empty-chat", "--ui-tab", "tasks"]
-        app.launch()
-
-        openSearchFromDrawer(in: app)
-        enterSearchQuery("cold-launch", in: app)
-
-        let taskResult = app.buttons["Global search task cold-launch"]
-        XCTAssertTrue(taskResult.waitForExistence(timeout: 5),
-                      "search finds a loaded task by title")
-        taskResult.tap()
-
-        XCTAssertTrue(app.navigationBars["Task"].waitForExistence(timeout: 10),
-                      "choosing a task routes to task detail")
-        XCTAssertTrue(app.staticTexts["cold-launch bug"].exists,
-                      "the selected task is the result that opened")
+    func testSearchOpensCrossProjectConversationWithoutAProjectSwitcher() {
+        let app = launchSearch("Lyra")
+        let result = app.descendants(matching: .any)["Chat row local:ui-preview-lyra-chat"].firstMatch
+        XCTAssertTrue(result.waitForExistence(timeout: 10))
+        XCTAssertFalse(app.buttons["Everywhere"].exists)
+        XCTAssertFalse(app.buttons["Project context button"].exists)
+        result.tap()
+        XCTAssertTrue(app.navigationBars["Lyra design review"].waitForExistence(timeout: 10))
     }
 
     @MainActor
     func testSearchMaterializesAndOpensAServerOnlyConversation() {
-        let app = XCUIApplication()
-        app.launchArguments = [
-            "--ui-preview-design-closeout",
-            "--ui-open-search",
-            "--ui-search-query", "desktop handoff",
-        ]
-        app.launch()
-
-        let result = app.buttons["Global search session ui-preview-server-only"]
-        XCTAssertTrue(result.waitForExistence(timeout: 10),
-                      "global search includes an eligible server-only conversation")
+        let app = launchSearch("Desktop handoff")
+        let result = app.descendants(matching: .any)["Chat row server:ui-preview-server-only"].firstMatch
+        XCTAssertTrue(result.waitForExistence(timeout: 10))
         result.tap()
-
-        XCTAssertTrue(app.navigationBars["Desktop handoff"].waitForExistence(timeout: 10),
-                      "choosing the result materializes and opens the server conversation")
+        XCTAssertTrue(app.navigationBars["Desktop handoff"].waitForExistence(timeout: 10))
     }
 
     @MainActor
-    func testSearchFindsALocallyRenamedBoundChatByAuthoritativeServerTitle() {
+    func testSearchFindsRenamedLocalChatByAuthoritativeTitleWithoutDuplicates() {
+        let app = launchSearch("authoritative desktop handoff")
+        let local = app.descendants(matching: .any)["Chat row local:ui-preview-renamed-local-chat"].firstMatch
+        XCTAssertTrue(local.waitForExistence(timeout: 10))
+        XCTAssertFalse(app.descendants(matching: .any)["Chat row server:ui-preview-bound-rename"].firstMatch.exists)
+        local.tap()
+        XCTAssertTrue(app.navigationBars["Renamed local chat"].waitForExistence(timeout: 10))
+    }
+
+    @MainActor
+    func testTaskAndWorkspaceNamesDoNotProduceNonChatResults() {
+        let app = launchSearch("scope anchor")
+        XCTAssertFalse(app.buttons["Global search task scope-anchor-current"].exists)
+        XCTAssertFalse(app.buttons["Global search project design-library"].exists)
+        XCTAssertTrue(app.textFields["Search chats…"].exists,
+                      "an empty search retains its editable field")
+        app.buttons["Clear search"].tap()
+        XCTAssertTrue(app.descendants(matching: .any)["Chat row local:ui-preview-lyra-chat"].firstMatch
+            .waitForExistence(timeout: 5))
+    }
+
+    @MainActor
+    private func launchSearch(_ query: String) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments = [
             "--ui-preview-design-closeout",
+            "--ui-preview-chats-home",
             "--ui-open-search",
-            "--ui-search-query", "authoritative desktop handoff",
         ]
         app.launch()
-
-        let localResult = app.buttons["Global search chat ui-preview-renamed-local-chat"]
-        XCTAssertTrue(localResult.waitForExistence(timeout: 10),
-                      "bound local chats should match authoritative server titles")
-        XCTAssertFalse(
-            app.buttons["Global search session ui-preview-bound-rename"].waitForExistence(timeout: 1),
-            "a bound server session should not appear as a duplicate result"
-        )
-
-        localResult.tap()
-
-        XCTAssertTrue(app.navigationBars["Renamed local chat"].waitForExistence(timeout: 10),
-                      "the local thread remains the open target for the combined result")
-    }
-
-    @MainActor
-    func testProjectScopeHidesCrossProjectResultsUntilEverywhereSelected() {
-        let app = XCUIApplication()
-        app.launchArguments = [
-            "--ui-preview-design-closeout",
-            "--ui-open-search",
-            "--ui-search-query", "scope anchor",
-        ]
-        app.launch()
-
-        XCTAssertTrue(
-            app.buttons["Global search task scope-anchor-current"].waitForExistence(timeout: 10),
-            "project scope keeps current-project results visible"
-        )
-        XCTAssertFalse(
-            app.buttons["Global search task scope-anchor-design"].waitForExistence(timeout: 1),
-            "project scope hides other project tasks by default"
-        )
-        XCTAssertFalse(
-            app.buttons["Global search task scope-anchor-unassigned"].waitForExistence(timeout: 1),
-            "project scope hides unassigned artifacts while a registered project is active"
-        )
-
-        toggleEverywhere(in: app)
-
-        XCTAssertTrue(
-            app.buttons["Global search task scope-anchor-design"].waitForExistence(timeout: 10),
-            "Everywhere reveals other project tasks"
-        )
-        XCTAssertTrue(
-            app.buttons["Global search task scope-anchor-unassigned"].waitForExistence(timeout: 10),
-            "Everywhere also reveals unassigned artifacts"
-        )
-    }
-
-    @MainActor
-    func testCrossProjectFamiliarResultAutoSwitchesContext() {
-        let app = XCUIApplication()
-        app.launchArguments = [
-            "--ui-preview-design-closeout",
-            "--ui-open-search",
-            "--ui-search-query", "Lyra",
-        ]
-        app.launch()
-
-        toggleEverywhere(in: app)
-
-        let familiarResult = app.buttons["Global search familiar lyra"]
-        XCTAssertTrue(familiarResult.waitForExistence(timeout: 10),
-                      "Everywhere search reveals the cross-project familiar")
-        familiarResult.tap()
-
-        XCTAssertTrue(app.navigationBars["Lyra design review"].waitForExistence(timeout: 10),
-                      "opening the familiar resolves to its existing cross-project chat")
-
-        let openNavigation = app.buttons["Open navigation"]
-        XCTAssertTrue(openNavigation.waitForExistence(timeout: 10))
-        openNavigation.tap()
-
-        let projectContext = app.buttons["Project context button"]
-        XCTAssertTrue(projectContext.waitForExistence(timeout: 5))
-        XCTAssertEqual(projectContext.value as? String, "Design Library")
-    }
-
-    @MainActor
-    func testUnassignedProjectScopeShowsOnlyUnassignedArtifacts() {
-        let app = XCUIApplication()
-        app.launchArguments = [
-            "--ui-preview-design-closeout",
-            "--ui-preview-search-unassigned",
-            "--ui-open-search",
-            "--ui-search-query", "scope anchor",
-        ]
-        app.launch()
-
-        XCTAssertTrue(
-            app.buttons["Global search task scope-anchor-unassigned"].waitForExistence(timeout: 10),
-            "Unassigned project scope keeps unassigned artifacts searchable"
-        )
-        XCTAssertFalse(
-            app.buttons["Global search task scope-anchor-current"].waitForExistence(timeout: 1),
-            "Unassigned scope excludes registered project tasks"
-        )
-        XCTAssertFalse(
-            app.buttons["Global search task scope-anchor-design"].waitForExistence(timeout: 1),
-            "Unassigned scope excludes other registered project tasks"
-        )
-    }
-
-    @MainActor
-    func testUnknownProjectTaskResultOpensInUnassignedTaskDetail() {
-        let app = XCUIApplication()
-        app.launchArguments = [
-            "--ui-preview-design-closeout",
-            "--ui-tab", "tasks",
-            "--ui-open-search",
-            "--ui-search-query", "scope anchor unassigned",
-        ]
-        app.launch()
-
-        toggleEverywhere(in: app)
-
-        let taskResult = app.buttons["Global search task scope-anchor-unassigned"]
-        XCTAssertTrue(taskResult.waitForExistence(timeout: 10),
-                      "Everywhere search should reveal deleted or unknown-project recovery tasks")
-        taskResult.tap()
-
-        let taskDetail = app.navigationBars["Task"]
-        XCTAssertTrue(taskDetail.waitForExistence(timeout: 10),
-                      "tapping the result opens Task detail instead of rejecting the task")
-        XCTAssertTrue(app.staticTexts["scope anchor unassigned"].waitForExistence(timeout: 5),
-                      "the opened detail matches the recovery task result")
-        taskDetail.swipeDown()
-
-        let openNavigation = app.buttons["Open navigation"]
-        XCTAssertTrue(openNavigation.waitForExistence(timeout: 10))
-        openNavigation.tap()
-
-        let projectContext = app.buttons["Project context button"]
-        XCTAssertTrue(projectContext.waitForExistence(timeout: 5))
-        XCTAssertEqual(projectContext.value as? String, "Unassigned")
-    }
-
-    @MainActor
-    func testClosingAndReopeningSearchResetsScopeToProject() {
-        let app = XCUIApplication()
-        app.launchArguments = [
-            "--ui-preview-design-closeout",
-            "--ui-open-search",
-            "--ui-search-query", "scope anchor",
-        ]
-        app.launch()
-
-        toggleEverywhere(in: app)
-        XCTAssertTrue(
-            app.buttons["Global search task scope-anchor-design"].waitForExistence(timeout: 10),
-            "Everywhere exposes cross-project results before close"
-        )
-
-        app.buttons["Close"].tap()
-        openSearchFromDrawer(in: app)
-
-        XCTAssertTrue(
-            app.buttons["Global search task scope-anchor-current"].waitForExistence(timeout: 10),
-            "reopened search returns to current-project results"
-        )
-        XCTAssertFalse(
-            app.buttons["Global search task scope-anchor-design"].waitForExistence(timeout: 1),
-            "closing and reopening resets search scope back to Project"
-        )
-    }
-
-    @MainActor
-    private func openSearchFromDrawer(in app: XCUIApplication) {
-        let openNavigation = app.buttons["Open navigation"]
-        XCTAssertTrue(openNavigation.waitForExistence(timeout: 10),
-                      "a primary destination exposes the navigation drawer")
-        openNavigation.tap()
-
-        let openSearch = app.buttons["Search everything"]
-        XCTAssertTrue(openSearch.waitForExistence(timeout: 5),
-                      "the drawer exposes app-wide search")
-        openSearch.tap()
-
-        XCTAssertTrue(app.searchFields["Search everything…"].waitForExistence(timeout: 10),
-                      "global search presents its canonical field")
-    }
-
-    @MainActor
-    private func enterSearchQuery(_ query: String, in app: XCUIApplication) {
-        let search = app.searchFields["Search everything…"]
-        XCTAssertTrue(search.waitForExistence(timeout: 10))
-        search.tap()
-        search.typeText(query)
-    }
-
-    @MainActor
-    private func toggleEverywhere(in app: XCUIApplication) {
-        let scope = app.segmentedControls["Global search scope"]
-        XCTAssertTrue(scope.waitForExistence(timeout: 10),
-                      "global search exposes the scope picker")
-        scope.buttons["Everywhere"].tap()
+        let field = app.textFields["Search chats…"]
+        XCTAssertTrue(field.waitForExistence(timeout: 10))
+        field.tap()
+        field.typeText(query)
+        return app
     }
 }

--- a/apps/ios/CovenCave/CovenCaveUITests/NewChatUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/NewChatUITests.swift
@@ -15,49 +15,40 @@ final class NewChatUITests: XCTestCase {
     }
 
     @MainActor
-    func testContextualNewChatUsesActiveProjectWithoutIndependentPicker() {
+    func testContextualNewChatRequiresLocalProjectSelection() {
         let app = launchContextualNewChat()
 
-        XCTAssertTrue(app.staticTexts["Coven Cave"].waitForExistence(timeout: 10))
-        XCTAssertFalse(app.buttons["New chat project"].exists)
+        let picker = app.buttons["New chat project"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 10))
+        XCTAssertFalse(app.buttons["Start chat"].isEnabled)
+        picker.tap()
+        app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Coven Cave")).firstMatch.tap()
         XCTAssertTrue(app.buttons["Start chat"].isEnabled)
     }
 
     @MainActor
-    func testContextualNewChatBlocksStartWhenFixedFamiliarLeavesActiveProject() {
+    func testContextualNewChatBlocksCommitWhenAccessIsRevoked() {
         let app = launchContextualNewChat(
             extraArguments: ["--ui-preview-new-chat-access-revoked"]
         )
 
-        XCTAssertTrue(
-            app.staticTexts["This familiar is no longer in Coven Cave."]
-                .waitForExistence(timeout: 10)
-        )
-        XCTAssertFalse(app.buttons["Start chat"].isEnabled)
-        XCTAssertFalse(app.buttons["New chat project"].exists)
+        let picker = app.buttons["New chat project"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 10))
+        picker.tap()
+        app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Coven Cave")).firstMatch.tap()
+        app.buttons["Start chat"].tap()
+        XCTAssertTrue(app.staticTexts.matching(
+            NSPredicate(format: "label CONTAINS %@", "Project access was revoked")
+        ).firstMatch.waitForExistence(timeout: 10))
+        XCTAssertTrue(app.navigationBars["New chat"].exists)
     }
 
     @MainActor
-    func testContextualNewChatShowsRecoveryOnlyGuidanceForUnassigned() {
-        let app = XCUIApplication()
-        app.launchArguments = [
-            "--ui-preview-empty-chat",
-            "--ui-preview-new-chat-unassigned",
-            "--ui-open-contextual-new-chat",
-        ]
-        app.launch()
-
-        XCTAssertFalse(
-            app.navigationBars["New chat"].waitForExistence(timeout: 3),
-            "Unassigned recovery mode must not open the New Chat sheet"
-        )
-        let openNavigation = app.buttons["Open navigation"]
-        XCTAssertTrue(openNavigation.waitForExistence(timeout: 10))
-        openNavigation.tap()
-        let projectContext = app.descendants(matching: .any)["Project context button"].firstMatch
-        XCTAssertTrue(
-            projectContext.waitForExistence(timeout: 10) && projectContext.isHittable
-        )
+    func testNewChatCanConfigureAccessWithoutAmbientProject() {
+        let app = launchContextualNewChat(extraArguments: ["--ui-preview-new-chat-unassigned"])
+        XCTAssertTrue(app.buttons["New chat project"].waitForExistence(timeout: 10))
+        XCTAssertFalse(app.buttons["Start chat"].isEnabled)
+        XCTAssertTrue(app.buttons["Refresh access"].exists)
     }
 
     @MainActor

--- a/apps/ios/CovenCave/CovenCaveUITests/SessionSwitchUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/SessionSwitchUITests.swift
@@ -13,9 +13,12 @@ final class SessionSwitchUITests: XCTestCase {
     private let firstThread = "Chat with Nyx on Jul 26"
     private let secondThread = "Chat with Nyx on Jul 27"
 
-    private func launchInFirstThread() -> XCUIApplication {
+    private func launchInFirstThread(clearDraft: Bool = false) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments = ["--ui-preview-empty-chat", "--ui-preview-second-thread"]
+        if clearDraft {
+            app.launchArguments += ["-cave.chat.draft.ui-preview-empty-chat", ""]
+        }
         app.launchEnvironment["CAVE_OPEN_THREAD"] = "ui-preview-empty-chat"
         app.launch()
         XCTAssertTrue(app.navigationBars[firstThread].waitForExistence(timeout: 15),
@@ -35,6 +38,77 @@ final class SessionSwitchUITests: XCTestCase {
         let sessionRow = app.buttons["Switch session"].firstMatch
         XCTAssertTrue(sessionRow.waitForExistence(timeout: 10), "the details card offers Conversation")
         sessionRow.tap()
+    }
+
+    @MainActor
+    private func openComposerActions(_ app: XCUIApplication) {
+        let attach = app.buttons["Attach or run a tool"]
+        XCTAssertTrue(attach.waitForExistence(timeout: 10), "the explicit launch opens the chat composer")
+        attach.tap()
+    }
+
+    @MainActor
+    func testComposerOffersChatActionsWithoutTaskOrMarketplaceManagement() {
+        let app = launchInFirstThread()
+        openComposerActions(app)
+
+        for action in ["Camera", "Photos", "Files", "Dictate", "Commands"] {
+            XCTAssertTrue(app.buttons[action].waitForExistence(timeout: 5),
+                          "the composer retains \(action)")
+        }
+        for retired in ["Link a task", "Create task", "Tasks", "Plugins"] {
+            XCTAssertFalse(app.buttons[retired].exists, "the composer must not offer \(retired)")
+        }
+        XCTAssertFalse(app.staticTexts["What tasks need attention?"].exists)
+        XCTAssertFalse(app.staticTexts["Work on the next priority"].exists)
+    }
+
+    @MainActor
+    func testCommandReferenceDoesNotOfferRetiredTaskNavigation() {
+        let app = launchInFirstThread()
+        openComposerActions(app)
+        app.buttons["Commands"].tap()
+
+        XCTAssertTrue(app.navigationBars["Commands"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["/help"].waitForExistence(timeout: 5),
+                      "native chat commands remain available")
+
+        let search = app.searchFields.firstMatch
+        XCTAssertTrue(search.waitForExistence(timeout: 5))
+        search.tap()
+        search.typeText("/board")
+
+        XCTAssertFalse(app.staticTexts["/board"].exists, "task navigation is not an offered command")
+        XCTAssertFalse(app.staticTexts["/help"].exists, "the search has filtered the catalog")
+        XCTAssertTrue(app.navigationBars["Commands"].exists, "search cannot navigate to Tasks")
+        app.navigationBars["Commands"].buttons["Close"].tap()
+        let done = app.navigationBars["Commands"].buttons["Done"]
+        XCTAssertTrue(done.waitForExistence(timeout: 5))
+        done.tap()
+        XCTAssertTrue(app.navigationBars[firstThread].waitForExistence(timeout: 5))
+    }
+
+    @MainActor
+    func testTypedLegacyTaskCommandExplainsDesktopOnlyAndKeepsTheChat() {
+        let app = launchInFirstThread(clearDraft: true)
+        let composer = app.descendants(matching: .any)["Message"].firstMatch
+        XCTAssertTrue(composer.waitForExistence(timeout: 5))
+        composer.tap()
+        composer.typeText("/board")
+
+        let run = app.buttons["Run command"]
+        XCTAssertTrue(run.waitForExistence(timeout: 5))
+        XCTAssertTrue(run.isEnabled)
+        run.tap()
+
+        let explanation = app.descendants(matching: .any).matching(
+            NSPredicate(format: "label CONTAINS %@ AND label CONTAINS %@", "Tasks", "desktop")
+        ).firstMatch
+        XCTAssertTrue(explanation.waitForExistence(timeout: 5),
+                      "the legacy command explains where Tasks is available")
+        XCTAssertTrue(app.navigationBars[firstThread].exists, "legacy commands do not leave the chat")
+        XCTAssertFalse(app.navigationBars["Tasks"].exists)
+        XCTAssertTrue(app.buttons["Session controls"].exists)
     }
 
     @MainActor

--- a/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveControls.swift
+++ b/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveControls.swift
@@ -2,33 +2,17 @@ import AppIntents
 import SwiftUI
 import WidgetKit
 
-// Control Center / Lock Screen controls (iOS 18). Each is a one-tap shortcut
-// that opens the app at the right surface via the covencave:// deep links the
-// app already routes (see CovenCaveApp.onOpenURL). The Tasks control also shows
-// a live "running" count read from the shared App Group snapshot.
-
-
-/// Supplies the current "running tasks" count for the Tasks control.
-struct RunningTasksValueProvider: ControlValueProvider {
-    var previewValue: Int { 1 }
-
-    func currentValue() async throws -> Int {
-        WidgetSnapshotStore.read()?.runningTaskCount ?? 0
-    }
-}
-
-/// Show how many tasks are running and open the Tasks destination.
-struct TasksControl: ControlWidget {
+/// A chat-only entrypoint from Control Center or the Lock Screen.
+struct ChatsControl: ControlWidget {
     var body: some ControlWidgetConfiguration {
         StaticControlConfiguration(
-            kind: "ai.opencoven.cave.control.tasks",
-            provider: RunningTasksValueProvider()
-        ) { running in
-            ControlWidgetButton(action: OpenURLIntent(URL(string: "covencave://tasks")!)) {
-                Label(running > 0 ? "\(running) running" : "Tasks", systemImage: "play.circle.fill")
+            kind: "ai.opencoven.cave.control.chats"
+        ) {
+            ControlWidgetButton(action: OpenURLIntent(URL(string: "covencave://chats")!)) {
+                Label("Chats", systemImage: "bubble.left.and.bubble.right.fill")
             }
         }
-        .displayName("Coven Tasks")
-        .description("See running tasks and open the Tasks destination.")
+        .displayName("Coven Chats")
+        .description("Open your conversations.")
     }
 }

--- a/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
+++ b/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
@@ -3,63 +3,6 @@ import AppIntents
 import WidgetKit
 import SwiftUI
 
-/// The "task running" Live Activity — Lock Screen banner + Dynamic Island.
-/// Shows the task title and a live elapsed-time counter from `startedAt`.
-struct TaskLiveActivity: Widget {
-    var body: some WidgetConfiguration {
-        ActivityConfiguration(for: TaskActivityAttributes.self) { context in
-            // Lock Screen / banner presentation.
-            HStack(spacing: 12) {
-                Image(systemName: "play.circle.fill")
-                    .font(.title2)
-                    .foregroundStyle(.tint)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Running task")
-                        .font(.caption2).foregroundStyle(.secondary)
-                    Text(context.attributes.title)
-                        .font(.headline).lineLimit(2)
-                }
-                Spacer(minLength: 8)
-                Text(context.attributes.startedAt, style: .timer)
-                    .font(.title3.monospacedDigit())
-                    .frame(maxWidth: 64, alignment: .trailing)
-            }
-            .padding()
-            .activityBackgroundTint(Color.black.opacity(0.35))
-            .activitySystemActionForegroundColor(.primary)
-            .widgetURL(URL(string: "covencave://task/\(context.attributes.taskId)"))
-        } dynamicIsland: { context in
-            DynamicIsland {
-                DynamicIslandExpandedRegion(.leading) {
-                    Image(systemName: "play.circle.fill").foregroundStyle(.tint)
-                }
-                DynamicIslandExpandedRegion(.trailing) {
-                    Text(context.attributes.startedAt, style: .timer)
-                        .font(.body.monospacedDigit())
-                        .frame(maxWidth: 64, alignment: .trailing)
-                }
-                DynamicIslandExpandedRegion(.center) {
-                    Text(context.attributes.title)
-                        .font(.subheadline.weight(.medium)).lineLimit(1)
-                }
-                DynamicIslandExpandedRegion(.bottom) {
-                    Text(context.state.statusLabel)
-                        .font(.caption2).foregroundStyle(.secondary)
-                }
-            } compactLeading: {
-                Image(systemName: "play.fill").foregroundStyle(.tint)
-            } compactTrailing: {
-                Text(context.attributes.startedAt, style: .timer)
-                    .font(.caption2.monospacedDigit())
-                    .frame(maxWidth: 44)
-            } minimal: {
-                Image(systemName: "play.fill").foregroundStyle(.tint)
-            }
-            .widgetURL(URL(string: "covencave://task/\(context.attributes.taskId)"))
-        }
-    }
-}
-
 // MARK: - Chat turn Live Activity
 
 /// The "familiar is working" Live Activity — mirrors a running chat turn on
@@ -123,8 +66,7 @@ struct ChatLiveActivity: Widget {
 @main
 struct CovenCaveWidgetsBundle: WidgetBundle {
     var body: some Widget {
-        TaskLiveActivity()
         ChatLiveActivity()
-        TasksControl()
+        ChatsControl()
     }
 }

--- a/apps/ios/CovenCave/README.md
+++ b/apps/ios/CovenCave/README.md
@@ -1,12 +1,30 @@
 # Coven Cave — Native iOS app
 
-A genuinely native SwiftUI client for Coven Cave. It connects to your desktop over
-your **Tailscale** network — **no token, no password**; tailnet membership is the
-trust boundary. This is *not* a webview wrapper around the web app.
+A native, chat-only SwiftUI client for Coven Cave. It connects to your desktop
+over your **Tailscale** network using a paired Cave access credential stored in
+the Keychain and scoped to the desktop endpoint. Tailnet reachability does not
+replace authorization. This is *not* a webview wrapper around the web app.
 
 See [`docs/ios-current-direction.md`](../../../docs/ios-current-direction.md)
 for the canonical active product direction. The older native rebuild and dated
 implementation plans are historical lineage, not active priority queues.
+
+## Chat-only experience
+
+Chats lists direct and group conversations across projects and devices, with
+pinning, archives, unread state, and chat search. An imported server session
+appears once, alongside locally created chats. iPhone starts at the conversation
+list; iPad keeps a conversation sidebar and detail pane.
+
+The drawer contains Chats, recent conversations, New chat, Search chats, and
+Settings. There are no Tasks, Projects, Automations, standalone Familiar hub,
+terminal, or global project filter. Familiar selection, permissions, appearance,
+connection, and security settings serve the chat experience.
+
+Project access is selected for a new conversation, not for the application.
+Existing chats keep their exact project root, participants, session IDs, drafts,
+and queued recipients. Cached history remains available during access-catalog
+recovery; sending requires current grants for the conversation's actual targets.
 
 ### Flow execution visibility
 
@@ -19,8 +37,8 @@ with a similar title remains a normal conversation.
 
 Directly opened execution transcripts replace the composer with a read-only
 notice, disable continuation/queued sends and voice calls, and omit reply, retry,
-and message-delete actions. Start a discussion from the Flow on desktop; native
-discussion creation still needs project-selection support for the new chat.
+and message-delete actions. Start a discussion from the Flow on desktop; Flow
+management is not part of native chat-only navigation.
 
 Client v1's canonical conversation inventory remains unfiltered. It publishes
 the same exact execution provenance without changing pagination, and both
@@ -81,13 +99,10 @@ sources as the whole `CovenCave` directory, so regeneration always picks new
 files up. CI regenerates before every iOS build (`ci.yml`), which is why `main`
 stays green while one laptop fails (`cave-bkp0o`).
 
-On first launch, enter your desktop's Tailscale MagicDNS name (e.g.
-`my-mac.tailnet.ts.net`) or its `100.x` address. `.ts.net` hosts use HTTPS; bare
-hosts/IPs default to `http://<host>:3000`.
-
-> The desktop must serve the mobile API tokenlessly over its Tailscale interface
-> (Phase 1b server change). Until that lands, point the app at a mock or a dev
-> server with the gate relaxed.
+On first launch, pair with the address and credential provided by your desktop.
+`.ts.net` MagicDNS hosts use HTTPS; bare hosts/IPs default to the packaged
+desktop's dedicated production port. An explicit URL can include a different
+port. Keep the desktop's access gate enabled.
 
 ## Layout
 
@@ -95,7 +110,7 @@ hosts/IPs default to `http://<host>:3000`.
 CovenCave/
   Models/        Familiar, SessionRow, ChatTurn, StreamEvent (SSE decoding),
                  PermissionModels (grants, proposals, effective access)
-  Networking/    CaveConnection (host/no-token), CaveClient (REST + SSE stream),
+  Networking/    CaveConnection (host/scoped credential), CaveClient (REST + SSE stream),
                  CaveClient+Permissions (grants console API)
   State/         AppModel (connection, familiars, threads), ChatThread (1:1 + group fan-out)
   Views/         Connection, ChatsHome, NewChat (group picker), Chat, MessageBubble,
@@ -109,12 +124,11 @@ Settings → **Familiar permissions** opens the same permissions console the
 desktop has: per-familiar project access (read/write, including "via group"
 levels inherited from access groups), the grant-request inbox (accept/reject
 with the 30-second undo window), and the recent allow/deny audit log. Each
-familiar's screen also has a key toolbar button scoped to just that familiar.
+familiar's access remains associated with its authoritative ID.
 
 Changing anything from the phone is **off by default**. The desktop's
-Settings → Phone section has two opt-ins — "Allow permission changes from
-phone" and "Allow file edits from phone" (the Code tab's Save) — and they can
-only be flipped on the desktop itself: the server refuses the toggles' PATCH
+Settings → Phone section has an "Allow permission changes from phone" opt-in,
+which can only be enabled on the desktop itself: the server refuses its PATCH
 from any non-loopback origin, so a phone (or anything else on the tailnet) can
 never widen its own authority. Until the opt-in is enabled the iOS console
 renders read-only with a banner pointing at the desktop setting.

--- a/docs/ios-current-direction.md
+++ b/docs/ios-current-direction.md
@@ -2,7 +2,7 @@
 
 Status: **canonical active direction**
 
-Last reconciled: 2026-09-04
+Last reconciled: 2026-09-12
 
 This page is the only iOS priority queue. Dated specifications, implementation
 plans, audits, handoff exports, and rebuild notes remain useful historical
@@ -14,16 +14,11 @@ Current authorities or Current priorities.
 1. [`coven-design-language.md`](coven-design-language.md) - tokens,
    accessibility, motion, copy, and interaction quality.
 2. This document - current native iOS product shape and priority order.
-3. [`specs/2026-09-04-ios-project-workspaces-direction.md`](specs/2026-09-04-ios-project-workspaces-direction.md)
-   - global Recent Chats, visible Project workspaces, local scope, object-owned
-   navigation, migration, and authority boundaries.
-4. [`specs/ios-new-chat-project-contract.md`](specs/ios-new-chat-project-contract.md)
+3. [`specs/ios-new-chat-project-contract.md`](specs/ios-new-chat-project-contract.md)
    - project-bound creation, persistence, retry, forwarding, voice, import, and
-   offline replay invariants. Its clauses requiring shell-project switching
-   before New Chat, global Familiar routing, thread opens, or task opens are
-   superseded by authority #3; #5297 must amend those clauses while preserving
-   explicit binding and fail-closed eligibility.
-5. [`design-handoff/IMPLEMENTATION-STATUS.md`](design-handoff/IMPLEMENTATION-STATUS.md)
+   offline replay invariants. Project choice belongs to a conversation, not
+   the application shell.
+4. [`design-handoff/IMPLEMENTATION-STATUS.md`](design-handoff/IMPLEMENTATION-STATUS.md)
    - evidence of what actually landed and what was deliberately not adopted.
 
 When these disagree with an older iOS note or plan, the order above wins.
@@ -31,40 +26,43 @@ When these disagree with an older iOS note or plan, the order above wins.
 The dated
 [`superpowers/specs/2026-08-03-ios-chat-familiars-first-design.md`](superpowers/specs/2026-08-03-ios-chat-familiars-first-design.md)
 remains implementation lineage for the current app. Its one-familiar-row Chats
-default is superseded by the project-workspaces direction. Pin, mute, archive,
+default is superseded by the chat-only direction. Pin, mute, archive,
 rename, duplicate, export, bulk delete, unread, session selection, exact
 Familiar identity, and one-visible-conversation behavior remain requirements
 until intentionally migrated by the active program.
 
 ## Current product direction
 
-- Chats opens to global Recent conversations. A conversation is the resumable
-  object; Familiar and Project identity stay visible on each row.
-- Projects are visible, directly navigable workspaces. A Project page groups
-  truthful existing chats, tasks, Familiars, and verified attention items
-  without becoming a new authority or database.
-- Chats, Tasks, Search, Familiars, and Needs You own explicit local scope.
-  Opening an object does not silently rescope unrelated surfaces.
-- A project explicitly confirmed after migration may become a visible default
-  for new work where it is current and unambiguous. The old persisted project
-  value is a display hint only because its operator/automatic provenance was
-  not stored. Neither value defines shell identity.
+- Native iOS is **chat-only**: conversations, chat search, familiar selection
+  within chat, permissions, and configuration that enables or customizes chat.
+- Chats opens to global conversations, including direct and group chats and
+  sessions started on other devices. Hydrated sessions appear once, not once
+  as a local thread and again as a server row. Pins, archive visibility, and
+  title/familiar search organize the list without a global project filter.
+- The drawer contains Chats, recent conversations, New chat, Search chats, and
+  Settings. There is no Tasks, Automations, Projects, Needs You, standalone
+  Familiar hub, workspace browser, global search, or terminal destination.
+- Familiar identity remains authoritative and visible in conversations and
+  participant selection; it is not an invitation to an operational hub.
+- A registered project is an exact conversation-level execution/access
+  binding. New chat can select eligible access locally; it never changes the
+  application's scope. Opening existing history preserves that chat's root,
+  session identity, participants, draft, and queued targets.
 - Cached history may remain readable while membership or authority data is
   loading, stale, degraded, disconnected, or unavailable. New sends and
   protected mutations remain fail-closed until exact current binding and grant
   data is known.
-- Unassigned is an explicit recovery-only collection, never a normal writable
-  project or new-work default.
-- Familiars remain first-class identity and operational hubs. Familiar
-  continuity, revision, embodiment, provenance, and authoritative IDs must not
-  be reconstructed from display name, prompt, avatar, or model.
-- The drawer remains the sole primary navigation surface. Its active program
-  adds a bounded Projects section and one All Projects destination; it does not
-  restore a bottom tab bar.
+- Unassigned remains a recovery-only classification inside history, never a
+  writable project, new-chat default, or separate workspace destination.
+- Familiar continuity, revision, embodiment, provenance, and authoritative IDs
+  must not be reconstructed from display name, prompt, avatar, or model.
+- Settings round trips and access-catalog refreshes do not remount Chats or
+  destroy its selection. iPhone launches to the list unless an explicit chat
+  intent is present; iPad keeps its list/detail layout.
 - The native iOS Terminal, PTY transport, xterm WebView, terminal composer,
   slash-command route, generated bundle, and tests remain retired. Desktop and
   web terminal surfaces are unaffected.
-- Chats, Tasks, and Settings retain one editorial title language while keeping
+- Chats and Settings retain one editorial title language while keeping
   the controls and navigation behavior specific to each destination.
 - Chats continues to protect conversation context at accessibility sizes and
   uses a floating Search/New Chat dock that compacts in landscape and caps its
@@ -72,9 +70,9 @@ until intentionally migrated by the active program.
   quality requirements.
 - Chats names the visible conversation count for its current organization and
   scope, and offers only truthful shortcuts when the list is sparse.
-- Settings continues to present Community as one icon row and Connection status
-  plus re-check as one row. Legal links keep the same concise icon-shelf
-  pattern.
+- Settings contains appearance, permissions, connection, security, chat
+  notifications/export, and legal information. Promotional/community browsing
+  is outside the mobile chat surface.
 - The open drawer preserves spatial context by presenting the live destination
   as a rounded, offset page.
 - Theme values come from `ChromePalette`; Dynamic Type, VoiceOver, Reduce
@@ -83,41 +81,29 @@ until intentionally migrated by the active program.
 
 ## Active program
 
-OpenCoven/coven-cave#5290 replaces ambient project mode with Project workspaces
-and global feeds. Its phase gates are authoritative:
+`cave-iusli` owns this chat-only implementation. The maintainer explicitly
+approved replacing the workspace roadmap, recorded on
+[#5290](https://github.com/OpenCoven/coven-cave/issues/5290#issuecomment-5644986219).
+This supersedes the product expansion in #5290, including project workspaces,
+Tasks, Needs You, and operational Familiar hubs. `cave-quv9h`'s native
+Automations destination conflicts with this boundary and must not be added.
 
-1. **Direction and baseline**
-   - #5291 ratifies information architecture and authority boundaries.
-   - #5292 captures pre-change Release physical-device evidence and budgets.
-2. **Fast state foundation**
-   - #5293 builds the immutable, disposable Cave read projection and removes
-     project-keyed destination remounts.
-   - #5294 migrates current rows/counts to the projection and makes Search
-     cancellable.
-3. **Global Chats and Project workspaces**
-   - #5295 makes global Recent Chats the default.
-   - #5296 adds the bounded drawer Projects section, All Projects, and project
-     workspace pages.
-   - #5297 replaces ambient scope with surface-local filters and exact
-     object-owned navigation while preserving fail-closed writes.
-4. **OpenCoven integration and closeout**
-   - #5298 integrates cross-project Familiar and verifiable Needs You views.
-   - #5299 closes physical-device, accessibility, migration, rollback, and R4
-     authority gates.
-
-Later phases remain blocked until their listed dependencies have merged and
-their Beads/worktrees satisfy the repository lifecycle.
+The dated project-workspaces specification remains historical evidence, not a
+second active roadmap. Its useful requirements for exact object ownership,
+cached reads, fail-closed writes, migration, accessibility, and physical-device
+performance remain applicable. Superseding that roadmap does not constitute
+passing its device baselines, authorization exercises, or release gates.
 
 ## Current priorities
 
-1. Complete #5291 and #5292 without beginning implementation behind either
-   phase gate.
+1. Complete the chat-only shell and conversation list on `cave-iusli`, retiring
+   non-chat navigation and external entrypoints rather than hiding them.
 2. Preserve reliability, pairing, honest failure states, draft durability,
-   queued-target immutability, and existing task/chat/project contracts.
-3. Build one projection and one canonical project browser; do not create
-   per-view caches or parallel workspace implementations.
-4. Remove hidden global-rescope side effects only in the R4 integration phase,
-   with upgrade, deep-link, offline replay, and real authorization evidence.
+   queued-target immutability, and exact chat/project authorization contracts.
+3. Use one disposable list projection for local/server deduplication, counts,
+   sorting, and chat search; do not scan full transcripts to organize every row.
+4. Keep New chat/import choice local and revalidate participants and access
+   before creation. Reject retired task links without loading task surfaces.
 5. Improve information density only with truthful operator context; do not
    invent attention, activity, status, progress, membership, or backend
    capability.
@@ -129,8 +115,8 @@ their Beads/worktrees satisfy the repository lifecycle.
 - No desktop/web redesign in this program.
 - No new project, chat, session, task, Familiar, or attention authority.
 - No chat project-binding move.
-- No project creation, deletion, re-rooting, access administration, or Git
-  management UI.
+- No project browser, project creation/deletion/re-rooting, or Git management UI.
+  Permissions needed for chat remain available.
 - No inferred urgency or model-generated Needs You eligibility.
 - No simulator timing represented as physical-device percentile evidence.
 - No release or TestFlight publication authorization.
@@ -143,6 +129,6 @@ their Beads/worktrees satisfy the repository lifecycle.
   old plan merely because they remain in the file.
 - A historical document becomes active again only when this page names it under
   Current priorities and a current Bead defines the remaining work.
-- Contradictory terminal, bottom-tab, ambient-project, familiars-first default,
-  unified-recents-without-project-binding, or tokenless-auth plans are
+- Contradictory workspace expansion, terminal, bottom-tab, ambient-project,
+  familiars-first default, unified-recents-without-project-binding, or tokenless-auth plans are
   explicitly superseded.

--- a/docs/specs/2026-09-04-ios-project-workspaces-direction.md
+++ b/docs/specs/2026-09-04-ios-project-workspaces-direction.md
@@ -1,6 +1,14 @@
 # Native iOS project workspaces direction
 
-Status: **approved direction for implementation**
+Status: **historical; workspace expansion superseded**
+
+The maintainer replaced this roadmap with the chat-only direction on
+2026-09-12 (`cave-iusli`). See
+[`../ios-current-direction.md`](../ios-current-direction.md) for the current
+authority. The original decision below is retained as historical evidence;
+its Tasks, Projects, Needs You, and operational Familiar destinations no
+longer authorize implementation. Exact conversation ownership, fail-closed
+writes, cached reads, migration, and real-device quality requirements remain.
 
 Date: 2026-09-04
 

--- a/docs/specs/ios-new-chat-project-contract.md
+++ b/docs/specs/ios-new-chat-project-contract.md
@@ -102,6 +102,21 @@ from its persisted root. Existing resumed sessions also send the root when it
 is known; the server's persisted conversation provenance remains
 authoritative.
 
+Queued turns also persist the project root, original recipients, and any
+already-established session IDs captured at composition. Reconnect must not
+retarget them to a replacement project or conversation. Older queued snapshots
+freeze recipients from the saved explicit list, delivery IDs, or saved roster,
+and capture their saved thread binding during restoration, before server
+metadata can reconcile the thread. A saved unknown root remains unknown; it cannot
+silently inherit later recovered access. Initially absent session IDs may become
+established normally. A refused turn keeps its content and delivery markers;
+the user can restore the original access or copy it into an explicitly selected
+new chat.
+
+A per-recipient refusal, including the last pre-POST check, leaves that recipient
+pending without withholding delivery to other permitted original recipients.
+Cancellation or loss of the connection lease still stops the whole replay.
+
 `ChatThread` rejects a network send locally when a new thread has no project.
 It does not append a user turn or create streaming placeholders in that state.
 This invariant protects any future constructor that bypasses the visible
@@ -124,34 +139,29 @@ new-chat and in-thread recovery flows.
 
 ### New Chat
 
-`NewChatView` keeps its familiar-first direct/group flow, but normal creation
-is now fixed to the shell's active registered project:
+`NewChatView` keeps its familiar-first direct/group flow. The project/access
+selection is local to the new conversation, never the shell:
 
-- the Project section shows the active project name and root, with copy that a
-  different root requires switching projects in Chats first;
-- the familiar roster comes only from `app.projectFamiliars`, so every new
-  chat participant already belongs to the active project context;
-- Markdown import captures the active project ID/root plus the explicit
-  familiar roster before presenting the document picker, then revalidates that
-  same context on callback; if the app switched projects, fell back to
-  Unassigned, or revoked any selected familiar while the picker was open, the
-  import aborts with actionable guidance instead of silently restoring under a
-  different roster or root;
-- Start/Create stays disabled when the active project is unavailable, when the
-  selected familiar leaves the active project, or when an Unassigned recovery
-  context is on screen.
+- the roster uses exact familiar IDs, independently of a legacy global filter;
+- the access choice contains only registered projects currently available to
+  every selected participant; changing participants revalidates that choice;
+- Markdown import captures the local project ID/root and explicit participant
+  roster before presenting the document picker, then revalidates the same
+  binding and current grants on callback; revoked access or changed selections
+  abort with actionable guidance rather than importing under another root;
+- Start/Create stays disabled while access is unknown, failed, revoked, or
+  empty. A stale global project selection is neither a default authority nor
+  a reason to hide the sheet.
 
-Unassigned is recovery-only. It still lists legacy projectless or
-unregistered-root chats, but it does not offer a normal New Chat flow.
-Actionable guidance tells the operator to refresh Chats or switch to a
-registered project instead.
+Unassigned remains recovery-only. A replacement uses the ordinary New chat
+flow with an explicit eligible binding; the old conversation is not rebound.
 
 ### Alternate entry points
 
 Every thread-creation path is explicit:
 
-- the Chats new-chat sheet passes the active registered root;
-- direct familiar shortcuts open the same fixed-root new-chat flow instead of
+- the Chats new-chat sheet passes its locally selected eligible root;
+- direct familiar shortcuts open the same locally scoped new-chat flow instead of
   creating a projectless thread;
 - familiar landing shortcuts outside `/new` (drawer roster, project-scoped
   familiar lists, slash-command switching, forwarding) reuse the local landing
@@ -161,14 +171,10 @@ Every thread-creation path is explicit:
   history reload waits for a confirmed successful send so queued, failed,
   cancelled, or otherwise unacknowledged local forward bubbles are never
   replaced; Unassigned never synthesizes a new landing chat;
-- global search familiar results resolve the familiar's global landing
-  conversation across every known context: prefer the most recent eligible
-  local landing thread, otherwise the newest server-only session, then route
-  through the canonical thread-open helper so the app switches into that
-  conversation's owning project or Unassigned before opening; only a familiar
-  that belongs to the current active registered project may synthesize a fresh
-  chat from global search, and every other no-history case surfaces actionable
-  guidance instead;
+- chat search resolves existing conversations across known contexts without
+  changing application scope. Familiar shortcuts reuse exact existing history
+  or open participant/access selection; they do not synthesize projectless
+  conversations;
 - the in-chat session picker passes the visible thread's explicit project
   context into `FamiliarThreadsView`, so its local rows, server-only rows,
   unread clears, counts, search, and replacement-chat affordances stay scoped
@@ -181,45 +187,34 @@ Every thread-creation path is explicit:
   returns a `sessionId`; chats whose root is missing, invalid, or Unassigned
   hide the call action and continue to surface project-recovery guidance
   instead of attempting a nil-root call;
-- every thread-open path (deep links, drawer recents, global search, task
-  chat opens, familiar landing, forwarding destinations, session switching)
+- every thread-open path (deep links, drawer recents, chat search,
+  familiar landing, forwarding destinations, session switching)
   resolves the thread root through the current registered-project resolver,
-  switches the app into that canonical project or Unassigned before
-  publishing the open intent, and surfaces actionable recovery guidance
-  instead of silently opening under the wrong project when metadata is
+  preserves the exact conversation binding when publishing the open intent,
+  and surfaces actionable recovery guidance instead of silently rebinding when metadata is
   malformed; ChatsHome and the in-chat session picker both validate the
   selected local or materialized server thread before presenting `ChatView`,
   and malformed dot-segment roots stay visible only as Unassigned recovery
   rows for inspect/export/delete flows;
-- group creation passes the active root;
-- `/new` starts in the active project only when every carried familiar still
-  belongs to that project; otherwise it blocks with actionable recovery
-  guidance rather than creating an invalid roster;
+- group creation passes its locally selected root;
+- `/new` preserves the current conversation's exact participants and eligible
+  root, or opens local selection when a fresh choice is required;
 - legacy projectless sessions offer a replacement-chat path rather than
   silently adopting the current project, and that replacement path applies the
   same roster validation as `/new`;
 - server-session materialization imports `project_root`;
 - session refresh backfills authoritative `project_root` values into restored
   local threads that already know a `sessionId`, so legacy snapshots leave
-  Unassigned as soon as the server can prove their root again — even when
-  task history fails — unless the operator explicitly selected Unassigned;
-- task entry points keep existing server-session `project_root` values, fetch
-  or reuse the authoritative session list before materializing a linked
-  session, prefer the server session's `familiarId` over any stale task or
-  caller fallback when rebuilding a local thread, only downgrade an existing
-  local copy to recovery-only after the linked session is confirmed missing or
-  confirmed projectless, preserve the local copy unchanged on transient linked
-  session load failures, and an unlinked task without a server session starts
-  in that task's registered project root after the app switches into the
-  matching project context;
-- Unassigned, deleted-project, or access-denied task launches block with
-  recovery guidance instead of creating a projectless thread.
+  recovery-only classification as soon as the server can prove their root
+  again; a failed refresh cannot silently replace a cached binding;
+- task entrypoints are retired on native iOS. Legacy task URLs, commands,
+  widgets, and intents must not hydrate a task or expose an operational
+  destination. This does not remove task functionality from desktop or web.
 
-Project/grants/familiars remain the fail-closed bootstrap boundary. Session
-and task history only help choose the default project context: if those
-best-effort history reads fail, iOS keeps the restored or alphabetical
-registered-project fallback and surfaces the stale/error signal without
-dropping back to the project-context gate.
+Project/grants/familiars remain the fail-closed write boundary, not the
+application's read/navigation boundary. Failed catalog or session refreshes
+surface honest errors while cached chats, Settings, and permission recovery
+remain reachable.
 
 `ChatView` also guards legacy or externally materialized projectless threads.
 Before the first send it loads projects for the thread's participants, selects
@@ -274,15 +269,10 @@ Add behavior tests that prove:
    behavior for malformed or oversized bodies.
 7. A project launch error before session creation reopens selection; a normal
    transport error does not.
-8. Task chat entry points use the task's registered root for direct and
-   familiar-picker launches, block Unassigned/deleted/inaccessible tasks, keep
-   mismatched server sessions on the server-authored root, and rebuild stale
-   local task threads with the server-authored familiar/session binding;
-   concurrent opens of the same authoritative task session still collapse onto
-   one repaired local thread and one stable task↔thread link; a confirmed
-   missing linked session or missing `project_root` may downgrade an existing
-   local copy to recovery-only, but a transient session-load failure must leave
-   any existing local thread unchanged.
+8. Retired task entrypoints are rejected before loading tasks or publishing
+   task navigation. Existing chat/session links preserve their exact
+   server-authored root and familiar identity without changing global scope;
+   a transient session-load failure leaves existing local history unchanged.
 9. Forwarding a just-materialized server-only landing chat reloads history only
    after an acknowledged send, while queued, failed, cancelled, and
    unacknowledged attempts preserve the local transcript.
@@ -293,10 +283,7 @@ Add behavior tests that prove:
     or `.done` arrives so a hangup mid-reply still resumes the same session;
     once the operator hangs up, late assistant transcript/audio/state updates
     stay suppressed even if that binding lands afterward;
-    when that first bound session belongs to a task-linked thread, iOS PATCHes
-    the card's `sessionId` immediately instead of waiting for a later text
-    reply; no production first-turn voice `SendBody` hardcodes
-    `projectRoot: nil`.
+    no production first-turn voice `SendBody` hardcodes `projectRoot: nil`.
 
 ### Linux CI contract
 

--- a/docs/workflows/testflight-receipt.md
+++ b/docs/workflows/testflight-receipt.md
@@ -22,6 +22,13 @@ in memory. Each five-minute ES256 JWT is scoped to one GET request. Neither
 tokens nor keys are printed, written to disk, or included in artifacts.
 Do not retrieve CI secrets or use local keys to work around authorization errors.
 
+The key ID is a bounded identifier, not a fixed ten-character value: Apple's
+JWT documentation gives an example, not a length requirement. The receipt
+preserves the configured ID and accepts 1-128 ASCII letters, digits, underscores,
+or hyphens; Apple remains responsible for authenticating that ID and signature.
+`INVALID_KEY_ID` is a local configuration failure before any Apple request,
+not an Apple authorization denial or a statement about build availability.
+
 The job summary and `testflight-receipt` JSON artifact (90-day retention) contain
 query timestamps, exact selectors, resource IDs, processing and beta states,
 assigned group IDs/types, and tester counts. Tester membership is read using the

--- a/scripts/ios-auto-reconnect.test.mjs
+++ b/scripts/ios-auto-reconnect.test.mjs
@@ -156,18 +156,23 @@ assert.match(
 );
 assert.match(
   model,
-  /func persistThreadsBeforeDispatch\(for lease: ConnectionDispatchLease\) async -> Bool \{[\s\S]{0,160}guard connectionDispatchLeaseIsCurrent\(lease\) else \{ return false \}[\s\S]{0,160}let persisted = await flushThreadsAndWait\(\)[\s\S]{0,120}return persisted && connectionDispatchLeaseIsCurrent\(lease\)/,
-  "checkpoint persistence must prove the same endpoint epoch before and after disk suspension",
+  /func persistThreadsBeforeDispatch\(for lease: ConnectionDispatchLease\) async -> Bool \{[\s\S]{0,160}guard connectionDispatchLeaseIsCurrent\(lease\),\s*requireCurrentChatAccess\(\) else \{ return false \}[\s\S]{0,160}let persisted = await flushThreadsAndWait\(\)[\s\S]{0,120}return persisted && connectionDispatchLeaseIsCurrent\(lease\) && requireCurrentChatAccess\(\)/,
+  "checkpoint persistence must prove the endpoint epoch and current chat access before and after disk suspension",
 );
 assert.equal(
   (chatView.match(/let dispatchLease = app\.captureConnectionDispatchLease\(\)/g) ?? []).length,
-  5,
-  "every live prose, suggestion, command, diagram, and forward send captures an endpoint lease",
+  7,
+  "the five live send paths, retry, and voice each capture an endpoint lease",
 );
 assert.equal(
-  (chatView.match(/liveDispatchLeaseIsCurrent: \{\s*app\.connectionDispatchLeaseIsCurrent\(dispatchLease\)\s*\}/g) ?? []).length,
-  5,
-  "every live send passes its lease into each fan-out child",
+  (chatView.match(/liveDispatchLeaseIsCurrent: \{\s*dispatchIsCurrent\((?:dispatchBinding|destinationBinding), in: (?:thread|destination), lease: dispatchLease\)\s*\}/g) ?? []).length,
+  6,
+  "every live send and retry passes its frozen target and endpoint through transport preflight",
+);
+assert.match(
+  chatView,
+  /private func dispatchIsCurrent\([\s\S]*?app\.connectionDispatchLeaseIsCurrent\(lease\)[\s\S]*?binding\.matches\(target\)[\s\S]*?app\.chatAccessIsCurrent\(projectRoot: binding\.projectRoot, familiarIds: binding\.familiarIds\)/,
+  "dispatch requires the exact frozen conversation and recipient grants, not just loaded catalogs",
 );
 assert.equal(
   (chatView.match(/persistBeforeDispatch: \{\s*await app\.persistThreadsBeforeDispatch\(for: dispatchLease\)\s*\}/g) ?? []).length,
@@ -208,7 +213,7 @@ const deferredSend = deferredSendStart >= 0 && deferredSendEnd > deferredSendSta
 const deferredPreflight = deferredSend.indexOf("guard preflight() else");
 const deferredRequest = deferredSend.indexOf('var req = try request("api/chat/send"');
 const deferredStarted = deferredSend.indexOf("onRequestStarted()");
-const deferredURLSession = deferredSend.indexOf("Self.streamSession.bytes(for: req)");
+const deferredURLSession = deferredSend.indexOf("(injectedSession ?? Self.streamSession).bytes(for: req)");
 assert.ok(
   deferredSend.includes("let task = Task { @MainActor in")
     && deferredPreflight >= 0
@@ -234,7 +239,7 @@ assert.match(
 );
 assert.match(
   chatView,
-  /private func forward\([\s\S]{0,260}guard let client = app\.client else \{ return \}\s*\n\s*let dispatchLease = app\.captureConnectionDispatchLease\(\)[\s\S]*?Task \{ @MainActor in[\s\S]*?destination\.send\([\s\S]*?liveDispatchLeaseIsCurrent:[\s\S]*?dispatchLease[\s\S]*?client: client/,
+  /private func forward\([\s\S]{0,260}guard let client = app\.client else \{ return \}\s*guard requireChatAccess\(\) else \{ return \}\s*guard app\.requireCurrentChatAccess\(projectRoot: thread\.projectRoot, familiarIds: \[familiar\.id\]\)\s*else \{ return \}\s*let dispatchLease = app\.captureConnectionDispatchLease\(\)[\s\S]*?Task \{ @MainActor in[\s\S]*?destination\.send\([\s\S]*?liveDispatchLeaseIsCurrent:[\s\S]*?dispatchLease[\s\S]*?client: client/,
   "forwarding must capture its CaveClient and matching epoch lease in the same actor turn before deferring work",
 );
 const queueFlushStart = model.indexOf("func flushQueuedMessages()");
@@ -265,10 +270,10 @@ assert.ok(
   replayImplementation.includes("dispatchLeaseIsCurrent: @escaping () -> Bool")
     && replayStream >= 0
     && replayImplementation.indexOf(
-      "liveDispatchLeaseIsCurrent: dispatchLeaseIsCurrent",
+      "liveDispatchLeaseIsCurrent: mayDispatchTarget",
       replayStream,
     ) > replayStream,
-  "fresh queued runs must not fall back to an unconditional deferred send preflight",
+  "fresh queued runs must carry both endpoint and exact-target authority into deferred send preflight",
 );
 
 console.log("ios-auto-reconnect: OK");

--- a/scripts/ios-chat-entrypoints.test.mjs
+++ b/scripts/ios-chat-entrypoints.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import test from "node:test";
+
+const ios = new URL("../apps/ios/CovenCave/", import.meta.url);
+const read = (path) => readFileSync(new URL(path, ios), "utf8");
+
+test("chat keeps conversation controls but no task or marketplace entrypoints", () => {
+  const chat = read("CovenCave/Views/ChatView.swift");
+  for (const retired of [
+    "showTasks", "LinkedTasksSheet", "linkedContextStrip", "app.tasks",
+    "app.loadTasks", "app.reconcileCardLinks", "PluginsPanel",
+  ]) {
+    assert.ok(!chat.includes(retired), `${retired} is retired from chat`);
+  }
+  for (const retained of [
+    "ModelPickerSheet(", "FamiliarPermissionsSheet(", "LiveVoiceCallView(",
+    "FamiliarPickerSheet(", "FamiliarThreadsView(", "attachmentPreviews",
+    "flushDraftPersistence()", "retryAssistant(", "modelMutationQueue",
+    "persistThreadsBeforeDispatch", "connectionDispatchLeaseIsCurrent",
+  ]) {
+    assert.ok(chat.includes(retained), `${retained} remains part of chat`);
+  }
+  assert.doesNotMatch(chat, /startFreshThreadInActiveProject|app\.activeProject|app\.canStartProjectChats/,
+    "new and replacement chats cannot inherit ambient workspace access");
+  assert.match(chat, /NewChatView\(initialFamiliarIds: thread\.familiarIds\)/,
+    "new and replacement chats reuse the explicit per-chat access workflow");
+});
+
+test("Siri and Spotlight offer chats, with side-effect-free legacy responses", () => {
+  const intents = read("CovenCave/Intents/CaveAppIntents.swift");
+  const offered = intents.slice(intents.indexOf("struct CaveShortcuts"));
+  assert.match(offered, /intent: OpenChatsIntent\(\)/);
+  assert.doesNotMatch(offered, /NewReminderIntent|RunningTasksIntent/);
+  for (const name of ["NewReminderIntent", "RunningTasksIntent"]) {
+    const legacy = intents.match(new RegExp(`struct ${name}: AppIntent \\{([\\s\\S]*?)(?=\\nstruct |\\n\\/\\/\\/|$)`))?.[1];
+    assert.ok(legacy, `${name} stays resolvable for saved shortcuts`);
+    assert.match(legacy, /static var isDiscoverable: Bool = false/);
+    assert.match(legacy, /\.result\(dialog: "[^"]*desktop/);
+    assert.doesNotMatch(legacy, /CaveClient|createReminder|\.tasks\(\)|OpenURLIntent/);
+  }
+});
+
+test("widgets and Control Center offer only chat destinations", () => {
+  const widgets = read("CovenCaveWidgets/CovenCaveWidgets.swift");
+  const controls = read("CovenCaveWidgets/CovenCaveControls.swift");
+  assert.match(widgets, /ChatLiveActivity\(\)/);
+  assert.match(widgets, /ChatsControl\(\)/);
+  assert.match(widgets, /covencave:\/\/thread\//);
+  assert.match(controls, /covencave:\/\/chats/);
+  assert.doesNotMatch(widgets + controls, /TaskLiveActivity|TasksControl|runningTaskCount|covencave:\/\/(?:task|reminder|automation)/);
+});
+
+test("retired reminder alerts are cleared without touching chat alerts or backend data", () => {
+  const reminders = read("CovenCave/Notifications/ReminderNotifications.swift");
+  const chat = read("CovenCave/Notifications/ChatNotifications.swift");
+  assert.match(reminders, /override init\(\)[\s\S]{0,100}Task \{ await ReminderNotifications\.clear\(\) \}/);
+  assert.match(reminders, /static func sync\(_: \[Reminder\]\) async \{\s*await clear\(\)/);
+  assert.match(reminders, /identifier\.hasPrefix\(idPrefix\)/);
+  assert.match(reminders, /idPrefix = "cave\.reminder\."/);
+  assert.match(reminders, /removePendingNotificationRequests\(withIdentifiers: ours\)/);
+  assert.match(reminders, /removeDeliveredNotifications\(withIdentifiers: retired\)/);
+  assert.match(reminders, /willPresent notification:[\s\S]{0,220}isRetiredRequest/);
+  assert.doesNotMatch(reminders, /UNCalendarNotificationTrigger|center\.add\(|center\.requestAuthorization|removeAll|CaveClient|destination: \.tasks/);
+  assert.match(chat, /requestAuthorization\(options: \[\.alert, \.sound, \.badge\]\)/);
+  assert.match(chat, /center\.add\(request\)/);
+});
+
+test("native quick actions and notification categories cannot advertise retired destinations", () => {
+  function swiftSources(directory) {
+    return readdirSync(new URL(directory, ios), { withFileTypes: true }).flatMap((entry) => {
+      const path = `${directory}/${entry.name}`;
+      return entry.isDirectory() ? swiftSources(path) : path.endsWith(".swift") ? [read(path)] : [];
+    });
+  }
+  const source = swiftSources("CovenCave").join("\n");
+  const plist = read("CovenCave/Info.plist");
+  assert.doesNotMatch(plist, /UIApplicationShortcutItems/);
+  assert.doesNotMatch(source, /UIApplicationShortcutItem\s*\(|UNNotificationCategory\s*\(/,
+    "adding native quick actions or categories requires an explicit chat-only contract");
+});
+
+test("chat UI scenarios explicitly open their fixture instead of assuming chat-first boot", () => {
+  const activity = read("CovenCaveUITests/AgentActivityUITests.swift");
+  const sessions = read("CovenCaveUITests/SessionSwitchUITests.swift");
+  assert.match(activity, /launchEnvironment\["CAVE_OPEN_THREAD"\] = "ui-preview-tool-activity"/);
+  assert.match(sessions, /launchEnvironment\["CAVE_OPEN_THREAD"\] = "ui-preview-empty-chat"/);
+  for (const scenario of [
+    "testComposerOffersChatActionsWithoutTaskOrMarketplaceManagement",
+    "testCommandReferenceDoesNotOfferRetiredTaskNavigation",
+    "testTypedLegacyTaskCommandExplainsDesktopOnlyAndKeepsTheChat",
+  ]) {
+    assert.match(sessions, new RegExp(`func ${scenario}\\(\\) \\{\\s*let app = launchInFirstThread\\((?:clearDraft: true)?\\)`));
+  }
+});
+
+test("readable chat history does not authorize sends while project access is unavailable", () => {
+  const chat = read("CovenCave/Views/ChatView.swift");
+  const commands = read("CovenCave/Models/SlashCommand.swift");
+  const app = read("CovenCave/State/AppModel.swift");
+  assert.match(app, /var chatAccessIsCurrent: Bool \{\s*projectsLoaded && projectMembershipLoaded && projectContextError == nil/);
+  assert.match(chat, /private var chatAccessLoaded: Bool \{\s*app\.chatAccessIsCurrent\(projectRoot: thread\.projectRoot, familiarIds: thread\.familiarIds\)/);
+  assert.match(chat, /private func requireChatAccess\(\) -> Bool \{\s*app\.requireCurrentChatAccess\(projectRoot: thread\.projectRoot, familiarIds: thread\.familiarIds\)/);
+  assert.match(chat, /if !chatAccessLoaded \{[\s\S]{0,350}Button\("Refresh access"\)/);
+  assert.match(chat, /private var voiceCallLaunch:[\s\S]{0,350}guard chatAccessLoaded else \{ return nil \}/);
+  assert.match(chat, /return chatAccessLoaded && thread\.canSendMessages/);
+  assert.match(chat, /case \.prose\(let text\):[\s\S]{0,160}guard requireChatAccess\(\) else \{ return \}/,
+    "ordinary sends check access before clearing drafts or attachments");
+  for (const name of ["sendSuggestion", "startDiagram", "forward"]) {
+    const body = chat.slice(chat.indexOf(`private func ${name}(`));
+    assert.match(body.slice(0, 700), /guard requireChatAccess\(\) else \{ return \}/,
+      `${name} checks current access before initiating a message write`);
+  }
+  assert.match(chat, /private func retryAssistant[\s\S]{0,550}app\.requireCurrentChatAccess\(projectRoot: thread\.projectRoot, familiarIds: \[familiarId\]\)/,
+    "retry authorizes the selected reply's recipient rather than an ambient roster");
+  const lateChecks = [...chat.matchAll(/liveDispatchLeaseIsCurrent: \{([\s\S]*?)\}/g)];
+  assert.equal(lateChecks.length, 6);
+  for (const [, check] of lateChecks) {
+    assert.match(check, /dispatchIsCurrent\((?:dispatchBinding|destinationBinding), in: (?:thread|destination), lease: dispatchLease\)/,
+      "the captured endpoint, root and recipients are rechecked at the actual dispatch");
+  }
+  assert.match(chat, /private func dispatchIsCurrent[\s\S]{0,600}connectionDispatchLeaseIsCurrent\(lease\)[\s\S]*binding\.matches\(target\)[\s\S]*app\.chatAccessIsCurrent\(projectRoot: binding\.projectRoot, familiarIds: binding\.familiarIds\)/);
+  assert.match(commands, /case \.sendAsPrompt, \.startDiagram: return true/);
+  assert.match(chat, /if command\.sendsChatMessage \{\s*guard requireChatAccess\(\)/,
+    "typed message commands keep the draft intact when authorization is unavailable");
+  assert.match(chat, /if case \.command\(let command, _\) = SlashInput\.parse\(draft\), !command\.sendsChatMessage \{\s*return true/,
+    "local navigation and desktop-only explanations remain usable");
+});
+
+test("voice retains one captured presentation and permanently ends it on authority loss", () => {
+  const chat = read("CovenCave/Views/ChatView.swift");
+  const view = read("CovenCave/Views/Voice/LiveVoiceCallView.swift");
+  const model = read("CovenCave/Views/Voice/LiveVoiceCallModel.swift");
+  const sender = read("CovenCave/Views/Voice/CaveVoiceTurnSender.swift");
+  const coordinator = read("CovenCave/Voice/VoiceCallCoordinator.swift");
+  const realtime = read("CovenCave/Voice/OpenAIRealtimeTransport.swift");
+  assert.match(chat, /@State private var voiceCall: LiveVoiceCallModel\?/);
+  assert.match(chat, /\.fullScreenCover\(item: \$voiceCall\) \{ model in\s*LiveVoiceCallView\(model: model\)/);
+  assert.doesNotMatch(chat, /showVoiceCall/);
+  assert.match(chat, /private func beginVoiceCall[\s\S]*let callThread = thread[\s\S]*captureConnectionDispatchLease\(\)[\s\S]*LiveVoiceCallModel\([\s\S]*client: client,[\s\S]*authorityIsCurrent: \{[\s\S]*dispatchIsCurrent\(binding, in: callThread, lease: dispatchLease\)[\s\S]*binding\.matches\(callThread, includingSessions: true\)/);
+  assert.match(view, /init\(model: LiveVoiceCallModel\)/);
+  assert.doesNotMatch(view, /LiveVoiceCallModel\(/);
+  assert.match(view, /onChange\(of: model\.authorityIsCurrent, initial: true\)[\s\S]*model\.refreshAuthority\(\)/);
+  assert.match(view, /\.onDisappear \{ model\.end\(\) \}/);
+  assert.match(model, /func start\(\) async \{\s*guard !hasStarted, !hasEnded, refreshAuthority\(\)/);
+  assert.match(model, /func refreshAuthority\(\) -> Bool \{[\s\S]*guard !authorityRevoked[\s\S]*authorityRevoked = true[\s\S]*end\(\)[\s\S]*VoiceCallCopy\.authorityChanged/);
+  assert.match(model, /realtimeSessionID\(client: client, projectRoot: projectRoot\)\s*guard canContinueLaunch\(generation\)/);
+  assert.match(model, /client\.mintVoiceSession\([\s\S]*?\)\s*guard canContinueLaunch\(generation\)/);
+  assert.match(sender, /client\.sendStream\(\s*body,\s*preflight: liveDispatchLeaseIsCurrent/);
+  assert.match(coordinator, /await mediaSession\.prepare\([^\n]*\)\s*guard liveAuthorityIsCurrent\(\), !state\.phase\.isTerminal/);
+  assert.match(realtime, /private func sendOffer[^\n]*\{\s*try requireActiveAuthority\(\)/);
+  const tests = read("CovenCaveTests/LiveVoiceCallModelTests.swift");
+  for (const scenario of [
+    "testStablePresentationStartsOnceAndDismissalCleansUpIdempotently",
+    "testAuthorityRecoveryNeverRestartsARevokedPresentation",
+    "testAuthorityIsRecheckedAfterSuspendedMicrophonePermission",
+    "testDismissalDuringTransportStartupStopsLateActivation",
+    "testRevocationDuringSessionCreationCleansUpWithoutMintingOrStarting",
+    "testEndDuringGrantMintingCannotStartALateTransport",
+  ]) {
+    assert.ok(tests.includes(`func ${scenario}(`), `native voice scenario ${scenario} is present`);
+  }
+});

--- a/scripts/ios-chat-familiars-home.test.mjs
+++ b/scripts/ios-chat-familiars-home.test.mjs
@@ -1,241 +1,75 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-// Familiars-first Chats home (cave-ru7ay): the home lists familiars, tapping
-// one opens its chat, and session selection lives in the config popover.
-const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
-const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
-const familiarThreads = await read("apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift");
-const familiarList = await read("apps/ios/CovenCave/CovenCave/Views/FamiliarsListView.swift");
+// The familiars-first home is intentionally migrated to individual global
+// conversations. Exact participant identity and the in-chat session picker stay.
+const read = (p) => readFile(new URL(`../apps/ios/CovenCave/CovenCave/${p}`, import.meta.url), "utf8");
+const model = await read("State/AppModel.swift");
+const familiarThreads = await read("Views/FamiliarThreadsView.swift");
+const home = await read("Views/ChatsHomeView.swift");
+const chat = await read("Views/ChatView.swift");
+const projection = await read("State/ChatListSnapshot.swift");
 
-// --- The project-scoped familiar chat helpers -------------------------------
-// Tapping a familiar should only consider the active project's direct/server
-// activity.
-assert.match(
-  model,
-  /func directThreads\(for familiarId: String, in context: ProjectContext\) -> \[ChatThread\]/,
-  "AppModel's direct-thread helpers must consume an explicit project context",
-);
-assert.match(
-  model,
-  /func landingDirectThread\(for familiarId: String, in context: ProjectContext\) -> ChatThread\?/,
-  "AppModel's landing-thread helper must consume an explicit project context",
-);
-assert.match(
-  model,
-  /func projectLandingDirectThread[\s\S]{0,320}?landingDirectThread\(for: familiarId, in: projectContext\)/,
-  "the active-project landing thread must delegate to the context-aware helper",
-);
-assert.match(
-  model,
-  /func serverOnlySessions\(for familiarId: String, in context: ProjectContext\) -> \[SessionRow\]/,
-  "server-only session helpers must consume an explicit project context",
-);
-assert.match(
-  model,
-  /func globalServerOnlySessions\(for familiarId: String\) -> \[SessionRow\]/,
-  "everywhere search keeps an explicit global server-only helper",
-);
-assert.match(
-  model,
-  /func projectRecentThreads\(limit: Int = 5\) -> \[ChatThread\]/,
-  "AppModel exposes project-scoped recents for the drawer",
-);
-assert.match(
-  model,
-  /func validatedOpenContext\(for thread: ChatThread\) -> ProjectContext\?[\s\S]*func canOpen\(_ thread: ChatThread\) -> Bool/,
-  "AppModel must expose a pure thread-open validation helper",
-);
-assert.match(
-  model,
-  /func threadOpenFailure\(for thread: ChatThread\) -> ThreadOpenFailure\?/,
-  "AppModel must expose thread-open failures for recovery UI",
-);
-assert.match(
-  model,
-  /var projectMostRecentThread: ChatThread\?/,
-  "AppModel exposes the most recent visible project thread",
-);
-assert.match(
-  familiarList,
-  /struct FamiliarsListPresentation[\s\S]*visibleFamiliars = app\.projectFamiliars/,
-  "FamiliarsListView should always derive its roster from the active project's familiar membership",
-);
-assert.match(
-  familiarList,
-  /showsCachedAccessBanner = app\.projectMembershipLoaded && app\.familiarsError != nil/,
-  "cached membership refresh failures should surface a stale-data banner instead of falling back globally",
-);
-assert.match(
-  familiarList,
-  /"No familiars have access"/,
-  "a registered project with an empty roster should explain that no familiars have access",
-);
-assert.match(
-  familiarList,
-  /"No recovery familiars"/,
-  "the Unassigned roster should use recovery-specific empty-state copy",
-);
-assert.match(
-  familiarList,
-  /FamiliarHubView\(familiar: familiar\)/,
-  "the roster opens the dashboard-backed Familiar hub",
-);
-
-const home = await read("apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift");
-
-// --- The home is a familiar list --------------------------------------------
-assert.doesNotMatch(
-  home,
-  /ForEach\(recentThreads\)/,
-  "the cross-familiar recents section is gone",
-);
-assert.doesNotMatch(
-  home,
-  /struct FamiliarRailItem/,
-  "the horizontal rail item is gone",
-);
+for (const name of ["directThreads", "landingDirectThread", "serverOnlySessions"]) {
+  assert.match(
+    model,
+    new RegExp(`func ${name}\\(for familiarId: String, in context: ProjectContext\\)`),
+    `${name} must continue accepting an exact conversation context`,
+  );
+}
+assert.match(model, /func threadOpenFailure\(for thread: ChatThread\) -> ThreadOpenFailure\?/);
+assert.match(model, /func globalServerOnlySessions\(for familiarId: String\) -> \[SessionRow\]/);
+assert.match(home, /ChatListSnapshot\(\s*threads: app\.chatThreads,\s*sessions: app\.chatServerSessions,/);
+assert.match(home, /ForEach\(snapshot\.entries\)/, "home renders real resumable conversations");
+assert.match(home, /\.tag\(ChatRoute\.thread\(thread\)\)/, "local rows select their exact conversation");
+assert.doesNotMatch(home, /filteredFamiliars|FamiliarConversationRow|handleProjectContextChange/);
+assert.match(home, /ServerSessionRow\(session: session\)/, "unhydrated desktop chats remain visible");
+assert.match(home, /requestOpenServerSession\(session, fallbackFamiliarId: session\.familiarId\)/);
+assert.match(projection, /represented\.contains\(SessionIdentity/, "hydrated sessions are deduplicated");
+assert.match(projection, /thread\.familiarIds\.contains\(familiarId\)/, "only actual participant bindings suppress server rows");
+assert.doesNotMatch(projection, /thread\.messages/, "list sorting and filtering never scan transcripts");
+assert.match(home, /struct ThreadRow[\s\S]*?thread\.messages\.last/, "each row observes its own preview");
+assert.match(home, /struct ThreadRow[\s\S]*?app\.seenBoundary\(for: thread\)/, "unread uses the conversation context");
+assert.match(home, /parts\.append\("unread"\)/, "unread is announced, not only colored");
+assert.match(home, /app\.threadDrafts\[thread\.id\]/, "unsent drafts remain discoverable");
 assert.match(
   home,
-  /ForEach\(filteredFamiliars\) \{ familiar in\s*\n\s*FamiliarConversationRow\(familiar: familiar\)/,
-  "the list renders one conversation row per familiar",
-);
-assert.match(
-  home,
-  /private var filteredFamiliars: \[Familiar\] \{[\s\S]{0,220}app\.projectFamiliars/,
-  "the visible familiar list is scoped to the active project",
-);
-assert.match(
-  home,
-  /private var activeProjectContext: ProjectContext \{[\s\S]*app\.projectContext \?\? \.unassigned[\s\S]*\}/,
-  "ChatsHome must snapshot the active project context for thread-history routing",
-);
-assert.match(
-  home,
-  /\.onChange\(of: activeProjectContext\.id\) \{[\s\S]*handleProjectContextChange\(\)/,
-  "ChatsHome must explicitly react when the active project id changes",
-);
-assert.match(
-  home,
-  /private func handleProjectContextChange\(\) \{[\s\S]*detailPath = \[\][\s\S]*selection = nil[\s\S]*selectMostRecentThreadIfNeeded\(\)/,
-  "project switches must clear stale sidebar/detail selection before seeding the next project's default chat",
-);
-assert.match(
-  home,
-  /FamiliarConversationRow[\s\S]*?\.tag\(ChatRoute\.familiar\(familiar\)\)/,
-  "familiar rows are tagged so the sidebar selection drives the detail column",
-);
-
-// The row carries the iMessage payload: who, what was last said, and when.
-assert.match(home, /struct FamiliarConversationRow: View/, "a familiar conversation row exists");
-assert.match(
-  home,
-  /struct FamiliarConversationRow[\s\S]*?AvatarView\(familiar: familiar/,
-  "the row shows the familiar's avatar",
-);
-assert.match(
-  home,
-  /struct FamiliarConversationRow[\s\S]*?app\.projectLandingDirectThread\(for: familiar\.id\)[\s\S]*?app\.projectServerOnlySessions\(for: familiar\.id\)/,
-  "the row must consider both local and server-only project activity",
-);
-assert.match(
-  home,
-  /struct FamiliarConversationRow[\s\S]*?app\.projectHasUnread\(familiar\.id\)/,
-  "the row keeps the unread indicator scoped to the active project",
-);
-assert.match(
-  home,
-  /struct FamiliarConversationRow[\s\S]*?app\.projectLastActivity\(for: familiar\.id\)/,
-  "the row timestamp must reflect the active project's latest local or server activity",
-);
-
-// --- One tap lands in the conversation ---------------------------------------
-// The detail column resolves a familiar to its chat. FamiliarThreadsView is no
-// longer the tap target; it becomes the session picker (Task 4).
-assert.match(
-  home,
-  /case \.familiar\(let familiar\):\s*\n\s*familiarChat\(familiar\)/,
-  "selecting a familiar shows its chat, not a thread list",
-);
-assert.match(
-  home,
-  /private func familiarChat[\s\S]{0,500}?app\.projectLandingDirectThread\(for: familiar\.id\)[\s\S]*?app\.projectServerOnlySessions\(for: familiar\.id\)\.first/,
-  "the detail pane must fall back to the active project's newest server-only session",
+  /private func selectMostRecentThreadIfNeeded\(\)[\s\S]*guard sizeClass == \.regular,[\s\S]*selection == nil/,
+  "only an empty wide detail may auto-select; iPhone keeps its conversation list",
 );
 assert.match(
   home,
   /private func chatDestination\([\s\S]*_ thread: ChatThread,[\s\S]*app\.threadOpenFailure\(for: thread\)[\s\S]*ThreadOpenRecoveryView/,
-  "ChatsHome must gate ChatView behind the shared thread-open validator",
-);
-assert.match(
-  home,
-  /private struct FamiliarServerLandingView: View[\s\S]*?app\.openServerSession\(session, familiarId: familiar\.id\)/,
-  "server-only familiar landings must materialize the project-scoped session before opening chat",
-);
-assert.match(
-  home,
-  /private struct FamiliarServerLandingView: View[\s\S]*app\.threadOpenFailure\(for: thread\)[\s\S]*ThreadOpenRecoveryView/,
-  "server-only familiar landings must recover instead of mounting an invalid sendable chat",
-);
-assert.match(
-  home,
-  /private func selectMostRecentThreadIfNeeded\(\) \{[\s\S]{0,700}projectThreads[\s\S]{0,220}projectLastActivity[\s\S]{0,220}open\(\.familiar\(familiar\)\)|open\(\.thread\(mostRecentGroupThread\)\)/,
-  "default selection must compare active-project familiar activity against group threads",
+  "malformed conversation metadata cannot silently become sendable",
 );
 
-const chat = await read("apps/ios/CovenCave/CovenCave/Views/ChatView.swift");
-
-// --- Conversation selection lives in the config card -------------------------
-// The card groups runtime identity, model choice, project, and conversation.
-assert.match(
-  chat,
-  /sessionDetailsCard[\s\S]*?sessionDetailRow\(\s*\n?\s*"Conversation"/,
-  "the config card exposes a Conversation row",
-);
-assert.match(
-  chat,
-  /"Conversation",[\s\S]{0,200}?showsChevron: true/,
-  "the Conversation row is tappable",
-);
-assert.match(
-  chat,
-  /showSessionPicker\s*=\s*true/,
-  "tapping the Conversation row opens the picker",
-);
+assert.match(chat, /sessionDetailsCard[\s\S]*?sessionDetailRow\(\s*"Conversation"/);
+assert.match(chat, /"Conversation",[\s\S]{0,200}?showsChevron: true/);
+assert.match(chat, /showSessionPicker\s*=\s*true/);
 assert.match(
   chat,
   /\.sheet\(isPresented: \$showSessionPicker\)[\s\S]{0,500}?FamiliarThreadsView\([\s\S]*projectContext: visibleThreadContext/,
-  "the picker is FamiliarThreadsView pinned to the visible thread context",
+  "the in-chat session picker is pinned to the visible conversation",
 );
-assert.match(
-  home,
-  /FamiliarThreadsView\(familiar: familiar,\s*projectContext: activeProjectContext,\s*path: \$detailPath/,
-  "ChatsHome must pass its active project context into FamiliarThreadsView",
-);
-assert.match(
-  familiarThreads,
-  /let projectContext: ProjectContext/,
-  "FamiliarThreadsView accepts an explicit project context",
-);
+assert.match(familiarThreads, /let projectContext: ProjectContext/);
 assert.match(
   familiarThreads,
   /app\.directThreads\(for: familiar\.id,\s*in: projectContext\)[\s\S]*app\.serverOnlySessions\(for: familiar\.id,\s*in: projectContext\)/,
-  "FamiliarThreadsView must derive local and server rows from its explicit project context",
 );
 assert.match(
   familiarThreads,
-  /private func chooseIfOpenable\(_ thread: ChatThread\) \{[\s\S]*guard app\.canOpen\(thread\) else \{[\s\S]*app\.threadOpenFailure\(for: thread\)[\s\S]*showToast/,
-  "FamiliarThreadsView must validate a thread before choosing it from the session picker",
+  /private func chooseIfOpenable\(_ thread: ChatThread\)[\s\S]*guard app\.canOpen\(thread\)[\s\S]*showToast/,
 );
 assert.match(
   familiarThreads,
-  /case \.local\(let thread\):\s*\n\s*chooseIfOpenable\(thread\)[\s\S]*case \.server\(let session\):[\s\S]*chooseIfOpenable\(app\.openServerSession\(session, familiarId: familiar\.id\)\)/,
-  "local and server rows in FamiliarThreadsView must share the same open validation path",
+  /case \.local\(let thread\):\s*chooseIfOpenable\(thread\)[\s\S]*case \.server\(let session\):[\s\S]*chooseIfOpenable\(app\.openServerSession\(session, familiarId: familiar\.id\)\)/,
 );
-assert.match(
-  familiarThreads,
-  /app\.markFamiliarViewed\(\[familiar\.id\],\s*in: projectContext\)/,
-  "FamiliarThreadsView must clear unread state in its explicit project context",
-);
+assert.doesNotMatch(familiarThreads, /app\.markFamiliarViewed\(/,
+  "opening the session picker does not read every listed conversation");
+assert.doesNotMatch(familiarThreads, /requestOpenDestination\(/, "New chat never changes shell scope");
+for (const action of ["setThreadPinned", "setThreadMuted", "setThreadArchived", "renameThread", "duplicateThread", "exportThreadsZip", "deleteThread"]) {
+  assert.ok(home.includes(action), `${action} remains reachable on the global chat list`);
+}
+assert.match(familiarThreads, /app\.deleteThreads\(selectedIds\)/, "session selection retains bulk deletion");
 
 console.log("ios-chat-familiars-home.test.mjs: ok");

--- a/scripts/ios-chat-only.test.mjs
+++ b/scripts/ios-chat-only.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const root = new URL("../apps/ios/CovenCave/CovenCave/", import.meta.url);
+const read = (path) => readFileSync(new URL(path, root), "utf8");
+
+test("the iOS shell mounts chat without an ambient project gate or remount", () => {
+  const source = read("Views/RootView.swift");
+  assert.ok(!source.includes("ProjectContextGateView()"), "project access must not hide readable chats or settings");
+  assert.ok(!source.includes(".id(app.projectContext"), "a project refresh must not destroy the conversation");
+  assert.ok(!source.includes("TasksView()"), "Tasks is not an iOS destination");
+  assert.ok(!source.includes("GlobalSearchView("), "search must stay inside chat");
+});
+
+test("the drawer contains chat navigation without global workspace controls", () => {
+  const source = read("Views/NavigationDrawer.swift");
+  for (const retired of ["ProjectContextButton", "openProjectSwitcher", "openFamiliars", 'label: "Tasks"', 'sectionLabel("Workspace")']) {
+    assert.ok(!source.includes(retired), `${retired} must not return to the chat-only drawer`);
+  }
+  assert.ok(source.includes('accessibilityLabel("Search chats")'));
+});
+
+test("Chats lists global conversations without scanning transcripts to organize rows", () => {
+  const source = read("Views/ChatsHomeView.swift");
+  assert.ok(source.includes("ChatListSnapshot("), "the home must use one shared conversation projection");
+  assert.ok(!source.includes("handleProjectContextChange"), "unrelated access changes must not reset selection");
+  assert.ok(!source.includes("app.projectFamiliars"), "the conversation list must not be globally project-filtered");
+  assert.ok(source.includes("setThreadArchived"), "archived history must remain reachable");
+  assert.ok(source.includes("setThreadPinned"), "conversation pinning must remain available");
+});
+
+test("settings stays focused on chat configuration rather than a content hub", () => {
+  const source = read("Views/SettingsView.swift");
+  assert.ok(!source.includes("communitySection"), "promotional navigation is outside the chat-only settings surface");
+  for (const retained of ["PermissionsView()", "securitySection", "chatsSection", "appearanceSection", "ConnectionSettingsView()"]) {
+    assert.ok(source.includes(retained), `${retained} must remain reachable`);
+  }
+});
+
+test("the largest type sizes keep conversation titles and counts readable", () => {
+  const home = read("Views/ChatsHomeView.swift");
+  const rows = read("Views/FamiliarThreadsView.swift");
+  assert.match(home, /if dynamicTypeSize\.isAccessibilitySize \|\| sizeClass == \.regular,\s*let detail = visibleConversationLabel/,
+    "the count must have its own full-width line instead of a truncated header badge");
+  assert.match(home, /\.lineLimit\(dynamicTypeSize\.isAccessibilitySize \? 2 : 1\)/);
+  assert.match(rows, /\.lineLimit\(dynamicTypeSize\.isAccessibilitySize \? 2 : 1\)/,
+    "server-only chat titles must also wrap at accessibility sizes");
+  assert.match(home, /isSelected \? chrome\.accentForeground : chrome\.textPrimary/,
+    "selected iPad rows use the accent's contrasting foreground");
+});
+
+test("the native guide describes chat-only navigation without weakening pairing", () => {
+  const guide = readFileSync(new URL("../apps/ios/CovenCave/README.md", import.meta.url), "utf8");
+  assert.match(guide, /native, chat-only SwiftUI client/);
+  assert.match(guide, /no Tasks, Projects, Automations/);
+  assert.match(guide, /global project filter/);
+  assert.match(guide, /paired Cave access credential/);
+  assert.match(guide, /sending requires current grants/);
+  assert.doesNotMatch(guide, /no token, no password|gate relaxed|serve the mobile API tokenlessly/);
+});
+
+test("conversation identity and compact search navigation are explicit", () => {
+  const home = read("Views/ChatsHomeView.swift");
+  const mounts = [...home.matchAll(/ChatView\(thread: thread\)/g)];
+  assert.ok(mounts.length > 0);
+  for (const mount of mounts) {
+    assert.match(home.slice(mount.index, mount.index + 100), /ChatView\(thread: thread\)\s*\.id\(thread\.id\)/,
+      "switching conversations must recreate only that conversation's draft and attachment state");
+  }
+  assert.match(home, /NavigationSplitView\(preferredCompactColumn: \$preferredCompactColumn\)/);
+  assert.match(home, /private func revealChatSearch\(\) \{\s*if sizeClass == \.compact \{\s*detailPath = \[\]\s*selection = nil\s*preferredCompactColumn = \.sidebar[\s\S]*searchFocused = true/,
+    "drawer search clears only compact selection to reveal the sidebar before focusing its field");
+  assert.match(home, /private func consumeThreadRequest\([\s\S]*?preferredCompactColumn = \.detail\s*app\.threadToOpen = nil/,
+    "an explicit open must reveal even the already-selected conversation after search");
+});

--- a/scripts/ios-chat-project-contract.test.mjs
+++ b/scripts/ios-chat-project-contract.test.mjs
@@ -175,7 +175,7 @@ assert.match(
 );
 assert.match(
   picker,
-  /else if projects\.isEmpty \{[\s\S]*(?:if\s+let\s+onManageAccess\s*\{\s*Button\(\s*"Project access"\s*,\s*action:\s*onManageAccess\s*\)\s*\}|guard\s+let\s+onManageAccess\s*=\s*onManageAccess\s*else\s*\{[\s\S]*?\}\s*Button\(\s*"Project access"\s*,\s*action:\s*onManageAccess\s*\))/,
+  /else if projects\.isEmpty \{[\s\S]*if let onManageAccess \{[\s\S]*Button\("Project access", action: onManageAccess\)/,
   "the empty project list must guard the Project access button behind a non-nil manage-access action",
 );
 assert.match(
@@ -195,13 +195,13 @@ assert.match(
 );
 assert.match(
   picker,
-  /ChatProjectSelection\.resolvedRoot\([\s\S]*current: selectedRoot,[\s\S]*recent: recentRoots,[\s\S]*projects: loaded/,
-  "new chats must resolve current, recent, then stable project fallback",
+  /if selectedRoot == nil, !requiresExplicitSelection \{[\s\S]*ChatProjectSelection\.resolvedRoot\([\s\S]*current: nil,[\s\S]*recent: recentRoots,[\s\S]*projects: loaded/,
+  "optional defaults may seed only an untouched selection",
 );
 assert.match(
   picker,
-  /requiresExplicitSelection[\s\S]*\\? nil[\s\S]*ChatProjectSelection\.resolvedRoot/,
-  "a rejected project must require an explicit replacement instead of silently retrying",
+  /isResolved = loaded\.contains \{ \$0\.root == selectedRoot \}/,
+  "a revoked selection must become unresolved rather than silently switching projects",
 );
 assert.doesNotMatch(
   picker,
@@ -227,13 +227,13 @@ assert.doesNotMatch(
 // All user-visible constructors route through selection and preserve the root.
 assert.match(
   newChat,
-  /private var activeProject: ProjectInfo\? \{ app\.activeProject \}/,
-  "New Chat must derive its root from the active project context",
+  /@State private var selectedProject: ProjectInfo\?/,
+  "New Chat must own its selected registered project",
 );
 assert.match(
   newChat,
-  /private var canLaunchChat: Bool \{[\s\S]*activeProjectRoot != nil[\s\S]*!selectedFamiliarIds\.isEmpty[\s\S]*unavailableSelectedFamiliarIDs\.isEmpty[\s\S]*\}/,
-  "launch gating must require the active project root and only active-project familiars",
+  /private var canLaunchChat: Bool \{[\s\S]*projectResolved && selectedProject != nil[\s\S]*!selectedFamiliarIds\.isEmpty && !isLaunching/,
+  "launch gating must require a resolved local project and stable nonempty roster",
 );
 assert.match(
   newChat,
@@ -242,28 +242,28 @@ assert.match(
 );
 assert.match(
   newChat,
-  /Section\("Project"\) \{[\s\S]*Label\(activeProject\.name, systemImage: "folder"\)[\s\S]*Switch projects from Chats to use a different project\./,
-  "New Chat must describe the fixed active project instead of offering a picker",
+  /Section\("Chat access"\) \{[\s\S]*ChatProjectPicker\([\s\S]*requiresExplicitSelection: true/,
+  "New Chat must offer explicit chat-local project access",
 );
 assert.match(
   newChat,
-  /let fixedFamiliarId: String\?[\s\S]*if fixedFamiliarId == nil[\s\S]*Section\(selected\.isEmpty \? "Choose familiars" :/,
-  "fixed familiar mode must hide the editable familiar roster",
+  /fixedFamiliarId == nil \|\| \$0\.id == fixedFamiliarId[\s\S]*\.disabled\(fixedFamiliarId != nil\)/,
+  "fixed familiar mode must preserve its immutable familiar roster",
+);
+assert.doesNotMatch(
+  newChat,
+  /app\.(?:activeProject|activeProjectRoot|projectContext|projectFamiliars)\b/,
+  "New Chat must never depend on the ambient project filter",
 );
 assert.match(
   newChat,
-  /private var blockedMessage: \(title: String, body: String, systemImage: String\)\? \{[\s\S]*Unassigned chats are recovery-only\./,
-  "Unassigned New Chat must surface recovery-only guidance",
+  /case \.familiarAccessRevoked\(let ids\):[\s\S]*Project access was revoked/,
+  "launch must surface revoked participant access",
 );
 assert.match(
   newChat,
-  /private var blockedMessage: \(title: String, body: String, systemImage: String\)\? \{[\s\S]*This familiar is no longer in/,
-  "fixed familiar launches must explain when the selected familiar leaves the active project",
-);
-assert.match(
-  newChat,
-  /private var selectedFamiliarIds: \[String\] \{[\s\S]*availableFamiliars\.map\(\\\.id\)\.filter \{ selected\.contains\(\$0\) \}[\s\S]*\}/,
-  "selectedFamiliarIds must stay inside the active project roster",
+  /private var selectedFamiliarIds: \[String\] \{[\s\S]*ChatProjectSelection\.familiarKey\(Array\(selected\)\)/,
+  "roster refresh must not silently remove chosen participants",
 );
 assert.match(
   newChat,
@@ -272,23 +272,23 @@ assert.match(
 );
 assert.match(
   newChat,
-  /startFreshThread\([\s\S]*projectRoot: activeProjectRoot[\s\S]*createGroup\([\s\S]*projectRoot: activeProjectRoot/,
-  "direct and group constructors must always persist the active project root",
+  /startFreshThread\([\s\S]*projectRoot: context\.projectRoot[\s\S]*createGroup\([\s\S]*projectRoot: context\.projectRoot/,
+  "direct and group constructors must always persist the captured project root",
 );
 assert.match(
   newChat,
-  /let launchContext = NewChatImportLaunchContext\([\s\S]*activeProject: activeProject,[\s\S]*selectedFamiliarIds: selectedFamiliarIds[\s\S]*\)[\s\S]*importLaunchContext = launchContext[\s\S]*importingFile = true/,
-  "imports must freeze the active project context before opening the picker",
+  /let context = NewChatImportLaunchContext\([\s\S]*selectedProject: selectedProject,[\s\S]*selectedFamiliarIds: selectedFamiliarIds[\s\S]*\)[\s\S]*importLaunchContext = context[\s\S]*importConnectionLease = app\.captureConnectionDispatchLease\(\)[\s\S]*importingFile = true/,
+  "imports must freeze the local project, roster, and connection before opening the picker",
 );
 assert.match(
   newChat,
-  /switch launchContext\.validate\([\s\S]*projectContext: app\.projectContext,[\s\S]*activeProject: activeProject,[\s\S]*projectMembership: app\.projectMembership[\s\S]*\)[\s\S]*importMarkdown\([\s\S]*familiarIds: launchContext\.familiarIds,[\s\S]*projectRoot: launchContext\.projectRoot/,
-  "imports must revalidate the frozen project context before opening the imported thread",
+  /guard await validate\(context, lease: lease\) else \{ return \}[\s\S]*importMarkdown\([\s\S]*familiarIds: context\.familiarIds,[\s\S]*projectRoot: context\.projectRoot/,
+  "imports must revalidate captured access before committing the imported thread",
 );
-assert.doesNotMatch(
+assert.match(
   newChat,
-  /ChatProjectPicker\(|showProjectAccess|projectRefreshToken|FamiliarPermissionsSheet/,
-  "normal New Chat must not offer an independent project picker or access sheet",
+  /await app\.refreshChatAccess\(\)[\s\S]*app\.loadChatProjects\(familiarIds: context\.familiarIds\)[\s\S]*connectionDispatchLeaseIsCurrent\(lease\)[\s\S]*membershipLoaded: app\.projectMembershipLoaded && app\.projectContextError == nil/,
+  "every commit must freshly verify exact local selection and membership on the captured connection",
 );
 assert.match(
   appModel,
@@ -312,8 +312,8 @@ assert.match(
 );
 assert.match(
   appModel,
-  /func startFreshThreadInActiveProject\([\s\S]*guard let activeProject, let activeProjectRoot else \{ return nil \}[\s\S]*guard projectMembershipLoaded else \{[\s\S]*Refresh Chats to load project access[\s\S]*\}[\s\S]*let invalidFamiliarIDs = familiarIds\.filter \{[\s\S]*projectMembership\.contains\(\$0, in: activeProject\)[\s\S]*Open New Chat to choose a valid roster or switch projects/,
-  "/new and replacement flows must validate every participant against the active project roster",
+  /func startFreshThread\(\s*in context: ProjectContext\?[\s\S]*guard projectMembershipLoaded, projectContextError == nil[\s\S]*projectMembership\.contains\(\$0, in: boundProject\)/,
+  "/new and replacement helpers must validate every participant against the supplied object's project",
 );
 assert.match(
   appModel,
@@ -387,8 +387,8 @@ assert.doesNotMatch(
 );
 assert.match(
   chat,
-  /startFreshThreadInActiveProject\([\s\S]*familiarIds: thread\.familiarIds/,
-  "/new and replacement flows must start in the active project",
+  /\.sheet\(isPresented: \$showNewChat\) \{\s*NewChatView\(initialFamiliarIds: thread\.familiarIds\)/,
+  "/new and replacement flows must preserve participants in explicit New Chat configuration",
 );
 assert.match(
   chat,
@@ -397,13 +397,18 @@ assert.match(
 );
 assert.match(
   chat,
-  /private var recoveryOnlyComposer: some View[\s\S]*Start replacement chat/,
-  "recovery-only chats must offer a start-replacement affordance when a project is active",
+  /private var recoveryOnlyComposer: some View[\s\S]*Button\("Start replacement chat", action: startReplacementChat\)[\s\S]*private func startReplacementChat\(\) \{\s*showNewChat = true\s*\}/,
+  "recovery-only chats must open local project selection without requiring an ambient project",
 );
 assert.match(
   chat,
-  /app\.markFamiliarViewed\(\s*thread\.familiarIds,\s*in:\s*app\.projectContext\(for: thread\)\s*\)/,
-  "opening a chat must clear unread state in that thread's own project context",
+  /app\.markThreadViewed\(thread\)/,
+  "opening a chat must clear only that thread's unread state",
+);
+assert.doesNotMatch(
+  chat,
+  /app\.markFamiliarViewed\(/,
+  "opening one chat must not clear unread state for sibling conversations",
 );
 assert.match(
   chat,
@@ -417,18 +422,18 @@ assert.match(
 );
 assert.match(
   chat,
-  /LiveVoiceCallView\([\s\S]*sessionId: voiceCallLaunch\.sessionId,[\s\S]*projectRoot: voiceCallLaunch\.projectRoot,[\s\S]*onSessionEstablished: \{ sessionId in[\s\S]*bindVoiceCallSession\(sessionId, for: voiceCallLaunch\.familiar\.id\)[\s\S]*onSessionDiscarded: \{ sessionId in[\s\S]*unbindVoiceCallSession\(sessionId, for: voiceCallLaunch\.familiar\.id\)[\s\S]*onCleanupWarning: \{ message in[\s\S]*app\.showToast\(message,[\s\S]*style: \.warning\)/,
-  "ChatView must pass thread project provenance into live voice calls, bind new server sessions, clear discarded bindings, and surface cleanup failures through app toasts",
+  /private func beginVoiceCall\(\) \{[\s\S]*let callThread = thread[\s\S]*voiceCall = LiveVoiceCallModel\([\s\S]*sessionId: launch\.sessionId,[\s\S]*projectRoot: launch\.projectRoot,[\s\S]*onSessionEstablished: \{ sessionId in[\s\S]*app\.bindThreadSession\(sessionId, to: callThread, for: familiarId\)[\s\S]*onSessionDiscarded: \{ sessionId in[\s\S]*callThread\.sessionIds\.removeValue\(forKey: familiarId\)[\s\S]*onCleanupWarning: \{ message in[\s\S]*app\.showToast\(message,[\s\S]*style: \.warning\)/,
+  "ChatView must freeze voice provenance and keep session binding, orphan cleanup, and warnings on the captured conversation",
 );
 assert.match(
   chat,
-  /private func bindVoiceCallSession\(_ sessionId: String, for familiarId: String\) \{[\s\S]*app\.bindThreadSession\(sessionId, to: thread, for: familiarId\)/,
-  "voice-session binding should flow through AppModel so task-linked voice chats reconcile their card session ids immediately",
+  /onSessionEstablished: \{ sessionId in[\s\S]*guard app\.connectionDispatchLeaseIsCurrent\(dispatchLease\),\s*binding\.matches\(callThread, includingSessions: true\) else \{ return \}[\s\S]*app\.bindThreadSession\(sessionId, to: callThread, for: familiarId\)/,
+  "voice-session binding must verify the captured connection and session identity before persisting",
 );
 assert.match(
   chat,
-  /private func unbindVoiceCallSession\(_ sessionId: String, for familiarId: String\) \{[\s\S]*thread\.sessionIds\.removeValue\(forKey: familiarId\)[\s\S]*app\.touch\(thread\)/,
-  "discarded auto-created voice sessions must remove their local thread binding",
+  /onSessionDiscarded: \{ sessionId in[\s\S]*guard app\.connectionDispatchLeaseIsCurrent\(dispatchLease\),\s*binding\.matches\(callThread, includingSessions: true\),\s*callThread\.sessionIds\[familiarId\] == sessionId else \{ return \}[\s\S]*callThread\.sessionIds\.removeValue\(forKey: familiarId\)[\s\S]*app\.touch\(callThread\)/,
+  "discarded auto-created voice sessions must remove only the matching captured local binding",
 );
 assert.match(
   appModel,
@@ -452,8 +457,13 @@ assert.match(
 );
 assert.match(
   appModel,
-  /private func completeProjectNavigation\([\s\S]*if let context, didSwitchProject \{[\s\S]*switchProject\(to: context\)[\s\S]*selectedTab = intent\.resolvedDestination[\s\S]*if let thread \{[\s\S]*threadToOpen = thread[\s\S]*if let card \{[\s\S]*cardToOpen = card/,
-  "the shared resolver must switch project first, then select the destination, then publish thread/task opens",
+  /private func completeProjectNavigation\([\s\S]*selectedTab = intent\.resolvedDestination[\s\S]*if let thread \{[\s\S]*threadToOpen = thread/,
+  "the shared resolver must publish the chosen chat object",
+);
+assert.doesNotMatch(
+  appModel.split("private func completeProjectNavigation(")[1].split("private func announceProjectNavigationSwitch")[0],
+  /switchProject|projectContext\s*=/,
+  "opening an object must not rescope the shell",
 );
 assert.match(
   appModel,
@@ -477,8 +487,8 @@ assert.match(
 );
 assert.match(
   voiceModel,
-  /private func startRealtime\(\) async \{[\s\S]*guard let projectRoot = state\.projectRoot else \{[\s\S]*projectRequiredCopy[\s\S]*\}[\s\S]*let sessionId = try await realtimeSessionID\(client: client, projectRoot: projectRoot\)[\s\S]*mintVoiceSession\([\s\S]*familiarId: familiar\.id,\s*sessionId: sessionId/,
-  "realtime voice must keep server-side grant minting while bootstrapping fresh calls through a project-scoped session",
+  /private func startRealtime\(generation: Int\) async \{[\s\S]*guard let projectRoot = state\.projectRoot else \{[\s\S]*projectRequiredCopy[\s\S]*\}[\s\S]*let sessionId = try await realtimeSessionID\(client: client, projectRoot: projectRoot\)\s*guard canContinueLaunch\(generation\) else \{ return \}[\s\S]*mintVoiceSession\([\s\S]*familiarId: familiar\.id,\s*sessionId: sessionId\s*\)\s*guard canContinueLaunch\(generation\) else \{ return \}/,
+  "realtime voice must mint project-scoped grants only while its captured launch remains current across suspensions",
 );
 assert.match(
   voiceModel,
@@ -547,28 +557,18 @@ assert.doesNotMatch(
 );
 assert.match(
   appModel,
-  /@discardableResult\s*func requestOpenGlobalFamiliarLandingThread\(for familiarId: String\) -> Bool \{[\s\S]*globalLandingDirectThread\(for: familiarId\)[\s\S]*globalServerOnlySessions\(for: familiarId\)\.first[\s\S]*openServerSession\([\s\S]*projectMembership\.contains\(familiarId, in: activeProject\)[\s\S]*directThread\(for: familiarId, in: \.project\(activeProject\)\)[\s\S]*requestOpen\(/,
-  "global familiar opens must prefer existing chats across contexts, then server-only sessions, and only synthesize a fresh active-project chat as a last resort",
+  /func requestOpenGlobalFamiliarLandingThread\(for familiarId: String\)[\s\S]*globalLandingDirectThread\(for: familiarId\)[\s\S]*globalServerOnlySessions\(for: familiarId\)[\s\S]*Open New chat to choose this familiar and its project access/,
+  "global familiar opens may reuse history but cannot silently synthesize an ambient-project chat",
 );
-assert.match(
+assert.doesNotMatch(
   root,
-  /case \.familiars: FamiliarsListView \{ familiar in[\s\S]*openFamiliarLandingThread\(\s*for:\s*familiar\.id,\s*in:\s*app\.projectContext\s*\)/,
-  "the root familiars sheet must route familiar opens through the shared landing-chat helper",
+  /case \.familiars: FamiliarsListView/,
+  "the retired global familiar hub must not remain in the root shell",
 );
-assert.match(
+assert.doesNotMatch(
   root,
-  /openFamiliar: \{ familiar in[\s\S]*requestOpenGlobalFamiliarLandingThread\(for: familiar\.id\)/,
-  "global search familiar opens must route through the global landing-chat helper",
-);
-assert.match(
-  root,
-  /openServerSession: \{ session, familiarId in[\s\S]*requestOpenServerSession\(\s*session,\s*fallbackFamiliarId: familiarId\s*\)/,
-  "global search server-session opens must route through the central project-aware session helper",
-);
-assert.match(
-  root,
-  /openProject: \{ project in[\s\S]*requestOpenProjectSearchResult\(project\)/,
-  "global search project opens must route through the central project-aware destination helper",
+  /GlobalSearchView\(/,
+  "the root must not mount retired global search",
 );
 assert.match(
   appModel,
@@ -577,13 +577,52 @@ assert.match(
 );
 assert.match(
   chat,
-  /case \.command\(let command, let args\):[\s\S]*case \.sendAsPrompt = command\.action,[\s\S]*!thread\.canSendMessages[\s\S]*thread\.needsProjectSelection = true[\s\S]*return[\s\S]*draft = ""/,
-  "prompt-like slash commands must preserve their draft until project context resolves",
+  /case \.command\(let command, let args\):[\s\S]*if command\.sendsChatMessage \{[\s\S]*guard requireChatAccess\(\) else \{ return \}[\s\S]*guard thread\.canSendMessages else \{[\s\S]*thread\.needsProjectSelection = true[\s\S]*return[\s\S]*draft = ""/,
+  "message-producing commands must preserve drafts until access and provenance resolve",
 );
+const chatBootstrap = appModel.split("private func resolveProjectContextSelection(")[1]
+  .split("private func applyProjectContextSelection(")[0];
+assert.doesNotMatch(chatBootstrap, /coordinatedTasksLoad|client\.tasks\(/,
+  "chat bootstrap must not hydrate retired tasks");
+assert.match(appModel, /func resolvePendingProjectNavigationIntent[\s\S]*guard intent\.resolvedDestination != \.tasks else \{[\s\S]*showDesktopOnlyDestination\(\)[\s\S]*if attemptHydrationIfNeeded/,
+  "retired task navigation must reject before any hydration");
+assert.match(appModel, /var chatAccessIsCurrent: Bool \{[\s\S]*projectsLoaded && projectMembershipLoaded && projectContextError == nil/,
+  "cached history cannot stand in for current send access");
+assert.match(appModel, /func chatAccessIsCurrent\(projectRoot: String\?, familiarIds: \[String\]\) -> Bool \{[\s\S]*let targets = Set\(familiarIds\)[\s\S]*guard chatAccessIsCurrent,[\s\S]*!targets\.isEmpty,[\s\S]*ProjectContext\.openContext\(for: projectRoot, in: projects\),\s*project\.root == projectRoot[\s\S]*targets\.allSatisfy \{ projectMembership\.contains\(\$0, in: project\) \}/,
+  "write access must resolve the bound project and require current membership for every exact recipient");
+const queuedReplay = appModel.split("func flushQueuedMessages() {")[1]
+  .split("/// Rolling renewal:")[0];
+assert.match(queuedReplay, /targetAccessIsCurrent: \{ \[weak self\] projectRoot, familiarId in[\s\S]*chatAccessIsCurrent\(\s*projectRoot: projectRoot,\s*familiarIds: \[familiarId\]/,
+  "queue dispatch must authorize the frozen recipient supplied by replay, not the current roster");
+assert.match(queuedReplay, /onAccessRefused:[\s\S]*showToast\([\s\S]*original recipients have been kept/,
+  "revoked queued access must be explained without discarding or retargeting the message");
+const targetReplay = thread.split("func replayQueued(client: CaveClient,")[1]
+  .split("/// Remove one message")[0];
+assert.match(targetReplay, /targetAccessIsCurrent: @escaping \(String\?, String\) -> Bool/,
+  "queued replay requires a per-target authorization callback");
+assert.match(targetReplay, /let targets = queuedMessage\.queuedTargetFamiliarIds[\s\S]*let queuedProjectRoot = queuedContext\.projectRoot[\s\S]*for familiarId in targets where !completed\.contains\(familiarId\)[\s\S]*let queuedSessionId = queuedContext\.sessionIds\[familiarId\] \?\? sessionIds\[familiarId\][\s\S]*targetAccessIsCurrent\(queuedProjectRoot, familiarId\)[\s\S]*guard mayDispatchTarget\(\) else \{ continue \}[\s\S]*let existingPlaceholder/,
+  "every frozen queued recipient must pass authorization before a placeholder, reconciliation, or write checkpoint");
+assert.match(targetReplay, /await persistBeforeDispatch\(\)[\s\S]*guard !Task\.isCancelled, dispatchLeaseIsCurrent\(\), mayDispatchTarget\(\) else[\s\S]*liveDispatchLeaseIsCurrent: mayDispatchTarget/,
+  "recipient/root authorization must run after persistence and inside the actual stream preflight");
+assert.match(targetReplay, /guard targets\.allSatisfy\(\{ completed\.contains\(\$0\) \}\) else \{ return \}\s*mutate\(queuedId\)/,
+  "a refused group target must keep the queue pending after allowed recipients finish");
+assert.match(nativeAppContextTests, /testChatWriteAccessUsesBoundProjectAndExactRosterNotReadability[\s\S]*testRevokedQueuedRecipientCannotBeReplacedByCurrentRosterAccess[\s\S]*testQueuedAccessPreservesLegacyRunRecipientFallback/,
+  "native tests must distinguish readable history, exact write access, and frozen legacy queue targets");
+assert.match(nativeAppContextTests, /testSuccessfulGrantRefreshRevocationLeavesQueuedRecipientUnsent[\s\S]*testFrozenQueuedGroupSkipsRevokedTargetWithoutStarvingAllowedRecipient[\s\S]*testGrantRevocationDuringQueuedPersistenceRollsBackWithoutPost[\s\S]*testQueuedGrantRevocationAtNetworkPreflightPreservesPendingLeg/,
+  "native tests must cover successful grant revocation, allowed siblings, checkpoint races, and final network preflight");
+assert.doesNotMatch(nativeAppContextTests, /FamiliarDetailStatsModel/,
+  "state tests must not retain the removed familiar task-analytics model");
+const shellReadiness = appModel.split("var hasLoadedSurfaces: Bool {")[1].split("\n    }")[0];
+assert.match(shellReadiness, /!chatThreads\.isEmpty \|\| !chatServerSessions\.isEmpty/,
+  "cold cached history must keep the shell readable without a live project catalog");
+assert.doesNotMatch(shellReadiness, /tasksLoaded|remindersLoaded/,
+  "retired non-chat data cannot make the chat shell ready");
+assert.match(appModel, /let shouldLoadCoreBeforeDispatch = !chatAccessIsCurrent[\s\S]*if shouldLoadCoreBeforeDispatch/,
+  "readable cached history must not skip access bootstrap before queued dispatch");
 assert.match(
   home,
-  /NewChatView\([\s\S]*fixedFamiliarId: fixedNewChatFamiliarId[\s\S]*presentNewChat\(fixedFamiliarId: familiar\.id\)/,
-  "home familiar shortcuts must open fixed-familiar New Chat from familiar rows",
+  /NewChatView\([\s\S]*fixedFamiliarId: fixedNewChatFamiliarId/,
+  "home must preserve fixed-familiar New Chat support",
 );
 assert.match(
   home,
@@ -592,8 +631,8 @@ assert.match(
 );
 assert.match(
   nativeAppContextTests,
-  /testRequestOpenSwitchesToThreadProjectBeforeOpening[\s\S]*testRequestOpenSwitchesToUnassignedForProjectlessThread[\s\S]*testRequestOpenCanonicalizesNestedWorktreeRootToRegisteredProject[\s\S]*testRequestOpenTreatsUnknownAndDeletedRootsAsUnassigned[\s\S]*testRequestOpenTaskSwitchesToTaskProjectBeforeOpening[\s\S]*testRequestOpenTaskSwitchesToUnassignedForProjectlessTask[\s\S]*testRequestOpenProjectSearchResultKeepsProjectScopedDestination[\s\S]*testRequestOpenProjectSearchResultFallsBackToChatsFromSettings[\s\S]*testRequestOpenServerSessionSwitchesToSessionProjectBeforeOpening[\s\S]*testRequestOpenTaskTreatsUnknownProjectAsUnassignedRecovery[\s\S]*testRequestOpenTaskFailsExplicitlyWhenProjectIDIsMalformed[\s\S]*testRequestOpenFailsExplicitlyWhenProjectMetadataIsInvalid[\s\S]*testRequestOpenDoesNotSwitchProjectWhenContextAlreadyMatches[\s\S]*testEntityMetadataWinsWhenAdvisoryProjectDisagrees[\s\S]*testProjectDeepLinkFailsExplicitlyWhenProjectIsUnknown[\s\S]*testProjectChatsDeepLinkSwitchesProjectAndPreservesDestination[\s\S]*testPendingTaskNavigationSurvivesFailedHydration/,
-  "native app-context tests must cover cross-project thread/task/session opens, project-search destination policy, unassigned recovery, unknown-project recovery tasks, malformed task ids, same-context no-ops, redundant-project mismatches, and pending intents that survive failed hydration",
+  /testRequestOpenPreservesAmbientProjectBeforeOpening[\s\S]*testRequestOpenPreservesAmbientProjectForProjectlessThread[\s\S]*testRequestOpenTaskRejectsDesktopOnlyDestination[\s\S]*testRequestOpenServerSessionPreservesAmbientProjectBeforeOpening[\s\S]*testPendingTaskNavigationIsRejectedBeforeHydration/,
+  "native app-context tests must cover non-rescoping object opens and fail-fast retired navigation",
 );
 assert.match(
   home,
@@ -657,8 +696,8 @@ assert.match(
 );
 assert.match(
   nativeAppContextTests,
-  /testRequestOpenGlobalFamiliarLandingThreadPrefersMostRecentLocalLandingAcrossContexts[\s\S]*testRequestOpenGlobalFamiliarLandingThreadMaterializesMostRecentServerOnlySessionAcrossContexts[\s\S]*testRequestOpenGlobalFamiliarLandingThreadCreatesFreshChatInActiveProjectWhenNoHistoryExists[\s\S]*testRequestOpenGlobalFamiliarLandingThreadShowsGuidanceWhenFamiliarBelongsToDifferentProject/,
-  "native AppModel tests must cover global familiar opens for existing local chats, server-only history, fresh active-project starts, and off-project guidance",
+  /testRequestOpenGlobalFamiliarLandingThreadPrefersMostRecentLocalLandingAcrossContexts[\s\S]*testRequestOpenGlobalFamiliarLandingThreadMaterializesMostRecentServerOnlySessionAcrossContexts[\s\S]*testGlobalFamiliarWithoutHistoryRequiresChatLocalConfiguration/,
+  "native AppModel tests must cover global history reuse and explicit new-chat configuration",
 );
 assert.match(
   nativeAppContextTests,
@@ -672,8 +711,8 @@ assert.match(
 );
 assert.match(
   uiTests,
-  /testContextualNewChatUsesActiveProjectWithoutIndependentPicker[\s\S]*testContextualNewChatBlocksStartWhenFixedFamiliarLeavesActiveProject[\s\S]*testContextualNewChatShowsRecoveryOnlyGuidanceForUnassigned/,
-  "simulator tests must cover the fixed active root, revoked access, and Unassigned recovery-only states",
+  /testContextualNewChatRequiresLocalProjectSelection[\s\S]*testContextualNewChatBlocksCommitWhenAccessIsRevoked[\s\S]*testNewChatCanConfigureAccessWithoutAmbientProject/,
+  "simulator tests must cover explicit selection, revoked access, and a missing ambient project",
 );
 assert.match(
   snapshotTests,

--- a/scripts/ios-chat-restyle.test.mjs
+++ b/scripts/ios-chat-restyle.test.mjs
@@ -19,14 +19,16 @@ const bubble = await read("apps/ios/CovenCave/CovenCave/Views/MessageBubble.swif
 
 // Copy uses the live design-language contract, not the prototype's terminology.
 assert.match(chatView, /Text\("Start a chat"\)/);
-assert.match(chatView, /Describe a task or choose a suggestion below\./);
-assert.match(chatView, /"What tasks need attention\?"/);
-assert.match(chatView, /"Work on the next priority"/);
+assert.match(chatView, /Write a message or choose a suggestion below\./);
+assert.match(chatView, /"Help me explore an idea"/);
+assert.match(chatView, /"Explain something to me"/);
+assert.doesNotMatch(chatView, /"What tasks need attention\?"|"Work on the next priority"|app\.tasks/,
+  "conversation starters do not depend on task dashboards");
 assert.doesNotMatch(chatView, /"Board unavailable"|"Load the live board"|"New Messages"/);
 assert.match(chatView, /TextField\("Write a message…", text: \$draft, axis: \.vertical\)/);
 assert.match(chatView, /TextField\("Write a message…"[\s\S]{0,120}\.accessibilityLabel\("Message"\)/);
 assert.match(newChat, /Button\(isGroup \? "Create group" : "Start chat"\)/);
-assert.match(newChat, /Button\("Refresh chats"\)/);
+assert.match(newChat, /Button\("Refresh access"\)/);
 assert.match(newChat, /Section\("Group name \(Optional\)"\)/);
 assert.match(newChat, /TextField\("e\.g\., Research crew"[\s\S]{0,120}\.accessibilityLabel\("Group name"\)/);
 assert.match(bubble, /Label\("Open in reader",/);

--- a/scripts/ios-claude-design-fidelity.test.mjs
+++ b/scripts/ios-claude-design-fidelity.test.mjs
@@ -1,11 +1,8 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-// The authoritative Claude Design handoff is broader than a palette pass. This
-// contract pins the iOS seams that previously regressed or shipped as static
-// mock state: the supplied empty-session start page, global navigation,
-// familiar discovery/detail, real response controls, live plugins, and the
-// authored task/table affordances.
+// Retain the handoff's visual, accessibility, and truthful-state contracts.
+// The current chat-only direction supersedes its operational destinations.
 
 const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
 
@@ -59,15 +56,11 @@ assert.match(
 );
 assert.match(chat, /"each familiar’s"/, "group ward copy describes every member’s access boundary");
 assert.match(chat, /\.disabled\(!canInspectWard\)/, "the group ward picker remains interactive");
-assert.match(chat, /"Review my open PRs"/, "first quick action follows the supplied start page");
-assert.match(
-  chat,
-  /Set\(app\.tasks\.flatMap\(\\\.githubLinks\)[\s\S]*?\$0\.state\?\.lowercased\(\) == "open"[\s\S]*?map \{ \$0\.url\.lowercased\(\) \}\)/,
-  "the open-PR starter count is deduplicated and excludes closed or unknown links",
-);
-assert.match(chat, /"What tasks need attention\?"/, "second quick action uses the canonical Tasks vocabulary");
-assert.match(chat, /"Work on \\\(\$0\.title\)"/, "third quick action is grounded in a real priority task");
-assert.match(chat, /icon: "arrow\.triangle\.branch"/, "the PR starter uses a valid native branch glyph");
+for (const suggestion of ["Help me explore an idea", "Explain something to me", "Help me draft a message"]) {
+  assert.ok(chat.includes(suggestion), "empty chat offers a conversational starting point");
+}
+assert.doesNotMatch(chat, /app\.tasks|app\.loadTasks|openPRCount/,
+  "chat starters do not fetch or summarize task dashboards");
 assert.match(
   chat,
   /private var emptyState:[\s\S]*?VStack\(spacing: 18\)/,
@@ -137,15 +130,15 @@ assert.match(
 );
 assert.match(
   home,
-  /private func selectMostRecentThreadIfNeeded\(\) \{[\s\S]{0,500}guard selection == nil,[\s\S]{0,500}!showNewChat,[\s\S]{0,500}app\.threadToOpen == nil,[\s\S]{0,500}app\.pendingProjectNavigationIntent == nil,[\s\S]{0,500}!app\.newChatRequested,[\s\S]{0,700}projectThreads[\s\S]{0,220}projectLastActivity[\s\S]{0,220}open\(\.familiar\(familiar\)\)|open\(\.thread\(mostRecentGroupThread\)\)/,
-  "the default never overrides a pending explicit navigation and only picks active-project familiar or group activity",
+  /private func selectMostRecentThreadIfNeeded\(\) \{[\s\S]{0,500}guard sizeClass == \.regular,[\s\S]{0,100}selection == nil,[\s\S]{0,500}!showNewChat,[\s\S]{0,500}app\.threadToOpen == nil,[\s\S]{0,500}app\.pendingProjectNavigationIntent == nil,[\s\S]{0,500}!app\.newChatRequested[\s\S]{0,700}app\.chatThreads[\s\S]{0,220}open\(\.thread\(thread\)\)/,
+  "only an empty wide detail gets a default; explicit navigation and the iPhone list are preserved",
 );
 
 // Authored navigation and discovery surfaces.
 assert.match(
   home,
-  /List\(selection: \$selection\) \{\s*ForEach\(filteredFamiliars\) \{ familiar in\s*FamiliarConversationRow\(familiar: familiar\)/s,
-  "Chats renders the familiar list it defines",
+  /List\(selection: \$selection\) \{\s*ForEach\(snapshot\.entries\)/s,
+  "Chats renders its shared conversation projection",
 );
 assert.match(root, /CaveNavigationDrawer\(/, "the global Claude Design drawer is mounted at app root");
 assert.match(
@@ -169,15 +162,12 @@ assert.doesNotMatch(root, /MainTabView/, "RootView mounts the semantically neutr
 assert.match(root, /struct MainShellView/, "the connected root uses MainShellView");
 assert.match(
   root,
-  /switch app\.selectedTab\s*\{\s*case \.chats:\s*ChatsHomeView\(\)\s*case \.tasks:\s*TasksView\(\)\s*case \.settings:\s*SettingsView\(\)\s*\}/s,
-  "the shell mounts exactly the selected application destination",
+  /ChatsHomeView\(\)[\s\S]*accessibilityHidden\(app\.selectedTab == \.settings\)[\s\S]*if app\.selectedTab == \.settings \{\s*SettingsView\(\)/s,
+  "Settings preserves the mounted conversation while hiding it from interaction and accessibility",
 );
-assert.match(
-  root,
-  /if app\.selectedTab == \.settings \{\s*SettingsView\(\)\s*\} else \{[\s\S]*switch app\.projectContextGateState/s,
-  "settings stays reachable even when the project context is gated",
-);
-for (const label of ["Chats", "Tasks"]) {
+assert.doesNotMatch(root, /switch app\.projectContextGateState/,
+  "chat and Settings remain reachable without an ambient project gate");
+for (const label of ["Chats"]) {
   const matches = drawer.match(new RegExp(`DrawerNavRow\\([\\s\\S]*?label: "${label}"`, "g")) ?? [];
   assert.equal(matches.length, 1, `drawer includes ${label} exactly once as a primary row`);
 }
@@ -186,14 +176,11 @@ assert.doesNotMatch(
   /DrawerNavRow\([\s\S]*?label: "Settings"/,
   "Settings is not duplicated as a primary drawer row",
 );
+assert.doesNotMatch(drawer, /sectionLabel\("Workspace"\)|label: "Tasks"|label: "Familiars"/,
+  "the drawer does not expose unrelated workspaces or operational hubs");
 assert.match(
   drawer,
-  /sectionLabel\("Workspace"\)[\s\S]*ProjectContextButton[\s\S]*label: "Familiars"/,
-  "Projects and Familiars are grouped as contextual workspace resources",
-);
-assert.match(
-  drawer,
-  /Label\("New Chat", systemImage: "square\.and\.pencil"\)[\s\S]*Button \{ go\(\.settings\) \}[\s\S]*accessibilityLabel\("Profile and settings"\)/,
+  /Label\("New chat", systemImage: "square\.and\.pencil"\)[\s\S]*Button \{ go\(\.settings\) \}[\s\S]*accessibilityLabel\("Profile and settings"\)/,
   "the footer pairs New Chat with the sole profile-driven Settings entry",
 );
 assert.match(
@@ -201,11 +188,8 @@ assert.match(
   /geo\.size\.width \* 0\.70/,
   "the drawer keeps enough of the active destination visible to preserve spatial context",
 );
-assert.match(
-  drawer,
-  /sectionLabel\("Workspace"\)[\s\S]{0,180}ProjectContextButton/,
-  "the project selector follows the contextual workspace heading",
-);
+assert.match(drawer, /accessibilityLabel\("Search chats"\)/,
+  "drawer search names its chat-only scope");
 assert.match(
   projectSwitcher,
   /PillSelector\([\s\S]{0,180}fillsWidth: true/,
@@ -241,7 +225,7 @@ assert.doesNotMatch(root, /TerminalView|PtyTerminal|case \.terminal/,
   "the connected shell cannot mount the retired iOS terminal");
 assert.match(
   home,
-  /EditorialSurfaceTitle\(\s*title: "Chats",\s*detail: visibleConversationLabel,\s*large: true/,
+  /EditorialSurfaceTitle\(\s*title: "Chats",\s*detail: visibleConversationLabel\(snapshot\.entries\.count\),\s*large: true/,
   "the Chats title uses the restrained editorial hierarchy",
 );
 assert.match(
@@ -274,22 +258,11 @@ assert.doesNotMatch(
   /private var homeSearchBar[\s\S]*?glassChrome\(\.bottom\)/,
   "the Chats footer no longer paints an edge-to-edge chrome bar",
 );
-assert.match(home, /private var lowDensityActions[\s\S]*?"New chat"[\s\S]*?"All familiars"/,
-  "low-density Chats lists offer truthful next actions without restoring recents");
+assert.match(home, /private var emptyState[\s\S]*?Button\("New chat"\)/,
+  "empty Chats offers a truthful conversation action");
 assert.match(home, /ViewThatFits\(in: \.horizontal\)/,
   "familiar rows protect name and timestamp hierarchy at large text sizes");
-assert.match(
-  settings,
-  /Section\("Community"\) \{\s*HStack\(spacing: 0\)/,
-  "Community presents its destinations as one icon shelf",
-);
-for (const label of ["Discord", "X", "Docs", "Podcast", "Blog"]) {
-  assert.match(
-    settings,
-    new RegExp(`iconShelfLink\\("${label}"|iconShelfLink\\(\\s*"${label}"`),
-    `Community keeps an accessible ${label} icon`,
-  );
-}
+assert.doesNotMatch(settings, /Section\("Community"\)/, "chat-only Settings excludes promotional browsing");
 assert.match(
   settings,
   /private var legalSection[\s\S]*?HStack\(spacing: 0\)[\s\S]*?Terms of Service[\s\S]*?Privacy/,
@@ -298,7 +271,7 @@ assert.match(
 assert.match(
   settings,
   /private func iconShelfLink[\s\S]*?\.frame\(maxWidth: \.infinity, minHeight: 52\)/,
-  "Community and Legal shelf controls share a full-width row-height contract",
+  "Legal shelf controls keep a full-width row-height contract",
 );
 assert.match(
   settings,
@@ -348,21 +321,14 @@ assert.match(
   /Color\.black\.opacity\(isOpen \? 0\.\d+ : 0\)/,
   "the closed drawer does not leave its dimming scrim over the app",
 );
-assert.match(
-  root,
-  /case \.projectSwitcher:\s*ProjectSwitcherView\(\)/,
-  "the project switcher is a real shell overlay destination",
-);
-assert.match(root, /case \.familiars: FamiliarsListView/, "Familiars is a real drawer destination");
+assert.doesNotMatch(root, /ProjectSwitcherView\(\)|case \.familiars:/,
+  "global workspace and Familiar hub overlays are retired");
+assert.doesNotMatch(drawer, /ProjectContextButton|openProjectSwitcher/,
+  "there is no global project switcher in the drawer");
 assert.match(
   drawer,
-  /ProjectContextButton \{[\s\S]{0,120}close\(\)[\s\S]{0,120}openProjectSwitcher\(\)/,
-  "the drawer header opens the project switcher from the current shell context",
-);
-assert.match(
-  drawer,
-  /private var recentThreads: \[ChatThread\] \{\s*app\.projectRecentThreads\(limit: 5\)\s*\}/,
-  "drawer recents come from the active project only",
+  /private var recentThreads: \[ChatThread\] \{[\s\S]*app\.chatThreads[\s\S]*prefix\(5\)/,
+  "drawer recents span conversations rather than a global project",
 );
 assert.match(
   projectSwitcher,
@@ -382,8 +348,8 @@ assert.match(
 assert.match(familiars, /struct FamiliarDetailView: View/, "familiar rows open a real detail surface");
 assert.match(
   home,
-  /FamiliarsListView \{ familiar in[\s\S]*fixedNewChatFamiliarId = familiar\.id[\s\S]*showNewChat = true/,
-  "the familiar detail chat action opens project-aware New Chat",
+  /NewChatView\(\s*fixedFamiliarId: fixedNewChatFamiliarId/,
+  "contextual New chat preserves the familiar without an operational hub",
 );
 assert.match(
   familiars,
@@ -525,11 +491,8 @@ assert.match(
   /@State private var modelMutationQueue = ChatModelMutationQueue\(\)[\s\S]{0,18000}private func chooseModel\([\s\S]{0,900}modelMutationQueue\.enqueue[\s\S]{0,900}client\.setChatModel/,
   "familiar-default model PATCHes are serialized in selection order",
 );
-assert.match(
-  familiars,
-  /static func activityValue\(for lastActivity: Date\?\) -> String \{[\s\S]*return "No activity yet"[\s\S]*lastActivity\.formatted\(date: \.abbreviated, time: \.shortened\)/,
-  "missing familiar activity falls back cleanly while real activity stays explicit and scoped",
-);
+assert.doesNotMatch(familiars, /FamiliarDetailStatsModel/,
+  "participant selection does not reconstruct an operational statistics hub");
 for (const section of ["Identity", "Defaults", "Access"]) {
   assert.match(familiars, new RegExp(`Text\\("${section}"\\)`), `familiar detail includes ${section}`);
 }
@@ -561,14 +524,15 @@ assert.match(
   /modelOverride: queuedMessage\.modelOverride/,
   "offline replay restores the queued model selection",
 );
+const threadRetry = thread.slice(thread.indexOf("func retry("), thread.indexOf("func appendSystem("));
 assert.match(
-  thread,
-  /let retryModel = source\?\.retryModel\(for: familiarId\)[\s\S]{0,300}ChatModelTurnBinding\.resolveRetry\([\s\S]{0,900}modelOverride: modelBinding\.modelOverride/,
+  threadRetry,
+  /let retryModel = source\?\.retryModel\(for: familiarId\)[\s\S]*ChatModelTurnBinding\.resolveRetry\([\s\S]*modelOverride: modelBinding\.modelOverride/,
   "retry restores the original per-familiar model selection",
 );
 assert.match(
-  thread,
-  /originalScope: source\?\.modelOverrideScope[\s\S]{0,900}modelOverrideScope: modelBinding\.scope/,
+  threadRetry,
+  /originalScope: source\?\.modelOverrideScope[\s\S]*modelOverrideScope: modelBinding\.scope/,
   "retry preserves explicit runtime-default intent without changing the chat's current model",
 );
 assert.match(
@@ -684,26 +648,19 @@ assert.doesNotMatch(
   "a new-chat model choice never mutates the familiar default",
 );
 assert.doesNotMatch(chat, /TODO\(no backend\)/, "session details no longer present known-fake controls");
-assert.match(chat, /linkedContextStrip/, "real linked task context is visible in the conversation");
-assert.match(
-  chat,
-  /FloatingAction\(id: "tasks", systemImage: "checklist", label: "Link a task"\) \{ showTasks = true \}/,
-  "an unlinked conversation can link its first task",
-);
+assert.doesNotMatch(chat, /linkedContextStrip|showTasks|LinkedTasksSheet/,
+  "chat does not expose task linking or task destinations");
 assert.match(
   chat,
   /case \.checking, \.degraded: return \(Color\.orange, "reconnecting"\)/,
   "the chat header reports reconnecting state instead of claiming readiness",
 );
-assert.match(
-  chat,
-  /app\.tasksError != nil\s*\?\s*"Tasks unavailable — open Tasks to retry"/,
-  "the start page does not report zero board work after a failed first load",
-);
+assert.match(chat, /if !chatAccessLoaded[\s\S]{0,350}Button\("Refresh access"\)/,
+  "readable history offers access recovery without implying that sends are authorized");
 assert.match(
   home,
-  /if app\.projectFamiliars\.isEmpty[\s\S]{0,80}app\.projectThreads\.isEmpty[\s\S]{0,80}app\.projectServerSessions\.isEmpty[\s\S]{0,220}if let error = app\.familiarsError \?\? app\.sessionsError \{[\s\S]{0,100}loadFailure\(error\)/,
-  "Chats renders first-load failure before the no-familiars empty state",
+  /if snapshot\.entries\.isEmpty && query\.isEmpty && snapshot\.archivedCount == 0[\s\S]{0,220}if let error = app\.familiarsError \?\? app\.sessionsError \{[\s\S]{0,100}loadFailure\(error\)/,
+  "Chats renders first-load failure without hiding cached or archived conversations",
 );
 assert.match(
   home,
@@ -727,14 +684,11 @@ assert.match(
 );
 assert.match(
   familiars,
-  /guard app\.projectMembershipLoaded else \{[\s\S]{0,200}if let error = app\.familiarsError \{[\s\S]{0,120}mode = \.firstLoadError\(error\)/,
+  /guard app\.familiarsLoaded else \{[\s\S]{0,200}if let error = app\.familiarsError \{[\s\S]{0,120}mode = \.firstLoadError\(error\)/,
   "the familiar roster renders first-load failure before empty state",
 );
-assert.match(
-  familiars,
-  /let taskValue = app\.tasksError == nil[\s\S]{0,120}\? "\\\(assignedTasks\.count\)"[\s\S]{0,160}app\.tasks\.isEmpty \? "Unknown" : "\\\(assignedTasks\.count\) cached"/,
-  "familiar task stats distinguish live, unavailable, and cached counts",
-);
+assert.match(familiars, /visibleFamiliars = app\.familiars/,
+  "participant selection does not inherit an ambient project filter");
 for (const [name, source] of [["projects", projects], ["familiars", familiars]]) {
   assert.match(
     source,
@@ -812,21 +766,8 @@ assert.match(
   /Button\(action: \{ tryInChat\(plugin\) \}\)[\s\S]*?\.disabled\(!canTryInChat\)/,
   "the detail action hands the usable plugin to chat",
 );
-assert.match(
-  chat,
-  /PluginsPanel \{ plugin in\s*prefillPlugin\(plugin\)\s*\}/,
-  "the marketplace handoff delegates the selected plugin to the draft-preserving prefill helper",
-);
-assert.match(
-  chat,
-  /private func prefillPlugin\(_ plugin: MarketplacePlugin\) \{[\s\S]*?let prompt = "Use \\\(plugin\.displayName\) to "/,
-  "the marketplace handoff builds the exact plugin prompt in a private helper",
-);
-assert.match(
-  chat,
-  /draft = draft\.isEmpty \? prompt : "\\\(draft\)\\n\\\(prompt\)"/,
-  "plugin prefill replaces only a blank draft and otherwise preserves it before a newline prompt",
-);
+assert.doesNotMatch(chat, /PluginsPanel|prefillPlugin/,
+  "chat no longer opens marketplace management");
 const composerBar = chat.slice(
   chat.indexOf("private var composerBar"),
   chat.indexOf("\n    private var composerBorderColor"),
@@ -852,7 +793,8 @@ assert.match(
   "the global drawer exposes app-wide search instead of a chat-only request",
 );
 assert.match(drawer, /openSearch\(\)/, "the drawer search control opens global search");
-assert.match(root, /case \.search:\s*GlobalSearchView\(/, "the root presents global search");
+assert.match(root, /openSearch: \{[\s\S]{0,140}app\.chatSearchRequested = true/,
+  "the drawer opens the chat list's search rather than a global operational search");
 assert.match(
   globalSearch,
   /\.searchable\(text: \$query, prompt: "Search everything…"\)/,
@@ -925,44 +867,8 @@ assert.match(
   /Text\(updated, format: \.relative\(presentation: \.numeric\)\)[\s\S]*?\.font\(\.caption\)\.foregroundStyle\(chrome\.textSecondary\)/,
   "project recency metadata remains legible in dark mode",
 );
-assert.match(
-  chat,
-  /private func validGitHubURL\(for link: CardGitHubLink\) -> URL\?/,
-  "linked chat context validates a real GitHub PR or issue URL",
-);
-assert.match(chat, /url\.host\?\.lowercased\(\) == "github\.com"/, "linked GitHub context stays on GitHub");
-assert.match(chat, /Link\(destination: context\.url\)/, "linked GitHub context opens its validated URL");
-assert.match(chat, /githubContextLabel/, "linked GitHub context has a concise visible label");
-assert.match(
-  chat,
-  /dynamicTypeSize\.isAccessibilitySize[\s\S]*?AnyLayout\(VStackLayout/,
-  "linked GitHub and task context stacks at accessibility text sizes",
-);
-assert.match(
-  chat,
-  /\.lineLimit\(dynamicTypeSize\.isAccessibilitySize \? nil : 1\)/,
-  "linked task titles can fully wrap at accessibility text sizes",
-);
-assert.match(
-  chat,
-  /Text\(cards\.count == 1 \? "Linked task"[\s\S]{0,260}\.fixedSize\(horizontal: false, vertical: true\)/,
-  "linked task context labels can wrap at accessibility text sizes",
-);
-assert.match(
-  chat,
-  /\.padding\(\.top, dynamicTypeSize\.isAccessibilitySize \? 16 : 0\)/,
-  "accessibility-sized linked context clears the navigation bar",
-);
-assert.match(
-  chat,
-  /\.padding\(\.bottom, dynamicTypeSize\.isAccessibilitySize \? 16 : 0\)/,
-  "accessibility-sized linked task text clears the context divider",
-);
-assert.match(
-  chat,
-  /private var linkedContextStrip:[\s\S]{0,2200}showTasks = true/,
-  "the GitHub affordance remains paired with the linked-task action",
-);
+assert.doesNotMatch(chat, /linkedContextStrip|githubContextLabel/,
+  "the retired task/PR summary strip cannot return to chat");
 assert.match(
   appModel,
   /--ui-preview-design-closeout/,
@@ -990,13 +896,13 @@ assert.match(
 );
 assert.match(
   home,
-  /private var filteredFamiliars: \[Familiar\] \{[\s\S]{0,220}app\.projectFamiliars/,
-  "Chats uses the active project's familiar roster",
+  /ChatListSnapshot\([\s\S]{0,220}familiars: app\.familiars/,
+  "global Chats keeps exact familiar identity without a project filter",
 );
 assert.match(
   home,
-  /private func familiarChat[\s\S]{0,260}app\.projectLandingDirectThread\(for: familiar\.id\)/,
-  "Chats resolves the visible conversation through the active project's landing thread",
+  /private func familiarChat[\s\S]{0,260}app\.globalLandingDirectThread\(for: familiar\.id\)/,
+  "familiar continuity finds existing history independently of an ambient project",
 );
 assert.match(
   familiars,
@@ -1004,7 +910,7 @@ assert.match(
   "the Familiar Profile is driven by the coherent dashboard snapshot",
 );
 assert.match(root, /--ui-open-search/, "simulator validation can launch directly into global search");
-assert.match(root, /--ui-open-projects/, "simulator validation can launch directly into projects");
+assert.doesNotMatch(root, /--ui-open-projects/, "a debug launch cannot resurrect project navigation");
 assert.match(
   globalSearch,
   /--ui-search-query/,

--- a/scripts/ios-connection-stability.test.mjs
+++ b/scripts/ios-connection-stability.test.mjs
@@ -53,8 +53,8 @@ assert.match(
 );
 assert.match(
   client,
-  /Self\.streamSession\.bytes\(for: req\)/,
-  "sendStream should use the dedicated streaming session",
+  /\(injectedSession \?\? Self\.streamSession\)\.bytes\(for: req\)/,
+  "sendStream defaults to the dedicated streaming session while honoring an explicitly supplied transport",
 );
 assert.doesNotMatch(
   client,

--- a/scripts/ios-familiar-profile.test.mjs
+++ b/scripts/ios-familiar-profile.test.mjs
@@ -8,6 +8,20 @@ const profile = await read("apps/ios/CovenCave/CovenCave/Views/FamiliarsListView
 const dashboard = await read("apps/ios/CovenCave/CovenCave/Models/FamiliarDashboard.swift");
 const models = await read("apps/ios/CovenCave/CovenCave/Models/Models.swift");
 
+const picker = profile.slice(0, profile.indexOf("struct FamiliarDetailView: View"));
+assert.doesNotMatch(picker, /FamiliarHubView|NavigationLink|FamiliarDetailStatsModel/,
+  "New chat selects a participant without entering an operational hub");
+assert.doesNotMatch(picker, /app\.projectFamiliars|app\.projectMembershipLoaded|app\.projectContext/,
+  "choosing a participant does not browse or switch an ambient project workspace");
+assert.match(picker, /visibleFamiliars = app\.familiars/);
+assert.match(picker, /guard app\.familiarsLoaded else/);
+assert.match(picker, /Button \{\s*dismiss\(\)\s*openFamiliar\(familiar\)/,
+  "choosing a participant returns it directly to the chat caller");
+assert.match(picker, /FamiliarPermissionsSheet\(familiar: familiar\)/,
+  "participant permissions stay reachable without loading dashboard data");
+assert.doesNotMatch(profile, /app\.tasks|app\.loadTasks\(/,
+  "participant selection and profile configuration never read or eagerly load task summaries");
+
 assert.match(
   hub,
   /if let profile = section\.data[\s\S]{0,600}FamiliarDetailView\([\s\S]{0,260}identity: snapshot\.identity[\s\S]{0,180}profile: profile[\s\S]{0,180}overview: snapshot\.overview/,

--- a/scripts/ios-familiar-row-actions.test.mjs
+++ b/scripts/ios-familiar-row-actions.test.mjs
@@ -2,40 +2,18 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const home = await readFile(
-  new URL("../apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift", import.meta.url),
-  "utf8",
+  new URL("../apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift", import.meta.url), "utf8",
 );
-
-// Familiar rows carry quick actions. Every assertion below is anchored inside
-// the familiar ForEach block: an earlier version of this test chained
-// `[\s\S]*` across the whole file and passed by matching a leading swipe on
-// THREAD rows against a "New chat" label in the rail's context menu — three
-// unrelated constructs that merely appeared in that order. Anchor, then match.
-const rowBlock = home.match(/ForEach\(filteredFamiliars\) \{ familiar in[\s\S]*?\n            \}/)?.[0];
-assert.ok(rowBlock, "the familiar ForEach block should be findable");
-
-assert.match(
-  home,
-  /private func startNewChat\(with familiar: Familiar\) \{[\s\S]*presentNewChat\(fixedFamiliarId: familiar\.id\)/,
-  "startNewChat should open project-aware New Chat with the familiar preselected",
-);
-
-assert.match(
-  rowBlock,
-  /\.swipeActions\(edge: \.leading\)[\s\S]{0,220}?startNewChat\(with: familiar\)[\s\S]{0,120}?Label\("New chat"/,
-  "leading swipe should start a new chat",
-);
-
-assert.match(
-  rowBlock,
-  /\.swipeActions\(edge: \.trailing[\s\S]{0,260}?app\.projectHasUnread\(familiar\.id\)[\s\S]{0,200}?markFamiliarViewed\(\[familiar\.id\]\)/,
-  "trailing swipe should mark read when unread",
-);
-
-assert.match(
-  rowBlock,
-  /\.contextMenu \{[\s\S]{0,400}?startNewChat\(with: familiar\)[\s\S]{0,400}?projectHasUnread\(familiar\.id\)[\s\S]{0,220}?Mark all read/,
-  "the context menu should offer New chat and Mark all read",
-);
-
+const rowBlock = home.match(/ForEach\(snapshot\.entries\) \{ entry in[\s\S]*?\n            \}/)?.[0];
+assert.ok(rowBlock, "the conversation ForEach block must exist");
+assert.match(rowBlock, /\.contextMenu \{ threadActions\(thread, activityAt: entry\.updatedAt\) \}/);
+assert.match(rowBlock, /\.swipeActions\(edge: \.leading\)[\s\S]{0,180}setThreadPinned/);
+assert.match(rowBlock, /\.swipeActions\(edge: \.trailing[\s\S]{0,500}setThreadArchived/);
+assert.match(rowBlock, /pendingDelete = thread/, "deletion requires confirmation");
+const actions = home.slice(home.indexOf("private func threadActions"), home.indexOf("private func consumeGlobalRequests"));
+assert.match(actions, /markThreadViewed\(thread, through: activityAt\)/,
+  "Mark read acknowledges only this conversation, through its displayed activity");
+assert.match(actions, /Label\("Mark read"/);
+assert.match(home, /presentNewChat\(fixedFamiliarId: familiar\.id\)/,
+  "contextual New chat keeps exact familiar identity");
 console.log("ios-familiar-row-actions: ok");

--- a/scripts/ios-import-markdown.test.mjs
+++ b/scripts/ios-import-markdown.test.mjs
@@ -11,11 +11,12 @@ const newChat = await read(`${iosRoot}/Views/NewChatView.swift`);
 // New Chat captures a project-scoped launch context before opening the picker
 // and revalidates the same project/root + roster on callback.
 assert.match(importContext, /struct NewChatImportLaunchContext: Equatable, Sendable/, "New Chat import should capture a dedicated launch context");
-assert.match(importContext, /init\?\(\s*activeProject: ProjectInfo\?,\s*selectedFamiliarIds: \[String\]\s*\)/, "launch context capture should require the active project and selected roster");
+assert.match(importContext, /init\?\(\s*selectedProject: ProjectInfo\?,\s*selectedFamiliarIds: \[String\]\s*\)/, "launch context capture should require the local project and selected roster");
 assert.match(importContext, /let familiarIds = ChatProjectSelection\.familiarKey\(selectedFamiliarIds\)[\s\S]*guard !projectId\.isEmpty,[\s\S]*!projectRoot\.isEmpty,[\s\S]*!familiarIds\.isEmpty else \{ return nil \}/, "captured imports must never proceed with an empty preferred roster");
-assert.match(importContext, /func validate\([\s\S]*projectContext: ProjectContext\?,[\s\S]*activeProject: ProjectInfo\?,[\s\S]*projectMembership: ProjectMembershipIndex[\s\S]*\) -> ValidationResult/, "launch context should validate against the current active project state");
-assert.match(importContext, /guard activeProjectId == projectId,[\s\S]*activeProjectRoot == projectRoot else \{[\s\S]*return \.projectChanged/, "validation must fail closed when the active project changes");
-assert.match(importContext, /let revokedFamiliarIds = familiarIds\.filter \{[\s\S]*!projectMembership\.contains\(\$0, inProjectID: activeProjectId\)/, "validation must fail closed when any selected familiar loses project access");
+assert.match(importContext, /func validate\([\s\S]*registeredProjects: \[ProjectInfo\],[\s\S]*accessibleProjects: \[ProjectInfo\],[\s\S]*projectMembership: ProjectMembershipIndex,[\s\S]*membershipLoaded: Bool/, "launch context must validate against fresh registration and accessible scopes");
+assert.match(importContext, /guard registeredProjects\.contains\(where: \{[\s\S]*\$0\.id == projectId && \$0\.root == projectRoot[\s\S]*return \.projectChanged/, "validation must reject changes to the exact captured registration");
+assert.match(importContext, /let revokedFamiliarIds = familiarIds\.filter \{[\s\S]*!projectMembership\.contains\(\$0, inProjectID: projectId\)/, "validation must fail closed when any selected familiar loses project access");
+assert.doesNotMatch(importContext, /activeProject|projectContext:/, "ambient changes must not retarget or cancel a valid local import");
 
 // Parser pulls title, participants, and **Author**-delimited turns.
 assert.match(parser, /func parseThreadMarkdown\(_ text: String\) -> ParsedThread/, "a parser should exist");
@@ -37,13 +38,13 @@ assert.match(newChat, /import UniformTypeIdentifiers/, "imports UTType");
 assert.match(newChat, /@State private var importLaunchContext: NewChatImportLaunchContext\?/, "New Chat should retain the captured launch context while the picker is open");
 assert.match(newChat, /Button \{ beginImport\(\) \} label: \{[\s\S]*Label\("Import from Markdown…", systemImage: "square\.and\.arrow\.down"\)/, "Import should capture launch context before the picker opens");
 assert.match(newChat, /\.fileImporter\([\s\S]*isPresented: \$importingFile/, "presents a file importer");
-assert.match(newChat, /let launchContext = NewChatImportLaunchContext\([\s\S]*activeProject: activeProject,[\s\S]*selectedFamiliarIds: selectedFamiliarIds[\s\S]*\)[\s\S]*importLaunchContext = launchContext[\s\S]*importingFile = true/, "Import should freeze the active project + preferred roster before presenting the picker");
-assert.match(newChat, /defer \{ importLaunchContext = nil \}/, "picker callbacks should always clear the captured launch context");
-assert.match(newChat, /switch launchContext\.validate\([\s\S]*projectContext: app\.projectContext,[\s\S]*activeProject: activeProject,[\s\S]*projectMembership: app\.projectMembership[\s\S]*\)/, "picker callbacks must revalidate the captured project context before import");
-assert.match(newChat, /case \.unassigned:[\s\S]*app\.showToast\(/, "Unassigned callbacks must abort with guidance");
-assert.match(newChat, /case \.projectChanged:[\s\S]*app\.showToast\(/, "project switches while the picker is open must abort with guidance");
-assert.match(newChat, /case \.familiarAccessRevoked\(let revokedFamiliarIds\):[\s\S]*app\.showToast\(/, "access revocation while the picker is open must abort with guidance");
-assert.match(newChat, /app\.importMarkdown\([\s\S]*fallbackTitle: fallback,[\s\S]*familiarIds: launchContext\.familiarIds,[\s\S]*projectRoot: launchContext\.projectRoot/, "imports must use the captured project root and preferred roster instead of live callback state");
+assert.match(newChat, /let context = NewChatImportLaunchContext\([\s\S]*selectedProject: selectedProject,[\s\S]*selectedFamiliarIds: selectedFamiliarIds[\s\S]*\)[\s\S]*importLaunchContext = context[\s\S]*importingFile = true/, "Import should freeze its local project and roster before presenting the picker");
+assert.match(newChat, /private func importFromFile[\s\S]*let context = importLaunchContext[\s\S]*importLaunchContext = nil[\s\S]*importConnectionLease = nil/, "picker callbacks consume the captured launch context exactly once");
+assert.match(newChat, /guard await validate\(context, lease: lease\) else \{ return \}[\s\S]*app\.importMarkdown\(/, "picker callbacks must revalidate captured access before import");
+assert.match(newChat, /case \.accessUnavailable:[\s\S]*reportLaunchError\(/, "missing grants must abort with actionable guidance");
+assert.match(newChat, /case \.projectChanged:[\s\S]*reportLaunchError\(/, "changed registrations must abort with guidance");
+assert.match(newChat, /case \.familiarAccessRevoked\(let ids\):[\s\S]*reportLaunchError\(/, "revoked access must abort with guidance");
+assert.match(newChat, /app\.importMarkdown\([\s\S]*familiarIds: context\.familiarIds,[\s\S]*projectRoot: context\.projectRoot/, "imports must use captured project and roster rather than callback state");
 assert.match(newChat, /startAccessingSecurityScopedResource\(\)/, "accesses the security-scoped file");
 
 console.log("ios-import-markdown.test.mjs: ok");

--- a/scripts/ios-ipad-split-chats.test.mjs
+++ b/scripts/ios-ipad-split-chats.test.mjs
@@ -2,16 +2,16 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 // On iPad the Chats tab should be a two-column NavigationSplitView: the home list
-// of familiars in the sidebar, and the selected familiar's conversation in the
+// of conversations in the sidebar, and the selected conversation in the
 // detail column. NavigationSplitView collapses to a single stack on iPhone, so
-// the familiar→chat drill is unchanged there. This locks the conversion.
+// list-to-chat drill stays native there.
 
 const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
 const src = await read("apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift");
 
 assert.match(
   src,
-  /NavigationSplitView \{[\s\S]*\} detail: \{[\s\S]*detailColumn/,
+  /NavigationSplitView\(preferredCompactColumn: \$preferredCompactColumn\) \{[\s\S]*\} detail: \{[\s\S]*detailColumn/,
   "ChatsHomeView should use NavigationSplitView with a detail column",
 );
 assert.doesNotMatch(
@@ -31,7 +31,7 @@ assert.match(
   /private func open\(_ route: ChatRoute\) \{\s*\n\s*detailPath = \[\]\s*\n\s*selection = route/,
   "programmatic opens should drive the selection",
 );
-assert.match(src, /\.tag\(ChatRoute\.familiar\(familiar\)\)/, "familiar rows should be tagged for selection");
+assert.match(src, /\.tag\(ChatRoute\.thread\(thread\)\)/, "conversation rows should be tagged for selection");
 
 // Detail column: familiar → its chat (its other sessions are reachable from
 // ChatView's config card, which pushes onto detailPath), a thread → the chat,
@@ -54,7 +54,7 @@ assert.match(
 // New selection resets the detail navigation.
 assert.match(
   src,
-  /\.onChange\(of: selection\) \{ _, _ in detailPath = \[\] \}/,
+  /\.onChange\(of: selection\) \{ _, selected in\s*detailPath = \[\]\s*preferredCompactColumn = selected == nil \? \.sidebar : \.detail/,
   "changing the sidebar selection should reset the detail navigation",
 );
 // Balanced style keeps the list visible on iPad.

--- a/scripts/ios-message-forwarding.test.mjs
+++ b/scripts/ios-message-forwarding.test.mjs
@@ -68,7 +68,7 @@ assert.match(
 
 assert.match(
   chat,
-  /guard let destination = app\.openFamiliarLandingThread\(\s*for: familiar\.id,\s*in: activeContext,\s*loadHistory: false\s*\) else \{[\s\S]*Switch to a registered project before forwarding[\s\S]*return[\s\S]*\}[\s\S]*destination\.send\(\s*prompt,[\s\S]*displayText: displayText,[\s\S]*client: client/,
+  /guard let destination = app\.openFamiliarLandingThread\(\s*for: familiar\.id,\s*in: activeContext,\s*loadHistory: false\s*\) else \{[\s\S]*Open New chat to choose project access for this familiar before forwarding[\s\S]*return[\s\S]*\}[\s\S]*destination\.send\(\s*prompt,[\s\S]*displayText: displayText,[\s\S]*client: client/,
   "forwarding should reuse or materialize the visible-thread landing thread synchronously before sending the context prompt with a compact visible label",
 );
 
@@ -137,5 +137,15 @@ assert.match(
   /app\.requestOpen\(destination\)/,
   "after forwarding, iOS should open the destination familiar thread",
 );
+
+const forwarding = chat.slice(chat.indexOf("private func forward("), chat.indexOf("private func reloadForwardedLandingHistoryIfConfirmed("));
+assert.match(forwarding, /app\.requireCurrentChatAccess\(projectRoot: thread\.projectRoot, familiarIds: \[familiar\.id\]\)/,
+  "the selected destination familiar needs an exact project grant before its landing thread is opened");
+assert.match(forwarding, /let destinationBinding = ChatDispatchBinding\(thread: destination\)/);
+assert.match(forwarding, /app\.requireCurrentChatAccess\(\s*projectRoot: destinationBinding\.projectRoot,\s*familiarIds: destinationBinding\.familiarIds/);
+assert.match(forwarding, /sourceBinding\.matches\(thread\),\s*dispatchIsCurrent\(destinationBinding, in: destination, lease: dispatchLease\)/,
+  "deferred forwarding cannot retarget the captured source or destination");
+assert.match(forwarding, /liveDispatchLeaseIsCurrent: \{\s*dispatchIsCurrent\(destinationBinding, in: destination, lease: dispatchLease\)/,
+  "the actual forward POST checks the destination grant, not only the source thread");
 
 console.log("ios-message-forwarding.test.mjs: ok");

--- a/scripts/ios-message-retry.test.mjs
+++ b/scripts/ios-message-retry.test.mjs
@@ -48,8 +48,8 @@ assert.match(
 // --- thread.retry re-streams a single familiar in place ---------------------
 assert.match(
   thread,
-  /func retry\(_ messageId: String, client: CaveClient,[\s\S]{0,120}?onConnectionFailure: \(\(Error\) -> Void\)\? = nil,[\s\S]{0,80}?onChange: @escaping \(\) -> Void\)/,
-  "ChatThread should expose retry(messageId:client:onConnectionFailure:onChange:)",
+  /func retry\(_ messageId: String, client: CaveClient,\s*liveDispatchLeaseIsCurrent: @escaping \(\) -> Bool,\s*persistAfterRefusal: @escaping \(\) async -> Bool,\s*onRefusal: @escaping \(\) -> Void,[\s\S]{0,160}onChange: @escaping \(\) -> Void\) -> Task<Void, Never>\?/,
+  "retry requires a live dispatch lease and durable, visible refusal handling",
 );
 assert.match(
   thread,
@@ -58,8 +58,26 @@ assert.match(
 );
 assert.match(
   thread,
-  /func retry[\s\S]*?\$0\.text = ""; \$0\.isError = false; \$0\.streaming = true[\s\S]*?stream\(familiarId: familiarId/,
+  /func retry[\s\S]*?\$0\.text = ""; \$0\.isError = false; \$0\.streaming = true[\s\S]*?stream\(\s*familiarId: familiarId/,
   "retry should reset the bubble and re-stream only its familiar (not a full send fan-out)",
 );
+
+const retry = thread.slice(thread.indexOf("func retry("), thread.indexOf("/// Append an inline system note"));
+assert.match(retry, /ChatDispatchBinding\(thread: self, familiarIds: \[familiarId\]\)/);
+assert.match(retry, /binding\.matches\(self, includingSessions: true\),\s*liveDispatchLeaseIsCurrent\(\)/);
+assert.match(retry, /liveDispatchLeaseIsCurrent: mayDispatch/);
+assert.match(retry, /let previousReply = messages\[idx\]/);
+assert.match(retry, /guard refusedBeforeDispatch else \{ return \}[\s\S]*messages\[current\] == retryPlaceholder[\s\S]*messages\[current\] = previousReply[\s\S]*await persistAfterRefusal\(\)/);
+assert.match(view, /func retryAssistant[\s\S]*captureConnectionDispatchLease\(\)[\s\S]*thread\.retry\([\s\S]*liveDispatchLeaseIsCurrent: \{\s*dispatchIsCurrent\(dispatchBinding, in: thread, lease: dispatchLease\)/);
+const tests = await read("apps/ios/CovenCave/CovenCaveTests/ChatRetryDispatchTests.swift");
+for (const scenario of [
+  "testRevocationAfterRetryReturnsRestoresAndPersistsOriginalReply",
+  "testDeferredNetworkPreflightRechecksAuthorityAndRestoresOriginalReply",
+  "testRootSessionAndRosterDriftBeforeDeferredPOSTFailClosed",
+  "testRefusalDoesNotOverwriteANewerTranscriptEdit",
+  "testFrozenSendBindingAllowsSiblingSessionEstablishmentButNotRetargeting",
+]) {
+  assert.ok(tests.includes(`func ${scenario}(`), `native regression scenario ${scenario} is present`);
+}
 
 console.log("ios-message-retry: OK");

--- a/scripts/ios-motion-polish.test.mjs
+++ b/scripts/ios-motion-polish.test.mjs
@@ -29,7 +29,7 @@ test("ChatsHomeView owns the zoom namespace and applies the zoom push", () => {
 test("zoom transition is gated on Reduce Motion", () => {
   assert.match(
     chatsHome,
-    /if reduceMotion \{\s*ChatView\(thread: thread\)\s*\} else \{/,
+    /if reduceMotion \{\s*ChatView\(thread: thread\)\s*\.id\(thread\.id\)\s*\} else \{/,
     "Reduce Motion must keep the standard push (no navigationTransition)",
   );
 });

--- a/scripts/ios-offline-compose.test.mjs
+++ b/scripts/ios-offline-compose.test.mjs
@@ -118,8 +118,8 @@ assert.match(
 );
 assert.match(
   thread,
-  /func replayQueued\(client: CaveClient,[\s\S]{0,160}?onConnectionFailure: \(\(Error\) -> Void\)\? = nil,[\s\S]{0,140}?dispatchLeaseIsCurrent: @escaping \(\) -> Bool,[\s\S]{0,140}?persistBeforeDispatch: @escaping \(\) async -> Bool,[\s\S]{0,160}?onChange: @escaping \(\) -> Void\) async/,
-  "ChatThread.replayQueued drives the reconnect send",
+  /func replayQueued\(client: CaveClient,[\s\S]{0,160}?onConnectionFailure: \(\(Error\) -> Void\)\? = nil,\s*dispatchLeaseIsCurrent: @escaping \(\) -> Bool,\s*targetAccessIsCurrent: @escaping \(String\?, String\) -> Bool,\s*onAccessRefused: @escaping \(String\?\) -> Void,\s*persistBeforeDispatch: @escaping \(\) async -> Bool,[\s\S]{0,160}?onChange: @escaping \(\) -> Void\) async/,
+  "ChatThread.replayQueued requires endpoint, per-target access, refusal feedback, and durability callbacks",
 );
 assert.match(
   thread,
@@ -129,6 +129,7 @@ assert.match(
 assert.match(thread, /var queuedRunIdsByFamiliarId: \[String: String\]\?/);
 assert.match(thread, /var queuedAttemptedFamiliarIds: \[String\]\?/);
 assert.match(thread, /var queuedTargetFamiliarIds: \[String\]\?/);
+assert.match(thread, /var queuedContext: QueuedContext\?/);
 assert.match(models, /var attentionClearOperationId: String\?/);
 assert.match(models, /var parentId: String\?/);
 const sendStart = thread.indexOf("func send(_ text: String");
@@ -179,6 +180,36 @@ assert.match(
   /let targets = queuedMessage\.queuedTargetFamiliarIds[\s\S]{0,180}queuedRunIdsByFamiliarId[\s\S]{0,100}\?\? familiarIds/,
   "replay freezes the original fan-out instead of using mutable group membership",
 );
+assert.match(
+  replayImplementation,
+  /let queuedContext = queuedMessage\.queuedContext,[\s\S]{0,100}let queuedProjectRoot = queuedContext\.projectRoot,[\s\S]{0,100}queuedProjectRoot == projectRoot/,
+  "replay requires the original persisted project rather than adopting a replacement thread root",
+);
+assert.match(
+  replayImplementation,
+  /let queuedSessionId = queuedContext\.sessionIds\[familiarId\] \?\? sessionIds\[familiarId\]/,
+  "an established queued session cannot be replaced, but an initially absent session may become established",
+);
+assert.match(
+  sendImplementation,
+  /queuedContext: \.init\(projectRoot: projectRoot, sessionIds: sessionIds\)/,
+  "a live send captures its original project and conversation before a checkpoint can suspend",
+);
+assert.match(
+  thread,
+  /migrated\.queuedContext = \.init\(projectRoot: projectRoot, sessionIds: sessionIds\)/,
+  "legacy queued turns capture saved provenance during construction, before thread hydration",
+);
+assert.match(
+  thread,
+  /if migrated\.queuedTargetFamiliarIds == nil \{[\s\S]{0,120}message\.queuedRunIdsByFamiliarId[\s\S]{0,100}\?\? familiarIds/,
+  "legacy recipients freeze from the saved delivery IDs or saved roster before hydration",
+);
+assert.match(
+  replayImplementation,
+  /if streamOutcome == \.queued, targetWasRefused,\s*!Task\.isCancelled, dispatchLeaseIsCurrent\(\) \{\s*continue/,
+  "a proven per-target preflight refusal does not starve allowed siblings or waive the endpoint lease",
+);
 assert.match(thread, /var sendPrompt: String\?/);
 assert.match(sendImplementation, /sendPrompt: shown == trimmed \? nil : trimmed/);
 assert.match(replayImplementation, /let prompt = queuedMessage\.sendPrompt \?\? queuedMessage\.text/);
@@ -206,13 +237,13 @@ const freshStream = replayImplementation.indexOf("let streamOutcome = await stre
 assert.ok(freshCheckpoint >= 0 && freshStream > freshCheckpoint);
 assert.match(
   replayImplementation.slice(freshCheckpoint, freshStream),
-  /else \{[\s\S]*?_ = await persistAfterRollback\(\)[\s\S]*?return\s*\n\s*\}[\s\S]*?guard !Task\.isCancelled, dispatchLeaseIsCurrent\(\) else \{[\s\S]*?_ = await persistAfterRollback\(\)[\s\S]*?return\s*\n\s*\}/,
+  /else \{[\s\S]*?_ = await persistAfterRollback\(\)[\s\S]*?return\s*\n\s*\}[\s\S]*?guard !Task\.isCancelled, dispatchLeaseIsCurrent\(\), mayDispatchTarget\(\) else \{[\s\S]*?_ = await persistAfterRollback\(\)[\s\S]*?return\s*\n\s*\}/,
   "failed and cancelled pre-POST checkpoints durably roll back before returning",
 );
 assert.match(
   replayImplementation.slice(freshStream),
-  /runId: runId,[\s\S]{0,160}liveDispatchLeaseIsCurrent: dispatchLeaseIsCurrent,[\s\S]{0,120}persistAfterProvablyUnsentRollback: persistAfterRollback/,
-  "queued replay passes the exact checkpointed run id and its local rollback durability closure into stream",
+  /runId: runId,[\s\S]{0,160}liveDispatchLeaseIsCurrent: mayDispatchTarget,[\s\S]{0,120}persistAfterProvablyUnsentRollback: persistAfterRollback/,
+  "queued replay passes its checkpointed run id, exact-target access fence, and local rollback durability into stream",
 );
 assert.match(
   sendImplementation,
@@ -319,7 +350,7 @@ assert.doesNotMatch(
 );
 assert.match(
   thread,
-  /mutate\(queuedId\) \{\s*\n\s*\$0\.queued = false[\s\S]{0,240}\$0\.queuedTargetFamiliarIds = nil\s*\n\s*\}/,
+  /mutate\(queuedId\) \{\s*\n\s*\$0\.queued = false[\s\S]{0,240}\$0\.queuedTargetFamiliarIds = nil\s*\n\s*\$0\.queuedContext = nil\s*\n\s*\}/,
   "the queue clears only after every intended familiar attempt has settled",
 );
 

--- a/scripts/ios-reconnect-pill.test.mjs
+++ b/scripts/ios-reconnect-pill.test.mjs
@@ -29,11 +29,8 @@ assert.match(
   /case \.checking where app\.connection != nil && !app\.hasLoadedSurfaces:\s*\n\s*ConnectingView\(\)/,
   "the Connecting screen is a cold-launch state, not a reconnect state",
 );
-assert.match(
-  root,
-  /case \.projectContextRequired where !app\.hasLoadedSurfaces:\s*\n[\s\S]*?ProjectContextGateView\(\)/,
-  "a first project-context failure should stay out of MainShell and show a dedicated retry gate",
-);
+assert.doesNotMatch(root, /ProjectContextGateView\(\)/,
+  "access-catalog failures must not replace readable chat and Settings with a global gate");
 assert.match(
   gate,
   /struct ProjectContextGateView: View[\s\S]*?Button\("Retry"\)/,
@@ -113,8 +110,8 @@ assert.match(
 );
 assert.match(
   model,
-  /var hasLoadedSurfaces: Bool \{\s*\n\s*familiarsLoaded \|\| sessionsLoaded \|\| tasksLoaded \|\| remindersLoaded \|\| projectsLoaded/,
-  "hasLoadedSurfaces should treat successful empty familiar loads as loaded shell state",
+  /var hasLoadedSurfaces: Bool \{\s*!chatThreads\.isEmpty \|\| !chatServerSessions\.isEmpty\s*\|\| familiarsLoaded \|\| sessionsLoaded \|\| projectsLoaded\s*\}/,
+  "cached chats or successful empty catalog loads keep the chat shell readable without task readiness",
 );
 
 console.log("ios-reconnect-pill: OK");

--- a/scripts/ios-self-healing-sync.test.mjs
+++ b/scripts/ios-self-healing-sync.test.mjs
@@ -39,10 +39,19 @@ assert.match(
 // context + familiars + theme + profile) runs beside the remaining already-open
 // surfaces, and reconnect mirrors a failed cached project-context refresh back
 // to the relevant stale-data banners instead of issuing a duplicate load.
+const refreshLoadedSurfaces = model.slice(
+  model.indexOf("private func refreshLoadedSurfaces("),
+  model.indexOf("/// `quiet` probes"),
+);
 assert.match(
-  model,
-  /private func refreshLoadedSurfaces\(configurationGeneration: UInt64\) async \{[\s\S]*?connectionConfigurationLeaseIsCurrent\(configurationGeneration\)[\s\S]*?let mirroredProjectContextFailures = loadedProjectContextFailureSurfaces[\s\S]*?withTaskGroup[\s\S]*?group\.addTask \{[\s\S]*?await self\.loadCoreResources\([\s\S]*?mirroringProjectContextFailuresTo: mirroredProjectContextFailures,[\s\S]*?configurationGeneration: configurationGeneration[\s\S]*?\)[\s\S]*?\}[\s\S]*?if sessionsLoaded \{ group\.addTask \{ await self\.loadSessions\(\) \} \}[\s\S]*?if tasksLoaded \{ group\.addTask \{ await self\.loadTasks\(\) \} \}[\s\S]*?if remindersLoaded \{ group\.addTask \{ await self\.loadReminders\(\) \} \}/,
-  "reconnect should refresh remaining loaded surfaces while mirroring cached project-context failures once",
+  refreshLoadedSurfaces,
+  /connectionConfigurationLeaseIsCurrent\(configurationGeneration\)[\s\S]*mirroringProjectContextFailuresTo: mirroredProjectContextFailures,[\s\S]*if sessionsLoaded \{ group\.addTask \{ await self\.loadSessions\(\) \} \}/,
+  "reconnect refreshes chat history and mirrors cached access failures once",
+);
+assert.doesNotMatch(
+  refreshLoadedSurfaces,
+  /loadTasks|loadReminders/,
+  "reconnect must not eagerly load retired non-chat surfaces",
 );
 assert.match(
   model,

--- a/scripts/ios-slash-commands.test.mjs
+++ b/scripts/ios-slash-commands.test.mjs
@@ -60,6 +60,19 @@ assert.doesNotMatch(iosSlash, /name: "\/terminal"|name: "\/comux"/,
   "the retired iOS terminal commands stay out of the native catalog");
 assert.doesNotMatch(chatView, /\.openTerminal|selectedTab = \.terminal/,
   "chat command routing cannot reach the retired iOS terminal");
+assert.doesNotMatch(iosSlash, /case openBoard/, "the catalog cannot dispatch native task navigation");
+assert.doesNotMatch(chatView, /case \.openBoard|selectedTab = \.tasks/,
+  "typed legacy task commands cannot mount Tasks");
+assert.match(
+  iosSlash,
+  /name: "\/board", aliases: \["\/tasks", "\/task"\][\s\S]{0,220}availability: \.desktopOnly, action: \.desktopOnly\("Tasks"\)/,
+  "legacy task command names resolve to a desktop-only explanation",
+);
+assert.match(
+  chatView,
+  /case \.desktopOnly\(let surface\):[\s\S]{0,160}app\.showToast/,
+  "retired commands explain their desktop-only availability rather than sending a prompt",
+);
 
 // /model is native on iOS: it switches the chat model via the model-state API.
 assert.match(
@@ -98,7 +111,7 @@ assert.match(
   "switchModel should PATCH an existing session, or clear the familiar default before the first session",
 );
 
-for (const command of ["/auto", "/journal", "/automations", "/remind", "/attach", "/tui", "/toggle-agent"]) {
+for (const command of ["/board", "/auto", "/journal", "/automations", "/remind", "/attach", "/tui", "/toggle-agent"]) {
   const escaped = command.replace("/", "\\/");
   assert.match(
     iosSlash,

--- a/scripts/ios-task-search-familiar-scope.test.mjs
+++ b/scripts/ios-task-search-familiar-scope.test.mjs
@@ -57,25 +57,10 @@ assert.match(
   /return trimmedQuery\.isEmpty \|\| card\.title\.lowercased\(\)\.contains\(trimmedQuery\)/,
   "the search query should still narrow the already project-and-familiar-scoped task set",
 );
-assert.match(
-  chat,
-  /if !app\.projectLinkedTasks\(for: thread\)\.isEmpty \{/,
-  "chat should only advertise linked tasks that still belong to the active project scope",
-);
-assert.match(
-  chat,
-  /private var linkedGitHubContext: \(link: CardGitHubLink, url: URL\)\? \{[\s\S]*app\.projectLinkedTasks\(for: thread\)/,
-  "linked GitHub context should come from the same project-scoped task set as the sheet",
-);
-assert.match(
-  chat,
-  /private var linkedContextStrip: some View \{[\s\S]*let cards = app\.projectLinkedTasks\(for: thread\)/,
-  "linked task count and header should use the same project-scoped helper as the sheet",
-);
 assert.doesNotMatch(
   chat,
-  /app\.linkedTasks\(for: thread\)/,
-  "chat should not advertise out-of-scope linked tasks once project scoping is active",
+  /app\.(?:projectLinkedTasks|linkedTasks)\(for: thread\)|linkedContextStrip|LinkedTasksSheet/,
+  "retained legacy task links are not a reachable native chat surface",
 );
 assert.match(
   tasks,

--- a/scripts/ios-thread-search.test.mjs
+++ b/scripts/ios-thread-search.test.mjs
@@ -63,12 +63,12 @@ assert.match(
   "results should open the thread when tapped",
 );
 
-// What survives on the home is familiar filtering — the home is a familiar list.
-assert.match(home, /private var filteredFamiliars: \[Familiar\]/, "the home should filter familiars");
+// Global home search organizes conversations without scanning transcripts.
+assert.match(home, /ChatListSnapshot\([\s\S]*query: query/, "home searches the conversation projection");
 assert.match(
   home,
-  /filteredFamiliars\.isEmpty/,
-  "the home's search empty-state should consider matching familiars",
+  /snapshot\.entries\.isEmpty && !query\.isEmpty/,
+  "home search retains an honest empty state for matching conversations",
 );
 
 console.log("ios-thread-search.test.mjs: ok");

--- a/scripts/ios-unread-badges.test.mjs
+++ b/scripts/ios-unread-badges.test.mjs
@@ -24,15 +24,19 @@ assert.match(model, /seedFamiliarViews\(nextFamiliars\.map\(\\\.id\), in: nil\)/
 assert.match(model, /loadFamiliarViews\(\)/, "init should load persisted views");
 assert.match(model, /cave-familiar-views\.json/, "views should persist to disk");
 
-// Opening a chat or a familiar's threads marks it read.
+assert.match(model, /var threadViews: \[String: Date\] = \[:\]/,
+  "read acknowledgements must have conversation-level identity");
+assert.match(model, /func markThreadViewed\(_ thread: ChatThread,/);
+assert.match(model, /projectContextDefaults\.set\(seen, forKey: Self\.threadViewKey\(thread\.id\)\)/,
+  "conversation read state must persist independently of familiar-wide migration baselines");
+
+// Opening one conversation must not acknowledge other conversations.
 const chat = await read("Views/ChatView.swift");
-assert.match(chat, /app\.markFamiliarViewed\(\s*thread\.familiarIds,\s*in: app\.projectContext\(for: thread\)\s*\)/, "opening a chat marks its familiars read in that thread's project context");
+assert.match(chat, /app\.markThreadViewed\(thread\)/, "opening a chat acknowledges only that conversation");
+assert.doesNotMatch(chat, /app\.markFamiliarViewed\(/);
 const threads = await read("Views/FamiliarThreadsView.swift");
-assert.match(
-  threads,
-  /app\.markFamiliarViewed\(\[familiar\.id\],\s*in: projectContext\)/,
-  "opening a familiar's threads marks it read in the explicit picker context",
-);
+assert.doesNotMatch(threads, /app\.markFamiliarViewed\(/,
+  "browsing the session picker is not reading every conversation");
 
 // The Chats row shows an accent unread dot.
 const home = await read("Views/ChatsHomeView.swift");
@@ -41,9 +45,11 @@ const home = await read("Views/ChatsHomeView.swift");
 // \s* between the calls so the rail's multi-line chain matches too.
 assert.match(
   home,
-  /if app\.projectHasUnread\(familiar\.id\) \{\s*Circle\(\)\s*\.fill\(chrome\.accent\)/,
-  "the familiar row avatar should show an accent unread dot",
+  /if hasUnread \{\s*Circle\(\)\s*\.fill\(accentColor\)/,
+  "the conversation row shows an accent unread dot",
 );
-assert.match(home, /if app\.projectHasUnread\(familiar\.id\) \{ parts\.append\("unread"\) \}/, "VoiceOver should announce unread");
+assert.match(home, /app\.seenBoundary\(for: thread\)/, "unread comes from the exact conversation context");
+assert.match(home, /app\.markThreadViewed\(thread, through: activityAt\)/);
+assert.match(home, /if hasUnread \{ parts\.append\("unread"\) \}/, "VoiceOver should announce unread");
 
 console.log("ios-unread-badges: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1964,6 +1964,8 @@ export const SUITES = {
     "scripts/ios-app-store-assets.test.mjs",
     "scripts/ios-chat-project-contract.test.mjs",
     "scripts/ios-chat-familiars-home.test.mjs",
+    "scripts/ios-chat-only.test.mjs",
+    "scripts/ios-chat-entrypoints.test.mjs",
     "scripts/ios-familiar-profile.test.mjs",
     "scripts/ios-project-generation.test.mjs",
     "scripts/ios-markdown-bundle.test.mjs",

--- a/scripts/testflight-receipt.mjs
+++ b/scripts/testflight-receipt.mjs
@@ -54,7 +54,11 @@ export function appleUrl(value) {
 export function tokenSigner(env) {
   const keyId = env.APPLE_API_KEY;
   const subject = env.APPLE_API_KEY_SUBJECT || "";
-  requireValue(typeof keyId === "string" && /^[A-Z0-9]{10}$/.test(keyId), "INVALID_KEY_ID");
+  // Apple's example is ten characters, not a key-ID length contract.
+  requireValue(
+    typeof keyId === "string" && keyId.length > 0 && keyId.length <= 128 && !/[^A-Za-z0-9_-]/.test(keyId),
+    "INVALID_KEY_ID",
+  );
   requireValue(subject === "" || subject === "user", "INVALID_KEY_SUBJECT");
   requireValue(subject === "user" || /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(env.APPLE_API_ISSUER || ""),
     "INVALID_TEAM_ISSUER");

--- a/scripts/testflight-receipt.test.mjs
+++ b/scripts/testflight-receipt.test.mjs
@@ -88,6 +88,31 @@ test("exact input validation does not echo arbitrary inputs", async () => {
   }
 });
 
+test("key IDs are bounded identifiers, not restricted to Apple's example length", async () => {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  const base = {
+    APPLE_API_KEY_SUBJECT: "user",
+    APPLE_API_KEY_BASE64: Buffer.from(privateKey.export({ type: "pkcs8", format: "pem" })).toString("base64"),
+  };
+  for (const keyId of ["TESTKEY123", "TESTKEY12345", "Test_Key-123", "A".repeat(128)]) {
+    const token = tokenSigner({ ...base, APPLE_API_KEY: keyId })("/v1/apps?limit=200", 1000);
+    const [header, payload, signature] = token.split(".");
+    assert.equal(JSON.parse(Buffer.from(header, "base64url")).kid, keyId);
+    assert.ok(verify("sha256", Buffer.from(`${header}.${payload}`),
+      { key: publicKey, dsaEncoding: "ieee-p1363" }, Buffer.from(signature, "base64url")));
+  }
+  for (const keyId of [
+    undefined, null, 123, "", "A".repeat(129), "PRIVATE KEY", "PRIVATE\nKEY",
+    "PRIVATE\n", "PRIVATE\r\n", "PRIVATE\u0000", "PRIVATE\u2028", "\"PRIVATE\"",
+  ]) {
+    const receipt = await runReceipt({ ...env, ...base, APPLE_API_KEY: keyId });
+    assert.equal(receipt.verdict, "UNKNOWN");
+    assert.equal(receipt.error.code, "INVALID_KEY_ID");
+    assert.equal(receipt.error.httpStatus, null);
+    assert.doesNotMatch(JSON.stringify(receipt), /PRIVATE/);
+  }
+});
+
 test("availability requires exact identity, matching beta lane and populated assigned group", async () => {
   const f = fixture();
   const receipt = await runReceipt(env, { api: f.api });

--- a/src/components/ios-theme-api.test.ts
+++ b/src/components/ios-theme-api.test.ts
@@ -21,12 +21,12 @@ assert.match(theme, /extension EnvironmentValues[\s\S]*var chrome:\s*ChromePalet
 
 assert.match(appModel, /var chrome:\s*ChromePalette = \.fallback/, "AppModel owns the current chrome palette");
 assert.match(appModel, /func loadTheme\(\) async[\s\S]*client\.fetchTheme\(\)[\s\S]*adopt\(snapshot\)/, "AppModel fetches and adopts the desktop palette");
-// Project-context bootstrap keeps theme/profile best-effort while the required
-// project scope loads through the same core-resource entry point.
+// Cached chats no longer gate the shell on catalog loading. Stale chat access
+// still refreshes through the core-resource entry point before dispatch.
 assert.match(
   appModel,
-  /let shouldGateShell = !hasLoadedSurfaces[\s\S]*await (?:loadCoreResources|refreshLoadedSurfaces)\([\s\S]*connectionState = \.connected/,
-  "AppModel gates the connected state on its initial core-resource load",
+  /let shouldLoadCoreBeforeDispatch = !chatAccessIsCurrent[\s\S]*if shouldLoadCoreBeforeDispatch \{[\s\S]*await (?:loadCoreResources|refreshLoadedSurfaces)\([\s\S]*guard refreshLeaseIsCurrent\([\s\S]*if case \.needsAuth = connectionState \{[\s\S]*return[\s\S]*connectionState = \.connected/,
+  "AppModel refreshes stale chat access before connecting and preserves lease and authentication guards",
 );
 assert.match(
   appModel,


### PR DESCRIPTION
## What changed

Implements the approved September 12 chat-only direction in #5290 (https://github.com/OpenCoven/coven-cave/issues/5290#issuecomment-5644986219), tracked by Bead `cave-iusli`.

- Replace operational/workspace navigation with Conversations and Settings, global chat search, and in-chat familiar selection. Retire Tasks/Reminders widgets, shortcuts and deep-link destinations while preserving compatible decoding.
- Keep cached history, per-thread drafts, attachments and read boundaries independent of global project selection. Bind project access to the exact conversation, with fresh fail-closed checks before send/retry/queued replay and immediate voice shutdown on revoked authority.
- Align native and source-contract coverage and repair TestFlight receipt preflight: Apple documents an example key ID, not a fixed ten-character requirement. Bounded identifier validation, P-256 signing, GET-only scopes, existing CI secrets and sanitized failures remain intact.

## Verification

`pnpm typecheck`, `pnpm lint`, all 1,443 app files, all 474 API files, all 103 mobile files, and all 2,035 test-wiring entries passed. Receipt/upload coverage: 23 cases. Native simulator build and test build succeeded; XCTest result bundles show 798/798 unit tests and 23/23 focused UI tests (navigation, search, new chat, session switching), with no failures or skips. One independent high-risk native review reported no actionable findings.

Local fixtures used short, authorized, non-Git temporary paths and process-only Git bare-fixture support; no product guard or global configuration was relaxed. The focused UI run required removing a stale simulator app install; no physical-device latency claim is made. The complete UI suite was not run.

This PR lands the new implementation, not a TestFlight delivery claim. A new stamped, candidate-validated, iOS-only release and exact Apple availability receipt follow after merge.