### PR TITLE
fix(ios): bind TestFlight beta details through build linkage

### DIFF
--- a/docs/workflows/testflight-receipt.md
+++ b/docs/workflows/testflight-receipt.md
@@ -35,6 +35,15 @@ assigned group IDs/types, and tester counts. Tester membership is read using the
 IDs-only relationship endpoint; tester IDs, names and emails are never emitted.
 Apple response bodies and arbitrary error messages are never logged.
 
+Beta-detail identity is proven by reading the exact build's
+`relationships/buildBetaDetail` ID and matching it to the returned detail.
+Apple defines the inverse `build` relationship and its inline linkage as optional;
+a links-only inverse is not an identity failure. When inverse linkage is supplied,
+it must still match the exact build. Missing or mismatched forward linkage remains
+an error. `buildBetaDetailHasBuildLinkage` records only whether the inverse linkage
+was supplied; it does not replace the forward identity proof. Resource-type,
+resource-ID and missing-linkage failures have distinct sanitized error codes.
+
 | Verdict | Meaning |
 | --- | --- |
 | `ABSENT` | No exact app, iOS pre-release version, or build is visible. |
@@ -64,6 +73,8 @@ has not finished processing; this workflow does not poll indefinitely.
 - [Pre-release versions](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-prereleaseversions)
 - [Builds](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds)
 - [Build beta detail](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-buildbetadetail)
+- [Build beta detail ID linkage](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-buildbetadetail)
+- [Build beta detail resource](https://developer.apple.com/documentation/appstoreconnectapi/buildbetadetail)
 - [Internal states](https://developer.apple.com/documentation/appstoreconnectapi/internalbetastate) and [external states](https://developer.apple.com/documentation/appstoreconnectapi/externalbetastate)
 - [Beta groups filtered by app and build](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-betagroups)
 - [Tester relationship IDs](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-betagroups-_id_-relationships-betatesters)

--- a/scripts/testflight-receipt.mjs
+++ b/scripts/testflight-receipt.mjs
@@ -46,7 +46,8 @@ export function appleUrl(value) {
     throw new ReceiptError("UNSAFE_API_URL");
   }
   requireValue(url.origin === ORIGIN && !url.username && !url.password && !url.hash
-    && /^\/v1\/(?:apps|preReleaseVersions|builds|betaGroups)(?:\/[A-Za-z0-9-]+(?:\/(?:buildBetaDetail|relationships\/betaTesters))?)?$/.test(url.pathname),
+    && (/^\/v1\/(?:apps|preReleaseVersions|builds|betaGroups)(?:\/[A-Za-z0-9-]+(?:\/(?:buildBetaDetail|relationships\/betaTesters))?)?$/.test(url.pathname)
+      || /^\/v1\/builds\/[A-Za-z0-9-]+\/relationships\/buildBetaDetail$/.test(url.pathname)),
   "UNSAFE_API_URL");
   return url;
 }
@@ -171,12 +172,14 @@ export function appleClient(signer, { fetchImpl = fetch, pause = sleep, now = Da
 }
 
 function resource(value, type) {
-  requireValue(value?.type === type && typeof value.id === "string"
-    && /^[A-Za-z0-9-]{1,100}$/.test(value.id));
+  requireValue(value?.type === type, "INVALID_RESOURCE_TYPE");
+  requireValue(typeof value.id === "string"
+    && /^[A-Za-z0-9-]{1,100}$/.test(value.id), "INVALID_RESOURCE_ID");
   return value;
 }
 
 function relationship(value, name, type, id) {
+  requireValue(value.relationships?.[name]?.data !== undefined, "MISSING_RELATIONSHIP_DATA");
   requireValue(resource(value.relationships?.[name]?.data, type).id === id, "IDENTITY_MISMATCH");
 }
 
@@ -226,11 +229,17 @@ export async function collectReceipt(receipt, api) {
   const expiration = Date.parse(build.attributes.expirationDate);
   requireValue(Number.isFinite(expiration), "INVALID_RESPONSE");
   receipt.expirationDate = new Date(expiration).toISOString();
+  // The inverse build relationship is optional; bind the detail through the exact build instead.
+  const detailLink = resource((await api.get(
+    `/v1/builds/${build.id}/relationships/buildBetaDetail`,
+  )).data, "buildBetaDetails");
   const detail = resource((await api.get(`/v1/builds/${build.id}/buildBetaDetail?${new URLSearchParams({
     include: "build", "fields[buildBetaDetails]": "internalBuildState,externalBuildState,build",
     "fields[builds]": "version",
   })}`)).data, "buildBetaDetails");
-  relationship(detail, "build", "builds", build.id);
+  requireValue(detail.id === detailLink.id, "IDENTITY_MISMATCH");
+  receipt.buildBetaDetailHasBuildLinkage = detail.relationships?.build?.data !== undefined;
+  if (receipt.buildBetaDetailHasBuildLinkage) relationship(detail, "build", "builds", build.id);
   receipt.buildBetaDetailId = detail.id;
   receipt.internalBuildState = state(detail.attributes?.internalBuildState, INTERNAL);
   receipt.externalBuildState = state(detail.attributes?.externalBuildState, EXTERNAL);

--- a/scripts/testflight-receipt.mjs
+++ b/scripts/testflight-receipt.mjs
@@ -230,9 +230,11 @@ export async function collectReceipt(receipt, api) {
   requireValue(Number.isFinite(expiration), "INVALID_RESPONSE");
   receipt.expirationDate = new Date(expiration).toISOString();
   // The inverse build relationship is optional; bind the detail through the exact build instead.
-  const detailLink = resource((await api.get(
+  const detailLinkResponse = await api.get(
     `/v1/builds/${build.id}/relationships/buildBetaDetail`,
-  )).data, "buildBetaDetails");
+  );
+  requireValue(detailLinkResponse?.data !== undefined, "MISSING_RELATIONSHIP_DATA");
+  const detailLink = resource(detailLinkResponse.data, "buildBetaDetails");
   const detail = resource((await api.get(`/v1/builds/${build.id}/buildBetaDetail?${new URLSearchParams({
     include: "build", "fields[buildBetaDetails]": "internalBuildState,externalBuildState,build",
     "fields[builds]": "version",

--- a/scripts/testflight-receipt.test.mjs
+++ b/scripts/testflight-receipt.test.mjs
@@ -151,7 +151,7 @@ test("beta details bind to the exact build even when inverse linkage is omitted"
 });
 
 test("missing, malformed or conflicting forward beta-detail linkage fails closed", async () => {
-  for (const linkage of [null, {}, [], { type: "builds", id: "detail-1" },
+  for (const linkage of [undefined, null, {}, [], { type: "builds", id: "detail-1" },
     { type: "buildBetaDetails", id: "other-detail" }, { type: "buildBetaDetails", id: "PRIVATE\nID" }]) {
     const f = fixture();
     f.data.buildBetaDetailLinkage = linkage;
@@ -159,6 +159,8 @@ test("missing, malformed or conflicting forward beta-detail linkage fails closed
     const receipt = await runReceipt(env, { api: f.api });
     assert.equal(receipt.verdict, "UNKNOWN");
     assert.ok(receipt.error);
+    if (linkage === undefined) assert.equal(receipt.error.code, "MISSING_RELATIONSHIP_DATA");
+    if (linkage === null) assert.equal(receipt.error.code, "INVALID_RESOURCE_TYPE");
     assert.deepEqual(receipt.groups, []);
     assert.doesNotMatch(JSON.stringify(receipt), /PRIVATE/);
   }

--- a/scripts/testflight-receipt.test.mjs
+++ b/scripts/testflight-receipt.test.mjs
@@ -24,6 +24,7 @@ function fixture() {
     buildBetaDetail: resource("buildBetaDetails", "detail-1", {
       internalBuildState: "IN_BETA_TESTING", externalBuildState: "READY_FOR_BETA_SUBMISSION",
     }, { build: relation("builds", "build-1") }),
+    buildBetaDetailLinkage: { type: "buildBetaDetails", id: "detail-1" },
     betaGroups: [resource("betaGroups", "group-1", { isInternalGroup: true, name: "PRIVATE GROUP NAME" },
       { app: relation("apps", "app-1") })],
     betaTesters: [{ type: "betaTesters", id: "private-tester-id" }],
@@ -36,7 +37,8 @@ function fixture() {
       assert.equal(options.method, "GET");
       assert.equal(options.redirect, "error");
       assert.ok(options.signal instanceof AbortSignal);
-      const key = url.pathname.split("/").at(-1);
+      const key = url.pathname.endsWith("/relationships/buildBetaDetail")
+        ? "buildBetaDetailLinkage" : url.pathname.split("/").at(-1);
       assert.ok(Object.hasOwn(data, key), `Unexpected endpoint ${key}`);
       return Response.json({ data: data[key], links: { next: null } });
     },
@@ -119,6 +121,8 @@ test("availability requires exact identity, matching beta lane and populated ass
   assert.equal(receipt.verdict, "TESTER_AVAILABLE");
   assert.equal(receipt.buildId, "build-1");
   assert.equal(receipt.processingState, "VALID");
+  assert.equal(receipt.buildBetaDetailId, "detail-1");
+  assert.equal(receipt.buildBetaDetailHasBuildLinkage, true);
   assert.deepEqual(receipt.groups, [{
     id: "group-1", isInternalGroup: true, buildState: "IN_BETA_TESTING", testerCount: 1, testerAvailable: true,
   }]);
@@ -130,7 +134,39 @@ test("availability requires exact identity, matching beta lane and populated ass
   assert.equal(groups.searchParams.get("filter[app]"), "app-1");
   assert.equal(groups.searchParams.get("filter[builds]"), "build-1");
   assert.ok(f.calls.some(({ url }) => url.pathname === "/v1/betaGroups/group-1/relationships/betaTesters"));
+  assert.ok(f.calls.some(({ url }) => url.pathname === "/v1/builds/build-1/relationships/buildBetaDetail"));
   assert.doesNotMatch(receiptSummary(receipt), /PRIVATE GROUP NAME|private-tester-id|private-token/);
+});
+
+test("beta details bind to the exact build even when inverse linkage is omitted", async () => {
+  for (const relationships of [undefined, {}, { build: { links: { related: "https://example.test/unused" } } }]) {
+    const f = fixture();
+    f.data.buildBetaDetail.relationships = relationships;
+    const receipt = await runReceipt(env, { api: f.api });
+    assert.equal(receipt.verdict, "TESTER_AVAILABLE");
+    assert.equal(receipt.buildBetaDetailId, "detail-1");
+    assert.equal(receipt.buildBetaDetailHasBuildLinkage, false);
+    assert.equal(f.calls.filter(({ url }) => url.pathname.endsWith("/relationships/buildBetaDetail")).length, 1);
+  }
+});
+
+test("missing, malformed or conflicting forward beta-detail linkage fails closed", async () => {
+  for (const linkage of [null, {}, [], { type: "builds", id: "detail-1" },
+    { type: "buildBetaDetails", id: "other-detail" }, { type: "buildBetaDetails", id: "PRIVATE\nID" }]) {
+    const f = fixture();
+    f.data.buildBetaDetailLinkage = linkage;
+    delete f.data.buildBetaDetail.relationships;
+    const receipt = await runReceipt(env, { api: f.api });
+    assert.equal(receipt.verdict, "UNKNOWN");
+    assert.ok(receipt.error);
+    assert.deepEqual(receipt.groups, []);
+    assert.doesNotMatch(JSON.stringify(receipt), /PRIVATE/);
+  }
+  const f = fixture();
+  f.data.buildBetaDetail.relationships.build.data = null;
+  const receipt = await runReceipt(env, { api: f.api });
+  assert.equal(receipt.verdict, "UNKNOWN");
+  assert.equal(receipt.error.code, "INVALID_RESOURCE_TYPE");
 });
 
 test("processing, absent, blocked, unknown and merely ready states are not success", async () => {
@@ -203,6 +239,8 @@ test("requests refuse foreign origins, redirects and unsafe or unbounded paginat
     "https://attacker.example/v1/apps", "http://api.appstoreconnect.apple.com/v1/apps",
     "//attacker.example/v1/apps", "https://user:pass@api.appstoreconnect.apple.com/v1/apps",
     "https://api.appstoreconnect.apple.com:444/v1/apps", "/v1/apps#fragment", "/v1/users",
+    "/v1/apps/app-1/relationships/buildBetaDetail",
+    "/v1/builds/build-1/relationships/other",
   ]) assert.throws(() => appleUrl(url), /UNSAFE_API_URL/);
   for (const next of [
     "https://attacker.example/v1/apps?limit=200",


### PR DESCRIPTION
## Summary
Complete the read-only availability proof for the already-uploaded 0.4.3 (2026091214). Apple marks the inverse build relationship and its inline linkage optional; require the exact build-to-detail relationship ID instead, compare it with the returned detail, and still reject conflicting inverse linkage whenever supplied. Preserve every processing, expiration, group-membership, GET-only, bounded-query and secret-redaction guard.

Record whether Apple supplied inverse linkage and distinguish resource-type, resource-ID and missing-linkage errors without logging response bodies. The precise live failure will be confirmed by the post-merge receipt; no new app upload or release-tag change is needed.

## Evidence
- 14 focused receipt cases passed, including omitted/links-only inverse relationships, missing and conflicting forward IDs, null inverse data, URL restrictions and redaction.
- git diff --check passed.
- Live failure reproduced by bounded read-only retry: https://github.com/OpenCoven/coven-cave/actions/runs/34703747223
- Apple contract: https://developer.apple.com/documentation/appstoreconnectapi/get-v1-builds-_id_-relationships-buildbetadetail

Canonical Bead: cave-iusli; delivery continuation under the existing takeover authorization.