### PR TITLE
Stamp v0.4.3 for the chat-only iOS release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ breaking config changes; patch releases stay additive.
 
 > Makes familiar conversations the native iOS app's home.
 
-An iOS-focused release following v0.4.2. This cut targets TestFlight only;
-desktop installers and the desktop updater are not advanced.
+An iOS-focused release following v0.4.2. TestFlight-only delivery requires an
+explicit iOS dispatch after stopping the automatic stable-tag release before
+publication; a stable tag push alone still selects all platforms.
 
 ### Changed
 - Replace native iOS workspace navigation with Conversations and Settings,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-09-12
+
+> Makes familiar conversations the native iOS app's home.
+
+An iOS-focused release following v0.4.2. This cut targets TestFlight only;
+desktop installers and the desktop updater are not advanced.
+
+### Changed
+- Replace native iOS workspace navigation with Conversations and Settings,
+  chat search, and familiar selection inside each conversation (#5379).
+- Remove Tasks, Reminders, and global project navigation from the native app,
+  including their widget and shortcut entrypoints. Project access remains an
+  explicit conversation-level binding.
+- Preserve cached history, conversation drafts and attachments, and per-thread
+  read state across navigation and reconnects.
+- Advance release metadata to 0.4.3 and the iOS build to 2026091214.
+
+### Fixed
+- Recheck exact conversation access before sends, retries, and queued replay;
+  stop active voice when that authority is revoked, without auto-restarting it.
+- Keep cached conversations readable when live catalogs are unavailable.
+- Accept bounded App Store Connect key identifiers without assuming a fixed
+  ten-character length in the read-only TestFlight availability receipt.
+
+### Included source updates
+- Improve desktop Home and chat entry flows, title visibility, automatic
+  conversation naming, and Markdown attachment reading.
+- Separate Flow execution conversations from ordinary Chat and retain research,
+  image, and human-answer commands during chat enhancement.
+- Strengthen cross-thread continuity, standard-user discovery, research run
+  projections, and isolated workflow/runtime fixtures.
+
 ## [0.4.2] - 2026-09-09
 
 > Reduces native iOS chat startup work and releases detached message renderers.

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.4.2"
+    MARKETING_VERSION: "0.4.3"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026090912"
+    CURRENT_PROJECT_VERSION: "2026091214"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aes-gcm",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.4.2"
+version = "0.4.3"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Release stamp for Bead `cave-iusli`, following implementation #5379 merged at `3f150f6d3743915b0337329790203cff67513508`.

Synchronizes all five version locations to **0.4.3**, advances the iOS build to **2026091214**, and finalizes scoped release notes. No application logic or dependency versions change.

The implementation passed complete local app/API/mobile gates, 798 native unit tests, 23 focused native UI tests, independent review and every CI lane. The stamp passed `pnpm release:verify --version 0.4.3` and the existing stamp-release/release-notes suites (13 reported cases).

After this protected PR merges: sign an RC at the exact merge, wait for candidate validation, and promote the same SHA with a signed final tag. **Stable-tag pushes select all platforms.** For the intended iOS-only cut, identify and cancel that exact automatic run before packaging/publication, verify no desktop publication steps ran, then dispatch `release.yml` from `main` with `tag=v0.4.3` and `platform=ios`. If automatic publication cannot be stopped in time, report the actual outcome rather than claiming platform isolation. Do not disable repository workflows or bypass signed promotion.

Capture separate upload, Apple processing and tester-availability receipts. The repaired GET-only preflight already authenticated successfully and returned the expected ABSENT for not-yet-uploaded 0.4.3/2026091214: https://github.com/OpenCoven/coven-cave/actions/runs/34698949684 . This is not a delivery claim.