### PR TITLE
fix(ios): accept empty optional TestFlight inverse linkage

### DIFF
--- a/docs/workflows/testflight-receipt.md
+++ b/docs/workflows/testflight-receipt.md
@@ -38,10 +38,13 @@ Apple response bodies and arbitrary error messages are never logged.
 Beta-detail identity is proven by reading the exact build's
 `relationships/buildBetaDetail` ID and matching it to the returned detail.
 Apple defines the inverse `build` relationship and its inline linkage as optional;
-a links-only inverse is not an identity failure. When inverse linkage is supplied,
-it must still match the exact build. Missing or mismatched forward linkage remains
-an error. `buildBetaDetailHasBuildLinkage` records only whether the inverse linkage
-was supplied; it does not replace the forward identity proof. Resource-type,
+a links-only inverse or an empty to-one linkage (`data: null`) supplies no inverse
+identity. When non-null inverse linkage is supplied, it must still match the exact
+build. Missing, null or mismatched **forward** linkage remains an error.
+`buildBetaDetailHasBuildLinkage` records whether non-null inverse linkage was
+supplied, and `buildBetaDetailBuildLinkageState` distinguishes `omitted`, `empty`
+and `present` without exposing response bodies. Neither replaces the mandatory
+forward identity proof. Resource-type,
 resource-ID and missing-linkage failures have distinct sanitized error codes.
 
 | Verdict | Meaning |

--- a/scripts/testflight-receipt.mjs
+++ b/scripts/testflight-receipt.mjs
@@ -240,9 +240,12 @@ export async function collectReceipt(receipt, api) {
     "fields[builds]": "version",
   })}`)).data, "buildBetaDetails");
   requireValue(detail.id === detailLink.id, "IDENTITY_MISMATCH");
-  receipt.buildBetaDetailHasBuildLinkage = detail.relationships?.build?.data !== undefined;
-  if (receipt.buildBetaDetailHasBuildLinkage) relationship(detail, "build", "builds", build.id);
   receipt.buildBetaDetailId = detail.id;
+  const inverseBuild = detail.relationships?.build?.data;
+  receipt.buildBetaDetailBuildLinkageState = inverseBuild === null ? "empty"
+    : inverseBuild === undefined ? "omitted" : "present";
+  receipt.buildBetaDetailHasBuildLinkage = inverseBuild !== undefined && inverseBuild !== null;
+  if (receipt.buildBetaDetailHasBuildLinkage) relationship(detail, "build", "builds", build.id);
   receipt.internalBuildState = state(detail.attributes?.internalBuildState, INTERNAL);
   receipt.externalBuildState = state(detail.attributes?.externalBuildState, EXTERNAL);
   const groups = await api.list("/v1/betaGroups", {

--- a/scripts/testflight-receipt.test.mjs
+++ b/scripts/testflight-receipt.test.mjs
@@ -138,14 +138,17 @@ test("availability requires exact identity, matching beta lane and populated ass
   assert.doesNotMatch(receiptSummary(receipt), /PRIVATE GROUP NAME|private-tester-id|private-token/);
 });
 
-test("beta details bind to the exact build even when inverse linkage is omitted", async () => {
-  for (const relationships of [undefined, {}, { build: { links: { related: "https://example.test/unused" } } }]) {
+test("beta details bind to the exact build when inverse linkage is omitted or empty", async () => {
+  for (const relationships of [undefined, {}, { build: { data: null } },
+    { build: { links: { related: "https://example.test/unused" } } }]) {
     const f = fixture();
     f.data.buildBetaDetail.relationships = relationships;
     const receipt = await runReceipt(env, { api: f.api });
     assert.equal(receipt.verdict, "TESTER_AVAILABLE");
     assert.equal(receipt.buildBetaDetailId, "detail-1");
     assert.equal(receipt.buildBetaDetailHasBuildLinkage, false);
+    assert.equal(receipt.buildBetaDetailBuildLinkageState,
+      relationships?.build?.data === null ? "empty" : "omitted");
     assert.equal(f.calls.filter(({ url }) => url.pathname.endsWith("/relationships/buildBetaDetail")).length, 1);
   }
 });
@@ -164,11 +167,15 @@ test("missing, malformed or conflicting forward beta-detail linkage fails closed
     assert.deepEqual(receipt.groups, []);
     assert.doesNotMatch(JSON.stringify(receipt), /PRIVATE/);
   }
-  const f = fixture();
-  f.data.buildBetaDetail.relationships.build.data = null;
-  const receipt = await runReceipt(env, { api: f.api });
-  assert.equal(receipt.verdict, "UNKNOWN");
-  assert.equal(receipt.error.code, "INVALID_RESOURCE_TYPE");
+  for (const inverse of [{ type: "apps", id: "build-1" }, {}, [], "PRIVATE"]) {
+    const f = fixture();
+    f.data.buildBetaDetail.relationships.build.data = inverse;
+    const receipt = await runReceipt(env, { api: f.api });
+    assert.equal(receipt.verdict, "UNKNOWN");
+    assert.equal(receipt.error.code, "INVALID_RESOURCE_TYPE");
+    assert.equal(receipt.buildBetaDetailBuildLinkageState, "present");
+    assert.doesNotMatch(JSON.stringify(receipt), /PRIVATE/);
+  }
 });
 
 test("processing, absent, blocked, unknown and merely ready states are not success", async () => {


### PR DESCRIPTION
## Summary
Keep the mandatory exact-build forward relationship proof from #5381, but distinguish an empty optional inverse (data: null) from a supplied inverse resource. A non-null inverse still must be a builds resource naming the exact build. Missing, null, malformed or conflicting forward linkage remains an error.

The live receipt now proves both forward resource lookups and their ID comparison succeeded, then fails validating the optional inverse: https://github.com/OpenCoven/coven-cave/actions/runs/34705974528 . Its prior boolean did not distinguish null from a resource. Record an allowlisted omitted/empty/present state so the next receipt establishes the actual shape without exposing any Apple body. Do not claim availability until that receipt succeeds.

## Verification
14 focused receipt cases pass, now covering an empty inverse with mandatory forward identity, invalid non-null inverse types, and continued rejection of null forward linkage. git diff --check passes. No app upload, version stamp, distribution mutation, credential change, or release-tag change.

Canonical Bead: cave-iusli; same authorized delivery continuation.